### PR TITLE
Show appropriate notification for auto-connects (WEBAPP-3495)

### DIFF
--- a/app/script/localization/strings-de.coffee
+++ b/app/script/localization/strings-de.coffee
@@ -270,6 +270,9 @@ z.string.de.conversation_edit_timestamp = 'Editiert um %@timestamp'
 z.string.de.conversation_likes_caption = '%@number Personen'
 z.string.de.conversation_send_pasted_file = 'Bild eingefügt am %date'
 
+# Collection
+z.string.de.collection_show_all = 'Zeige alle %no'
+
 # Archive
 z.string.de.archive_header = 'Archivieren'
 
@@ -302,8 +305,8 @@ z.string.de.invite_meta_key_pc = 'Strg'
 z.string.de.invite_hint_selected = 'Zum Kopieren %meta_key + C drücken'
 z.string.de.invite_hint_unselected = 'Markieren und %meta_key + C drücken'
 z.string.de.invite_headline = 'Lade Freunde zu Wire ein'
-z.string.de.invite_message = 'Ich benutze Wire. Suche nach %username oder gehe auf wire.com/download.'
-z.string.de.invite_message_no_email = 'Ich bin bei Wire. Gehe auf https://get.wire.com, um mich als Kontakt hinzuzufügen.'
+z.string.de.invite_message = 'Ich benutze Wire. Suche nach %username oder gehe auf get.wire.com.'
+z.string.de.invite_message_no_email = 'Ich benutze Wire. Gehe auf get.wire.com, um mich als Kontakt hinzuzufügen.'
 
 # Extensions
 z.string.de.extensions_bubble_button_gif = 'Gif'
@@ -522,6 +525,7 @@ z.string.de.warning_connectivity_no_internet = 'Keine Internetverbindung. Du kan
 # Browser notifications
 z.string.de.system_notification_asset_add = 'Hat ein Bild geteilt'
 z.string.de.system_notification_connection_accepted = 'Hat deine Kontaktanfrage akzeptiert'
+z.string.de.system_notification_connection_connected = 'Ist jetzt ein Kontakt von dir'
 z.string.de.system_notification_connection_request = 'Möchte dich als Kontakt hinzufügen'
 z.string.de.system_notification_conversation_create = '%s.first_name hat eine Unterhaltung begonnen'
 z.string.de.system_notification_conversation_rename = '%s.first_name hat die Unterhaltung in %name umbenannt'

--- a/app/script/localization/strings-es.coffee
+++ b/app/script/localization/strings-es.coffee
@@ -266,6 +266,9 @@ z.string.es.conversation_context_menu_unlike = 'No me gusta'
 z.string.es.conversation_delete_timestamp = 'Eliminados en %@fecha y hora'
 z.string.es.conversation_edit_timestamp = 'Editado %@fecha y hora'
 z.string.es.conversation_likes_caption = '%@numbero de personas'
+z.string.es.conversation_send_pasted_file = 'Imagen pegada el %date'
+
+# Collection
 
 # Archive
 z.string.es.archive_header = 'Archivar'
@@ -445,7 +448,8 @@ z.string.es.preferences_options_data_checkbox = 'Reportes de uso y fallas'
 z.string.es.preferences_options_data_detail = 'Ayudar a mejorar Wire enviando información anónima.'
 z.string.es.preferences_options_notifications = 'Notificaciones'
 z.string.es.preferences_options_notifications_none = 'Desactivar'
-z.string.es.preferences_options_notifications_obfuscate = 'Ocultar detalles del mensaje'
+z.string.es.preferences_options_notifications_obfuscate = 'Ocultar detalles'
+z.string.es.preferences_options_notifications_obfuscate_message = 'Mostrar remitente'
 z.string.es.preferences_options_notifications_on = 'Mostrar remitente y mensaje'
 
 # Search
