### PR TITLE
defer file upload (WEBAPP-3322)

### DIFF
--- a/app/script/conversation/ConversationRepository.coffee
+++ b/app/script/conversation/ConversationRepository.coffee
@@ -1470,7 +1470,7 @@ class z.conversation.ConversationRepository
   Post images to a conversation.
 
   @param conversation_et [z.entity.Conversation] Conversation to post the images
-  @param images [Object] Message content
+  @param images [Array|FileList]
   ###
   upload_images: (conversation_et, images) =>
     return if not @_can_upload_assets_to_conversation conversation_et
@@ -1483,15 +1483,17 @@ class z.conversation.ConversationRepository
   ###
   Post files to a conversation.
   @param conversation_et [z.entity.Conversation] Conversation to post the files
-  @param files [Object] File objects
+  @param files [Array|FileList] File objects
   ###
   upload_files: (conversation_et, files) =>
     return if not @_can_upload_assets_to_conversation conversation_et
-    for file in files
+
+    z.util.foreach_deferred files, (file) =>
       if @use_v3_api
         @upload_file_v3 conversation_et, file
       else
         @upload_file conversation_et, file
+    , 10
 
   ###
   Post file to a conversation.

--- a/app/script/util/util.coffee
+++ b/app/script/util/util.coffee
@@ -610,3 +610,19 @@ z.util.format_time_remaining = (time_remaining) ->
     title += "#{moment_duration.seconds()} #{z.localization.Localizer.get_text z.string.ephememal_units_seconds}"
 
   return title or ''
+
+###
+Execute provided function on each item of the array with the given interval
+@param array [Array]
+@param fn [Function]
+@param interval [Number] Interval in ms
+###
+z.util.foreach_deferred = (array, fn, interval) ->
+  remaining_items = Array.prototype.slice.apply array
+  interval_id = window.setInterval ->
+    removed_element = remaining_items.shift()
+    if removed_element?
+      fn removed_element
+    else
+      window.clearInterval interval_id
+  , interval

--- a/test/unit_tests/util/UtilSpec.coffee
+++ b/test/unit_tests/util/UtilSpec.coffee
@@ -772,4 +772,4 @@ describe 'z.util.foreach_deferred', ->
       expect(result).toBe 6
       expect(spy.calls.count()).toBe 3
       done()
-    , 1000
+    , 2000

--- a/test/unit_tests/util/UtilSpec.coffee
+++ b/test/unit_tests/util/UtilSpec.coffee
@@ -756,3 +756,20 @@ describe 'z.util.add_http', ->
   it 'does not add https if present', ->
     url = 'https://wire.com/'
     expect(z.util.add_http url).toBe 'https://wire.com/'
+
+describe 'z.util.foreach_deferred', ->
+  it 'should iterate over array', (done) ->
+
+    spy = jasmine.createSpy 'spy'
+    result = 0
+
+    z.util.foreach_deferred [1, 2, 3], (item) ->
+      result += item
+      spy()
+    , 10
+
+    window.setTimeout ->
+      expect(result).toBe 6
+      expect(spy.calls.count()).toBe 3
+      done()
+    , 1000


### PR DESCRIPTION
Happended when two or more filse where saved with the same timestamp in the database, which would overwrite the previous one. Until we have a proper timestamp fix, deferring the fileupload should help.