### PR TITLE
chore: Revert unneded team logo changes

### DIFF
--- a/src/script/team/TeamRepository.js
+++ b/src/script/team/TeamRepository.js
@@ -173,28 +173,30 @@ export class TeamRepository {
     }
   }
 
-  async sendAccountInfo() {
+  sendAccountInfo() {
     if (Environment.desktop) {
-      let imageDataUrl;
-
       const imageResource = this.isTeam() ? this.team().getIconResource() : this.selfUser().previewPictureResource();
+      const imagePromise = imageResource ? imageResource.load() : Promise.resolve();
 
-      if (imageResource) {
-        const imageBlob = await imageResource.load();
-        imageDataUrl = await loadDataUrl(imageBlob);
-      }
+      imagePromise
+        .then(imageBlob => {
+          if (imageBlob) {
+            return loadDataUrl(imageBlob);
+          }
+        })
+        .then(imageDataUrl => {
+          const accountInfo = {
+            accentID: this.selfUser().accent_id(),
+            name: this.teamName(),
+            picture: imageDataUrl,
+            teamID: this.team().id,
+            teamRole: this.selfUser().teamRole(),
+            userID: this.selfUser().id,
+          };
 
-      const accountInfo = {
-        accentID: this.selfUser().accent_id(),
-        name: this.teamName(),
-        picture: imageDataUrl,
-        teamID: this.team().id,
-        teamRole: this.selfUser().teamRole(),
-        userID: this.selfUser().id,
-      };
-
-      this.logger.info('Publishing account info', accountInfo);
-      amplify.publish(WebAppEvents.TEAM.INFO, accountInfo);
+          this.logger.info('Publishing account info', accountInfo);
+          amplify.publish(WebAppEvents.TEAM.INFO, accountInfo);
+        });
     }
   }
 

--- a/test/unit_tests/team/TeamRepositorySpec.js
+++ b/test/unit_tests/team/TeamRepositorySpec.js
@@ -96,4 +96,20 @@ describe('TeamRepository', () => {
       });
     });
   });
+
+  describe('sendAccountInfo', () => {
+    it(`doesn't crash when there is no account avatar`, async () => {
+      const selfUser = team_repository.selfUser();
+
+      expect(team_repository.isTeam()).toBe(false);
+
+      selfUser.previewPictureResource({
+        load: () => Promise.resolve(),
+      });
+
+      const accountInfo = await team_repository.sendAccountInfo(true);
+
+      expect(accountInfo.picture).toBeUndefined();
+    });
+  });
 });

--- a/test/unit_tests/team/TeamRepositorySpec.js
+++ b/test/unit_tests/team/TeamRepositorySpec.js
@@ -98,13 +98,11 @@ describe('TeamRepository', () => {
   });
 
   describe('sendAccountInfo', () => {
-    it(`doesn't crash when there is no account avatar`, async () => {
-      const selfUser = team_repository.selfUser();
+    it(`doesn't crash when there is no team logo`, async () => {
+      expect(team_repository.isTeam()).toBe(true);
 
-      expect(team_repository.isTeam()).toBe(false);
-
-      selfUser.previewPictureResource({
-        load: () => Promise.resolve(),
+      team_repository.selfUser().getIconResource = async () => ({
+        load: async () => undefined,
       });
 
       const accountInfo = await team_repository.sendAccountInfo(true);


### PR DESCRIPTION
This reverts `TeamRepository.js` from https://github.com/wireapp/wire-webapp/pull/6904 and now returns the data (currently only used for the test).