### PR TITLE
fix: Don't update screenshare when changing webcam

### DIFF
--- a/src/page/template/content/preferences-av.htm
+++ b/src/page/template/content/preferences-av.htm
@@ -5,7 +5,7 @@
     <!-- ko if: deviceSupport.audioInput() -->
       <section class="preferences-section">
         <header class="preferences-header preferences-av-header" data-bind="text: t('preferencesAVMicrophone')"></header>
-        <!-- ko if: !audioMediaStream() -->
+        <!-- ko if: !hasAudioTrack() -->
           <div class="preferences-av-detail">
             <a rel="nofollow noopener noreferrer" target="_blank" data-bind="text: t('preferencesAVPermissionDetail'), attr: {href: Config.URL.SUPPORT.DEVICE_ACCESS_DENIED}"></a>
           </div>
@@ -27,7 +27,7 @@
             <label class="icon-down preferences-av-label" data-bind="visible: !hasOnlyOneMicrophone()"></label>
           </div>
         </div>
-        <input-level class="preferences-av-meter accent-text" params="level: audioLevel, disabled: !audioMediaStream()"></input-level>
+        <input-level class="preferences-av-meter accent-text" params="level: audioLevel, disabled: !hasAudioTrack()"></input-level>
       </section>
     <!-- /ko -->
 
@@ -56,19 +56,19 @@
     <!-- ko if: deviceSupport.videoInput() -->
       <section class="preferences-section">
         <header class="preferences-header preferences-av-header" data-bind="text: t('preferencesAVCamera')"></header>
-        <!-- ko if: !videoMediaStream() -->
+        <!-- ko if: !hasVideoTrack() -->
           <div class="preferences-av-detail">
             <a rel="nofollow noopener noreferrer" target="_blank" data-bind="text: t('preferencesAVPermissionDetail'), attr: {href: Config.URL.SUPPORT.DEVICE_ACCESS_DENIED}"></a>
           </div>
         <!-- /ko -->
-        <div class="preferences-option" data-bind="css: {'preferences-av-select-disabled': !videoMediaStream()}">
+        <div class="preferences-option" data-bind="css: {'preferences-av-select-disabled': !hasVideoTrack()}">
           <div class="preferences-option-icon preferences-av-select-icon">
             <camera-icon></camera-icon>
           </div>
           <div class="input-select">
             <select class="preferences-av-select" name="select"
-                    data-bind="attr: {'disabled': availableDevices.audioInput().length < 2 || !videoMediaStream()},
-                               css: {'preferences-av-select-disabled': !videoMediaStream()},
+                    data-bind="attr: {'disabled': availableDevices.audioInput().length < 2 || !hasVideoTrack()},
+                               css: {'preferences-av-select-disabled': !hasVideoTrack()},
                                options: availableDevices.videoInput,
                                optionsText: function(item) {return item.label || z.string.preferencesAVCamera},
                                optionsValue: 'deviceId',
@@ -81,13 +81,13 @@
         <!-- ko if: isTemporaryGuest() -->
           <div class="preferences-detail" data-bind="text: t('preferencesAVTemporaryDisclaimer')"></div>
         <!-- /ko -->
-        <!-- ko ifnot: videoMediaStream() -->
+        <!-- ko ifnot: hasVideoTrack() -->
           <div class="preferences-av-video-disabled">
               <div class="preferences-av-video-disabled__info" data-bind="html: t('preferencesAVNoCamera', brandName, {'faqLink': '<a href=\'https://support.wire.com/hc/articles/202935412\' data-uie-name=\'go-no-camera-faq\' target=\'_blank\' rel=\'noopener noreferrer\'>', '/faqLink': '</a>', 'br': '<br>'})"></div>
-              <div class="preferences-av-video-disabled__try-again" data-bind="click: tryAgain, text: z.string.preferencesAVTryAgain" data-uie-name="do-try-again-preferences-av"></div>
+              <div class="preferences-av-video-disabled__try-again" data-bind="click: tryAgainVideo, text: z.string.preferencesAVTryAgain" data-uie-name="do-try-again-preferences-av"></div>
           </div>
         <!-- /ko -->
-        <!-- ko if: videoMediaStream() -->
+        <!-- ko if: hasVideoTrack() -->
           <video class="preferences-av-video mirror"
                 autoplay
                 playsinline

--- a/src/page/template/content/preferences-av.htm
+++ b/src/page/template/content/preferences-av.htm
@@ -10,21 +10,21 @@
             <a rel="nofollow noopener noreferrer" target="_blank" data-bind="text: t('preferencesAVPermissionDetail'), attr: {href: Config.URL.SUPPORT.DEVICE_ACCESS_DENIED}"></a>
           </div>
         <!-- /ko -->
