### PR TITLE
chore: Remove Jasmine ESLint plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,7 @@
   "env": {
     "jasmine": true
   },
-  "extends": ["@wireapp/eslint-config", "plugin:jasmine/recommended"],
+  "extends": ["@wireapp/eslint-config"],
   "globals": {
     "$": true,
     "_": true,
@@ -65,13 +65,8 @@
       }
     }
   ],
-  "plugins": ["jasmine"],
   "rules": {
     "id-length": "off",
-    "jasmine/no-expect-in-setup-teardown": "off",
-    "jasmine/no-spec-dupes": "off",
-    "jasmine/no-suite-dupes": "off",
-    "jasmine/prefer-toHaveBeenCalledWith": "off",
     "no-magic-numbers": "off"
   }
 }

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "eslint-config-prettier": "6.10.1",
     "eslint-plugin-babel": "5.3.0",
     "eslint-plugin-import": "2.20.2",
-    "eslint-plugin-jasmine": "4.1.1",
     "eslint-plugin-jsdoc": "24.0.0",
     "eslint-plugin-no-unsanitized": "3.0.2",
     "eslint-plugin-prettier": "3.1.3",

--- a/test/helper/TestFactory.js
+++ b/test/helper/TestFactory.js
@@ -119,7 +119,6 @@ export class TestFactory {
     this.cryptography_repository.currentClient = ko.observable(currentClient);
 
     if (mockCryptobox === true) {
-      // eslint-disable-next-line jasmine/no-unsafe-spy
       spyOn(this.cryptography_repository, 'initCryptobox').and.returnValue(Promise.resolve());
     } else {
       const storeEngine = storageRepository.storageService.engine;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5306,11 +5306,6 @@ eslint-plugin-import@2.20.2:
     read-pkg-up "^2.0.0"
     resolve "^1.12.0"
 
-eslint-plugin-jasmine@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jasmine/-/eslint-plugin-jasmine-4.1.1.tgz#afdf8ca6a91e85041d9e0fb650af446874bf8852"
-  integrity sha512-uS7kvt7RPUB/gLDwhJ/Ax0APrmkj7In8VJWkiZLYHafz2Ix74mMRJx82YZZ3zHRa/YOuTL+ig6dW/aKwdNzUuw==
-
 eslint-plugin-jsdoc@24.0.0:
   version "24.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-24.0.0.tgz#41c7b06d33741e41e80a8f08c82aaa58ceef2e4b"


### PR DESCRIPTION
We disabled most of the rules and it's not part of our [original config](https://github.com/wireapp/wire-web-packages/blob/master/packages/eslint-config/eslintrc.json) so we are better off without it.