### PR TITLE
chore: Ignore husky v5 update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,4 +78,4 @@ updates:
           - '>= 13.a'
       - dependency-name: 'husky'
         versions:
-          - '>= 5'
+          - '>= 5.a'


### PR DESCRIPTION
Trying to ignore: https://github.com/wireapp/wire-webapp/pull/10586