### PR TITLE
chore: Chrome custom launcher cleanup

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -69,18 +69,6 @@ module.exports = function(config) {
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     browsers: ['ChromeHeadless'],
 
-    customLaunchers: {
-      ChromeHeadless: {
-        base: 'Chrome',
-        flags: [
-          '--disable-gpu',
-          '--headless',
-          '--no-sandbox',
-          '--remote-debugging-port=9222',
-        ],
-      },
-    },
-
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
     singleRun: true,


### PR DESCRIPTION
The `ChromeHeadless` launcher became a default in [karma-chrome-launcher](https://github.com/karma-runner/karma-chrome-launcher/tree/v2.2.0#available-browsers) and therefore doesn't need a custom configuration anymore.