### PR TITLE
fix: Replace incorrect CSS perspective property

### DIFF
--- a/src/style/common/mixins.less
+++ b/src/style/common/mixins.less
@@ -248,7 +248,9 @@
 
 .hardware-acc {
   -webkit-backface-visibility: hidden;
-  -webkit-perspective: 1000;
+  // Note: Using perspective (with a value different from `0` or `none`) creates a new stacking context which will cause the browser to take advantage of GPU rendering.
+  // @see https://css-tricks.com/almanac/properties/p/perspective/
+  -webkit-perspective: revert;
 }
 
 .mirror {


### PR DESCRIPTION
The value `1000` was invalid, so I am using `revert` now