### PR TITLE
chore: use release-5.1 dist-tag for avs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@bower_components/webapp-module-bubble": "wireapp/webapp-module-bubble#1.1.2",
     "@bower_components/webapp-module-namespace": "wireapp/webapp-module-namespace#1.0.2",
     "@wireapp/antiscroll-2": "1.0.2",
-    "@wireapp/avs": "5.1.39",
+    "@wireapp/avs": "release-5.1",
     "@wireapp/commons": "2.2.8",
     "@wireapp/core": "12.17.51",
     "@wireapp/protocol-messaging": "1.24.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1562,7 +1562,7 @@
     spark-md5 "3.0.0"
     tough-cookie "3.0.1"
 
-"@wireapp/avs@5.1.39":
+"@wireapp/avs@release-5.1":
   version "5.1.39"
   resolved "https://registry.yarnpkg.com/@wireapp/avs/-/avs-5.1.39.tgz#c1d4ae3a424d72e7b741edd6d62ef64069cbfbd6"
   integrity sha512-Y3TNhkL/J+aKTeTI9qUOd/U1wnh02sEQg+5vhYH6VrK6ki7rQIKdHnmXy8InYuQ7WdLMrdly0qHIaYmswwH4iw==


### PR DESCRIPTION
This will enable dependabot to fetch the right version upgrade for @wireapp/avs package