### PR TITLE
runfix: Don't force the role on the temporary guest

### DIFF
--- a/src/script/conversation/ConversationRoleRepository.ts
+++ b/src/script/conversation/ConversationRoleRepository.ts
@@ -114,9 +114,6 @@ export class ConversationRoleRepository {
   };
 
   getUserRole = (conversation: Conversation, userEntity: User): string => {
-    if (userEntity.isTemporaryGuest()) {
-      return DefaultRole.WIRE_MEMBER;
-    }
     return conversation.roles()[userEntity.id];
   };
 


### PR DESCRIPTION
This was in place to correct a bug on the backend. This is now fixed and temporary guest users should now have the correct role of a member.