### PR TITLE
Fixes for error reports

### DIFF
--- a/app/script/auth/AuthService.coffee
+++ b/app/script/auth/AuthService.coffee
@@ -120,7 +120,8 @@ class z.auth.AuthService
               $.ajax settings
             , 500
           else
-            error_description = "Requesting access token failed after '#{options.retries}' attempt(s): #{errorThrown}"
+            error_description = "Requesting access token failed: #{errorThrown}"
+
             if jqXHR.responseJSON or jqXHR.responseText?.startsWith '{'
               error = jqXHR.responseJSON or JSON.parse jqXHR.responseText
               if error.code is z.service.BackendClientError::STATUS_CODE.FORBIDDEN
@@ -132,7 +133,7 @@ class z.auth.AuthService
               Raygun.send error
 
             @save_access_token_in_client()
-            @logger.log @logger.levels.ERROR, error_description, jqXHR
+            @logger.log @logger.levels.ERROR, "#{error_description} - '#{options.retries}' attempt(s)", jqXHR
             reject error
 
       if @client.access_token

--- a/app/script/conversation/ConversationRepository.coffee
+++ b/app/script/conversation/ConversationRepository.coffee
@@ -340,6 +340,8 @@ class z.conversation.ConversationRepository
   @return [Boolean] Is the message marked as read
   ###
   is_message_read: (conversation_id, message_id) =>
+    return false if not conversation_id or not message_id
+
     conversation_et = @get_conversation_by_id conversation_id
     message_et = conversation_et.get_message_by_id message_id
 

--- a/app/script/event/WebSocketService.coffee
+++ b/app/script/event/WebSocketService.coffee
@@ -156,7 +156,7 @@ class z.event.WebSocketService
       ping_interval_diff = @last_ping_time - current_time
 
       if ping_interval_diff > PING_INTERVAL + PING_INTERVAL_THRESHOLD
-        @logger.log @logger.levels.WARN, 'Ping interval check failed', event
+        @logger.log @logger.levels.WARN, 'Ping interval check failed'
         @reconnect z.event.WebSocketService::CHANGE_TRIGGER.PING_INTERVAL
       else
         @logger.log @logger.levels.INFO, 'Sending ping to WebSocket'

--- a/app/script/service/Client.coffee
+++ b/app/script/service/Client.coffee
@@ -28,6 +28,7 @@ IGNORED_BACKEND_ERRORS = [
   z.service.BackendClientError::STATUS_CODE.NOT_FOUND
   z.service.BackendClientError::STATUS_CODE.PRECONDITION_FAILED
   z.service.BackendClientError::STATUS_CODE.REQUEST_TIMEOUT
+  z.service.BackendClientError::STATUS_CODE.REQUEST_TOO_LARGE
   z.service.BackendClientError::STATUS_CODE.TOO_MANY_REQUESTS
 ]
 

--- a/app/script/user/UserRepository.coffee
+++ b/app/script/user/UserRepository.coffee
@@ -256,7 +256,6 @@ class z.user.UserRepository
   _update_connection_status: (user_et, status, show_conversation = false) =>
     return Promise.resolve()
     .then =>
-      # check if the status has changed
       return if user_et.connection().status() is status
       return @user_service.update_connection_status user_et.id, status
     .then (response) =>
@@ -265,9 +264,10 @@ class z.user.UserRepository
       @logger.log @logger.levels.ERROR,
         "Connection status change to '#{status}' for user '#{user_et.id}' failed: #{error.message}", error
       custom_data =
+        current_status: user_et.connection().status()
         failed_action: status
         server_error: error
-      Raygun.send new Error('Connection Status change failed'), custom_data
+      Raygun.send new Error('Connection status change failed'), custom_data
 
   ###############################################################################
   # Events

--- a/app/script/view_model/ActionsViewModel.coffee
+++ b/app/script/view_model/ActionsViewModel.coffee
@@ -114,7 +114,7 @@ class z.ViewModel.ActionsViewModel
 
   click_on_unarchive_action: =>
     @conversation_repository.unarchive_conversation @_click_on_action(), =>
