### PR TITLE
Improve auto-updater behavior on Windows (WEBAPP-3544)

### DIFF
--- a/app/page/index.html
+++ b/app/page/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- Wire, Copyright (C) 2016 Wire Swiss GmbH -->
+<!-- Wire, Copyright (C) Wire Swiss GmbH -->
 <!-- {{config.CURRENT_VERSION_ID}} -->
 <html id="wire-main-app">
   <head>

--- a/app/page/template/warning.htm
+++ b/app/page/template/warning.htm
@@ -147,6 +147,14 @@
         </div>
       <!-- /ko -->
 
+      <!-- ko if: top_warning() === z.ViewModel.WarningType.LIFECYCLE_UPDATE -->
+        <div class="warning-bar warning-bar-connection warning-bar-click bg-theme" data-bind="click: function(){amplify.publish(z.event.WebApp.LIFECYCLE.REFRESH)}">
+          <div class="warning-bar-message">
+            <span data-bind="l10n_text: z.string.warning_lifecycle_update"></span>&nbsp;
+            <a class="warning-bar-link" data-bind="l10n_text: z.string.warning_lifecycle_update_link" rel="nofollow noopener noreferrer" target="_blank"></a>
+          </div>
+        </div>
+      <!-- /ko -->
     </div>
   <!-- /ko -->
 

--- a/app/script/announce/AnnounceRepository.coffee
+++ b/app/script/announce/AnnounceRepository.coffee
@@ -19,8 +19,10 @@
 window.z ?= {}
 z.announce ?= {}
 
-CHECK_TIMEOUT = 5 * 60 * 1000
-CHECK_INTERVAL = 3 * 60 * 60 * 1000
+ANNOUNCE_CONFIG =
+  CHECK_TIMEOUT: 5 * 60 * 1000
+  CHECK_INTERVAL: 3 * 60 * 60 * 1000
+  UPDATE_INTERVAL: 6 * 60 * 60 * 1000
 
 class z.announce.AnnounceRepository
   PRIMARY_KEY_CURRENT_announce: 'local_identity'
@@ -30,20 +32,26 @@ class z.announce.AnnounceRepository
 
   init: ->
     window.setTimeout =>
-      @fetch_announcements()
-      @schedule_check()
-    , CHECK_TIMEOUT
+      @check_announcements()
+      @schedule_checks()
+    , ANNOUNCE_CONFIG.CHECK_TIMEOUT
 
-  fetch_announcements: =>
+  check_announcements: =>
     @announce_service.get_announcements()
     .then @process_announce_list
     .catch (error) =>
       @logger.error "Failed to fetch announcements: #{error}"
 
+  check_version: =>
+    @announce_service.get_version()
+    .then (server_version) ->
+      amplify.publish z.event.WebApp.LIFECYCLE.UPDATE if server_version > z.util.Environment.version false, true
+    .catch (error) =>
+      @logger.error "Failed to fetch version: #{error}"
 
-
-  schedule_check: =>
-    window.setInterval @fetch_announcements, CHECK_INTERVAL
+  schedule_checks: =>
+    window.setInterval @check_announcements, ANNOUNCE_CONFIG.CHECK_INTERVAL
+    window.setInterval @check_version, ANNOUNCE_CONFIG.UPDATE_INTERVAL
 
   process_announce_list: (announcements_list) =>
     if announcements_list
@@ -76,7 +84,6 @@ class z.announce.AnnounceRepository
             if announcement.link
               z.util.safe_window_open announcement.link
             if announcement.refresh
-              window.location.reload true
-              window.focus()
+              amplify.publish z.event.WebApp.LIFECYCLE.REFRESH
             notification.close()
           break

--- a/app/script/announce/AnnounceService.coffee
+++ b/app/script/announce/AnnounceService.coffee
@@ -35,3 +35,11 @@ class z.announce.AnnounceService
         resolve data['result']
       .fail (jqXHR, textStatus, errorThrown) ->
         reject new Error errorThrown
+
+  get_version: ->
+    return new Promise (resolve, reject) ->
+      $.get 'version/'
+      .done (data) ->
+        resolve data.version
+      .fail (jqXHR, textStatus, errorThrown) ->
+        reject new Error errorThrown

