### PR TITLE
refactor: First step to resolve cyclic dependencies

### DIFF
--- a/src/script/broadcast/BroadcastRepository.js
+++ b/src/script/broadcast/BroadcastRepository.js
@@ -136,7 +136,7 @@ z.broadcast.BroadcastRepository = class BroadcastRepository {
         return accumulator + userEntity.devices().length;
       }
       return accumulator + z.client.ClientRepository.CONFIG.AVERAGE_NUMBER_OF_CLIENTS;
-    });
+    }, 0);
   }
 
   /**

--- a/src/script/broadcast/BroadcastRepository.js
+++ b/src/script/broadcast/BroadcastRepository.js
@@ -17,7 +17,6 @@
  *
  */
 
-import {GenericMessage} from '@wireapp/protocol-messaging';
 import Logger from 'utils/Logger';
 
 window.z = window.z || {};
@@ -128,28 +127,5 @@ z.broadcast.BroadcastRepository = class BroadcastRepository {
           return this._sendEncryptedMessage(eventInfoEntity, updatedPayload);
         });
       });
-  }
-
-  _getNumberOfClients(userEntities) {
-    return userEntities.reduce((accumulator, userEntity) => {
-      if (userEntity.devices().length) {
-        return accumulator + userEntity.devices().length;
-      }
-      return accumulator + z.client.ClientRepository.CONFIG.AVERAGE_NUMBER_OF_CLIENTS;
-    }, 0);
-  }
-
-  /**
-   * Estimate whether message should be send as type external.
-   *
-   * @private
-   * @param {GenericMessage} genericMessage - Generic message that will be send
-   * @returns {boolean} Is payload likely to be too big so that we switch to type external?
-   */
-  _shouldSendAsExternal(genericMessage) {
-    const messageInBytes = new Uint8Array(GenericMessage.encode(genericMessage).finish()).length;
-    const estimatedPayloadInBytes = this._getNumberOfClients() * messageInBytes;
-
-    return estimatedPayloadInBytes > z.conversation.ConversationRepository.CONFIG.EXTERNAL_MESSAGE_THRESHOLD;
   }
 };

--- a/src/script/config/dependenciesGraph.js
+++ b/src/script/config/dependenciesGraph.js
@@ -31,6 +31,7 @@ import GiphyRepository from '../extension/GiphyRepository';
 import GiphyService from '../extension/GiphyService';
 import LinkPreviewRepository from '../links/LinkPreviewRepository';
 import MediaRepository from '../media/MediaRepository';
+import {MessageSender} from '../message/MessageSender';
 import PermissionRepository from '../permission/PermissionRepository';
 import PropertiesRepository from '../properties/PropertiesRepository';
 import PropertiesService from '../properties/PropertiesService';
@@ -63,6 +64,7 @@ dependencies.set(LinkPreviewRepository, {
   name: 'LinkPreviewRepository',
 });
 dependencies.set(MediaRepository, {dependencies: [PermissionRepository], name: 'MediaRepository'});
+dependencies.set(MessageSender, {dependencies: [], name: 'MessageSender'});
 dependencies.set(PermissionRepository, {dependencies: [], name: 'PermissionRepository'});
 dependencies.set(PropertiesRepository, {dependencies: [PropertiesService, SelfService], name: 'PropertiesRepository'});
 dependencies.set(PropertiesService, {dependencies: [BackendClient], name: 'PropertiesService'});
