### PR TITLE
fix: Use the shadow input as the ground truth for textarea height

### DIFF
--- a/app/page/template/content/conversation/input-bar.htm
+++ b/app/page/template/content/conversation/input-bar.htm
@@ -20,7 +20,6 @@
                              enter: onInputEnter,
                              hasFocus: hasFocus,
                              textInput: input,
-                             resize: {triggerValue: input, callback: scrollMessageList, syncElement: '.shadow-input', delayedResize: true},
                              click: onInputClick,
                              attr: {'placeholder': inputPlaceholder},
                              css: {'conversation-input-bar-text--accent': hasLocalEphemeralTimer()},
@@ -28,7 +27,10 @@
                   data-uie-name="input-message"
                   dir="auto">
         </textarea>
-        <div class="shadow-input" data-bind="html: richTextInput, scrollSync: '#conversation-input-bar-text'" data-uie-name="input-message-rich-text"></div>
+        <div class="shadow-input" data-bind="html: richTextInput,
+                                             scrollSync: '#conversation-input-bar-text',
+                                             heightSync: {target: '#conversation-input-bar-text', trigger: richTextInput, callback: scrollMessageList}"
+             data-uie-name="input-message-rich-text"></div>
       </div>
       <mention-suggestions params="suggestions: mentionSuggestions, targetInputSelector: '#conversation-input-bar-text', onSelectionValidated: addMention"></mention-suggestions>
 

--- a/app/script/view_model/bindings/CommonBindings.js
+++ b/app/script/view_model/bindings/CommonBindings.js
@@ -185,7 +185,7 @@ ko.bindingHandlers.heightSync = {
 
     // initial resize
     resizeTarget();
-    const valueSubscription = triggerValue.subscribe(resizeTarget);
+    const valueSubscription = triggerValue.subscribe(() => window.requestAnimationFrame(resizeTarget));
     ko.utils.domNodeDisposal.addDisposeCallback(element, () => valueSubscription.dispose());
   },
 };

--- a/app/style/content/conversation/input-bar.less
+++ b/app/style/content/conversation/input-bar.less
@@ -37,7 +37,6 @@
   .custom-scrollbar;
   .reset-textarea;
 
-  overflow: hidden;
   max-width: @conversation-max-width - @conversation-message-sender-width - @conversation-message-timestamp-width;
   height: @conversation-input-line-height;
   min-height: @conversation-input-line-height;
@@ -47,6 +46,8 @@
   margin-bottom: (@conversation-input-min-height - @conversation-input-line-height) / 2;
   background-color: transparent;
   line-height: @conversation-input-line-height;
+  overflow-x: hidden;
+  overflow-y: auto;
 
   &::placeholder {
     .label-xs;


### PR DESCRIPTION
This will be a game changer in term of performance.

Resizing textarea to its content is pretty expensive because the way to do that is:
- resize the textarea to 0 ;
- compute the scrollHeight (trigger a complete reflow) ;
- set the new size to the computed scrollHeight (will trigger another reflow) ;

Because the visible content is displayed by a div, which do not need any reflow to know their size, the idea is to use this div to know how to size the textarea:
- when text change, we read the height of the div (basically a free operation) ;
- if the size is different than the size of the textarea, we set the textarea with the new size.

So now we trigger a reflow (and some costy operations) **only** when a new line is added to the textarea