### PR TITLE
chore: Add automatic GitHub releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_deploy:
       yarn global add generate-changelog
       generate-changelog -t ${TRAVIS_COMMIT_RANGE} -x chore,runfix -f "${CHANGELOG_FILE}"
       tail -n +2 "${CHANGELOG_FILE}" > "${CHANGELOG_FILE}.tmp" && mv "${CHANGELOG_FILE}.tmp" "${CHANGELOG_FILE}"
-      printf "\n\n##### Changelog\n- https://github.com/wireapp/wire-webapp/compare/${TRAVIS_COMMIT_RANGE}"
+      printf "\n\n##### Changelog\n- https://github.com/wireapp/wire-webapp/compare/${TRAVIS_COMMIT_RANGE}" >> "${CHANGELOG_FILE}"
     fi
 
 # https://github.com/travis-ci/dpl#elastic-beanstalk

--- a/.travis.yml
+++ b/.travis.yml
@@ -145,18 +145,20 @@ deploy:
 
   # GitHub Production Releases
   - provider: releases
-    skip_cleanup: true
     api_key: "$GH_TOKEN"
+    draft: true
     file: "CHANGELOG.md"
+    skip_cleanup: true
     on:
       repo: wireapp/wire-webapp
       branch: prod
 
   # GitHub Staging Releases
   - provider: releases
-    skip_cleanup: true
     api_key: "$GH_TOKEN"
+    draft: true
     file: "CHANGELOG.md"
+    skip_cleanup: true
     on:
       tags: true
       condition: $TRAVIS_TAG =~ .*-staging.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_deploy:
       git config --local user.name "Wire Travis CI"
       git config --local user.email "webapp+travis@wire.com"
       git tag $TRAVIS_TAG
-      yarn global add generate-changelog
+      yarn global add generate-changelog@1.7.1
       generate-changelog -t ${TRAVIS_COMMIT_RANGE} -x chore,runfix -f "${CHANGELOG_FILE}"
       tail -n +2 "${CHANGELOG_FILE}" > "${CHANGELOG_FILE}.tmp" && mv "${CHANGELOG_FILE}.tmp" "${CHANGELOG_FILE}"
       printf "\n\n##### Changelog\n- https://github.com/${TRAVIS_REPO_SLUG}/compare/${TRAVIS_COMMIT_RANGE}" >> "${CHANGELOG_FILE}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_deploy:
       git tag $TRAVIS_TAG
       yarn global add generate-changelog@1.7.1
       generate-changelog -t ${TRAVIS_COMMIT_RANGE} -x chore,runfix -f "${CHANGELOG_FILE}"
-   sed -i '1,2d' "${CHANGELOG_FILE}"
+      sed -i '1,2d' "${CHANGELOG_FILE}"
       printf "\n\n##### Changelog\n- https://github.com/${TRAVIS_REPO_SLUG}/compare/${TRAVIS_COMMIT_RANGE}" >> "${CHANGELOG_FILE}"
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,24 @@ after_success:
   - if [[ "${TRAVIS_TAG}" =~ .*-staging.* ]]; then yarn build:prod; fi
   - if [ "$TRAVIS_BRANCH" == "prod" ]; then yarn build:prod || { echo 'contents of npm-debug.log:' && cat /home/travis/build/wireapp/wire-webapp/npm-debug.log && exit 1; } fi
 
