### PR TITLE
Disable audio output selection on Firefox (WEBAPP-3466)

### DIFF
--- a/app/page/template/content/preferences-av.htm
+++ b/app/page/template/content/preferences-av.htm
@@ -32,7 +32,7 @@
         </section>
       <!-- /ko -->
 
-      <!-- ko if: available_devices.audio_output().length -->
+      <!-- ko if: available_devices.audio_output().length && z.util.Environment.browser.supports.audio_output_selection -->
         <section class="preferences-section">
           <header class="preferences-header preferences-av-header" data-bind="l10n_text: z.string.preferences_av_speakers"></header>
           <div class="preferences-option">

--- a/app/script/media/MediaElementHandler.coffee
+++ b/app/script/media/MediaElementHandler.coffee
@@ -71,7 +71,8 @@ class z.media.MediaElementHandler
       media_element.dataset['flow_id'] = media_stream_info.flow_id
       media_element.muted = false
       media_element.setAttribute 'autoplay', true
-      @_set_media_element_output media_element, @current_device_id.audio_output()
+      if z.util.Environment.browser.supports.audio_output_selection
+        @_set_media_element_output media_element, @current_device_id.audio_output()
       return media_element
     catch error
       @logger.error "Unable to create AudioElement for flow '#{media_stream_info.flow_id}'", error
@@ -99,6 +100,8 @@ class z.media.MediaElementHandler
   @param sink_id [String] ID of MediaDevice to be used
   ###
   _set_media_element_output: (media_element, sink_id) ->
+    return if not media_element.setSinkId
+
     media_element.setSinkId sink_id
     .then =>
       @logger.info "Audio output device '#{sink_id}' attached to flow '#{media_element.dataset['flow_id']}", media_element

--- a/app/script/util/Environment.coffee
+++ b/app/script/util/Environment.coffee
@@ -59,6 +59,10 @@ z.util.Environment = do ->
       return false if window.Notification.requestPermission is undefined
       return false if document.visibilityState is undefined
       return true
+
+    supports_audio_output_selection: ->
+      return true if @is_chrome()
+      return false
     supports_calling: ->
       return false if not @supports_media_devices()
       return false if window.WebSocket is undefined
@@ -126,6 +130,7 @@ z.util.Environment = do ->
     opera: _check.is_opera()
 
     supports:
+      audio_output_selection: _check.supports_audio_output_selection()
       calling: _check.supports_calling()
       media_devices: _check.supports_media_devices()
       notifications: _check.supports_notifications()

--- a/app/script/util/Environment.coffee
+++ b/app/script/util/Environment.coffee
@@ -61,8 +61,7 @@ z.util.Environment = do ->
       return true
 
     supports_audio_output_selection: ->
-      return true if @is_chrome()
-      return false
+      return @is_chrome()
     supports_calling: ->
       return false if not @supports_media_devices()
       return false if window.WebSocket is undefined


### PR DESCRIPTION
## Type of change
Audio output device selection is not supported on Firefox

https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/setSinkId