### PR TITLE
feat: Allow the SDP to be sent whenever a single relay is found (WEBAPP-5974)

### DIFF
--- a/src/script/calling/entities/FlowEntity.js
+++ b/src/script/calling/entities/FlowEntity.js
@@ -24,6 +24,7 @@ import SDP_NEGOTIATION_MODE from '../enum/SDPNegotiationMode';
 import SDP_SOURCE from '../enum/SDPSource';
 import TERMINATION_REASON from '../enum/TerminationReason';
 import TimeUtil from 'utils/TimeUtil';
+import {isValidIceCandidatesGathering, getIceCandidatesTypes} from 'utils/PeerConnectionUtil';
 
 window.z = window.z || {};
 window.z.calling = z.calling || {};
@@ -877,10 +878,7 @@ z.calling.entities.FlowEntity = class FlowEntity {
           const connectionConfig =
             (this.peerConnection.getConfiguration && this.peerConnection.getConfiguration()) ||
             this.peerConnectionConfiguration;
-          const isValidGathering = z.util.PeerConnectionUtil.isValidIceCandidatesGathering(
-            connectionConfig,
-            iceCandidates
-          );
+          const isValidGathering = isValidIceCandidatesGathering(connectionConfig, iceCandidates);
           const attempts = this.iceCandidatesGatheringAttempts;
           const hasReachMaxGatheringAttempts = attempts >= FlowEntity.CONFIG.MAX_ICE_CANDIDATE_GATHERING_ATTEMPTS;
           if (!hasReachMaxGatheringAttempts && !isValidGathering) {
@@ -893,7 +891,7 @@ z.calling.entities.FlowEntity = class FlowEntity {
 
         this.iceCandidatesGatheringAttempts = 1;
 
-        const iceCandidateTypes = z.util.PeerConnectionUtil.getIceCandidatesTypes(iceCandidates);
+        const iceCandidateTypes = getIceCandidatesTypes(iceCandidates);
 
         const iceCandidateTypesLog = Object.keys(iceCandidateTypes)
           .map(candidateType => `${iceCandidateTypes[candidateType]} ${candidateType}`)

--- a/src/script/main/globals.js
+++ b/src/script/main/globals.js
@@ -21,7 +21,6 @@ import LocalizerUtilGlobal from '../util/LocalizerUtil.js';
 import linkifyGlobal from '../util/linkify.js';
 import htmlGlobal from '../util/linkify-html.js';
 import NumberUtilGlobal from '../util/NumberUtil.js';
-import PeerConnectionUtilGlobal from '../util/PeerConnectionUtil.js';
 import helpersGlobal from '../util/scroll-helpers.js';
 import StorageUtilGlobal from '../util/StorageUtil.js';
 import StringUtilGlobal from '../util/StringUtil.js';

--- a/src/script/util/PeerConnectionUtil.js
+++ b/src/script/util/PeerConnectionUtil.js
@@ -17,43 +17,35 @@
  *
  */
 
-z.util.PeerConnectionUtil = {
-  getIceCandidatesTypes(iceCandidates) {
-    return iceCandidates.reduce((types, candidateStr) => {
-      const typeMatches = candidateStr.match(/typ (\w+)/);
-      if (!typeMatches) {
-        return types;
-      }
-      const candidateType = typeMatches[1];
-      types[candidateType] = types[candidateType] + 1 || 1;
+export function getIceCandidatesTypes(iceCandidates) {
+  return iceCandidates.reduce((types, candidateStr) => {
+    const typeMatches = candidateStr.match(/typ (\w+)/);
+    if (!typeMatches) {
       return types;
-    }, {});
-  },
+    }
+    const candidateType = typeMatches[1];
+    types[candidateType] = types[candidateType] + 1 || 1;
+    return types;
+  }, {});
+}
 
-  /**
-   * Returns true if the number and types of ice candidates gathered are sufficient to start a call
-   *
-   * @param {RTCConfiguration} peerConnectionConfig - the configuration of the peerConnection that initiated the ICE candidate gathering
-   * @param {Array<string>} iceCandidates - ICE candidate strings from SDP
-   * @returns {boolean} True if the candidates gathered are enough to send a SDP
-   */
-  isValidIceCandidatesGathering(peerConnectionConfig, iceCandidates) {
-    if (iceCandidates.length <= 0) {
-      // if there are no candidates, no need to check for more conditions
-      // the call cannot work
-      return false;
-    }
-    const numberOfRelays = iceCandidates.filter(candidate => candidate.toLowerCase().includes('relay')).length;
-    const numberOfIceServers = (peerConnectionConfig.iceServers || []).length;
-    if (numberOfIceServers <= 0) {
-      return true;
-    }
-    if (numberOfIceServers === 1 && numberOfRelays >= 1) {
-      return true;
-    }
-    if (numberOfIceServers >= 2 && numberOfRelays >= 2) {
-      return true;
-    }
+/**
+ * Returns true if the number and types of ice candidates gathered are sufficient to start a call
+ *
+ * @param {RTCConfiguration} peerConnectionConfig - the configuration of the peerConnection that initiated the ICE candidate gathering
+ * @param {Array<string>} iceCandidates - ICE candidate strings from SDP
+ * @returns {boolean} True if the candidates gathered are enough to send a SDP
+ */
+export function isValidIceCandidatesGathering(peerConnectionConfig, iceCandidates) {
+  if (iceCandidates.length <= 0) {
+    // if there are no candidates, no need to check for more conditions
+    // the call cannot work
     return false;
-  },
-};
+  }
+  const numberOfRelays = iceCandidates.filter(candidate => candidate.toLowerCase().includes('relay')).length;
+  const numberOfIceServers = (peerConnectionConfig.iceServers || []).length;
+  if (numberOfIceServers <= 0) {
+    return true;
+  }
+  return numberOfRelays >= 1;
+}

--- a/test/unit_tests/util/PeerConnectionUtilSpec.js
+++ b/test/unit_tests/util/PeerConnectionUtilSpec.js
@@ -17,7 +17,9 @@
  *
  */
 
-describe('z.util.PeerConnectionUtil', () => {
+import {isValidIceCandidatesGathering, getIceCandidatesTypes} from 'utils/PeerConnectionUtil';
+
+describe('PeerConnectionUtil', () => {
   const hostIceCandidates = [
     'a=candidate:0 1 UDP 2122252543 192.168.120.196 32785 typ host',
     'a=candidate:3 1 TCP 2105524479 192.168.120.196 9 typ host tcptype active',
@@ -35,20 +37,20 @@ describe('z.util.PeerConnectionUtil', () => {
 
   describe('isValidIceCandidatesGathering', () => {
     it('returns false if no ice candidate gathered', () => {
-      const result = z.util.PeerConnectionUtil.isValidIceCandidatesGathering({}, []);
+      const result = isValidIceCandidatesGathering({}, []);
 
       expect(result).toBe(false);
     });
 
     it('returns true if there are some not-relay candidates with empty iceServers config', () => {
-      const result = z.util.PeerConnectionUtil.isValidIceCandidatesGathering({iceServers: []}, hostIceCandidates);
+      const result = isValidIceCandidatesGathering({iceServers: []}, hostIceCandidates);
 
       expect(result).toBe(true);
     });
 
     it('returns true if there are as many relay ice candidates as there are iceServers', () => {
       [1, 2, 3, 4, 5, 6].forEach(numberOfServers => {
-        const result = z.util.PeerConnectionUtil.isValidIceCandidatesGathering(
+        const result = isValidIceCandidatesGathering(
           {iceServers: new Array(numberOfServers)},
           relayIceCandidates.slice(0, numberOfServers)
         );
@@ -59,10 +61,7 @@ describe('z.util.PeerConnectionUtil', () => {
 
     it('returns false if there are some ice servers and no relay candidate', () => {
       [1, 2, 3, 4, 5, 6].forEach(numberOfServers => {
-        const result = z.util.PeerConnectionUtil.isValidIceCandidatesGathering(
-          {iceServers: new Array(numberOfServers)},
-          hostIceCandidates
-        );
+        const result = isValidIceCandidatesGathering({iceServers: new Array(numberOfServers)}, hostIceCandidates);
 
         expect(result).toBe(false);
       });
@@ -70,7 +69,7 @@ describe('z.util.PeerConnectionUtil', () => {
 
     it('returns true if there is one ice server and one or more candidates', () => {
       [1, 2, 3, 4, 5, 6].forEach(numberOfCandidates => {
-        const result = z.util.PeerConnectionUtil.isValidIceCandidatesGathering(
+        const result = isValidIceCandidatesGathering(
           {iceServers: new Array(1)},
           relayIceCandidates.slice(0, numberOfCandidates)
         );
@@ -84,7 +83,7 @@ describe('z.util.PeerConnectionUtil', () => {
     it('detects types of candidates', () => {
       const candidates = hostIceCandidates.concat(relayIceCandidates);
 
-      expect(z.util.PeerConnectionUtil.getIceCandidatesTypes(candidates)).toEqual({
+      expect(getIceCandidatesTypes(candidates)).toEqual({
         host: hostIceCandidates.length,
         relay: relayIceCandidates.length,
       });


### PR DESCRIPTION
Currently when send the SDP only if we have more than 2 ICE candidates (or the timeout has been reached).
As discussed with AVS, it's perfectly fine to send the SDP when we have a single ICE candidate.