### PR TITLE
chore: Remove loading tasks from "grunt/tasks"

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,9 +67,6 @@ module.exports = grunt => {
   });
   /* eslint-enable sort-keys */
 
-  // Tasks
-  grunt.loadTasks('grunt/tasks');
-
   grunt.registerTask('init', 'npmBower');
 
   grunt.registerTask('build', [


### PR DESCRIPTION
The `grunt/tasks` directory got removed so no need for Grunt to look for task definitions in this directory.