### PR TITLE
refactor: Simplify the sdp sending timeout protocol

### DIFF
--- a/app/page/template/_dist/app.htm
+++ b/app/page/template/_dist/app.htm
@@ -15,6 +15,7 @@
 <script src="/script/util/moment.js"></script>
 <script src="/script/util/NumberUtil.js"></script>
 <script src="/script/util/ObjectUtil.js"></script>
+<script src="/script/util/PeerConnectionUtil.js"></script>
 <script src="/script/util/PromiseQueue.js"></script>
 <script src="/script/util/scroll-helpers.js"></script>
 <script src="/script/util/StorageUtil.js"></script>

--- a/app/script/calling/entities/FlowEntity.js
+++ b/app/script/calling/entities/FlowEntity.js
@@ -867,20 +867,10 @@ z.calling.entities.FlowEntity = class FlowEntity {
           }
         }
 
-        const iceCandidateTypes = iceCandidates.reduce((types, candidateStr) => {
-          const typeMatches = candidateStr.match(/typ (\w+)/);
-          if (!typeMatches) {
-            return types;
-          }
-          const candidateType = typeMatches[1];
-          types[candidateType] = types[candidateType] ? types[candidateType] + 1 : 1;
-          return types;
-        }, {});
+        const iceCandidateTypes = z.util.PeerConnectionUtil.getIceCandidatesTypes(iceCandidates);
 
         const iceCandidateTypesLog = Object.keys(iceCandidateTypes)
-          .map(candidateType => {
-            return `${iceCandidateTypes[candidateType]} ${candidateType}`;
-          })
+          .map(candidateType => `${iceCandidateTypes[candidateType]} ${candidateType}`)
           .join(', ');
 
         const logMessage = {
@@ -899,7 +889,7 @@ z.calling.entities.FlowEntity = class FlowEntity {
               this.callLogger.obfuscateSdp(this.localSdp().sdp),
             ],
           },
-          message: `Sending local '{0}' SDP containing '{1}' ICE candidates ('{2}') for flow with '{3}'\n{4}`,
+          message: `Sending local '{0}' SDP containing '{1}' ICE candidates ({2}) for flow with '{3}'\n{4}`,
         };
         this.callLogger.debug(logMessage);
 

