### PR TITLE
chore: Remove deprecated wrapper events

### DIFF
--- a/src/script/event/WebApp.ts
+++ b/src/script/event/WebApp.ts
@@ -197,15 +197,11 @@ export const WebAppEvents = {
     PICTURE: 'wire.webapp.shortcut.picture',
     PING: 'wire.webapp.shortcut.ping',
     PREV: 'wire.webapp.shortcut.prev',
-    SILENCE: 'wire.webapp.shortcut.silence', // todo: deprecated - remove when user base of wrappers version >= 3.4 is large enough
     START: 'wire.webapp.shortcut.start',
   },
   SIGN_OUT: 'wire.webapp.logout',
   STORAGE: {
     SAVE_ENTITY: 'wire.webapp.storage.save_entity',
-  },
-  SYSTEM_NOTIFICATION: {
-    CLICK: 'wire.webapp.notification.click', // todo: deprecated - remove when user base of wrappers version >= 3.2 is large enough
   },
   TEAM: {
     EVENT_FROM_BACKEND: 'wire.webapp.team.event_from_backend',

--- a/src/script/view_model/ListViewModel.js
+++ b/src/script/view_model/ListViewModel.js
@@ -148,7 +148,6 @@ z.viewModel.ListViewModel = class ListViewModel {
     amplify.subscribe(WebAppEvents.SHORTCUT.ARCHIVE, this.clickToArchive.bind(this));
     amplify.subscribe(WebAppEvents.SHORTCUT.DELETE, this.clickToClear.bind(this));
     amplify.subscribe(WebAppEvents.SHORTCUT.NOTIFICATIONS, this.changeNotificationSetting);
-    amplify.subscribe(WebAppEvents.SHORTCUT.SILENCE, this.changeNotificationSetting); // todo: deprecated - remove when user base of wrappers version >= 3.4 is large enough
   }
 
   answerCall = conversationEntity => {


### PR DESCRIPTION
These events are not in use by the wrapper for almost a year.