### PR TITLE
fix: Catch invalid URIs on link preview generation (WEBAPP-5661)

### DIFF
--- a/app/script/links/LinkPreviewRepository.js
+++ b/app/script/links/LinkPreviewRepository.js
@@ -141,20 +141,22 @@ z.links.LinkPreviewRepository = class LinkPreviewRepository {
    */
   _fetchOpenGraphData(link) {
     return new Promise(resolve => {
-      return window.openGraph(link, (error, data) => {
-        if (error) {
-          resolve();
-        }
+      return window
+        .openGraph(link, (error, data) => {
+          if (error) {
+            resolve();
+          }
 
-        if (data) {
-          data = Object.entries(data).reduce((filteredData, [key, value]) => {
-            filteredData[key] = Array.isArray(value) ? value[0] : value;
-            return filteredData;
-          }, {});
-        }
+          if (data) {
+            data = Object.entries(data).reduce((filteredData, [key, value]) => {
+              filteredData[key] = Array.isArray(value) ? value[0] : value;
+              return filteredData;
+            }, {});
+          }
 
-        resolve(data);
-      });
+          resolve(data);
+        })
+        .catch(resolve);
     });
   }
 

--- a/test/unit_tests/links/LinkPreviewRepositorySpec.js
+++ b/test/unit_tests/links/LinkPreviewRepositorySpec.js
@@ -19,6 +19,7 @@
 
 'use strict';
 
+// grunt test_init && grunt test_run:links/LinkPreviewRepository
 describe('z.links.LinkPreviewRepository', () => {
   let link_preview_repository = null;
 
@@ -87,9 +88,7 @@ describe('z.links.LinkPreviewRepository', () => {
     });
 
     it('catches errors that are raised by the openGraph lib when invalid URIs are parsed', done => {
-      window.openGraph = function() {
-        return Promise.reject(new Error('Invalid URI'));
-      };
+      window.openGraph = () => Promise.reject(new Error('Invalid URI'));
 
       const invalidUrl = 'http:////api/apikey';
       link_preview_repository

--- a/test/unit_tests/links/LinkPreviewRepositorySpec.js
+++ b/test/unit_tests/links/LinkPreviewRepositorySpec.js
@@ -27,16 +27,32 @@ describe('z.links.LinkPreviewRepository', () => {
     link_preview_repository = new z.links.LinkPreviewRepository(undefined, properties_repository);
   });
 
-  afterEach(() => {
-    window.openGraph = undefined;
-  });
+  afterEach(() => (window.openGraph = undefined));
+
+  function mockSucceedingOpenGraph() {
+    return (url, callback) => {
+      return Promise.resolve()
+        .then(meta => {
+          if (callback) {
+            callback(null, meta);
+          }
+
+          return meta;
+        })
+        .catch(error => {
+          if (callback) {
+            callback(error);
+          }
+
+          throw error;
+        });
+    };
+  }
 
   describe('getLinkPreview', () => {
-    beforeEach(() => {
-      spyOn(link_preview_repository, '_fetchOpenGraphData').and.returnValue(Promise.resolve());
-    });
+    it('rejects if openGraph lib is not available', done => {
+      window.openGraph = undefined;
 
-    it('should reject if open graph lib is not available', done => {
       link_preview_repository
         .getLinkPreview()
         .then(done.fail)
@@ -46,27 +62,41 @@ describe('z.links.LinkPreviewRepository', () => {
         });
     });
 
-    it('should fetch open graph data if openGraph lib is available', done => {
-      window.openGraph = {};
+    it('fetches open graph data if openGraph lib is available', done => {
+      window.openGraph = mockSucceedingOpenGraph();
 
       link_preview_repository
-        .getLinkPreview()
+        .getLinkPreview('https://app.wire.com/')
         .then(done.fail)
         .catch(error => {
-          expect(link_preview_repository._fetchOpenGraphData).toHaveBeenCalled();
           expect(error.type).toBe(z.error.LinkPreviewError.TYPE.NO_DATA_AVAILABLE);
           done();
         });
     });
 
-    it('should reject if link is blacklisted', done => {
-      window.openGraph = {};
+    it('rejects if a link is blacklisted', done => {
+      window.openGraph = mockSucceedingOpenGraph();
 
       link_preview_repository
         .getLinkPreview('youtube.com')
         .then(done.fail)
         .catch(error => {
           expect(error.type).toBe(z.error.LinkPreviewError.TYPE.BLACKLISTED);
+          done();
+        });
+    });
+
+    it('catches errors that are raised by the openGraph lib when invalid URIs are parsed', done => {
+      window.openGraph = function() {
+        return Promise.reject(new Error('Invalid URI'));
+      };
+
+      const invalidUrl = 'http:////api/apikey';
+      link_preview_repository
+        .getLinkPreview(invalidUrl)
+        .then(done.fail)
+        .catch(error => {
+          expect(error.type).toBe(z.error.LinkPreviewError.TYPE.UNSUPPORTED_TYPE);
           done();
         });
     });


### PR DESCRIPTION
Our wrappers can generate link previews. To make this work, the wrapper exposes an open graph library to the `window.openGraph` namespace. This library is then being used from the webapp code when calling `wire.app.repository.links.getLinkPreview` which calls the underlying `_fetchOpenGraphData` function.

In some cases (for example when entering an invalid URI), the `window.openGraph` library (which uses a Promise interface) throws an error but we never catched that error inside of `_fetchOpenGraphData`. Now we do.

This addresses the following crash report:
- https://app.raygun.com/crashreporting/8785p7/errors/3014612384
