### PR TITLE
cleaup: Remove Prettier rules from eslint

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -65,14 +65,7 @@ rules:
   prefer-promise-reject-errors: 2
   prefer-spread: 2
   prefer-template: 2
-  prettier/prettier: [2, {
-      bracketSpacing: false,
-      printWidth: 120,
-      semi: true,
-      singleQuote: true,
-      trailingComma: es5,
-    }
-  ]
+  prettier/prettier: 2
   sort-keys: [2, asc, {caseSensitive: true, natural: true}]
   sort-vars: 2
   valid-jsdoc:


### PR DESCRIPTION
To avoid duplication since they are already there: https://github.com/wireapp/wire-webapp/blob/dev/.prettierrc.yaml