### PR TITLE
feat: Use the local user search algorithm everywhere (WEBAPP-5475)

### DIFF
--- a/app/page/template/list/start-ui.htm
+++ b/app/page/template/list/start-ui.htm
@@ -71,7 +71,7 @@
                 <!-- ko ifnot: isTeam() -->
                   <span class="start-ui-list-header" data-bind="l10n_text: z.string.searchConnections"></span>
                 <!-- /ko -->
-                <user-list class="search-list-theme-black" params="user: contacts, click: clickOnContact"></user-list>
+                <user-list class="search-list-theme-black" params="user: contacts, click: clickOnContact, searchRepository: searchRepository"></user-list>
               </div>
             <!-- /ko -->
           <!-- /ko -->
@@ -85,7 +85,7 @@
                 <!-- ko ifnot: isTeam() -->
                   <span class="start-ui-list-header start-ui-list-header-connections" data-bind="l10n_text: z.string.searchConnections"></span>
                 <!-- /ko -->
-                <user-list class="search-list-theme-black" params="user: searchResults.contacts, click: clickOnContact"></user-list>
+                <user-list class="search-list-theme-black" params="user: searchResults.contacts, click: clickOnContact, searchRepository: searchRepository"></user-list>
               </div>
               <div class="start-ui-groups" data-bind="visible: searchResults.groups().length > 0">
                 <!-- ko if: isTeam() -->
@@ -98,7 +98,7 @@
               </div>
               <div class="others" data-bind="visible: searchResults.others().length > 0">
                 <span class="start-ui-list-header" data-bind="l10n_text: z.string.searchOthers"></span>
-                <user-list class="search-list-theme-black" params="user: searchResults.others, click: clickOnOther, mode: z.components.UserList.MODE.OTHERS"></user-list>
+                <user-list class="search-list-theme-black" params="user: searchResults.others, click: clickOnOther, mode: z.components.UserList.MODE.OTHERS, searchRepository: searchRepository"></user-list>
               </div>
             </div>
           <!-- /ko -->

--- a/app/page/template/modal/group-creation.htm
+++ b/app/page/template/modal/group-creation.htm
@@ -26,7 +26,7 @@
     <div class="modal-center group-creation-modal-center">
       <!-- ko if: stateIsParticipants() -->
         <div class="group-creation-list-wrapper" data-bind="antiscroll: shouldUpdateScrollbar">
-          <user-list class="group-creation-modal-participants-list user-list-light" params="user: contacts, filter: participantsInput, selected: selectedContacts"></user-list>
+          <user-list class="group-creation-modal-participants-list user-list-light" params="user: contacts, filter: participantsInput, selected: selectedContacts, searchRepository: searchRepository"></user-list>
         </div>
       <!-- /ko -->
       <!-- ko if: stateIsPreferences() -->

--- a/app/page/template/panel/add-participants.htm
+++ b/app/page/template/panel/add-participants.htm
@@ -17,7 +17,7 @@
       <div class="add-participants__list panel__content">
         <div class="panel__content__scroll" data-bind="antiscroll: shouldUpdateScrollbar">
           <!-- ko if: isStateAddPeople() -->
-            <user-list class="user-list-light" params="user: contacts, filter: searchInput, selected: selectedContacts"></user-list>
+            <user-list class="user-list-light" params="user: contacts, filter: searchInput, selected: selectedContacts, searchRepository: searchRepository"></user-list>
           <!-- /ko -->
           <!-- ko if: isStateAddService() -->
             <!-- ko if: services().length -->

--- a/app/page/template/panel/conversation-details.htm
+++ b/app/page/template/panel/conversation-details.htm
@@ -46,7 +46,7 @@
                 </div>
               </div>
             <!-- /ko -->
-  
+
             <!-- ko if: activeConversation() && activeConversation().is_group() -->
               <div class="conversation-details__participant_count">
                 <!-- ko if: userParticipants().length -->
@@ -107,7 +107,7 @@
             <!-- ko if: activeConversation() && activeConversation().is_group() -->
               <!-- ko if: userParticipants().length -->
                 <div class="conversation-details__list-head" data-bind="text: z.string.conversationDetailsPeople"></div>
