### PR TITLE
Properly filter search results based on usernames (WEBAPP-1694, WEBAPP-3462)

### DIFF
--- a/app/script/calling/entities/Flow.coffee
+++ b/app/script/calling/entities/Flow.coffee
@@ -574,7 +574,7 @@ class z.calling.entities.Flow
             outline = undefined
 
         if @negotiation_mode() is z.calling.enum.SDPNegotiationMode.ICE_RESTART or (sdp_source is z.calling.enum.SDPSource.LOCAL and @is_group())
-          if z.util.contains sdp_line, 'opus'
+          if z.util.StringUtil.includes sdp_line, 'opus'
             outlines.push sdp_line
             outline = "a=ptime:#{AUDIO_PTIME}"
             @logger.info "Changed audio p-time in local SDP: #{outline}"
@@ -674,7 +674,7 @@ class z.calling.entities.Flow
   @param ice_candidate [RTCIceCandidate] Received remote ICE candidate
   ###
   add_remote_ice_candidate: (ice_candidate) =>
-    if z.util.contains ice_candidate.candidate, 'end-of-candidates'
+    if z.util.StringUtil.includes ice_candidate.candidate, 'end-of-candidates'
       @logger.info 'Ignoring remote non-candidate'
       return
 
@@ -729,7 +729,7 @@ class z.calling.entities.Flow
   @param ice_candidate [RTCICECandidate] Local ICE candidate to be send
   ###
   _send_ice_candidate: (ice_candidate) ->
-    if not z.util.contains ice_candidate.candidate, 'UDP'
+    unless z.util.StringUtil.includes ice_candidate.candidate, 'UDP'
       return @logger.info "Local ICE candidate ignored as it is not of type 'UDP'"
 
     if @conversation_id and @id

--- a/app/script/components/inputElement.coffee
+++ b/app/script/components/inputElement.coffee
@@ -25,7 +25,7 @@ class z.components.InputElement
     @value = params.value
 
     @change = (data, event) =>
-      new_name = z.util.remove_line_breaks event.target.value.trim()
+      new_name = z.util.StringUtil.remove_line_breaks event.target.value.trim()
       old_name = @value().trim()
       event.target.value = old_name
       @editing false

--- a/app/script/components/userAvatar.coffee
+++ b/app/script/components/userAvatar.coffee
@@ -37,7 +37,7 @@ class z.components.UserAvatar
 
     @initials = ko.pureComputed =>
       if @element.hasClass 'user-avatar-xs'
-        return z.util.get_first_character @user.initials()
+        return z.util.StringUtil.get_first_character @user.initials()
       else
         return @user.initials()
 

--- a/app/script/components/userList.coffee
+++ b/app/script/components/userList.coffee
@@ -73,7 +73,8 @@ class z.components.UserListViewModel
     # filter all list items if a filter is provided
     if @user_filter?
       @filtered_user_ets = ko.pureComputed =>
-        ko.utils.arrayFilter @user_ets(), (user_et) => user_et.matches @user_filter()
+        normalized_query = z.search.SearchRepository.normalize_query @user_filter()
+        ko.utils.arrayFilter(@user_ets(), (user_et) => user_et.matches normalized_query, @user_filter().trim().startsWith '@').slice 0, 30
 
     # check every list item before selection if selected_filter is provided
     if @user_selected_filter?

--- a/app/script/conversation/ConversationRepository.coffee
+++ b/app/script/conversation/ConversationRepository.coffee
@@ -324,14 +324,16 @@ class z.conversation.ConversationRepository
       .filter (conversation_et) ->
         return false if not conversation_et.is_group()
         if is_username
-          return true if z.util.compare_names conversation_et.display_name(), "@#{query}"
-          return true for user_et in conversation_et.participating_user_ets() when z.util.name_starts_with user_et.username(), query
+          return true if z.util.StringUtil.compare_transliteration conversation_et.display_name(), "@#{query}"
+          return true for user_et in conversation_et.participating_user_ets() when z.util.StringUtil.starts_with user_et.username(), query
         else
-          return true if z.util.compare_names conversation_et.display_name(), query
-          return true for user_et in conversation_et.participating_user_ets() when z.util.compare_names user_et.name(), query
+          return true if z.util.StringUtil.compare_transliteration conversation_et.display_name(), query
+          return true for user_et in conversation_et.participating_user_ets() when z.util.StringUtil.compare_transliteration user_et.name(), query
         return false
       .sort (conversation_a, conversation_b) ->
-        return z.util.sort_names conversation_a.display_name(), conversation_b.display_name()
+        if is_username
+          return z.util.StringUtil.sort_by_priority conversation_a.display_name(), conversation_b.display_name(), "#{@query}"
+        return z.util.StringUtil.sort_by_priority conversation_a.display_name(), conversation_b.display_name(), query
 
   ###
   Get the next unarchived conversation.
@@ -339,7 +341,7 @@ class z.conversation.ConversationRepository
   @return [z.entity.Conversation] Next conversation
   ###
   get_next_conversation: (conversation_et) ->
-    return z.util.array_get_next @conversations_unarchived(), conversation_et
+    return z.util.ArrayUtil.get_next_item @conversations_unarchived(), conversation_et
 
   ###
   Get unarchived conversation with the most recent event.

--- a/app/script/conversation/ConversationRepository.coffee
+++ b/app/script/conversation/ConversationRepository.coffee
@@ -320,17 +320,22 @@ class z.conversation.ConversationRepository
   @return [Array<z.entity.Conversation>] Matching group conversations
   ###
   get_groups_by_name: (query, is_username) =>
-    @sorted_conversations().filter (conversation_et) ->
-      return false if not conversation_et.is_group()
-      if is_username
-        return true if z.util.compare_names conversation_et.display_name(), "@#{query}"
-        for user_et in conversation_et.participating_user_ets()
-          return true if user_et.username()?.startsWith query
-      else
-        return true if z.util.compare_names conversation_et.display_name(), query
-        for user_et in conversation_et.participating_user_ets()
-          return true if z.util.compare_names user_et.name(), query
-      return false
+    return @sorted_conversations()
+      .filter (conversation_et) ->
+        return false if not conversation_et.is_group()
+        if is_username
+          return true if z.util.compare_names conversation_et.display_name(), "@#{query}"
+          return true for user_et in conversation_et.participating_user_ets() when user_et.username()?.startsWith query
+        else
+          return true if z.util.compare_names conversation_et.display_name(), query
+          return true for user_et in conversation_et.participating_user_ets() when z.util.compare_names user_et.name(), query
+        return false
+      .sort (conversation_a, conversation_b) ->
+        name_a = conversation_a.display_name().toLowerCase()
+        name_b = conversation_b.display_name().toLowerCase()
+        return -1 if name_a < name_b
+        return 1 if name_a > name_b
+        return 0
 
   ###
   Get the next unarchived conversation.

--- a/app/script/conversation/ConversationRepository.coffee
+++ b/app/script/conversation/ConversationRepository.coffee
@@ -315,15 +315,21 @@ class z.conversation.ConversationRepository
 
   ###
   Get group conversations by name
-  @param group_name [String] Query to be searched in group conversation names
+  @param query [String] Query to be searched in group conversation names
+  @param is_username [Boolean] Query string is username
   @return [Array<z.entity.Conversation>] Matching group conversations
   ###
-  get_groups_by_name: (group_name) =>
+  get_groups_by_name: (query, is_username) =>
     @sorted_conversations().filter (conversation_et) ->
       return false if not conversation_et.is_group()
-      return true if z.util.compare_names conversation_et.display_name(), group_name
-      for user_et in conversation_et.participating_user_ets()
-        return true if z.util.compare_names user_et.name(), group_name
+      if is_username
+        return true if z.util.compare_names conversation_et.display_name(), "@#{query}"
+        for user_et in conversation_et.participating_user_ets()
+          return true if user_et.username()?.startsWith query
+      else
+        return true if z.util.compare_names conversation_et.display_name(), query
+        for user_et in conversation_et.participating_user_ets()
+          return true if z.util.compare_names user_et.name(), query
       return false
 
   ###

--- a/app/script/conversation/ConversationRepository.coffee
+++ b/app/script/conversation/ConversationRepository.coffee
@@ -325,17 +325,13 @@ class z.conversation.ConversationRepository
         return false if not conversation_et.is_group()
         if is_username
           return true if z.util.compare_names conversation_et.display_name(), "@#{query}"
-          return true for user_et in conversation_et.participating_user_ets() when user_et.username()?.startsWith query
+          return true for user_et in conversation_et.participating_user_ets() when z.util.name_starts_with user_et.username(), query
         else
           return true if z.util.compare_names conversation_et.display_name(), query
           return true for user_et in conversation_et.participating_user_ets() when z.util.compare_names user_et.name(), query
         return false
       .sort (conversation_a, conversation_b) ->
-        name_a = conversation_a.display_name().toLowerCase()
-        name_b = conversation_b.display_name().toLowerCase()
-        return -1 if name_a < name_b
-        return 1 if name_a > name_b
-        return 0
+        return z.util.sort_names conversation_a.display_name(), conversation_b.display_name()
 
   ###
   Get the next unarchived conversation.

--- a/app/script/conversation/ConversationRepository.coffee
+++ b/app/script/conversation/ConversationRepository.coffee
@@ -331,9 +331,8 @@ class z.conversation.ConversationRepository
           return true for user_et in conversation_et.participating_user_ets() when z.util.StringUtil.compare_transliteration user_et.name(), query
         return false
       .sort (conversation_a, conversation_b) ->
-        if is_username
-          return z.util.StringUtil.sort_by_priority conversation_a.display_name(), conversation_b.display_name(), "#{@query}"
-        return z.util.StringUtil.sort_by_priority conversation_a.display_name(), conversation_b.display_name(), query
+        sort_query = if is_username then "@#{@query}" else query
+        return z.util.StringUtil.sort_by_priority conversation_a.display_name(), conversation_b.display_name(), sort_query
 
   ###
   Get the next unarchived conversation.

--- a/app/script/entity/Conversation.coffee
+++ b/app/script/entity/Conversation.coffee
@@ -164,12 +164,12 @@ class z.entity.Conversation
     @display_name = ko.pureComputed =>
       if @type() in [z.conversation.ConversationType.CONNECT, z.conversation.ConversationType.ONE2ONE]
         return @participating_user_ets()[0].name() if @participating_user_ets()[0]?.name()
-        return z.localization.Localizer.get_text z.string.truncation
+        return '…'
       else if @is_group()
         return @name() if @name()
         return (@participating_user_ets().map (user_et) -> user_et.first_name()).join ', ' if @participating_user_ets().length > 0
         return z.localization.Localizer.get_text z.string.conversations_empty_conversation if @participating_user_ids().length is 0
-        return z.localization.Localizer.get_text z.string.truncation
+        return '…'
       else
         return @name()
 

--- a/app/script/entity/User.coffee
+++ b/app/script/entity/User.coffee
@@ -90,7 +90,7 @@ class z.entity.User
     @initials = ko.pureComputed =>
       initials = ''
       if @first_name()? and @last_name()?
-        initials = z.util.get_first_character(@first_name()) + z.util.get_first_character(@last_name())
+        initials = z.util.StringUtil.get_first_character(@first_name()) + z.util.StringUtil.get_first_character(@last_name())
       else
         initials = @first_name().slice 0, 2
       return initials.toUpperCase()
