### PR TITLE
runfix: Add flag to message to determine if it was expecting read receipts

### DIFF
--- a/app/script/conversation/ConversationRepository.js
+++ b/app/script/conversation/ConversationRepository.js
@@ -3819,7 +3819,7 @@ z.conversation.ConversationRepository = class ConversationRepository {
     if (conversationEntity.is1to1()) {
       return !!this.propertyRepository.receiptMode();
     }
-    return conversationEntity.expectsReadConfirmation();
+    return true;
   }
 
   /**

--- a/app/script/conversation/ConversationService.js
+++ b/app/script/conversation/ConversationService.js
@@ -405,6 +405,10 @@ z.conversation.ConversationService = class ConversationService {
     });
   }
 
+  loadConversation(conversationId) {
+    return this.storageService.load(this.CONVERSATION_STORE_NAME, conversationId);
+  }
+
   /**
    * Get active conversations from database.
    * @returns {Promise} Resolves with active conversations

--- a/app/script/conversation/ReceiptMode.js
+++ b/app/script/conversation/ReceiptMode.js
@@ -1,0 +1,4 @@
+export default {
+  DELIVERY: 0,
+  DELIVERY_AND_READ: 1,
+};

--- a/app/script/entity/Conversation.js
+++ b/app/script/entity/Conversation.js
@@ -18,6 +18,7 @@
  */
 
 import ko from 'knockout';
+import ReceiptMode from '../conversation/ReceiptMode';
 
 window.z = window.z || {};
 window.z.entity = z.entity || {};