--- a/app/script/auth/AuthRepository.coffee
+++ b/app/script/auth/AuthRepository.coffee
@@ -132,7 +132,7 @@ class z.auth.AuthRepository
       if error.type is z.auth.AccessTokenError::TYPE.REQUEST_FORBIDDEN or z.util.Environment.frontend.is_localhost()
         @logger.warn "Session expired on access token refresh: #{error.message}", error
         Raygun.send error
-        amplify.publish z.event.WebApp.SIGN_OUT, z.auth.SignOutReasion.SESSION_EXPIRED, false, true
+        amplify.publish z.event.WebApp.LIFECYCLE.SIGN_OUT, z.auth.SignOutReasion.SESSION_EXPIRED, false, true
       else if error.type isnt z.auth.AccessTokenError::TYPE.REFRESH_IN_PROGRESS
         @logger.error "Refreshing access token failed: '#{error.type}'", error
         amplify.publish z.event.WebApp.WARNING.SHOW, z.ViewModel.WarningType.CONNECTIVITY_RECONNECT

--- a/app/script/client/ClientRepository.coffee
+++ b/app/script/client/ClientRepository.coffee
@@ -32,7 +32,8 @@ class z.client.ClientRepository
 
     amplify.subscribe z.event.Backend.USER.CLIENT_ADD, @on_client_add
     amplify.subscribe z.event.Backend.USER.CLIENT_REMOVE, @on_client_remove
-    amplify.subscribe z.event.WebApp.LOGOUT.ASK_TO_CLEAR_DATA, @logout_client
+    amplify.subscribe z.event.WebApp.LIFECYCLE.ASK_TO_CLEAR_DATA, @logout_client
+    amplify.subscribe z.event.WebApp.LOGOUT.ASK_TO_CLEAR_DATA, @logout_client # todo: deprecated - remove when user base of wrappers version >= 2.12 is large enough
 
     return @
 
@@ -395,10 +396,10 @@ class z.client.ClientRepository
     if @current_client().type is z.client.ClientType.PERMANENT
       amplify.publish z.event.WebApp.WARNING.MODAL, z.ViewModel.ModalType.LOGOUT,
         action: (clear_data) ->
-          amplify.publish z.event.WebApp.SIGN_OUT, z.auth.SignOutReasion.USER_REQUESTED, clear_data
+          amplify.publish z.event.WebApp.LIFECYCLE.SIGN_OUT, z.auth.SignOutReasion.USER_REQUESTED, clear_data
     else
       @delete_temporary_client()
-      .then -> amplify.publish z.event.WebApp.SIGN_OUT, z.auth.SignOutReasion.USER_REQUESTED, true
+      .then -> amplify.publish z.event.WebApp.LIFECYCLE.SIGN_OUT, z.auth.SignOutReasion.USER_REQUESTED, true
 
   ###
   Removes a stored client and the session connected with it.
@@ -575,6 +576,6 @@ class z.client.ClientRepository
     return if not client_id
 
     if client_id is @current_client().id
-      amplify.publish z.event.WebApp.SIGN_OUT, z.auth.SignOutReasion.CLIENT_REMOVED, true
+      amplify.publish z.event.WebApp.LIFECYCLE.SIGN_OUT, z.auth.SignOutReasion.CLIENT_REMOVED, true
     else
       amplify.publish z.event.WebApp.CLIENT.REMOVE, @self_user().id, client_id

--- a/app/script/event/WebApp.coffee
+++ b/app/script/event/WebApp.coffee
@@ -99,7 +99,6 @@ z.event.WebApp =
     NOTIFICATION_HANDLING_STATE: 'wire.webapp.event.notification_handling'
   LIST:
     SCROLL: 'wire.webapp.list.scroll'
-  LOADED: 'wire.webapp.loaded'
   PEOPLE:
     HIDE: 'wire.webapp.participant-et.hide'
     SHOW: 'wire.webapp.participant-et.show'
