### PR TITLE
fix: Hide guest options for guest conversations

### DIFF
--- a/app/script/conversation/ConversationStateHandler.js
+++ b/app/script/conversation/ConversationStateHandler.js
@@ -36,7 +36,7 @@ z.conversation.ConversationStateHandler = class ConversationStateHandler {
 
   changeAccessState(conversationEntity, accessState) {
     const isTeamConversation = conversationEntity && conversationEntity.team_id;
-    if (isTeamConversation) {
+    if (isTeamConversation && !conversationEntity.is_guest()) {
       const isStateChange = conversationEntity.accessState() !== accessState;
 
       if (isStateChange) {

--- a/app/script/conversation/ConversationStateHandler.js
+++ b/app/script/conversation/ConversationStateHandler.js
@@ -35,8 +35,8 @@ z.conversation.ConversationStateHandler = class ConversationStateHandler {
   }
 
   changeAccessState(conversationEntity, accessState) {
-    const isTeamConversation = conversationEntity && conversationEntity.team_id;
-    if (isTeamConversation && !conversationEntity.is_guest()) {
+    const isConversationInTeam = conversationEntity && conversationEntity.inTeam();
+    if (isConversationInTeam) {
       const isStateChange = conversationEntity.accessState() !== accessState;
 
       if (isStateChange) {

--- a/app/script/entity/Conversation.js
+++ b/app/script/entity/Conversation.js
@@ -59,6 +59,7 @@ z.entity.Conversation = class Conversation {
     this.is_guest = ko.observable(false);
     this.is_managed = false;
 
+    this.inTeam = ko.pureComputed(() => this.team_id && !this.is_guest());
     this.isGuestRoom = ko.pureComputed(() => this.accessState() === z.conversation.ACCESS_STATE.TEAM.GUEST_ROOM);
     this.isTeamOnly = ko.pureComputed(() => this.accessState() === z.conversation.ACCESS_STATE.TEAM.TEAM_ONLY);
 

--- a/app/script/view_model/list/StartUIViewModel.js
+++ b/app/script/view_model/list/StartUIViewModel.js
@@ -557,7 +557,7 @@ z.viewModel.list.StartUIViewModel = class StartUIViewModel {
     const normalizedQuery = z.search.SearchRepository.normalizeQuery(query);
     const conversationsForServices = this.conversationRepository
       .get_groups_by_name(normalizedQuery, false)
-      .filter(conversationEntity => conversationEntity.team_id);
+      .filter(conversationEntity => conversationEntity.team_id && !conversationEntity.is_guest());
     this.serviceConversations(conversationsForServices);
   }
 

--- a/app/script/view_model/list/StartUIViewModel.js
+++ b/app/script/view_model/list/StartUIViewModel.js
@@ -557,7 +557,7 @@ z.viewModel.list.StartUIViewModel = class StartUIViewModel {
     const normalizedQuery = z.search.SearchRepository.normalizeQuery(query);
     const conversationsForServices = this.conversationRepository
       .get_groups_by_name(normalizedQuery, false)
-      .filter(conversationEntity => conversationEntity.team_id && !conversationEntity.is_guest());
+      .filter(conversationEntity => conversationEntity.inTeam());
     this.serviceConversations(conversationsForServices);
   }
 

--- a/app/script/view_model/panel/ConversationDetailsViewModel.js
+++ b/app/script/view_model/panel/ConversationDetailsViewModel.js
@@ -134,7 +134,9 @@ z.viewModel.panel.ConversationDetailsViewModel = class ConversationDetailsViewMo
         return userEntity.is_connected() || userEntity.is_team_member();
       }
     });
-    this.showActionGuestOptions = ko.pureComputed(() => this.conversationEntity().team_id);
+    this.showActionGuestOptions = ko.pureComputed(() => {
+      return this.conversationEntity().team_id && !this.conversationEntity().is_guest();
+    });
     this.showActionLeave = ko.pureComputed(() => {
       return this.conversationEntity().is_group() && !this.conversationEntity().removed_from_conversation();
     });

--- a/app/script/view_model/panel/ConversationDetailsViewModel.js
+++ b/app/script/view_model/panel/ConversationDetailsViewModel.js
@@ -134,9 +134,7 @@ z.viewModel.panel.ConversationDetailsViewModel = class ConversationDetailsViewMo
         return userEntity.is_connected() || userEntity.is_team_member();
       }
     });
-    this.showActionGuestOptions = ko.pureComputed(() => {
-      return this.conversationEntity().team_id && !this.conversationEntity().is_guest();
-    });
+    this.showActionGuestOptions = ko.pureComputed(() => this.conversationEntity().inTeam());
     this.showActionLeave = ko.pureComputed(() => {
       return this.conversationEntity().is_group() && !this.conversationEntity().removed_from_conversation();
     });

--- a/app/script/view_model/panel/GuestOptionsViewModel.js
+++ b/app/script/view_model/panel/GuestOptionsViewModel.js
@@ -111,7 +111,7 @@ z.viewModel.panel.GuestOptionsViewModel = class GuestOptionsViewModel {
 
   toggleAccessState() {
     const conversationEntity = this.conversationEntity();
-    if (conversationEntity.team_id) {
+    if (conversationEntity.team_id && !conversationEntity.is_guest()) {
       const newAccessState = this.isTeamOnly()
         ? z.conversation.ACCESS_STATE.TEAM.GUEST_ROOM
         : z.conversation.ACCESS_STATE.TEAM.TEAM_ONLY;

--- a/app/script/view_model/panel/GuestOptionsViewModel.js
+++ b/app/script/view_model/panel/GuestOptionsViewModel.js
@@ -111,7 +111,7 @@ z.viewModel.panel.GuestOptionsViewModel = class GuestOptionsViewModel {
 
   toggleAccessState() {
     const conversationEntity = this.conversationEntity();
-    if (conversationEntity.team_id && !conversationEntity.is_guest()) {
+    if (conversationEntity.inTeam()) {
       const newAccessState = this.isTeamOnly()
         ? z.conversation.ACCESS_STATE.TEAM.GUEST_ROOM
         : z.conversation.ACCESS_STATE.TEAM.TEAM_ONLY;


### PR DESCRIPTION
The guest options feature should not only be linked to the fact that a conversation is a team conversation but also whether you are a guest in that particular conversation.