### PR TITLE
fix: Remove dexie-observables in favor of CRUD hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "crypto-js": "3.1.9-1",
     "dexie": "2.0.4",
     "dexie-batch": "0.4.1",
-    "dexie-observable": "1.0.0-beta.5",
     "highlightjs": "9.12.0",
     "jquery": "3.3.1",
     "jquery-mousewheel": "3.1.13",

--- a/src/script/auth/configureClient.ts
+++ b/src/script/auth/configureClient.ts
@@ -19,7 +19,6 @@
 
 import {APIClient} from '@wireapp/api-client';
 import {IndexedDBEngine} from '@wireapp/store-engine';
-import 'dexie-observable';
 import * as config from './config';
 
 const configureClient = () => {

--- a/src/script/storage/StorageService.js
+++ b/src/script/storage/StorageService.js
@@ -18,11 +18,21 @@
  */
 
 import Dexie from 'dexie';
-import 'dexie-observable';
+
+import StorageSchemata from '../storage/StorageSchemata';
 
 import * as StorageUtil from 'utils/StorageUtil';
 
 class StorageService {
+  static get CONFIG() {
+    return {
+      DEXIE_CRUD_EVENTS: {
+        DELETING: 'deleting',
+        UPDATING: 'updating',
+      },
+      LISTENABLE_TABLES: [StorageSchemata.OBJECT_STORE.EVENTS],
+    };
+  }
   // Construct an new StorageService.
   constructor() {
     this.logger = new z.util.Logger('StorageService', z.config.LOGGER.OPTIONS);
@@ -60,19 +70,12 @@ class StorageService {
         }
       });
 
-      this.db.on('changes', changes => {
-        changes.forEach(change => {
-          this.dbListeners
-            .filter(listener => listener.type === change.type && listener.store === change.table)
-            .forEach(listener => listener.callback(change));
-        });
-      });
-
       this._upgradeStores(this.db);
 
       return this.db
         .open()
         .then(() => {
+          this._initCrudHooks();
           this.logger.info(`Storage Service initialized with database '${this.dbName}' version '${this.db.verno}'`);
           return this.dbName;
         })
@@ -84,8 +87,38 @@ class StorageService {
     });
   }
 
+  _initCrudHooks() {
+    const dbListeners = this.dbListeners;
+    const config = StorageService.CONFIG;
+    const DEXIE_EVENTS = config.DEXIE_CRUD_EVENTS;
+
+    config.LISTENABLE_TABLES.forEach(table => {
+      this.db[table].hook(DEXIE_EVENTS.UPDATING, function(modifications, primaryKey, obj, transaction) {
+        this.onsuccess = updatedObj =>
+          transaction.on('complete', () => {
+            dbListeners
+              .filter(listener => {
+                return listener.store === table && listener.type === DEXIE_EVENTS.UPDATING;
+              })
+              .forEach(({callback}) => callback({obj: updatedObj, oldObj: obj}));
+          });
+      });
+
+      this.db[table].hook(DEXIE_EVENTS.DELETING, function(primaryKey, obj, transaction) {
+        this.onsuccess = () =>
+          transaction.on('complete', () => {
+            dbListeners
+              .filter(listener => {
+                return listener.store === table && listener.type === DEXIE_EVENTS.DELETING;
+              })
+              .forEach(({callback}) => callback({oldObj: obj}));
+          });
+      });
+    });
+  }
+
   _upgradeStores(db) {
-    z.storage.StorageSchemata.SCHEMATA.forEach(({schema, upgrade, version}) => {
+    StorageSchemata.SCHEMATA.forEach(({schema, upgrade, version}) => {
       const versionUpdate = db.version(version).stores(schema);
       if (upgrade) {
         versionUpdate.upgrade(transaction => {
@@ -98,13 +131,11 @@ class StorageService {
 
   // Hooks
   addUpdatedListener(storeName, callback) {
-    const dexieUpdateEventType = 2;
-    this.dbListeners.push({callback, store: storeName, type: dexieUpdateEventType});
+    this.dbListeners.push({callback, store: storeName, type: StorageService.CONFIG.DEXIE_CRUD_EVENTS.UPDATING});
   }
 
   addDeletedListener(storeName, callback) {
-    const dexieDeleteEventType = 3;
-    this.dbListeners.push({callback, store: storeName, type: dexieDeleteEventType});
+    this.dbListeners.push({callback, store: storeName, type: StorageService.CONFIG.DEXIE_CRUD_EVENTS.DELETING});
   }
 
   //##############################################################################

--- a/yarn.lock
+++ b/yarn.lock
@@ -3954,11 +3954,6 @@ dexie-batch@0.4.1:
   resolved "https://registry.yarnpkg.com/dexie-batch/-/dexie-batch-0.4.1.tgz#c4c586683909c78b0de47bcdb7de4841a41ae757"
   integrity sha512-6gQaxoAkImTXhjRE0ZJUaWLC5I7IhpWWLO6VtsdzVfOlBgFpx/YfIVQGahdL1JPAE3s9M/7fVyQqW7it99M3qQ==
 
-dexie-observable@1.0.0-beta.5:
-  version "1.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/dexie-observable/-/dexie-observable-1.0.0-beta.5.tgz#a62fa51e38b3724c631301e72b0dc51635703ff4"
-  integrity sha512-n/q5hArT6+2sPZ+BunpwkXtcjt3/41gheQfmBt4pW73ot6bFGSW4lC5t6p9O7VdA/xyapt/Bukzkzjs4dEAd0Q==
-
 dexie@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/dexie/-/dexie-2.0.4.tgz#6027a5e05879424e8f9979d8c14e7420f27e3a11"


### PR DESCRIPTION
Fixes https://github.com/wireapp/wire-desktop/issues/2108

We do not actually need the full power of dexie-observable (namely: tabs syncing), which was generating a lot of disk writes.
Now we implement our own dexie hooks to listen to database changes.