### PR TITLE
fix: remove deprecated mute call shortcut (WEBAPP-4210)

### DIFF
--- a/app/script/ui/Shortcut.js
+++ b/app/script/ui/Shortcut.js
@@ -52,19 +52,6 @@ z.ui.Shortcut = (() => {
         },
       },
     },
-    [z.ui.ShortcutType.CALL_REJECT]: {
-      event: z.event.WebApp.SHORTCUT.CALL_REJECT,
-      shortcut: {
-        electron: {
-          macos: 'command + .',
-          pc: 'ctrl + .',
-        },
-        webapp: {
-          macos: 'command + alt + .',
-          pc: 'ctrl + alt + .',
-        },
-      },
-    },
     [z.ui.ShortcutType.PREV]: {
       event: z.event.WebApp.SHORTCUT.PREV,
       shortcut: {

--- a/app/script/ui/Shortcut.js
+++ b/app/script/ui/Shortcut.js
@@ -65,19 +65,6 @@ z.ui.Shortcut = (() => {
         },
       },
     },
-    [z.ui.ShortcutType.CALL_MUTE]: {
-      event: z.event.WebApp.SHORTCUT.CALL_MUTE,
-      shortcut: {
-        electron: {
-          macos: 'command + alt + m',
-          pc: 'ctrl + alt + m',
-        },
-        webapp: {
-          macos: 'command + alt + m',
-          pc: 'ctrl + alt + m',
-        },
-      },
-    },
     [z.ui.ShortcutType.PREV]: {
       event: z.event.WebApp.SHORTCUT.PREV,
       shortcut: {


### PR DESCRIPTION
This shortcut is not supposed to be there anymore.
Fixes a conflict between the `mute call` and the `mute conversation` shortcuts.