### PR TITLE
refactor: Move to a stateless MentionEntity (WEBAPP-5516)

### DIFF
--- a/app/page/template/partials/template-message.htm
+++ b/app/page/template/partials/template-message.htm
@@ -117,7 +117,7 @@
       <!-- /ko -->
       <!-- ko if: asset.is_text() -->
         <!-- ko if: asset.should_render_text -->
-          <div class="text" data-bind="html: asset.render(), event: {click: $parents[1].handleClickOnMessage}, css: {'text-graphite': $parent.is_editing, 'text-large': z.util.EmojiUtil.includesOnlyEmojies(asset.text), 'text-graphite': message.status() === z.message.StatusType.SENDING, 'ephemeral-message-obfuscated': message.isObfuscated()}" dir="auto"></div>
+          <div class="text" data-bind="html: asset.render($parents[1].selfUser().id), event: {click: $parents[1].handleClickOnMessage}, css: {'text-graphite': $parent.is_editing, 'text-large': z.util.EmojiUtil.includesOnlyEmojies(asset.text), 'text-graphite': message.status() === z.message.StatusType.SENDING, 'ephemeral-message-obfuscated': message.isObfuscated()}" dir="auto"></div>
         <!-- /ko -->
         <!-- ko foreach: asset.previews() -->
           <link-preview-asset class="message-asset" data-bind="css: {'ephemeral-asset-expired': message.isObfuscated()}" params="message: message"></link-preview-asset>

