### PR TITLE
refactor: Optimize loading view performances

### DIFF
--- a/src/script/view_model/LoadingViewModel.js
+++ b/src/script/view_model/LoadingViewModel.js
@@ -18,23 +18,22 @@
  */
 
 import {t} from 'utils/LocalizerUtil';
+import ko from 'knockout';
 
-window.z = window.z || {};
-window.z.viewModel = z.viewModel || {};
-
-z.viewModel.LoadingViewModel = class LoadingViewModel {
-  constructor(mainViewModel, repositories) {
-    this.elementId = 'loading-screen';
-    this.userRepository = repositories.user;
+export class LoadingViewModel {
+  constructor() {
     this.loadingMessage = ko.observable('');
     this.loadingProgress = ko.observable(0);
     amplify.subscribe(z.event.WebApp.APP.UPDATE_PROGRESS, this.updateProgress.bind(this));
 
-    ko.applyBindings(this, document.getElementById(this.elementId));
+    const elementId = 'loading-screen';
+    this.element = document.getElementById(elementId);
+    ko.applyBindings(this, this.element);
   }
 
   removeFromView() {
-    $(`#${this.elementId}`).remove();
+    ko.cleanNode(this.element);
+    this.element.remove();
     amplify.unsubscribeAll(z.event.WebApp.APP.UPDATE_PROGRESS);
   }
 
@@ -47,11 +46,6 @@ z.viewModel.LoadingViewModel = class LoadingViewModel {
       let updatedLoadingMessage;
 
       switch (message) {
-        case t('initReceivedSelfUser'): {
-          updatedLoadingMessage = t('initReceivedSelfUser', this.userRepository.self().first_name());
-          break;
-        }
-
         case t('initDecryption'):
         case t('initEvents'): {
           if (!z.config.FEATURE.SHOW_LOADING_INFORMATION) {
@@ -76,4 +70,4 @@ z.viewModel.LoadingViewModel = class LoadingViewModel {
       this.loadingMessage(updatedLoadingMessage);
     }
   }
-};
+}

--- a/src/script/view_model/MainViewModel.js
+++ b/src/script/view_model/MainViewModel.js
@@ -83,7 +83,6 @@ z.viewModel.MainViewModel = class MainViewModel {
 
     this.modals = new z.viewModel.ModalsViewModel();
     this.lightbox = new z.viewModel.ImageDetailViewViewModel(this, repositories);
-    this.loading = new z.viewModel.LoadingViewModel(this, repositories);
     this.shortcuts = new z.viewModel.ShortcutsViewModel(this, repositories);
     this.title = new WindowTitleViewModel(this, repositories);
     this.favicon = new z.viewModel.FaviconViewModel(window.amplify);


### PR DESCRIPTION
In the current state of the app, we instantiate **all** the views of the app at bootstrap time. 
This part of the app's bootstrap is pretty expensive (because it does all the bindings between the view models and the real DOM).

**But** when the app loads the data it needs (conversations, users, crypto...) we just need a single view model (namely the `LoadingViewModel`).

This PR will start loading the data of the app **before** loading all the other views.