### PR TITLE
Extend storage tests

### DIFF
--- a/app/page/template/_dist/app.htm
+++ b/app/page/template/_dist/app.htm
@@ -20,6 +20,7 @@
 <script src="/script/util/Invite.js"></script>
 <!-- Storage -->
 <script src="/script/storage/SkipError.js"></script>
+<script src="/script/storage/StorageError.js"></script>
 <script src="/script/storage/StorageKey.js"></script>
 <script src="/script/storage/StorageRepository.js"></script>
 <script src="/script/storage/StorageService.js"></script>

--- a/app/script/conversation/ConversationService.coffee
+++ b/app/script/conversation/ConversationService.coffee
@@ -199,6 +199,7 @@ class z.conversation.ConversationService
 
   @param message_id [String] ID of conversation to remove message from
   @param primary_key [String] ID of the actual message
+  @return [Promise] Resolves with the number of deleted records
   ###
   delete_message_from_db: (conversation_id, message_id) ->
     @storage_service.db[@storage_service.OBJECT_STORE_CONVERSATION_EVENTS]

--- a/app/script/conversation/ConversationService.coffee
+++ b/app/script/conversation/ConversationService.coffee
@@ -42,7 +42,7 @@ class z.conversation.ConversationService
       @storage_service.save store_name, conversation_et.id, conversation_et.serialize()
       .then (primary_key) =>
         @logger.log @logger.levels.INFO, "Conversation '#{primary_key}' was stored for the first time"
-        resolve()
+        resolve conversation_et
       .catch (error) =>
         @logger.log @logger.levels.ERROR, "Conversation '#{conversation_et.id}' could not be stored", error
         reject error

--- a/app/script/conversation/ConversationService.coffee
+++ b/app/script/conversation/ConversationService.coffee
@@ -283,7 +283,7 @@ class z.conversation.ConversationService
   @param conversation_id [String] ID of conversation
   @param offset [String] Timestamp that loaded events have to undercut
   @param limit [Number] Amount of events to load
-  @return [Promise] Promise that resolves with the retrieved records
+  @return [Promise] Promise that resolves with the retrieved records ([events, has_further_events])
   ###
   load_events_from_db: (conversation_id, offset, limit = z.config.MESSAGES_FETCH_LIMIT) ->
     return new Promise (resolve, reject) =>

--- a/app/script/conversation/EventMapper.coffee
+++ b/app/script/conversation/EventMapper.coffee
@@ -92,7 +92,8 @@ class z.conversation.EventMapper
     message_et.primary_key = "#{conversation_et.id}@#{message_et.from}@#{message_et.timestamp}"
 
     if window.isNaN message_et.timestamp
-      @logger.log @logger.levels.ERROR, 'Could not get timestamp for message', event
+      @logger.log @logger.levels.WARN, "Could not get timestamp for message '#{message_et.id}'. Skipping it.", event
+      message_et = undefined
 
     return message_et
 
@@ -336,9 +337,9 @@ class z.conversation.EventMapper
   ###
   _map_link_previews: (link_previews = []) ->
     return link_previews
-      .map (encoded_link_preview) -> z.proto.LinkPreview.decode64 encoded_link_preview
-      .map (link_preview) => @_map_link_preview link_preview
-      .filter (link_preview_et) -> link_preview_et?
+    .map (encoded_link_preview) -> z.proto.LinkPreview.decode64 encoded_link_preview
+    .map (link_preview) => @_map_link_preview link_preview
+    .filter (link_preview_et) -> link_preview_et?
 
   ###
   Map link preview
@@ -430,8 +431,8 @@ class z.conversation.EventMapper
     asset_et.file_name = data.data.info.name
     asset_et.meta = data.data.meta
     asset_et.original_resource z.assets.AssetRemoteData.v2 asset_et.conversation_id, asset_et.id, data.data.otr_key, data.data.sha256,
-    if data.data.preview_id?
-      asset_et.preview_resource z.assets.AssetRemoteData.v2 asset_et.conversation_id, data.data.preview_id, data.data.preview_otr_key, data.data.preview_sha256
+      if data.data.preview_id?
+        asset_et.preview_resource z.assets.AssetRemoteData.v2 asset_et.conversation_id, data.data.preview_id, data.data.preview_otr_key, data.data.preview_sha256
     asset_et.status data.data.status or z.assets.AssetTransferState.UPLOADING # TODO
     return asset_et
 

--- a/app/script/entity/message/Asset.coffee
+++ b/app/script/entity/message/Asset.coffee
@@ -78,8 +78,8 @@ class z.entity.Asset
   ###
   is_video: ->
     if @type is z.assets.AssetType.FILE and @file_type?.startsWith('video') and not z.util.Environment.browser.firefox
-      can_play_audio = document.createElement('video').canPlayType @file_type
-      return true if can_play_audio isnt ''
+      can_play = document.createElement('video').canPlayType @file_type
+      return true if can_play isnt ''
     return false
   ###
   Check if asset is a audio.
@@ -88,8 +88,8 @@ class z.entity.Asset
   ###
   is_audio: ->
     if @type is z.assets.AssetType.FILE and @file_type?.startsWith 'audio'
-      can_play_audio = document.createElement('audio').canPlayType @file_type
-      return true if can_play_audio isnt ''
+      can_play = document.createElement('audio').canPlayType @file_type
+      return true if can_play isnt ''
     return false
 
   ###

--- a/app/script/storage/StorageError.coffee
+++ b/app/script/storage/StorageError.coffee
@@ -1,0 +1,11 @@
+window.z ?= {}
+z.storage ?= {}
+
+class z.storage.StorageError
+  constructor: (@message = 'Unknown storage error') ->
+    @name = @constructor.name
+    @stack = (new Error()).stack
+
+  @:: = new Error()
+  @::constructor = @
+  @::INVALID_TIMESTAMP = 'Invalid timestamp'

