### PR TITLE
refactor: Improve performance of "z.util.ArrayUtil.chunk" (WEBAPP-5336)

### DIFF
--- a/app/script/util/ArrayUtil.js
+++ b/app/script/util/ArrayUtil.js
@@ -25,9 +25,8 @@ window.z.util = z.util || {};
 z.util.ArrayUtil = {
   chunk: (array, size) => {
     const chunks = [];
-    const temporaryArray = Array.from(array);
-    while (temporaryArray.length) {
-      chunks.push(temporaryArray.splice(0, size));
+    for (let index = 0, length = array.length; index < length; index += size) {
+      chunks.push(array.slice(index, index + size));
     }
     return chunks;
   },


### PR DESCRIPTION
## Type of change

Uploading huge MP3 files (~80 MB) produce heavy load on the browser and can crash the render process because of an inperformant array chunking implementation. 

The implementation of this PR solves the performance issue and has the benefit of using [array.slice](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Array/slice) which doesn't modify the source array. Because of the nature of "array.splice" we don't need to create a `temporaryArray` anymore before starting the chunking process. It also uses a for-loop with a cached length which brings an additional 3-6% of performance.

For the future we should consider enforcing for-loops with cached lengths because it's easy to implement and brings extra bits of performance. There are ESLint plugins like [eslint-plugin-no-for-each](https://www.npmjs.com/package/eslint-plugin-no-for-each) which can enforce this rule.