### PR TITLE
chore: Remove “on” from device activation timestamp string

### DIFF
--- a/app/script/localization/webapp.js
+++ b/app/script/localization/webapp.js
@@ -625,7 +625,7 @@ z.string.preferencesAVTryAgain= 'Try Again';
 
 
 z.string.preferencesDevicesActivatedIn = 'in {{location}}';
-z.string.preferencesDevicesActivatedOn = 'Activated on {{date}}';
+z.string.preferencesDevicesActivatedOn = 'Activated {{date}}';
 z.string.preferencesDevicesActive = 'Active';
 z.string.preferencesDevicesActiveDetail = 'If you don’t recognize a device above, remove it and reset your password.';
 z.string.preferencesDevicesCurrent = 'Current';


### PR DESCRIPTION
This better supports relative timestamps like “just now”.