--- a/app/script/storage/StorageRepository.coffee
+++ b/app/script/storage/StorageRepository.coffee
@@ -186,7 +186,7 @@ class z.storage.StorageRepository extends cryptobox.CryptoboxStore
 
   @param primary_key [String] Primary key to save the object with
   @param value [value] Object to be stored
-  @return [Promise] Promise that will resolve with the saved record
+  @return [Promise] Promise that will resolve with the saved record's key
   ###
   save_value: (primary_key, value) =>
     return @storage_service.save @storage_service.OBJECT_STORE_AMPLIFY, primary_key, value: value

--- a/app/script/storage/StorageRepository.coffee
+++ b/app/script/storage/StorageRepository.coffee
@@ -205,12 +205,13 @@ class z.storage.StorageRepository extends cryptobox.CryptoboxStore
   Construct a unique primary key.
 
   @param conversation_id [String] ID of conversation
-  @param sender_id [String, undefined] ID of message sender
+  @param sender_id [String] ID of message sender
   @param time [String] Time in ISO format to create timestamp from
   @return [String] Generated primary key
   ###
   construct_primary_key: (conversation_id, sender_id = @storage_service.user_id, time) ->
     timestamp = new Date(time).getTime()
+    throw new z.storage.StorageError z.storage.StorageError::INVALID_TIMESTAMP if window.isNaN timestamp
     return "#{conversation_id}@#{sender_id}@#{timestamp}"
 
   ###

--- a/app/script/storage/StorageService.coffee
+++ b/app/script/storage/StorageService.coffee
@@ -114,7 +114,7 @@ class z.storage.StorageService
       @db.version(3).stores version_3
       @db.version(4).stores version_4
       .upgrade (transaction) =>
-        @logger.log @logger.levels.WARN, 'Database upgrade to version 4 needed', transaction
+        @logger.log @logger.levels.WARN, 'Database upgrade to version 4', transaction
         transaction[@OBJECT_STORE_CLIENTS].toCollection().modify (client) =>
           client.meta =
             is_verified: true
@@ -123,7 +123,7 @@ class z.storage.StorageService
       @db.version(5).stores version_4
       @db.version(6).stores version_4
       .upgrade (transaction) =>
-        @logger.log @logger.levels.WARN, 'Database upgrade to version 6 needed', transaction
+        @logger.log @logger.levels.WARN, 'Database upgrade to version 6', transaction
         transaction[@OBJECT_STORE_CONVERSATIONS].toCollection().eachKey (key) =>
           @db[@OBJECT_STORE_CONVERSATIONS].update key, {id: key}
         transaction[@OBJECT_STORE_SESSIONS].toCollection().eachKey (key) =>

