### PR TITLE
feat: Decrypt but ignore messages from legal hold clients

### DIFF
--- a/src/script/client/ClientRepository.js
+++ b/src/script/client/ClientRepository.js
@@ -183,6 +183,13 @@ export class ClientRepository {
     return this.clientService.saveClientInDb(primaryKey, clientPayload);
   }
 
+  async loadClientFromDb(userId, clientId) {
+    const isSelfUser = userId === this.selfUser().id;
+    const primaryKey = this._constructPrimaryKey(userId, clientId);
+    const clientPayload = await this.clientService.loadClientFromDb(primaryKey);
+    return this.clientMapper.mapClient(clientPayload, isSelfUser);
+  }
+
   /**
    * Updates properties for a client record in database.
    *

--- a/src/script/event/EventRepository.js
+++ b/src/script/event/EventRepository.js
@@ -563,7 +563,7 @@ export class EventRepository {
    * @private
    * @param {Object} event - Mapped event to be distributed
    * @param {EventRepository.SOURCE} source - Source of notification
-   * @returns {undefined} No return value
+   * @returns {Promise<void>} Empty promise
    */
   async _distributeEvent(event, source) {
     const {conversation: conversationId, from: userId, type} = event;

--- a/src/script/event/EventRepository.js
+++ b/src/script/event/EventRepository.js
@@ -644,7 +644,7 @@ export class EventRepository {
         }, Promise.resolve(mappedEvent));
       })
       .then(mappedEvent => {
-        mappedEvent.from_client = event.data && event.data.sender ? event.data && event.data.sender : '';
+        mappedEvent.from_client = event.data && event.data.sender ? event.data.sender : '';
         const shouldSaveEvent = EventTypeHandling.STORE.includes(mappedEvent.type);
         return shouldSaveEvent ? this._handleEventSaving(mappedEvent, source) : mappedEvent;
       })

--- a/src/script/event/EventRepository.js
+++ b/src/script/event/EventRepository.js
@@ -644,7 +644,7 @@ export class EventRepository {
         }, Promise.resolve(mappedEvent));
       })
       .then(mappedEvent => {
-        mappedEvent.from_client = event.data && event.data.sender || '';
+        mappedEvent.from_client = (event.data && event.data.sender) || '';
         const shouldSaveEvent = EventTypeHandling.STORE.includes(mappedEvent.type);
         return shouldSaveEvent ? this._handleEventSaving(mappedEvent, source) : mappedEvent;
       })

--- a/src/script/event/EventRepository.js
+++ b/src/script/event/EventRepository.js
@@ -644,7 +644,7 @@ export class EventRepository {
         }, Promise.resolve(mappedEvent));
       })
       .then(mappedEvent => {
-        mappedEvent.from_client = event.data && event.data.sender ? event.data.sender : '';
+        mappedEvent.from_client = event.data && event.data.sender || '';
         const shouldSaveEvent = EventTypeHandling.STORE.includes(mappedEvent.type);
         return shouldSaveEvent ? this._handleEventSaving(mappedEvent, source) : mappedEvent;
       })

--- a/src/script/event/EventRepository.js
+++ b/src/script/event/EventRepository.js
@@ -657,9 +657,9 @@ export class EventRepository {
    * @private
    * @param {JSON} event - Backend event extracted from notification stream
    * @param {EventRepository.SOURCE} source - Source of event
-   * @returns {JSON} The distributed event
+   * @returns {Promise<JSON>} The distributed event
    */
-  _handleEventDistribution(event, source) {
+  async _handleEventDistribution(event, source) {
     const eventDate = this._getIsoDateFromEvent(event);
     const isInjectedEvent = source === EventRepository.SOURCE.INJECTED;
     const canSetEventDate = !isInjectedEvent && eventDate;
@@ -672,7 +672,7 @@ export class EventRepository {
       this._validateCallEventLifetime(event);
     }
 
-    this._distributeEvent(event, source);
+    await this._distributeEvent(event, source);
 
     return event;
   }


### PR DESCRIPTION
It looks like `_distributeEvent` is a "fire and forget" method which is why I am not awaiting it in `_handleEventDistribution` of `EventRepository.js`. Or have I overlooked something?