### PR TITLE
feat: Make the router listen to standard hashchange event

### DIFF
--- a/src/script/router/Router.js
+++ b/src/script/router/Router.js
@@ -45,6 +45,7 @@ export class Router {
       originalReplaceState(...args);
       parseRoute();
     };
+    window.addEventListener('hashchange', parseRoute);
 
     // tigger an initial parsing of the current url
     parseRoute();

--- a/test/unit_tests/router/RouterSpec.js
+++ b/test/unit_tests/router/RouterSpec.js
@@ -78,6 +78,24 @@ describe('Router', () => {
     });
   });
 
+  describe('hash change event listener', () => {
+    it('triggers routing when a hashchange event is triggered', done => {
+      const handlers = {conversation: () => {}};
+      spyOn(handlers, 'conversation');
+
+      new Router({'/conversation/:id': handlers.conversation});
+
+      expect(handlers.conversation).not.toHaveBeenCalled();
+
+      window.location.hash = '#/conversation/uuid';
+
+      setTimeout(() => {
+        expect(handlers.conversation).toHaveBeenCalled();
+        done();
+      });
+    });
+  });
+
   describe('history.replaceState proxy', () => {
     it('calls the matching handler when a new state is replaced', () => {
       const routes = {


### PR DESCRIPTION
This will allow the wrapper and the end to end tests to use standard url changes to trigger conversation switching.

From the wrapper, doing `window.location.hash = '/conversation/....';` will trigger the conversation switching