### PR TITLE
Update “OS X” name to “macOS”

### DIFF
--- a/app/script/localization/strings-de.coffee
+++ b/app/script/localization/strings-de.coffee
@@ -18,7 +18,7 @@
 
 #General terms
 z.string.de.wire = 'Wire'
-z.string.de.wire_osx = 'Wire für OS X'
+z.string.de.wire_osx = 'Wire für macOS'
 z.string.de.wire_windows = 'Wire für Windows'
 z.string.de.truncation = '…'
 z.string.de.nonexistent_user = 'Gelöschte Person'

--- a/app/script/localization/strings.coffee
+++ b/app/script/localization/strings.coffee
@@ -18,7 +18,7 @@
 
 #General terms
 z.string.wire = 'Wire'
-z.string.wire_osx = 'Wire for OS X'
+z.string.wire_osx = 'Wire for macOS'
 z.string.wire_windows = 'Wire for Windows'
 z.string.truncation = '…'
 z.string.nonexistent_user = 'Deleted User'


### PR DESCRIPTION
After the official release of macOS Sierra, all remaining “OS X” references in UI copy should be updated to use the new “macOS” name.