### PR TITLE
test: Fix Jasmine linter warnings

### DIFF
--- a/test/unit_tests/calling/videoGridHandlerSpec.js
+++ b/test/unit_tests/calling/videoGridHandlerSpec.js
@@ -151,7 +151,7 @@ describe('videoGridHandler', () => {
 
   function generateVideoParticipant(id) {
     const participant = new Participant(id, 'deviceid');
-    spyOn(participant, 'hasActiveVideo').and.returnValue(true);
+    participant.hasActiveVideo = () => true;
     return participant;
   }
 

--- a/test/unit_tests/components/panel/userActionsSpec.js
+++ b/test/unit_tests/components/panel/userActionsSpec.js
@@ -36,7 +36,7 @@ describe('user-actions', () => {
           user.is_me = true;
 
           const conversation = new Conversation();
-          spyOn(conversation, 'isGroup').and.returnValue(true);
+          conversation.isGroup = () => true;
           return {conversation: () => conversation, isSelfActivated: true, user: () => user};
         },
         testName: 'generates actions for self user profile',
@@ -56,8 +56,8 @@ describe('user-actions', () => {
         getParams: () => {
           const user = new User();
           const conversation = new Conversation();
+          conversation.isGroup = () => true;
           user.connection().status(ConnectionStatus.ACCEPTED);
-          spyOn(conversation, 'isGroup').and.returnValue(true);
           return {conversation: () => conversation, isSelfActivated: true, user: () => user};
         },
         testName: 'generates actions for another user profile to which I am connected',

--- a/test/unit_tests/event/EventRepositorySpec.js
+++ b/test/unit_tests/event/EventRepositorySpec.js
@@ -138,7 +138,7 @@ describe('EventRepository', () => {
       TestFactory.event_repository.connectWebSocket();
       await TestFactory.event_repository.initializeFromStream();
 
-      expect(TestFactory.notification_service.getLastNotificationIdFromDb);
+      expect(TestFactory.notification_service.getLastNotificationIdFromDb).toBeDefined();
       expect(TestFactory.notification_service.getNotificationsLast).toHaveBeenCalledWith(clientId);
       expect(TestFactory.notification_service.getNotifications).toHaveBeenCalledWith(
         clientId,


### PR DESCRIPTION
Fixes the following warnings:

> /unit_tests/calling/videoGridHandlerSpec.js
  154:5  warning  Spy declared outside of before/after/it block  jasmine/no-unsafe-spy
/unit_tests/components/panel/userActionsSpec.js
  39:11  warning  Spy declared outside of before/after/it block  jasmine/no-unsafe-spy
  60:11  warning  Spy declared outside of before/after/it block  jasmine/no-unsafe-spy
/unit_tests/event/EventRepositorySpec.js
  141:7  warning  Expect must have a corresponding matcher call  jasmine/expect-matcher