### PR TITLE
runfix: Avoid temporal coupling with the notification_handling_state

### DIFF
--- a/src/script/components/list/conversationListCallingCell.js
+++ b/src/script/components/list/conversationListCallingCell.js
@@ -21,10 +21,7 @@ import {t} from 'utils/LocalizerUtil';
 import TimeUtil from 'utils/TimeUtil';
 import TERMINATION_REASON from '../../calling/enum/TerminationReason';
 
-window.z = window.z || {};
-window.z.components = z.components || {};
-
-z.components.ConversationListCallingCell = class ConversationListCallingCell {
+class ConversationListCallingCell {
   constructor(params) {
     this.conversation = params.conversation;
 
@@ -152,7 +149,7 @@ z.components.ConversationListCallingCell = class ConversationListCallingCell {
   onToggleVideo() {
     amplify.publish(z.event.WebApp.CALL.MEDIA.TOGGLE, this.conversation.id, z.media.MediaType.VIDEO);
   }
-};
+}
 
 ko.components.register('conversation-list-calling-cell', {
   template: `
@@ -261,5 +258,5 @@ ko.components.register('conversation-list-calling-cell', {
       </div>
     <!-- /ko -->
  `,
-  viewModel: z.components.ConversationListCallingCell,
+  viewModel: ConversationListCallingCell,
 });

--- a/src/script/view_model/list/ConversationListViewModel.js
+++ b/src/script/view_model/list/ConversationListViewModel.js
@@ -50,7 +50,9 @@ z.viewModel.list.ConversationListViewModel = class ConversationListViewModel {
     this.logger = Logger('z.viewModel.list.ConversationListViewModel');
     this.multitasking = this.contentViewModel.multitasking;
 
-    this.showCalls = ko.observable(false);
+    this.showCalls = ko.observable();
+    this.setShowCallsState(repositories.event.notificationHandlingState());
+    repositories.event.notificationHandlingState.subscribe(this.setShowCallsState.bind(this));
 
     this.contentState = this.contentViewModel.state;
     this.selectedConversation = ko.observable();
@@ -115,7 +117,6 @@ z.viewModel.list.ConversationListViewModel = class ConversationListViewModel {
   }
 
   _initSubscriptions() {
-    amplify.subscribe(z.event.WebApp.EVENT.NOTIFICATION_HANDLING_STATE, this.setShowCallsState.bind(this));
     amplify.subscribe(z.event.WebApp.LIFECYCLE.LOADED, this.onWebappLoaded.bind(this));
     amplify.subscribe(z.event.WebApp.SHORTCUT.START, this.clickOnPeopleButton.bind(this));
   }


### PR DESCRIPTION
Because I recently delayed the instantiation of all the views to when we actually need them, we were missing the event `NOTIFICATION_HANDLING_STATE` in the `ConversationListViewModel` (this class is instantiated after the event is fired).
Thus we need to explicitly read the value of the handling state when the class is build and then subscribe to changes.

This remove an implicit temporal coupling.