### PR TITLE
👓 Content blurred 

### DIFF
--- a/app/style/common/variables.less
+++ b/app/style/common/variables.less
@@ -227,7 +227,7 @@
 @bubble-image-margin:          2px;
 @common-contacts-avatar-size:  48px;
 
-@bubble-transition_offset:     104%;
+@bubble-transition_offset:     100%;
 
 // ----------------------------------------------------------------------------
 // Media queries breakpoints


### PR DESCRIPTION
## Description

Rendering of elements on non-integer boundary (position) produce a blurry element (including his content) on webkit browsers.

```css
.show-user .participants-transition {
   transform: translateX(-104%); 
}
.group-user-profile {
   top: 0px;
   right: -104%;
}
.user-profile {
   width: 288px;
   ....
}
```

.group-user-profile will be rendered on the X axis at 0 (top) - (288/(100/104)) = **299,52px** from the absolute right. As this position is not a integer it will render a blurry box.

Translation and right positionning at 100% or 125% will fix this issues with a 288px box width.

## Screenshots

![blurri](https://cloud.githubusercontent.com/assets/18439883/18666935/b70f3028-7f2e-11e6-8851-ba6e3854b09f.png)

### to

![polish](https://cloud.githubusercontent.com/assets/18439883/18666945/c215d47c-7f2e-11e6-910f-660d1ce39586.png)


## Type of change
<!--- What type of changes does your code introduce? -->

- [x] Bug fix

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have signed [Wire's contributor agreement](https://github.com/wireapp/wire#contributing-to-the-code). ** not yet sent, but I will **
- [x] ~~My Pull Request contains test coverage for my changes.~~

