### PR TITLE
fix: Differentiate link preview updates and edit messages (WEBAPP-5300)

### DIFF
--- a/app/script/event/EventRepository.js
+++ b/app/script/event/EventRepository.js
@@ -651,8 +651,8 @@ z.event.EventRepository = class EventRepository {
 
     //first check if a message that should be replaced exists in DB
     const findEventToReplacePromise = mappedData.replacing_message_id
-      ? this.conversationService.load_event_from_db(mappedData.replacing_message_id)
-      : Promise.resolve(undefined);
+      ? this.conversationService.load_event_from_db(conversationId, mappedData.replacing_message_id)
+      : Promise.resolve();
 
     return findEventToReplacePromise.then(eventToReplace => {
       const hasLinkPreview = mappedData.previews && mappedData.previews.length;

--- a/app/script/event/EventRepository.js
+++ b/app/script/event/EventRepository.js
@@ -656,17 +656,19 @@ z.event.EventRepository = class EventRepository {
 
     return findEventToReplacePromise.then(eventToReplace => {
       const hasLinkPreview = mappedData.previews && mappedData.previews.length;
-      if (!eventToReplace && mappedData.replacing_message_id && !hasLinkPreview) {
+      const isReplacementWithoutOriginal = !eventToReplace && mappedData.replacing_message_id;
+      if (isReplacementWithoutOriginal && !hasLinkPreview) {
+        // the only valid case of a replacement with no original message is when an edited message gets a link preview
         this._throwValidationError('Edit event without original event');
       }
 
       const handleEvent = newEvent => {
         // check for duplicates (same id)
-        const loadPromise = newEvent.id
+        const loadEventPromise = newEvent.id
           ? this.conversationService.load_event_from_db(conversationId, newEvent.id)
           : Promise.resolve();
 
-        return loadPromise.then(storedEvent => {
+        return loadEventPromise.then(storedEvent => {
           if (storedEvent) {
             return this._handleLinkPreviewUpdate(storedEvent, newEvent);
           }

--- a/app/script/event/EventRepository.js
+++ b/app/script/event/EventRepository.js
@@ -669,10 +669,9 @@ z.event.EventRepository = class EventRepository {
           : Promise.resolve();
 
         return loadEventPromise.then(storedEvent => {
-          if (storedEvent) {
-            return this._handleLinkPreviewUpdate(storedEvent, newEvent);
-          }
-          return this.conversationService.save_event(newEvent);
+          return storedEvent
+            ? this._handleLinkPreviewUpdate(storedEvent, newEvent)
+            : this.conversationService.save_event(newEvent);
         });
       };
 

--- a/test/unit_tests/event/EventRepositorySpec.js
+++ b/test/unit_tests/event/EventRepositorySpec.js
@@ -561,7 +561,7 @@ describe('Event Repository', () => {
         .catch(done.fail);
     });
 
-    it('ignores edit message with missing associated initial message', done => {
+    it('ignores edit message with missing associated original message', done => {
       const linkPreviewEvent = JSON.parse(JSON.stringify(event));
       spyOn(TestFactory.event_repository.conversationService, 'load_event_from_db').and.returnValue(Promise.resolve());
       spyOn(TestFactory.event_repository.conversationService, 'update_event').and.returnValue(Promise.resolve());

--- a/test/unit_tests/event/EventRepositorySpec.js
+++ b/test/unit_tests/event/EventRepositorySpec.js
@@ -560,6 +560,23 @@ describe('Event Repository', () => {
         })
         .catch(done.fail);
     });
+
+    it('ignores edit message with missing associated initial message', done => {
+      const linkPreviewEvent = JSON.parse(JSON.stringify(event));
+      spyOn(TestFactory.event_repository.conversationService, 'load_event_from_db').and.returnValue(Promise.resolve());
+      spyOn(TestFactory.event_repository.conversationService, 'update_event').and.returnValue(Promise.resolve());
+
+      linkPreviewEvent.data.replacing_message_id = 'initial_message_id';
+
+      TestFactory.event_repository
+        ._handleEventSaving(linkPreviewEvent)
+        .then(() => done.fail('Should have thrown an error'))
+        .catch(error => {
+          expect(TestFactory.event_repository.conversationService.update_event).not.toHaveBeenCalled();
+          expect(TestFactory.event_repository.conversationService.save_event).not.toHaveBeenCalled();
+          done();
+        });
+    });
   });
 
   describe('_handleEventValidation', () => {


### PR DESCRIPTION
Here is a little graph of the workflow when a new event arrives in the event repository handler.
![screenshot from 2018-07-31 15-26-08](https://user-images.githubusercontent.com/1090716/43462364-3049040a-94d6-11e8-9fdf-715fd1ec7d6f.png)
