### PR TITLE
Updated database query for conversation events

### DIFF
--- a/app/script/conversation/ConversationService.coffee
+++ b/app/script/conversation/ConversationService.coffee
@@ -324,6 +324,9 @@ class z.conversation.ConversationService
     if not start or not end
       return @_load_events_from_db_deprecated conversation_id, start, end, limit
 
+    from = new Date start
+    to = new Date end
+
     include_minimum = from.getTime() < to.getTime()
     if not include_minimum
       [from, to] = [to, from]

--- a/app/script/conversation/ConversationService.coffee
+++ b/app/script/conversation/ConversationService.coffee
@@ -314,8 +314,8 @@ class z.conversation.ConversationService
   TODO: Make sure that only valid values (no Strings, No timestamps but Dates(!), ...) are passed to this function!
 
   @param conversation_id [String] ID of conversation
-  @param start [Number|undefined] starting from this timestamp
-  @param end [Number|undefined] stop when reaching timestamp
+  @param lower_bound [Date] Load from this date (included)
+  @param upper_bound [Date] Load until this date (excluded)
   @param limit [Number] Amount of events to load
   @return [Promise] Promise that resolves with the retrieved records
   @see https://github.com/dfahlander/Dexie.js/issues/366

--- a/app/script/conversation/ConversationService.coffee
+++ b/app/script/conversation/ConversationService.coffee
@@ -335,7 +335,7 @@ class z.conversation.ConversationService
     .limit limit
     .toArray()
     .catch (error) =>
-      @logger.log @logger.levels.ERROR, "Unexpected set of parameters. 'start': #{lower_bound}, 'end': #{end}, Trace: #{new Error().stack}"
+      @logger.log @logger.levels.ERROR, "Failed to load events from database: '#{error.message}'"
       throw error
 
   ###

--- a/app/script/conversation/ConversationService.coffee
+++ b/app/script/conversation/ConversationService.coffee
@@ -321,8 +321,8 @@ class z.conversation.ConversationService
   @see https://github.com/dfahlander/Dexie.js/issues/366
   ###
   load_events_from_db: (conversation_id, start, end, limit = z.config.MESSAGES_FETCH_LIMIT) ->
-    from = new Date start
-    to = new Date end
+    if not start or not end
+      return @_load_events_from_db_deprecated conversation_id, start, end, limit
 
     include_minimum = from.getTime() < to.getTime()
     if not include_minimum

--- a/app/script/conversation/ConversationService.coffee
+++ b/app/script/conversation/ConversationService.coffee
@@ -322,12 +322,11 @@ class z.conversation.ConversationService
   ###
   load_events_from_db: (conversation_id, lower_bound = new Date(0), upper_bound = new Date(), limit = z.config.MESSAGES_FETCH_LIMIT) ->
     if not _.isDate(lower_bound) or not _.isDate upper_bound
-      throw new Error 'False parameters for load events'
+      throw new Error "Lower bound (#{typeof lower_bound}) and upper bound (#{typeof upper_bound}) must be of type 'Date'."
     else if lower_bound.getTime() > upper_bound.getTime()
-      throw new Error 'Lower bound should not be greater than upper bound'
+      throw new Error "Lower bound (#{lower_bound.getTime()}) cannot be greater than upper bound (#{upper_bound.getTime()})."
     else if z.util.Environment.browser.edge
-      # fallback
-      @_load_events_from_db_deprecated conversation_id, lower_bound.getTime(), upper_bound.getTime(), limit
+      return @_load_events_from_db_deprecated conversation_id, lower_bound.getTime(), upper_bound.getTime(), limit
 
     @storage_service.db[@storage_service.OBJECT_STORE_CONVERSATION_EVENTS]
     .where '[conversation+time]'

--- a/app/script/conversation/ConversationService.coffee
+++ b/app/script/conversation/ConversationService.coffee
@@ -331,7 +331,6 @@ class z.conversation.ConversationService
     if not include_minimum
       [from, to] = [to, from]
 
-    console.log "WE ARE HERE!"
     @storage_service.db[@storage_service.OBJECT_STORE_CONVERSATION_EVENTS]
       .where '[conversation+time]'
       .between [conversation_id, from.toISOString()], [conversation_id, to.toISOString()], include_minimum, false

--- a/app/script/conversation/ConversationService.coffee
+++ b/app/script/conversation/ConversationService.coffee
@@ -321,7 +321,7 @@ class z.conversation.ConversationService
   @see https://github.com/dfahlander/Dexie.js/issues/366
   ###
   load_events_from_db: (conversation_id, start, end, limit = z.config.MESSAGES_FETCH_LIMIT) ->
