### PR TITLE
fix: track-wise local media stream tracks replacement

### DIFF
--- a/app/script/calling/entities/FlowEntity.js
+++ b/app/script/calling/entities/FlowEntity.js
@@ -516,8 +516,8 @@ z.calling.entities.FlowEntity = class FlowEntity {
       videoTracks: mediaStream.getVideoTracks(),
     });
 
-    mediaStream = z.media.MediaStreamHandler.detectMediaStreamType(mediaStream);
-    const isTypeAudio = mediaStream.type === z.media.MediaType.AUDIO;
+    const mediaType = z.media.MediaStreamHandler.detectMediaStreamType(mediaStream);
+    const isTypeAudio = mediaType === z.media.MediaType.AUDIO;
     if (isTypeAudio) {
       mediaStream = this.audio.wrapAudioOutputStream(mediaStream);
     }
@@ -1227,7 +1227,8 @@ z.calling.entities.FlowEntity = class FlowEntity {
    * @returns {Promise} Resolves when negotiation has been restarted
    */
   replaceMediaStream(mediaStreamInfo, outdatedMediaStream) {
-    const {stream: mediaStream, type: mediaType} = mediaStreamInfo;
+    const mediaStream = mediaStreamInfo.stream;
+    const mediaType = mediaStreamInfo.getType();
     const negotiationMode = z.calling.enum.SDP_NEGOTIATION_MODE.STREAM_CHANGE;
 
     return Promise.resolve()
@@ -1248,7 +1249,8 @@ z.calling.entities.FlowEntity = class FlowEntity {
    * @returns {Promise} Resolves when a MediaStreamTrack has been replaced
    */
   replaceMediaTrack(mediaStreamInfo) {
-    const {stream: mediaStream, type: mediaType} = mediaStreamInfo;
+    const mediaStream = mediaStreamInfo.stream;
+    const mediaType = mediaStreamInfo.getType();
     const [mediaStreamTrack] = mediaStream.getTracks();
 
     return Promise.resolve()

--- a/app/script/media/MediaElementHandler.js
+++ b/app/script/media/MediaElementHandler.js
@@ -41,7 +41,7 @@ z.media.MediaElementHandler = class MediaElementHandler {
    * @returns {undefined} No return value
    */
   addMediaElement(mediaStreamInfo) {
-    if (mediaStreamInfo.type !== z.media.MediaType.VIDEO) {
+    if (mediaStreamInfo.getType() !== z.media.MediaType.VIDEO) {
       const remoteMediaElement = this._createMediaElement(mediaStreamInfo);
       this.remoteMediaElements.push(remoteMediaElement);
 

--- a/app/script/media/MediaElementHandler.js
+++ b/app/script/media/MediaElementHandler.js
@@ -41,7 +41,8 @@ z.media.MediaElementHandler = class MediaElementHandler {
    * @returns {undefined} No return value
    */
   addMediaElement(mediaStreamInfo) {
-    if (mediaStreamInfo.getType() !== z.media.MediaType.VIDEO) {
+    const isVideoStream = mediaStreamInfo.getType() === z.media.MediaType.VIDEO;
+    if (!isVideoStream) {
       const remoteMediaElement = this._createMediaElement(mediaStreamInfo);
       this.remoteMediaElements.push(remoteMediaElement);
 

--- a/app/script/media/MediaStreamHandler.js
+++ b/app/script/media/MediaStreamHandler.js
@@ -26,7 +26,7 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
   /**
    * Detect whether a MediaStream has a video MediaStreamTrack attached
    * @param {MediaStream} mediaStream - MediaStream to detect the type off
-   * @returns {MediaStream} MediaStream with new type information
+   * @returns {MediaType} Media type information
    */
   static detectMediaStreamType(mediaStream) {
     const audioTracks = mediaStream.getAudioTracks();
@@ -35,12 +35,9 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
     const hasAudioTrack = audioTracks && audioTracks.length;
     const hasVideoTrack = videoTracks && videoTracks.length;
     if (hasVideoTrack) {
-      mediaStream.type = hasAudioTrack ? z.media.MediaType.AUDIO_VIDEO : z.media.MediaType.VIDEO;
-    } else {
-      mediaStream.type = hasAudioTrack ? z.media.MediaType.AUDIO : z.media.MediaType.NONE;
+      return hasAudioTrack ? z.media.MediaType.AUDIO_VIDEO : z.media.MediaType.VIDEO;
     }
-
-    return mediaStream;
+    return hasAudioTrack ? z.media.MediaType.AUDIO : z.media.MediaType.NONE;
   }
 
   /**
@@ -60,6 +57,7 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
         return mediaStream.getTracks();
       }
 
+      case z.media.MediaType.SCREEN:
       case z.media.MediaType.VIDEO: {
         return mediaStream.getVideoTracks();
       }
@@ -106,11 +104,13 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
     this.remoteMediaStreamInfo = ko.observableArray([]);
     this.remoteMediaStreamInfoIndex = {
       audio: ko.pureComputed(() => {
-        return this.remoteMediaStreamInfo().filter(mediaStreamInfo => mediaStreamInfo.type === z.media.MediaType.AUDIO);
+        return this.remoteMediaStreamInfo().filter(mediaStreamInfo => {
+          return mediaStreamInfo.getType() === z.media.MediaType.AUDIO;
+        });
       }),
       video: ko.pureComputed(() => {
         const videoTypes = [z.media.MediaType.AUDIO_VIDEO, z.media.MediaType.VIDEO];
-        return this.remoteMediaStreamInfo().filter(mediaStreamInfo => videoTypes.includes(mediaStreamInfo.type));
+        return this.remoteMediaStreamInfo().filter(mediaStreamInfo => videoTypes.includes(mediaStreamInfo.getType()));
       }),
     };
 
@@ -191,28 +191,10 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
   /**
    * Replace the MediaStream after a change of the selected input device.
    * @param {z.media.MediaStreamInfo} mediaStreamInfo - Info about new MediaStream
-   * @returns {Promise} Resolves when the MediaStream has been replaced
+   * @returns {undefined} No return value
    */
-  replaceMediaStream(mediaStreamInfo) {
-    const {stream: mediaStream} = mediaStreamInfo;
-
-    const replaceMediaStream = (localMediaStream, newMediaStreamInfo) => {
-      this._releaseMediaStream(localMediaStream);
-      this._setStreamState(newMediaStreamInfo);
-      this.localMediaStream(newMediaStreamInfo.stream);
-    };
-
-    const replaceMediaTracks = (localMediaStream, newMediaStream) => {
-      localMediaStream.getTracks().forEach(localTrack => {
-        newMediaStream.getTracks().forEach(newTrack => {
-          if (localTrack.kind === newTrack.kind) {
-            localTrack.stop();
-            localMediaStream.removeTrack(localTrack);
-            localMediaStream.addTrack(newTrack);
-          }
-        });
-      });
-    };
+  changeMediaStream(mediaStreamInfo) {
+    const mediaStream = mediaStreamInfo.stream;
 
     const logMessage = `Received new MediaStream containing '${mediaStream.getTracks().length}' track/s`;
     const logObject = {
@@ -226,11 +208,30 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
       ? this._updateJoinedCall(mediaStreamInfo)
       : Promise.resolve(mediaStreamInfo);
 
-    return replacePromise.then(updateMediaStreamInfo => {
-      return updateMediaStreamInfo.replaced
-        ? replaceMediaStream(this.localMediaStream(), updateMediaStreamInfo)
-        : replaceMediaTracks(this.localMediaStream(), updateMediaStreamInfo.stream);
-    });
+    replacePromise.then(updatedMediaStreamInfo => this._handleReplacedMediaStream(updatedMediaStreamInfo));
+  }
+
+  _handleReplacedMediaStream(mediaStreamInfo) {
+    const replaceMediaStreamLocally = newMediaStreamInfo => {
+      const newMediaStream = mediaStreamInfo.stream;
+      const newMediaStreamType = mediaStreamInfo.getType();
+
+      this._releaseMediaStream(this.localMediaStream());
+      this._setStreamState(newMediaStream, newMediaStreamType);
+      this.localMediaStream(newMediaStream);
+    };
+
+    const replaceMediaTracksLocally = newMediaStreamInfo => {
+      const mediaStream = newMediaStreamInfo.stream;
+      const mediaType = newMediaStreamInfo.getType();
+
+      this._releaseTracksFromStream(this.localMediaStream(), mediaType);
+      this._addTracksToStream(mediaStream, this.localMediaStream(), mediaType);
+    };
+
+    return mediaStreamInfo.replaced
+      ? replaceMediaStreamLocally(mediaStreamInfo)
+      : replaceMediaTracksLocally(mediaStreamInfo);
   }
 
   /**
@@ -267,7 +268,7 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
       .then(streamConstraints => {
         return this.requestMediaStream(mediaType, streamConstraints).then(mediaStreamInfo => {
           this._setSelfStreamState(mediaType);
-          this.replaceMediaStream(mediaStreamInfo);
+          this.changeMediaStream(mediaStreamInfo);
         });
       })
       .catch(error => {
@@ -294,6 +295,11 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
     });
   }
 
+  _addTracksToStream(sourceStream, targetStream, mediaType) {
+    const mediaStreamTracks = MediaStreamHandler.getMediaTracks(sourceStream, mediaType);
+    mediaStreamTracks.forEach(mediaStreamTrack => targetStream.addTrack(mediaStreamTrack));
+  }
+
   _checkDeviceAvailability(mediaType) {
     const videoTypes = [z.media.MediaType.AUDIO_VIDEO, z.media.MediaType.VIDEO];
     const noVideoTypes = !this.deviceSupport.videoInput() && videoTypes.includes(mediaType);
@@ -310,49 +316,6 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
     }
 
     return Promise.resolve();
-  }
-
-  /**
-   * Request a MediaStream.
-   *
-   * @private
-   * @param {z.media.MediaType} mediaType - Type of MediaStream to be requested
-   * @param {RTCMediaStreamConstraints} mediaStreamConstraints - Constraints for the MediaStream to be requested
-   * @returns {Promise} Resolves with the stream and its type
-   */
-  _requestMediaStream(mediaType, mediaStreamConstraints) {
-    this.logger.info(`Requesting MediaStream access for '${mediaType}'`, mediaStreamConstraints);
-    this.requestHintTimeout = window.setTimeout(() => {
-      this._hidePermissionFailedHint(mediaType);
-      this._showPermissionRequestHint(mediaType);
-      this.requestHintTimeout = undefined;
-    }, MediaStreamHandler.CONFIG.PERMISSION_HINT_DELAY);
-
-    return navigator.mediaDevices
-      .getUserMedia(mediaStreamConstraints)
-      .then(mediaStream => {
-        this._clearPermissionRequestHint(mediaType);
-        return new z.media.MediaStreamInfo(z.media.MediaStreamSource.LOCAL, 'self', mediaStream);
-      })
-      .catch(error => {
-        const {message, name} = error;
-        this.logger.warn(`MediaStream request for '${mediaType}' failed: ${name} ${message}`);
-        this._clearPermissionRequestHint(mediaType);
-
-        if (z.media.MEDIA_STREAM_ERROR_TYPES.DEVICE.includes(name)) {
-          throw new z.media.MediaError(z.media.MediaError.TYPE.MEDIA_STREAM_DEVICE, mediaType);
-        }
-
-        if (z.media.MEDIA_STREAM_ERROR_TYPES.MISC.includes(name)) {
-          throw new z.media.MediaError(z.media.MediaError.TYPE.MEDIA_STREAM_MISC, mediaType);
-        }
-
-        if (z.media.MEDIA_STREAM_ERROR_TYPES.PERMISSION.includes(name)) {
-          throw new z.media.MediaError(z.media.MediaError.TYPE.MEDIA_STREAM_PERMISSION, mediaType);
-        }
-
-        throw error;
-      });
   }
 
   /**
@@ -404,7 +367,8 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
    */
   _initiateMediaStreamSuccess(mediaStreamInfo) {
     if (mediaStreamInfo) {
-      const {stream: mediaStream} = mediaStreamInfo;
+      const mediaStream = mediaStreamInfo.stream;
+      const mediaType = mediaStreamInfo.getType();
 
       const logMessage = `Received initial MediaStream containing '${mediaStream.getTracks().length}' tracks/s`;
       const logObject = {
@@ -414,7 +378,7 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
       };
       this.logger.debug(logMessage, logObject);
 
-      this._setStreamState(mediaStreamInfo);
+      this._setStreamState(mediaStream, mediaType);
       this.localMediaStream(mediaStream);
     }
   }
@@ -444,7 +408,7 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
   }
 
   /**
-   * Release the MediaStream.
+   * Release a MediaStream.
    *
    * @private
    * @param {MediaStream} mediaStream - MediaStream to be released
@@ -452,40 +416,75 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
    * @returns {boolean} Have tracks been stopped
    */
   _releaseMediaStream(mediaStream, mediaType = z.media.MediaType.AUDIO_VIDEO) {
-    if (mediaStream) {
-      const mediaStreamTracks = z.media.MediaStreamHandler.getMediaTracks(mediaStream, mediaType);
+    return mediaStream ? this._releaseTracksFromStream(mediaStream, mediaType) : false;
+  }
 
-      if (mediaStreamTracks.length) {
-        mediaStreamTracks.forEach(mediaStreamTrack => {
-          mediaStream.removeTrack(mediaStreamTrack);
-          mediaStreamTrack.stop();
-          this.logger.info(`Stopping MediaStreamTrack of kind '${mediaStreamTrack.kind}' successful`, mediaStreamTrack);
-        });
+  /**
+   * Release tracks from a MediaStream.
+   *
+   * @private
+   * @param {MediaStream} mediaStream - MediaStream to release tracks from
+   * @param {z.media.MediaType} [mediaType=z.media.MediaType.AUDIO_VIDEO] - Type of MediaStreamTracks to be released
+   * @returns {boolean} Have tracks been stopped
+   */
+  _releaseTracksFromStream(mediaStream, mediaType) {
+    const mediaStreamTracks = MediaStreamHandler.getMediaTracks(mediaStream, mediaType);
 
-        return true;
-      }
+    if (mediaStreamTracks.length) {
+      mediaStreamTracks.forEach(mediaStreamTrack => {
+        mediaStream.removeTrack(mediaStreamTrack);
+        mediaStreamTrack.stop();
+        this.logger.info(`Stopping MediaStreamTrack of kind '${mediaStreamTrack.kind}' successful`, mediaStreamTrack);
+      });
 
-      this.logger.warn('No MediaStreamTrack found to stop', mediaStream);
-      return false;
+      return true;
     }
 
+    this.logger.warn('No MediaStreamTrack found to stop', mediaStream);
     return false;
   }
 
-  _replaceMediaTrack(mediaStreamInfo, flowEntities) {
-    const replacementPromises = flowEntities.map(flowEntity => flowEntity.replaceMediaTrack(mediaStreamInfo));
-    return Promise.all(replacementPromises).then(() => mediaStreamInfo);
-  }
+  /**
+   * Request a MediaStream.
+   *
+   * @private
+   * @param {z.media.MediaType} mediaType - Type of MediaStream to be requested
+   * @param {RTCMediaStreamConstraints} mediaStreamConstraints - Constraints for the MediaStream to be requested
+   * @returns {Promise} Resolves with the stream and its type
+   */
+  _requestMediaStream(mediaType, mediaStreamConstraints) {
+    this.logger.info(`Requesting MediaStream access for '${mediaType}'`, mediaStreamConstraints);
+    this.requestHintTimeout = window.setTimeout(() => {
+      this._hidePermissionFailedHint(mediaType);
+      this._showPermissionRequestHint(mediaType);
+      this.requestHintTimeout = undefined;
+    }, MediaStreamHandler.CONFIG.PERMISSION_HINT_DELAY);
 
-  _replaceMediaStream(mediaStreamInfo, flowEntities) {
-    return this._upgradeMediaStream(mediaStreamInfo).then(newMediaStreamInfo => {
-      newMediaStreamInfo.replaced = true;
+    return navigator.mediaDevices
+      .getUserMedia(mediaStreamConstraints)
+      .then(mediaStream => {
+        this._clearPermissionRequestHint(mediaType);
+        return new z.media.MediaStreamInfo(z.media.MediaStreamSource.LOCAL, 'self', mediaStream);
+      })
+      .catch(error => {
+        const {message, name} = error;
+        this.logger.warn(`MediaStream request for '${mediaType}' failed: ${name} ${message}`);
+        this._clearPermissionRequestHint(mediaType);
 
-      const upgradePromises = flowEntities.map(flowEntity => {
-        return flowEntity.replaceMediaStream(newMediaStreamInfo, this.localMediaStream());
+        if (z.media.MEDIA_STREAM_ERROR_TYPES.DEVICE.includes(name)) {
+          throw new z.media.MediaError(z.media.MediaError.TYPE.MEDIA_STREAM_DEVICE, mediaType);
+        }
+
+        if (z.media.MEDIA_STREAM_ERROR_TYPES.MISC.includes(name)) {
+          throw new z.media.MediaError(z.media.MediaError.TYPE.MEDIA_STREAM_MISC, mediaType);
+        }
+
+        if (z.media.MEDIA_STREAM_ERROR_TYPES.PERMISSION.includes(name)) {
+          throw new z.media.MediaError(z.media.MediaError.TYPE.MEDIA_STREAM_PERMISSION, mediaType);
+        }
+
+        throw error;
       });
-      return Promise.all(upgradePromises).then(() => newMediaStreamInfo);
-    });
   }
 
   _selectPermissionDeniedWarningType(mediaType) {
@@ -584,19 +583,37 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
    * @returns {Promise} Resolves when MediaStream was replaced
    */
   _updateJoinedCall(mediaStreamInfo) {
-    this._setStreamState(mediaStreamInfo);
+    this._setStreamState(mediaStreamInfo.stream, mediaStreamInfo.getType());
     const flowEntities = this.joinedCall().getFlows();
     const [firstFlowEntity] = flowEntities;
 
+    const replaceMediaTrackInFlows = (streamInfo, flows) => {
+      const replacementPromises = flows.map(flowEntity => flowEntity.replaceMediaTrack(streamInfo));
+      return Promise.all(replacementPromises).then(() => streamInfo);
+    };
+
+    const replaceMediaStreamInFlows = (streamInfo, flows) => {
+      return this._updateMediaStream(streamInfo).then(newMediaStreamInfo => {
+        newMediaStreamInfo.replaced = true;
+
+        const upgradePromises = flows.map(flowEntity => {
+          return flowEntity.replaceMediaStream(newMediaStreamInfo, this.localMediaStream());
+        });
+        return Promise.all(upgradePromises).then(() => newMediaStreamInfo);
+      });
+    };
+
     return firstFlowEntity
-      .supportsTrackReplacement(mediaStreamInfo.type)
+      .supportsTrackReplacement(mediaStreamInfo.getType())
       .then(replacementSupported => {
         return replacementSupported
-          ? this._replaceMediaTrack(mediaStreamInfo, flowEntities)
-          : this._replaceMediaStream(mediaStreamInfo, flowEntities);
+          ? replaceMediaTrackInFlows(mediaStreamInfo, flowEntities)
+          : replaceMediaStreamInFlows(mediaStreamInfo, flowEntities);
       })
       .catch(error => {
-        const logMessage = `Failed to update call with '${mediaStreamInfo.type}': ${error.name} - ${error.message}`;
+        const logMessage = `Failed to update call with '${mediaStreamInfo.getType()}': ${error.name} - ${
+          error.message
+        }`;
         this.logger.error(logMessage, error);
         throw error;
       });
@@ -609,25 +626,20 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
    * @param {z.media.MediaStreamInfo} mediaStreamInfo - MediaStreamInfo containing new MediaStreamTracks
    * @returns {Promise<z.media.MediaStreamInfo>} Resolves with new MediaStream to be used
    */
-  _upgradeMediaStream(mediaStreamInfo) {
+  _updateMediaStream(mediaStreamInfo) {
     if (!this.localMediaStream()) {
       return Promise.reject(new z.media.MediaError(z.media.MediaError.TYPE.STREAM_NOT_FOUND));
     }
 
-    const {stream: newMediaStream, type: mediaType} = mediaStreamInfo;
-    z.media.MediaStreamHandler.getMediaTracks(this.localMediaStream(), mediaType).forEach(mediaStreamTrack => {
-      this.localMediaStream().removeTrack(mediaStreamTrack);
-      mediaStreamTrack.stop();
-      this.logger.debug(`Stopping MediaStreamTrack of kind '${mediaStreamTrack.kind}' successful`, mediaStreamTrack);
-    });
+    const newMediaStream = mediaStreamInfo.stream;
+    const mediaType = mediaStreamInfo.getType();
+    this._releaseTracksFromStream(this.localMediaStream(), mediaType);
 
     const clonedMediaStream = this.localMediaStream().clone();
+    const clonedMediaStreamType = MediaStreamHandler.detectMediaStreamType(clonedMediaStream);
     // Reset MediaStreamTrack enabled states as older Chrome versions fail to copy these when cloning
-    this._setStreamState(clonedMediaStream);
-
-    z.media.MediaStreamHandler.getMediaTracks(newMediaStream, mediaType).forEach(mediaStreamTrack => {
-      clonedMediaStream.addTrack(mediaStreamTrack);
-    });
+    this._setStreamState(clonedMediaStream, clonedMediaStreamType);
+    this._addTracksToStream(newMediaStream, clonedMediaStream, mediaType);
 
     this.logger.info(`Upgraded the MediaStream to update '${mediaType}'`, clonedMediaStream);
     return Promise.resolve(new z.media.MediaStreamInfo(z.media.MediaStreamSource.LOCAL, 'self', clonedMediaStream));
@@ -644,7 +656,7 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
    */
   addRemoteMediaStream(mediaStreamInfo) {
     const handledStreamTypes = [z.media.MediaType.AUDIO, z.media.MediaType.VIDEO, z.media.MediaType.AUDIO_VIDEO];
-    if (!handledStreamTypes.includes(mediaStreamInfo.type)) {
+    if (!handledStreamTypes.includes(mediaStreamInfo.getType())) {
       throw new z.media.MediaError(z.media.MediaError.TYPE.UNHANDLED_MEDIA_TYPE);
     }
 
@@ -757,12 +769,11 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
   /**
    * Set the enabled state of a new MediaStream.
    * @private
-   * @param {z.media.MediaStreamInfo} mediaStreamInfo - Info about MediaStream to set state off
+   * @param {MediaStream} mediaStream - MediaStream to set state on
+   * @param {z.media.MediaType} mediaType - Type to set state for
    * @returns {undefined} No return value
    */
-  _setStreamState(mediaStreamInfo) {
-    const {stream: mediaStream, type: mediaType} = mediaStreamInfo;
-
+  _setStreamState(mediaStream, mediaType) {
     const includesAudioTracks = MediaStreamHandler.CONFIG.MEDIA_TYPE.CONTAINS_AUDIO.includes(mediaType);
     if (includesAudioTracks) {
       this._setTrackState(mediaStream, z.media.MediaType.AUDIO);
@@ -775,7 +786,7 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
   }
 
   _setTrackState(mediaStream, mediaType) {
-    const streamTracks = z.media.MediaStreamHandler.getMediaTracks(mediaStream, mediaType);
+    const streamTracks = MediaStreamHandler.getMediaTracks(mediaStream, mediaType);
 
     if (streamTracks.length > 1) {
       this.logger.warn(`Media stream contains multiple '${mediaType}' tracks`, streamTracks);
@@ -860,7 +871,7 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
     }
 
     if (this.localMediaStream()) {
-      const mediaStreamTracks = z.media.MediaStreamHandler.getMediaTracks(this.localMediaStream(), mediaType);
+      const mediaStreamTracks = MediaStreamHandler.getMediaTracks(this.localMediaStream(), mediaType);
       mediaStreamTracks.forEach(mediaStreamTrack => (mediaStreamTrack.enabled = sendState));
     }
   }

--- a/app/script/media/MediaStreamHandler.js
+++ b/app/script/media/MediaStreamHandler.js
@@ -611,10 +611,8 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
           : replaceMediaStreamInFlows(mediaStreamInfo, flowEntities);
       })
       .catch(error => {
-        const logMessage = `Failed to update call with '${mediaStreamInfo.getType()}': ${error.name} - ${
-          error.message
-        }`;
-        this.logger.error(logMessage, error);
+        const message = `Failed to update call with '${mediaStreamInfo.getType()}': ${error.name} - ${error.message}`;
+        this.logger.error(message, error);
         throw error;
       });
   }

--- a/app/script/media/MediaStreamHandler.js
+++ b/app/script/media/MediaStreamHandler.js
@@ -197,14 +197,14 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
     const {stream: mediaStream} = mediaStreamInfo;
 
     const replaceMediaStream = (localMediaStream, newMediaStreamInfo) => {
-      this._releaseMediaStream(this.localMediaStream());
-      this._setStreamState(updateMediaStreamInfo);
-      this.localMediaStream(updateMediaStreamInfo.stream);
+      this._releaseMediaStream(localMediaStream);
+      this._setStreamState(newMediaStreamInfo);
+      this.localMediaStream(newMediaStreamInfo.stream);
     };
 
     const replaceMediaTracks = (localMediaStream, newMediaStream) => {
       localMediaStream.getTracks().forEach(localTrack => {
-        updateMediaStreamInfo.stream.getTracks().forEach(newTrack => {
+        newMediaStream.getTracks().forEach(newTrack => {
           if (localTrack.kind === newTrack.kind) {
             localTrack.stop();
             localMediaStream.removeTrack(localTrack);

--- a/app/script/media/MediaStreamInfo.js
+++ b/app/script/media/MediaStreamInfo.js
@@ -28,15 +28,11 @@ z.media.MediaStreamInfo = class MediaStreamInfo {
     this.flowId = flowId;
     this.stream = stream;
     this.callEntity = callEntity;
-    this.type = z.media.MediaType.NONE;
 
     this.conversationId = callEntity ? callEntity.id : undefined;
-    this.updateStreamType();
-    return this;
   }
 
-  updateStreamType() {
-    this.stream = z.media.MediaStreamHandler.detectMediaStreamType(this.stream);
-    return (this.type = this.stream.type);
+  getType() {
+    return z.media.MediaStreamHandler.detectMediaStreamType(this.stream);
   }
 };

--- a/test/unit_tests/media/MediaStreamHandlerSpec.js
+++ b/test/unit_tests/media/MediaStreamHandlerSpec.js
@@ -39,7 +39,7 @@ describe('z.media.MediaStreamHandler', () => {
     it('throws an error if stream type is not recognized', () => {
       const streamHandler = TestFactory.media_repository.streamHandler;
 
-      const newMediaStream = {type: 'random'};
+      const newMediaStream = {getType: () => 'random'};
 
       try {
         streamHandler.addRemoteMediaStream(newMediaStream);
@@ -53,9 +53,9 @@ describe('z.media.MediaStreamHandler', () => {
       const streamHandler = TestFactory.media_repository.streamHandler;
 
       const recognizedStreams = [
-        {type: z.media.MediaType.AUDIO},
-        {type: z.media.MediaType.VIDEO},
-        {type: z.media.MediaType.AUDIO_VIDEO},
+        {getType: () => z.media.MediaType.AUDIO},
+        {getType: () => z.media.MediaType.VIDEO},
+        {getType: () => z.media.MediaType.AUDIO_VIDEO},
       ];
 
       const expectedStreams = [
@@ -78,9 +78,9 @@ describe('z.media.MediaStreamHandler', () => {
     it('returns the media streams indexed by type', () => {
       const streamHandler = TestFactory.media_repository.streamHandler;
 
-      const audioStream = {type: z.media.MediaType.AUDIO};
-      const videoStream = {type: z.media.MediaType.VIDEO};
-      const audioVideoStream = {type: z.media.MediaType.AUDIO_VIDEO};
+      const audioStream = {getType: () => z.media.MediaType.AUDIO};
+      const videoStream = {getType: () => z.media.MediaType.VIDEO};
+      const audioVideoStream = {getType: () => z.media.MediaType.AUDIO_VIDEO};
 
       const expectedAudioStreams = [[audioStream], [audioStream], [audioStream]];
 


### PR DESCRIPTION
Fixes an issue (on Firefox) where the stream tracks are not released when switching video devices during the call and hanging up