### PR TITLE
fix: Expose z.announce.UPDATE_SOURCE for backwards compatibility

### DIFF
--- a/app/script/lifecycle/UpdateSource.js
+++ b/app/script/lifecycle/UpdateSource.js
@@ -22,7 +22,11 @@
 window.z = window.z || {};
 window.z.lifecycle = z.lifecycle || {};
 
-window.z.lifecycle.UPDATE_SOURCE = {
+z.lifecycle.UPDATE_SOURCE = {
   DESKTOP: 'desktop',
   WEBAPP: 'webapp',
 };
+
+// Add backward compatibility until update of wrapper >3.1
+window.z.announce = z.announce || {};
+z.announce.UPDATE_SOURCE = z.lifecycle.UPDATE_SOURCE;


### PR DESCRIPTION
Needed until https://github.com/wireapp/wire-desktop/pull/964 has reached most production users