### PR TITLE
chore: Remove support for JSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     }
   },
   "lint-staged": {
-    "*.{js,jsx}": [
+    "*.js": [
       "eslint --fix",
       "git add"
     ],


### PR DESCRIPTION
We use TSX instead of JSX now and ESLint doesn't work for TSX, so there is no need to add TSX but also no need to keep JSX.