--- a/app/script/calling/entities/FlowEntity.js
+++ b/app/script/calling/entities/FlowEntity.js
@@ -501,7 +501,6 @@ z.calling.entities.FlowEntity = class FlowEntity {
   _createPeerConnection() {
     return this._createPeerConnectionConfiguration().then(pcConfiguration => {
       this.peerConnection = new window.RTCPeerConnection(pcConfiguration);
-      this.iceCandidatesGatheringAttempts = 0;
       this.telemetry.time_step(z.telemetry.calling.CallSetupSteps.PEER_CONNECTION_CREATED);
       this.signalingState(this.peerConnection.signalingState);
 
@@ -1482,6 +1481,7 @@ z.calling.entities.FlowEntity = class FlowEntity {
       this.telemetry.disconnected();
 
       this.clearTimeouts();
+      this.iceCandidatesGatheringAttempts = 0;
       this._closeDataChannel();
       this._closePeerConnection();
       this._resetSignalingStates();

--- a/app/script/calling/entities/FlowEntity.js
+++ b/app/script/calling/entities/FlowEntity.js
@@ -86,7 +86,7 @@ z.calling.entities.FlowEntity = class FlowEntity {
     //##############################################################################
 
     this.peerConnection = undefined;
-    this.iceCandidatesGatheringAttempts = 0;
+    this.iceCandidatesGatheringAttempts = 1;
     this.pcInitialized = ko.observable(false);
 
     this.mediaStream = this.callEntity.localMediaStream;
@@ -1481,7 +1481,7 @@ z.calling.entities.FlowEntity = class FlowEntity {
       this.telemetry.disconnected();
 
       this.clearTimeouts();
-      this.iceCandidatesGatheringAttempts = 0;
+      this.iceCandidatesGatheringAttempts = 1;
       this._closeDataChannel();
       this._closePeerConnection();
       this._resetSignalingStates();

--- a/app/script/util/PeerConnectionUtil.js
+++ b/app/script/util/PeerConnectionUtil.js
@@ -1,0 +1,49 @@
+/*
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+'use strict';
+
+z.util.PeerConnectionUtil = {
+  /**
+   * Counts the number of relay candidate in a list of ICE candidates.
+   *
+   * @param {RTCConfiguration} peerConnectionConfig - the configuration of the peerConnection that initiated the ICE candidate gathering
+   * @param {Array<string>} iceCandidates - ICE candidate strings from SDP
+   * @returns {boolean} True if the candidates gathered are enough to send a SDP
+   */
+  isValidIceCandidatesGathering(peerConnectionConfig, iceCandidates) {
+    if (iceCandidates.length <= 0) {
+      // if there are no candidates, no need to check for more conditions
+      // the call cannot work
+      return false;
+    }
+    const numberOfRelays = iceCandidates.filter(candidate => candidate.toLowerCase().includes('relay')).length;
+    const numberOfIceServers = (peerConnectionConfig.iceServers || []).length;
+    if (numberOfIceServers <= 0) {
+      return true;
+    }
+    if (numberOfIceServers === 1 && numberOfRelays >= 1) {
+      return true;
+    }
+    if (numberOfIceServers >= 2 && numberOfRelays >= 2) {
+      return true;
+    }
+    return false;
+  },
+};

--- a/app/script/util/PeerConnectionUtil.js
+++ b/app/script/util/PeerConnectionUtil.js
@@ -20,8 +20,20 @@
 'use strict';
 
 z.util.PeerConnectionUtil = {
+  getIceCandidatesTypes(iceCandidates) {
+    return iceCandidates.reduce((types, candidateStr) => {
+      const typeMatches = candidateStr.match(/typ (\w+)/);
+      if (!typeMatches) {
+        return types;
+      }
+      const candidateType = typeMatches[1];
+      types[candidateType] = types[candidateType] + 1 || 1;
+      return types;
+    }, {});
+  },
+
   /**
-   * Counts the number of relay candidate in a list of ICE candidates.
+   * Returns true if the number and types of ice candidates gathered are sufficient to start a call
    *
    * @param {RTCConfiguration} peerConnectionConfig - the configuration of the peerConnection that initiated the ICE candidate gathering
    * @param {Array<string>} iceCandidates - ICE candidate strings from SDP

--- a/test/unit_tests/util/PeerConnectionUtilSpec.js
+++ b/test/unit_tests/util/PeerConnectionUtilSpec.js
@@ -78,4 +78,14 @@ describe('z.util.PeerConnectionUtil', () => {
       });
     });
   });
+
+  describe('getIceCandidatesTypes', () => {
+    it('detects types of candidates', () => {
+      const candidates = hostIceCandidates.concat(relayIceCandidates);
+      expect(z.util.PeerConnectionUtil.getIceCandidatesTypes(candidates)).toEqual({
+        host: hostIceCandidates.length,
+        relay: relayIceCandidates.length,
+      });
+    });
+  });
 });

--- a/test/unit_tests/util/PeerConnectionUtilSpec.js
+++ b/test/unit_tests/util/PeerConnectionUtilSpec.js
@@ -1,0 +1,81 @@
+/*
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+// grunt test_init && grunt test_run:util/NumberUtil
+
+'use strict';
+
+describe('z.util.PeerConnectionUtil', () => {
+  const hostIceCandidates = [
+    'a=candidate:0 1 UDP 2122252543 192.168.120.196 32785 typ host',
+    'a=candidate:3 1 TCP 2105524479 192.168.120.196 9 typ host tcptype active',
+    'a=candidate:0 2 UDP 2122252542 192.168.120.196 47577 typ host',
+    'a=candidate:3 2 TCP 2105524478 192.168.120.196 9 typ host tcptype active',
+  ];
+  const relayIceCandidates = [
+    'a=candidate:2 1 UDP 92216831 52.59.229.255 45814 typ relay raddr 52.59.229.255 rport 45814',
+    'a=candidate:2 2 UDP 92216830 52.59.229.255 51684 typ relay raddr 52.59.229.255 rport 51684',
+    'a=candidate:4 1 UDP 8331263 52.59.229.255 59586 typ relay raddr 52.59.229.255 rport 59586',
+    'a=candidate:4 2 UDP 8331262 52.59.229.255 53103 typ relay raddr 52.59.229.255 rport 53103',
+    'a=candidate:5 1 UDP 8331263 52.59.229.255 40234 typ relay raddr 52.59.229.255 rport 40234',
+    'a=candidate:5 2 UDP 8331262 52.59.229.255 58977 typ relay raddr 52.59.229.255 rport 58977',
+  ];
+
+  describe('isValidIceCandidatesGathering', () => {
+    it('returns false if no ice candidate gathered', () => {
+      const result = z.util.PeerConnectionUtil.isValidIceCandidatesGathering({}, []);
+      expect(result).toBe(false);
+    });
+
+    it('returns true if there are some not-relay candidates with empty iceServers config', () => {
+      const result = z.util.PeerConnectionUtil.isValidIceCandidatesGathering({iceServers: []}, hostIceCandidates);
+      expect(result).toBe(true);
+    });
+
+    it('returns true if there are as many relay ice candidates as there are iceServers', () => {
+      [1, 2, 3, 4, 5, 6].forEach(numberOfServers => {
+        const result = z.util.PeerConnectionUtil.isValidIceCandidatesGathering(
+          {iceServers: new Array(numberOfServers)},
+          relayIceCandidates.slice(0, numberOfServers)
+        );
+        expect(result).toBe(true);
+      });
+    });
+
+    it('returns false if there are some ice servers and no relay candidate', () => {
+      [1, 2, 3, 4, 5, 6].forEach(numberOfServers => {
+        const result = z.util.PeerConnectionUtil.isValidIceCandidatesGathering(
+          {iceServers: new Array(numberOfServers)},
+          hostIceCandidates
+        );
+        expect(result).toBe(false);
+      });
+    });
+
+    it('returns true if there is one ice server and one or more candidates', () => {
+      [1, 2, 3, 4, 5, 6].forEach(numberOfCandidates => {
+        const result = z.util.PeerConnectionUtil.isValidIceCandidatesGathering(
+          {iceServers: new Array(1)},
+          relayIceCandidates.slice(0, numberOfCandidates)
+        );
+        expect(result).toBe(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Previous behavior:

- waiting 5 seconds for ICE candidate gathering
- after 5 seconds, if the SDP contains relays ICE candidate we send the SDP else we wait 1 second and replay this timeout as long as we don't have relay candidates

New behavior:

- we only wait 1 second for the ICE candidate gathering (and loop until we have a bunch of relays candidate in the SDP).


This PR also adds a log with the types of candidates we have gathered