### PR TITLE
fix: Change “Full house” dialog title

### DIFF
--- a/app/script/localization/webapp.js
+++ b/app/script/localization/webapp.js
@@ -245,7 +245,7 @@ z.string.modalConversationGuestOptionsRequestCodeMessage = 'Could not request ac
 z.string.modalConversationGuestOptionsRevokeCodeMessage = 'Could not revoke access link. Please try again.';
 z.string.modalConversationGuestOptionsToggleGuestsMessage = 'Could not change guests state.';
 
-z.string.modalConversationTooManyMembersHeadline = 'Full house';
+z.string.modalConversationTooManyMembersHeadline = 'The group is full';
 z.string.modalConversationTooManyMembersMessage = 'Up to {{number1}} people can join a conversation. Currently there is only room for {{number2}} more.';
 
 z.string.modalGifTooLargeHeadline = 'Selected animation is too large';


### PR DESCRIPTION
The “Full house” dialog title that appears when a conversation reaches the maximum number of participants is a remnant of our earlier informal tone.

This should be revised to adapt to our recent B2B tone.

See https://github.com/wireapp/copywriting/issues/37.