### PR TITLE
Use emoji font only after text fonts

### DIFF
--- a/app/style/common/variables.less
+++ b/app/style/common/variables.less
@@ -30,7 +30,7 @@
 // ----------------------------------------------------------------------------
 @ars-font-path:       '../font/';
 
-@font-family-base:      BlinkMacSystemFont, -apple-system, Helvetica Neue, emoji, Arial, sans-serif;
+@font-family-base:      BlinkMacSystemFont, -apple-system, Helvetica Neue, Arial, sans-serif, emoji;
 @font-family-ephemeral: Redacted Script;
 
 @font-size-xxs:       8px;


### PR DESCRIPTION
This is a follow-up on what we discussed in Linux Feedback Group. With the current order of fonts, when a user doesn't have either of `BlinkMacSystemFont, -apple-system, Helvetica Neue`, the `emoji` font is attempted to be used to render all text. In particular, this makes it render space character as a zero-width space, like so:

![wire 2017-05-18 at 17 57 44](https://cloud.githubusercontent.com/assets/1177900/26213558/d7f4e8c2-3bf9-11e7-97a0-dc24babcc582.png)

Defining the emoji font as the very last seems to solve the issue.

![wire 2017-05-18 at 17 58 25](https://cloud.githubusercontent.com/assets/1177900/26213606/fe6c16e2-3bf9-11e7-911c-c95e75e2ccd1.png)