### PR TITLE
runfix: Return after changing conversation access state

### DIFF
--- a/src/script/conversation/ConversationStateHandler.ts
+++ b/src/script/conversation/ConversationStateHandler.ts
@@ -85,6 +85,7 @@ export class ConversationStateHandler extends AbstractConversationEventHandler {
 
             this._showModal(messageString);
           }
+          return;
         }
       }
     }


### PR DESCRIPTION
Missing return, was introduced in https://github.com/wireapp/wire-webapp/pull/10088.