### PR TITLE
Explicitly pass self user to missed message event builder (WEBAPP-3834)

### DIFF
--- a/app/script/conversation/ConversationRepository.coffee
+++ b/app/script/conversation/ConversationRepository.coffee
@@ -1799,7 +1799,7 @@ class z.conversation.ConversationRepository
   on_missed_events: =>
     @filtered_conversations()
     .filter (conversation_et) -> not conversation_et.removed_from_conversation()
-    .forEach (conversation_et) -> amplify.publish z.event.WebApp.EVENT.INJECT, z.conversation.EventBuilder.build_missed conversation_et
+    .forEach (conversation_et) => amplify.publish z.event.WebApp.EVENT.INJECT, z.conversation.EventBuilder.build_missed conversation_et, @user_repository.self()
 
   ###
   Listener for incoming events from the WebSocket.

--- a/app/script/conversation/EventBuilder.coffee
+++ b/app/script/conversation/EventBuilder.coffee
@@ -83,11 +83,11 @@ z.conversation.EventBuilder = do ->
     data:
       deleted_time: time
 
-  build_missed = (conversation_et) ->
+  build_missed = (conversation_et, self_user_et) ->
     conversation: conversation_et.id
     id: z.util.create_random_uuid()
     type: z.event.Client.CONVERSATION.MISSED_MESSAGES
-    from: conversation_et.self.id
+    from: self_user_et.id
     time: new Date().toISOString()
 
   return {

--- a/test/unit_tests/conversation/EventBuilderSpec.coffee
+++ b/test/unit_tests/conversation/EventBuilderSpec.coffee
@@ -19,8 +19,9 @@
 # grunt test_init && grunt test_run:conversation/EventBuilder
 
 describe 'z.conversation.EventBuilder', ->
-  conversation_et = undefined
   event_mapper = undefined
+  conversation_et = undefined
+  self_user_et = undefined
 
   beforeEach ->
     self_user_et = new z.entity.User z.util.create_random_uuid()
@@ -52,7 +53,7 @@ describe 'z.conversation.EventBuilder', ->
     expect(message_et.user_ids()).toEqual user_ids
 
   it 'build_missed', ->
-    event = z.conversation.EventBuilder.build_missed conversation_et
+    event = z.conversation.EventBuilder.build_missed conversation_et, self_user_et
     message_et = event_mapper.map_json_event event, conversation_et
     expect(message_et).toBeDefined()
     expect(message_et.super_type).toBe z.message.SuperType.MISSED


### PR DESCRIPTION
Notification stream is handled at the same time as users are mapped onto the conversations. Thus you end up in a race condition where self on the conversation might be undefined.