### PR TITLE
chore: Bump grunt-contrib-uglify to version 'harmony-v3.0.28'

### DIFF
--- a/grunt/config/uglify.js
+++ b/grunt/config/uglify.js
@@ -31,10 +31,12 @@ module.exports = {
     },
     options: {
       banner: '/*! <%= pkg.name %> - <%= grunt.option("version") %> */',
-      preserveComments: false,
-      screwIE8: true,
-      sourceMap: true,
-      sourceMapIncludeSources: true,
+      output: {
+        comments: false,
+      },
+      sourceMap: {
+        includeSources: true,
+      },
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "grunt-contrib-connect": "1.0.2",
     "grunt-contrib-copy": "1.0.0",
     "grunt-contrib-less": "1.4.1",
-    "grunt-contrib-uglify": "wireapp/grunt-contrib-uglify#harmony-v2.8.22",
+    "grunt-contrib-uglify": "wireapp/grunt-contrib-uglify#harmony-v3.0.28",
     "grunt-contrib-watch": "1.0.0",
     "grunt-gitinfo": "0.1.8",
     "grunt-include-replace": "5.0.0",


### PR DESCRIPTION
Based on version '3.0.1'
Using uglifyjs2 'harmony-v3.0.28'