### PR TITLE
fix: Priortize types in secondary line alert state

### DIFF
--- a/app/script/conversation/ConversationCellState.js
+++ b/app/script/conversation/ConversationCellState.js
@@ -65,17 +65,17 @@ z.conversation.ConversationCellState = (() => {
               break;
             }
 
-            case ACTIVITY_TYPE.PING: {
-              stringId = activityCountIsOne
-                ? z.string.conversationsSecondaryLinePing
-                : z.string.conversationsSecondaryLinePings;
-              break;
-            }
-
             case ACTIVITY_TYPE.MESSAGE: {
               stringId = activityCountIsOne
                 ? z.string.conversationsSecondaryLineNewMessage
                 : z.string.conversationsSecondaryLineNewMessages;
+              break;
+            }
+
+            case ACTIVITY_TYPE.PING: {
+              stringId = activityCountIsOne
+                ? z.string.conversationsSecondaryLinePing
+                : z.string.conversationsSecondaryLinePings;
               break;
             }
 

--- a/app/script/conversation/ConversationCellState.js
+++ b/app/script/conversation/ConversationCellState.js
@@ -93,17 +93,16 @@ z.conversation.ConversationCellState = (() => {
   const _getStateAlert = {
     description: conversationEntity => _accumulateActivity(conversationEntity),
     icon: conversationEntity => {
-      const lastAlertMessage = conversationEntity.unreadEvents().find(_isAlert);
+      const hasMissedCall = conversationEntity
+        .unreadEvents()
+        .some(messageEntity => messageEntity.is_call() && messageEntity.was_missed());
+      if (hasMissedCall) {
+        return z.conversation.ConversationStatusIcon.MISSED_CALL;
+      }
 
-      if (lastAlertMessage) {
-        const isMissedCall = lastAlertMessage.is_call() && lastAlertMessage.was_missed();
-        if (isMissedCall) {
-          return z.conversation.ConversationStatusIcon.MISSED_CALL;
-        }
-
-        if (lastAlertMessage.is_ping()) {
-          return z.conversation.ConversationStatusIcon.UNREAD_PING;
-        }
+      const hasPing = conversationEntity.unreadEvents().some(messageEntity => messageEntity.is_ping());
+      if (hasPing) {
+        return z.conversation.ConversationStatusIcon.UNREAD_PING;
       }
     },
     match: conversationEntity => {

--- a/app/script/conversation/ConversationCellState.js
+++ b/app/script/conversation/ConversationCellState.js
@@ -32,8 +32,8 @@ z.conversation.ConversationCellState = (() => {
   const _accumulateActivity = conversationEntity => {
     const activities = {
       [ACTIVITY_TYPE.CALL]: 0,
-      [ACTIVITY_TYPE.MESSAGE]: 0,
       [ACTIVITY_TYPE.PING]: 0,
+      [ACTIVITY_TYPE.MESSAGE]: 0,
     };
 
     conversationEntity.unreadEvents().forEach(messageEntity => {
@@ -96,13 +96,13 @@ z.conversation.ConversationCellState = (() => {
       const lastAlertMessage = conversationEntity.unreadEvents().find(_isAlert);
 
       if (lastAlertMessage) {
-        if (lastAlertMessage.is_ping()) {
-          return z.conversation.ConversationStatusIcon.UNREAD_PING;
-        }
-
         const isMissedCall = lastAlertMessage.is_call() && lastAlertMessage.was_missed();
         if (isMissedCall) {
           return z.conversation.ConversationStatusIcon.MISSED_CALL;
+        }
+
+        if (lastAlertMessage.is_ping()) {
+          return z.conversation.ConversationStatusIcon.UNREAD_PING;
         }
       }
     },

--- a/app/script/conversation/ConversationCellState.js
+++ b/app/script/conversation/ConversationCellState.js
@@ -65,17 +65,17 @@ z.conversation.ConversationCellState = (() => {
               break;
             }
 
-            case ACTIVITY_TYPE.MESSAGE: {
-              stringId = activityCountIsOne
-                ? z.string.conversationsSecondaryLineNewMessage
-                : z.string.conversationsSecondaryLineNewMessages;
-              break;
-            }
-
             case ACTIVITY_TYPE.PING: {
               stringId = activityCountIsOne
                 ? z.string.conversationsSecondaryLinePing
                 : z.string.conversationsSecondaryLinePings;
+              break;
+            }
+
+            case ACTIVITY_TYPE.MESSAGE: {
+              stringId = activityCountIsOne
+                ? z.string.conversationsSecondaryLineNewMessage
+                : z.string.conversationsSecondaryLineNewMessages;
               break;
             }
 


### PR DESCRIPTION
This PR will
* correct the priority order of icons shown next to the conversation title in the conversation list
* correct the priority order of the subtitle string in the conversation list

Correct order:
1. Missed call
2. Ping
3. Normal message