### PR TITLE
fix: longer focusDelay to avoid flicker (WEBAPP-5387)

### DIFF
--- a/app/page/template/panel/add-participants.htm
+++ b/app/page/template/panel/add-participants.htm
@@ -6,7 +6,7 @@
       <close-icon class="icon-button" data-bind="click: onClose" data-uie-name="do-close"></close-icon>
     </div>
     <div class="panel__content">
-      <user-input class="user-list-light" params="input: searchInput, selected: selectedContacts, placeholder: z.string.addParticipantsSearchPlaceholder, focusDelay: z.motion.MotionDuration.MEDIUM" spellcheck="false"></user-input>
+      <user-input class="user-list-light" params="input: searchInput, selected: selectedContacts, placeholder: z.string.addParticipantsSearchPlaceholder, focusDelay: z.motion.MotionDuration.LONG" spellcheck="false"></user-input>
       <!-- ko if: showIntegrations() -->
         <div class="add-participants__tabs">
           <div class="add-participants__tab" data-bind="css: {'add-participants__tab--active': isStateAddPeople}, click: clickOnAddPeople, l10n_text: z.string.addParticipantsTabsPeople" data-uie-name="do-add-people"></div>

--- a/app/page/template/panel/conversation-participants.htm
+++ b/app/page/template/panel/conversation-participants.htm
@@ -6,7 +6,7 @@
             <close-icon class="right-panel-close icon-button" data-bind="click: onClose" data-uie-name="do-close"></close-icon>
         </div>
         <div class="panel__content conversation-participants__content">
-            <user-input class="user-list-light" params="input: searchInput, placeholder: z.string.conversationParticipantsSearchPlaceholder, focusDelay: z.motion.MotionDuration.MEDIUM" spellcheck="false"></user-input>
+            <user-input class="user-list-light" params="input: searchInput, placeholder: z.string.conversationParticipantsSearchPlaceholder, focusDelay: z.motion.MotionDuration.LONG" spellcheck="false"></user-input>
             <div class="conversation-participants__list panel__content">
                 <div class="panel__content__scroll" data-bind="antiscroll: shouldUpdateScrollbar">
                     <user-list class="user-list-light" params="user: participants, click: clickOnShowUser, filter: searchInput, altStyle: true, highlightedUsers: highlightedUsers" data-uie-name="list-conversation-participants"></user-list>


### PR DESCRIPTION
This *might* fix the issue of occasional flicker when opening the side panel by clicking on show more.
I was not able to reproduce it reliably, but suspect it to be a timing issue/race condition.
By extending the time this should not happen anymore.