### PR TITLE
chore: Enable copy-config without git

### DIFF
--- a/.copyconfigrc.js
+++ b/.copyconfigrc.js
@@ -19,9 +19,12 @@ const selectConfiguration = () => {
     console.log(`Selecting configuration "${distribution}" (reason: custom distribution)`);
     return distribution;
   }
-  const currentBranch = execSync('git rev-parse --abbrev-ref HEAD')
-    .toString()
-    .trim();
+  let currentBranch = '';
+  try {
+    currentBranch = execSync('git rev-parse --abbrev-ref HEAD')
+      .toString()
+      .trim();
+  } catch (error) {}
   switch (currentBranch) {
     case 'master':
     case 'staging': {
@@ -33,9 +36,12 @@ const selectConfiguration = () => {
       return 'staging';
     }
     default: {
-      const isTaggedCommit = !!execSync('git tag -l --points-at HEAD')
-        .toString()
-        .trim();
+      let isTaggedCommit = false;
+      try {
+        isTaggedCommit = !!execSync('git tag -l --points-at HEAD')
+          .toString()
+          .trim();
+      } catch (error) {}
       if (isTaggedCommit) {
         console.log('Selecting configuration "master" (reason: tagged commit)');
         return 'master';

--- a/bin/push_docker.js
+++ b/bin/push_docker.js
@@ -24,7 +24,7 @@ const appConfigPkg = require('../app-config/package.json');
 const pkg = require('../package.json');
 const {execSync} = require('child_process');
 
-const currentBranch = execSync('git rev-parse --abbrev-ref HEAD')
+const currentBranch = execSync('git rev-parse HEAD')
   .toString()
   .trim();
 

--- a/server/bin/create_commit_sha_file.js
+++ b/server/bin/create_commit_sha_file.js
@@ -24,5 +24,7 @@ const path = require('path');
 const {execSync} = require('child_process');
 
 const distFolder = 'dist';
-const commitSha = execSync('git rev-parse HEAD').toString();
+const commitSha = execSync('git rev-parse HEAD')
+  .toString()
+  .trim();
 fs.outputFileSync(path.resolve(distFolder, 'commit'), commitSha);


### PR DESCRIPTION
The configuration file for `copy-config` tries to read the current branch via git. If the directory is not a git repository (e.g. downloaded as an archive), the command fails and the configuration files are not downloaded.

This fixes https://github.com/wireapp/wire-webapp/issues/7985.