### PR TITLE
fix: Check for navigator.mediaDevices

### DIFF
--- a/src/script/media/MediaStreamHandler.ts
+++ b/src/script/media/MediaStreamHandler.ts
@@ -58,7 +58,7 @@ export class MediaStreamHandler {
     this.screensharingMethod = ScreensharingMethods.NONE;
     if (window.desktopCapturer) {
       this.screensharingMethod = ScreensharingMethods.DESKTOP_CAPTURER;
-    } else if (navigator.mediaDevices.getDisplayMedia) {
+    } else if (!!navigator.mediaDevices && navigator.mediaDevices.getDisplayMedia) {
       this.screensharingMethod = ScreensharingMethods.DISPLAY_MEDIA;
     } else if (Environment.browser.firefox) {
       this.screensharingMethod = ScreensharingMethods.USER_MEDIA;


### PR DESCRIPTION
`navigator.mediaDevices` can be undefined, for example [if the current document isn't loaded securely](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia) (this is the case when testing locally in a VM)