### PR TITLE
fix: Explicitely update event in DB when receiving a link preview message (WEBAPP-4366)

### DIFF
--- a/app/script/conversation/ConversationRepository.js
+++ b/app/script/conversation/ConversationRepository.js
@@ -3192,10 +3192,6 @@ z.conversation.ConversationRepository = class ConversationRepository {
           return this._update_edited_message(conversation_et, event_json);
         }
 
-        if (event_data.previews.length) {
-          return this._update_link_preview(conversation_et, event_json);
-        }
-
         return event_json;
       })
       .then(updated_event_json => {
@@ -3436,7 +3432,7 @@ z.conversation.ConversationRepository = class ConversationRepository {
       .then(messageEntity => this.ephemeralHandler.validateMessage(messageEntity))
       .then(messageEntity => {
         if (conversationEntity && messageEntity) {
-          conversationEntity.add_message(messageEntity);
+          conversationEntity.add_message(messageEntity, true);
         }
         return {conversationEntity, messageEntity};
       });
@@ -3709,23 +3705,6 @@ z.conversation.ConversationRepository = class ConversationRepository {
         return event_json;
       }
     );
-  }
-
-  /**
-   * Update link preview message.
-   *
-   * @private
-   * @param {Conversation} conversation_et - Conversation of updated message
-   * @param {JSON} event_json - Link preview message event
-   * @returns {Promise} Resolves with the updated event_json
-   */
-  _update_link_preview(conversation_et, event_json) {
-    return this.conversation_service.load_event_from_db(conversation_et.id, event_json.id).then(stored_message => {
-      if (stored_message) {
-        this._delete_message(conversation_et, stored_message);
-      }
-      return event_json;
-    });
   }
 
   //##############################################################################

--- a/app/script/entity/Conversation.js
+++ b/app/script/entity/Conversation.js
@@ -348,6 +348,7 @@ z.entity.Conversation = class Conversation {
           const duplicateIndex = this.messages_unordered.indexOf(duplicateEntity);
           this.messages_unordered.splice(duplicateIndex, 1, messageEntity);
         }
+        // The duplicated message has been treated (either replaced or ignored). Our job here is done.
         return;
       }
       this.messages_unordered.push(messageEntity);

