### PR TITLE
chore: Remove dotenv types

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,6 @@
     "pm2": "4.1.2"
   },
   "devDependencies": {
-    "@types/dotenv": "6.1.1",
     "@types/express": "4.17.1",
     "@types/express-sitemap-xml": "1.0.3",
     "@types/express-useragent": "1.0.0",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -198,13 +198,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/dotenv@6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@types/dotenv/-/dotenv-6.1.1.tgz#f7ce1cc4fe34f0a4373ba99fefa437b0bec54b46"
-  integrity sha512-ftQl3DtBvqHl9L16tpqqzA4YzCSXZfi7g8cQceTz5rOlYtk/IZbFjAv3mLOQlNIgOaylCQWQoBdDQHPgEBJPHg==
-  dependencies:
-    "@types/node" "*"
-
 "@types/dotenv@^4.0.0":
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/@types/dotenv/-/dotenv-4.0.3.tgz#ebcfc40da7bc0728b705945b7db48485ec5b4b67"


### PR DESCRIPTION
They are not needed anymore [since v8.2.0](https://github.com/motdotla/dotenv/compare/v8.1.0...v8.2.0).