@@ -134,5 +134,5 @@ class z.entity.User
   ###
   matches: (query, is_username) =>
     if is_username
-      return z.util.name_starts_with @username(), query
-    return z.util.compare_names(@name(), query) or @username() is query
+      return z.util.StringUtil.starts_with @username(), query
+    return z.util.StringUtil.compare_transliteration(@name(), query) or @username() is query

--- a/app/script/entity/User.coffee
+++ b/app/script/entity/User.coffee
@@ -130,6 +130,9 @@ class z.entity.User
   ###
   Check whether username, name or email matches the given query
   @param query [String]
+  @param is_username [Boolean] Query string is username
   ###
-  matches: (query) =>
+  matches: (query, is_username) =>
+    if is_username
+      return @username()?.startsWith query
     return z.util.compare_names(@name(), query) or @username() is query or @email() is query

--- a/app/script/entity/User.coffee
+++ b/app/script/entity/User.coffee
@@ -134,5 +134,5 @@ class z.entity.User
   ###
   matches: (query, is_username) =>
     if is_username
-      return @username()?.startsWith query
+      return z.util.name_starts_with @username(), query
     return z.util.compare_names(@name(), query) or @username() is query

--- a/app/script/entity/User.coffee
+++ b/app/script/entity/User.coffee
@@ -128,11 +128,11 @@ class z.entity.User
     @devices.remove (client_et) -> client_et.id is client_id
 
   ###
-  Check whether username, name or email matches the given query
+  Check whether username or name matches the given query
   @param query [String]
   @param is_username [Boolean] Query string is username
   ###
   matches: (query, is_username) =>
     if is_username
       return @username()?.startsWith query
-    return z.util.compare_names(@name(), query) or @username() is query or @email() is query
+    return z.util.compare_names(@name(), query) or @username() is query

--- a/app/script/localization/strings-de.coffee
+++ b/app/script/localization/strings-de.coffee
@@ -21,7 +21,6 @@ z.string.de.wire = 'Wire'
 z.string.de.wire_macos = 'Wire für macOS'
 z.string.de.wire_windows = 'Wire für Windows'
 z.string.de.wire_linux = 'Wire für Linux'
-z.string.de.truncation = '…'
 z.string.de.nonexistent_user = 'Gelöschte Person'
 z.string.de.and = 'und'
 

--- a/app/script/localization/strings-hr.coffee
+++ b/app/script/localization/strings-hr.coffee
@@ -20,7 +20,6 @@
 z.string.hr.wire_macos = 'Wire za macOS'
 z.string.hr.wire_windows = 'Wire za Windows'
 z.string.hr.wire_linux = 'Wire za Linux'
-z.string.hr.truncation = '…'
 z.string.hr.nonexistent_user = 'Izbrisani korisnik'
 z.string.hr.and = 'i'
 

--- a/app/script/localization/strings.coffee
+++ b/app/script/localization/strings.coffee
@@ -21,7 +21,6 @@ z.string.wire = 'Wire'
 z.string.wire_macos = 'Wire for macOS'
 z.string.wire_windows = 'Wire for Windows'
 z.string.wire_linux = 'Wire for Linux'
-z.string.truncation = '…'
 z.string.nonexistent_user = 'Deleted User'
 z.string.and = 'and'
 

--- a/app/script/main/app.coffee
+++ b/app/script/main/app.coffee
@@ -409,7 +409,7 @@ class z.main.App
         amplify_objects = amplify.store()
         for amplify_key, amplify_value of amplify_objects
           continue if amplify_key is cookie_label_key and clear_data
-          do_not_delete.push amplify_key if z.util.contains amplify_key, z.storage.StorageKey.AUTH.COOKIE_LABEL
+          do_not_delete.push amplify_key if z.util.StringUtil.includes amplify_key, z.storage.StorageKey.AUTH.COOKIE_LABEL
 
         @repository.cache.clear_cache session_expired, do_not_delete
 

--- a/app/script/media/MediaDevicesHandler.coffee
+++ b/app/script/media/MediaDevicesHandler.coffee
@@ -171,7 +171,7 @@ class z.media.MediaDevicesHandler
     @get_media_devices()
     .then =>
       [current_device, current_index] = @_get_current_device @available_devices.video_input(), @current_device_id.video_input()
-      next_device = @available_devices.video_input()[z.util.iterate_array_index(@available_devices.video_input(), @current_device_index.video_input()) or 0]
+      next_device = @available_devices.video_input()[z.util.ArrayUtil.iterate_index(@available_devices.video_input(), @current_device_index.video_input()) or 0]
       @current_device_id.video_input next_device.deviceId
       @logger.info "Switching the active camera from '#{current_device.label or current_device.deviceId}' to '#{next_device.label or next_device.deviceId}'"
 
@@ -180,7 +180,7 @@ class z.media.MediaDevicesHandler
     @get_screen_sources()
     .then =>
       [current_device, current_index] = @_get_current_device @available_devices.screen_input(), @current_device_id.screen_input()
-      next_device = @available_devices.screen_input()[z.util.iterate_array_index(@available_devices.screen_input(), @current_device_index.screen_input()) or 0]
+      next_device = @available_devices.screen_input()[z.util.ArrayUtil.iterate_index(@available_devices.screen_input(), @current_device_index.screen_input()) or 0]
       @current_device_id.screen_input next_device.id
       @logger.info "Switching the active screen from '#{current_device.name or current_device.id}' to '#{next_device.name or next_device.id}'"
 

--- a/app/script/media/MediaEmbeds.coffee
+++ b/app/script/media/MediaEmbeds.coffee
@@ -51,7 +51,7 @@ z.media.MediaEmbeds = do ->
     if z.util.Environment.electron
       opt.allowfullscreen = ''
 
-    return z.util.string_format iframe_container, opt.class, opt.width, opt.height, opt.src, opt.frameborder, opt.allowfullscreen
+    return z.util.StringUtil.format iframe_container, opt.class, opt.width, opt.height, opt.src, opt.frameborder, opt.allowfullscreen
 
   # Enum of different regex for the supported services.
   _regex =
@@ -155,7 +155,7 @@ z.media.MediaEmbeds = do ->
         video: false
         height: height
 
-      embed = z.util.string_format iframe, height, link_src
+      embed = z.util.StringUtil.format iframe, height, link_src
       message = _append_iframe link, message, embed
 
     return message
@@ -200,7 +200,7 @@ z.media.MediaEmbeds = do ->
     vimeo_color = theme_color?.replace '#', ''
 
     if link_src.match _regex.vimeo
-      return message if z.util.contains link_src, '/user'
+      return message if z.util.StringUtil.includes link_src, '/user'
 
       iframe = _create_iframe_container
         src: "https://player.vimeo.com/video/$1?portrait=0&color=#{vimeo_color}&badge=0"

--- a/app/script/search/SearchRepository.coffee
+++ b/app/script/search/SearchRepository.coffee
@@ -22,6 +22,14 @@ z.search ?= {}
 # Search repository for all interactions with the search service.
 class z.search.SearchRepository
   ###
+  Trim and remove @.
+  @param query [String] Search string
+  ###
+  @normalize_query: (query) ->
+    return '' unless _.isString query
+    return query.trim().replace /^[@]/, ''
+
+  ###
   Construct a new Conversation Repository.
   @param search_service [z.search.SearchService] Backend REST API search service implementation
   @param user_repository [z.user.UserRepository] Repository for all user and connection interactions
@@ -81,13 +89,6 @@ class z.search.SearchRepository
     @search_result_mapper.map_results response.results, z.search.SEARCH_MODE.ONBOARDING
     .then ([search_ets, mode]) =>
       return @_prepare_search_result search_ets, mode
-
-  ###
-  Trim and remove @.
-  @param query [String]
-  ###
-  normalize_search_query: (query) ->
-    return query.trim().replace /^[@]/, ''
 
   ###
   Preparing the search results for display.

--- a/app/script/system_notification/SystemNotificationRepository.coffee
+++ b/app/script/system_notification/SystemNotificationRepository.coffee
@@ -172,7 +172,7 @@ class z.SystemNotification.SystemNotificationRepository
   _create_body_content: (message_et) ->
     if message_et.has_asset_text()
       for asset_et in message_et.assets() when asset_et.is_text()
-        return z.util.truncate_text asset_et.text, z.config.BROWSER_NOTIFICATION.BODY_LENGTH if not asset_et.previews().length
+        return z.util.StringUtil.truncate asset_et.text, z.config.BROWSER_NOTIFICATION.BODY_LENGTH if not asset_et.previews().length
     else if message_et.has_asset_image()
       return  z.localization.Localizer.get_text z.string.system_notification_asset_add
     else if message_et.has_asset_location()
@@ -439,10 +439,10 @@ class z.SystemNotification.SystemNotificationRepository
   _create_title: (conversation_et, message_et) ->
     if conversation_et.display_name?()
       if conversation_et.is_group()
-        return  z.util.truncate_text "#{message_et.user().first_name()} in #{conversation_et.display_name()}", z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
-      return z.util.truncate_text conversation_et.display_name(), z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
+        return z.util.StringUtil.truncate "#{message_et.user().first_name()} in #{conversation_et.display_name()}", z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
+      return z.util.StringUtil.truncate conversation_et.display_name(), z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
     return Raygun.send new Error 'Message does not contain user info' if not message_et.user()
-    return z.util.truncate_text message_et.user().name(), z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
+    return z.util.StringUtil.truncate message_et.user().name(), z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
 
   ###
   Create obfuscated title.
@@ -450,7 +450,7 @@ class z.SystemNotification.SystemNotificationRepository
   @return [String] Obfuscated notification message title
   ###
   _create_title_obfuscated: ->
-    return z.util.truncate_text z.localization.Localizer.get_text(z.string.system_notification_obfuscated_title), z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
+    return z.util.StringUtil.truncate z.localization.Localizer.get_text(z.string.system_notification_obfuscated_title), z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
 
   ###
   Creates the notification trigger.

--- a/app/script/tracking/EventTrackingRepository.coffee
+++ b/app/script/tracking/EventTrackingRepository.coffee
@@ -221,7 +221,7 @@ class z.tracking.EventTrackingRepository
 
   _localytics_disabled: ->
     if not z.util.get_url_parameter z.auth.URLParameter.LOCALYTICS
-      for domain in LOCALYTICS.DISABLED_DOMAINS when z.util.contains window.location.hostname, domain
+      for domain in LOCALYTICS.DISABLED_DOMAINS when z.util.StringUtil.includes window.location.hostname, domain
         @logger.debug 'Localytics reporting is disabled due to domain'
         return true
     return false

--- a/app/script/ui/Shortcut.coffee
+++ b/app/script/ui/Shortcut.coffee
@@ -159,7 +159,7 @@ z.ui.Shortcut = do ->
   _register_event = (platform_specific_shortcut, event) ->
 
     # bind also 'command + alt + n' for start shortcut
-    if z.util.contains platform_specific_shortcut, 'graveaccent'
+    if z.util.StringUtil.includes platform_specific_shortcut, 'graveaccent'
       replaced_shortcut = platform_specific_shortcut.replace 'graveaccent', 'n'
       _register_event replaced_shortcut, event
 
@@ -167,7 +167,7 @@ z.ui.Shortcut = do ->
       keyboardJS.releaseKey e.keyCode
 
       # hotfix WEBAPP-1916
