### PR TITLE
Improve Windows fonts: use OpenSans before Arial if available

### DIFF
--- a/app/style/common/variables.less
+++ b/app/style/common/variables.less
@@ -30,7 +30,7 @@
 // ----------------------------------------------------------------------------
 @ars-font-path:       '../font/';
 
-@font-family-base:      BlinkMacSystemFont, -apple-system, Helvetica Neue, emoji, Arial, sans-serif;
+@font-family-base:      BlinkMacSystemFont, -apple-system, Helvetica Neue, emoji, Open Sans, Arial, sans-serif;
 @font-family-ephemeral: Redacted Script;
 
 @font-size-xxs:       8px;


### PR DESCRIPTION
I had a chance to see Wire on Windows, and... oh wow, I feel bad for Windows users and their `Arial` font.

Apparently `Open Sans` is used on my Linux, and IMHO it is making Wire look soooo much better than with `Arial` on Windows. It is thinner, and well, just nicer 🙂

@markesaaremets I guess this review is mostly for you. Click on gif to see it full-size.

Before (thick): `Arial`
After (thin): `Open Sans`

![windows-fonts](https://cloud.githubusercontent.com/assets/1177900/25594592/8c3b8b1a-2ec1-11e7-97ec-94ea6a23f327.gif)