@@ -109,8 +108,16 @@ z.event.WebApp =
   LEFT:
     HIDE: 'wire.webapp.left.hide'
     FADE_IN: 'wire.webapp.left.fade-in'
+  LIFECYCLE:
+    ASK_TO_CLEAR_DATA: 'wire.webapp.lifecycle.ask_to_clear_data'
+    LOADED: 'wire.webapp.lifecycle.loaded'
+    REFRESH: 'wire.webapp.lifecycle.refresh'
+    RESTART: 'wire.webapp.lifecycle.restart'
+    SIGN_OUT: 'wire.webapp.lifecycle.sign_out'
+    UPDATE: 'wire.webapp.lifecycle.update'
+  LOADED: 'wire.webapp.loaded' # todo: deprecated - remove when user base of wrappers version >= 2.12 is large enough
   LOGOUT:
-    ASK_TO_CLEAR_DATA: 'wire.webapp.logout.ask-to-clear-data'
+    ASK_TO_CLEAR_DATA: 'wire.webapp.logout.ask-to-clear-data' # todo: deprecated - remove when user base of wrappers version >= 2.12 is large enough
   PREFERENCES:
     MANAGE_ACCOUNT: 'wire.webapp.preferences.manage-account'
     MANAGE_DEVICES: 'wire.webapp.preferences.manage-devices'

--- a/app/script/localization/strings.coffee
+++ b/app/script/localization/strings.coffee
@@ -526,6 +526,10 @@ z.string.warning_tell_me_how = 'Tell me how'
 z.string.warning_connectivity_connection_lost = 'Trying to connect. Wire may not be able to deliver messages.'
 z.string.warning_connectivity_no_internet = 'No Internet. You won’t be able to send or receive messages.'
 
+# Warnings: Desktop Update
+z.string.warning_lifecycle_update = 'A new version of Wire is available.'
+z.string.warning_lifecycle_update_link = 'Update now'
+
 # Browser notifications
 z.string.system_notification_asset_add = 'Shared a picture'
 z.string.system_notification_connection_accepted = 'Accepted your connection request'

--- a/app/script/main/app.coffee
+++ b/app/script/main/app.coffee
@@ -137,9 +137,9 @@ class z.main.App
 
   # Subscribe to amplify events.
   _subscribe_to_events: ->
-    amplify.subscribe z.event.WebApp.LIFECYCLE.UPDATE, @update
     amplify.subscribe z.event.WebApp.LIFECYCLE.REFRESH, @refresh
     amplify.subscribe z.event.WebApp.LIFECYCLE.SIGN_OUT, @logout
+    amplify.subscribe z.event.WebApp.LIFECYCLE.UPDATE, @update
 
 
   ###############################################################################
@@ -214,9 +214,8 @@ class z.main.App
       @_show_ui()
       @telemetry.time_step z.telemetry.app_init.AppInitTimingsStep.SHOWING_UI
       @telemetry.report()
-      # todo: deprecated - remove after update of supporting wrappers
-      amplify.publish z.event.WebApp.LOADED
       amplify.publish z.event.WebApp.LIFECYCLE.LOADED
+      amplify.publish z.event.WebApp.LOADED # todo: deprecated - remove when user base of wrappers version >= 2.12 is large enough
       @telemetry.time_step z.telemetry.app_init.AppInitTimingsStep.APP_LOADED
       return @repository.conversation.update_conversations @repository.conversation.conversations_unarchived()
     .then =>

--- a/app/script/util/Environment.coffee
+++ b/app/script/util/Environment.coffee
@@ -88,8 +88,12 @@ z.util.Environment = do ->
 
   app_version = ->
     if $("[property='wire:version']").attr('version')?
-      version = $("[property='wire:version']").attr('version').trim().split '-'
-      return "#{version[0]}.#{version[1]}.#{version[2]}.#{version[3]}#{version[4]}"
+      return $("[property='wire:version']").attr('version').trim()
+    return ''
+
+  formatted_app_version = ->
+    version = app_version().split '-'
+    return "#{version[0]}.#{version[1]}.#{version[2]}.#{version[3]}#{version[4]}"
 
   ################
   # PUBLIC METHODS
