### PR TITLE
runfix: Reset @wireapp/core to 16.6.14

### DIFF
--- a/bin/release_tag.ts
+++ b/bin/release_tag.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import {GIPHY_RATING} from '@wireapp/api-client/dist/giphy';
 import {APIClient} from '@wireapp/api-client';
 import {ClientType} from '@wireapp/api-client/dist/client';
 import {Account} from '@wireapp/core';
@@ -112,7 +111,7 @@ const ask = (questionToAsk: string): Promise<string> => {
 };
 
 const sendRandomGif = async (account: Account, conversationId: string, query: string): Promise<void> => {
-  const giphySearchResult = await account.service.giphy.getRandomGif(query, GIPHY_RATING.MILD_SUBSTANCE);
+  const giphySearchResult = await account.service.giphy.getRandomGif(query);
   if (!giphySearchResult.data) {
     logger.warn(`No gif found for search query "${query}" :(`);
     return;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@wireapp/antiscroll-2": "1.0.2",
     "@wireapp/avs": "5.6.13",
     "@wireapp/commons": "3.5.2",
-    "@wireapp/core": "16.9.4",
+    "@wireapp/core": "16.6.14",
     "@wireapp/protocol-messaging": "1.25.4",
     "@wireapp/react-ui-kit": "7.29.3",
     "@wireapp/store-engine-dexie": "1.3.3",

--- a/src/script/extension/GiphyRepository.ts
+++ b/src/script/extension/GiphyRepository.ts
@@ -19,6 +19,7 @@
 
 import {Logger, getLogger} from '../util/Logger';
 import {GiphyService} from './GiphyService';
+import {GiphySorting} from '@wireapp/api-client/dist/giphy';
 
 export interface Gif {
   animated: string;
@@ -27,10 +28,10 @@ export interface Gif {
 }
 
 export interface RandomGifOptions {
-  /** How many retries to get the correct size. Default is `3`. */
-  maxRetries?: number;
   /** Maximum gif size in bytes. Default is 3 megabytes. */
   maxSize?: number;
+  /** How many retries to get the correct size. Default is 3. */
+  maxRetries?: number;
   /** Search query term or phrase */
   tag: string;
 }
@@ -42,9 +43,11 @@ export interface GetGifOptions {
   number: number;
   /**  Search query term or phrase */
   query: string;
+  results?: number;
   /**  Will return a randomized result. Default is `true`. */
   random?: boolean;
-  results?: number;
+  /**  Specify sorting ('relevant' or 'recent'). Default is "relevant". */
+  sorting: GiphySorting;
 }
 
 export class GiphyRepository {
@@ -58,6 +61,9 @@ export class GiphyRepository {
     NUMBER_OF_RESULTS: 6,
   };
 
+  /**
+   * @param giphyService Giphy REST API implementation
+   */
   constructor(giphyService: GiphyService) {
     this.giphyService = giphyService;
     this.logger = getLogger('GiphyRepository');
@@ -67,51 +73,59 @@ export class GiphyRepository {
   /**
    * Get random GIF for a word or phrase.
    */
-  async getRandomGif(options: RandomGifOptions, retry: number = 0): Promise<Gif> {
+  getRandomGif(options: RandomGifOptions): Promise<Gif> {
     options = {
       maxRetries: GiphyRepository.CONFIG.MAX_RETRIES,
       maxSize: GiphyRepository.CONFIG.MAX_SIZE,
       ...options,
     };
 
-    const hasReachedRetryLimit = retry >= options.maxRetries;
-    if (hasReachedRetryLimit) {
-      throw new Error(`Unable to fetch a proper gif within ${options.maxRetries} retries`);
-    }
+    const _getRandomGif = (retry = 0): Promise<Gif> => {
+      const hasReachedRetryLimit = retry >= options.maxRetries;
+      if (hasReachedRetryLimit) {
+        throw new Error(`Unable to fetch a proper gif within ${options.maxRetries} retries`);
+      }
 
-    const {data: randomGif} = await this.giphyService.getRandom(options.tag);
-    if (!randomGif.id) {
-      throw new Error(`Could not find any gif with tag '${options.tag}'`);
-    }
-    const {
-      data: {images, url},
-    } = await this.giphyService.getById(randomGif.id);
-    const staticGif = images.fixed_width_still;
-    const animatedGif = images.downsized;
-    const exceedsMaxSize = window.parseInt(animatedGif.size, 10) > options.maxSize;
+      return this.giphyService
+        .getRandom(options.tag)
+        .then(({data: randomGif}) => {
+          if (!randomGif.id) {
+            throw new Error(`Could not find any gif with tag '${options.tag}'`);
+          }
+          return this.giphyService.getById(randomGif.id);
+        })
+        .then(({data: {images, url}}) => {
+          const staticGif = images.fixed_width_still;
+          const animatedGif = images.downsized;
 
-    if (exceedsMaxSize) {
-      this.logger.info(`Gif size (${animatedGif.size}) is over maximum size (${animatedGif.size})`);
-      return this.getRandomGif(options, retry + 1);
-    }
+          const exceedsMaxSize = parseInt(animatedGif.size, 10) > options.maxSize;
+          if (exceedsMaxSize) {
+            this.logger.info(`Gif size (${animatedGif.size}) is over maximum size (${animatedGif.size})`);
+            return _getRandomGif(retry + 1);
+          }
 
-    return {
-      animated: animatedGif.url,
-      static: staticGif.url,
-      url: url,
+          return {
+            animated: animatedGif.url,
+            static: staticGif.url,
+            url: url,
+          };
+        });
     };
+
+    return _getRandomGif();
   }
 
   /**
    * Get random GIFs for a word or phrase.
    */
-  async getGifs(options: GetGifOptions): Promise<Gif[]> {
+  getGifs(options: GetGifOptions): Promise<Gif[]> {
     let offset = 0;
 
     options = {
       maxSize: GiphyRepository.CONFIG.MAX_SIZE,
       random: true,
       results: GiphyRepository.CONFIG.NUMBER_OF_RESULTS,
+      sorting: GiphySorting.RELEVANT,
       ...options,
     };
 
@@ -129,39 +143,41 @@ export class GiphyRepository {
       }
     }
 
-    try {
-      const {data: gifs, pagination} = await this.giphyService.getSearch({
+    return this.giphyService
+      .getSearch({
         limit: 100,
-        offset,
+        offset: offset,
         q: options.query,
-      });
+        sort: options.sorting,
+      })
+      .then(({data: gifs, pagination}) => {
+        const result = [];
 
-      const result = [];
-
-      if (options.random) {
-        gifs.sort(() => 0.5 - Math.random());
-      }
-
-      this.gifQueryCache[options.query] = pagination.total_count;
-
-      for (const {images, url} of gifs.slice(0, options.number)) {
-        const staticGif = images.fixed_width_still;
-        const animatedGif = images.downsized;
-        const exceedsMaxSize = parseInt(animatedGif.size, 10) > options.maxSize;
-
-        if (!exceedsMaxSize) {
-          result.push({
-            animated: animatedGif.url,
-            static: staticGif.url,
-            url,
-          });
+        if (options.random) {
+          gifs = gifs.sort(() => 0.5 - Math.random());
         }
-      }
 
-      return result;
-    } catch (error) {
-      this.logger.info(`Unable to fetch gif for query: ${options.query}`, error);
-      throw error;
-    }
+        this.gifQueryCache[options.query] = pagination.total_count;
+
+        for (const {images, url} of gifs.slice(0, options.number)) {
+          const staticGif = images.fixed_width_still;
+          const animatedGif = images.downsized;
+
+          const exceedsMaxSize = parseInt(animatedGif.size, 10) > options.maxSize;
+          if (!exceedsMaxSize) {
+            result.push({
+              animated: animatedGif.url,
+              static: staticGif.url,
+              url,
+            });
+          }
+        }
+
+        return result;
+      })
+      .catch(error => {
+        this.logger.info(`Unable to fetch gif for query: ${options.query}`, error);
+        throw error;
+      });
   }
 }

--- a/src/script/extension/GiphyService.ts
+++ b/src/script/extension/GiphyService.ts
@@ -18,12 +18,7 @@
  */
 
 import {APIClient} from '@wireapp/api-client';
-import {
-  GiphySearchOptions,
-  GiphyMultipleResult,
-  GiphyResult,
-  GiphyTrendingOptions,
-} from '@wireapp/api-client/dist/giphy';
+import {GiphySearch, GiphyResult, GiphySearchResult} from '@wireapp/api-client/dist/giphy';
 
 export class GiphyService {
   private readonly apiClient: APIClient;
@@ -33,40 +28,28 @@ export class GiphyService {
   }
 
   /**
-   * Get GIFs for an ID
-   * @param ids A single id to fetch GIF data
+   * Get GIFs for IDs.
+   * @param ids A single id or comma separated list of IDs to fetch GIF size data
+   * @returns Resolves with the size data
    */
-  getById(id: string): Promise<GiphyResult> {
-    return this.apiClient.giphy.api.getGiphyById(id);
+  getById(ids: string | string[]): Promise<GiphyResult> {
+    return this.apiClient.giphy.api.getGiphyById(ids);
   }
 
   /**
-   * Get GIFs for IDs
-   * @param ids Multiple IDs to fetch GIF data
-   */
-  getByIds(ids: string[]): Promise<GiphyMultipleResult> {
-    return this.apiClient.giphy.api.getGiphyByIds({ids});
-  }
-
-  /**
-   * Get a randomg Giphy GIFs.
+   * Search all Giphy GIFs for a word or phrase.
    * @param tag GIF tag to limit randomness by
+   * @returns Resolves with random gifs for given tag
    */
   getRandom(tag: string): Promise<GiphyResult> {
-    return this.apiClient.giphy.api.getGiphyRandom({tag});
+    return this.apiClient.giphy.api.getGiphyRandom(tag);
   }
 
   /**
    * Search GIFs for a word or phrase.
+   * @returns Resolves with matches
    */
-  getSearch(options: GiphySearchOptions): Promise<GiphyMultipleResult> {
+  getSearch(options: GiphySearch): Promise<GiphySearchResult> {
     return this.apiClient.giphy.api.getGiphySearch(options);
-  }
-
-  /**
-   * Search GIFs for a word or phrase.
-   */
-  getTrending(options: GiphyTrendingOptions): Promise<GiphyMultipleResult> {
-    return this.apiClient.giphy.api.getGiphyTrending(options);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1812,32 +1812,46 @@
   resolved "https://registry.yarnpkg.com/@wireapp/antiscroll-2/-/antiscroll-2-1.0.2.tgz#71a78d294ee0c88f42d50477ab61fa39272f5bca"
   integrity sha512-9KeB3yh9k01PjpuuRQsve4yY3+OVS2/hp9j+N13Is5wYCZRkUzZVCs8w9CyA/C6J5o9ukH0EzT7uurysWuhn/A==
 
-"@wireapp/api-client@11.17.2":
-  version "11.17.2"
-  resolved "https://registry.yarnpkg.com/@wireapp/api-client/-/api-client-11.17.2.tgz#4f0b9d6132489abf602eb6b5734db718d5552f84"
-  integrity sha512-J5ACnpzFEZKWCqkvF3J52ITABUT/sZDfbz11k371c/CY1mwf3lEdNgk9173e3yc75ICjiXb9UzeKJ/WjpvmoZA==
+"@wireapp/api-client@11.8.5":
+  version "11.8.5"
+  resolved "https://registry.yarnpkg.com/@wireapp/api-client/-/api-client-11.8.5.tgz#93aa98187340c1cb53f8e5b784ce2c468c40c608"
+  integrity sha512-l8E8s9qpXnmUKcFrqr/cjaXV7zcxnqTQC6mKy1MNp5Tu9HTMz+QDVzp3Std0JtR+fZIm83fkWqayftXoGhsawQ==
   dependencies:
     "@types/node" "~12"
     "@types/spark-md5" "3.0.2"
     "@types/tough-cookie" "4.0.0"
-    "@wireapp/commons" "3.5.2"
-    "@wireapp/priority-queue" "1.6.1"
+    "@wireapp/commons" "3.4.0"
+    "@wireapp/priority-queue" "1.5.7"
     axios "0.19.2"
     logdown "3.3.1"
     reconnecting-websocket "4.4.0"
     spark-md5 "3.0.1"
     tough-cookie "4.0.0"
-    ws "7.2.5"
+    ws "7.2.3"
 
 "@wireapp/avs@5.6.13":
   version "5.6.13"
   resolved "https://registry.yarnpkg.com/@wireapp/avs/-/avs-5.6.13.tgz#470c1d2c56e6b1a3901adb17baa34fa7a9e9c158"
   integrity sha512-u+EpcAuwjNWqzB2n1oSgUfFry3HjkD2A/ZQ5yaDvW17UC4FqgtnSN3vMafu1MYkxnTc5LAPVoJPTF3yhOP8GlA==
 
-"@wireapp/cbor@4.6.3":
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/@wireapp/cbor/-/cbor-4.6.3.tgz#39ae14430d62e410ec5f1d5f3dbe222bd2d048bb"
-  integrity sha512-EHRhYUt5JMiwnXB6Vz4BxT1wsrCcg9K7olFhwxPLV1WEtJrf2gAKbg2p66Qv2kOFiE8A9VaoqWPZSeBofpVUYg==
+"@wireapp/cbor@4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/cbor/-/cbor-4.6.0.tgz#d1b4504fe3bd28a5f736f12b6994e794e286e244"
+  integrity sha512-13mfyWx1XbLmi1s32ZEIXrtRzhtp8K+lg68hRmVwxrBE8/qieGj+AYlmt6/vrA2ExoqvoqDOUoB/WROmmw/hBw==
+
+"@wireapp/commons@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/commons/-/commons-3.4.0.tgz#c295fe50fb82fe641293d57f394b71a7ec3a823e"
+  integrity sha512-NNK2iK5JIKkOCk+WFfr/8+vI2BDWKehlWwrK3bhiXveo/bzm32ROUK/+tZ8doHeguj5SLqNmzkk2GFxBEVCg5w==
+  dependencies:
+    "@types/fs-extra" "8.1.0"
+    "@types/node" "~12"
+    "@types/platform" "1.3.2"
+    ansi-regex "5.0.0"
+    fs-extra "9.0.0"
+    logdown "3.3.1"
+    platform "1.3.5"
+    url-search-params-polyfill "8.0.0"
 
 "@wireapp/commons@3.5.2":
   version "3.5.2"
@@ -1866,34 +1880,34 @@
     logdown "3.3.1"
     rimraf "3.0.2"
 
-"@wireapp/core@16.9.4":
-  version "16.9.4"
-  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-16.9.4.tgz#95de8e5b814d548c2a94d695afe6c9ad6263d5ec"
-  integrity sha512-ZdO5Dolp2aouQBuWm7TEpk1yUWJopLV76U5daXHDaHk+OHm1zz2KVYzLBfzsXjEEEeFLiOBYhngdMMgZ1L9crw==
+"@wireapp/core@16.6.14":
+  version "16.6.14"
+  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-16.6.14.tgz#52bc9f02202320b7336b2ec77e78d801ac37902f"
+  integrity sha512-SA6nUe0N/vIr+5fxoimXBjU+h/75mfTy7G0KgGGaEmRaMY6sQPLG6d/6cOqEfRoZciugi++yp19K9kKbxsohSQ==
   dependencies:
     "@types/long" "4.0.1"
     "@types/node" "~12"
-    "@wireapp/api-client" "11.17.2"
-    "@wireapp/cryptobox" "12.2.7"
+    "@wireapp/api-client" "11.8.5"
+    "@wireapp/cryptobox" "12.2.3"
     "@wireapp/protocol-messaging" "1.25.4"
-    "@wireapp/store-engine" "4.5.2"
-    bazinga64 "5.7.2"
+    "@wireapp/store-engine" "4.4.0"
+    bazinga64 "5.7.0"
     hash.js "1.1.7"
     logdown "3.3.1"
     protobufjs "6.8.9"
     pure-uuid "1.6.0"
 
-"@wireapp/cryptobox@12.2.7":
-  version "12.2.7"
-  resolved "https://registry.yarnpkg.com/@wireapp/cryptobox/-/cryptobox-12.2.7.tgz#7b5d1557b6b92279e328902654f274d5984dfb99"
-  integrity sha512-LVTGk2CwwBwjLIYj6lSa8QlvTHPgz9X/jqCTemuTgbqAvsOJHpp0jxHS4PbrP2xC+nLATFD87O6K+Q9SHoK/Pg==
+"@wireapp/cryptobox@12.2.3":
+  version "12.2.3"
+  resolved "https://registry.yarnpkg.com/@wireapp/cryptobox/-/cryptobox-12.2.3.tgz#b91fa25624880d20283591ccd97ba9216eb87d20"
+  integrity sha512-nbrk5arYrRQZAlQHAVU8EKC1Ma1Vq5nb3cRe+PdjG+wrArY/OvAVxP2WxqO1qqK9O//zqAPwbJyB9KrhlCCxvg==
   dependencies:
     "@types/node" "~12"
-    "@wireapp/lru-cache" "3.6.3"
-    "@wireapp/priority-queue" "1.6.1"
-    "@wireapp/proteus" "9.8.5"
-    "@wireapp/store-engine" "4.5.2"
-    bazinga64 "5.7.2"
+    "@wireapp/lru-cache" "3.5.0"
+    "@wireapp/priority-queue" "1.5.7"
+    "@wireapp/proteus" "9.8.2"
+    "@wireapp/store-engine" "4.4.0"
+    bazinga64 "5.7.0"
     logdown "3.3.1"
 
 "@wireapp/eslint-config@1.4.0":
@@ -1901,35 +1915,35 @@
   resolved "https://registry.yarnpkg.com/@wireapp/eslint-config/-/eslint-config-1.4.0.tgz#2ba4c88ed7fd3ae52bb378cf862d408d692ab3f0"
   integrity sha512-dF4H3wcssqd4aiEPJxL5u2xzMyLwmbOeGJh7OtnBak80CTgOsS1f3hORokUuJ4axCzA+XVqjiPDLc8d51AEu7g==
 
-"@wireapp/lru-cache@3.6.3":
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/@wireapp/lru-cache/-/lru-cache-3.6.3.tgz#86f1f687cec2249d2aa95f083a19be610a704375"
-  integrity sha512-tr6HpHILWjfRAlJSfU/hjpa9LCaDHP2vsaP85FmfjoNG5MKgpGR6iJQ4Glsgmcr0T9bcLp1Bsms9SDVuI9YgHQ==
+"@wireapp/lru-cache@3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/lru-cache/-/lru-cache-3.5.0.tgz#efb1a489655c92cef5e3476cb0d71ebd581f48dc"
+  integrity sha512-5IG5nueypeft0o2PQNxO5HsVthhe3egefulvjUeGmfF96U5E6ATLT/OH7zh30XBU34RPQVsHDUK/LIMzniFkYg==
 
 "@wireapp/prettier-config@0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@wireapp/prettier-config/-/prettier-config-0.3.0.tgz#e8129b31021c81d90d564d9c4ff0f7f7b514e943"
   integrity sha512-BFokvX4NZlkhWq5/OoJUCS8Iels+MeRgzpd5V9QR3hj5swwCFGxJOAL7soPXkSNWo91gI1qwiTp8szB1O9aCfQ==
 
-"@wireapp/priority-queue@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@wireapp/priority-queue/-/priority-queue-1.6.1.tgz#477d7f1a6e44fbd393d8d941f532855d3fe797ca"
-  integrity sha512-0+i7KcEpEjuS5994dj5lfFj5t8flxOtN+OWNN6KfIrU2pnJrFMUmM7glTxzo5iPiPJb2bQmJmjTGCvWUa+dEIA==
+"@wireapp/priority-queue@1.5.7":
+  version "1.5.7"
+  resolved "https://registry.yarnpkg.com/@wireapp/priority-queue/-/priority-queue-1.5.7.tgz#9de65ed36f9038af81e4c32dbb942e40a2796785"
+  integrity sha512-rDuF6YUH3tcBrk3UO/dIVYmAAj/yXjAXxsimpG1Kyp7cPdQ3U3n6+6Wtl8kTj7VqguuMV/allqfzDkexZpJE+w==
   dependencies:
     "@types/node" "~12"
     logdown "3.3.1"
     pure-uuid "1.6.0"
 
-"@wireapp/proteus@9.8.5":
-  version "9.8.5"
-  resolved "https://registry.yarnpkg.com/@wireapp/proteus/-/proteus-9.8.5.tgz#3a064c8d343a7a8a3325a2fa90a84a24fda14943"
-  integrity sha512-JnIusdQChsWrq/sunKvPiWrOBqEEZhawmY+xRRjnpK/B7IweqLIQkWXZvLqmKxomfoiFs/bbNoL4VqITRLNuOQ==
+"@wireapp/proteus@9.8.2":
+  version "9.8.2"
+  resolved "https://registry.yarnpkg.com/@wireapp/proteus/-/proteus-9.8.2.tgz#bd806877af07b998ed303c9c585a14df422143ae"
+  integrity sha512-3SfVm7fIdG6liJvnr1KZWVdQgkWLEqSttZElthudj1nANFsdnfGMfEHTig6PZn7V0CXaHq8JrtvtAcTlnhlH7Q==
   dependencies:
     "@types/chai" "4.2.11"
     "@types/ed2curve" "0.2.2"
     "@types/libsodium-wrappers-sumo" "0.7.3"
     "@types/node" "~12"
-    "@wireapp/cbor" "4.6.3"
+    "@wireapp/cbor" "4.6.0"
     ed2curve "0.3.0"
     libsodium-wrappers-sumo "0.7.6"
 
@@ -1973,10 +1987,10 @@
     "@wireapp/websql" "0.0.15"
     uint32 "0.2.1"
 
-"@wireapp/store-engine@4.5.2":
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/@wireapp/store-engine/-/store-engine-4.5.2.tgz#a736f2bfe44c76b785b9c58b30f675d4389438c3"
-  integrity sha512-umr1Kz6RFvvLoeIiTbDLWAb9MASqMJtJDkEnUuKtghU0cDaf76dlj2gAQTGDlUIl8KBwcw0R/h3HkrypfzTnog==
+"@wireapp/store-engine@4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/store-engine/-/store-engine-4.4.0.tgz#ca1f504ee11f744c4ccb5d5a83409157df754104"
+  integrity sha512-MxYYE17RRPqF/SMgTysWQyKi+Z4/X+fDR7PjGtNq2TgT7ae/SznB14F6g+A0ununKdeyFKahubxaIpC5MFL5Fg==
   dependencies:
     "@types/node" "~12"
 
@@ -2796,6 +2810,11 @@ base@^0.11.1:
     isobject "^3.0.1"
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
+
+bazinga64@5.7.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/bazinga64/-/bazinga64-5.7.0.tgz#3a947e4de1c3eb36d357a5c6383c243b927c3f32"
+  integrity sha512-hUq22GPWLMiU5LNtwlgo1xT6WBWNYtQ9M4b4ddVkyMvI+pjM2PIJ4pNG8RaaQez8QbdQXyQJ0SnUqgVfHvyFIQ==
 
 bazinga64@5.7.2:
   version "5.7.2"
@@ -13745,10 +13764,10 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@7.2.5:
-  version "7.2.5"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.5.tgz#abb1370d4626a5a9cd79d8de404aa18b3465d10d"
-  integrity sha512-C34cIU4+DB2vMyAbmEKossWq2ZQDr6QEyuuCzWrM9zfw1sGc0mYiJ0UnG9zzNykt49C2Fi34hvr2vssFQRS6EA==
+ws@7.2.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.3.tgz#a5411e1fb04d5ed0efee76d26d5c46d830c39b46"
+  integrity sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==
 
 ws@~3.3.1:
   version "3.3.3"


### PR DESCRIPTION
With the latest version of "@wireapp/core" we seem to have some logout issues. That's why I preemptively revert the core version to the one on "master". This also means that the Giphy improvements will be reverted but proper login/logout is more important than Giphy. We will focus on Giphy and logout fixes again with the upcoming releases.

Reverted PR is:
- feat: Update giphy API (#8737)