### PR TITLE
runfix: Use interval instead of mutation events to detect overlayed elements (WEBAPP-5970)

### DIFF
--- a/src/script/ui/overlayedObserver.js
+++ b/src/script/ui/overlayedObserver.js
@@ -18,26 +18,21 @@
  */
 
 /**
- * Keeps track of elements that are overlayed by other elemenst (thus not visible on screen).
+ * Keeps track of elements that are overlayed by other elements (thus not visible on screen).
  *
  */
 // keeps track of all the elements we need to check when there is a mutation
 const overlayedElements = new Map();
+let overlayCheckerInterval = undefined;
 
-const checkOverlayedElements = mutations => {
-  mutations.forEach(({removedNodes}) => {
-    if (removedNodes && removedNodes.length) {
-      overlayedElements.forEach((onVisible, element) => {
-        if (!isOverlayed(element)) {
-          onVisible();
-          removeElement(element);
-        }
-      });
+function checkOverlayedElements() {
+  overlayedElements.forEach((onVisible, element) => {
+    if (!isOverlayed(element)) {
+      onVisible();
+      removeElement(element);
     }
   });
-};
-
-const mutationObserver = new MutationObserver(checkOverlayedElements);
+}
 
 /**
  * Returns true if an element is above the element being watched.
@@ -57,16 +52,17 @@ const addElement = (element, onVisible) => {
   if (!isOverlayed(element)) {
     return onVisible();
   }
-  if (overlayedElements.size === 0) {
-    mutationObserver.observe(document.body, {childList: true, subtree: true});
+  if (!overlayCheckerInterval) {
+    overlayCheckerInterval = setInterval(checkOverlayedElements, 300);
   }
   overlayedElements.set(element, onVisible);
 };
 
 const removeElement = element => {
   overlayedElements.delete(element);
-  if (overlayedElements.size < 1) {
-    mutationObserver.disconnect();
+  if (overlayedElements.size < 1 && overlayCheckerInterval) {
+    clearInterval(overlayCheckerInterval);
+    overlayCheckerInterval = undefined;
   }
 };
 

--- a/test/unit_tests/ui/overlayedObserverSpec.js
+++ b/test/unit_tests/ui/overlayedObserverSpec.js
@@ -20,6 +20,14 @@
 import overlayedObserver from 'src/script/ui/overlayedObserver';
 
 describe('overlayedObserver', () => {
+  beforeEach(() => {
+    jasmine.clock().install();
+  });
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+
   describe('addElement', () => {
     it('calls the callback right away if the element is not overlayed', () => {
       const callbackSpy = {
@@ -60,9 +68,10 @@ describe('overlayedObserver', () => {
       overlayedObserver.onElementVisible(element, callbackSpy.onVisible);
 
       expect(callbackSpy.onVisible).not.toHaveBeenCalled();
+      overlayedObserver.removeElement(element);
     });
 
-    it('calls the callback when an overlayed element becomes visible', done => {
+    it('calls the callback when an overlayed element becomes visible', () => {
       const callbackSpy = {
         onVisible: () => {},
       };
@@ -88,11 +97,9 @@ describe('overlayedObserver', () => {
       expect(callbackSpy.onVisible).not.toHaveBeenCalled();
 
       document.body.removeChild(overlay);
+      jasmine.clock().tick(301);
 
-      window.setTimeout(() => {
-        expect(callbackSpy.onVisible).toHaveBeenCalled();
-        done();
-      });
+      expect(callbackSpy.onVisible).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
The previous implementation needed a DOM modification to actually check for visible elements.
(which means a CSS transition, for example, will not trigger a check and can cause visible elements not to be detected).

The new implementation is based on interval. Probably a bit less efficient but will cover way more cases and will be more scalable in the future