### PR TITLE
fix: Icon color of rename and timer update system messages (WEBAPP-5224)

### DIFF
--- a/app/page/template/partials/template-message.htm
+++ b/app/page/template/partials/template-message.htm
@@ -283,7 +283,7 @@
 
 <script type="text/html" id="system">
   <div class="message-header">
-    <div class="message-header-icon text-graphite">
+    <div class="message-header-icon message-header-icon--svg text-graphite">
       <span data-bind="component: $parent.getSystemMessageIconComponent(message)"></span>
     </div>
     <div class="message-header-label">


### PR DESCRIPTION
Applicability to timer update system message still needs to be confirmed with design.