### PR TITLE
chore: Skip coverage table in CI builds

### DIFF
--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Test
         # Run for all PRs and pushes to master/dev with DISTRIBUTION == 'wire'
         if: env.DISTRIBUTION == 'wire'
-        run: yarn test --coverage --coverage-reporters=lcov --detectOpenHandles=false --forceExit
+        run: yarn test --coverage --coverage-reporters=clover --detectOpenHandles=false --forceExit
 
       - name: Monitor coverage
         # Run for all PRs with DISTRIBUTION == 'wire'

--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Test
         # Run for all PRs and pushes to master/dev with DISTRIBUTION == 'wire'
         if: env.DISTRIBUTION == 'wire'
-        run: yarn test --coverage --detectOpenHandles=false --reporters="lcov" --forceExit
+        run: yarn test --coverage --coverage-reporters=lcov --detectOpenHandles=false --forceExit
 
       - name: Monitor coverage
         # Run for all PRs with DISTRIBUTION == 'wire'

--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Test
         # Run for all PRs and pushes to master/dev with DISTRIBUTION == 'wire'
         if: env.DISTRIBUTION == 'wire'
-        run: yarn test --coverage --detectOpenHandles=false --forceExit
+        run: yarn test --coverage --detectOpenHandles=false --reporters="lcov" --forceExit
 
       - name: Monitor coverage
         # Run for all PRs with DISTRIBUTION == 'wire'


### PR DESCRIPTION
We just need the Clover output to get the "Coverage Report" from GitHub Actions, so we can ommit this table:

![image](https://user-images.githubusercontent.com/469989/110974137-7bac8380-835e-11eb-903a-85d9f7399fe7.png)
