### PR TITLE
test: Simplify the method to instantiate components in tests

### DIFF
--- a/test/api/knockoutHelpers.js
+++ b/test/api/knockoutHelpers.js
@@ -19,12 +19,13 @@
 
 import ko from 'knockout';
 
-export function instantiateComponent(componentName, viewModel, params) {
+export function instantiateComponent(componentName, params = {}) {
   return new Promise(resolve => {
     const destination = document.body;
     ko.cleanNode(destination);
-    destination.innerHTML = `<div data-bind="component: {name: '${componentName}', params: {${params}}}"></div>`; // eslint-disable-line no-unsanitized/property
-    ko.applyBindings(viewModel, destination);
+    const paramsStr = `{${Object.keys(params).join(',')}}`;
+    destination.innerHTML = `<div data-bind="component: {name: '${componentName}', params: ${paramsStr}}"></div>`; // eslint-disable-line no-unsanitized/property
+    ko.applyBindings(params, destination);
     setImmediate(() => {
       resolve(destination);
     });

--- a/test/unit_tests/components/participantAvatarSpec.js
+++ b/test/unit_tests/components/participantAvatarSpec.js
@@ -26,21 +26,21 @@ import 'src/script/components/participantAvatar';
 describe('participant-avatar', () => {
   it("displays user's initials if no avatar is defined", () => {
     const testInitials = 'PA';
-    const viewModel = {user: new User()};
-    spyOn(viewModel.user, 'initials').and.returnValue(testInitials);
-    return instantiateComponent('participant-avatar', viewModel, 'participant: user').then(domContainer => {
+    const viewModel = {participant: new User()};
+    spyOn(viewModel.participant, 'initials').and.returnValue(testInitials);
+    return instantiateComponent('participant-avatar', viewModel).then(domContainer => {
       expect(domContainer.querySelector('.avatar-initials').innerText).toBe(testInitials);
     });
   });
 
   it("loads user's avatar when element is visible", () => {
-    const viewModel = {user: new User()};
+    const viewModel = {participant: new User()};
     const avatarPreview = AssetRemoteData.v3();
-    viewModel.user.previewPictureResource(avatarPreview);
+    viewModel.participant.previewPictureResource(avatarPreview);
 
     spyOn(avatarPreview, 'getObjectUrl').and.returnValue(Promise.resolve('/avatar'));
 
-    return instantiateComponent('participant-avatar', viewModel, 'participant: user').then(domContainer => {
+    return instantiateComponent('participant-avatar', viewModel).then(domContainer => {
       return new Promise(resolve => {
         setTimeout(() => {
           expect(avatarPreview.getObjectUrl).toHaveBeenCalled();

--- a/test/unit_tests/components/receiptModeToggleSpec.js
+++ b/test/unit_tests/components/receiptModeToggleSpec.js
@@ -25,7 +25,7 @@ import 'src/script/components/receiptModeToggle';
 describe('read-receipt-toggle', () => {
   it('renders the toggle according to the conversation read receipt mode', () => {
     const viewModel = {conversation: new Conversation()};
-    return instantiateComponent('read-receipt-toggle', viewModel, 'conversation: conversation').then(domContainer => {
+    return instantiateComponent('read-receipt-toggle', viewModel).then(domContainer => {
       const toggle = domContainer.querySelector('.slider-input');
 
       expect(toggle.checked).toBe(false);
@@ -37,14 +37,10 @@ describe('read-receipt-toggle', () => {
   });
 
   it('updates the conversation receipt mode when toggle is clicked', () => {
-    const viewModel = {conversation: new Conversation(), handleReceiptModeChanged: () => {}};
-    spyOn(viewModel, 'handleReceiptModeChanged');
+    const viewModel = {conversation: new Conversation(), onReceiptModeChanged: () => {}};
+    spyOn(viewModel, 'onReceiptModeChanged');
 
-    return instantiateComponent(
-      'read-receipt-toggle',
-      viewModel,
-      'conversation: conversation, onReceiptModeChanged: handleReceiptModeChanged'
-    ).then(domContainer => {
+    return instantiateComponent('read-receipt-toggle', viewModel).then(domContainer => {
       const toggle = domContainer.querySelector('.slider-input');
 
       expect(toggle.checked).toBe(false);
@@ -53,13 +49,13 @@ describe('read-receipt-toggle', () => {
 
       expect(toggle.checked).toBe(true);
       expect(viewModel.conversation.receiptMode()).toBe(1);
-      expect(viewModel.handleReceiptModeChanged).toHaveBeenCalledWith(viewModel.conversation, 1);
+      expect(viewModel.onReceiptModeChanged).toHaveBeenCalledWith(viewModel.conversation, 1);
 
       toggle.click();
 
       expect(toggle.checked).toBe(false);
       expect(viewModel.conversation.receiptMode()).toBe(0);
-      expect(viewModel.handleReceiptModeChanged).toHaveBeenCalledWith(viewModel.conversation, 0);
+      expect(viewModel.onReceiptModeChanged).toHaveBeenCalledWith(viewModel.conversation, 0);
     });
   });
 });


### PR DESCRIPTION
The `instantiateComponent` test helper method doesn't need a "param" parameter now. It deduces the params to give the component automatically from the view model given