@@ -139,7 +143,8 @@ z.util.Environment = do ->
 
   electron: _check.is_electron()
 
-  version: (show_wrapper_version = true) ->
+  version: (show_wrapper_version = true, do_not_format = false) ->
     return 'dev' if z.util.Environment.frontend.is_localhost()
+    return app_version() if do_not_format
     return window.electron_version if window.electron_version and show_wrapper_version
-    return app_version()
+    return formatted_app_version()

--- a/app/script/view_model/WarningsViewModel.coffee
+++ b/app/script/view_model/WarningsViewModel.coffee
@@ -30,6 +30,7 @@ z.ViewModel.WarningType =
   DENIED_CAMERA: 'camera_access_denied'
   DENIED_MICROPHONE: 'mic_access_denied'
   DENIED_SCREEN: 'screen_access_denied'
+  LIFECYCLE_UPDATE: 'lifecycle_update'
   NOT_FOUND_CAMERA: 'not_found_camera'
   NOT_FOUND_MICROPHONE: 'not_found_microphone'
   UNSUPPORTED_INCOMING_CALL: 'unsupported_incoming_call'
@@ -37,6 +38,7 @@ z.ViewModel.WarningType =
   CONNECTIVITY_RECONNECT: 'connectivity_reconnect'
   CONNECTIVITY_RECOVERY: 'connectivity_recovery'
   NO_INTERNET: 'no_internet'
+
 
 class z.ViewModel.WarningsViewModel
   constructor: (element_id) ->
@@ -50,6 +52,7 @@ class z.ViewModel.WarningsViewModel
     @warnings.subscribe (warnings) ->
       mini_modes = [
         z.ViewModel.WarningType.CONNECTIVITY_RECONNECT
+        z.ViewModel.WarningType.LIFECYCLE_UPDATE
         z.ViewModel.WarningType.NO_INTERNET
       ]
       if warnings.length is 0
@@ -102,7 +105,7 @@ class z.ViewModel.WarningsViewModel
     @warnings.remove type
 
   show_warning: (type, info) =>
-    @dismiss_warning() if @top_warning() and type in [z.ViewModel.WarningType.CONNECTIVITY_RECONNECT, z.ViewModel.WarningType.NO_INTERNET]
+    @dismiss_warning() if type in [z.ViewModel.WarningType.CONNECTIVITY_RECONNECT, z.ViewModel.WarningType.NO_INTERNET] and @top_warning() isnt z.ViewModel.WarningType.LIFECYCLE_UPDATE
     @logger.warn "Showing warning of type '#{type}'"
     if info?
       @first_name info.first_name

--- a/app/script/view_model/WindowTitleViewModel.coffee
+++ b/app/script/view_model/WindowTitleViewModel.coffee
@@ -22,7 +22,7 @@ z.ViewModel ?= {}
 class z.ViewModel.WindowTitleViewModel
   constructor: (@content_state, @user_repository, @conversation_repository) ->
     @logger = new z.util.Logger 'z.ViewModel.WindowTitleViewModel', z.config.LOGGER.OPTIONS
-    amplify.subscribe z.event.WebApp.LOADED, @initiate_title_updates
+    amplify.subscribe z.event.WebApp.LIFECYCLE.LOADED, @initiate_title_updates
 
   initiate_title_updates: =>
     @logger.info 'Starting to update window title'

--- a/app/script/view_model/bindings/ConversationListBindings.coffee
+++ b/app/script/view_model/bindings/ConversationListBindings.coffee
@@ -58,7 +58,7 @@ ko.bindingHandlers.bordered_list = do ->
     $element.on 'scroll', -> calculate_borders $element
     $('.left').on 'click', -> calculate_borders $element
     $(window).on 'resize', -> calculate_borders $element
-    amplify.subscribe z.event.WebApp.LOADED, -> calculate_borders $element
+    amplify.subscribe z.event.WebApp.LIFECYCLE.LOADED, -> calculate_borders $element
 
   update: (element, valueAccessor) ->
     ko.unwrap valueAccessor()