@@ -453,7 +457,10 @@ z.string.es.search_group_hint = 'Seguir intentando o elegir más personas para c
 z.string.es.search_connect = 'Conectar'
 z.string.es.search_connections = 'Conexiones'
 z.string.es.search_groups = 'Grupos'
+z.string.es.search_placeholder = 'Buscar por nombre o usuario'
 z.string.es.search_top_people = 'Personas más importantes'
+z.string.es.search_try_search = 'Encontrar personas por nombre o usuario'
+z.string.es.search_no_contacts_on_wire = 'No tienes contactos en Wire. Trata de encontrar personas por nombre o usuario.'
 z.string.es.search_others = 'Conectar'
 z.string.es.search_friend_in_common = '%no persona en común'
 z.string.es.search_friends_in_common = '%no personas en común'

--- a/app/script/localization/strings-fr.coffee
+++ b/app/script/localization/strings-fr.coffee
@@ -266,6 +266,9 @@ z.string.fr.conversation_context_menu_unlike = 'Je n’aime plus'
 z.string.fr.conversation_delete_timestamp = 'Supprimé le %@timestamp'
 z.string.fr.conversation_edit_timestamp = 'Édité le %@timestamp'
 z.string.fr.conversation_likes_caption = '%@number personnes'
+z.string.fr.conversation_send_pasted_file = 'Image copiée le %date'
+
+# Collection
 
 # Archive
 z.string.fr.archive_header = 'Archiver'
@@ -287,7 +290,11 @@ z.string.fr.conversations_popover_silence = 'Désactiver le micro'
 z.string.fr.conversations_popover_unarchive = 'Désarchiver'
 
 # Takeover
+z.string.fr.takeover_headline = 'Les noms sont ici.'
+z.string.fr.takeover_sub = 'Choisissez votre nom unique sur Wire.'
 z.string.fr.takeover_link = 'En savoir plus '
+z.string.fr.takeover_button_choose = 'Choisissez le vôtre'
+z.string.fr.takeover_button_keep = 'Garder celui-là'
 
 # Invites
 z.string.fr.invite_meta_key_mac = 'Cmd'
@@ -398,6 +405,9 @@ z.string.fr.preferences_account_reset_password = 'Réinitialiser le mot de passe
 z.string.fr.preferences_account_delete = 'Supprimer le compte'
 z.string.fr.preferences_account_log_out = 'Se déconnecter'
 z.string.fr.preferences_account_username_placeholder = 'Votre nom complet'
+z.string.fr.preferences_account_username_hint = 'Au moins 2 caractères. a — z, 0 — 9 et _ seulement.'
+z.string.fr.preferences_account_username_available = 'Disponible'
+z.string.fr.preferences_account_username_error_taken = 'Déjà pris'
 
 z.string.fr.preferences_av_camera = 'Caméra'
 z.string.fr.preferences_av_microphone = 'Microphone'
@@ -437,7 +447,8 @@ z.string.fr.preferences_options_data_checkbox = 'Rapports d’utilisation et de 
 z.string.fr.preferences_options_data_detail = 'Améliorez Wire en envoyant des informations anonymes.'
 z.string.fr.preferences_options_notifications = 'Notifications'
 z.string.fr.preferences_options_notifications_none = 'Désactivé'
-z.string.fr.preferences_options_notifications_obfuscate = 'Masquer les détails du message'
+z.string.fr.preferences_options_notifications_obfuscate = 'Cacher les détails'
+z.string.fr.preferences_options_notifications_obfuscate_message = 'Afficher l’expéditeur'
 z.string.fr.preferences_options_notifications_on = 'Afficher l’expéditeur et le message'
 
 # Search
@@ -445,8 +456,13 @@ z.string.fr.search_group_hint = 'Continuez d’écrire ou ajoutez plus de person
 z.string.fr.search_connect = 'Connecter'
 z.string.fr.search_connections = 'Connexions'
 z.string.fr.search_groups = 'Groupes'
