### PR TITLE
fix: Keep giphy sorting option

### DIFF
--- a/app/script/extension/GiphyRepository.js
+++ b/app/script/extension/GiphyRepository.js
@@ -125,12 +125,10 @@ z.extension.GiphyRepository = class GiphyRepository {
     }
 
     if (options.random) {
-      options.sorting = z.util.ArrayUtil.randomElement(['recent', 'relevant']);
-
       const total = this.gifQueryCache[options.query];
       if (total) {
         const resultExceedsTotal = options.results >= total;
-        offset = resultExceedsTotal ? 0 : Math.floor(Math.random() * total - options.number);
+        offset = resultExceedsTotal ? 0 : Math.floor(Math.random() * (total - options.number));
       }
     }
 

--- a/app/script/extension/GiphyService.js
+++ b/app/script/extension/GiphyService.js
@@ -73,7 +73,7 @@ z.extension.GiphyService = class GiphyService {
    * @param {string} options.q - Search query term or phrase
    * @param {number} [options.limit=25] - Number of results to return (maximum 100)
    * @param {number} [options.offset=0] - Results offset
-   * @param {string} [options.sorting='recent'] - Specify sorting ('relevant' or 'recent')
+   * @param {string} [options.sorting='relevant'] - Specify sorting ('relevant' or 'recent')
    * @returns {Promise} Resolves with matches
    */
   getSearch(options) {


### PR DESCRIPTION
Calling the giphy proxy with
```ts
{
  q: 'cat',
  sort: 'recent'
}
```
returns results since there are new cat GIFs every day, while
```ts
{
  q: 'elon musk weed',
  sort: 'recent'
}
```
returns no results since usually there are no recent GIFs for Elon Musk smoking weed.

I suggest we don't randomly switch the sorting so we never have an empty giphy selection window.

Related: https://github.com/wireapp/wire-desktop/issues/1748