### PR TITLE
fix: Log error message when init fails

### DIFF
--- a/src/script/main/app.js
+++ b/src/script/main/app.js
@@ -430,7 +430,7 @@ class App {
     if (z.util.Environment.desktop) {
       logMessage = `${logMessage} - Electron '${platform.os.family}' '${z.util.Environment.version()}'`;
     }
-    this.logger.info(logMessage, {error});
+    this.logger.warn(`${logMessage}: ${error.message}`, {error});
 
     const {message, type} = error;
     const isAuthError = error instanceof z.error.AuthError;

--- a/src/script/main/app.js
+++ b/src/script/main/app.js
@@ -428,7 +428,7 @@ class App {
   _appInitFailure(error, isReload) {
     let logMessage = `Could not initialize app version '${z.util.Environment.version(false)}'`;
     if (z.util.Environment.desktop) {
-      logMessage = `${logMessage} - Electron '${platform.os.family}' '${z.util.Environment.version()}'`;
+      logMessage += ` - Electron '${platform.os.family}' '${z.util.Environment.version()}'`;
     }
     this.logger.warn(`${logMessage}: ${error.message}`, {error});
 


### PR DESCRIPTION
This PR will
* log the error message immediately behind the info message
* switch to a warning log instead of the info log

---

**Reason**

Currently we see logs like

```json
{
  "level": "info",
  "message": "z.main.App | 11:08:33.752 | Could not initialize app version '2019.01.24.1302' - Electron 'OS X' '3.4.2872-internal'",
  "timestamp": "2019-01-28T10:21:33.752Z"
}
```

but the actual error is not logged.