### PR TITLE
fix: Set active ports on outgoing SDP for Firefox (WEBAPP-5322)

### DIFF
--- a/app/script/calling/SDPMapper.js
+++ b/app/script/calling/SDPMapper.js
@@ -107,7 +107,7 @@ z.calling.SDPMapper = {
           }
         } else if (z.util.Environment.browser.firefox && isLocalSdp && isOffer) {
           // Set ports to activate media in outgoing Firefox SDP to ensure enabled media
-          outline = sdpLine.replace('m=video 0', 'm=video 9').replace('m=application 0', 'm=application 9');
+          outline = sdpLine.replace(/^m=(application|video) 0/, 'm=$1 9');
         }
       } else if (sdpLine.startsWith('a=rtpmap')) {
         const shouldAddPTime = isLocalSdpInGroup || isIceRestart;

--- a/app/script/calling/SDPMapper.js
+++ b/app/script/calling/SDPMapper.js
@@ -91,40 +91,29 @@ z.calling.SDPMapper = {
           const browserString = `${z.util.Environment.browser.name} ${z.util.Environment.browser.version}`;
           const webappVersion = z.util.Environment.version(false);
 
-          if (z.util.Environment.desktop) {
-            const desktopVersion = z.util.Environment.version(true);
-            outline = `a=tool:electron ${desktopVersion} ${webappVersion} (${browserString})`;
-          } else {
-            outline = `a=tool:webapp ${webappVersion} (${browserString})`;
-          }
+          outline = z.util.Environment.desktop
+            ? `a=tool:electron ${z.util.Environment.version(true)} ${webappVersion} (${browserString})`
+            : `a=tool:webapp ${webappVersion} (${browserString})`;
         }
       } else if (sdpLine.startsWith('a=candidate')) {
         iceCandidates.push(sdpLine);
-      } else if (sdpLine.startsWith('a=mid')) {
-        // Remove once obsolete due to high uptake of clients based on AVS build 3.3.11 containing fix for AUDIO-1215
-        const isAffectedSetup = z.util.Environment.browser.firefox && !isLocalSdp && !isOffer;
-        const shouldFixMediaStreamId = isAffectedSetup && sdpLine === 'a=mid:data';
-        if (shouldFixMediaStreamId) {
-          outline = 'a=mid:sdparta_2';
-        }
-      } else if (sdpLine.startsWith('m=audio')) {
-        // Code to nail in bit-rate and ptime settings for improved performance and experience
-        const shouldAddBitRate = isLocalSdpInGroup || isIceRestart;
-        if (shouldAddBitRate) {
-          sdpLines.push(sdpLine);
-          outline = `b=AS:${z.calling.SDPMapper.CONFIG.AUDIO_BITRATE}`;
+      } else if (sdpLine.startsWith('m=')) {
+        if (sdpLine.startsWith('m=audio')) {
+          // Code to nail in bit-rate and ptime settings for improved performance and experience
+          const shouldAddBitRate = isLocalSdpInGroup || isIceRestart;
+          if (shouldAddBitRate) {
+            sdpLines.push(sdpLine);
+            outline = `b=AS:${z.calling.SDPMapper.CONFIG.AUDIO_BITRATE}`;
+          }
+        } else if (z.util.Environment.browser.firefox && isLocalSdp && isOffer) {
+          // Set ports to activate media in outgoing Firefox SDP to ensure enabled media
+          outline = sdpLine.replace('m=video 0', 'm=video 9').replace('m=application 0', 'm=application 9');
         }
       } else if (sdpLine.startsWith('a=rtpmap')) {
         const shouldAddPTime = isLocalSdpInGroup || isIceRestart;
         if (shouldAddPTime && z.util.StringUtil.includes(sdpLine, 'opus')) {
           sdpLines.push(sdpLine);
           outline = `a=ptime:${z.calling.SDPMapper.CONFIG.AUDIO_PTIME}`;
-        }
-      } else if (sdpLine.startsWith('a=fmtp')) {
-        // Workaround for incompatibility between Chrome 57 and AVS builds. Remove once update of clients with AVS 3.3.x is high enough.
-        const shouldFixCodec = sdpLine === 'a=fmtp:125 apt=100';
-        if (shouldFixCodec) {
-          outline = 'a=fmtp:125 apt=96';
         }
       }
 


### PR DESCRIPTION
- adds a workaround for AVS incompatibility when Firefox sends 0 as ports
- Removes obsolete SDP rewrite; no clients in the wild still use AVS 3.3.x