### PR TITLE
fix: Make login link clickable in Firefox again

### DIFF
--- a/app/script/auth/page/Index.js
+++ b/app/script/auth/page/Index.js
@@ -52,6 +52,7 @@ class Index extends Component {
     this.props.trackEvent({name: TrackingAction.EVENT_NAME.START.OPENED_LOGIN});
     const link = document.createElement('a');
     link.href = pathWithParams(ROUTE.LOGIN, 'mode=login');
+    document.body.appendChild(link); // workaround for Firefox
     link.click();
   };
 

--- a/app/script/auth/page/Verify.js
+++ b/app/script/auth/page/Verify.js
@@ -56,6 +56,7 @@ const Verify = ({account, authError, history, isInTeamFlow, intl: {formatMessage
         .then(() => {
           const link = document.createElement('a');
           link.href = pathWithParams(ROUTE.LOGIN, 'reason=registration');
+          document.body.appendChild(link); // workaround for Firefox
           link.click();
         })
         .catch(error => console.error('Failed to create personal account', error));


### PR DESCRIPTION
## Type of change

Adds another workaround on top of the workaround for the desktop application test framework. The former workaround broke the navigation in Firefox.