### PR TITLE
refactor: Remove url-search-params-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "@types/sinon": "9.0.10",
     "@wireapp/antiscroll-2": "1.0.2",
     "@wireapp/avs": "6.6.14",
     "@wireapp/core": "16.12.77",
@@ -45,7 +44,6 @@
     "tsyringe": "4.3.0",
     "uint32": "0.2.1",
     "underscore": "1.12.0",
-    "url-search-params-polyfill": "8.1.0",
     "use-react-router": "1.0.7",
     "uuidjs": "4.2.7",
     "webrtc-adapter": "6.4.8"
@@ -87,6 +85,7 @@
     "@types/redux-mock-store": "1.0.2",
     "@types/sdp-transform": "2.4.4",
     "@types/simplebar": "5.1.1",
+    "@types/sinon": "9.0.10",
     "@types/speakingurl": "13.0.2",
     "@types/uint32": "0.2.0",
     "@types/underscore": "1.10.24",

--- a/src/script/media/MediaEmbeds.ts
+++ b/src/script/media/MediaEmbeds.ts
@@ -17,8 +17,6 @@
  *
  */
 
-import 'url-search-params-polyfill';
-
 import {Runtime} from '@wireapp/commons';
 import {formatString} from 'Util/StringUtil';
 

--- a/src/script/util/LoggerUtil.ts
+++ b/src/script/util/LoggerUtil.ts
@@ -17,8 +17,6 @@
  *
  */
 
-import 'url-search-params-polyfill';
-
 export function enableLogging(force = false, search = window.location.search): void {
   let localStorage;
 


### PR DESCRIPTION
Since all current browser versions [support](https://caniuse.com/?search=URLSearchParams) `URLSearchParams`, we can now remove the polyfill.

![image](https://user-images.githubusercontent.com/5497598/104708806-734d1900-571e-11eb-8130-f0b32f8bdc7a.png)
