### PR TITLE
cached processed text

### DIFF
--- a/app/script/conversation/EventMapper.coffee
+++ b/app/script/conversation/EventMapper.coffee
@@ -333,7 +333,7 @@ class z.conversation.EventMapper
   ###
   _map_asset_text: (data) ->
     asset_et = new z.entity.Text data.id
-    asset_et.key = "text##{data.nonce}"
+    asset_et.nonce = data.nonce
     asset_et.text = data.content or data.message
     asset_et.previews @_map_link_previews data.previews
     return asset_et

--- a/test/unit_tests/conversation/EventMapperSpec.coffee
+++ b/test/unit_tests/conversation/EventMapperSpec.coffee
@@ -45,7 +45,8 @@ describe 'Event Mapper', ->
         type: z.event.Backend.CONVERSATION.MESSAGE_ADD
 
       message_et = event_mapper.map_json_event event, conversation_et
-      expect(message_et.get_first_asset().text).toBe 'foo'
+      expect(message_et.get_first_asset().text).toBe event.data.content
+      expect(message_et.get_first_asset().nonce).toBe event.data.nonce
       expect(message_et).toBeDefined()
 
     it 'maps text messages with link previews', ->
@@ -66,7 +67,8 @@ describe 'Event Mapper', ->
         type: z.event.Backend.CONVERSATION.MESSAGE_ADD
 
       message_et = event_mapper.map_json_event event, conversation_et
-      expect(message_et.get_first_asset().text).toBe 'test.com'
+      expect(message_et.get_first_asset().text).toBe event.data.content
+      expect(message_et.get_first_asset().nonce).toBe event.data.nonce
       expect(message_et.get_first_asset().previews().length).toBe 1
       expect(message_et.get_first_asset().previews()[0].original_url).toBe 'test.com'
       expect(message_et).toBeDefined()

--- a/test/unit_tests/entity/message/TextSpec.coffee
+++ b/test/unit_tests/entity/message/TextSpec.coffee
@@ -1,0 +1,41 @@
+#
+# Wire
+# Copyright (C) 2016 Wire Swiss GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see http://www.gnu.org/licenses/.
+#
+
+# grunt test_init && grunt test_run:entity/message/File
+
+describe 'z.entity.Text', ->
+
+  text = null
+
+  beforeEach ->
+    text = new z.entity.Text()
+    text.text = 'foo'
+    text.none = z.util.create_random_uuid()
+
+    spyOn(z.util, 'render_message').and.callThrough()
+
+  describe 'cached processed text', ->
+
+    it 'should cache processed tect', ->
+      processed_text = text.render()
+      expect(text.text).toBe processed_text
+
+      processed_text = text.render()
+      expect(text.text).toBe processed_text
+      expect(z.util.render_message.calls.count()).toBe 1
+


### PR DESCRIPTION
## Description
Cache already processed text (links, media embeds, markdown). This should increase performance when switching conversations and reduce memory allocation.

Possible Risks:
1. Text in the cache gets overwritten by a different message. Since the key to cache is a V4 UUID the possibility of having conflicts is not an issue.
2. User edits the text. Since the edited message is stored as a new message with a new nonce, it would create a new entry in the cache. The old one would be remove when new message are stored in the cache

## Screenshots
<img width="325" alt="bildschirmfoto 2016-11-03 um 19 07 12" src="https://cloud.githubusercontent.com/assets/174685/19997964/3cb54fe2-a26a-11e6-9d7c-9955fd6050b4.png">

## Type of change
I used an lru cache to store the processed text. 

- [x] Bug fix

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My Pull Request contains test coverage for my changes.