-                <user-list params="user: userParticipants, click: clickOnShowUser, altStyle: true" data-uie-name="list-users"></user-list>
+                <user-list params="user: userParticipants, click: clickOnShowUser, altStyle: true, searchRepository: searchRepository" data-uie-name="list-users"></user-list>
                 <!-- ko if: showAllUsersCount() > 0 -->
                   <div class="panel__action-item panel__action-item--no-border" data-bind="click: clickOnShowAll" data-uie-name="go-conversation-participants">
                     <people-icon class="panel__action-item__icon"></people-icon>
@@ -116,7 +116,7 @@
                   </div>
                 <!-- /ko -->
               <!-- /ko -->
-  
+
               <!-- ko if: serviceParticipants().length -->
                 <div class="conversation-details__list-head" data-bind="text: z.string.conversationDetailsServices"></div>
                 <service-list params="services: serviceParticipants, click: clickOnShowService, altStyle: true" data-uie-name="list-services"></service-list>

--- a/app/page/template/panel/conversation-participants.htm
+++ b/app/page/template/panel/conversation-participants.htm
@@ -9,7 +9,7 @@
             <user-input class="user-list-light" params="input: searchInput, placeholder: z.string.conversationParticipantsSearchPlaceholder, focusDelay: z.motion.MotionDuration.LONG" spellcheck="false"></user-input>
             <div class="conversation-participants__list panel__content">
                 <div class="panel__content__scroll" data-bind="antiscroll: shouldUpdateScrollbar">
-                    <user-list class="user-list-light" params="user: participants, click: clickOnShowUser, filter: searchInput, altStyle: true, highlightedUsers: highlightedUsers" data-uie-name="list-conversation-participants"></user-list>
+                    <user-list class="user-list-light" params="user: participants, click: clickOnShowUser, filter: searchInput, altStyle: true, highlightedUsers: highlightedUsers, searchRepository: searchRepository" data-uie-name="list-conversation-participants"></user-list>
                 </div>
             </div>
         </div>

--- a/app/script/components/userList.js
+++ b/app/script/components/userList.js
@@ -81,7 +81,7 @@ z.components.UserList = class UserList {
           const trimmedQuery = this.filter().trim();
           const isHandle = trimmedQuery.startsWith('@') && z.user.UserHandleGenerator.validate_handle(normalizedQuery);
           const properties = isHandle ? [SEARCHABLE_FIELDS.USERNAME] : [SEARCHABLE_FIELDS.NAME];
-          return this.searchRepository.searchUserInSet(trimmedQuery, this.userEntities(), properties);
+          return this.searchRepository.searchUserInSet(trimmedQuery.replace(/^@/, ''), this.userEntities(), properties);
         }
       }
       return this.userEntities();

