### PR TITLE
fix: Remove undefined match from searchparams

### DIFF
--- a/app/script/auth/util/urlUtil.js
+++ b/app/script/auth/util/urlUtil.js
@@ -18,7 +18,11 @@
  */
 
 export function pathWithParams(path, additionalParams) {
-  const searchParams = window.location.search.replace(/^\?/, '').split('&');
+  const searchParams = window.location.search
+    .replace(/^\?/, '')
+    .split('&')
+    .filter(searchParam => searchParam);
+
   if (additionalParams) {
     searchParams.push(additionalParams);
   }


### PR DESCRIPTION
From #2037, went missing in conflict resolution during the reverse merge.