--- a/test/api/TestFactory.js
+++ b/test/api/TestFactory.js
@@ -225,7 +225,7 @@ window.TestFactory.prototype.exposeConversationActors = function () {
   var self = this;
   return new Promise(function (resolve) {
     self.exposeUserActors().then(function () {
-      window.conversation_service = new z.conversation.ConversationService(self.client);
+      window.conversation_service = new z.conversation.ConversationService(self.client, window.storage_service);
       window.conversation_service.logger.level = self.settings.logging_level;
 
       window.conversation_repository = new z.conversation.ConversationRepository(

--- a/test/unit_tests/conversation/ConversationRepositorySpec.coffee
+++ b/test/unit_tests/conversation/ConversationRepositorySpec.coffee
@@ -19,11 +19,13 @@
 # grunt test_init && grunt test_run:conversation/ConversationRepository
 #@formatter:off
 describe 'z.conversation.ConversationRepository', ->
+  test_factory = new TestFactory()
+
+  client = test_factory.client
   conversation_et = null
   self_user_et = null
   server = null
-  test_factory = new TestFactory()
-  client = test_factory.client
+  storage_service = null
 
   _find_conversation = (conversation, conversations) ->
     ko.utils.arrayFirst conversations(), (conversation_et) ->
@@ -58,6 +60,8 @@ describe 'z.conversation.ConversationRepository', ->
 
     test_factory.exposeConversationActors()
     .then (conversation_repository) ->
+      storage_service = conversation_repository.conversation_service.storage_service
+
       conversation_et = _generate_conversation z.conversation.ConversationType.SELF
       conversation_et.id = payload.conversations.knock.post.conversation
       conversation_repository.save_conversation conversation_et
@@ -110,72 +114,8 @@ describe 'z.conversation.ConversationRepository', ->
 
   afterEach ->
     server.restore()
+    storage_service.clear_all_stores()
     jQuery.ajax.restore()
-
-  xdescribe 'Sending Ping events', ->
-    # @todo Unit test for sending encrypted pings
-    it 'can ping', ->
-      conversation_repository.send_ping conversation_et
-      server.respond()
-
-      expect(conversation_et.messages().length).toBe 1
-      expect(conversation_et.messages()[0].super_type).toEqual 'ping'
-
-  # @todo Initialize z.proto Message types
-  xdescribe 'Check for duplicated messages', ->
-    it 'ignores duplicated events (even if they do not occur in pairs)', ->
-      first_message = {"conversation": conversation_et.id, "time": "2015-03-12T16:43:37.993Z", "data": {"content": "Hello ", "nonce": "7092baae-d9ba-44a7-923b-0bffd076993f"}, "from": "d5a39ffb-6ce3-4cc8-9048-0e15d031b4c5", "id": "1ec.800122000a775854", "type": "conversation.message-add"}
-      second_message = {"conversation": conversation_et.id, "time": "2015-03-12T16:43:41.063Z", "data": {"content": "World", "nonce": "cef2e84f-4d22-4e4d-b252-74153a4bcc23"}, "from": "d5a39ffb-6ce3-4cc8-9048-0e15d031b4c5", "id": "1ed.800122000a775857", "type": "conversation.message-add"}
-      third_message = {"conversation": conversation_et.id, "time": "2015-03-12T16:44:51.253Z", "data": {"content": "!", "nonce": "4bc077b2-e261-4577-936f-2a105ddffd58"}, "from": "d5a39ffb-6ce3-4cc8-9048-0e15d031b4c5", "id": "1ee.800122000a77587e", "type": "conversation.message-add"}
-
-      conversation_repository.on_conversation_event first_message
-      conversation_repository.on_conversation_event first_message
-
-      expect(conversation_et.messages().length).toBe 1
-
-      conversation_repository.on_conversation_event second_message
-      conversation_repository.on_conversation_event first_message
-      conversation_repository.on_conversation_event third_message
-      conversation_repository.on_conversation_event first_message
-
-      expect(conversation_et.messages().length).toBe 3
-
-    it 'ignores duplicated events (in any order) of different event types', ->
-      text = {"conversation": conversation_et.id, "time": "2015-03-12T23:33:53.717Z", "data": {"content": "Message", "nonce": "1dab326f-d410-47eb-bbc6-429642f8841b"}, "from": "d5a39ffb-6ce3-4cc8-9048-0e15d031b4c5", "id": "1a8.800122000a777d0e", "type": "conversation.message-add"}
-      ping = {"conversation": conversation_et.id, "time": "2015-03-12T23:33:58.636Z", "data": {"nonce": "c2ebd2bf-d742-4c0c-b2a5-5b06f7d422f0"}, "from": "d5a39ffb-6ce3-4cc8-9048-0e15d031b4c5", "id": "1a9.800122000a777d10", "type": "conversation.knock"}
-      hot_ping = {"conversation": conversation_et.id, "time": "2015-03-12T23:34:00.254Z", "data": {"nonce": "c2ebd2bf-d742-4c0c-b2a5-5b06f7d422f0", "ref": "1a9.800122000a777d10"}, "from": "d5a39ffb-6ce3-4cc8-9048-0e15d031b4c5", "id": "1aa.800122000a777d11", "type": "conversation.hot-knock"}
-      call_activate = {"conversation": conversation_et.id, "time": "2015-03-12T23:34:10.501Z", "data": null, "from": "d5a39ffb-6ce3-4cc8-9048-0e15d031b4c5", "id": "1ab.800122000a5c3101", "type": "conversation.voice-channel-activate"}
-      call_deactivate = {"conversation": conversation_et.id, "time": "2015-03-12T23:34:28.328Z", "data": {"reason": "missed"}, "from": "d5a39ffb-6ce3-4cc8-9048-0e15d031b4c5", "id": "1ac.800122000a5c3109", "type": "conversation.voice-channel-deactivate"}
-      preview_image = {"conversation": conversation_et.id, "time": "2015-03-12T23:43:32.850Z", "data": {"content_length": 931, "data": "...", "content_type": "image/jpeg", "id": "3af1cdda-7f20-5cd9-b5fc-c13001979790", "info": {"height": 30, "tag": "preview", "original_width": 2448, "width": 30, "name": null, "correlation_id": "53f970d9-2e82-498f-89d2-5f8f25b0fafa", "original_height": 2448, "nonce": "53f970d9-2e82-498f-89d2-5f8f25b0fafa", "public": false}}, "from": "d5a39ffb-6ce3-4cc8-9048-0e15d031b4c5", "id": "1ae.800122000a5c318d", "type": "conversation.asset-add"}
-      full_size_image = {"conversation": conversation_et.id, "time": "2015-03-12T23:43:36.405Z", "data": {"content_length": 212646, "data": null, "content_type": "image/jpeg", "id": "688309d6-c4aa-5bb1-908f-5051b74c1978", "info": {"height": 1448, "tag": "medium", "original_width": 2448, "width": 1448, "name": null, "correlation_id": "53f970d9-2e82-498f-89d2-5f8f25b0fafa", "original_height": 2448, "nonce": "53f970d9-2e82-498f-89d2-5f8f25b0fafa", "public": false}}, "from": "d5a39ffb-6ce3-4cc8-9048-0e15d031b4c5", "id": "1af.800122000a5c318e", "type": "conversation.asset-add"}
-
-      conversation_repository.on_conversation_event call_deactivate
-      conversation_repository.on_conversation_event ping
-      conversation_repository.on_conversation_event hot_ping
-      conversation_repository.on_conversation_event call_deactivate
-      conversation_repository.on_conversation_event call_deactivate
-      conversation_repository.on_conversation_event hot_ping
-      conversation_repository.on_conversation_event text
-      conversation_repository.on_conversation_event ping
-      conversation_repository.on_conversation_event preview_image
-      conversation_repository.on_conversation_event full_size_image
-      conversation_repository.on_conversation_event text
-      conversation_repository.on_conversation_event text
-      conversation_repository.on_conversation_event call_activate
-      conversation_repository.on_conversation_event text
-
-      expect(conversation_et.messages().length).toBe 7
-
-    it 'accepts full size images being sent before preview images', ->
-      preview_image = {"conversation": conversation_et.id, "time": "2015-03-12T23:43:32.850Z", "data": {"content_length": 931, "data": "...", "content_type": "image/jpeg", "id": "3af1cdda-7f20-5cd9-b5fc-c13001979790", "info": {"height": 30, "tag": "preview", "original_width": 2448, "width": 30, "name": null, "correlation_id": "53f970d9-2e82-498f-89d2-5f8f25b0fafa", "original_height": 2448, "nonce": "53f970d9-2e82-498f-89d2-5f8f25b0fafa", "public": false}}, "from": "d5a39ffb-6ce3-4cc8-9048-0e15d031b4c5", "id": "1ae.800122000a5c318d", "type": "conversation.asset-add"}
-      full_size_image = {"conversation": conversation_et.id, "time": "2015-03-12T23:43:36.405Z", "data": {"content_length": 212646, "data": null, "content_type": "image/jpeg", "id": "688309d6-c4aa-5bb1-908f-5051b74c1978", "info": {"height": 1448, "tag": "medium", "original_width": 2448, "width": 1448, "name": null, "correlation_id": "53f970d9-2e82-498f-89d2-5f8f25b0fafa", "original_height": 2448, "nonce": "53f970d9-2e82-498f-89d2-5f8f25b0fafa", "public": false}}, "from": "d5a39ffb-6ce3-4cc8-9048-0e15d031b4c5", "id": "1af.800122000a5c318e", "type": "conversation.asset-add"}
-
-      conversation_repository.on_conversation_event full_size_image
-      conversation_repository.on_conversation_event preview_image
-      # Duplicated events will be ignored
-      conversation_repository.on_conversation_event full_size_image
-
-      expect(conversation_et.messages().length).toBe 2
 
   describe 'handle member join correctly', ->
 
@@ -197,7 +137,6 @@ describe 'z.conversation.ConversationRepository', ->
       conversation_repository.on_conversation_event member_join_event
       expect(conversation_repository.member_join).toHaveBeenCalled()
 
-    # TODO: HERE!
     it 'ignores member join if joining a one2on2 conversation', ->
 
       # conversation has a corresponding pending connection
@@ -642,7 +581,7 @@ describe 'z.conversation.ConversationRepository', ->
       should_send_as_external = conversation_repository._send_as_external_message conversation_et, generic_message
       expect(should_send_as_external).toBeFalsy()
 
-  xdescribe 'get_events', ->
+  describe 'get_events', ->
     it 'gets messages which are not broken by design', (done) ->
       conversation_et = new z.entity.Conversation '573b6978-7700-443e-9ce5-ff78b35ac590'
       bad_message = {"raw":{"from":"532af01e-1e24-4366-aacf-33b67d4ee376","type":"conversation.otr-message-add","conversation":"573b6978-7700-443e-9ce5-ff78b35ac590"},"meta":{"timestamp":null,"version":1},"mapped":{"conversation":"573b6978-7700-443e-9ce5-ff78b35ac590","id":"aeac8355-739b-4dfc-a119-891a52c6a8dc","from":"532af01e-1e24-4366-aacf-33b67d4ee376","data":{"content":"Hello World :)","nonce":"aeac8355-739b-4dfc-a119-891a52c6a8dc"},"type":"conversation.message-add"}}
@@ -651,15 +590,15 @@ describe 'z.conversation.ConversationRepository', ->
       bad_message_key = "#{conversation_et.id}@#{bad_message.raw.from}@NaN"
       good_message_key = "#{conversation_et.id}@#{good_message.raw.from}@#{new Date(good_message.raw.time).getTime()}"
 
-      # TODO: Combine "exposeStorageActors" & "exposeConversationActors"
-      storage_service = conversation_repository.conversation_service.storage_service
       object_store = storage_service.OBJECT_STORE_CONVERSATION_EVENTS
 
       save_messages = []
-      save_messages.push storage_service.save object_store, bad_message, bad_message_key
+      save_messages.push storage_service.save object_store, bad_message_key, bad_message
       save_messages.push storage_service.save object_store, good_message_key, good_message
 
       Promise.all save_messages
       .then =>
-        expect('A').toBe 'A'
+        return conversation_repository.get_events conversation_et
+      .then (loaded_events) =>
+        expect(loaded_events.length).toBe 1
         done()

--- a/test/unit_tests/conversation/ConversationServiceSpec.coffee
+++ b/test/unit_tests/conversation/ConversationServiceSpec.coffee
@@ -100,7 +100,7 @@ describe 'Conversation Service', ->
         {
           key: "#{conversation_id}@#{sender_id}@1470317313389"
           object: {"raw":{"from":"8b497692-7a38-4a5d-8287-e3d1006577d6","time":"2016-08-04T13:28:33.389Z","type":"conversation.otr-message-add","conversation":"35a9a89d-70dc-4d9e-88a2-4d8758458a6a"},"meta":{"timestamp":1470317313389,"version":1},"mapped":{"conversation":"35a9a89d-70dc-4d9e-88a2-4d8758458a6a","id":"5a8cd79a-82bb-49ca-a59e-9a8e76df77fb","from":"8b497692-7a38-4a5d-8287-e3d1006577d6","time":"2016-08-04T13:28:33.389Z","data":{"content":"Fifth message","nonce":"5a8cd79a-82bb-49ca-a59e-9a8e76df77fb","previews":[]},"type":"conversation.message-add"}}
-        },
+        }
       ]
       # @formatter:on
 

--- a/test/unit_tests/conversation/ConversationServiceSpec.coffee
+++ b/test/unit_tests/conversation/ConversationServiceSpec.coffee
@@ -20,39 +20,89 @@
 
 describe 'Conversation Service', ->
   server = null
+
   urls =
     rest_url: 'http://localhost'
     websocket_url: 'wss://localhost'
 
   conversation_service = null
 
-  beforeEach ->
-    server = sinon.fakeServer.create()
+  test_factory = new TestFactory()
 
-    client = new z.service.Client urls
-    client.logger.level = client.logger.levels.OFF
-    conversation_service = new z.conversation.ConversationService client
+  beforeAll (done) ->
+    test_factory.exposeStorageActors()
+    .then (storage_repository) ->
+      server = sinon.fakeServer.create()
+      client = test_factory.client
+      storage_service = storage_repository.storage_service
+      conversation_service = new z.conversation.ConversationService client, storage_service
+      done()
+    .catch done.fail
 
   afterEach ->
     server.restore()
 
-  # https://dev-nginz-https.zinfra.io/conversations/last-events
-  it 'can get the latest event IDs of all conversations', ->
-    request_url = "#{urls.rest_url}/conversations/last-events"
-    server.respondWith 'GET', request_url, [
-      200
-      {'Content-Type': 'application/json'}
-      JSON.stringify payload.conversations.last_events.get
-    ]
-    callback = sinon.spy()
+  describe 'get_last_events', ->
+    it 'can get the latest event IDs of all conversations', ->
+      request_url = "#{urls.rest_url}/conversations/last-events"
+      server.respondWith 'GET', request_url, [
+        200
+        {'Content-Type': 'application/json'}
+        JSON.stringify payload.conversations.last_events.get
+      ]
+      callback = sinon.spy()
 
-    conversation_service.get_last_events callback
-    server.respond()
-
-    expect(callback).toBeTruthy
-    if callback.called
+      conversation_service.get_last_events callback
+      server.respond()
       response = callback.getCall(0).args[0]
+      expect(callback).toBeTruthy
       expect(response.has_more).toBeFalsy()
       expect(response.conversations.length).toBe 5
       expect(response.conversations[0].event).toEqual '13c.800122000a64b3ee'
       expect(response.conversations[4].id).toEqual '0925d3a9-65a8-4445-b6dd-56f82a1ec75b'
+
+  describe 'load_events_from_db', ->
+
+    it 'returns an information set about the loaded events even if no records are found', (done) ->
+      conversation_service.load_events_from_db 'invalid_id', 1466549621778, 30
+      .then (loaded_events) =>
+        [events, has_further_events] = loaded_events
+        expect(events.length).toBe 0
+        expect(has_further_events).toBe false
+        done()
+
+    xit 'works', (done) ->
+      conversation_payload = {
+        "access": ["private"],
+        "creator": "0410795a-58dc-40d8-b216-cbc2360be21a",
+        "members": {
+          "self": {
+            "hidden_ref": null,
+            "status": 0,
+            "last_read": "24fe.800122000b16c279",
+            "muted_time": null,
+            "otr_muted_ref": null,
+            "muted": false,
+            "status_time": "2014-12-03T18:39:12.319Z",
+            "hidden": false,
+            "status_ref": "0.0",
+            "id": "532af01e-1e24-4366-aacf-33b67d4ee376",
+            "otr_archived": false,
+            "cleared": null,
+            "otr_muted": false,
+            "otr_archived_ref": "2016-07-25T11:30:07.883Z",
+            "archived": null
+          }, "others": [{"status": 0, "id": "0410795a-58dc-40d8-b216-cbc2360be21a"}]
+        },
+        "name": "Michael Koppen",
+        "id": "573b6978-7700-443e-9ce5-ff78b35ac590",
+        "type": 2,
+        "last_event_time": "2016-06-21T22:53:41.778Z",
+        "last_event": "24fe.800122000b16c279"
+      }
+
+      conversation_service.load_events_from_db conversation_payload.id, 1466549621778, 30
+      .then (loaded_events) =>
+        console.log "BENY", loaded_events
+        expect(loaded_events.length).toBe 0
+        done()

--- a/test/unit_tests/conversation/ConversationServiceSpec.coffee
+++ b/test/unit_tests/conversation/ConversationServiceSpec.coffee
@@ -74,7 +74,9 @@ describe 'Conversation Service', ->
         expect(has_further_events).toBe false
         done()
 
-    it 'works', (done) ->
+  describe 'save_conversation_in_db', ->
+
+    it 'saves a conversation', (done) ->
       conversation_payload = {
         "access": ["private"],
         "creator": "0410795a-58dc-40d8-b216-cbc2360be21a",
@@ -97,7 +99,7 @@ describe 'Conversation Service', ->
             "archived": null
           }, "others": [{"status": 0, "id": "0410795a-58dc-40d8-b216-cbc2360be21a"}]
         },
-        "name": "Michael Koppen",
+        "name": "Michael",
         "id": "573b6978-7700-443e-9ce5-ff78b35ac590",
         "type": 2,
         "last_event_time": "2016-06-21T22:53:41.778Z",

--- a/test/unit_tests/conversation/ConversationServiceSpec.coffee
+++ b/test/unit_tests/conversation/ConversationServiceSpec.coffee
@@ -125,35 +125,9 @@ describe 'Conversation Service', ->
 
   describe 'save_conversation_in_db', ->
     it 'saves a conversation', (done) ->
-      conversation_payload = {
-        "access": ["private"],
-        "creator": "0410795a-58dc-40d8-b216-cbc2360be21a",
-        "members": {
-          "self": {
-            "hidden_ref": null,
-            "status": 0,
-            "last_read": "24fe.800122000b16c279",
-            "muted_time": null,
-            "otr_muted_ref": null,
-            "muted": false,
-            "status_time": "2014-12-03T18:39:12.319Z",
-            "hidden": false,
-            "status_ref": "0.0",
-            "id": "532af01e-1e24-4366-aacf-33b67d4ee376",
-            "otr_archived": false,
-            "cleared": null,
-            "otr_muted": false,
-            "otr_archived_ref": "2016-07-25T11:30:07.883Z",
-            "archived": null
-          }, "others": [{"status": 0, "id": "0410795a-58dc-40d8-b216-cbc2360be21a"}]
-        },
-        "name": "Michael",
-        "id": "573b6978-7700-443e-9ce5-ff78b35ac590",
-        "type": 2,
-        "last_event_time": "2016-06-21T22:53:41.778Z",
-        "last_event": "24fe.800122000b16c279"
-      }
-
+      # @formatter:off
+      conversation_payload = {"access":["private"],"creator":"0410795a-58dc-40d8-b216-cbc2360be21a","members":{"self":{"hidden_ref":null,"status":0,"last_read":"24fe.800122000b16c279","muted_time":null,"otr_muted_ref":null,"muted":false,"status_time":"2014-12-03T18:39:12.319Z","hidden":false,"status_ref":"0.0","id":"532af01e-1e24-4366-aacf-33b67d4ee376","otr_archived":false,"cleared":null,"otr_muted":false,"otr_archived_ref":"2016-07-25T11:30:07.883Z","archived":null},"others":[{"status":0,"id":"0410795a-58dc-40d8-b216-cbc2360be21a"}]},"name":"Michael","id":"573b6978-7700-443e-9ce5-ff78b35ac590","type":2,"last_event_time":"2016-06-21T22:53:41.778Z","last_event":"24fe.800122000b16c279"}
+      # @formatter:on
       conversation_et = conversation_mapper.map_conversation conversation_payload
       conversation_service.save_conversation_in_db conversation_et
       .then (conversation_record) =>

--- a/test/unit_tests/conversation/ConversationServiceSpec.coffee
+++ b/test/unit_tests/conversation/ConversationServiceSpec.coffee
@@ -27,6 +27,7 @@ describe 'Conversation Service', ->
     websocket_url: 'wss://localhost'
 
   conversation_service = null
+  storage_service = null
 
   test_factory = new TestFactory()
 
@@ -43,6 +44,7 @@ describe 'Conversation Service', ->
     .catch done.fail
 
   afterEach ->
+    storage_service.clear_all_stores()
     server.restore()
 
   describe 'get_last_events', ->
@@ -65,7 +67,6 @@ describe 'Conversation Service', ->
       expect(response.conversations[4].id).toEqual '0925d3a9-65a8-4445-b6dd-56f82a1ec75b'
 
   describe 'load_events_from_db', ->
-
     it 'returns an information set about the loaded events even if no records are found', (done) ->
       conversation_service.load_events_from_db 'invalid_id', 1466549621778, 30
       .then (loaded_events) =>
@@ -74,8 +75,55 @@ describe 'Conversation Service', ->
         expect(has_further_events).toBe false
         done()
 
-  describe 'save_conversation_in_db', ->
+    it 'returns conversation events', (done) ->
+      conversation_id = '35a9a89d-70dc-4d9e-88a2-4d8758458a6a'
+      sender_id = '8b497692-7a38-4a5d-8287-e3d1006577d6'
 
+      # @formatter:off
+      messages = [
+        {
+          key: "#{conversation_id}@#{sender_id}@1470317275182"
+          object: {"raw":{"from":"8b497692-7a38-4a5d-8287-e3d1006577d6","time":"2016-08-04T13:27:55.182Z","type":"conversation.otr-message-add","conversation":"35a9a89d-70dc-4d9e-88a2-4d8758458a6a"},"meta":{"timestamp":1470317275182,"version":1},"mapped":{"conversation":"35a9a89d-70dc-4d9e-88a2-4d8758458a6a","id":"68a28ab1-d7f8-4014-8b52-5e99a05ea3b1","from":"8b497692-7a38-4a5d-8287-e3d1006577d6","time":"2016-08-04T13:27:55.182Z","data":{"content":"First message","nonce":"68a28ab1-d7f8-4014-8b52-5e99a05ea3b1","previews":[]},"type":"conversation.message-add"}}
+        },
+        {
+          key: "#{conversation_id}@#{sender_id}@1470317278993"
+          object: {"raw":{"from":"8b497692-7a38-4a5d-8287-e3d1006577d6","time":"2016-08-04T13:27:58.993Z","type":"conversation.otr-message-add","conversation":"35a9a89d-70dc-4d9e-88a2-4d8758458a6a"},"meta":{"timestamp":1470317278993,"version":1},"mapped":{"conversation":"35a9a89d-70dc-4d9e-88a2-4d8758458a6a","id":"4af67f76-09f9-4831-b3a4-9df877b8c29a","from":"8b497692-7a38-4a5d-8287-e3d1006577d6","time":"2016-08-04T13:27:58.993Z","data":{"content":"Second message","nonce":"4af67f76-09f9-4831-b3a4-9df877b8c29a","previews":[]},"type":"conversation.message-add"}}
+        },
+        {
+          key: "#{conversation_id}@#{sender_id}@1470317282495"
+          object: {"raw":{"from":"8b497692-7a38-4a5d-8287-e3d1006577d6","time":"2016-08-04T13:28:02.495Z","type":"conversation.otr-message-add","conversation":"35a9a89d-70dc-4d9e-88a2-4d8758458a6a"},"meta":{"timestamp":1470317282495,"version":1},"mapped":{"conversation":"35a9a89d-70dc-4d9e-88a2-4d8758458a6a","id":"2e70c133-afe6-4265-bb4b-e71704529668","from":"8b497692-7a38-4a5d-8287-e3d1006577d6","time":"2016-08-04T13:28:02.495Z","data":{"content":"Third message","nonce":"2e70c133-afe6-4265-bb4b-e71704529668","previews":[]},"type":"conversation.message-add"}}
+        },
+        {
+          key: "#{conversation_id}@#{sender_id}@1470317310019"
+          object: {"raw":{"from":"8b497692-7a38-4a5d-8287-e3d1006577d6","time":"2016-08-04T13:28:30.019Z","type":"conversation.otr-message-add","conversation":"35a9a89d-70dc-4d9e-88a2-4d8758458a6a"},"meta":{"timestamp":1470317310019,"version":1},"mapped":{"conversation":"35a9a89d-70dc-4d9e-88a2-4d8758458a6a","id":"0880f7b9-b8f1-45e4-825e-fa120daa98b2","from":"8b497692-7a38-4a5d-8287-e3d1006577d6","time":"2016-08-04T13:28:30.019Z","data":{"content":"Fourth message","nonce":"0880f7b9-b8f1-45e4-825e-fa120daa98b2","previews":[]},"type":"conversation.message-add"}}
+        },
+        {
+          key: "#{conversation_id}@#{sender_id}@1470317313389"
+          object: {"raw":{"from":"8b497692-7a38-4a5d-8287-e3d1006577d6","time":"2016-08-04T13:28:33.389Z","type":"conversation.otr-message-add","conversation":"35a9a89d-70dc-4d9e-88a2-4d8758458a6a"},"meta":{"timestamp":1470317313389,"version":1},"mapped":{"conversation":"35a9a89d-70dc-4d9e-88a2-4d8758458a6a","id":"5a8cd79a-82bb-49ca-a59e-9a8e76df77fb","from":"8b497692-7a38-4a5d-8287-e3d1006577d6","time":"2016-08-04T13:28:33.389Z","data":{"content":"Fifth message","nonce":"5a8cd79a-82bb-49ca-a59e-9a8e76df77fb","previews":[]},"type":"conversation.message-add"}}
+        },
+      ]
+      # @formatter:on
+
+      promises = []
+      for message in messages
+        promise = conversation_service.storage_service.save storage_service.OBJECT_STORE_CONVERSATION_EVENTS, message.key, message.object
+        promises.push promise
+
+      Promise.all promises
+      .then =>
+        limit = 4
+        conversation_service.load_events_from_db conversation_id, undefined, limit
+        .then (loaded_events) =>
+          [events, has_further_events] = loaded_events
+          expect(events.length).toBe limit
+          expect(has_further_events).toBe true
+          expect(events[0].meta.timestamp).toBe messages[messages.length - 1].object.meta.timestamp
+          expect(events[1].meta.timestamp).toBe messages[messages.length - 2].object.meta.timestamp
+          expect(events[2].meta.timestamp).toBe messages[messages.length - 3].object.meta.timestamp
+          expect(events[3].meta.timestamp).toBe messages[messages.length - limit].object.meta.timestamp
+          done()
+
+  describe 'save_conversation_in_db', ->
     it 'saves a conversation', (done) ->
       conversation_payload = {
         "access": ["private"],

--- a/test/unit_tests/storage/StorageRepositorySpec.coffee
+++ b/test/unit_tests/storage/StorageRepositorySpec.coffee
@@ -59,11 +59,11 @@ describe 'z.storage.StorageRepository', ->
       .toThrowError z.storage.StorageError::INVALID_TIMESTAMP
 
   describe 'save_value',  ->
-    it 'persists values', (done)->
-      primary_key = 'test'
-      object = {type: 'test'}
+    it 'persists values in an object format', (done)->
+      primary_key = 'test_key'
+      value = 'test_value'
 
-      storage_repository.save_value primary_key, object
+      storage_repository.save_value primary_key, value
       .then (storage_key) ->
         expect(storage_key).toBe primary_key
         done()

--- a/test/unit_tests/storage/StorageRepositorySpec.coffee
+++ b/test/unit_tests/storage/StorageRepositorySpec.coffee
@@ -38,6 +38,26 @@ describe 'z.storage.StorageRepository', ->
 
       expect(actual).toBe expected
 
+    it 'works with timestamps', ->
+      conversation_id = '35d8767e-83c9-4e9a-a5ee-32ba7de706f2'
+      sender_id = '532af01e-1e24-4366-aacf-33b67d4ee376'
+      timestamp = 1468091455076
+
+      actual = storage_repository.construct_primary_key conversation_id, sender_id, timestamp
+      expected = "#{conversation_id}@#{sender_id}@#{timestamp}"
+
+      expect(actual).toBe expected
+
+    it 'throws an error on missing timestamps', ->
+      expect ->
+        storage_repository.construct_primary_key 'A', 'A'
+      .toThrowError z.storage.StorageError::INVALID_TIMESTAMP
+
+    it 'throws an error on invalid timestamps', ->
+      expect ->
+        storage_repository.construct_primary_key 'A', 'A', 'A'
+      .toThrowError z.storage.StorageError::INVALID_TIMESTAMP
+
   describe 'save_value',  ->
     it 'persists values', (done)->
       primary_key = 'test'

--- a/test/unit_tests/storage/StorageRepositorySpec.coffee
+++ b/test/unit_tests/storage/StorageRepositorySpec.coffee
@@ -59,11 +59,11 @@ describe 'z.storage.StorageRepository', ->
       .toThrowError z.storage.StorageError::INVALID_TIMESTAMP
 
   describe 'save_value',  ->
-    it 'persists values in an object format', (done)->
+    it 'persists primitive values in an object format', (done)->
       primary_key = 'test_key'
-      value = 'test_value'
+      primitive_value = 'test_value'
 
-      storage_repository.save_value primary_key, value
+      storage_repository.save_value primary_key, primitive_value
       .then (storage_key) ->
         expect(storage_key).toBe primary_key
         done()

--- a/test/unit_tests/storage/StorageRepositorySpec.coffee
+++ b/test/unit_tests/storage/StorageRepositorySpec.coffee
@@ -1,0 +1,48 @@
+#
+# Wire
+# Copyright (C) 2016 Wire Swiss GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see http://www.gnu.org/licenses/.
+#
+
+# grunt test_init && grunt test_run:storage/StorageRepository
+
+describe 'z.storage.StorageRepository', ->
+  test_factory = new TestFactory()
+
+  beforeAll (done) ->
+    test_factory.exposeStorageActors().then(done).catch done.fail
+
+  describe 'construct_primary_key', ->
+    it 'constructs primary keys', ->
+      conversation_id = '35d8767e-83c9-4e9a-a5ee-32ba7de706f2'
+      sender_id = '532af01e-1e24-4366-aacf-33b67d4ee376'
+      time = '2016-07-09T19:10:55.076Z'
+
+      actual = storage_repository.construct_primary_key conversation_id, sender_id, time
+      expected = "#{conversation_id}@#{sender_id}@1468091455076"
+
+      expect(actual).toBe expected
+
+  describe 'save_value',  ->
+    it 'persists values', (done)->
+      primary_key = 'test'
+      object = {type: 'test'}
+
+      storage_repository.save_value primary_key, object
+      .then (storage_key) ->
+        expect(storage_key).toBe primary_key
+        done()
+      .catch done.fail
+

--- a/test/unit_tests/storage/StorageRepositorySpec.coffee
+++ b/test/unit_tests/storage/StorageRepositorySpec.coffee
@@ -24,6 +24,9 @@ describe 'z.storage.StorageRepository', ->
   beforeAll (done) ->
     test_factory.exposeStorageActors().then(done).catch done.fail
 
+  beforeEach ->
+    storage_repository.clear_all_stores()
+
   describe 'construct_primary_key', ->
     it 'constructs primary keys', ->
       conversation_id = '35d8767e-83c9-4e9a-a5ee-32ba7de706f2'


### PR DESCRIPTION
- https://wearezeta.atlassian.net/browse/WEBAPP-2581
- https://wearezeta.atlassian.net/browse/WEBAPP-2881
- https://wearezeta.atlassian.net/browse/WEBAPP-2970

Buggy:
```javascript
conversation_service.load_events_from_db
```

Call Chain:
```
get_events -> load_events_from_db -> _add_events_to_conversation -> map_json_events
```

```javascript
wire.app.repository.storage.storage_service.load_all('conversation_events','573b6978-7700-443e-9ce5-ff78b35ac590@0410795a-58dc-40d8-b216-cbc2360be21a')
.then(function(result){console.log(result);});
```

```javascript
wire.app.repository.conversation.conversation_service.load_events_from_db('573b6978-7700-443e-9ce5-ff78b35ac590', new Date('2016-06-02T21:57:59.316Z').getTime(), 30)
.then(function(info){console.log(info);});
```

Needs to fail if there is an invalid timestamp:
```javascript
construct_primary_key
```

Problematic:

```javascript
wire.app.repository.conversation.conversation_service.load_events_from_db('573b6978-7700-443e-9ce5-ff78b35ac590', undefined, 30)
.then(function(info){console.log(info);});
```

**Troublemaker**

Event:
```
573b6978-7700-443e-9ce5-ff78b35ac590@532af01e-1e24-4366-aacf-33b67d4ee376@NaN
```

```javascript
{"raw":{"from":"532af01e-1e24-4366-aacf-33b67d4ee376","type":"conversation.otr-message-add","conversation":"573b6978-7700-443e-9ce5-ff78b35ac590"},"meta":{"timestamp":null,"version":1},"mapped":{"conversation":"573b6978-7700-443e-9ce5-ff78b35ac590","id":"aeac8355-739b-4dfc-a119-891a52c6a8dc","from":"532af01e-1e24-4366-aacf-33b67d4ee376","data":{"content":"Hey, bist du schon @home? :)","nonce":"aeac8355-739b-4dfc-a119-891a52c6a8dc"},"type":"conversation.message-add"}}
```

**Bug**

![bug](https://cloud.githubusercontent.com/assets/469989/17397801/0436687c-5a3a-11e6-9ae4-096bb1e08534.png)

**STR**

- Write something in 1:1 conversation
- Save corrupt message
- Get message from remote participant
- Switch conversation
- Go back to 1:1 conversation
- Message from remote participant should be still there

**Save corrupt message**

```javascript
wire.app.repository.storage.storage_service.save('conversation_events', 'de7466b0-985c-4dc3-ad57-17877db45b4c@8b497692-7a38-4a5d-8287-e3d1006577d6@NaN', {"raw":{"from":"8b497692-7a38-4a5d-8287-e3d1006577d6","type":"conversation.otr-message-add","conversation":"de7466b0-985c-4dc3-ad57-17877db45b4c"},"meta":{"timestamp":null,"version":1},"mapped":{"conversation":"573b6978-7700-443e-9ce5-ff78b35ac590","id":"aeac8355-739b-4dfc-a119-891a52c6a8dc","from":"532af01e-1e24-4366-aacf-33b67d4ee376","data":{"content":"Hello World :)","nonce":"aeac8355-739b-4dfc-a119-891a52c6a8dc"},"type":"conversation.message-add"}}).then(function(result){console.log('Corrupt message saved', result);})
```