--- a/app/script/components/userList.js
+++ b/app/script/components/userList.js
@@ -77,9 +77,10 @@ z.components.UserList = class UserList {
       if (typeof this.filter === 'function') {
         const normalizedQuery = z.search.SearchRepository.normalizeQuery(this.filter());
         if (normalizedQuery) {
+          const SEARCHABLE_FIELDS = z.search.SearchRepository.CONFIG.SEARCHABLE_FIELDS;
           const trimmedQuery = this.filter().trim();
           const isHandle = trimmedQuery.startsWith('@') && z.user.UserHandleGenerator.validate_handle(normalizedQuery);
-          const properties = isHandle ? ['username'] : ['first_name', 'last_name'];
+          const properties = isHandle ? [SEARCHABLE_FIELDS.USERNAME] : [SEARCHABLE_FIELDS.NAME];
           return this.searchRepository.searchUserInSet(trimmedQuery, this.userEntities(), properties);
         }
       }

--- a/app/script/components/userList.js
+++ b/app/script/components/userList.js
@@ -46,6 +46,7 @@ z.components.UserList = class UserList {
     this.filter = params.filter;
     this.selectedUsers = params.selected;
     this.mode = params.mode || UserList.MODE.DEFAULT;
+    this.searchRepository = params.searchRepository;
     this.userEntities = params.user;
     const highlightedUsers = params.highlightedUsers ? params.highlightedUsers() : [];
     this.highlightedUserIds = highlightedUsers.map(user => user.id);
@@ -78,12 +79,8 @@ z.components.UserList = class UserList {
         if (normalizedQuery) {
           const trimmedQuery = this.filter().trim();
           const isHandle = trimmedQuery.startsWith('@') && z.user.UserHandleGenerator.validate_handle(normalizedQuery);
-          const excludedEmojis = Array.from(normalizedQuery).filter(char => {
-            return z.util.EmojiUtil.UNICODE_RANGES.includes(char);
-          });
-          return this.userEntities().filter(userEntity => {
-            return userEntity.matches(normalizedQuery, isHandle, excludedEmojis);
-          });
+          const properties = isHandle ? ['username'] : ['first_name', 'last_name'];
+          return this.searchRepository.searchUserInSet(trimmedQuery, this.userEntities(), properties);
         }
       }
       return this.userEntities();

--- a/app/script/components/userList.js
+++ b/app/script/components/userList.js
@@ -81,7 +81,7 @@ z.components.UserList = class UserList {
           const trimmedQuery = this.filter().trim();
           const isHandle = trimmedQuery.startsWith('@') && z.user.UserHandleGenerator.validate_handle(normalizedQuery);
           const properties = isHandle ? [SEARCHABLE_FIELDS.USERNAME] : undefined;
-          return this.searchRepository.searchUserInSet(trimmedQuery.replace(/^@/, ''), this.userEntities(), properties);
+          return this.searchRepository.searchUserInSet(normalizedQuery, this.userEntities(), properties);
         }
       }
       return this.userEntities();

--- a/app/script/components/userList.js
+++ b/app/script/components/userList.js
@@ -80,7 +80,7 @@ z.components.UserList = class UserList {
           const SEARCHABLE_FIELDS = z.search.SearchRepository.CONFIG.SEARCHABLE_FIELDS;
           const trimmedQuery = this.filter().trim();
           const isHandle = trimmedQuery.startsWith('@') && z.user.UserHandleGenerator.validate_handle(normalizedQuery);
-          const properties = isHandle ? [SEARCHABLE_FIELDS.USERNAME] : [SEARCHABLE_FIELDS.NAME];
+          const properties = isHandle ? [SEARCHABLE_FIELDS.USERNAME] : undefined;
           return this.searchRepository.searchUserInSet(trimmedQuery.replace(/^@/, ''), this.userEntities(), properties);
         }
       }

--- a/app/script/search/SearchRepository.js
+++ b/app/script/search/SearchRepository.js
@@ -112,11 +112,12 @@ z.search.SearchRepository = class SearchRepository {
 
     const isStrictMatch = value.toLowerCase().startsWith(term.toLowerCase());
     if (isStrictMatch) {
+      // if the pattern matches the raw text, give the maximum value to the match
       return 100;
     }
     const isStrictTransliteratedMatch = z.util.StringUtil.compareTransliteration(value, term, excludedEmojis, true);
     if (isStrictTransliteratedMatch) {
-      // if the pattern matches the raw text, give the maximum value to the match
+      // give a little less points if the pattern strictly matches the transliterated string
       return 50;
     }
     const isLoosyMatch = z.util.StringUtil.compareTransliteration(value, term, excludedEmojis, false);

--- a/app/script/search/SearchRepository.js
+++ b/app/script/search/SearchRepository.js
@@ -110,10 +110,14 @@ z.search.SearchRepository = class SearchRepository {
     }, {});
     const value = ko.unwrap(userEntity[property]) || '';
 
