### PR TITLE
refactor: Remove synchronous openGraph

### DIFF
--- a/src/script/links/LinkPreviewRepository.js
+++ b/src/script/links/LinkPreviewRepository.js
@@ -17,10 +17,6 @@
  *
  */
 
-// OpenGraphData is used in JSDoc
-// eslint-disable-next-line no-unused-vars
-import {Data as OpenGraphData} from 'open-graph';
-
 import {base64ToBlob} from 'Util/util';
 
 import {getFirstLinkWithOffset} from './LinkPreviewHelpers';

--- a/src/script/links/LinkPreviewRepository.js
+++ b/src/script/links/LinkPreviewRepository.js
@@ -17,9 +17,9 @@
  *
  */
 
-// OpenGraphResult is used in JSDoc
+// OpenGraphData is used in JSDoc
 // eslint-disable-next-line no-unused-vars
-import {Data as OpenGraphResult} from 'open-graph';
+import {Data as OpenGraphData} from 'open-graph';
 
 import {base64ToBlob} from 'Util/util';
 
@@ -143,7 +143,7 @@ class LinkPreviewRepository {
    *
    * @private
    * @param {string} link - Link to fetch open graph data from
-   * @returns {Promise<OpenGraphResult | Error>} Resolves with the retrieved open graph data
+   * @returns {Promise<OpenGraphData | Error>} Resolves with the retrieved open graph data
    */
   async _fetchOpenGraphData(link) {
     try {

--- a/test/unit_tests/links/LinkPreviewRepositorySpec.js
+++ b/test/unit_tests/links/LinkPreviewRepositorySpec.js
@@ -36,31 +36,11 @@ describe('LinkPreviewRepository', () => {
     link_preview_repository = new LinkPreviewRepository(new AssetService(backendClient), propertiesRepository);
   });
 
-  afterEach(() => (window.openGraph = undefined));
-
-  function mockSucceedingOpenGraph() {
-    return (url, callback) => {
-      return Promise.resolve()
-        .then(meta => {
-          if (callback) {
-            callback(null, meta);
-          }
-
-          return meta;
-        })
-        .catch(error => {
-          if (callback) {
-            callback(error);
-          }
-
-          throw error;
-        });
-    };
-  }
+  afterEach(() => (window.openGraphAsync = undefined));
 
   describe('_getLinkPreview', () => {
     it('fetches open graph data if openGraph lib is available', done => {
-      window.openGraph = mockSucceedingOpenGraph();
+      window.openGraphAsync = () => Promise.resolve();
 
       link_preview_repository
         ._getLinkPreview('https://app.wire.com/')
@@ -72,7 +52,7 @@ describe('LinkPreviewRepository', () => {
     });
 
     it('rejects if a link is blacklisted', done => {
-      window.openGraph = mockSucceedingOpenGraph();
+      window.openGraphAsync = () => Promise.resolve();
 
       link_preview_repository
         ._getLinkPreview('https://www.youtube.com/watch?v=t4gjl-uwUHc')
@@ -84,7 +64,7 @@ describe('LinkPreviewRepository', () => {
     });
 
     it('catches errors that are raised by the openGraph lib when invalid URIs are parsed', done => {
-      window.openGraph = () => Promise.reject(new Error('Invalid URI'));
+      window.openGraphAsync = () => Promise.reject(new Error('Invalid URI'));
 
       const invalidUrl = 'http:////api/apikey';
       link_preview_repository


### PR DESCRIPTION
Follow-up to https://github.com/wireapp/wire-desktop/pull/3158.

This removes the usage of `window.openGraph` which was provided by the Wrapper but is already replaced by `window.openGraphAsync` for 8 months.