### PR TITLE
chore: Use filesystem caching with webpack 5

### DIFF
--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -27,6 +27,13 @@ const auth = path.resolve(SRC_PATH, 'script/auth');
 const srcScript = path.resolve(SRC_PATH, 'script');
 
 module.exports = {
+  cache: {
+    buildDependencies: {
+      // https://webpack.js.org/blog/2020-10-10-webpack-5-release/#persistent-caching
+      config: [__filename],
+    },
+    type: 'filesystem',
+  },
   devtool: 'source-map',
   entry: {
     app: path.resolve(srcScript, 'main/app.ts'),


### PR DESCRIPTION
Webpack 5 introduced **persistent caching** which allows to save its cache on the disk (fileystem). Saving webpack's cache on disk, rather than saving it in-memory, speeds up webpack's compilation on consecutive starts by a lot.

When running our webapp, the compile step of webpack takes around 25 seconds on my machine:

> webpack 5.24.0 compiled with 1 warning in 24502ms
> webpack built 0c5abf71da034c869f6c in 734ms

Using webpack's filesystem cache, the first start will still take 25 seconds on my machine but following starts (using the cache from the first start) just take 2.5 seconds:

> webpack 5.24.0 compiled with 1 warning in 2232 ms
> webpack built 0c5abf71da034c869f6c in 758ms

Read more about it here: https://webpack.js.org/blog/2020-10-10-webpack-5-release/#persistent-caching