### PR TITLE
Fix "complex" emoji display in popup

### DIFF
--- a/app/style/content/conversation/conversation-input.less
+++ b/app/style/content/conversation/conversation-input.less
@@ -197,17 +197,17 @@
     .symbol {
       display: inline-block;
       padding-left: 12px;
-      padding-right: 12px;
       font-size: @font-size-sm;
       text-align: center;
       vertical-align: middle;
-      width: 40px;
+      position: absolute;
     }
 
     .name {
       display: inline-block;
       padding-right: 16px;
       vertical-align: middle;
+      margin-left: 40px;
 
       &:first-letter {
         text-transform: capitalize;


### PR DESCRIPTION
This is a funny bug. Apparently the `width` of the emoji icon column in the popup is too narrow, and when that happens the "complex" emojis (those that consist of 2+ unicode characters) are rendered as 2+ separate emojis.

Look at the gif:

![wire](https://cloud.githubusercontent.com/assets/1177900/26323237/639dbbce-3f2e-11e7-976d-6f781c8ac0cc.gif)

The fix is simple: to let the column expand and consume however much space it requires to render emojis, while preserving the `40px` "real" width.

-------

Before:

![image](https://cloud.githubusercontent.com/assets/1177900/26323317/aac1ef84-3f2e-11e7-8e19-490333888ea8.png)

After: 

![image](https://cloud.githubusercontent.com/assets/1177900/26323299/966af288-3f2e-11e7-85a0-4e90a8b337c3.png)


------

P.S. This does not fix #1267, that one is still a valid bug.