-      return if (z.util.contains(platform_specific_shortcut, 'command') and not e.metaKey)
+      return if z.util.StringUtil.includes(platform_specific_shortcut, 'command') and not e.metaKey
 
       e.preventDefault()
       amplify.publish event
@@ -189,7 +189,7 @@ z.ui.Shortcut = do ->
       .replace 'up', '↑'
       .replace 'down', '↓'
       .replace 'graveaccent', 'n'
-      .replace /\w+/g, (string) -> z.util.capitalize_first_char string
+      .replace /\w+/g, (string) -> z.util.StringUtil.capitalize_first_char string
 
   get_shortcut = (shortcut_name) ->
     platform = if z.util.Environment.electron then 'electron' else 'webapp'

--- a/app/script/user/UserRepository.coffee
+++ b/app/script/user/UserRepository.coffee
@@ -369,7 +369,7 @@ class z.user.UserRepository
 
     # create chunks
     fetched_user_ets = []
-    chunks = z.util.array_chunks user_ids, z.config.MAXIMUM_USERS_PER_REQUEST
+    chunks = z.util.ArrayUtil.chunk user_ids, z.config.MAXIMUM_USERS_PER_REQUEST
     number_of_loaded_chunks = 0
 
     for chunk in chunks
@@ -466,7 +466,9 @@ class z.user.UserRepository
         return false if not user_et.connected()
         return user_et.matches query, is_username
       .sort (user_a, user_b) ->
-        return z.util.sort_names user_a.name(), user_b.name()
+        if is_username
+          return z.util.StringUtil.sort_by_priority user_a.username(), user_b.username(), query
+        return z.util.StringUtil.sort_by_priority user_a.name(), user_b.name(), query
 
   ###
   Is the user the logged in user.

--- a/app/script/user/UserRepository.coffee
+++ b/app/script/user/UserRepository.coffee
@@ -457,13 +457,14 @@ class z.user.UserRepository
   ###
   Search for user.
   @param query [String] Find user using name, username or email
+  @param is_username [Boolean] Query string is username
   @return [Array<z.entity.User>] Matching users
   ###
-  search_for_connected_users: (query) =>
+  search_for_connected_users: (query, is_username) =>
     return @users()
       .filter (user_et) ->
         return false if not user_et.connected()
-        return user_et.matches query
+        return user_et.matches query, is_username
       .sort (user_a, user_b) ->
         name_a = user_a.name().toLowerCase()
         name_b = user_b.name().toLowerCase()

--- a/app/script/user/UserRepository.coffee
+++ b/app/script/user/UserRepository.coffee
@@ -466,11 +466,7 @@ class z.user.UserRepository
         return false if not user_et.connected()
         return user_et.matches query, is_username
       .sort (user_a, user_b) ->
-        name_a = user_a.name().toLowerCase()
-        name_b = user_b.name().toLowerCase()
-        return -1 if name_a < name_b
-        return 1 if name_a > name_b
-        return 0
+        return z.util.sort_names user_a.name(), user_b.name()
 
   ###
   Is the user the logged in user.

--- a/app/script/user/UserRepository.coffee
+++ b/app/script/user/UserRepository.coffee
@@ -456,7 +456,7 @@ class z.user.UserRepository
 
   ###
   Search for user.
-  @param query [String] Find user using name, username or email
+  @param query [String] Find user using name or username
   @param is_username [Boolean] Query string is username
   @return [Array<z.entity.User>] Matching users
   ###

--- a/app/script/util/ArrayUtil.coffee
+++ b/app/script/util/ArrayUtil.coffee
@@ -18,55 +18,83 @@
 
 window.z ?= {}
 z.util ?= {}
-z.util.ArrayUtil ?= {}
 
-###
-Returns random element
 
-@param array [Array] source
-@return [Object] random element
-###
-z.util.ArrayUtil.random_element = (array) ->
-  array[Math.floor(Math.random() * array.length)]
+z.util.ArrayUtil =
+  # returns chunks of the given size
+  chunk: (array, size) ->
+    chunks = []
+    temp_array = [].concat array
+    while temp_array.length
+      chunks.push temp_array.splice 0, size
+    return chunks
 
-###
-Remove given element from array
+  find_closest: (array, value) ->
+    closest = array[0]
+    array.forEach (current) ->
+      closest = current if value >= current
+    return closest
 
-@param array [Array] source
-@return [Array|undefined] containing the removed element
-###
-z.util.ArrayUtil.remove_element = (array, element) ->
-  index = array.indexOf element
-  array.splice index, 1 if index > -1
+  get_next_item: (array, item, filter) ->
+    index = array.indexOf item
+    next_index = index + 1
 
-z.util.ArrayUtil.contains = (array, value) ->
-  return array.indexOf(value) > -1
+    # couldn't find the item
+    return null if index is -1
 
-z.util.ArrayUtil.find_closest = (array, value) ->
-  closest = array[0]
-  array.forEach (current) ->
-    closest = current if value >= current
-  return closest
+    # item is last item in the array
+    return array[index - 1] if next_index is array.length and index > 0
 
-###
-Interpolates an array of numbers using linear interpolation
+    return if next_index >= array.length
 
-@param array [Array] source
-@param length [Number] new length
-@return [Array] new array with interpolated values
-###
-z.util.ArrayUtil.interpolate = (array, length) ->
-  new_array = []
-  scale_factor = (array.length - 1) / (length - 1)
+    for i in [next_index..array.length]
+      current_item = array[i]
+      return current_item unless filter? and not filter current_item
 
-  new_array[0] = array[0]
-  new_array[length - 1] = array[array.length - 1]
+  ###
+  Interpolates an array of numbers using linear interpolation
 
-  for i in [1...length - 1]
-    original_index = i * scale_factor
-    before = Math.floor(original_index).toFixed()
-    after = Math.ceil(original_index).toFixed()
-    point = original_index - before
-    new_array[i] = array[before] + (array[after] - array[before]) * point # linear interpolation
+  @param array [Array] source
+  @param length [Number] new length
+  @return [Array] new array with interpolated values
+  ###
+  interpolate: (array, length) ->
+    new_array = []
+    scale_factor = (array.length - 1) / (length - 1)
 
-  return new_array
+    new_array[0] = array[0]
+    new_array[length - 1] = array[array.length - 1]
+
+    for i in [1...length - 1]
+      original_index = i * scale_factor
+      before = Math.floor(original_index).toFixed()
+      after = Math.ceil(original_index).toFixed()
+      point = original_index - before
+      new_array[i] = array[before] + (array[after] - array[before]) * point # linear interpolation
+
+    return new_array
+
+  is_last_item: (array, item) ->
+    return array.indexOf(item) is array.length - 1
+
+  iterate_index: (array, current_index) ->
+    return undefined if not _.isArray(array) or not _.isNumber current_index
+    return undefined if not array.length
+    return (current_index + 1) % array.length
+
+  ###
+  Returns random element
+  @param array [Array] source
+  @return [Object] random element
+  ###
+  random_element: (array = []) ->
+    return array[Math.floor(Math.random() * array.length)]
+
+  ###
+  Remove given element from array
+  @param array [Array] source
+  @return [Array|undefined] containing the removed element
+  ###
+  remove_element: (array = [], element) ->
+    index = array.indexOf element
+    array.splice index, 1 if index > -1

--- a/app/script/util/StringUtil.coffee
+++ b/app/script/util/StringUtil.coffee
@@ -18,7 +18,32 @@
 
 window.z ?= {}
 z.util ?= {}
+
+
 z.util.StringUtil =
+  capitalize_first_char: (string = '') ->
+    return "#{string.charAt(0).toUpperCase()}#{string.substring 1}"
+
+  compare_transliteration: (name_a, name_b) ->
+    return z.util.StringUtil.includes window.getSlug(name_a), window.getSlug name_b
+
+  format: ->
+    string = arguments[0]
+    for index in [0...arguments.length]
+      reg = new RegExp "\\{#{index}\\}", 'gm'
+      string = string.replace reg, arguments[++index]
+    return string
+
+  get_first_character: (string) ->
+    reg = new RegExp /([\uE000-\uF8FF]|\uD83C[\uDF00-\uDFFF]|\uD83D[\uDC00-\uDDFF])/
+    find_emoji_in_string = reg.exec string
+    if find_emoji_in_string and find_emoji_in_string.index is 0
+      return find_emoji_in_string[0]
+    return string[0]
+
+  includes: (string = '', query = '') ->
+    return string.toLowerCase().includes query.toLowerCase()
+
   obfuscate: (text) ->
     alphabet = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'x', 'y', 'z']
     obfuscated = ''
@@ -30,3 +55,33 @@ z.util.StringUtil =
         obfuscated += z.util.ArrayUtil.random_element alphabet
 
     return obfuscated
+
+  remove_line_breaks: (string = '') ->
+    return string.replace /(\r\n|\n|\r)/gm, ''
+
+  sort_by_priority: (string_a = '', string_b = '', query) ->
+    string_a = string_a.toLowerCase()
+    string_b = string_b.toLowerCase()
+
+    if query
+      if z.util.StringUtil.starts_with string_a, query
+        return -1 unless z.util.StringUtil.starts_with string_b, query
+      else if z.util.StringUtil.starts_with string_b, query
+        return 1 unless z.util.StringUtil.starts_with string_a, query
+    return -1 if string_a < string_b
+    return 1 if string_a > string_b
+    return 0
+
+  starts_with: (string = '', query) ->
+    return string.toLowerCase().startsWith query.toLowerCase()
+
+  trim_line_breaks: (string = '') ->
+    return string.replace /^\s+|\s+$/g, ''
+
+  truncate: (string, output_length, word_boundary = true) ->
+    if string.length > output_length
+      trunc_index = output_length - 1
+      if word_boundary and string.lastIndexOf(' ', output_length - 1) > output_length - 25
+        trunc_index = string.lastIndexOf ' ', output_length - 1
+      string = "#{string.substr 0, trunc_index}#{z.localization.Localizer.get_text z.string.truncation}"
+    return string

--- a/app/script/util/StringUtil.coffee
+++ b/app/script/util/StringUtil.coffee
@@ -83,5 +83,5 @@ z.util.StringUtil =
       trunc_index = output_length - 1
       if word_boundary and string.lastIndexOf(' ', output_length - 1) > output_length - 25
         trunc_index = string.lastIndexOf ' ', output_length - 1
-      string = "#{string.substr 0, trunc_index}#{z.localization.Localizer.get_text z.string.truncation}"
+      string = "#{string.substr 0, trunc_index}…"
     return string

--- a/app/script/util/util.coffee
+++ b/app/script/util/util.coffee
@@ -628,8 +628,25 @@ z.util.get_first_name = (user_et, declension = z.string.Declension.NOMINATIVE) -
   return user_et.first_name()
 
 
+z.util.name_starts_with = (name = '', query) ->
+  return name.toLowerCase().startsWith query.toLowerCase()
+
+
 z.util.compare_names = (name_a, name_b) ->
-  z.util.contains window.getSlug(name_a), window.getSlug(name_b)
+  return z.util.contains window.getSlug(name_a), window.getSlug(name_b)
+
+
+z.util.sort_names = (name_a, name_b) ->
+  name_a = name_a.toLowerCase()
+  name_b = name_b.toLowerCase()
+
+  if z.util.name_starts_with name_a, query
+    return -1 unless z.util.name_starts_with name_b, query
+  else if z.util.name_starts_with name_b, query
+    return 1 unless z.util.name_starts_with name_a, query
+  return -1 if name_a < name_b
+  return 1 if name_a > name_b
+  return 0
 
 
 z.util.capitalize_first_char = (s) ->

