### PR TITLE
refactor: obtain electron version from user agent

### DIFF
--- a/app/script/util/Environment.js
+++ b/app/script/util/Environment.js
@@ -135,6 +135,14 @@ window.z.util = z.util || {};
   };
 
   z.util.Environment = {
+    _electron_version: function(user_agent) {
+      const result = /(Wire|WireInternal)\/(\S+)/.exec(user_agent);
+      if (result) {
+        const [, , version] = result;
+        return version;
+      }
+      return undefined;
+    },
     backend: {
       account_url: function() {
         if (z.util.Environment.backend.current === z.service.BackendEnvironment.PRODUCTION) {
@@ -180,14 +188,6 @@ window.z.util = z.util || {};
       linux: !os.is_mac() && !os.is_windows(),
       mac: os.is_mac(),
       win: os.is_windows(),
-    },
-    _electron_version: function(user_agent) {
-      const result = /(Wire|WireInternal)\/(\S+)/.exec(user_agent);
-      if (result) {
-        const [match, app, version] = result;
-        return version;
-      }
-      return undefined;
     },
     version: function(show_wrapper_version = true, do_not_format = false) {
       if (z.util.Environment.frontend.is_localhost()) {

--- a/app/script/util/Environment.js
+++ b/app/script/util/Environment.js
@@ -138,8 +138,7 @@ window.z.util = z.util || {};
     _electron_version: function(user_agent) {
       const result = /(Wire|WireInternal)\/(\S+)/.exec(user_agent);
       if (result) {
-        const [, , version] = result;
-        return version;
+        return result[2]; // [match, app, version]
       }
       return undefined;
     },

--- a/app/script/util/Environment.js
+++ b/app/script/util/Environment.js
@@ -181,6 +181,14 @@ window.z.util = z.util || {};
       mac: os.is_mac(),
       win: os.is_windows(),
     },
+    _electron_version: function(user_agent) {
+      const result = /(Wire|WireInternal)\/(\S+)/.exec(user_agent);
+      if (result) {
+        const [match, app, version] = result;
+        return version;
+      }
+      return undefined;
+    },
     version: function(show_wrapper_version = true, do_not_format = false) {
       if (z.util.Environment.frontend.is_localhost()) {
         return 'dev';
@@ -190,8 +198,9 @@ window.z.util = z.util || {};
         return app_version();
       }
 
-      if (window.electron_version && show_wrapper_version) {
-        return window.electron_version;
+      const electron_version = this._electron_version(navigator.userAgent);
+      if (electron_version && show_wrapper_version) {
+        return electron_version;
       }
 
       return formatted_app_version();

--- a/test/unit_tests/util/EnvironmentSpec.js
+++ b/test/unit_tests/util/EnvironmentSpec.js
@@ -28,4 +28,22 @@ xdescribe('EnvironmentSpec', function() {
       expect(z.util.Environment.browser.edge).toBe(true);
     });
   });
+
+  describe('z.util.Environment._electron_version', function() {
+    it('detects wrapper version for internal', function() {
+      const user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Electron/1.7.3 WireInternal/2.14.2744 Safari/537.36';
+      expect(z.util.Environment._electron_version(user_agent)).toBe('2.14.2744');
+    });
+
+    it('detects wrapper version for public', function() {
+      const user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Wire/2.13.2734 Chrome/56.0.2924.87 Electron/1.6.4 Safari/537.36';
+      expect(z.util.Environment._electron_version(user_agent)).toBe('2.13.2734');
+    });
+
+    it('return undefined if no version is present', function() {
+      const user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110';
+      expect(z.util.Environment._electron_version(user_agent)).not.toBeDefined();
+    });
+  });
+
 });

--- a/test/unit_tests/util/EnvironmentSpec.js
+++ b/test/unit_tests/util/EnvironmentSpec.js
@@ -21,13 +21,7 @@
 
 'use strict';
 
-xdescribe('EnvironmentSpec', function() {
-  window.navigator.userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240';
-  describe('z.util.Environment.browser', function() {
-    it('detects Microsoft Edge', function() {
-      expect(z.util.Environment.browser.edge).toBe(true);
-    });
-  });
+describe('EnvironmentSpec', function() {
 
   describe('z.util.Environment._electron_version', function() {
     it('detects wrapper version for internal', function() {


### PR DESCRIPTION
There is no need to set the electron version using the wrapper since it can be obtained from the user agent. For sake of testability i create a helper function that is exposed under 'z.util.Environment._electron_version'