### PR TITLE
fix: Show full text match count only when > 1 (WEBAPP-4637)

### DIFF
--- a/app/script/components/fullSearch.js
+++ b/app/script/components/fullSearch.js
@@ -142,7 +142,7 @@ ko.components.register('full-search', {
             <span data-bind="text: moment($data.timestamp()).format('MMMM D, YYYY')" data-uie-name="full-search-item-timestamp"></span>
           </div>
         </div>
-        <div class="badge" data-bind="text: matches_count, visible: matches_count" data-uie-name="full-search-item-badge"> 1"></div>
+        <div class="badge" data-bind="text: matches_count, visible: matches_count > 1" data-uie-name="full-search-item-badge"></div>
       </div>
     </div>
   `,


### PR DESCRIPTION
Fix regression introduced by https://github.com/wireapp/wire-webapp/pull/2273/files#diff-db6327a5050e237a103a5712439d6d46R145