### PR TITLE
Send confirmation status only to other user

### DIFF
--- a/app/script/conversation/ConversationRepository.coffee
+++ b/app/script/conversation/ConversationRepository.coffee
@@ -813,12 +813,13 @@ class z.conversation.ConversationRepository
   ###
   Send a confirmation for a content message.
   @param conversation [z.entity.Conversation] Conversation that content message was received in
-  @param message_id [String] ID of message for which to acknowledge receipt
+  @param message_et [String] ID of message for which to acknowledge receipt
   ###
-  send_confirmation_status: (conversation_et, message_id) =>
+  send_confirmation_status: (conversation_et, message_et) =>
+    return true # disable for now
     generic_message = new z.proto.GenericMessage z.util.create_random_uuid()
-    generic_message.set 'confirmation', new z.proto.Confirmation message_id, z.proto.Confirmation.Type.DELIVERED
-    @_send_generic_message conversation_et.id, generic_message
+    generic_message.set 'confirmation', new z.proto.Confirmation message_et.id, z.proto.Confirmation.Type.DELIVERED
+    @_send_generic_message_to_users conversation_et.id, generic_message, [message_et.user().id]
 
   ###
   Sends an OTR Image Asset
@@ -1201,18 +1202,37 @@ class z.conversation.ConversationRepository
       @_send_encrypted_message conversation_id, generic_message, payload
 
   ###
-  Sends otr message to a conversation.
-
+  Sends a generic message to specific users in a conversation.
   @private
   @param conversation_id [String] Conversation ID
   @param generic_message [z.protobuf.GenericMessage] Protobuf message to be encrypted and send
-  @param payload [Object]
+  @param user_ids [Array<String>] Array of user IDs to send message to
   @return [Promise] Promise that resolves after sending the encrypted message
   ###
-  _send_encrypted_message: (conversation_id, generic_message, payload) =>
+  _send_generic_message_to_users: (conversation_id, generic_message, user_ids) =>
+    @_create_user_client_map conversation_id
+    .then (user_client_map) =>
+      delete user_client_map[user_id] for user_id in user_ids
+      return @cryptography_repository.encrypt_generic_message user_client_map, generic_message
+    .then (payload) =>
+      @_send_encrypted_message conversation_id, generic_message, payload, user_ids
+
+  ###
+  Sends otr message to a conversation.
+
+  @private
+  @note Options for the precondition check on missing clients are:
+    'false' - all clients, 'Array<String>' - only clients of listed users, 'true' - force sending
+  @param conversation_id [String] Conversation ID
+  @param generic_message [z.protobuf.GenericMessage] Protobuf message to be encrypted and send
+  @param payload [Object]
+  @param precondition_option [Array<String>|Boolean] Level that backend checks for missing clients
+  @return [Promise] Promise that resolves after sending the encrypted message
+  ###
+  _send_encrypted_message: (conversation_id, generic_message, payload, precondition_option = false) =>
     @logger.log @logger.levels.INFO,
       "Sending encrypted '#{generic_message.content}' message to conversation '#{conversation_id}'", payload
-    @conversation_service.post_encrypted_message conversation_id, payload, false
+    @conversation_service.post_encrypted_message conversation_id, payload, precondition_option
     .catch (error_response) =>
       return @_update_payload_for_changed_clients error_response, generic_message, payload
       .then (updated_payload) =>
@@ -1443,7 +1463,7 @@ class z.conversation.ConversationRepository
   add_event: (conversation_et, event_json) =>
     @_add_event_to_conversation event_json, conversation_et, (message_et) =>
       if conversation_et.is_one2one() and not message_et.user().is_me and message_et.type in z.event.EventTypeHandling.CONFIRM
-        @send_confirmation_status conversation_et, message_et.id
+        @send_confirmation_status conversation_et, message_et
       @_send_event_notification event_json, conversation_et, message_et
 
   ###

--- a/app/script/conversation/ConversationService.coffee
+++ b/app/script/conversation/ConversationService.coffee
@@ -377,16 +377,20 @@ class z.conversation.ConversationService
     }
   }
 
-  @param conversation_id [String] ID of conversation to send message in
+  @note Options for the precondition check on missing clients are:
+    'false' - all clients, 'Array<String>' - only clients of listed users, 'true' - force sending  @param conversation_id [String] ID of conversation to send message in
   @param payload [Object] Payload to be posted
   @option [OtrRecipients] recipients Map with per-recipient data
   @option [String] sender Client ID of the sender
-  @param force_sending [Boolean] Should the backend ignore missing clients
+  @param precondition_option [Array<String>|Boolean] Level that backend checks for missing clients
   @return [Promise] Promise that resolve when the message was sent
   ###
-  post_encrypted_message: (conversation_id, payload, force_sending) ->
+  post_encrypted_message: (conversation_id, payload, precondition_option) ->
     url = @client.create_url "/conversations/#{conversation_id}/otr/messages"
-    url = "#{url}?ignore_missing=true" if force_sending
+    if _.isArray precondition_option
+      url = "#{url}?report_missing=#{precondition_option.join ','}"
+    else if precondition_option
+      url = "#{url}?ignore_missing=true"
 
     @client.send_json
       url: url

--- a/app/script/view_model/ConversationInputViewModel.coffee
+++ b/app/script/view_model/ConversationInputViewModel.coffee
@@ -177,7 +177,7 @@ class z.ViewModel.ConversationInputViewModel
     @list_not_bottom not is_scrolled_bottom
 
   on_window_click: (event) =>
-    return if $(event.target).closest(".conversation-input").length
+    return if $(event.target).closest('.conversation-input').length
     @cancel_edit()
 
   on_input_click: =>


### PR DESCRIPTION
- implemented the new backend endpoint to only send the confirmation to a specific user in a conversation
- disabled the sending completely due to the side effects found in nightly run