@@ -175,7 +176,7 @@ z.entity.Conversation = class Conversation {
     this.localMessageTimer = ko.observable(null);
     this.globalMessageTimer = ko.observable(null);
 
-    this.receiptMode = ko.observable(0);
+    this.receiptMode = ko.observable(ReceiptMode.DELIVERY);
     this.expectsReadConfirmation = ko.pureComputed(() => {
       if (this.is1to1() || this.inTeam()) {
         return !!this.receiptMode();

--- a/app/script/event/EventRepository.js
+++ b/app/script/event/EventRepository.js
@@ -663,7 +663,7 @@ z.event.EventRepository = class EventRepository {
     const conversationId = event.conversation;
     const mappedData = event.data || {};
 
-    //first check if a message that should be replaced exists in DB
+    // first check if a message that should be replaced exists in DB
     const findEventToReplacePromise = mappedData.replacing_message_id
       ? this.eventService.loadEvent(conversationId, mappedData.replacing_message_id)
       : Promise.resolve();

--- a/app/script/event/preprocessor/ReceiptsMiddleware.js
+++ b/app/script/event/preprocessor/ReceiptsMiddleware.js
@@ -27,11 +27,11 @@ export default class ReceiptsMiddleware {
    * It will update original messages when a confirmation is received
    *
    * @param {z.event.EventService} eventService - Repository that handles events
-   * @param {ConversationService} conversationService - Backend REST API conversation service implementation
+   * @param {ConversationRepository} conversationRepository -  Repository for conversation interactions
    */
-  constructor(eventService, conversationService) {
+  constructor(eventService, conversationRepository) {
     this.eventService = eventService;
-    this.conversationService = conversationService;
+    this.conversationRepository = conversationRepository;
     this.logger = new z.util.Logger('ReceiptsMiddleware', z.config.LOGGER.OPTIONS);
   }
 
@@ -44,10 +44,10 @@ export default class ReceiptsMiddleware {
   processEvent(event) {
     switch (event.type) {
       case z.event.Client.CONVERSATION.MESSAGE_ADD: {
-        return this.conversationService.loadConversation(event.conversation).then(conversation => {
-          const isGroupConversation = conversation.type === z.conversation.ConversationType.GROUP;
+        return this.conversationRepository.get_conversation_by_id(event.conversation).then(conversation => {
+          const isGroupConversation = conversation.type() === z.conversation.ConversationType.GROUP;
           if (isGroupConversation) {
-            const expectsReadConfirmation = conversation.receipt_mode === ReceiptMode.DELIVERY_AND_READ;
+            const expectsReadConfirmation = conversation.receiptMode() === ReceiptMode.DELIVERY_AND_READ;
             event.data.expects_read_confirmation = !!expectsReadConfirmation;
           }
           return event;

--- a/app/script/main/app.js
+++ b/app/script/main/app.js
@@ -151,7 +151,7 @@ class App {
       this.service.event,
       z.message.MessageHasher
     );
-    const readReceiptMiddleware = new ReceiptsMiddleware(this.service.event, this.service.conversation);
+    const readReceiptMiddleware = new ReceiptsMiddleware(this.service.event, repositories.conversation);
 
     repositories.event.setEventProcessMiddlewares([
       serviceMiddleware.processEvent.bind(serviceMiddleware),

--- a/app/script/main/app.js
+++ b/app/script/main/app.js
@@ -151,7 +151,7 @@ class App {
       this.service.event,
       z.message.MessageHasher
     );
-    const readReceiptMiddleware = new ReceiptsMiddleware(this.service.event);
+    const readReceiptMiddleware = new ReceiptsMiddleware(this.service.event, this.service.conversation);
 
     repositories.event.setEventProcessMiddlewares([
       serviceMiddleware.processEvent.bind(serviceMiddleware),

--- a/app/script/properties/PropertiesRepository.js
+++ b/app/script/properties/PropertiesRepository.js
@@ -17,6 +17,7 @@
  *
  */
 
+import ReceiptMode from '../conversation/ReceiptMode';
 import WebappProperties from './WebappProperties';
 
 class PropertiesRepository {
@@ -218,7 +219,7 @@ class PropertiesRepository {
 
   saveReceiptMode(receiptMode) {
     const property = PropertiesRepository.CONFIG.ENABLE_READ_RECEIPTS;
-    if (receiptMode === 0) {
+    if (receiptMode === ReceiptMode.DELIVERY) {
       return this.propertiesService.deletePropertiesByKey(property.key);
     }
     return this.propertiesService.putPropertiesByKey(property.key, receiptMode);

--- a/app/script/view_model/content/GroupCreationViewModel.js
+++ b/app/script/view_model/content/GroupCreationViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import ReceiptMode from '../../conversation/ReceiptMode';
+
 window.z = window.z || {};
 window.z.viewModel = z.viewModel || {};
 window.z.viewModel.content = z.viewModel.content || {};
@@ -163,7 +165,7 @@ z.viewModel.content.GroupCreationViewModel = class GroupCreationViewModel {
 
       const accessState = this.isTeam() ? this.accessState() : undefined;
       const options = {
-        receipt_mode: this.enableReadReceipts() ? 1 : 0,
+        receipt_mode: this.enableReadReceipts() ? ReceiptMode.DELIVERY_AND_READ : ReceiptMode.DELIVERY,
       };
 
       this.conversationRepository

--- a/app/script/view_model/content/MessageListViewModel.js
+++ b/app/script/view_model/content/MessageListViewModel.js
@@ -32,7 +32,7 @@ window.z.viewModel.content = z.viewModel.content || {};
  * Message list rendering view model.
  *
  * @todo Get rid of the participants dependencies whenever bubble implementation has changed
- * @todo Remove all jquery selectors
+ * @todo Remove all jQuery selectors
  */
 z.viewModel.content.MessageListViewModel = class MessageListViewModel {
   constructor(mainViewModel, contentViewModel, repositories) {


### PR DESCRIPTION
This PR fixes the following use case.

**Scenario**

- Read receipts are turned ON
- User A goes offline
- User B sends message 1
- User B sends message 2
- User B sends message 3
- User B turns read receipts OFF
- User B sends message 4
- User B turns read receipts ON
- User B sends message 5
- User A goes online

**Expected result**

- User A replies with a read receipt to message 1, 2, 3 & 5
- User A does not reply with a read receipt to message 4
