### PR TITLE
runfix: Avoid race condition when fetching users (WEBAPP-6282)

### DIFF
--- a/src/script/main/app.js
+++ b/src/script/main/app.js
@@ -382,6 +382,9 @@ class App {
         return this._handleUrlParams();
       })
       .then(() => {
+        return this.repository.conversation.updateConversationsOnAppInit();
+      })
+      .then(() => {
         telemetry.time_step(AppInitTimingsStep.APP_LOADED);
         this._showInterface();
         loadingView.removeFromView();
@@ -389,7 +392,6 @@ class App {
         amplify.publish(WebAppEvents.LIFECYCLE.LOADED);
         modals.ready();
         showInitialModal(this.repository.user.self().availability());
-        return this.repository.conversation.updateConversationsOnAppInit();
       })
       .then(() => {
         telemetry.time_step(AppInitTimingsStep.UPDATED_CONVERSATIONS);


### PR DESCRIPTION
At app load time, we update the conversations (fetch the users and make sure everything is there). But since we did not wait for this to be over when loading the app, we would also load those users again when displaying the conversation. 
This resulted in 2 requests being sent in parallel and 2 user entities being created for the same user