--- a/app/script/util/util.coffee
+++ b/app/script/util/util.coffee
@@ -37,12 +37,6 @@ z.util.is_same_location = (past_location, current_location) ->
   return past_location isnt '' and current_location.startsWith past_location
 
 
-z.util.iterate_array_index = (array, current_index) ->
-  return undefined if not _.isArray(array) or not _.isNumber current_index
-  return undefined if not array.length
-  return (current_index + 1) % array.length
-
-
 z.util.load_image = (blob) ->
   return new Promise (resolve, reject) ->
     object_url = window.URL.createObjectURL blob
@@ -85,7 +79,7 @@ z.util.load_url_blob = (url) ->
 
 
 z.util.append_url_parameter = (url, param) ->
-  separator = if z.util.contains url, '?' then '&' else '?'
+  separator = if z.util.StringUtil.includes url, '?' then '&' else '?'
   return "#{url}#{separator}#{param}"
 
 
@@ -427,57 +421,6 @@ z.util.sort_object_by_keys = (object, reverse) ->
 
   return sorted_object
 
-z.util.sort_user_by_first_name = (user_a, user_b) ->
-  name_a = user_a.first_name().toLowerCase()
-  name_b = user_b.first_name().toLowerCase()
-  return -1 if name_a < name_b
-  return 1 if name_a > name_b
-  return 0
-
-
-z.util.remove_line_breaks = (string) ->
-  string.replace /(\r\n|\n|\r)/gm, ''
-
-
-z.util.trim_line_breaks = (string) ->
-  string.replace /^\s+|\s+$/g, ''
-
-
-z.util.contains = (string = '', query) ->
-  string = string.toLowerCase()
-  query = query.toLowerCase()
-  return string.indexOf(query) isnt -1
-
-
-z.util.array_get_next = (array, item, filter) ->
-  index = array.indexOf item
-  next_index = index + 1
-
-  # couldn't find the item
-  return null if index is -1
-
-  # item is last item in the array
-  return array[index - 1] if next_index is array.length and index > 0
-
-  return if next_index >= array.length
-
-  for i in [next_index..array.length]
-    current_item = array[i]
-    return current_item unless filter? and not filter current_item
-
-
-z.util.array_is_last = (array, item) ->
-  return array.indexOf(item) is array.length - 1
-
-
-# returns chunks of the given size
-z.util.array_chunks = (array, size) ->
-  chunks = []
-  temp_array = [].concat array
-  while temp_array.length
-    chunks.push temp_array.splice 0, size
-  return chunks
-
 
 # This will remove url(' and url(" from the beginning of the string.
 # It will also remove ") and ') from the end if present.
@@ -504,15 +447,6 @@ z.util.valid_profile_image_size = (file, min_width, min_height, callback) ->
   image.src = window.URL.createObjectURL file
 
 
-z.util.truncate_text = (text, output_length, word_boundary = true) ->
-  if text.length > output_length
-    trunc_index = output_length - 1
-    if word_boundary and text.lastIndexOf(' ', output_length - 1) > output_length - 25
-      trunc_index = text.lastIndexOf ' ', output_length - 1
-    text = "#{text.substr 0, trunc_index}#{z.localization.Localizer.get_text z.string.truncation}"
-  return text
-
-
 z.util.is_valid_email = (email) ->
   re = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
   return re.test email
@@ -533,22 +467,6 @@ z.util.is_valid_phone_number = (phone_number) ->
     regular_expression = /^\+[0-9]\d{1,14}$/
   return regular_expression.test phone_number
 
-
-z.util.get_first_character = (string) ->
-  re = new RegExp /([\uE000-\uF8FF]|\uD83C[\uDF00-\uDFFF]|\uD83D[\uDC00-\uDDFF])/
-  find_emoji_in_string = re.exec string
-  if find_emoji_in_string and find_emoji_in_string.index is 0
-    return find_emoji_in_string[0]
-  else
-    return string[0]
-
-
-z.util.string_format = ->
-  s = arguments[0]
-  for i in [0...arguments.length]
-    reg = new RegExp "\\{#{i}\\}", 'gm'
-    s = s.replace reg, arguments[++i]
-  return s
 
 ###
 JS Implementation of MurmurHash3 (r136) (as of May 20, 2011)
@@ -626,31 +544,6 @@ z.util.get_first_name = (user_et, declension = z.string.Declension.NOMINATIVE) -
     else if declension is z.string.Declension.ACCUSATIVE
       return z.localization.Localizer.get_text z.string.conversation_you_accusative
   return user_et.first_name()
-
-
-z.util.name_starts_with = (name = '', query) ->
-  return name.toLowerCase().startsWith query.toLowerCase()
-
-
-z.util.compare_names = (name_a, name_b) ->
-  return z.util.contains window.getSlug(name_a), window.getSlug(name_b)
-
-
-z.util.sort_names = (name_a, name_b) ->
-  name_a = name_a.toLowerCase()
-  name_b = name_b.toLowerCase()
-
-  if z.util.name_starts_with name_a, query
-    return -1 unless z.util.name_starts_with name_b, query
-  else if z.util.name_starts_with name_b, query
-    return 1 unless z.util.name_starts_with name_a, query
-  return -1 if name_a < name_b
-  return 1 if name_a > name_b
-  return 0
-
-
-z.util.capitalize_first_char = (s) ->
-  return "#{s.charAt(0).toUpperCase()}#{s.substring 1}"
 
 
 z.util.print_devices_id = (id) ->

--- a/app/script/view_model/ConversationInputViewModel.coffee
+++ b/app/script/view_model/ConversationInputViewModel.coffee
@@ -251,7 +251,7 @@ class z.ViewModel.ConversationInputViewModel
     if @pasted_file()?
       return @on_send_pasted_files()
 
-    message = z.util.trim_line_breaks @input()
+    message = z.util.StringUtil.trim_line_breaks @input()
 
     if message.length > z.config.MAXIMUM_MESSAGE_LENGTH
       amplify.publish z.event.WebApp.WARNING.MODAL, z.ViewModel.ModalType.TOO_LONG_MESSAGE,

--- a/app/script/view_model/ParticipantsViewModel.coffee
+++ b/app/script/view_model/ParticipantsViewModel.coffee
@@ -42,7 +42,7 @@ class z.ViewModel.ParticipantsViewModel
     ko.computed =>
       conversation_et = @conversation()
       participants = [].concat conversation_et.participating_user_ets()
-      participants.sort z.util.sort_user_by_first_name
+      participants.sort (user_a, user_b) -> z.util.StringUtil.sort_by_priority user_a.first_name(), user_b.first_name()
 
       @participants participants
       @participants_verified (user_et for user_et in participants when user_et.is_verified())
@@ -80,7 +80,7 @@ class z.ViewModel.ParticipantsViewModel
         is_participant = ko.utils.arrayFirst @participants(), (participant) -> user_et.id is participant.id
         is_connected = user_et.connection().status() is z.user.ConnectionStatus.ACCEPTED
         return is_participant is null and is_connected
-      connected_users.sort z.util.sort_user_by_first_name
+      connected_users.sort (user_a, user_b) -> z.util.StringUtil.sort_by_priority user_a.first_name(), user_b.first_name()
     , @, deferEvaluation: true
 
     @add_people_tooltip = z.localization.Localizer.get_text
@@ -155,7 +155,7 @@ class z.ViewModel.ParticipantsViewModel
     @user_profile user_et
 
   rename_conversation: (data, event) =>
-    new_name = z.util.remove_line_breaks event.target.value.trim()
+    new_name = z.util.StringUtil.remove_line_breaks event.target.value.trim()
     old_name = @conversation().display_name().trim()
     event.target.value = old_name
     @editing false

--- a/app/script/view_model/content/ConnectRequestsViewModel.coffee
+++ b/app/script/view_model/content/ConnectRequestsViewModel.coffee
@@ -54,5 +54,5 @@ class z.ViewModel.content.ConnectRequestsViewModel
   @param request [z.entity.User] Rendered connection request
   ###
   after_render: (elements, request) =>
-    if z.util.array_is_last @connect_requests(), request
+    if z.util.ArrayUtil.is_last_item @connect_requests(), request
       window.requestAnimationFrame -> $('.connect-requests').scroll_to_bottom()

--- a/app/script/view_model/list/StartUIViewModel.coffee
+++ b/app/script/view_model/list/StartUIViewModel.coffee
@@ -45,7 +45,7 @@ class z.ViewModel.list.StartUIViewModel
       .then (user_ets) =>
         return unless normalized_query is z.search.SearchRepository.normalize_query @search_input()
         if is_username
-          user_ets = user_ets.filter (user_et) -> return user_et.username()?.startsWith normalized_query
+          user_ets = user_ets.filter (user_et) -> return z.util.name_starts_with user_et.username(), normalized_query
         @search_results.others user_ets
       .catch (error) =>
         @logger.error "Error searching for contacts: #{error.message}", error

--- a/app/script/view_model/list/StartUIViewModel.coffee
+++ b/app/script/view_model/list/StartUIViewModel.coffee
@@ -45,7 +45,7 @@ class z.ViewModel.list.StartUIViewModel
       .then (user_ets) =>
         return unless normalized_query is z.search.SearchRepository.normalize_query @search_input()
         if is_username
-          user_ets = user_ets.filter (user_et) -> return z.util.name_starts_with user_et.username(), normalized_query
+          user_ets = user_ets.filter (user_et) -> return z.util.StringUtil.starts_with user_et.username(), normalized_query
         @search_results.others user_ets
       .catch (error) =>
         @logger.error "Error searching for contacts: #{error.message}", error

--- a/app/script/view_model/list/StartUIViewModel.coffee
+++ b/app/script/view_model/list/StartUIViewModel.coffee
@@ -34,27 +34,25 @@ class z.ViewModel.list.StartUIViewModel
     @logger = new z.util.Logger 'z.ViewModel.list.StartUIViewModel', z.config.LOGGER.OPTIONS
 
     @search = _.debounce (query) =>
-      query = @search_repository.normalize_search_query query
-      if query
-        @clear_search_results()
+      normalized_query = z.search.SearchRepository.normalize_query query
+      return unless normalized_query
+      @clear_search_results()
 
-        # contacts
-        @search_results.contacts @user_repository.search_for_connected_users query
+      # Contacts, groups and others
+      is_username = query.trim().startsWith '@'
 
-        # search for groups
-        @search_results.groups @conversation_repository.get_groups_by_name query
+      @search_repository.search_by_name normalized_query
+      .then (user_ets) =>
+        return unless normalized_query is z.search.SearchRepository.normalize_query @search_input()
+        if is_username
+          user_ets = user_ets.filter (user_et) -> return user_et.username()?.startsWith normalized_query
+        @search_results.others user_ets
+      .catch (error) =>
+        @logger.error "Error searching for contacts: #{error.message}", error
+      @search_results.contacts @user_repository.search_for_connected_users normalized_query, is_username
+      @search_results.groups @conversation_repository.get_groups_by_name normalized_query, is_username
 