-        <div class="preferences-option" data-bind="css: {'preferences-av-select-disabled': hasOnlyOneMicrophone()}">
+        <div class="preferences-option" data-bind="css: {'preferences-av-select-disabled': hasNoneOrOneAudioInput()}">
           <div class="preferences-option-icon preferences-av-select-icon">
             <div class="icon-microphone"></div>
           </div>
           <div class="input-select">
             <select class="preferences-av-select" name="select"
-                    data-bind="attr: {'disabled': hasOnlyOneMicrophone()},
-                               css: {'preferences-av-select-disabled': hasOnlyOneMicrophone()},
+                    data-bind="attr: {'disabled': hasNoneOrOneAudioInput()},
+                               css: {'preferences-av-select-disabled': hasNoneOrOneAudioInput()},
                                options: availableDevices.audioInput,
                                optionsText: function(item) {return item.label || z.string.preferencesAVMicrophone},
                                optionsValue: 'deviceId',
                                value: currentDeviceId.audioInput"
                     data-uie-name="enter-microphone">
             </select>
-            <label class="icon-down preferences-av-label" data-bind="visible: !hasOnlyOneMicrophone()"></label>
+            <label class="icon-down preferences-av-label" data-bind="visible: !hasNoneOrOneAudioInput()"></label>
           </div>
         </div>
         <input-level class="preferences-av-meter accent-text" params="level: audioLevel, disabled: !hasAudioTrack()"></input-level>
@@ -61,21 +61,21 @@
             <a rel="nofollow noopener noreferrer" target="_blank" data-bind="text: t('preferencesAVPermissionDetail'), attr: {href: Config.URL.SUPPORT.DEVICE_ACCESS_DENIED}"></a>
           </div>
         <!-- /ko -->
-        <div class="preferences-option" data-bind="css: {'preferences-av-select-disabled': !hasVideoTrack()}">
+        <div class="preferences-option" data-bind="css: {'preferences-av-select-disabled': hasNoneOrOneVideoInput()}">
           <div class="preferences-option-icon preferences-av-select-icon">
             <camera-icon></camera-icon>
           </div>
           <div class="input-select">
             <select class="preferences-av-select" name="select"
-                    data-bind="attr: {'disabled': availableDevices.audioInput().length < 2 || !hasVideoTrack()},
-                               css: {'preferences-av-select-disabled': !hasVideoTrack()},
+                    data-bind="attr: {'disabled': hasNoneOrOneVideoInput()},
+                               css: {'preferences-av-select-disabled': hasNoneOrOneVideoInput()},
                                options: availableDevices.videoInput,
                                optionsText: function(item) {return item.label || z.string.preferencesAVCamera},
                                optionsValue: 'deviceId',
                                value: currentDeviceId.videoInput"
                     data-uie-name="enter-camera">
             </select>
-            <label class="icon-down preferences-av-label" data-bind="visible: availableDevices.videoInput().length >= 2"></label>
+            <label class="icon-down preferences-av-label" data-bind="visible: !hasNoneOrOneVideoInput()"></label>
           </div>
         </div>
         <!-- ko if: isTemporaryGuest() -->

--- a/src/page/template/content/preferences-av.htm
+++ b/src/page/template/content/preferences-av.htm
@@ -84,7 +84,7 @@
         <!-- ko ifnot: hasVideoTrack() -->
           <div class="preferences-av-video-disabled">
               <div class="preferences-av-video-disabled__info" data-bind="html: t('preferencesAVNoCamera', brandName, {'faqLink': '<a href=\'https://support.wire.com/hc/articles/202935412\' data-uie-name=\'go-no-camera-faq\' target=\'_blank\' rel=\'noopener noreferrer\'>', '/faqLink': '</a>', 'br': '<br>'})"></div>
-              <div class="preferences-av-video-disabled__try-again" data-bind="click: tryAgainVideo, text: z.string.preferencesAVTryAgain" data-uie-name="do-try-again-preferences-av"></div>
+              <div class="preferences-av-video-disabled__try-again" data-bind="click: updateMediaStreamVideoTrack, text: z.string.preferencesAVTryAgain" data-uie-name="do-try-again-preferences-av"></div>
           </div>
         <!-- /ko -->
         <!-- ko if: hasVideoTrack() -->

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -573,7 +573,10 @@ export class CallingRepository {
         break;
 
       case MediaType.VIDEO:
-        activeCall.selfParticipant.releaseVideoStream();
+        // Don't stop video input (coming from A/V preferences) when screensharing is activated
+        if (!activeCall.selfParticipant.sharesScreen()) {
+          activeCall.selfParticipant.releaseVideoStream();
+        }
         break;
     }
     return true;
