### PR TITLE
runfix: Do not use ovewritten replaceState method (WEBAPP-6028)

### DIFF
--- a/src/script/router/Router.js
+++ b/src/script/router/Router.js
@@ -27,32 +27,22 @@ export class Router {
     };
     const routes = Object.assign({}, defaultRoute, routeDefinitions);
 
-    const parseRoute = () => {
+    this.parseRoute = () => {
       const currentPath = window.location.hash.replace('#', '') || '/';
 
       const {value} = switchPath(currentPath, routes);
       return typeof value === 'function' ? value() : value;
     };
 
-    /**
-     * We need to proxy the replaceState method of history in order to trigger an event and warn the app that something happens.
-     * This is needed because the replaceState method can be called from outside of the app (eg. in the desktop app)
-     * @returns {void}
-     */
-    const originalReplaceState = window.history.replaceState.bind(window.history);
-
-    window.history.replaceState = (...args) => {
-      originalReplaceState(...args);
-      parseRoute();
-    };
-    window.addEventListener('hashchange', parseRoute);
+    window.addEventListener('hashchange', this.parseRoute);
 
     // tigger an initial parsing of the current url
-    parseRoute();
+    this.parseRoute();
   }
 
   navigate(path) {
     window.history.replaceState(null, null, `#${path}`);
+    this.parseRoute();
     return this;
   }
 }

--- a/test/unit_tests/router/RouterSpec.js
+++ b/test/unit_tests/router/RouterSpec.js
@@ -20,25 +20,11 @@
 import {Router} from 'src/script/router/Router';
 
 describe('Router', () => {
-  let originalReplaceStateFn;
-
-  beforeEach(() => {
-    originalReplaceStateFn = window.history.replaceState;
-  });
-
   afterEach(() => {
     window.location.hash = '#';
-    window.history.replaceState = originalReplaceStateFn;
   });
 
   describe('constructor', () => {
-    it("overwrites browser's replaceState method", () => {
-      const originalReplaceState = window.history.replaceState;
-      new Router();
-
-      expect(originalReplaceState).not.toBe(window.history.replaceState);
-    });
-
     it('parse the current URL when instantiated', () => {
       const routes = {'/conv': () => {}};
       spyOn(routes, '/conv');
@@ -93,34 +79,6 @@ describe('Router', () => {
         expect(handlers.conversation).toHaveBeenCalled();
         done();
       });
-    });
-  });
-
-  describe('history.replaceState proxy', () => {
-    it('calls the matching handler when a new state is replaced', () => {
-      const routes = {
-        '/conversation/:id': () => {},
-        '/user/:id': () => {},
-      };
-
-      spyOn(routes, '/conversation/:id');
-      spyOn(routes, '/user/:id');
-
-      new Router(routes);
-
-      window.history.replaceState('', '', '#/nomatch');
-
-      expect(routes['/conversation/:id']).not.toHaveBeenCalled();
-      expect(routes['/user/:id']).not.toHaveBeenCalled();
-
-      window.history.replaceState('', '', '#/conversation/uuid');
-
-      expect(routes['/conversation/:id']).toHaveBeenCalled();
-      expect(routes['/user/:id']).not.toHaveBeenCalled();
-
-      window.history.replaceState('', '', '#/user/uuid');
-
-      expect(routes['/user/:id']).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
This conflicted with Raygun's internals (which is also replacing this method). We don't need that overwrite anymore since the wrapper is going to use the more standard window.location.hash directly