@@ -87,6 +89,7 @@ export {
   GiphyService,
   LinkPreviewRepository,
   MediaRepository,
+  MessageSender,
   RichProfileRepository,
   PermissionRepository,
   PropertiesRepository,

--- a/src/script/main/app.js
+++ b/src/script/main/app.js
@@ -156,6 +156,7 @@ class App {
       repositories.event,
       repositories.giphy,
       resolve(graph.LinkPreviewRepository),
+      resolve(graph.MessageSender),
       repositories.serverTime,
       repositories.team,
       repositories.user,
@@ -192,6 +193,7 @@ class App {
       repositories.client,
       repositories.conversation,
       repositories.cryptography,
+      resolve(graph.MessageSender),
       repositories.user
     );
     repositories.calling = new z.calling.CallingRepository(

--- a/src/script/message/MessageSender.js
+++ b/src/script/message/MessageSender.js
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2018 Wire Swiss GmbH
+ * Copyright (C) 2019 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,13 +17,17 @@
  *
  */
 
-window.z = window.z || {};
-window.z.service = z.service || {};
+import PromiseQueue from 'utils/PromiseQueue';
 
-z.service.QUEUE_STATE = {
-  ACCESS_TOKEN_REFRESH: 'z.service.QUEUE_STATE.ACCESS_TOKEN_REFRESH',
-  CONNECTIVITY_PROBLEM: 'z.service.QUEUE_STATE.CONNECTIVITY_PROBLEM',
-  READY: 'z.service.QUEUE_STATE.READY',
-};
+export class MessageSender {
+  constructor() {
+    this.sendingQueue = new PromiseQueue({name: 'MessageSender', paused: true});
+  }
+  queueMessage(sendingFunction) {
+    return this.sendingQueue.push(sendingFunction);
+  }
 
-export const QUEUE_STATE = z.service.QUEUE_STATE;
+  pauseQueue(pauseState = true) {
+    this.sendingQueue.pause(pauseState);
+  }
+}

--- a/src/script/user/UserRepository.js
+++ b/src/script/user/UserRepository.js
@@ -333,7 +333,6 @@ export default class UserRepository {
     });
 
     const recipients = this.teamUsers().concat(this.self());
-
     amplify.publish(z.event.WebApp.BROADCAST.SEND_MESSAGE, {genericMessage, recipients});
   }
 

--- a/src/script/user/UserRepository.js
+++ b/src/script/user/UserRepository.js
@@ -332,7 +332,9 @@ export default class UserRepository {
       messageId: z.util.createRandomUuid(),
     });
 
-    amplify.publish(z.event.WebApp.BROADCAST.SEND_MESSAGE, genericMessage);
+    const recipients = this.teamUsers().concat(this.self());
+
+    amplify.publish(z.event.WebApp.BROADCAST.SEND_MESSAGE, {genericMessage, recipients});
   }
 
   /**

--- a/test/api/TestFactory.js
+++ b/test/api/TestFactory.js
@@ -324,6 +324,7 @@ window.TestFactory.prototype.exposeConversationActors = function() {
         TestFactory.event_repository,
         undefined,
         resolve(graph.LinkPreviewRepository),
+        resolve(graph.MessageSender),
         resolve(graph.ServerTimeRepository),
         TestFactory.team_repository,
         TestFactory.user_repository,

--- a/test/unit_tests/message/MessageSenderSpec.js
+++ b/test/unit_tests/message/MessageSenderSpec.js
@@ -1,0 +1,53 @@
+/*
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {resolve, graph} from '../../api/testResolver';
+
+describe('MessageSender', () => {
+  it('is in a paused state by default', done => {
+    const messageSender = resolve(graph.MessageSender);
+    const testData = {sendMessageFunction: () => Promise.resolve()};
+    spyOn(testData, 'sendMessageFunction').and.callThrough();
+
+    messageSender.queueMessage(testData.sendMessageFunction);
+    setTimeout(() => {
+      expect(testData.sendMessageFunction).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('execute the sending queue when set to an active state', done => {
+    const messageSender = resolve(graph.MessageSender);
+    const testData = {sendMessageFunction: () => Promise.resolve()};
+    spyOn(testData, 'sendMessageFunction').and.callThrough();
+
+    messageSender.queueMessage(testData.sendMessageFunction);
+    messageSender.queueMessage(testData.sendMessageFunction);
+    messageSender.queueMessage(testData.sendMessageFunction);
+
+    expect(testData.sendMessageFunction).not.toHaveBeenCalled();
+
+    messageSender.pauseQueue(false);
+
+    setTimeout(() => {
+      expect(testData.sendMessageFunction).toHaveBeenCalledTimes(3);
+      done();
+    }, 50);
+  });
+});


### PR DESCRIPTION
This is a first step to factorizing the way we send messages in Wire. 

Right now, we have 2 methods that, basically, have the same logic `ConversationRepository._sendEncryptedMessage` and `BroadcastRepository._sendEncryptedMessage`. 

Harmonizing this will be a long journey of identifying patterns and resolving cyclic dependencies but we will get there. 