-        # search for others
-        @search_repository.search_by_name query
-        .then (user_ets) =>
-          if query is @search_repository.normalize_search_query @search_input()
-            @search_results.others user_ets
-          else
-            @logger.info "Resolved Search query #{query} is outdated"
-        .catch (error) =>
-          @logger.error "Error searching for contacts: #{error.message}", error
-
-        @searched_for_user query
+      @searched_for_user query
     , 300
 
     @searched_for_user = _.once (query) ->

--- a/test/unit_tests/entity/ConversationSpec.coffee
+++ b/test/unit_tests/entity/ConversationSpec.coffee
@@ -183,10 +183,10 @@ describe 'Conversation', ->
 
     it 'displays a fallback if no user name has been set', ->
       conversation_et.type z.conversation.ConversationType.ONE2ONE
-      expect(conversation_et.display_name()).toBe z.string.truncation
+      expect(conversation_et.display_name()).toBe '…'
 
       conversation_et.type z.conversation.ConversationType.CONNECT
-      expect(conversation_et.display_name()).toBe z.string.truncation
+      expect(conversation_et.display_name()).toBe '…'
 
     it 'displays a group conversation name with names from the participants', ->
       third_user = new z.entity.User z.util.create_random_uuid()
@@ -208,7 +208,7 @@ describe 'Conversation', ->
       conversation_et.participating_user_ids.push other_user.id
       conversation_et.participating_user_ids.push user.id
 
-      expect(conversation_et.display_name()).toBe z.string.truncation
+      expect(conversation_et.display_name()).toBe '…'
 
     it 'displays the conversation name for a self conversation', ->
       conversation_et.type z.conversation.ConversationType.SELF

--- a/test/unit_tests/system_notification/SystemNotificationRepositorySpec.coffee
+++ b/test/unit_tests/system_notification/SystemNotificationRepositorySpec.coffee
@@ -159,7 +159,7 @@ describe 'z.SystemNotification.SystemNotificationRepository', ->
 
         system_notification_repository.notify conversation_et, message_et
         .then ->
-          notification_content.title = z.string.truncation
+          notification_content.title = '…'
 
           result = JSON.stringify system_notification_repository._show_notification.calls.first().args[0]
           expect(result).toEqual JSON.stringify notification_content
@@ -193,7 +193,7 @@ describe 'z.SystemNotification.SystemNotificationRepository', ->
 
         system_notification_repository.notify conversation_et, message_et
         .then ->
-          notification_content.title = z.string.truncation
+          notification_content.title = '…'
 
           result = JSON.stringify system_notification_repository._show_notification.calls.first().args[0]
           expect(result).toEqual JSON.stringify notification_content
@@ -231,7 +231,7 @@ describe 'z.SystemNotification.SystemNotificationRepository', ->
 
         system_notification_repository.notify conversation_et, message_et
         .then ->
-          notification_content.title = z.string.truncation
+          notification_content.title = '…'
 
           result = JSON.stringify system_notification_repository._show_notification.calls.first().args[0]
           expect(result).toEqual JSON.stringify notification_content
@@ -290,7 +290,7 @@ describe 'z.SystemNotification.SystemNotificationRepository', ->
 
         system_notification_repository.notify conversation_et, message_et
         .then ->
-          notification_content.title = z.string.truncation
+          notification_content.title = '…'
 
           result = JSON.stringify system_notification_repository._show_notification.calls.first().args[0]
           expect(result).toEqual JSON.stringify notification_content
@@ -349,7 +349,7 @@ describe 'z.SystemNotification.SystemNotificationRepository', ->
 
         system_notification_repository.notify conversation_et, message_et
         .then ->
-          notification_content.title = z.string.truncation
+          notification_content.title = '…'
 
           result = JSON.stringify system_notification_repository._show_notification.calls.first().args[0]
           expect(result).toEqual JSON.stringify notification_content
@@ -664,7 +664,7 @@ describe 'z.SystemNotification.SystemNotificationRepository', ->
 
       system_notification_repository.notify conversation_et, message_et
       .then ->
-        notification_content.title = z.string.truncation
+        notification_content.title = '…'
 
         result = JSON.stringify system_notification_repository._show_notification.calls.first().args[0]
         expect(result).toEqual JSON.stringify notification_content

--- a/test/unit_tests/system_notification/SystemNotificationRepositorySpec.coffee
+++ b/test/unit_tests/system_notification/SystemNotificationRepositorySpec.coffee
@@ -40,7 +40,7 @@ describe 'z.SystemNotification.SystemNotificationRepository', ->
 
       # Notification
       notification_content =
-        title: z.util.truncate_text conversation_et.display_name(), z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
+        title: z.util.StringUtil.truncate conversation_et.display_name(), z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
         options:
           body: ''
           data:
@@ -171,7 +171,7 @@ describe 'z.SystemNotification.SystemNotificationRepository', ->
         system_notification_repository.notify conversation_et, message_et
         .then ->
           title = "#{message_et.user().first_name()} in #{conversation_et.display_name()}"
-          notification_content.title = z.util.truncate_text title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
+          notification_content.title = z.util.StringUtil.truncate title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
 
           result = JSON.stringify system_notification_repository._show_notification.calls.first().args[0]
           expect(result).toEqual JSON.stringify notification_content
@@ -205,7 +205,7 @@ describe 'z.SystemNotification.SystemNotificationRepository', ->
         system_notification_repository.notify conversation_et, message_et
         .then ->
           title = "#{message_et.user().first_name()} in #{conversation_et.display_name()}"
-          notification_content.title = z.util.truncate_text title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
+          notification_content.title = z.util.StringUtil.truncate title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
 
           result = JSON.stringify system_notification_repository._show_notification.calls.first().args[0]
           expect(result).toEqual JSON.stringify notification_content
@@ -243,7 +243,7 @@ describe 'z.SystemNotification.SystemNotificationRepository', ->
         system_notification_repository.notify conversation_et, message_et
         .then ->
           title = "#{message_et.user().first_name()} in #{conversation_et.display_name()}"
-          notification_content.title = z.util.truncate_text title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
+          notification_content.title = z.util.StringUtil.truncate title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
 
           result = JSON.stringify system_notification_repository._show_notification.calls.first().args[0]
           expect(result).toEqual JSON.stringify notification_content
@@ -257,7 +257,7 @@ describe 'z.SystemNotification.SystemNotificationRepository', ->
         system_notification_repository.notify conversation_et, message_et
         .then ->
           title = "#{message_et.user().first_name()} in #{conversation_et.display_name()}"
-          notification_content.title = z.util.truncate_text title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
+          notification_content.title = z.util.StringUtil.truncate title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
           notification_content.options.body = z.string.system_notification_obfuscated
 
           result = JSON.stringify system_notification_repository._show_notification.calls.first().args[0]
@@ -302,7 +302,7 @@ describe 'z.SystemNotification.SystemNotificationRepository', ->
         system_notification_repository.notify conversation_et, message_et
         .then ->
           title = "#{message_et.user().first_name()} in #{conversation_et.display_name()}"
-          notification_content.title = z.util.truncate_text title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
+          notification_content.title = z.util.StringUtil.truncate title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
 
           result = JSON.stringify system_notification_repository._show_notification.calls.first().args[0]
           expect(result).toEqual JSON.stringify notification_content
@@ -316,7 +316,7 @@ describe 'z.SystemNotification.SystemNotificationRepository', ->
         system_notification_repository.notify conversation_et, message_et
         .then ->
           title = "#{message_et.user().first_name()} in #{conversation_et.display_name()}"
-          notification_content.title = z.util.truncate_text title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
+          notification_content.title = z.util.StringUtil.truncate title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
           notification_content.options.body = z.string.system_notification_obfuscated
 
           result = JSON.stringify system_notification_repository._show_notification.calls.first().args[0]
@@ -361,7 +361,7 @@ describe 'z.SystemNotification.SystemNotificationRepository', ->
         system_notification_repository.notify conversation_et, message_et
         .then ->
           title = "#{message_et.user().first_name()} in #{conversation_et.display_name()}"
-          notification_content.title = z.util.truncate_text title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
+          notification_content.title = z.util.StringUtil.truncate title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
 
           result = JSON.stringify system_notification_repository._show_notification.calls.first().args[0]
           expect(result).toEqual JSON.stringify notification_content
@@ -375,7 +375,7 @@ describe 'z.SystemNotification.SystemNotificationRepository', ->
         system_notification_repository.notify conversation_et, message_et
         .then ->
           title = "#{message_et.user().first_name()} in #{conversation_et.display_name()}"
-          notification_content.title = z.util.truncate_text title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
+          notification_content.title = z.util.StringUtil.truncate title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
           notification_content.options.body = z.string.system_notification_obfuscated
 
           result = JSON.stringify system_notification_repository._show_notification.calls.first().args[0]
@@ -439,7 +439,7 @@ describe 'z.SystemNotification.SystemNotificationRepository', ->
   describe 'shows a well-formed group notification', ->
     beforeEach ->
       title = "#{message_et.user().first_name()} in #{conversation_et.display_name()}"
-      notification_content.title = z.util.truncate_text title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
+      notification_content.title = z.util.StringUtil.truncate title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
       notification_content.trigger = system_notification_repository._create_trigger conversation_et, message_et
 
     it 'if a group is created', (done) ->
@@ -487,7 +487,7 @@ describe 'z.SystemNotification.SystemNotificationRepository', ->
       beforeEach ->
         message_et.type = z.event.Backend.CONVERSATION.MEMBER_JOIN
         title = "#{message_et.user().first_name()} in #{conversation_et.display_name()}"
-        notification_content.title = z.util.truncate_text title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
+        notification_content.title = z.util.StringUtil.truncate title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
         notification_content.trigger = system_notification_repository._create_trigger conversation_et, message_et
 
       it 'with one user being added to the conversation', (done) ->
@@ -536,7 +536,7 @@ describe 'z.SystemNotification.SystemNotificationRepository', ->
       beforeEach ->
         message_et.type = z.event.Backend.CONVERSATION.MEMBER_LEAVE
         title = "#{message_et.user().first_name()} in #{conversation_et.display_name()}"
-        notification_content.title = z.util.truncate_text title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
+        notification_content.title = z.util.StringUtil.truncate title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
         notification_content.trigger = system_notification_repository._create_trigger conversation_et, message_et
 
       it 'with one user being removed from the conversation', (done) ->
@@ -604,7 +604,7 @@ describe 'z.SystemNotification.SystemNotificationRepository', ->
       message_et.user user_et
 
       title = message_et.user().name()
-      notification_content.title = z.util.truncate_text title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
+      notification_content.title = z.util.StringUtil.truncate title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
       notification_content.options.data.conversation_id = connection_et.conversation_id
       notification_content.options.tag = connection_et.conversation_id
       notification_content.trigger = system_notification_repository._create_trigger conversation_et, message_et
@@ -676,7 +676,7 @@ describe 'z.SystemNotification.SystemNotificationRepository', ->
       system_notification_repository.notify conversation_et, message_et
       .then ->
         title = "#{message_et.user().first_name()} in #{conversation_et.display_name()}"
-        notification_content.title = z.util.truncate_text title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
+        notification_content.title = z.util.StringUtil.truncate title, z.config.BROWSER_NOTIFICATION.TITLE_LENGTH, false
 
         result = JSON.stringify system_notification_repository._show_notification.calls.first().args[0]
         expect(result).toEqual JSON.stringify notification_content

