### PR TITLE
challenge_cookie parameter is no longer necessary

### DIFF
--- a/app/script/auth/AuthService.js
+++ b/app/script/auth/AuthService.js
@@ -258,7 +258,7 @@ z.auth.AuthService = class AuthService {
         },
         processData: false,
         type: 'POST',
-        url: `${this.client.create_url(AuthService.CONFIG.URL_REGISTER)}?challenge_cookie=true`,
+        url: `${this.client.create_url(AuthService.CONFIG.URL_REGISTER)}`,
         xhrFields: {
           withCredentials: true,
         },


### PR DESCRIPTION
## Type of change
<!--- Please describe what your code improves. -->
Only a cleanup. This parameter was introduced in the scope of https://github.com/wearezeta/backend-issues/issues/350 and is no longer necessary nor supported.
