### PR TITLE
runfix: Merge arrays as primitive values when merging two entities (WEBAPP-5853 WEBAPP-5854)

### DIFF
--- a/app/script/util/objectUtil.js
+++ b/app/script/util/objectUtil.js
@@ -17,7 +17,7 @@
  *
  */
 
-import {isObject} from 'underscore';
+import {isObject, isArray} from 'underscore';
 
 /**
  * Creates an object copy and applies a mapping functions to all properties of that object.
@@ -57,7 +57,7 @@ export const escapeProperties = object => mapRecursive(object, _.escape);
  * @returns {Entity} mergedEntity
  */
 export const mergeEntities = (destination, source, ignoredProperties = []) => {
-  if (!isObject(source) || !isObject(destination)) {
+  if (!isObject(source) || !isObject(destination) || isArray(source)) {
     return source;
   }
 
@@ -78,5 +78,6 @@ export const mergeEntities = (destination, source, ignoredProperties = []) => {
   observableValues.forEach(([property, value]) => {
     destination[property](mergeEntities(ko.unwrap(destination[property]), ko.unwrap(value)));
   });
+
   return destination;
 };

--- a/test/unit_tests/util/objectUtilSpec.js
+++ b/test/unit_tests/util/objectUtilSpec.js
@@ -136,5 +136,15 @@ describe('objectUtil', () => {
 
       expect(merged.value).toBe(source.value);
     });
+
+    it('replaces array with the value from the source', () => {
+      const destination = {value: [1, 2, 3]};
+      const source = {value: []};
+
+      const merged = mergeEntities(destination, source);
+
+      expect(merged.value.length).toBe(source.value.length);
+      expect(merged.value).toBe(source.value);
+    });
   });
 });


### PR DESCRIPTION
We were treating array like object when merging 2 entities. 
Meaning that we would `delete` properties that are in the destination object and not in the source object.

So if we have 2 arrays
destination : [<RemoteAsset>]
source : []

We will end up with 
[undefined] (thus the errors with link previews and assets)