### PR TITLE
fix: Safer localStorage access from logger (WEBAPP-6423)

### DIFF
--- a/src/script/util/LoggerUtil.js
+++ b/src/script/util/LoggerUtil.js
@@ -20,14 +20,15 @@
 import 'url-search-params-polyfill';
 
 function enableLogging(force = false, search = window.location.search) {
-  /**
-   * If users disable cookies in their browsers, they won't have access to the localStorage API.
-   * The following check will fix this error:
-   * > Failed to read the 'localStorage' property from 'Window': Access is denied for this document
-   */
   let localStorage;
 
   try {
+    /**
+     * If users disable cookies in their browsers, they won't have access to the localStorage API.
+     * The following check will fix this error:
+     * > Failed to read the 'localStorage' property from 'Window': Access is denied for this document
+     * (note: Some version of Firefox do not throw an error but, instead, return a null object, we also need to account for that scenario)
+     */
     localStorage = window.localStorage;
   } catch (error) {}
   if (!localStorage) {

--- a/src/script/util/LoggerUtil.js
+++ b/src/script/util/LoggerUtil.js
@@ -29,7 +29,8 @@ function enableLogging(force = false, search = window.location.search) {
 
   try {
     localStorage = window.localStorage;
-  } catch (error) {
+  } catch (error) {}
+  if (!localStorage) {
     return;
   }
 


### PR DESCRIPTION
This could be due to a Firefox regression where, when cookies are not enabled, firefox does not throw an error but instead gives back a null object