### PR TITLE
fix: Leave guestroom during call

### DIFF
--- a/app/script/conversation/ConversationRepository.js
+++ b/app/script/conversation/ConversationRepository.js
@@ -1214,7 +1214,7 @@ z.conversation.ConversationRepository = class ConversationRepository {
 
   leaveGuestRoom() {
     if (this.selfUser().isTemporaryGuest()) {
-      const conversationEntity = this.getMostRecentConversation();
+      const conversationEntity = this.getMostRecentConversation(true);
       return this.conversation_service.deleteMembers(conversationEntity.id, this.selfUser().id);
     }
   }


### PR DESCRIPTION
## Type of change

While we are changing the calling UI logic, this ensures a more reliable way to leave the app as a temporary guest. Previously this would fail if there was an active call.