### PR TITLE
runfix: Don't create link previews for links in code blocks

### DIFF
--- a/app/script/links/LinkPreviewHelpers.js
+++ b/app/script/links/LinkPreviewHelpers.js
@@ -22,7 +22,7 @@
 window.z = window.z || {};
 window.z.links = z.links || {};
 
-const codeBlockRegex = /(`|```)[^]*?\1/gm;
+const codeBlockRegex = /(`+)[^`]*?\1$/gm;
 
 z.links.LinkPreviewHelpers = {
   /**

--- a/test/unit_tests/links/LinkPreviewHelpersSpec.js
+++ b/test/unit_tests/links/LinkPreviewHelpersSpec.js
@@ -71,10 +71,14 @@ describe('getFirstLinkWithOffset', () => {
     expect(z.links.LinkPreviewHelpers.getFirstLinkWithOffset(text)).toBeUndefined();
   });
 
-  it('should not return anything for links in code blocks)', () => {
-    const text = 'cool code: `wire.com`';
+  it('should not return anything for links in code blocks', () => {
+    const singleTick = 'cool code: `wire.com`';
+    const moreTicks = 'cool code: ```\nwire.com\n```';
+    const manyTicks = 'cool code: ``````\nwire.com\n``````';
 
-    expect(z.links.LinkPreviewHelpers.getFirstLinkWithOffset(text)).toBeUndefined();
+    expect(z.links.LinkPreviewHelpers.getFirstLinkWithOffset(singleTick)).toBeUndefined();
+    expect(z.links.LinkPreviewHelpers.getFirstLinkWithOffset(moreTicks)).toBeUndefined();
+    expect(z.links.LinkPreviewHelpers.getFirstLinkWithOffset(manyTicks)).toBeUndefined();
   });
 
   it('should return the correct link and offset for a single link without text)', () => {


### PR DESCRIPTION
Follow-up to https://github.com/wireapp/wire-webapp/pull/5180.

<details closed>
<summary>Regex comparison</summary>

---

**Old regex**

![screenshot from 2018-11-23 10-50-46](https://user-images.githubusercontent.com/5497598/48937210-afeda300-ef0d-11e8-94d5-e204ee43b7e7.png)

---

**New regex**

![screenshot from 2018-11-23 10-50-56](https://user-images.githubusercontent.com/5497598/48937219-b845de00-ef0d-11e8-8d97-80d2d0576a32.png)
</details>