### PR TITLE
fix: Display conversation not found modal at the right time

### DIFF
--- a/src/script/conversation/ConversationRepository.js
+++ b/src/script/conversation/ConversationRepository.js
@@ -1025,9 +1025,8 @@ export class ConversationRepository {
    * @returns {boolean} Is the conversation active
    */
   is_active_conversation(conversationEntity) {
-    if (this.active_conversation()) {
-      return this.active_conversation().id === conversationEntity.id;
-    }
+    const activeConversation = this.active_conversation();
+    return !!activeConversation && activeConversation.id === conversationEntity.id;
   }
 
   /**

--- a/src/script/conversation/ConversationRepository.js
+++ b/src/script/conversation/ConversationRepository.js
@@ -1026,7 +1026,7 @@ export class ConversationRepository {
    */
   is_active_conversation(conversationEntity) {
     const activeConversation = this.active_conversation();
-    return !!activeConversation && activeConversation.id === conversationEntity.id;
+    return !!activeConversation && !!conversationEntity && activeConversation.id === conversationEntity.id;
   }
 
   /**


### PR DESCRIPTION
Right now, every error in `showConversation` causes the "conversation not found" modal to appear and is being swallowed then.
To be able to find and fix errors within this function, we will only swallow the `CONVERSATION_NOT_FOUND` error and surface the others. Since the promise inside the function is floating, it should not break the flow of other functions.