### PR TITLE
Use preselected audio input/output devices (WEBAPP-3466)

### DIFF
--- a/app/script/media/MediaElementHandler.coffee
+++ b/app/script/media/MediaElementHandler.coffee
@@ -22,9 +22,10 @@ z.media ?= {}
 # MediaElement handler
 class z.media.MediaElementHandler
   # Construct a new MediaElement handler.
-  constructor: ->
+  constructor: (@media_repository) ->
     @logger = new z.util.Logger 'z.media.MediaElementHandler', z.config.LOGGER.OPTIONS
 
+    @current_device_id = @media_repository.devices_handler.current_device_id
     @remote_media_elements = ko.observableArray []
 
   ###
@@ -70,6 +71,7 @@ class z.media.MediaElementHandler
       media_element.dataset['flow_id'] = media_stream_info.flow_id
       media_element.muted = false
       media_element.setAttribute 'autoplay', true
+      @_set_media_element_output media_element, @current_device_id.audio_output()
       return media_element
     catch error
       @logger.error "Unable to create AudioElement for flow '#{media_stream_info.flow_id}'", error

--- a/app/script/media/MediaRepository.coffee
+++ b/app/script/media/MediaRepository.coffee
@@ -42,7 +42,7 @@ class z.media.MediaRepository
     @logger = new z.util.Logger 'z.media.MediaRepository', z.config.LOGGER.OPTIONS
 
     @devices_handler = new z.media.MediaDevicesHandler @
-    @element_handler = new z.media.MediaElementHandler()
+    @element_handler = new z.media.MediaElementHandler @
     @stream_handler = new z.media.MediaStreamHandler @
 
     @audio_context = undefined

--- a/app/script/media/MediaStreamHandler.coffee
+++ b/app/script/media/MediaStreamHandler.coffee
@@ -135,7 +135,7 @@ class z.media.MediaStreamHandler
   @return [Object] Video stream constraints
   ###
   _get_audio_stream_constraints: (media_device_id) ->
-    if _.isString media_device_id and media_device_id isnt 'default'
+    if _.isString media_device_id
       media_stream_constraints =
         deviceId:
           exact: media_device_id


### PR DESCRIPTION
## Type of change
- when starting an audio call we would not use the preselected audio output device, only subsequent changes to this were properly set to the audio element
