### PR TITLE
refactor: Use API client for file uploads

### DIFF
--- a/src/script/assets/AssetService.ts
+++ b/src/script/assets/AssetService.ts
@@ -18,13 +18,13 @@
  */
 
 import {APIClient} from '@wireapp/api-client';
+import {AssetOptions, AssetRetentionPolicy} from '@wireapp/api-client/dist/asset';
 import {Asset, LegalHoldStatus} from '@wireapp/protocol-messaging';
 
 import {arrayToMd5Base64, loadFileBuffer, loadImage} from 'Util/util';
 import {assetV3, legacyAsset} from 'Util/ValidationUtil';
 import {WebWorker} from 'Util/worker';
 
-import {AssetRetentionPolicy} from '../assets/AssetRetentionPolicy';
 import {PROTO_MESSAGE_TYPE} from '../cryptography/ProtoMessageType';
 import {encryptAesAsset} from './AssetCrypto';
 import {BackendClient} from '../service/BackendClient';
@@ -40,11 +40,9 @@ export interface CompressedImage {
   compressedImage: HTMLImageElement;
 }
 
-export interface AssetUploadOptions {
+export interface AssetUploadOptions extends AssetOptions {
   expectsReadConfirmation: boolean;
   legalHoldStatus?: LegalHoldStatus;
-  public: boolean;
-  retention: AssetRetentionPolicy;
 }
 
 export class AssetService {
@@ -66,7 +64,7 @@ export class AssetService {
       this._compressProfileImage(image),
       this._compressImage(image),
     ]);
-    const assetUploadOptions = {
+    const assetUploadOptions: AssetUploadOptions = {
       expectsReadConfirmation: false,
       public: true,
       retention: AssetRetentionPolicy.ETERNAL,

--- a/src/script/assets/AssetService.ts
+++ b/src/script/assets/AssetService.ts
@@ -48,7 +48,7 @@ export interface AssetUploadOptions {
 }
 
 export class AssetService {
-  private readonly apiClient: APIClient;
+  public readonly apiClient: APIClient;
   private readonly backendClient: BackendClient;
 
   constructor(apiClient: APIClient, backendClient: BackendClient) {

--- a/src/script/assets/AssetUploader.ts
+++ b/src/script/assets/AssetUploader.ts
@@ -100,9 +100,7 @@ export class AssetUploader {
     const uploadStatus = this._findUploadStatus(messageId);
     if (uploadStatus) {
       uploadStatus.xhr?.abort();
-      if (uploadStatus.cancelHandler) {
-        uploadStatus.cancelHandler();
-      }
+      uploadStatus.cancelHandler?.();
       this._removeFromQueue(messageId);
     }
   }

--- a/src/script/assets/AssetUploader.ts
+++ b/src/script/assets/AssetUploader.ts
@@ -41,7 +41,7 @@ export class AssetUploader {
     this.assetService = assetService;
   }
 
-  async uploadAssetV2(messageId: string, file: Blob, options: AssetUploadOptions): Promise<Asset> {
+  async uploadFile(messageId: string, file: Blob, options: AssetUploadOptions): Promise<Asset> {
     const bytes = (await loadFileBuffer(file)) as ArrayBuffer;
     const {cipherText, keyBytes, sha256} = await encryptAesAsset(bytes);
     const progressObservable: ko.Observable<number> = ko.observable(0);

--- a/src/script/assets/AssetUploader.ts
+++ b/src/script/assets/AssetUploader.ts
@@ -17,7 +17,6 @@
  *
  */
 
-/* eslint-disable no-unused-expressions */
 import ko from 'knockout';
 import {Asset} from '@wireapp/protocol-messaging';
 import {AssetService, AssetUploadOptions} from './AssetService';
@@ -44,7 +43,7 @@ export class AssetUploader {
   async uploadFile(messageId: string, file: Blob, options: AssetUploadOptions): Promise<Asset> {
     const bytes = (await loadFileBuffer(file)) as ArrayBuffer;
     const {cipherText, keyBytes, sha256} = await encryptAesAsset(bytes);
-    const progressObservable: ko.Observable<number> = ko.observable(0);
+    const progressObservable = ko.observable(0);
     const request = await this.assetService.apiClient.asset.api.postAsset(
       new Uint8Array(cipherText),
       {
@@ -72,7 +71,7 @@ export class AssetUploader {
         });
         return protoAsset;
       })
-      .then((asset: Asset) => {
+      .then(asset => {
         this._removeFromQueue(messageId);
         return asset;
       });
@@ -99,6 +98,8 @@ export class AssetUploader {
   cancelUpload(messageId: string): void {
     const uploadStatus = this._findUploadStatus(messageId);
     if (uploadStatus) {
+      /* eslint-disable no-unused-expressions */
+      /* @see https://github.com/typescript-eslint/typescript-eslint/issues/1138 */
       uploadStatus.xhr?.abort();
       uploadStatus.cancelHandler?.();
       this._removeFromQueue(messageId);

--- a/src/script/conversation/ConversationRepository.js
+++ b/src/script/conversation/ConversationRepository.js
@@ -1882,7 +1882,7 @@ export class ConversationRepository {
 
         const uploadPromise =
           asImage === true
-            ? this.assetUploader.uploadAsset(messageId, file, options, asImage)
+            ? this.assetUploader.uploadAsset(messageId, file, options)
             : this.assetUploader.uploadFile(messageId, file, options);
         return uploadPromise;
       })
@@ -2001,7 +2001,7 @@ export class ConversationRepository {
 
         const messageEntityPromise = this.getMessageInConversationById(conversationEntity, messageId);
         return messageEntityPromise.then(messageEntity => {
-          return this.assetUploader.uploadAsset(messageEntity.id, imageBlob, options).then(uploadedImageAsset => {
+          return this.assetUploader.uploadFile(messageEntity.id, imageBlob, options).then(uploadedImageAsset => {
             const assetPreview = new Asset.Preview(imageBlob.type, imageBlob.size, uploadedImageAsset.uploaded);
             const protoAsset = new Asset({
               [PROTO_MESSAGE_TYPE.ASSET_PREVIEW]: assetPreview,

--- a/src/script/conversation/ConversationRepository.js
+++ b/src/script/conversation/ConversationRepository.js
@@ -39,6 +39,7 @@ import {
 } from '@wireapp/protocol-messaging';
 import {flatten} from 'underscore';
 import {ConnectionStatus} from '@wireapp/api-client/dist/connection';
+import {RequestCancellationError} from '@wireapp/api-client/dist/user';
 
 import {getLogger} from 'Util/Logger';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
@@ -1882,7 +1883,7 @@ export class ConversationRepository {
         const uploadPromise =
           asImage === true
             ? this.assetUploader.uploadAsset(messageId, file, options, asImage)
-            : this.assetUploader.uploadAssetV2(messageId, file, options);
+            : this.assetUploader.uploadFile(messageId, file, options);
         return uploadPromise;
       })
       .then(asset => {
@@ -3034,6 +3035,8 @@ export class ConversationRepository {
     } catch (error) {
       if (this._isUserCancellationError(error)) {
         throw error;
+      } else if (error instanceof RequestCancellationError) {
+        return;
       }
       this.logger.error(`Failed to upload asset for conversation '${conversationEntity.id}': ${error.message}`, error);
       const messageEntity = await this.getMessageInConversationById(conversationEntity, messageId);

--- a/src/script/conversation/ConversationRepository.js
+++ b/src/script/conversation/ConversationRepository.js
@@ -1879,7 +1879,10 @@ export class ConversationRepository {
           retention,
         };
 
-        const uploadPromise = this.assetUploader.uploadAsset(messageId, file, options, asImage);
+        const uploadPromise =
+          asImage === true
+            ? this.assetUploader.uploadAsset(messageId, file, options, asImage)
+            : this.assetUploader.uploadAssetV2(messageId, file, options);
         return uploadPromise;
       })
       .then(asset => {

--- a/test/unit_tests/assets/AssetUploaderSpec.js
+++ b/test/unit_tests/assets/AssetUploaderSpec.js
@@ -33,12 +33,6 @@ describe('AssetsUploader', () => {
   const assetUploader = new AssetUploader(
     new AssetService(container.resolve(APIClientSingleton), container.resolve(BackendClient)),
   );
-  it('starts uploading when given an asset message', () => {
-    spyOn(assetUploader.assetService, 'uploadAsset').and.returnValue(Promise.resolve());
-    assetUploader.uploadAsset(messageId, file, options);
-
-    expect(assetUploader.assetService.uploadAsset).toHaveBeenCalledWith(file, options, jasmine.any(Function));
-  });
 
   it('keeps track of current uploads', () => {
     const xhr = {upload: {}};


### PR DESCRIPTION
We will be slowly phasing out the `AssetService`. As a first step we will replace file uploads (audio, video, pdf, zip, ...) with a version from API client. 

Next PRs:
- Adjust legacy file upload tests
- Remove legacy file upload
- Replace image upload
- Adjust legacy image upload tests
- Remove legacy image upload code