### PR TITLE
runfix: Throw error if client type is unspecified

### DIFF
--- a/src/page/template/content/preferences-account.htm
+++ b/src/page/template/content/preferences-account.htm
@@ -147,7 +147,7 @@
     </section>
 
     <!-- ko if: isActivatedAccount() -->
-      <!-- ko if: !isTemporaryAndNonPersistent() -->
+      <!-- ko if: !isTemporaryAndNonPersistent -->
         <section class="preferences-section preferences-section-conversation-history">
           <hr class="preferences-separator">
           <header class="preferences-header" data-bind="text: t('preferencesOptionsBackupHeader')"></header>

--- a/src/script/cryptography/CryptographyRepository.js
+++ b/src/script/cryptography/CryptographyRepository.js
@@ -73,7 +73,7 @@ export class CryptographyRepository {
 
   /**
    * Initializes the repository by creating a new Cryptobox.
-   * @param {Dexie} [database] - Dexie instance
+   * @param {Dexie} [database] - Database instance
    * @returns {Promise} Resolves after initialization
    */
   loadCryptobox(database) {

--- a/src/script/cryptography/CryptographyRepository.js
+++ b/src/script/cryptography/CryptographyRepository.js
@@ -22,10 +22,9 @@ import {IndexedDBEngine} from '@wireapp/store-engine-dexie';
 import {Cryptobox, version as cryptoboxVersion} from '@wireapp/cryptobox';
 import {errors as ProteusErrors} from '@wireapp/proteus';
 import {GenericMessage} from '@wireapp/protocol-messaging';
-
+import {SQLeetEngine} from '@wireapp/store-engine-sqleet';
 import {getLogger} from 'Util/Logger';
-import {loadValue} from 'Util/StorageUtil';
-import {arrayToBase64, base64ToArray, isTemporaryClientAndNonPersistent, zeroPadding} from 'Util/util';
+import {arrayToBase64, base64ToArray, zeroPadding} from 'Util/util';
 
 import {CryptographyMapper} from './CryptographyMapper';
 import {CryptographyService} from './CryptographyService';
@@ -35,7 +34,6 @@ import {WebAppEvents} from '../event/WebApp';
 import {EventName} from '../tracking/EventName';
 import {ClientEntity} from '../client/ClientEntity';
 import {BackendClientError} from '../error/BackendClientError';
-import {StorageKey} from '../storage/StorageKey';
 import {StorageService} from '../storage/StorageService';
 
 export class CryptographyRepository {
@@ -66,7 +64,7 @@ export class CryptographyRepository {
 
   /**
    * Initializes the repository by loading an existing Cryptobox.
-   * @param {Dexie | MemoryStore} database - Dexie or MemoryStore
+   * @param {Dexie | SQLeetEngine} database - Database instance
    * @param {string} [databaseName] - The database name
    * @returns {Promise} Resolves after initialization
    */
@@ -103,14 +101,14 @@ export class CryptographyRepository {
    * Initialize the repository.
    *
    * @private
-   * @param {Dexie | MemoryStore} database - Dexie instance or MemoryStore
+   * @param {Dexie | SQLeetEngine} database - Database instance
    * @param {string} [databaseName] - The database name
    * @returns {Promise} Resolves after initialization
    */
   async _init(database, databaseName = database.name) {
     let storeEngine;
 
-    if (isTemporaryClientAndNonPersistent(loadValue(StorageKey.AUTH.PERSIST))) {
+    if (database instanceof SQLeetEngine) {
       this.logger.info(`Initializing Cryptobox with encrypted database '${databaseName}'...`);
       storeEngine = await StorageService.getUnitializedEngine();
     } else {

--- a/src/script/event/NotificationService.ts
+++ b/src/script/event/NotificationService.ts
@@ -195,7 +195,8 @@ export class NotificationService {
     let message: EventRecord;
 
     if (this.storageService.isTemporaryAndNonPersistent) {
-      message = Object.values(this.storageService.objectDb.events).filter(event => event.id === messageId)[0];
+      const events = await this.storageService.getAll<EventRecord>(StorageSchemata.OBJECT_STORE.EVENTS);
+      message = Object.values(events).filter(event => event.id === messageId)[0];
     } else {
       message = await this.storageService.db
         .table(StorageSchemata.OBJECT_STORE.EVENTS)

--- a/src/script/main/app.js
+++ b/src/script/main/app.js
@@ -115,6 +115,22 @@ import {GiphyService} from '../extension/GiphyService';
 import {PermissionRepository} from '../permission/PermissionRepository';
 import {loadValue} from 'Util/StorageUtil';
 
+function doRedirect(signOutReason) {
+  let url = `/auth/${location.search}`;
+  const isImmediateSignOutReason = App.CONFIG.SIGN_OUT_REASONS.IMMEDIATE.includes(signOutReason);
+  if (isImmediateSignOutReason) {
+    url = appendParameter(url, `${URLParameter.REASON}=${signOutReason}`);
+  }
+
+  const redirectToLogin = signOutReason !== SIGN_OUT_REASON.NOT_SIGNED_IN;
+  if (redirectToLogin) {
+    url = `${url}#login`;
+  }
+
+  Dexie.delete('/sqleet');
+  window.location.replace(url);
+}
+
 class App {
   static get CONFIG() {
     return {
@@ -355,10 +371,7 @@ class App {
         telemetry.time_step(AppInitTimingsStep.VALIDATED_CLIENT);
         telemetry.add_statistic(AppInitStatisticsValue.CLIENT_TYPE, clientEntity.type);
 
-        return this.repository.cryptography.loadCryptobox(
-          this.service.storage.db || this.service.storage.objectDb,
-          this.service.storage.dbName,
-        );
+        return this.repository.cryptography.loadCryptobox(this.service.storage.db);
       })
       .then(() => {
         loadingView.updateProgress(10);
@@ -848,7 +861,7 @@ class App {
 
   /**
    * Redirect to the login page after internet connectivity has been verified.
-   * @param {SIGN_OUT_REASON} signOutReason - Redirect triggered by session expiration
+   * @param {SIGN_OUT_REASON} signOutReason - Redirect triggered by session expiration_redirectToLogin
    * @returns {undefined} No return value
    */
   _redirectToLogin(signOutReason) {
@@ -862,19 +875,7 @@ class App {
         return window.location.replace(url);
       }
 
-      let url = `/auth/${location.search}`;
-      const isImmediateSignOutReason = App.CONFIG.SIGN_OUT_REASONS.IMMEDIATE.includes(signOutReason);
-      if (isImmediateSignOutReason) {
-        url = appendParameter(url, `${URLParameter.REASON}=${signOutReason}`);
-      }
-
-      const redirectToLogin = signOutReason !== SIGN_OUT_REASON.NOT_SIGNED_IN;
-      if (redirectToLogin) {
-        url = `${url}#login`;
-      }
-
-      Dexie.delete('/sqleet');
-      window.location.replace(url);
+      doRedirect(signOutReason);
     });
   }
 
@@ -930,7 +931,10 @@ $(async () => {
       restUrl: Config.BACKEND_REST,
       webSocketUrl: Config.BACKEND_WS,
     });
-    if (isTemporaryClientAndNonPersistent(loadValue(StorageKey.AUTH.PERSIST))) {
+    const clientType = loadValue(StorageKey.AUTH.PERSIST);
+    if (clientType === undefined) {
+      doRedirect(SIGN_OUT_REASON.USER_REQUESTED);
+    } else if (isTemporaryClientAndNonPersistent(clientType)) {
       const engine = await StorageService.getUnitializedEngine();
       wire.app = new App(backendClient, appContainer, engine);
     } else {

--- a/src/script/main/app.js
+++ b/src/script/main/app.js
@@ -861,7 +861,7 @@ class App {
 
   /**
    * Redirect to the login page after internet connectivity has been verified.
-   * @param {SIGN_OUT_REASON} signOutReason - Redirect triggered by session expiration_redirectToLogin
+   * @param {SIGN_OUT_REASON} signOutReason - Redirect triggered by session expiration
    * @returns {undefined} No return value
    */
   _redirectToLogin(signOutReason) {

--- a/src/script/storage/StorageService.ts
+++ b/src/script/storage/StorageService.ts
@@ -21,7 +21,6 @@ import {CRUDEngine, error as StoreEngineError} from '@wireapp/store-engine';
 import {IndexedDBEngine} from '@wireapp/store-engine-dexie';
 
 import {SQLeetEngine} from '@wireapp/store-engine-sqleet';
-import {MemoryStore} from '@wireapp/store-engine/dist/commonjs/engine';
 import Dexie from 'dexie';
 import {getEphemeralValue} from 'Util/ephemeralValueStore';
 
@@ -51,7 +50,6 @@ enum DEXIE_CRUD_EVENT {
 
 export class StorageService {
   public db?: Dexie & DexieObservable;
-  public objectDb?: MemoryStore;
   private readonly hasHookSupport: boolean;
   private readonly dbListeners: DatabaseListener[];
   private readonly engine: CRUDEngine;

--- a/src/script/util/util.ts
+++ b/src/script/util/util.ts
@@ -24,28 +24,30 @@ import sodium from 'libsodium-wrappers-sumo';
 import {formatE164} from 'phoneformat.js';
 import UUID from 'uuidjs';
 
-import {Environment} from './Environment';
-import {loadValue} from './StorageUtil';
-
 import {QUERY_KEY} from '../auth/route';
 import * as URLUtil from '../auth/util/urlUtil';
 import {Config} from '../Config';
 import {Conversation} from '../entity/Conversation';
 import {StorageKey} from '../storage/StorageKey';
 
-export const isTemporaryClientAndNonPersistent = (persist: boolean = false): boolean => {
+import {Environment} from './Environment';
+import {loadValue} from './StorageUtil';
+
+export const isTemporaryClientAndNonPersistent = (persist: boolean): boolean => {
+  if (persist === undefined) {
+    throw new Error('Type of client is unspecified.');
+  }
+
   const isNonPersistentByUrl = URLUtil.getURLParameter(QUERY_KEY.PERSIST_TEMPORARY_CLIENTS) === 'false';
   const isNonPersistentByServerConfig = Config.FEATURE?.PERSIST_TEMPORARY_CLIENTS === false;
   const isNonPersistent = isNonPersistentByUrl || isNonPersistentByServerConfig;
 
-  const isTemporaryByLocalStorage = loadValue(StorageKey.AUTH.PERSIST) === false;
-  const isTemporaryByClientSelection = persist === false;
-  const isTemporary = isTemporaryByLocalStorage || isTemporaryByClientSelection;
+  const isTemporary = persist === false;
   return isTemporary && isNonPersistent;
 };
 
 export const checkIndexedDb = (): Promise<void> => {
-  if (isTemporaryClientAndNonPersistent()) {
+  if (isTemporaryClientAndNonPersistent(loadValue(StorageKey.AUTH.PERSIST))) {
     return Promise.resolve();
   }
 

--- a/src/script/view_model/AuthViewModel.js
+++ b/src/script/view_model/AuthViewModel.js
@@ -1517,7 +1517,7 @@ class AuthViewModel {
     this.logger.info('Logging in');
 
     this._get_self_user()
-      .then(() => this.cryptography_repository.loadCryptobox(this.storageService.db || this.storageService.dbObject))
+      .then(() => this.cryptography_repository.loadCryptobox(this.storageService.db || this.storageService))
       .then(() => this.client_repository.getValidLocalClient())
       .catch(error => {
         const user_missing_email = error.type === z.error.UserError.TYPE.USER_MISSING_EMAIL;
@@ -1607,7 +1607,7 @@ class AuthViewModel {
 
   _register_client(autoLogin) {
     return this.cryptography_repository
-      .createCryptobox(this.storageService.db || this.storageService.objectDb, this.storageService.dbName)
+      .createCryptobox(this.storageService.db)
       .then(() => this.client_repository.registerClient(autoLogin ? undefined : this.password()))
       .then(clientObservable => {
         this.event_repository.currentClient = clientObservable;

--- a/src/script/view_model/content/PreferencesAccountViewModel.js
+++ b/src/script/view_model/content/PreferencesAccountViewModel.js
@@ -49,6 +49,8 @@ import {ContentViewModel} from '../ContentViewModel';
 
 import 'Components/availabilityState';
 import {isAppLockEnabled} from './AppLockViewModel';
+import {loadValue} from 'Util/StorageUtil';
+import {StorageKey} from '../../storage';
 
 window.z = window.z || {};
 window.z.viewModel = z.viewModel || {};
@@ -133,7 +135,7 @@ z.viewModel.content.PreferencesAccountViewModel = class PreferencesAccountViewMo
     this.manageTeamUrl = getManageTeamUrl('client_settings');
     this.createTeamUrl = getCreateTeamUrl('client');
 
-    this.isTemporaryAndNonPersistent = isTemporaryClientAndNonPersistent;
+    this.isTemporaryAndNonPersistent = isTemporaryClientAndNonPersistent(loadValue(StorageKey.AUTH.PERSIST));
     this.isConsentCheckEnabled = () => Config.FEATURE.CHECK_CONSENT;
     this.canEditProfile = user => user.managedBy() === User.CONFIG.MANAGED_BY.WIRE;
 


### PR DESCRIPTION
Although `isTemporaryClientAndNonPersistent` is written in TypeScript there might be some JavaScript code calling that method with an `undefined` value, so I am throwing an error now in this particular case.