### PR TITLE
fix: File constructor not implemented in MS Edge (WEBAPP-3471)

### DIFF
--- a/app/script/view_model/bindings/CommonBindings.js
+++ b/app/script/view_model/bindings/CommonBindings.js
@@ -75,7 +75,7 @@ ko.bindingHandlers.paste_file = {
 
       const files = items
         .filter(item => item.kind === 'file')
-        .map(item => new File([item.getAsFile()], null, {type: item.type}))
+        .map(item => new Blob([item.getAsFile()], {type: item.type}))
         .filter(item => item && item.size !== 4); // Pasted files result in 4 byte blob (OSX)
 
       if (files.length > 0) {


### PR DESCRIPTION
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/9551546/