--- a/app/script/view_model/list/ConversationListViewModel.coffee
+++ b/app/script/view_model/list/ConversationListViewModel.coffee
@@ -104,7 +104,7 @@ class z.ViewModel.list.ConversationListViewModel
     amplify.subscribe z.event.WebApp.SHORTCUT.NEXT, @_go_to_next_conversation
     amplify.subscribe z.event.WebApp.SHORTCUT.PREV, @_go_to_prev_conversation
     amplify.subscribe z.event.WebApp.SHORTCUT.START, @click_on_people_button
-    amplify.subscribe z.event.WebApp.LOADED, @on_webapp_loaded
+    amplify.subscribe z.event.WebApp.LIFECYCLE.LOADED, @on_webapp_loaded
 
   _go_to_next_conversation: =>
     conversations = @conversation_repository.conversations_unarchived()

--- a/app/script/view_model/list/ConversationListViewModel.coffee
+++ b/app/script/view_model/list/ConversationListViewModel.coffee
@@ -99,12 +99,12 @@ class z.ViewModel.list.ConversationListViewModel
     @content_view_model.show_conversation conversation_et
 
   _init_subscriptions: =>
+    amplify.subscribe z.event.WebApp.LIFECYCLE.LOADED, @on_webapp_loaded
     amplify.subscribe z.event.WebApp.SEARCH.BADGE.SHOW, => @show_badge true
     amplify.subscribe z.event.WebApp.SEARCH.BADGE.HIDE, => @show_badge false
     amplify.subscribe z.event.WebApp.SHORTCUT.NEXT, @_go_to_next_conversation
     amplify.subscribe z.event.WebApp.SHORTCUT.PREV, @_go_to_prev_conversation
     amplify.subscribe z.event.WebApp.SHORTCUT.START, @click_on_people_button
-    amplify.subscribe z.event.WebApp.LIFECYCLE.LOADED, @on_webapp_loaded
 
   _go_to_next_conversation: =>
     conversations = @conversation_repository.conversations_unarchived()

--- a/app/script/view_model/list/ListViewModel.coffee
+++ b/app/script/view_model/list/ListViewModel.coffee
@@ -59,8 +59,8 @@ class z.ViewModel.list.ListViewModel
 
 
   _init_subscriptions: =>
-    amplify.subscribe z.event.WebApp.LOADED, => @webapp_loaded true
-    amplify.subscribe z.event.WebApp.PROFILE.SETTINGS.SHOW, @open_preferences_account # @todo remove when user base of wrappers version >= 2.11 is large enough
+    amplify.subscribe z.event.WebApp.LIFECYCLE.LOADED, => @webapp_loaded true
+    amplify.subscribe z.event.WebApp.PROFILE.SETTINGS.SHOW, @open_preferences_account # todo: deprecated remove when user base of wrappers version >= 2.11 is large enough
     amplify.subscribe z.event.WebApp.PREFERENCES.MANAGE_ACCOUNT, @open_preferences_account
     amplify.subscribe z.event.WebApp.PREFERENCES.MANAGE_DEVICES, @open_preferences_devices
     amplify.subscribe z.event.WebApp.SEARCH.SHOW, @open_start_ui

--- a/app/script/view_model/list/ListViewModel.coffee
+++ b/app/script/view_model/list/ListViewModel.coffee
@@ -60,9 +60,9 @@ class z.ViewModel.list.ListViewModel
 
   _init_subscriptions: =>
     amplify.subscribe z.event.WebApp.LIFECYCLE.LOADED, => @webapp_loaded true
-    amplify.subscribe z.event.WebApp.PROFILE.SETTINGS.SHOW, @open_preferences_account # todo: deprecated remove when user base of wrappers version >= 2.11 is large enough
     amplify.subscribe z.event.WebApp.PREFERENCES.MANAGE_ACCOUNT, @open_preferences_account
     amplify.subscribe z.event.WebApp.PREFERENCES.MANAGE_DEVICES, @open_preferences_devices