--- a/app/script/entity/Conversation.js
+++ b/app/script/entity/Conversation.js
@@ -340,14 +340,16 @@ z.entity.Conversation = class Conversation {
    * @returns {undefined} No return value.
    */
   add_message(messageEntity, replaceDuplicate = false) {
+    const duplicateEntity = this._findDuplicate(messageEntity);
     this.update_timestamps(messageEntity);
-    if (replaceDuplicate) {
-      const duplicateEntity = this._findDuplicate(messageEntity);
-      if (duplicateEntity) {
-        const duplicateIndex = this.messages_unordered.indexOf(duplicateEntity);
-        this.messages_unordered.splice(duplicateIndex, 1, messageEntity);
-        return;
-      }
+    if (duplicateEntity && !replaceDuplicate) {
+      // If there is a duplicate in db, but we don't want to replace it our job here is done.
+      return;
+    }
+    if (duplicateEntity) {
+      const duplicateIndex = this.messages_unordered.indexOf(duplicateEntity);
+      this.messages_unordered.splice(duplicateIndex, 1, messageEntity);
+      return;
     }
     this.messages_unordered.push(messageEntity);
     amplify.publish(z.event.WebApp.CONVERSATION.MESSAGE.ADDED, messageEntity);

--- a/app/script/entity/Conversation.js
+++ b/app/script/entity/Conversation.js
@@ -482,15 +482,18 @@ z.entity.Conversation = class Conversation {
   }
 
   _findDuplicate(messageEntity) {
-    for (const existingMessageEntity of this.messages_unordered()) {
-      const duplicateMessageId = messageEntity.id && existingMessageEntity.id === messageEntity.id;
-      const fromSameSender = existingMessageEntity.from === messageEntity.from;
-
-      if (duplicateMessageId && fromSameSender) {
-        return existingMessageEntity;
-      }
+    if (!messageEntity.id) {
+      return;
     }
-    return undefined;
+    const areSameMessage = (messageEntity1, messageEntity2) => {
+      const sameId = messageEntity1.id && messageEntity2.id === messageEntity1.id;
+      const sameSender = messageEntity1.from === messageEntity2.from;
+      return sameId && sameSender;
+    };
+
+    return this.messages_unordered().find(existingMessageEntity =>
+      areSameMessage(messageEntity, existingMessageEntity)
+    );
   }
 
   update_timestamp_server(time, is_backend_timestamp = false) {

--- a/app/script/entity/Conversation.js
+++ b/app/script/entity/Conversation.js
@@ -474,28 +474,25 @@ z.entity.Conversation = class Conversation {
    * @returns {z.entity.Message|undefined} Message if it is not a duplicate
    */
   _checkForDuplicate(messageEntity) {
-    const existingMessageEntity = this._findDuplicate(messageEntity);
-    if (existingMessageEntity) {
-      const logData = {additionalMessage: messageEntity, existingMessage: existingMessageEntity};
-      this.logger.warn(`Filtered message '${messageEntity.id}' as duplicate in view`, logData);
-      return undefined;
+    if (messageEntity) {
+      const existingMessageEntity = this._findDuplicate(messageEntity);
+      if (existingMessageEntity) {
+        const logData = {additionalMessage: messageEntity, existingMessage: existingMessageEntity};
+        this.logger.warn(`Filtered message '${messageEntity.id}' as duplicate in view`, logData);
+        return undefined;
+      }
+      return messageEntity;
     }
-    return messageEntity;
   }
 
   _findDuplicate(messageEntity) {
-    if (!messageEntity.id) {
-      return;
+    if (messageEntity && messageEntity.id) {
+      return this.messages_unordered().find(existingMessageEntity => {
+        const sameId = messageEntity.id && existingMessageEntity.id === messageEntity.id;
+        const sameSender = messageEntity.from === existingMessageEntity.from;
+        return sameId && sameSender;
+      });
     }
-    const areSameMessage = (messageEntity1, messageEntity2) => {
-      const sameId = messageEntity1.id && messageEntity2.id === messageEntity1.id;
-      const sameSender = messageEntity1.from === messageEntity2.from;
-      return sameId && sameSender;
-    };
-
-    return this.messages_unordered().find(existingMessageEntity =>
-      areSameMessage(messageEntity, existingMessageEntity)
-    );
   }
 
   update_timestamp_server(time, is_backend_timestamp = false) {

--- a/app/script/entity/Conversation.js
+++ b/app/script/entity/Conversation.js
@@ -488,7 +488,7 @@ z.entity.Conversation = class Conversation {
   _findDuplicate(messageEntity) {
     if (messageEntity && messageEntity.id) {
       return this.messages_unordered().find(existingMessageEntity => {
-        const sameId = messageEntity.id && existingMessageEntity.id === messageEntity.id;
+        const sameId = existingMessageEntity.id === messageEntity.id;
         const sameSender = messageEntity.from === existingMessageEntity.from;
         return sameId && sameSender;
       });

--- a/app/script/entity/Conversation.js
+++ b/app/script/entity/Conversation.js
@@ -340,19 +340,19 @@ z.entity.Conversation = class Conversation {
    * @returns {undefined} No return value.
    */
   add_message(messageEntity, replaceDuplicate = false) {
-    const duplicateEntity = this._findDuplicate(messageEntity);
-    this.update_timestamps(messageEntity);
-    if (duplicateEntity && !replaceDuplicate) {
-      // If there is a duplicate in db, but we don't want to replace it our job here is done.
-      return;
+    if (messageEntity) {
+      const duplicateEntity = this._findDuplicate(messageEntity);
+      this.update_timestamps(messageEntity);
+      if (duplicateEntity) {
+        if (replaceDuplicate) {
+          const duplicateIndex = this.messages_unordered.indexOf(duplicateEntity);
+          this.messages_unordered.splice(duplicateIndex, 1, messageEntity);
+        }
+        return;
+      }
+      this.messages_unordered.push(messageEntity);
+      amplify.publish(z.event.WebApp.CONVERSATION.MESSAGE.ADDED, messageEntity);
     }
-    if (duplicateEntity) {
-      const duplicateIndex = this.messages_unordered.indexOf(duplicateEntity);
-      this.messages_unordered.splice(duplicateIndex, 1, messageEntity);
-      return;
-    }
-    this.messages_unordered.push(messageEntity);
-    amplify.publish(z.event.WebApp.CONVERSATION.MESSAGE.ADDED, messageEntity);
   }
 
   /**

--- a/app/script/event/EventRepository.js
+++ b/app/script/event/EventRepository.js
@@ -637,14 +637,8 @@ z.event.EventRepository = class EventRepository {
 
     return this.conversationService.load_event_from_db(conversationId, eventId).then(storedEvent => {
       if (storedEvent) {
-        const {data: mappedData, from: mappedFrom, type: mappedType, time: mappedTime} = event;
-        const {
-          data: storedData,
-          from: storedFrom,
-          type: storedType,
-          time: storedTime,
-          primary_key: storedPrimaryKey,
-        } = storedEvent;
+        const {data: mappedData, from: mappedFrom, type: mappedType} = event;
+        const {data: storedData, from: storedFrom, type: storedType} = storedEvent;
 
         const logMessage = `Ignored '${mappedType}' (${eventId}) in '${conversationId}' from '${mappedFrom}':'`;
 
@@ -679,9 +673,9 @@ z.event.EventRepository = class EventRepository {
         }
 
         // Only valid case for a duplicate message ID: First update to a text message matching the previous text content with a link preview
-        event.server_time = mappedTime;
-        event.time = storedTime;
-        event.primary_key = storedPrimaryKey;
+        event.server_time = event.time;
+        event.time = storedEvent.time;
+        event.primary_key = storedEvent.primary_key;
         return this.conversationService.update_event(event);
       }
 

--- a/test/unit_tests/entity/ConversationSpec.js
+++ b/test/unit_tests/entity/ConversationSpec.js
@@ -124,6 +124,15 @@ describe('Conversation', () => {
       expect(conversation_et.messages().length).toBe(1);
     });
 
+    it('should replace existing message with new message', () => {
+      const initialLength = conversation_et.messages().length;
+      const newMessageEntity = new z.entity.Message(z.util.createRandomUuid());
+      newMessageEntity.id = initial_message_et.id;
+      conversation_et.add_message(newMessageEntity, true);
+      expect(conversation_et.messages().length).toBe(initialLength);
+      expect(conversation_et.messages()[0]).toBe(newMessageEntity);
+    });
+
     it('should add message with a newer timestamp', () => {
       const message_et = new z.entity.Message(z.util.createRandomUuid());
       message_et.timestamp(second_timestamp);

--- a/test/unit_tests/event/EventRepositorySpec.js
+++ b/test/unit_tests/event/EventRepositorySpec.js
@@ -477,6 +477,9 @@ describe('Event Repository', () => {
       spyOn(TestFactory.event_repository.conversationService, 'load_event_from_db').and.returnValue(
         Promise.resolve(previously_stored_event)
       );
+      spyOn(TestFactory.event_repository.conversationService, 'update_event').and.returnValue(
+        Promise.resolve(previously_stored_event)
+      );
 
       const initial_time = event.time;
       const changed_time = new Date(new Date(event.time).getTime() + 60 * 1000).toISOString();
@@ -488,7 +491,8 @@ describe('Event Repository', () => {
         .then(saved_event => {
           expect(saved_event.time).toEqual(initial_time);
           expect(saved_event.time).not.toEqual(changed_time);
-          expect(TestFactory.event_repository.conversationService.save_event).toHaveBeenCalled();
+          expect(saved_event.primary_key).toEqual(previously_stored_event.primary_key);
+          expect(TestFactory.event_repository.conversationService.update_event).toHaveBeenCalled();
           done();
         })
         .catch(done.fail);


### PR DESCRIPTION
Quick explanation:

# Initial behavior when a link preview is received

- the EventRepository merges the event with the previous text message already in DB (if found)
- the EventRepository save this "new" event in DB (so there are 2 duplicates in DB right now)
- the ConversationRepo takes the relay and delete the previous event (supposedly the text event).

Work well in most of the cases, but will actually delete the `linkPreview` event if there is no `textEvent` already in DB (which could occur if, say, a client send a `linkPreviewEvent` before the actual `textEvent`)

# New behavior

- the EventRepository merges the event with the previous text message already in DB (if found) ;
- the EventRepository **updates** the event in DB if found ;
- the ConversationRepo is no more responsible for touching the DB (deleting the previous event).