### PR TITLE
feat: Expose wire in global namespace for wrapper check

### DIFF
--- a/app/script/auth/configureWrapper.js
+++ b/app/script/auth/configureWrapper.js
@@ -1,0 +1,23 @@
+/*
+ * Wire
+ * Copyright (C) 2017 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+// Expose wire object in global namespace to satisfy wrapper check
+const configureWrapper = () => (window.wire = {});
+
+export default configureWrapper;

--- a/app/script/auth/main.js
+++ b/app/script/auth/main.js
@@ -22,10 +22,12 @@ import {Account} from '@wireapp/core';
 import {AppContainer} from 'react-hot-loader';
 import {Provider} from 'react-redux';
 import configureStore from './configureStore';
+import configureWrapper from './configureWrapper';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Root from './page/Root';
 
+configureWrapper();
 const core = new Account();
 const store = configureStore({apiClient: core.apiClient, core});
 


### PR DESCRIPTION
Opted for doing this in code instead of html as it adds another layer of protection. If the html loads but the js file fails, we will still have a proper check that would trigger a reload incase it is not there.