### PR TITLE
fix: Check clientEntities array length

### DIFF
--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -317,7 +317,7 @@ export class UserRepository {
       return this.get_users_by_id(userIds).then(userEntities => {
         userEntities.forEach(userEntity => {
           const clientEntities = recipients[userEntity.id];
-          const tooManyClients = clientEntities > 8;
+          const tooManyClients = clientEntities.length > 8;
           if (tooManyClients) {
             this.logger.warn(`Found '${clientEntities.length}' clients for '${userEntity.name()}'`, clientEntities);
           }


### PR DESCRIPTION
[`getAllClientsFromDb()`](https://github.com/wireapp/wire-webapp/blob/2b5ec4cf474a088f5dffcef84558a18ba6963ae5/src/script/client/ClientRepository.js#L99)  in `ClientRepository` returns an object of the following form:

```ts
{
  // userEntity
  '3db4b337-bb12-4352-ac27-8c3dae0dc053': [
    {
      // ClientEntity
      meta: {
        // metadata
      }
    }
  ],
  // userEntity
  '8b2a7f55-e49b-4b04-9e5d-773b5d25ea26': [
    {
      // ClientEntity
      meta: {
        // metadata
      }
  ]
}
```

But `_assignAllClients()` takes one of the `userEntity` entries and checks if it's larger than 8, which makes no sense. Instead, we need to check the length of the `userEntity` array.