### PR TITLE
refactor: Using platform module where possible

### DIFF
--- a/app/script/auth/util/RuntimeUtil.js
+++ b/app/script/auth/util/RuntimeUtil.js
@@ -50,7 +50,7 @@ export default class RuntimeUtil {
   }
 
   static getPlatform() {
-    if (isDesktop()) {
+    if (RuntimeUtil.isDesktop()) {
       if (platform.os.family.includes(RuntimeUtil.PLATFORM_NAME.WINDOWS)) {
         return RuntimeUtil.PLATFORM_TYPE.DESKTOP_WINDOWS;
       }

--- a/app/script/auth/util/RuntimeUtil.js
+++ b/app/script/auth/util/RuntimeUtil.js
@@ -1,6 +1,39 @@
-import '../../util/Environment';
+/*
+ * Wire
+ * Copyright (C) 2017 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import platform from 'platform';
 
 export default class RuntimeUtil {
+  static BROWSER_NAME = {
+    CHROME: 'Chrome',
+    EDGE: 'Microsoft Edge',
+    ELECTRON: 'Electron',
+    FIREFOX: 'Firefox',
+    OPERA: 'Opera',
+    WIRE: 'Wire',
+  };
+
+  static PLATFORM_NAME = {
+    MACINTOSH: 'Mac',
+    WINDOWS: 'Win',
+  };
+
   static PLATFORM_TYPE = {
     BROWSER_APP: 'web',
     DESKTOP_LINUX: 'linux',
@@ -8,12 +41,20 @@ export default class RuntimeUtil {
     DESKTOP_WINDOWS: 'windows',
   };
 
+  static isElectron() {
+    return platform.name === RuntimeUtil.BROWSER_NAME.ELECTRON;
+  }
+
+  static isDesktop() {
+    return RuntimeUtil.isElectron() && platform.ua.includes(RuntimeUtil.BROWSER_NAME.WIRE);
+  }
+
   static getPlatform() {
-    if (z.util.Environment.desktop) {
-      if (z.util.Environment.os.win) {
+    if (isDesktop()) {
+      if (platform.os.family.includes(RuntimeUtil.PLATFORM_NAME.WINDOWS)) {
         return RuntimeUtil.PLATFORM_TYPE.DESKTOP_WINDOWS;
       }
-      if (z.util.Environment.os.mac) {
+      if (platform.ua.includes(RuntimeUtil.PLATFORM_NAME.MACINTOSH)) {
         return RuntimeUtil.PLATFORM_TYPE.DESKTOP_MACOS;
       }
       return RuntimeUtil.PLATFORM_TYPE.DESKTOP_LINUX;

--- a/app/script/util/Environment.js
+++ b/app/script/util/Environment.js
@@ -46,20 +46,20 @@ window.z.util = z.util || {};
 
   const _check = {
     get_version: () => {
-      if (platform.version) {
-        return window.parseInt(platform.version.split('.')[0], 10);
+      if (window.platform.version) {
+        return window.parseInt(window.platform.version.split('.')[0], 10);
       }
     },
     is_chrome() {
-      return platform.name === BROWSER_NAME.CHROME || this.is_electron();
+      return window.platform.name === BROWSER_NAME.CHROME || this.is_electron();
     },
     is_desktop() {
-      return this.is_electron() && navigator.userAgent.includes(BROWSER_NAME.WIRE);
+      return this.is_electron() && window.platform.ua.includes(BROWSER_NAME.WIRE);
     },
-    is_edge: () => platform.name === BROWSER_NAME.EDGE,
-    is_electron: () => platform.name === BROWSER_NAME.ELECTRON,
-    is_firefox: () => platform.name === BROWSER_NAME.FIREFOX,
-    is_opera: () => platform.name === BROWSER_NAME.OPERA,
+    is_edge: () => window.platform.name === BROWSER_NAME.EDGE,
+    is_electron: () => window.platform.name === BROWSER_NAME.ELECTRON,
+    is_firefox: () => window.platform.name === BROWSER_NAME.FIREFOX,
+    is_opera: () => window.platform.name === BROWSER_NAME.OPERA,
     supports_audio_output_selection() {
       return this.is_chrome();
     },
@@ -95,8 +95,8 @@ window.z.util = z.util || {};
   };
 
   const os = {
-    is_mac: () => navigator.platform.includes(PLATFORM_NAME.MACINTOSH),
-    is_windows: () => navigator.platform.includes(PLATFORM_NAME.WINDOWS),
+    is_mac: () => window.platform.ua.includes(PLATFORM_NAME.MACINTOSH),
+    is_windows: () => window.platform.os.family.includes(PLATFORM_NAME.WINDOWS),
   };
 
   // add body information
@@ -131,7 +131,7 @@ window.z.util = z.util || {};
       chrome: _check.is_chrome(),
       edge: _check.is_edge(),
       firefox: _check.is_firefox(),
-      name: platform.name,
+      name: window.platform.name,
       opera: _check.is_opera(),
       supports: {
         audio_output_selection: _check.supports_audio_output_selection(),
@@ -163,7 +163,7 @@ window.z.util = z.util || {};
         return app_version();
       }
 
-      const electron_version = this._electron_version(navigator.userAgent);
+      const electron_version = this._electron_version(window.platform.ua);
       if (electron_version && show_wrapper_version) {
         return electron_version;
       }


### PR DESCRIPTION
## Changes

1. In `app/script/util/Environment.js` we are using `window.platform` and `navigator.platform`. To prevent confusion between these two I prefixed them (either with `window` or with `navigator`).
2. I replaced some `navigator.platform` calls in favor of `window.platform` because `window.platform` is defined by [platform.js](https://github.com/bestiejs/platform.js) and platform.js is a superset of `navigator`, so there is no need to keep the pure `navigator`.
3. I made `RuntimeUtil.js` independant of `app/script/util/Environment.js` because on the long run `RuntimeUtil.js` will replace `app/script/util/Environment.js` (when moving fully to React). The short-term benefit is, that testing React components becomes much easier because the `RuntimeUtil.js` imports only [platform](https://www.npmjs.com/package/platform) and thus doesn't have any dependencies to `window` or `navigator`.
