### PR TITLE
fix: Attach marketing consent subscriber (WEBAPP-5846)

### DIFF
--- a/app/script/user/UserRepository.js
+++ b/app/script/user/UserRepository.js
@@ -433,7 +433,7 @@ z.user.UserRepository = class UserRepository {
       .then(userData => this._upgradePictureAsset(userData))
       .then(response => this.user_mapper.mapSelfUserFromJson(response))
       .then(userEntity => {
-        const promises = [this.save_user(userEntity, true), this.getMarketingConsent()];
+        const promises = [this.save_user(userEntity, true), this.initMarketingConsent()];
         return Promise.all(promises).then(() => userEntity);
       })
       .catch(error => {
@@ -798,7 +798,7 @@ z.user.UserRepository = class UserRepository {
     });
   }
 
-  getMarketingConsent() {
+  initMarketingConsent() {
     if (!z.config.FEATURE.CHECK_CONSENT) {
       this.logger.warn(`Consent check feature is disabled. Defaulting to '${this.marketingConsent()}'`);
       return Promise.resolve();
@@ -811,7 +811,6 @@ z.user.UserRepository = class UserRepository {
           if (isMarketingConsent) {
             const hasGivenConsent = consentValue === z.user.ConsentValue.GIVEN;
             this.marketingConsent(hasGivenConsent);
-            this.marketingConsent.subscribe(changedConsentValue => this.changeMarketingConsent(changedConsentValue));
 
             this.logger.log(`Marketing consent retrieved as '${consentValue}'`);
             return;
@@ -819,6 +818,9 @@ z.user.UserRepository = class UserRepository {
         }
 
         this.logger.log(`Marketing consent not set. Defaulting to '${this.marketingConsent()}'`);
+      })
+      .then(() => {
+        this.marketingConsent.subscribe(changedConsentValue => this.changeMarketingConsent(changedConsentValue));
       })
       .catch(error => {
         this.logger.warn(`Failed to retrieve marketing consent: ${error.message || error.code}`, error);


### PR DESCRIPTION
We need to subscribe to updates on the `marketingConsent` property but the subscriber has only been added when consent was already given. 

When the user did not give consent from the beginning, then we would also not attach a subscriber on the UI property, so if the user then changes the consent value in the UI, nothing happens. 

This will be fixed with the PR you are currently reviewing. 😺 