### PR TITLE
chore: Trigger staging releases based on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,8 +88,8 @@ deploy:
     env: wire-webapp-rc
     bucket_name: wire-webapp-builds
     on:
-      repo: wireapp/wire-webapp
-      branch: staging
+      tags: true
+      condition: $TRAVIS_TAG =~ *-staging*
 
   # https://wire-webapp-staging.zinfra.io/
   - provider: elasticbeanstalk
@@ -104,8 +104,8 @@ deploy:
     env: wire-webapp-staging
     bucket_name: wire-webapp-builds
     on:
-      repo: wireapp/wire-webapp
-      branch: staging
+      tags: true
+      condition: $TRAVIS_TAG =~ *-staging*
 
   # https://wire-webapp-prod.wire.com/
   - provider: elasticbeanstalk


### PR DESCRIPTION
[Tagging suggestion](https://github.com/wireapp/wire-webapp/releases/new) from GitHub:

> If the tag isn’t meant for production use, add a pre-release version after the version name. Some good pre-release versions might be v0.2-alpha or v5.9-beta.3.

In the long run we would like to name releases like `v1.5.7-staging` but for now we can go with `2019-02-11-staging`.
