### PR TITLE
Bots (WEBAPP-2077)

### DIFF
--- a/app/script/announce/AnnounceService.coffee
+++ b/app/script/announce/AnnounceService.coffee
@@ -19,10 +19,12 @@
 window.z ?= {}
 z.announce ?= {}
 
+ANNOUNCE_SERVICE_URL = 'api/v1/announce/'
+
 class z.announce.AnnounceService
   constructor: ->
     @logger = new z.util.Logger 'z.announce.AnnounceService', z.config.LOGGER.OPTIONS
-    @url = "#{z.config.ANNOUNCE_URL}?order=created&active=true"
+    @url = "#{z.util.Environment.backend.website_url()}#{ANNOUNCE_SERVICE_URL}?order=created&active=true"
     @url += '&production=true' if z.util.Environment.frontend.is_production()
     return @
 

--- a/app/script/bot/BotRepository.coffee
+++ b/app/script/bot/BotRepository.coffee
@@ -23,7 +23,11 @@ class z.bot.BotRepository
   constructor: (@bot_service, @conversation_repository) ->
     @logger = new z.util.Logger 'z.bot.BotRepository', z.config.LOGGER.OPTIONS
 
-  # Add bot to conversation.
+  ###
+  Add bot to conversation.
+  @param bot_name [String] Bot name registered on backend
+  @param create_conversation [Boolean] A new conversation is created if true otherwise bot is added to active conversation, defaults to true
+  ###
   add_bot: (bot_name, create_conversation = true) =>
     bot_result = undefined
 

--- a/app/script/bot/BotService.coffee
+++ b/app/script/bot/BotService.coffee
@@ -19,10 +19,12 @@
 window.z ?= {}
 z.bot ?= {}
 
+BOT_SERVICE_URL = 'api/v1/bot/'
+
 class z.bot.BotService
   constructor: ->
     @logger = new z.util.Logger 'z.bot.BotService', z.config.LOGGER.OPTIONS
-    @url = "#{z.config.BOT_URL}"
+    @url = "#{z.util.Environment.backend.website_url()}#{BOT_SERVICE_URL}"
     return @
 
   fetch_bot: (bot_name) ->

--- a/app/script/config.coffee
+++ b/app/script/config.coffee
@@ -107,5 +107,8 @@ z.config =
 
   UNSPLASH_URL: 'https://source.unsplash.com/1200x1200/?landscape'
 
+  ACCOUNT_PRODUCTION_URL: 'https://account-wire.com/'
+  ACCOUNT_STAGING_URL: 'https://wire-account-staging.zinfra.io/'
+
   WEBSITE_PRODUCTION_URL: 'https://wire.com/'
   WEBSITE_STAGING_URL: 'https://staging-website.zinfra.io/'

--- a/app/script/config.coffee
+++ b/app/script/config.coffee
@@ -106,5 +106,6 @@ z.config =
   MAXIMUM_USERS_PER_REQUEST: 200
 
   UNSPLASH_URL: 'https://source.unsplash.com/1200x1200/?landscape'
-  ANNOUNCE_URL: 'https://wire.com/api/v1/announce/'
-  BOT_URL: 'https://wire.com/api/v1/bot/'
+
+  WEBSITE_PRODUCTION_URL: 'https://wire.com/'
+  WEBSITE_STAGING_URL: 'https://staging-website.zinfra.io/'

--- a/app/script/conversation/ConversationRepository.coffee
+++ b/app/script/conversation/ConversationRepository.coffee
@@ -625,7 +625,7 @@ class z.conversation.ConversationRepository
   ###
   Remove bot from conversation.
   @param conversation_et [z.entity.Conversation] Conversation to remove member from
-  @param user_id [String] ID of bot to be removed from the the conversation
+  @param user_id [String] ID of bot to be removed from the conversation
   ###
   remove_bot: (conversation_et, user_id) =>
     @conversation_service.delete_bots conversation_et.id, user_id
@@ -637,7 +637,7 @@ class z.conversation.ConversationRepository
   ###
   Remove member from conversation.
   @param conversation_et [z.entity.Conversation] Conversation to remove member from
-  @param user_id [String] ID of member to be removed from the the conversation
+  @param user_id [String] ID of member to be removed from the conversation
   ###
   remove_member: (conversation_et, user_id) =>
     @conversation_service.delete_members conversation_et.id, user_id
@@ -645,6 +645,16 @@ class z.conversation.ConversationRepository
       if response
         amplify.publish z.event.WebApp.EVENT.INJECT, response
         return response
+
+  ###
+  Remove participant from conversation.
+  @param conversation_et [z.entity.Conversation] Conversation to remove participant from
+  @param user_et [z.entity.User] User to be removed from the conversation
+  ###
+  remove_participant: (conversation_et, user_et) =>
+    if user_et.is_bot()
+      return @conversation_repository.remove_bot @conversation(), user_et.id
+    return @conversation_repository.remove_member @conversation(), user_et
 
   ###
   Rename conversation.

