### PR TITLE
Release bot keeps its identity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,16 @@ language: node_js
 node_js:
   - "6"
 
-# http://docs.travis-ci.com/user/gui-and-headless-browsers
+# http://docs.travis-ci.com/user/gui-and-headless-browsers/
 before_install:
   - export CHROME_BIN=/usr/bin/google-chrome
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+
+# https://docs.travis-ci.com/user/caching/
+cache:
+  directories:
+    - $HOME/cryptobox
 
 notifications:
   email: false
@@ -96,6 +101,6 @@ deploy:
 after_deploy:
   - "AUTHOR_OF_LAST_COMMIT=$(git log | grep Author: | cut -d' ' -f2- | uniq | head -n1)"
   - "SUMMARY_OF_LAST_COMMIT=$(git log -1 --pretty=%s)"
-  - npm install wire-webapp-core@0.1.2
+  - npm install wire-webapp-core@0.3.0
   - chmod ugo+x ./bin/deployment_notification.js
   - node ./bin/deployment_notification.js "$AUTHOR_OF_LAST_COMMIT" "$SUMMARY_OF_LAST_COMMIT"

--- a/bin/deployment_notification.js
+++ b/bin/deployment_notification.js
@@ -20,6 +20,7 @@
 'use strict';
 
 const wire = require('wire-webapp-core');
+const cryptobox = require('wire-webapp-cryptobox');
 
 const login = {
   email: process.env.WIRE_WEBAPP_BOT_EMAIL,
@@ -62,7 +63,11 @@ content.message =
   + `\r\n- Last commit from: ${commit.author}`
   + `\r\n- Last commit message: ${commit.message}`;
 
-new wire.User(login.email, login.password).login(false)
+const storagePath = `${process.env.HOME}/cryptobox`;
+const store = new cryptobox.store.FileStore(storagePath);
+const box = new cryptobox.Cryptobox(store, 1);
+
+new wire.User(login, box).login(false)
 .then(function(service) {
   return service.conversation.sendTextMessage(content.conversationId, content.message);
 })

--- a/bin/deployment_notification.js
+++ b/bin/deployment_notification.js
@@ -19,8 +19,8 @@
 
 'use strict';
 
-const wire = require('wire-webapp-core');
 const cryptobox = require('wire-webapp-cryptobox');
+const wire = require('wire-webapp-core');
 
 const login = {
   email: process.env.WIRE_WEBAPP_BOT_EMAIL,


### PR DESCRIPTION
Our Webapp Release Bot always created a new identity when posting a deployment notification. This is an attempt to have a sticky identity for our release bot.