### PR TITLE
refactor: Remove filter option from "ArrayUtil.getNextItem"

### DIFF
--- a/app/script/util/ArrayUtil.js
+++ b/app/script/util/ArrayUtil.js
@@ -35,7 +35,7 @@ z.util.ArrayUtil = {
     return array2.filter(element => !array1.includes(element));
   },
 
-  getNextItem: (array, currentItem, filter) => {
+  getNextItem: (array, currentItem) => {
     const currentIndex = array.indexOf(currentItem);
 
     // couldn't find the item
@@ -46,20 +46,11 @@ z.util.ArrayUtil = {
     const nextIndex = currentIndex + 1;
 
     // item is last item in the array
-    if (nextIndex === array.length && currentIndex > 0) {
-      return array[currentIndex - 1];
+    if (nextIndex === array.length) {
+      return currentIndex > 0 ? array[currentIndex - 1] : undefined;
     }
 
-    if (nextIndex >= array.length) {
-      return undefined;
-    }
-
-    for (let index = nextIndex; index <= array.length; index++) {
-      const nextItem = array[index];
-      if (typeof filter !== 'function' || !!filter(nextItem)) {
-        return nextItem;
-      }
-    }
+    return array[nextIndex];
   },
 
   /**

--- a/app/script/util/Crypto.js
+++ b/app/script/util/Crypto.js
@@ -29,7 +29,7 @@ z.util.Crypto = {
       let hash = uint32.toUint32(0);
       const key = string.toLowerCase();
 
-      for (let index = 0; index < key.length; index++) {
+      for (let index = 0; index <= key.length - 1; index++) {
         hash = uint32.addMod32(hash, uint32.toUint32(key.charCodeAt(index)));
         hash = uint32.addMod32(hash, uint32.shiftLeft(hash, 10));
         hash = uint32.xor(hash, uint32.shiftRight(hash, 6));

--- a/app/script/util/Crypto.js
+++ b/app/script/util/Crypto.js
@@ -29,7 +29,7 @@ z.util.Crypto = {
       let hash = uint32.toUint32(0);
       const key = string.toLowerCase();
 
-      for (let index = 0; index <= key.length - 1; index++) {
+      for (let index = 0; index < key.length; index++) {
         hash = uint32.addMod32(hash, uint32.toUint32(key.charCodeAt(index)));
         hash = uint32.addMod32(hash, uint32.shiftLeft(hash, 10));
         hash = uint32.xor(hash, uint32.shiftRight(hash, 6));

--- a/test/unit_tests/util/ArrayUtilSpec.js
+++ b/test/unit_tests/util/ArrayUtilSpec.js
@@ -23,11 +23,7 @@
 
 describe('z.util.ArrayUtil', () => {
   describe('chunk', () => {
-    let array = null;
-
-    beforeEach(() => {
-      array = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-    });
+    const array = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
     it('returns one chunk with all items when the size is bigger than the array', () => {
       const actual = z.util.ArrayUtil.chunk(array, 10);
@@ -63,14 +59,9 @@ describe('z.util.ArrayUtil', () => {
     const thirdItem = 'c';
     const unknownItem = 'd';
     const array = [firstItem, secondItem, thirdItem];
-    const filter = item => item !== secondItem;
 
     it('returns the second item when first item was given', () => {
       expect(z.util.ArrayUtil.getNextItem(array, firstItem)).toEqual(secondItem);
-    });
-
-    it('returns the third item when first item was given and filter skips the second item', () => {
-      expect(z.util.ArrayUtil.getNextItem(array, firstItem, filter)).toEqual(thirdItem);
     });
 
     it('returns the second item when last item was given', () => {

--- a/test/unit_tests/util/ArrayUtilSpec.js
+++ b/test/unit_tests/util/ArrayUtilSpec.js
@@ -23,7 +23,11 @@
 
 describe('z.util.ArrayUtil', () => {
   describe('chunk', () => {
-    const array = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    let array = null;
+
+    beforeEach(() => {
+      array = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    });
 
     it('returns one chunk with all items when the size is bigger than the array', () => {
       const actual = z.util.ArrayUtil.chunk(array, 10);


### PR DESCRIPTION
## Type of change

In our code we use `z.util.ArrayUtil.getNextItem` only in `get_next_conversation` of the `ConversationRepository` class. There we use it without a third parameter (the filter option), so we can simplify the `getNextItem` util by removing it's filter functionality.