### PR TITLE
feat: Make recent webapps compatible with old URL configs

### DIFF
--- a/src/script/Config.ts
+++ b/src/script/Config.ts
@@ -45,7 +45,7 @@ export class Configuration {
   readonly MAX_GROUP_PARTICIPANTS = env.MAX_GROUP_PARTICIPANTS || 500;
   readonly MAX_VIDEO_PARTICIPANTS = env.MAX_VIDEO_PARTICIPANTS || 4;
   readonly NEW_PASSWORD_MINIMUM_LENGTH = env.NEW_PASSWORD_MINIMUM_LENGTH || ValidationUtil.DEFAULT_PASSWORD_MIN_LENGTH;
-  readonly URL = env.URL || {
+  readonly URL = {
     ACCOUNT_BASE: 'https://account.wire.com',
     MOBILE_BASE: '',
     PRIVACY_POLICY: 'https://wire-website-staging.zinfra.io/security',
@@ -68,6 +68,7 @@ export class Configuration {
     TERMS_OF_USE_TEAMS: 'https://wire-website-staging.zinfra.io/legal/terms/teams',
     WEBSITE_BASE: 'https://wire.com',
     WHATS_NEW: 'https://medium.com/wire-news/webapp-updates/home',
+    ...env.URL,
   };
   readonly VERSION = env.VERSION || '0.0.0';
   readonly WEBSITE_LABEL = env.WEBSITE_LABEL;


### PR DESCRIPTION
**Current situation**
The current config code sets `URL` to what is given by `env.URL` or a set of default values. 

**Problem**
When you are now launching the webapp with a very old configuration, then `env.URL` might not have entries like `URL.SUPPORT.HISTORY`, so our code fails at statements like `Config.getConfig().URL.SUPPORT.HISTORY`.

**Solution**
To make new Wire web app versions compatible with old configs, we can set `URL` to a set of defaults first and then spread the config properties of our custom (old) config into the config object. Thus it will be guaranteed that we have a config with meaningful default values.

**Real-World Scenario**
I ran into this problem by using a webapp version (commit ID 14ee262578ec98843cfd48bf1bcd9edd0074d611) from 2021 with a config from 2020.

- My old config:

```
window.wire = window.wire || {};
window.wire.env = {
  ANALYTICS_API_KEY: '',
  APP_NAME: 'Webapp',
  BACKEND_REST: 'https://prod-nginz-https.wire.com',
  BACKEND_WS: 'wss://prod-nginz-ssl.wire.com',
  BRAND_NAME: 'Wire',
  ENVIRONMENT: 'production',
  FEATURE: {
    ALLOWED_FILE_UPLOAD_EXTENSIONS: ['*'],
    APPLOCK_SCHEDULED_TIMEOUT: null,
    APPLOCK_UNFOCUS_TIMEOUT: null,
    CHECK_CONSENT: true,
    DEFAULT_LOGIN_TEMPORARY_CLIENT: false,
    ENABLE_ACCOUNT_REGISTRATION: true,
    ENABLE_DEBUG: false,
    ENABLE_DOMAIN_DISCOVERY: true,
    ENABLE_PHONE_LOGIN: true,
    ENABLE_SSO: true,
    PERSIST_TEMPORARY_CLIENTS: true,
    SHOW_LOADING_INFORMATION: false,
  },
  MAX_GROUP_PARTICIPANTS: 500,
  MAX_VIDEO_PARTICIPANTS: 4,
  NEW_PASSWORD_MINIMUM_LENGTH: 8,
  RAYGUN_API_KEY: '',
  URL: {
    ACCOUNT_BASE: 'https://account.wire.com',
    MOBILE_BASE: '',
    PRIVACY_POLICY: 'https://wire.com/security',
    SUPPORT_BASE: 'https://support.wire.com',
    TEAMS_BASE: 'https://teams.wire.com',
    TERMS_OF_USE_PERSONAL: 'https://wire.com/legal/terms/personal',
    TERMS_OF_USE_TEAMS: 'https://wire.com/legal/terms/teams',
    WEBSITE_BASE: 'https://wire.com',
  },
  VERSION: '2020-02-14-13-07',
  APP_BASE: 'https://app.wire.com',
};
```