### PR TITLE
chore: Upgrade "travis-bot" to latest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ notifications:
 
 # http://docs.travis-ci.com/user/deployment/
 before_deploy:
-  - yarn global add @wireapp/travis-bot@0.1.110
+  - yarn global add @wireapp/travis-bot@latest
   - if [ "$TRAVIS_BRANCH" == "dev" ]; then yarn run deploy-travis-dev; fi
   - if [ "$TRAVIS_BRANCH" == "edge" ]; then yarn run deploy-travis-staging; fi
   - if [ "$TRAVIS_BRANCH" == "staging" ]; then yarn run deploy-travis-staging; fi


### PR DESCRIPTION
After the api-client was fixed in https://github.com/wireapp/wire-web-packages/pull/590, we can revert the downgrade.

This reverts commit 382b250126a5b5316fbdc65f15612287eafa45f5.