### PR TITLE
fix: Decorrelate AV Preferences' mediaStream from the one used in a call (WEBAPP-6227)

### DIFF
--- a/src/page/template/content/preferences-av.htm
+++ b/src/page/template/content/preferences-av.htm
@@ -2,10 +2,6 @@
   <div class="preferences-titlebar" data-bind="text: t('preferencesAV')"></div>
   <div class="preferences-content" data-bind="fadingscrollbar">
 
-  <!-- ko if: hasOngoingCall() -->
-    Changing the settings during the call is temporarily unavailable
-  <!-- /ko -->
-  <!-- ko if: !hasOngoingCall() -->
     <!-- ko if: deviceSupport.audioInput() -->
       <section class="preferences-section">
         <header class="preferences-header preferences-av-header" data-bind="text: t('preferencesAVMicrophone')"></header>
@@ -100,7 +96,6 @@
         <!-- /ko -->
       </section>
     <!-- /ko -->
-  <!-- /ko -->
 
   </div>
 </div>

--- a/src/script/media/MediaDevicesHandler.js
+++ b/src/script/media/MediaDevicesHandler.js
@@ -157,11 +157,6 @@ export class MediaDevicesHandler {
 
     this.currentDeviceId.audioInput.subscribe(mediaDeviceId => {
       storeValue(MediaDeviceType.AUDIO_INPUT, mediaDeviceId);
-
-      const updateStream = mediaDeviceId && this.mediaRepository.streamHandler.localMediaStream();
-      if (updateStream) {
-        this._replaceInputDevice(MediaType.AUDIO, MediaDeviceType.AUDIO_INPUT, mediaDeviceId);
-      }
     });
 
     this.currentDeviceId.audioOutput.subscribe(mediaDeviceId => {
@@ -177,25 +172,13 @@ export class MediaDevicesHandler {
       if (mediaDeviceId) {
         this._updateCurrentIndexFromId(MediaDeviceType.SCREEN_INPUT, mediaDeviceId);
       }
-
-      const isMediaTypeScreen = this.mediaRepository.streamHandler.localMediaType() === MediaType.SCREEN;
-      const updateStream = mediaDeviceId && isMediaTypeScreen && this.mediaRepository.streamHandler.localMediaStream();
-      if (updateStream) {
-        this._replaceInputDevice(MediaType.SCREEN, MediaDeviceType.SCREEN_INPUT, mediaDeviceId);
-      }
     });
 
     this.currentDeviceId.videoInput.subscribe(mediaDeviceId => {
-      if (mediaDeviceId) {
-        this._updateCurrentIndexFromId(MediaDeviceType.VIDEO_INPUT, mediaDeviceId);
-      }
-
       storeValue(MediaDeviceType.VIDEO_INPUT, mediaDeviceId);
 
-      const isMediaTypeVideo = this.mediaRepository.streamHandler.localMediaType() === MediaType.VIDEO;
-      const updateStream = mediaDeviceId && isMediaTypeVideo && this.mediaRepository.streamHandler.localMediaStream();
-      if (updateStream) {
-        this._replaceInputDevice(MediaType.VIDEO, MediaDeviceType.VIDEO_INPUT, mediaDeviceId);
+      if (mediaDeviceId) {
+        this._updateCurrentIndexFromId(MediaDeviceType.VIDEO_INPUT, mediaDeviceId);
       }
     });
   }

--- a/src/script/media/MediaStreamHandler.js
+++ b/src/script/media/MediaStreamHandler.js
@@ -196,11 +196,14 @@ export class MediaStreamHandler {
 
   /**
    * Replace the MediaStream after a change of the selected input device.
-   * @param {MediaStreamInfo} mediaStreamInfo - Info about new MediaStream
-   * @returns {undefined} No return value
+   * @param {MediaStream} mediaStream - the new mediastream (tracks will be clone, this mediaStream can be disposed of once changed)
+   * @param {MediaType} mediaType - Type of the media that needs to be changed
+   * @returns {Promise<void>} Resolves when the local media stream and the call have been updated
    */
-  changeMediaStream(mediaStreamInfo) {
-    const mediaStream = mediaStreamInfo.stream;
+  changeMediaStream(mediaStream, mediaType) {
+    if (!this.localMediaStream()) {
+      return Promise.resolve();
+    }
 
     const logMessage = `Received new MediaStream containing '${mediaStream.getTracks().length}' track/s`;
     const logObject = {
@@ -208,39 +211,43 @@ export class MediaStreamHandler {
       stream: mediaStream,
       videoTracks: mediaStream.getVideoTracks(),
     };
+
     this.logger.debug(logMessage, logObject);
+    const newTracks = MediaStreamHandler.getMediaTracks(mediaStream, mediaType);
+    const newMediaStream = new MediaStream(newTracks.map(track => track.clone()));
+    const mediaStreamInfo = new MediaStreamInfo(MediaStreamSource.LOCAL, 'self', newMediaStream);
 
     const replacePromise = this.joinedCall()
       ? this._updateJoinedCall(mediaStreamInfo)
       : Promise.resolve({replacedTrack: false, streamInfo: mediaStreamInfo});
 
-    replacePromise.then(this._handleReplacedMediaStream.bind(this));
+    return replacePromise.then(this._handleReplacedMediaStream.bind(this));
   }
 
   _handleReplacedMediaStream({replacedTrack, streamInfo: mediaStreamInfo}) {
-    const replaceMediaStreamLocally = newMediaStreamInfo => {
-      const newMediaStream = newMediaStreamInfo.stream;
-      const newMediaStreamType = newMediaStreamInfo.getType();
+    const replaceMediaStreamLocally = mediaStream => {
+      const newMediaStreamType = MediaStreamHandler.detectMediaStreamType(mediaStream);
 
       this._releaseMediaStream(this.localMediaStream());
-      this._setStreamState(newMediaStream, newMediaStreamType);
-      this.localMediaStream(newMediaStream);
+      this._setStreamState(mediaStream, newMediaStreamType);
+      this.localMediaStream(mediaStream);
     };
 
-    const replaceMediaTracksLocally = newMediaStreamInfo => {
-      const mediaStream = newMediaStreamInfo.stream;
-      const mediaType = newMediaStreamInfo.getType();
+    const replaceMediaTracksLocally = mediaStream => {
+      const mediaType = MediaStreamHandler.detectMediaStreamType(mediaStream);
       const localMediaStream = this.localMediaStream();
 
       if (localMediaStream) {
-        this._releaseTracksFromStream(localMediaStream, mediaType);
+        this.releaseTracksFromStream(localMediaStream, mediaType);
         this._addTracksToStream(mediaStream, localMediaStream, mediaType);
       } else {
         this.localMediaStream(mediaStream);
       }
     };
 
-    return replacedTrack ? replaceMediaTracksLocally(mediaStreamInfo) : replaceMediaStreamLocally(mediaStreamInfo);
+    return replacedTrack
+      ? replaceMediaTracksLocally(mediaStreamInfo.stream)
+      : replaceMediaStreamLocally(mediaStreamInfo.stream);
   }
 
   /**
@@ -275,16 +282,9 @@ export class MediaStreamHandler {
 
     return constraintsPromise
       .then(streamConstraints => this.requestMediaStream(mediaType, streamConstraints))
-      .then(mediaStreamInfo => {
-        // FIXME: the mediaStreamInUse should be more intelligent and handle all scenarios where the stream is actually needed
-        if (!isPreferenceChange && !this.mediaStreamInUse()) {
-          // in case the stream is returned after the call has actually ended, we need to release the stream right away
-          this.logger.warn('Releasing obsolete MediaStream as there is no active call', mediaStreamInfo);
-          return this._releaseMediaStream(mediaStreamInfo.stream);
-        }
-
+      .then(({stream}) => {
         this._setSelfStreamState(mediaType);
-        this.changeMediaStream(mediaStreamInfo);
+        this.changeMediaStream(stream, mediaType).then(() => stream.getTracks().forEach(track => track.stop()));
       })
       .catch(error => {
         const isMediaTypeScreen = mediaType === MediaType.SCREEN;
@@ -523,7 +523,7 @@ export class MediaStreamHandler {
    * @returns {boolean} Have tracks been stopped
    */
   _releaseMediaStream(mediaStream, mediaType = MediaType.AUDIO_VIDEO) {
-    return mediaStream ? this._releaseTracksFromStream(mediaStream, mediaType) : false;
+    return mediaStream ? this.releaseTracksFromStream(mediaStream, mediaType) : false;
   }
 
   /**
@@ -534,7 +534,7 @@ export class MediaStreamHandler {
    * @param {MediaType} [mediaType=MediaType.AUDIO_VIDEO] - Type of MediaStreamTracks to be released
    * @returns {boolean} Have tracks been stopped
    */
-  _releaseTracksFromStream(mediaStream, mediaType) {
+  releaseTracksFromStream(mediaStream, mediaType) {
     const mediaStreamTracks = MediaStreamHandler.getMediaTracks(mediaStream, mediaType);
 
     if (mediaStreamTracks.length) {
@@ -751,15 +751,14 @@ export class MediaStreamHandler {
       return Promise.reject(new z.error.MediaError(z.error.MediaError.TYPE.STREAM_NOT_FOUND));
     }
 
-    const newMediaStream = mediaStreamInfo.stream;
-    const mediaType = mediaStreamInfo.getType();
-    this._releaseTracksFromStream(this.localMediaStream(), mediaType);
+    const mediaType = MediaStreamHandler.detectMediaStreamType(mediaStreamInfo.stream);
+    this.releaseTracksFromStream(this.localMediaStream(), mediaType);
 
     const clonedMediaStream = this.localMediaStream().clone();
     const clonedMediaStreamType = MediaStreamHandler.detectMediaStreamType(clonedMediaStream);
     // Reset MediaStreamTrack enabled states as older Chrome versions fail to copy these when cloning
     this._setStreamState(clonedMediaStream, clonedMediaStreamType);
-    this._addTracksToStream(newMediaStream, clonedMediaStream, mediaType);
+    this._addTracksToStream(mediaStreamInfo.stream, clonedMediaStream, mediaType);
 
     this.logger.info(`Upgraded the MediaStream to update '${mediaType}'`, clonedMediaStream);
     return Promise.resolve(new MediaStreamInfo(MediaStreamSource.LOCAL, 'self', clonedMediaStream));
@@ -807,21 +806,6 @@ export class MediaStreamHandler {
   // Media handling
   //##############################################################################
 
-  /**
-   * Check for active calls that need a MediaStream.
-   * @returns {boolean} Returns true if an active media stream is needed for at least one call
-   */
-  mediaStreamInUse() {
-    for (const callEntity of this.currentCalls.values()) {
-      const callNeedsMediaStream = callEntity.needsMediaStream();
-      if (callNeedsMediaStream) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
   // Toggle the mute state of the microphone.
   toggleAudioSend() {
     return this._toggleAudioSend();
@@ -847,11 +831,9 @@ export class MediaStreamHandler {
 
   // Reset the MediaStream and states.
   resetMediaStream() {
-    if (!this.mediaStreamInUse()) {
-      this.releaseMediaStream();
-      this.resetSelfStates();
-      this.mediaRepository.closeAudioContext();
-    }
+    this.releaseMediaStream();
+    this.resetSelfStates();
+    this.mediaRepository.closeAudioContext();
   }
 
   /**

--- a/src/script/media/MediaStreamHandler.js
+++ b/src/script/media/MediaStreamHandler.js
@@ -196,7 +196,7 @@ export class MediaStreamHandler {
 
   /**
    * Replace the MediaStream after a change of the selected input device.
-   * @param {MediaStream} mediaStream - the new mediastream (tracks will be clone, this mediaStream can be disposed of once changed)
+   * @param {MediaStream} mediaStream - the new mediastream (tracks will be cloned, this mediaStream can be disposed of once changed)
    * @param {MediaType} mediaType - Type of the media that needs to be changed
    * @returns {Promise<void>} Resolves when the local media stream and the call have been updated
    */

--- a/src/script/view_model/bindings/VideoCallingBindings.js
+++ b/src/script/view_model/bindings/VideoCallingBindings.js
@@ -28,6 +28,9 @@ ko.bindingHandlers.muteMediaElement = {
 
 ko.bindingHandlers.sourceStream = {
   update(element, valueAccessor) {
-    element.srcObject = valueAccessor();
+    const stream = valueAccessor();
+    if (stream) {
+      element.srcObject = stream;
+    }
   },
 };

--- a/src/script/view_model/content/PreferencesAVViewModel.js
+++ b/src/script/view_model/content/PreferencesAVViewModel.js
@@ -39,7 +39,6 @@ z.viewModel.content.PreferencesAVViewModel = class PreferencesAVViewModel {
   }
 
   constructor(mainViewModel, contentViewModel, repositories) {
-    this.hasOngoingCall = ko.observable(false);
     this.initiateDevices = this.initiateDevices.bind(this);
     this.releaseDevices = this.releaseDevices.bind(this);
 
@@ -56,9 +55,37 @@ z.viewModel.content.PreferencesAVViewModel = class PreferencesAVViewModel {
     this.currentDeviceId = this.devicesHandler.currentDeviceId;
     this.deviceSupport = this.devicesHandler.deviceSupport;
 
+    const updateStream = mediaType => {
+      const currentCallMediaStream = this.streamHandler.localMediaStream();
+      // release first the current call's tracks and the preferences' tracks (Firefox doesn't allow to request another mic if one is already active)
+      if (currentCallMediaStream) {
+        this.streamHandler.releaseTracksFromStream(currentCallMediaStream, mediaType);
+      }
+      if (this.mediaStream()) {
+        this.streamHandler.releaseTracksFromStream(this.mediaStream(), mediaType);
+      }
+
+      return this._getMediaStream(mediaType).then(stream => {
+        if (!stream) {
+          return this.mediaStream(undefined);
+        }
+        this.streamHandler.changeMediaStream(stream, mediaType);
+        if (this.mediaStream()) {
+          stream.getTracks().forEach(track => {
+            this.mediaStream().addTrack(track);
+          });
+        } else {
+          stream.getTracks().forEach(track => track.stop());
+        }
+      });
+    };
+
+    this.currentDeviceId.audioInput.subscribe(() => updateStream(MediaType.AUDIO));
+    this.currentDeviceId.videoInput.subscribe(() => updateStream(MediaType.VIDEO));
+
     this.constraintsHandler = this.mediaRepository.constraintsHandler;
     this.streamHandler = this.mediaRepository.streamHandler;
-    this.mediaStream = this.streamHandler.localMediaStream;
+    this.mediaStream = ko.observable();
 
     this.isVisible = false;
 
@@ -93,14 +120,10 @@ z.viewModel.content.PreferencesAVViewModel = class PreferencesAVViewModel {
    * @returns {undefined} No return value
    */
   initiateDevices() {
-    if (this.callingRepository.joinedCall()) {
-      this.hasOngoingCall(true);
-      return;
-    }
-    this.hasOngoingCall(false);
     this.isVisible = true;
 
     this._getMediaStream().then(mediaStream => {
+      this.mediaStream(mediaStream);
       if (mediaStream && !this.audioInterval) {
         this._initiateAudioMeter(mediaStream);
       }
@@ -123,65 +146,24 @@ z.viewModel.content.PreferencesAVViewModel = class PreferencesAVViewModel {
   }
 
   /**
-   * Check supported media type.
+   * Get current MediaStream or initiate it.
    * @private
-   * @returns {Promise} Resolves with a MediaType or false
+   * @param {MediaType} requestedMediaType - MediaType to request the user
+   * @returns {Promise} Resolves with a MediaStream
    */
-  _checkMediaSupport() {
-    let mediaType;
-    if (this.deviceSupport.audioInput()) {
-      mediaType = this.deviceSupport.videoInput() ? MediaType.AUDIO_VIDEO : MediaType.AUDIO;
-    } else {
-      mediaType = this.deviceSupport.videoInput() ? MediaType.VIDEO : undefined;
+  _getMediaStream(requestedMediaType = MediaType.AUDIO_VIDEO) {
+    if (!this.deviceSupport.videoInput() && !this.deviceSupport.audioInput()) {
+      this.permissionDenied(true);
+      return Promise.resolve(undefined);
     }
-
-    return mediaType
-      ? Promise.resolve(mediaType)
-      : Promise.reject(new z.error.MediaError(z.error.MediaError.TYPE.MEDIA_STREAM_DEVICE));
-  }
-
-  /**
-   * Get current MediaStream or initiate it.
-   * @private
-   * @returns {Promise} Resolves with a MediaStream
-   */
-  _getCurrentMediaStream() {
-    const hasActiveStream = this.deviceSupport.videoInput()
-      ? !!this.mediaStream() && this.streamHandler.localMediaType() === MediaType.VIDEO
-      : !!this.mediaStream();
-
-    return Promise.resolve(hasActiveStream ? this.mediaStream() : undefined);
-  }
-
-  /**
-   * Get current MediaStream or initiate it.
-   * @private
-   * @returns {Promise} Resolves with a MediaStream
-   */
-  _getMediaStream() {
-    return this._getCurrentMediaStream().then(mediaStream => (mediaStream ? mediaStream : this._initiateMediaStream()));
-  }
-
-  /**
-   * Initiate MediaStream.
-   * @private
-   * @returns {Promise} Resolves with a MediaStream
-   */
-  _initiateMediaStream() {
-    return this._checkMediaSupport()
-      .then(mediaType => {
-        return this.constraintsHandler
-          .getMediaStreamConstraints(this.deviceSupport.audioInput(), this.deviceSupport.videoInput())
-          .then(streamConstraints => this.streamHandler.requestMediaStream(mediaType, streamConstraints));
-      })
-      .then(mediaStreamInfo => {
-        if (this.deviceSupport.videoInput()) {
-          this.streamHandler.localMediaType(MediaType.VIDEO);
-        }
-
-        this.streamHandler.localMediaStream(mediaStreamInfo.stream);
-        return this.streamHandler.localMediaStream();
-      })
+    const supportsVideo = this.deviceSupport.videoInput();
+    const supportsAudio = this.deviceSupport.audioInput();
+    const requestAudio = supportsAudio && [MediaType.AUDIO, MediaType.AUDIO_VIDEO].includes(requestedMediaType);
+    const requestVideo = supportsVideo && [MediaType.VIDEO, MediaType.AUDIO_VIDEO].includes(requestedMediaType);
+    return this.constraintsHandler
+      .getMediaStreamConstraints(requestAudio, requestVideo)
+      .then(streamConstraints => this.streamHandler.requestMediaStream(requestedMediaType, streamConstraints))
+      .then(({stream}) => stream)
       .catch(error => {
         this.logger.error(`Requesting MediaStream failed: ${error.message}`, error);
 
@@ -244,7 +226,10 @@ z.viewModel.content.PreferencesAVViewModel = class PreferencesAVViewModel {
   }
 
   _releaseMediaStream() {
-    this.streamHandler.resetMediaStream();
+    if (this.mediaStream()) {
+      this.streamHandler.releaseTracksFromStream(this.mediaStream());
+      this.mediaStream(undefined);
+    }
     this.permissionDenied(false);
   }
 };


### PR DESCRIPTION
Previously, mediaStream were shared accross the preferences page and a potential current call. Which lead to hard-to-find mediaStream leaks (because it's hard to know if you need to release the tracks of the media stream from the call and/or the preference page).

Now, we have discinct workflow for both the page and a call. Which means they are both responsible for cleaning their own mediaStream, but never the media stream of someone else. It makes the dataflow easier to understand and to scale in the future