### PR TITLE
chore: Increase karma noActivity timeout

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -53,7 +53,7 @@ module.exports = function(config) {
   config.set({
     autoWatch: false,
     basePath: './',
-    browserNoActivityTimeout: 60000,
+    browserNoActivityTimeout: 120000,
     browsers: ['ChromeNoSandbox'],
     client: {
       jasmine: {


### PR DESCRIPTION
Since more and more sources are being build before the tests actually start, Karma eventually think that nothing is happening during the building process thus triggering the noActivityTimeout