### PR TITLE
fix: use 'application/octet-stream' as mime type for the archive download

### DIFF
--- a/app/script/util/util.js
+++ b/app/script/util/util.js
@@ -236,7 +236,7 @@ z.util.base64ToBlob = base64 => {
  * @returns {number} Timeout identifier
  */
 
-z.util.downloadBlob = (blob, filename) => {
+z.util.downloadBlob = (blob, filename, mimeType) => {
   const url = window.URL.createObjectURL(blob);
   const link = document.createElement('a');
   // firefox needs the element to be in the DOM for the download to start
@@ -245,6 +245,9 @@ z.util.downloadBlob = (blob, filename) => {
   link.href = url;
   link.download = filename;
   link.style = 'display: none';
+  if (mimeType) {
+    link.type = mimeType;
+  }
   link.click();
 
   // Wait before removing resource and link. Needed in FF

--- a/app/script/view_model/content/HistoryExportViewModel.js
+++ b/app/script/view_model/content/HistoryExportViewModel.js
@@ -92,7 +92,7 @@ z.viewModel.content.HistoryExportViewModel = class HistoryExportViewModel {
           }`;
           this.onSuccess();
 
-          z.util.downloadBlob(archiveBlob, filename);
+          z.util.downloadBlob(archiveBlob, filename, 'application/octet-stream');
         })
         .catch(this.onError.bind(this));
     });


### PR DESCRIPTION
## Type of change

This is more relevant as we don't really want the browser to detect that it's a `zip` file and let it suggests the user to unzip it