### PR TITLE
fix: Typecasting for incoming login errors

### DIFF
--- a/app/script/auth/page/Login.tsx
+++ b/app/script/auth/page/Login.tsx
@@ -238,7 +238,7 @@ class Login extends React.Component<CombinedProps, State> {
       .then(this.navigateChooseHandleOrWebapp)
       .catch((error: Error | BackendError) => {
         if ((error as BackendError).label) {
-          const backendError: BackendError = error as BackendError;
+          const backendError = error as BackendError;
           switch (backendError.label) {
             case BackendError.LABEL.NEW_CLIENT: {
               this.props.resetAuthError();


### PR DESCRIPTION
The `catch` clause receives all kinds of errors but from the implementation it thinks that they are all of kind `BackendError` and do have a `label` which is not true. 

So far the TypeScript code assumed that error is of type `any` which we always want to avoid, so I type-casted the errors because I ran into a scenario where I received an error in the `catch` clause which did NOT have a `label` and caused another error because the `default` case of the `switch` block failed when executing `backendError.label.endsWith(errorType)`.