### PR TITLE
Add feature check for window.Notification support in AnnounceRepository

### DIFF
--- a/app/script/announce/AnnounceRepository.coffee
+++ b/app/script/announce/AnnounceRepository.coffee
@@ -49,6 +49,7 @@ class z.announce.AnnounceRepository
         key = "#{z.storage.StorageKey.ANNOUNCE.ANNOUNCE_KEY}@#{announce.key}"
         if not z.storage.get_value key
           z.storage.set_value key, 'read'
+          return if not z.util.Environment.browser.supports.notifications
           return if window.Notification.permission is z.util.BrowserPermissionType.DENIED
 
           if not (z.localization.Localizer.locale is 'en')

--- a/app/script/system_notification/SystemNotificationRepository.coffee
+++ b/app/script/system_notification/SystemNotificationRepository.coffee
@@ -383,7 +383,7 @@ class z.SystemNotification.SystemNotificationRepository
   @param message_et [z.entity.Message] Message entity
   ###
   _notify_banner: (conversation_et, message_et) ->
-    return if z.util.Environment.browser.supports.notifications is false
+    return if not z.util.Environment.browser.supports.notifications
     return if window.Notification.permission is z.util.BrowserPermissionType.DENIED
     return if document.hasFocus()
     return if message_et.user()?.is_me


### PR DESCRIPTION
Notifications in MS Edge for Windows are only supported with the just released Anniversary update. We were missing the feature check for that in the `AnnounceRepository`

https://blogs.windows.com/msedgedev/2016/05/16/web-notifications-microsoft-edge/