### PR TITLE
dont update last notification id with tansient notifications (WEBAPP-3799)

### DIFF
--- a/app/script/event/EventRepository.coffee
+++ b/app/script/event/EventRepository.coffee
@@ -410,26 +410,23 @@ class z.event.EventRepository
   ###
   _handle_notification: (notification) =>
     return new Promise (resolve, reject) =>
-      events = notification.payload
-      source = switch @notification_handling_state()
-        when z.event.NotificationHandlingState.WEB_SOCKET
-          @NOTIFICATION_SOURCE.WEB_SOCKET
-        else
-          @NOTIFICATION_SOURCE.STREAM
+      {payload: events, id, transient} = notification
+      source = if transient? then @NOTIFICATION_SOURCE.WEB_SOCKET else @NOTIFICATION_SOURCE.STREAM
+      is_transient_event = transient is true
 
-      @logger.info "Handling notification '#{notification.id}' from '#{source}' containing '#{events.length}' events", notification
+      @logger.info "Handling notification '#{id}' from '#{source}' containing '#{events.length}' events", notification
 
       if events.length is 0
         @logger.warn 'Notification payload does not contain any events'
-        @_update_last_notification_id notification.id
-        resolve @last_notification_id()
+        @_update_last_notification_id(id) if not is_transient_event
+        resolve()
       else
         Promise.all (@_handle_event event for event in events)
         .then =>
-          @_update_last_notification_id notification.id
-          resolve @last_notification_id()
+          @_update_last_notification_id(id) if not is_transient_event
+          resolve()
         .catch (error) =>
-          @logger.error "Failed to handle notification '#{notification.id}' from '#{source}': #{error.message}", error
+          @logger.error "Failed to handle notification '#{id}' from '#{source}': #{error.message}", error
           reject error
 
   ###

--- a/test/unit_tests/event/EventRepositorySpec.coffee
+++ b/test/unit_tests/event/EventRepositorySpec.coffee
@@ -105,6 +105,34 @@ describe 'Event Repository', ->
         done()
       .catch done.fail
 
+  describe '_handle_notification', ->
+    last_notification_id = undefined
+
+    beforeEach ->
+      last_notification_id = z.util.create_random_uuid()
+      event_repository.last_notification_id last_notification_id
+
+    it 'should not update last notification id if transient is true', (done) ->
+      notification_payload = {id: z.util.create_random_uuid(), payload: [], transient: true}
+
+      event_repository._handle_notification(notification_payload).then =>
+        expect(event_repository.last_notification_id()).toBe last_notification_id
+        done()
+
+    it 'should update last notification id if transient is false', (done) ->
+      notification_payload = {id: z.util.create_random_uuid(), payload: [], transient: false}
+
+      event_repository._handle_notification(notification_payload).then =>
+        expect(event_repository.last_notification_id()).toBe notification_payload.id
+        done()
+
+    it 'should update last notification id if transient is not present', (done) ->
+      notification_payload = {id: z.util.create_random_uuid(), payload: []}
+
+      event_repository._handle_notification(notification_payload).then =>
+        expect(event_repository.last_notification_id()).toBe notification_payload.id
+        done()
+
   describe '_handle_event', ->
     beforeEach ->
       event_repository.notification_handling_state z.event.NotificationHandlingState.WEB_SOCKET


### PR DESCRIPTION
we should not store transient notification ids as last notification id since this results in an 404 error next time we ask for notifications with this id. Since the resulting error looks similar to what we would get in case of missed messages, we show the "you havent used this... " message