### PR TITLE
 refactor: move DB updates from ConversationRepository to the EventRepository

### DIFF
--- a/app/script/conversation/ConversationRepository.js
+++ b/app/script/conversation/ConversationRepository.js
@@ -2744,9 +2744,6 @@ z.conversation.ConversationRepository = class ConversationRepository {
       case z.event.Client.CONVERSATION.GROUP_CREATION:
         return this._onGroupCreation(conversationEntity, eventJson);
 
-      case z.event.Client.CONVERSATION.MESSAGE_ADD:
-        return this._on_message_add(conversationEntity, eventJson);
-
       case z.event.Client.CONVERSATION.MESSAGE_DELETE:
         return this._onMessageDeleted(conversationEntity, eventJson);
 
@@ -2759,6 +2756,7 @@ z.conversation.ConversationRepository = class ConversationRepository {
       case z.event.Client.CONVERSATION.REACTION:
         return this._on_reaction(conversationEntity, eventJson);
 
+      case z.event.Client.CONVERSATION.MESSAGE_ADD:
       case z.event.Backend.CONVERSATION.MESSAGE_TIMER_UPDATE:
       case z.event.Client.CONVERSATION.DELETE_EVERYWHERE:
       case z.event.Client.CONVERSATION.INCOMING_MESSAGE_TOO_BIG:
@@ -3176,32 +3174,6 @@ z.conversation.ConversationRepository = class ConversationRepository {
     if (isActiveConversation && (conversationEntity.is_archived() || conversationEntity.is_cleared())) {
       amplify.publish(z.event.WebApp.CONVERSATION.SHOW, nextConversationEt);
     }
-  }
-
-  /**
-   * A text message received in a conversation.
-   *
-   * @private
-   * @param {Conversation} conversation_et - Conversation to add the event to
-   * @param {Object} event_json - JSON data of 'conversation.message-add'
-   * @returns {Promise} Resolves when the event was handled
-   */
-  _on_message_add(conversation_et, event_json) {
-    return Promise.resolve()
-      .then(() => {
-        const event_data = event_json.data;
-
-        if (event_data.replacing_message_id) {
-          return this._update_edited_message(conversation_et, event_json);
-        }
-
-        return event_json;
-      })
-      .then(updated_event_json => {
-        if (updated_event_json) {
-          return this._addEventToConversation(conversation_et, updated_event_json);
-        }
-      });
   }
 
   /**

--- a/app/script/conversation/ConversationRepository.js
+++ b/app/script/conversation/ConversationRepository.js
@@ -2756,12 +2756,12 @@ z.conversation.ConversationRepository = class ConversationRepository {
       case z.event.Client.CONVERSATION.REACTION:
         return this._on_reaction(conversationEntity, eventJson);
 
-      case z.event.Client.CONVERSATION.MESSAGE_ADD:
       case z.event.Backend.CONVERSATION.MESSAGE_TIMER_UPDATE:
       case z.event.Client.CONVERSATION.DELETE_EVERYWHERE:
       case z.event.Client.CONVERSATION.INCOMING_MESSAGE_TOO_BIG:
       case z.event.Client.CONVERSATION.KNOCK:
       case z.event.Client.CONVERSATION.LOCATION:
+      case z.event.Client.CONVERSATION.MESSAGE_ADD:
       case z.event.Client.CONVERSATION.MISSED_MESSAGES:
       case z.event.Client.CONVERSATION.UNABLE_TO_DECRYPT:
       case z.event.Client.CONVERSATION.VERIFICATION:

--- a/app/script/conversation/ConversationRepository.js
+++ b/app/script/conversation/ConversationRepository.js
@@ -3650,38 +3650,6 @@ z.conversation.ConversationRepository = class ConversationRepository {
     return this.conversation_service.update_asset_as_uploaded_in_db(message_et.primary_key, event_json);
   }
 
-  /**
-   * Update edited message with timestamp from the original message and delete original.
-   *
-   * @private
-   * @param {Conversation} conversation_et - Conversation of edited message
-   * @param {JSON} event_json - Edit message event
-   * @returns {Promise} Resolves with the updated event_json
-   */
-  _update_edited_message(conversation_et, event_json) {
-    const {data: event_data, from, id, time} = event_json;
-
-    return this.get_message_in_conversation_by_id(conversation_et, event_data.replacing_message_id).then(
-      original_message_et => {
-        const from_original_user = from === original_message_et.from;
-        if (!from_original_user) {
-          throw new z.conversation.ConversationError(z.conversation.ConversationError.TYPE.WRONG_USER);
-        }
-
-        if (!original_message_et.timestamp()) {
-          throw new TypeError('Missing timestamp');
-        }
-
-        event_json.edited_time = time;
-        event_json.time = new Date(original_message_et.timestamp()).toISOString();
-        this._delete_message_by_id(conversation_et, id);
-        this._delete_message_by_id(conversation_et, event_data.replacing_message_id);
-        this.conversation_service.save_event(event_json);
-        return event_json;
-      }
-    );
-  }
-
   //##############################################################################
   // Tracking helpers
   //##############################################################################

--- a/app/script/entity/Conversation.js
+++ b/app/script/entity/Conversation.js
@@ -340,9 +340,9 @@ z.entity.Conversation = class Conversation {
    */
   add_message(messageEntity, replaceDuplicate = false) {
     if (messageEntity) {
-      const entityToReplace =
-        this._findDuplicate(messageEntity.id, messageEntity.from) ||
-        this._findDuplicate(messageEntity.replacing_message_id, messageEntity.from);
+      const messageWithLinkPreview = () => this._findDuplicate(messageEntity.id, messageEntity.from);
+      const editedMessage = () => this._findDuplicate(messageEntity.replacing_message_id, messageEntity.from);
+      const entityToReplace = messageWithLinkPreview() || editedMessage();
       this.update_timestamps(messageEntity);
       if (entityToReplace) {
         if (replaceDuplicate) {

--- a/app/script/event/EventRepository.js
+++ b/app/script/event/EventRepository.js
@@ -708,13 +708,9 @@ z.event.EventRepository = class EventRepository {
      *  - a message has been updated
      */
     if (newData.replacing_message_id) {
-      // case of a message edit
-      const dataUpdates = Object.assign({}, originalEvent.data, {
-        content: newData.content,
-      });
-      updates = Object.assign({}, originalEvent, {
-        data: dataUpdates,
+      updates = Object.assign({}, newEvent, {
         edited_time: newEvent.time,
+        time: originalEvent.time,
       });
     } else if (newData.link_previews.length) {
       // case of a link preview


### PR DESCRIPTION
Ok so, this is a first step toward freeing the `ConversationRepository` from persisting events in the DB.

Here I migrated the `edit message` functionality. Now the `EventRepository` is responsible for checking if there are duplicates in the DB and updates them accordingly. 

This avoids multiple writes to the DB when an event arrives. Previously the `EventRepo` would save most of the event, and, eventually, the `ConversationRepo` would remove them from there (which triggered the bug fixed here https://github.com/wireapp/wire-webapp/pull/4079).

There is still one place where the `ConversationRepository` stores events, for the `asset` handling. 
I might need the help of @gregor on this one, since I am not sure how to reproduce the case where it happens. https://github.com/wireapp/wire-webapp/blob/59d4a22f7873abe72f6c734870f8720fa1f58f8c/app/script/conversation/ConversationRepository.js#L3249