### PR TITLE
fix: Mentioning the same user twice (WEBAPP-5483)

### DIFF
--- a/app/script/message/MentionEntity.js
+++ b/app/script/message/MentionEntity.js
@@ -33,7 +33,7 @@ z.message.MentionEntity = class Mention {
 
     this.isSelfMentioned = ko.pureComputed(() => {
       const isTypeUserId = this.type === z.cryptography.PROTO_MESSAGE_TYPE.MENTION_TYPE_USER_ID;
-      return isTypeUserId && (this.userEntity() && this.userEntity().is_me);
+      return isTypeUserId && this.userEntity() && this.userEntity().is_me;
     });
   }
 

--- a/app/script/message/MentionEntity.js
+++ b/app/script/message/MentionEntity.js
@@ -33,7 +33,7 @@ z.message.MentionEntity = class Mention {
 
     this.isSelfMentioned = ko.pureComputed(() => {
       const isTypeUserId = this.type === z.cryptography.PROTO_MESSAGE_TYPE.MENTION_TYPE_USER_ID;
-      return isTypeUserId && this.userEntity().is_me;
+      return isTypeUserId && (this.userEntity() && this.userEntity().is_me);
     });
   }
 


### PR DESCRIPTION
When constructing `z.message.MentionEntity`, its `userEntity` observable is `undefined` and can break the access on `this.userEntity().is_me`. 

That's why I added the check for `this.userEntity()`.