### PR TITLE
chore: Enable the --specs flag for *.test.ts files

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -26,7 +26,10 @@ const testCode = 'src/script/**/*.test.ts';
 
 function getSpecs(specList) {
   if (specList) {
-    return specList.split(',').map(specPath => `test/unit_tests/${specPath}Spec.js`);
+    const list = specList.split(',');
+    const legacySpecs = list.map(specPath => `test/unit_tests/${specPath}Spec.js`);
+    const specs = list.map(specPath => `src/script/${specPath}.test.ts`);
+    return specs.concat(legacySpecs);
   }
   return ['test/unit_tests/**/*.js'].concat(testCode);
 }


### PR DESCRIPTION
Will allow to run a single test file from the cli regardless of if the test is in `test/unit_tests` directory or in `src/components/**/*.test.ts`.

example:

```
yarn test:app --specs=assets/AssetCrypto
```