### PR TITLE
Always grant delete for everyone messages (WEBAPP-3636)

### DIFF
--- a/app/script/conversation/ConversationRepository.coffee
+++ b/app/script/conversation/ConversationRepository.coffee
@@ -1435,7 +1435,7 @@ class z.conversation.ConversationRepository
     return new Promise (resolve, reject) =>
       if conversation_et.verification_state() is z.conversation.ConversationVerificationState.UNVERIFIED
         resolve()
-      else if generic_message.content in ['cleared', 'confirmation', 'lastRead']
+      else if generic_message.content in ['cleared', 'confirmation', 'deleted', 'lastRead']
         resolve()
       else
         send_anyway = false


### PR DESCRIPTION
Delete for everyone messages should always be granted as stated in the spec
