### PR TITLE
Revert "chore: bump highlight.js from 10.5.0 to 10.6.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "countly-sdk-web": "20.11.0",
     "date-fns": "2.17.0",
     "dexie-batch": "0.4.2",
-    "highlight.js": "10.6.0",
+    "highlight.js": "10.5.0",
     "http-status-codes": "2.1.4",
     "jquery": "3.5.1",
     "jquery-mousewheel": "3.1.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6833,10 +6833,10 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-highlight.js@*, highlight.js@10.6.0:
-  version "10.6.0"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.6.0.tgz#0073aa71d566906965ba6e1b7be7b2682f5e18b6"
-  integrity sha512-8mlRcn5vk/r4+QcqerapwBYTe+iPL5ih6xrNylxrnBdHQiijDETfXX7VIxC3UiCRiINBJfANBAsPzAvRQj8RpQ==
+highlight.js@*, highlight.js@10.5.0:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.5.0.tgz#3f09fede6a865757378f2d9ebdcbc15ba268f98f"
+  integrity sha512-xTmvd9HiIHR6L53TMC7TKolEj65zG1XU+Onr8oi86mYa+nLcIbxTTWkpW7CsEwv/vK7u1zb8alZIMLDqqN6KTw==
 
 history@^4.9.0:
   version "4.10.1"


### PR DESCRIPTION
Reverts wireapp/wire-webapp#10509