### PR TITLE
Support latest emoji on macOS

### DIFF
--- a/app/style/common/variables.less
+++ b/app/style/common/variables.less
@@ -18,11 +18,19 @@
  */
 
 // ----------------------------------------------------------------------------
+// Local Emoji Font
+// ----------------------------------------------------------------------------
+@font-face {
+  font-family: emoji;
+  src: local('Apple Color Emoji');
+}
+
+// ----------------------------------------------------------------------------
 // Font
 // ----------------------------------------------------------------------------
 @ars-font-path:       '../font/';
 
-@font-family-base:      BlinkMacSystemFont, -apple-system, Helvetica Neue, Arial, sans-serif;
+@font-family-base:      BlinkMacSystemFont, -apple-system, Helvetica Neue, emoji, Arial, sans-serif;
 @font-family-ephemeral: Redacted Script;
 
 @font-size-xxs:       8px;


### PR DESCRIPTION
@Dexwell  In order to avoid font change on Windows, references to Segoe UI Emoji have been removed. This works fine on Windows. Please retest on macOS.

https://github.com/wireapp/wire-webapp/pull/1040
