### PR TITLE
Lint scripts & styles together

### DIFF
--- a/app/style/base.less
+++ b/app/style/base.less
@@ -48,6 +48,6 @@ a {
   text-decoration: none;
 }
 
-input[type=text]::-ms-clear {
+input[type='text']::-ms-clear {
   display: none;
 }

--- a/app/style/content/preferences/options.less
+++ b/app/style/content/preferences/options.less
@@ -25,7 +25,7 @@
 .preferences-options-radio {
   margin: 0 0 0 -34px;
 
-  input[type=radio] {
+  input[type='radio'] {
     display: none;
   }
 
@@ -53,7 +53,7 @@
     border: 1px solid @graphite;
   }
 
-  input[type=radio]:checked + label:before {
+  input[type='radio']:checked + label:before {
     border-color: currentColor;
     border-width: 6px;
     background-color: #fff;

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
     "deploy-travis-dev": "grunt app_deploy_travis:dev",
     "deploy-travis-prod": "grunt app_deploy_travis:prod",
     "deploy-travis-staging": "grunt app_deploy_travis:staging",
-    "lint": "eslint -c .eslintrc.yaml --ignore-path .gitignore --quiet app/script/**/*.js test/**/*.js bin/*.js",
-    "lint-fix": "eslint --fix -c .eslintrc.yaml --ignore-path .gitignore --quiet app/script/**/*.js test/**/*.js bin/*.js",
-    "stylelint": "stylelint app/style/**/*.less --syntax less",
+    "lint": "yarn lint-scripts && yarn lint-styles",
+    "lint-scripts": "eslint -c .eslintrc.yaml --ignore-path .gitignore --quiet app/script/**/*.js test/**/*.js bin/*.js",
+    "lint-styles": "stylelint app/style/**/*.less --syntax less",
     "postinstall": "grunt init",
     "start": "grunt",
     "test": "yarn lint && yarn stylelint && grunt check && grunt test"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lint-styles": "stylelint app/style/**/*.less --syntax less",
     "postinstall": "grunt init",
     "start": "grunt",
-    "test": "yarn lint && yarn stylelint && grunt check && grunt test"
+    "test": "yarn lint && grunt check && grunt test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I realized that we don't lint our LESS files when running `yarn lint`. We only lint LESS files when executing `yarn test`. That's why I created separate tasks (`lint-scripts` & `lint-styles`) to lint scripts or styles and a generic task (`lint`) which lints both (scripts & styles).

I also removed the `lint-fix` script as it was just a copy of the previous `lint` task including `--fix`. But you can pass additional arguments to `npm` or `yarn` by using `--`. Please note the necessary `--`. So if you want to run `yarn lint-scripts` with automatic fixes, just do:

```bash
yarn lint-scripts -- --fix
```