### PR TITLE
fix: release media streams when call is picked up from another device

### DIFF
--- a/app/script/calling/CallingRepository.js
+++ b/app/script/calling/CallingRepository.js
@@ -379,6 +379,7 @@ z.calling.CallingRepository = class CallingRepository {
         if (isSelfUser && !callEntity.selfClientJoined()) {
           callEntity.selfUserJoined(true);
           callEntity.wasConnected = true;
+          this.mediaStreamHandler.resetMediaStream();
           return callEntity.state(z.calling.enum.CALL_STATE.REJECTED);
         }
 

--- a/app/script/entity/Conversation.js
+++ b/app/script/entity/Conversation.js
@@ -152,7 +152,7 @@ z.entity.Conversation = class Conversation {
       const callEntity = this.call();
       if (callEntity) {
         const callIsOngoing = callEntity.state() === z.calling.enum.CALL_STATE.ONGOING;
-        return (callIsOngoing && !callEntity.selfUserJoined()) || callEntity.isDeclined();
+        return !callEntity.selfUserJoined() && (callIsOngoing || callEntity.isDeclined());
       }
       return false;
     });

--- a/app/script/media/MediaStreamHandler.js
+++ b/app/script/media/MediaStreamHandler.js
@@ -574,9 +574,9 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
   needsMediaStream() {
     for (const callEntity of this.calls()) {
       const isIncomingCall = callEntity.state() === z.calling.enum.CALL_STATE.INCOMING;
-      const isIncomingVideoCall = isIncomingCall && callEntity.isRemoteVideoCall();
+      const hasPreJoinVideoPreview = isIncomingCall && callEntity.isRemoteVideoCall();
 
-      if (callEntity.selfClientJoined() || isIncomingVideoCall) {
+      if (!callEntity.isOngoingOnAnotherClient() && (callEntity.selfClientJoined() || hasPreJoinVideoPreview)) {
         return true;
       }
     }


### PR DESCRIPTION
Two small fixes here:

- do not show the `join` button when the group call is picked up from another device
- actually release the mediaStream when the call is picked up somewhere else