### PR TITLE
fix: Ignore db blocked events if not data loss was involved

### DIFF
--- a/src/script/storage/StorageService.js
+++ b/src/script/storage/StorageService.js
@@ -54,7 +54,11 @@ class StorageService {
 
       this.db = new Dexie(this.dbName);
 
-      this.db.on('blocked', () => this.logger.error('Database is blocked'));
+      this.db.on('blocked', event => {
+        if (event.dataLoss !== 'none') {
+          this.logger.error('Database is blocked', event);
+        }
+      });
 
       this.db.on('changes', changes => {
         changes.forEach(change => {


### PR DESCRIPTION
There is a bug in dexie-observable and Chrome that falsly trigger this
event

see https://github.com/dfahlander/Dexie.js/issues/787