### PR TITLE
chore: Remove path.join from copy config

### DIFF
--- a/.copyconfigrc.js
+++ b/.copyconfigrc.js
@@ -2,7 +2,7 @@ const pkg = require('./package.json');
 const {execSync} = require('child_process');
 const path = require('path');
 
-const currentBranch = execSync(`git rev-parse --abbrev-ref HEAD`)
+const currentBranch = execSync('git rev-parse --abbrev-ref HEAD')
   .toString()
   .trim();
 const configurationEntry = `wire-web-config-default-${currentBranch === 'prod' ? 'prod' : 'staging'}`;

--- a/.copyconfigrc.js
+++ b/.copyconfigrc.js
@@ -2,7 +2,6 @@ const pkg = require('./package.json');
 const {execSync} = require('child_process');
 const path = require('path');
 
-const source = path.join(pkg.name, 'content');
 const currentBranch = execSync(`git rev-parse --abbrev-ref HEAD`)
   .toString()
   .trim();
@@ -11,8 +10,8 @@ const repositoryUrl = pkg.dependencies[configurationEntry];
 
 module.exports = {
   files: {
-    [`${source}/**`]: 'resource/',
-    [path.join(pkg.name, '.env.defaults')]: path.join(__dirname, '.env.defaults'),
+    [`${pkg.name}/content/**`]: 'resource/',
+    [`${pkg.name}/.env.defaults`]: `${__dirname}/.env.defaults`,
   },
   repositoryUrl,
 };


### PR DESCRIPTION
`path.join` is not needed as the full path will be resolved by `copy-config`.