### PR TITLE
runfix: Force perferences linked view model to read the initial values

### DIFF
--- a/src/script/event/WebApp.js
+++ b/src/script/event/WebApp.js
@@ -177,7 +177,6 @@ z.event.WebApp = {
       INTERFACE: {
         THEME: 'wire.webapp.properties.update.interface.theme',
         USE_DARK_MODE: 'wire.webapp.properties.update.interface.use_dark_mode',
-        USE_DARK_MODE_TOGGLE: 'wire.webapp.properties.update.interface.use_dark_mode_toggle',
       },
       NOTIFICATIONS: 'wire.webapp.properties.update.notifications',
       PREVIEWS: {

--- a/src/script/main/app.js
+++ b/src/script/main/app.js
@@ -34,6 +34,7 @@ import AppInitStatisticsValue from '../telemetry/app_init/AppInitStatisticsValue
 import AppInitTimingsStep from '../telemetry/app_init/AppInitTimingsStep';
 import AppInitTelemetry from '../telemetry/app_init/AppInitTelemetry';
 import {MainViewModel} from '../view_model/MainViewModel';
+import {ThemeViewModel} from '../view_model/ThemeViewModel';
 import {WindowHandler} from '../ui/WindowHandler';
 
 import DebugUtil from '../util/DebugUtil';
@@ -278,6 +279,7 @@ class App {
    * @returns {undefined} No return value
    */
   initApp(isReload = this._isReload()) {
+    new ThemeViewModel(this.repository.properties);
     const loadingView = new LoadingViewModel();
     const telemetry = new AppInitTelemetry();
     z.util

--- a/src/script/main/globals.js
+++ b/src/script/main/globals.js
@@ -201,7 +201,6 @@ import ContentViewModelGlobal from '../view_model/ContentViewModel.js';
 import CollectionDetailsViewModelGlobal from '../view_model/content/CollectionDetailsViewModel.js';
 import CollectionViewModelGlobal from '../view_model/content/CollectionViewModel.js';
 import ConnectRequestsViewModelGlobal from '../view_model/content/ConnectRequestsViewModel.js';
-import EmojiInputViewModelGlobal from '../view_model/content/EmojiInputViewModel.js';
 import GiphyViewModelGlobal from '../view_model/content/GiphyViewModel.js';
 import HistoryExportViewModelGlobal from '../view_model/content/HistoryExportViewModel.js';
 import HistoryImportViewModelGlobal from '../view_model/content/HistoryImportViewModel.js';

--- a/src/script/util/DebugUtil.js
+++ b/src/script/util/DebugUtil.js
@@ -46,7 +46,7 @@ export default class DebugUtil {
     this.sodium = sodium;
     this.Dexie = Dexie;
 
-    this.logger = Logger('z.util.DebugUtil');
+    this.logger = Logger('DebugUtil');
   }
 
   blockAllConnections() {

--- a/src/script/view_model/ContentViewModel.js
+++ b/src/script/view_model/ContentViewModel.js
@@ -21,6 +21,7 @@ import Logger from 'utils/Logger';
 import MessageListViewModel from './content/MessageListViewModel';
 import {UserModalViewModel} from './content/UserModalViewModel';
 import {GroupCreationViewModel} from './content/GroupCreationViewModel';
+import {EmojiInputViewModel} from './content/EmojiInputViewModel';
 
 import {t} from 'utils/LocalizerUtil';
 
@@ -68,7 +69,7 @@ z.viewModel.ContentViewModel = class ContentViewModel {
     this.collectionDetails = new z.viewModel.content.CollectionDetailsViewModel();
     this.collection = new z.viewModel.content.CollectionViewModel(mainViewModel, this, repositories);
     this.connectRequests = new z.viewModel.content.ConnectRequestsViewModel(mainViewModel, this, repositories);
-    this.emojiInput = new z.viewModel.content.EmojiInputViewModel(mainViewModel, this, repositories);
+    this.emojiInput = new EmojiInputViewModel(repositories.properties);
     this.giphy = new z.viewModel.content.GiphyViewModel(mainViewModel, this, repositories);
     this.inputBar = new z.viewModel.content.InputBarViewModel(
       mainViewModel,

--- a/src/script/view_model/MainViewModel.js
+++ b/src/script/view_model/MainViewModel.js
@@ -19,7 +19,6 @@
 
 import Logger from 'utils/Logger';
 
-import ThemeViewModel from './ThemeViewModel';
 import WindowTitleViewModel from '../view_model/WindowTitleViewModel';
 
 export class MainViewModel {
@@ -68,7 +67,6 @@ export class MainViewModel {
 
     this.panel = new z.viewModel.PanelViewModel(this, repositories);
     this.content = new z.viewModel.ContentViewModel(this, repositories);
-    this.theme = new ThemeViewModel(this, repositories);
     this.list = new z.viewModel.ListViewModel(this, repositories);
 
     this.modals = new z.viewModel.ModalsViewModel();

--- a/src/script/view_model/ThemeViewModel.js
+++ b/src/script/view_model/ThemeViewModel.js
@@ -23,28 +23,21 @@ export const THEMES = {
   DEFAULT: 'default',
 };
 
-class ThemeViewModel {
-  constructor(mainViewModel, repositories) {
-    this.propertiesRepository = repositories.properties;
-    this.setTheme = this.setTheme.bind(this);
+export class ThemeViewModel {
+  constructor(propertiesRepository) {
+    this.setTheme(propertiesRepository.getPreference(z.properties.PROPERTIES_TYPE.INTERFACE.THEME));
 
-    amplify.subscribe(z.event.WebApp.PROPERTIES.UPDATE.INTERFACE.USE_DARK_MODE_TOGGLE, useDarkMode => {
-      const newTheme = useDarkMode ? THEMES.DARK : THEMES.DEFAULT;
-      this.propertiesRepository.savePreference(z.properties.PROPERTIES_TYPE.INTERFACE.THEME, newTheme);
-    });
     amplify.subscribe(z.event.WebApp.PROPERTIES.UPDATE.INTERFACE.THEME, this.setTheme);
     amplify.subscribe(z.event.WebApp.PROPERTIES.UPDATED, properties =>
       this.setTheme(properties.settings.interface.theme)
     );
   }
 
-  setTheme(newTheme) {
+  setTheme = newTheme => {
     const classes = document.body.className
       .split(' ')
       .filter(elementClass => !elementClass.startsWith(THEMES_CLASS_PREFIX))
       .concat(`${THEMES_CLASS_PREFIX}${newTheme}`);
     document.body.className = classes.join(' ');
-  }
+  };
 }
-
-export default ThemeViewModel;

--- a/src/script/view_model/content/EmojiInputViewModel.js
+++ b/src/script/view_model/content/EmojiInputViewModel.js
@@ -20,11 +20,7 @@
 import emojiBindings from './emoji.json';
 import * as StorageUtil from 'utils/StorageUtil';
 
-window.z = window.z || {};
-window.z.viewModel = z.viewModel || {};
-window.z.viewModel.content = z.viewModel.content || {};
-
-z.viewModel.content.EmojiInputViewModel = class EmojiInputViewModel {
+export class EmojiInputViewModel {
   static get CONFIG() {
     return {
       LIST: {
@@ -103,7 +99,7 @@ z.viewModel.content.EmojiInputViewModel = class EmojiInputViewModel {
   }
   /* eslint-enable sort-keys, no-multi-spaces */
 
-  constructor(mainViewModel, contentViewModel, repositories) {
+  constructor(propertiesRepository) {
     this.removeEmojiPopup = this.removeEmojiPopup.bind(this);
 
     const EMOJI_DIV_CLASS = 'conversation-input-bar-emoji-list';
@@ -120,7 +116,7 @@ z.viewModel.content.EmojiInputViewModel = class EmojiInputViewModel {
     this.emojiStartPosition = -1;
     this.emojiUsageCount = StorageUtil.getValue(z.storage.StorageKey.CONVERSATION.EMOJI_USAGE_COUNT) || {};
 
-    this.shouldReplaceEmoji = repositories.properties.getPreference(z.properties.PROPERTIES_TYPE.EMOJI.REPLACE_INLINE);
+    this.shouldReplaceEmoji = propertiesRepository.getPreference(z.properties.PROPERTIES_TYPE.EMOJI.REPLACE_INLINE);
 
     $(document).on('click', `.${EMOJI_DIV_CLASS}`, event => {
       const clicked = $(event.target);
@@ -443,4 +439,4 @@ z.viewModel.content.EmojiInputViewModel = class EmojiInputViewModel {
   _escapeRegexp(string) {
     return string.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
   }
-};
+}

--- a/src/script/view_model/content/EmojiInputViewModel.js
+++ b/src/script/view_model/content/EmojiInputViewModel.js
@@ -105,7 +105,6 @@ z.viewModel.content.EmojiInputViewModel = class EmojiInputViewModel {
 
   constructor(mainViewModel, contentViewModel, repositories) {
     this.removeEmojiPopup = this.removeEmojiPopup.bind(this);
-    this.updatedReplaceEmojiPreference = this.updatedReplaceEmojiPreference.bind(this);
 
     const EMOJI_DIV_CLASS = 'conversation-input-bar-emoji-list';
     this.INLINE_MAX_LENGTH = EmojiInputViewModel.INLINE_REPLACEMENT.reduce((accumulator, currentItem) => {
@@ -261,9 +260,9 @@ z.viewModel.content.EmojiInputViewModel = class EmojiInputViewModel {
     });
   }
 
-  updatedReplaceEmojiPreference(preference) {
+  updatedReplaceEmojiPreference = preference => {
     this.shouldReplaceEmoji = preference;
-  }
+  };
 
   _tryReplaceInlineEmoji(input) {
     const {selectionStart: selection, value: text} = input;

--- a/src/script/view_model/content/PreferencesAccountViewModel.js
+++ b/src/script/view_model/content/PreferencesAccountViewModel.js
@@ -110,11 +110,12 @@ z.viewModel.content.PreferencesAccountViewModel = class PreferencesAccountViewMo
     this.isConsentCheckEnabled = () => z.config.FEATURE.CHECK_CONSENT;
     this.canEditProfile = user => user.managedBy() === User.CONFIG.MANAGED_BY.WIRE;
 
+    this.updateProperties(this.propertiesRepository.properties);
     this._initSubscriptions();
   }
 
   _initSubscriptions() {
-    amplify.subscribe(z.event.WebApp.PROPERTIES.UPDATED, this.updateProperties.bind(this));
+    amplify.subscribe(z.event.WebApp.PROPERTIES.UPDATED, this.updateProperties);
   }
 
   changeAccentColor(id) {
@@ -399,7 +400,7 @@ z.viewModel.content.PreferencesAccountViewModel = class PreferencesAccountViewMo
     return true;
   }
 
-  updateProperties(properties) {
-    this.optionPrivacy(properties.settings.privacy.improve_wire);
-  }
+  updateProperties = ({settings}) => {
+    this.optionPrivacy(settings.privacy.improve_wire);
+  };
 };

--- a/src/script/view_model/content/PreferencesOptionsViewModel.js
+++ b/src/script/view_model/content/PreferencesOptionsViewModel.js
@@ -54,8 +54,9 @@ z.viewModel.content.PreferencesOptionsViewModel = class PreferencesOptionsViewMo
     });
 
     this.optionDarkMode = ko.observable();
-    this.optionDarkMode.subscribe(darkModePreference => {
-      amplify.publish(z.event.WebApp.PROPERTIES.UPDATE.INTERFACE.USE_DARK_MODE_TOGGLE, darkModePreference);
+    this.optionDarkMode.subscribe(useDarkMode => {
+      const newTheme = useDarkMode ? ThemeViewModelThemes.DARK : ThemeViewModelThemes.DEFAULT;
+      this.propertiesRepository.savePreference(z.properties.PROPERTIES_TYPE.INTERFACE.THEME, newTheme);
     });
     amplify.subscribe(z.event.WebApp.PROPERTIES.UPDATE.INTERFACE.USE_DARK_MODE, this.optionDarkMode);
 
@@ -75,6 +76,7 @@ z.viewModel.content.PreferencesOptionsViewModel = class PreferencesOptionsViewMo
     });
 
     amplify.subscribe(z.event.WebApp.PROPERTIES.UPDATED, this.updateProperties.bind(this));
+    this.updateProperties(this.propertiesRepository.properties);
   }
 
   connectMacOSContacts() {
@@ -104,11 +106,11 @@ z.viewModel.content.PreferencesOptionsViewModel = class PreferencesOptionsViewMo
     });
   }
 
-  updateProperties(properties) {
-    this.optionAudio(properties.settings.sound.alerts);
-    this.optionReplaceInlineEmoji(properties.settings.emoji.replace_inline);
-    this.optionDarkMode(properties.settings.interface.theme === ThemeViewModelThemes.DARK);
-    this.optionSendPreviews(properties.settings.previews.send);
-    this.optionNotifications(properties.settings.notifications);
-  }
+  updateProperties = ({settings}) => {
+    this.optionAudio(settings.sound.alerts);
+    this.optionReplaceInlineEmoji(settings.emoji.replace_inline);
+    this.optionDarkMode(settings.interface.theme === ThemeViewModelThemes.DARK);
+    this.optionSendPreviews(settings.previews.send);
+    this.optionNotifications(settings.notifications);
+  };
 };


### PR DESCRIPTION
This is how the app bootstrapped before:

- setting up repositories
- setting up all the view models
- the properties repository initiate its values and sends an event
- the instantiated view models react to that event

New behavior:
- setting up repo
- properties repo initiate its values
- when view models are initiated, they read the values they need from the properties repo

=> no more temporal coupling (we can initiate the values of the properties repo **before** or **after** the views has been instantiated)