### PR TITLE
feat: Add caching mechanism to load image once

### DIFF
--- a/app/script/assets/AssetRemoteData.js
+++ b/app/script/assets/AssetRemoteData.js
@@ -36,6 +36,8 @@ z.assets.AssetRemoteData = class AssetRemoteData {
     this.generateUrl = undefined;
     this.identifier = undefined;
 
+    this.loadPromise = undefined;
+
     this.logger = new z.util.Logger('z.assets.AssetRemoteData', z.config.LOGGER.OPTIONS);
   }
 
@@ -112,7 +114,11 @@ z.assets.AssetRemoteData = class AssetRemoteData {
   load() {
     let type;
 
-    return this._loadBuffer()
+    if (this.loadPromise) {
+      return this.loadPromise;
+    }
+
+    this.loadPromise = this._loadBuffer()
       .then(({buffer, mimeType}) => {
         type = mimeType;
         const isEncryptedAsset = this.otrKey && this.sha256;
@@ -130,7 +136,10 @@ z.assets.AssetRemoteData = class AssetRemoteData {
         if (!isExpectedError) {
           throw error;
         }
-      });
+      })
+      .finally(() => (this.loadPromise = undefined));
+
+    return this.loadPromise;
   }
 
   _loadBuffer() {

--- a/app/script/assets/AssetRemoteData.js
+++ b/app/script/assets/AssetRemoteData.js
@@ -121,6 +121,7 @@ z.assets.AssetRemoteData = class AssetRemoteData {
     this.loadPromise = this._loadBuffer()
       .then(({buffer, mimeType}) => {
         type = mimeType;
+        this.loadPromise = undefined;
         const isEncryptedAsset = this.otrKey && this.sha256;
         return isEncryptedAsset
           ? z.assets.AssetCrypto.decryptAesAsset(buffer, this.otrKey.buffer, this.sha256.buffer)
@@ -128,6 +129,7 @@ z.assets.AssetRemoteData = class AssetRemoteData {
       })
       .then(plaintext => new Blob([new Uint8Array(plaintext)], {mime_type: type}))
       .catch(error => {
+        this.loadPromise = undefined;
         const errorMessage = (error && error.message) || '';
         const isAssetNotFound = errorMessage.endsWith(z.error.BackendClientError.STATUS_CODE.NOT_FOUND);
         const isServerError = errorMessage.endsWith(z.error.BackendClientError.STATUS_CODE.INTERNAL_SERVER_ERROR);
@@ -136,8 +138,7 @@ z.assets.AssetRemoteData = class AssetRemoteData {
         if (!isExpectedError) {
           throw error;
         }
-      })
-      .finally(() => (this.loadPromise = undefined));
+      });
 
     return this.loadPromise;
   }


### PR DESCRIPTION
I believe service worker does cache the images. But, at app's load time, we send a bunch of requests to the server (could be a lot), and I don't think service worker helps on this.... (?)