### PR TITLE
fix: request media on incoming call (WEBAPP-5113)

### DIFF
--- a/app/script/calling/CallingRepository.js
+++ b/app/script/calling/CallingRepository.js
@@ -1283,9 +1283,10 @@ z.calling.CallingRepository = class CallingRepository {
           this.injectActivateEvent(callMessageEntity, source);
 
           const eventFromWebSocket = source === z.event.EventRepository.SOURCE.WEB_SOCKET;
-          if (eventFromWebSocket && callEntity.isRemoteVideoSend()) {
-            const mediaStreamType = z.media.MediaType.AUDIO_VIDEO;
-            this.mediaStreamHandler.initiate_media_stream(callEntity.id, mediaStreamType, callEntity.isGroup);
+          if (eventFromWebSocket) {
+            const fixedMediaType = mediaType === z.media.MediaType.VIDEO ? z.media.MediaType.AUDIO_VIDEO : mediaType;
+
+            this.mediaStreamHandler.initiate_media_stream(callEntity.id, fixedMediaType, callEntity.isGroup);
           }
 
           return callEntity;

--- a/app/script/calling/CallingRepository.js
+++ b/app/script/calling/CallingRepository.js
@@ -1283,10 +1283,9 @@ z.calling.CallingRepository = class CallingRepository {
           this.injectActivateEvent(callMessageEntity, source);
 
           const eventFromWebSocket = source === z.event.EventRepository.SOURCE.WEB_SOCKET;
-          if (eventFromWebSocket) {
-            const fixedMediaType = mediaType === z.media.MediaType.VIDEO ? z.media.MediaType.AUDIO_VIDEO : mediaType;
-
-            this.mediaStreamHandler.initiate_media_stream(callEntity.id, fixedMediaType, callEntity.isGroup);
+          if (eventFromWebSocket && callEntity.isRemoteVideoSend()) {
+            const mediaStreamType = z.media.MediaType.AUDIO_VIDEO;
+            this.mediaStreamHandler.initiate_media_stream(callEntity.id, mediaStreamType, callEntity.isGroup);
           }
 
           return callEntity;

--- a/app/script/media/MediaStreamHandler.js
+++ b/app/script/media/MediaStreamHandler.js
@@ -566,10 +566,7 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
 
   // Toggle the mute state of the microphone.
   toggle_audio_send() {
-    const hasActiveAudioStream = !!this.localMediaStream();
-    return hasActiveAudioStream
-      ? this._toggleAudioSend()
-      : Promise.reject(new z.media.MediaError(z.media.MediaError.TYPE.NO_AUDIO_STREAM_FOUND));
+    return this._toggleAudioSend();
   }
 
   // Toggle the screen.
@@ -713,9 +710,11 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
         amplify.publish(z.event.WebApp.CALL.MEDIA.MUTE_AUDIO, !stateObservable());
       }
 
-      const mediaStreamTracks = z.media.MediaStreamHandler.get_media_tracks(mediaStream, mediaType);
-      mediaStreamTracks.forEach(mediaStreamTrack => (mediaStreamTrack.enabled = stateObservable()));
-      return mediaStreamTracks;
+      if (mediaStream) {
+        const mediaStreamTracks = z.media.MediaStreamHandler.get_media_tracks(mediaStream, mediaType);
+        mediaStreamTracks.forEach(mediaStreamTrack => (mediaStreamTrack.enabled = stateObservable()));
+        return mediaStreamTracks;
+      }
     });
   }
 };


### PR DESCRIPTION
Turned out that to be able to mute a channel, the media channel needs to be requested first.
This allows the user to toggle any media channel off before picking up.

This changes the global behavior of the app. Now, when there is an incoming call, we request the userMedia (same behavior as video calls)
