### PR TITLE
fix: Use a less generic method to replace live message entities

### DIFF
--- a/app/script/conversation/ConversationRepository.js
+++ b/app/script/conversation/ConversationRepository.js
@@ -235,9 +235,8 @@ z.conversation.ConversationRepository = class ConversationRepository {
 
   _updateLocalMessageEntity(updatedEvent, oldEvent) {
     this.find_conversation_by_id(updatedEvent.conversation).then(conversationEntity => {
-      this._replaceMessageInConversation(conversationEntity, oldEvent.id, updatedEvent).then(messageEntity => {
-        amplify.publish(z.event.WebApp.CONVERSATION.MESSAGE.UPDATED, oldEvent.id, messageEntity);
-      });
+      const messageEntity = this._replaceMessageInConversation(conversationEntity, oldEvent.id, updatedEvent);
+      amplify.publish(z.event.WebApp.CONVERSATION.MESSAGE.UPDATED, oldEvent.id, messageEntity);
     });
   }
 
@@ -3589,11 +3588,9 @@ z.conversation.ConversationRepository = class ConversationRepository {
     if (!originalMessage) {
       return Promise.resolve();
     }
-    return this._initMessageEntity(conversationEntity, newData).then(messageEntity => {
-      const replacedMessageEntity = conversationEntity.replaceMessage(originalMessage, messageEntity);
-      this.ephemeralHandler.validateMessage(replacedMessageEntity);
-      return replacedMessageEntity;
-    });
+    const replacedMessageEntity = this.event_mapper.updateMessageAddEvent(originalMessage, newData);
+    this.ephemeralHandler.validateMessage(replacedMessageEntity);
+    return replacedMessageEntity;
   }
 
   /**

--- a/app/script/entity/Conversation.js
+++ b/app/script/entity/Conversation.js
@@ -20,8 +20,6 @@
 import ko from 'knockout';
 import ReceiptMode from '../conversation/ReceiptMode';
 
-import {mergeEntities} from '../util/objectUtil';
-
 window.z = window.z || {};
 window.z.entity = z.entity || {};
 
@@ -407,12 +405,6 @@ class Conversation {
       amplify.publish(z.event.WebApp.CONVERSATION.MESSAGE.ADDED, messageEntity);
       return true;
     }
-  }
-
-  replaceMessage(originalMessage, newMessage) {
-    // we don't want to change the `user` observable of message as they are entities shared by other parts of the app
-    const propertiesToIgnore = ['user'];
-    return mergeEntities(originalMessage, newMessage, propertiesToIgnore);
   }
 
   /**

--- a/app/script/util/objectUtil.js
+++ b/app/script/util/objectUtil.js
@@ -17,8 +17,6 @@
  *
  */
 
-import {isObject, isArray} from 'underscore';
-
 /**
  * Creates an object copy and applies a mapping functions to all properties of that object.
  *
@@ -46,49 +44,3 @@ const mapRecursive = (object, mappingFunction) => {
  * @returns {Object} Object copy with escaped properties
  */
 export const escapeProperties = object => mapRecursive(object, _.escape);
-
-/**
- * Deep merges two high end entities together (containing observables)
- * This will allow fine grained change detection on the observable level.
- *
- * @param {Entity} destination - the object that will receive the properties from the source object
- * @param {Entity} source - the entity containing the data that will be fed to the destination
- * @param {string[]} ignoredProperties - list of properties that should be left untouched from the destination entity
- * @returns {Entity} mergedEntity
- */
-export const mergeEntities = (destination, source, ignoredProperties = []) => {
-  if (!isObject(source) || !isObject(destination)) {
-    return source;
-  }
-  if (isArray(source)) {
-    destination.length = source.length;
-    source.forEach((value, index) => {
-      if (JSON.stringify(destination[index]) !== JSON.stringify(value)) {
-        // only modify the object if the serialization is different. This avoids generating false positive diffs and prevents UI blinking
-        destination[index] = mergeEntities(destination[index], value, ignoredProperties);
-      }
-    });
-    return destination;
-  }
-  const properties = Object.entries(source).filter(([property]) => !ignoredProperties.includes(property));
-  const rawValues = properties.filter(([_, accessor]) => {
-    return typeof accessor !== 'function';
-  });
-
-  const deletedProperties = Object.keys(destination).filter(property => !source.hasOwnProperty(property));
-
-  const observableValues = properties.filter(([_, accessor]) => {
-    return ko.isObservable(accessor) && !ko.isComputed(accessor) && !ko.isPureComputed(accessor);
-  });
-
-  // update raw values first (in order to have them up to date when observables are updated)
-  rawValues.forEach(
-    ([property, value]) => (destination[property] = mergeEntities(destination[property], value, ignoredProperties))
-  );
-  deletedProperties.forEach(property => delete destination[property]);
-  observableValues.forEach(([property, value]) => {
-    destination[property](mergeEntities(ko.unwrap(destination[property]), ko.unwrap(value), ignoredProperties));
-  });
-
-  return destination;
-};

--- a/test/unit_tests/util/objectUtilSpec.js
+++ b/test/unit_tests/util/objectUtilSpec.js
@@ -17,8 +17,7 @@
  *
  */
 
-import {escapeProperties, mergeEntities} from 'app/script/util/objectUtil';
-import ko from 'knockout';
+import {escapeProperties} from 'app/script/util/objectUtil';
 
 describe('objectUtil', () => {
   describe('escapeProperties', () => {
@@ -36,113 +35,6 @@ describe('objectUtil', () => {
       expect(escaped_object.age).toBe('&lt;b&gt;25&lt;/b&gt;');
       expect(escaped_object.favorite.place).toBe('&lt;b&gt;Berlin&lt;/b&gt;');
       expect(escaped_object.name).toBe('Lara');
-    });
-  });
-
-  describe('mergeEntities', () => {
-    it('merges raw values', () => {
-      const destination = {
-        value: 1,
-      };
-      const source = {
-        value: 2,
-      };
-
-      const merged = mergeEntities(destination, source);
-
-      expect(merged.value).toEqual(source.value);
-    });
-
-    it('does not replace observables but push new value instead', () => {
-      const originalValue = ko.observable(1);
-
-      const destination = {
-        value: originalValue,
-      };
-      const source = {
-        value: ko.observable(2),
-      };
-
-      const merged = mergeEntities(destination, source);
-
-      expect(merged.value).toBe(originalValue);
-      expect(merged.value()).toBe(source.value());
-    });
-
-    it('deeply merges nested data structures', () => {
-      const originalValue = {value: 11};
-
-      const destination = {value: originalValue};
-      const source = {value: {value: 12}};
-
-      const merged = mergeEntities(destination, source);
-
-      expect(merged.value).toBe(originalValue);
-      expect(merged.value.value).toBe(source.value.value);
-    });
-
-    it('deeply merges nested data structures containing observables', () => {
-      const originalValue = {value: ko.observable(11)};
-
-      const destination = {value: originalValue};
-      const source = {value: {value: ko.observable(12)}};
-
-      const merged = mergeEntities(destination, source);
-
-      expect(merged.value).toBe(originalValue);
-      expect(merged.value.value()).toBe(source.value.value());
-    });
-
-    it('deeply merges observables containing objects', () => {
-      const originalValue = ko.observable({value: 11});
-
-      const destination = {value: originalValue};
-      const source = {value: ko.observable({value: 12})};
-
-      const merged = mergeEntities(destination, source);
-
-      expect(merged.value).toBe(originalValue);
-      expect(merged.value()).toBe(originalValue());
-      expect(merged.value().value).toBe(source.value().value);
-    });
-
-    it('leaves ignored property to their initial value', () => {
-      const originalName = 'felix';
-      const destination = {name: originalName, value: 11};
-      const source = {name: 'other', value: 12};
-
-      const merged = mergeEntities(destination, source, ['name']);
-
-      expect(merged.value).toBe(source.value);
-      expect(merged.name).toBe(originalName);
-    });
-
-    it('reset properties of the destination object', () => {
-      const destination = {value: {value: 1}};
-      const source = {value: {}};
-
-      const merged = mergeEntities(destination, source);
-
-      expect(merged.value.value).toBe(undefined);
-    });
-
-    it('overwrite object with primitive values', () => {
-      const destination = {value: {value: 1}};
-      const source = {value: undefined};
-
-      const merged = mergeEntities(destination, source);
-
-      expect(merged.value).toBe(source.value);
-    });
-
-    it('updates destination array values with source array values', () => {
-      const destination = {value: [1, 2, 3]};
-      const source = {value: []};
-
-      const merged = mergeEntities(destination, source);
-
-      expect(merged.value.length).toBe(source.value.length);
-      expect(merged.value).toBe(destination.value);
     });
   });
 });


### PR DESCRIPTION
The current generic entities merger is powerful but starts to need to many special cases (mainly due to observables being nested and object being shared across multiple entities).
This solution is aware what kind of entity it's merging and can act smart about it. 