### PR TITLE
fix: Handle events that fail validation

### DIFF
--- a/app/script/event/EventRepository.js
+++ b/app/script/event/EventRepository.js
@@ -587,7 +587,7 @@ z.event.EventRepository = class EventRepository {
           throw error;
         }
 
-        return true;
+        return event;
       });
   }
 

--- a/app/script/event/EventRepository.js
+++ b/app/script/event/EventRepository.js
@@ -579,31 +579,8 @@ z.event.EventRepository = class EventRepository {
    * @returns {Promise} Resolves with the saved record or boolean true if the event was skipped
    */
   _handleEvent(event, source) {
-    return this._handleEventValidation(event, source).then(validatedEvent =>
-      this._processEvent(validatedEvent, source)
-    );
-  }
-
-  /**
-   * Decrypts, saves and distributes an event received from the backend.
-   *
-   * @private
-   * @param {JSON} event - Backend event extracted from notification stream
-   * @param {z.event.EventRepository.SOURCE} source - Source of event
-   * @returns {Promise} Resolves with the saved record or boolean true if the event was skipped
-   */
-  _processEvent(event, source) {
-    const isEncryptedEvent = event.type === z.event.Backend.CONVERSATION.OTR_MESSAGE_ADD;
-    const mapEvent = isEncryptedEvent
-      ? this.cryptographyRepository.handleEncryptedEvent(event)
-      : Promise.resolve(event);
-
-    return mapEvent
-      .then(mappedEvent => {
-        const saveEvent = z.event.EventTypeHandling.STORE.includes(mappedEvent.type);
-        return saveEvent ? this._handleEventSaving(mappedEvent, source) : mappedEvent;
-      })
-      .then(savedEvent => this._handleEventDistribution(savedEvent, source))
+    return this._handleEventValidation(event, source)
+      .then(validatedEvent => this.processEvent(validatedEvent, source))
       .catch(error => {
         const isIgnoredError = EventRepository.CONFIG.IGNORED_ERRORS.includes(error.type);
         if (!isIgnoredError) {
@@ -612,6 +589,27 @@ z.event.EventRepository = class EventRepository {
 
         return true;
       });
+  }
+
+  /**
+   * Decrypts, saves and distributes an event received from the backend.
+   *
+   * @param {JSON} event - Backend event extracted from notification stream
+   * @param {z.event.EventRepository.SOURCE} source - Source of event
+   * @returns {Promise} Resolves with the saved record or boolean true if the event was skipped
+   */
+  processEvent(event, source) {
+    const isEncryptedEvent = event.type === z.event.Backend.CONVERSATION.OTR_MESSAGE_ADD;
+    const mapEvent = isEncryptedEvent
+      ? this.cryptographyRepository.handleEncryptedEvent(event)
+      : Promise.resolve(event);
+
+    return mapEvent
+      .then(mappedEvent => {
+        const shouldSaveEvent = z.event.EventTypeHandling.STORE.includes(mappedEvent.type);
+        return shouldSaveEvent ? this._handleEventSaving(mappedEvent, source) : mappedEvent;
+      })
+      .then(savedEvent => this._handleEventDistribution(savedEvent, source));
   }
 
   /**
@@ -719,7 +717,7 @@ z.event.EventRepository = class EventRepository {
       const isIgnoredEvent = z.event.EventTypeHandling.IGNORE.includes(eventType);
       if (isIgnoredEvent) {
         this.logger.info(`Event ignored: '${event.type}'`, {event_json: JSON.stringify(event), event_object: event});
-        const errorMessage = 'Event validation failed: Type ignored';
+        const errorMessage = 'Event ignored: Type ignored';
         throw new z.event.EventError(z.event.EventError.TYPE.VALIDATION_FAILED, errorMessage);
       }
 

--- a/app/script/util/DebugUtil.js
+++ b/app/script/util/DebugUtil.js
@@ -283,7 +283,7 @@ z.util.DebugUtil = class DebugUtil {
       })
       .then(events => {
         this.logger.info(`Reprocessing "${events.length}" OTR messages...`);
-        events.forEach(event => this.eventRepository._processEvent(event, z.event.EventRepository.SOURCE.STREAM));
+        events.forEach(event => this.eventRepository.processEvent(event, z.event.EventRepository.SOURCE.STREAM));
       });
   }
 };

--- a/test/unit_tests/event/EventRepositorySpec.js
+++ b/test/unit_tests/event/EventRepositorySpec.js
@@ -359,7 +359,7 @@ describe('Event Repository', () => {
     });
   });
 
-  describe('_processEvent', () => {
+  describe('processEvent', () => {
     it('processes OTR events', done => {
       const text = 'Hello, this is a test!';
       const ownClientId = 'f180a823bf0d1204';
@@ -382,7 +382,7 @@ describe('Event Repository', () => {
             type: 'conversation.otr-message-add',
           };
           const source = z.event.EventRepository.SOURCE.STREAM;
-          return TestFactory.event_repository._processEvent(event, source);
+          return TestFactory.event_repository.processEvent(event, source);
         })
         .then(messagePayload => {
           expect(messagePayload.data.content).toBe(text);


### PR DESCRIPTION
Events there did not pass validation because they are being ignored (`conversation.is-typing`) or because of outdated timestamps were no longer properly handled and resulted in lots of errors in the console.