+z.string.fr.search_placeholder = 'Rechercher par nom ou par identifiant'
 z.string.fr.search_top_people = 'Personnes favorites'
+z.string.fr.search_try_search = 'Trouver des personnes par\nnom ou nom d’utilisateur'
+z.string.fr.search_no_contacts_on_wire = 'Vous n’avez pas de contacts sur Wire.\nEssayez de trouver des gens par\nleur nom ou leur nom d’utilisateur.'
 z.string.fr.search_others = 'Connecter'
+z.string.fr.search_friend_in_common = '%no personne en commun'
+z.string.fr.search_friends_in_common = '%no personnes en commun'
 
 # Google contacts upload
 z.string.fr.upload_google_headline = 'Trouvez des personnes\nà qui parler.'
@@ -473,6 +489,7 @@ z.string.fr.url_support_mic_access_denied = 'https://support.wire.com/hc/en-us/a
 z.string.fr.url_support_mic_not_found = 'https://support.wire.com/hc/en-us/articles/202970662'
 z.string.fr.url_support_screen_access_denied = 'https://support.wire.com/hc/en-us/articles/202935412'
 z.string.fr.url_support_screen_whitelist = 'https://support.wire.com/hc/en-us/articles/209423889'
+z.string.fr.url_support_usernames = 'https://wire.com/support/username'
 z.string.fr.url_decrypt_error_1 = 'https://wire.com/privacy/error-1'
 z.string.fr.url_decrypt_error_2 = 'https://wire.com/privacy/error-2'
 

--- a/app/script/localization/strings-it.coffee
+++ b/app/script/localization/strings-it.coffee
@@ -300,8 +300,6 @@ z.string.it.invite_meta_key_pc = 'Ctrl'
 z.string.it.invite_hint_selected = 'Premere %meta_key + C per copiare'
 z.string.it.invite_hint_unselected = 'Selezionare e premere % meta_key + C'
 z.string.it.invite_headline = 'Invita amici ad usare Wire'
-z.string.it.invite_message = 'Sono su Wire, cerca %username o visita wire.com/download.'
-z.string.it.invite_message_no_email = 'Sono su Wire. Visita https://get.wire.com per connetterti con me.'
 
 # Extensions
 z.string.it.extensions_bubble_button_gif = 'Gif'
@@ -445,7 +443,8 @@ z.string.it.preferences_options_data_checkbox = 'Segnalazioni di crash e dati di
 z.string.it.preferences_options_data_detail = 'Migliora Wire con l’invio di informazioni anonime.'
 z.string.it.preferences_options_notifications = 'Notifiche'
 z.string.it.preferences_options_notifications_none = 'Off'
-z.string.it.preferences_options_notifications_obfuscate = 'Nascondi i dettagli messaggio'
+z.string.it.preferences_options_notifications_obfuscate = 'Nascondi dettagli'
+z.string.it.preferences_options_notifications_obfuscate_message = 'Mostra mittente'
 z.string.it.preferences_options_notifications_on = 'Mostra mittente e messaggio'
 
 # Search

--- a/app/script/localization/strings-pt.coffee
+++ b/app/script/localization/strings-pt.coffee
@@ -446,7 +446,8 @@ z.string.pt.preferences_options_data_checkbox = 'Relatórios de uso e erro'
 z.string.pt.preferences_options_data_detail = 'Faça o Wire melhorar mandando informações de uso anônimas.'
 z.string.pt.preferences_options_notifications = 'Notificações'
 z.string.pt.preferences_options_notifications_none = 'Desligar'
-z.string.pt.preferences_options_notifications_obfuscate = 'Esconder detalhes da mensagem'
+z.string.pt.preferences_options_notifications_obfuscate = 'Ocultar detalhes'
+z.string.pt.preferences_options_notifications_obfuscate_message = 'Mostrar remetente'
 z.string.pt.preferences_options_notifications_on = 'Mostrar o remetente e a mensagem'
 
 # Search

