### PR TITLE
chore: Update raygun4js to version 2.10.0

### DIFF
--- a/app/script/tracking/EventTrackingRepository.js
+++ b/app/script/tracking/EventTrackingRepository.js
@@ -283,32 +283,6 @@ z.tracking.EventTrackingRepository = class EventTrackingRepository {
   //##############################################################################
 
   /**
-   * Attach to rejected Promises.
-   * @returns {undefined} No return value
-   */
-  _attach_promise_rejection_handler() {
-    window.onunhandledrejection = ({reason: error, promise: rejected_promise}) => {
-      if (window.onerror) {
-        if (error) {
-          if (_.isString(error)) {
-            window.onerror.call(this, error, null, null, null);
-          } else if (error.message) {
-            window.onerror.call(this, error.message, error.fileName, error.lineNumber, error.columnNumber, error);
-          }
-        }
-
-        if (rejected_promise) {
-          window.setTimeout(() => {
-            rejected_promise.catch(promise_error => {
-              this.logger.log(this.logger.levels.OFF, 'Handled uncaught Promise in error reporting', promise_error);
-            });
-          }, 0);
-        }
-      }
-    };
-  }
-
-  /**
    * Checks if a Raygun payload should be reported.
    *
    * @see https://github.com/MindscapeHQ/raygun4js#onbeforesend
@@ -330,16 +304,11 @@ z.tracking.EventTrackingRepository = class EventTrackingRepository {
     return false;
   }
 
-  _detach_promise_rejection_handler() {
-    window.onunhandledrejection = undefined;
-  }
-
   _disable_error_reporting() {
     this.logger.debug('Disabling Raygun error reporting');
     this.is_error_reporting_activated = false;
     Raygun.detach();
     Raygun.init(EventTrackingRepository.CONFIG.ERROR_REPORTING.API_KEY, {disableErrorTracking: true});
-    this._detach_promise_rejection_handler();
   }
 
   _enable_error_reporting() {
@@ -371,6 +340,5 @@ z.tracking.EventTrackingRepository = class EventTrackingRepository {
       Raygun.withCustomData({electron_version: z.util.Environment.version(true)});
     }
     Raygun.onBeforeSend(this._check_error_payload.bind(this));
-    this._attach_promise_rejection_handler();
   }
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@bower_components/platform.js": "bestiejs/platform.js#1.3.5",
     "@bower_components/poster-image": "herrmannplatz/poster-image#1.1.1",
     "@bower_components/protobuf": "gregor/protobuf.js#32ada41d3c963bd5f43d7cdadced2d6d2ccd082a",
-    "@bower_components/raygun4js": "MindscapeHQ/raygun4js#2.9.4",
+    "@bower_components/raygun4js": "MindscapeHQ/raygun4js#2.10.0",
     "@bower_components/speakingurl": "pid/speakingurl#v14.0.1",
     "@bower_components/uint32": "fxa/uint32.js#0.2.1",
     "@bower_components/underscore": "jashkenas/underscore#1.8.3",

--- a/test/unit_tests/tracking/EventTrackingRepositorySpec.js
+++ b/test/unit_tests/tracking/EventTrackingRepositorySpec.js
@@ -138,45 +138,4 @@ describe('z.tracking.EventTrackingRepository', () => {
       expect(error_payload).toBe(false);
     });
   });
-
-  describe('_attach_promise_rejection_handler', () => {
-    const error_description = 'Unit test error';
-
-    beforeAll(done => {
-      TestFactory.tracking_repository.init(true).then(() => {
-        TestFactory.tracking_repository._attach_promise_rejection_handler();
-        done();
-      });
-    });
-
-    afterAll(() => TestFactory.tracking_repository._detach_promise_rejection_handler());
-
-    it('handles a Promise rejected with an Error that is uncaught', done => {
-      window.onerror = (error_message, file_name, line_number, column_number, error) => {
-        expect(error_message).toBe(error_description);
-        expect(error.message).toBe(error_description);
-        done();
-      };
-
-      Promise.reject(new Error('Unit test error'));
-    });
-
-    it('handles a Promise rejected with a String that is uncaught', done => {
-      window.onerror = (error_message, file_name) => {
-        expect(error_message).toBe(error_description);
-        expect(file_name).toBeNull();
-        done();
-      };
-
-      /* eslint-disable prefer-promise-reject-errors */
-      Promise.reject(error_description);
-      /* eslint-enable prefer-promise-reject-errors */
-    });
-
-    it('ignores a rejected Promise that is caught', done => {
-      window.onerror = done.fail;
-
-      Promise.reject(new Error(error_description)).catch(() => done());
-    });
-  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -186,9 +186,9 @@
     glob "^5.0.10"
     yargs "^3.10.0"
 
-"@bower_components/raygun4js@MindscapeHQ/raygun4js#2.9.4":
-  version "2.9.4"
-  resolved "https://codeload.github.com/MindscapeHQ/raygun4js/tar.gz/91ab41003273ad2f007b408f3b13228626e8ab42"
+"@bower_components/raygun4js@MindscapeHQ/raygun4js#2.10.0":
+  version "2.10.0"
+  resolved "https://codeload.github.com/MindscapeHQ/raygun4js/tar.gz/ef4b04ed0ff9a73f02e1bb32ba86c2bc5fba5a59"
 
 "@bower_components/speakingurl@pid/speakingurl#v14.0.1":
   version "14.0.1"


### PR DESCRIPTION
Raygun finally added unhandled Promise rejection handling to their feature set. We can update the dependency and remove our code and tests.