### PR TITLE
feat: update calling tracking (WEBAPP-4991)

### DIFF
--- a/app/script/calling/CallingRepository.js
+++ b/app/script/calling/CallingRepository.js
@@ -1228,10 +1228,17 @@ z.calling.CallingRepository = class CallingRepository {
    */
   _createCall(callMessageEntity, creatingUserEntity) {
     const {conversationId, sessionId} = callMessageEntity;
+    const mediaType = this._getMediaTypeFromProperties(callMessageEntity.properties);
 
     return this.getCallById(conversationId).catch(() => {
       return this.conversationRepository.get_conversation_by_id(conversationId).then(conversationEntity => {
-        const callEntity = new z.calling.entities.CallEntity(conversationEntity, creatingUserEntity, sessionId, this);
+        const callEntity = new z.calling.entities.CallEntity(
+          conversationEntity,
+          creatingUserEntity,
+          sessionId,
+          this,
+          mediaType
+        );
 
         this.calls.push(callEntity);
         return callEntity;

--- a/app/script/calling/CallingRepository.js
+++ b/app/script/calling/CallingRepository.js
@@ -1278,7 +1278,6 @@ z.calling.CallingRepository = class CallingRepository {
         callEntity.state(callState);
 
         return callEntity.addOrUpdateParticipant(userId, false, callMessageEntity).then(() => {
-          this.telemetry.initiateNewCall(mediaType);
           this.telemetry.track_event(z.tracking.EventName.CALLING.RECEIVED_CALL, callEntity);
           this.injectActivateEvent(callMessageEntity, source);
 
@@ -1331,7 +1330,6 @@ z.calling.CallingRepository = class CallingRepository {
       callEntity.direction = z.calling.enum.CALL_STATE.OUTGOING;
       callEntity.state(z.calling.enum.CALL_STATE.OUTGOING);
 
-      this.telemetry.initiateNewCall(mediaType);
       this.telemetry.track_event(z.tracking.EventName.CALLING.INITIATED_CALL, callEntity);
       return callEntity;
     });

--- a/app/script/calling/CallingRepository.js
+++ b/app/script/calling/CallingRepository.js
@@ -1228,17 +1228,10 @@ z.calling.CallingRepository = class CallingRepository {
    */
   _createCall(callMessageEntity, creatingUserEntity) {
     const {conversationId, sessionId} = callMessageEntity;
-    const mediaType = this._getMediaTypeFromProperties(callMessageEntity.properties);
 
     return this.getCallById(conversationId).catch(() => {
       return this.conversationRepository.get_conversation_by_id(conversationId).then(conversationEntity => {
-        const callEntity = new z.calling.entities.CallEntity(
-          conversationEntity,
-          creatingUserEntity,
-          sessionId,
-          this,
-          mediaType
-        );
+        const callEntity = new z.calling.entities.CallEntity(conversationEntity, creatingUserEntity, sessionId, this);
 
         this.calls.push(callEntity);
         return callEntity;

--- a/app/script/calling/CallingRepository.js
+++ b/app/script/calling/CallingRepository.js
@@ -1255,9 +1255,9 @@ z.calling.CallingRepository = class CallingRepository {
 
     return this.userRepository
       .get_user_by_id(userId)
-      .then(remoteUserEntity =>
-        this._createCall(callMessageEntity, remoteUserEntity, z.calling.enum.CALL_STATE.INCOMING)
-      )
+      .then(remoteUserEntity => {
+        return this._createCall(callMessageEntity, remoteUserEntity, z.calling.enum.CALL_STATE.INCOMING);
+      })
       .then(callEntity => {
         const mediaType = this._getMediaTypeFromProperties(properties);
         const conversationName = callEntity.conversationEntity.display_name();

--- a/app/script/calling/CallingRepository.js
+++ b/app/script/calling/CallingRepository.js
@@ -1093,7 +1093,6 @@ z.calling.CallingRepository = class CallingRepository {
     const conversationId = callEntity.id;
     this.callLogger.info(`Joining call in conversation '${conversationId}'`, callEntity);
 
-    callEntity.initiateTelemetry(mediaType);
     return this.mediaStreamHandler.localMediaStream()
       ? Promise.resolve(callEntity)
       : this.mediaStreamHandler
@@ -1224,15 +1223,18 @@ z.calling.CallingRepository = class CallingRepository {
    * @private
    * @param {z.calling.entities.CallMessageEntity} callMessageEntity - Call message entity of type z.calling.enum.CALL_MESSAGE_TYPE.SETUP
    * @param {z.entity.User} creatingUserEntity - User that created call
+   * @param {z.calling.enum.CALL_STATE} direction - direction of the call (outgoing or incoming)
    * @returns {Promise} Resolves with the new call entity
    */
-  _createCall(callMessageEntity, creatingUserEntity) {
-    const {conversationId, sessionId} = callMessageEntity;
+  _createCall(callMessageEntity, creatingUserEntity, direction) {
+    const {conversationId, sessionId, properties} = callMessageEntity;
+    const mediaType = this._getMediaTypeFromProperties(properties);
 
     return this.getCallById(conversationId).catch(() => {
       return this.conversationRepository.get_conversation_by_id(conversationId).then(conversationEntity => {
         const callEntity = new z.calling.entities.CallEntity(conversationEntity, creatingUserEntity, sessionId, this);
 
+        callEntity.initiateTelemetry(direction, mediaType);
         this.calls.push(callEntity);
         return callEntity;
       });
@@ -1253,7 +1255,9 @@ z.calling.CallingRepository = class CallingRepository {
 
     return this.userRepository
       .get_user_by_id(userId)
-      .then(remoteUserEntity => this._createCall(callMessageEntity, remoteUserEntity))
+      .then(remoteUserEntity =>
+        this._createCall(callMessageEntity, remoteUserEntity, z.calling.enum.CALL_STATE.INCOMING)
+      )
       .then(callEntity => {
         const mediaType = this._getMediaTypeFromProperties(properties);
         const conversationName = callEntity.conversationEntity.display_name();
@@ -1267,7 +1271,6 @@ z.calling.CallingRepository = class CallingRepository {
         };
         this.callLogger.info(logMessage, callEntity);
 
-        callEntity.direction = z.calling.enum.CALL_STATE.INCOMING;
         callEntity.setRemoteVersion(callMessageEntity);
 
         if (callEntity.conversationEntity.is_muted()) {
@@ -1313,7 +1316,8 @@ z.calling.CallingRepository = class CallingRepository {
   _createOutgoingCall(callMessageEntity) {
     const {properties} = callMessageEntity;
 
-    return this._createCall(callMessageEntity, this.userRepository.self()).then(callEntity => {
+    const direction = z.calling.enum.CALL_STATE.OUTGOING;
+    return this._createCall(callMessageEntity, this.userRepository.self(), direction).then(callEntity => {
       const mediaType = this._getMediaTypeFromProperties(properties);
       const conversationName = callEntity.conversationEntity.display_name();
       const conversationId = callEntity.conversationEntity.id;
@@ -1327,7 +1331,6 @@ z.calling.CallingRepository = class CallingRepository {
       };
       this.callLogger.info(logMessage, callEntity);
 
-      callEntity.direction = z.calling.enum.CALL_STATE.OUTGOING;
       callEntity.state(z.calling.enum.CALL_STATE.OUTGOING);
 
       this.telemetry.track_event(z.tracking.EventName.CALLING.INITIATED_CALL, callEntity);

--- a/app/script/calling/CallingRepository.js
+++ b/app/script/calling/CallingRepository.js
@@ -1278,7 +1278,7 @@ z.calling.CallingRepository = class CallingRepository {
         callEntity.state(callState);
 
         return callEntity.addOrUpdateParticipant(userId, false, callMessageEntity).then(() => {
-          this.telemetry.set_media_type(mediaType);
+          this.telemetry.initiateNewCall(mediaType);
           this.telemetry.track_event(z.tracking.EventName.CALLING.RECEIVED_CALL, callEntity);
           this.injectActivateEvent(callMessageEntity, source);
 
@@ -1331,7 +1331,7 @@ z.calling.CallingRepository = class CallingRepository {
       callEntity.direction = z.calling.enum.CALL_STATE.OUTGOING;
       callEntity.state(z.calling.enum.CALL_STATE.OUTGOING);
 
-      this.telemetry.set_media_type(mediaType);
+      this.telemetry.initiateNewCall(mediaType);
       this.telemetry.track_event(z.tracking.EventName.CALLING.INITIATED_CALL, callEntity);
       return callEntity;
     });

--- a/app/script/calling/entities/CallEntity.js
+++ b/app/script/calling/entities/CallEntity.js
@@ -428,7 +428,7 @@ z.calling.entities.CallEntity = class CallEntity {
     const toggledVideo = mediaType === z.media.MediaType.SCREEN && !this.selfState.videoSend();
     const toggledScreen = mediaType === z.media.MediaType.VIDEO && !this.selfState.screenSend();
     if (toggledVideo || toggledScreen) {
-      this.telemetry.hasSwitchedAV = true;
+      this.telemetry.setAVtoggled();
     }
 
     const callEventPromises = this.getFlows().map(({remoteClientId, remoteUserId}) => {

--- a/app/script/calling/entities/CallEntity.js
+++ b/app/script/calling/entities/CallEntity.js
@@ -97,7 +97,6 @@ z.calling.entities.CallEntity = class CallEntity {
     this.previousState = undefined;
 
     this.participants = ko.observableArray([]);
-    this.maxNumberOfParticipants = 0;
     this.interruptedParticipants = ko.observableArray([]);
 
     // Media
@@ -135,7 +134,9 @@ z.calling.entities.CallEntity = class CallEntity {
       return false;
     });
 
-    this.participantsCount = ko.pureComputed(() => this.getNumberOfParticipants(this.selfUserJoined()));
+    ko.pureComputed(() => this.getNumberOfParticipants(this.selfUserJoined())).subscribe(usersInCall => {
+      this.telemetry.numberOfParticipantsChanged(usersInCall);
+    });
 
     // Observable subscriptions
     this.wasConnected = false;
@@ -167,10 +168,6 @@ z.calling.entities.CallEntity = class CallEntity {
         return amplify.publish(z.event.WebApp.AUDIO.PLAY_IN_LOOP, z.audio.AudioType.NETWORK_INTERRUPTION);
       }
       amplify.publish(z.event.WebApp.AUDIO.STOP, z.audio.AudioType.NETWORK_INTERRUPTION);
-    });
-
-    this.participantsCount.subscribe(usersInCall => {
-      this.maxNumberOfParticipants = Math.max(usersInCall, this.maxNumberOfParticipants);
     });
 
     this.selfClientJoined.subscribe(isJoined => {

--- a/app/script/calling/entities/CallEntity.js
+++ b/app/script/calling/entities/CallEntity.js
@@ -134,8 +134,10 @@ z.calling.entities.CallEntity = class CallEntity {
       return false;
     });
 
-    ko.pureComputed(() => this.getNumberOfParticipants(this.selfUserJoined())).subscribe(usersInCall => {
-      this.telemetry.numberOfParticipantsChanged(usersInCall);
+    this.participants.subscribe(participants => {
+      const additionalCount = this.selfClientJoined() ? 1 : 0;
+      const numberOfParticipants = participants.length + additionalCount;
+      this.telemetry.numberOfParticipantsChanged(numberOfParticipants);
     });
 
     // Observable subscriptions
@@ -783,16 +785,6 @@ z.calling.entities.CallEntity = class CallEntity {
 
         throw error;
       });
-  }
-
-  /**
-   * Get the number of participants in the call.
-   * @param {boolean} [countSelfUser=false] - Add self user to count
-   * @returns {number} Number of participants in call
-   */
-  getNumberOfParticipants(countSelfUser = false) {
-    const additionalCount = countSelfUser ? 1 : 0;
-    return this.participants().length + additionalCount;
   }
 
   /**

--- a/app/script/calling/entities/CallEntity.js
+++ b/app/script/calling/entities/CallEntity.js
@@ -47,12 +47,15 @@ z.calling.entities.CallEntity = class CallEntity {
    * @param {z.entity.User} creatingUser - Entity of user starting the call
    * @param {string} sessionId - Session ID to identify call
    * @param {z.calling.CallingRepository} callingRepository - Calling Repository
+   * @param {z.media.MediaType} initialMediaType - The initial type of the call
    */
-  constructor(conversationEntity, creatingUser, sessionId, callingRepository) {
+  constructor(conversationEntity, creatingUser, sessionId, callingRepository, initialMediaType) {
     this.conversationEntity = conversationEntity;
     this.creatingUser = creatingUser;
     this.sessionId = sessionId;
     this.callingRepository = callingRepository;
+
+    this.initialMediaType = initialMediaType;
 
     const {id: conversationId, is_group} = conversationEntity;
     const {mediaStreamHandler, mediaRepository, selfStreamState, telemetry, userRepository} = this.callingRepository;
@@ -146,8 +149,7 @@ z.calling.entities.CallEntity = class CallEntity {
           this.scheduleGroupCheck();
         }
 
-        const attributes = {direction: this.direction};
-        this.telemetry.track_event(z.tracking.EventName.CALLING.ESTABLISHED_CALL, this, attributes);
+        this.telemetry.track_event(z.tracking.EventName.CALLING.ESTABLISHED_CALL, this);
         this.timerStart = Date.now() - CallEntity.CONFIG.TIMER.INIT_THRESHOLD;
 
         this.callTimerInterval = window.setInterval(() => {
@@ -216,8 +218,7 @@ z.calling.entities.CallEntity = class CallEntity {
 
       const isConnectingCall = state === z.calling.enum.CALL_STATE.CONNECTING;
       if (isConnectingCall) {
-        const attributes = {direction: this.direction};
-        this.telemetry.track_event(z.tracking.EventName.CALLING.JOINED_CALL, this, attributes);
+        this.telemetry.track_event(z.tracking.EventName.CALLING.JOINED_CALL, this);
       }
 
       this.previousState = state;

--- a/app/script/calling/entities/CallEntity.js
+++ b/app/script/calling/entities/CallEntity.js
@@ -133,9 +133,10 @@ z.calling.entities.CallEntity = class CallEntity {
       return false;
     });
 
-    this.participants.subscribe(participants => {
+    ko.pureComputed(() => {
       const additionalCount = this.selfClientJoined() ? 1 : 0;
-      const numberOfParticipants = participants.length + additionalCount;
+      return this.participants().length + additionalCount;
+    }).subscribe(numberOfParticipants => {
       this.telemetry.numberOfParticipantsChanged(numberOfParticipants);
     });
 

--- a/app/script/calling/entities/CallEntity.js
+++ b/app/script/calling/entities/CallEntity.js
@@ -83,7 +83,6 @@ z.calling.entities.CallEntity = class CallEntity {
     // States
     this.callTimerInterval = undefined;
     this.timerStart = undefined;
-    this.direction = undefined;
     this.durationTime = ko.observable(0);
     this.groupCheckTimeoutId = undefined;
     this.terminationReason = undefined;
@@ -951,11 +950,12 @@ z.calling.entities.CallEntity = class CallEntity {
 
   /**
    * Initiate the call telemetry.
+   * @param {z.calling.enum.CALL_STATE} direction - direction of the call (outgoing or incoming)
    * @param {z.media.MediaType} [mediaType=z.media.MediaType.AUDIO] - Media type for this call
    * @returns {undefined} No return value
    */
-  initiateTelemetry(mediaType = z.media.MediaType.AUDIO) {
-    this.telemetry.initiateNewCall(mediaType);
+  initiateTelemetry(direction, mediaType = z.media.MediaType.AUDIO) {
+    this.telemetry.initiateNewCall(direction, mediaType);
     this.timings = new z.telemetry.calling.CallSetupTimings(this.id);
   }
 

--- a/app/script/calling/entities/CallEntity.js
+++ b/app/script/calling/entities/CallEntity.js
@@ -966,7 +966,7 @@ z.calling.entities.CallEntity = class CallEntity {
    * @returns {undefined} No return value
    */
   initiateTelemetry(mediaType = z.media.MediaType.AUDIO) {
-    this.telemetry.set_media_type(mediaType);
+    this.telemetry.initiateNewCall(mediaType);
     this.timings = new z.telemetry.calling.CallSetupTimings(this.id);
   }
 

--- a/app/script/telemetry/calling/CallTelemetry.js
+++ b/app/script/telemetry/calling/CallTelemetry.js
@@ -32,7 +32,7 @@ z.telemetry.calling.CallTelemetry = class CallTelemetry {
     this.remote_version = undefined;
     this.hasSwitchedAV = false;
 
-    this.media_type = z.media.MediaType.AUDIO;
+    this.mediaType = z.media.MediaType.AUDIO;
   }
 
   //##############################################################################
@@ -79,13 +79,14 @@ z.telemetry.calling.CallTelemetry = class CallTelemetry {
   //##############################################################################
 
   /**
-   * Set the media type of the call.
-   * @param {z.media.MediaType} [media_type=z.media.MediaType.AUDIO] - Media type for this call
+   * Prepare the call telemetry for a new call (resets to initial values)
+   * @param {z.media.MediaType} [mediaType=z.media.MediaType.AUDIO] - Media type for this call
    * @returns {undefined} No return value
    */
-  set_media_type(media_type = z.media.MediaType.AUDIO) {
-    this.media_type = media_type;
-    this.logger.info(`Set media type to '${this.media_type}'`);
+  initiateNewCall(mediaType = z.media.MediaType.AUDIO) {
+    this.mediaType = mediaType;
+    this.hasSwitchedAV = false;
+    this.logger.info(`Initiate new call of type '${this.mediaType}'`);
   }
 
   /**
@@ -111,6 +112,8 @@ z.telemetry.calling.CallTelemetry = class CallTelemetry {
     if (callEntity) {
       const {conversationEntity, isGroup, maxNumberOfParticipants, direction} = callEntity;
 
+      const videoTypes = [z.media.MediaType.VIDEO, z.media.MediaType.AUDIO_VIDEO];
+
       attributes = Object.assign(
         {
           conversation_participants: conversationEntity.getNumberOfParticipants(),
@@ -125,7 +128,7 @@ z.telemetry.calling.CallTelemetry = class CallTelemetry {
           ].includes(eventName)
             ? this.remote_version
             : undefined,
-          started_as_video: this.media_type === z.media.MediaType.VIDEO,
+          started_as_video: videoTypes.includes(this.mediaType),
           with_service: conversationEntity.isWithBot(),
         },
         z.tracking.helpers.getGuestAttributes(conversationEntity),

--- a/app/script/telemetry/calling/CallTelemetry.js
+++ b/app/script/telemetry/calling/CallTelemetry.js
@@ -30,6 +30,7 @@ z.telemetry.calling.CallTelemetry = class CallTelemetry {
 
     this.sessions = {};
     this.remote_version = undefined;
+    this.hasSwitchedAV = false;
 
     this.media_type = z.media.MediaType.AUDIO;
   }
@@ -124,7 +125,7 @@ z.telemetry.calling.CallTelemetry = class CallTelemetry {
           ].includes(eventName)
             ? this.remote_version
             : undefined,
-          started_as_video: callEntity.initialMediaType === z.media.MediaType.VIDEO,
+          started_as_video: this.media_type === z.media.MediaType.VIDEO,
           with_service: conversationEntity.isWithBot(),
         },
         z.tracking.helpers.getGuestAttributes(conversationEntity),
@@ -166,6 +167,7 @@ z.telemetry.calling.CallTelemetry = class CallTelemetry {
       }
 
       const attributes = {
+        AV_switch_toggled: this.hasSwitchedAV,
         duration: duration_bucket,
         duration_sec: duration,
         reason: terminationReason,

--- a/app/script/telemetry/calling/CallTelemetry.js
+++ b/app/script/telemetry/calling/CallTelemetry.js
@@ -30,7 +30,7 @@ z.telemetry.calling.CallTelemetry = class CallTelemetry {
 
     this.sessions = {};
     this.remote_version = undefined;
-    this.hasSwitchedAV = false;
+    this.hasToggledAV = false;
 
     this.mediaType = z.media.MediaType.AUDIO;
   }
@@ -85,8 +85,12 @@ z.telemetry.calling.CallTelemetry = class CallTelemetry {
    */
   initiateNewCall(mediaType = z.media.MediaType.AUDIO) {
     this.mediaType = mediaType;
-    this.hasSwitchedAV = false;
+    this.hasToggledAV = false;
     this.logger.info(`Initiate new call of type '${this.mediaType}'`);
+  }
+
+  setAVToggled() {
+    this.hasToggledAV = true;
   }
 
   /**
@@ -170,7 +174,7 @@ z.telemetry.calling.CallTelemetry = class CallTelemetry {
       }
 
       const attributes = {
-        AV_switch_toggled: this.hasSwitchedAV,
+        AV_switch_toggled: this.hasToggledAV,
         duration: duration_bucket,
         duration_sec: duration,
         reason: terminationReason,

--- a/app/script/telemetry/calling/CallTelemetry.js
+++ b/app/script/telemetry/calling/CallTelemetry.js
@@ -31,6 +31,7 @@ z.telemetry.calling.CallTelemetry = class CallTelemetry {
     this.sessions = {};
     this.remote_version = undefined;
     this.hasToggledAV = false;
+    this.maxNumberOfParticipants = 0;
 
     this.mediaType = z.media.MediaType.AUDIO;
   }
@@ -86,6 +87,7 @@ z.telemetry.calling.CallTelemetry = class CallTelemetry {
   initiateNewCall(mediaType = z.media.MediaType.AUDIO) {
     this.mediaType = mediaType;
     this.hasToggledAV = false;
+    this.maxNumberOfParticipants = 0;
     this.logger.info(`Initiate new call of type '${this.mediaType}'`);
   }
 
@@ -114,14 +116,14 @@ z.telemetry.calling.CallTelemetry = class CallTelemetry {
    */
   track_event(eventName, callEntity, attributes = {}) {
     if (callEntity) {
-      const {conversationEntity, isGroup, maxNumberOfParticipants, direction} = callEntity;
+      const {conversationEntity, isGroup, direction} = callEntity;
 
       const videoTypes = [z.media.MediaType.VIDEO, z.media.MediaType.AUDIO_VIDEO];
 
       attributes = Object.assign(
         {
           conversation_participants: conversationEntity.getNumberOfParticipants(),
-          conversation_participants_in_call: maxNumberOfParticipants ? maxNumberOfParticipants : undefined,
+          conversation_participants_in_call: this.maxNumberOfParticipants ? this.maxNumberOfParticipants : undefined,
           conversation_type: isGroup
             ? z.tracking.attribute.ConversationType.GROUP
             : z.tracking.attribute.ConversationType.ONE_TO_ONE,
@@ -184,5 +186,9 @@ z.telemetry.calling.CallTelemetry = class CallTelemetry {
       const eventName = z.tracking.EventName.CALLING.ENDED_CALL;
       this.track_event(eventName, callEntity, attributes);
     }
+  }
+
+  numberOfParticipantsChanged(newNumberOfParticipants) {
+    this.maxNumberOfParticipants = Math.max(this.maxNumberOfParticipants, newNumberOfParticipants);
   }
 };

--- a/app/script/telemetry/calling/CallTelemetry.js
+++ b/app/script/telemetry/calling/CallTelemetry.js
@@ -32,6 +32,7 @@ z.telemetry.calling.CallTelemetry = class CallTelemetry {
     this.remote_version = undefined;
     this.hasToggledAV = false;
     this.maxNumberOfParticipants = 0;
+    this.direction = undefined;
 
     this.mediaType = z.media.MediaType.AUDIO;
   }
@@ -81,14 +82,16 @@ z.telemetry.calling.CallTelemetry = class CallTelemetry {
 
   /**
    * Prepare the call telemetry for a new call (resets to initial values)
+   * @param {z.calling.enum.CALL_STATE} direction - direction of the call (outgoing or incoming)
    * @param {z.media.MediaType} [mediaType=z.media.MediaType.AUDIO] - Media type for this call
    * @returns {undefined} No return value
    */
-  initiateNewCall(mediaType = z.media.MediaType.AUDIO) {
+  initiateNewCall(direction, mediaType = z.media.MediaType.AUDIO) {
     this.mediaType = mediaType;
     this.hasToggledAV = false;
     this.maxNumberOfParticipants = 0;
-    this.logger.info(`Initiate new call of type '${this.mediaType}'`);
+    this.direction = direction;
+    this.logger.info(`Initiate new '${direction}' call of type '${this.mediaType}'`);
   }
 
   setAVToggled() {
@@ -116,7 +119,7 @@ z.telemetry.calling.CallTelemetry = class CallTelemetry {
    */
   track_event(eventName, callEntity, attributes = {}) {
     if (callEntity) {
-      const {conversationEntity, isGroup, direction} = callEntity;
+      const {conversationEntity, isGroup} = callEntity;
 
       const videoTypes = [z.media.MediaType.VIDEO, z.media.MediaType.AUDIO_VIDEO];
 
@@ -129,7 +132,7 @@ z.telemetry.calling.CallTelemetry = class CallTelemetry {
           conversation_type: isGroup
             ? z.tracking.attribute.ConversationType.GROUP
             : z.tracking.attribute.ConversationType.ONE_TO_ONE,
-          direction,
+          direction: this.direction,
           remote_version: [
             z.tracking.EventName.CALLING.ESTABLISHED_CALL,
             z.tracking.EventName.CALLING.JOINED_CALL,

--- a/app/script/telemetry/calling/CallTelemetry.js
+++ b/app/script/telemetry/calling/CallTelemetry.js
@@ -158,27 +158,9 @@ z.telemetry.calling.CallTelemetry = class CallTelemetry {
     if (!window.isNaN(duration)) {
       this.logger.info(`Call duration: ${duration} seconds.`, durationTime());
 
-      let duration_bucket;
-      if (duration <= 15) {
-        duration_bucket = '0s-15s';
-      } else if (duration <= 30) {
-        duration_bucket = '16s-30s';
-      } else if (duration <= 60) {
-        duration_bucket = '31s-60s';
-      } else if (duration <= 3 * 60) {
-        duration_bucket = '61s-3min';
-      } else if (duration <= 10 * 60) {
-        duration_bucket = '3min-10min';
-      } else if (duration <= 60 * 60) {
-        duration_bucket = '10min-1h';
-      } else {
-        duration_bucket = '1h-infinite';
-      }
-
       const attributes = {
         AV_switch_toggled: this.hasToggledAV,
-        duration: duration_bucket,
-        duration_sec: duration,
+        duration: duration,
         reason: terminationReason,
         remote_version: this.remote_version,
       };

--- a/app/script/telemetry/calling/CallTelemetry.js
+++ b/app/script/telemetry/calling/CallTelemetry.js
@@ -123,7 +123,9 @@ z.telemetry.calling.CallTelemetry = class CallTelemetry {
       attributes = Object.assign(
         {
           conversation_participants: conversationEntity.getNumberOfParticipants(),
-          conversation_participants_in_call: this.maxNumberOfParticipants ? this.maxNumberOfParticipants : undefined,
+          conversation_participants_in_call_max: this.maxNumberOfParticipants
+            ? this.maxNumberOfParticipants
+            : undefined,
           conversation_type: isGroup
             ? z.tracking.attribute.ConversationType.GROUP
             : z.tracking.attribute.ConversationType.ONE_TO_ONE,
@@ -165,8 +167,7 @@ z.telemetry.calling.CallTelemetry = class CallTelemetry {
         remote_version: this.remote_version,
       };
 
-      const eventName = z.tracking.EventName.CALLING.ENDED_CALL;
-      this.track_event(eventName, callEntity, attributes);
+      this.track_event(z.tracking.EventName.CALLING.ENDED_CALL, callEntity, attributes);
     }
   }
 

--- a/app/script/tracking/Helpers.js
+++ b/app/script/tracking/Helpers.js
@@ -95,6 +95,11 @@ z.tracking.helpers = {
         user_type: _getUserType(conversationEntity),
       };
     }
+
+    return {
+      is_allow_guests: false,
+      user_type: z.tracking.attribute.UserType.USER,
+    };
   },
 
   getParticipantTypes(userEntities, countSelf) {


### PR DESCRIPTION
@gregor this is a WIP, but most of the properties are done.

Here is the general state:
`calling.initiated_call` :heavy_check_mark: 
`calling.joined_call`  :heavy_check_mark: 
`calling.established_call` :heavy_check_mark: 
`calling.received_call` :heavy_check_mark: 
`calling.ended_call` :heavy_check_mark: 

~~for the `joined_call`, I added a property on the `callEntity` with the media type used when the call is created (so that it's immutable, and we are garantied we cannot mess with the value).~~
~~The side effect is that, if you wait for the `timeout` before picking up and then join (with audio), the call would have been created with the `video` property to `true` (I guess the call is not destroyed between the timeout and the join action).~~

~~For the `ended_call` we used to track `duration` and `duration_sec` I wonder if we really want to remove the logic for the old `duration` property. (the new spec says it should be a `number` while it's a string right now).~~

~~For the `ended_call`, there is the `AV_switch_toggle` left to do~~