--- a/app/script/localization/strings-ro.coffee
+++ b/app/script/localization/strings-ro.coffee
@@ -446,7 +446,8 @@ z.string.ro.preferences_options_data_checkbox = 'Rapoarte de folosire și de ava
 z.string.ro.preferences_options_data_detail = 'Ajută la îmbunătățirea Wire prin trimiterea de informații anonime.'
 z.string.ro.preferences_options_notifications = 'Notificări'
 z.string.ro.preferences_options_notifications_none = 'Închis'
-z.string.ro.preferences_options_notifications_obfuscate = 'Ascunde detaliile mesajelor'
+z.string.ro.preferences_options_notifications_obfuscate = 'Ascunde detaliile'
+z.string.ro.preferences_options_notifications_obfuscate_message = 'Arată expeditorul'
 z.string.ro.preferences_options_notifications_on = 'Arată expeditorul și mesajul'
 
 # Search

--- a/app/script/localization/strings-ru.coffee
+++ b/app/script/localization/strings-ru.coffee
@@ -266,6 +266,9 @@ z.string.ru.conversation_context_menu_unlike = 'Не нравится'
 z.string.ru.conversation_delete_timestamp = 'Удалено %@timestamp'
 z.string.ru.conversation_edit_timestamp = 'Изменено %@timestamp'
 z.string.ru.conversation_likes_caption = '%@number участникам'
+z.string.ru.conversation_send_pasted_file = 'Изображение добавлено %date'
+
+# Collection
 
 # Archive
 z.string.ru.archive_header = 'Архив'
@@ -324,7 +327,6 @@ z.string.ru.people_no_matches = 'Совпадений не найдено.\nПо
 z.string.ru.people_invite = 'Пригласить людей'
 z.string.ru.people_share = 'Поделиться контактами'
 z.string.ru.people_bring_your_friends = 'Приведите друзей в Wire'
-z.string.ru.people_invite_detail = 'Предоставление доступа к вашим контактам поможет вам связаться с другими людьми. Вся информация анонимна, мы не предоставляем её третьим лицам.'
 z.string.ru.people_invite_button_contacts = 'Из контактов'
 z.string.ru.people_invite_button_gmail = 'Из Gmail'
 z.string.ru.people_invite_headline = 'Приведите друзей'
@@ -446,7 +448,8 @@ z.string.ru.preferences_options_data_checkbox = 'Отчеты о сбоях и �
 z.string.ru.preferences_options_data_detail = 'Сделайте Wire лучше, отправляя анонимную информацию.'
 z.string.ru.preferences_options_notifications = 'Уведомления'
 z.string.ru.preferences_options_notifications_none = 'Выключены'
-z.string.ru.preferences_options_notifications_obfuscate = 'Скрывать подробности сообщения'
+z.string.ru.preferences_options_notifications_obfuscate = 'Скрывать содержание сообщения'
+z.string.ru.preferences_options_notifications_obfuscate_message = 'Показывать имя отправителя'
 z.string.ru.preferences_options_notifications_on = 'Показывать имя отправителя и текст сообщения'
 
 # Search

--- a/app/script/localization/strings-sl.coffee
+++ b/app/script/localization/strings-sl.coffee
@@ -445,7 +445,8 @@ z.string.sl.preferences_options_data_checkbox = 'Podatki o uporabi in poročila 
 z.string.sl.preferences_options_data_detail = 'Izboljšajte Wire s pošiljanjem anonimnih informacij.'
 z.string.sl.preferences_options_notifications = 'Obvestila'
 z.string.sl.preferences_options_notifications_none = 'Izklopljeno'
