### PR TITLE
Fix cursor position after inserting complex emoji

### DIFF
--- a/app/script/view_model/ConversationInputEmojiViewModel.js
+++ b/app/script/view_model/ConversationInputEmojiViewModel.js
@@ -340,8 +340,9 @@ z.ViewModel.ConversationInputEmojiViewModel = class ConversationInputEmojiViewMo
   _enter_emoji(input, emoji_icon) {
     const text_before_emoji = input.value.substr(0, this.emoji_start_pos - 1);
     const text_after_emoji = input.value.substr(input.selectionStart);
+    const new_cursor_pos = text_before_emoji.length + emoji_icon.length;
     input.value = `${text_before_emoji}${emoji_icon}${text_after_emoji}`;
-    input.setSelectionRange(this.emoji_start_pos, this.emoji_start_pos);
+    input.setSelectionRange(new_cursor_pos, new_cursor_pos);
     this.remove_emoji_popup();
     $(input).change();
     $(input).focus();


### PR DESCRIPTION
One more addition for complex emojis besides #1277 and #1282.
Code assumed that emoji always consists of one character, but as I now know, this is not correct.

Before:

![wire-before](https://cloud.githubusercontent.com/assets/1177900/26528364/82a2fb1c-43aa-11e7-8976-b5f72ec1f63a.gif)

After:

![wire-after](https://cloud.githubusercontent.com/assets/1177900/26528353/4c5dd9aa-43aa-11e7-89e1-f1bd2dcd1f02.gif)

---------------

Still not perfect, you see extra wide spaces and generally Chrome treats emojis as separate characters. I know why this happens, but I need to speak to EmojiOne maintainer first, he might assist creating a generic solution, not specific only for Wire.

![wire-fun](https://cloud.githubusercontent.com/assets/1177900/26528352/462dcbda-43aa-11e7-87b7-3c96559fd5e7.gif)

> 🏌️‍♀️ is really 🏌️ and ♀️
> :family_man_boy_boy:  is really 👨, 👦 and 👦