### PR TITLE
fix: Set the correct lang in <html>

### DIFF
--- a/app/script/localization/Localizer.js
+++ b/app/script/localization/Localizer.js
@@ -35,6 +35,8 @@ class Localizer {
 
     this.locale = stored_locale || current_browser_locale || DEFAULT_LOCALE;
 
+    document.getElementsByTagName('html')[0].setAttribute('lang', this.locale);
+
     moment.locale([this.locale, DEFAULT_LOCALE]);
 
     if (z.string[this.locale]) {


### PR DESCRIPTION
Specially for greek when you changing the text to uppercase with CSS it renders it wrong if the languages is not set.

Wrong:
<img width="175" alt="screen shot 2018-03-27 at 10 42 54" src="https://user-images.githubusercontent.com/125676/37956446-affba8bc-31ab-11e8-92d0-a2735167a10c.png">

Correct:
<img width="182" alt="screen shot 2018-03-27 at 10 43 09" src="https://user-images.githubusercontent.com/125676/37956448-b01703f0-31ab-11e8-818d-0340070627fd.png">

https://jsbin.com/zobisuziso/1/edit?html,css,output