--- a/test/unit_tests/user/UserServiceSpec.coffee
+++ b/test/unit_tests/user/UserServiceSpec.coffee
@@ -69,7 +69,6 @@ describe 'User Service', ->
       .then (response) =>
         expect(response.length).toBe 1
         expect(response[0].id).toBe 'd5a39ffb-6ce3-4cc8-9048-0e15d031b4c5'
-        expect(response[0].email).toBe 'jd@wire.com'
         done()
       .catch done.fail
 
@@ -104,7 +103,6 @@ describe 'User Service', ->
       .then (response) =>
         expect(response.length).toBe 2
         expect(response[0].id).toBe 'd5a39ffb-6ce3-4cc8-9048-0e15d031b4c5'
-        expect(response[1].email).toBe 'jr@wire.com'
         done()
       .catch done.fail
 
@@ -139,7 +137,6 @@ describe 'User Service', ->
       .then (response) =>
         expect(response.length).toBe 1
         expect(response[0].id).toBe 'd5a39ffb-6ce3-4cc8-9048-0e15d031b4c5'
-        expect(response[0].email).toBe 'jd@wire.com'
         done()
       .catch done.fail
 

--- a/test/unit_tests/util/ArrayUtilSpec.coffee
+++ b/test/unit_tests/util/ArrayUtilSpec.coffee
@@ -16,18 +16,100 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 #
 
-###############################################################################
-# z.util.ArrayUtil.interpolate
-###############################################################################
-describe 'z.util.ArrayUtil.interpolate', ->
+describe 'z.util.ArrayUtil', ->
+  describe 'chunk', ->
+    arr = null
 
-  it 'should interpolate array with bigger length', ->
-    expect(z.util.ArrayUtil.interpolate([1, 5, 3], 5)).toEqual [1, 3, 5, 4, 3]
+    beforeEach ->
+      arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
-  it 'should interpolate array with bigger length', ->
-    expect(z.util.ArrayUtil.interpolate([1, 3, 5, 4, 3], 3)).toEqual [1, 5, 3]
+    it 'returns one chunk with all items when the size is bigger than the array', ->
+      actual = z.util.ArrayUtil.chunk arr, 10
+      expect(actual.length).toBe 1
+      expect(actual[0].length).toBe 10
+      expect(actual[0][0]).toBe 1
+      expect(actual[0][9]).toBe 10
 
-  it 'should keep first and last value', ->
-    interpolated_array = z.util.ArrayUtil.interpolate([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], 5)
-    expect(interpolated_array[0]).toEqual 0
-    expect(interpolated_array[interpolated_array.length - 1]).toEqual 9
+    it 'returns the correct chunks', ->
+      actual = z.util.ArrayUtil.chunk arr, 3
+      expect(actual.length).toBe 4
+      expect(actual[0].length).toBe 3
+      expect(actual[1].length).toBe 3
+      expect(actual[2].length).toBe 3
+      expect(actual[3].length).toBe 1
+
+    it 'does not effect the original array', ->
+      actual = z.util.ArrayUtil.chunk arr, 3
+      expect(actual.length).toBe 4
+      expect(actual[0].length).toBe 3
+      expect(actual[1].length).toBe 3
+      expect(actual[2].length).toBe 3
+      expect(actual[3].length).toBe 1
+      expect(arr.length).toBe 10
+
+
+  describe 'get_next_item', ->
+    a = 'a'
+    b = 'b'
+    c = 'c'
+    d = 'd'
+    array = [a, b, c]
+    filter = (item) -> item isnt 'b'
+
+    it 'can return the second item when first item was given', ->
+      expect(z.util.ArrayUtil.get_next_item array, a).toEqual b
+
+    it 'can return the third item when first item was given and filter skips the second item', ->
+      expect(z.util.ArrayUtil.get_next_item array, a, filter).toEqual c
+
+    it 'can return the second item when last item was given', ->
+      expect(z.util.ArrayUtil.get_next_item array, c).toEqual b
+
+    it 'can return undefined when item is not in the array', ->
+      expect(z.util.ArrayUtil.get_next_item array, d).toEqual null
+
+
+  describe 'interpolate', ->
+    it 'should interpolate array with bigger length', ->
+      expect(z.util.ArrayUtil.interpolate([1, 5, 3], 5)).toEqual [1, 3, 5, 4, 3]
+
+    it 'should interpolate array with bigger length', ->
+      expect(z.util.ArrayUtil.interpolate([1, 3, 5, 4, 3], 3)).toEqual [1, 5, 3]
+
+    it 'should keep first and last value', ->
+      interpolated_array = z.util.ArrayUtil.interpolate([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], 5)
+      expect(interpolated_array[0]).toEqual 0
+      expect(interpolated_array[interpolated_array.length - 1]).toEqual 9
+
+
+  describe 'is_last_item', ->
+    a = 'a'
+    b = 'b'
+    c = 'c'
+    d = 'd'
+    array = [a, b, c]
+
+    it 'returns true for the last item', ->
+      expect(z.util.ArrayUtil.is_last_item array, c).toBeTruthy()
+
+    it 'returns false for any item that is not the last', ->
+      expect(z.util.ArrayUtil.is_last_item array, a).toBeFalsy()
+      expect(z.util.ArrayUtil.is_last_item array, b).toBeFalsy()
+
+    it 'returns false for an item that is not in the array', ->
+      expect(z.util.ArrayUtil.is_last_item array, d).toBeFalsy()
+
+
+  describe 'iterate_index', ->
+    it 'returns undefined in case of wrong input parameters', ->
+      expect(z.util.ArrayUtil.iterate_index 'Test', 0).toBe undefined
+      expect(z.util.ArrayUtil.iterate_index [1, 2, 3], 'Test').toBe undefined
+      expect(z.util.ArrayUtil.iterate_index [], 0).toBe undefined
+
+    it 'should iterate through the array index', ->
+      array = [1, 2, 3, 4, 5]
+      expect(z.util.ArrayUtil.iterate_index array, 0).toBe 1
+      expect(z.util.ArrayUtil.iterate_index array, 1).toBe 2
+      expect(z.util.ArrayUtil.iterate_index array, 2).toBe 3
+      expect(z.util.ArrayUtil.iterate_index array, 3).toBe 4
+      expect(z.util.ArrayUtil.iterate_index array, 4).toBe 0

--- a/test/unit_tests/util/StringUtilSpec.coffee
+++ b/test/unit_tests/util/StringUtilSpec.coffee
@@ -19,9 +19,41 @@
 # grunt test_init && grunt test_run:util/StringUtil
 
 describe 'z.util.StringUtil', ->
+  describe 'compare_transliteration', ->
+    it 'René equals Rene', ->
+      expect(z.util.StringUtil.compare_transliteration 'René', 'Rene').toBeTruthy()
+
+    it 'Παναγιώτα equals Panagiota', ->
+      expect(z.util.StringUtil.compare_transliteration 'Παναγιώτα', 'Panagiota').toBeTruthy()
+
+    it 'ΠΑΝΑΓΙΩΤΑ equals PANAGIOTA', ->
+      expect(z.util.StringUtil.compare_transliteration 'ΠΑΝΑΓΙΩΤΑ', 'PANAGIOTA').toBeTruthy()
+
+    it 'Björn equals Bjoern', ->
+      expect(z.util.StringUtil.compare_transliteration 'Björn', 'Bjoern').toBeTruthy()
+
+    it 'Bjørn equals Bjorn', ->
+      expect(z.util.StringUtil.compare_transliteration 'Bjørn', 'Bjorn').toBeTruthy()
+
+
+  describe 'format', ->
+    it 'returns string with replaced placeholder', ->
+      expect(z.util.StringUtil.format 'foo={0}&bar={1}', 1, 2).toBe 'foo=1&bar=2'
+
+
+  describe 'includes', ->
+    string = 'Club Zeta'
+
+    it 'returns true for positive matches', ->
+      expect(z.util.StringUtil.includes string, 'ub').toBeTruthy()
+      expect(z.util.StringUtil.includes string, 'Club Z').toBeTruthy()
+      expect(z.util.StringUtil.includes string, 'club z').toBeTruthy()
+
+    it 'returns false for no matches', ->
+      expect(z.util.StringUtil.includes string, 'wurst').toBeFalsy()
+
 
   describe 'obfuscate', ->
-
     it 'obfuscates a text preserving it\'s whitespaces', ->
       text = 'You Are The Sunshine Of My Life'
       obfuscated = z.util.StringUtil.obfuscate text
@@ -47,3 +79,65 @@ describe 'z.util.StringUtil', ->
       obfuscated = z.util.StringUtil.obfuscate text
       expect(obfuscated).not.toBe text
       expect(obfuscated.length).toBe text.length
+
+
+  describe 'remove_line_breaks', ->
+    it 'removes all the line breaks', ->
+      expect(z.util.StringUtil.remove_line_breaks '\nA\nB\nC\nD\n').toBe 'ABCD'
+
+
+  describe 'sort_by_priority', ->
+    it 'can sort strings', ->
+      string_1 = 'a b'
+      string_2 = 'c d'
+
+      expect(z.util.StringUtil.sort_by_priority string_1, string_2).toEqual -1
+      expect(z.util.StringUtil.sort_by_priority string_2, string_1).toEqual 1
+      expect(z.util.StringUtil.sort_by_priority string_1, string_1).toEqual 0
+      expect(z.util.StringUtil.sort_by_priority string_1, string_2, 'a').toEqual -1
+      expect(z.util.StringUtil.sort_by_priority string_1, string_2, 'c').toEqual 1
+      expect(z.util.StringUtil.sort_by_priority string_1, string_2, 'A').toEqual -1
+      expect(z.util.StringUtil.sort_by_priority string_1, string_2, 'C').toEqual 1
+
+
+  describe 'starts_with', ->
+    string = 'To be, or not to be, that is the question.'
+
+    it 'returns true for positive matches', ->
+      expect(z.util.StringUtil.starts_with string, 'To be').toBeTruthy()
+      expect(z.util.StringUtil.starts_with string, 'to be').toBeTruthy()
+
+    it 'returns false for no matches', ->
+      expect(z.util.StringUtil.starts_with string, 'not to be').toBeFalsy()
+
+
+  describe 'z.util.trim_line_breaks', ->
+    it 'removes line breaks at the beginning and/or end', ->
+      expect(z.util.StringUtil.trim_line_breaks '\n\n\n\n\nB\nC\nD').toBe 'B\nC\nD'
+      expect(z.util.StringUtil.trim_line_breaks 'B\nC\nD\n\n\n\n\n').toBe 'B\nC\nD'
+      expect(z.util.StringUtil.trim_line_breaks '\n\n\n\nB\nC\n\n\n\n\n').toBe 'B\nC'
+
+    it 'does not remove line breaks in between', ->
+      expect(z.util.StringUtil.trim_line_breaks 'A\nB\nC\nD').toBe 'A\nB\nC\nD'
+
+
+  describe 'truncate', ->
+    it 'returns the full string if it is shorter than the target length', ->
+      text = z.util.StringUtil.truncate "#{lorem_ipsum.substr 0, 80}", 90
+      expect(text.length).toBe 80
+      expect(text.charAt 79).not.toBe '…'
+
+    it 'returns a truncated string of correct length if it is longer than the target length', ->
+      text = z.util.StringUtil.truncate "#{lorem_ipsum.substr 0, 80}", 70
+      expect(text.length).toBe 64
+      expect(text.charAt 63).toBe '…'
+
+    it 'returns a truncated string of correct length if word boundary is disabled', ->
+      text = z.util.StringUtil.truncate "#{lorem_ipsum.substr 0, 80}", 70, false
+      expect(text.length).toBe 70
+      expect(text.charAt 69).toBe '…'
+
+    it 'returns a truncated string of correct length if word boundary is disabled and there are no whitespaces in the string', ->
+      text = z.util.StringUtil.truncate "#{lorem_ipsum.replace(/\s/g, '').substr 0, 80}", 70
+      expect(text.length).toBe 70
+      expect(text.charAt 69).toBe '…'

