### PR TITLE
refactor: Extract global app config from the CallingRepository

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "stylelint": "prettier --ignore-path .gitignore --write \"**/*.less\" && stylelint --fix --ignore-path .gitignore \"**/*.less\"",
     "build:style": "node ./bin/less.js",
     "test": "yarn test:types && yarn lint && yarn test:server && yarn test:auth && yarn test:app",
-    "test:app": "node --max-old-space-size=4096 ./node_modules/.bin/karma start karma.conf.js",
+    "test:app": "karma start karma.conf.js",
     "test:auth": "yarn bundle:test && karma start karma.conf.react.js",
     "test:server": "cd server && yarn test",
     "test:types": "yarn tsc --noEmit",

--- a/src/script/auth/config.ts
+++ b/src/script/auth/config.ts
@@ -74,6 +74,8 @@ class Configuration {
     SHOW_LOADING_INFORMATION: false,
   };
   readonly APP_INSTANCE_ID = UUID();
+  readonly MAX_VIDEO_PARTICIPANTS = 4;
+  readonly CALLING_PROTOCOL_VERSION = '3.0';
 }
 
 const Config = new Configuration();

--- a/src/script/calling/CallingRepository.js
+++ b/src/script/calling/CallingRepository.js
@@ -35,8 +35,6 @@ export class CallingRepository {
       DATA_CHANNEL_MESSAGE_TYPES: [CALL_MESSAGE_TYPE.HANGUP, CALL_MESSAGE_TYPE.PROP_SYNC],
       DEFAULT_CONFIG_TTL: 60 * 60, // 60 minutes in seconds
       MAX_FIREFOX_TURN_COUNT: 3,
-      MAX_VIDEO_PARTICIPANTS: 4,
-      PROTOCOL_VERSION: '3.0',
     };
   }
 

--- a/src/script/conversation/EventBuilder.js
+++ b/src/script/conversation/EventBuilder.js
@@ -18,7 +18,7 @@
  */
 
 import TERMINATION_REASON from '../calling/enum/TerminationReason';
-import {CallingRepository} from '../calling/CallingRepository';
+import {Config} from '../auth/config';
 
 window.z = window.z || {};
 window.z.conversation = z.conversation || {};
@@ -209,7 +209,7 @@ z.conversation.EventBuilder = {
       conversation: conversationId,
       from: userId,
       id: z.util.createRandomUuid(),
-      protocol_version: CallingRepository.CONFIG.PROTOCOL_VERSION,
+      protocol_version: Config.CALLING_PROTOCOL_VERSION,
       time: time,
       type: z.event.Client.CONVERSATION.VOICE_CHANNEL_ACTIVATE,
     };
@@ -225,7 +225,7 @@ z.conversation.EventBuilder = {
       },
       from: userId,
       id: z.util.createRandomUuid(),
-      protocol_version: CallingRepository.CONFIG.PROTOCOL_VERSION,
+      protocol_version: Config.CALLING_PROTOCOL_VERSION,
       time: time,
       type: z.event.Client.CONVERSATION.VOICE_CHANNEL_DEACTIVATE,
     };

--- a/src/script/entity/Conversation.js
+++ b/src/script/entity/Conversation.js
@@ -22,7 +22,7 @@ import Logger from 'utils/Logger';
 import ko from 'knockout';
 import ReceiptMode from '../conversation/ReceiptMode';
 import {t} from 'utils/LocalizerUtil';
-import {CallingRepository} from '../calling/CallingRepository';
+import {Config} from '../auth/config';
 
 export default class Conversation {
   static get TIMESTAMP_TYPE() {
@@ -701,7 +701,7 @@ export default class Conversation {
     }
 
     const participantCount = this.getNumberOfParticipants(true, false);
-    const passesParticipantLimit = participantCount <= CallingRepository.CONFIG.MAX_VIDEO_PARTICIPANTS;
+    const passesParticipantLimit = participantCount <= Config.MAX_VIDEO_PARTICIPANTS;
 
     if (!passesParticipantLimit) {
       return false;


### PR DESCRIPTION
This limits importing the full CallingRepository in classes that only need to read config values from it