-    if not start or not end
+    if not _.isNumber(start) or not _.isNumber(end)
       return @_load_events_from_db_deprecated conversation_id, start, end, limit
 
     from = new Date start
@@ -331,6 +331,7 @@ class z.conversation.ConversationService
     if not include_minimum
       [from, to] = [to, from]
 
+    console.log "WE ARE HERE!"
     @storage_service.db[@storage_service.OBJECT_STORE_CONVERSATION_EVENTS]
       .where '[conversation+time]'
       .between [conversation_id, from.toISOString()], [conversation_id, to.toISOString()], include_minimum, false

--- a/app/script/conversation/ConversationService.coffee
+++ b/app/script/conversation/ConversationService.coffee
@@ -335,7 +335,7 @@ class z.conversation.ConversationService
     .limit limit
     .toArray()
     .catch (error) =>
-      @logger.log @logger.levels.ERROR, "Failed to load events from database: '#{error.message}'"
+      @logger.log @logger.levels.ERROR, "Failed to load events for conversation '#{conversation_id}' from database: '#{error.message}'"
       throw error
 
   ###

--- a/app/script/entity/Conversation.coffee
+++ b/app/script/entity/Conversation.coffee
@@ -213,9 +213,12 @@ class z.entity.Conversation
 
   @param timestamp [String] Timestamp to be set
   @param type [z.conversation.ConversationUpdateType] Type of timestamp to be updated
-  @return [String] Timestamp value
+  @return [Boolean|number] Timestamp value which can be 'false' (boolean) if there is no timestamp
   ###
   set_timestamp: (timestamp, type) =>
+    if _.isString timestamp
+      timestamp = window.parseInt timestamp, 10
+
     switch type
       when z.conversation.ConversationUpdateType.ARCHIVED_TIMESTAMP
         entity_timestamp = @archived_timestamp

--- a/test/unit_tests/conversation/ConversationMapperSpec.coffee
+++ b/test/unit_tests/conversation/ConversationMapperSpec.coffee
@@ -166,3 +166,10 @@ describe 'Conversation Mapper', ->
 
       expect(updated_conversation_et.last_event_timestamp()).toBe time
       expect(updated_conversation_et.muted_state()).toBe true
+
+    it 'accepts string values which must be parsed later on', ->
+      conversation_et.last_read_timestamp 0
+      self_status = {"last_read_timestamp":"1480339377099"}
+      last_read_timestamp_number = window.parseInt self_status.last_read_timestamp, 10
+      updated_conversation_et = conversation_mapper.update_self_status conversation_et, self_status
+      expect(updated_conversation_et.last_read_timestamp()).toBe last_read_timestamp_number

--- a/test/unit_tests/conversation/ConversationServiceSpec.coffee
+++ b/test/unit_tests/conversation/ConversationServiceSpec.coffee
@@ -126,12 +126,16 @@ describe 'z.conversation.ConversationService', ->
       conversation_service.load_events_from_db conversation_id
       .then (events) =>
         expect(events.length).toBe 10
+        expect(events[0].time).toBe '2016-11-23T12:19:06.808Z'
+        expect(events[9].time).toBe '2016-11-23T12:19:06.799Z'
         done()
 
     it 'loads all events with limit', (done) ->
       conversation_service.load_events_from_db conversation_id, undefined, undefined, 5
       .then (events) =>
         expect(events.length).toBe 5
+        expect(events[0].time).toBe '2016-11-23T12:19:06.808Z'
+        expect(events[4].time).toBe '2016-11-23T12:19:06.804Z'
         done()
 
     it 'loads events with lower bound', (done) ->

--- a/test/unit_tests/conversation/ConversationServiceSpec.coffee
+++ b/test/unit_tests/conversation/ConversationServiceSpec.coffee
@@ -216,7 +216,7 @@ describe 'z.conversation.ConversationService', ->
         done()
       .catch done.fail
 
-    it 'does not delete if event if key is wrong', (done) ->
+    it 'does not delete the event if key is wrong', (done) ->
       conversation_service.delete_message_with_key_from_db conversation_id, 'wrongKey'
       .then ->
         conversation_service.load_events_from_db conversation_id

--- a/test/unit_tests/conversation/ConversationServiceSpec.coffee
+++ b/test/unit_tests/conversation/ConversationServiceSpec.coffee
@@ -20,15 +20,9 @@
 
 describe 'z.conversation.ConversationService', ->
   conversation_mapper = null
-  server = null
-
-  urls =
-    rest_url: 'http://localhost'
-    websocket_url: 'wss://localhost'
-
   conversation_service = null
+  server = null
   storage_service = null