-z.string.sl.preferences_options_notifications_obfuscate = 'Skrij podrobnosti sporočila'
+z.string.sl.preferences_options_notifications_obfuscate = 'Skrij podrobnosti'
+z.string.sl.preferences_options_notifications_obfuscate_message = 'Pokaži pošiljatelja'
 z.string.sl.preferences_options_notifications_on = 'Pokaži pošiljatelja in sporočilo'
 
 # Search
@@ -469,6 +470,7 @@ z.string.sl.upload_google_message_error = 'Nismo prejeli vaših podatkov. Prosim
 z.string.sl.upload_google_button_again = 'Poskusite ponovno'
 
 # URLs
+z.string.sl.url_password_reset = 'forgot/'
 z.string.sl.url_terms_of_use = 'https://wire.com/legal/terms/'
 z.string.sl.url_support_calling = 'https://support.wire.com/hc/en-us/articles/202969412'
 z.string.sl.url_support_camera_access_denied = 'https://support.wire.com/hc/en-us/articles/202935412'

--- a/app/script/localization/strings-tr.coffee
+++ b/app/script/localization/strings-tr.coffee
@@ -446,7 +446,8 @@ z.string.tr.preferences_options_data_checkbox = 'Kullanım ve kilitlenme raporla
 z.string.tr.preferences_options_data_detail = 'Anonim bilgiler göndererek Wire’ın daha iyi olmasını sağlayabilirsiniz.'
 z.string.tr.preferences_options_notifications = 'Bildirimler'
 z.string.tr.preferences_options_notifications_none = 'Yok'
-z.string.tr.preferences_options_notifications_obfuscate = 'Mesaj detaylarını gizle'
+z.string.tr.preferences_options_notifications_obfuscate = 'Ayrıntıyı gizle'
+z.string.tr.preferences_options_notifications_obfuscate_message = 'Göndereni göster'
 z.string.tr.preferences_options_notifications_on = 'Göndereni ve mesajı göster'
 
 # Search
@@ -470,6 +471,7 @@ z.string.tr.upload_google_message_error = 'Bilgilerinzi alamadık. Lütfen kişi
 z.string.tr.upload_google_button_again = 'Tekrar deneyin'
 
 # URLs
+z.string.tr.url_password_reset = 'forgot/'
 z.string.tr.url_legal = 'https://wire.com/legal/'
 z.string.tr.url_privacy = 'https://wire.com/privacy/'
 z.string.tr.url_privacy_why = 'https://wire.com/privacy/why/'

--- a/app/script/localization/strings-uk.coffee
+++ b/app/script/localization/strings-uk.coffee
@@ -266,6 +266,9 @@ z.string.uk.conversation_context_menu_unlike = 'Не подобається'
 z.string.uk.conversation_delete_timestamp = 'Видалене: %@timestamp'
 z.string.uk.conversation_edit_timestamp = 'Відредаговане: %@timestamp'
 z.string.uk.conversation_likes_caption = '%@number учасників'
+z.string.uk.conversation_send_pasted_file = 'Надіслав(-ла) зображення %date'
+
+# Collection
 
 # Archive
 z.string.uk.archive_header = 'Архівувати'
@@ -287,7 +290,11 @@ z.string.uk.conversations_popover_silence = 'Вимкнути звук'
 z.string.uk.conversations_popover_unarchive = 'Розархівувати'
 
 # Takeover
+z.string.uk.takeover_headline = 'Ніки вже тут.'
+z.string.uk.takeover_sub = 'Зарезервуйте свій унікальний нік в Wire.'
 z.string.uk.takeover_link = 'Дізнатися більше'
+z.string.uk.takeover_button_choose = 'Вибрати власний'
+z.string.uk.takeover_button_keep = 'Залишити цей'
 
 # Invites
 z.string.uk.invite_meta_key_mac = 'Cmd'
@@ -398,6 +405,9 @@ z.string.uk.preferences_account_reset_password = 'Виконати скидан�
 z.string.uk.preferences_account_delete = 'Видалити акаунт'
 z.string.uk.preferences_account_log_out = 'Вийти'
 z.string.uk.preferences_account_username_placeholder = 'Ваше повне ім’я'
