### PR TITLE
fix: Margin for the login button in the auth page

### DIFF
--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -387,6 +387,7 @@ class Login extends React.Component<CombinedProps, State> {
                           <Loading size={32} />
                         ) : (
                           <RoundIconButton
+                            style={{marginLeft: 16}}
                             tabIndex={4}
                             disabled={!email || !password}
                             type="submit"


### PR DESCRIPTION
### before
<img width="433" alt="Screenshot 2019-04-10 at 13 17 41" src="https://user-images.githubusercontent.com/125676/55871375-27f1f800-5b93-11e9-8b73-de7ef9cf82fb.png">

### after
<img width="428" alt="Screenshot 2019-04-10 at 13 17 32" src="https://user-images.githubusercontent.com/125676/55871383-2c1e1580-5b93-11e9-98b9-036d6588c2f2.png">
