### PR TITLE
Enforce valid JSDoc 3 types

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,8 +1,8 @@
 env:
   browser: true
-  node: true
   es6: true
   jasmine: true
+  node: true
 
 extends:
   "eslint:recommended"
@@ -75,4 +75,16 @@ rules:
   space-unary-ops: [2, {words: true, nonwords: false}]
   spaced-comment: [2, always, {exceptions: ["#"]}]
   strict: [2, global]
-  valid-jsdoc: [2, {prefer: {return: returns}, requireParamDescription: true, requireReturnDescription: true}]
+  valid-jsdoc:
+    - error
+    -
+      prefer:
+        class: class
+        return: returns
+      preferType:
+        Boolean: boolean
+        Number: number
+        object: Object
+        String: string
+      requireParamDescription: true
+      requireReturnDescription: true

--- a/app/script/assets/AssetRemoteData.js
+++ b/app/script/assets/AssetRemoteData.js
@@ -45,7 +45,7 @@ z.assets.AssetRemoteData = class AssetRemoteData {
    * @param {Uint8Array} [otr_key] - Encryption key
    * @param {Uint8Array} [sha256] - Checksum
    * @param {string} [asset_token] - Token data
-   * @param {Boolean} [force_caching=false] - Cache asset in ServiceWorker
+   * @param {boolean} [force_caching=false] - Cache asset in ServiceWorker
    * @returns {z.assets.AssetRemoteData} V3 asset remote data
    */
   static v3(asset_key, otr_key, sha256, asset_token, force_caching = false) {
@@ -62,7 +62,7 @@ z.assets.AssetRemoteData = class AssetRemoteData {
    * @param {string} asset_id - ID to retrieve asset with
    * @param {Uint8Array} otr_key - Encryption key
    * @param {Uint8Array} sha256 - Checksum
-   * @param {Boolean} [force_caching=false] - Cache asset in ServiceWorker
+   * @param {boolean} [force_caching=false] - Cache asset in ServiceWorker
    * @returns {z.assets.AssetRemoteData} V2 asset remote data
    */
   static v2(conversation_id, asset_id, otr_key, sha256, force_caching = false) {
@@ -78,7 +78,7 @@ z.assets.AssetRemoteData = class AssetRemoteData {
    * @deprecated
    * @param {string} conversation_id - ID of conversation
    * @param {string} asset_id - ID to retrieve asset with
-   * @param {Boolean} [force_caching=false] - Cache asset in ServiceWorker
+   * @param {boolean} [force_caching=false] - Cache asset in ServiceWorker
    * @returns {z.assets.AssetRemoteData} V1 asset remote data
    */
   static v1(conversation_id, asset_id, force_caching = false) {

--- a/app/script/assets/AssetService.js
+++ b/app/script/assets/AssetService.js
@@ -154,7 +154,7 @@ z.assets.AssetService = class AssetService {
    *
    * @param {Uint8Array} bytes - Asset binary data
    * @param {Object} options - Asset upload options
-   * @param {Boolean} options.public - Flag whether asset is public
+   * @param {boolean} options.public - Flag whether asset is public
    * @param {z.assets.AssetRetentionPolicy} options.retention - Retention duration policy for asset
    * @param {Function} xhr_accessor_function - Function will get a reference to the underlying XMLHTTPRequest
    * @returns {Promise} Resolves when asset has been uploaded
@@ -173,7 +173,7 @@ z.assets.AssetService = class AssetService {
    *
    * @param {Blob|File} file - File asset to be uploaded
    * @param {Object} options - Asset upload options
-   * @param {Boolean} options.public - Flag whether asset is public
+   * @param {boolean} options.public - Flag whether asset is public
    * @param {z.assets.AssetRetentionPolicy} options.retention - Retention duration policy for asset
    * @param {Function} xhr_accessor_function - Function will get a reference to the underlying XMLHTTPRequest
    * @returns {Promise} Resolves when asset has been uploaded
@@ -196,7 +196,7 @@ z.assets.AssetService = class AssetService {
    *
    * @param {Blob|File} image - Image asset to be uploaded
    * @param {Object} options - Asset upload options
-   * @param {Boolean} options.public - Flag whether asset is public
+   * @param {boolean} options.public - Flag whether asset is public
    * @param {z.assets.AssetRetentionPolicy} options.retention - Retention duration policy for asset
    * @returns {Promise} Resolves when asset has been uploaded
    */
@@ -221,7 +221,7 @@ z.assets.AssetService = class AssetService {
    * @deprecated
    * @param {string} asset_id - ID of asset
    * @param {string} conversation_id - Conversation ID
-   * @param {Boolean} force_caching - Cache asset in ServiceWorker
+   * @param {boolean} force_caching - Cache asset in ServiceWorker
    * @returns {string} URL of v1 asset
    */
   generate_asset_url(asset_id, conversation_id, force_caching) {
@@ -239,7 +239,7 @@ z.assets.AssetService = class AssetService {
    * @deprecated
    * @param {string} asset_id - ID of asset
    * @param {string} conversation_id - Conversation ID
-   * @param {Boolean} force_caching - Cache asset in ServiceWorker
+   * @param {boolean} force_caching - Cache asset in ServiceWorker
    * @returns {string} URL of v2 asset
    */
   generate_asset_url_v2(asset_id, conversation_id, force_caching) {
@@ -256,7 +256,7 @@ z.assets.AssetService = class AssetService {
    *
    * @param {string} asset_key - ID of asset
    * @param {string} asset_token - Asset token
-   * @param {Boolean} force_caching - Cache asset in ServiceWorker
+   * @param {boolean} force_caching - Cache asset in ServiceWorker
    * @returns {string} URL of v3 asset
    */
   generate_asset_url_v3(asset_key, asset_token, force_caching) {
@@ -306,8 +306,8 @@ z.assets.AssetService = class AssetService {
    * @param {string} conversation_id - ID of conversation
    * @param {Object} json_payload - Payload to post
    * @param {Uint8Array|ArrayBuffer} image_data - Asset data to upload
-   * @param {Array|Boolean} precondition_option - Level that backend checks for missing clients
-   * @param {String} upload_id - Id to track upload with
+   * @param {Array|boolean} precondition_option - Level that backend checks for missing clients
+   * @param {string} upload_id - Id to track upload with
    * @returns {Promise} Resolves when asset has been uploaded
    */
   post_asset_v2(conversation_id, json_payload, image_data, precondition_option, upload_id) {
@@ -360,7 +360,7 @@ z.assets.AssetService = class AssetService {
    *
    * @param {Uint8Array|ArrayBuffer} asset_data - Asset data
    * @param {Object} metadata - Asset metadata
-   * @param {Boolean} metadata.public - Flag whether asset is public
+   * @param {boolean} metadata.public - Flag whether asset is public
    * @param {z.assets.AssetRetentionPolicy} metadata.retention - Retention duration policy for asset
    * @param {Function} xhr_accessor_function - Function will get a reference to the underlying XMLHTTPRequest
    * @returns {Promise} Resolves when asset has been uploaded

--- a/app/script/audio/AudioRepository.js
+++ b/app/script/audio/AudioRepository.js
@@ -104,7 +104,7 @@ window.z.audio.AudioRepository = class AudioRepository {
    * @private
    * @param {z.audio.AudioType} audio_id - Sound identifier
    * @param {HTMLAudioElement} audio_element - AudioElement to play
-   * @param {Boolean} play_in_loop - Play sound in loop
+   * @param {boolean} play_in_loop - Play sound in loop
    * @returns {Promise} Resolves with the HTMLAudioElement
    */
   _play(audio_id, audio_element, play_in_loop = false) {

--- a/app/script/auth/AuthRepository.js
+++ b/app/script/auth/AuthRepository.js
@@ -55,7 +55,7 @@ window.z.auth.AuthRepository = class AuthRepository {
    * @option {string} login - phone The phone number for a password or SMS login
    * @option {string} login - password The password for a password login
    * @option {string} login - code The login code for an SMS login
-   * @param {Boolean} persist - Request a persistent cookie instead of a session cookie
+   * @param {boolean} persist - Request a persistent cookie instead of a session cookie
    * @returns {Promise} Promise that resolves with the received access token
    */
   login(login, persist) {

--- a/app/script/auth/AuthService.js
+++ b/app/script/auth/AuthService.js
@@ -202,7 +202,7 @@
      * @option {string} login - phone The phone number for a password or SMS login
      * @option {string} login - password The password for a password login
      * @option {string} login - code The login code for an SMS login
-     * @param {Boolean} persist - Request a persistent cookie instead of a session cookie
+     * @param {boolean} persist - Request a persistent cookie instead of a session cookie
      * @returns {Promise} Promise that resolves with access token
      */
     post_login(login, persist) {

--- a/app/script/bot/BotRepository.js
+++ b/app/script/bot/BotRepository.js
@@ -32,7 +32,7 @@ z.bot.BotRepository = class BotRepository {
   /**
    * Add bot to conversation.
    * @param {string} bot_name - Bot name registered on backend
-   * @param {Boolean} [create_conversation=true] - A new conversation is created if true otherwise bot is added to active conversation
+   * @param {boolean} [create_conversation=true] - A new conversation is created if true otherwise bot is added to active conversation
    * @returns {Promise} Resolves when bot was added to conversation
    */
   add_bot(bot_name, create_conversation = true) {

--- a/app/script/cache/CacheRepository.js
+++ b/app/script/cache/CacheRepository.js
@@ -37,9 +37,9 @@ z.cache.CacheRepository = class CacheRepository {
   /**
    * Deletes cached data.
    *
-   * @param {Boolean} [keep_conversation_input=false] - Should conversation input be kept
-   * @param {Array<String>} [protected_key_patterns=[z.storage.StorageKey.AUTH.SHOW_LOGIN]] - Keys which should NOT be deleted from the cache
-   * @returns {Array<String>} Keys which have been deleted from the cache
+   * @param {boolean} [keep_conversation_input=false] - Should conversation input be kept
+   * @param {Array<string>} [protected_key_patterns=[z.storage.StorageKey.AUTH.SHOW_LOGIN]] - Keys which should NOT be deleted from the cache
+   * @returns {Array<string>} Keys which have been deleted from the cache
    */
   clear_cache(keep_conversation_input = false, protected_key_patterns = [z.storage.StorageKey.AUTH.SHOW_LOGIN]) {
     const deleted_keys = [];

--- a/app/script/client/ClientRepository.js
+++ b/app/script/client/ClientRepository.js
@@ -429,7 +429,7 @@ z.client.ClientRepository = class ClientRepository {
   /**
    * Cleanup local sessions.
    * @note If quick_clean parameter is set to false, there will be one backend request per user that has a session.
-   * @param {Boolean} [quick_clean=true] - Optional value whether to check all users with local sessions or the ones with too many sessions
+   * @param {boolean} [quick_clean=true] - Optional value whether to check all users with local sessions or the ones with too many sessions
    * @returns {undefined} No return value
    */
   cleanup_clients_and_sessions(quick_clean = true) {

--- a/app/script/client/ClientService.js
+++ b/app/script/client/ClientService.js
@@ -156,7 +156,7 @@ z.client.ClientService = class ClientService {
   /**
    * Loads a persisted client from the database.
    * @param {string} primary_key - Primary key used to find a client in the database
-   * @returns {Promise<JSON|String>} Resolves with the client's payload or the primary key if not found
+   * @returns {Promise<JSON|string>} Resolves with the client's payload or the primary key if not found
    */
   load_client_from_db(primary_key) {
     return this.storage_service.db[this.storage_service.OBJECT_STORE_CLIENTS]

--- a/app/script/event/EventRepository.js
+++ b/app/script/event/EventRepository.js
@@ -188,8 +188,8 @@ z.event.EventRepository = class EventRepository {
   /**
    * Get notifications for the current client from the stream.
    *
-   * @param {String} notification_id - Event ID to start from
-   * @param {Number} [limit=10000] - Max. number of notifications to retrieve from backend at once
+   * @param {string} notification_id - Event ID to start from
+   * @param {number} [limit=10000] - Max. number of notifications to retrieve from backend at once
    * @returns {Promise} Resolves when all new notifications from the stream have been handled
    */
   get_notifications(notification_id, limit = 10000) {
@@ -549,7 +549,7 @@ z.event.EventRepository = class EventRepository {
    * @private
    * @param {Array} events - Events contained in a notification
    * @param {string} id - Notification ID
-   * @param {Boolean} transient - Type of notification
+   * @param {boolean} transient - Type of notification
    * @returns {Promise} Resolves with the ID of the handled notification
    */
   _handle_notification({payload: events, id, transient}) {
@@ -613,7 +613,7 @@ z.event.EventRepository = class EventRepository {
    *
    * @private
    * @param {Object} event - Event to validate
-   * @returns {Boolean} Returns true if event is handled within is lifetime, otherwise throws error
+   * @returns {boolean} Returns true if event is handled within is lifetime, otherwise throws error
    */
   _validate_call_event_lifetime(event) {
     if (this.notification_handling_state() === z.event.NOTIFICATION_HANDLING_STATE.WEB_SOCKET) return true;

--- a/app/script/event/NotificationService.js
+++ b/app/script/event/NotificationService.js
@@ -48,9 +48,9 @@ z.event.NotificationService = class NotificationService {
   /**
    * Get notifications from the stream.
    *
-   * @param {String} client_id - Only return notifications targeted at the given client
-   * @param {String} notification_id - Only return notifications more recent than this notification ID (like "7130304a-c839-11e5-8001-22000b0fe035")
-   * @param {Number} size - Maximum number of notifications to return
+   * @param {string} client_id - Only return notifications targeted at the given client
+   * @param {string} notification_id - Only return notifications more recent than this notification ID (like "7130304a-c839-11e5-8001-22000b0fe035")
+   * @param {number} size - Maximum number of notifications to return
    * @returns {Promise} Resolves with the retrieved notifications
    */
   get_notifications(client_id, notification_id, size) {
@@ -67,7 +67,7 @@ z.event.NotificationService = class NotificationService {
 
   /**
    * Get the last notification for a given client.
-   * @param {String} client_id - Client ID to retrieve notification ID for
+   * @param {string} client_id - Client ID to retrieve notification ID for
    * @returns {Promise} Resolves with the last known notification ID for given client
    */
   get_notifications_last(client_id) {

--- a/app/script/event/WebSocketService.js
+++ b/app/script/event/WebSocketService.js
@@ -175,7 +175,7 @@ z.event.WebSocketService = class WebSocketService {
    * Reset the WebSocket connection.
    *
    * @param {z.event.WebSocketService.CHANGE_TRIGGER} trigger - Trigger of the reset
-   * @param {Boolean} [reconnect=false] - Re-establish the WebSocket connection
+   * @param {boolean} [reconnect=false] - Re-establish the WebSocket connection
    * @returns {undefined} No return value
    */
   reset(trigger, reconnect = false) {

--- a/app/script/extension/GiphyRepository.js
+++ b/app/script/extension/GiphyRepository.js
@@ -39,8 +39,8 @@ z.extension.GiphyRepository = class GiphyRepository {
    *
    * @param {Object} options - Search options
    * @param {string} options.tag - Search query term or phrase
-   * @param {Number} [options.retry=3] - How many retries to get the correct size
-   * @param {Number} [options.max_size=3MB] - Maximum gif size in bytes
+   * @param {number} [options.retry=3] - How many retries to get the correct size
+   * @param {number} [options.max_size=3MB] - Maximum gif size in bytes
    * @returns {Promise} Resolves with a random matching gif
    */
   get_random_gif(options) {
@@ -84,9 +84,9 @@ z.extension.GiphyRepository = class GiphyRepository {
    *
    * @param {Object} options - Search options
    * @param {string} options.query - Search query term or phrase
-   * @param {Number} options.number - Amount of GIFs to retrieve
-   * @param {Number} [options.max_size=3MB] - Maximum gif size in bytes
-   * @param {Boolean} [options.random=true] - Will return an randomized result
+   * @param {number} options.number - Amount of GIFs to retrieve
+   * @param {number} [options.max_size=3MB] - Maximum gif size in bytes
+   * @param {boolean} [options.random=true] - Will return an randomized result
    * @param {string} [options.sorting='recent'] - Specify sorting ('relevant' or 'recent')
    * @returns {Promise} Resolves with gifs
    */

--- a/app/script/extension/GiphyService.js
+++ b/app/script/extension/GiphyService.js
@@ -52,7 +52,7 @@ z.extension.GiphyService = class GiphyService {
 
   /**
    * Search all Giphy GIFs for a word or phrase.
-   * @param {String} tag - GIF tag to limit randomness by
+   * @param {string} tag - GIF tag to limit randomness by
    * @returns {Promise} Resolves with random gifs for given tag
    */
   get_random(tag) {
@@ -67,8 +67,8 @@ z.extension.GiphyService = class GiphyService {
    *
    * @param {Object} options - Search options
    * @param {string} options.query - Search query term or phrase
-   * @param {Number} [options.limit=25] - Number of results to return (maximum 100)
-   * @param {Number} [options.offset=0] - Results offset
+   * @param {number} [options.limit=25] - Number of results to return (maximum 100)
+   * @param {number} [options.offset=0] - Results offset
    * @param {string} [options.sorting='recent'] - Specify sorting ('relevant' or 'recent')
    * @returns {Promise} Resolves with matches
    */

--- a/app/script/links/LinkPreviewHelpers.js
+++ b/app/script/links/LinkPreviewHelpers.js
@@ -38,7 +38,7 @@ z.links.LinkPreviewHelpers = {
   /**
    * Get first link and link offset for given text.
    * @param {string} text - Text to parse
-   * @returns {Array<string, number>} First link and it's offset
+   * @returns {Array<string, number>} First link and its offset
    */
   get_first_link_with_offset(text) {
     const links = twttr.txt.extractUrls(text);

--- a/app/script/links/LinkPreviewHelpers.js
+++ b/app/script/links/LinkPreviewHelpers.js
@@ -27,7 +27,7 @@ z.links.LinkPreviewHelpers = {
   /**
    * Check if the text contains only one link
    * @param {string} text - Text to parse
-   * @returns {Boolean} Text contains only a link
+   * @returns {boolean} Text contains only a link
    */
   contains_only_link(text) {
     text = text.trim();
@@ -38,7 +38,7 @@ z.links.LinkPreviewHelpers = {
   /**
    * Get first link and link offset for given text.
    * @param {string} text - Text to parse
-   * @returns {Array<string, Number>} First link and its offset
+   * @returns {Array<string, number>} First link and it's offset
    */
   get_first_link_with_offset(text) {
     const links = twttr.txt.extractUrls(text);

--- a/app/script/location/GeoLocation.js
+++ b/app/script/location/GeoLocation.js
@@ -46,8 +46,8 @@ z.location = (() => {
 
   /**
    * Reverse loop up for geo location
-   * @param {Number} latitude - Latitude of location
-   * @param {Number} longitude - Longitude of location
+   * @param {number} latitude - Latitude of location
+   * @param {number} longitude - Longitude of location
    * @returns {Promise} Resolves with the location information
    */
   const get_location = (latitude, longitude) => {
@@ -71,10 +71,10 @@ z.location = (() => {
   /**
    * Return link to Google Maps
    *
-   * @param {Number} lat - Latitude of location
-   * @param {Number} lng - Longitude of location
-   * @param {String} name - Name of location
-   * @param {String} zoom - Map zoom level
+   * @param {number} lat - Latitude of location
+   * @param {number} lng - Longitude of location
+   * @param {string} name - Name of location
+   * @param {string} zoom - Map zoom level
    * @returns {string} URL to location in Google Maps
    */
   const get_maps_url = (lat, lng, name, zoom) => {

--- a/app/script/media/MediaDevicesHandler.js
+++ b/app/script/media/MediaDevicesHandler.js
@@ -252,7 +252,7 @@ z.media.MediaDevicesHandler = class MediaDevicesHandler {
 
   /**
    * Check for availability of selected devices.
-   * @param {Boolean} video_send - Also check for video devices
+   * @param {boolean} video_send - Also check for video devices
    * @returns {Promise} Resolves when the current device has been updated
    */
   update_current_devices(video_send) {
@@ -313,7 +313,7 @@ z.media.MediaDevicesHandler = class MediaDevicesHandler {
    * Add underscore to MediaDevice types.
    * @private
    * @param {z.media.MediaDeviceType} device_type - Device type string to update
-   * @returns {String} Updated device type
+   * @returns {string} Updated device type
    */
   _type_conversion(device_type) {
     return device_type.replace('input', '_input').replace('output', '_output');

--- a/app/script/media/MediaEmbeds.js
+++ b/app/script/media/MediaEmbeds.js
@@ -70,7 +70,7 @@ z.media.MediaEmbeds = (function() {
    *
    * @private
    * @param {HTMLAnchorElement} link - Link element
-   * @param {String} message - Message containing the link
+   * @param {string} message - Message containing the link
    * @param {string} iframe - HTML of iframe
    * @returns {string} Message content
    */
@@ -114,7 +114,7 @@ z.media.MediaEmbeds = (function() {
    *
    * @private
    * @param {string} timestamp - Youtube timestamp (1h8m55s)
-   * @returns {Number} Timestamp in seconds
+   * @returns {number} Timestamp in seconds
    */
   const _convert_youtube_timestamp_to_seconds = function(timestamp) {
     if (timestamp) {

--- a/app/script/media/MediaRepository.js
+++ b/app/script/media/MediaRepository.js
@@ -33,7 +33,7 @@ const AUDIO_CONTEXT_STATE = {
 z.media.MediaRepository = class MediaRepository {
   /**
    * Extended check for MediaDevices support of browser.
-   * @returns {Boolean} True if MediaDevices are supported
+   * @returns {boolean} True if MediaDevices are supported
   */
   static supports_media_devices() {
     return z.util.Environment.browser.supports.media_devices;

--- a/app/script/media/MediaStreamHandler.js
+++ b/app/script/media/MediaStreamHandler.js
@@ -107,8 +107,8 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
    * Get the MediaStreamConstraints to be used for MediaStream creation.
    *
    * @private
-   * @param {Boolean} [request_audio=false] - Request audio in the constraints
-   * @param {Boolean} [request_video=false] - Request video in the constraints
+   * @param {boolean} [request_audio=false] - Request audio in the constraints
+   * @param {boolean} [request_video=false] - Request video in the constraints
    * @returns {Promise} Resolves with MediaStreamConstraints and their type
    */
   get_media_stream_constraints(request_audio = false, request_video = false) {
@@ -221,7 +221,7 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
    * Initiate the MediaStream.
    *
    * @param {string} conversation_id - Conversation ID of call
-   * @param {Boolean} [video_send=false] - Should MediaStream contain video
+   * @param {boolean} [video_send=false] - Should MediaStream contain video
    * @returns {Promise} Resolves when the MediaStream has been initiated
    */
   initiate_media_stream(conversation_id, video_send = false) {
@@ -466,7 +466,7 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
    * @private
    * @param {MediaStream} media_stream - MediaStream to be released
    * @param {z.media.MediaType} [media_type=z.media.MediaType.AUDIO_VIDEO] - Type of MediaStreamTracks to be released
-   * @returns {Boolean} Have tracks been stopped
+   * @returns {boolean} Have tracks been stopped
    */
   _release_media_stream(media_stream, media_type = z.media.MediaType.AUDIO_VIDEO) {
     if (media_stream) {
@@ -579,7 +579,7 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
 
   /**
    * Check for active calls that need a MediaStream.
-   * @returns {Boolean} Returns true if an active media stream is needed for at least one call
+   * @returns {boolean} Returns true if an active media stream is needed for at least one call
    */
   needs_media_stream() {
     for (const call_et of this.calls()) {

--- a/app/script/properties/PropertiesRepository.js
+++ b/app/script/properties/PropertiesRepository.js
@@ -88,7 +88,7 @@ z.properties.PropertiesRepository = class PropertiesRepository {
   /**
    * Updated properties handler.
    * @param {z.properties.Properties} properties - New properties
-   * @returns {Boolean} Always returns true to ensure other subscribers handling the event
+   * @returns {boolean} Always returns true to ensure other subscribers handling the event
    */
   properties_updated(properties) {
     if (properties[z.properties.PROPERTIES_TYPE.ENABLE_DEBUGGING]) {

--- a/app/script/search/SearchRepository.js
+++ b/app/script/search/SearchRepository.js
@@ -67,7 +67,7 @@ z.search.SearchRepository = class SearchRepository {
 
   /**
    * Search for users on the backend by name.
-   * @param {String} name - Search query
+   * @param {string} name - Search query
    * @returns {Promise} Resolves with the search results
    */
   search_by_name(name) {

--- a/app/script/search/SearchService.js
+++ b/app/script/search/SearchService.js
@@ -37,8 +37,8 @@ z.search.SearchService = class SearchService {
   /**
    * Search for a user.
    *
-   * @param {String} query - Query string (case insensitive)
-   * @param {Number} size - Number of requested user
+   * @param {string} query - Query string (case insensitive)
+   * @param {number} size - Number of requested user
    * @returns {Promise} Resolves with the search results
    */
   get_contacts(query, size) {

--- a/app/script/system_notification/SystemNotificationRepository.js
+++ b/app/script/system_notification/SystemNotificationRepository.js
@@ -504,7 +504,7 @@ z.system_notification.SystemNotificationRepository = class SystemNotificationRep
    * Creates the notification icon.
    *
    * @private
-   * @param {Boolean} should_obfuscate_sender - Sender visible in notification
+   * @param {boolean} should_obfuscate_sender - Sender visible in notification
    * @param {z.entity.User} user_et - Sender of message
    * @returns {string} Icon URL
   */
@@ -648,7 +648,7 @@ z.system_notification.SystemNotificationRepository = class SystemNotificationRep
    * Should message in a notification be obfuscated.
    * @private
    * @param {z.entity.Message} message_et - Message entity
-   * @returns {Boolean} Obfucscate message in notification
+   * @returns {boolean} Obfucscate message in notification
    */
   _should_obfuscate_notification_message(message_et) {
     return message_et.is_ephemeral() || [
@@ -661,7 +661,7 @@ z.system_notification.SystemNotificationRepository = class SystemNotificationRep
    * Should sender in a notification be obfuscated.
    * @private
    * @param {z.entity.Message} message_et - Message entity
-   * @returns {Boolean} Obfuscate sender in noticiation
+   * @returns {boolean} Obfuscate sender in noticiation
    */
   _should_obfuscate_notification_sender(message_et) {
     return message_et.is_ephemeral() || this.notifications_preference() === z.system_notification.SystemNotificationPreference.OBFUSCATE;
@@ -672,7 +672,7 @@ z.system_notification.SystemNotificationRepository = class SystemNotificationRep
    * @private
    * @param {z.entity.Conversation} conversation_et - Conversation entity
    * @param {z.entity.Message} message_et - Message entity
-   * @returns {Promise<Boolean>} Resolves whether notification should be hidden
+   * @returns {Promise<boolean>} Resolves whether notification should be hidden
    */
   _should_hide_notification(conversation_et, message_et) {
     return Promise.resolve()
@@ -729,7 +729,7 @@ z.system_notification.SystemNotificationRepository = class SystemNotificationRep
    * @param {string} notification_content.title - Notification title
    * @param {Object} notification_content.options - Notification options
    * @param {Function} notification_content.trigger - Function to be triggered on click [Function] trigger
-   * @param {Number} notification_content.timeout - Timeout for notification
+   * @param {number} notification_content.timeout - Timeout for notification
    * @returns {undefined} No return value
    */
   _show_notification_in_browser(notification_content) {

--- a/app/script/telemetry/calling/CallTelemetry.js
+++ b/app/script/telemetry/calling/CallTelemetry.js
@@ -101,7 +101,7 @@ z.telemetry.calling.CallTelemetry = class CallTelemetry {
 
   /**
    * Set the media type of the call.
-   * @param {Boolean} [video_send=false] - Call contains video
+   * @param {boolean} [video_send=false] - Call contains video
    * @returns {undefined} No return value
    */
   set_media_type(video_send = false) {

--- a/app/script/telemetry/calling/FlowTelemetry.js
+++ b/app/script/telemetry/calling/FlowTelemetry.js
@@ -123,7 +123,7 @@ z.telemetry.calling.FlowTelemetry = class FlowTelemetry {
    * Check stream for flowing bytes.
    *
    * @param {z.media.MediaType} media_type - Media type of stream
-   * @param {Number} [attempt=1] - Attempt of stream check
+   * @param {number} [attempt=1] - Attempt of stream check
    * @returns {undefined} No return value
    */
   check_stream(media_type, attempt = 1) {
@@ -186,7 +186,7 @@ z.telemetry.calling.FlowTelemetry = class FlowTelemetry {
 
   /**
    * Update 'is_answer' status of flow.
-   * @param {Boolean} is_answer - Is the flow an answer
+   * @param {boolean} is_answer - Is the flow an answer
    * @returns {undefined} No return value
    */
   update_is_answer(is_answer) {

--- a/app/script/tracking/EventTrackingRepository.js
+++ b/app/script/tracking/EventTrackingRepository.js
@@ -295,7 +295,7 @@ z.tracking.EventTrackingRepository = class EventTrackingRepository {
    *
    * @see https://github.com/MindscapeHQ/raygun4js#onbeforesend
    * @param {JSON} raygun_payload - Error payload about to be send
-   * @returns {JSON|Boolean} Payload if error will be reported, otherwise "false"
+   * @returns {JSON|boolean} Payload if error will be reported, otherwise "false"
    */
   _check_error_payload(raygun_payload) {
     if (!this.last_report) {


### PR DESCRIPTION
In JSDoc 3 (and TypeScript definitions) the common practice is to use types with lowercase (like `number` and `string`). The only exception is `Object`. 

As a rule of thumb, use lowercase for [primitives](https://developer.mozilla.org/en-US/docs/Glossary/Primitive) and uppercase for objects and object equivalents.

You can also follow along the issue on this topic here: https://github.com/jsdoc3/jsdoc3.github.com/issues/149