### PR TITLE
refactor: Remove traces of the Message entity in the EventService

### DIFF
--- a/app/script/conversation/ConversationEphemeralHandler.js
+++ b/app/script/conversation/ConversationEphemeralHandler.js
@@ -109,7 +109,7 @@ z.conversation.ConversationEphemeralHandler = class ConversationEphemeralHandler
           ephemeral_started: messageEntity.ephemeral_started(),
         };
 
-        this.eventService.updateMessage(messageEntity, changes);
+        this.eventService.updateEvent(messageEntity.primary_key, changes);
         break;
       }
 
@@ -160,7 +160,7 @@ z.conversation.ConversationEphemeralHandler = class ConversationEphemeralHandler
       ephemeral_expires: true,
     };
 
-    this.eventService.updateMessage(messageEntity, changes);
+    this.eventService.updateEvent(messageEntity.primary_key, changes);
     this.logger.info(`Obfuscated asset message '${messageEntity.id}'`);
   }
 
@@ -179,7 +179,7 @@ z.conversation.ConversationEphemeralHandler = class ConversationEphemeralHandler
       ephemeral_expires: true,
     };
 
-    this.eventService.updateMessage(messageEntity, changes);
+    this.eventService.updateEvent(messageEntity.primary_key, changes);
     this.logger.info(`Obfuscated image message '${messageEntity.id}'`);
   }
 
@@ -218,7 +218,7 @@ z.conversation.ConversationEphemeralHandler = class ConversationEphemeralHandler
       ephemeral_expires: true,
     };
 
-    this.eventService.updateMessage(messageEntity, changes);
+    this.eventService.updateEvent(messageEntity.primary_key, changes);
     this.logger.info(`Obfuscated text message '${messageEntity.id}'`);
   }
 

