### PR TITLE
Remove unused local identity primary key from AnnounceRepository

### DIFF
--- a/app/script/announce/AnnounceRepository.coffee
+++ b/app/script/announce/AnnounceRepository.coffee
@@ -25,7 +25,6 @@ ANNOUNCE_CONFIG =
   UPDATE_INTERVAL: 6 * 60 * 60 * 1000
 
 class z.announce.AnnounceRepository
-  PRIMARY_KEY_CURRENT_announce: 'local_identity'
   constructor: (@announce_service) ->
     @logger = new z.util.Logger 'z.announce.AnnounceRepository', z.config.LOGGER.OPTIONS
     return @


### PR DESCRIPTION
It's been there since the initial commit months ago for no apparent reason
