### PR TITLE
refactor: Centralize handling of conversations' last read timestamp (WEBAPP-5967)

### DIFF
--- a/src/script/conversation/ConversationRepository.js
+++ b/src/script/conversation/ConversationRepository.js
@@ -1133,6 +1133,7 @@ z.conversation.ConversationRepository = class ConversationRepository {
     const eventInfoEntity = new z.conversation.EventInfoEntity(genericMessage, this.self_conversation().id);
     this.sendGenericMessageToConversation(eventInfoEntity)
       .then(() => {
+        amplify.publish(z.event.WebApp.NOTIFICATION.REMOVE_READ);
         this.logger.info(`Marked conversation '${conversationId}' as read on '${new Date(timestamp).toISOString()}'`);
       })
       .catch(error => {

--- a/src/script/notification/NotificationRepository.js
+++ b/src/script/notification/NotificationRepository.js
@@ -150,6 +150,7 @@ z.notification.NotificationRepository = class NotificationRepository {
       this._notifySound(messageEntity);
       return this._notifyBanner(messageEntity, connectionEntity, conversationEntity);
     }
+    return Promise.resolve();
   }
 
   // Remove notifications from the queue that are no longer unread

--- a/src/script/notification/NotificationRepository.js
+++ b/src/script/notification/NotificationRepository.js
@@ -146,12 +146,10 @@ z.notification.NotificationRepository = class NotificationRepository {
       ? NotificationRepository.shouldNotifyInConversation(conversationEntity, messageEntity, this.selfUser().id)
       : true;
 
-    return Promise.resolve(notifyInConversation).then(shouldNotifyInConversation => {
-      if (shouldNotifyInConversation) {
-        this._notifySound(messageEntity);
-        return this._notifyBanner(messageEntity, connectionEntity, conversationEntity);
-      }
-    });
+    if (notifyInConversation) {
+      this._notifySound(messageEntity);
+      return this._notifyBanner(messageEntity, connectionEntity, conversationEntity);
+    }
   }
 
   // Remove notifications from the queue that are no longer unread


### PR DESCRIPTION
As of the Read Receipt feature (https://github.com/wireapp/wire-webapp/pull/5411) we have a mechanism to reliably detect when a message has been read.

This is a perfect opportunity to rethink the way the `last_read_timestamp` of the conversation is handled.

This PR brings the power of the read detection to update the timestamp. Which means we will now update this timestamp live while the user scrolls the message list.

Another benefit of this is that we have a single place where we send the message that synchronizes all the clients.  