### PR TITLE
fix: Avoid flickering of embed media when liked (WEBAPP-5866)

### DIFF
--- a/src/script/components/message.js
+++ b/src/script/components/message.js
@@ -51,6 +51,7 @@ class Message {
     this.selfId = selfId;
     this.isSelfTemporaryGuest = isSelfTemporaryGuest;
     this.isLastDeliveredMessage = isLastDeliveredMessage;
+    this.accentColor = ko.pureComputed(() => message.user().accent_color());
 
     this.onClickImage = onClickImage;
     this.onClickInvitePeople = onClickInvitePeople;
@@ -274,7 +275,7 @@ const normalTemplate = `
       <!-- /ko -->
       <!-- ko if: asset.is_text() -->
         <!-- ko if: asset.should_render_text -->
-          <div class="text" data-bind="html: asset.render($parent.selfId(), message.user().accent_color()), event: {click: $parent.onClickMessage}, css: {'text-large': z.util.EmojiUtil.includesOnlyEmojies(asset.text), 'text-foreground': message.status() === z.message.StatusType.SENDING, 'ephemeral-message-obfuscated': message.isObfuscated()}" dir="auto"></div>
+          <div class="text" data-bind="html: asset.render($parent.selfId(), $parent.accentColor()), event: {click: $parent.onClickMessage}, css: {'text-large': z.util.EmojiUtil.includesOnlyEmojies(asset.text), 'text-foreground': message.status() === z.message.StatusType.SENDING, 'ephemeral-message-obfuscated': message.isObfuscated()}" dir="auto"></div>
         <!-- /ko -->
         <!-- ko foreach: asset.previews() -->
           <link-preview-asset class="message-asset" data-bind="css: {'ephemeral-asset-expired': message.isObfuscated()}" params="message: message"></link-preview-asset>


### PR DESCRIPTION
The idea is to wrap nested observables into a pureComputed to end up with primitive values that knockout will filter by itself