### PR TITLE
Scroll conversation view without using a mouse

### DIFF
--- a/src/script/util/KeyboardUtil.ts
+++ b/src/script/util/KeyboardUtil.ts
@@ -44,7 +44,7 @@ export const isOneOfKeys = (keyboardEvent: KeyboardEvent, expectedKeys: string[]
 export const isArrowKey = (keyboardEvent: KeyboardEvent): boolean =>
   isOneOfKeys(keyboardEvent, [KEY.ARROW_DOWN, KEY.ARROW_LEFT, KEY.ARROW_RIGHT, KEY.ARROW_UP]);
 
-export const isPageUpDownKey = (keyboardEvent: KeyboardEvent): boolean => 
+export const isPageUpDownKey = (keyboardEvent: KeyboardEvent): boolean =>
   isOneOfKeys(keyboardEvent, [KEY.PAGE_UP, KEY.PAGE_DOWN]);
 
 export const isKey = (keyboardEvent?: KeyboardEvent, expectedKey = '') => {

--- a/src/script/util/KeyboardUtil.ts
+++ b/src/script/util/KeyboardUtil.ts
@@ -29,6 +29,8 @@ export const KEY = {
   ENTER: 'Enter',
   ESC: 'Escape',
   KEY_V: 'v',
+  PAGE_DOWN: 'PageDown',
+  PAGE_UP: 'PageUp',
   SPACE: ' ',
   TAB: 'Tab',
 };
@@ -41,6 +43,8 @@ export const isOneOfKeys = (keyboardEvent: KeyboardEvent, expectedKeys: string[]
 
 export const isArrowKey = (keyboardEvent: KeyboardEvent): boolean =>
   isOneOfKeys(keyboardEvent, [KEY.ARROW_DOWN, KEY.ARROW_LEFT, KEY.ARROW_RIGHT, KEY.ARROW_UP]);
+
+export const isPageUpDownKey = keyboardEvent => isOneOfKeys(keyboardEvent, [KEY.PAGE_UP, KEY.PAGE_DOWN]);
 
 export const isKey = (keyboardEvent?: KeyboardEvent, expectedKey = '') => {
   const eventKey = keyboardEvent?.key.toLowerCase() || '';

--- a/src/script/util/KeyboardUtil.ts
+++ b/src/script/util/KeyboardUtil.ts
@@ -44,7 +44,8 @@ export const isOneOfKeys = (keyboardEvent: KeyboardEvent, expectedKeys: string[]
 export const isArrowKey = (keyboardEvent: KeyboardEvent): boolean =>
   isOneOfKeys(keyboardEvent, [KEY.ARROW_DOWN, KEY.ARROW_LEFT, KEY.ARROW_RIGHT, KEY.ARROW_UP]);
 
-export const isPageUpDownKey = keyboardEvent => isOneOfKeys(keyboardEvent, [KEY.PAGE_UP, KEY.PAGE_DOWN]);
+export const isPageUpDownKey = (keyboardEvent: KeyboardEvent): boolean => 
+  isOneOfKeys(keyboardEvent, [KEY.PAGE_UP, KEY.PAGE_DOWN]);
 
 export const isKey = (keyboardEvent?: KeyboardEvent, expectedKey = '') => {
   const eventKey = keyboardEvent?.key.toLowerCase() || '';

--- a/src/script/view_model/bindings/MessageListBindings.js
+++ b/src/script/view_model/bindings/MessageListBindings.js
@@ -24,7 +24,7 @@ import 'jquery-mousewheel';
 
 import {t} from 'Util/LocalizerUtil';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
-import {isArrowKey, isMetaKey, isPasteAction} from 'Util/KeyboardUtil';
+import {isArrowKey, isPageUpDownKey, isMetaKey, isPasteAction} from 'Util/KeyboardUtil';
 import {noop} from 'Util/util';
 import {LLDM} from 'Util/moment';
 
@@ -49,8 +49,11 @@ ko.bindingHandlers.focus_on_keydown = {
             const active_element_is_input =
               document.activeElement && ['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName);
             const is_arrow_key = isArrowKey(keyboard_event);
+            const is_pageupdown_key = isPageUpDownKey(keyboard_event);
 
-            if (!active_element_is_input && !is_arrow_key) {
+            if (is_pageupdown_key) {
+              document.activeElement.blur();
+            } else if (!active_element_is_input && !is_arrow_key) {
               if (!isMetaKey(keyboard_event) || isPasteAction(keyboard_event)) {
                 element.focus();
               }

--- a/src/script/view_model/content/InputBarViewModel.js
+++ b/src/script/view_model/content/InputBarViewModel.js
@@ -556,21 +556,6 @@ z.viewModel.content.InputBarViewModel = class InputBarViewModel {
   }
 
   onInputKeyDown(data, keyboardEvent) {
-    const textAreaValue = $(keyboardEvent.target).val();
-
-    // Manually move the cursor when pressing "Page Up", and do nothing else
-    // see https://bugs.chromium.org/p/chromium/issues/detail?id=890248
-    if (keyboardEvent.keyCode === 33) {
-      keyboardEvent.target.setSelectionRange(0, 0);
-      return false;
-    }
-
-    // Manually move the cursor when pressing "Page Down", and do nothing else
-    if (keyboardEvent.keyCode === 34 && textAreaValue) {
-      keyboardEvent.target.setSelectionRange(textAreaValue.length, textAreaValue.length);
-      return false;
-    }
-
     const inputHandledByEmoji = !this.editedMention() && this.emojiInput.onInputKeyDown(data, keyboardEvent);
 
     if (!inputHandledByEmoji) {


### PR DESCRIPTION
This is an attempt to help with #549, although I couldn't make it work 100%, so feedback and ideas are welcome 🙂 

**What works:** Click somewhere in the middle of the conversation view. Pressing PageUp and PageDown will scroll through the history. Press "hello" and it will be entered in the text area. Press PageUp / PageDown again and it will scroll conversation history again.

**What doesn't work:** Click in the text area. Pressing PageUp / PageDown will **not** scroll conversation history 🙁 I was trying different things, focusing on `#conversation` div or `body`, adding `tabindex`, nothing helps 😞 

In my mind, even this state is already a significant improvement, annoying, but better than nothing.

Let me know your thoughts.

P.S. I noticed a small leak, in `MessageListBindings.js` function `focus_on_keydown` gets executed multiple times if you switch between contacts in the sidebar, so if you switch back and forth 20 times, that callback will be called 20 times now. I'm not sure how to fix it (and it doesn't belong to this PR maybe), but maybe you will know how to do it 🙂 