### PR TITLE
Backwards compatibility and enabling unit tests for AudioRepository

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "grunt-todo": "0.5.0",
     "jasmine-ajax": "3.2.0",
     "jasmine-core": "2.4.1",
-    "karma": "1.2.0",
+    "karma": "1.1.2",
     "karma-chrome-launcher": "1.0.1",
     "karma-coverage": "1.1.1",
     "karma-jasmine": "1.0.2",

--- a/test/unit_tests/audio/AudioRepositorySpec.coffee
+++ b/test/unit_tests/audio/AudioRepositorySpec.coffee
@@ -61,12 +61,12 @@ describe 'z.audio.AudioRepository', ->
         expect(error.type).toBe z.audio.AudioError::TYPE.NOT_FOUND
         done()
 
-  xdescribe '_play', ->
+  describe '_play', ->
     beforeEach ->
       audio_repository.audio_elements[z.audio.AudioType.OUTGOING_CALL] = new Audio "/audio/#{z.audio.AudioType.OUTGOING_CALL}.mp3"
 
     afterEach ->
-      audio_repository.audio_elements[z.audio.AudioType.OUTGOING_CALL].stop()
+      audio_repository.audio_elements[z.audio.AudioType.OUTGOING_CALL].pause()
 
     it 'plays an available sound', (done) ->
       audio_repository._play z.audio.AudioType.OUTGOING_CALL, audio_repository.audio_elements[z.audio.AudioType.OUTGOING_CALL], false
@@ -87,10 +87,26 @@ describe 'z.audio.AudioRepository', ->
     it 'does not play a sound twice concurrently', (done) ->
       audio_repository.audio_elements[z.audio.AudioType.OUTGOING_CALL].play()
       .then ->
-        audio_repository._play z.audio.AudioType.OUTGOING_CALL
+        audio_repository._play z.audio.AudioType.OUTGOING_CALL, audio_repository.audio_elements[z.audio.AudioType.OUTGOING_CALL]
       .then done.fail
       .catch (error) ->
         expect(error).toEqual jasmine.any z.audio.AudioError
         expect(error.type).toBe z.audio.AudioError::TYPE.ALREADY_PLAYING
+        done()
+      .catch done.fail
+
+    it 'handles a missing audio id sound', (done) ->
+      audio_repository._play undefined, audio_repository.audio_elements[z.audio.AudioType.OUTGOING_CALL]
+      .catch (error) ->
+        expect(error).toEqual jasmine.any z.audio.AudioError
+        expect(error.type).toBe z.audio.AudioError::TYPE.NOT_FOUND
+        done()
+      .catch done.fail
+
+    it 'handles a missing audio element', (done) ->
+      audio_repository._play z.audio.AudioType.OUTGOING_CALL, undefined
+      .catch (error) ->
+        expect(error).toEqual jasmine.any z.audio.AudioError
+        expect(error.type).toBe z.audio.AudioError::TYPE.NOT_FOUND
         done()
       .catch done.fail


### PR DESCRIPTION
Turns out the bug in Karma was new in the latest release already filed and fixed:
https://github.com/karma-runner/karma/issues/2310

I also added backwards compatibility for Firefox for the non Promise based Audio.play()