### PR TITLE
fix: Enable personal account creation from wrapper (WEBAPP-4522)

### DIFF
--- a/app/script/auth/page/Index.js
+++ b/app/script/auth/page/Index.js
@@ -27,27 +27,26 @@ import {injectIntl} from 'react-intl';
 import {Logo, COLOR} from '@wireapp/react-ui-kit/Identity';
 import {ProfileIcon, RoundContainer, TeamIcon} from '@wireapp/react-ui-kit/Icon';
 import {Link, Paragraph, Text, Bold} from '@wireapp/react-ui-kit/Text';
+import {pathWithParams} from '../util/urlUtil';
 
 class Index extends Component {
   componentDidMount() {
     this.props.trackEvent({name: TrackingAction.EVENT_NAME.START.OPENED_START_SCREEN});
   }
 
-  onRegisterPersonalClick = () =>
-    this.trackAndNavigate(
-      TrackingAction.EVENT_NAME.START.OPENED_PERSONAL_REGISTRATION,
-      `${ROUTE.LOGIN}?hl=${this.props.language}#register`
-    );
+  onRegisterPersonalClick = () => {
+    const locationPath = pathWithParams(ROUTE.LOGIN, 'mode=register');
+    this.trackAndNavigate(TrackingAction.EVENT_NAME.START.OPENED_PERSONAL_REGISTRATION, locationPath);
+  };
 
   onRegisterTeamClick = () => {
-    return Promise.resolve()
-      .then(() => this.props.trackEvent({name: TrackingAction.EVENT_NAME.START.OPENED_TEAM_REGISTRATION}))
-      .then(() => this.props.history.push(ROUTE.CREATE_TEAM));
+    this.props.trackEvent({name: TrackingAction.EVENT_NAME.START.OPENED_TEAM_REGISTRATION});
+    this.props.history.push(ROUTE.CREATE_TEAM);
   };
 
   onLoginClick = () => {
-    const searchParams = window.location.search;
-    this.trackAndNavigate(TrackingAction.EVENT_NAME.START.OPENED_LOGIN, `${ROUTE.LOGIN}${searchParams}#login`);
+    const locationPath = pathWithParams(ROUTE.LOGIN, 'mode=login');
+    this.trackAndNavigate(TrackingAction.EVENT_NAME.START.OPENED_LOGIN, locationPath);
   };
 
   trackAndNavigate = (eventName, url) => {

--- a/app/script/auth/util/urlUtil.js
+++ b/app/script/auth/util/urlUtil.js
@@ -17,20 +17,19 @@
  *
  */
 
-'use strict';
+export function pathWithParams(path, additionalParam) {
+  const searchParams = window.location.search
+    .replace(/^\?/, '')
+    .split('&')
+    .filter(searchParam => searchParam);
 
-window.z = window.z || {};
-window.z.auth = z.auth || {};
+  if (additionalParam) {
+    searchParams.push(additionalParam);
+  }
+  const joinedParams = searchParams.join('&');
+  return `${path}${joinedParams.length ? `?${joinedParams}` : ''}`;
+}
 
-z.auth.URLParameter = {
-  BOT_NAME: 'bot_name',
-  BOT_PROVIDER: 'bot_provider',
-  BOT_SERVICE: 'bot_service',
-  CONNECT: 'connect',
-  ENVIRONMENT: 'env',
-  INVITE: 'invite',
-  LOCALE: 'hl',
-  MODE: 'mode',
-  REASON: 'reason',
-  TRACKING: 'tracking',
-};
+export function getURLParameter(parameterName) {
+  return (window.location.search.split(`${parameterName}=`)[1] || '').split('&')[0];
+}

--- a/app/script/view_model/AuthViewModel.js
+++ b/app/script/view_model/AuthViewModel.js
@@ -314,6 +314,16 @@ z.ViewModel.AuthViewModel = class AuthViewModel {
   }
 
   _init_url_parameter() {
+    const mode = z.util.get_url_parameter(z.auth.URLParameter.MODE);
+    if (mode) {
+      const expectedModes = [z.auth.AuthView.MODE.ACCOUNT_LOGIN, z.auth.AuthView.MODE.ACCOUNT_REGISTER];
+      const isExpectedMode = expectedModes.includes(mode);
+      if (isExpectedMode) {
+        this._set_hash(mode);
+        return;
+      }
+    }
+
     const is_connect = z.util.get_url_parameter(z.auth.URLParameter.CONNECT);
     if (is_connect) {
       this.get_wire(true);
@@ -1175,7 +1185,8 @@ z.ViewModel.AuthViewModel = class AuthViewModel {
   }
 
   clicked_on_navigate_back() {
-    window.location.replace(`/auth${location.search}`);
+    const locationPath = this._append_existing_parameters(/auth/);
+    window.location.replace(locationPath);
   }
 
   click_on_remove_device_submit(password, device) {


### PR DESCRIPTION
Every page navigation on the wrapper will reset the hash to `#login`

As the navigation from the react based index page to `#register` breaks due to this and the user ends up on the login form instead we are repurposing name to mitigate the situation. 