### PR TITLE
runfix: Return original event if no quote found

### DIFF
--- a/app/script/event/preprocessor/QuotedMessageMiddleware.js
+++ b/app/script/event/preprocessor/QuotedMessageMiddleware.js
@@ -76,6 +76,10 @@ z.event.preprocessor.QuotedMessageMiddleware = class QuotedMessageMiddleware {
   _handleEditEvent(event) {
     const originalMessageId = event.data.replacing_message_id;
     return this._findRepliesToMessage(event.conversation, originalMessageId).then(({originalEvent, replies}) => {
+      if (!originalEvent) {
+        return event;
+      }
+
       this.logger.info(`Updating '${replies.length}' replies to updated message '${originalMessageId}'`);
 
       replies.forEach(reply => {
@@ -139,7 +143,9 @@ z.event.preprocessor.QuotedMessageMiddleware = class QuotedMessageMiddleware {
   _findRepliesToMessage(conversationId, messageId) {
     return this.eventService.loadEvent(conversationId, messageId).then(originalEvent => {
       if (!originalEvent) {
-        return [];
+        return {
+          replies: [],
+        };
       }
       return this.eventService
         .loadEventsReplyingToMessage(conversationId, messageId, originalEvent.time)


### PR DESCRIPTION
When receiving an `edit` message for a non-existing original message an error was thrown because of a wrong return value. The return value was corrected and the correct warning fallback will appear instead.