### PR TITLE
Properly cleanup outdated sessions

### DIFF
--- a/app/script/cryptography/CryptographyRepository.coffee
+++ b/app/script/cryptography/CryptographyRepository.coffee
@@ -171,6 +171,19 @@ class z.cryptography.CryptographyRepository
   ###############################################################################
 
   ###
+  Create a map of all local sessions.
+  @return [Object] Object of users each containing an array of local sessions
+  ###
+  create_user_session_map: =>
+    user_session_map = {}
+    for session_id, session of sessions
+      ids = z.client.Client.dismantle_user_client_id session_id
+      user_session_map[ids.user_id] ?= []
+      user_session_map[ids.user_id].push ids.client_id
+    @logger.info "Created user session map for '#{Object.keys(user_session_map).length}' users", user_session_map
+    return user_session_map
+
+  ###
   Deletes a session.
 
   @param user_id [String] User ID of our chat partner

--- a/app/script/cryptography/CryptographyRepository.coffee
+++ b/app/script/cryptography/CryptographyRepository.coffee
@@ -552,6 +552,7 @@ class z.cryptography.CryptographyRepository
       decrypted_message = session.decrypt msg_bytes
     else
       [session, decrypted_message] = @_session_from_message user_id, client_id, msg_bytes
+      amplify.publish z.event.WebApp.CLIENT.ADD, user_id, new z.client.Client {id: client_id}
 
     generic_message = z.proto.GenericMessage.decode decrypted_message
     @save_session session

--- a/app/script/cryptography/CryptographyRepository.coffee
+++ b/app/script/cryptography/CryptographyRepository.coffee
@@ -552,7 +552,7 @@ class z.cryptography.CryptographyRepository
       decrypted_message = session.decrypt msg_bytes
     else
       [session, decrypted_message] = @_session_from_message user_id, client_id, msg_bytes
-      amplify.publish z.event.WebApp.CLIENT.ADD, user_id, new z.client.Client {id: client_id}
+      amplify.publish z.event.WebApp.CLIENT.ADD, user_id, new z.client.Client id: client_id
 
     generic_message = z.proto.GenericMessage.decode decrypted_message
     @save_session session

--- a/app/script/main/app.coffee
+++ b/app/script/main/app.coffee
@@ -214,6 +214,7 @@ class z.main.App
       @telemetry.time_step z.telemetry.app_init.AppInitTimingsStep.UPDATED_CONVERSATIONS
       @repository.announce.init()
       @repository.audio.init true
+      @repository.client.cleanup_clients_and_sessions true
       @logger.info 'App fully loaded'
     .catch (error) =>
       error_message = "Error during initialization of app version '#{z.util.Environment.version false}'"


### PR DESCRIPTION
This PR contains of two parts:

1. Never miss to add a client to the database:

The reason we have so many obsolete sessions in our database is that we map a session to each client in the db. We miss to initially store a client if a session is initiated from a message containing a pre-key during decryption. If the client was removed on the backend before we ever send a message to this user, we would never cleanup this session. This happens for example with clients that create many temporary clients like our internal bots before they used the service provider architecture.

This is fixed by storing a client locally when we create the session from a pre-key message during decryption just like we do when create a session from a pre-key during encryption.

2. Remove exisiting obsolete sessions:

On app start I will check the number of session we have for each client. If this number is greater then the maximum of concurrent clients enforced by the backend, we will retrieve the current clients from the backend and perform a cleanup. Thus the cleanup requires one backend request per user to clean sessions up for.

The impact should be fairly low as I opted against performing the cleanup for each user. Instead it will only do so if the number of local sessions for a user unquestionable indicates that we have obsolete ones.

In case you want to perform a full cleanup you can manually do so by calling `wire.app.repository.client.cleanup_clients_and_sessions(false)` from the console.