### PR TITLE
fix: Cleanup Giphy Modal after closing

### DIFF
--- a/src/script/view_model/content/GiphyViewModel.ts
+++ b/src/script/view_model/content/GiphyViewModel.ts
@@ -137,7 +137,9 @@ export class GiphyViewModel {
     this._getRandomGif();
 
     if (!this.modal) {
-      this.modal = new Modal('#giphy-modal');
+      this.modal = new Modal('#giphy-modal', () => {
+        this.modal = undefined;
+      });
     }
 
     this.modal.show();


### PR DESCRIPTION
This fixes https://github.com/wireapp/wire-webapp/issues/5826.