### PR TITLE
 chore: Improve error for failed event mapping

### DIFF
--- a/app/script/conversation/EventMapper.js
+++ b/app/script/conversation/EventMapper.js
@@ -48,9 +48,11 @@ z.conversation.EventMapper = class EventMapper {
           try {
             return this._mapJsonEvent(event, conversationEntity, createDummyImage);
           } catch (error) {
-            const errorMessage = `Failure while mapping events. Affected type '${event.type}': ${error.message}`;
+            const errorMessage = `Failure while mapping events. Affected '${event.type}' event: ${error.message}`;
             this.logger.error(errorMessage, {error, event});
-            Raygun.send(new Error(errorMessage), {eventType: event.type});
+
+            const customData = {eventTime: new Date(event.time).toISOString(), eventType: event.type};
+            Raygun.send(new Error(errorMessage), customData);
           }
         })
         .filter(messageEntity => messageEntity);
@@ -74,9 +76,11 @@ z.conversation.EventMapper = class EventMapper {
           throw error;
         }
 
-        const errorMessage = `Failure while mapping event. Affected type '${event.type}': ${error.message}`;
+        const errorMessage = `Failure while mapping event. Affected '${event.type}' event: ${error.message}`;
         this.logger.error(errorMessage, {error, event});
-        Raygun.send(new Error(errorMessage), {eventType: event.type});
+
+        const customData = {eventTime: new Date(event.time).toISOString(), eventType: event.type};
+        Raygun.send(new Error(errorMessage), customData);
 
         throw new z.conversation.ConversationError(z.conversation.ConversationError.TYPE.MESSAGE_NOT_FOUND);
       });

--- a/app/script/conversation/EventMapper.js
+++ b/app/script/conversation/EventMapper.js
@@ -151,7 +151,7 @@ z.conversation.EventMapper = class EventMapper {
         messageEntity = this._mapEventVoiceChannelDeactivate(event);
         break;
       default:
-        this.logger.warn(`Ignored unhandled event ${event.id ? `'${event.id}' ` : ''}of type '${event.type}'`, event);
+        this.logger.warn(`Ignored unhandled '${event.type}' event ${event.id ? `'${event.id}' ` : ''}`, event);
         throw new z.conversation.ConversationError(z.conversation.ConversationError.TYPE.MESSAGE_NOT_FOUND);
     }
 


### PR DESCRIPTION
From the logs it seems like we have 'conversation.member-update' events in the database. Those should not be there. Let's figure out where they stem from.