### PR TITLE
fix: Show read receipts setting in team conversations (WEBAPP-5797)

### DIFF
--- a/app/page/template/panel/conversation-details.htm
+++ b/app/page/template/panel/conversation-details.htm
@@ -116,9 +116,11 @@
                     </div>
                   </div>
                 <!-- /ko -->
-                <div class="conversation-details__read-receipts">
-                  <read-receipt-toggle params="conversation: activeConversation, onReceiptModeChanged: updateConversationReceiptMode"></read-receipt-toggle>
-                </div>
+                <!-- ko if: showOptionReadReceipts() -->
+                  <div class="conversation-details__read-receipts">
+                    <read-receipt-toggle params="conversation: activeConversation, onReceiptModeChanged: updateConversationReceiptMode"></read-receipt-toggle>
+                  </div>
+                <!-- /ko -->
               <!-- /ko -->
             </div>
           <!-- /ko -->

--- a/app/script/entity/Conversation.js
+++ b/app/script/entity/Conversation.js
@@ -176,7 +176,12 @@ z.entity.Conversation = class Conversation {
     this.globalMessageTimer = ko.observable(null);
 
     this.receiptMode = ko.observable(0);
-    this.expectsReadConfirmation = ko.pureComputed(() => !!this.receiptMode());
+    this.expectsReadConfirmation = ko.pureComputed(() => {
+      if (this.is1to1 || this.inTeam()) {
+        return !!this.receiptMode();
+      }
+      return false;
+    });
 
     this.messageTimer = ko.pureComputed(() => this.globalMessageTimer() || this.localMessageTimer());
     this.hasGlobalMessageTimer = ko.pureComputed(() => this.globalMessageTimer() > 0);

--- a/app/script/entity/Conversation.js
+++ b/app/script/entity/Conversation.js
@@ -177,7 +177,7 @@ z.entity.Conversation = class Conversation {
 
     this.receiptMode = ko.observable(0);
     this.expectsReadConfirmation = ko.pureComputed(() => {
-      if (this.is1to1 || this.inTeam()) {
+      if (this.is1to1() || this.inTeam()) {
         return !!this.receiptMode();
       }
       return false;

--- a/app/script/view_model/panel/ConversationDetailsViewModel.js
+++ b/app/script/view_model/panel/ConversationDetailsViewModel.js
@@ -149,7 +149,10 @@ export default class ConversationDetailsViewModel extends BasePanelViewModel {
     });
 
     this.showOptionReadReceipts = ko.pureComputed(() => {
-      return this.activeConversation().is1to1() || this.activeConversation().inTeam();
+      return (
+        (this.activeConversation().is1to1() && this.activeConversation().expectsReadConfirmation()) ||
+        this.activeConversation().inTeam()
+      );
     });
 
     this.hasAdvancedNotifications = ko.pureComputed(() => {

--- a/app/script/view_model/panel/ConversationDetailsViewModel.js
+++ b/app/script/view_model/panel/ConversationDetailsViewModel.js
@@ -149,10 +149,9 @@ export default class ConversationDetailsViewModel extends BasePanelViewModel {
     });
 
     this.showOptionReadReceipts = ko.pureComputed(() => {
-      const conversation = this.activeConversation();
+      const activeConversation = this.activeConversation();
       return (
-        (conversation.is1to1() && conversation.expectsReadConfirmation()) ||
-        conversation.inTeam()
+        (activeConversation.is1to1() && activeConversation.expectsReadConfirmation()) || activeConversation.inTeam()
       );
     });
 

--- a/app/script/view_model/panel/ConversationDetailsViewModel.js
+++ b/app/script/view_model/panel/ConversationDetailsViewModel.js
@@ -148,6 +148,10 @@ export default class ConversationDetailsViewModel extends BasePanelViewModel {
       return this.isActiveGroupParticipant() && this.activeConversation().inTeam();
     });
 
+    this.showOptionReadReceipts = ko.pureComputed(() => {
+      return this.activeConversation().is1to1() || this.activeConversation().inTeam();
+    });
+
     this.hasAdvancedNotifications = ko.pureComputed(() => {
       return this.activeConversation() && this.activeConversation().isMutable() && this.isTeam();
     });

--- a/app/script/view_model/panel/ConversationDetailsViewModel.js
+++ b/app/script/view_model/panel/ConversationDetailsViewModel.js
@@ -149,9 +149,10 @@ export default class ConversationDetailsViewModel extends BasePanelViewModel {
     });
 
     this.showOptionReadReceipts = ko.pureComputed(() => {
+      const conversation = this.activeConversation();
       return (
-        (this.activeConversation().is1to1() && this.activeConversation().expectsReadConfirmation()) ||
-        this.activeConversation().inTeam()
+        (conversation.is1to1() && conversation.expectsReadConfirmation()) ||
+        conversation.inTeam()
       );
     });
 


### PR DESCRIPTION
With this PR the read receipts system message and read receipts conversation setting will only show up when:
- It's a 1:1 conversation
- It's a team conversation