### PR TITLE
chore: Clone only one layer of the config repo

### DIFF
--- a/bin/configure.js
+++ b/bin/configure.js
@@ -44,7 +44,7 @@ const ignoreList = ['.DS_Store'];
 
 console.log(`Cleaning config directory "${configDir}"`);
 fs.removeSync(configDir);
-execSync(`git clone --single-branch -b ${gitConfigurationVersion} ${gitConfigurationUrl} ${configDirName}`, {
+execSync(`git clone --depth 1 -b ${gitConfigurationVersion} ${gitConfigurationUrl} ${configDirName}`, {
   stdio: [0, 1],
 });
 


### PR DESCRIPTION
This PR will

* let `configure.js` clone only the latest commit of the config repo.
* remove `--single-branch` since `--depth` implies it.

See https://git-scm.com/docs/git-clone#git-clone---depthltdepthgt.