### PR TITLE
fix: Add backward compatibility for wire-desktop v3.4

### DIFF
--- a/app/script/main/app.js
+++ b/app/script/main/app.js
@@ -205,6 +205,10 @@ z.main.App = class App {
       calling: new z.calling.CallingService(this.backendClient),
       client: new z.client.ClientService(this.backendClient, storageService),
       connect: new z.connect.ConnectService(this.backendClient),
+      // Can be removed once desktop version with the following PR has been published (probably v3.5):
+      // https://github.com/wireapp/wire-desktop/pull/1938/files
+      connect_google: {},
+      connectGoogle: {},
       connection: new z.connection.ConnectionService(this.backendClient),
       conversation: new z.conversation.ConversationService(this.backendClient, eventService, storageService),
       cryptography: new z.cryptography.CryptographyService(this.backendClient),


### PR DESCRIPTION
Current wrappers (v3.4 and below) rely on the following namespaces:
- window.wire.app.service.connectGoogle._authenticate
- window.wire.app.service.connect_google._authenticate

We removed them (https://github.com/wireapp/wire-webapp/pull/5198) but this requires to have new wrappers out because that have this change included: https://github.com/wireapp/wire-desktop/pull/1938

Until then we still need to stick around with the namespace exposure so I am bringing these back.