### PR TITLE
feat: Add Chrome Origin Trial for WebRTC insertable streams (WEBAPP-7049)

### DIFF
--- a/server/Server.ts
+++ b/server/Server.ts
@@ -201,6 +201,7 @@ class Server {
     this.app.locals.config = {
       APP_BASE: this.config.SERVER.APP_BASE,
       BRAND_NAME: this.config.CLIENT.BRAND_NAME,
+      CHROME_ORIGIN_TRIAL_TOKEN: this.config.CLIENT.CHROME_ORIGIN_TRIAL_TOKEN,
       OPEN_GRAPH: this.config.SERVER.OPEN_GRAPH,
       VERSION: this.config.CLIENT.VERSION,
     };

--- a/server/ServerConfig.ts
+++ b/server/ServerConfig.ts
@@ -8,6 +8,7 @@ export interface ServerConfig {
     BACKEND_REST: string;
     BACKEND_WS: string;
     BRAND_NAME: string;
+    CHROME_ORIGIN_TRIAL_TOKEN: string;
     COUNTLY_API_KEY: string;
     ENVIRONMENT: string;
     FEATURE: {

--- a/server/config.ts
+++ b/server/config.ts
@@ -127,6 +127,7 @@ const config: ServerConfig = {
     BACKEND_REST: process.env.BACKEND_REST,
     BACKEND_WS: process.env.BACKEND_WS,
     BRAND_NAME: process.env.BRAND_NAME,
+    CHROME_ORIGIN_TRIAL_TOKEN: process.env.CHROME_ORIGIN_TRIAL_TOKEN,
     COUNTLY_API_KEY: process.env.COUNTLY_API_KEY,
     ENVIRONMENT: nodeEnvironment,
     FEATURE: {

--- a/src/page/template/graph.htm
+++ b/src/page/template/graph.htm
@@ -1,5 +1,5 @@
-<meta property="og:title" content="{{@config.OPEN_GRAPH.TITLE}}" />
-<meta property="og:description" name="description" content="{{@config.OPEN_GRAPH.DESCRIPTION}}" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="{{@config.APP_BASE}}" />
-<meta property="og:image" content="{{@config.OPEN_GRAPH.IMAGE_URL}}" />
+    <meta property="og:title" content="{{@config.OPEN_GRAPH.TITLE}}" />
+    <meta property="og:description" name="description" content="{{@config.OPEN_GRAPH.DESCRIPTION}}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="{{@config.APP_BASE}}" />
+    <meta property="og:image" content="{{@config.OPEN_GRAPH.IMAGE_URL}}" />

--- a/src/page/template/meta.htm
+++ b/src/page/template/meta.htm
@@ -2,6 +2,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="geoip" country="{{country}}" />
     <meta property="wire:version" version="{{@config.VERSION}}" />
+    <meta http-equiv="origin-trial" content="{{@config.CHROME_ORIGIN_TRIAL_TOKEN}}">
 
     <link href="/image/favicon.ico?{{@config.VERSION}}" type="image/x-icon" rel="shortcut icon" sizes="48x48" />
     <link href="/image/meta/wire-icon-256.png?{{@config.VERSION}}" rel="icon" sizes="256x256" type="image/png" />

--- a/src/page/template/meta.htm
+++ b/src/page/template/meta.htm
@@ -2,8 +2,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="geoip" country="{{country}}" />
     <meta property="wire:version" version="{{@config.VERSION}}" />
-    <meta http-equiv="origin-trial" content="{{@config.CHROME_ORIGIN_TRIAL_TOKEN}}">
-
+    {{#if @config.CHROME_ORIGIN_TRIAL_TOKEN}}<meta http-equiv="origin-trial" content="{{@config.CHROME_ORIGIN_TRIAL_TOKEN}}">{{/if}}
     <link href="/image/favicon.ico?{{@config.VERSION}}" type="image/x-icon" rel="shortcut icon" sizes="48x48" />
     <link href="/image/meta/wire-icon-256.png?{{@config.VERSION}}" rel="icon" sizes="256x256" type="image/png" />
     <link href="/image/meta/wire-icon-128.png?{{@config.VERSION}}" rel="icon" sizes="128x128" type="image/png" />

--- a/src/script/main/globals.ts
+++ b/src/script/main/globals.ts
@@ -90,6 +90,7 @@ declare global {
         BACKEND_REST: string;
         BACKEND_WS: string;
         BRAND_NAME: string;
+        CHROME_ORIGIN_TRIAL_TOKEN: string;
         COUNTLY_API_KEY: string;
         ENVIRONMENT: string;
         FEATURE: {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5497598/89789438-e5428600-db20-11ea-9395-d0a15a7e9be1.png)

---

![image](https://user-images.githubusercontent.com/5497598/89789478-effd1b00-db20-11ea-87bc-048946ad96de.png)

---

This needs setting the environment variable `CHROME_ORIGIN_TRIAL_TOKEN` to a token from https://developers.chrome.com/origintrials/.