### PR TITLE
feat: Improve event loading performance

### DIFF
--- a/app/script/conversation/ConversationService.js
+++ b/app/script/conversation/ConversationService.js
@@ -470,18 +470,24 @@ z.conversation.ConversationService = class ConversationService {
   /**
    * Load conversation event.
    *
-   * @param {string} conversation_id - ID of conversation
-   * @param {string} message_id - ID of message to retrieve
+   * @param {string} conversationId - ID of conversation
+   * @param {string} messageId - ID of message to retrieve
    * @returns {Promise} Resolves with the stored record
    */
-  load_event_from_db(conversation_id, message_id) {
+  load_event_from_db(conversationId, messageId) {
+    if (!conversationId || !messageId) {
+      this.logger.error(`Cannot get event '${messageId}' in conversation '${conversation_id}' without IDs`);
+      throw new z.conversation.ConversationError(z.conversation.ConversationError.TYPE.MESSAGE_NOT_FOUND);
+    }
+
     return this.storageService.db[this.EVENT_STORE_NAME]
-      .where('conversation')
-      .equals(conversation_id)
-      .filter(record => message_id && record.id === message_id)
+      .where('id')
+      .equals(messageId)
+      .filter(record => record.conversation === conversationId)
       .first()
       .catch(error => {
-        this.logger.error(`Failed to get event for conversation '${conversation_id}': ${error.message}`, error);
+        const logMessage = `Failed to get event '${messageId}' for conversation '${conversationId}': ${error.message}`;
+        this.logger.error(logMessage, error);
         throw error;
       });
   }


### PR DESCRIPTION
Thx to @atomrc for the debugging session looking into the bottle necks of our load performance.

This is a simple but powerful optimization:
Loading events from the database is a process that slows down over time with the database growing and containing more events per conversation.

If we load a specific event from the conversation we use the conversation index to get all events in that conversation and then filter them in JavaScript. The more events the conversation contains the slower this process will be.

This reverses this approach. Instead we rely on the message ID index. Message IDs are UUID that are unique within a conversation. Chances that different conversations contain the same IDs is slim by the entropy of UUIDs. Only then do we filter by conversation in JavaScript iterating over mostly one database record only.

In manual tests I have seen improvements in the call from 150ms down to 10ms only. 🎆 