### PR TITLE
fix: Force loading the polyfills for setImmediate and clearImmediate (WEBAPP-5440)

### DIFF
--- a/app/script/auth/main.js
+++ b/app/script/auth/main.js
@@ -17,6 +17,9 @@
  *
  */
 
+// We need to force babel to load the setImmediate and clearImmediate polyfill because only setImmediate is set on electron side which means the polyfill won't be loaded later on.
+// https://github.com/electron/electron/issues/2984
+import 'core-js/modules/web.immediate';
 import {AppContainer} from 'react-hot-loader';
 import {Provider} from 'react-redux';
 import configureStore from './configureStore';


### PR DESCRIPTION
Ok, hold on to your socks, this is a tough one.

On the webapp side, we need (Dexie needs to be precise) both `setImmediate` and `clearImmediate`. 
Dexies uses a polyfill to actually declare both of them if the browser doesn't have them.

So in the case of a browser `setImmediate` AND `clearImmediate` are not defined so Dexie's polyfill triggers and define both

In the case of the desktop app, we actually set ONLY `setImmediate` in the preload script (see https://github.com/wireapp/wire-desktop/blob/796ab90f104861697d0cd662b63b6c5836242d68/electron/renderer/static/webview-preload.js#L195). 
Which means that when Dexie loads its polyfill, `setImmediate` is defined (but not `clearImmediate`) so the polyfill doesn't do anything and we end up in the bug we current have on the login page.

This fix, forces the webapp to load the polyfill for both `setImmediate` and `clearImmediate` (so Dexie's polyfill won't be loaded).