+z.string.uk.preferences_account_username_hint = 'Мінімум 2 символи з множини a—z, 0—9, та _.'
+z.string.uk.preferences_account_username_available = 'Доступний'
+z.string.uk.preferences_account_username_error_taken = 'Уже зарезервований'
 
 z.string.uk.preferences_av_camera = 'Камера'
 z.string.uk.preferences_av_microphone = 'Мікрофон'
@@ -437,7 +447,8 @@ z.string.uk.preferences_options_data_checkbox = 'Статистика викор
 z.string.uk.preferences_options_data_detail = 'Зробіть Wire кращим, відправляючи анонімну інформацію.'
 z.string.uk.preferences_options_notifications = 'Сповіщення'
 z.string.uk.preferences_options_notifications_none = 'Вимкнений'
-z.string.uk.preferences_options_notifications_obfuscate = 'Приховувати деталі повідомлення'
+z.string.uk.preferences_options_notifications_obfuscate = 'Приховати деталі'
+z.string.uk.preferences_options_notifications_obfuscate_message = 'Показувати відправника'
 z.string.uk.preferences_options_notifications_on = 'Показувати відправника та повідомлення'
 
 # Search
@@ -445,8 +456,13 @@ z.string.uk.search_group_hint = 'Спробуйте ще раз або вибе�
 z.string.uk.search_connect = 'Додати до контактів'
 z.string.uk.search_connections = 'Контакти'
 z.string.uk.search_groups = 'Групи'
+z.string.uk.search_placeholder = 'Пошук за іменем або ніком'
 z.string.uk.search_top_people = 'Топ-контакти'
+z.string.uk.search_try_search = 'Шукайте людай\nза іменем або ніком'
+z.string.uk.search_no_contacts_on_wire = 'У вас поки що немає контактів в Wire.\nСпробуйте знайти людей\nза їхніми іменами або ніками.'
 z.string.uk.search_others = 'Додати до контактів'
+z.string.uk.search_friend_in_common = '%no спільний знайомий'
+z.string.uk.search_friends_in_common = '%no спільних знайомих'
 
 # Google contacts upload
 z.string.uk.upload_google_headline = 'Знайдіть людей,\nщоб порозмовляти.'
@@ -456,6 +472,7 @@ z.string.uk.upload_google_message_error = 'Ми не отримали вашу �
 z.string.uk.upload_google_button_again = 'Спробувати ще раз'
 
 # URLs
+z.string.uk.url_password_reset = 'forgot/'
 z.string.uk.url_legal = 'https://wire.com/legal/'
 z.string.uk.url_privacy = 'https://wire.com/privacy/'
 z.string.uk.url_privacy_why = 'https://wire.com/privacy/why/'
@@ -473,6 +490,7 @@ z.string.uk.url_support_mic_access_denied = 'https://support.wire.com/hc/en-us/a
 z.string.uk.url_support_mic_not_found = 'https://support.wire.com/hc/en-us/articles/202970662'
 z.string.uk.url_support_screen_access_denied = 'https://support.wire.com/hc/en-us/articles/202935412'
 z.string.uk.url_support_screen_whitelist = 'https://support.wire.com/hc/en-us/articles/209423889'
+z.string.uk.url_support_usernames = 'https://wire.com/support/username'
 z.string.uk.url_decrypt_error_1 = 'https://wire.com/privacy/error-1'
 z.string.uk.url_decrypt_error_2 = 'https://wire.com/privacy/error-2'
 

--- a/app/script/localization/strings.coffee
+++ b/app/script/localization/strings.coffee
@@ -525,6 +525,7 @@ z.string.warning_connectivity_no_internet = 'No Internet. You won’t be able to
 # Browser notifications
 z.string.system_notification_asset_add = 'Shared a picture'
 z.string.system_notification_connection_accepted = 'Accepted your connection request'
