### PR TITLE
Extended RtcRtpSender.replaceTrack feature check (WEBAPP-3700

### DIFF
--- a/app/script/calling/entities/EFlow.coffee
+++ b/app/script/calling/entities/EFlow.coffee
@@ -645,6 +645,7 @@ class z.calling.entities.EFlow
     .then =>
       if @peer_connection.getSenders
         for rtp_sender in @peer_connection.getSenders() when rtp_sender.track.kind is media_stream_info.type
+          throw new z.calling.v2.CallError z.calling.v2.CallError::TYPE.RTP_SENDER_NOT_SUPPORTED unless rtp_sender.replaceTrack
           return rtp_sender
         throw new z.calling.v2.CallError z.calling.v2.CallError::TYPE.NO_REPLACEABLE_TRACK
       throw new z.calling.v2.CallError z.calling.v2.CallError::TYPE.RTP_SENDER_NOT_SUPPORTED

--- a/app/script/calling/entities/Flow.coffee
+++ b/app/script/calling/entities/Flow.coffee
@@ -739,6 +739,7 @@ class z.calling.entities.Flow
     .then =>
       if @peer_connection.getSenders
         for rtp_sender in @peer_connection.getSenders() when rtp_sender.track.kind is media_stream_info.type
+          throw new z.calling.v2.CallError z.calling.v2.CallError::TYPE.RTP_SENDER_NOT_SUPPORTED unless rtp_sender.replaceTrack
           return rtp_sender
         throw new z.calling.v2.CallError z.calling.v2.CallError::TYPE.NO_REPLACEABLE_TRACK
       throw new z.calling.v2.CallError z.calling.v2.CallError::TYPE.RTP_SENDER_NOT_SUPPORTED


### PR DESCRIPTION
## Type of change
Parts of the RtcRtpSender support are implemented in latest Chrome versions. ReplaceTrack is not yet part of that implementation though. Thus the current feature check failed.