### PR TITLE
refactor: Remove unecessary manual updates of messages in message list

### DIFF
--- a/app/script/conversation/ConversationRepository.js
+++ b/app/script/conversation/ConversationRepository.js
@@ -3595,8 +3595,10 @@ z.conversation.ConversationRepository = class ConversationRepository {
   _addEventToConversation(conversationEntity, eventJson) {
     return this._initMessageEntity(conversationEntity, eventJson).then(messageEntity => {
       if (conversationEntity && messageEntity) {
-        conversationEntity.add_message(messageEntity);
-        this.ephemeralHandler.validateMessage(messageEntity);
+        const wasAdded = conversationEntity.add_message(messageEntity);
+        if (wasAdded) {
+          this.ephemeralHandler.validateMessage(messageEntity);
+        }
       }
       return {conversationEntity, messageEntity};
     });

--- a/app/script/conversation/ConversationRepository.js
+++ b/app/script/conversation/ConversationRepository.js
@@ -3595,24 +3595,9 @@ z.conversation.ConversationRepository = class ConversationRepository {
   _addEventToConversation(conversationEntity, eventJson) {
     return this._initMessageEntity(conversationEntity, eventJson).then(messageEntity => {
       if (conversationEntity && messageEntity) {
-        const replacedEntity = conversationEntity.add_message(messageEntity, true);
-        if (replacedEntity) {
-          const messages = conversationEntity.messages_unordered();
-
-          const updatedMessages = messages.map(message => {
-            const hasEditedQuote = message.quote && message.quote() && message.quote().messageId === replacedEntity.id;
-            if (hasEditedQuote) {
-              const {error, userId} = message.quote();
-              const newQuote = new z.message.QuoteEntity({error, messageId: messageEntity.id, userId});
-              message.quote(newQuote);
-            }
-            return message;
-          });
-
-          conversationEntity.messages_unordered(updatedMessages);
-        }
+        conversationEntity.add_message(messageEntity);
+        this.ephemeralHandler.validateMessage(messageEntity);
       }
-      this.ephemeralHandler.validateMessage(messageEntity);
       return {conversationEntity, messageEntity};
     });
   }

--- a/app/script/entity/Conversation.js
+++ b/app/script/entity/Conversation.js
@@ -397,23 +397,12 @@ class Conversation {
     if (messageEntity) {
       const messageWithLinkPreview = () => this._findDuplicate(messageEntity.id, messageEntity.from);
       const editedMessage = () => this._findDuplicate(messageEntity.replacing_message_id, messageEntity.from);
-      const entityToReplace = messageWithLinkPreview() || editedMessage();
-      this.update_timestamps(messageEntity);
-      if (entityToReplace) {
-        if (replaceDuplicate) {
-          if (messageEntity.is_content()) {
-            messageEntity.quote(entityToReplace.quote());
-
-            const existingReceipts = entityToReplace.readReceipts();
-            if (existingReceipts.length) {
-              messageEntity.readReceipts(existingReceipts);
-            }
-          }
-          this.replaceMessage(entityToReplace, messageEntity);
-        }
-        // The duplicated message has been treated (either replaced or ignored). Our job here is done.
-        return entityToReplace;
+      const alreadyAdded = messageWithLinkPreview() || editedMessage();
+      if (alreadyAdded) {
+        return;
       }
+
+      this.update_timestamps(messageEntity);
       this.messages_unordered.push(messageEntity);
       amplify.publish(z.event.WebApp.CONVERSATION.MESSAGE.ADDED, messageEntity);
     }

--- a/app/script/entity/Conversation.js
+++ b/app/script/entity/Conversation.js
@@ -399,12 +399,13 @@ class Conversation {
       const editedMessage = () => this._findDuplicate(messageEntity.replacing_message_id, messageEntity.from);
       const alreadyAdded = messageWithLinkPreview() || editedMessage();
       if (alreadyAdded) {
-        return;
+        return false;
       }
 
       this.update_timestamps(messageEntity);
       this.messages_unordered.push(messageEntity);
       amplify.publish(z.event.WebApp.CONVERSATION.MESSAGE.ADDED, messageEntity);
+      return true;
     }
   }
 

--- a/test/unit_tests/entity/ConversationSpec.js
+++ b/test/unit_tests/entity/ConversationSpec.js
@@ -138,20 +138,15 @@ describe('Conversation', () => {
       expect(conversation_et.messages().length).toBe(1);
     });
 
-    it('updates existing message values with new message', () => {
+    it('does not add new message if it already exists in the message list', () => {
       const initialLength = conversation_et.messages().length;
       const newMessageEntity = new Message(z.util.createRandomUuid());
       newMessageEntity.id = initial_message_et.id;
-      newMessageEntity.status(3);
-      newMessageEntity.version = 3;
-      newMessageEntity.readReceipts([{userId: 'user-id'}]);
 
       conversation_et.add_message(newMessageEntity, true);
 
       expect(conversation_et.messages().length).toBe(initialLength);
-      expect(conversation_et.messages()[0].readReceipts()).toEqual(newMessageEntity.readReceipts());
-      expect(conversation_et.messages()[0].status()).toEqual(newMessageEntity.status());
-      expect(conversation_et.messages()[0].version).toEqual(newMessageEntity.version);
+      expect(conversation_et.messages().some(message => message == newMessageEntity)).toBe(false);
     });
 
     it('should add message with a newer timestamp', () => {
@@ -217,36 +212,6 @@ describe('Conversation', () => {
         conversation_et.add_message(message_et);
 
         expect(conversation_et.last_event_timestamp()).toBe(first_timestamp);
-      });
-
-      it('keeps the amount of read receipts if an edit message comes in', () => {
-        const conversationId = z.util.createRandomUuid();
-        const messageId = z.util.createRandomUuid();
-        const senderId = z.util.createRandomUuid();
-
-        const textMessage = new ContentMessage(messageId);
-        textMessage.add_asset(new z.entity.Text());
-        textMessage.conversation_id = conversationId;
-        textMessage.from = senderId;
-        textMessage.readReceipts([
-          {
-            time: new Date().toISOString(),
-            userId: z.util.createRandomUuid(),
-          },
-        ]);
-
-        const editMessage = new ContentMessage(z.util.createRandomUuid());
-        editMessage.conversation_id = conversationId;
-        editMessage.from = senderId;
-        editMessage.replacing_message_id = messageId;
-
-        conversation_et.id = conversationId;
-        conversation_et.add_message(textMessage, false);
-
-        expect(editMessage.readReceipts().length).toBe(0);
-        conversation_et.add_message(editMessage, true);
-
-        expect(editMessage.readReceipts().length).toBe(1);
       });
     });
 


### PR DESCRIPTION
Because updates of message already loaded in memory is now made automatically by the DB listener, we don't need to manually replace them in the message list. 

Next step would be to automatically add messages when they are added in the DB (that will remove even more code here).

Next step would be to automatically delete messages when they are deleted in DB. 

When we reach that step, we will have a single place that handles add/update/delete events: The event repository. 