### PR TITLE
fix: Close mention suggestions on whitespace character (WEBAPP-5487)

### DIFF
--- a/app/script/view_model/content/InputBarViewModel.js
+++ b/app/script/view_model/content/InputBarViewModel.js
@@ -404,7 +404,7 @@ z.viewModel.content.InputBarViewModel = class InputBarViewModel {
     const isOverMention =
       this.findMentionAtPosition(selectionStart, this.currentMentions) ||
       this.findMentionAtPosition(selectionEnd, this.currentMentions);
-    const isOverValidMentionString = /^@\w*$/.test(wordBeforeSelection);
+    const isOverValidMentionString = /^@\S*$/.test(wordBeforeSelection);
 
     if (!isSpaceSelected && !isOverMention && isOverValidMentionString) {
       const wordAfterSelection = value.substring(selectionEnd).replace(/\s.*/, '');


### PR DESCRIPTION
The `isOverValidMentionString` test now matches mentions which **don't include whitespaces** (`\S`). That's the same pattern which iOS and Android use and it allows us to look for mentions that include umlauts, accented characters and/or chinese characters.