--- a/app/script/conversation/ConversationCellState.js
+++ b/app/script/conversation/ConversationCellState.js
@@ -40,7 +40,7 @@ z.conversation.ConversationCellState = (() => {
     let mentionText = undefined;
 
     conversationEntity.unreadEvents().forEach(messageEntity => {
-      const isSelfMentioned = messageEntity.is_content() && messageEntity.isSelfMentioned(conversationEntity.self.id);
+      const isSelfMentioned = messageEntity.is_content() && messageEntity.isUserMentioned(conversationEntity.self.id);
       if (isSelfMentioned) {
         activities[ACTIVITY_TYPE.MENTION] += 1;
 
@@ -131,7 +131,7 @@ z.conversation.ConversationCellState = (() => {
     icon: conversationEntity => {
       const hasSelfMention = conversationEntity
         .unreadEvents()
-        .some(messageEntity => messageEntity.is_content() && messageEntity.isSelfMentioned(conversationEntity.self.id));
+        .some(messageEntity => messageEntity.is_content() && messageEntity.isUserMentioned(conversationEntity.self.id));
       if (hasSelfMention) {
         return z.conversation.ConversationStatusIcon.UNREAD_MENTION;
       }
@@ -150,7 +150,7 @@ z.conversation.ConversationCellState = (() => {
     },
     match: conversationEntity => {
       return conversationEntity.unreadEvents().some(messageEntity => {
-        const isSelfMentioned = messageEntity.is_content() && messageEntity.isSelfMentioned(conversationEntity.self.id);
+        const isSelfMentioned = messageEntity.is_content() && messageEntity.isUserMentioned(conversationEntity.self.id);
         const isMissedCall = messageEntity.is_call() && messageEntity.was_missed();
         return isSelfMentioned || isMissedCall || messageEntity.is_ping();
       });

--- a/app/script/conversation/ConversationCellState.js
+++ b/app/script/conversation/ConversationCellState.js
@@ -40,7 +40,7 @@ z.conversation.ConversationCellState = (() => {
     let mentionText = undefined;
 
     conversationEntity.unreadEvents().forEach(messageEntity => {
-      const isSelfMentioned = messageEntity.is_content() && messageEntity.isSelfMentioned();
+      const isSelfMentioned = messageEntity.is_content() && messageEntity.isSelfMentioned(conversationEntity.self.id);
       if (isSelfMentioned) {
         activities[ACTIVITY_TYPE.MENTION] += 1;
 
@@ -131,7 +131,7 @@ z.conversation.ConversationCellState = (() => {
     icon: conversationEntity => {
       const hasSelfMention = conversationEntity
         .unreadEvents()
-        .some(messageEntity => messageEntity.is_content() && messageEntity.isSelfMentioned());
+        .some(messageEntity => messageEntity.is_content() && messageEntity.isSelfMentioned(conversationEntity.self.id));
       if (hasSelfMention) {
         return z.conversation.ConversationStatusIcon.UNREAD_MENTION;
       }
@@ -150,7 +150,7 @@ z.conversation.ConversationCellState = (() => {
     },
     match: conversationEntity => {
       return conversationEntity.unreadEvents().some(messageEntity => {
-        const isSelfMentioned = messageEntity.is_content() && messageEntity.isSelfMentioned();
+        const isSelfMentioned = messageEntity.is_content() && messageEntity.isSelfMentioned(conversationEntity.self.id);
         const isMissedCall = messageEntity.is_call() && messageEntity.was_missed();
         return isSelfMentioned || isMissedCall || messageEntity.is_ping();
       });

--- a/app/script/conversation/ConversationRepository.js
+++ b/app/script/conversation/ConversationRepository.js
@@ -3561,14 +3561,8 @@ z.conversation.ConversationRepository = class ConversationRepository {
               assetEntity.theme_color = messageEntity.user().accent_color();
             }
           });
-
-          const textAsset = messageEntity.get_first_asset();
-          if (textAsset.mentions && textAsset.mentions().length) {
-            textAsset.mentions().forEach(mentionEntity => mentionEntity.setSelfId(this.selfUser().id));
-          }
         }
       }
-
       return messageEntity;
     });
   }

--- a/app/script/conversation/ConversationRepository.js
+++ b/app/script/conversation/ConversationRepository.js
@@ -3563,6 +3563,7 @@ z.conversation.ConversationRepository = class ConversationRepository {
           });
         }
       }
+
       return messageEntity;
     });
   }

--- a/app/script/entity/Conversation.js
+++ b/app/script/entity/Conversation.js
@@ -394,7 +394,9 @@ z.entity.Conversation = class Conversation {
     return this.unreadEvents()
       .slice()
       .reverse()
-      .find(messageEntity => messageEntity.visible() && messageEntity.is_content() && messageEntity.isSelfMentioned());
+      .find(messageEntity => {
+        return messageEntity.visible() && messageEntity.is_content() && messageEntity.isSelfMentioned(this.self.id);
+      });
   }
 
   get_last_known_timestamp(time_offset) {

--- a/app/script/entity/Conversation.js
+++ b/app/script/entity/Conversation.js
@@ -395,7 +395,7 @@ z.entity.Conversation = class Conversation {
       .slice()
       .reverse()
       .find(messageEntity => {
-        return messageEntity.visible() && messageEntity.is_content() && messageEntity.isSelfMentioned(this.self.id);
+        return messageEntity.visible() && messageEntity.is_content() && messageEntity.isUserMentioned(this.self.id);
       });
   }
 

--- a/app/script/entity/message/ContentMessage.js
+++ b/app/script/entity/message/ContentMessage.js
@@ -108,9 +108,9 @@ z.entity.ContentMessage = class ContentMessage extends z.entity.Message {
     }
   }
 
-  isSelfMentioned(selfId) {
+  isUserMentioned(userId) {
     return this.has_asset_text()
-      ? this.assets().some(assetEntity => assetEntity.is_text() && assetEntity.isSelfMentioned(selfId))
+      ? this.assets().some(assetEntity => assetEntity.is_text() && assetEntity.isUserMentioned(userId))
       : false;
   }
 

--- a/app/script/entity/message/ContentMessage.js
+++ b/app/script/entity/message/ContentMessage.js
@@ -108,11 +108,9 @@ z.entity.ContentMessage = class ContentMessage extends z.entity.Message {
     }
   }
 
-  isSelfMentioned() {
+  isSelfMentioned(selfId) {
     return this.has_asset_text()
-      ? this.assets().some(assetEntity => {
-          return assetEntity.is_text() && assetEntity.mentions().some(mentionEntity => mentionEntity.isSelfMentioned());
-        })
+      ? this.assets().some(assetEntity => assetEntity.is_text() && assetEntity.isSelfMentioned(selfId))
       : false;
   }
 

--- a/app/script/entity/message/Text.js
+++ b/app/script/entity/message/Text.js
@@ -54,7 +54,7 @@ z.entity.Text = class Text extends z.entity.Asset {
     return !this.previews().length ? z.media.MediaParser.renderMediaEmbeds(message, this.theme_color) : message;
   }
 
-  isSelfMentioned(selfId) {
-    return this.mentions().some(mentionEntity => mentionEntity.targetsUser(selfId));
+  isUserMentioned(userId) {
+    return this.mentions().some(mentionEntity => mentionEntity.targetsUser(userId));
   }
 };

--- a/app/script/entity/message/Text.js
+++ b/app/script/entity/message/Text.js
@@ -49,12 +49,12 @@ z.entity.Text = class Text extends z.entity.Asset {
   }
 
   // Process text before rendering it
-  render() {
-    const message = z.util.renderMessage(this.text, this.mentions());
+  render(selfId) {
+    const message = z.util.renderMessage(this.text, selfId, this.mentions());
     return !this.previews().length ? z.media.MediaParser.renderMediaEmbeds(message, this.theme_color) : message;
   }
 
-  isSelfMentioned() {
-    return this.mentions().some(mentionEntity => mentionEntity.isSelfMentioned());
+  isSelfMentioned(selfId) {
+    return this.mentions().some(mentionEntity => mentionEntity.targetsUser(selfId));
   }
 };

--- a/app/script/main/app.js
+++ b/app/script/main/app.js
@@ -172,7 +172,8 @@ z.main.App = class App {
     repositories.notification = new z.notification.NotificationRepository(
       repositories.calling,
       repositories.conversation,
-      repositories.permission
+      repositories.permission,
+      repositories.user
     );
     repositories.videoGrid = new z.calling.VideoGridRepository(repositories.calling, repositories.media);
 

--- a/app/script/message/MentionEntity.js
+++ b/app/script/message/MentionEntity.js
@@ -41,19 +41,11 @@ z.message.MentionEntity = class MentionEntity {
     this.type = z.cryptography.PROTO_MESSAGE_TYPE.MENTION_TYPE_USER_ID;
 
     this.userId = userId;
-    this.userEntity = ko.observable();
-
-    // id of the self user (needed to know if the mention is a selfMention)
-    this.selfId = undefined;
   }
 
-  setSelfId(userId) {
-    this.selfId = userId;
-  }
-
-  isSelfMentioned() {
+  targetsUser(selfId) {
     const isTypeUserId = this.type === z.cryptography.PROTO_MESSAGE_TYPE.MENTION_TYPE_USER_ID;
-    return isTypeUserId && this.userId === this.selfId;
+    return isTypeUserId && this.userId === selfId;
   }
 
   // Index of first char outside of mention

--- a/app/script/notification/NotificationRepository.js
+++ b/app/script/notification/NotificationRepository.js
@@ -212,7 +212,7 @@ z.notification.NotificationRepository = class NotificationRepository {
     if (messageEntity.has_asset_text()) {
       for (const assetEntity of messageEntity.assets()) {
         if (assetEntity.is_text()) {
-          const notificationText = assetEntity.isSelfMentioned(this.userRepository.self().id)
+          const notificationText = assetEntity.isUserMentioned(this.userRepository.self().id)
             ? `${z.l10n.text(z.string.notificationMention)} ${assetEntity.text}`
             : assetEntity.text;
 
@@ -334,7 +334,7 @@ z.notification.NotificationRepository = class NotificationRepository {
    * @returns {string} Notification message body
    */
   _createBodyObfuscated(messageEntity) {
-    const isSelfMentioned = messageEntity.is_content() && messageEntity.isSelfMentioned(this.userRepository.self().id);
+    const isSelfMentioned = messageEntity.is_content() && messageEntity.isUserMentioned(this.userRepository.self().id);
     const stringId = isSelfMentioned ? z.string.notificationObfuscatedMention : z.string.notificationObfuscated;
     return z.l10n.text(stringId);
   }
@@ -568,7 +568,7 @@ z.notification.NotificationRepository = class NotificationRepository {
     const conversationId = this._getConversationId(connectionEntity, conversationEntity);
 
     const containsSelfMention =
-      messageEntity.is_content() && messageEntity.isSelfMentioned(this.userRepository.self().id);
+      messageEntity.is_content() && messageEntity.isUserMentioned(this.userRepository.self().id);
     if (containsSelfMention) {
       return () => amplify.publish(z.event.WebApp.CONVERSATION.SHOW, conversationEntity, messageEntity, true);
     }

--- a/app/script/notification/NotificationRepository.js
+++ b/app/script/notification/NotificationRepository.js
@@ -76,6 +76,7 @@ z.notification.NotificationRepository = class NotificationRepository {
     });
 
     this.permissionState = this.permissionRepository.permissionState[z.permission.PermissionType.NOTIFICATIONS];
+    this.selfUser = this.userRepository.self;
   }
 
   subscribeToEvents() {
@@ -212,7 +213,7 @@ z.notification.NotificationRepository = class NotificationRepository {
     if (messageEntity.has_asset_text()) {
       for (const assetEntity of messageEntity.assets()) {
         if (assetEntity.is_text()) {
-          const notificationText = assetEntity.isUserMentioned(this.userRepository.self().id)
+          const notificationText = assetEntity.isUserMentioned(this.selfUser().id)
             ? `${z.l10n.text(z.string.notificationMention)} ${assetEntity.text}`
             : assetEntity.text;
 
@@ -334,7 +335,7 @@ z.notification.NotificationRepository = class NotificationRepository {
    * @returns {string} Notification message body
    */
   _createBodyObfuscated(messageEntity) {
-    const isSelfMentioned = messageEntity.is_content() && messageEntity.isUserMentioned(this.userRepository.self().id);
+    const isSelfMentioned = messageEntity.is_content() && messageEntity.isUserMentioned(this.selfUser().id);
     const stringId = isSelfMentioned ? z.string.notificationObfuscatedMention : z.string.notificationObfuscated;
     return z.l10n.text(stringId);
   }
@@ -567,8 +568,7 @@ z.notification.NotificationRepository = class NotificationRepository {
   _createTrigger(messageEntity, connectionEntity, conversationEntity) {
     const conversationId = this._getConversationId(connectionEntity, conversationEntity);
 
-    const containsSelfMention =
-      messageEntity.is_content() && messageEntity.isUserMentioned(this.userRepository.self().id);
+    const containsSelfMention = messageEntity.is_content() && messageEntity.isUserMentioned(this.selfUser().id);
     if (containsSelfMention) {
       return () => amplify.publish(z.event.WebApp.CONVERSATION.SHOW, conversationEntity, messageEntity, true);
     }

--- a/app/script/notification/NotificationRepository.js
+++ b/app/script/notification/NotificationRepository.js
@@ -54,11 +54,14 @@ z.notification.NotificationRepository = class NotificationRepository {
    * @param {z.calling.CallingRepository} callingRepository - Repository for all call interactions
    * @param {z.conversation.ConversationRepository} conversationRepository - Repository for all conversation interactions
    * @param {z.permission.PermissionRepository} permissionRepository - Repository for all permission interactions
+   * @param {z.user.UserRepository} userRepository - Repository for users
    */
-  constructor(callingRepository, conversationRepository, permissionRepository) {
+  constructor(callingRepository, conversationRepository, permissionRepository, userRepository) {
     this.callingRepository = callingRepository;
     this.conversationRepository = conversationRepository;
     this.permissionRepository = permissionRepository;
+    this.userRepository = userRepository;
+
     this.logger = new z.util.Logger('z.notification.NotificationRepository', z.config.LOGGER.OPTIONS);
 
     this.notifications = [];
@@ -209,7 +212,7 @@ z.notification.NotificationRepository = class NotificationRepository {
     if (messageEntity.has_asset_text()) {
       for (const assetEntity of messageEntity.assets()) {
         if (assetEntity.is_text()) {
-          const notificationText = assetEntity.isSelfMentioned()
+          const notificationText = assetEntity.isSelfMentioned(this.userRepository.self().id)
             ? `${z.l10n.text(z.string.notificationMention)} ${assetEntity.text}`
             : assetEntity.text;
 
@@ -331,7 +334,7 @@ z.notification.NotificationRepository = class NotificationRepository {
    * @returns {string} Notification message body
    */
   _createBodyObfuscated(messageEntity) {
-    const isSelfMentioned = messageEntity.is_content() && messageEntity.isSelfMentioned();
+    const isSelfMentioned = messageEntity.is_content() && messageEntity.isSelfMentioned(this.userRepository.self().id);
     const stringId = isSelfMentioned ? z.string.notificationObfuscatedMention : z.string.notificationObfuscated;
     return z.l10n.text(stringId);
   }
@@ -564,7 +567,8 @@ z.notification.NotificationRepository = class NotificationRepository {
   _createTrigger(messageEntity, connectionEntity, conversationEntity) {
     const conversationId = this._getConversationId(connectionEntity, conversationEntity);
 
-    const containsSelfMention = messageEntity.is_content() && messageEntity.isSelfMentioned();
+    const containsSelfMention =
+      messageEntity.is_content() && messageEntity.isSelfMentioned(this.userRepository.self().id);
     if (containsSelfMention) {
       return () => amplify.publish(z.event.WebApp.CONVERSATION.SHOW, conversationEntity, messageEntity, true);
     }

--- a/app/script/util/util.js
+++ b/app/script/util/util.js
@@ -289,7 +289,7 @@ z.util.alias = {
 };
 
 // Note: We are using "Underscore.js" to escape HTML in the original message
-z.util.renderMessage = (message, mentionEntities = []) => {
+z.util.renderMessage = (message, selfId, mentionEntities = []) => {
   const createMentionHash = mention => ` @${btoa(JSON.stringify(mention)).replace(/=/g, '')}`;
   const renderMention = mentionData => {
     const elementClasses = mentionData.isSelfMentioned ? ' self-mention' : '';
@@ -311,7 +311,7 @@ z.util.renderMessage = (message, mentionEntities = []) => {
       const mentionText = message.slice(mention.startIndex, mention.startIndex + mention.length);
       const mentionKey = createMentionHash(mention);
       mentionTexts[mentionKey] = {
-        isSelfMentioned: mention.isSelfMentioned(),
+        isSelfMentioned: mention.targetsUser(selfId),
         text: mentionText,
         userId: mention.userId,
       };

--- a/test/api/TestFactory.js
+++ b/test/api/TestFactory.js
@@ -449,7 +449,8 @@ window.TestFactory.prototype.exposeNotificationActors = function() {
       TestFactory.notification_repository = new z.notification.NotificationRepository(
         TestFactory.calling_repository,
         TestFactory.conversation_repository,
-        TestFactory.permission_repository
+        TestFactory.permission_repository,
+        TestFactory.user_repository
       );
 
       return TestFactory.notification_repository;

--- a/test/unit_tests/util/UtilSpec.js
+++ b/test/unit_tests/util/UtilSpec.js
@@ -186,10 +186,7 @@ describe('z.util.renderMessage', () => {
       {
         expected:
           '<strong>salut</strong> <span class="message-mention self-mention" data-uie-name="label-self-mention"><span class="mention-at-sign">@</span>you</span> and <span class="message-mention" data-uie-name="label-other-mention" data-user-id="toi-id"><span class="mention-at-sign">@</span>toi</span>',
-        mentions: [
-          {isSelfMentioned: true, length: 4, startIndex: 10, userId: 'you-id'},
-          {length: 4, startIndex: 19, userId: 'toi-id'},
-        ],
+        mentions: [{length: 4, startIndex: 10, userId: 'self-id'}, {length: 4, startIndex: 19, userId: 'toi-id'}],
         testCase: 'displays self mentions differently',
         text: '**salut** @you and @toi',
       },
@@ -205,12 +202,11 @@ describe('z.util.renderMessage', () => {
     tests.forEach(({expected, mentions, testCase, text}) => {
       const mentionEntities = mentions.map(mention => {
         const mentionEntity = new z.message.MentionEntity(mention.startIndex, mention.length, mention.userId);
-        mentionEntity.isSelfMentioned = () => mention.isSelfMentioned;
         return mentionEntity;
       });
 
       it(testCase, () => {
-        const result = z.util.renderMessage(text, mentionEntities);
+        const result = z.util.renderMessage(text, 'self-id', mentionEntities);
         expect(result).toEqual(expected);
       });
     });


### PR DESCRIPTION
We now explicitly pass the selfUserId when we need to compare against it and not rely on previous piece of code to have set it.

This will allow us to avoid running into temporal coupling.