### PR TITLE
runfix: Warn when a user cannot be found

### DIFF
--- a/src/script/user/UserRepository.js
+++ b/src/script/user/UserRepository.js
@@ -495,7 +495,7 @@ export default class UserRepository {
       .catch(error => {
         const isNotFound = error.type === z.error.UserError.TYPE.USER_NOT_FOUND;
         if (!isNotFound) {
-          this.logger.error(`Failed to get user '${user_id}': ${error.message}`, error);
+          this.logger.warn(`Failed to find user with ID '${user_id}': ${error.message}`, error);
         }
         throw error;
       });


### PR DESCRIPTION
When people land on `app.wire.com/#/user/wrongid`  then it's a valid case that we log an error for it but it should be warning since it's not severe.