### PR TITLE
runfix: Reset location hash when the user modal has been closed (WEBAPP-6044)

### DIFF
--- a/src/script/main/app.js
+++ b/src/script/main/app.js
@@ -619,7 +619,9 @@ class App {
 
     const router = new Router({
       '/conversation/:conversationId': conversationId => this.view.content.showConversation(conversationId),
-      '/user/:userId': userId => this.view.content.userModal.showUser(userId),
+      '/user/:userId': userId => {
+        this.view.content.userModal.showUser(userId, () => router.navigate('/'));
+      },
     });
     initRouterBindings(router);
 

--- a/src/script/view_model/content/UserModalViewModel.js
+++ b/src/script/view_model/content/UserModalViewModel.js
@@ -27,9 +27,11 @@ export class UserModalViewModel {
     this.isVisible = ko.observable(false);
     this.user = ko.observable(null);
     this.userNotFound = ko.observable(false);
+    this.onClosedCallback = () => {};
     this.onClosed = () => {
       this.user(null);
       this.userNotFound(false);
+      this.onClosedCallback();
     };
     this.hide = () => this.isVisible(false);
   }
@@ -44,7 +46,8 @@ export class UserModalViewModel {
     this.hide();
   };
 
-  showUser(userId) {
+  showUser(userId, onModalClosed = () => {}) {
+    this.onClosedCallback = onModalClosed;
     this.user(null);
     this.userNotFound(false);
     if (userId) {


### PR DESCRIPTION
Will allow the top level components to change the hash back to `/` when a user modal is closed (so that it can be reopened later on)