### PR TITLE
fix: Use Tweet description as title

### DIFF
--- a/src/script/links/LinkPreviewProtoBuilder.js
+++ b/src/script/links/LinkPreviewProtoBuilder.js
@@ -57,7 +57,7 @@ z.links.LinkPreviewProtoBuilder = {
           const protoTweet = new z.proto.Tweet(author, username);
 
           protoLinkPreview.set(z.cryptography.PROTO_MESSAGE_TYPE.TWEET, protoTweet);
-          protoLinkPreview.set(z.cryptography.PROTO_MESSAGE_TYPE.LINK_PREVIEW_TITLE, truncatedTitle);
+          protoLinkPreview.set(z.cryptography.PROTO_MESSAGE_TYPE.LINK_PREVIEW_TITLE, truncatedDescription);
         }
 
         return protoLinkPreview;


### PR DESCRIPTION
Fix for a bug introduced in https://github.com/wireapp/wire-webapp/pull/5598.