### PR TITLE
fix: Link embedding

### DIFF
--- a/app/script/links/LinkPreviewBlackList.js
+++ b/app/script/links/LinkPreviewBlackList.js
@@ -30,6 +30,7 @@ z.links.LinkPreviewBlackList = (() => {
     'discover',
     'discussion',
     'featured',
+    'home',
     'messages',
     'mobile',
     'pages',
@@ -46,7 +47,7 @@ z.links.LinkPreviewBlackList = (() => {
     `soundcloud.com/(?!(${soundcloudStatic.join('|')}))`,
     'spotify.com/(?![A-z]{2}/)',
     'youtu.be',
-    'youtube(-nocookie)?.com/watch',
+    'youtube(-nocookie)?.com/(watch|embed)',
     'vimeo.com/(channels(/[^/]+)?/)?[0-9]+',
   ];
 

--- a/app/script/links/LinkPreviewBlackList.js
+++ b/app/script/links/LinkPreviewBlackList.js
@@ -23,7 +23,7 @@ window.z = window.z || {};
 window.z.links = z.links || {};
 
 z.links.LinkPreviewBlackList = (() => {
-  const soundcloudStatic = [
+  const soundCloudStatic = [
     'about',
     'channels',
     'charts',
@@ -44,7 +44,7 @@ z.links.LinkPreviewBlackList = (() => {
     'you',
   ];
   const BLACKLIST = [
-    `soundcloud.com/(?!${soundcloudStatic.join('|')})`,
+    `soundcloud.com/(?!${soundCloudStatic.join('|')})`,
     'spotify.com/(?!\\w\\w/)',
     'youtu.be',
     'youtube(-nocookie)?.com/(watch|embed)',

--- a/app/script/links/LinkPreviewBlackList.js
+++ b/app/script/links/LinkPreviewBlackList.js
@@ -44,11 +44,11 @@ z.links.LinkPreviewBlackList = (() => {
     'you',
   ];
   const BLACKLIST = [
-    `soundcloud.com/(?!(${soundcloudStatic.join('|')}))`,
-    'spotify.com/(?![A-z]{2}/)',
+    `soundcloud.com/(?!${soundcloudStatic.join('|')})`,
+    'spotify.com/(?!\\w\\w/)',
     'youtu.be',
     'youtube(-nocookie)?.com/(watch|embed)',
-    'vimeo.com/(channels(/[^/]+)?/|video/)?[0-9]+',
+    'vimeo.com/(channels/[^/]+/|video/)?[0-9]+',
   ];
 
   return {

--- a/app/script/links/LinkPreviewBlackList.js
+++ b/app/script/links/LinkPreviewBlackList.js
@@ -23,9 +23,34 @@ window.z = window.z || {};
 window.z.links = z.links || {};
 
 z.links.LinkPreviewBlackList = (() => {
-  const BLACKLIST = ['soundcloud', 'spotify', 'youtu[.]?be', 'vimeo'];
+  const soundcloudStatic = [
+    'about',
+    'channels',
+    'charts',
+    'discover',
+    'discussion',
+    'featured',
+    'messages',
+    'mobile',
+    'pages',
+    'playlists',
+    'sets',
+    'settings',
+    'stream',
+    'terms-of-use',
+    'upload',
+    'videos',
+    'you',
+  ];
+  const BLACKLIST = [
+    `soundcloud.com/(?!(${soundcloudStatic.join('|')}))`,
+    'spotify.com/(?![A-z]{2}/)',
+    'youtu.be',
+    'youtube(-nocookie)?.com/watch',
+    'vimeo.com/(channels(/[^/]+)?/)?[0-9]+',
+  ];
 
   return {
-    isBlacklisted: url => RegExp(BLACKLIST.join('|')).test(url),
+    isBlacklisted: url => new RegExp(BLACKLIST.join('|')).test(url),
   };
 })();

--- a/app/script/links/LinkPreviewBlackList.js
+++ b/app/script/links/LinkPreviewBlackList.js
@@ -48,7 +48,7 @@ z.links.LinkPreviewBlackList = (() => {
     'spotify.com/(?![A-z]{2}/)',
     'youtu.be',
     'youtube(-nocookie)?.com/(watch|embed)',
-    'vimeo.com/(channels(/[^/]+)?/)?[0-9]+',
+    'vimeo.com/(channels(/[^/]+)?/|video/)?[0-9]+',
   ];
 
   return {

--- a/app/script/media/MediaEmbeds.js
+++ b/app/script/media/MediaEmbeds.js
@@ -70,8 +70,8 @@ z.media.MediaEmbeds = (function() {
     // example: http://regexr.com/3ase5
     soundcloud: /(https?:\/\/(?:www\.|m\.)?)?soundcloud\.com(\/[\w-]+){2,3}/g,
     spotify: /https?:\/\/(?:play\.|open\.)*spotify\.com\/([^?]+)/g,
-    vimeo: /https?:\/\/(?:vimeo\.com\/|player\.vimeo\.com\/)(?:video\/|(?:channels\/staffpicks\/|channels\/)|)((\w|-){7,9})/g,
-    youtube: /(?:youtube(?:-nocookie|)\.com\/\S*(?:(?:\/e(?:mbed))?\/|watch\/?\?(?:\S*?&?v=))|youtu\.be\/)([a-zA-Z0-9_-]{6,11})/g,
+    vimeo: /https?:\/\/(?:(?:player\.)?vimeo\.com\/)(?:channels(?:\/[^/]+)?\/)?([0-9]+)/g,
+    youtube: /(?:youtube(?:-nocookie)?\.com\/\S*(?:(?:\/e(?:mbed))?\/|watch\/?\?(?:\S*?&?v=))|youtu\.be\/)([a-zA-Z0-9_-]{6,11})/g,
   };
 
   /**
@@ -260,10 +260,6 @@ z.media.MediaEmbeds = (function() {
       const vimeoColor = themeColor ? themeColor.replace('#', '') : undefined;
 
       if (linkSrc.match(_regex.vimeo)) {
-        if (z.util.StringUtil.includes(linkSrc, '/user')) {
-          return message;
-        }
-
         const iframe = _createIframeContainer({
           src: `https://player.vimeo.com/video/$1?portrait=0&color=${vimeoColor}&badge=0`,
           type: 'vimeo',

--- a/app/script/media/MediaEmbeds.js
+++ b/app/script/media/MediaEmbeds.js
@@ -70,7 +70,7 @@ z.media.MediaEmbeds = (function() {
     // example: http://regexr.com/3ase5
     soundcloud: /(https?:\/\/(?:www\.|m\.)?)?soundcloud\.com(\/[\w-]+){2,3}/g,
     spotify: /https?:\/\/(?:play\.|open\.)*spotify\.com\/([^?]+)/g,
-    vimeo: /https?:\/\/(?:(?:player\.)?vimeo\.com\/)(?:channels(?:\/[^/]+)?\/)?([0-9]+)/g,
+    vimeo: /https?:\/\/(?:(?:player\.)?vimeo\.com\/)(?:channels(?:\/[^/]+)?\/|video\/)?([0-9]+)/g,
     youtube: /(?:youtube(?:-nocookie)?\.com\/\S*(?:(?:\/e(?:mbed))?\/|watch\/?\?(?:\S*?&?v=))|youtu\.be\/)([a-zA-Z0-9_-]{6,11})/g,
   };
 

--- a/test/unit_tests/links/LinkPreviewBlackListSpec.js
+++ b/test/unit_tests/links/LinkPreviewBlackListSpec.js
@@ -70,6 +70,12 @@ describe('is_blacklisted', () => {
     expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(true);
   });
 
+  it('should return true if link is Vimeo embed', () => {
+    const url = 'https://player.vimeo.com/video/27999954';
+
+    expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(true);
+  });
+
   it('should return false if link is Vimeo static', () => {
     const url = 'https://vimeo.com/upload';
 

--- a/test/unit_tests/links/LinkPreviewBlackListSpec.js
+++ b/test/unit_tests/links/LinkPreviewBlackListSpec.js
@@ -25,36 +25,60 @@ describe('is_blacklisted', () => {
   it('should return true if link is youtu.be', () => {
     const url = 'https://youtu.be/t4gjl-uwUHc';
 
-    expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBeTruthy();
+    expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(true);
   });
 
-  it('should return true if link is youtube', () => {
+  it('should return true if link is YouTube', () => {
     const url = 'https://www.youtube.com/watch?v=t4gjl-uwUHc';
 
-    expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBeTruthy();
+    expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(true);
   });
 
-  it('should return true if link is spotify', () => {
-    const url = 'spotify.com';
+  it('should return false if link is YouTube static', () => {
+    const url = 'https://www.youtube.com/account';
 
-    expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBeTruthy();
+    expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(false);
   });
 
-  it('should return true if link is soundcloud', () => {
-    const url = 'soundcloud.com';
+  it('should return true if link is Spotify', () => {
+    const url = 'https://play.spotify.com/artist/7Ln80lUS6He07XvHI8qqHH/';
 
-    expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBeTruthy();
+    expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(true);
   });
 
-  it('should return true if link is vimeo', () => {
-    const url = 'vimeo.com';
+  it('should return false if link is Spotify static', () => {
+    const url = 'https://www.spotify.com/en/legal';
 
-    expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBeTruthy();
+    expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(false);
+  });
+
+  it('should return true if link is SoundCloud', () => {
+    const url = 'https://soundcloud.com/ago_music/ago-royal-oats-ft-waldo-prod';
+
+    expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(true);
+  });
+
+  it('should return false if link is SoundCloud static', () => {
+    const url = 'https://soundcloud.com/discover';
+
+    expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(false);
+  });
+
+  it('should return true if link is Vimeo', () => {
+    const url = 'https://vimeo.com/27999954';
+
+    expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(true);
+  });
+
+  it('should return false if link is Vimeo static', () => {
+    const url = 'https://vimeo.com/upload';
+
+    expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(false);
   });
 
   it('should return false if link is wire.com', () => {
     const url = 'wire.com';
 
-    expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBeFalsy();
+    expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(false);
   });
 });

--- a/test/unit_tests/links/LinkPreviewBlackListSpec.js
+++ b/test/unit_tests/links/LinkPreviewBlackListSpec.js
@@ -22,67 +22,85 @@
 // grunt test_run:links/LinkPreviewBlackList
 
 describe('is_blacklisted', () => {
-  it('should return true if link is youtu.be', () => {
+  it('blacklists youtu.be links', () => {
     const url = 'https://youtu.be/t4gjl-uwUHc';
 
     expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(true);
   });
 
-  it('should return true if link is YouTube', () => {
+  it('blacklists YouTube video links', () => {
     const url = 'https://www.youtube.com/watch?v=t4gjl-uwUHc';
 
     expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(true);
   });
 
-  it('should return false if link is YouTube static', () => {
+  it("doesn't blacklist YouTube static links", () => {
     const url = 'https://www.youtube.com/account';
 
     expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(false);
   });
 
-  it('should return true if link is Spotify', () => {
+  it('blacklists Spotify artist links', () => {
     const url = 'https://play.spotify.com/artist/7Ln80lUS6He07XvHI8qqHH/';
 
     expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(true);
   });
 
-  it('should return false if link is Spotify static', () => {
+  it('blacklists Spotify song links', () => {
+    const url = 'https://open.spotify.com/track/5FVd6KXrgO9B3JPmC8OPst';
+
+    expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(true);
+  });
+
+  it("doesn't blacklist Spotify static links", () => {
     const url = 'https://www.spotify.com/en/legal';
 
     expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(false);
   });
 
-  it('should return true if link is SoundCloud', () => {
+  it('blacklists SoundCloud', () => {
     const url = 'https://soundcloud.com/ago_music/ago-royal-oats-ft-waldo-prod';
 
     expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(true);
   });
 
-  it('should return false if link is SoundCloud static', () => {
+  it("doesn't blacklist SoundCloud static links", () => {
     const url = 'https://soundcloud.com/discover';
 
     expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(false);
   });
 
-  it('should return true if link is Vimeo', () => {
+  it('blacklists Vimeo video links', () => {
     const url = 'https://vimeo.com/27999954';
 
     expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(true);
   });
 
-  it('should return true if link is Vimeo embed', () => {
+  it('blacklists Vimeo embed video links', () => {
     const url = 'https://player.vimeo.com/video/27999954';
 
     expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(true);
   });
 
-  it('should return false if link is Vimeo static', () => {
+  it('blacklists Vimeo channel video links', () => {
+    const url = 'https://vimeo.com/channels/staffpicks/278174511';
+
+    expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(true);
+  });
+
+  it('blacklists Vimeo embed links', () => {
+    const url = 'https://player.vimeo.com/video/27999954';
+
+    expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(true);
+  });
+
+  it("doesn't blacklist Vimeo static links", () => {
     const url = 'https://vimeo.com/upload';
 
     expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(false);
   });
 
-  it('should return false if link is wire.com', () => {
+  it("doesn't blacklist wire.com", () => {
     const url = 'wire.com';
 
     expect(z.links.LinkPreviewBlackList.isBlacklisted(url)).toBe(false);

--- a/test/unit_tests/links/LinkPreviewRepositorySpec.js
+++ b/test/unit_tests/links/LinkPreviewRepositorySpec.js
@@ -20,6 +20,7 @@
 'use strict';
 
 // grunt test_run:links/LinkPreviewRepository
+
 describe('z.links.LinkPreviewRepository', () => {
   let link_preview_repository = null;
 
@@ -79,7 +80,7 @@ describe('z.links.LinkPreviewRepository', () => {
       window.openGraph = mockSucceedingOpenGraph();
 
       link_preview_repository
-        .getLinkPreview('youtube.com')
+        .getLinkPreview('https://www.youtube.com/watch?v=t4gjl-uwUHc')
         .then(done.fail)
         .catch(error => {
           expect(error.type).toBe(z.error.LinkPreviewError.TYPE.BLACKLISTED);

--- a/test/unit_tests/media/MediaEmbedsSpec.js
+++ b/test/unit_tests/media/MediaEmbedsSpec.js
@@ -261,7 +261,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      it("doesn't render YouTube profile link", () => {
+      it("doesn't render a YouTube profile link", () => {
         const message =
           '<a href="https://www.youtube-nocookie.com/user/GoogleWebDesigner" target="_blank" rel="nofollow">https://www.youtube-nocookie.com/user/GoogleWebDesigner</a>';
         const iframe =
@@ -358,7 +358,7 @@ describe('MediaEmbeds', () => {
     });
 
     describe('Spotify', () => {
-      it('renders artists (https://open.spotify.com/user/1123867741/playlist/2w63WroxrrIbNg4WIxdoBn)', () => {
+      it('renders artists', () => {
         const link = 'https://open.spotify.com/user/1123867741/playlist/2w63WroxrrIbNg4WIxdoBn';
         const partial_link = 'user/1123867741/playlist/2w63WroxrrIbNg4WIxdoBn';
 
@@ -368,7 +368,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      it('renders track (https://open.spotify.com/track/26fwlVGkISUr5P91hAeTW8)', () => {
+      it('renders a track', () => {
         const link = 'https://open.spotify.com/track/26fwlVGkISUr5P91hAeTW8';
         const partial_link = 'track/26fwlVGkISUr5P91hAeTW8';
 
@@ -378,7 +378,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      it('renders album (https://open.spotify.com/album/7iN0r7Sl624EkOUNUCOGu9)', () => {
+      it('renders an album', () => {
         const link = 'https://open.spotify.com/album/7iN0r7Sl624EkOUNUCOGu9';
         const partial_link = 'album/7iN0r7Sl624EkOUNUCOGu9';
 
@@ -388,7 +388,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      it('renders playlist (https://open.spotify.com/user/1123867741/playlist/2w63WroxrrIbNg4WIxdoBn)', () => {
+      it('renders a playlist (https://open.spotify.com/user/1123867741/playlist/2w63WroxrrIbNg4WIxdoBn)', () => {
         const link = 'https://open.spotify.com/user/1123867741/playlist/2w63WroxrrIbNg4WIxdoBn';
         const partial_link = 'user/1123867741/playlist/2w63WroxrrIbNg4WIxdoBn';
 
@@ -398,7 +398,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      it('renders track with params (https://play.spotify.com/track/5yEPxDjbbzUzyauGtnmVEC?play=true&utm_source=open.spotify.com&utm_medium=open)', () => {
+      it('renders a track with params', () => {
         const link =
           'https://play.spotify.com/track/5yEPxDjbbzUzyauGtnmVEC?play=true&utm_source=open.spotify.com&utm_medium=open';
         const partial_link = 'track/5yEPxDjbbzUzyauGtnmVEC';
@@ -427,7 +427,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message, '#333')).toBe(message);
       });
 
-      it('renders link with params', () => {
+      it('renders a link with params', () => {
         const id = '127053285';
         const link = 'https://vimeo.com/channels/staffpicks/127053285?utm_source=social&utm_campaign=9914';
 

--- a/test/unit_tests/media/MediaEmbedsSpec.js
+++ b/test/unit_tests/media/MediaEmbedsSpec.js
@@ -114,6 +114,10 @@ describe('MediaEmbeds', () => {
         expect('https://vimeo.com/27999954'.match(re_vimeo)).not.toBeNull();
       });
 
+      it('matches valid Vimeo embed URLs', () => {
+        expect('https://player.vimeo.com/video/27999954'.match(re_vimeo)).not.toBeNull();
+      });
+
       it("doesn't match normal Vimeo links", () => {
         test_link_variants('vimeo', re_vimeo);
       });

--- a/test/unit_tests/media/MediaEmbedsSpec.js
+++ b/test/unit_tests/media/MediaEmbedsSpec.js
@@ -81,7 +81,7 @@ describe('MediaEmbeds', () => {
         ).not.toBeNull();
       });
 
-      it('doesn’t match normal Spotify links', () => {
+      it("doesn't match normal Spotify links", () => {
         test_link_variants('spotify', re_spotify);
       });
     });
@@ -98,11 +98,11 @@ describe('MediaEmbeds', () => {
         expect('https://soundcloud.com/groups/playlist-digital-sintonia'.match(re_soundcloud)).not.toBeNull();
       });
 
-      it('doesn’t match https://soundcloud.com/dp-conference', () => {
+      it("doesn't match https://soundcloud.com/dp-conference", () => {
         expect('https://soundcloud.com/dp-conference'.match(re_soundcloud)).toBeNull();
       });
 
-      it('doesn’t match normal SoundCloud links', () => {
+      it("doesn't match normal SoundCloud links", () => {
         test_link_variants('soundcloud', re_soundcloud);
       });
     });
@@ -114,7 +114,7 @@ describe('MediaEmbeds', () => {
         expect('https://vimeo.com/27999954'.match(re_vimeo)).not.toBeNull();
       });
 
-      it('doesn’t match normal Vimeo links', () => {
+      it("doesn't match normal Vimeo links", () => {
         test_link_variants('vimeo', re_vimeo);
       });
     });
@@ -151,14 +151,14 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(message);
       });
 
-      it('https://www.youtube-nocookie.com/playlist?list=PLNy867I3fkD6LqNQdk5rAPb6xAI-SbZOd', () => {
+      it('renders a playlist', () => {
         const link = 'https://www.youtube-nocookie.com/playlist?list=PLNy867I3fkD6LqNQdk5rAPb6xAI-SbZOd';
         const message = build_message_with_anchor(link);
 
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(message);
       });
 
-      it('renders link with params (http://www.youtube-nocookie.com/watch?v=6o-nmK9WRGE&feature=player_embedded)', () => {
+      it('renders a link with params', () => {
         const link = 'http://www.youtube-nocookie.com/watch?v=6o-nmK9WRGE&feature=player_embedded';
 
         const message = build_message_with_anchor(link);
@@ -167,7 +167,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      it('renders link with params (http://www.youtube-nocookie.com/watch?v=0zM3nApSvMg&feature=feedrec_grec_index)', () => {
+      it('renders a link with params', () => {
         const link = 'http://www.youtube-nocookie.com/watch?v=0zM3nApSvMg&feature=feedrec_grec_index';
 
         const message = build_message_with_anchor(link);
@@ -176,7 +176,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      it('renders link with params (http://www.youtube-nocookie.com/v/0zM3nApSvMg?fs=1&hl=en_US&rel=0)', () => {
+      it('renders a link with params', () => {
         const link = 'http://www.youtube-nocookie.com/v/0zM3nApSvMg?fs=1&hl=en_US&rel=0';
 
         const message = build_message_with_anchor(link);
@@ -185,7 +185,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      it('renders link with timestamp (http://www.youtube-nocookie.com/watch?v=0zM3nApSvMg#t=0m10s)', () => {
+      it('renders a link with timestamp', () => {
         const link = 'http://www.youtube-nocookie.com/watch?v=0zM3nApSvMg#t=0m10s';
 
         const message = build_message_with_anchor(link);
@@ -194,7 +194,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      it('renders link with timestamp inverted (https://www.youtube-nocookie.com/watch?t=125&v=CfEWiV8PoZo)', () => {
+      it('renders a link with timestamp inverted', () => {
         const link = 'https://www.youtube-nocookie.com/watch?t=125&v=CfEWiV8PoZo';
 
         const message = build_message_with_anchor(link);
@@ -203,7 +203,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      it('renders embed link (http://www.youtube-nocookie.com/embed/0zM3nApSvMg?rel=0)', () => {
+      it('renders an embed link', () => {
         const link = 'http://www.youtube-nocookie.com/embed/0zM3nApSvMg?rel=0';
 
         const message = build_message_with_anchor(link);
@@ -212,7 +212,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      it('renders watch link (http://www.youtube-nocookie.com/watch?v=0zM3nApSvMg)', () => {
+      it('renders a watch link', () => {
         const link = 'http://www.youtube-nocookie.com/watch?v=0zM3nApSvMg';
 
         const message = build_message_with_anchor(link);
@@ -221,7 +221,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      it('renders a short link (http://youtu.be/0zM3nApSvMg)', () => {
+      it('renders a short link', () => {
         const link = 'http://youtu.be/0zM3nApSvMg';
 
         const message = build_message_with_anchor(link);
@@ -230,7 +230,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      it('renders a short link playlist (https://youtu.be/oL1xf_X0W2s?list=PLuKg-WhduhkmIcFMN7wxfVWYu8qnk0jMN)', () => {
+      it('renders a short link playlist', () => {
         const link = 'https://youtu.be/oL1xf_X0W2s?list=PLuKg-WhduhkmIcFMN7wxfVWYu8qnk0jMN';
 
         const message = build_message_with_anchor(link);
@@ -239,7 +239,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      it('renders a mobile link (https://m.youtube-nocookie.com/?#/watch?v=0zM3nApSvMg)', () => {
+      it('renders a mobile link', () => {
         const link = 'https://m.youtube-nocookie.com/?#/watch?v=0zM3nApSvMg';
 
         const message = build_message_with_anchor(link);
@@ -248,7 +248,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      it('renders another mobile link (https://www.youtube-nocookie.com/watch?v=1w4Gf97q2oU&feature=youtu.be)', () => {
+      it('renders another mobile link', () => {
         const link = 'https://www.youtube-nocookie.com/watch?v=1w4Gf97q2oU&feature=youtu.be';
 
         const message = build_message_with_anchor(link);
@@ -257,7 +257,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      it('doesn`t render Youtube profile link', () => {
+      it("doesn't render YouTube profile link", () => {
         const message =
           '<a href="https://www.youtube-nocookie.com/user/GoogleWebDesigner" target="_blank" rel="nofollow">https://www.youtube-nocookie.com/user/GoogleWebDesigner</a>';
         const iframe =
@@ -266,7 +266,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      it('removes autoplay param from url (https://www.youtube-nocookie.com/watch?v=oHg5SJYRHA0&autoplay=1)', () => {
+      it('removes autoplay param from url', () => {
         const link = 'https://www.youtube-nocookie.com/watch?v=oHg5SJYRHA0&autoplay=1';
 
         const message = build_message_with_anchor(link);
@@ -276,7 +276,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      return it('removes autoplay param from url (https://www.youtube-nocookie.com/watch?autoplay=1&v=oHg5SJYRHA0)', () => {
+      it('removes autoplay param from url', () => {
         const link = 'https://www.youtube-nocookie.com/watch?autoplay=1&v=oHg5SJYRHA0';
 
         const message = build_message_with_anchor(link);
@@ -288,7 +288,7 @@ describe('MediaEmbeds', () => {
     });
 
     describe('SoundCloud', () => {
-      it('renders a track (https://soundcloud.com/ago_music/ago-royal-oats-ft-waldo-prod)', () => {
+      it('renders a track', () => {
         const link = 'https://soundcloud.com/ago_music/ago-royal-oats-ft-waldo-prod';
 
         const message = build_message_with_anchor(link);
@@ -297,7 +297,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      it('renders a playlist (https://soundcloud.com/onedirectionmusic/sets/liams-you-i-remix-playlist)', () => {
+      it('renders a playlist', () => {
         const link = 'https://soundcloud.com/onedirectionmusic/sets/liams-you-i-remix-playlist';
 
         const message = build_message_with_anchor(link);
@@ -306,19 +306,19 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      it('renders profiles without embeds (https://soundcloud.com/dp-conference)', () => {
+      it('renders profiles without embeds', () => {
         const message = build_message_with_anchor('https://soundcloud.com/dp-conference');
 
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(message);
       });
 
-      it('renders profiles without embeds even if profiles have a trailing slash (https://soundcloud.com/dp-conference/)', () => {
+      it('renders profiles without embeds even if profiles have a trailing slash', () => {
         const message = build_message_with_anchor('https://soundcloud.com/dp-conference/');
 
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(message);
       });
 
-      it('renders a group (https://soundcloud.com/groups/playlist-digital-sintonia)', () => {
+      it('renders a group', () => {
         const link = 'https://soundcloud.com/groups/playlist-digital-sintonia';
 
         const message = build_message_with_anchor(link);
@@ -327,7 +327,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      it('renders a track without trailing slash (https://soundcloud.com/florian-paetzold/limp-bizkit-my-way-florian-paetzold-remix-free-download)', () => {
+      it('renders a track without trailing slash', () => {
         const link = 'https://soundcloud.com/florian-paetzold/limp-bizkit-my-way-florian-paetzold-remix-free-download';
 
         const message = build_message_with_anchor(link);
@@ -336,7 +336,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      it('renders a track with trailing slash (https://soundcloud.com/florian-paetzold/limp-bizkit-my-way-florian-paetzold-remix-free-download/)', () => {
+      it('renders a track with trailing slash', () => {
         const link = 'https://soundcloud.com/florian-paetzold/limp-bizkit-my-way-florian-paetzold-remix-free-download/';
 
         const message = build_message_with_anchor(link);
@@ -345,7 +345,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      return it('doesn’t render links which cannot be rendered (https://soundcloud.com/fdvm/lulleaux-fdvm-up-to-you-original-mix/recommended)', () => {
+      it("doesn't render SoundCloud links which cannot be rendered", () => {
         const link = 'https://soundcloud.com/fdvm/lulleaux-fdvm-up-to-you-original-mix/recommended';
         const message = `<a href="${link}" target="_blank" rel="nofollow">${link}</a>`;
 
@@ -394,7 +394,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message)).toBe(iframe);
       });
 
-      return it('renders track with params (https://play.spotify.com/track/5yEPxDjbbzUzyauGtnmVEC?play=true&utm_source=open.spotify.com&utm_medium=open)', () => {
+      it('renders track with params (https://play.spotify.com/track/5yEPxDjbbzUzyauGtnmVEC?play=true&utm_source=open.spotify.com&utm_medium=open)', () => {
         const link =
           'https://play.spotify.com/track/5yEPxDjbbzUzyauGtnmVEC?play=true&utm_source=open.spotify.com&utm_medium=open';
         const partial_link = 'track/5yEPxDjbbzUzyauGtnmVEC';
@@ -407,7 +407,7 @@ describe('MediaEmbeds', () => {
     });
 
     describe('Vimeo', () => {
-      it('renders https://vimeo.com/27999954', () => {
+      it('renders a video', () => {
         const id = '27999954';
         const link = 'https://vimeo.com/27999954';
 
@@ -417,13 +417,13 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message, '#333')).toBe(iframe);
       });
 
-      it("doesn't render user https://vimeo.com/user38597062", () => {
+      it("doesn't render a user's profile page", () => {
         const message = build_message_with_anchor('https://vimeo.com/user38597062');
 
         expect(z.media.MediaParser.renderMediaEmbeds(message, '#333')).toBe(message);
       });
 
-      return it('renders link with params (https://vimeo.com/channels/staffpicks/127053285?utm_source=social&utm_campaign=9914)', () => {
+      it('renders link with params', () => {
         const id = '127053285';
         const link = 'https://vimeo.com/channels/staffpicks/127053285?utm_source=social&utm_campaign=9914';
 
@@ -436,19 +436,19 @@ describe('MediaEmbeds', () => {
   });
 
   describe('convertYouTubeTimestampToSeconds', () => {
-    it('doesn´t convert timestamp that only contains numbers', () => {
+    it("doesn't convert a timestamp that only contains numbers", () => {
       expect(z.media.MediaEmbeds.convertYouTubeTimestampToSeconds('125')).toBe(125);
     });
 
-    it('converts timestamp with only seconds', () => {
+    it('converts a timestamp with only seconds', () => {
       expect(z.media.MediaEmbeds.convertYouTubeTimestampToSeconds('25s')).toBe(25);
     });
 
-    it('converts timestamp with only minutes and seconds', () => {
+    it('converts a timestamp with only minutes and seconds', () => {
       expect(z.media.MediaEmbeds.convertYouTubeTimestampToSeconds('31m08s')).toBe(1868);
     });
 
-    it('converts timestamp with hours, minutes and seconds', () => {
+    it('converts a timestamp with hours, minutes and seconds', () => {
       expect(z.media.MediaEmbeds.convertYouTubeTimestampToSeconds('1h1m1s')).toBe(3661);
     });
 

--- a/test/unit_tests/media/MediaEmbedsSpec.js
+++ b/test/unit_tests/media/MediaEmbedsSpec.js
@@ -417,7 +417,7 @@ describe('MediaEmbeds', () => {
         expect(z.media.MediaParser.renderMediaEmbeds(message, '#333')).toBe(iframe);
       });
 
-      it('doesn’t render user https://vimeo.com/user38597062', () => {
+      it("doesn't render user https://vimeo.com/user38597062", () => {
         const message = build_message_with_anchor('https://vimeo.com/user38597062');
 
         expect(z.media.MediaParser.renderMediaEmbeds(message, '#333')).toBe(message);


### PR DESCRIPTION
This PR will
* add link preview rendering for static SoundCloud, YouTube, Vimeo and Spotify pages
* allow embedding all vimeo channel videos, not only from staff picks
* close #529