### PR TITLE
fix: Speed up base64 to array conversion

### DIFF
--- a/src/script/assets/AssetCrypto.ts
+++ b/src/script/assets/AssetCrypto.ts
@@ -17,6 +17,12 @@
  *
  */
 
+export interface EncryptedAsset {
+  cipherText: ArrayBuffer;
+  keyBytes: ArrayBuffer;
+  sha256: ArrayBuffer;
+}
+
 /**
  * @param cipherText - Encrypted plaintext
  * @param keyBytes - AES key used for encryption
@@ -28,51 +34,32 @@ export const decryptAesAsset = async (
   keyBytes: ArrayBuffer,
   referenceSha256: ArrayBuffer,
 ): Promise<ArrayBuffer> => {
-  return window.crypto.subtle
-    .digest('SHA-256', cipherText)
-    .then(computedSha256 => {
-      if (_equalHashes(referenceSha256, computedSha256)) {
-        return window.crypto.subtle.importKey('raw', keyBytes, 'AES-CBC', false, ['decrypt']);
-      }
-
-      throw new Error('Encrypted asset does not match its SHA-256 hash');
-    })
-    .then(key => {
-      const iv = cipherText.slice(0, 16);
-      const assetCipherText = cipherText.slice(16);
-      return window.crypto.subtle.decrypt({iv: iv, name: 'AES-CBC'}, key, assetCipherText);
-    });
+  const computedSha256 = await window.crypto.subtle.digest('SHA-256', cipherText);
+  if (!_equalHashes(referenceSha256, computedSha256)) {
+    throw new Error('Encrypted asset does not match its SHA-256 hash');
+  }
+  const key = await window.crypto.subtle.importKey('raw', keyBytes, 'AES-CBC', false, ['decrypt']);
+  const iv = cipherText.slice(0, 16);
+  const assetCipherText = cipherText.slice(16);
+  return window.crypto.subtle.decrypt({iv: iv, name: 'AES-CBC'}, key, assetCipherText);
 };
 
-export const encryptAesAsset = async (
-  plaintext: ArrayBuffer,
-): Promise<{cipherText: ArrayBuffer; keyBytes: ArrayBuffer; sha256: ArrayBuffer}> => {
+export const encryptAesAsset = async (plaintext: ArrayBuffer): Promise<EncryptedAsset> => {
   const iv = _generateRandomBytes(16);
   const rawKeyBytes = _generateRandomBytes(32);
-  let key: CryptoKey;
   let ivCipherText: Uint8Array;
-  let computedSha256: ArrayBuffer;
 
-  return window.crypto.subtle
-    .importKey('raw', rawKeyBytes.buffer, 'AES-CBC', true, ['encrypt'])
-    .then(ckey => {
-      key = ckey;
+  const key = await window.crypto.subtle.importKey('raw', rawKeyBytes.buffer, 'AES-CBC', true, ['encrypt']);
 
-      return window.crypto.subtle.encrypt({iv: iv.buffer, name: 'AES-CBC'}, key, plaintext);
-    })
-    .then(cipherText => {
-      ivCipherText = new Uint8Array(cipherText.byteLength + iv.byteLength);
-      ivCipherText.set(iv, 0);
-      ivCipherText.set(new Uint8Array(cipherText), iv.byteLength);
+  const cipherText = await window.crypto.subtle.encrypt({iv: iv.buffer, name: 'AES-CBC'}, key, plaintext);
+  ivCipherText = new Uint8Array(cipherText.byteLength + iv.byteLength);
+  ivCipherText.set(iv, 0);
+  ivCipherText.set(new Uint8Array(cipherText), iv.byteLength);
 
-      return window.crypto.subtle.digest('SHA-256', ivCipherText);
-    })
-    .then(digest => {
-      computedSha256 = digest;
+  const digest = await window.crypto.subtle.digest('SHA-256', ivCipherText);
+  const keyBytes = await window.crypto.subtle.exportKey('raw', key);
 
-      return window.crypto.subtle.exportKey('raw', key);
-    })
-    .then(keyBytes => ({cipherText: ivCipherText.buffer, keyBytes: keyBytes, sha256: computedSha256}));
+  return {cipherText: ivCipherText.buffer, keyBytes: keyBytes, sha256: digest};
 };
 
 const _equalHashes = (bufferA: ArrayBuffer, bufferB: ArrayBuffer): boolean => {

--- a/src/script/assets/AssetService.ts
+++ b/src/script/assets/AssetService.ts
@@ -205,14 +205,12 @@ export class AssetService {
     xhr.setRequestHeader('Authorization', `${this.backendClient.accessTokenType} ${this.backendClient.accessToken}`);
     xhr.send(new Blob([body, assetData, footer]));
 
-    const xhrResult = await new Promise<UploadAssetResponse>((resolve, reject) => {
+    return new Promise<UploadAssetResponse>((resolve, reject) => {
       xhr.onload = function(event): void {
         return this.status === 201 ? resolve(JSON.parse(this.response)) : reject(event);
       };
       xhr.onerror = reject;
     });
-
-    return xhrResult;
   }
 
   _compressImage(image: File | Blob): Promise<CompressedImage> {

--- a/src/script/assets/AssetService.ts
+++ b/src/script/assets/AssetService.ts
@@ -164,7 +164,7 @@ export class AssetService {
     return isEternal ? AssetRetentionPolicy.ETERNAL : AssetRetentionPolicy.PERSISTENT;
   }
 
-  postAsset(
+  async postAsset(
     assetData: Uint8Array,
     options: AssetUploadOptions,
     xhrAccessorFunction?: Function,
@@ -179,7 +179,7 @@ export class AssetService {
 
     const optionsString = JSON.stringify(options);
 
-    const md5Base64Hash = arrayToMd5Base64(assetData);
+    const md5Base64Hash = await arrayToMd5Base64(assetData);
 
     const body = [
       `--${BOUNDARY}`,
@@ -205,12 +205,14 @@ export class AssetService {
     xhr.setRequestHeader('Authorization', `${this.backendClient.accessTokenType} ${this.backendClient.accessToken}`);
     xhr.send(new Blob([body, assetData, footer]));
 
-    return new Promise<UploadAssetResponse>((resolve, reject) => {
+    const xhrResult = await new Promise<UploadAssetResponse>((resolve, reject) => {
       xhr.onload = function(event): void {
         return this.status === 201 ? resolve(JSON.parse(this.response)) : reject(event);
       };
       xhr.onerror = reject;
     });
+
+    return xhrResult;
   }
 
   _compressImage(image: File | Blob): Promise<CompressedImage> {

--- a/src/script/broadcast/BroadcastService.ts
+++ b/src/script/broadcast/BroadcastService.ts
@@ -43,7 +43,7 @@ export class BroadcastService {
    * @param {Object} payload.recipients - Map with per-recipient data
    * @param {string} payload.sender - Client ID of the sender
    * @param {Array<string>|boolean} preconditionOption - Level that backend checks for missing clients
-   * @returns {Promise} Promise that resolve when the message was sent
+   * @returns {Promise} Promise that resolves when the message was sent
    */
   postBroadcastMessage(
     payload: {recipients: {}; sender: string},

--- a/src/script/conversation/ConversationEphemeralHandler.js
+++ b/src/script/conversation/ConversationEphemeralHandler.js
@@ -22,7 +22,7 @@ import {Article, LinkPreview} from '@wireapp/protocol-messaging';
 import {getLogger} from 'Util/Logger';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
 import {clamp} from 'Util/NumberUtil';
-import {arrayToBase64Sync, noop} from 'Util/util';
+import {arrayToBase64, noop} from 'Util/util';
 import {obfuscate} from 'Util/StringUtil';
 
 import {EphemeralStatusType} from '../message/EphemeralStatusType';
@@ -90,9 +90,9 @@ export class ConversationEphemeralHandler extends AbstractConversationEventHandl
    *
    * @param {Message} messageEntity - Message to check
    * @param {number} timeOffset - Approximate time different to backend in milliseconds
-   * @returns {undefined} No return value
+   * @returns {Promise<void>} No return value
    */
-  checkMessageTimer(messageEntity, timeOffset) {
+  async checkMessageTimer(messageEntity, timeOffset) {
     const hasHitBackend = messageEntity.status() > StatusType.SENDING;
     if (!hasHitBackend) {
       return;
@@ -100,7 +100,7 @@ export class ConversationEphemeralHandler extends AbstractConversationEventHandl
 
     switch (messageEntity.ephemeral_status()) {
       case EphemeralStatusType.TIMED_OUT: {
-        this._timeoutEphemeralMessage(messageEntity);
+        await this._timeoutEphemeralMessage(messageEntity);
         break;
       }
 
@@ -123,13 +123,13 @@ export class ConversationEphemeralHandler extends AbstractConversationEventHandl
     }
   }
 
-  validateMessage(messageEntity) {
+  async validateMessage(messageEntity) {
     const isEphemeralMessage = messageEntity.ephemeral_status() !== EphemeralStatusType.NONE;
     if (!isEphemeralMessage) {
       return messageEntity;
     }
 
-    const isExpired = !!this._updateTimedMessage(messageEntity);
+    const isExpired = !!(await this._updateTimedMessage(messageEntity));
     if (!isExpired) {
       const {id, conversation_id: conversationId} = messageEntity;
       const matchingMessageEntity = this.timedMessages().find(timedMessageEntity => {
@@ -147,10 +147,11 @@ export class ConversationEphemeralHandler extends AbstractConversationEventHandl
     }
   }
 
-  validateMessages(messageEntities) {
-    return messageEntities
-      .map(messageEntity => this.validateMessage(messageEntity))
-      .filter(messageEntity => messageEntity);
+  async validateMessages(messageEntities) {
+    const validatedMessages = await Promise.all(
+      messageEntities.map(messageEntity => this.validateMessage(messageEntity)),
+    );
+    return validatedMessages.filter(messageEntity => !!messageEntity);
   }
 
   _obfuscateAssetMessage(messageEntity) {
@@ -188,9 +189,9 @@ export class ConversationEphemeralHandler extends AbstractConversationEventHandl
     this.logger.info(`Obfuscated image message '${messageEntity.id}'`);
   }
 
-  _obfuscateMessage(messageEntity) {
+  async _obfuscateMessage(messageEntity) {
     if (messageEntity.has_asset_text()) {
-      this._obfuscateTextMessage(messageEntity);
+      await this._obfuscateTextMessage(messageEntity);
     } else if (messageEntity.has_asset()) {
       this._obfuscateAssetMessage(messageEntity);
     } else if (messageEntity.has_asset_image()) {
@@ -200,23 +201,25 @@ export class ConversationEphemeralHandler extends AbstractConversationEventHandl
     }
   }
 
-  _obfuscateTextMessage(messageEntity) {
+  async _obfuscateTextMessage(messageEntity) {
     messageEntity.ephemeral_expires(true);
 
     const assetEntity = messageEntity.get_first_asset();
     const obfuscatedAsset = new Text(messageEntity.id);
-    const obfuscatedPreviews = assetEntity.previews().map(linkPreview => {
-      linkPreview.obfuscate();
-      const protoArticle = new Article({permanentUrl: linkPreview.url, title: linkPreview.title}); // deprecated format
-      const linkPreviewProto = new LinkPreview({
-        article: protoArticle,
-        permanentUrl: linkPreview.url,
-        title: linkPreview.title,
-        url: linkPreview.url,
-        urlOffset: 0,
-      });
-      return arrayToBase64Sync(LinkPreview.encode(linkPreviewProto).finish());
-    });
+    const obfuscatedPreviews = await Promise.all(
+      assetEntity.previews().map(linkPreview => {
+        linkPreview.obfuscate();
+        const protoArticle = new Article({permanentUrl: linkPreview.url, title: linkPreview.title}); // deprecated format
+        const linkPreviewProto = new LinkPreview({
+          article: protoArticle,
+          permanentUrl: linkPreview.url,
+          title: linkPreview.title,
+          url: linkPreview.url,
+          urlOffset: 0,
+        });
+        return arrayToBase64(LinkPreview.encode(linkPreviewProto).finish());
+      }),
+    );
 
     obfuscatedAsset.text = obfuscate(assetEntity.text);
     obfuscatedAsset.previews(assetEntity.previews());
@@ -234,10 +237,10 @@ export class ConversationEphemeralHandler extends AbstractConversationEventHandl
     this.logger.info(`Obfuscated text message '${messageEntity.id}'`);
   }
 
-  _timeoutEphemeralMessage(messageEntity) {
+  async _timeoutEphemeralMessage(messageEntity) {
     if (!messageEntity.is_expired()) {
       if (messageEntity.user().is_me) {
-        this._obfuscateMessage(messageEntity);
+        await this._obfuscateMessage(messageEntity);
       }
 
       this.eventListeners.onMessageTimeout(messageEntity);
@@ -258,23 +261,24 @@ export class ConversationEphemeralHandler extends AbstractConversationEventHandl
     return Promise.resolve(conversationEntity);
   }
 
-  _updateTimedMessage(messageEntity) {
+  async _updateTimedMessage(messageEntity) {
     if (typeof messageEntity.ephemeral_expires() === 'string') {
       const remainingTime = Math.max(0, messageEntity.ephemeral_expires() - Date.now());
       messageEntity.ephemeral_remaining(remainingTime);
 
       const isExpired = remainingTime === 0;
       if (isExpired) {
-        this._timeoutEphemeralMessage(messageEntity);
+        await this._timeoutEphemeralMessage(messageEntity);
         return messageEntity;
       }
     }
   }
 
-  _updateTimedMessages() {
-    const expiredMessages = this.timedMessages()
-      .map(messageEntity => this._updateTimedMessage(messageEntity))
-      .filter(messageEntity => messageEntity);
+  async _updateTimedMessages() {
+    const updatedMessages = await Promise.all(
+      this.timedMessages().map(messageEntity => this._updateTimedMessage(messageEntity)),
+    );
+    const expiredMessages = updatedMessages.filter(messageEntity => !!messageEntity);
 
     if (expiredMessages.length) {
       this.timedMessages.remove(messageEntity => {

--- a/src/script/conversation/ConversationEphemeralHandler.js
+++ b/src/script/conversation/ConversationEphemeralHandler.js
@@ -22,7 +22,7 @@ import {Article, LinkPreview} from '@wireapp/protocol-messaging';
 import {getLogger} from 'Util/Logger';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
 import {clamp} from 'Util/NumberUtil';
-import {arrayToBase64, noop} from 'Util/util';
+import {arrayToBase64Sync, noop} from 'Util/util';
 import {obfuscate} from 'Util/StringUtil';
 
 import {EphemeralStatusType} from '../message/EphemeralStatusType';
@@ -215,7 +215,7 @@ export class ConversationEphemeralHandler extends AbstractConversationEventHandl
         url: linkPreview.url,
         urlOffset: 0,
       });
-      return arrayToBase64(LinkPreview.encode(linkPreviewProto).finish());
+      return arrayToBase64Sync(LinkPreview.encode(linkPreviewProto).finish());
     });
 
     obfuscatedAsset.text = obfuscate(assetEntity.text);

--- a/src/script/conversation/ConversationRepository.js
+++ b/src/script/conversation/ConversationRepository.js
@@ -328,9 +328,8 @@ export class ConversationRepository {
       updatedEvent,
     );
     if (replacedMessageEntity) {
-      this._updateMessageUserEntities(replacedMessageEntity).then(messageEntity => {
-        amplify.publish(WebAppEvents.CONVERSATION.MESSAGE.UPDATED, oldEvent.id, messageEntity);
-      });
+      const messageEntity = await this._updateMessageUserEntities(replacedMessageEntity);
+      amplify.publish(WebAppEvents.CONVERSATION.MESSAGE.UPDATED, oldEvent.id, messageEntity);
     }
   }
 

--- a/src/script/conversation/EventMapper.js
+++ b/src/script/conversation/EventMapper.js
@@ -70,24 +70,21 @@ export class EventMapper {
    * @param {Conversation} conversationEntity - Conversation entity the events belong to
    * @returns {Promise<Array<Message>>} Resolves with the mapped message entities
    */
-  mapJsonEvents(events, conversationEntity) {
-    return Promise.resolve().then(() => {
-      return events
-        .filter(event => event)
-        .reverse()
-        .map(event => {
-          try {
-            return this._mapJsonEvent(event, conversationEntity);
-          } catch (error) {
-            const errorMessage = `Failure while mapping events. Affected '${event.type}' event: ${error.message}`;
-            this.logger.error(errorMessage, {error, event});
-
-            const customData = {eventTime: new Date(event.time).toISOString(), eventType: event.type};
-            Raygun.send(new Error(errorMessage), customData);
-          }
-        })
-        .filter(messageEntity => messageEntity);
-    });
+  async mapJsonEvents(events, conversationEntity) {
+    const reversedEvents = events.filter(event => !!event).reverse();
+    const mappedEvents = await Promise.all(
+      reversedEvents.map(event => {
+        try {
+          return this._mapJsonEvent(event, conversationEntity);
+        } catch (error) {
+          const errorMessage = `Failure while mapping events. Affected '${event.type}' event: ${error.message}`;
+          this.logger.error(errorMessage, {error, event});
+          const customData = {eventTime: new Date(event.time).toISOString(), eventType: event.type};
+          Raygun.send(new Error(errorMessage), customData);
+        }
+      }),
+    );
+    return mappedEvents.filter(messageEntity => !!messageEntity);
   }
 
   /**
@@ -121,9 +118,9 @@ export class EventMapper {
    *
    * @param {Message} originalEntity - the original message to update
    * @param {Object} event - new json data to feed into the entity
-   * @returns {Message} - the updated message entity
+   * @returns {Promise<Message>} - the updated message entity
    */
-  updateMessageEvent(originalEntity, event) {
+  async updateMessageEvent(originalEntity, event) {
     const {id, data: eventData, edited_time: editedTime} = event;
 
     if (eventData.quote) {
@@ -133,7 +130,8 @@ export class EventMapper {
 
     if (id !== originalEntity.id && originalEntity.has_asset_text()) {
       originalEntity.assets.removeAll();
-      originalEntity.assets.push(this._mapAssetText(eventData));
+      const textAsset = await this._mapAssetText(eventData);
+      originalEntity.assets.push(textAsset);
     } else if (originalEntity.get_first_asset) {
       const asset = originalEntity.get_first_asset();
       if (eventData.status && asset.status) {
@@ -142,7 +140,8 @@ export class EventMapper {
       }
       if (eventData.previews) {
         if (asset.previews().length !== eventData.previews.length) {
-          asset.previews(this._mapAssetLinkPreviews(eventData.previews));
+          const previews = await this._mapAssetLinkPreviews(eventData.previews);
+          asset.previews(previews);
         }
       }
 
@@ -179,9 +178,9 @@ export class EventMapper {
    *
    * @param {Object} event - Event data
    * @param {Conversation} conversationEntity - Conversation entity the event belong to
-   * @returns {Message} Mapped message entity
+   * @returns {Promise<Message>} Mapped message entity
    */
-  _mapJsonEvent(event, conversationEntity) {
+  async _mapJsonEvent(event, conversationEntity) {
     let messageEntity;
 
     switch (event.type) {
@@ -247,7 +246,8 @@ export class EventMapper {
       }
 
       case ClientEvent.CONVERSATION.MESSAGE_ADD: {
-        messageEntity = addMetadata(this._mapEventMessageAdd(event), event);
+        const addMessage = await this._mapEventMessageAdd(event);
+        messageEntity = addMetadata(addMessage, event);
         break;
       }
 
@@ -475,13 +475,14 @@ export class EventMapper {
    *
    * @private
    * @param {Object} event - Message data
-   * @returns {ContentMessage} Content message entity
+   * @returns {Promise<ContentMessage>} Content message entity
    */
-  _mapEventMessageAdd(event) {
+  async _mapEventMessageAdd(event) {
     const {data: eventData, edited_time: editedTime} = event;
     const messageEntity = new ContentMessage();
 
-    messageEntity.assets.push(this._mapAssetText(eventData));
+    const assets = await this._mapAssetText(eventData);
+    messageEntity.assets.push(assets);
     messageEntity.replacing_message_id = eventData.replacing_message_id;
     messageEntity.edited_timestamp(new Date(editedTime || eventData.edited_time).getTime());
 
@@ -763,11 +764,12 @@ export class EventMapper {
    *
    * @private
    * @param {Array} linkPreviews - Link previews as base64 encoded proto messages
-   * @returns {Array<LinkPreview>} Array of mapped link previews
+   * @returns {Promise<LinkPreview[]>} Array of mapped link previews
    */
-  _mapAssetLinkPreviews(linkPreviews) {
-    return linkPreviews
-      .map(encodedLinkPreview => LinkPreview.decode(base64ToArray(encodedLinkPreview)))
+  async _mapAssetLinkPreviews(linkPreviews) {
+    const arrays = await Promise.all(linkPreviews.map(base64 => base64ToArray(base64)));
+    return arrays
+      .map(encodedLinkPreview => LinkPreview.decode(encodedLinkPreview))
       .map(linkPreview => this._mapAssetLinkPreview(linkPreview))
       .filter(linkPreviewEntity => linkPreviewEntity);
   }
@@ -778,12 +780,14 @@ export class EventMapper {
    * @private
    * @param {Array} mentions - Mentions as base64 encoded proto messages
    * @param {string} messageText - Text of message
-   * @returns {Array<MentionEntity>} Array of mapped mentions
+   * @returns {Promise<MentionEntity[]>} Array of mapped mentions
    */
-  _mapAssetMentions(mentions, messageText) {
-    return mentions
+  async _mapAssetMentions(mentions, messageText) {
+    const arrays = await Promise.all(mentions.map(base64 => base64ToArray(base64)));
+
+    return arrays
       .map(encodedMention => {
-        const protoMention = Mention.decode(base64ToArray(encodedMention));
+        const protoMention = Mention.decode(encodedMention);
         return new MentionEntity(protoMention.start, protoMention.length, protoMention.userId);
       })
       .filter((mentionEntity, _, allMentions) => {
@@ -803,18 +807,20 @@ export class EventMapper {
    *
    * @private
    * @param {Object} eventData - Asset data received as JSON
-   * @returns {Text} Text asset entity
+   * @returns {Promise<Text>} Text asset entity
    */
-  _mapAssetText(eventData) {
+  async _mapAssetText(eventData) {
     const {id, content, mentions, message, previews} = eventData;
     const messageText = content || message;
     const assetEntity = new Text(id, messageText);
 
     if (mentions && mentions.length) {
-      assetEntity.mentions(this._mapAssetMentions(mentions, messageText));
+      const mappedMentions = await this._mapAssetMentions(mentions, messageText);
+      assetEntity.mentions(mappedMentions);
     }
     if (previews && previews.length) {
-      assetEntity.previews(this._mapAssetLinkPreviews(previews));
+      const mappedLinkPreviews = await this._mapAssetLinkPreviews(previews);
+      assetEntity.previews(mappedLinkPreviews);
     }
 
     return assetEntity;

--- a/src/script/conversation/EventMapper.js
+++ b/src/script/conversation/EventMapper.js
@@ -767,8 +767,8 @@ export class EventMapper {
    * @returns {Promise<LinkPreview[]>} Array of mapped link previews
    */
   async _mapAssetLinkPreviews(linkPreviews) {
-    const arrays = await Promise.all(linkPreviews.map(base64 => base64ToArray(base64)));
-    return arrays
+    const encodedLinkPreviews = await Promise.all(linkPreviews.map(base64 => base64ToArray(base64)));
+    return encodedLinkPreviews
       .map(encodedLinkPreview => LinkPreview.decode(encodedLinkPreview))
       .map(linkPreview => this._mapAssetLinkPreview(linkPreview))
       .filter(linkPreviewEntity => linkPreviewEntity);

--- a/src/script/conversation/EventMapper.js
+++ b/src/script/conversation/EventMapper.js
@@ -73,9 +73,9 @@ export class EventMapper {
   async mapJsonEvents(events, conversationEntity) {
     const reversedEvents = events.filter(event => !!event).reverse();
     const mappedEvents = await Promise.all(
-      reversedEvents.map(event => {
+      reversedEvents.map(async event => {
         try {
-          return this._mapJsonEvent(event, conversationEntity);
+          return await this._mapJsonEvent(event, conversationEntity);
         } catch (error) {
           const errorMessage = `Failure while mapping events. Affected '${event.type}' event: ${error.message}`;
           this.logger.error(errorMessage, {error, event});
@@ -783,9 +783,8 @@ export class EventMapper {
    * @returns {Promise<MentionEntity[]>} Array of mapped mentions
    */
   async _mapAssetMentions(mentions, messageText) {
-    const arrays = await Promise.all(mentions.map(base64 => base64ToArray(base64)));
-
-    return arrays
+    const encodedMentions = await Promise.all(mentions.map(base64 => base64ToArray(base64)));
+    return encodedMentions
       .map(encodedMention => {
         const protoMention = Mention.decode(encodedMention);
         return new MentionEntity(protoMention.start, protoMention.length, protoMention.userId);

--- a/src/script/cryptography/CryptographyMapper.js
+++ b/src/script/cryptography/CryptographyMapper.js
@@ -99,7 +99,7 @@ export class CryptographyMapper {
       }
 
       case GENERIC_MESSAGE_TYPE.EDITED: {
-        specificContent = this._mapEdited(genericMessage.edited, genericMessage.messageId);
+        specificContent = await this._mapEdited(genericMessage.edited, genericMessage.messageId);
         break;
       }
 

--- a/src/script/event/EventRepository.js
+++ b/src/script/event/EventRepository.js
@@ -669,7 +669,12 @@ export class EventRepository {
     const isInjectedEvent = source === EventRepository.SOURCE.INJECTED;
     const canSetEventDate = !isInjectedEvent && eventDate;
     if (canSetEventDate) {
-      // HOTFIX: The "conversation.voice-channel-deactivate" event is the ONLY event which we inject with a source set to WebSocket. This is wrong but changing it will break our current conversation archive functionality (WEBAPP-6435). That's why we need to explicitly list the "conversation.voice-channel-deactivate" here because injected events should NEVER modify the last event timestamp which we use to query the backend's notification stream.
+      /*
+       * HOTFIX: The "conversation.voice-channel-deactivate" event is the ONLY event which we inject with a source set to WebSocket.
+       * This is wrong but changing it will break our current conversation archive functionality (WEBAPP-6435).
+       * That's why we need to explicitly list the "conversation.voice-channel-deactivate" here because injected events should NEVER
+       * modify the last event timestamp which we use to query the backend's notification stream.
+       */
       if (event.type !== ClientEvent.CONVERSATION.VOICE_CHANNEL_DEACTIVATE) {
         this._updateLastEventDate(eventDate);
       }

--- a/src/script/event/preprocessor/QuotedMessageMiddleware.js
+++ b/src/script/event/preprocessor/QuotedMessageMiddleware.js
@@ -20,7 +20,7 @@
 import {Quote} from '@wireapp/protocol-messaging';
 
 import {getLogger} from 'Util/Logger';
-import {base64ToArraySync} from 'Util/util';
+import {base64ToArray} from 'Util/util';
 
 import {ClientEvent} from '../Client';
 import {QuoteEntity} from '../../message/QuoteEntity';
@@ -94,69 +94,69 @@ export class QuotedMessageMiddleware {
     });
   }
 
-  _handleAddEvent(event) {
+  async _handleAddEvent(event) {
     const rawQuote = event.data && event.data.quote;
 
     if (!rawQuote) {
-      return Promise.resolve(event);
+      return event;
     }
 
-    const quote = Quote.decode(base64ToArraySync(rawQuote));
+    const encodedQuote = await base64ToArray(rawQuote);
+    const quote = Quote.decode(encodedQuote);
     this.logger.info('Found quoted message', quote);
 
     const messageId = quote.quotedMessageId;
 
-    return this.eventService.loadEvent(event.conversation, messageId).then(quotedMessage => {
-      if (!quotedMessage) {
-        this.logger.warn(`Quoted message with ID "${messageId}" not found.`);
-        const quoteData = {
-          error: {
-            type: QuoteEntity.ERROR.MESSAGE_NOT_FOUND,
-          },
-        };
+    const quotedMessage = await this.eventService.loadEvent(event.conversation, messageId);
+    if (!quotedMessage) {
+      this.logger.warn(`Quoted message with ID "${messageId}" not found.`);
+      const quoteData = {
+        error: {
+          type: QuoteEntity.ERROR.MESSAGE_NOT_FOUND,
+        },
+      };
 
-        const decoratedData = Object.assign({}, event.data, {quote: quoteData});
-        return Promise.resolve(Object.assign({}, event, {data: decoratedData}));
-      }
+      const decoratedData = {...event.data, quote: quoteData};
+      return {...event, data: decoratedData};
+    }
 
-      const quotedMessageHash = new Uint8Array(quote.quotedMessageSha256).buffer;
+    const quotedMessageHash = new Uint8Array(quote.quotedMessageSha256).buffer;
 
-      return MessageHasher.validateHash(quotedMessage, quotedMessageHash).then(isValid => {
-        let quoteData;
+    const isValid = await MessageHasher.validateHash(quotedMessage, quotedMessageHash);
+    let quoteData;
 
-        if (!isValid) {
-          this.logger.warn(`Quoted message hash for message ID "${messageId}" does not match.`);
-          quoteData = {
-            error: {
-              type: QuoteEntity.ERROR.INVALID_HASH,
-            },
-          };
-        } else {
-          quoteData = {
-            message_id: messageId,
-            user_id: quotedMessage.from,
-          };
-        }
+    if (!isValid) {
+      this.logger.warn(`Quoted message hash for message ID "${messageId}" does not match.`);
+      quoteData = {
+        error: {
+          type: QuoteEntity.ERROR.INVALID_HASH,
+        },
+      };
+    } else {
+      quoteData = {
+        message_id: messageId,
+        user_id: quotedMessage.from,
+      };
+    }
 
-        const decoratedData = Object.assign({}, event.data, {quote: quoteData});
-        return Promise.resolve(Object.assign({}, event, {data: decoratedData}));
-      });
-    });
+    const decoratedData = {...event.data, quote: quoteData};
+    return {...event, data: decoratedData};
   }
 
-  _findRepliesToMessage(conversationId, messageId) {
-    return this.eventService.loadEvent(conversationId, messageId).then(originalEvent => {
-      if (!originalEvent) {
-        return {
-          replies: [],
-        };
-      }
-      return this.eventService
-        .loadEventsReplyingToMessage(conversationId, messageId, originalEvent.time)
-        .then(replies => ({
-          originalEvent,
-          replies,
-        }));
-    });
+  async _findRepliesToMessage(conversationId, messageId) {
+    const originalEvent = await this.eventService.loadEvent(conversationId, messageId);
+
+    if (!originalEvent) {
+      return {
+        replies: [],
+      };
+    }
+
+    const replies = await this.eventService.loadEventsReplyingToMessage(conversationId, messageId, originalEvent.time);
+
+    return {
+      originalEvent,
+      replies,
+    };
   }
 }

--- a/src/script/event/preprocessor/QuotedMessageMiddleware.js
+++ b/src/script/event/preprocessor/QuotedMessageMiddleware.js
@@ -20,7 +20,7 @@
 import {Quote} from '@wireapp/protocol-messaging';
 
 import {getLogger} from 'Util/Logger';
-import {base64ToArray} from 'Util/util';
+import {base64ToArraySync} from 'Util/util';
 
 import {ClientEvent} from '../Client';
 import {QuoteEntity} from '../../message/QuoteEntity';
@@ -101,7 +101,7 @@ export class QuotedMessageMiddleware {
       return Promise.resolve(event);
     }
 
-    const quote = Quote.decode(base64ToArray(rawQuote));
+    const quote = Quote.decode(base64ToArraySync(rawQuote));
     this.logger.info('Found quoted message', quote);
 
     const messageId = quote.quotedMessageId;

--- a/src/script/links/LinkPreviewRepository.js
+++ b/src/script/links/LinkPreviewRepository.js
@@ -163,10 +163,9 @@ class LinkPreviewRepository {
    * @param {string} dataUri - image data as base64 encoded data URI
    * @returns {Promise} Resolves with the uploaded asset
    */
-  _uploadPreviewImage(dataUri) {
-    return Promise.resolve(base64ToBlob(dataUri)).then(blob =>
-      this.assetService.uploadImageAsset(blob, {public: true}),
-    );
+  async _uploadPreviewImage(dataUri) {
+    const blob = await base64ToBlob(dataUri);
+    return this.assetService.uploadImageAsset(blob, {public: true});
   }
 }
 

--- a/src/script/storage/StorageSchemata.ts
+++ b/src/script/storage/StorageSchemata.ts
@@ -17,7 +17,7 @@
  *
  */
 import {Dexie} from 'dexie';
-import {base64ToArray} from 'Util/util';
+import {base64ToArraySync} from 'Util/util';
 import {categoryFromEvent} from '../message/MessageCategorization';
 
 interface DexieSchema {
@@ -269,19 +269,19 @@ export class StorageSchemata {
             .table(StorageSchemata.OBJECT_STORE.KEYS)
             .toCollection()
             .modify(record => {
-              record.serialised = base64ToArray(record.serialised).buffer;
+              record.serialised = base64ToArraySync(record.serialised).buffer;
             });
           transaction
             .table(StorageSchemata.OBJECT_STORE.PRE_KEYS)
             .toCollection()
             .modify(record => {
-              record.serialised = base64ToArray(record.serialised).buffer;
+              record.serialised = base64ToArraySync(record.serialised).buffer;
             });
           transaction
             .table(StorageSchemata.OBJECT_STORE.SESSIONS)
             .toCollection()
             .modify(record => {
-              record.serialised = base64ToArray(record.serialised).buffer;
+              record.serialised = base64ToArraySync(record.serialised).buffer;
             });
         },
         version: 12,

--- a/src/script/storage/StorageSchemata.ts
+++ b/src/script/storage/StorageSchemata.ts
@@ -16,7 +16,9 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  *
  */
+
 import {Dexie} from 'dexie';
+
 import {base64ToArraySync} from 'Util/util';
 import {categoryFromEvent} from '../message/MessageCategorization';
 

--- a/src/script/util/util.ts
+++ b/src/script/util/util.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {Decoder, Encoder} from 'bazinga64';
+import {Decoder} from 'bazinga64';
 import JsMD5 from 'js-md5';
 import {ObservableArray} from 'knockout';
 import sodium from 'libsodium-wrappers-sumo';
@@ -203,12 +203,6 @@ export const base64ToArray = async (base64: string): Promise<Uint8Array> => {
   await sodium.ready;
   return sodium.from_base64(stripDataUri(base64), sodium.base64_variants.ORIGINAL);
 };
-
-/**
- * Convert an ArrayBuffer or an Uint8Array to a base64 string
- */
-export const arrayToBase64Sync = (array: ArrayBuffer | Uint8Array): string =>
-  Encoder.toBase64(new Uint8Array(array)).asString;
 
 /**
  * Convert an ArrayBuffer or an Uint8Array to a base64 string asynchronously

--- a/src/script/view_model/content/MessageListViewModel.js
+++ b/src/script/view_model/content/MessageListViewModel.js
@@ -535,9 +535,9 @@ class MessageListViewModel {
       conversationEntity.setTimestamp(messageEntity.timestamp(), Conversation.TIMESTAMP_TYPE.LAST_READ);
     };
 
-    const startTimer = () => {
+    const startTimer = async () => {
       if (messageEntity.conversation_id === conversationEntity.id) {
-        this.conversation_repository.checkMessageTimer(messageEntity);
+        await this.conversation_repository.checkMessageTimer(messageEntity);
       }
     };
 

--- a/test/unit_tests/cryptography/CryptographyRepositorySpec.js
+++ b/test/unit_tests/cryptography/CryptographyRepositorySpec.js
@@ -149,7 +149,7 @@ describe('CryptographyRepository', () => {
         GenericMessage.encode(genericMessage).finish(),
         aliceBundle.serialise(),
       );
-      const encodedCipherText = arrayToBase64(cipherText);
+      const encodedCipherText = await arrayToBase64(cipherText);
 
       const mockedEvent = {
         data: {

--- a/test/unit_tests/event/EventRepositorySpec.js
+++ b/test/unit_tests/event/EventRepositorySpec.js
@@ -334,7 +334,7 @@ describe('EventRepository', () => {
   });
 
   describe('processEvent', () => {
-    it('processes OTR events', () => {
+    it('processes OTR events', async () => {
       const text = 'Hello, this is a test!';
       const ownClientId = 'f180a823bf0d1204';
       const client = new ClientEntity();
@@ -343,28 +343,24 @@ describe('EventRepository', () => {
       TestFactory.client_repository.currentClient(client);
       TestFactory.cryptography_repository.createCryptobox.and.callThrough();
 
-      return Promise.resolve()
-        .then(() => TestFactory.cryptography_repository.createCryptobox(TestFactory.storage_service.db))
-        .then(() => TestFactory.cryptography_repository.cryptobox.get_prekey())
-        .then(async preKeyBundle => {
-          const ciphertext = await createEncodedCiphertext(preKeyBundle, text);
-          const event = {
-            conversation: 'fdc6cf1a-4e37-424e-a106-ab3d2cc5c8e0',
-            data: {
-              recipient: ownClientId,
-              sender: '4c28652a6dd21938',
-              text: ciphertext,
-            },
-            from: '6f88716b-1383-44da-9d57-45b51cc64d90',
-            time: '2018-07-10T14:54:21.621Z',
-            type: 'conversation.otr-message-add',
-          };
-          const source = EventRepository.SOURCE.STREAM;
-          return TestFactory.event_repository.processEvent(event, source);
-        })
-        .then(messagePayload => {
-          expect(messagePayload.data.content).toBe(text);
-        });
+      await TestFactory.cryptography_repository.createCryptobox(TestFactory.storage_service.db);
+      const preKeyBundle = await TestFactory.cryptography_repository.cryptobox.get_prekey();
+      const ciphertext = await createEncodedCiphertext(preKeyBundle, text);
+      const event = {
+        conversation: 'fdc6cf1a-4e37-424e-a106-ab3d2cc5c8e0',
+        data: {
+          recipient: ownClientId,
+          sender: '4c28652a6dd21938',
+          text: ciphertext,
+        },
+        from: '6f88716b-1383-44da-9d57-45b51cc64d90',
+        time: '2018-07-10T14:54:21.621Z',
+        type: 'conversation.otr-message-add',
+      };
+      const source = EventRepository.SOURCE.STREAM;
+      const messagePayload = await TestFactory.event_repository.processEvent(event, source);
+
+      expect(messagePayload.data.content).toBe(text);
     });
   });
 

--- a/test/unit_tests/message/MentionEntitySpec.js
+++ b/test/unit_tests/message/MentionEntitySpec.js
@@ -87,9 +87,10 @@ describe('MentionEntity', () => {
       expect(endMentionEntity.validate(endTextMessage)).toBe(true);
     });
 
-    it('supports line breaks in texts with mentions', () => {
+    it('supports line breaks in texts with mentions', async () => {
       const encodedMention = 'CAEQCBokNDRiZDc3NmUtODcxOS00MzIwLWIxYTAtMzU0Y2NkOGU5ODNh';
-      const protoMention = Mention.decode(base64ToArray(encodedMention));
+      const mentionArray = await base64ToArray(encodedMention);
+      const protoMention = Mention.decode(mentionArray);
       const mentionEntity = new MentionEntity(protoMention.start, protoMention.length, protoMention.userId);
       const messageText = '\n@Firefox';
 

--- a/test/unit_tests/util/UtilSpec.js
+++ b/test/unit_tests/util/UtilSpec.js
@@ -42,16 +42,19 @@ import {
 import {Conversation} from 'src/script/entity/Conversation';
 
 describe('arrayToMd5Base64', () => {
-  it('converts a typed array to base64', () => {
-    expect(arrayToMd5Base64(new Uint8Array([8, 8]))).toBe('w+7NCDwPSCf1JgWbA7deTA==');
+  it('converts a typed array to base64', async () => {
+    const actual = await arrayToMd5Base64(new Uint8Array([8, 8]));
+    const expected = 'w+7NCDwPSCf1JgWbA7deTA==';
+
+    expect(actual).toBe(expected);
   });
 });
 
 describe('base64ToBlob', () => {
-  it('encodes Base64 data URI to blob', () => {
-    const base64 = arrayToBase64(new Uint8Array([1, 2, 3]));
+  it('encodes Base64 data URI to blob', async () => {
+    const base64 = await arrayToBase64(new Uint8Array([1, 2, 3]));
     const data_uri = `data:application/octet-binary;base64,${base64}`;
-    const blob = base64ToBlob(data_uri);
+    const blob = await base64ToBlob(data_uri);
 
     expect(blob.type).toBe('application/octet-binary');
   });
@@ -158,8 +161,8 @@ describe('koArrayUnshiftAll', () => {
 });
 
 describe('base64ToArray', () => {
-  it('can convert a gif', () => {
-    const actual = base64ToArray(
+  it('can convert a gif', async () => {
+    const actual = await base64ToArray(
       'data:image/gif;base64,R0lGODlhLQAwAPQHAKQAAPz4+AQA4AQoKASA+Kx4WOSoiHwAAPwAALQAAPz8/NyYIExoaCxISMzo6Hx4eMzMzAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH/C05FVFNDQVBFMi4wAwEAAAAh+QQEDwD/ACwAAAAALQAwAAAE/1DJSau9OOvNu/9gKI5kaZ5oqq5s605DHL9XjNz3QMMD7us02w1ABAQCAGCrNwQcnsfAQbliEmVYLMsq9Hmpp8G1ly2DTYOpAWswHNuBQeFcihXasbZ7gJfT63drfHCDdn8kcoGDa3qCLnaNMgWTcy9xgX1aNHFyepqbYomUh1UJAj87FAOmBDikdTMSAwICra4VMnWyQDG0BL8EVLGvGUrGvsCxCsaIuzy0Ab/LPLKwaQcKT7PIwdjayidPU9vIMU9BtOnAtLy5KeTcAr1JMgzExTLp3AML/TH9Cwg0cAdiAIOD5IAFWyDO3JMFAxpIvAdDosVt66411BjjoL0PEVcfDMxXi52MbxsvghQ5ckCcdBEvHnDgYADNMisdtHQpo8EDjw0cTBFX81OHAQ+wxAlQUyRLjd+WgeNwRGnVGEFbijuAw0SUABSqJpXxY+oKTjOMplq7IwIAIfkEBQoAEQAsAAAIACwAJwAABf+gIo5kOQ4oaq5su6JIHA9ubSuwrNN3Tw46gDAQACB4vhsQIQQcDkQiAJl0LZ2pbLZaA2J14Bm3hZpqz6rxy5A1GIhuIqpAVePc7AE+oGfzDXR2PwVuKHt9A3+BdmkDBYR9bHiSgSlcPCpzhXOPdJmYVUiYkWiVJ6EiaTiOhJuOo6mXKAcicpydiwoHlnZPJwIEO4kivoIjvnzAOgQ8xcbHTwMJAssDT7TPLwPABN3M2V3c3nXgJdsCEN0Q5OUn297f7SvJ4uzyOAL53bz3CvT54uLdO8cNoL4zas4A9JYPhYB3KBgwsGelgUSJ21B0W8DRIccFzBo0oEhGpEmHwBZmXHN4bYGWUA+06LsWbdZKkyOTDHCAxhrNXT6jXZyoM2YKnEFrOljKEymJACOgmhgwEsWDodaY8ky6lV+tLikcIHVAU8jKrqp6RBnAoCoKnjTBrEpbS2oXtzmEeWVBRMkWhP2+lgsBACH5BAUKAA8ALAAABgAsACkAAAT/UMlJKx142M07x0iIYF5pKqCokmc7DSoQBMDqtjAC7PO816ObCQbIGDM1jdAzKKqeo+KS2Twei8pp5mXIGAIDQzfQxXRfrJKSFBa3wW5yV3xmZTtZzaDgFs/8cm0Fei9DEnYFfH10bQaJa2snGQdoZXuJg2ZpB1s3B58KYHxWZoMSn5RTp5+io16PAaiqFqwYmJgasrMbnwMCpKC7HWACBCoEd8IfCQLHycoWA8zO0FTFBNjI1UzX2c/bLwICAdhg4B++2drnG77d3+fE4tjw4O7i4mnsoff4xfXK+vn7B+0IGAIDB2o7ImQAg4cPByBcQPGXL4oL/kGMeGNAg48fXS+iWoBhwchfIEN2tCIAVa8BLg9YZOgCQ0pfMTHERAlS3xCHEDE4GDpUKFEHGDb6VOOxJwAHLnWiclDkZr0A7Y4gQIpKKicHI2gOi8YQChQUYlfaIWXkUKd9cONGAAAh+QQFCgALACwBAAYAKwAmAAAE/1DJSWsdeNjN+8ZIiGBeaYJiSposNaRAEABq274IoMuyTo+2Uy5DzNA0Qc8AgEupmEnlslhkIqOZycCQMQS23AAXw9WulBISmGvwggdidluzunKQi4ViUJi3ZX9xYAV5V3YfaUh8fX5tcgYFBYqKJxgHZmOLkV1nB1k2B6EKX31UZJISoZdRqaGkpV2bAaqsFqqvkZsaorUcoaYCA7y9HF8EKQTBxCfHIgIJh8sWA80hz9HSLgTb28HY2Wnc3d/ge3l5AsrlH+Le6+zd6u8Uxsnp5OAY6fvy89T8+84JHEiwoMEF9gCmO8iwoYKGECNKnEixosWLGDNq3HgxAMeOEws+SgzQwaNIgjIiAAAh+QQFCgARACwCAAYAKgAoAAAF/6AijmRpnmiqrmzLDjDszueA3LdM0zbu67uVDRAIAI6/oJBYDBwOR0BOiYpZrdApldTzeQfZwZZ7LcMAwO2gACsaDG6DVb4KvArywOA9CLzle3xjCmt5gX1/MG9sVDF6eIF8iQYFjIRiM5gyMZWVMYubmpkjfWtmiaIimC2aYo+fi2yrOqusMAcij52eaQcxVE+5MD4EAqvBg8F6BMTGIsiDCk++zDgCCWDQ0aQE3d3Gtdtc3t/h4sIQ3RACzucmA+Tg7iXL3+3zqjD29/Pw3uwAzSkpUwyggH0CeTBgoM8YOHb/2JXZMaBBA3gLMoLLuKAbDGMLF17MZGXBNHDTOl5KrGjRYsJ3LS9O83VrZsErDxLa4RKS4cyaP804eFmCpUsHSIdmm2b0YoycKHaSsuIgaNKqA3rmhDGSXg2qS4/MHBpTaRoSRehZUeDlp9mKUJVIveIFwZWu5yZeaRECACH5BAUPABAALAIACAAqACcAAAT/UMlJq7046807HyDojdeAnKdIriaKqusHBAFgA+8Qb8NBB4eg7bXDhI7HIUJXpLRcUBBu2ZwgryYpgFkdFAYBg4EmPhp63KYXVA6XB+JvuriGn91n+7c6CbDFZ4B6e3wSXgWIIYAGcoV9V4uEjo+KcSABkxV+iJwDCXOZCn4uAp+hFk8EpaA7IRVPCKoCXK4shmkDBLqyKr22hla5uwKzVsYkTDBgugHEyskxIUEKB8Kys9NBtU3awsTOPdNqtQPEw9/FXQxJs+Xn36wdIQ0EC/Yg9gvW6O0wHw0ABywIUi3cAX27rg1gwDDeK4brDIIgqE3AuQEAMzq0olFiuCPmTMCBaPCgwcZbRxw4GKCyWkaT8PyMJHlSARIHBHs4aACxZAiZIx08qGlTxESKGHnSpAHmyNAYKJAGNfnM34gQLpyCwXTqCFCik34UiQAAIfkEBQoAEQAsAgAIACoAJwAABf+gIo5kSQ4oaq5saw5IHKtuXcNyTtv8CAOBAGCo6xkHwGDgcBgCZkZbajptQqMsXG47sA6wWaoYBdiBfQVU0GBYG6bvWkBaeAcG7EGA/cbnzyd1en56fChsaYApd4J8b4YGBYkKZlIiKimSkimImF+URz6MY4afn6A9pl+jh4hppzSnPCkHIoyam2YHKYBMtig5BAKnvoAjvncEwcMixcbHTAPKMgIJXc7PJdIE3MKV2drd3MzgLHcQ3BAC5OUr2+Pf7QrJ4+zyPij19vfvwuvrsoyJ8fdPX0AwAxgwyDds2IB13f6JwTKgQQNpCzI6zLiAG4phChVePDJlAZMDDk9kdgRY0aLFg1lcXjy5CwXNA/6oPIA5T1vIhTRt3hwzwAHPFzKLOlgq9GTLlyl2mtM2xUFQpUt3/dyJYmSJOS+qXmsCgKZRmUZ5rQjydYqCLUHTdpV6BiylKVsQUPEqbyKVe/JCAAAh+QQFCgAPACwCAAYAKgAoAAAE/1DJSSsdeNjNu8VIiGBeWYJiSprsNKRAEABqy74IoMuyTo+2Uy5DzNA0wc4AgEupmEnlslhkIpMZlyFjCAwM28AWs3WtlBLSF7z2ssVbcHl13Vw1gwIbLOPD1wV4Lh5IdAV6e3JrBoeFhScYB2ZjeYeBZGcHWS0HnQpeelRkgRKdklEKpqChXI0BpqgVqpWWl6mnsRadogIDnrkcXgQpBL3AJ8MiAgl1xx/JIcvNzhcE1ta909Rp19ja2woDAdYBAsbgz9fZ6OnF5+wTwu7v8OED5vj06APz+d/H/PIJ/NeiSLh+AgUQwEPExgAGECEGXEAxmwCKCxQ+jMiA4IUGIGJB3ltgagEGkp0yDggpsiAVAaZ2+YqZzeCNlSHvxdQ001QvlmcgccTgoGhRokYdYBhaJ4AUoAAcxIxkygEToM2ccqCCQKkpqpocjLBJQasFLwadqEVgr+FZsxXcirLpth6qCAAh+QQFCgALACwBAAYAKwAmAAAE/1DJSesceNjN+8ZIiGBeaYJiSposNaRAEABq274IoMuyTo+2Uy5DzNA0Qc8AgEupmEnlslhkIqOZiyFjCAwM28AWs72slBLSF7z2ssVbcHl15VwHi0WBDZb14WsFGnlpJUh0BXt8cmsGiYeHJxgHZmMDiY9kZwdZNgefCl57VGSCEp+UUaefoqNcjwGoqhasGJiYGrKzG58DAqSgux1eAgQpBHXCdgkCx8nKFgPMztBSxQTYyNVK19nP2xcCAnl53+AKGN3a5x/i3uwWxO7r8OHi92fw8vfu5P7/AAMKXMCvIIGBCBMGSMiwocOHECNKnEixosWLExVgzChh4caGFAcCWPgYUEIEACH5BAUKABEALAAABgAsACkAAAX/oCKOZGmeaKqubOsqQxy/tBkjOD7U9Z3/O15r8AMYAwEAIihMERFGwOGARAKYTRtOKut2syci90fWgUuxq3c9O48Ghq7BgJwjYwVsFj6Pzel8AwFweW4wBX18gH2DBoV7QQMFiIqKcY47MjyRmZKJkpN5M216LEycf2yFpz0ibTCgqXicrpsxByJ3eKGTTAeaWVNvAgRAgiLChsKDxD8EQcmGClO/CQLOA9TSNgPEBN/P207e4KXirgICEN8Q5ucx5OHnJszk7u/p3sDzCvX54PLmdUv3LR/BNU3W/CsoAF63ZwMYMLjnpIFEid1ifFvAER7HBc8aNKCIYoDIk/CIZi2gBo/aAi89HnghSG2KjJomUdIY4IBNtpq/ftq8OHGnTBknRwKN4aBpz6RYAoyQamNkjAdEszntKfQA1325VnRxANVBTSMsv75yUSWiVaZdycBam4uq2Lc+jIFFgWTIF4T8wm4LAQA7',
     );
     /* eslint-disable comma-spacing */
@@ -169,11 +172,11 @@ describe('base64ToArray', () => {
     expect(actual).toEqual(expected);
   });
 
-  it('can convert array buffer back and forth', () => {
+  it('can convert array buffer back and forth', async () => {
     const buffer = new ArrayBuffer(8);
     const array = new Uint8Array(buffer);
-    const bufferEncoded = arrayToBase64(array);
-    const bufferDecoded = base64ToArray(bufferEncoded);
+    const bufferEncoded = await arrayToBase64(array);
+    const bufferDecoded = await base64ToArray(bufferEncoded);
 
     expect(bufferDecoded).toEqual(array);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1316,9 +1316,9 @@
     "@types/libsodium-wrappers" "*"
 
 "@types/libsodium-wrappers@*":
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.6.tgz#0702395d73de9556dbde05c91ba4925eb64f5aee"
-  integrity sha512-CrTY7kY5s7dxdioA2N5x6iTNgRllWGENzGCqQD/aazsakxKB4NYTJdh83ERCScev3Po5FRnVHj2TUkc6sD1oqw==
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.7.tgz#cdb25e85458612ec80f0157c3815fac187d0b6d2"
+  integrity sha512-Li91pVKcLvQJK3ZolwCPo85oxf2gKBCApgnesRxYg4OVYchLXcJB2eivX8S87vfQVv6ZRnyCO1lLDosZGJfpRg==
 
 "@types/linkify-it@*", "@types/linkify-it@2.1.0":
   version "2.1.0"


### PR DESCRIPTION
This PR will
- use `libsodium` to convert arrays to base64 and vice-versa
- make the conversion functions asynchronous so they don't block the whole I/O
  - thus refactoring some normal functions to `async`
- refactor some promise-returning functions to `async` to make them more readable
- rename the synchronous version of `base64ToArray()` to `base64ToArraySync()` since we need it in the `StorageSchemata`

Best viewed [without whitespace changes](https://github.com/wireapp/wire-webapp/pull/7740/files?w=1).