### PR TITLE
fix: Set alwaysStrict option in TypeScript

### DIFF
--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "alwaysStrict": true,
     "module": "commonjs",
     "outDir": "dist",
     "removeComments": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
+    "alwaysStrict": true,
     "baseUrl": ".",
     "declaration": false,
     "downlevelIteration": true,


### PR DESCRIPTION
This will add `'use strict';` to transpiled JS files.

Citing [an answer](https://stackoverflow.com/a/31395185) from StackOverflow:

> For my money, **yes**, `"use strict";` should be included in TypeScript files.
>
> Disregarding the *compile time* effects of "use strict"; on Typescript, there is likely a runtime *impact* when the generated javascript is executed:
> 
> - [MDN identifies performance improvements](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#Securing_JavaScript) in avoiding boxing `this` in function calls, and the removal of the `function.caller` and `function.arguments` properties.
> 
> - Jeff Walden of Mozilla has also hinted at opportunities for performance gains in [this StackOverflow answer](https://stackoverflow.com/questions/3145966/is-strict-mode-more-performant/4642633#4642633).