+    amplify.subscribe z.event.WebApp.PROFILE.SETTINGS.SHOW, @open_preferences_account # todo: deprecated remove when user base of wrappers version >= 2.11 is large enough
     amplify.subscribe z.event.WebApp.SEARCH.SHOW, @open_start_ui
     amplify.subscribe z.event.WebApp.TAKEOVER.SHOW, @show_takeover
     amplify.subscribe z.event.WebApp.TAKEOVER.DISMISS, @dismiss_takeover

--- a/app/style/warnings.less
+++ b/app/style/warnings.less
@@ -51,6 +51,10 @@
   justify-content: center;
 }
 
+.warning-bar-click {
+  cursor: pointer;
+}
+
 .warning-bar-progress {
   background-color: @w-yellow;
   animation: anim 2.1s @ease-in-out-quart infinite;
@@ -88,6 +92,11 @@
 
 .warning-bar-icon {
   font-size: @icon-size-md;
+  margin-right: 8px;
+}
+
+.warning-bar-icon-small {
+  font-size: @icon-size-sm;
   margin-right: 8px;
 }
 

--- a/app/style/warnings.less
+++ b/app/style/warnings.less
@@ -95,11 +95,6 @@
   margin-right: 8px;
 }
 
-.warning-bar-icon-small {
-  font-size: @icon-size-sm;
-  margin-right: 8px;
-}
-
 .warning-bar-link {
   cursor: pointer;
   &,

--- a/aws/application.py
+++ b/aws/application.py
@@ -120,12 +120,19 @@ def demo():
     'demo/index.html',
   ))
 
+
 @application.route('/sw.js')
 def service_worker():
  response = flask.make_response(flask.render_template('sw.js'))
  response.headers['Content-Type'] = 'application/javascript'
  response.headers['Cache-Control'] = 'no-cache'
  return response
+
+@application.route('/version/')
+@main.latest_browser_required
+def version():
+  return flask.jsonify({'version': config.CURRENT_VERSION_ID})
+
 
 ###############################################################################
 # Error Stuff

--- a/grunt/tasks/aws.coffee
+++ b/grunt/tasks/aws.coffee
@@ -42,4 +42,4 @@ module.exports = (grunt) ->
     grunt.file.write path.join('aws', 'version'), grunt.option 'version'
 
   grunt.registerTask 'aws_prepare',      ['aws_version_file', 'clean:aws', 'copy:aws', 'copy:aws_templates', 'clean:aws_app', 'clean:aws_s3', 'compress:aws']
-  grunt.registerTask 'aws_run',          ['init', 'prepare_prod', 'aws_prepare', 'open:aws', 'shell:aws', 'watch']
+  grunt.registerTask 'aws_run',          ['init', 'prepare_prod', 'aws_prepare', 'open:aws', 'shell:aws']

--- a/grunt/tasks/aws.coffee
+++ b/grunt/tasks/aws.coffee
@@ -42,4 +42,4 @@ module.exports = (grunt) ->
     grunt.file.write path.join('aws', 'version'), grunt.option 'version'
 
   grunt.registerTask 'aws_prepare',      ['aws_version_file', 'clean:aws', 'copy:aws', 'copy:aws_templates', 'clean:aws_app', 'clean:aws_s3', 'compress:aws']
-  grunt.registerTask 'aws_run',          ['init', 'prepare_prod', 'aws_prepare', 'open:aws', 'shell:aws']
+  grunt.registerTask 'aws_run',          ['init', 'prepare_prod', 'aws_prepare', 'open:aws', 'shell:aws', 'watch']

--- a/test/unit_tests/announce/AnnounceRepositorySpec.coffee
+++ b/test/unit_tests/announce/AnnounceRepositorySpec.coffee
@@ -78,6 +78,6 @@ describe 'z.announce.AnnounceRepository', ->
     server.restore()
 
   it 'can fetch an announcement', (done) ->
-    announce_repository.fetch_announcements()
+    announce_repository.check_announcements()
     .then done
     .catch done.fail


### PR DESCRIPTION
Related to https://github.com/wireapp/wire-desktop/pull/336

- will listen to updated versions of the Wire for Windows version
- adds a current version reporting on the webapp server side
- browser will check against that version every 6 hours
- bar informing the user will be shown at that time
- click reloads the webapp or restarts the Windows wrapper