### PR TITLE
Clarify GVC limitation

### DIFF
--- a/app/script/localization/webapp.js
+++ b/app/script/localization/webapp.js
@@ -379,7 +379,7 @@ z.string.groupCreationParticipantsActionSkip = 'Skip';
 z.string.groupCreationParticipantsHeader = 'Add people';
 z.string.groupCreationParticipantsHeaderWithCounter = 'Add people ({{number}})';
 z.string.groupCreationParticipantsPlaceholder = 'Search by name';
-z.string.groupSizeInfo = 'Up to {{count}} people can join a group conversation. Video calls work in groups of 4 or less.';
+z.string.groupSizeInfo = 'Up to {{count}} people can join a group conversation. Video calls work with up to 3 other people and you.';
 
 // Guest room
 z.string.guestRoomConversationName = 'Guest room';


### PR DESCRIPTION
Since the number of participants shown in the conversation does not include the current user, we need to change this copy to prevent confusion when the conversation shows “4 people” and the Video Call icon is not available.

