### PR TITLE
fix: Improve detection of missing members when an event is received (WEBAPP-5975)

### DIFF
--- a/src/script/conversation/ConversationRepository.js
+++ b/src/script/conversation/ConversationRepository.js
@@ -2951,15 +2951,16 @@ z.conversation.ConversationRepository = class ConversationRepository {
       const isFromUnknownUser = !allParticipantIds.includes(sender);
 
       if (isFromUnknownUser) {
-        const leavingEventTypes = [
+        const membersUpdateMessages = [
           z.event.Backend.CONVERSATION.MEMBER_LEAVE,
+          z.event.Backend.CONVERSATION.MEMBER_JOIN,
           z.event.Client.CONVERSATION.TEAM_MEMBER_LEAVE,
         ];
-        const isLeaveEvent = leavingEventTypes.includes(eventJson.type);
-        if (isLeaveEvent) {
-          const isFromLeavingUser = eventJson.data.user_ids.includes(sender);
-          if (isFromLeavingUser) {
-            // we ignore leave events that are sent by the user actually leaving
+        const isMembersUpdateEvent = membersUpdateMessages.includes(eventJson.type);
+        if (isMembersUpdateEvent) {
+          const isFromUpdatedMember = eventJson.data.user_ids.includes(sender);
+          if (isFromUpdatedMember) {
+            // we ignore leave/join events that are sent by the user actually leaving or joining
             return conversationEntity;
           }
         }


### PR DESCRIPTION
Currently, if we receive a `join` event, we will check that the sender is already in the conversation participants. If not we will manually add it. But this step is also done by actually parsing the `join` event.

Thus we can filter `join` events that are sent by the actual user joining the conversation.