### PR TITLE
fix: Improve extra messages loading behavior (WEBAPP-5621)

### DIFF
--- a/app/page/template/content/conversation/message-list.htm
+++ b/app/page/template/content/conversation/message-list.htm
@@ -1,5 +1,5 @@
  <div id="message-list" class="message-list" data-bind="with: $root.messageList, show_all_timestamps: true">
-   <div class="messages-wrap" data-bind="antiscroll, event: {scroll: on_scroll}">
+   <div class="messages-wrap" data-bind="antiscroll, event: {mousewheel: onMouseWheel, scroll: onScroll}">
      <div class="messages"
           data-bind="css: {'flex-center': verticallyCenterMessage},
                      foreach: {data: conversation().messages_visible, as: 'message'}">

--- a/app/script/view_model/content/MessageListViewModel.js
+++ b/app/script/view_model/content/MessageListViewModel.js
@@ -116,7 +116,9 @@ z.viewModel.content.MessageListViewModel = class MessageListViewModel {
 
       if (hitTop) {
         return this._loadPrecedingMessages();
-      } else if (hitBottom) {
+      }
+
+      if (hitBottom) {
         this._loadFollowingMessages().then(() => {
           this._mark_conversation_as_read_on_focus(this.conversation());
         });

--- a/app/script/view_model/content/MessageListViewModel.js
+++ b/app/script/view_model/content/MessageListViewModel.js
@@ -117,8 +117,9 @@ z.viewModel.content.MessageListViewModel = class MessageListViewModel {
       if (hitTop) {
         return this._loadPrecedingMessages();
       } else if (hitBottom) {
-        this._loadFollowingMessages();
-        this._mark_conversation_as_read_on_focus(this.conversation());
+        this._loadFollowingMessages().then(() => {
+          this._mark_conversation_as_read_on_focus(this.conversation());
+        });
       }
     }, 100);
 


### PR DESCRIPTION
This PR changes the scroll behavior quite a bit.

The basic idea is:

- if the container is not scrollable (the content is smaller than the container), then the `mousewheel` event handles loading the messages depending on the direction the user wants to scroll.
- if the container is scrollable, we just load messages depending on whether we hit the top of the bottom of the message list