### PR TITLE
fix: Redirect to login page on logout error

### DIFF
--- a/src/script/main/app.js
+++ b/src/script/main/app.js
@@ -729,6 +729,7 @@ class App {
       try {
         _logout();
       } catch (error) {
+        this.logger.error(`Logout triggered by '${signOutReason}' and errored: ${error.message}.`);
         _redirectToLogin();
       }
     }

--- a/src/script/main/app.js
+++ b/src/script/main/app.js
@@ -726,7 +726,11 @@ class App {
     };
 
     if (App.CONFIG.SIGN_OUT_REASONS.IMMEDIATE.includes(signOutReason)) {
-      return _logout();
+      try {
+        _logout();
+      } catch (error) {
+        _redirectToLogin();
+      }
     }
 
     if (navigator.onLine) {


### PR DESCRIPTION
In our `_logoutOnBackend` function we catch potential logout errors:

```js
.then(() => _logout())
.catch(() => _redirectToLogin());
```

When the signout reason is immediate, then we call `_logout()` without catching it, so I added a catch there too because I ran into a scenario where I had an error during that logout call and where I was not being redirected to the login page:

![image](https://user-images.githubusercontent.com/469989/53251819-d3b3b700-36bd-11e9-85de-22d6ac357107.png)