--- a/test/unit_tests/util/UtilSpec.coffee
+++ b/test/unit_tests/util/UtilSpec.coffee
@@ -241,25 +241,6 @@ describe 'z.util.ko_array_unshift_all', ->
     expected = [1, 2, 3, 4]
     expect(actual()).toEqual expected
 
-describe 'z.util.contains', ->
-  string = 'Club Zeta'
-
-  it 'finds "ub" in Club Zeta', ->
-    actual = z.util.contains string, 'ub'
-    expect(actual).toBeTruthy()
-
-  it 'finds "Club Z" in Club Zeta', ->
-    actual = z.util.contains string, 'Club Z'
-    expect(actual).toBeTruthy()
-
-  it 'finds "club z" in Club Zeta', ->
-    actual = z.util.contains string, 'club z'
-    expect(actual).toBeTruthy()
-
-  it 'doesn\'t find "wurst" in Club Zeta', ->
-    actual = z.util.contains string, 'wurst'
-    expect(actual).toBeFalsy()
-
 describe 'z.util.base64_to_array', ->
   it 'can convert a gif', ->
     actual = z.util.base64_to_array 'data:image/gif;base64,R0lGODlhLQAwAPQHAKQAAPz4+AQA4AQoKASA+Kx4WOSoiHwAAPwAALQAAPz8/NyYIExoaCxISMzo6Hx4eMzMzAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH/C05FVFNDQVBFMi4wAwEAAAAh+QQEDwD/ACwAAAAALQAwAAAE/1DJSau9OOvNu/9gKI5kaZ5oqq5s605DHL9XjNz3QMMD7us02w1ABAQCAGCrNwQcnsfAQbliEmVYLMsq9Hmpp8G1ly2DTYOpAWswHNuBQeFcihXasbZ7gJfT63drfHCDdn8kcoGDa3qCLnaNMgWTcy9xgX1aNHFyepqbYomUh1UJAj87FAOmBDikdTMSAwICra4VMnWyQDG0BL8EVLGvGUrGvsCxCsaIuzy0Ab/LPLKwaQcKT7PIwdjayidPU9vIMU9BtOnAtLy5KeTcAr1JMgzExTLp3AML/TH9Cwg0cAdiAIOD5IAFWyDO3JMFAxpIvAdDosVt66411BjjoL0PEVcfDMxXi52MbxsvghQ5ckCcdBEvHnDgYADNMisdtHQpo8EDjw0cTBFX81OHAQ+wxAlQUyRLjd+WgeNwRGnVGEFbijuAw0SUABSqJpXxY+oKTjOMplq7IwIAIfkEBQoAEQAsAAAIACwAJwAABf+gIo5kOQ4oaq5su6JIHA9ubSuwrNN3Tw46gDAQACB4vhsQIQQcDkQiAJl0LZ2pbLZaA2J14Bm3hZpqz6rxy5A1GIhuIqpAVePc7AE+oGfzDXR2PwVuKHt9A3+BdmkDBYR9bHiSgSlcPCpzhXOPdJmYVUiYkWiVJ6EiaTiOhJuOo6mXKAcicpydiwoHlnZPJwIEO4kivoIjvnzAOgQ8xcbHTwMJAssDT7TPLwPABN3M2V3c3nXgJdsCEN0Q5OUn297f7SvJ4uzyOAL53bz3CvT54uLdO8cNoL4zas4A9JYPhYB3KBgwsGelgUSJ21B0W8DRIccFzBo0oEhGpEmHwBZmXHN4bYGWUA+06LsWbdZKkyOTDHCAxhrNXT6jXZyoM2YKnEFrOljKEymJACOgmhgwEsWDodaY8ky6lV+tLikcIHVAU8jKrqp6RBnAoCoKnjTBrEpbS2oXtzmEeWVBRMkWhP2+lgsBACH5BAUKAA8ALAAABgAsACkAAAT/UMlJKx142M07x0iIYF5pKqCokmc7DSoQBMDqtjAC7PO816ObCQbIGDM1jdAzKKqeo+KS2Twei8pp5mXIGAIDQzfQxXRfrJKSFBa3wW5yV3xmZTtZzaDgFs/8cm0Fei9DEnYFfH10bQaJa2snGQdoZXuJg2ZpB1s3B58KYHxWZoMSn5RTp5+io16PAaiqFqwYmJgasrMbnwMCpKC7HWACBCoEd8IfCQLHycoWA8zO0FTFBNjI1UzX2c/bLwICAdhg4B++2drnG77d3+fE4tjw4O7i4mnsoff4xfXK+vn7B+0IGAIDB2o7ImQAg4cPByBcQPGXL4oL/kGMeGNAg48fXS+iWoBhwchfIEN2tCIAVa8BLg9YZOgCQ0pfMTHERAlS3xCHEDE4GDpUKFEHGDb6VOOxJwAHLnWiclDkZr0A7Y4gQIpKKicHI2gOi8YQChQUYlfaIWXkUKd9cONGAAAh+QQFCgALACwBAAYAKwAmAAAE/1DJSWsdeNjN+8ZIiGBeaYJiSposNaRAEABq274IoMuyTo+2Uy5DzNA0Qc8AgEupmEnlslhkIqOZycCQMQS23AAXw9WulBISmGvwggdidluzunKQi4ViUJi3ZX9xYAV5V3YfaUh8fX5tcgYFBYqKJxgHZmOLkV1nB1k2B6EKX31UZJISoZdRqaGkpV2bAaqsFqqvkZsaorUcoaYCA7y9HF8EKQTBxCfHIgIJh8sWA80hz9HSLgTb28HY2Wnc3d/ge3l5AsrlH+Le6+zd6u8Uxsnp5OAY6fvy89T8+84JHEiwoMEF9gCmO8iwoYKGECNKnEixosWLGDNq3HgxAMeOEws+SgzQwaNIgjIiAAAh+QQFCgARACwCAAYAKgAoAAAF/6AijmRpnmiqrmzLDjDszueA3LdM0zbu67uVDRAIAI6/oJBYDBwOR0BOiYpZrdApldTzeQfZwZZ7LcMAwO2gACsaDG6DVb4KvArywOA9CLzle3xjCmt5gX1/MG9sVDF6eIF8iQYFjIRiM5gyMZWVMYubmpkjfWtmiaIimC2aYo+fi2yrOqusMAcij52eaQcxVE+5MD4EAqvBg8F6BMTGIsiDCk++zDgCCWDQ0aQE3d3Gtdtc3t/h4sIQ3RACzucmA+Tg7iXL3+3zqjD29/Pw3uwAzSkpUwyggH0CeTBgoM8YOHb/2JXZMaBBA3gLMoLLuKAbDGMLF17MZGXBNHDTOl5KrGjRYsJ3LS9O83VrZsErDxLa4RKS4cyaP804eFmCpUsHSIdmm2b0YoycKHaSsuIgaNKqA3rmhDGSXg2qS4/MHBpTaRoSRehZUeDlp9mKUJVIveIFwZWu5yZeaRECACH5BAUPABAALAIACAAqACcAAAT/UMlJq7046807HyDojdeAnKdIriaKqusHBAFgA+8Qb8NBB4eg7bXDhI7HIUJXpLRcUBBu2ZwgryYpgFkdFAYBg4EmPhp63KYXVA6XB+JvuriGn91n+7c6CbDFZ4B6e3wSXgWIIYAGcoV9V4uEjo+KcSABkxV+iJwDCXOZCn4uAp+hFk8EpaA7IRVPCKoCXK4shmkDBLqyKr22hla5uwKzVsYkTDBgugHEyskxIUEKB8Kys9NBtU3awsTOPdNqtQPEw9/FXQxJs+Xn36wdIQ0EC/Yg9gvW6O0wHw0ABywIUi3cAX27rg1gwDDeK4brDIIgqE3AuQEAMzq0olFiuCPmTMCBaPCgwcZbRxw4GKCyWkaT8PyMJHlSARIHBHs4aACxZAiZIx08qGlTxESKGHnSpAHmyNAYKJAGNfnM34gQLpyCwXTqCFCik34UiQAAIfkEBQoAEQAsAgAIACoAJwAABf+gIo5kSQ4oaq5saw5IHKtuXcNyTtv8CAOBAGCo6xkHwGDgcBgCZkZbajptQqMsXG47sA6wWaoYBdiBfQVU0GBYG6bvWkBaeAcG7EGA/cbnzyd1en56fChsaYApd4J8b4YGBYkKZlIiKimSkimImF+URz6MY4afn6A9pl+jh4hppzSnPCkHIoyam2YHKYBMtig5BAKnvoAjvncEwcMixcbHTAPKMgIJXc7PJdIE3MKV2drd3MzgLHcQ3BAC5OUr2+Pf7QrJ4+zyPij19vfvwuvrsoyJ8fdPX0AwAxgwyDds2IB13f6JwTKgQQNpCzI6zLiAG4phChVePDJlAZMDDk9kdgRY0aLFg1lcXjy5CwXNA/6oPIA5T1vIhTRt3hwzwAHPFzKLOlgq9GTLlyl2mtM2xUFQpUt3/dyJYmSJOS+qXmsCgKZRmUZ5rQjydYqCLUHTdpV6BiylKVsQUPEqbyKVe/JCAAAh+QQFCgAPACwCAAYAKgAoAAAE/1DJSSsdeNjNu8VIiGBeWYJiSprsNKRAEABqy74IoMuyTo+2Uy5DzNA0wc4AgEupmEnlslhkIpMZlyFjCAwM28AWs3WtlBLSF7z2ssVbcHl13Vw1gwIbLOPD1wV4Lh5IdAV6e3JrBoeFhScYB2ZjeYeBZGcHWS0HnQpeelRkgRKdklEKpqChXI0BpqgVqpWWl6mnsRadogIDnrkcXgQpBL3AJ8MiAgl1xx/JIcvNzhcE1ta909Rp19ja2woDAdYBAsbgz9fZ6OnF5+wTwu7v8OED5vj06APz+d/H/PIJ/NeiSLh+AgUQwEPExgAGECEGXEAxmwCKCxQ+jMiA4IUGIGJB3ltgagEGkp0yDggpsiAVAaZ2+YqZzeCNlSHvxdQ001QvlmcgccTgoGhRokYdYBhaJ4AUoAAcxIxkygEToM2ccqCCQKkpqpocjLBJQasFLwadqEVgr+FZsxXcirLpth6qCAAh+QQFCgALACwBAAYAKwAmAAAE/1DJSesceNjN+8ZIiGBeaYJiSposNaRAEABq274IoMuyTo+2Uy5DzNA0Qc8AgEupmEnlslhkIqOZiyFjCAwM28AWs72slBLSF7z2ssVbcHl15VwHi0WBDZb14WsFGnlpJUh0BXt8cmsGiYeHJxgHZmMDiY9kZwdZNgefCl57VGSCEp+UUaefoqNcjwGoqhasGJiYGrKzG58DAqSgux1eAgQpBHXCdgkCx8nKFgPMztBSxQTYyNVK19nP2xcCAnl53+AKGN3a5x/i3uwWxO7r8OHi92fw8vfu5P7/AAMKXMCvIIGBCBMGSMiwocOHECNKnEixosWLExVgzChh4caGFAcCWPgYUEIEACH5BAUKABEALAAABgAsACkAAAX/oCKOZGmeaKqubOsqQxy/tBkjOD7U9Z3/O15r8AMYAwEAIihMERFGwOGARAKYTRtOKut2syci90fWgUuxq3c9O48Ghq7BgJwjYwVsFj6Pzel8AwFweW4wBX18gH2DBoV7QQMFiIqKcY47MjyRmZKJkpN5M216LEycf2yFpz0ibTCgqXicrpsxByJ3eKGTTAeaWVNvAgRAgiLChsKDxD8EQcmGClO/CQLOA9TSNgPEBN/P207e4KXirgICEN8Q5ucx5OHnJszk7u/p3sDzCvX54PLmdUv3LR/BNU3W/CsoAF63ZwMYMLjnpIFEid1ifFvAER7HBc8aNKCIYoDIk/CIZi2gBo/aAi89HnghSG2KjJomUdIY4IBNtpq/ftq8OHGnTBknRwKN4aBpz6RYAoyQamNkjAdEszntKfQA1325VnRxANVBTSMsv75yUSWiVaZdycBam4uq2Lc+jIFFgWTIF4T8wm4LAQA7'
