### PR TITLE
runfix: Allow spaces in upload extension filter

### DIFF
--- a/server/ServerConfig.ts
+++ b/server/ServerConfig.ts
@@ -9,7 +9,7 @@ export interface ServerConfig {
     BRAND_NAME: string;
     ENVIRONMENT: string;
     FEATURE: {
-      ALLOWED_FILE_UPLOAD_EXTENSIONS: string;
+      ALLOWED_FILE_UPLOAD_EXTENSIONS: string[];
       APPLOCK_SCHEDULED_TIMEOUT: number;
       APPLOCK_UNFOCUS_TIMEOUT: number;
       CHECK_CONSENT: boolean;

--- a/server/config.ts
+++ b/server/config.ts
@@ -127,7 +127,9 @@ const config: ServerConfig = {
     BRAND_NAME: process.env.BRAND_NAME,
     ENVIRONMENT: nodeEnvironment,
     FEATURE: {
-      ALLOWED_FILE_UPLOAD_EXTENSIONS: process.env.FEATURE_ALLOWED_FILE_UPLOAD_EXTENSIONS || '*',
+      ALLOWED_FILE_UPLOAD_EXTENSIONS: (process.env.FEATURE_ALLOWED_FILE_UPLOAD_EXTENSIONS || '*')
+        .split(',')
+        .map(extension => extension.trim()),
       APPLOCK_SCHEDULED_TIMEOUT: process.env.FEATURE_APPLOCK_SCHEDULED_TIMEOUT
         ? Number(process.env.FEATURE_APPLOCK_SCHEDULED_TIMEOUT)
         : null,

--- a/src/script/global.d.ts
+++ b/src/script/global.d.ts
@@ -41,7 +41,7 @@ declare global {
         BRAND_NAME: string;
         ENVIRONMENT: string;
         FEATURE: {
-          ALLOWED_FILE_UPLOAD_EXTENSIONS: string;
+          ALLOWED_FILE_UPLOAD_EXTENSIONS: string[];
           APPLOCK_SCHEDULED_TIMEOUT: number;
           APPLOCK_UNFOCUS_TIMEOUT: number;
           CHECK_CONSENT: boolean;

--- a/src/script/view_model/content/InputBarViewModel.js
+++ b/src/script/view_model/content/InputBarViewModel.js
@@ -57,7 +57,9 @@ z.viewModel.content.InputBarViewModel = class InputBarViewModel {
         CONCURRENT_UPLOAD_LIMIT: 10,
       },
       FILES: {
-        ALLOWED_FILE_UPLOAD_EXTENSIONS: Config.FEATURE.ALLOWED_FILE_UPLOAD_EXTENSIONS.split(','),
+        ALLOWED_FILE_UPLOAD_EXTENSIONS: Config.FEATURE.ALLOWED_FILE_UPLOAD_EXTENSIONS.split(',').map(extension =>
+          extension.trim(),
+        ),
       },
       GIPHY_TEXT_LENGTH: 256,
       IMAGE: {

--- a/src/script/view_model/content/InputBarViewModel.js
+++ b/src/script/view_model/content/InputBarViewModel.js
@@ -57,9 +57,7 @@ z.viewModel.content.InputBarViewModel = class InputBarViewModel {
         CONCURRENT_UPLOAD_LIMIT: 10,
       },
       FILES: {
-        ALLOWED_FILE_UPLOAD_EXTENSIONS: Config.FEATURE.ALLOWED_FILE_UPLOAD_EXTENSIONS.split(',').map(extension =>
-          extension.trim(),
-        ),
+        ALLOWED_FILE_UPLOAD_EXTENSIONS: Config.FEATURE.ALLOWED_FILE_UPLOAD_EXTENSIONS,
       },
       GIPHY_TEXT_LENGTH: 256,
       IMAGE: {


### PR DESCRIPTION
Right now setting the env variable `FEATURE_ALLOWED_FILE_UPLOAD_EXTENSIONS` to this:
```
.xls, .doc, .txt
```
will not work. You had to explicitly remove the spaces:
```
.xls,.doc,.txt
```

This PR will allow setting the env variable with spaces to make it better readable.