### PR TITLE
Send current access token on token refresh (WEBAPP-3390)

### DIFF
--- a/app/script/auth/AuthService.coffee
+++ b/app/script/auth/AuthService.coffee
@@ -79,6 +79,8 @@ class z.auth.AuthService
 
       $.ajax
         crossDomain: true
+        headers:
+          Authorization: "Bearer #{window.decodeURIComponent(@client.access_token)}" if @client.access_token
         type: 'POST'
         url: @client.create_url "#{@URL_ACCESS}"
         xhrFields:


### PR DESCRIPTION
Backend needs to old access token to match incoming REST request and outgoing WebSocket connections
