### PR TITLE
fix: pull patch for incorrect emoji codepoints

### DIFF
--- a/src/script/view_model/content/emoji.json
+++ b/src/script/view_model/content/emoji.json
@@ -5216,12 +5216,12 @@
   },
   "1f468-2764-1f468": {
     "aliases": [":couple_with_heart_mm:"],
-    "code": "1f468-2764-fe0f-1f468",
+    "code": "1f468-200d-2764-fe0f-200d-1f468",
     "name": ":couple_mm:"
   },
   "1f468-2764-1f48b-1f468": {
     "aliases": [":couplekiss_mm:"],
-    "code": "1f468-2764-fe0f-1f48b-1f468",
+    "code": "1f468-200d-2764-fe0f-200d-1f48b-1f468",
     "name": ":kiss_mm:"
   },
   "1f469": {
@@ -6146,22 +6146,22 @@
   },
   "1f469-2764-1f468": {
     "aliases": [],
-    "code": "1f469-2764-fe0f-1f468",
+    "code": "1f469-200d-2764-fe0f-200d-1f468",
     "name": ":couple_with_heart_woman_man:"
   },
   "1f469-2764-1f469": {
     "aliases": [":couple_with_heart_ww:"],
-    "code": "1f469-2764-fe0f-1f469",
+    "code": "1f469-200d-2764-fe0f-200d-1f469",
     "name": ":couple_ww:"
   },
   "1f469-2764-1f48b-1f468": {
     "aliases": [],
-    "code": "1f469-2764-fe0f-1f48b-1f468",
+    "code": "1f469-200d-2764-fe0f-200d-1f48b-1f468",
     "name": ":kiss_woman_man:"
   },
   "1f469-2764-1f48b-1f469": {
     "aliases": [":couplekiss_ww:"],
-    "code": "1f469-2764-fe0f-1f48b-1f469",
+    "code": "1f469-200d-2764-fe0f-200d-1f48b-1f469",
     "name": ":kiss_ww:"
   },
   "1f46a": {


### PR DESCRIPTION
Pulling in fix for emoji codepoints as released in https://github.com/joypixels/emoji-assets/releases/tag/v5.0.3

To test:

1. Enter emoji `:couple with heart ww` and press `Enter`
1. Press `Backspace`

Expected: emoji is gone
Actual: emoji is broken down in its components