### PR TITLE
Show proper collection date headers (WEBAPP-4035)

### DIFF
--- a/app/script/view_model/content/CollectionDetailsViewModel.js
+++ b/app/script/view_model/content/CollectionDetailsViewModel.js
@@ -97,7 +97,7 @@ z.ViewModel.content.CollectionDetailsViewModel = class CollectionDetailsViewMode
   }
 
   should_show_header(message_et) {
-    if (this.last_message_timestamp) {
+    if (!this.last_message_timestamp) {
       this.last_message_timestamp = message_et.timestamp();
       return true;
     }


### PR DESCRIPTION
Fixes a regression from the es6 migration: https://github.com/wireapp/wire-webapp/pull/1235/files#diff-01ce0e6da5f969dcb1bfd096ff6d4f3eL73
