### PR TITLE
Message sending naming cleanup

### DIFF
--- a/app/script/conversation/ConversationRepository.coffee
+++ b/app/script/conversation/ConversationRepository.coffee
@@ -1124,7 +1124,7 @@ class z.conversation.ConversationRepository
       user_client_map = {}
 
       for user_et in user_ets
-        continue if user_et.is_me and skip_own_clients
+        continue if skip_own_clients and user_et.is_me
         user_client_map[user_et.id] = (client_et.id for client_et in user_et.devices())
 
       return user_client_map
@@ -1245,7 +1245,7 @@ class z.conversation.ConversationRepository
   @return [Promise] Promise that resolves when the message was sent
   ###
   _send_generic_message: (conversation_id, generic_message, user_ids, native_push = true) =>
-    Promise.resolve @_send_as_external_message conversation_id, generic_message
+    Promise.resolve @_should_send_as_external conversation_id, generic_message
     .then (send_as_external) =>
       if send_as_external
         @_send_external_generic_message conversation_id, generic_message, user_ids, native_push
@@ -1335,7 +1335,7 @@ class z.conversation.ConversationRepository
   @param generic_message [z.protobuf.GenericMessage] Generic message that will be send
   @return [Boolean] Is payload likely to be too big so that we switch to type external?
   ###
-  _send_as_external_message: (conversation_id, generic_message) ->
+  _should_send_as_external: (conversation_id, generic_message) ->
     return new Promise (resolve) =>
       @get_conversation_by_id conversation_id, (conversation_et) ->
         estimated_number_of_clients = conversation_et.number_of_participants() * 4

--- a/app/script/cryptography/CryptographyRepository.coffee
+++ b/app/script/cryptography/CryptographyRepository.coffee
@@ -209,16 +209,13 @@ class z.cryptography.CryptographyRepository
   @return [Promise<Array<cryptobox.CryptoboxSession>>] Promise that resolves with an array of sessions
   ###
   get_sessions: (user_client_map) =>
-    return new Promise (resolve, reject) =>
-      [cryptobox_session_map, missing_session_map] = @_get_sessions_local user_client_map
-      @logger.log @logger.levels.INFO, "Found local sessions for '#{Object.keys(cryptobox_session_map).length}' users", cryptobox_session_map
+    [cryptobox_session_map, missing_session_map] = @_get_sessions_local user_client_map
+    @logger.log @logger.levels.INFO, "Found local sessions for '#{Object.keys(cryptobox_session_map).length}' users", cryptobox_session_map
 
-      @_get_sessions_missing cryptobox_session_map, missing_session_map
-      .then (cryptobox_session_map) ->
-        resolve cryptobox_session_map
-      .catch (error) =>
-        @logger.log @logger.levels.ERROR, "Failed to get sessions: #{error.message}", [error, user_client_map]
-        reject error
+    @_get_sessions_missing cryptobox_session_map, missing_session_map
+    .catch (error) =>
+      @logger.log @logger.levels.ERROR, "Failed to get sessions: #{error.message}", [error, user_client_map]
+      throw error
 
   ###
   Loads the session from Cryptobox.

--- a/test/unit_tests/conversation/ConversationRepositorySpec.coffee
+++ b/test/unit_tests/conversation/ConversationRepositorySpec.coffee
@@ -738,7 +738,7 @@ describe 'z.conversation.ConversationRepository', ->
           done()
         .catch done.fail
 
-  describe '_send_as_external_message', ->
+  describe '_should_send_as_external', ->
 
     it 'should return true for big payload', (done) ->
       external_conversation_et = _generate_conversation()
@@ -748,7 +748,7 @@ describe 'z.conversation.ConversationRepository', ->
       generic_message = new z.proto.GenericMessage z.util.create_random_uuid()
       generic_message.set 'text', new z.proto.Text 'massive external message massive external message massive external message massive external message massive external message massive external message massive external message massive external message massive external messagemassive external message massive external message massive external message massive external message massive external message massive external message massive external message massive external message massive external messagemassive external message massive external message massive external message massive external message massive external message massive external message massive external message massive external message massive external messagemassive external message massive external message massive external message massive external message massive external message massive external message massive external message massive external message massive external message'
 
-      conversation_repository._send_as_external_message conversation_et.id, generic_message
+      conversation_repository._should_send_as_external conversation_et.id, generic_message
       .then (should_send_as_external) ->
         expect(should_send_as_external).toBeTruthy()
         done()
@@ -762,7 +762,7 @@ describe 'z.conversation.ConversationRepository', ->
       generic_message = new z.proto.GenericMessage z.util.create_random_uuid()
       generic_message.set 'text', new z.proto.Text 'Test'
 
-      conversation_repository._send_as_external_message conversation_et.id, generic_message
+      conversation_repository._should_send_as_external conversation_et.id, generic_message
       .then (should_send_as_external) ->
         expect(should_send_as_external).toBeFalsy()
         done()


### PR DESCRIPTION
`_send_as_external_message` -> `should_send_as_external` 