### PR TITLE
feat: Keep unread preferences notifications in localStorage

### DIFF
--- a/app/script/event/WebApp.js
+++ b/app/script/event/WebApp.js
@@ -189,10 +189,6 @@ z.event.WebApp = {
     UPDATED: 'wire.webapp.properties.updated',
   },
   SEARCH: {
-    BADGE: {
-      HIDE: 'wire.webapp.search.badge.hide',
-      SHOW: 'wire.webapp.search.badge.show',
-    },
     HIDE: 'wire.webapp.search.hide',
     SHOW: 'wire.webapp.search.show',
   },

--- a/app/script/view_model/content/PreferencesAccountViewModel.js
+++ b/app/script/view_model/content/PreferencesAccountViewModel.js
@@ -22,6 +22,7 @@ import {groupBy} from 'underscore';
 import backendEvent from '../../event/Backend';
 import PropertiesRepository from '../../properties/PropertiesRepository';
 import {getCreateTeamUrl, getManageTeamUrl, URL_PATH} from '../../externalRoute';
+import * as StorageUtil from 'utils/StorageUtil';
 
 window.z = window.z || {};
 window.z.viewModel = z.viewModel || {};
@@ -65,10 +66,13 @@ z.viewModel.content.PreferencesAccountViewModel = class PreferencesAccountViewMo
     this.isActivatedAccount = this.userRepository.isActivatedAccount;
     this.selfUser = this.userRepository.self;
 
-    this.notifications = ko.observableArray([]);
+    const notificationsStorageKey = 'preferences_notifications';
+    const storedNotifications = StorageUtil.getValue(notificationsStorageKey);
+    this.notifications = ko.observableArray(storedNotifications ? JSON.parse(storedNotifications) : []);
     this.notifications.subscribe(notifications => {
-      const event = notifications.length > 0 ? z.event.WebApp.SEARCH.BADGE.SHOW : z.event.WebApp.SEARCH.BADGE.HIDE;
-      amplify.publish(event);
+      return notifications.length > 0
+        ? StorageUtil.setValue(notificationsStorageKey, JSON.stringify(notifications))
+        : StorageUtil.resetValue(notificationsStorageKey);
     });
 
     this.name = ko.pureComputed(() => this.selfUser().name());

--- a/app/script/view_model/list/ConversationListViewModel.js
+++ b/app/script/view_model/list/ConversationListViewModel.js
@@ -104,7 +104,9 @@ z.viewModel.list.ConversationListViewModel = class ConversationListViewModel {
 
     this.showConnectRequests = ko.pureComputed(() => this.connectRequests().length);
 
-    this.showBadge = ko.observable(false);
+    this.showBadge = ko.pureComputed(() => {
+      return this.contentViewModel.preferencesAccount.notifications().length > 0;
+    });
 
     this._initSubscriptions();
   }
@@ -113,8 +115,6 @@ z.viewModel.list.ConversationListViewModel = class ConversationListViewModel {
     amplify.subscribe(z.event.WebApp.EVENT.NOTIFICATION_HANDLING_STATE, this.setShowCallsState.bind(this));
     amplify.subscribe(z.event.WebApp.LIFECYCLE.LOADED, this.onWebappLoaded.bind(this));
     amplify.subscribe(z.event.WebApp.SHORTCUT.START, this.clickOnPeopleButton.bind(this));
-    amplify.subscribe(z.event.WebApp.SEARCH.BADGE.SHOW, () => this.showBadge(true));
-    amplify.subscribe(z.event.WebApp.SEARCH.BADGE.HIDE, () => this.showBadge(false));
   }
 
   clickOnAvailability(viewModel, event) {


### PR DESCRIPTION
Will do a followup PR that will create a proper repository to store those notifications (instead of hard linking view models together)