### PR TITLE
feat: Bootstrap a router that listens to history.replaceState calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "sdp-transform": "2.7.0",
     "simplebar": "3.1.3",
     "speakingurl": "14.0.1",
+    "switch-path": "1.2.0",
     "uint32": "0.2.1",
     "underscore": "1.9.1",
     "url-search-params-polyfill": "5.0.0",

--- a/src/script/router/Router.js
+++ b/src/script/router/Router.js
@@ -1,0 +1,57 @@
+/*
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import switchPath from 'switch-path';
+
+export class Router {
+  constructor(routeDefinitions) {
+    const defaultRoute = {
+      // do nothing if url was not matched
+      '*': null,
+    };
+    const routes = Object.assign({}, defaultRoute, routeDefinitions);
+
+    const parseRoute = () => {
+      const currentPath = window.location.hash.replace('#', '') || '/';
+
+      const {value} = switchPath(currentPath, routes);
+      return typeof value === 'function' ? value() : value;
+    };
+
+    /**
+     * We need to proxy the replaceState method of history in order to trigger an event and warn the app that something happens.
+     * This is needed because the replaceState method can be called from outside of the app (eg. in the desktop app)
+     * @returns {void}
+     */
+    const originalReplaceState = window.history.replaceState.bind(window.history);
+
+    window.history.replaceState = (...args) => {
+      originalReplaceState(...args);
+      parseRoute();
+    };
+
+    // tigger an initial parsing of the current url
+    parseRoute();
+  }
+
+  navigate(path) {
+    window.history.replaceState(null, null, `#${path}`);
+    return this;
+  }
+}

--- a/test/unit_tests/router/RouterSpec.js
+++ b/test/unit_tests/router/RouterSpec.js
@@ -1,0 +1,108 @@
+/*
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Router} from 'src/script/router/Router';
+
+describe('Router', () => {
+  let originalReplaceStateFn;
+
+  beforeEach(() => {
+    originalReplaceStateFn = window.history.replaceState;
+  });
+
+  afterEach(() => {
+    window.location.hash = '#';
+    window.history.replaceState = originalReplaceStateFn;
+  });
+
+  describe('constructor', () => {
+    it("overwrites browser's replaceState method", () => {
+      const originalReplaceState = window.history.replaceState;
+      new Router();
+
+      expect(originalReplaceState).not.toBe(window.history.replaceState);
+    });
+
+    it('parse the current URL when instantiated', () => {
+      const routes = {'/conv': () => {}};
+      spyOn(routes, '/conv');
+
+      window.location.hash = '#/conv';
+      new Router(routes);
+
+      expect(routes['/conv']).toHaveBeenCalled();
+    });
+  });
+
+  describe('navigate', () => {
+    it('allows to navigate to specific url and call the associated handler', () => {
+      const handlers = {conversation: () => {}, user: () => {}};
+
+      spyOn(handlers, 'conversation');
+      spyOn(handlers, 'user');
+
+      const router = new Router({
+        '/conversation/:id': handlers.conversation,
+        '/user/:id': handlers.user,
+      });
+
+      router.navigate('/nomatch');
+
+      expect(handlers.conversation).not.toHaveBeenCalled();
+      expect(handlers.user).not.toHaveBeenCalled();
+
+      router.navigate('/conversation/uuid');
+
+      expect(handlers.conversation).toHaveBeenCalled();
+      expect(handlers.user).not.toHaveBeenCalled();
+
+      router.navigate('/user/uuid');
+
+      expect(handlers.user).toHaveBeenCalled();
+    });
+  });
+
+  describe('history.replaceState proxy', () => {
+    it('calls the matching handler when a new state is replaced', () => {
+      const routes = {
+        '/conversation/:id': () => {},
+        '/user/:id': () => {},
+      };
+
+      spyOn(routes, '/conversation/:id');
+      spyOn(routes, '/user/:id');
+
+      new Router(routes);
+
+      window.history.replaceState('', '', '#/nomatch');
+
+      expect(routes['/conversation/:id']).not.toHaveBeenCalled();
+      expect(routes['/user/:id']).not.toHaveBeenCalled();
+
+      window.history.replaceState('', '', '#/conversation/uuid');
+
+      expect(routes['/conversation/:id']).toHaveBeenCalled();
+      expect(routes['/user/:id']).not.toHaveBeenCalled();
+
+      window.history.replaceState('', '', '#/user/uuid');
+
+      expect(routes['/user/:id']).toHaveBeenCalled();
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -11432,6 +11432,11 @@ svgo@^1.0.0:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
+switch-path@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/switch-path/-/switch-path-1.2.0.tgz#3f872cb3c7eb2b77fb9509dea4e3f3ff25ecf556"
+  integrity sha1-P4css8frK3f7lQnepOPz/yXs9VY=
+
 symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"


### PR DESCRIPTION
Ok, this is a very rough draft that enables switching to a conversation by using the `history.replaceState` method.

This PR is mostly to allow the wrapper to make use of that method.
The code will be further refactored in follow up PRs.