### PR TITLE
refactor: simplify PanelViewModel api (WEBAPP-5248, WEBAPP-5249)

### DIFF
--- a/app/page/template/panel/add-participants.htm
+++ b/app/page/template/panel/add-participants.htm
@@ -6,7 +6,7 @@
       <close-icon class="icon-button" data-bind="click: onClose" data-uie-name="do-close"></close-icon>
     </div>
     <div class="panel__content">
-      <user-input class="user-list-light" params="input: searchInput, selected: selectedContacts, placeholder: z.string.addParticipantsSearchPlaceholder" spellcheck="false"></user-input>
+      <user-input class="user-list-light" params="input: searchInput, selected: selectedContacts, placeholder: z.string.addParticipantsSearchPlaceholder, focusDelay: z.motion.MotionDuration.MEDIUM" spellcheck="false"></user-input>
       <!-- ko if: showIntegrations() -->
         <div class="add-participants__tabs">
           <div class="add-participants__tab" data-bind="css: {'add-participants__tab--active': isStateAddPeople}, click: clickOnAddPeople, l10n_text: z.string.addParticipantsTabsPeople" data-uie-name="do-add-people"></div>

--- a/app/script/event/WebApp.js
+++ b/app/script/event/WebApp.js
@@ -161,11 +161,6 @@ z.event.WebApp = {
   PENDING: {
     SHOW: 'wire.webapp.pending.show',
   },
-  PEOPLE: {
-    HIDE: 'wire.webapp.people.hide',
-    SHOW: 'wire.webapp.people.show',
-    TOGGLE: 'wire.webapp.people.toggle',
-  },
   PREFERENCES: {
     MANAGE_ACCOUNT: 'wire.webapp.preferences.manage_account',
     MANAGE_DEVICES: 'wire.webapp.preferences.manage_devices',

--- a/app/script/view_model/MainViewModel.js
+++ b/app/script/view_model/MainViewModel.js
@@ -74,9 +74,9 @@ z.viewModel.MainViewModel = class MainViewModel {
 
     this.actions = new z.viewModel.ActionsViewModel(this, repositories);
 
+    this.panel = new z.viewModel.PanelViewModel(this, repositories);
     this.content = new z.viewModel.ContentViewModel(this, repositories);
     this.list = new z.viewModel.ListViewModel(this, repositories);
-    this.panel = new z.viewModel.PanelViewModel(this, repositories);
 
     this.modals = new z.viewModel.ModalsViewModel();
     this.lightbox = new z.viewModel.ImageDetailViewViewModel(this, repositories);

--- a/app/script/view_model/PanelViewModel.js
+++ b/app/script/view_model/PanelViewModel.js
@@ -128,7 +128,7 @@ z.viewModel.PanelViewModel = class PanelViewModel {
     const isStateChange = this.state() !== state;
     if (!isStateChange) {
       const currentInstance = this.subViews[state];
-      const isNewParams = params && params.entity.id !== currentInstance.getEntityId();
+      const isNewParams = params && params.entity && params.entity.id !== currentInstance.getEntityId();
       if (!isNewParams) {
         return this.closePanel();
       }

--- a/app/script/view_model/PanelViewModel.js
+++ b/app/script/view_model/PanelViewModel.js
@@ -224,7 +224,7 @@ z.viewModel.PanelViewModel = class PanelViewModel {
   }
 
   _hidePanel(state) {
-    if (!state || !this.subViews[state]) {
+    if (!this.subViews[state]) {
       return;
     }
     this.exitingState(undefined);

--- a/app/script/view_model/PanelViewModel.js
+++ b/app/script/view_model/PanelViewModel.js
@@ -52,7 +52,7 @@ z.viewModel.PanelViewModel = class PanelViewModel {
       subViews[state] = new viewModel({
         isVisible: ko.pureComputed(this._isStateVisible.bind(this, state)),
         mainViewModel: this.mainViewModel,
-        navigateTo: this.navigateTo.bind(this),
+        navigateTo: this._navigateTo.bind(this),
         onClose: this.closePanel.bind(this),
         onGoBack: this._goBack.bind(this),
         repositories: this.repositories,
@@ -102,18 +102,6 @@ z.viewModel.PanelViewModel = class PanelViewModel {
   }
 
   /**
-   * Will navigate from the current state to the new state.
-   *
-   * @param {string} newState - the new state to navigate to.
-   * @param {Object} params - params to give to the new view.
-   * @returns {void} nothing returned.
-   */
-  navigateTo(newState, params) {
-    this._switchState(newState, this.state(), params);
-    this.stateHistory.push({params, state: newState});
-  }
-
-  /**
    * Toggles (open/close) a panel.
    * If the state given is the one visible (and the parameters are the same), the panel closes.
    * Else the panels opens on the given state.
@@ -151,6 +139,18 @@ z.viewModel.PanelViewModel = class PanelViewModel {
       this._resetState();
       return true;
     });
+  }
+
+  /**
+   * Will navigate from the current state to the new state.
+   *
+   * @param {string} newState - the new state to navigate to.
+   * @param {Object} params - params to give to the new view.
+   * @returns {void} nothing returned.
+   */
+  _navigateTo(newState, params) {
+    this._switchState(newState, this.state(), params);
+    this.stateHistory.push({params, state: newState});
   }
 
   _forceClosePanel() {

--- a/app/script/view_model/PanelViewModel.js
+++ b/app/script/view_model/PanelViewModel.js
@@ -173,12 +173,11 @@ z.viewModel.PanelViewModel = class PanelViewModel {
     return (isStateExiting || isStateActive) && this.isVisible();
   }
 
-  _goBack(overrideParams) {
+  _goBack() {
     this.stateHistory.pop();
     const toHistory = this.stateHistory[this.stateHistory.length - 1];
-    const toState = toHistory.state;
-    const params = overrideParams !== undefined ? overrideParams : toHistory.params;
-    this._switchState(toState, this.state(), params, true);
+    const {state, params} = toHistory;
+    this._switchState(state, this.state(), params, true);
   }
 
   _switchContent(newContentState) {

--- a/app/script/view_model/content/MessageListViewModel.js
+++ b/app/script/view_model/content/MessageListViewModel.js
@@ -392,11 +392,11 @@ z.viewModel.content.MessageListViewModel = class MessageListViewModel {
     }
 
     const params = {entity: userEntity};
-    if (userEntity.isBot) {
-      this.mainViewModel.panel.togglePanel(z.viewModel.PanelViewModel.STATE.GROUP_PARTICIPANT_SERVICE, params);
-    } else {
-      this.mainViewModel.panel.togglePanel(z.viewModel.PanelViewModel.STATE.GROUP_PARTICIPANT_USER, params);
-    }
+    const panelId = userEntity.isBot
+      ? z.viewModel.PanelViewModel.STATE.GROUP_PARTICIPANT_SERVICE
+      : z.viewModel.PanelViewModel.STATE.GROUP_PARTICIPANT_USER;
+
+    this.mainViewModel.panel.togglePanel(panelId, params);
   }
 
   /**

--- a/app/script/view_model/content/MessageListViewModel.js
+++ b/app/script/view_model/content/MessageListViewModel.js
@@ -383,7 +383,20 @@ z.viewModel.content.MessageListViewModel = class MessageListViewModel {
    * @returns {undefined} No return value
    */
   onMessageUserClick(userEntity) {
-    amplify.publish(z.event.WebApp.PEOPLE.SHOW, userEntity);
+    userEntity = ko.unwrap(userEntity);
+    const conversationEntity = this.conversation_repository.active_conversation();
+    const isSingleModeConversation = conversationEntity.is_one2one() || conversationEntity.is_request();
+
+    if (isSingleModeConversation && !userEntity.is_me) {
+      return this.mainViewModel.panel.togglePanel(z.viewModel.PanelViewModel.STATE.CONVERSATION_DETAILS);
+    }
+
+    const params = {entity: userEntity};
+    if (userEntity.isBot) {
+      this.mainViewModel.panel.togglePanel(z.viewModel.PanelViewModel.STATE.GROUP_PARTICIPANT_SERVICE, params);
+    } else {
+      this.mainViewModel.panel.togglePanel(z.viewModel.PanelViewModel.STATE.GROUP_PARTICIPANT_USER, params);
+    }
   }
 
   /**
@@ -500,7 +513,7 @@ z.viewModel.content.MessageListViewModel = class MessageListViewModel {
   }
 
   clickOnInvitePeople() {
-    this.mainViewModel.panel.navigateTo(z.viewModel.PanelViewModel.STATE.GUEST_OPTIONS);
+    this.mainViewModel.panel.togglePanel(z.viewModel.PanelViewModel.STATE.GUEST_OPTIONS);
   }
 
   /**

--- a/app/script/view_model/panel/BasePanelViewModel.js
+++ b/app/script/view_model/panel/BasePanelViewModel.js
@@ -32,7 +32,7 @@ z.viewModel.panel.BasePanelViewModel = class BasePanelViewModel {
     this.repositories = repositories;
     this.mainViewModel = mainViewModel;
     this.activeConversation = repositories.conversation.active_conversation;
-    this.actionViewModel = mainViewModel.actions;
+    this.actionsViewModel = mainViewModel.actions;
     this.isActivatedAccount = mainViewModel.isActivatedAccount;
   }
 

--- a/app/script/view_model/panel/ConversationDetailsViewModel.js
+++ b/app/script/view_model/panel/ConversationDetailsViewModel.js
@@ -223,25 +223,25 @@ z.viewModel.panel.ConversationDetailsViewModel = class ConversationDetailsViewMo
   }
 
   clickToArchive() {
-    this.actionViewModel.archiveConversation(this.activeConversation());
+    this.actionsViewModel.archiveConversation(this.activeConversation());
   }
 
   clickToBlock() {
     const userEntity = this.activeConversation().firstUserEntity();
     const nextConversationEntity = this.conversationRepository.get_next_conversation(this.activeConversation());
 
-    this.actionViewModel.blockUser(userEntity, true, nextConversationEntity);
+    this.actionsViewModel.blockUser(userEntity, true, nextConversationEntity);
   }
 
   clickToCancelRequest() {
     const userEntity = this.activeConversation().firstUserEntity();
     const nextConversationEntity = this.conversationRepository.get_next_conversation(this.activeConversation());
 
-    this.actionViewModel.cancelConnectionRequest(userEntity, true, nextConversationEntity);
+    this.actionsViewModel.cancelConnectionRequest(userEntity, true, nextConversationEntity);
   }
 
   clickToClear() {
-    this.actionViewModel.clearConversation(this.activeConversation());
+    this.actionsViewModel.clearConversation(this.activeConversation());
   }
 
   clickToEditGroupName() {
@@ -251,11 +251,11 @@ z.viewModel.panel.ConversationDetailsViewModel = class ConversationDetailsViewMo
   }
 
   clickToLeave() {
-    this.actionViewModel.leaveConversation(this.activeConversation());
+    this.actionsViewModel.leaveConversation(this.activeConversation());
   }
 
   clickToToggleMute() {
-    this.actionViewModel.toggleMuteConversation(this.activeConversation());
+    this.actionsViewModel.toggleMuteConversation(this.activeConversation());
   }
 
   renameConversation(data, event) {

--- a/app/script/view_model/panel/ConversationDetailsViewModel.js
+++ b/app/script/view_model/panel/ConversationDetailsViewModel.js
@@ -203,7 +203,7 @@ z.viewModel.panel.ConversationDetailsViewModel = class ConversationDetailsViewMo
   }
 
   clickOnDevices() {
-    this.navigateTo(z.viewModel.PanelViewModel.STATE.PARTICIPANT_DEVICES, this.firstParticipant());
+    this.navigateTo(z.viewModel.PanelViewModel.STATE.PARTICIPANT_DEVICES, {entity: this.firstParticipant()});
   }
 
   clickOnGuestOptions() {

--- a/app/script/view_model/panel/ConversationDetailsViewModel.js
+++ b/app/script/view_model/panel/ConversationDetailsViewModel.js
@@ -215,11 +215,11 @@ z.viewModel.panel.ConversationDetailsViewModel = class ConversationDetailsViewMo
   }
 
   clickOnShowUser(userEntity) {
-    this.navigateTo(z.viewModel.PanelViewModel.STATE.GROUP_PARTICIPANT_USER, userEntity);
+    this.navigateTo(z.viewModel.PanelViewModel.STATE.GROUP_PARTICIPANT_USER, {entity: userEntity});
   }
 
   clickOnShowService(serviceEntity) {
-    this.navigateTo(z.viewModel.PanelViewModel.STATE.GROUP_PARTICIPANT_SERVICE, {service: serviceEntity});
+    this.navigateTo(z.viewModel.PanelViewModel.STATE.GROUP_PARTICIPANT_SERVICE, {entity: serviceEntity});
   }
 
   clickToArchive() {

--- a/app/script/view_model/panel/ConversationParticipantsViewModel.js
+++ b/app/script/view_model/panel/ConversationParticipantsViewModel.js
@@ -49,7 +49,7 @@ z.viewModel.panel.ConversationParticipantsViewModel = class ConversationParticip
   }
 
   clickOnShowUser(userEntity) {
-    this.navigateTo(z.viewModel.PanelViewModel.STATE.GROUP_PARTICIPANT_USER, userEntity);
+    this.navigateTo(z.viewModel.PanelViewModel.STATE.GROUP_PARTICIPANT_USER, {entity: userEntity});
   }
 
   initView(highlightedUsers = []) {

--- a/app/script/view_model/panel/GroupParticipantServiceViewModel.js
+++ b/app/script/view_model/panel/GroupParticipantServiceViewModel.js
@@ -72,7 +72,7 @@ z.viewModel.panel.GroupParticipantServiceViewModel = class GroupParticipantServi
       .then(this.onGoBack);
   }
 
-  initView({service, addMode = false}) {
+  initView({entity: service, addMode = false}) {
     const serviceEntity = ko.unwrap(service);
     this.selectedParticipant(serviceEntity);
     this.selectedService(undefined);

--- a/app/script/view_model/panel/GroupParticipantUserViewModel.js
+++ b/app/script/view_model/panel/GroupParticipantUserViewModel.js
@@ -142,8 +142,8 @@ z.viewModel.panel.GroupParticipantUserViewModel = class GroupParticipantUserView
     this.actionsViewModel.unblockUser(this.selectedParticipant(), false);
   }
 
-  initView(user) {
-    const userEntity = ko.unwrap(user);
+  initView({entity: user}) {
+    const userEntity = user;
     this.selectedParticipant(userEntity);
 
     if (userEntity.isTemporaryGuest()) {

--- a/app/script/view_model/panel/GroupParticipantUserViewModel.js
+++ b/app/script/view_model/panel/GroupParticipantUserViewModel.js
@@ -97,7 +97,7 @@ z.viewModel.panel.GroupParticipantUserViewModel = class GroupParticipantUserView
   }
 
   clickOnDevices() {
-    this.navigateTo(z.viewModel.PanelViewModel.STATE.PARTICIPANT_DEVICES, this.selectedParticipant());
+    this.navigateTo(z.viewModel.PanelViewModel.STATE.PARTICIPANT_DEVICES, {entity: this.selectedParticipant()});
   }
 
   clickOnShowProfile() {

--- a/app/script/view_model/panel/ParticipantDevicesViewModel.js
+++ b/app/script/view_model/panel/ParticipantDevicesViewModel.js
@@ -173,7 +173,7 @@ z.viewModel.panel.ParticipantDevicesViewModel = class ParticipantDevicesViewMode
       .catch(error => this.logger.warn(`Failed to toggle client verification: ${error.message}`));
   }
 
-  initView(userEntity) {
+  initView({entity: userEntity}) {
     this.showSelfFingerprint(false);
     this.selectedClient(undefined);
     this.deviceMode(ParticipantDevicesViewModel.MODE.REQUESTING);


### PR DESCRIPTION
Mainly an attempt to remove the circular dependency between the `switchState` and the `_openPanel` method and to clarify the api of the `PanelViewModel`