### PR TITLE
fix: use base64 for avatar image urls

### DIFF
--- a/app/script/assets/AssetRemoteData.js
+++ b/app/script/assets/AssetRemoteData.js
@@ -97,9 +97,9 @@ z.assets.AssetRemoteData = class AssetRemoteData {
     const objectUrl = z.assets.AssetURLCache.getUrl(this.identifier);
     return objectUrl
       ? Promise.resolve(objectUrl)
-      : this.load().then(blob => {
+      : this.load().then(async blob => {
           if (blob) {
-            const url = window.URL.createObjectURL(blob);
+            const url = await z.util.loadDataUrl(blob);
             z.assets.AssetURLCache.setUrl(this.identifier, url);
             return url;
           }

--- a/app/script/util/util.js
+++ b/app/script/util/util.js
@@ -90,9 +90,7 @@ z.util.loadImage = function(blob) {
 z.util.loadDataUrl = file => {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
-    reader.onload = function() {
-      resolve(this.result);
-    };
+    reader.onload = () => resolve(reader.result);
     reader.onerror = reject;
     reader.readAsDataURL(file);
   });
@@ -101,9 +99,7 @@ z.util.loadDataUrl = file => {
 z.util.loadFileBuffer = file => {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
-    reader.onload = function() {
-      resolve(this.result);
-    };
+    reader.onload = () => resolve(reader.result);
     reader.onerror = reject;
     reader.readAsArrayBuffer(file);
   });


### PR DESCRIPTION
This should fix the issue of some avatars not being displayed under certain (not completely known) conditions.