### PR TITLE
feat: Increase the ice candidates gathering timeout to 10 seconds

### DIFF
--- a/src/script/calling/entities/FlowEntity.js
+++ b/src/script/calling/entities/FlowEntity.js
@@ -27,7 +27,7 @@ z.calling.entities.FlowEntity = class FlowEntity {
   static get CONFIG() {
     return {
       DATA_CHANNEL_LABEL: 'calling-3.0',
-      MAX_ICE_CANDIDATE_GATHERING_ATTEMPTS: 5,
+      MAX_ICE_CANDIDATE_GATHERING_ATTEMPTS: 10,
       NEGOTIATION_THRESHOLD: 0.5 * z.util.TimeUtil.UNITS_IN_MILLIS.SECOND,
       RECONNECTION_TIMEOUT: 2.5 * z.util.TimeUtil.UNITS_IN_MILLIS.SECOND,
       RENEGOTIATION_TIMEOUT: 30 * z.util.TimeUtil.UNITS_IN_MILLIS.SECOND,


### PR DESCRIPTION
As discussed with @jspittka we decided to increase the timeout after which we send the SPD payload (even if no relay candidates have been found).

This will prevent call from simply dropping in really bad networks while keeping a decent amount of waiting time. 