### PR TITLE
refactor: Remove version from HTML

### DIFF
--- a/src/page/template/meta.htm
+++ b/src/page/template/meta.htm
@@ -1,7 +1,6 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="geoip" country="{{country}}" />
-    <meta property="wire:version" version="{{@config.VERSION}}" />
     {{#if @config.CHROME_ORIGIN_TRIAL_TOKEN}}<meta http-equiv="origin-trial" content="{{{@config.CHROME_ORIGIN_TRIAL_TOKEN}}}">{{/if}}
     <link href="/image/favicon.ico?{{@config.VERSION}}" type="image/x-icon" rel="shortcut icon" sizes="48x48" />
     <link href="/image/meta/wire-icon-256.png?{{@config.VERSION}}" rel="icon" sizes="256x256" type="image/png" />

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -494,7 +494,7 @@ class App {
       telemetry.timeStep(AppInitTimingsStep.UPDATED_CONVERSATIONS);
       if (userRepository.isActivatedAccount()) {
         // start regularly polling the server to check if there is a new version of Wire
-        startNewVersionPolling(Environment.version(false, true), this.update.bind(this));
+        startNewVersionPolling(Environment.version(false), this.update.bind(this));
       }
       audioRepository.init(true);
       conversationRepository.cleanup_conversations();

--- a/src/script/util/Environment.ts
+++ b/src/script/util/Environment.ts
@@ -18,6 +18,7 @@
  */
 
 import {Runtime} from '@wireapp/commons';
+import {Config} from '../Config';
 import {BackendEnvironment} from '../service/BackendEnvironment';
 
 const APP_ENV = {
@@ -26,20 +27,10 @@ const APP_ENV = {
   VIRTUAL_HOST: 'wire.ms', // The domain "wire.ms" is our virtual host for testing contact uploads
 };
 
-const getAppVersion = (): string => {
-  const versionElement = document.head.querySelector("[property='wire:version']");
-  return versionElement?.getAttribute('version').trim() || '';
-};
-
 const getElectronVersion = (userAgent: string): string => {
   // [match, version]
   const [, electronVersion] = /Wire(?:Internal)?\/(\S+)/.exec(userAgent) || [];
   return electronVersion;
-};
-
-const getFormattedAppVersion = (): string => {
-  const [year, month, day, hour, minute] = getAppVersion().split('.');
-  return `${year}.${month}.${day}.${hour}.${minute}`;
 };
 
 const isLocalhost = (): boolean => [APP_ENV.LOCALHOST, APP_ENV.VIRTUAL_HOST].includes(window.location.hostname);
@@ -62,11 +53,11 @@ export const Environment = {
     }
 
     if (doNotFormat) {
-      return getAppVersion();
+      return Config.getConfig().VERSION;
     }
 
     const electronVersion = getElectronVersion(Runtime.getUserAgent());
     const showElectronVersion = electronVersion && showWrapperVersion;
-    return showElectronVersion ? electronVersion : getFormattedAppVersion();
+    return showElectronVersion ? electronVersion : Config.getConfig().VERSION;
   },
 };

--- a/src/script/util/Environment.ts
+++ b/src/script/util/Environment.ts
@@ -47,13 +47,9 @@ export const Environment = {
     isLocalhost,
     isProduction,
   },
-  version: (showWrapperVersion = true, doNotFormat = false): string => {
+  version: (showWrapperVersion = true): string => {
     if (Environment.frontend.isLocalhost()) {
       return 'dev';
-    }
-
-    if (doNotFormat) {
-      return Config.getConfig().VERSION;
     }
 
     const electronVersion = getElectronVersion(Runtime.getUserAgent());


### PR DESCRIPTION
Since the introduction of the config file approach, there is no more need to read the "version" from our HTML code.