### PR TITLE
refactor: Use hash instead of URL param for SSO links

### DIFF
--- a/src/script/auth/route.ts
+++ b/src/script/auth/route.ts
@@ -28,7 +28,6 @@ const QUERY_KEY = {
   LOCALE: 'hl',
   LOGOUT_REASON: 'reason',
   PWA_AWARE: 'pwa_aware',
-  SSO_CODE: 'sso_code',
   TRACKING: 'tracking',
 };
 
@@ -52,7 +51,7 @@ const ROUTE = {
   INDEX: '/',
   INITIAL_INVITE: '/teaminvite',
   LOGIN: '/login',
-  SSO: '/sso',
+  SSO: '/sso/:code?',
   VERIFY: '/verify',
 };
 


### PR DESCRIPTION
This:

- http://localhost:8081/auth/?sso_code=wire-26233198-77f3-4aac-97ad-03de41168ab7#sso

Will become:

- http://localhost:8081/auth/#sso/wire-26233198-77f3-4aac-97ad-03de41168ab7