### PR TITLE
chore: CI change docker tag name scheme

### DIFF
--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -239,9 +239,9 @@ jobs:
           DOCKER_USERNAME: ${{secrets.WEBTEAM_QUAY_USERNAME}}
         run: |
           if [ "$DISTRIBUTION" == "wire" ]; then
-            yarn docker '' staging
+            yarn docker '' staging "$TAG"
           else
-            yarn docker "$DISTRIBUTION" staging
+            yarn docker "$DISTRIBUTION" staging "$TAG"
           fi
 
       - name: Push production Docker image
@@ -251,9 +251,9 @@ jobs:
           DOCKER_USERNAME: ${{secrets.WEBTEAM_QUAY_USERNAME}}
         run: |
           if [ "$DISTRIBUTION" == "wire" ]; then
-            yarn docker '' production
+            yarn docker '' production "$TAG"
           else
-            yarn docker "$DISTRIBUTION" production
+            yarn docker "$DISTRIBUTION" production "$TAG"
           fi
 
       - name: Generate changelog

--- a/bin/push_docker.js
+++ b/bin/push_docker.js
@@ -64,10 +64,10 @@ const dockerCommands = [
   `docker build . --tag ${commitShortSha}`,
 ];
 
-tags.forEach( containerImageTag => {
+tags.forEach( containerImageTagName => {
   dockerCommands.push(
-    `docker tag ${commitShortSha} ${containerImageTag}`,
-    `docker push ${containerImageTag}`
+    `docker tag ${commitShortSha} ${containerImageTagName}`,
+    `docker push ${containerImageTagName}`
   );
 });
 

--- a/bin/push_docker.js
+++ b/bin/push_docker.js
@@ -64,10 +64,10 @@ const dockerCommands = [
   `docker build . --tag ${commitShortSha}`,
 ];
 
-tags.forEach( containerImageTagValue => {
+tags.forEach(containerImageTagValue => {
   dockerCommands.push(
     `docker tag ${commitShortSha} ${containerImageTagValue}`,
-    `docker push ${containerImageTagValue}`
+    `docker push ${containerImageTagValue}`,
   );
 });
 

--- a/bin/push_docker.js
+++ b/bin/push_docker.js
@@ -64,11 +64,10 @@ const dockerCommands = [
   `docker build . --tag ${commitShortSha}`,
 ];
 
-// prettier-ignore
-tags.forEach( tag => {
+tags.forEach( containerImageTag => {
   dockerCommands.push(
-    `docker tag ${commitShortSha} ${tag}`,
-    `docker push ${tag}`
+    `docker tag ${commitShortSha} ${containerImageTag}`,
+    `docker push ${containerImageTag}`
   );
 });
 

--- a/bin/push_docker.js
+++ b/bin/push_docker.js
@@ -64,10 +64,10 @@ const dockerCommands = [
   `docker build . --tag ${commitShortSha}`,
 ];
 
-tags.forEach( containerImageTagName => {
+tags.forEach( containerImageTagValue => {
   dockerCommands.push(
-    `docker tag ${commitShortSha} ${containerImageTagName}`,
-    `docker push ${containerImageTagName}`
+    `docker tag ${commitShortSha} ${containerImageTagValue}`,
+    `docker push ${containerImageTagValue}`
   );
 });
 


### PR DESCRIPTION
*This change set aims to fix the naming scheme if container image tags with a focus on release versions.*

1. refactor: make script used to push Docker images a bit more readable

* remove dashes from values and add them inline when needed
* remove obsolete variables along the way

2. ci: change container image tag names to reflect

* before, image tags did not indicate actual releases
* before, `pkg.version` was a) meaningless and b) kept being static '0.2.0'

This way, it's a one-step lookup to the corresponding webapp release

If CI is triggered via release tag, the tags are, e.g.:

  * 2021-04-01-production.0-v0.28.3-254d51 - '${RELEASE_NAME}-${COMMIT_ID_SHORT}-${CONFIG_VERSION}'
  * edge - '${STAGE}'

If CI is triggered via dev or edge branch, the tag is, e.g.:

  * dev - '${STAGE}'

This allows to uniquely and readable pin the image version on one hand, and at
the same time use a dynamic tag to always fetch latest (e.g. `imagePullPolicy: Always`)

__NOTE:__ As a follow-up it is planned to create another step in CI to create a PR on https://github.com/wireapp/wire-server to update the container image tag in the Helm chart values whenever a new release is being created. This PR basically lays the groundwork for that.

/cc @Yserz 