### PR TITLE
chore: Remove isEditing state from message entity

### DIFF
--- a/app/script/entity/message/Message.js
+++ b/app/script/entity/message/Message.js
@@ -72,7 +72,6 @@ z.entity.Message = class Message {
 
     this.conversation_id = '';
     this.from = '';
-    this.isEditing = ko.observable(false);
     this.primary_key = undefined;
     this.status = ko.observable(z.message.StatusType.UNSPECIFIED);
     this.type = '';

--- a/app/script/view_model/content/InputBarViewModel.js
+++ b/app/script/view_model/content/InputBarViewModel.js
@@ -355,9 +355,6 @@ z.viewModel.content.InputBarViewModel = class InputBarViewModel {
   }
 
   cancelMessageEditing() {
-    if (this.editMessageEntity()) {
-      this.editMessageEntity().isEditing(false);
-    }
     this.editMessageEntity(undefined);
     this._resetDraftState();
   }
@@ -390,7 +387,6 @@ z.viewModel.content.InputBarViewModel = class InputBarViewModel {
     if (messageEntity && messageEntity.is_editable() && messageEntity !== this.editMessageEntity()) {
       this.cancelMessageReply();
       this.cancelMessageEditing();
-      messageEntity.isEditing(true);
       this.editMessageEntity(messageEntity);
 
       this.input(messageEntity.get_first_asset().text);


### PR DESCRIPTION
As a follow-up to https://github.com/wireapp/wire-webapp/pull/5015#discussion_r229745265 @atomrc and I agreed to remove the `isEditing` state from the message entity (it was not used in any conditions anyway).