### PR TITLE
fix: Do no fail silently if it is not possible to determine if mention is self mention (WEBAPP-5496)

### DIFF
--- a/app/script/conversation/ConversationRepository.js
+++ b/app/script/conversation/ConversationRepository.js
@@ -3564,9 +3564,7 @@ z.conversation.ConversationRepository = class ConversationRepository {
 
           const textAsset = messageEntity.get_first_asset();
           if (textAsset.mentions && textAsset.mentions().length) {
-            textAsset.mentions().forEach(mentionEntity => {
-              mentionEntity.setReaderId(this.selfUser().id);
-            });
+            textAsset.mentions().forEach(mentionEntity => mentionEntity.setSelfId(this.selfUser().id));
           }
         }
       }

--- a/app/script/conversation/ConversationRepository.js
+++ b/app/script/conversation/ConversationRepository.js
@@ -3564,20 +3564,9 @@ z.conversation.ConversationRepository = class ConversationRepository {
 
           const textAsset = messageEntity.get_first_asset();
           if (textAsset.mentions && textAsset.mentions().length) {
-            const mentionedUserIds = textAsset
-              .mentions()
-              .map(mentionEntity => mentionEntity.userId)
-              .filter(userId => userId);
-
-            if (mentionedUserIds.length) {
-              return this.user_repository.get_users_by_id(mentionedUserIds).then(mentionedUserEntities => {
-                mentionedUserEntities.forEach(mentionedUserEntity => {
-                  const mentionEntity = textAsset.mentions().find(({userId}) => mentionedUserEntity.id === userId);
-                  mentionEntity.userEntity(mentionedUserEntity);
-                });
-                return messageEntity;
-              });
-            }
+            textAsset.mentions().forEach(mentionEntity => {
+              mentionEntity.setReaderId(this.selfUser().id);
+            });
           }
         }
       }

--- a/app/script/message/MentionEntity.js
+++ b/app/script/message/MentionEntity.js
@@ -43,20 +43,20 @@ z.message.MentionEntity = class MentionEntity {
     this.userId = userId;
     this.userEntity = ko.observable();
 
-    // id of the user who will read the mention
-    this.readerId = undefined;
+    // id of the self user (needed to know if the mention is a selfMention)
+    this.selfId = undefined;
   }
 
-  setReaderId(userId) {
-    this.readerId = userId;
+  setSelfId(userId) {
+    this.selfId = userId;
   }
 
   isSelfMentioned() {
-    if (this.readerId === undefined) {
-      throw new Error('Cannot determine if mention is a self mention if reader is not set');
+    if (this.selfId === undefined) {
+      throw new Error('Cannot determine if mention is a self mention if selfId is not set');
     }
     const isTypeUserId = this.type === z.cryptography.PROTO_MESSAGE_TYPE.MENTION_TYPE_USER_ID;
-    return isTypeUserId && this.userId === this.readerId;
+    return isTypeUserId && this.userId === this.selfId;
   }
 
   // Index of first char outside of mention

--- a/app/script/message/MentionEntity.js
+++ b/app/script/message/MentionEntity.js
@@ -43,10 +43,20 @@ z.message.MentionEntity = class MentionEntity {
     this.userId = userId;
     this.userEntity = ko.observable();
 
-    this.isSelfMentioned = ko.pureComputed(() => {
-      const isTypeUserId = this.type === z.cryptography.PROTO_MESSAGE_TYPE.MENTION_TYPE_USER_ID;
-      return isTypeUserId && this.userEntity() && this.userEntity().is_me;
-    });
+    // id of the user who will read the mention
+    this.readerId = undefined;
+  }
+
+  setReaderId(userId) {
+    this.readerId = userId;
+  }
+
+  isSelfMentioned() {
+    if (this.readerId === undefined) {
+      throw new Error('Cannot determine if mention is a self mention if reader is not set');
+    }
+    const isTypeUserId = this.type === z.cryptography.PROTO_MESSAGE_TYPE.MENTION_TYPE_USER_ID;
+    return isTypeUserId && this.userId === this.readerId;
   }
 
   // Index of first char outside of mention


### PR DESCRIPTION
This changes a bit the `MentionEntity` API.

It doesn't need a full userEntity now and has a new method that set who is going to read the message

It also crash if we ask it if it's a self mention while the reader is not set