+before_deploy:
+  - |
+    if [[ "${TRAVIS_TAG}" =~ .*-staging.* ]] || [ "${TRAVIS_BRANCH}" == "prod" ]; then
+      CHANGELOG_FILE="CHANGELOG.md"
+      if [ "${TRAVIS_BRANCH}" == "prod" ]; then
+        LAST_PROD_TAG="$(git tag | grep -P '^((?!staging).)*$' | tail -n 1)"
+        export TRAVIS_TAG="${TRAVIS_TAG:-$(date +'%Y-%m-%d-%H-%M')}"
+        export TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE:-"${LAST_PROD_TAG}...${TRAVIS_TAG}"}"
+      fi
+      git config --local user.name "Wire Travis CI"
+      git config --local user.email "webapp+travis@wire.com"
+      git tag $TRAVIS_TAG
+      yarn global add generate-changelog
+      generate-changelog -t ${TRAVIS_COMMIT_RANGE} -x chore,runfix -f "${CHANGELOG_FILE}"
+      tail -n +2 "${CHANGELOG_FILE}" > "${CHANGELOG_FILE}.tmp" && mv "${CHANGELOG_FILE}.tmp" "${CHANGELOG_FILE}"
+      printf "\n\n##### Changelog\n- https://github.com/wireapp/wire-webapp/compare/${TRAVIS_COMMIT_RANGE}"
+    fi
+
 # https://github.com/travis-ci/dpl#elastic-beanstalk
 deploy:
   # https://wire-webapp-edge.zinfra.io/
@@ -124,6 +142,24 @@ deploy:
     on:
       repo: wireapp/wire-webapp
       branch: prod
+
+  # GitHub Production Releases
+  - provider: releases
+    skip_cleanup: true
+    api_key: "$GH_TOKEN"
+    file: "CHANGELOG.md"
+    on:
+      repo: wireapp/wire-webapp
+      branch: prod
+
+  # GitHub Staging Releases
+  - provider: releases
+    skip_cleanup: true
+    api_key: "$GH_TOKEN"
+    file: "CHANGELOG.md"
+    on:
+      tags: true
+      condition: $TRAVIS_TAG =~ .*-staging.*
 
 after_deploy:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ after_success:
 before_deploy:
   - |
     if [[ "${TRAVIS_TAG}" =~ .*-staging.* ]] || [ "${TRAVIS_BRANCH}" == "prod" ]; then
-      CHANGELOG_FILE="CHANGELOG.md"
+      export CHANGELOG_FILE="CHANGELOG.md"
       if [ "${TRAVIS_BRANCH}" == "prod" ]; then
         LAST_PROD_TAG="$(git tag | grep -P '^((?!staging).)*$' | tail -n 1)"
         export TRAVIS_TAG="${TRAVIS_TAG:-$(date +'%Y-%m-%d-%H-%M')}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_deploy:
       yarn global add generate-changelog
       generate-changelog -t ${TRAVIS_COMMIT_RANGE} -x chore,runfix -f "${CHANGELOG_FILE}"
       tail -n +2 "${CHANGELOG_FILE}" > "${CHANGELOG_FILE}.tmp" && mv "${CHANGELOG_FILE}.tmp" "${CHANGELOG_FILE}"
-      printf "\n\n##### Changelog\n- https://github.com/wireapp/wire-webapp/compare/${TRAVIS_COMMIT_RANGE}" >> "${CHANGELOG_FILE}"
+      printf "\n\n##### Changelog\n- https://github.com/${TRAVIS_REPO_SLUG}/compare/${TRAVIS_COMMIT_RANGE}" >> "${CHANGELOG_FILE}"
     fi
 
 # https://github.com/travis-ci/dpl#elastic-beanstalk

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_deploy:
       git tag $TRAVIS_TAG
       yarn global add generate-changelog@1.7.1
       generate-changelog -t ${TRAVIS_COMMIT_RANGE} -x chore,runfix -f "${CHANGELOG_FILE}"
-      tail -n +2 "${CHANGELOG_FILE}" > "${CHANGELOG_FILE}.tmp" && mv "${CHANGELOG_FILE}.tmp" "${CHANGELOG_FILE}"
+   sed -i '1,2d' "${CHANGELOG_FILE}"
       printf "\n\n##### Changelog\n- https://github.com/${TRAVIS_REPO_SLUG}/compare/${TRAVIS_COMMIT_RANGE}" >> "${CHANGELOG_FILE}"
     fi
 


### PR DESCRIPTION
This will create a GitHub release as a draft everytime we create a staging tag or merge to `prod`.

Unfortunately due to https://github.com/travis-ci/dpl/issues/155 it is not possible to automatically fill the description with the changelog but instead a changelog file is attached which needs to be copied into the description field ~~and deleted from the release~~.