### PR TITLE
fix(server): Add date to request only if the value exists

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -42,6 +42,6 @@
     "create-commit-sha": "node ./bin/create_commit_sha_file.js",
     "clean": "rimraf ./dist/",
     "start:prod": "pm2 start \"./index.js\" --name \"Webapp\" && pm2 logs",
-    "test": "yarn jest"
+    "test": "jest"
   }
 }

--- a/server/routes/error/ErrorRoutes.ts
+++ b/server/routes/error/ErrorRoutes.ts
@@ -37,12 +37,14 @@ const InternalErrorRoute = (): express.ErrorRequestHandler => (err, req, res) =>
     message: 'Internal server error',
     stack: err.stack,
   };
-  const request = {
-    date: req.headers.date,
+  const request: any = {
     host: req.hostname,
     ip: req.ip,
     url: req.url,
   };
+  if (req.headers?.date) {
+    request.date = req.headers.date;
+  }
   req.app.locals.error = error;
   req.app.locals.request = request;
   return res.status(error.code).render('error');


### PR DESCRIPTION
After seeing these errors:

```
0|Webapp  | TypeError: Cannot read property 'date' of undefined
0|Webapp  |     at /var/app/routes/error/ErrorRoutes.ts:41:23
0|Webapp  |     at Layer.handle [as handle_request] (/var/app/current/node_modules/express/lib/router/layer.js:95:5)
0|Webapp  |     at trim_prefix (/var/app/current/node_modules/express/lib/router/index.js:317:13)
0|Webapp  |     at /var/app/current/node_modules/express/lib/router/index.js:284:7
0|Webapp  |     at Function.process_params (/var/app/current/node_modules/express/lib/router/index.js:335:12)
0|Webapp  |     at next (/var/app/current/node_modules/express/lib/router/index.js:275:10)
0|Webapp  |     at /var/app/current/node_modules/express/lib/router/index.js:635:15
0|Webapp  |     at next (/var/app/current/node_modules/express/lib/router/index.js:260:14)
0|Webapp  |     at Function.handle (/var/app/current/node_modules/express/lib/router/index.js:174:3)
0|Webapp  |     at router (/var/app/current/node_modules/express/lib/router/index.js:47:12)
```