@@ -586,15 +589,22 @@ export class CallingRepository {
     if (!call) {
       return;
     }
+
     if (mediaType === MediaType.AUDIO) {
       const audioTracks = mediaStream.getAudioTracks().map(track => track.clone());
-      call.selfParticipant.setAudioStream(new MediaStream(audioTracks));
-      this.wCall.replaceTrack(call.conversationId, audioTracks[0]);
+      if (audioTracks.length > 0) {
+        call.selfParticipant.setAudioStream(new MediaStream(audioTracks));
+        this.wCall.replaceTrack(call.conversationId, audioTracks[0]);
+      }
     }
-    if (mediaType === MediaType.VIDEO && call.selfParticipant.sharesCamera()) {
+
+    // Don't update video input (coming from A/V preferences) when screensharing is activated
+    if (mediaType === MediaType.VIDEO && call.selfParticipant.sharesCamera() && !call.selfParticipant.sharesScreen()) {
       const videoTracks = mediaStream.getVideoTracks().map(track => track.clone());
-      call.selfParticipant.setVideoStream(new MediaStream(videoTracks));
-      this.wCall.replaceTrack(call.conversationId, videoTracks[0]);
+      if (videoTracks.length > 0) {
+        call.selfParticipant.setVideoStream(new MediaStream(videoTracks));
+        this.wCall.replaceTrack(call.conversationId, videoTracks[0]);
+      }
     }
   }
 

--- a/src/script/media/MediaStreamHandler.ts
+++ b/src/script/media/MediaStreamHandler.ts
@@ -123,24 +123,17 @@ export class MediaStreamHandler {
     return shouldCheckPermissions ? checkPermissionStates(permissionTypes) : true;
   }
 
-  releaseTracksFromStream(mediaStream: MediaStream, mediaType: MediaType): boolean {
+  releaseTracksFromStream(mediaStream: MediaStream, mediaType: MediaType): void {
     const mediaStreamTracks = this.getMediaTracks(mediaStream, mediaType);
 
-    if (mediaStreamTracks.length) {
-      mediaStreamTracks.forEach((mediaStreamTrack: MediaStreamTrack) => {
-        mediaStream.removeTrack(mediaStreamTrack);
-        mediaStreamTrack.stop();
-        this.logger.info(
-          `Stopped MediaStreamTrack ID '${mediaStreamTrack.id}' of kind '${mediaStreamTrack.kind}'`,
-          mediaStreamTrack,
-        );
-      });
-
-      return true;
-    }
-
-    this.logger.warn('No MediaStreamTracks found to stop', mediaStream);
-    return false;
+    mediaStreamTracks.forEach((mediaStreamTrack: MediaStreamTrack) => {
+      mediaStream.removeTrack(mediaStreamTrack);
+      mediaStreamTrack.stop();
+      this.logger.info(
+        `Stopped MediaStreamTrack ID '${mediaStreamTrack.id}' of kind '${mediaStreamTrack.kind}'`,
+        mediaStreamTrack,
+      );
+    });
   }
 
   private getMediaStream(

--- a/src/script/view_model/ContentViewModel.js
+++ b/src/script/view_model/ContentViewModel.js
@@ -124,8 +124,8 @@ export class ContentViewModel {
       repositories.user,
     );
     this.preferencesAV = new PreferencesAVViewModel(repositories.media, repositories.user, {
-      mediaSourceChanged: repositories.calling.changeMediaSource.bind(repositories.calling),
-      willChangeMediaSource: repositories.calling.stopMediaSource.bind(repositories.calling),
+      replaceActiveMediaSource: repositories.calling.changeMediaSource.bind(repositories.calling),
+      stopActiveMediaSource: repositories.calling.stopMediaSource.bind(repositories.calling),
     });
     this.preferencesDeviceDetails = new PreferencesDeviceDetailsViewModel(
       mainViewModel,
@@ -163,7 +163,7 @@ export class ContentViewModel {
           this.preferencesAccount.popNotification();
           break;
         case ContentViewModel.STATE.PREFERENCES_AV:
-          this.preferencesAV.initiateDevices(MediaType.AUDIO_VIDEO);
+          this.preferencesAV.updateMediaStreamTrack(MediaType.AUDIO_VIDEO);
           break;
         case ContentViewModel.STATE.PREFERENCES_DEVICES:
           this.preferencesDevices.updateDeviceInfo();

--- a/src/script/view_model/ContentViewModel.js
+++ b/src/script/view_model/ContentViewModel.js
@@ -46,6 +46,7 @@ import {TitleBarViewModel} from './content/TitleBarViewModel';
 import {PreferencesAboutViewModel} from './content/PreferencesAboutViewModel';
 import {PreferencesDevicesViewModel} from './content/PreferencesDevicesViewModel';
 import {PreferencesDeviceDetailsViewModel} from './content/PreferencesDeviceDetailsViewModel';
+import {MediaType} from '../media/MediaType';
 
 export class ContentViewModel {
   static get STATE() {
@@ -162,7 +163,7 @@ export class ContentViewModel {
           this.preferencesAccount.popNotification();
           break;
         case ContentViewModel.STATE.PREFERENCES_AV:
-          this.preferencesAV.initiateDevices();
+          this.preferencesAV.initiateDevices(MediaType.AUDIO_VIDEO);
           break;
         case ContentViewModel.STATE.PREFERENCES_DEVICES:
           this.preferencesDevices.updateDeviceInfo();
@@ -390,7 +391,7 @@ export class ContentViewModel {
 
     const isStatePreferencesAv = this.previousState === ContentViewModel.STATE.PREFERENCES_AV;
     if (isStatePreferencesAv) {
-      this.preferencesAV.releaseDevices();
+      this.preferencesAV.releaseDevices(MediaType.AUDIO_VIDEO);
     }
   }
 

--- a/src/script/view_model/content/PreferencesAVViewModel.ts
+++ b/src/script/view_model/content/PreferencesAVViewModel.ts
@@ -90,7 +90,7 @@ export class PreferencesAVViewModel {
     this.Config = Config.getConfig();
 
     this.currentDeviceId.audioInput.subscribe(() => this.updateMediaStreamTrack(MediaType.AUDIO));
-    this.currentDeviceId.videoInput.subscribe(() => this.tryAgainVideo());
+    this.currentDeviceId.videoInput.subscribe(() => this.updateMediaStreamVideoTrack());
 
     this.constraintsHandler = mediaRepository.constraintsHandler;
     this.streamHandler = mediaRepository.streamHandler;
@@ -116,7 +116,7 @@ export class PreferencesAVViewModel {
     });
   }
 
-  tryAgainVideo() {
+  updateMediaStreamVideoTrack() {
     return this.updateMediaStreamTrack(MediaType.VIDEO);
   }
 

--- a/test/unit_tests/calling/CallingRepositorySpec.js
+++ b/test/unit_tests/calling/CallingRepositorySpec.js
@@ -176,27 +176,6 @@ describe('CallingRepository', () => {
     });
   });
 
-  describe('changeMediaSource', () => {
-    it('changes active call sent media streams', () => {
-      spyOn(callingRepository.wCall, 'replaceTrack');
-      const selfParticipant = new Participant();
-      spyOn(selfParticipant, 'releaseStream');
-      spyOn(selfParticipant, 'sharesCamera').and.returnValue(true);
-      const call = new Call('', '', 0, selfParticipant, 0);
-      const newMediaStream = new MediaStream();
-
-      callingRepository.changeMediaSource(newMediaStream, MediaType.AUDIO, call);
-
-      expect(selfParticipant.releaseStream).toHaveBeenCalledTimes(1);
-      expect(callingRepository.wCall.replaceTrack).toHaveBeenCalledTimes(1);
-
-      callingRepository.changeMediaSource(newMediaStream, MediaType.VIDEO, call);
-
-      expect(selfParticipant.releaseStream).toHaveBeenCalledTimes(2);
-      expect(callingRepository.wCall.replaceTrack).toHaveBeenCalledTimes(2);
-    });
-  });
-
   describe('incoming call', () => {
     it('create a stores a new call when an incoming call arrives', done => {
       spyOn(callingRepository.conversationRepository, 'grantMessage').and.returnValue(Promise.resolve());


### PR DESCRIPTION
**Fixes:**
1. It is now possible to select a different webcam when one of your webcams is not working
1. When hosting a screenshare and select a different webcam in A/V preferences, the webcam won't replace/break your screensharing session anymore
1. Microphones & webcams can be changed on-the-fly when being in a call and switching devices in A/V preferences
1. Switching to a broken webcam during a videocall session won't crash the videocall anymore
1. Changing your audio input in A/V preferences won't trigger a new media request for your video device (avoids webcam preview flickering)
1. Changing your video input in A/V preferences won't trigger a new media request for your audio device