### PR TITLE
fix: Remove internal check for wrapper device name

### DIFF
--- a/src/script/auth/module/action/ClientAction.ts
+++ b/src/script/auth/module/action/ClientAction.ts
@@ -19,7 +19,6 @@
 
 import {ClientClassification, ClientType, RegisteredClient} from '@wireapp/api-client/dist/commonjs/client/index';
 import {ClientInfo} from '@wireapp/core/dist/client/';
-import * as config from '../../config';
 import * as Runtime from '../../Runtime';
 import * as StringUtil from '../../util/stringUtil';
 import {ThunkAction} from '../reducer';

--- a/src/script/auth/module/action/ClientAction.ts
+++ b/src/script/auth/module/action/ClientAction.ts
@@ -19,7 +19,7 @@
 
 import {ClientClassification, ClientType, RegisteredClient} from '@wireapp/api-client/dist/commonjs/client/index';
 import {ClientInfo} from '@wireapp/core/dist/client/';
-import * as Environment from '../../Environment';
+import * as config from '../../config';
 import * as Runtime from '../../Runtime';
 import * as StringUtil from '../../util/stringUtil';
 import {ThunkAction} from '../reducer';
@@ -110,7 +110,7 @@ export class ClientAction {
       } else {
         deviceModel = 'Wire Linux';
       }
-      if (!Environment.isEnvironment(Environment.ENVIRONMENT.PRODUCTION)) {
+      if (config.ENVIRONMENT !== 'production') {
         deviceModel = `${deviceModel} (Internal)`;
       }
     } else if (clientType === ClientType.TEMPORARY) {

--- a/src/script/auth/module/action/ClientAction.ts
+++ b/src/script/auth/module/action/ClientAction.ts
@@ -110,9 +110,6 @@ export class ClientAction {
       } else {
         deviceModel = 'Wire Linux';
       }
-      if (config.ENVIRONMENT !== 'production') {
-        deviceModel = `${deviceModel} (Internal)`;
-      }
     } else if (clientType === ClientType.TEMPORARY) {
       deviceModel = `${deviceModel} (Temporary)`;
     }


### PR DESCRIPTION
As agreed with @Yserz and @bennyn, we can remove the internal check as it's causing too many problems.

`Environment.ENVIRONMENT.PRODUCTION` will be removed as a next step soon.