### PR TITLE
runfix: Convert message timestamp to seconds before hashing

### DIFF
--- a/app/script/message/MessageHasher.js
+++ b/app/script/message/MessageHasher.js
@@ -64,7 +64,11 @@ z.message.MessageHasher = (() => {
    * @returns {number[]} the timestamp as long endian bytes
    * @private
    */
-  const getTimestampBytes = event => Long.fromInt(new Date(event.time).getTime()).toBytesBE();
+  const getTimestampBytes = event => {
+    const unixTimestamp = new Date(event.time).getTime();
+    const timestampSeconds = Math.floor(unixTimestamp / 1e3);
+    return Long.fromInt(timestampSeconds).toBytesBE();
+  };
 
   const getTextBytes = event => z.util.StringUtil.utf8ToUtf16BE(event.data.content);
 

--- a/test/unit_tests/message/MessageHasherSpec.js
+++ b/test/unit_tests/message/MessageHasherSpec.js
@@ -37,19 +37,19 @@ describe('z.message.MessageHasher', () => {
       it('correctly hashes text events', () => {
         const tests = [
           {
-            event: createTextEvent('This has **markdown**', 1540213965),
+            event: createTextEvent('This has **markdown**', 1540213965000),
             expectedHashValue: 'f25a925d55116800e66872d2a82d8292adf1d4177195703f976bc884d32b5c94',
           },
           {
-            event: createTextEvent('بغداد', 1540213965),
+            event: createTextEvent('بغداد', 1540213965000),
             expectedHashValue: '5830012f6f14c031bf21aded5b07af6e2d02d01074f137d106d4645e4dc539ca',
           },
           {
-            event: createTextEvent('Hello 👩‍💻👨‍👩‍👧!', 1540213769),
+            event: createTextEvent('Hello 👩‍💻👨‍👩‍👧!', 1540213769000),
             expectedHashValue: '4f8ee55a8b71a7eb7447301d1bd0c8429971583b15a91594b45dee16f208afd5',
           },
           {
-            event: createTextEvent('https://www.youtube.com/watch?v=DLzxrzFCyOs', 1540213769),
+            event: createTextEvent('https://www.youtube.com/watch?v=DLzxrzFCyOs', 1540213769000),
             expectedHashValue: 'ef39934807203191c404ebb3acba0d33ec9dce669f9acec49710d520c365b657',
           },
         ];
@@ -70,12 +70,12 @@ describe('z.message.MessageHasher', () => {
       it('correctly hashes location events', () => {
         const tests = [
           {
-            event: createLocationEvent(52.5166667, 13.4, 1540213769),
+            event: createLocationEvent(52.5166667, 13.4, 1540213769000),
             expectedHashValue: '56a5fa30081bc16688574fdfbbe96c2eee004d1fb37dc714eec6efb340192816',
           },
 
           {
-            event: createLocationEvent(51.509143, -0.117277, 1540213769),
+            event: createLocationEvent(51.509143, -0.117277, 1540213769000),
             expectedHashValue: '803b2698104f58772dbd715ec6ee5853d835df98a4736742b2a676b2217c9499',
           },
         ];
@@ -96,22 +96,22 @@ describe('z.message.MessageHasher', () => {
       it('correctly hashes asset events', () => {
         const tests = [
           {
-            event: createAssetEvent('3-2-1-38d4f5b9', 1540213769),
+            event: createAssetEvent('3-2-1-38d4f5b9', 1540213769000),
             expectedHashValue: 'bf20de149847ae999775b3cc88e5ff0c0382e9fa67b9d382b1702920b8afa1de',
           },
 
           {
-            event: createAssetEvent('3-3-3-82a62735', 1540213965),
+            event: createAssetEvent('3-3-3-82a62735', 1540213965000),
             expectedHashValue: '2235f5b6c00d9b0917675399d0314c8401f0525457b00aa54a38998ab93b90d6',
           },
 
           {
-            event: createAssetEvent('3-2-1-38d4f5b9', 1540213769),
+            event: createAssetEvent('3-2-1-38d4f5b9', 1540213769000),
             expectedHashValue: 'bf20de149847ae999775b3cc88e5ff0c0382e9fa67b9d382b1702920b8afa1de',
           },
 
           {
-            event: createAssetEvent('3-3-3-82a62735', 1540213965),
+            event: createAssetEvent('3-3-3-82a62735', 1540213965000),
             expectedHashValue: '2235f5b6c00d9b0917675399d0314c8401f0525457b00aa54a38998ab93b90d6',
           },
         ];


### PR DESCRIPTION
Internally we use milliseconds for the event date, but all teams agreed to use seconds for hashing.