### PR TITLE
test: Use ISO date when using `EventInfoEntity.setTimestamp()`

### DIFF
--- a/src/script/conversation/EventInfoEntity.ts
+++ b/src/script/conversation/EventInfoEntity.ts
@@ -62,8 +62,8 @@ export class EventInfoEntity {
     return this.type || (this.genericMessage && this.genericMessage.content);
   }
 
-  setTimestamp(time: string | number): void {
-    this.timestamp = new Date(Number(time)).getTime();
+  setTimestamp(isoDate: string): void {
+    this.timestamp = new Date(isoDate).getTime();
   }
 
   setType(type: GENERIC_MESSAGE_TYPE): void {

--- a/src/script/conversation/EventInfoEntity.ts
+++ b/src/script/conversation/EventInfoEntity.ts
@@ -62,8 +62,8 @@ export class EventInfoEntity {
     return this.type || (this.genericMessage && this.genericMessage.content);
   }
 
-  setTimestamp(time: string): void {
-    this.timestamp = new Date(time).getTime();
+  setTimestamp(time: string | number): void {
+    this.timestamp = new Date(Number(time)).getTime();
   }
 
   setType(type: GENERIC_MESSAGE_TYPE): void {

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -738,7 +738,7 @@ export class MessageRepository {
 
     const injectedEvent = await this.eventRepository.injectEvent(mappedEvent);
     const eventInfoEntity = new EventInfoEntity(genericMessage, conversationEntity.id);
-    eventInfoEntity.setTimestamp((injectedEvent as any).time as string);
+    eventInfoEntity.setTimestamp(injectedEvent.time);
     const sentPayload = await this.sendGenericMessageToConversation(eventInfoEntity);
     this.trackContributed(conversationEntity, genericMessage);
     const backendIsoDate = syncTimestamp ? sentPayload.time : '';

--- a/src/script/storage/record/EventRecord.ts
+++ b/src/script/storage/record/EventRecord.ts
@@ -55,6 +55,7 @@ export interface EventRecord<T = any> {
   selected_button_id?: string;
   server_time?: string;
   status?: StatusType;
+  /** The time as ISO date string */
   time: string;
   timestamp?: number;
   type: string;

--- a/test/unit_tests/conversation/ClientMismatchHandlerSpec.js
+++ b/test/unit_tests/conversation/ClientMismatchHandlerSpec.js
@@ -90,7 +90,7 @@ describe('ClientMismatchHandler', () => {
 
       const timestamp = new Date(clientMismatch.time).getTime();
       const eventInfoEntity = new EventInfoEntity(undefined, conversation.id);
-      eventInfoEntity.setTimestamp(timestamp);
+      eventInfoEntity.setTimestamp(clientMismatch.time);
 
       await clientMismatchHandler.onClientMismatch(eventInfoEntity, clientMismatch, payload);
       expect(conversationRepositorySpy.addMissingMember).toHaveBeenCalledWith(
@@ -154,7 +154,7 @@ describe('ClientMismatchHandler', () => {
         sender: '43619b6a2ec22e24',
       };
 
-      eventInfoEntity.setTimestamp(new Date(clientMismatch.time).getTime());
+      eventInfoEntity.setTimestamp(clientMismatch.time);
       await clientMismatchHandler.onClientMismatch(eventInfoEntity, clientMismatch, payload);
 
       const expectedReceipients = {


### PR DESCRIPTION
before:
`new Date('1461926303002') -> Invalid Date`

after:
`new Date(1461926303002) -> 2016-04-29T10:38:23.002Z`