-    const isStrictMatch = z.util.StringUtil.compareTransliteration(value, term, excludedEmojis, true);
+    const isStrictMatch = value.toLowerCase().startsWith(term.toLowerCase());
     if (isStrictMatch) {
-      // if the pattern matches the raw text, give the maximum value to the match
       return 100;
+    }
+    const isStrictTransliteratedMatch = z.util.StringUtil.compareTransliteration(value, term, excludedEmojis, true);
+    if (isStrictTransliteratedMatch) {
+      // if the pattern matches the raw text, give the maximum value to the match
+      return 50;
     }
     const isLoosyMatch = z.util.StringUtil.compareTransliteration(value, term, excludedEmojis, false);
     if (!isLoosyMatch) {
@@ -121,7 +125,7 @@ z.search.SearchRepository = class SearchRepository {
       return 0;
     }
 
-    const tokens = z.util.StringUtil.computeTransliteration(value).split(/\W+/g);
+    const tokens = z.util.StringUtil.computeTransliteration(value).split(/-/g);
     // computing the match value by testing all components of the property
     return tokens.reverse().reduce((weight, token, index) => {
       const indexWeight = index + 1;

--- a/app/script/team/TeamRepository.js
+++ b/app/script/team/TeamRepository.js
@@ -147,23 +147,6 @@ z.team.TeamRepository = class TeamRepository {
     }
   }
 
-  /**
-   * Search for user.
-   * @param {string} query - Find user by name or handle
-   * @param {boolean} isHandle - Query string is handle
-   * @returns {Array<z.entity.User>} Matching users
-   */
-  searchForTeamUsers(query, isHandle) {
-    const excludedEmojis = Array.from(query).filter(char => z.util.EmojiUtil.UNICODE_RANGES.includes(char));
-    return this.teamUsers()
-      .filter(userEntity => userEntity.matches(query, isHandle, excludedEmojis))
-      .sort((userA, userB) => {
-        return isHandle
-          ? z.util.StringUtil.sortByPriority(userA.username(), userB.username(), query)
-          : z.util.StringUtil.sortByPriority(userA.name(), userB.name(), query);
-      });
-  }
-
   sendAccountInfo() {
     if (z.util.Environment.desktop) {
       const imageResource = this.isTeam() ? undefined : this.selfUser().previewPictureResource();

--- a/app/script/user/UserRepository.js
+++ b/app/script/user/UserRepository.js
@@ -781,23 +781,6 @@ z.user.UserRepository = class UserRepository {
   }
 
   /**
-   * Search for user.
-   * @param {string} query - Find user by name or handle
-   * @param {boolean} is_handle - Query string is handle
-   * @returns {Array<z.entity.User>} Matching users
-   */
-  search_for_connected_users(query, is_handle) {
-    const excludedEmojis = Array.from(query).filter(char => z.util.EmojiUtil.UNICODE_RANGES.includes(char));
-    return this.connected_users()
-      .filter(user_et => user_et.matches(query, is_handle, excludedEmojis))
-      .sort((user_a, user_b) => {
-        return is_handle
-          ? z.util.StringUtil.sortByPriority(user_a.username(), user_b.username(), query)
-          : z.util.StringUtil.sortByPriority(user_a.name(), user_b.name(), query);
-      });
-  }
-
-  /**
    * Is the user the logged in user.
    * @param {z.entity.User|string} user_id - User entity or user ID
    * @returns {boolean} Is the user the logged in user

--- a/app/script/util/StringUtil.js
+++ b/app/script/util/StringUtil.js
@@ -41,7 +41,7 @@ z.util.StringUtil = {
   },
 
   computeTransliteration: (string, excludedChars = {}) => {
-    const options = {custom: excludedChars};
+    const options = {custom: excludedChars, uric: true};
     return window.getSlug(string, options);
   },
 

--- a/app/script/view_model/content/GroupCreationViewModel.js
+++ b/app/script/view_model/content/GroupCreationViewModel.js
@@ -39,6 +39,7 @@ z.viewModel.content.GroupCreationViewModel = class GroupCreationViewModel {
     this.clickOnToggleGuestMode = this.clickOnToggleGuestMode.bind(this);
 
     this.conversationRepository = repositories.conversation;
+    this.searchRepository = repositories.search;
     this.teamRepository = repositories.team;
     this.userRepository = repositories.user;
     this.isTeam = this.teamRepository.isTeam;

--- a/app/script/view_model/list/StartUIViewModel.js
+++ b/app/script/view_model/list/StartUIViewModel.js
@@ -568,7 +568,7 @@ z.viewModel.list.StartUIViewModel = class StartUIViewModel {
       const localSearchFields = isHandle ? [SEARCHABLE_FIELDS.USERNAME] : undefined;
 
       const contactSearchResults = this.searchRepository.searchUserInSet(
-        trimmedQuery.replace(/^@/, ''),
+        normalizedQuery,
         localSearchSources,
         localSearchFields
       );

--- a/app/script/view_model/list/StartUIViewModel.js
+++ b/app/script/view_model/list/StartUIViewModel.js
@@ -565,7 +565,7 @@ z.viewModel.list.StartUIViewModel = class StartUIViewModel {
         : this.userRepository.connected_users();
 
       const SEARCHABLE_FIELDS = z.search.SearchRepository.CONFIG.SEARCHABLE_FIELDS;
-      const localSearchFields = trimmedQuery.startsWith('@') ? [SEARCHABLE_FIELDS.USERNAME] : [SEARCHABLE_FIELDS.NAME];
+      const localSearchFields = isHandle ? [SEARCHABLE_FIELDS.USERNAME] : undefined;
 
       const contactSearchResults = this.searchRepository.searchUserInSet(
         trimmedQuery.replace(/^@/, ''),

--- a/app/script/view_model/list/StartUIViewModel.js
+++ b/app/script/view_model/list/StartUIViewModel.js
@@ -565,15 +565,11 @@ z.viewModel.list.StartUIViewModel = class StartUIViewModel {
         : this.userRepository.connected_users();
 
       const SEARCHABLE_FIELDS = z.search.SearchRepository.CONFIG.SEARCHABLE_FIELDS;
-      const localSearchFields = isHandle ? [SEARCHABLE_FIELDS.USERNAME] : undefined;
+      const searchFields = isHandle ? [SEARCHABLE_FIELDS.USERNAME] : undefined;
 
-      const contactSearchResults = this.searchRepository.searchUserInSet(
-        normalizedQuery,
-        localSearchSources,
-        localSearchFields
-      );
+      const contactResults = this.searchRepository.searchUserInSet(normalizedQuery, localSearchSources, searchFields);
 
-      this.searchResults.contacts(contactSearchResults);
+      this.searchResults.contacts(contactResults);
       this.searchResults.groups(this.conversationRepository.getGroupsByName(normalizedQuery, isHandle));
     }
   }

--- a/app/script/view_model/list/StartUIViewModel.js
+++ b/app/script/view_model/list/StartUIViewModel.js
@@ -560,12 +560,20 @@ z.viewModel.list.StartUIViewModel = class StartUIViewModel {
         })
         .catch(error => this.logger.error(`Error searching for contacts: ${error.message}`, error));
 
-      if (this.isTeam()) {
-        this.searchResults.contacts(this.teamRepository.searchForTeamUsers(normalizedQuery, isHandle));
-      } else {
-        this.searchResults.contacts(this.userRepository.search_for_connected_users(normalizedQuery, isHandle));
-      }
+      const localSearchSources = this.isTeam()
+        ? this.teamRepository.teamUsers()
+        : this.userRepository.connected_users();
 
+      const SEARCHABLE_FIELDS = z.search.SearchRepository.CONFIG.SEARCHABLE_FIELDS;
+      const localSearchFields = trimmedQuery.startsWith('@') ? [SEARCHABLE_FIELDS.USERNAME] : [SEARCHABLE_FIELDS.NAME];
+
+      const contactSearchResults = this.searchRepository.searchUserInSet(
+        trimmedQuery.replace(/^@/, ''),
+        localSearchSources,
+        localSearchFields
+      );
+
+      this.searchResults.contacts(contactSearchResults);
       this.searchResults.groups(this.conversationRepository.getGroupsByName(normalizedQuery, isHandle));
     }
   }

--- a/app/script/view_model/panel/AddParticipantsViewModel.js
+++ b/app/script/view_model/panel/AddParticipantsViewModel.js
@@ -37,6 +37,7 @@ z.viewModel.panel.AddParticipantsViewModel = class AddParticipantsViewModel exte
 
     this.conversationRepository = this.repositories.conversation;
     this.integrationRepository = this.repositories.integration;
+    this.searchRepository = params.repositories.search;
     this.teamRepository = this.repositories.team;
     this.userRepository = this.repositories.user;
 

--- a/app/script/view_model/panel/ConversationDetailsViewModel.js
+++ b/app/script/view_model/panel/ConversationDetailsViewModel.js
@@ -38,8 +38,9 @@ z.viewModel.panel.ConversationDetailsViewModel = class ConversationDetailsViewMo
     this.clickOnShowUser = this.clickOnShowUser.bind(this);
 
     this.conversationRepository = this.repositories.conversation;
-    this.teamRepository = this.repositories.team;
     this.integrationRepository = this.repositories.integration;
+    this.searchRepository = params.repositories.search;
+    this.teamRepository = this.repositories.team;
 
     this.logger = new z.util.Logger('z.viewModel.panel.ConversationDetailsViewModel', z.config.LOGGER.OPTIONS);
 

--- a/app/script/view_model/panel/ConversationParticipantsViewModel.js
+++ b/app/script/view_model/panel/ConversationParticipantsViewModel.js
@@ -28,6 +28,7 @@ z.viewModel.panel.ConversationParticipantsViewModel = class ConversationParticip
   constructor(params) {
     super(params);
 
+    this.searchRepository = params.repositories.search;
     this.clickOnShowUser = this.clickOnShowUser.bind(this);
 
     this.participants = ko.pureComputed(() => {

--- a/test/unit_tests/search/SearchRepositorySpec.js
+++ b/test/unit_tests/search/SearchRepositorySpec.js
@@ -113,6 +113,22 @@ describe('z.search.SearchRepository', () => {
       expect(suggestions.map(serializeUser)).toEqual([]);
     });
 
+    it('prioritize exact matches with special characters', () => {
+      const smilyFelix = generateUser('smily', '😋Felix');
+      const atFelix = generateUser('at', '@Felix');
+      const simplyFelix = generateUser('simple', 'Felix');
+
+      const unsortedUsers = [atFelix, smilyFelix, simplyFelix];
+
+      let suggestions = TestFactory.search_repository.searchUserInSet('felix', unsortedUsers);
+      let expected = [simplyFelix, smilyFelix, atFelix];
+      expect(suggestions.map(serializeUser)).toEqual(expected.map(serializeUser));
+
+      suggestions = TestFactory.search_repository.searchUserInSet('😋', unsortedUsers);
+      expected = [smilyFelix];
+      expect(suggestions.map(serializeUser)).toEqual(expected.map(serializeUser));
+    });
+
     it('handles sorting matching results', () => {
       const first = generateUser('xxx', '_surname');
       const second = generateUser('xxx', 'surname _lastname');

--- a/test/unit_tests/user/UserRepositorySpec.js
+++ b/test/unit_tests/user/UserRepositorySpec.js
@@ -192,59 +192,6 @@ describe('z.user.UserRepository', () => {
       });
     });
 
-    describe('search_for_connected_users', () => {
-      let user_et_a = null;
-      let user_et_b = null;
-
-      beforeEach(done => {
-        const connection_et = new z.entity.Connection();
-        connection_et.status(z.user.ConnectionStatus.ACCEPTED);
-
-        user_et_a = new z.entity.User(z.util.createRandomUuid());
-        user_et_a.name('René');
-        user_et_a.username('foo');
-        user_et_a.connection(connection_et);
-
-        user_et_b = new z.entity.User(z.util.createRandomUuid());
-        user_et_b.name('Gregor');
-        user_et_b.connection(connection_et);
-
-        TestFactory.user_repository
-          .save_users([user_et_a, user_et_b])
-          .then(done)
-          .catch(done.fail);
-      });
-
-      afterEach(() => {
-        TestFactory.user_repository.users.removeAll();
-      });
-
-      it('finds the correct user by searching for the full name', () => {
-        const result = TestFactory.user_repository.search_for_connected_users('Gregor');
-        expect(result.length).toBe(1);
-        expect(result[0].id).toBe(user_et_b.id);
-      });
-
-      it('finds the correct user by searching for the full name (transliteration)', () => {
-        const result = TestFactory.user_repository.search_for_connected_users('Rene');
-        expect(result.length).toBe(1);
-        expect(result[0].id).toBe(user_et_a.id);
-      });
-
-      it('finds the correct user by searching for the username', () => {
-        const result = TestFactory.user_repository.search_for_connected_users('foo');
-        expect(result.length).toBe(1);
-        expect(result[0].id).toBe(user_et_a.id);
-      });
-
-      it('finds the correct users', () => {
-        const result = TestFactory.user_repository.search_for_connected_users('e');
-        expect(result.length).toBe(2);
-        expect(result[0].id).toBe(user_et_b.id);
-        expect(result[1].id).toBe(user_et_a.id);
-      });
-    });
-
     describe('save_user', () => {
       afterEach(() => {
         TestFactory.user_repository.users.removeAll();


### PR DESCRIPTION
Main changes:
- we can match handles with patterns that are in between the handle (`ichel` matches `michel`)
- the results are now sorted with the following priorities
  - first name matches from the start
  - last name matches from the start
  - first name matches in between
  - last name matches in between

Here are a few examples that give different results

### `@test_benny` matches because `benny` is somewhere in the handle

![screenshot from 2018-09-17 16-30-13](https://user-images.githubusercontent.com/1090716/45631252-d0772800-ba9a-11e8-8074-738259b7a93d.png)

### `Node` is before `Dusan Stevanovic` because the first name has the priority

![screenshot from 2018-09-17 16-41-06](https://user-images.githubusercontent.com/1090716/45631253-d0772800-ba9a-11e8-96fa-b0a877495de7.png)
