### PR TITLE
chore: Add "yarn dist" script

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "deploy-travis-dev": "grunt app_deploy_travis:dev",
     "deploy-travis-prod": "grunt app_deploy_travis:prod",
     "deploy-travis-staging": "grunt app_deploy_travis:staging",
+    "dist": "grunt prepare_dist",
     "fix": "yarn fix:assets && yarn fix:scripts",
     "fix:assets": "yarn prettier --write && yarn stylelint",
     "fix:scripts": "yarn test:scripts --fix",


### PR DESCRIPTION
Most of our projects have a `yarn dist` goal. It's very handy if you just want to compile code before running the tests. To streamline our projects, I also added `yarn dist` to the webapp. 

It offers us the following possiblity:

```bash
yarn dist
grunt test_run:util/TimeUtil
```

In the long run the idea is to execute individual tests just by working with Jasmine's `fdescribe` and `fit`. Then a test run with the latest code will be as simple as this:

```bash
yarn dist
yarn test
```