--- a/app/script/conversation/ConversationRepository.js
+++ b/app/script/conversation/ConversationRepository.js
@@ -2224,7 +2224,7 @@ z.conversation.ConversationRepository = class ConversationRepository {
 
         this.checkMessageTimer(messageEntity);
         if (z.event.EventTypeHandling.STORE.includes(messageEntity.type) || messageEntity.has_asset_image()) {
-          return this.eventService.updateMessage(messageEntity, changes);
+          return this.eventService.updateEvent(messageEntity.primary_key, changes);
         }
       })
       .catch(error => {
@@ -2952,7 +2952,7 @@ z.conversation.ConversationRepository = class ConversationRepository {
 
         if (was_updated) {
           const changes = {status: message_et.status()};
-          return this.eventService.updateMessage(message_et, changes);
+          return this.eventService.updateEvent(message_et.primary_key, changes);
         }
       })
       .catch(error => {

--- a/app/script/conversation/ConversationRepository.js
+++ b/app/script/conversation/ConversationRepository.js
@@ -3320,7 +3320,7 @@ z.conversation.ConversationRepository = class ConversationRepository {
           this.logger.debug(log, {changes, event: eventJson});
 
           return this._updateMessageUserEntities(messageEntity).then(changedMessageEntity => {
-            this.eventService.updateMessageSequentially(changedMessageEntity, changes, conversationId);
+            this.eventService.updateEventSequentially(changedMessageEntity.primary_key, changes);
             return this._prepareReactionNotification(conversationEntity, changedMessageEntity, eventJson);
           });
         }

--- a/app/script/event/EventRepository.js
+++ b/app/script/event/EventRepository.js
@@ -718,7 +718,7 @@ z.event.EventRepository = class EventRepository {
       updates = Object.assign({}, this._getUpdatesForLinkPreview(originalEvent, newEvent), updates);
     }
     const identifiedUpdates = Object.assign({}, primaryKeyUpdate, updates);
-    return this.eventService.updateEvent(identifiedUpdates);
+    return this.eventService.replaceEvent(identifiedUpdates);
   }
 
   _handleDuplicatedEvent(originalEvent, newEvent) {
@@ -746,7 +746,7 @@ z.event.EventRepository = class EventRepository {
       case z.assets.AssetTransferState.UPLOADED: {
         const updatedData = Object.assign({}, originalEvent.data, newEventData);
         const updatedEvent = Object.assign({}, originalEvent, {data: updatedData});
-        return this.eventService.updateEvent(updatedEvent);
+        return this.eventService.replaceEvent(updatedEvent);
       }
 
       case z.assets.AssetTransferState.UPLOAD_FAILED: {
@@ -794,7 +794,7 @@ z.event.EventRepository = class EventRepository {
 
     const updates = this._getUpdatesForLinkPreview(originalEvent, newEvent);
     const identifiedUpdates = Object.assign({}, {primary_key: originalEvent.primary_key}, updates);
-    return this.eventService.updateEvent(identifiedUpdates);
+    return this.eventService.replaceEvent(identifiedUpdates);
   }
 
   _getUpdatesForMessageEdit(originalEvent, newEvent) {

--- a/app/script/event/EventService.js
+++ b/app/script/event/EventService.js
@@ -245,12 +245,12 @@ z.event.EventService = class EventService {
   /**
    * Update a message entity in the database.
    *
-   * @param {Message} messageEntity - Message event to update in the database.
+   * @param {number} primaryKey - event's primary key
    * @param {Object} [updates={}] - Updates to perform on the message.
    * @returns {Promise} Resolves when the message was updated in database.
    */
-  updateMessage(messageEntity, updates) {
-    return Promise.resolve(messageEntity.primary_key).then(primaryKey => {
+  updateEvent(primaryKey, updates) {
+    return Promise.resolve(primaryKey).then(key => {
       const hasChanges = updates && !!Object.keys(updates).length;
       if (!hasChanges) {
         throw new z.conversation.ConversationError(z.conversation.ConversationError.TYPE.NO_CHANGES);
@@ -261,7 +261,7 @@ z.event.EventService = class EventService {
         throw new z.conversation.ConversationError(z.conversation.ConversationError.TYPE.WRONG_CHANGE);
       }
 
-      const identifiedUpdates = Object.assign({}, updates, {primary_key: primaryKey});
+      const identifiedUpdates = Object.assign({}, updates, {primary_key: key});
       return this.replaceEvent(identifiedUpdates);
     });
   }

--- a/app/script/event/EventService.js
+++ b/app/script/event/EventService.js
@@ -156,7 +156,7 @@ z.event.EventService = class EventService {
    * @param {Object} event - JSON event to be stored
    * @returns {Promise} Resolves with the updated record
    */
-  updateEvent(event) {
+  replaceEvent(event) {
     return this.storageService.update(this.EVENT_STORE_NAME, event.primary_key, event).then(() => event);
   }
 
@@ -262,7 +262,7 @@ z.event.EventService = class EventService {
       }
 
       const identifiedUpdates = Object.assign({}, updates, {primary_key: primaryKey});
-      return this.updateEvent(identifiedUpdates);
+      return this.replaceEvent(identifiedUpdates);
     });
   }
 };

--- a/test/unit_tests/event/EventRepositorySpec.js
+++ b/test/unit_tests/event/EventRepositorySpec.js
@@ -463,7 +463,7 @@ describe('Event Repository', () => {
     it('saves a text message with link preview with an ID previously used by the same user for a plain text message', () => {
       previously_stored_event = JSON.parse(JSON.stringify(event));
       spyOn(TestFactory.event_service, 'loadEvent').and.returnValue(Promise.resolve(previously_stored_event));
-      spyOn(TestFactory.event_service, 'updateEvent').and.returnValue(Promise.resolve(previously_stored_event));
+      spyOn(TestFactory.event_service, 'replaceEvent').and.returnValue(Promise.resolve(previously_stored_event));
 
       const initial_time = event.time;
       const changed_time = new Date(new Date(event.time).getTime() + 60 * 1000).toISOString();
@@ -474,14 +474,14 @@ describe('Event Repository', () => {
         expect(saved_event.time).toEqual(initial_time);
         expect(saved_event.time).not.toEqual(changed_time);
         expect(saved_event.primary_key).toEqual(previously_stored_event.primary_key);
-        expect(TestFactory.event_service.updateEvent).toHaveBeenCalled();
+        expect(TestFactory.event_service.replaceEvent).toHaveBeenCalled();
       });
     });
 
     it('ignores edit message with missing associated original message', () => {
       const linkPreviewEvent = JSON.parse(JSON.stringify(event));
       spyOn(TestFactory.event_service, 'loadEvent').and.returnValue(Promise.resolve());
-      spyOn(TestFactory.event_service, 'updateEvent').and.returnValue(Promise.resolve());
+      spyOn(TestFactory.event_service, 'replaceEvent').and.returnValue(Promise.resolve());
 
       linkPreviewEvent.data.replacing_message_id = 'initial_message_id';
 
@@ -489,7 +489,7 @@ describe('Event Repository', () => {
         ._handleEventSaving(linkPreviewEvent)
         .then(() => fail('Should have thrown an error'))
         .catch(error => {
-          expect(TestFactory.event_service.updateEvent).not.toHaveBeenCalled();
+          expect(TestFactory.event_service.replaceEvent).not.toHaveBeenCalled();
           expect(TestFactory.event_service.saveEvent).not.toHaveBeenCalled();
         });
     });
@@ -505,13 +505,13 @@ describe('Event Repository', () => {
       spyOn(TestFactory.event_service, 'loadEvent').and.callFake((conversationId, messageId) => {
         return messageId === replacingId ? Promise.resolve() : Promise.resolve(storedEvent);
       });
-      spyOn(TestFactory.event_service, 'updateEvent').and.callFake(ev => ev);
+      spyOn(TestFactory.event_service, 'replaceEvent').and.callFake(ev => ev);
 
       linkPreviewEvent.data.replacing_message_id = replacingId;
       linkPreviewEvent.data.previews = ['preview'];
 
       return TestFactory.event_repository._handleEventSaving(linkPreviewEvent).then(updatedEvent => {
-        expect(TestFactory.event_service.updateEvent).toHaveBeenCalled();
+        expect(TestFactory.event_service.replaceEvent).toHaveBeenCalled();
         expect(TestFactory.event_service.saveEvent).not.toHaveBeenCalled();
         expect(updatedEvent.data.previews[0]).toEqual('preview');
       });
@@ -520,7 +520,7 @@ describe('Event Repository', () => {
     it('updates edited messages', () => {
       const originalMessage = JSON.parse(JSON.stringify(event));
       spyOn(TestFactory.event_service, 'loadEvent').and.returnValue(Promise.resolve(originalMessage));
-      spyOn(TestFactory.event_service, 'updateEvent').and.callFake(updates => updates);
+      spyOn(TestFactory.event_service, 'replaceEvent').and.callFake(updates => updates);
 
       const initial_time = event.time;
       const changed_time = new Date(new Date(event.time).getTime() + 60 * 1000).toISOString();
@@ -535,7 +535,7 @@ describe('Event Repository', () => {
         expect(updatedEvent.time).not.toEqual(changed_time);
         expect(updatedEvent.data.content).toEqual('new content');
         expect(updatedEvent.primary_key).toEqual(originalMessage.primary_key);
-        expect(TestFactory.event_service.updateEvent).toHaveBeenCalled();
+        expect(TestFactory.event_service.replaceEvent).toHaveBeenCalled();
       });
     });
 
@@ -548,12 +548,12 @@ describe('Event Repository', () => {
       });
       const editEvent = Object.assign({}, event);
       spyOn(TestFactory.event_service, 'loadEvent').and.returnValue(Promise.resolve(storedEvent));
-      spyOn(TestFactory.event_service, 'updateEvent').and.callFake(ev => ev);
+      spyOn(TestFactory.event_service, 'replaceEvent').and.callFake(ev => ev);
 
       editEvent.data.replacing_message_id = replacingId;
 
       return TestFactory.event_repository._handleEventSaving(editEvent).then(updatedEvent => {
-        expect(TestFactory.event_service.updateEvent).toHaveBeenCalled();
+        expect(TestFactory.event_service.replaceEvent).toHaveBeenCalled();
         expect(TestFactory.event_service.saveEvent).not.toHaveBeenCalled();
         expect(updatedEvent.data.previews.length).toEqual(0);
       });
@@ -653,13 +653,13 @@ describe('Event Repository', () => {
         time: '2017-09-06T09:43:36.528Z',
       });
 
-      spyOn(TestFactory.event_service, 'updateEvent').and.callFake(eventToUpdate => Promise.resolve(eventToUpdate));
+      spyOn(TestFactory.event_service, 'replaceEvent').and.callFake(eventToUpdate => Promise.resolve(eventToUpdate));
       spyOn(TestFactory.event_service, 'loadEvent').and.returnValue(Promise.resolve(initialAssetEvent));
 
       return TestFactory.event_repository.processEvent(updateStatusEvent).then(updatedEvent => {
         expect(updatedEvent.type).toEqual(z.event.Client.CONVERSATION.ASSET_ADD);
         expect(updatedEvent.data.status).toEqual(updateStatusEvent.data.status);
-        expect(TestFactory.event_service.updateEvent).toHaveBeenCalled();
+        expect(TestFactory.event_service.replaceEvent).toHaveBeenCalled();
       });
     });
 
@@ -673,13 +673,13 @@ describe('Event Repository', () => {
         time: '2017-09-06T09:43:36.528Z',
       });
 
-      spyOn(TestFactory.event_service, 'updateEvent').and.callFake(eventToUpdate => Promise.resolve(eventToUpdate));
+      spyOn(TestFactory.event_service, 'replaceEvent').and.callFake(eventToUpdate => Promise.resolve(eventToUpdate));
       spyOn(TestFactory.event_service, 'loadEvent').and.returnValue(Promise.resolve(initialAssetEvent));
 
       return TestFactory.event_repository.processEvent(AssetPreviewEvent).then(updatedEvent => {
         expect(updatedEvent.type).toEqual(z.event.Client.CONVERSATION.ASSET_ADD);
         expect(updatedEvent.data.preview_key).toEqual(AssetPreviewEvent.data.preview_key);
-        expect(TestFactory.event_service.updateEvent).toHaveBeenCalled();
+        expect(TestFactory.event_service.replaceEvent).toHaveBeenCalled();
       });
     });
   });

--- a/test/unit_tests/event/EventServiceCommon.js
+++ b/test/unit_tests/event/EventServiceCommon.js
@@ -319,7 +319,7 @@ window.testEventServiceClass = (testedServiceName, className) => {
       });
     });
 
-    describe('updateEvent', () => {
+    describe('replaceEvent', () => {
       /* eslint-disable sort-keys*/
       const updatedEvent = {
         conversation: conversationId,
@@ -335,7 +335,7 @@ window.testEventServiceClass = (testedServiceName, className) => {
       it('update event in the database', () => {
         spyOn(TestFactory.storage_service, 'update').and.callFake(event => Promise.resolve(event));
 
-        return TestFactory[testedServiceName].updateEvent(updatedEvent).then(event => {
+        return TestFactory[testedServiceName].replaceEvent(updatedEvent).then(event => {
           expect(TestFactory.storage_service.update).toHaveBeenCalledWith(eventStoreName, 12, event);
         });
       });
@@ -538,12 +538,12 @@ window.testEventServiceClass = (testedServiceName, className) => {
       /* eslint-enable comma-spacing, key-spacing, sort-keys, quotes */
 
       it('updated event in the database', () => {
-        spyOn(TestFactory[testedServiceName], 'updateEvent').and.returnValue(Promise.resolve());
+        spyOn(TestFactory[testedServiceName], 'replaceEvent').and.returnValue(Promise.resolve());
 
         MessageEntity.time = new Date().toISOString();
         MessageEntity.primary_key = 1337;
         return TestFactory[testedServiceName].updateMessage(MessageEntity, {time: MessageEntity.time}).then(() => {
-          expect(TestFactory[testedServiceName].updateEvent).toHaveBeenCalled();
+          expect(TestFactory[testedServiceName].replaceEvent).toHaveBeenCalled();
         });
       });
 

--- a/test/unit_tests/event/EventServiceCommon.js
+++ b/test/unit_tests/event/EventServiceCommon.js
@@ -525,9 +525,9 @@ window.testEventServiceClass = (testedServiceName, className) => {
       });
     });
 
-    describe('updateMessage', () => {
+    describe('updateEvent', () => {
       /* eslint-disable comma-spacing, key-spacing, sort-keys, quotes */
-      const MessageEntity = {
+      const messageEntity = {
         conversation: conversationId,
         id: '4af67f76-09f9-4831-b3a4-9df877b8c29a',
         from: senderId,
@@ -540,16 +540,18 @@ window.testEventServiceClass = (testedServiceName, className) => {
       it('updated event in the database', () => {
         spyOn(TestFactory[testedServiceName], 'replaceEvent').and.returnValue(Promise.resolve());
 
-        MessageEntity.time = new Date().toISOString();
-        MessageEntity.primary_key = 1337;
-        return TestFactory[testedServiceName].updateMessage(MessageEntity, {time: MessageEntity.time}).then(() => {
-          expect(TestFactory[testedServiceName].replaceEvent).toHaveBeenCalled();
-        });
+        messageEntity.time = new Date().toISOString();
+        messageEntity.primary_key = 1337;
+        return TestFactory[testedServiceName]
+          .updateEvent(messageEntity.primary_key, {time: messageEntity.time})
+          .then(() => {
+            expect(TestFactory[testedServiceName].replaceEvent).toHaveBeenCalled();
+          });
       });
 
       it('fails if changes are not specified', () => {
         return TestFactory[testedServiceName]
-          .updateMessage(event, undefined)
+          .updateEvent(12, undefined)
           .then(() => fail('should have thrown'))
           .catch(error => {
             expect(error).toEqual(jasmine.any(z.conversation.ConversationError));


### PR DESCRIPTION
The idea is to have a little dumber `EventService`. 
To do that I removed the knowledge of the `Message` entity class from the API of the `EventService`. 

My view on this would be that `Entities` should stay on the application level (view + repositories) and low level classes should not be aware of those classes (if possible of course)

Here is the current state of the `EventService` API

![screenshot_2018-08-17 jsdoc class eventservice](https://user-images.githubusercontent.com/1090716/44263756-6e6b9e80-a220-11e8-818a-8addcee2a2de.png)
