### PR TITLE
fix: Don't scroll page out-of-view (WEBAPP-5705)

### DIFF
--- a/app/script/view_model/content/InputBarViewModel.js
+++ b/app/script/view_model/content/InputBarViewModel.js
@@ -521,6 +521,21 @@ z.viewModel.content.InputBarViewModel = class InputBarViewModel {
   }
 
   onInputKeyDown(data, keyboardEvent) {
+    const textAreaValue = $(keyboardEvent.target).val();
+
+    // Manually move the cursor when pressing "Page Up", and do nothing else
+    // see https://bugs.chromium.org/p/chromium/issues/detail?id=890248
+    if (keyboardEvent.keyCode === 33) {
+      keyboardEvent.target.setSelectionRange(0, 0);
+      return false;
+    }
+
+    // Manually move the cursor when pressing "Page Down", and do nothing else
+    if (keyboardEvent.keyCode === 34 && textAreaValue) {
+      keyboardEvent.target.setSelectionRange(textAreaValue.length, textAreaValue.length);
+      return false;
+    }
+
     const inputHandledByEmoji = !this.editedMention() && this.emojiInput.onInputKeyDown(data, keyboardEvent);
 
     if (!inputHandledByEmoji) {


### PR DESCRIPTION
See https://bugs.chromium.org/p/chromium/issues/detail?id=890248 and https://stackoverflow.com/questions/17808854/pressing-pageup-while-in-textarea-moves-website-out-of-the-window.

This fixes https://github.com/wireapp/wire-desktop/issues/2012.