-      amplify.subscribe z.event.WebApp.ARCHIVE.CLOSE if @conversation_repository.conversations_archived().length is 0
+      amplify.publish z.event.WebApp.ARCHIVE.CLOSE if @conversation_repository.conversations_archived().length is 0
 
   _click_on_action: =>
     conversation_et = @selected_conversation() or @conversation_repository.active_conversation()

--- a/app/script/view_model/ActionsViewModel.coffee
+++ b/app/script/view_model/ActionsViewModel.coffee
@@ -79,47 +79,60 @@ class z.ViewModel.ActionsViewModel
     event.stopPropagation()
 
   click_on_archive_action: =>
-    @conversation_repository.archive_conversation @_click_on_action()
+    @_click_on_action()
+    .then (conversation_et) =>
+      @conversation_repository.archive_conversation conversation_et
 
   click_on_block_action: =>
-    conversation_et = @_click_on_action()
-    next_conversation_et = @conversation_repository.get_next_conversation conversation_et
-    user_et = conversation_et.participating_user_ets()[0]
-    amplify.publish z.event.WebApp.WARNINGS.MODAL, z.ViewModel.ModalType.BLOCK,
-      data: user_et.first_name()
-      action: => @user_repository.block_user user_et, ->
-        amplify.publish z.event.WebApp.CONVERSATION.SWITCH, conversation_et, next_conversation_et
+    @_click_on_action()
+    .then (conversation_et) =>
+      next_conversation_et = @conversation_repository.get_next_conversation conversation_et
+      user_et = conversation_et.participating_user_ets()[0]
+      amplify.publish z.event.WebApp.WARNINGS.MODAL, z.ViewModel.ModalType.BLOCK,
+        data: user_et.first_name()
+        action: => @user_repository.block_user user_et, ->
+          amplify.publish z.event.WebApp.CONVERSATION.SWITCH, conversation_et, next_conversation_et
 
   click_on_cancel_action: =>
-    conversation_et = @_click_on_action()
-    next_conversation_et = @conversation_repository.get_next_conversation conversation_et
-    @user_repository.cancel_connection_request conversation_et.participating_user_ets()[0], next_conversation_et
+    @_click_on_action()
+    .then (conversation_et) =>
+      next_conversation_et = @conversation_repository.get_next_conversation conversation_et
+      @user_repository.cancel_connection_request conversation_et.participating_user_ets()[0], next_conversation_et
 
   click_on_clear_action: =>
-    conversation_et = @_click_on_action()
-    amplify.publish z.event.WebApp.WARNINGS.MODAL, z.ViewModel.ModalType.CLEAR,
-      data: conversation_et.display_name()
-      conversation: conversation_et
-      action: (leave = false) => @conversation_repository.clear_conversation conversation_et, leave
+    @_click_on_action()
+    .then (conversation_et) =>
+      amplify.publish z.event.WebApp.WARNINGS.MODAL, z.ViewModel.ModalType.CLEAR,
+        data: conversation_et.display_name()
+        conversation: conversation_et
+        action: (leave = false) => @conversation_repository.clear_conversation conversation_et, leave
 
   click_on_leave_action: =>
-    conversation_et = @_click_on_action()
-    next_conversation_et = @conversation_repository.get_next_conversation conversation_et
-    amplify.publish z.event.WebApp.WARNINGS.MODAL, z.ViewModel.ModalType.LEAVE,
-      data: conversation_et.display_name()
-      action: => @conversation_repository.leave_conversation conversation_et, next_conversation_et
+    @_click_on_action()
+    .then (conversation_et) =>
+      next_conversation_et = @conversation_repository.get_next_conversation conversation_et
+      amplify.publish z.event.WebApp.WARNINGS.MODAL, z.ViewModel.ModalType.LEAVE,
+        data: conversation_et.display_name()
+        action: => @conversation_repository.leave_conversation conversation_et, next_conversation_et
 
   click_on_mute_action: =>
