### PR TITLE
fix: Check for first client on client creation (WEBAPP-5643)

### DIFF
--- a/app/script/auth/module/action/ClientAction.ts
+++ b/app/script/auth/module/action/ClientAction.ts
@@ -63,7 +63,7 @@ export class ClientAction {
       dispatch(ClientActionCreator.startInitializeClient());
       let isFirstClient = false;
       return Promise.resolve()
-        .then(() => clientAction.doGetAllClients())
+        .then(() => dispatch(clientAction.doGetAllClients()))
         .then(clients => (isFirstClient = !clients || !clients.length))
         .then(() => core.initClient({clientType, password}, clientAction.generateClientPayload(clientType)))
         .then(creationStatus =>


### PR DESCRIPTION
Previously we checked for the presence of the password when creating a client on registration/login in order to detect if the client will be the first one of the user. This worked due to the fact that a password is only required for subsequent client creations.

With the introduction of SSO users, client creation will never require a password for this kind of users. With that the simple check for the password is not sufficient anymore. Thus an additional request to the backend is needed since we never know if the user will create an additional or a first client. 

This might not be necessary if only considering client handling within the webapp but account creations on team-settings, which happen without creating any clients, lead to the problem that at the point of a login on the webapp side we never know if there is a client or not.