### PR TITLE
Allow images from filesystem

### DIFF
--- a/aws/main.py
+++ b/aws/main.py
@@ -97,7 +97,7 @@ def update_headers(response):
     "connect-src 'self' blob: https://*.unsplash.com https://maps.googleapis.com https://*.giphy.com https://api.raygun.io https://www.google.com https://*.wire.com https://wire.com wss://prod-nginz-ssl.wire.com https://*.zinfra.io wss://*.zinfra.io",
     "font-src 'self' data:",
     "frame-src 'self' https://accounts.google.com https://*.youtube.com https://*.soundcloud.com https://*.vimeo.com https://*.spotify.com",
-    "img-src 'self' blob: data: https://*.giphy.com https://1-ps.googleusercontent.com https://*.localytics.com https://*.wire.com https://*.cloudfront.net https://*.zinfra.io https://csi.gstatic.com",
+    "img-src 'self' blob: data: filesystem: https://*.giphy.com https://1-ps.googleusercontent.com https://*.localytics.com https://*.wire.com https://*.cloudfront.net https://*.zinfra.io https://csi.gstatic.com",
     # Note: The "blob:" attribute needs to be explicitly set for Chrome 47+: https://code.google.com/p/chromium/issues/detail?id=473904
     "media-src blob: data: *",
     "object-src 'self' https://*.youtube.com 1-ps.googleusercontent.com",


### PR DESCRIPTION
Fix for CSP issue:

> Refused to load the image 'file:///C:/Users/Benny/AppData/Local/wireinternal/app-2.9.2641/resources/app.asar/img/notification.png' because it violates the following Content Security Policy directive: "img-src 'self' blob: data: https://*.giphy.com https://1-ps.googleusercontent.com https://*.localytics.com https://*.wire.com https://*.cloudfront.net https://*.zinfra.io https://csi.gstatic.com".