### PR TITLE
hide avatar using knockouts virtual if binding

### DIFF
--- a/app/page/template/partials/template-message.htm
+++ b/app/page/template/partials/template-message.htm
@@ -45,17 +45,19 @@
 </script>
 
 <script type="text/html" id="normal">
-  <div class="message-header" data-bind="visible: !$parent.should_hide_user_avatar($data)">
-    <div class="message-header-icon">
-      <user-avatar class="sender-avatar user-avatar-xs" data-bubble="#participants-bubble" data-placement="vertical" params="user: message.user(), click: $parent.on_message_user_click"></user-avatar>
+  <!-- ko if: !$parent.should_hide_user_avatar($data) -->
+    <div class="message-header">
+      <div class="message-header-icon">
+        <user-avatar class="sender-avatar user-avatar-xs" data-bubble="#participants-bubble" data-placement="vertical" params="user: message.user(), click: $parent.on_message_user_click"></user-avatar>
+      </div>
+      <div class="message-header-label label-bold">
+        <span data-bind='text: message.user().first_name()'></span>
+        <!-- ko if: was_edited() -->
+          <span class="message-header-label-icon icon-edit" data-bind="attr: {title: message.display_edited_timestamp()}"></span>
+        <!-- /ko -->
+      </div>
     </div>
-    <div class="message-header-label label-bold">
-      <span data-bind='text: message.user().first_name()'></span>
-      <!-- ko if: was_edited() -->
-        <span class="message-header-label-icon icon-edit" data-bind="attr: {title: message.display_edited_timestamp()}"></span>
-      <!-- /ko -->
-    </div>
-  </div>
+  <!-- /ko -->
   <div class="message-body">
 
     <!-- ko foreach: {data: message.assets, as: 'asset'} -->


### PR DESCRIPTION
## Type of change
Since the user avatar was removed using `display: none`, all knockout bindings where triggered. This can be avoided using the if binding.

## Screenshot
<!--- Please add a screenshot if it's a design change. -->
<!--- Info: https://help.github.com/articles/file-attachments-on-issues-and-pull-requests/ -->

