### PR TITLE
chore(deps): bump @wireapp/avs from 5.1.40 to 5.3.44

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@wireapp/antiscroll-2": "1.0.2",
-    "@wireapp/avs": "5.1.40",
+    "@wireapp/avs": "5.1.44",
     "@wireapp/commons": "2.2.23",
     "@wireapp/core": "14.4.2",
     "@wireapp/protocol-messaging": "1.24.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@wireapp/antiscroll-2": "1.0.2",
-    "@wireapp/avs": "5.1.44",
+    "@wireapp/avs": "5.3.44",
     "@wireapp/commons": "2.2.23",
     "@wireapp/core": "14.4.2",
     "@wireapp/protocol-messaging": "1.24.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1799,10 +1799,10 @@
     tough-cookie "3.0.1"
     ws "7.2.0"
 
-"@wireapp/avs@5.1.40":
-  version "5.1.40"
-  resolved "https://registry.yarnpkg.com/@wireapp/avs/-/avs-5.1.40.tgz#4e0d2eb48388891ec600af433b573bb0ec6cdfc8"
-  integrity sha512-z1PHXzv3x/KMrZ7SwSosT/UQNYARSpdfU3zWnQdh1ZofSjtuDDHcWFZ7+LxuBtfrgNFXh7M29LACscvgICs7gg==
+"@wireapp/avs@5.1.44":
+  version "5.3.44"
+  resolved "https://registry.yarnpkg.com/@wireapp/avs/-/avs-5.3.44.tgz#ac933ac0a2a9ffc4f3681a5a74768dc3da2833fc"
+  integrity sha512-swkiBz8/s0wVeFxxsKqqW9mVodju4WBqrAoF+3DkMrl8n5EKYbs0HocXV5enVajUiJj8lbo1/oeJIWQFZfKpAw==
 
 "@wireapp/cbor@4.3.23":
   version "4.3.23"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1799,7 +1799,7 @@
     tough-cookie "3.0.1"
     ws "7.2.0"
 
-"@wireapp/avs@5.1.44":
+"@wireapp/avs@5.3.44":
   version "5.3.44"
   resolved "https://registry.yarnpkg.com/@wireapp/avs/-/avs-5.3.44.tgz#ac933ac0a2a9ffc4f3681a5a74768dc3da2833fc"
   integrity sha512-swkiBz8/s0wVeFxxsKqqW9mVodju4WBqrAoF+3DkMrl8n5EKYbs0HocXV5enVajUiJj8lbo1/oeJIWQFZfKpAw==


### PR DESCRIPTION
## Type of change

Update to AVS 5.3.44.