@@ -376,89 +357,6 @@ describe 'z.util.sort_groups_by_last_event', ->
 
     expect(actual).toEqual expected
 
-xdescribe 'z.util.sort_user_by_first_name', ->
-  it 'can sort a list of users', ->
-    user_a = new z.entity.User()
-    user_a.name = 'a a'
-    user_b = new z.entity.User()
-    user_b.name = 'b b'
-    user_c = new z.entity.User()
-    user_c.name = 'c c'
-    users = [user_c, user_b, user_a]
-
-    actual = users.sort z.util.sort_user_by_first_name
-    expected = [user_a, user_b, user_c]
-
-    expect(actual).toEqual expected
-
-describe 'z.util.array_get_next', ->
-  a = 'a'
-  b = 'b'
-  c = 'c'
-  d = 'd'
-  array = [a, b, c]
-  filter = (item) -> item isnt 'b'
-
-  it 'can return the second item when first item was given', ->
-    actual = z.util.array_get_next array, a
-    expected = b
-    expect(actual).toEqual expected
-
-  it 'can return the third item when first item was given and filter skips the second item', ->
-    actual = z.util.array_get_next array, a, filter
-    expected = c
-    expect(actual).toEqual expected
-
-  it 'can return the second item when last item was given', ->
-    actual = z.util.array_get_next array, c
-    expected = b
-    expect(actual).toEqual expected
-
-  it 'can return undefined when item is not in the array', ->
-    actual = z.util.array_get_next array, d
-    expected = null
-    expect(actual).toEqual expected
-
-describe 'z.util.array_is_last', ->
-  a = 'a'
-  b = 'b'
-  c = 'c'
-  d = 'd'
-  array = [a, b, c]
-
-  it 'returns true for the last item', ->
-    actual = z.util.array_is_last array, c
-    expect(actual).toBeTruthy()
-
-  it 'returns false for any item that is not the last', ->
-    actual = z.util.array_is_last array, a
-    expect(actual).toBeFalsy()
-
-  it 'returns false for an item that is not in the array', ->
-    actual = z.util.array_is_last array, d
-    expect(actual).toBeFalsy()
-
-describe 'z.util.truncate_text', ->
-  it 'returns the full string if it is shorter than the target length', ->
-    text = z.util.truncate_text "#{lorem_ipsum.substr 0, 80}", 90
-    expect(text.length).toBe 80
-    expect(text.charAt 79).not.toBe '…'
-
-  it 'returns a truncated string of correct length if it is longer than the target length', ->
-    text = z.util.truncate_text "#{lorem_ipsum.substr 0, 80}", 70
-    expect(text.length).toBe 64
-    expect(text.charAt 63).toBe '…'
-
-  it 'returns a truncated string of correct length if word boundary is disabled', ->
-    text = z.util.truncate_text "#{lorem_ipsum.substr 0, 80}", 70, false
-    expect(text.length).toBe 70
-    expect(text.charAt 69).toBe '…'
-
-  it 'returns a truncated string of correct length if word boundary is disabled and there are no whitespaces in the string', ->
-    text = z.util.truncate_text "#{lorem_ipsum.replace(/\s/g, '').substr 0, 80}", 70
-    expect(text.length).toBe 70
-    expect(text.charAt 69).toBe '…'
-
 describe 'z.util.strip_url_wrapper', ->
   it 'return the string without url wrapper (single quotes)', ->
     text = z.util.strip_url_wrapper "url('/path/to/image/image.png')"
@@ -499,63 +397,6 @@ describe 'z.util.naked_url', ->
 
   it 'returns empty string if url is not set', ->
     expect(z.util.naked_url()).toBe ''
-
-describe 'z.util.string_format', ->
-  it 'returns string with replaced placeholder', ->
-    actual = z.util.string_format 'foo={0}&bar={1}', 1, 2
-    expect(actual).toBe 'foo=1&bar=2'
-
-describe 'z.util.array_chunks', ->
-  arr = null
-
-  beforeEach ->
-    arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
-  it 'returns one chunk with all items when the size is bigger than the array', ->
-    actual = z.util.array_chunks arr, 10
-    expect(actual.length).toBe 1
-    expect(actual[0].length).toBe 10
-    expect(actual[0][0]).toBe 1
-    expect(actual[0][9]).toBe 10
-
-  it 'returns the correct chunks', ->
-    actual = z.util.array_chunks arr, 3
-    expect(actual.length).toBe 4
-    expect(actual[0].length).toBe 3
-    expect(actual[1].length).toBe 3
-    expect(actual[2].length).toBe 3
-    expect(actual[3].length).toBe 1
-
-  it 'does not effect the original array', ->
-    actual = z.util.array_chunks arr, 3
-    expect(actual.length).toBe 4
-    expect(actual[0].length).toBe 3
-    expect(actual[1].length).toBe 3
-    expect(actual[2].length).toBe 3
-    expect(actual[3].length).toBe 1
-    expect(arr.length).toBe 10
-
-describe 'z.util.remove_line_breaks', ->
-  it 'removes all the line breaks', ->
-    actual = z.util.remove_line_breaks 'A\nB\nC\nD'
-    expect(actual).toBe 'ABCD'
-
-describe 'z.util.trim_line_breaks', ->
-  it 'does not remove line breaks in between', ->
-    actual = z.util.trim_line_breaks 'A\nB\nC\nD'
-    expect(actual).toBe 'A\nB\nC\nD'
-
-  it 'removes line breaks at the beginning', ->
-    actual = z.util.trim_line_breaks '\n\n\n\n\nB\nC\nD'
-    expect(actual).toBe 'B\nC\nD'
-
-  it 'removes line breaks at the end', ->
-    actual = z.util.trim_line_breaks 'B\nC\nD\n\n\n\n\n'
-    expect(actual).toBe 'B\nC\nD'
-
-  it 'removes all line breaks at the beginning and the end', ->
-    actual = z.util.trim_line_breaks '\n\n\n\nB\nC\n\n\n\n\n'
-    expect(actual).toBe 'B\nC'
 
 describe 'z.util.append_url_parameter', ->
   it 'append param with & when url contains param', ->
@@ -868,19 +709,6 @@ describe 'bucket_values', ->
     expect(z.util.bucket_values 100, [0, 5, 10, 15, 20, 25]).toBe '26-'
     expect(z.util.bucket_values 10023, [0, 100, 200, 500, 1000, 2000]).toBe '2001-'
 
-describe 'iterate_array_index', ->
-  it 'returns undefined in case of wrong input parameters', ->
-    expect(z.util.iterate_array_index 'Test', 0).toBe undefined
-    expect(z.util.iterate_array_index [1, 2, 3], 'Test').toBe undefined
-    expect(z.util.iterate_array_index [], 0).toBe undefined
-
-  it 'should iterate through the array index', ->
-    expect(z.util.iterate_array_index [1, 2, 3, 4, 5], 0).toBe 1
-    expect(z.util.iterate_array_index [1, 2, 3, 4, 5], 1).toBe 2
-    expect(z.util.iterate_array_index [1, 2, 3, 4, 5], 2).toBe 3
-    expect(z.util.iterate_array_index [1, 2, 3, 4, 5], 3).toBe 4
-    expect(z.util.iterate_array_index [1, 2, 3, 4, 5], 4).toBe 0
-
 describe 'z.util.zero_padding', ->
   it 'can add one zero to 6', ->
     actual = z.util.zero_padding 6
@@ -919,19 +747,3 @@ describe 'z.util.add_http', ->
   it 'does not add https if present', ->
     url = 'https://wire.com/'
     expect(z.util.add_http url).toBe 'https://wire.com/'
-
-describe 'z.util.compare_names', ->
-  it 'René equals Rene', ->
-    expect(z.util.compare_names('René', 'Rene')).toBeTruthy()
-
-  it 'Παναγιώτα equals Panagiota', ->
-    expect(z.util.compare_names('Παναγιώτα', 'Panagiota')).toBeTruthy()
-
-  it 'ΠΑΝΑΓΙΩΤΑ equals PANAGIOTA', ->
-    expect(z.util.compare_names('ΠΑΝΑΓΙΩΤΑ', 'PANAGIOTA')).toBeTruthy()
-
-  it 'Björn equals Bjoern', ->
-    expect(z.util.compare_names('Björn', 'Bjoern')).toBeTruthy()
-
-  it 'Bjørn equals Bjorn', ->
-    expect(z.util.compare_names('Bjørn', 'Bjorn')).toBeTruthy()


### PR DESCRIPTION
## Type of change
Since the usernames launch our search results are not well filtered.

If a search query starts with an @, we will now return the following:
- connected users if their username starts with the search query
- groups if there is a member of that group whos username starts with the search query
- others if their username starts with that search query

Email matches are removed as the email address will no longer provided by the backend for any other user than yourself. Search resuls are also properly prioritized. Matches starting with the query come first, all other entries are alphabetically ordered as expected.

This also works in the filter to add people to a group

## Screenshot
### Old search results
<img width="213" alt="old_results" src="https://cloud.githubusercontent.com/assets/10243309/22017035/dc81abba-dca8-11e6-893c-cc10dc0b55fb.png"><img width="214" alt="old_results2" src="https://cloud.githubusercontent.com/assets/10243309/22017036/dc821438-dca8-11e6-87c3-870f538ca338.png">


### New search results
<img width="215" alt="new_results" src="https://cloud.githubusercontent.com/assets/10243309/22017053/f311204a-dca8-11e6-9af6-32d9bcdffdd3.png"><img width="212" alt="new_results2" src="https://cloud.githubusercontent.com/assets/10243309/22017054/f314bade-dca8-11e6-8894-cce0079bdf0d.png">
