### PR TITLE
fix: Specifying decryption error 213

### DIFF
--- a/app/script/cryptography/CryptographyRepository.js
+++ b/app/script/cryptography/CryptographyRepository.js
@@ -298,7 +298,8 @@ z.cryptography.CryptographyRepository = class CryptographyRepository {
 
     if (event_data.text === CryptographyRepository.REMOTE_ENCRYPTION_FAILURE) {
       const decryption_error = new Proteus.errors.DecryptError.InvalidMessage(
-        "The sending client couldn't encrypt a message for our client."
+        "The sending client couldn't encrypt a message for our client.",
+        213
       );
       return Promise.resolve(this._handle_decryption_failure(decryption_error, event));
     }


### PR DESCRIPTION
## Type of change

`DecryptError.InvalidMessage` always had error code "2" (Unknown decryption error). It now uses error code "213" which makes clear that the error is based on a encryption error from the sender side.