### PR TITLE
Disable conversation renaming UI if removed from conversation (WEBAPP-797)

### DIFF
--- a/app/page/template/content/conversation/participants.htm
+++ b/app/page/template/content/conversation/participants.htm
@@ -10,7 +10,7 @@
               <div data-bind="visible: !editing(), text: conversation().display_name(), click: edit, l10n_tooltip: z.string.tooltip_people_rename" data-uie-name="status-name"></div>
               <textarea data-bind="visible: editing, value: conversation().display_name(), enter: rename_conversation, hasFocus: editing, resize" data-uie-name="enter-name" maxlength="64" dir="auto"></textarea>
             </div>
-            <span class="edit icon-edit" data-bind="visible: !editing(), click: edit"></span>
+            <span class="edit icon-edit" data-bind="visible: editable() && !editing(), click: edit"></span>
             <div class="people popover-meta text-uppercase" data-bind="l10n_text: {'id': z.string.people_people, 'replace': {'placeholder': '%no', 'content': participants().length}}"></div>
           </div>
           <div class="participants-group-list">

--- a/app/script/view_model/ParticipantsViewModel.coffee
+++ b/app/script/view_model/ParticipantsViewModel.coffee
@@ -56,7 +56,8 @@ class z.ViewModel.ParticipantsViewModel
 
     # switch between div and input field to edit the conversation name
     @editing = ko.observable false
-    @edit = -> @editing true
+    @editable = ko.pureComputed => return not @conversation().removed_from_conversation()
+    @edit = -> @editing true if @editable()
 
     @editing.subscribe (value) =>
       if value is false


### PR DESCRIPTION
## Type of change
- disallows editing of group tittle on UI level if user was removed from conversation
- previously we caught the 404 backend error, this is a better UX as the edit options is not there in the first place