-
   test_factory = new TestFactory()
 
   beforeAll (done) ->

--- a/test/unit_tests/conversation/ConversationServiceSpec.coffee
+++ b/test/unit_tests/conversation/ConversationServiceSpec.coffee
@@ -117,7 +117,7 @@ describe 'z.conversation.ConversationService', ->
       .catch done.fail
 
     it 'doesn\'t load events for invalid conversation id', (done) ->
-      conversation_service.load_events_from_db 'invalid_id', 1479903546808, 30
+      conversation_service.load_events_from_db 'invalid_id', new Date(30), new Date 1479903546808
       .then (events) =>
         expect(events.length).toBe 0
         done()
@@ -129,13 +129,23 @@ describe 'z.conversation.ConversationService', ->
         done()
 
     it 'loads all events with limit', (done) ->
-      conversation_service.load_events_from_db conversation_id, null, null, 5
+      conversation_service.load_events_from_db conversation_id, undefined, undefined, 5
       .then (events) =>
         expect(events.length).toBe 5
         done()
 
-    it 'loads events with start timestamp', (done) ->
-      conversation_service.load_events_from_db conversation_id, 1479903546803
+    it 'loads events with lower bound', (done) ->
+      conversation_service.load_events_from_db conversation_id, new Date 1479903546805
+      .then (events) =>
+        expect(events.length).toBe 4
+        expect(events[0].time).toBe '2016-11-23T12:19:06.808Z'
+        expect(events[1].time).toBe '2016-11-23T12:19:06.807Z'
+        expect(events[2].time).toBe '2016-11-23T12:19:06.806Z'
+        expect(events[3].time).toBe '2016-11-23T12:19:06.805Z'
+        done()
+
+    it 'loads events with upper bound', (done) ->
+      conversation_service.load_events_from_db conversation_id, undefined, new Date 1479903546803
       .then (events) =>
         expect(events.length).toBe 4
         expect(events[0].time).toBe '2016-11-23T12:19:06.802Z'
@@ -144,15 +154,15 @@ describe 'z.conversation.ConversationService', ->
         expect(events[3].time).toBe '2016-11-23T12:19:06.799Z'
         done()
 
-    it 'loads events with start and end timestamp', (done) ->
-      conversation_service.load_events_from_db conversation_id, 1479903546807, 1479903546805
+    it 'loads events with upper and lower bound', (done) ->
+      conversation_service.load_events_from_db conversation_id, new Date(1479903546806), new Date 1479903546807
       .then (events) =>
         expect(events.length).toBe 1
         expect(events[0].time).toBe '2016-11-23T12:19:06.806Z'
         done()
 
-    it 'loads events with start and end timestamp and a fetch limit', (done) ->
-      conversation_service.load_events_from_db conversation_id, 1479903546807, 1479903546800, 2
+    it 'loads events with upper and lower bound and a fetch limit', (done) ->
+      conversation_service.load_events_from_db conversation_id, new Date(1479903546800), new Date(1479903546807), 2
       .then (events) =>
         expect(events.length).toBe 2
         expect(events[0].time).toBe '2016-11-23T12:19:06.806Z'

--- a/test/unit_tests/entity/ConversationSpec.coffee
+++ b/test/unit_tests/entity/ConversationSpec.coffee
@@ -665,3 +665,13 @@ describe 'Conversation', ->
       next_delivered_message_et.status z.message.StatusType.DELIVERED
       conversation_et.add_message next_delivered_message_et
       expect(conversation_et.get_last_delivered_message()).toBe next_delivered_message_et
+
+  describe 'set_timestamp', ->
+    it 'turns strings into numbers', ->
+      lrt = conversation_et.last_read_timestamp()
+      expect(lrt).toBe 0
+      new_lrt_string = '1480338525243'
+      new_lrt_number = window.parseInt new_lrt_string, 10
+      conversation_et.set_timestamp new_lrt_string, z.conversation.ConversationUpdateType.LAST_READ_TIMESTAMP
+      expect(conversation_et.last_read_timestamp()).toBe new_lrt_number
+


### PR DESCRIPTION
## Type of change
<!--- Please describe what your code improves. -->
I am trying to always pass proper values (which are of type `number`) to `load_events_from_db`. In cases where this fails (because of whatever reason), the old `_load_events_from_db_deprecated` function will be called. 

Because `_load_events_from_db_deprecated` is also called in the `catch` block, it will be used by Microsoft Edge (no explicit check for MS Edge needed).

## Screenshot
<!--- Please add a screenshot if it's a design change. -->
<!--- Info: https://help.github.com/articles/file-attachments-on-issues-and-pull-requests/ -->
