### PR TITLE
chore: Directly upload translations

### DIFF
--- a/bin/translations_upload.ts
+++ b/bin/translations_upload.ts
@@ -19,12 +19,6 @@
 
 import {join, resolve} from 'path';
 import {execSync} from 'child_process';
-import readline from 'readline';
-
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout,
-});
 
 const root = resolve(__dirname, '..');
 
@@ -33,10 +27,4 @@ const uploadToCrowdin = (): void => {
   execSync(`crowdin upload sources --identity="${crowdinYaml}"`, {stdio: [0, 1]});
 };
 
-rl.question(
-  '\x1b[41m\x1b[1m\x1b[5m !!! WAIT !!! \x1b[0m \x1b[1mDid you pull and run the project at least once before uploading to Crowdin?\x1b[0m (type "yes")\n',
-  answer => {
-    rl.close();
-    return answer === 'yes' ? uploadToCrowdin() : process.exit();
-  },
-);
+uploadToCrowdin();


### PR DESCRIPTION
The app is build automatically before uploading translations. Thus the extra prompt is not necessary anymore.