+z.string.system_notification_connection_connected = 'Are now connected'
 z.string.system_notification_connection_request = 'Wants to connect'
 z.string.system_notification_conversation_create = '%s.first_name started a conversation'
 z.string.system_notification_conversation_rename = '%s.first_name renamed the conversation to %name'

--- a/app/script/message/SystemMessageType.coffee
+++ b/app/script/message/SystemMessageType.coffee
@@ -31,5 +31,6 @@ z.message.SystemMessageType =
   CONVERSATION_CREATE: 'created-group'
   CONVERSATION_RENAME: 'rename'
   CONVERSATION_RESUME: 'resume'
-  CONNECTION_REQUEST: 'connecting'
   CONNECTION_ACCEPTED: 'created-one-to-one'
+  CONNECTION_CONNECTED: 'connected'
+  CONNECTION_REQUEST: 'connecting'

--- a/app/script/system_notification/SystemNotificationRepository.coffee
+++ b/app/script/system_notification/SystemNotificationRepository.coffee
@@ -284,6 +284,8 @@ class z.SystemNotification.SystemNotificationRepository
           return @_create_body_member_leave message_et
       when z.message.SystemMessageType.CONNECTION_ACCEPTED
         return z.localization.Localizer.get_text z.string.system_notification_connection_accepted
+      when z.message.SystemMessageType.CONNECTION_CONNECTED
+        return z.localization.Localizer.get_text z.string.system_notification_connection_connected
       when z.message.SystemMessageType.CONNECTION_REQUEST
         return z.localization.Localizer.get_text z.string.system_notification_connection_request
       when z.message.SystemMessageType.CONVERSATION_CREATE

--- a/app/script/user/UserRepository.coffee
+++ b/app/script/user/UserRepository.coffee
@@ -290,7 +290,10 @@ class z.user.UserRepository
         when z.user.ConnectionStatus.PENDING
           message_et.member_message_type = z.message.SystemMessageType.CONNECTION_REQUEST
         when z.user.ConnectionStatus.ACCEPTED
-          message_et.member_message_type = z.message.SystemMessageType.CONNECTION_ACCEPTED
+          if previous_state is z.user.ConnectionStatus.SENT
+            message_et.member_message_type = z.message.SystemMessageType.CONNECTION_ACCEPTED
+          else
+            message_et.member_message_type = z.message.SystemMessageType.CONNECTION_CONNECTED
       amplify.publish z.event.WebApp.SYSTEM_NOTIFICATION.NOTIFY, connection_et, message_et
 
 

--- a/test/unit_tests/system_notification/SystemNotificationRepositorySpec.coffee
+++ b/test/unit_tests/system_notification/SystemNotificationRepositorySpec.coffee
@@ -636,6 +636,19 @@ describe 'z.SystemNotification.SystemNotificationRepository', ->
         done()
       .catch done.fail
 
+    it 'if you are automatically connected', (done) ->
+      message_et.member_message_type = z.message.SystemMessageType.CONNECTION_CONNECTED
+
+      system_notification_repository.notify connection_et, message_et
+      .then ->
+        notification_content.options.body = z.string.system_notification_connection_connected
+
+        result = JSON.stringify system_notification_repository._show_notification.calls.first().args[0]
+        expect(result).toEqual JSON.stringify notification_content
+        expect(system_notification_repository._show_notification).toHaveBeenCalledTimes 1
+        done()
+        .catch done.fail
+
   describe 'shows a well-formed ping notification', ->
     beforeAll ->
       user_et = user_repository.user_mapper.map_user_from_object payload.users.get.one[0]


### PR DESCRIPTION
## Type of change

If we had a new connection due to an auto-connect, the notification triggered would always look like our outgoing request was accepted. This PR fixes this and will show a more generic notification in this case instead that you are connected to a new contact.