### PR TITLE
Support JavaScript for writing source files

### DIFF
--- a/grunt/config/copy.coffee
+++ b/grunt/config/copy.coffee
@@ -34,8 +34,15 @@ module.exports =
       'image/**/*'
       'font/**/*'
       'style/*.css'
+      'script/*/*.js'
       'worker/*'
     ]
+
+  dist_js:
+    cwd: '<%= dir.app_ %>'
+    dest: '<%= dir.dist %>'
+    expand: true
+    src: 'script/*/*.js'
 
   dist_audio:
     cwd: '<%= dir.app_ %>/ext/audio/wire-audio-files'
@@ -64,6 +71,7 @@ module.exports =
       'image/**/*'
       'font/**/*'
       'style/*.css'
+      'script/*/*.js'
       'worker/*'
     ]
 

--- a/grunt/config/copy.coffee
+++ b/grunt/config/copy.coffee
@@ -34,7 +34,7 @@ module.exports =
       'image/**/*'
       'font/**/*'
       'style/*.css'
-      'script/*/*.js'
+      'script/**/*.js'
       'worker/*'
     ]
 
@@ -42,7 +42,7 @@ module.exports =
     cwd: '<%= dir.app_ %>'
     dest: '<%= dir.dist %>'
     expand: true
-    src: 'script/*/*.js'
+    src: 'script/**/*.js'
 
   dist_audio:
     cwd: '<%= dir.app_ %>/ext/audio/wire-audio-files'
@@ -71,7 +71,7 @@ module.exports =
       'image/**/*'
       'font/**/*'
       'style/*.css'
-      'script/*/*.js'
+      'script/**/*.js'
       'worker/*'
     ]
 

--- a/grunt/config/watch.coffee
+++ b/grunt/config/watch.coffee
@@ -32,6 +32,10 @@ module.exports =
     files: ['<%= dir.app_ %>/**/*.coffee', 'sw.coffee']
     tasks: ['coffee:dist']
 
+  js:
+    files: '<%= dir.app_ %>/**/*.js'
+    tasks: ['copy:dist_js']
+
   templates:
     files: '<%= dir.app_ %>/**/*.htm*'
     tasks: ['prepare_template']


### PR DESCRIPTION
So simply instead of creating `.coffee` files inside the `app/script` directory we can now create `.js` files and the rest remain the same.