### PR TITLE
Override domain default on 'wire.app.enable_debugging()'

### DIFF
--- a/app/script/main/app.coffee
+++ b/app/script/main/app.coffee
@@ -443,10 +443,12 @@ class z.main.App
 
   # Disable debugging on any environment.
   disable_debugging: ->
+    z.config.LOGGER.OPTIONS.domains['app.wire.com'] = -> 0
     amplify.publish z.event.WebApp.PROPERTIES.CHANGE.DEBUG, false
 
   # Enable debugging on any environment.
   enable_debugging: ->
+    z.config.LOGGER.OPTIONS.domains['app.wire.com'] = -> 300
     amplify.publish z.event.WebApp.PROPERTIES.CHANGE.DEBUG, true
 
   # Report call telemetry to Raygun for analysis.


### PR DESCRIPTION
- `wire.app.enable_debugging()` only eanbles all existing logggers
- later instances (eg. new call or flow entities) would fall back to defaults as noticed in https://github.com/wireapp/wire-desktop/issues/11