### PR TITLE
fix: Trigger emoji popup after word boundary only (WEBAPP-4327)

### DIFF
--- a/app/script/view_model/ConversationInputEmojiViewModel.js
+++ b/app/script/view_model/ConversationInputEmojiViewModel.js
@@ -290,14 +290,14 @@ z.ViewModel.ConversationInputEmojiViewModel = class ConversationInputEmojiViewMo
   }
 
   _update_emoji_popup(input) {
-    const text = input.value;
+    const {selectionStart: selection, value: text} = input;
     if (!text) {
       return;
     }
 
-    const query = text.substr(this.emoji_start_pos, input.selectionStart - this.emoji_start_pos);
+    const query = text.substr(this.emoji_start_pos, selection - this.emoji_start_pos);
     if (!query.length) {
-      return this.emoji_div.remove();
+      return this._close_emoji_popup();
     }
 
     if (!this.emoji_list.length || query.startsWith(' ') || /\s{2,}/.test(query)) {

--- a/app/script/view_model/ConversationInputEmojiViewModel.js
+++ b/app/script/view_model/ConversationInputEmojiViewModel.js
@@ -25,7 +25,6 @@ z.ViewModel = z.ViewModel || {};
 const EMOJI_LIST_LENGTH = 5;
 const EMOJI_LIST_OFFSET_LEFT = 8;
 const EMOJI_LIST_OFFSET_TOP = 8;
-const QUERY_MIN_LENGTH = 1;
 
 // DO NOT USE COLON WITH LOWERCASE LETTERS IN THE SHORTCUTS, or you will prevent searching emojis.
 // For example, while :D should be replaced with unicode symbol, :d should allow searching for :dancer:
@@ -213,12 +212,14 @@ z.ViewModel.ConversationInputEmojiViewModel = class ConversationInputEmojiViewMo
     }
 
     const input = keyboard_event.target;
-    const text = input.value || '';
-    if (text[input.selectionStart - 1] === ':') {
-      this.emoji_start_pos = input.selectionStart;
+    const {selectionStart: selection, value: text = ''} = input;
+
+    const popup_trigger = text.slice(Math.max(selection - 2, 0), selection);
+    if (/\B:$/.test(popup_trigger)) {
+      this.emoji_start_pos = selection;
       this._update_emoji_popup(input);
     } else if (this.emoji_start_pos !== -1) {
-      if (input.selectionStart < this.emoji_start_pos || text[this.emoji_start_pos - 1] !== ':') {
+      if (selection < this.emoji_start_pos || text[this.emoji_start_pos - 1] !== ':') {
         this.remove_emoji_popup();
       } else {
         this._update_emoji_popup(input);
@@ -244,8 +245,9 @@ z.ViewModel.ConversationInputEmojiViewModel = class ConversationInputEmojiViewMo
     if (!this.should_replace_inline_emoji) {
       return false;
     }
-    const text = input.value || '';
-    const text_until_cursor = text.substring(Math.max(0, input.selectionStart - EMOJI_INLINE_MAX_LENGTH - 1), input.selectionStart);
+
+    const {selectionStart: selection, value: text = ''} = input;
+    const text_until_cursor = text.substring(Math.max(0, selection - EMOJI_INLINE_MAX_LENGTH - 1), selection);
 
     for (const replacement of EMOJI_INLINE_REPLACEMENT) {
       const icon = this.emoji_dict[replacement.name];
@@ -254,7 +256,7 @@ z.ViewModel.ConversationInputEmojiViewModel = class ConversationInputEmojiViewMo
       }
       const valid_inline_emoji_regexp = new RegExp(`(^|\\s)${this._escape_regexp(replacement.shortcut)}$`);
       if (valid_inline_emoji_regexp.test(text_until_cursor)) {
-        this.emoji_start_pos = input.selectionStart - replacement.shortcut.length + 1;
+        this.emoji_start_pos = selection - replacement.shortcut.length + 1;
         this._enter_emoji(input, icon);
         return true;
       }
@@ -266,8 +268,10 @@ z.ViewModel.ConversationInputEmojiViewModel = class ConversationInputEmojiViewMo
     if (!this.should_replace_inline_emoji) {
       return false;
     }
-    let text_before_cursor = input.value.substr(0, input.selectionStart);
-    let text_after_cursor = input.value.substr(input.selectionStart);
+
+    const {selectionStart: selection, value: text} = input;
+    let text_before_cursor = text.substr(0, selection);
+    let text_after_cursor = text.substr(selection);
 
     for (const replacement of EMOJI_INLINE_REPLACEMENT) {
       const icon = this.emoji_dict[replacement.name];
@@ -286,56 +290,68 @@ z.ViewModel.ConversationInputEmojiViewModel = class ConversationInputEmojiViewMo
   }
 
   _update_emoji_popup(input) {
-    if (!input.value) {
+    const text = input.value;
+    if (!text) {
       return;
     }
 
-    const query = input.value.substr(this.emoji_start_pos, input.selectionStart - this.emoji_start_pos);
-    if (query.length < QUERY_MIN_LENGTH || query[0] === ' ' || /\s{2,}/.test(query) || this.emoji_list.length === 0) {
-      this.emoji_div.remove();
-    } else {
-      const query_words = query.split(' ');
-      const emoji_matched = this.emoji_list
-        .filter((emoji) => {
-          const emoji_name_words = emoji.name.split(' ');
-          return query_words.every((query_word) => emoji_name_words.some((emoji_name_word) => emoji_name_word.startsWith(query_word)));
-        })
-        .reduce((acc, emoji, index) => {
-          if (!acc.find((item) => item.icon === emoji.icon)) {
-            acc.push(emoji);
-          }
-          return acc;
-        }, [])
-        .sort((emoji_a, emoji_b) => {
-          const usage_count_a = this._get_usage_count(emoji_a.name);
-          const usage_count_b = this._get_usage_count(emoji_b.name);
-          if (usage_count_a === usage_count_b) {
-            return z.util.StringUtil.sort_by_priority(emoji_a.name, emoji_b.name, query);
-          }
-          return usage_count_b - usage_count_a;
-        })
-        .slice(0, EMOJI_LIST_LENGTH)
-        .map((emoji) => `<div class='emoji'><span class='symbol'>${emoji.icon}</span><span class='name'>${emoji.name}</span></div>`)
-        .join('');
-
-      if (emoji_matched === '') {
-        this._close_emoji_popup();
-      } else {
-        window.addEventListener('click', this.remove_emoji_popup);
-        this.emoji_div
-          .html(emoji_matched)
-          .appendTo('body')
-          .show();
-        this.emoji_div.find('.emoji:nth(0)').addClass('selected');
-
-        const pos = this._get_cursor_pixel_pos(input);
-        const top = pos.top - this.emoji_div.height() - EMOJI_LIST_OFFSET_TOP;
-        const left = pos.left - EMOJI_LIST_OFFSET_LEFT;
-
-        this.emoji_div.css('left', left);
-        this.emoji_div.css('top', top);
-      }
+    const query = text.substr(this.emoji_start_pos, input.selectionStart - this.emoji_start_pos);
+    if (!query.length) {
+      return this.emoji_div.remove();
     }
+
+    if (!this.emoji_list.length || query.startsWith(' ') || /\s{2,}/.test(query)) {
+      return this.remove_emoji_popup();
+    }
+
+    const query_words = query.split(' ');
+    const expected_words = (query.match(/\s/g) || []).length + 1;
+
+    const emoji_matched = this.emoji_list
+      .filter((emoji) => {
+        const emoji_name_words = emoji.name.split(' ');
+
+        if (emoji_name_words.length < expected_words) {
+          return false;
+        }
+
+        return query_words.every((query_word) => emoji_name_words.some((emoji_name_word) => emoji_name_word.startsWith(query_word)));
+      })
+      .reduce((acc, emoji, index) => {
+        if (!acc.find((item) => item.icon === emoji.icon)) {
+          acc.push(emoji);
+        }
+        return acc;
+      }, [])
+      .sort((emoji_a, emoji_b) => {
+        const usage_count_a = this._get_usage_count(emoji_a.name);
+        const usage_count_b = this._get_usage_count(emoji_b.name);
+        if (usage_count_a === usage_count_b) {
+          return z.util.StringUtil.sort_by_priority(emoji_a.name, emoji_b.name, query);
+        }
+        return usage_count_b - usage_count_a;
+      })
+      .slice(0, EMOJI_LIST_LENGTH)
+      .map((emoji) => `<div class='emoji'><span class='symbol'>${emoji.icon}</span><span class='name'>${emoji.name}</span></div>`)
+      .join('');
+
+    if (emoji_matched === '') {
+      return this._close_emoji_popup();
+    }
+
+    window.addEventListener('click', this.remove_emoji_popup);
+    this.emoji_div
+      .html(emoji_matched)
+      .appendTo('body')
+      .show();
+    this.emoji_div.find('.emoji:nth(0)').addClass('selected');
+
+    const pos = this._get_cursor_pixel_pos(input);
+    const top = pos.top - this.emoji_div.height() - EMOJI_LIST_OFFSET_TOP;
+    const left = pos.left - EMOJI_LIST_OFFSET_LEFT;
+
+    this.emoji_div.css('left', left);
+    this.emoji_div.css('top', top);
   }
 
   _rotate_emoji_popup(backward) {
@@ -356,8 +372,10 @@ z.ViewModel.ConversationInputEmojiViewModel = class ConversationInputEmojiViewMo
   }
 
   _enter_emoji(input, emoji_icon) {
-    const text_before_emoji = input.value.substr(0, this.emoji_start_pos - 1);
-    const text_after_emoji = input.value.substr(input.selectionStart);
+    const {selectionStart: selection, value: text} = input;
+
+    const text_before_emoji = text.substr(0, this.emoji_start_pos - 1);
+    const text_after_emoji = text.substr(selection);
     const new_cursor_pos = text_before_emoji.length + emoji_icon.length;
     input.value = `${text_before_emoji}${emoji_icon}${text_after_emoji}`;
     input.setSelectionRange(new_cursor_pos, new_cursor_pos);


### PR DESCRIPTION
## Type of change
This addresses two issues in the current design:

**Emoji popup would open if you type `this:1`**

Previous
![Popup_previous](https://user-images.githubusercontent.com/10243309/30933300-79a5f7be-a3ca-11e7-8cad-9f1c42082199.png)

Now
![Popup_now](https://user-images.githubusercontent.com/10243309/30933201-32b4b07a-a3ca-11e7-9381-d8e3814a26ed.png)

**Word boundary is respected resulting earlier invalid match dismissal**

Previous
![Boundary_previous](https://user-images.githubusercontent.com/10243309/30933358-a9cd8f10-a3ca-11e7-8afa-d363b914d4dd.png)

Now
![Boundary_now](https://user-images.githubusercontent.com/10243309/30933256-5a35d854-a3ca-11e7-826a-97a9788d8ee3.png)