### PR TITLE
fix: Only release media stream that are being replaced (WEBAPP-5419)

### DIFF
--- a/app/script/media/MediaStreamHandler.js
+++ b/app/script/media/MediaStreamHandler.js
@@ -214,7 +214,7 @@ z.media.MediaStreamHandler = class MediaStreamHandler {
       const newMediaStream = newMediaStreamInfo.stream;
       const newMediaStreamType = newMediaStreamInfo.getType();
 
-      this._releaseMediaStream(this.localMediaStream());
+      this._releaseMediaStream(this.localMediaStream(), mediaStreamInfo.getType());
       this._setStreamState(newMediaStream, newMediaStreamType);
       this.localMediaStream(newMediaStream);
     };


### PR DESCRIPTION
Because we didn't give a precise type when replacing the content of the media stream, we would fallback to a replacement of `audio/video` BUT we would feed in only a `video` track.
Which means the `audio` track will be released but not replaced, resulting in audio loss on the receiver side