### PR TITLE
fix: Set user-select to none for certain message parts

### DIFF
--- a/app/style/components/user-avatar.less
+++ b/app/style/components/user-avatar.less
@@ -22,6 +22,7 @@ user-avatar {
   display: inline-block;
   cursor: pointer;
   transform: translateZ(0);
+  user-select: none;
 
   &.user-avatar-lg {
     .square(@avatar-diameter-lg);

--- a/app/style/content/conversation/message-list.less
+++ b/app/style/content/conversation/message-list.less
@@ -128,6 +128,7 @@
   line-height: 40px;
   margin-bottom: 16px;
   padding-top: 8px; // TODO margin top is not working because of collapsing margins
+  user-select: none;
 
   &:not(.message-timestamp-visible) {
     display: none;
@@ -345,6 +346,7 @@
     position: absolute;
     right: 24px;
     top: 3px;
+    user-select: none;
   }
 
   .message-ephemeral-timer {


### PR DESCRIPTION
Prevent a selection start in message timestamps and avatars. Chrome currently does allow it to be part of the selection when you start before the blocked section. This should be aligned with the CSS spec at some point.