### PR TITLE
refactor: Remove unnecessary underscore helpers

### DIFF
--- a/src/script/auth/ValidationError.ts
+++ b/src/script/auth/ValidationError.ts
@@ -17,15 +17,13 @@
  *
  */
 
-import {isString} from 'underscore';
-
 export class ValidationError extends Error {
   types: string | string[];
 
   constructor(types: string | string[], errorMessage: string) {
     super();
 
-    if (isString(types)) {
+    if (typeof types === 'string') {
       types = [types];
     }
 

--- a/src/script/broadcast/BroadcastService.js
+++ b/src/script/broadcast/BroadcastService.js
@@ -48,7 +48,7 @@ export class BroadcastService {
    */
   postBroadcastMessage(payload, preconditionOption) {
     let url = `${BroadcastService.CONFIG.URL_BROADCAST}/otr/messages`;
-    if (_.isArray(preconditionOption)) {
+    if (Array.isArray(preconditionOption)) {
       url = `${url}?report_missing=${preconditionOption.join(',')}`;
     } else if (preconditionOption) {
       url = `${url}?ignore_missing=true`;

--- a/src/script/client/ClientEntity.ts
+++ b/src/script/client/ClientEntity.ts
@@ -19,7 +19,6 @@
 
 import {ClientClassification} from '@wireapp/api-client/dist/commonjs/client/';
 import ko from 'knockout';
-import {isString} from 'underscore';
 
 import {zeroPadding} from 'Util/util';
 import {ClientMapper} from './ClientMapper';
@@ -69,7 +68,7 @@ export class ClientEntity {
    * Splits an ID into user ID & client ID.
    */
   static dismantleUserClientId(id: string): {clientId: string; userId: string} {
-    const [userId, clientId] = isString(id) ? id.split('@') : ([] as string[]);
+    const [userId, clientId] = typeof id === 'string' ? id.split('@') : ([] as string[]);
     return {clientId, userId};
   }
 

--- a/src/script/client/ClientRepository.js
+++ b/src/script/client/ClientRepository.js
@@ -140,7 +140,7 @@ export class ClientRepository {
         throw new z.error.ClientError(z.error.ClientError.TYPE.DATABASE_FAILURE);
       })
       .then(clientPayload => {
-        if (_.isString(clientPayload)) {
+        if (typeof clientPayload === 'string') {
           this.logger.info('No local client found in database');
           throw new z.error.ClientError(z.error.ClientError.TYPE.NO_VALID_CLIENT);
         }

--- a/src/script/components/asset/controls/audioSeekBar.js
+++ b/src/script/components/asset/controls/audioSeekBar.js
@@ -17,6 +17,8 @@
  *
  */
 
+import {debounce} from 'underscore';
+
 import {interpolate} from 'Util/ArrayUtil';
 import {clamp} from 'Util/NumberUtil';
 
@@ -49,7 +51,7 @@ class AudioSeekBarComponent {
       this.loudness = this._normalizeLoudness(assetMeta.loudness, this.element.clientHeight);
     }
 
-    this._onResizeFired = _.debounce(() => {
+    this._onResizeFired = debounce(() => {
       this._renderLevels();
       this._onTimeUpdate();
     }, 500);
@@ -87,7 +89,7 @@ class AudioSeekBarComponent {
   _onLevelClick(event) {
     const mouse_x = event.pageX - event.currentTarget.getBoundingClientRect().left;
     const calculatedTime = (this.audioElement.duration * mouse_x) / event.currentTarget.clientWidth;
-    const currentTime = window.isNaN(calculatedTime) ? 0 : calculatedTime;
+    const currentTime = isNaN(calculatedTime) ? 0 : calculatedTime;
 
     this.audioElement.currentTime = clamp(currentTime, 0, this.audioElement.duration);
     this._onTimeUpdate();

--- a/src/script/components/fullSearch.js
+++ b/src/script/components/fullSearch.js
@@ -18,6 +18,7 @@
  */
 
 import moment from 'moment';
+import {debounce} from 'underscore';
 
 import {isScrolledBottom} from 'Util/scroll-helpers';
 import {koArrayPushAll} from 'Util/util';
@@ -59,7 +60,7 @@ class FullSearch {
 
     this.input = ko.observable();
     this.input.subscribe(
-      _.debounce(searchQuery => {
+      debounce(searchQuery => {
         searchQuery = searchQuery.trim();
 
         this.onInputChange(searchQuery);
@@ -109,7 +110,7 @@ class FullSearch {
     const markOffset = transformedText.indexOf('<mark') - 1;
     let sliceOffset = markOffset;
 
-    for (const index of _.range(markOffset).reverse()) {
+    for (const index of [...Array(markOffset).keys()].reverse()) {
       if (index < markOffset - FullSearch.CONFIG.PRE_MARKED_OFFSET) {
         break;
       }

--- a/src/script/conversation/ConversationEphemeralHandler.js
+++ b/src/script/conversation/ConversationEphemeralHandler.js
@@ -259,7 +259,7 @@ export class ConversationEphemeralHandler extends AbstractConversationEventHandl
   }
 
   _updateTimedMessage(messageEntity) {
-    if (_.isString(messageEntity.ephemeral_expires())) {
+    if (typeof messageEntity.ephemeral_expires() === 'string') {
       const remainingTime = Math.max(0, messageEntity.ephemeral_expires() - Date.now());
       messageEntity.ephemeral_remaining(remainingTime);
 

--- a/src/script/conversation/ConversationMapper.js
+++ b/src/script/conversation/ConversationMapper.js
@@ -17,13 +17,15 @@
  *
  */
 
+import {isObject} from 'underscore';
+import ko from 'knockout';
+
 import {ACCESS_MODE} from './AccessMode';
 import {ACCESS_ROLE} from './AccessRole';
 import {ACCESS_STATE} from './AccessState';
 import {NOTIFICATION_STATE} from './NotificationSetting';
 import {ConversationType} from './ConversationType';
 import {ConversationStatus} from './ConversationStatus';
-import ko from 'knockout';
 import {Conversation} from '../entity/Conversation';
 import {BaseError} from '../error/BaseError';
 
@@ -103,7 +105,7 @@ export class ConversationMapper {
     if (conversationsData === undefined) {
       throw new z.error.ConversationError(BaseError.TYPE.MISSING_PARAMETER);
     }
-    if (!_.isArray(conversationsData) || !conversationsData.length) {
+    if (!Array.isArray(conversationsData) || !conversationsData.length) {
       throw new z.error.ConversationError(BaseError.TYPE.INVALID_PARAMETER);
     }
     return conversationsData.map((conversationData, index) => {
@@ -254,7 +256,7 @@ export class ConversationMapper {
     if (conversationData === undefined) {
       throw new z.error.ConversationError(BaseError.TYPE.MISSING_PARAMETER);
     }
-    if (!_.isObject(conversationData) || !Object.keys(conversationData).length) {
+    if (!isObject(conversationData) || !Object.keys(conversationData).length) {
       throw new z.error.ConversationError(BaseError.TYPE.INVALID_PARAMETER);
     }
 

--- a/src/script/conversation/ConversationRepository.js
+++ b/src/script/conversation/ConversationRepository.js
@@ -36,6 +36,8 @@ import {
   Reaction,
   Text,
 } from '@wireapp/protocol-messaging';
+import {flatten} from 'underscore';
+
 import {GENERIC_MESSAGE_TYPE} from '../cryptography/GenericMessageType';
 import {PROTO_MESSAGE_TYPE} from '../cryptography/ProtoMessageType';
 
@@ -794,7 +796,7 @@ export class ConversationRepository {
    */
   updateConversations(conversationEntities) {
     const mapOfUserIds = conversationEntities.map(conversationEntity => conversationEntity.participating_user_ids());
-    const userIds = _.flatten(mapOfUserIds);
+    const userIds = flatten(mapOfUserIds);
 
     return this.user_repository
       .get_users_by_id(userIds)
@@ -871,7 +873,7 @@ export class ConversationRepository {
    * @returns {Promise} Resolves with the Conversation entity
    */
   get_conversation_by_id(conversation_id) {
-    if (!_.isString(conversation_id)) {
+    if (typeof conversation_id !== 'string') {
       return Promise.reject(new z.error.ConversationError(z.error.ConversationError.TYPE.NO_CONVERSATION_ID));
     }
     const conversationEntity = this.find_conversation_by_id(conversation_id);
@@ -2493,7 +2495,7 @@ export class ConversationRepository {
           changes.time = isoDate;
 
           const timestamp = new Date(isoDate).getTime();
-          if (!_.isNaN(timestamp)) {
+          if (!isNaN(timestamp)) {
             messageEntity.timestamp(timestamp);
             conversationEntity.update_timestamp_server(timestamp, true);
             conversationEntity.update_timestamps(messageEntity);
@@ -3464,7 +3466,7 @@ export class ConversationRepository {
   async _onCreate(eventJson, eventSource) {
     const {conversation: conversationId, data: eventData, time} = eventJson;
     const eventTimestamp = new Date(time).getTime();
-    const initialTimestamp = _.isNaN(eventTimestamp) ? this.getLatestEventTimestamp(true) : eventTimestamp;
+    const initialTimestamp = isNaN(eventTimestamp) ? this.getLatestEventTimestamp(true) : eventTimestamp;
     try {
       const existingConversationEntity = this.find_conversation_by_id(conversationId);
       if (existingConversationEntity) {

--- a/src/script/conversation/ConversationService.js
+++ b/src/script/conversation/ConversationService.js
@@ -368,7 +368,7 @@ export class ConversationService {
   post_encrypted_message(conversation_id, payload, precondition_option) {
     let url = `${ConversationService.CONFIG.URL_CONVERSATIONS}/${conversation_id}/otr/messages`;
 
-    if (_.isArray(precondition_option)) {
+    if (Array.isArray(precondition_option)) {
       url = `${url}?report_missing=${precondition_option.join(',')}`;
     } else if (precondition_option === true) {
       url = `${url}?ignore_missing=true`;

--- a/src/script/conversation/EventMapper.js
+++ b/src/script/conversation/EventMapper.js
@@ -316,7 +316,7 @@ export class EventMapper {
       messageEntity.ephemeral_started(event.ephemeral_started || '0');
     }
 
-    if (window.isNaN(messageEntity.timestamp())) {
+    if (isNaN(messageEntity.timestamp())) {
       this.logger.warn(`Could not get timestamp for message '${messageEntity.id}'. Skipping it.`, event);
       messageEntity = undefined;
     }

--- a/src/script/entity/Conversation.js
+++ b/src/script/entity/Conversation.js
@@ -19,6 +19,7 @@
 
 import ko from 'knockout';
 import {LegalHoldStatus} from '@wireapp/protocol-messaging';
+import {debounce} from 'underscore';
 
 import {getLogger} from 'Util/Logger';
 import {t} from 'Util/LocalizerUtil';
@@ -336,7 +337,7 @@ export class Conversation {
     });
 
     this.shouldPersistStateChanges = false;
-    this.publishPersistState = _.debounce(() => amplify.publish(WebAppEvents.CONVERSATION.PERSIST_STATE, this), 100);
+    this.publishPersistState = debounce(() => amplify.publish(WebAppEvents.CONVERSATION.PERSIST_STATE, this), 100);
 
     this._initSubscriptions();
   }
@@ -402,7 +403,7 @@ export class Conversation {
    * @returns {boolean|number} Timestamp value which can be 'false' (boolean) if there is no timestamp
    */
   setTimestamp(timestamp, type, forceUpdate = false) {
-    if (_.isString(timestamp)) {
+    if (typeof timestamp === 'string') {
       timestamp = window.parseInt(timestamp, 10);
     }
 
@@ -488,7 +489,7 @@ export class Conversation {
   }
 
   get_next_iso_date(currentTimestamp) {
-    if (!_.isNumber(currentTimestamp)) {
+    if (typeof currentTimestamp !== 'number') {
       currentTimestamp = Date.now();
     }
     const timestamp = Math.max(this.last_server_timestamp() + 1, currentTimestamp);
@@ -545,7 +546,7 @@ export class Conversation {
    * @returns {undefined} No return value
    */
   remove_messages(timestamp) {
-    if (timestamp && _.isNumber(timestamp)) {
+    if (timestamp && typeof timestamp === 'number') {
       return this.messages_unordered.remove(message_et => timestamp >= message_et.timestamp());
     }
     this.messages_unordered.removeAll();
@@ -615,7 +616,7 @@ export class Conversation {
     if (is_backend_timestamp) {
       const timestamp = new Date(time).getTime();
 
-      if (!_.isNaN(timestamp)) {
+      if (!isNaN(timestamp)) {
         this.setTimestamp(timestamp, Conversation.TIMESTAMP_TYPE.LAST_SERVER);
       }
     }

--- a/src/script/entity/message/Message.js
+++ b/src/script/entity/message/Message.js
@@ -60,11 +60,11 @@ export class Message {
         return EphemeralStatusType.TIMED_OUT;
       }
 
-      if (_.isNumber(this.ephemeral_expires())) {
+      if (typeof this.ephemeral_expires() === 'number') {
         return EphemeralStatusType.INACTIVE;
       }
 
-      if (_.isString(this.ephemeral_expires())) {
+      if (typeof this.ephemeral_expires() === 'string') {
         const isExpiring = Date.now() >= this.ephemeral_expires();
         return isExpiring ? EphemeralStatusType.TIMED_OUT : EphemeralStatusType.ACTIVE;
       }

--- a/src/script/error/BackendClientError.js
+++ b/src/script/error/BackendClientError.js
@@ -17,6 +17,8 @@
  *
  */
 
+import {isObject} from 'underscore';
+
 import {BaseError} from './BaseError';
 
 export class BackendClientError extends BaseError {
@@ -25,10 +27,10 @@ export class BackendClientError extends BaseError {
 
     super('BackendClientError', BackendClientError.TYPE.GENERIC, message);
 
-    if (_.isObject(params)) {
+    if (isObject(params)) {
       this.code = params.code;
       this.label = params.label;
-    } else if (_.isNumber(params)) {
+    } else if (typeof params === 'number') {
       this.code = params;
     }
   }

--- a/src/script/event/EventService.js
+++ b/src/script/event/EventService.js
@@ -210,7 +210,7 @@ export class EventService {
       includeFrom,
       includeTo: true,
     };
-    if (!_.isDate(fromDate)) {
+    if (!(fromDate instanceof Date)) {
       const errorMessage = `fromDate ('${typeof fromDate}') must be of type 'Date'.`;
       throw new Error(errorMessage);
     }
@@ -231,7 +231,7 @@ export class EventService {
    */
   async _loadEventsInDateRange(conversationId, fromDate, toDate, limit, includes) {
     const {includeFrom, includeTo} = includes;
-    if (!_.isDate(toDate) || !_.isDate(fromDate)) {
+    if (!(toDate instanceof Date) || !(fromDate instanceof Date)) {
       const errorMessage = `Lower bound (${typeof toDate}) and upper bound (${typeof fromDate}) must be of type 'Date'.`;
       throw new Error(errorMessage);
     }

--- a/src/script/event/EventServiceNoCompound.js
+++ b/src/script/event/EventServiceNoCompound.js
@@ -60,7 +60,7 @@ export class EventServiceNoCompound extends EventService {
       ? (date, timestamp) => timestamp <= date
       : (date, timestamp) => timestamp < date;
 
-    if (!_.isDate(toDate) || !_.isDate(fromDate)) {
+    if (!(toDate instanceof Date) || !(fromDate instanceof Date)) {
       const errorMessage = `Lower bound (${typeof toDate}) and upper bound (${typeof fromDate}) must be of type 'Date'.`;
       throw new Error(errorMessage);
     }

--- a/src/script/media/MediaConstraintsHandler.ts
+++ b/src/script/media/MediaConstraintsHandler.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import {isString} from 'underscore';
 import {Logger, getLogger} from 'Util/Logger';
 import {CurrentAvailableDeviceId} from './MediaDevicesHandler';
 
@@ -162,7 +161,7 @@ export class MediaConstraintsHandler {
   ): MediaTrackConstraints {
     const streamConstraints = MediaConstraintsHandler.CONFIG.CONSTRAINTS.VIDEO[mode];
 
-    if (isString(mediaDeviceId) && mediaDeviceId !== MediaConstraintsHandler.CONFIG.DEFAULT_DEVICE_ID) {
+    if (typeof mediaDeviceId === 'string' && mediaDeviceId !== MediaConstraintsHandler.CONFIG.DEFAULT_DEVICE_ID) {
       streamConstraints.deviceId = {exact: mediaDeviceId};
     } else {
       streamConstraints.facingMode = MediaConstraintsHandler.CONFIG.CONSTRAINTS.VIDEO.PREFERRED_FACING_MODE;

--- a/src/script/media/MediaEmbeds.js
+++ b/src/script/media/MediaEmbeds.js
@@ -17,6 +17,7 @@
  *
  */
 
+import {extend} from 'underscore';
 import 'url-search-params-polyfill';
 
 import {Environment} from 'Util/Environment';
@@ -39,7 +40,7 @@ const _createIframeContainer = options => {
     width: '100%',
   };
 
-  options = _.extend(defaults, options);
+  options = extend(defaults, options);
   const iframeContainer = `<div class="{0}"><iframe class="${options.type}" width="{1}" height="{2}" src="{3}" frameborder="{4}"{5}></iframe></div>`;
 
   if (!options.video) {

--- a/src/script/notification/NotificationRepository.js
+++ b/src/script/notification/NotificationRepository.js
@@ -114,7 +114,7 @@ export class NotificationRepository {
    */
   checkPermission() {
     return this._checkPermissionState().then(isPermitted => {
-      if (_.isBoolean(isPermitted)) {
+      if (typeof isPermitted === 'boolean') {
         return isPermitted;
       }
 

--- a/src/script/search/SearchRepository.js
+++ b/src/script/search/SearchRepository.js
@@ -42,7 +42,7 @@ export class SearchRepository {
    * @returns {string} Normalized search query
    */
   static normalizeQuery(query) {
-    if (!_.isString(query)) {
+    if (typeof query !== 'string') {
       return '';
     }
     return query

--- a/src/script/telemetry/app_init/AppInitStatistics.js
+++ b/src/script/telemetry/app_init/AppInitStatistics.js
@@ -17,8 +17,6 @@
  *
  */
 
-import {isNumber, isString} from 'underscore';
-
 import {getLogger} from 'Util/Logger';
 
 import {AppInitStatisticsValue} from './AppInitStatisticsValue';
@@ -39,7 +37,7 @@ export class AppInitStatistics {
   }
 
   add(statistic, value, bucket_size) {
-    if (bucket_size && _.isNumber(value)) {
+    if (bucket_size && typeof value === 'number') {
       const buckets = Math.floor(value / bucket_size) + (value % bucket_size ? 1 : 0);
 
       return (this[statistic] = value === 0 ? 0 : bucket_size * buckets);
@@ -52,7 +50,7 @@ export class AppInitStatistics {
     const statistics = {};
 
     Object.entries(this).forEach(([key, value]) => {
-      if (_.isNumber(value) || _.isString(value)) {
+      if (typeof value === 'number' || typeof value === 'string') {
         statistics[key] = value;
       }
     });
@@ -62,7 +60,10 @@ export class AppInitStatistics {
 
   log() {
     const statsData = Object.entries(this).reduce((stats, [key, value]) => {
-      return isNumber(value) || isString(value) ? {...stats, [key]: value} : stats;
+      if (typeof value === 'number' || typeof value === 'string') {
+        stats[key] = value;
+      }
+      return stats;
     }, {});
     this.logger.debug('App initialization statistics', statsData);
   }

--- a/src/script/telemetry/app_init/AppInitTimings.js
+++ b/src/script/telemetry/app_init/AppInitTimings.js
@@ -17,8 +17,6 @@
  *
  */
 
-import {isNumber, isString} from 'underscore';
-
 import {getLogger} from 'Util/Logger';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
 
@@ -42,7 +40,7 @@ export class AppInitTimings {
     const timings = {};
 
     Object.entries(this).forEach(([key, value]) => {
-      if (key.toString() !== 'init' && _.isNumber(value)) {
+      if (key.toString() !== 'init' && typeof value === 'number') {
         timings[key] = value;
       }
     });
@@ -60,7 +58,10 @@ export class AppInitTimings {
 
   log() {
     const statsData = Object.entries(this).reduce((stats, [key, value]) => {
-      return isNumber(value) || isString(value) ? {...stats, [key]: value} : stats;
+      if (typeof value === 'number' || typeof value === 'string') {
+        stats[key] = value;
+      }
+      return stats;
     }, {});
     this.logger.debug('App initialization step durations', statsData);
   }

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -20,7 +20,7 @@
 import {Availability, GenericMessage} from '@wireapp/protocol-messaging';
 import {amplify} from 'amplify';
 import ko from 'knockout';
-import {flatten, isString} from 'underscore';
+import {flatten} from 'underscore';
 import {GENERIC_MESSAGE_TYPE} from '../cryptography/GenericMessageType';
 
 import {chunk} from 'Util/ArrayUtil';
@@ -602,8 +602,8 @@ export class UserRepository {
     const find_users = user_ids.map(user_id => _find_user(user_id));
 
     return Promise.all(find_users).then(resolve_array => {
-      const known_user_ets = resolve_array.filter(array_item => !isString(array_item)) as User[];
-      const unknown_user_ids = resolve_array.filter(array_item => isString(array_item)) as string[];
+      const known_user_ets = resolve_array.filter(array_item => typeof array_item !== 'string') as User[];
+      const unknown_user_ids = resolve_array.filter(array_item => typeof array_item === 'string') as string[];
 
       if (offline || !unknown_user_ids.length) {
         return known_user_ets;
@@ -617,7 +617,7 @@ export class UserRepository {
    * Is the user the logged in user.
    */
   is_me(user_id: User | string): boolean {
-    if (!isString(user_id)) {
+    if (typeof user_id !== 'string') {
       user_id = user_id.id;
     }
     return this.self().id === user_id;

--- a/src/script/util/LocalizerUtil.js
+++ b/src/script/util/LocalizerUtil.js
@@ -19,14 +19,13 @@
 
 import {escapeString, getSelfName} from './SanitizationUtil';
 import {sortByPriority} from './StringUtil';
-import {isString, isNumber} from 'underscore';
 
 export const DEFAULT_LOCALE = 'en';
 
 let locale = DEFAULT_LOCALE;
 let strings = {};
 
-const isStringOrNumber = toTest => isString(toTest) || isNumber(toTest);
+const isStringOrNumber = toTest => typeof toTest === 'string' || typeof toTest === 'number';
 
 const replaceSubstituteEscaped = (string, regex, substitute) => {
   const replacement = isStringOrNumber(substitute)

--- a/src/script/util/UrlUtil.ts
+++ b/src/script/util/UrlUtil.ts
@@ -16,7 +16,6 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  *
  */
-import {isNumber} from 'underscore';
 
 import {t} from 'Util/LocalizerUtil';
 import {includesString} from 'Util/StringUtil';
@@ -27,7 +26,7 @@ export const appendParameter = (url: string, parameter: string) => {
 };
 
 export const buildSupportUrl = (supportId: string) =>
-  isNumber(supportId)
+  typeof supportId === 'number'
     ? `${window.wire.env.URL.SUPPORT_BASE}${t('urlSupportArticles')}${supportId}`
     : `${window.wire.env.URL.SUPPORT_BASE}${t('urlSupportRequests')}`;
 

--- a/src/script/util/util.js
+++ b/src/script/util/util.js
@@ -156,7 +156,7 @@ export const loadUrlBlob = url => {
  * @returns {string} File extension
  */
 export const getFileExtension = filename => {
-  if (!_.isString(filename) || !filename.includes('.')) {
+  if (typeof filename !== 'string' || !filename.includes('.')) {
     return '';
   }
 
@@ -173,7 +173,7 @@ export const getFileExtension = filename => {
  * @returns {string} New String without extension
  */
 export const trimFileExtension = filename => {
-  if (_.isString(filename)) {
+  if (typeof filename === 'string') {
     if (filename.endsWith('.tar.gz')) {
       filename = filename.replace(/\.tar\.gz$/, '');
     }

--- a/src/script/view_model/bindings/CommonBindings.js
+++ b/src/script/view_model/bindings/CommonBindings.js
@@ -21,10 +21,8 @@ import ko from 'knockout';
 import $ from 'jquery';
 import moment from 'moment';
 import SimpleBar from 'simplebar';
-import {debounce} from 'underscore';
-/* eslint-disable no-unused-vars */
-import antiscroll2 from '@wireapp/antiscroll-2/dist/antiscroll-2';
-/* eslint-enable no-unused-vars */
+import {debounce, throttle} from 'underscore';
+import '@wireapp/antiscroll-2/dist/antiscroll-2';
 
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
 import {t} from 'Util/LocalizerUtil';
@@ -165,7 +163,7 @@ ko.bindingHandlers.resize = {
         textareaElement.style.overflowY = newStyleOverflowY;
       }
     }).bind(null, element);
-    const throttledResizeTextarea = _.throttle(resizeTextarea, 100, {leading: !params.delayedResize});
+    const throttledResizeTextarea = throttle(resizeTextarea, 100, {leading: !params.delayedResize});
 
     resizeTextarea();
     return ko.applyBindingsToNode(
@@ -455,7 +453,7 @@ ko.bindingHandlers.antiscroll = {
       const resize_event = `resize.${Date.now()}`;
       $(window).on(
         resize_event,
-        _.throttle(() => {
+        throttle(() => {
           antiscroll.rebuild();
         }, 100),
       );

--- a/src/script/view_model/bindings/ConversationListBindings.js
+++ b/src/script/view_model/bindings/ConversationListBindings.js
@@ -17,13 +17,14 @@
  *
  */
 
+import {throttle} from 'underscore';
 import {isScrollable, isScrolledBottom, isScrolledTop} from 'Util/scroll-helpers';
 
 import {WebAppEvents} from '../../event/WebApp';
 
 // show scroll borders
 ko.bindingHandlers.bordered_list = (function() {
-  const calculate_borders = _.throttle(element => {
+  const calculate_borders = throttle(element => {
     if (element) {
       window.requestAnimationFrame(() => {
         const list_column = $(element).parent();

--- a/src/script/view_model/list/StartUIViewModel.js
+++ b/src/script/view_model/list/StartUIViewModel.js
@@ -17,6 +17,8 @@
  *
  */
 
+import {debounce} from 'underscore';
+
 import {getLogger} from 'Util/Logger';
 import {alias} from 'Util/util';
 import {t} from 'Util/LocalizerUtil';
@@ -95,7 +97,7 @@ class StartUIViewModel {
 
     this.submittedSearch = false;
 
-    this.search = _.debounce(query => {
+    this.search = debounce(query => {
       this._clearSearchResults();
       if (this.peopleTabActive()) {
         return this._searchPeople(query);

--- a/test/unit_tests/cryptography/CryptographyMapperSpec.js
+++ b/test/unit_tests/cryptography/CryptographyMapperSpec.js
@@ -34,6 +34,7 @@ import {
   Reaction,
   Text,
 } from '@wireapp/protocol-messaging';
+import {isObject} from 'underscore';
 
 import {GENERIC_MESSAGE_TYPE} from 'src/script/cryptography/GenericMessageType';
 import {CryptographyMapper} from 'src/script/cryptography/CryptographyMapper';
@@ -81,7 +82,7 @@ describe('CryptographyMapper', () => {
       });
 
       return mapper.mapGenericMessage(generic_message, event).then(event_json => {
-        expect(_.isObject(event_json)).toBeTruthy();
+        expect(isObject(event_json)).toBeTruthy();
         expect(event_json.type).toBe(ClientEvent.CONVERSATION.ASSET_ADD);
         expect(event_json.conversation).toBe(event.conversation);
         expect(event_json.from).toBe(event.from);
@@ -112,7 +113,7 @@ describe('CryptographyMapper', () => {
       });
 
       return mapper.mapGenericMessage(generic_message, event).then(event_json => {
-        expect(_.isObject(event_json)).toBeTruthy();
+        expect(isObject(event_json)).toBeTruthy();
         expect(event_json.type).toBe(ClientEvent.CONVERSATION.ASSET_ADD);
         expect(event_json.conversation).toBe(event.conversation);
         expect(event_json.from).toBe(event.from);
@@ -151,7 +152,7 @@ describe('CryptographyMapper', () => {
       });
 
       return mapper.mapGenericMessage(generic_message, event).then(event_json => {
-        expect(_.isObject(event_json)).toBeTruthy();
+        expect(isObject(event_json)).toBeTruthy();
         expect(event_json.type).toBe(ClientEvent.CONVERSATION.ASSET_ADD);
         expect(event_json.conversation).toBe(event.conversation);
         expect(event_json.from).toBe(event.from);
@@ -173,7 +174,7 @@ describe('CryptographyMapper', () => {
       });
 
       return mapper.mapGenericMessage(generic_message, event).then(event_json => {
-        expect(_.isObject(event_json)).toBeTruthy();
+        expect(isObject(event_json)).toBeTruthy();
         expect(event_json.type).toBe(ClientEvent.CONVERSATION.ASSET_ADD);
         expect(event_json.conversation).toBe(event.conversation);
         expect(event_json.from).toBe(event.from);
@@ -194,7 +195,7 @@ describe('CryptographyMapper', () => {
       });
 
       return mapper.mapGenericMessage(generic_message, event).then(event_json => {
-        expect(_.isObject(event_json)).toBeTruthy();
+        expect(isObject(event_json)).toBeTruthy();
         expect(event_json.type).toBe(ClientEvent.CONVERSATION.ASSET_ADD);
         expect(event_json.conversation).toBe(event.conversation);
         expect(event_json.from).toBe(event.from);
@@ -229,7 +230,7 @@ describe('CryptographyMapper', () => {
       });
 
       return mapper.mapGenericMessage(generic_message, event).then(event_json => {
-        expect(_.isObject(event_json)).toBeTruthy();
+        expect(isObject(event_json)).toBeTruthy();
         expect(event_json.type).toBe(ClientEvent.CONVERSATION.ASSET_ADD);
         expect(event_json.conversation).toBe(event.conversation);
         expect(event_json.from).toBe(event.from);
@@ -249,7 +250,7 @@ describe('CryptographyMapper', () => {
       });
 
       return mapper.mapGenericMessage(generic_message, event).then(event_json => {
-        expect(_.isObject(event_json)).toBeTruthy();
+        expect(isObject(event_json)).toBeTruthy();
         expect(event_json.type).toBe(ClientEvent.USER.AVAILABILITY);
         expect(event_json.conversation).toBe(event.conversation);
         expect(event_json.from).toBe(event.from);
@@ -273,7 +274,7 @@ describe('CryptographyMapper', () => {
       });
 
       return mapper.mapGenericMessage(generic_message, event).then(event_json => {
-        expect(_.isObject(event_json)).toBeTruthy();
+        expect(isObject(event_json)).toBeTruthy();
         expect(event_json.type).toBe(BackendEvent.CONVERSATION.MEMBER_UPDATE);
         expect(event_json.conversation).toBe(event.conversation);
         expect(event_json.from).toBe(event.from);
@@ -297,7 +298,7 @@ describe('CryptographyMapper', () => {
       });
 
       return mapper.mapGenericMessage(generic_message, event).then(event_json => {
-        expect(_.isObject(event_json)).toBeTruthy();
+        expect(isObject(event_json)).toBeTruthy();
         expect(event_json.type).toBe(ClientEvent.CONVERSATION.MESSAGE_HIDDEN);
         expect(event_json.conversation).toBe(event.conversation);
         expect(event_json.from).toBe(event.from);
@@ -316,7 +317,7 @@ describe('CryptographyMapper', () => {
       });
 
       return mapper.mapGenericMessage(generic_message, event).then(event_json => {
-        expect(_.isObject(event_json)).toBeTruthy();
+        expect(isObject(event_json)).toBeTruthy();
         expect(event_json.type).toBe(ClientEvent.CONVERSATION.MESSAGE_DELETE);
         expect(event_json.conversation).toBe(event.conversation);
         expect(event_json.from).toBe(event.from);
@@ -353,7 +354,7 @@ describe('CryptographyMapper', () => {
       });
 
       return mapper.mapGenericMessage(generic_message, event).then(event_json => {
-        expect(_.isObject(event_json)).toBeTruthy();
+        expect(isObject(event_json)).toBeTruthy();
         expect(event_json.type).toBe(ClientEvent.CONVERSATION.ASSET_ADD);
         expect(event_json.conversation).toBe(event.conversation);
         expect(event_json.from).toBe(event.from);
@@ -398,7 +399,7 @@ describe('CryptographyMapper', () => {
       });
 
       return mapper.mapGenericMessage(generic_message, event).then(event_json => {
-        expect(_.isObject(event_json)).toBeTruthy();
+        expect(isObject(event_json)).toBeTruthy();
         expect(event_json.type).toBe(ClientEvent.CONVERSATION.ASSET_ADD);
         expect(event_json.conversation).toBe(event.conversation);
         expect(event_json.from).toBe(event.from);
@@ -442,7 +443,7 @@ describe('CryptographyMapper', () => {
       delete event.data.id;
 
       return mapper.mapGenericMessage(generic_message, event).then(event_json => {
-        expect(_.isObject(event_json)).toBeTruthy();
+        expect(isObject(event_json)).toBeTruthy();
         expect(event_json.type).toBe(ClientEvent.CONVERSATION.ASSET_ADD);
         expect(event_json.conversation).toBe(event.conversation);
         expect(event_json.from).toBe(event.from);
@@ -481,7 +482,7 @@ describe('CryptographyMapper', () => {
       });
 
       return mapper.mapGenericMessage(generic_message, event).then(event_json => {
-        expect(_.isObject(event_json)).toBeTruthy();
+        expect(isObject(event_json)).toBeTruthy();
         expect(event_json.type).toBe(ClientEvent.CONVERSATION.KNOCK);
         expect(event_json.conversation).toBe(event.conversation);
         expect(event_json.from).toBe(event.from);
@@ -529,7 +530,7 @@ describe('CryptographyMapper', () => {
       });
 
       return mapper.mapGenericMessage(generic_message, event).then(event_json => {
-        expect(_.isObject(event_json)).toBeTruthy();
+        expect(isObject(event_json)).toBeTruthy();
         expect(event_json.type).toBe(BackendEvent.CONVERSATION.MEMBER_UPDATE);
         expect(event_json.conversation).toBe(event.conversation);
         expect(event_json.from).toBe(event.from);
@@ -553,7 +554,7 @@ describe('CryptographyMapper', () => {
       });
 
       return mapper.mapGenericMessage(generic_message, event).then(event_json => {
-        expect(_.isObject(event_json)).toBeTruthy();
+        expect(isObject(event_json)).toBeTruthy();
         expect(event_json.type).toBe(ClientEvent.CONVERSATION.REACTION);
         expect(event_json.conversation).toBe(event.conversation);
         expect(event_json.from).toBe(event.from);
@@ -571,7 +572,7 @@ describe('CryptographyMapper', () => {
       });
 
       return mapper.mapGenericMessage(generic_message, event).then(event_json => {
-        expect(_.isObject(event_json)).toBeTruthy();
+        expect(isObject(event_json)).toBeTruthy();
         expect(event_json.type).toBe(ClientEvent.CONVERSATION.MESSAGE_ADD);
         expect(event_json.conversation).toBe(event.conversation);
         expect(event_json.from).toBe(event.from);
@@ -641,7 +642,7 @@ describe('CryptographyMapper', () => {
           return mapper.mapGenericMessage(external_message, event);
         })
         .then(event_json => {
-          expect(_.isObject(event_json)).toBeTruthy();
+          expect(isObject(event_json)).toBeTruthy();
           expect(event_json.type).toBe(ClientEvent.CONVERSATION.KNOCK);
           expect(event_json.conversation).toBe(event.conversation);
           expect(event_json.from).toBe(event.from);
@@ -663,7 +664,7 @@ describe('CryptographyMapper', () => {
       });
 
       return mapper.mapGenericMessage(generic_message, event).then(event_json => {
-        expect(_.isObject(event_json)).toBeTruthy();
+        expect(isObject(event_json)).toBeTruthy();
         expect(event_json.type).toBe(ClientEvent.CONVERSATION.LOCATION);
         expect(event_json.conversation).toBe(event.conversation);
         expect(event_json.from).toBe(event.from);
@@ -689,7 +690,7 @@ describe('CryptographyMapper', () => {
       });
 
       return mapper.mapGenericMessage(generic_message, event).then(event_json => {
-        expect(_.isObject(event_json)).toBeTruthy();
+        expect(isObject(event_json)).toBeTruthy();
         expect(event_json.type).toBe(ClientEvent.CONVERSATION.REACTION);
         expect(event_json.conversation).toBe(event.conversation);
         expect(event_json.from).toBe(event.from);
@@ -715,7 +716,7 @@ describe('CryptographyMapper', () => {
       });
 
       return mapper.mapGenericMessage(generic_message, event).then(event_json => {
-        expect(_.isObject(event_json)).toBeTruthy();
+        expect(isObject(event_json)).toBeTruthy();
         expect(event_json.type).toBe(ClientEvent.CALL.E_CALL);
         expect(event_json.conversation).toBe(event.conversation);
         expect(event_json.from).toBe(event.from);

--- a/test/unit_tests/cryptography/CryptographyRepositorySpec.js
+++ b/test/unit_tests/cryptography/CryptographyRepositorySpec.js
@@ -21,7 +21,6 @@ import {MemoryEngine} from '@wireapp/store-engine';
 import {Cryptobox} from '@wireapp/cryptobox';
 import * as Proteus from '@wireapp/proteus';
 import {GenericMessage, Text} from '@wireapp/protocol-messaging';
-import {isString} from 'underscore';
 
 import {arrayToBase64, createRandomUuid} from 'Util/util';
 
@@ -95,7 +94,7 @@ describe('CryptographyRepository', () => {
         expect(Object.keys(payload.recipients).length).toBe(2);
         expect(Object.keys(payload.recipients[john_doe.id]).length).toBe(2);
         expect(Object.keys(payload.recipients[jane_roe.id]).length).toBe(1);
-        expect(isString(payload.recipients[jane_roe.id][jane_roe.clients.phone_id])).toBe(true);
+        expect(payload.recipients[jane_roe.id][jane_roe.clients.phone_id]).toEqual(jasmine.any(String));
       });
     });
   });

--- a/test/unit_tests/tracking/EventTrackingRepositorySpec.js
+++ b/test/unit_tests/tracking/EventTrackingRepositorySpec.js
@@ -124,7 +124,9 @@ describe('EventTrackingRepository', () => {
 
       expect(error_payload).toBe(raygun_payload);
 
-      _.times(100, () => (error_payload = TestFactory.tracking_repository._checkErrorPayload(raygun_payload)));
+      for (let index = 0; index < 100; index++) {
+        error_payload = TestFactory.tracking_repository._checkErrorPayload(raygun_payload);
+      }
 
       expect(error_payload).toBe(false);
       jasmine.clock().mockDate(Date.now());

--- a/test/unit_tests/util/StringUtilSpec.js
+++ b/test/unit_tests/util/StringUtilSpec.js
@@ -17,8 +17,6 @@
  *
  */
 
-import _ from 'underscore';
-
 import {
   padStart,
   bytesToHex,
@@ -65,7 +63,7 @@ describe('StringUtil', () => {
 
   describe('getRandomChar', () => {
     it('always returns an alphanumeric character', () => {
-      _.range(1000).map(() => {
+      [...Array(1000).keys()].map(() => {
         expect(getRandomChar()).toMatch(/(\w|\d){1}/);
       });
     });


### PR DESCRIPTION
- underscore's `isString`, `isNumber` and `isBoolean`, `isDate` anyway only [check for the type](https://underscorejs.org/docs/underscore.html#section-149), nothing fancy here
- underscore's `isNaN` also [checks if value is a number](https://underscorejs.org/docs/underscore.html#section-153), but native `isNaN` does that, too
- `times()` is (in our use case) actually just a `for` loop
- `range()` is just an array of incrementing numbers

For future refactorings I can recommend [**You don't need Lodash/Underscore**](https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_range) :rocket: 