-    @conversation_repository.toggle_silence_conversation @_click_on_action()
+    @_click_on_action()
+    .then (conversation_et) =>
+      @conversation_repository.toggle_silence_conversation conversation_et
 
   click_on_unarchive_action: =>
-    @conversation_repository.unarchive_conversation @_click_on_action(), =>
-      amplify.publish z.event.WebApp.ARCHIVE.CLOSE if @conversation_repository.conversations_archived().length is 0
+    @_click_on_action()
+    .then (conversation_et) =>
+      @conversation_repository.unarchive_conversation conversation_et, =>
+        amplify.publish z.event.WebApp.ARCHIVE.CLOSE if @conversation_repository.conversations_archived().length is 0
 
   _click_on_action: =>
-    conversation_et = @selected_conversation() or @conversation_repository.active_conversation()
-    return if not conversation_et
-    amplify.publish z.event.WebApp.ARCHIVE.CLOSE if not conversation_et.is_archived()
-    @action_bubbles[conversation_et.id]?.hide()
-    @selected_conversation null
-    return conversation_et
+    return new Promise (resolve) =>
+      conversation_et = @selected_conversation() or @conversation_repository.active_conversation()
+      if conversation_et
+        amplify.publish z.event.WebApp.ARCHIVE.CLOSE if not conversation_et.is_archived()
+        @action_bubbles[conversation_et.id]?.hide()
+        @selected_conversation null
+        resolve conversation_et
+      else
+        @logger.log @logger.levels.ERROR, 'Cannot complete menu actions as there is no active conversation'

--- a/app/script/view_model/ConversationTitlebarViewModel.coffee
+++ b/app/script/view_model/ConversationTitlebarViewModel.coffee
@@ -69,6 +69,7 @@ class z.ViewModel.ConversationTitlebarViewModel
     amplify.unsubscribe z.event.WebApp.SHORTCUT.ADD_PEOPLE
 
   click_on_call_button: =>
+    return if not @conversation_et()
     amplify.publish z.event.WebApp.CALL.STATE.TOGGLE, @conversation_et().id
 
   click_on_maximize: =>
@@ -80,6 +81,7 @@ class z.ViewModel.ConversationTitlebarViewModel
     @show_participants()
 
   click_on_video_button: =>
+    return if not @conversation_et()
     if @conversation_et().is_group()
       amplify.publish z.event.WebApp.WARNINGS.MODAL, z.ViewModel.ModalType.CALL_NO_VIDEO_IN_GROUP
     else

--- a/app/script/view_model/MessageListViewModel.coffee
+++ b/app/script/view_model/MessageListViewModel.coffee
@@ -374,7 +374,7 @@ class z.ViewModel.MessageListViewModel
 
       if z.util.array_is_last @conversation().messages_visible(), message
         # Defer initial rendering
-        window.requestAnimFrame => @on_initial_rendering()
+        window.requestAnimFrame => @on_initial_rendering?()
 
   before_message_remove: (dom_node) ->
     if $(dom_node).hasClass 'message' and not @conversation_is_changing

--- a/app/script/view_model/MessageListViewModel.coffee
+++ b/app/script/view_model/MessageListViewModel.coffee
@@ -326,6 +326,7 @@ class z.ViewModel.MessageListViewModel
   ###
   after_message_render: (elements, message) =>
     window.requestAnimFrame =>
+      return if not @conversation_repository.active_conversation()
       message_index = @conversation_repository.active_conversation().messages_visible().indexOf message
       if message_index > 0
         last_message = @conversation_repository.active_conversation().messages_visible()[message_index - 1]


### PR DESCRIPTION
- WebSocket fails to reconnect due to broken log message
- logging cleanup
- add 413 backend error to ignored list
- prevent exception when active_conversation is not set
- execute on_initial_rendering() only if set
- add safeguard for attempted calls from wrapper menus
- close archive after unarchiving last conversation
- execute menu actions on conversations only