### PR TITLE
chore: Use Babel for complete app

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -94,6 +94,12 @@ module.exports = function(config) {
       module: {
         rules: [
           {
+            exclude: /node_modules/,
+            include: path.resolve('src/script/'),
+            loader: 'babel-loader',
+            test: /\.[tj]sx?$/,
+          },
+          {
             loader: 'svg-inline-loader?removeSVGTagAttrs=false',
             test: /\.svg$/,
           },

--- a/src/script/util/marked.js
+++ b/src/script/util/marked.js
@@ -5,7 +5,7 @@
  */
 /*global define*/
 
-// Need to keep those imporst as commonjs flavor because this file uses `module.exports`
+// Need to keep those import as commonjs flavor because this file uses `module.exports`
 const _ = require('underscore');
 require('./linkify');
 

--- a/src/script/util/util.js
+++ b/src/script/util/util.js
@@ -19,12 +19,12 @@
 
 import {Decoder, Encoder} from 'bazinga64';
 import UUID from 'uuidjs';
-import marked from './marked.js';
 import hljs from 'highlightjs';
 import CryptoJS from 'crypto-js';
 
 /* eslint-disable no-unused-vars */
 import PhoneFormatGlobal from 'phoneformat.js';
+import marked from './marked.js';
 import StringUtilGlobal from './StringUtil';
 /* eslint-enable no-unused-vars */
 
@@ -332,7 +332,7 @@ z.util.renderMessage = (message, selfId, mentionEntities = []) => {
       );
     }, message);
 
-  mentionlessText = marked(mentionlessText, {
+  mentionlessText = window.marked(mentionlessText, {
     highlight: function(code) {
       const containsMentions = mentionEntities.some(mention => {
         const hash = createMentionHash(mention);

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -41,7 +41,7 @@ module.exports = {
     rules: [
       {
         exclude: /node_modules/,
-        include: srcScript,
+        include: src,
         loader: 'babel-loader',
         test: /\.[tj]sx?$/,
       },


### PR DESCRIPTION
This will give us the possibility to finally use `async` & `await`, [Object destructuring](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) and many other sweets while shipping for MS Edge 17.