### PR TITLE
Add JoyPixels to the list of local emoji fonts

### DIFF
--- a/src/style/common/variables.less
+++ b/src/style/common/variables.less
@@ -23,7 +23,7 @@
 @font-face {
   font-family: emoji;
   src: local('Apple Color Emoji'), local('Segoe UI Emoji'), local('Android Emoji'), local('Noto Color Emoji'),
-    local('JoyPixels'), local('Emoji One'), local('Twemoji');
+    local('JoyPixels'), local('Twemoji');
 
   // Define a whitelist of glyphs to render with emoji font according to standard.
   // http://unicode.org/Public/emoji/12.1/emoji-data.txt

--- a/src/style/common/variables.less
+++ b/src/style/common/variables.less
@@ -23,7 +23,7 @@
 @font-face {
   font-family: emoji;
   src: local('Apple Color Emoji'), local('Segoe UI Emoji'), local('Android Emoji'), local('Noto Color Emoji'),
-    local('Emoji One'), local('Twemoji');
+    local('JoyPixels'), local('Emoji One'), local('Twemoji');
 
   // Define a whitelist of glyphs to render with emoji font according to standard.
   // http://unicode.org/Public/emoji/12.1/emoji-data.txt


### PR DESCRIPTION
EmojiOne was rebranded to JoyPixels almost a year ago.

To be honest, I would have just removed the `local('Emoji One')`, but I wasn't sure if you prefer to keep it for some legacy reasons?
