### PR TITLE
chore: Bump @wireapp/avs from 6.2.23 to 6.2.26 (#6282)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@wireapp/antiscroll-2": "1.0.2",
-    "@wireapp/avs": "6.2.23",
+    "@wireapp/avs": "6.2.26",
     "@wireapp/commons": "3.7.1",
     "@wireapp/core": "16.12.4",
     "@wireapp/protocol-messaging": "1.25.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2048,10 +2048,10 @@
     tough-cookie "4.0.0"
     ws "7.3.1"
 
-"@wireapp/avs@6.2.23":
-  version "6.2.23"
-  resolved "https://registry.yarnpkg.com/@wireapp/avs/-/avs-6.2.23.tgz#79320f8f6c6d6af2407c6c327e9b5fb7613919d3"
-  integrity sha512-JP4qLCFpSRjgA7kUlXOg3+aay8oOiStqrbTm13f7Me6Zph00ThwN4kZAnmPZIj3OAWSn1m5BuA1c7gS2X2yWUg==
+"@wireapp/avs@6.2.25":
+  version "6.2.25"
+  resolved "https://registry.yarnpkg.com/@wireapp/avs/-/avs-6.2.25.tgz#eb30bf70a706f0e4d61a148211c6b89e527086a0"
+  integrity sha512-yu3pP0pzaupDbNH1+3aArJnUWq8Lwlqf6pGTOKEaH1irWzG2BVosq/ZSt9yFQu5tQ6g4Y5ekt5VV4bxB0uCcrw==
 
 "@wireapp/cbor@4.6.11":
   version "4.6.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2048,10 +2048,10 @@
     tough-cookie "4.0.0"
     ws "7.3.1"
 
-"@wireapp/avs@6.2.25":
-  version "6.2.25"
-  resolved "https://registry.yarnpkg.com/@wireapp/avs/-/avs-6.2.25.tgz#eb30bf70a706f0e4d61a148211c6b89e527086a0"
-  integrity sha512-yu3pP0pzaupDbNH1+3aArJnUWq8Lwlqf6pGTOKEaH1irWzG2BVosq/ZSt9yFQu5tQ6g4Y5ekt5VV4bxB0uCcrw==
+"@wireapp/avs@6.2.26":
+  version "6.2.26"
+  resolved "https://registry.yarnpkg.com/@wireapp/avs/-/avs-6.2.26.tgz#75baa97be8b8f60607fca4f6535333aa305fba1b"
+  integrity sha512-7t/k1+SgUoqpJnIJ5LWbFBkV9glfa3PXvVImnQ7OoYJCSfccqRG/lrnCBA48A4OKVZ/+kuMpj/4KY0rfXZTDBw==
 
 "@wireapp/cbor@4.6.11":
   version "4.6.11"


### PR DESCRIPTION
Fixes #6282 