### PR TITLE
fix: clear unnecessary forced polyfill for setImmediate (WEBAPP-5442)

### DIFF
--- a/app/script/auth/main.tsx
+++ b/app/script/auth/main.tsx
@@ -17,9 +17,6 @@
  *
  */
 
-// We need to force babel to load the setImmediate and clearImmediate polyfill because only setImmediate is set on electron side which means the polyfill won't be loaded later on.
-// https://github.com/electron/electron/issues/2984
-import 'core-js/modules/web.immediate';
 import * as cookieStore from 'js-cookie';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';


### PR DESCRIPTION
This can be merged once this fix https://github.com/wireapp/wire-desktop/pull/1715 is released and adopted