### PR TITLE
refactor: Create wrapping module for the logger

### DIFF
--- a/src/script/assets/AssetRemoteData.js
+++ b/src/script/assets/AssetRemoteData.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 class AssetRemoteData {
   /**
    * Use either AssetRemoteData.v2 or AssetRemoteData.v3 to initialize.
@@ -35,7 +37,7 @@ class AssetRemoteData {
 
     this.loadPromise = undefined;
 
-    this.logger = new z.util.Logger('AssetRemoteData', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('AssetRemoteData', z.config.LOGGER.OPTIONS);
   }
 
   generateUrl() {

--- a/src/script/assets/AssetService.js
+++ b/src/script/assets/AssetService.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 // AssetService for all asset handling and the calls to the backend REST API.
 export default class AssetService {
   /**
@@ -25,7 +27,7 @@ export default class AssetService {
    */
   constructor(backendClient) {
     this.backendClient = backendClient;
-    this.logger = new z.util.Logger('AssetService', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('AssetService', z.config.LOGGER.OPTIONS);
   }
 
   /**

--- a/src/script/auth/AuthRepository.js
+++ b/src/script/auth/AuthRepository.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import * as StorageUtil from 'utils/StorageUtil';
 
 window.z = window.z || {};
@@ -46,7 +48,7 @@ z.auth.AuthRepository = class AuthRepository {
   constructor(authService) {
     this.accessTokenRefresh = undefined;
     this.authService = authService;
-    this.logger = new z.util.Logger('z.auth.AuthRepository', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.auth.AuthRepository', z.config.LOGGER.OPTIONS);
 
     this.queueState = this.authService.backendClient.queueState;
 

--- a/src/script/auth/AuthService.js
+++ b/src/script/auth/AuthService.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import BackendClient from '../service/BackendClient';
 
 window.z = window.z || {};
@@ -37,7 +39,7 @@ z.auth.AuthService = class AuthService {
 
   constructor(backendClient) {
     this.backendClient = backendClient;
-    this.logger = new z.util.Logger('z.auth.AuthService', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.auth.AuthService', z.config.LOGGER.OPTIONS);
   }
 
   /**

--- a/src/script/backup/BackupRepository.js
+++ b/src/script/backup/BackupRepository.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import JSZip from 'jszip';
 
 import StorageSchemata from '../storage/StorageSchemata';
@@ -48,7 +50,7 @@ z.backup.BackupRepository = class BackupRepository {
    * @param {UserRepository} userRepository - Repository for all user interactions
    */
   constructor(backupService, clientRepository, connectionRepository, conversationRepository, userRepository) {
-    this.logger = new z.util.Logger('z.backup.BackupRepository', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.backup.BackupRepository', z.config.LOGGER.OPTIONS);
 
     this.backupService = backupService;
     this.clientRepository = clientRepository;

--- a/src/script/broadcast/BroadcastRepository.js
+++ b/src/script/broadcast/BroadcastRepository.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.broadcast = z.broadcast || {};
 
@@ -37,7 +39,7 @@ z.broadcast.BroadcastRepository = class BroadcastRepository {
     this.conversationRepository = conversationRepository;
     this.cryptographyRepository = cryptographyRepository;
     this.userRepository = userRepository;
-    this.logger = new z.util.Logger('z.broadcast.BroadcastRepository', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.broadcast.BroadcastRepository', z.config.LOGGER.OPTIONS);
 
     this.clientMismatchHandler = this.conversationRepository.clientMismatchHandler;
 

--- a/src/script/broadcast/BroadcastService.js
+++ b/src/script/broadcast/BroadcastService.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.broadcast = z.broadcast || {};
 
@@ -34,7 +36,7 @@ z.broadcast.BroadcastService = class BroadcastService {
    */
   constructor(backendClient) {
     this.backendClient = backendClient;
-    this.logger = new z.util.Logger('z.broadcast.BroadcastService', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.broadcast.BroadcastService', z.config.LOGGER.OPTIONS);
   }
 
   /**

--- a/src/script/client/ClientRepository.js
+++ b/src/script/client/ClientRepository.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import platform from 'platform';
 
 import * as StorageUtil from 'utils/StorageUtil';
@@ -40,7 +42,7 @@ z.client.ClientRepository = class ClientRepository {
     this.clientService = clientService;
     this.cryptographyRepository = cryptographyRepository;
     this.selfUser = ko.observable(undefined);
-    this.logger = new z.util.Logger('z.client.ClientRepository', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.client.ClientRepository', z.config.LOGGER.OPTIONS);
 
     this.clientMapper = new z.client.ClientMapper();
     this.clients = ko.pureComputed(() => (this.selfUser() ? this.selfUser().devices() : []));

--- a/src/script/client/ClientService.js
+++ b/src/script/client/ClientService.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.client = z.client || {};
 
@@ -37,7 +39,7 @@ z.client.ClientService = class ClientService {
   constructor(backendClient, storageService) {
     this.backendClient = backendClient;
     this.storageService = storageService;
-    this.logger = new z.util.Logger('z.client.ClientService', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.client.ClientService', z.config.LOGGER.OPTIONS);
 
     this.CLIENT_STORE_NAME = z.storage.StorageSchemata.OBJECT_STORE.CLIENTS;
   }

--- a/src/script/components/asset/audioAsset.js
+++ b/src/script/components/asset/audioAsset.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import AbstractAssetTransferStateTracker from './AbstractAssetTransferStateTracker';
 
 class AudioAssetComponent extends AbstractAssetTransferStateTracker {
@@ -30,7 +32,7 @@ class AudioAssetComponent extends AbstractAssetTransferStateTracker {
   constructor(params, component_info) {
     super(ko.unwrap(params.message));
     this.dispose = this.dispose.bind(this);
-    this.logger = new z.util.Logger('AudioAssetComponent', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('AudioAssetComponent', z.config.LOGGER.OPTIONS);
 
     this.message = ko.unwrap(params.message);
     this.asset = this.message.get_first_asset();

--- a/src/script/components/asset/videoAsset.js
+++ b/src/script/components/asset/videoAsset.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import AbstractAssetTransferStateTracker from './AbstractAssetTransferStateTracker';
 
 class VideoAssetComponent extends AbstractAssetTransferStateTracker {
@@ -29,7 +31,7 @@ class VideoAssetComponent extends AbstractAssetTransferStateTracker {
    */
   constructor(params, component_info) {
     super(ko.unwrap(params.message));
-    this.logger = new z.util.Logger('VideoAssetComponent', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('VideoAssetComponent', z.config.LOGGER.OPTIONS);
 
     this.message = ko.unwrap(params.message);
     this.asset = this.message.get_first_asset();

--- a/src/script/components/userProfile.js
+++ b/src/script/components/userProfile.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.components = z.components || {};
 
@@ -24,7 +26,7 @@ z.components.UserProfile = class UserProfile {
   constructor(params) {
     this.dispose = this.dispose.bind(this);
 
-    this.logger = new z.util.Logger('z.components.UserProfile', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.components.UserProfile', z.config.LOGGER.OPTIONS);
 
     this.userEntity = params.user;
 

--- a/src/script/connect/ConnectRepository.js
+++ b/src/script/connect/ConnectRepository.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.connect = z.connect || {};
 
@@ -24,7 +26,7 @@ z.connect.ConnectRepository = class ConnectRepository {
   constructor(connectService, propertiesRepository) {
     this.connectService = connectService;
     this.propertiesRepository = propertiesRepository;
-    this.logger = new z.util.Logger('z.connect.ConnectRepository', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.connect.ConnectRepository', z.config.LOGGER.OPTIONS);
   }
 
   /**

--- a/src/script/connect/ConnectService.js
+++ b/src/script/connect/ConnectService.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.connect = z.connect || {};
 
@@ -27,7 +29,7 @@ z.connect.ConnectService = class ConnectService {
    */
   constructor(backendClient) {
     this.backendClient = backendClient;
-    this.logger = new z.util.Logger('z.connect.ConnectService', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.connect.ConnectService', z.config.LOGGER.OPTIONS);
   }
 
   /**

--- a/src/script/connection/ConnectionMapper.js
+++ b/src/script/connection/ConnectionMapper.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.connection = z.connection || {};
 
@@ -27,7 +29,7 @@ window.z.connection = z.connection || {};
 z.connection.ConnectionMapper = class ConnectionMapper {
   // Construct a new connection mapper.
   constructor() {
-    this.logger = new z.util.Logger('z.connection.ConnectionMapper', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.connection.ConnectionMapper', z.config.LOGGER.OPTIONS);
 
     /**
      * Converts JSON connection into connection entity.

--- a/src/script/connection/ConnectionRepository.js
+++ b/src/script/connection/ConnectionRepository.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.connection = z.connection || {};
 
@@ -36,7 +38,7 @@ z.connection.ConnectionRepository = class ConnectionRepository {
     this.connectionService = connectionService;
     this.userRepository = userRepository;
 
-    this.logger = new z.util.Logger('z.connection.ConnectionRepository', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.connection.ConnectionRepository', z.config.LOGGER.OPTIONS);
 
     this.connectionMapper = new z.connection.ConnectionMapper();
     this.connectionEntities = ko.observableArray([]);

--- a/src/script/connection/ConnectionService.js
+++ b/src/script/connection/ConnectionService.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.connection = z.connection || {};
 
@@ -34,7 +36,7 @@ z.connection.ConnectionService = class ConnectionService {
    */
   constructor(backendClient) {
     this.backendClient = backendClient;
-    this.logger = new z.util.Logger('z.connection.ConnectionService', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.connection.ConnectionService', z.config.LOGGER.OPTIONS);
   }
 
   /**

--- a/src/script/conversation/ClientMismatchHandler.js
+++ b/src/script/conversation/ClientMismatchHandler.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.conversation = z.conversation || {};
 
@@ -28,7 +30,7 @@ z.conversation.ClientMismatchHandler = class ClientMismatchHandler {
     this.serverTimeRepository = serverTimeRepository;
     this.userRepository = userRepository;
 
-    this.logger = new z.util.Logger('z.conversation.ClientMismatchHandler', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.conversation.ClientMismatchHandler', z.config.LOGGER.OPTIONS);
   }
 
   /**

--- a/src/script/conversation/ConversationEphemeralHandler.js
+++ b/src/script/conversation/ConversationEphemeralHandler.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.conversation = z.conversation || {};
 
@@ -53,7 +55,7 @@ z.conversation.ConversationEphemeralHandler = class ConversationEphemeralHandler
     this.checkMessageTimer = this.checkMessageTimer.bind(this);
 
     this.conversationMapper = conversationMapper;
-    this.logger = new z.util.Logger('z.conversation.ConversationEphemeralHandler', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.conversation.ConversationEphemeralHandler', z.config.LOGGER.OPTIONS);
 
     this.timedMessages = ko.observableArray([]);
 

--- a/src/script/conversation/ConversationMapper.js
+++ b/src/script/conversation/ConversationMapper.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 // @ts-check
 
 /**
@@ -89,7 +91,7 @@ import Conversation from '../entity/Conversation';
 class ConversationMapper {
   // Construct a new Conversation Mapper.
   constructor() {
-    this.logger = new z.util.Logger('ConversationMapper', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('ConversationMapper', z.config.LOGGER.OPTIONS);
   }
 
   /**

--- a/src/script/conversation/ConversationRepository.js
+++ b/src/script/conversation/ConversationRepository.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import poster from 'poster-image';
 
 import EventMapper from './EventMapper';
@@ -95,7 +97,7 @@ z.conversation.ConversationRepository = class ConversationRepository {
     this.user_repository = user_repository;
     this.propertyRepository = propertyRepository;
     this.assetUploader = assetUploader;
-    this.logger = new z.util.Logger('z.conversation.ConversationRepository', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.conversation.ConversationRepository', z.config.LOGGER.OPTIONS);
 
     this.conversationMapper = new ConversationMapper();
     this.event_mapper = new EventMapper();

--- a/src/script/conversation/ConversationService.js
+++ b/src/script/conversation/ConversationService.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.conversation = z.conversation || {};
 
@@ -38,7 +40,7 @@ z.conversation.ConversationService = class ConversationService {
     this.backendClient = backendClient;
     this.eventService = eventService;
     this.storageService = storageService;
-    this.logger = new z.util.Logger('z.conversation.ConversationService', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.conversation.ConversationService', z.config.LOGGER.OPTIONS);
 
     this.CONVERSATION_STORE_NAME = z.storage.StorageSchemata.OBJECT_STORE.CONVERSATIONS;
     this.EVENT_STORE_NAME = z.storage.StorageSchemata.OBJECT_STORE.EVENTS;

--- a/src/script/conversation/ConversationVerificationStateHandler.js
+++ b/src/script/conversation/ConversationVerificationStateHandler.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.conversation = z.conversation || {};
 
@@ -25,7 +27,7 @@ z.conversation.ConversationVerificationStateHandler = class ConversationVerifica
     this.conversationRepository = conversationRepository;
     this.eventRepository = eventRepository;
     this.serverTimeRepository = serverTimeRepository;
-    this.logger = new z.util.Logger('z.conversation.ConversationVerificationStateHandler', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.conversation.ConversationVerificationStateHandler', z.config.LOGGER.OPTIONS);
 
     amplify.subscribe(z.event.WebApp.USER.CLIENT_ADDED, this.onClientAdded.bind(this));
     amplify.subscribe(z.event.WebApp.USER.CLIENT_REMOVED, this.onClientRemoved.bind(this));

--- a/src/script/conversation/EventMapper.js
+++ b/src/script/conversation/EventMapper.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import ReceiptModeUpdateMessage from '../entity/message/ReceiptModeUpdateMessage';
 import {t} from 'utils/LocalizerUtil';
 
@@ -26,7 +28,7 @@ export default class EventMapper {
    * Construct a new Event Mapper.
    */
   constructor() {
-    this.logger = new z.util.Logger('EventMapper', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('EventMapper', z.config.LOGGER.OPTIONS);
   }
 
   /**

--- a/src/script/cryptography/CryptographyMapper.js
+++ b/src/script/cryptography/CryptographyMapper.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 export default class CryptographyMapper {
   static get CONFIG() {
     return {
@@ -26,7 +28,7 @@ export default class CryptographyMapper {
 
   // Construct a new CryptographyMapper.
   constructor() {
-    this.logger = new z.util.Logger('z.cryptography.CryptographyMapper', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.cryptography.CryptographyMapper', z.config.LOGGER.OPTIONS);
   }
 
   /**

--- a/src/script/cryptography/CryptographyRepository.js
+++ b/src/script/cryptography/CryptographyRepository.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import StoreEngine from '@wireapp/store-engine';
 import {Cryptobox, version as cryptoboxVersion} from '@wireapp/cryptobox';
 import {errors as ProteusErrors} from '@wireapp/proteus';
@@ -45,7 +47,7 @@ z.cryptography.CryptographyRepository = class CryptographyRepository {
   constructor(cryptographyService, storageRepository) {
     this.cryptographyService = cryptographyService;
     this.storageRepository = storageRepository;
-    this.logger = new z.util.Logger('z.cryptography.CryptographyRepository', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.cryptography.CryptographyRepository', z.config.LOGGER.OPTIONS);
 
     this.cryptographyMapper = new CryptographyMapper();
 

--- a/src/script/cryptography/CryptographyService.js
+++ b/src/script/cryptography/CryptographyService.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.cryptography = z.cryptography || {};
 
@@ -34,7 +36,7 @@ z.cryptography.CryptographyService = class CryptographyService {
    */
   constructor(backendClient) {
     this.backendClient = backendClient;
-    this.logger = new z.util.Logger('z.cryptography.CryptographyService', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.cryptography.CryptographyService', z.config.LOGGER.OPTIONS);
   }
 
   /**

--- a/src/script/entity/Conversation.js
+++ b/src/script/entity/Conversation.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import ko from 'knockout';
 import ReceiptMode from '../conversation/ReceiptMode';
 import {t} from 'utils/LocalizerUtil';
@@ -44,7 +46,7 @@ class Conversation {
   constructor(conversation_id = '') {
     this.id = conversation_id;
 
-    this.logger = new z.util.Logger(`Conversation (${this.id})`, z.config.LOGGER.OPTIONS);
+    this.logger = new Logger(`Conversation (${this.id})`, z.config.LOGGER.OPTIONS);
 
     this.accessState = ko.observable(z.conversation.ACCESS_STATE.UNKNOWN);
     this.accessCode = ko.observable();

--- a/src/script/entity/message/File.js
+++ b/src/script/entity/message/File.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.entity = z.entity || {};
 
@@ -26,7 +28,7 @@ z.entity.File = class File extends z.entity.Asset {
     this.cancel_download = this.cancel_download.bind(this);
 
     this.type = z.assets.AssetType.FILE;
-    this.logger = new z.util.Logger('z.entity.File', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.entity.File', z.config.LOGGER.OPTIONS);
 
     // z.assets.AssetTransferState
     this.status = ko.observable();

--- a/src/script/entity/message/MediumImage.js
+++ b/src/script/entity/message/MediumImage.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.entity = z.entity || {};
 
@@ -36,7 +38,7 @@ z.entity.MediumImage = class MediumImage extends z.entity.Asset {
 
     // z.assets.AssetRemoteData
     this.resource = ko.observable();
-    this.logger = new z.util.Logger('z.entity.MediumImage', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.entity.MediumImage', z.config.LOGGER.OPTIONS);
   }
 
   /**

--- a/src/script/event/EventRepository.js
+++ b/src/script/event/EventRepository.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import {t} from 'utils/LocalizerUtil';
 
 window.z = window.z || {};
@@ -78,7 +80,7 @@ z.event.EventRepository = class EventRepository {
     this.cryptographyRepository = cryptographyRepository;
     this.serverTimeRepository = serverTimeRepository;
     this.userRepository = userRepository;
-    this.logger = new z.util.Logger('z.event.EventRepository', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.event.EventRepository', z.config.LOGGER.OPTIONS);
 
     this.currentClient = undefined;
 

--- a/src/script/event/EventService.js
+++ b/src/script/event/EventService.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.event = z.event || {};
 
@@ -28,7 +30,7 @@ z.event.EventService = class EventService {
    */
   constructor(storageService) {
     this.storageService = storageService;
-    this.logger = new z.util.Logger('z.conversation.EventService', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.conversation.EventService', z.config.LOGGER.OPTIONS);
     this.EVENT_STORE_NAME = z.storage.StorageSchemata.OBJECT_STORE.EVENTS;
   }
 

--- a/src/script/event/NotificationService.js
+++ b/src/script/event/NotificationService.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.event = z.event || {};
 
@@ -40,7 +42,7 @@ z.event.NotificationService = class NotificationService {
   constructor(backendClient, storageService) {
     this.backendClient = backendClient;
     this.storageService = storageService;
-    this.logger = new z.util.Logger('z.event.NotificationService', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.event.NotificationService', z.config.LOGGER.OPTIONS);
 
     this.AMPLIFY_STORE_NAME = z.storage.StorageSchemata.OBJECT_STORE.AMPLIFY;
   }

--- a/src/script/event/WebSocketService.js
+++ b/src/script/event/WebSocketService.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import * as StorageUtil from 'utils/StorageUtil';
 
 window.z = window.z || {};
@@ -53,7 +55,7 @@ z.event.WebSocketService = class WebSocketService {
     this.sendPing = this.sendPing.bind(this);
 
     this.backendClient = backendClient;
-    this.logger = new z.util.Logger('z.event.WebSocketService', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.event.WebSocketService', z.config.LOGGER.OPTIONS);
 
     this.clientId = undefined;
     this.connectionUrl = '';

--- a/src/script/event/preprocessor/QuotedMessageMiddleware.js
+++ b/src/script/event/preprocessor/QuotedMessageMiddleware.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.event = z.event || {};
 window.z.event.preprocessor = z.event.preprocessor || {};
@@ -33,7 +35,7 @@ z.event.preprocessor.QuotedMessageMiddleware = class QuotedMessageMiddleware {
   constructor(eventService, messageHasher) {
     this.eventService = eventService;
     this.messageHasher = messageHasher;
-    this.logger = new z.util.Logger('z.event.preprocessor.QuotedMessageMiddleware', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.event.preprocessor.QuotedMessageMiddleware', z.config.LOGGER.OPTIONS);
   }
 
   /**

--- a/src/script/event/preprocessor/ReceiptsMiddleware.js
+++ b/src/script/event/preprocessor/ReceiptsMiddleware.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import ReceiptMode from '../../conversation/ReceiptMode';
 import StatusType from '../../message/StatusType';
 
@@ -34,7 +36,7 @@ export default class ReceiptsMiddleware {
     this.eventService = eventService;
     this.userRepository = userRepository;
     this.conversationRepository = conversationRepository;
-    this.logger = new z.util.Logger('ReadReceiptMiddleware', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('ReadReceiptMiddleware', z.config.LOGGER.OPTIONS);
   }
 
   /**

--- a/src/script/event/preprocessor/ServiceMiddleware.js
+++ b/src/script/event/preprocessor/ServiceMiddleware.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.event = z.event || {};
 window.z.event.preprocessor = z.event.preprocessor || {};
@@ -31,7 +33,7 @@ z.event.preprocessor.ServiceMiddleware = class ServiceMiddleware {
   constructor(conversationRepository, userRepository) {
     this.userRepository = userRepository;
     this.conversationRepository = conversationRepository;
-    this.logger = new z.util.Logger('z.event.preprocessor.ServiceMiddleware', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.event.preprocessor.ServiceMiddleware', z.config.LOGGER.OPTIONS);
   }
 
   processEvent(event) {

--- a/src/script/integration/IntegrationRepository.js
+++ b/src/script/integration/IntegrationRepository.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import {t} from 'utils/LocalizerUtil';
 
 window.z = window.z || {};
@@ -36,7 +38,7 @@ z.integration.IntegrationRepository = class IntegrationRepository {
   }
 
   constructor(integrationService, conversationRepository, teamRepository) {
-    this.logger = new z.util.Logger('z.integration.IntegrationRepository', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.integration.IntegrationRepository', z.config.LOGGER.OPTIONS);
 
     this.integrationService = integrationService;
 

--- a/src/script/integration/IntegrationService.js
+++ b/src/script/integration/IntegrationService.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.integration = z.integration || {};
 
@@ -35,7 +37,7 @@ z.integration.IntegrationService = class IntegrationService {
    */
   constructor(backendClient) {
     this.backendClient = backendClient;
-    this.logger = new z.util.Logger('z.integration.IntegrationService', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.integration.IntegrationService', z.config.LOGGER.OPTIONS);
   }
 
   getProvider(providerId) {

--- a/src/script/lifecycle/LifecycleRepository.js
+++ b/src/script/lifecycle/LifecycleRepository.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.lifecycle = z.lifecycle || {};
 
@@ -30,7 +32,7 @@ z.lifecycle.LifecycleRepository = class LifecycleRepository {
   }
 
   constructor(lifecycleService, userRepository) {
-    this.logger = new z.util.Logger('z.lifecycle.LifecycleRepository', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.lifecycle.LifecycleRepository', z.config.LOGGER.OPTIONS);
     this.lifecycleService = lifecycleService;
     this.userRepository = userRepository;
 

--- a/src/script/lifecycle/LifecycleService.js
+++ b/src/script/lifecycle/LifecycleService.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.lifecycle = z.lifecycle || {};
 
@@ -30,7 +32,7 @@ z.lifecycle.LifecycleService = class LifecycleService {
   }
 
   constructor() {
-    this.logger = new z.util.Logger('z.lifecycle.LifecycleService', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.lifecycle.LifecycleService', z.config.LOGGER.OPTIONS);
   }
 
   getVersion() {

--- a/src/script/links/LinkPreviewRepository.js
+++ b/src/script/links/LinkPreviewRepository.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.links = z.links || {};
 
@@ -26,7 +28,7 @@ z.links.LinkPreviewRepository = class LinkPreviewRepository {
     this.updatedSendPreference = this.updatedSendPreference.bind(this);
 
     this.assetService = assetService;
-    this.logger = new z.util.Logger('z.links.LinkPreviewRepository', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.links.LinkPreviewRepository', z.config.LOGGER.OPTIONS);
 
     this.shouldSendPreviews = propertiesRepository.getPreference(z.properties.PROPERTIES_TYPE.PREVIEWS.SEND);
 

--- a/src/script/main/app.js
+++ b/src/script/main/app.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import platform from 'platform';
 import PropertiesRepository from '../properties/PropertiesRepository';
 import PropertiesService from '../properties/PropertiesService';
@@ -73,7 +75,7 @@ class App {
    */
   constructor(authComponent) {
     this.backendClient = authComponent.backendClient;
-    this.logger = new z.util.Logger('z.main.App', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.main.App', z.config.LOGGER.OPTIONS);
 
     this.telemetry = new AppInitTelemetry();
     this.windowHandler = new z.ui.WindowHandler().init();

--- a/src/script/main/globals.js
+++ b/src/script/main/globals.js
@@ -1,14 +1,12 @@
 /* eslint-disable no-unused-vars */
 import {amplify} from 'amplify';
 import Cookies from 'js-cookie';
-import moment from 'moment';
 import jQuery from 'jquery';
 import ko from 'knockout';
 import raygun from '../../../node_modules/raygun4js/dist/raygun.vanilla.js';
 
 import namespace from '../../ext/js/webapp-module-namespace/Namespace.js';
 import bubble from '../../ext/js/webapp-module-bubble/webapp-module-bubble.js';
-import logger from '../../ext/js/webapp-module-logger/Logger.js';
 
 import configGlobal from '../config.js';
 import envGlobal from '../util/Environment.js';
@@ -344,9 +342,6 @@ import authServiceGlobal from '../auth/AuthService.js';
 import authRepoGlobal from '../auth/AuthRepository.js';
 import audioPreferenceGlobal from '../audio/AudioPreference.js';
 /* eslint-enable no-unused-vars */
-
-// can be removed if we migrate 'webapp-module-logger'
-window.moment = moment;
 
 window.amplify = amplify;
 window.Cookies = Cookies;

--- a/src/script/media/MediaConstraintsHandler.js
+++ b/src/script/media/MediaConstraintsHandler.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 export default class MediaConstraintsHandler {
   static get CONFIG() {
     return {
@@ -67,7 +69,7 @@ export default class MediaConstraintsHandler {
    */
   constructor(mediaRepository) {
     this.mediaRepository = mediaRepository;
-    this.logger = new z.util.Logger('z.media.MediaConstraintsHandler', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.media.MediaConstraintsHandler', z.config.LOGGER.OPTIONS);
   }
 
   //##############################################################################

--- a/src/script/media/MediaDevicesHandler.js
+++ b/src/script/media/MediaDevicesHandler.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import * as StorageUtil from 'utils/StorageUtil';
 import MediaRepository from './MediaRepository';
 
@@ -34,7 +36,7 @@ export default class MediaDevicesHandler {
    */
   constructor(mediaRepository) {
     this.mediaRepository = mediaRepository;
-    this.logger = new z.util.Logger('MediaDevicesHandler', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('MediaDevicesHandler', z.config.LOGGER.OPTIONS);
 
     this.availableDevices = {
       audioInput: ko.observableArray([]),

--- a/src/script/media/MediaElementHandler.js
+++ b/src/script/media/MediaElementHandler.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 export default class MediaElementHandler {
   /**
    * Construct an new MediaElement handler.
@@ -24,7 +26,7 @@ export default class MediaElementHandler {
    */
   constructor(mediaRepository) {
     this.mediaRepository = mediaRepository;
-    this.logger = new z.util.Logger('MediaElementHandler', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('MediaElementHandler', z.config.LOGGER.OPTIONS);
 
     this.currentDeviceId = this.mediaRepository.devicesHandler.currentDeviceId;
     this.remoteMediaElements = ko.observableArray([]);

--- a/src/script/media/MediaStreamHandler.js
+++ b/src/script/media/MediaStreamHandler.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 export default class MediaStreamHandler {
   /**
    * Detect whether a MediaStream has a video MediaStreamTrack attached
@@ -88,7 +90,7 @@ export default class MediaStreamHandler {
 
     this.mediaRepository = mediaRepository;
     this.permissionRepository = permissionRepository;
-    this.logger = new z.util.Logger('MediaStreamHandler', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('MediaStreamHandler', z.config.LOGGER.OPTIONS);
 
     this.currentCalls = new Map();
     this.joinedCall = ko.observable();

--- a/src/script/notification/NotificationRepository.js
+++ b/src/script/notification/NotificationRepository.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import {t, Declension} from 'utils/LocalizerUtil';
 import SanitizationUtil from 'utils/SanitizationUtil';
 
@@ -63,7 +65,7 @@ z.notification.NotificationRepository = class NotificationRepository {
     this.permissionRepository = permissionRepository;
     this.userRepository = userRepository;
 
-    this.logger = new z.util.Logger('z.notification.NotificationRepository', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.notification.NotificationRepository', z.config.LOGGER.OPTIONS);
 
     this.notifications = [];
 

--- a/src/script/permission/PermissionRepository.js
+++ b/src/script/permission/PermissionRepository.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 /**
  * Permission repository to check browser permissions.
  *
@@ -34,7 +36,7 @@ export default class PermissionRepository {
    * @param {z.conversation.ConversationService} conversationRepository - Repository for all conversation interactions
    */
   constructor(callingRepository, conversationRepository) {
-    this.logger = new z.util.Logger('z.permission.PermissionRepository', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.permission.PermissionRepository', z.config.LOGGER.OPTIONS);
 
     this.permissionState = {
       [z.permission.PermissionType.CAMERA]: ko.observable(undefined),

--- a/src/script/properties/PropertiesRepository.js
+++ b/src/script/properties/PropertiesRepository.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import ConsentType from '../user/ConsentType';
 import ConsentValue from '../user/ConsentValue';
 import ReceiptMode from '../conversation/ReceiptMode';
@@ -42,7 +44,7 @@ class PropertiesRepository {
   constructor(propertiesService, selfService) {
     this.propertiesService = propertiesService;
     this.selfService = selfService;
-    this.logger = new z.util.Logger('PropertiesRepository', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('PropertiesRepository', z.config.LOGGER.OPTIONS);
 
     this.properties = new WebappProperties();
     this.selfUser = ko.observable();
@@ -168,7 +170,7 @@ class PropertiesRepository {
    */
   propertiesUpdated(properties) {
     if (properties[z.properties.PROPERTIES_TYPE.ENABLE_DEBUGGING]) {
-      amplify.publish(z.util.Logger.prototype.LOG_ON_DEBUG, properties[z.properties.PROPERTIES_TYPE.ENABLE_DEBUGGING]);
+      amplify.publish(Logger.prototype.LOG_ON_DEBUG, properties[z.properties.PROPERTIES_TYPE.ENABLE_DEBUGGING]);
     }
     return true;
   }
@@ -278,7 +280,7 @@ class PropertiesRepository {
         amplify.publish(z.event.WebApp.PROPERTIES.UPDATE.EMOJI.REPLACE_INLINE, updatedPreference);
         break;
       case z.properties.PROPERTIES_TYPE.ENABLE_DEBUGGING:
-        amplify.publish(z.util.Logger.prototype.LOG_ON_DEBUG, updatedPreference);
+        amplify.publish(Logger.prototype.LOG_ON_DEBUG, updatedPreference);
         break;
       case z.properties.PROPERTIES_TYPE.NOTIFICATIONS:
         amplify.publish(z.event.WebApp.PROPERTIES.UPDATE.NOTIFICATIONS, updatedPreference);

--- a/src/script/properties/PropertiesService.js
+++ b/src/script/properties/PropertiesService.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 class PropertiesService {
   static get CONFIG() {
     return {
@@ -30,7 +32,7 @@ class PropertiesService {
    */
   constructor(backendClient) {
     this.backendClient = backendClient;
-    this.logger = new z.util.Logger('z.properties.PropertiesService', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.properties.PropertiesService', z.config.LOGGER.OPTIONS);
   }
 
   /**

--- a/src/script/search/SearchRepository.js
+++ b/src/script/search/SearchRepository.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.search = z.search || {};
 
@@ -55,7 +57,7 @@ class SearchRepository {
   constructor(searchService, userRepository) {
     this.searchService = searchService;
     this.userRepository = userRepository;
-    this.logger = new z.util.Logger('z.search.SearchRepository', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.search.SearchRepository', z.config.LOGGER.OPTIONS);
   }
 
   /**

--- a/src/script/search/SearchService.js
+++ b/src/script/search/SearchService.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.search = z.search || {};
 
@@ -27,7 +29,7 @@ z.search.SearchService = class SearchService {
    */
   constructor(backendClient) {
     this.backendClient = backendClient;
-    this.logger = new z.util.Logger('z.search.SearchService', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.search.SearchService', z.config.LOGGER.OPTIONS);
   }
 
   /**

--- a/src/script/storage/StorageRepository.js
+++ b/src/script/storage/StorageRepository.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.storage = z.storage || {};
 
@@ -39,7 +41,7 @@ z.storage.StorageRepository = class StorageRepository {
    */
   constructor(storageService) {
     this.storageService = storageService;
-    this.logger = new z.util.Logger('z.storage.StorageRepository', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.storage.StorageRepository', z.config.LOGGER.OPTIONS);
 
     this.AMPLIFY_STORE_NAME = z.storage.StorageSchemata.OBJECT_STORE.AMPLIFY;
   }

--- a/src/script/storage/StorageService.js
+++ b/src/script/storage/StorageService.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import Dexie from 'dexie';
 
 import StorageSchemata from '../storage/StorageSchemata';
@@ -35,7 +37,7 @@ class StorageService {
   }
   // Construct an new StorageService.
   constructor() {
-    this.logger = new z.util.Logger('StorageService', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('StorageService', z.config.LOGGER.OPTIONS);
 
     this.db = undefined;
     this.dbName = undefined;

--- a/src/script/team/TeamMapper.js
+++ b/src/script/team/TeamMapper.js
@@ -17,11 +17,13 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import {roleFromTeamPermissions} from './../user/UserPermission';
 
 export default class TeamMapper {
   constructor() {
-    this.logger = new z.util.Logger('TeamMapper', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('TeamMapper', z.config.LOGGER.OPTIONS);
   }
 
   mapTeamFromObject(data) {

--- a/src/script/team/TeamRepository.js
+++ b/src/script/team/TeamRepository.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import TeamMapper from './TeamMapper';
 
 window.z = window.z || {};
@@ -31,7 +33,7 @@ z.team.TeamRepository = class TeamRepository {
    * @param {UserRepository} userRepository - Repository for all user interactions
    */
   constructor(teamService, userRepository) {
-    this.logger = new z.util.Logger('z.team.TeamRepository', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.team.TeamRepository', z.config.LOGGER.OPTIONS);
 
     this.teamMapper = new TeamMapper();
     this.teamService = teamService;

--- a/src/script/team/TeamService.js
+++ b/src/script/team/TeamService.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.team = z.team || {};
 
@@ -34,7 +36,7 @@ z.team.TeamService = class TeamService {
    */
   constructor(backendClient) {
     this.backendClient = backendClient;
-    this.logger = new z.util.Logger('z.team.TeamService', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.team.TeamService', z.config.LOGGER.OPTIONS);
   }
 
   getTeamById(teamId) {

--- a/src/script/telemetry/app_init/AppInitStatistics.js
+++ b/src/script/telemetry/app_init/AppInitStatistics.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import AppInitStatisticsValue from './AppInitStatisticsValue';
 
 export default class AppInitStatistics {
@@ -28,7 +30,7 @@ export default class AppInitStatistics {
   }
 
   constructor() {
-    this.logger = new z.util.Logger('AppInitStatistics', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('AppInitStatistics', z.config.LOGGER.OPTIONS);
 
     amplify.subscribe(z.event.WebApp.TELEMETRY.BACKEND_REQUESTS, this.update_backend_requests.bind(this));
   }

--- a/src/script/telemetry/app_init/AppInitTelemetry.js
+++ b/src/script/telemetry/app_init/AppInitTelemetry.js
@@ -17,11 +17,13 @@
  *
  */
 import AppInitStatistics from './AppInitStatistics';
+import Logger from 'utils/Logger';
+
 import AppInitTimings from './AppInitTimings';
 
 export default class AppInitTelemetry {
   constructor() {
-    this.logger = new z.util.Logger('AppInitTelemetry', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('AppInitTelemetry', z.config.LOGGER.OPTIONS);
     this.timings = new AppInitTimings();
     this.statistics = new AppInitStatistics();
   }

--- a/src/script/telemetry/app_init/AppInitTimings.js
+++ b/src/script/telemetry/app_init/AppInitTimings.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import AppInitTimingsStep from './AppInitTimingsStep';
 
 export default class AppInitTimings {
@@ -29,7 +31,7 @@ export default class AppInitTimings {
   }
 
   constructor() {
-    this.logger = new z.util.Logger('AppInitTimings', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('AppInitTimings', z.config.LOGGER.OPTIONS);
     this.init = window.performance.now();
   }
 

--- a/src/script/telemetry/calling/CallLogger.js
+++ b/src/script/telemetry/calling/CallLogger.js
@@ -1,5 +1,6 @@
 import CryptoJS from 'crypto-js';
 import sdpTransform from 'sdp-transform';
+import Logger from 'utils/Logger';
 
 z.telemetry.calling.CallLogger = class CallLogger {
   static get CONFIG() {
@@ -51,7 +52,7 @@ z.telemetry.calling.CallLogger = class CallLogger {
   constructor(name, id, options, messageLog) {
     name = id ? this._createName(name, id) : name;
 
-    this.logger = new z.util.Logger(name, options);
+    this.logger = new Logger(name, options);
     this.levels = this.logger.levels;
 
     this.messageLog = messageLog;

--- a/src/script/telemetry/calling/CallSetupTimings.js
+++ b/src/script/telemetry/calling/CallSetupTimings.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.telemetry = z.telemetry || {};
 window.z.telemetry.calling = z.telemetry.calling || {};
@@ -27,7 +29,7 @@ z.telemetry.calling.CallSetupTimings = class CallSetupTimings {
     this.log = this.log.bind(this);
     this.call_id = call_id;
 
-    this.logger = new z.util.Logger('z.telemetry.calling.CallSetupTimings', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.telemetry.calling.CallSetupTimings', z.config.LOGGER.OPTIONS);
 
     this.is_answer = false;
     this.flowId = undefined;

--- a/src/script/telemetry/calling/CallTelemetry.js
+++ b/src/script/telemetry/calling/CallTelemetry.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.telemetry = z.telemetry || {};
 window.z.telemetry.calling = z.telemetry.calling || {};
@@ -24,7 +26,7 @@ window.z.telemetry.calling = z.telemetry.calling || {};
 // Call traces entity.
 z.telemetry.calling.CallTelemetry = class CallTelemetry {
   constructor() {
-    this.logger = new z.util.Logger('z.telemetry.calling.CallTelemetry', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.telemetry.calling.CallTelemetry', z.config.LOGGER.OPTIONS);
 
     this.sessions = {};
     this.remote_version = undefined;

--- a/src/script/telemetry/calling/FlowTelemetry.js
+++ b/src/script/telemetry/calling/FlowTelemetry.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.telemetry = z.telemetry || {};
 window.z.telemetry.calling = z.telemetry.calling || {};
@@ -38,7 +40,7 @@ z.telemetry.calling.FlowTelemetry = class FlowTelemetry {
     const loggerId = this.id.substr(0, 8);
     const loggerTimestamp = new Date().getMilliseconds();
     const loggerName = `z.telemetry.calling.FlowTelemetry - ${loggerId} (${loggerTimestamp})`;
-    this.logger = new z.util.Logger(loggerName, z.config.LOGGER.OPTIONS);
+    this.logger = new Logger(loggerName, z.config.LOGGER.OPTIONS);
     this.is_answer = false;
     this.peer_connection = undefined;
 

--- a/src/script/time/ServerTimeRepository.js
+++ b/src/script/time/ServerTimeRepository.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import ko from 'knockout';
 
 window.z = window.z || {};
@@ -24,7 +26,7 @@ window.z.time = z.time || {};
 
 z.time.ServerTimeRepository = class ServerTimeRepository {
   constructor() {
-    this.logger = new z.util.Logger('z.time.ServerTimeRepository', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.time.ServerTimeRepository', z.config.LOGGER.OPTIONS);
     this.timeOffset = ko.observable(undefined);
   }
 

--- a/src/script/tracking/EventTrackingRepository.js
+++ b/src/script/tracking/EventTrackingRepository.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.tracking = z.tracking || {};
 
@@ -51,7 +53,7 @@ z.tracking.EventTrackingRepository = class EventTrackingRepository {
   constructor(teamRepository, userRepository) {
     this.updatePrivacyPreference = this.updatePrivacyPreference.bind(this);
 
-    this.logger = new z.util.Logger('z.tracking.EventTrackingRepository', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.tracking.EventTrackingRepository', z.config.LOGGER.OPTIONS);
 
     this.teamRepository = teamRepository;
     this.userRepository = userRepository;

--- a/src/script/ui/WindowHandler.js
+++ b/src/script/ui/WindowHandler.js
@@ -17,13 +17,15 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.ui = z.ui || {};
 
 z.ui.WindowHandler = class WindowHandler {
   constructor() {
     this.init = this.init.bind(this);
-    this.logger = new z.util.Logger('z.ui.WindowHandler', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.ui.WindowHandler', z.config.LOGGER.OPTIONS);
 
     this.height = 0;
     this.width = 0;

--- a/src/script/user/UserMapper.js
+++ b/src/script/user/UserMapper.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import User from '../entity/User';
 
 export default class UserMapper {
@@ -26,7 +28,7 @@ export default class UserMapper {
    * @param {z.time.ServerTimeRepository} serverTimeRepository - Handles time shift between server and client
    */
   constructor(serverTimeRepository) {
-    this.logger = new z.util.Logger('UserMapper', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('UserMapper', z.config.LOGGER.OPTIONS);
     this.serverTimeRepository = serverTimeRepository;
   }
 

--- a/src/script/user/UserRepository.js
+++ b/src/script/user/UserRepository.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import ko from 'knockout';
 
 import {UNSPLASH_URL} from '../externalRoute';
@@ -50,7 +52,7 @@ export default class UserRepository {
    * @param {PropertiesRepository} propertyRepository - Handles account level properties
    */
   constructor(user_service, asset_service, selfService, client_repository, serverTimeRepository, propertyRepository) {
-    this.logger = new z.util.Logger('UserRepository', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('UserRepository', z.config.LOGGER.OPTIONS);
 
     this.asset_service = asset_service;
     this.client_repository = client_repository;

--- a/src/script/user/UserService.js
+++ b/src/script/user/UserService.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 export default class UserService {
   static get URL() {
     return {
@@ -33,7 +35,7 @@ export default class UserService {
    */
   constructor(backendClient, storageService) {
     this.backendClient = backendClient;
-    this.logger = new z.util.Logger('UserService', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('UserService', z.config.LOGGER.OPTIONS);
     this.storageService = storageService;
 
     this.USER_STORE_NAME = z.storage.StorageSchemata.OBJECT_STORE.USERS;

--- a/src/script/util/DebugUtil.js
+++ b/src/script/util/DebugUtil.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import $ from 'jquery';
 import sodium from 'libsodium-wrappers-sumo';
 import Dexie from 'dexie';
@@ -37,7 +39,7 @@ export default class DebugUtil {
     this.sodium = sodium;
     this.Dexie = Dexie;
 
-    this.logger = new z.util.Logger('z.util.DebugUtil', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.util.DebugUtil', z.config.LOGGER.OPTIONS);
   }
 
   blockAllConnections() {

--- a/src/script/util/Logger.js
+++ b/src/script/util/Logger.js
@@ -1,0 +1,27 @@
+/*
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import '../../ext/js/webapp-module-logger/Logger.js';
+import {amplify} from 'amplify';
+import moment from 'moment';
+
+window.amplify = amplify; // The logger needs amplify to be on the root scope
+window.moment = moment; // The logger needs amplify to be on the root scope
+
+export default z.util.Logger;

--- a/src/script/util/PromiseQueue.js
+++ b/src/script/util/PromiseQueue.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.util = z.util || {};
 
@@ -41,7 +43,7 @@ z.util.PromiseQueue = class PromiseQueue {
     const {concurrent = 1, name, paused = false, timeout = PromiseQueue.CONFIG.UNBLOCK_INTERVAL} = options;
 
     const loggerName = `z.util.PromiseQueue${name ? ` (${name})` : ''}`;
-    this.logger = new z.util.Logger(loggerName, z.config.LOGGER.OPTIONS);
+    this.logger = new Logger(loggerName, z.config.LOGGER.OPTIONS);
 
     this._blocked = false;
     this._concurrent = concurrent;

--- a/src/script/util/dependenciesResolver.js
+++ b/src/script/util/dependenciesResolver.js
@@ -18,6 +18,7 @@
  */
 
 import {memoize} from 'underscore';
+import Logger from './Logger';
 
 let dependencyGraph;
 let loggerConfig;
@@ -52,7 +53,7 @@ const resolver = {
       throw new Error(`No dependencies configuration for class: ${dependencyClass}`);
     }
     const dependencies = config.dependencies.map(resolver.resolve);
-    const dependencyLogger = new z.util.Logger(config.name, loggerConfig);
+    const dependencyLogger = new Logger(config.name, loggerConfig);
     return new dependencyClass(...dependencies.concat(dependencyLogger));
   }),
 };

--- a/src/script/view_model/ActionsViewModel.js
+++ b/src/script/view_model/ActionsViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import {t} from 'utils/LocalizerUtil';
 
 window.z = window.z || {};
@@ -29,7 +31,7 @@ z.viewModel.ActionsViewModel = class ActionsViewModel {
     this.conversationRepository = repositories.conversation;
     this.integrationRepository = repositories.integration;
     this.userRepository = repositories.user;
-    this.logger = new z.util.Logger('z.viewModel.ListViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.ListViewModel', z.config.LOGGER.OPTIONS);
   }
 
   acceptConnectionRequest(userEntity, showConversation) {

--- a/src/script/view_model/AuthViewModel.js
+++ b/src/script/view_model/AuthViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import Cookies from 'js-cookie';
 
 import App from '../main/app';
@@ -53,7 +55,7 @@ class AuthViewModel {
     this.click_on_remove_device_submit = this.click_on_remove_device_submit.bind(this);
 
     this.elementId = 'auth-page';
-    this.logger = new z.util.Logger('z.viewModel.AuthViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.AuthViewModel', z.config.LOGGER.OPTIONS);
 
     this.authRepository = authComponent.repository;
     this.audio_repository = authComponent.audio;

--- a/src/script/view_model/ContentViewModel.js
+++ b/src/script/view_model/ContentViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.viewModel = z.viewModel || {};
 
@@ -48,7 +50,7 @@ z.viewModel.ContentViewModel = class ContentViewModel {
     this.mainViewModel = mainViewModel;
     this.conversationRepository = repositories.conversation;
     this.userRepository = repositories.user;
-    this.logger = new z.util.Logger('z.viewModel.ContentViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.ContentViewModel', z.config.LOGGER.OPTIONS);
 
     // State
     this.state = ko.observable(ContentViewModel.STATE.WATERMARK);

--- a/src/script/view_model/ListViewModel.js
+++ b/src/script/view_model/ListViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import {t} from 'utils/LocalizerUtil';
 
 window.z = window.z || {};
@@ -62,7 +64,7 @@ z.viewModel.ListViewModel = class ListViewModel {
     this.isProAccount = this.teamRepository.isTeam;
     this.selfUser = this.userRepository.self;
 
-    this.logger = new z.util.Logger('z.viewModel.ListViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.ListViewModel', z.config.LOGGER.OPTIONS);
 
     // State
     this.state = ko.observable(ListViewModel.STATE.CONVERSATIONS);

--- a/src/script/view_model/MainViewModel.js
+++ b/src/script/view_model/MainViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.viewModel = z.viewModel || {};
 
@@ -66,7 +68,7 @@ z.viewModel.MainViewModel = class MainViewModel {
 
     this.elementId = 'wire-main';
     this.userRepository = repositories.user;
-    this.logger = new z.util.Logger('z.viewModel.MainViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.MainViewModel', z.config.LOGGER.OPTIONS);
 
     this.selfUser = this.userRepository.self;
 

--- a/src/script/view_model/ModalsViewModel.js
+++ b/src/script/view_model/ModalsViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import {t} from 'utils/LocalizerUtil';
 
 window.z = window.z || {};
@@ -36,7 +38,7 @@ z.viewModel.ModalsViewModel = class ModalsViewModel {
   }
 
   constructor() {
-    this.logger = new z.util.Logger('z.viewModel.ModalsViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.ModalsViewModel', z.config.LOGGER.OPTIONS);
     this.elementId = 'modals';
 
     this.modals = {};

--- a/src/script/view_model/ShortcutsViewModel.js
+++ b/src/script/view_model/ShortcutsViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.viewModel = z.viewModel || {};
 
@@ -26,7 +28,7 @@ z.viewModel.ShortcutsViewModel = class ShortcutsViewModel {
     this.onRejectCall = this.onRejectCall.bind(this);
 
     this.callingRepository = repositories.calling;
-    this.logger = new z.util.Logger('z.viewModel.ShortcutsViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.ShortcutsViewModel', z.config.LOGGER.OPTIONS);
 
     this.joinedCall = this.callingRepository.joinedCall;
     this.joinedCall.subscribe(callEntity => this._updateShortcutSubscription(callEntity));

--- a/src/script/view_model/VideoCallingViewModel.js
+++ b/src/script/view_model/VideoCallingViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.viewModel = z.viewModel || {};
 
@@ -43,7 +45,7 @@ z.viewModel.VideoCallingViewModel = class VideoCallingViewModel {
 
     this.contentViewModel = mainViewModel.content;
     this.multitasking = this.contentViewModel.multitasking;
-    this.logger = new z.util.Logger('z.viewModel.VideoCallingViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.VideoCallingViewModel', z.config.LOGGER.OPTIONS);
 
     this.devicesHandler = this.mediaRepository.devicesHandler;
     this.streamHandler = this.mediaRepository.streamHandler;

--- a/src/script/view_model/WarningsViewModel.js
+++ b/src/script/view_model/WarningsViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import {t} from 'utils/LocalizerUtil';
 
 window.z = window.z || {};
@@ -61,7 +63,7 @@ z.viewModel.WarningsViewModel = class WarningsViewModel {
 
   constructor() {
     this.elementId = 'warnings';
-    this.logger = new z.util.Logger('z.viewModel.WarningsViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.WarningsViewModel', z.config.LOGGER.OPTIONS);
 
     // Array of warning banners
     this.warnings = ko.observableArray();

--- a/src/script/view_model/WindowTitleViewModel.js
+++ b/src/script/view_model/WindowTitleViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import {t} from 'utils/LocalizerUtil';
 import ko from 'knockout';
 
@@ -31,7 +33,7 @@ export default class WindowTitleViewModel {
     this.contentState = mainViewModel.content.state;
     this.conversationRepository = repositories.conversation;
     this.userRepository = repositories.user;
-    this.logger = new z.util.Logger('WindowTitleViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('WindowTitleViewModel', z.config.LOGGER.OPTIONS);
 
     this.updateWindowTitle = ko.observable(false);
 

--- a/src/script/view_model/content/CollectionDetailsViewModel.js
+++ b/src/script/view_model/content/CollectionDetailsViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import moment from 'moment';
 import {isToday, isCurrentYear, isSameDay, isSameMonth} from '../../util/moment';
 import {t} from 'utils/LocalizerUtil';
@@ -34,7 +36,7 @@ z.viewModel.content.CollectionDetailsViewModel = class CollectionDetailsViewMode
     this.removedFromView = this.removedFromView.bind(this);
     this.setConversation = this.setConversation.bind(this);
 
-    this.logger = new z.util.Logger('z.viewModel.CollectionDetailsViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.CollectionDetailsViewModel', z.config.LOGGER.OPTIONS);
 
     this.template = ko.observable();
     this.conversationEntity = ko.observable();

--- a/src/script/view_model/content/CollectionViewModel.js
+++ b/src/script/view_model/content/CollectionViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.viewModel = z.viewModel || {};
 window.z.viewModel.content = z.viewModel.content || {};
@@ -36,7 +38,7 @@ z.viewModel.content.CollectionViewModel = class CollectionViewModel {
 
     this.collectionDetails = contentViewModel.collectionDetails;
     this.conversation_repository = repositories.conversation;
-    this.logger = new z.util.Logger('z.viewModel.CollectionViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.CollectionViewModel', z.config.LOGGER.OPTIONS);
 
     this.conversationEntity = ko.observable();
 

--- a/src/script/view_model/content/ConnectRequestsViewModel.js
+++ b/src/script/view_model/content/ConnectRequestsViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.viewModel = z.viewModel || {};
 window.z.viewModel.content = z.viewModel.content || {};
@@ -36,7 +38,7 @@ z.viewModel.content.ConnectRequestsViewModel = class ConnectRequestsViewModel {
 
     this.mainViewModel = mainViewModel;
     this.userRepository = repositories.user;
-    this.logger = new z.util.Logger('z.viewModel.content.ConnectRequestsViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.content.ConnectRequestsViewModel', z.config.LOGGER.OPTIONS);
 
     this.actionsViewModel = this.mainViewModel.actions;
     this.connectRequests = this.userRepository.connect_requests;

--- a/src/script/view_model/content/GiphyViewModel.js
+++ b/src/script/view_model/content/GiphyViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.viewModel = z.viewModel || {};
 window.z.viewModel.content = z.viewModel.content || {};
@@ -42,7 +44,7 @@ z.viewModel.content.GiphyViewModel = class GiphyViewModel {
     this.clickToSelectGif = this.clickToSelectGif.bind(this);
 
     this.giphyRepository = repositories.giphy;
-    this.logger = new z.util.Logger('z.viewModel.content.GiphyViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.content.GiphyViewModel', z.config.LOGGER.OPTIONS);
 
     this.modal = undefined;
     this.state = ko.observable(GiphyViewModel.STATE.DEFAULT);

--- a/src/script/view_model/content/GroupCreationViewModel.js
+++ b/src/script/view_model/content/GroupCreationViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import ReceiptMode from '../../conversation/ReceiptMode';
 import {t} from 'utils/LocalizerUtil';
 
@@ -34,7 +36,7 @@ z.viewModel.content.GroupCreationViewModel = class GroupCreationViewModel {
   }
 
   constructor(mainViewModel, contentViewModel, repositories) {
-    this.logger = new z.util.Logger('z.viewModel.content.GroupCreationViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.content.GroupCreationViewModel', z.config.LOGGER.OPTIONS);
 
     this.clickOnCreate = this.clickOnCreate.bind(this);
     this.clickOnToggleGuestMode = this.clickOnToggleGuestMode.bind(this);

--- a/src/script/view_model/content/HistoryExportViewModel.js
+++ b/src/script/view_model/content/HistoryExportViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import {t} from 'utils/LocalizerUtil';
 
 window.z = window.z || {};
@@ -42,7 +44,7 @@ z.viewModel.content.HistoryExportViewModel = class HistoryExportViewModel {
   constructor(mainViewModel, contentViewModel, repositories) {
     this.backupRepository = repositories.backup;
     this.userRepository = repositories.user;
-    this.logger = new z.util.Logger('z.viewModel.content.HistoryExportViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.content.HistoryExportViewModel', z.config.LOGGER.OPTIONS);
 
     this.hasError = ko.observable(false);
     this.state = ko.observable(HistoryExportViewModel.STATE.PREPARING);

--- a/src/script/view_model/content/HistoryImportViewModel.js
+++ b/src/script/view_model/content/HistoryImportViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import JSZip from 'jszip';
 
 import {t} from 'utils/LocalizerUtil';
@@ -37,7 +39,7 @@ z.viewModel.content.HistoryImportViewModel = class HistoryImportViewModel {
   constructor(mainViewModel, contentViewModel, repositories) {
     this.backupRepository = repositories.backup;
 
-    this.logger = new z.util.Logger('z.viewModel.content.HistoryExportViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.content.HistoryExportViewModel', z.config.LOGGER.OPTIONS);
 
     this.error = ko.observable(null);
     this.errorHeadline = ko.observable('');

--- a/src/script/view_model/content/InputBarViewModel.js
+++ b/src/script/view_model/content/InputBarViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import * as StorageUtil from 'utils/StorageUtil';
 import {resolve, graph} from '../../config/appResolver';
 import {t} from 'utils/LocalizerUtil';
@@ -66,7 +68,7 @@ z.viewModel.content.InputBarViewModel = class InputBarViewModel {
     this.conversationRepository = repositories.conversation;
     this.searchRepository = repositories.search;
     this.userRepository = repositories.user;
-    this.logger = new z.util.Logger('z.viewModel.content.InputBarViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.content.InputBarViewModel', z.config.LOGGER.OPTIONS);
 
     this.conversationEntity = this.conversationRepository.active_conversation;
     this.selfUser = this.userRepository.self;

--- a/src/script/view_model/content/MessageListViewModel.js
+++ b/src/script/view_model/content/MessageListViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import moment from 'moment';
 import $ from 'jquery';
 import {groupBy} from 'underscore';
@@ -57,7 +59,7 @@ z.viewModel.content.MessageListViewModel = class MessageListViewModel {
     this.integrationRepository = repositories.integration;
     this.locationRepository = repositories.location;
     this.userRepository = repositories.user;
-    this.logger = new z.util.Logger('z.viewModel.content.MessageListViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.content.MessageListViewModel', z.config.LOGGER.OPTIONS);
 
     this.actionsViewModel = this.mainViewModel.actions;
     this.selfUser = this.userRepository.self;

--- a/src/script/view_model/content/PreferencesAVViewModel.js
+++ b/src/script/view_model/content/PreferencesAVViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.viewModel = z.viewModel || {};
 window.z.viewModel.content = z.viewModel.content || {};
@@ -37,7 +39,7 @@ z.viewModel.content.PreferencesAVViewModel = class PreferencesAVViewModel {
     this.initiateDevices = this.initiateDevices.bind(this);
     this.releaseDevices = this.releaseDevices.bind(this);
 
-    this.logger = new z.util.Logger('z.viewModel.content.PreferencesAVViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.content.PreferencesAVViewModel', z.config.LOGGER.OPTIONS);
 
     this.mediaRepository = repositories.media;
     this.userRepository = repositories.user;

--- a/src/script/view_model/content/PreferencesAboutViewModel.js
+++ b/src/script/view_model/content/PreferencesAboutViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import {
   getPrivacyPolicyUrl,
   getSupportContactUrl,
@@ -32,7 +34,7 @@ window.z.viewModel.content = z.viewModel.content || {};
 
 z.viewModel.content.PreferencesAboutViewModel = class PreferencesAboutViewModel {
   constructor(mainViewModel, contentViewModel, repositories) {
-    this.logger = new z.util.Logger('z.viewModel.content.PreferencesAboutViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.content.PreferencesAboutViewModel', z.config.LOGGER.OPTIONS);
 
     this.userRepository = repositories.user;
     this.selfUser = this.userRepository.self;

--- a/src/script/view_model/content/PreferencesAccountViewModel.js
+++ b/src/script/view_model/content/PreferencesAccountViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import PreferenceNotificationRepository from '../../notification/PreferenceNotificationRepository';
 import {getCreateTeamUrl, getManageTeamUrl, URL_PATH, getAccountPagesUrl} from '../../externalRoute';
 import {t} from 'utils/LocalizerUtil';
@@ -52,7 +54,7 @@ z.viewModel.content.PreferencesAccountViewModel = class PreferencesAccountViewMo
     this.changeAccentColor = this.changeAccentColor.bind(this);
     this.removedFromView = this.removedFromView.bind(this);
 
-    this.logger = new z.util.Logger('z.viewModel.content.PreferencesAccountViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.content.PreferencesAccountViewModel', z.config.LOGGER.OPTIONS);
 
     this.mainViewModel = mainViewModel;
     this.backupRepository = repositories.backup;

--- a/src/script/view_model/content/PreferencesDeviceDetailsViewModel.js
+++ b/src/script/view_model/content/PreferencesDeviceDetailsViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import {t} from 'utils/LocalizerUtil';
 
 window.z = window.z || {};
@@ -36,7 +38,7 @@ z.viewModel.content.PreferencesDeviceDetailsViewModel = class PreferencesDeviceD
     this.clientRepository = repositories.client;
     this.conversationRepository = repositories.conversation;
     this.cryptographyRepository = repositories.cryptography;
-    this.logger = new z.util.Logger('z.viewModel.content.PreferencesDeviceDetailsViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.content.PreferencesDeviceDetailsViewModel', z.config.LOGGER.OPTIONS);
 
     this.actionsViewModel = mainViewModel.actions;
     this.selfUser = this.clientRepository.selfUser;

--- a/src/script/view_model/content/PreferencesDevicesViewModel.js
+++ b/src/script/view_model/content/PreferencesDevicesViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import {t} from 'utils/LocalizerUtil';
 
 window.z = window.z || {};
@@ -33,7 +35,7 @@ z.viewModel.content.PreferencesDevicesViewModel = class PreferencesDevicesViewMo
     this.conversationRepository = repositories.conversation;
     this.cryptographyRepository = repositories.cryptography;
     this.userRepository = repositories.user;
-    this.logger = new z.util.Logger('z.viewModel.content.PreferencesDevicesViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.content.PreferencesDevicesViewModel', z.config.LOGGER.OPTIONS);
 
     this.actionsViewModel = mainViewModel.actions;
     this.preferencesDeviceDetails = contentViewModel.preferencesDeviceDetails;

--- a/src/script/view_model/content/PreferencesOptionsViewModel.js
+++ b/src/script/view_model/content/PreferencesOptionsViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import {t} from 'utils/LocalizerUtil';
 
 window.z = window.z || {};
@@ -33,7 +35,7 @@ z.viewModel.content.PreferencesOptionsViewModel = class PreferencesOptionsViewMo
   }
 
   constructor(mainViewModel, contentViewModel, repositories) {
-    this.logger = new z.util.Logger('z.viewModel.content.PreferencesOptionsViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.content.PreferencesOptionsViewModel', z.config.LOGGER.OPTIONS);
 
     this.callingRepository = repositories.calling;
     this.propertiesRepository = repositories.properties;

--- a/src/script/view_model/content/TitleBarViewModel.js
+++ b/src/script/view_model/content/TitleBarViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import {t} from 'utils/LocalizerUtil';
 
 window.z = window.z || {};
@@ -32,7 +34,7 @@ z.viewModel.content.TitleBarViewModel = class TitleBarViewModel {
     this.conversationRepository = repositories.conversation;
     this.userRepository = repositories.user;
     this.multitasking = contentViewModel.multitasking;
-    this.logger = new z.util.Logger('z.viewModel.content.TitleBarViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.content.TitleBarViewModel', z.config.LOGGER.OPTIONS);
 
     this.panelViewModel = mainViewModel.panel;
 

--- a/src/script/view_model/list/ArchiveViewModel.js
+++ b/src/script/view_model/list/ArchiveViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.viewModel = z.viewModel || {};
 window.z.viewModel.list = z.viewModel.list || {};
@@ -36,7 +38,7 @@ z.viewModel.list.ArchiveViewModel = class ArchiveViewModel {
 
     this.listViewModel = listViewModel;
     this.conversationRepository = repositories.conversation;
-    this.logger = new z.util.Logger('z.viewModel.list.ArchiveViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.list.ArchiveViewModel', z.config.LOGGER.OPTIONS);
 
     this.archivedConversations = this.conversationRepository.conversations_archived;
 

--- a/src/script/view_model/list/ConversationListViewModel.js
+++ b/src/script/view_model/list/ConversationListViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import {t} from 'utils/LocalizerUtil';
 
 window.z = window.z || {};
@@ -46,7 +48,7 @@ z.viewModel.list.ConversationListViewModel = class ConversationListViewModel {
     this.contentViewModel = mainViewModel.content;
     this.listViewModel = listViewModel;
 
-    this.logger = new z.util.Logger('z.viewModel.list.ConversationListViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.list.ConversationListViewModel', z.config.LOGGER.OPTIONS);
     this.multitasking = this.contentViewModel.multitasking;
 
     this.showCalls = ko.observable(false);

--- a/src/script/view_model/list/PreferencesListViewModel.js
+++ b/src/script/view_model/list/PreferencesListViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 window.z = window.z || {};
 window.z.viewModel = z.viewModel || {};
 window.z.viewModel.list = z.viewModel.list || {};
@@ -32,7 +34,7 @@ z.viewModel.list.PreferencesListViewModel = class PreferencesListViewModel {
     this.mainViewModel = mainViewModel;
     this.listViewModel = listViewModel;
     this.userRepository = repositories.user;
-    this.logger = new z.util.Logger('z.viewModel.list.PreferencesListViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.list.PreferencesListViewModel', z.config.LOGGER.OPTIONS);
 
     this.contentViewModel = this.mainViewModel.content;
     this.contentState = this.contentViewModel.state;

--- a/src/script/view_model/list/StartUIViewModel.js
+++ b/src/script/view_model/list/StartUIViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import {getManageTeamUrl, getManageServicesUrl} from '../../externalRoute';
 import {generatePermissionHelpers} from '../../user/UserPermission';
 import {t} from 'utils/LocalizerUtil';
@@ -65,7 +67,7 @@ z.viewModel.list.StartUIViewModel = class StartUIViewModel {
     this.searchRepository = repositories.search;
     this.teamRepository = repositories.team;
     this.userRepository = repositories.user;
-    this.logger = new z.util.Logger('z.viewModel.list.StartUIViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.list.StartUIViewModel', z.config.LOGGER.OPTIONS);
 
     this.actionsViewModel = this.mainViewModel.actions;
 

--- a/src/script/view_model/list/TakeoverViewModel.js
+++ b/src/script/view_model/list/TakeoverViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import {getSupportUsernameUrl} from '../../externalRoute';
 
 window.z = window.z || {};
@@ -35,7 +37,7 @@ z.viewModel.list.TakeoverViewModel = class TakeoverViewModel {
     this.listViewModel = listViewModel;
     this.conversationRepository = repositories.conversation;
     this.userRepository = repositories.user;
-    this.logger = new z.util.Logger('z.viewModel.list.TakeoverViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.list.TakeoverViewModel', z.config.LOGGER.OPTIONS);
 
     this.selfUser = this.userRepository.self;
 

--- a/src/script/view_model/list/TemporaryGuestViewModel.js
+++ b/src/script/view_model/list/TemporaryGuestViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import {t} from 'utils/LocalizerUtil';
 
 window.z = window.z || {};
@@ -39,7 +41,7 @@ z.viewModel.list.TemporaryGuestViewModel = class TemporaryGuestViewModel {
     this.permissionRepository = repositories.permission;
     this.videoGridRepository = repositories.videoGrid;
 
-    this.logger = new z.util.Logger('z.viewModel.list.TemporaryGuestViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.list.TemporaryGuestViewModel', z.config.LOGGER.OPTIONS);
 
     this.callConversations = this.conversationRepository.conversations_calls;
     this.selfUser = this.userRepository.self;

--- a/src/script/view_model/panel/AddParticipantsViewModel.js
+++ b/src/script/view_model/panel/AddParticipantsViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import BasePanelViewModel from './BasePanelViewModel';
 import {getManageServicesUrl} from '../../externalRoute';
 import {t} from 'utils/LocalizerUtil';
@@ -39,7 +41,7 @@ export default class AddParticipantsViewModel extends BasePanelViewModel {
     this.teamRepository = team;
     this.userRepository = user;
 
-    this.logger = new z.util.Logger('z.viewModel.panel.AddParticipantsViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.panel.AddParticipantsViewModel', z.config.LOGGER.OPTIONS);
 
     this.isTeam = this.teamRepository.isTeam;
     this.selfUser = this.userRepository.self;

--- a/src/script/view_model/panel/ConversationDetailsViewModel.js
+++ b/src/script/view_model/panel/ConversationDetailsViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 /* eslint-disable no-unused-vars */
 import receiptModeToggle from 'components/receiptModeToggle';
 /* eslint-enable no-unused-vars */
@@ -50,7 +52,7 @@ export default class ConversationDetailsViewModel extends BasePanelViewModel {
 
     this.actionsViewModel = mainViewModel.actions;
 
-    this.logger = new z.util.Logger('z.viewModel.panel.ConversationDetailsViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.panel.ConversationDetailsViewModel', z.config.LOGGER.OPTIONS);
 
     this.isActivatedAccount = this.userRepository.isActivatedAccount;
     this.isTeam = this.teamRepository.isTeam;

--- a/src/script/view_model/panel/GroupParticipantServiceViewModel.js
+++ b/src/script/view_model/panel/GroupParticipantServiceViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import BasePanelViewModel from './BasePanelViewModel';
 
 export default class GroupParticipantServiceViewModel extends BasePanelViewModel {
@@ -28,7 +30,7 @@ export default class GroupParticipantServiceViewModel extends BasePanelViewModel
     this.integrationRepository = repositories.integration;
     this.actionsViewModel = mainViewModel.actions;
 
-    this.logger = new z.util.Logger('z.viewModel.panel.GroupParticipantServiceViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.panel.GroupParticipantServiceViewModel', z.config.LOGGER.OPTIONS);
 
     this.selectedParticipant = ko.observable(undefined);
     this.selectedService = ko.observable(undefined);

--- a/src/script/view_model/panel/GroupParticipantUserViewModel.js
+++ b/src/script/view_model/panel/GroupParticipantUserViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import BasePanelViewModel from './BasePanelViewModel';
 import {t} from 'utils/LocalizerUtil';
 
@@ -33,7 +35,7 @@ export default class GroupParticipantUserViewModel extends BasePanelViewModel {
     this.userRepository = repositories.user;
     this.actionsViewModel = mainViewModel.actions;
 
-    this.logger = new z.util.Logger('GroupParticipantUserViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('GroupParticipantUserViewModel', z.config.LOGGER.OPTIONS);
 
     this.selectedParticipant = ko.observable(undefined);
 

--- a/src/script/view_model/panel/GuestsAndServicesViewModel.js
+++ b/src/script/view_model/panel/GuestsAndServicesViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import BasePanelViewModel from './BasePanelViewModel';
 import {t} from 'utils/LocalizerUtil';
 
@@ -39,7 +41,7 @@ export default class GuestsAndServicesViewModel extends BasePanelViewModel {
     const conversationRepository = repositories.conversation;
     this.stateHandler = conversationRepository.stateHandler;
 
-    this.logger = new z.util.Logger('z.viewModel.panel.GuestsAndServicesViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.panel.GuestsAndServicesViewModel', z.config.LOGGER.OPTIONS);
 
     this.isLinkCopied = ko.observable(false);
     this.requestOngoing = ko.observable(false);

--- a/src/script/view_model/panel/ParticipantDevicesViewModel.js
+++ b/src/script/view_model/panel/ParticipantDevicesViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import Logger from 'utils/Logger';
+
 import BasePanelViewModel from './BasePanelViewModel';
 import {getPrivacyHowUrl, getPrivacyWhyUrl} from '../../externalRoute';
 import {t} from 'utils/LocalizerUtil';
@@ -39,7 +41,7 @@ export default class ParticipantDevicesViewModel extends BasePanelViewModel {
     this.conversationRepository = conversation;
     this.cryptographyRepository = cryptography;
 
-    this.logger = new z.util.Logger('z.viewModel.panel.ParticipantDevicesViewModel', z.config.LOGGER.OPTIONS);
+    this.logger = new Logger('z.viewModel.panel.ParticipantDevicesViewModel', z.config.LOGGER.OPTIONS);
 
     this.selfClient = this.clientRepository.currentClient;
 

--- a/test/api/TestFactory.js
+++ b/test/api/TestFactory.js
@@ -45,13 +45,10 @@ window.TestFactory = function(logger_level) {
   });
   initialLoggerOptions.level = logger_level;
 
-  this.logger = new z.util.Logger('TestFactory', z.config.LOGGER.OPTIONS);
-
   return this;
 };
 
 window.TestFactory.prototype.exposeServerActors = function() {
-  this.logger.info('- exposeServerActors');
   return Promise.resolve().then(() => {
     TestFactory.serverTimeRepository = new z.time.ServerTimeRepository();
     return TestFactory.serverTimeRepository;
@@ -63,7 +60,6 @@ window.TestFactory.prototype.exposeServerActors = function() {
  * @returns {Promise<z.auth.AuthRepository>} The authentication repository.
  */
 window.TestFactory.prototype.exposeAuthActors = function() {
-  this.logger.info('- exposeAuthActors');
   return Promise.resolve().then(() => {
     TestFactory.authService = new z.auth.AuthService(resolve(graph.BackendClient));
 
@@ -77,7 +73,6 @@ window.TestFactory.prototype.exposeAuthActors = function() {
  * @returns {Promise<z.storage.StorageRepository>} The storage repository.
  */
 window.TestFactory.prototype.exposeStorageActors = function() {
-  this.logger.info('- exposeStorageActors');
   return Promise.resolve()
     .then(() => {
       TestFactory.storage_service = resolve(graph.StorageService);
@@ -92,13 +87,10 @@ window.TestFactory.prototype.exposeStorageActors = function() {
 };
 
 window.TestFactory.prototype.exposeBackupActors = function() {
-  this.logger.info('- exposeBackupActors');
   return Promise.resolve()
     .then(() => this.exposeStorageActors())
     .then(() => this.exposeConversationActors())
     .then(() => {
-      this.logger.info('✓ exposedUserActors');
-
       TestFactory.backup_service = resolve(graph.BackupService);
 
       TestFactory.backup_repository = new z.backup.BackupRepository(
@@ -119,12 +111,9 @@ window.TestFactory.prototype.exposeBackupActors = function() {
  * @returns {Promise<z.cryptography.CryptographyRepository>} The cryptography repository.
  */
 window.TestFactory.prototype.exposeCryptographyActors = function(mockCryptobox = true) {
-  this.logger.info('- exposeCryptographyActors');
   return Promise.resolve()
     .then(() => this.exposeStorageActors())
     .then(() => {
-      this.logger.info('✓ exposedStorageActors');
-
       const currentClient = new z.client.ClientEntity(true);
       currentClient.id = entities.clients.john_doe.permanent.id;
       TestFactory.cryptography_service = new z.cryptography.CryptographyService(resolve(graph.BackendClient));
@@ -149,12 +138,9 @@ window.TestFactory.prototype.exposeCryptographyActors = function(mockCryptobox =
  * @returns {Promise<z.client.ClientRepository>} The client repository.
  */
 window.TestFactory.prototype.exposeClientActors = function() {
-  this.logger.info('- exposeClientActors');
   return Promise.resolve()
     .then(() => this.exposeCryptographyActors())
     .then(() => {
-      this.logger.info('✓ exposedCryptographyActors');
-
       const clientEntity = new z.client.ClientEntity({
         address: '192.168.0.1',
         class: 'desktop',
@@ -203,13 +189,10 @@ window.TestFactory.prototype.exposeClientActors = function() {
  * @returns {Promise<z.event.EventRepository>} The event repository.
  */
 window.TestFactory.prototype.exposeEventActors = function() {
-  this.logger.info('- exposeEventActors');
   return Promise.resolve()
     .then(() => this.exposeCryptographyActors())
     .then(() => this.exposeUserActors())
     .then(() => {
-      this.logger.info('✓ exposedCryptographyActors');
-
       TestFactory.web_socket_service = new z.event.WebSocketService(
         resolve(graph.BackendClient),
         TestFactory.storage_service
@@ -246,13 +229,10 @@ window.TestFactory.prototype.exposeEventActors = function() {
  * @returns {Promise<UserRepository>} The user repository.
  */
 window.TestFactory.prototype.exposeUserActors = function() {
-  this.logger.info('- exposeUserActors');
   return Promise.resolve()
     .then(() => this.exposeClientActors())
     .then(() => this.exposeServerActors())
     .then(() => {
-      this.logger.info('✓ exposedClientActors');
-
       TestFactory.asset_service = resolve(graph.AssetService);
       TestFactory.connection_service = new z.connection.ConnectionService(resolve(graph.BackendClient));
       TestFactory.user_service = resolve(graph.UserService);
@@ -277,12 +257,9 @@ window.TestFactory.prototype.exposeUserActors = function() {
  * @returns {Promise<z.connection.ConnectionRepository>} The connection repository.
  */
 window.TestFactory.prototype.exposeConnectionActors = function() {
-  this.logger.info('- exposeConnectionActors');
   return Promise.resolve()
     .then(() => this.exposeUserActors())
     .then(() => {
-      this.logger.info('✓ exposedConnectionActors');
-
       TestFactory.connection_service = new z.connection.ConnectionService(resolve(graph.BackendClient));
 
       TestFactory.connection_repository = new z.connection.ConnectionRepository(
@@ -299,12 +276,9 @@ window.TestFactory.prototype.exposeConnectionActors = function() {
  * @returns {Promise<z.connect.ConnectRepository>} The connect repository.
  */
 window.TestFactory.prototype.exposeConnectActors = function() {
-  this.logger.info('- exposeConnectActors');
   return Promise.resolve()
     .then(() => this.exposeUserActors())
     .then(() => {
-      this.logger.info('✓ exposedUserActors');
-
       TestFactory.connectService = new z.connect.ConnectService(resolve(graph.BackendClient));
 
       TestFactory.connect_repository = new z.connect.ConnectRepository(
@@ -321,12 +295,9 @@ window.TestFactory.prototype.exposeConnectActors = function() {
  * @returns {Promise<z.search.SearchRepository>} The search repository.
  */
 window.TestFactory.prototype.exposeSearchActors = function() {
-  this.logger.info('- exposeSearchActors');
   return Promise.resolve()
     .then(() => this.exposeUserActors())
     .then(() => {
-      this.logger.info('✓ exposedTeamActors');
-
       TestFactory.search_service = new z.search.SearchService(resolve(graph.BackendClient));
 
       TestFactory.search_repository = new z.search.SearchRepository(
@@ -339,12 +310,9 @@ window.TestFactory.prototype.exposeSearchActors = function() {
 };
 
 window.TestFactory.prototype.exposeTeamActors = function() {
-  this.logger.info('- exposeTeamActors');
   return Promise.resolve()
     .then(() => this.exposeUserActors())
     .then(() => {
-      this.logger.info('✓ exposedUserActors');
-
       TestFactory.teamService = new z.team.TeamService(resolve(graph.BackendClient));
       return TestFactory.teamService;
     })
@@ -359,14 +327,11 @@ window.TestFactory.prototype.exposeTeamActors = function() {
  * @returns {Promise<z.conversation.ConversationRepository>} The conversation repository.
  */
 window.TestFactory.prototype.exposeConversationActors = function() {
-  this.logger.info('- exposeConversationActors');
   return Promise.resolve()
     .then(() => this.exposeConnectionActors())
     .then(() => this.exposeTeamActors())
     .then(() => this.exposeEventActors())
     .then(() => {
-      this.logger.info('✓ exposedTeamActors');
-
       TestFactory.conversation_service = new z.conversation.ConversationService(
         resolve(graph.BackendClient),
         TestFactory.event_service,
@@ -397,10 +362,7 @@ window.TestFactory.prototype.exposeConversationActors = function() {
  * @returns {Promise<z.calling.CallCenter>} The call center.
  */
 window.TestFactory.prototype.exposeCallingActors = function() {
-  this.logger.info('- exposeCallingActors');
   return this.exposeConversationActors().then(() => {
-    this.logger.info('✓ exposedConversationActors');
-
     TestFactory.calling_service = new z.calling.CallingService(resolve(graph.BackendClient));
 
     TestFactory.calling_repository = new z.calling.CallingRepository(
@@ -422,15 +384,11 @@ window.TestFactory.prototype.exposeCallingActors = function() {
  * @returns {Promise<z.notification.NotificationRepository>} The repository for system notifications.
  */
 window.TestFactory.prototype.exposeNotificationActors = function() {
-  this.logger.info('- exposeNotificationActors');
   return this.exposeConversationActors()
     .then(() => {
-      this.logger.info('✓ exposedConversationActors');
       return this.exposeCallingActors();
     })
     .then(() => {
-      this.logger.info('✓ exposedCallingActors');
-
       TestFactory.notification_repository = new z.notification.NotificationRepository(
         TestFactory.calling_repository,
         TestFactory.conversation_repository,
@@ -447,12 +405,9 @@ window.TestFactory.prototype.exposeNotificationActors = function() {
  * @returns {Promise<z.tracking.EventTrackingRepository>} The event tracking repository.
  */
 window.TestFactory.prototype.exposeTrackingActors = function() {
-  this.logger.info('- exposeTrackingActors');
   return Promise.resolve()
     .then(() => this.exposeTeamActors())
     .then(() => {
-      this.logger.info('✓ exposesTeamActors');
-
       TestFactory.tracking_repository = new z.tracking.EventTrackingRepository(
         TestFactory.team_repository,
         TestFactory.user_repository
@@ -467,11 +422,9 @@ window.TestFactory.prototype.exposeTrackingActors = function() {
  * @returns {Promise<z.lifecycle.LifecycleRepository>} The lifecycle repository.
  */
 window.TestFactory.prototype.exposeLifecycleActors = function() {
-  this.logger.info('- exposeLifecycleActors');
   return Promise.resolve()
     .then(() => this.exposeUserActors())
     .then(() => {
-      this.logger.info('✓ exposedConversationActors');
       TestFactory.lifecycle_service = new z.lifecycle.LifecycleService();
 
       TestFactory.lifecycle_repository = new z.lifecycle.LifecycleRepository(


### PR DESCRIPTION
A step forward into not relying on things being published on the `window` scope. 

Also removed all the logs we have in the `TestFactory` which are never displayed and do not serve any purposes anymore