### PR TITLE
fix: Avoid blinking when loading the textarea of a conversation

### DIFF
--- a/app/script/view_model/bindings/CommonBindings.js
+++ b/app/script/view_model/bindings/CommonBindings.js
@@ -166,7 +166,7 @@ ko.bindingHandlers.resize = {
     }).bind(null, element);
     const throttledResizeTextarea = _.throttle(resizeTextarea, 100, {leading: !params.delayedResize});
 
-    throttledResizeTextarea();
+    resizeTextarea();
     if (triggerValue === undefined) {
       return ko.applyBindingsToNode(
         element,


### PR DESCRIPTION
It's fine and better in term of UX to trigger the first resize of the textarea synchronously to avoid a blinking frame