### PR TITLE
Fix some recent bugs with emoji autocomplete

### DIFF
--- a/app/script/view_model/ConversationInputEmojiViewModel.js
+++ b/app/script/view_model/ConversationInputEmojiViewModel.js
@@ -54,6 +54,7 @@ z.ViewModel.ConversationInputEmojiViewModel = class ConversationInputEmojiViewMo
         this.emoji_dict = text.split('\n');
       });
 
+    this.bound_remove_emoji_list = this.remove_emoji_list.bind(this);
     this._init_subscriptions();
   }
 
@@ -133,9 +134,9 @@ z.ViewModel.ConversationInputEmojiViewModel = class ConversationInputEmojiViewMo
         .join('');
 
       if (emoji_matched === '') {
-        this.remove_emoji_list();
+        this.close_emoji_list();
       } else {
-        window.addEventListener('click', this.remove_emoji_list.bind(this));
+        window.addEventListener('click', this.bound_remove_emoji_list);
         this.emoji_list
           .html(emoji_matched)
           .appendTo('body')
@@ -170,9 +171,13 @@ z.ViewModel.ConversationInputEmojiViewModel = class ConversationInputEmojiViewMo
     $(input).focus();
   }
 
-  remove_emoji_list() {
-    window.removeEventListener('click', this.remove_emoji_list);
+  close_emoji_list() {
+    window.removeEventListener('click', this.bound_remove_emoji_list);
     this.emoji_list.remove();
+  }
+
+  remove_emoji_list() {
+    this.close_emoji_list();
     this.emoji_start_pos = -1;
   }
 


### PR DESCRIPTION
1. `remove_emoji_list` is executed multiple times on click, even if emoji popup is closed.

This happens because `this.remove_emoji_list.bind(this)` creates a new function every time, and `window.removeEventListener('click', this.bound_remove_emoji_list)` is trying to unassign a different function and silently fails to do so. The fix is to create a bound function and use it to assign and unassign a click-listener, so that `addEventListener` and `removeEventListener` are operating on exactly the same function.

2. Unable to fix typo while typing emoji name

Previously if you entered a typo (like `winn`), emoji popup was closed, but as soon as you removed the second `n` it reappeared with suggestions like `wink`. Now it doesn't reappear, so you have to remove everything and start from scratch. This happenned because when nothing is matched, previously emoji popup was only closed, but then code was changed to actually _remove_ the popup.

/cc @gregor 