### PR TITLE
fix: Explicitly set `SameSite=Lax` for SingleInstanceHandler cookie (WEBAPP-6865)

### DIFF
--- a/src/script/main/SingleInstanceHandler.ts
+++ b/src/script/main/SingleInstanceHandler.ts
@@ -61,7 +61,13 @@ export class SingleInstanceHandler {
     if (!!Cookies.get(cookieName)) {
       return false;
     }
-    Cookies.set(cookieName, {appInstanceId: this.instanceId});
+    Cookies.set(
+      cookieName,
+      {appInstanceId: this.instanceId},
+      {
+        sameSite: 'Lax',
+      },
+    );
     if (this.onOtherInstanceStarted) {
       this._startSingleInstanceCheck();
     }

--- a/test/unit_tests/main/SingleInstanceHandlerSpec.js
+++ b/test/unit_tests/main/SingleInstanceHandlerSpec.js
@@ -29,7 +29,13 @@ describe('SingleInstanceHandler', () => {
       spyOn(Cookies, 'set').and.returnValue(undefined);
       const result = singleInstanceHandler.registerInstance(instanceId);
 
-      expect(Cookies.set).toHaveBeenCalledWith('app_opened', {appInstanceId: instanceId});
+      expect(Cookies.set).toHaveBeenCalledWith(
+        'app_opened',
+        {appInstanceId: instanceId},
+        {
+          sameSite: 'Lax',
+        },
+      );
       expect(result).toBe(true);
     });
 


### PR DESCRIPTION
It seems browsers handle the default value for SameSite cookie differently (also across versions). In order to prevent browser specific bugs we set the SameSite attribute explicitly.