### PR TITLE
Remove "Segoe UI Symbol" from the list of emoji fonts

### DIFF
--- a/app/style/common/variables.less
+++ b/app/style/common/variables.less
@@ -22,7 +22,7 @@
 // ----------------------------------------------------------------------------
 @font-face {
   font-family: emoji;
-  src: local('Apple Color Emoji'), local('Segoe UI Emoji'), local('Segoe UI Symbol'), local('Android Emoji'), local('Noto Color Emoji'), local('Emoji One'), local('Twemoji');
+  src: local('Apple Color Emoji'), local('Segoe UI Emoji'), local('Android Emoji'), local('Noto Color Emoji'), local('Emoji One'), local('Twemoji');
 
   // Define a whitelist of glyphs to render with emoji font according to standard.
   // http://unicode.org/Public/emoji/5.0/emoji-data.txt


### PR DESCRIPTION
According to [wiki](https://en.wikipedia.org/wiki/Segoe#Variations), `Segoe UI Symbol` was first added in Windows 7. According to @fichtennadel in #1733, there is also a `Segoe UI Emoji` on Windows 7. So apparently they both exist since Windows 7.

Further experiments in #1733 show that:
1. Simply defining `Segoe UI Symbol` makes it take precedence over `Segoe UI Emoji`, rendering emojis in black and white (in Firefox).
2. Chrome doesn't seem to support `Segoe UI Emoji`, but removing `Segoe UI Symbol` doesn't have any effect, the emojis are still rendered with `Segoe UI Symbol`.

Therefore, it seems safe to remove `Segoe UI Symbol` from the list. Would be nice if someone with a Windows 7 could actually test this PR before merging.

/cc @fichtennadel