### PR TITLE
Always use v3 for 1to1 calls (WEBAPP-3727)

### DIFF
--- a/app/script/calling/CallingRepository.coffee
+++ b/app/script/calling/CallingRepository.coffee
@@ -67,7 +67,6 @@ class z.calling.CallingRepository
 
     @flow_status = undefined
 
-    @protocol_version_1to1 = ko.pureComputed => @calling_config()?.features?.protocol_version_1to1
     @protocol_version_group = ko.pureComputed => @calling_config()?.features?.protocol_version_group
 
     @share_call_states()
@@ -107,12 +106,10 @@ class z.calling.CallingRepository
   outgoing_protocol_version: (conversation_id) =>
     conversation_et = @conversation_repository.get_conversation_by_id conversation_id
 
-    protocol_version = z.calling.enum.PROTOCOL.VERSION_3
-    if @use_v3_api is false or conversation_et?.is_group() or (@use_v3_api isnt true and @protocol_version_1to1() is z.calling.enum.PROTOCOL.VERSION_2)
-      protocol_version = z.calling.enum.PROTOCOL.VERSION_2
+    protocol_version = if conversation_et?.is_group() then z.calling.enum.PROTOCOL.VERSION_2 else z.calling.enum.PROTOCOL.VERSION_3
 
     @logger.log "Selected outgoing call protocol version: #{protocol_version}",
-      {conversation_type: conversation_et?.type(), backend_protocol_1to1: @protocol_version_1to1(), use_v3_api: @use_v3_api}
+      {conversation_type: conversation_et?.type(), backend_protocol_group: @protocol_version_group(), use_v3_api: @use_v3_api}
     return protocol_version
 
   # Initiate calling config update.

--- a/test/unit_tests/calling/CallingRepositorySpec.coffee
+++ b/test/unit_tests/calling/CallingRepositorySpec.coffee
@@ -51,14 +51,17 @@ describe 'z.calling.CallingRepository', ->
       expect(calling_repository.outgoing_protocol_version group_conversation_id).toBe z.calling.enum.PROTOCOL.VERSION_2
 
       calling_repository.use_v3_api = false
-      expect(calling_repository.outgoing_protocol_version conversation_id).toBe z.calling.enum.PROTOCOL.VERSION_2
+      expect(calling_repository.outgoing_protocol_version conversation_id).toBe z.calling.enum.PROTOCOL.VERSION_3
       expect(calling_repository.outgoing_protocol_version group_conversation_id).toBe z.calling.enum.PROTOCOL.VERSION_2
 
     it 'should return the expected protocol version if backend switch is set to v2', ->
-      calling_repository.calling_config {features: protocol_version_1to1: z.calling.enum.PROTOCOL.VERSION_2}
+      calling_repository.calling_config
+        features:
+          protocol_version_1to1: z.calling.enum.PROTOCOL.VERSION_2
+          protocol_version_group: z.calling.enum.PROTOCOL.VERSION_2
 
       calling_repository.use_v3_api = undefined
-      expect(calling_repository.outgoing_protocol_version conversation_id).toBe z.calling.enum.PROTOCOL.VERSION_2
+      expect(calling_repository.outgoing_protocol_version conversation_id).toBe z.calling.enum.PROTOCOL.VERSION_3
       expect(calling_repository.outgoing_protocol_version group_conversation_id).toBe z.calling.enum.PROTOCOL.VERSION_2
 
       calling_repository.use_v3_api = true
@@ -66,11 +69,14 @@ describe 'z.calling.CallingRepository', ->
       expect(calling_repository.outgoing_protocol_version group_conversation_id).toBe z.calling.enum.PROTOCOL.VERSION_2
 
       calling_repository.use_v3_api = false
-      expect(calling_repository.outgoing_protocol_version conversation_id).toBe z.calling.enum.PROTOCOL.VERSION_2
+      expect(calling_repository.outgoing_protocol_version conversation_id).toBe z.calling.enum.PROTOCOL.VERSION_3
       expect(calling_repository.outgoing_protocol_version group_conversation_id).toBe z.calling.enum.PROTOCOL.VERSION_2
 
     it 'should return the expected protocol version if backend switch is set to v3', ->
-      calling_repository.calling_config {features: protocol_version_1to1: z.calling.enum.PROTOCOL.VERSION_3}
+      calling_repository.calling_config
+        features:
+          protocol_version_1to1: z.calling.enum.PROTOCOL.VERSION_3
+          protocol_version_group: z.calling.enum.PROTOCOL.VERSION_3
 
       calling_repository.use_v3_api = undefined
       expect(calling_repository.outgoing_protocol_version conversation_id).toBe z.calling.enum.PROTOCOL.VERSION_3
@@ -81,5 +87,5 @@ describe 'z.calling.CallingRepository', ->
       expect(calling_repository.outgoing_protocol_version group_conversation_id).toBe z.calling.enum.PROTOCOL.VERSION_2
 
       calling_repository.use_v3_api = false
-      expect(calling_repository.outgoing_protocol_version conversation_id).toBe z.calling.enum.PROTOCOL.VERSION_2
+      expect(calling_repository.outgoing_protocol_version conversation_id).toBe z.calling.enum.PROTOCOL.VERSION_3
       expect(calling_repository.outgoing_protocol_version group_conversation_id).toBe z.calling.enum.PROTOCOL.VERSION_2


### PR DESCRIPTION
- ignore backend alltogether