### PR TITLE
Disable calling features currently defunct in v3 (WEBAPP-3711)

### DIFF
--- a/app/page/template/list/conversations.htm
+++ b/app/page/template/list/conversations.htm
@@ -118,7 +118,7 @@
                     </div>
                   </div>
                 <!-- /ko -->
-                <!-- ko ifnot: is_group() -->
+                <!-- ko if: $parent.show_toggle_video() -->
                   <div class="calls-controls-action calls-controls-action-video">
                     <div class="up">
                       <div class="button-round button-round-dark icon-video"

--- a/app/page/template/video-calling.htm
+++ b/app/page/template/video-calling.htm
@@ -62,8 +62,10 @@
               <div class="video-controls-button button-round button-round-md icon-screensharing"
                    data-bind="click: clicked_on_share_screen, css: {'toggled': self_stream_state.screen_send(), 'button-round-dark': !show_remote_participant(), 'disabled': disable_toggle_screen()}"></div>
             <!-- /ko -->
-            <div class="video-controls-button button-round button-round-md icon-video"
-                 data-bind="click: clicked_on_stop_video, css: {'toggled': self_stream_state.video_send(), 'button-round-dark': !show_remote_participant()}"></div>
+            <!-- ko if: show_toggle_video() -->
+              <div class="video-controls-button button-round button-round-md icon-video"
+                   data-bind="click: clicked_on_stop_video, css: {'toggled': self_stream_state.video_send(), 'button-round-dark': !show_remote_participant()}"></div>
+            <!-- /ko -->
             <div class="video-controls-button button-round button-round-md button-round-theme-red icon-end-call"
                  data-uie-name="do-call-controls-video-call-cancel"
                  data-bind="click: clicked_on_cancel_call"></div>

--- a/app/script/view_model/VideoCallingViewModel.coffee
+++ b/app/script/view_model/VideoCallingViewModel.coffee
@@ -82,17 +82,26 @@ class z.ViewModel.VideoCallingViewModel
       is_visible = (@joined_call()?.is_remote_screen_send() or @joined_call()?.is_remote_video_send()) and @remote_video_stream()
       return @is_ongoing() and is_visible
 
+    @joined_v3_call = ko.pureComputed =>
+      return @joined_call()? and @joined_call() instanceof z.calling.entities.ECall
+
     @show_switch_camera = ko.pureComputed =>
+      return false if @joined_v3_call()
       is_visible = @local_video_stream() and @available_devices.video_input().length > 1 and @self_stream_state.video_send()
       return @is_ongoing() and is_visible
     @show_switch_screen = ko.pureComputed =>
+      return false if @joined_v3_call()
       is_visible = @local_video_stream() and @available_devices.screen_input().length > 1 and @self_stream_state.screen_send()
       return @is_ongoing() and is_visible
 
     @show_controls = ko.pureComputed =>
       is_visible = @show_remote_video() or @show_remote_participant() and not @multitasking.is_minimized()
       return @is_ongoing() and is_visible
-    @show_toggle_screen = ko.pureComputed ->
+    @show_toggle_video = ko.pureComputed =>
+      return false if @joined_v3_call() and @media_repository.stream_handler.local_media_type() is z.media.MediaType.AUDIO
+      return @joined_call()?.conversation_et.is_one2one()
+    @show_toggle_screen = ko.pureComputed =>
+      return false if @joined_v3_call()
       return z.calling.CallingRepository.supports_screen_sharing()
     @disable_toggle_screen = ko.pureComputed =>
       return @joined_call()?.is_remote_screen_send()

--- a/app/script/view_model/list/ConversationListViewModel.coffee
+++ b/app/script/view_model/list/ConversationListViewModel.coffee
@@ -84,8 +84,15 @@ class z.ViewModel.list.ConversationListViewModel
 
     @self_stream_state = @calling_repository.self_stream_state
 
-    @show_toggle_screen = ko.pureComputed ->
+    @joined_v3_call = ko.pureComputed =>
+      return @joined_call()? and @joined_call() instanceof z.calling.entities.ECall
+
+    @show_toggle_screen = ko.pureComputed =>
+      return false if @joined_v3_call()
       return z.calling.CallingRepository.supports_screen_sharing()
+    @show_toggle_video = ko.pureComputed =>
+      return false if @joined_v3_call() and @calling_repository.media_repository.stream_handler.local_media_type() is z.media.MediaType.AUDIO
+      return @joined_call()?.conversation_et.is_one2one()
     @disable_toggle_screen = ko.pureComputed =>
       return @joined_call()?.is_remote_screen_send()
 


### PR DESCRIPTION
## Type of change

The initial release of calling v3 does not support renegoatiation. In order to avoid broken functionality in 1:1 calls, the following will be disabled in the UI:

- screen sharing is not an available option
 - camera cannot be switched during video calls
- audio calls cannot be upgraded to video calls

Changes need to be made to call UI in both conversation list and full screen mode
