### PR TITLE
fix: Exchange UUID library due to broken message IDs (WEBAPP-6898)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "underscore": "1.10.2",
     "url-search-params-polyfill": "8.1.0",
     "use-react-router": "1.0.7",
+    "uuidjs": "4.2.5",
     "webrtc-adapter": "6.4.8"
   },
   "devDependencies": {

--- a/src/script/Config.ts
+++ b/src/script/Config.ts
@@ -18,7 +18,7 @@
  */
 
 import {ValidationUtil} from '@wireapp/commons';
-import UUID from 'pure-uuid';
+import {createRandomUuid} from 'Util/util';
 const env = window.wire.env;
 
 export const ACCENT_ID = {
@@ -34,7 +34,7 @@ export const ACCENT_ID = {
 export class Configuration {
   readonly APP_BASE = env.APP_BASE || 'https://app.wire.com';
   readonly APP_NAME = env.APP_NAME || 'Webapp';
-  readonly APP_INSTANCE_ID = new UUID(4).format();
+  readonly APP_INSTANCE_ID = createRandomUuid();
   readonly BACKEND_NAME = env.BACKEND_NAME || 'Wire';
   readonly BACKEND_REST = env.BACKEND_REST || 'https://prod-nginz-https.wire.com';
   readonly BACKEND_WS = env.BACKEND_WS || 'wss://prod-nginz-ssl.wire.com';

--- a/src/script/components/infoToggle.ts
+++ b/src/script/components/infoToggle.ts
@@ -17,8 +17,8 @@
  *
  */
 
-import UUID from 'pure-uuid';
 import ko from 'knockout';
+import {createRandomUuid} from 'Util/util';
 
 interface InfoToggleParams {
   dataUieName: string;
@@ -41,7 +41,7 @@ class InfoToggle {
     this.dataUieNameInfoText = `status-info-toggle-${params.dataUieName}`;
     this.dataUieNameLabelText = `do-toggle-${params.dataUieName}`;
     this.info = params.info;
-    this.inputId = new UUID(4).format();
+    this.inputId = createRandomUuid();
     this.isChecked = params.isChecked;
     this.isDisabled = params.isDisabled;
     this.name = params.name;

--- a/src/script/util/util.ts
+++ b/src/script/util/util.ts
@@ -20,7 +20,7 @@
 import {Decoder} from 'bazinga64';
 import type {ObservableArray} from 'knockout';
 import sodium from 'libsodium-wrappers-sumo';
-import UUID from 'pure-uuid';
+import UUID from 'uuidjs';
 import {UrlUtil} from '@wireapp/commons';
 
 import {QUERY_KEY} from '../auth/route';
@@ -261,7 +261,7 @@ export const downloadFile = (url: string, fileName: string, mimeType?: string): 
   }, 100);
 };
 
-export const createRandomUuid = (): string => new UUID(4).format();
+export const createRandomUuid = (): string => UUID.generate();
 
 // Note IE10 listens to "transitionend" instead of "animationend"
 export const alias = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13716,6 +13716,11 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
 
+uuidjs@4.2.5:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/uuidjs/-/uuidjs-4.2.5.tgz#a80439ece05dfe6ed875a5d62de0820046055713"
+  integrity sha512-0utbJ3L/C/AUv8cRAfFnUC7XhvRvaQaGNPbrroBeXF26BWfYT6aD8/n5UQ4ic3bpkJfVd2W15yQS+YCwvQxtXA==
+
 v8-compile-cache@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz#00f7494d2ae2b688cfe2899df6ed2c54bef91dbe"


### PR DESCRIPTION
We are switching the UUID generation library because of: https://github.com/rse/pure-uuid/issues/17