--- a/app/script/conversation/ConversationRepository.coffee
+++ b/app/script/conversation/ConversationRepository.coffee
@@ -652,7 +652,7 @@ class z.conversation.ConversationRepository
   @param user_et [z.entity.User] User to be removed from the conversation
   ###
   remove_participant: (conversation_et, user_et) =>
-    if user_et.is_bot()
+    if user_et.is_bot
       return @conversation_repository.remove_bot @conversation(), user_et.id
     return @conversation_repository.remove_member @conversation(), user_et
 

--- a/app/script/conversation/ConversationRepository.coffee
+++ b/app/script/conversation/ConversationRepository.coffee
@@ -621,23 +621,30 @@ class z.conversation.ConversationRepository
         callback next_conversation_et
       else
         @archive_conversation conversation_et, next_conversation_et
-    .catch (error) =>
-      @logger.error "Failed to leave conversation (#{conversation_et.id}): #{error}"
+
+  ###
+  Remove bot from conversation.
+  @param conversation_et [z.entity.Conversation] Conversation to remove member from
+  @param user_id [String] ID of bot to be removed from the the conversation
+  ###
+  remove_bot: (conversation_et, user_id) =>
+    @conversation_service.delete_bots conversation_et.id, user_id
+    .then (response) ->
+      if response
+        amplify.publish z.event.WebApp.EVENT.INJECT, response
+        return response
 
   ###
   Remove member from conversation.
-
   @param conversation_et [z.entity.Conversation] Conversation to remove member from
   @param user_id [String] ID of member to be removed from the the conversation
-  @param callback [Function] Function to be called on server return
   ###
-  remove_member: (conversation_et, user_id, callback) =>
+  remove_member: (conversation_et, user_id) =>
     @conversation_service.delete_members conversation_et.id, user_id
     .then (response) ->
-      amplify.publish z.event.WebApp.EVENT.INJECT, response
-      callback?()
-    .catch (error) =>
-      @logger.error "Failed to remove member from conversation (#{conversation_et.id}): #{error}"
+      if response
+        amplify.publish z.event.WebApp.EVENT.INJECT, response
+        return response
 
   ###
   Rename conversation.
@@ -653,8 +660,6 @@ class z.conversation.ConversationRepository
       amplify.publish z.event.WebApp.EVENT.INJECT, response
     .then ->
       callback?()
-    .catch (error) =>
-      @logger.error "Failed to rename conversation (#{conversation_et.id}): #{error.message}"
 
   reset_session: (user_id, client_id, conversation_id) =>
     @logger.info "Resetting session with client '#{client_id}' of user '#{user_id}'"

--- a/app/script/conversation/ConversationService.coffee
+++ b/app/script/conversation/ConversationService.coffee
@@ -88,6 +88,18 @@ class z.conversation.ConversationService
   ###############################################################################
 
   ###
+  Remove bot from conversation.
+
+  @param conversation_id [String] ID of conversation to remove bot from
+  @param user_id [String] ID of bot to be removed from the the conversation
+  @param callback [Function] Function to be called on server return
+  ###
+  delete_bots: (conversation_id, user_id) ->
+    @client.send_request
+      url: @client.create_url "/conversations/#{conversation_id}/bots/#{user_id}"
+      type: 'DELETE'
+
+  ###
   Remove member from conversation.
 
   @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/conversations/removeMember

--- a/app/script/entity/User.coffee
+++ b/app/script/entity/User.coffee
@@ -49,7 +49,7 @@ class z.entity.User
   ###
   constructor: (@id = '') ->
     @is_me = false
-    @is_bot = ko.observable false
+    @is_bot = false
 
     @joaat_hash = -1
 

--- a/app/script/entity/User.coffee
+++ b/app/script/entity/User.coffee
@@ -49,6 +49,7 @@ class z.entity.User
   ###
   constructor: (@id = '') ->
     @is_me = false
+    @is_bot = ko.observable false
 
     @joaat_hash = -1
 

--- a/app/script/localization/strings-de.coffee
+++ b/app/script/localization/strings-de.coffee
@@ -472,7 +472,7 @@ z.string.de.upload_google_message_error = 'Wir haben die Informationen nicht erh
 z.string.de.upload_google_button_again = 'Erneut versuchen'
 
 # URLs
-z.string.de.url_password_reset = 'https://wire.com/forgot/?hl=de'
+z.string.de.url_password_reset = 'forgot/?hl=de'
 z.string.de.url_legal = 'https://wire.com/legal/?hl=de'
 z.string.de.url_privacy = 'https://wire.com/privacy/?hl=de'
 z.string.de.url_privacy_why = 'https://wire.com/privacy/why/'

