### PR TITLE
fix: Modals sometimes wouldn't be removed from view (WEBAPP-5709)

### DIFF
--- a/app/page/template/_dist/app.htm
+++ b/app/page/template/_dist/app.htm
@@ -444,6 +444,7 @@
 <!-- View -->
 <script src="/script/ui/AvailabilityContextMenu.js"></script>
 <script src="/script/ui/ContextMenu.js"></script>
+<script src="/script/ui/Modal.js"></script>
 <script src="/script/ui/OverlayedObserver.js"></script>
 <script src="/script/ui/ShortcutType.js"></script>
 <script src="/script/ui/Shortcut.js"></script>

--- a/app/page/template/_dist/component.htm
+++ b/app/page/template/_dist/component.htm
@@ -1,5 +1,4 @@
 <!-- Components -->
 <script src="/ext/js/webapp-module-namespace/Namespace.js"></script>
 <script src="/ext/js/webapp-module-bubble/webapp-module-bubble.js"></script>
-<script src="/ext/js/webapp-module-modal/webapp-module-modal.js"></script>
 <script src="/ext/js/webapp-module-logger/Logger.js"></script>

--- a/app/script/ui/Modal.js
+++ b/app/script/ui/Modal.js
@@ -39,11 +39,9 @@ z.ui.Modal = class Modal {
     this.beforeHideCallback = beforeHideCallback;
 
     this.autoclose = true;
-    this.initExits();
-  }
 
