### PR TITLE
Rephrase error message about local browser storage not being available

### DIFF
--- a/src/script/strings.ts
+++ b/src/script/strings.ts
@@ -293,7 +293,7 @@ export const unsupportedStrings = defineMessages({
     id: 'unsupported.headlineCookies',
   },
   headlineIndexedDb: {
-    defaultMessage: 'You are in private mode',
+    defaultMessage: 'Your browser is in private mode',
     id: 'unsupported.headlineIndexedDb',
   },
   subheadBrowser: {


### PR DESCRIPTION
## Type of change

error message phrasing

## Reason

I just ran into the error message after deploying the wire-server
in demo mode for learning purposes. I found the phrasing a bit
misleading, since it could have referred to a broken server
installation instead. I admit, it't a very edgy case, but
I guess a bit more explicit phasing doesnt do any harm.

## NOTE

in case of acceptance, there is still some work to do,
because the i18n is missing