### PR TITLE
chore: Use approximate version for @types/node

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -28,7 +28,7 @@
     "@types/hbs": "4.0.1",
     "@types/helmet": "0.0.43",
     "@types/jasmine": "3.3.12",
-    "@types/node": "10.14.6",
+    "@types/node": "~10",
     "jasmine": "3.4.0",
     "nyc": "14.1.0",
     "rimraf": "2.6.3",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -305,7 +305,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.7.tgz#85dbb71c510442d00c0631f99dae957ce44fd104"
   integrity sha512-suFHr6hcA9mp8vFrZTgrmqW2ZU3mbWsryQtQlY/QvwTISCw7nw/j+bCQPPohqmskhmqa5wLNuMHTTsc+xf1MQg==
 
-"@types/node@10.14.6":
+"@types/node@~10":
   version "10.14.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.6.tgz#9cbfcb62c50947217f4d88d4d274cc40c22625a9"
   integrity sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg==


### PR DESCRIPTION
This should always be in sync with [`.travis.yml`](https://github.com/wireapp/wire-webapp/blob/070cb527e2f0d0c1331f0029ecc0eadf8631e5b1/.travis.yml#L25).