--- a/app/script/localization/strings.coffee
+++ b/app/script/localization/strings.coffee
@@ -473,7 +473,7 @@ z.string.upload_google_message_error = 'We did not receive your information. Ple
 z.string.upload_google_button_again = 'Try again'
 
 # URLs
-z.string.url_password_reset = 'https://wire.com/forgot/'
+z.string.url_password_reset = 'forgot/'
 z.string.url_legal = 'https://wire.com/legal/'
 z.string.url_privacy = 'https://wire.com/privacy/'
 z.string.url_privacy_why = 'https://wire.com/privacy/why/'

--- a/app/script/util/Environment.coffee
+++ b/app/script/util/Environment.coffee
@@ -98,7 +98,16 @@ z.util.Environment = do ->
   # "backend.current" is "undefined" when you are not connected to the backend (for example, if you are on the login page).
   # In such situations use methods like "is_staging" to detect environments.
   #
-  backend: current: undefined
+  backend:
+    account_url: ->
+      if z.util.Environment.backend.current is z.service.BackendEnvironment.PRODUCTION
+        return z.config.ACCOUNT_PRODUCTION_URL
+      return z.config.ACCOUNT_STAGING_URL
+    current: undefined
+    website_url: ->
+      if z.util.Environment.backend.current is z.service.BackendEnvironment.PRODUCTION
+        return z.config.WEBSITE_PRODUCTION_URL
+      return z.config.WEBSITE_STAGING_URL
 
   frontend:
     is_localhost: ->

--- a/app/script/view_model/AuthViewModel.coffee
+++ b/app/script/view_model/AuthViewModel.coffee
@@ -536,7 +536,7 @@ class z.ViewModel.AuthViewModel
 
   clicked_on_password: ->
     amplify.publish z.event.WebApp.ANALYTICS.EVENT, z.tracking.EventName.PASSWORD_RESET, value: 'fromSignIn'
-    z.util.safe_window_open z.localization.Localizer.get_text z.string.url_password_reset
+    z.util.safe_window_open "#{z.util.Environment.backend.website_url()}#{z.localization.Localizer.get_text z.string.url_password_reset}"
 
   clicked_on_register: => @_set_hash z.auth.AuthView.MODE.ACCOUNT_REGISTER
 

--- a/app/script/view_model/ParticipantsViewModel.coffee
+++ b/app/script/view_model/ParticipantsViewModel.coffee
@@ -191,8 +191,12 @@ class z.ViewModel.ParticipantsViewModel
       data:
         user: user_et
       confirm: =>
-        @conversation_repository.remove_member @conversation(), user_et.id, (response) =>
-          @reset_view() if response
+        if user_et.is_bot()
+          remove_promise = @conversation_repository.remove_bot @conversation(), user_et.id
+        else
+          remove_promise = @conversation_repository.remove_member @conversation(), user_et.id
+
+        remove_promise.then (response) => @reset_view() if response
 
   show_preferences_account: ->
     amplify.publish z.event.WebApp.PREFERENCES.MANAGE_ACCOUNT

--- a/app/script/view_model/ParticipantsViewModel.coffee
+++ b/app/script/view_model/ParticipantsViewModel.coffee
@@ -191,12 +191,9 @@ class z.ViewModel.ParticipantsViewModel
       data:
         user: user_et
       confirm: =>
-        if user_et.is_bot()
-          remove_promise = @conversation_repository.remove_bot @conversation(), user_et.id
-        else
-          remove_promise = @conversation_repository.remove_member @conversation(), user_et.id
-
-        remove_promise.then (response) => @reset_view() if response
+        @conversation_repository.remove_participant @conversation(), user_et
+        .then (response) =>
+          @reset_view() if response
 
   show_preferences_account: ->
     amplify.publish z.event.WebApp.PREFERENCES.MANAGE_ACCOUNT

--- a/app/script/view_model/content/PreferencesAccountViewModel.coffee
+++ b/app/script/view_model/content/PreferencesAccountViewModel.coffee
@@ -159,7 +159,7 @@ class z.ViewModel.content.PreferencesAccountViewModel
 
   click_on_reset_password: ->
     amplify.publish z.event.WebApp.ANALYTICS.EVENT, z.tracking.EventName.PASSWORD_RESET, value: 'fromProfile'
-    z.util.safe_window_open z.string.url_password_reset
+    z.util.safe_window_open "#{z.util.Environment.backend.website_url()}#{z.localization.Localizer.get_text z.string.url_password_reset}"
 
   set_picture: (files, callback) =>
     input_picture = files[0]


### PR DESCRIPTION
- URLs are backend environment depending (bot and announcements API, password reset link)
- added the ability to remove a bot from a conversation

To remove a bot you currently need a little workaround, we have no meaning of identifying a user as a bot in a conversation right now. If you want to remove a bot you have to set such flag manually. In a 1to1 conversation you can simply do so with the following command from the console while in that conversation:

`wire.app.repository.conversation.active_conversation().participating_user_ets()[0].is_bot(true)`


