### PR TITLE
fix: Use URLSearchParams class instead of URL().searchParams (WEBAPP-6017)

### DIFF
--- a/src/script/util/LoggerUtil.js
+++ b/src/script/util/LoggerUtil.js
@@ -19,7 +19,7 @@
 
 import 'url-search-params-polyfill';
 
-function enableLogging(force = false, location = window.location.href) {
+function enableLogging(force = false, search = window.location.search) {
   /**
    * If users disable cookies in their browsers, they won't have access to the localStorage API.
    * The following check will fix this error:
@@ -33,7 +33,7 @@ function enableLogging(force = false, location = window.location.href) {
     return;
   }
 
-  const namespace = new URL(location).searchParams.get('enableLogging');
+  const namespace = new URLSearchParams(search).get('enableLogging');
 
   if (namespace) {
     localStorage.setItem('debug', namespace);

--- a/test/unit_tests/util/LoggerUtilSpec.js
+++ b/test/unit_tests/util/LoggerUtilSpec.js
@@ -6,11 +6,11 @@ describe('enableLogging', () => {
   it('writes a specified logger namespace into the localStorage API', () => {
     const namespace = '@wireapp';
 
-    enableLogging(false, `https://app.wire.com/auth/?enableLogging=${namespace}`);
+    enableLogging(false, `?enableLogging=${namespace}`);
 
     expect(localStorage.getItem('debug')).toBe(namespace);
 
-    enableLogging(true, `https://app.wire.com/auth/?enableLogging=${namespace}`);
+    enableLogging(true, `?enableLogging=${namespace}`);
 
     expect(localStorage.getItem('debug')).toBe(namespace);
   });
@@ -19,7 +19,7 @@ describe('enableLogging', () => {
     const namespace = '@wireapp';
     localStorage.setItem('debug', namespace);
 
-    enableLogging(false, 'https://app.wire.com/auth/');
+    enableLogging(false, '');
 
     expect(localStorage.getItem('debug')).toBe(null);
   });
@@ -28,7 +28,7 @@ describe('enableLogging', () => {
     const namespace = '@wireapp';
     localStorage.setItem('debug', namespace);
 
-    enableLogging(true, 'https://app.wire.com/auth/');
+    enableLogging(true, '');
 
     expect(localStorage.getItem('debug')).toBe('@wireapp/webapp*');
   });


### PR DESCRIPTION
The first method is polyfilled by `url-search-params-polyfill` but the second method is not