### PR TITLE
fix: Add new husky precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,11 @@
   "engines": {
     "yarn": ">= 1.0.0"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
   "lint-staged": {
     "*.{js,jsx}": [
       "eslint --fix",
@@ -166,7 +171,6 @@
     "fix:assets": "yarn prettier --write && yarn stylelint",
     "fix:scripts": "yarn test:scripts --fix",
     "postinstall": "grunt init",
-    "precommit": "lint-staged",
     "prettier": "prettier --ignore-path .gitignore \"**/*.{json,md}\"",
     "start": "concurrently \"yarn start:dev\" \"grunt\"",
     "start:dev": "webpack-dev-server --config webpack.config.dev.js --open",


### PR DESCRIPTION
`husky` 1.0.0 has changed the way of adding precommit hooks. See https://github.com/typicode/husky#upgrading-from-014.

Follow-up to https://github.com/wireapp/wire-web-packages/pull/1162