-  initExits() {
     keyboardJS.bind('esc', this._hide);
+
     if (this.modal) {
       this.modal.addEventListener('click', this.handleClick);
     }

--- a/app/script/ui/Modal.js
+++ b/app/script/ui/Modal.js
@@ -1,0 +1,131 @@
+/*
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+'use strict';
+
+window.z = window.z || {};
+window.z.ui = z.ui || {};
+
+z.ui.Modal = class Modal {
+  static get CLASS() {
+    return {
+      FADE_IN: 'modal-fadein',
+      SHOW: 'modal-show',
+    };
+  }
+
+  constructor(modal, hideCallback, beforeHideCallback) {
+    this._hide = this._hide.bind(this);
+    this.handleClick = this.handleClick.bind(this);
+
+    this.modal = typeof modal === 'string' ? document.querySelector(modal) : modal;
+    this.hideCallback = hideCallback;
+    this.beforeHideCallback = beforeHideCallback;
+
+    this.autoclose = true;
+    this.initExits();
+  }
+
+  initExits() {
+    keyboardJS.bind('esc', this._hide);
+    if (this.modal) {
+      this.modal.addEventListener('click', this.handleClick);
+    }
+  }
+
+  handleClick(event) {
+    if (event.target === this.modal) {
+      this._hide();
+    }
+  }
+
+  _hide() {
+    if (this.autoclose) {
+      this.hide();
+    }
+  }
+
+  show() {
+    if (this.modal) {
+      this.modal.classList.add(Modal.CLASS.SHOW);
+      setTimeout(() => this.modal.classList.add(Modal.CLASS.FADE_IN), 50);
+    }
+  }
+
+  hide(callback) {
+    this.callOptional(this.beforeHideCallback);
+
+    if (this.modal) {
+      this.modal.classList.remove(Modal.CLASS.FADE_IN);
+      const transitionendPromise = new Promise(resolve => this.modal.addEventListener('transitionend', resolve));
+      const timeoutPromise = new Promise(resolve => {
+        const {transitionDelay, transitionDuration} = getComputedStyle(this.modal, '::before');
+
+        const delays = transitionDelay.split(',').map(parseFloat);
+        const durations = transitionDuration.split(',').map(parseFloat);
+
+        const totals = delays.map((delay, index) => delay + durations[index]);
+        const longestDelay = Math.max(...totals);
+
+        setTimeout(resolve, longestDelay * 1000);
+      });
+
+      Promise.race([transitionendPromise, timeoutPromise]).then(() => {
+        if (this.modal) {
+          this.modal.classList.remove(Modal.CLASS.SHOW);
+        }
+        this.callOptional(this.hideCallback);
+        this.callOptional(callback);
+      });
+    }
+  }
+
+  callOptional(fn) {
+    if (typeof fn === 'function') {
+      return fn();
+    }
+  }
+
+  toggle() {
+    if (this.isShown()) {
+      this.hide();
+    } else {
+      this.show();
+    }
+  }
+
+  isShown() {
+    return !!this.modal && this.modal.classList.contains(Modal.CLASS.SHOW);
+  }
+
+  isHidden() {
+    return !this.isShown();
+  }
+
+  setAutoclose(autoclose) {
+    this.autoclose = autoclose;
+  }
+
+  destroy() {
+    if (this.modal) {
+      this.modal.removeEventListener('click', this.handleClick);
+    }
+    keyboardJS.unbind('esc', this._hide);
+  }
+};

--- a/app/script/view_model/AuthViewModel.js
+++ b/app/script/view_model/AuthViewModel.js
@@ -741,7 +741,7 @@ z.viewModel.AuthViewModel = class AuthViewModel {
           break;
 
         case z.auth.AuthView.MODE.LIMIT:
-          if (!this.device_modal || this.device_modal.is_hidden()) {
+          if (!this.device_modal || this.device_modal.isHidden()) {
             this.clicked_on_manage_devices();
           }
           break;
@@ -824,11 +824,11 @@ z.viewModel.AuthViewModel = class AuthViewModel {
   clicked_on_manage_devices() {
     if (!this.device_modal) {
       const hideCallback = $(document).off('keydown.deviceModal');
-      this.device_modal = new zeta.webapp.module.Modal('#modal-limit', hideCallback);
+      this.device_modal = new z.ui.Modal('#modal-limit', hideCallback);
       this.device_modal.autoclose = false;
     }
 
-    if (this.device_modal.is_hidden()) {
+    if (this.device_modal.isHidden()) {
       this.client_repository.getClientsForSelf();
       $(document).on('keydown.deviceModal', keyboard_event => {
         if (z.util.KeyboardUtil.isEscapeKey(keyboard_event)) {

--- a/app/script/view_model/AuthViewModel.js
+++ b/app/script/view_model/AuthViewModel.js
@@ -825,7 +825,7 @@ z.viewModel.AuthViewModel = class AuthViewModel {
     if (!this.device_modal) {
       const hideCallback = $(document).off('keydown.deviceModal');
       this.device_modal = new z.ui.Modal('#modal-limit', hideCallback);
-      this.device_modal.autoclose = false;
+      this.device_modal.setAutoclose(false);
     }
 
     if (this.device_modal.isHidden()) {

--- a/app/script/view_model/ImageDetailViewViewModel.js
+++ b/app/script/view_model/ImageDetailViewViewModel.js
@@ -89,7 +89,7 @@ z.viewModel.ImageDetailViewViewModel = class ImageDetailViewViewModel {
     amplify.subscribe(z.event.WebApp.CONVERSATION.MESSAGE.REMOVED, this.messageRemoved);
 
     if (!this.imageModal) {
-      this.imageModal = new zeta.webapp.module.Modal('#detail-view', this.hideCallback, this.beforeHideCallback);
+      this.imageModal = new z.ui.Modal('#detail-view', this.hideCallback, this.beforeHideCallback);
     }
 
     this.imageModal.show();

--- a/app/script/view_model/ModalsViewModel.js
+++ b/app/script/view_model/ModalsViewModel.js
@@ -82,7 +82,7 @@ z.viewModel.ModalsViewModel = class ModalsViewModel {
     }
 
     const {preventClose = false, action: actionFn, close: closeFn, secondary: secondaryFn} = options;
-    const modal = new zeta.webapp.module.Modal(type, null, () => {
+    const modal = new z.ui.Modal(type, null, () => {
       $(type)
         .find('.modal-close')
         .off('click');
@@ -138,7 +138,7 @@ z.viewModel.ModalsViewModel = class ModalsViewModel {
         modal.hide();
       });
 
-    if (!modal.is_shown()) {
+    if (!modal.isShown()) {
       this.logger.info(`Show modal of type '${type}'`);
     }
 

--- a/app/script/view_model/ModalsViewModel.js
+++ b/app/script/view_model/ModalsViewModel.js
@@ -142,7 +142,7 @@ z.viewModel.ModalsViewModel = class ModalsViewModel {
       this.logger.info(`Show modal of type '${type}'`);
     }
 
-    modal.autoclose = !preventClose;
+    modal.setAutoclose(!preventClose);
     modal.toggle();
   }
 

--- a/app/script/view_model/content/GiphyViewModel.js
+++ b/app/script/view_model/content/GiphyViewModel.js
@@ -141,7 +141,7 @@ z.viewModel.content.GiphyViewModel = class GiphyViewModel {
     this._getRandomGif();
 
     if (!this.modal) {
-      this.modal = new zeta.webapp.module.Modal('#giphy-modal');
+      this.modal = new z.ui.Modal('#giphy-modal');
     }
 
     this.modal.show();

--- a/app/script/view_model/content/GroupCreationViewModel.js
+++ b/app/script/view_model/content/GroupCreationViewModel.js
@@ -125,7 +125,7 @@ z.viewModel.content.GroupCreationViewModel = class GroupCreationViewModel {
 
     if (!this.modal) {
       this.modal = new z.ui.Modal('#group-creation-modal', this._afterHideModal.bind(this));
-      this.modal.autoclose = false;
+      this.modal.setAutoclose(false);
     }
 
     this.state(GroupCreationViewModel.STATE.PREFERENCES);

--- a/app/script/view_model/content/GroupCreationViewModel.js
+++ b/app/script/view_model/content/GroupCreationViewModel.js
@@ -124,7 +124,7 @@ z.viewModel.content.GroupCreationViewModel = class GroupCreationViewModel {
     this.method = method;
 
     if (!this.modal) {
-      this.modal = new zeta.webapp.module.Modal('#group-creation-modal', this._afterHideModal.bind(this));
+      this.modal = new z.ui.Modal('#group-creation-modal', this._afterHideModal.bind(this));
       this.modal.autoclose = false;
     }
 

--- a/app/style/auth/auth.less
+++ b/app/style/auth/auth.less
@@ -19,7 +19,6 @@
 
 @import (less) 'ext/css/normalize-css/normalize.css';
 @import (less) '../fonts/zeta-neue.css';
-@import 'ext/less/webapp-module-modal/webapp-module-modal';
 @import 'ext/less/wire-theme/wire-theme';
 
 @import '../common/accent-color';

--- a/app/style/common/modal.less
+++ b/app/style/common/modal.less
@@ -18,12 +18,36 @@
  */
 
 .modal {
+  position: fixed;
   z-index: @z-index-modal;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
   overflow-x: hidden;
   overflow-y: auto;
 
+  &.modal-show {
+    display: flex;
+  }
+
   &::before {
     position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background-color: fade(#000, 64%);
+
+    content: ' ';
+    opacity: 0;
+    transition-delay: 0.35s;
+    transition-duration: 0.55s;
+    transition-property: opacity;
+    transition-timing-function: @ease-out-quart;
   }
 
   .modal-header {
@@ -32,12 +56,31 @@
     }
   }
 
+  &.modal-fadein {
+    &:before {
+      opacity: 1;
+      transition-delay: 0s;
+      transition-duration: 0.35s;
+      transition-property: opacity;
+      transition-timing-function: @ease-out-quart;
+    }
+
+    .modal-content {
+      .modal-content-anim-open();
+    }
+  }
+
   .modal-content {
+    .modal-content-anim-close();
     position: relative;
+    display: block;
+    overflow: hidden;
     width: 384px;
     padding: @modal-padding;
     margin: auto; // http://stackoverflow.com/questions/24538100/issue-when-centering-vertically-with-flexbox-when-heights-are-unknown
-    cursor: default;
+    
+    background-color: #fff;
+    border-radius: 4px;cursor: default;
 
     a.close {
       position: absolute;
@@ -168,4 +211,23 @@
   & div:nth-child(even) {
     margin-bottom: 16px;
   }
+}
+
+// mixings
+.modal-content-anim-close {
+  opacity: 0;
+  transform: scale(0.88);
+  transition-delay: 0s, 0s;
+  transition-duration: 0.35s, 0.35s;
+  transition-property: transform, opacity;
+  transition-timing-function: @ease-in-expo, @ease-in-expo;
+}
+
+.modal-content-anim-open {
+  opacity: 1;
+  transform: scale(1);
+  transition-delay: 0.15s, 0.15s;
+  transition-duration: 0.55s, 0.55s;
+  transition-property: transform, opacity;
+  transition-timing-function: @ease-out-expo, @ease-out-expo;
 }

--- a/app/style/main.less
+++ b/app/style/main.less
@@ -25,7 +25,6 @@
 @import (less) 'fonts/zeta-neue.css';
 
 @import 'ext/less/webapp-module-bubble/webapp-module-bubble';
-@import 'ext/less/webapp-module-modal/webapp-module-modal';
 @import 'ext/less/wire-theme/wire-theme';
 
 @import 'common/accent-color';

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@bower_components/uuid": "LiosK/UUID.js#v4.0.3",
     "@bower_components/webapp-module-bubble": "wireapp/webapp-module-bubble#1.1.1",
     "@bower_components/webapp-module-logger": "wireapp/webapp-module-logger#v1.1.2",
-    "@bower_components/webapp-module-modal": "wireapp/webapp-module-modal#v1.0.2",
     "@bower_components/webapp-module-namespace": "wireapp/webapp-module-namespace#1.0.2",
     "@bower_components/webrtc-adapter": "webrtcHacks/adapter#v6.4.4",
     "@bower_components/wire-audio-files": "wireapp/wire-audio-files#v1.1.1",
@@ -347,10 +346,6 @@
     },
     "@bower_components/webapp-module-logger": {
       "js": "dist/js/Logger.js"
-    },
-    "@bower_components/webapp-module-modal": {
-      "js": "dist/script/*.js",
-      "less": "app/style/webapp-module-modal.less"
     },
     "@bower_components/webapp-module-namespace": {
       "js": "js/*.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -999,7 +999,6 @@
 
 "@bower_components/raygun4js@MindscapeHQ/raygun4js#v2.13.2":
   version "2.13.2"
-  uid "3a240172d66d70cc406437cee1c19fea0ae63c26"
   resolved "https://codeload.github.com/MindscapeHQ/raygun4js/tar.gz/3a240172d66d70cc406437cee1c19fea0ae63c26"
 
 "@bower_components/speakingurl@pid/speakingurl#v14.0.1":
@@ -1031,10 +1030,6 @@
 "@bower_components/webapp-module-logger@wireapp/webapp-module-logger#v1.1.2":
   version "1.1.2"
   resolved "https://codeload.github.com/wireapp/webapp-module-logger/tar.gz/2281c01352a515f88316962817badb4e9767e273"
-
-"@bower_components/webapp-module-modal@wireapp/webapp-module-modal#v1.0.2":
-  version "1.0.2"
-  resolved "https://codeload.github.com/wireapp/webapp-module-modal/tar.gz/9d7d42fb87cbc679989a842b55461df2600a6f44"
 
 "@bower_components/webapp-module-namespace@wireapp/webapp-module-namespace#1.0.2":
   version "1.0.2"


### PR DESCRIPTION
With this PR the external dependency to the modal module is removed.
It is now written is es6 rather than coffee script and introduces an additional callback for the end of the hiding transition as the `transitionend` event might not fire under rare circumstances.