### PR TITLE
chore(ci): Add job to update image tag in corresponding Helm chart

### DIFF
--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -117,6 +117,24 @@ jobs:
           env.BUILD_DESKTOP == 'true'
         run: yarn build:prod
 
+      - name: Assembling release information
+        if: contains(env.TAG, 'production') && matrix.DISTRIBUTION == 'DISTRIBUTION_0'
+        # NOTE: always using 'master' config, since release version is only consumed at
+        #       'production' stage for now
+        shell: bash
+        run: |
+          configVersion=$(cat ./app-config/package.json | jq -r '.dependencies["wire-web-config-default-master"]' | awk -F '#' '{ print $2 }')
+          packageVersion=$(cat ./package.json | jq -r '.version')
+          containerImageTag="${TAG:-${packageVersion}}-${configVersion}-${GITHUB_SHA::7}"
+          echo "{\"imageTag\": \"${containerImageTag}\", \"releaseName\": \"${TAG:-v${packageVersion}}\"}" > ./release-info.json
+
+      - name: Storing release information
+        if: contains(env.TAG, 'production') && matrix.DISTRIBUTION == 'DISTRIBUTION_0'
+        uses: actions/upload-artifact@v2
+        with:
+          name: release-info.json
+          path: ./release-info.json
+
       # https://wire-webapp-avs.zinfra.io/
       - name: Deploy avs build to Elastic Beanstalk
         if: env.BRANCH_NAME == 'avs' && matrix.DISTRIBUTION == 'DISTRIBUTION_0'
@@ -323,6 +341,66 @@ jobs:
           name: webapp-dist
           path: ./server/dist
 
+  update_helm_chart:
+    name: Update Helm chart
+    runs-on: ubuntu-latest
+
+    needs: test_build_deploy
+
+    steps:
+      - name: Obtaining release information artifact
+        id: release-info-artifact
+        uses: actions/download-artifact@v2
+        continue-on-error: true
+        with:
+          name: release-info.json
+      - name: Indicating whether release info exist
+        id: release-info-file
+        env:
+          ARTIFACT_LOCAL_PATH: '${{ steps.release-info-artifact.outputs.download-path }}/release-info.json'
+        shell: bash
+        run: |
+          test -s "${ARTIFACT_LOCAL_PATH}" && echo '::set-output name=exists::true'
+          echo "::set-output name=releaseInfo::$(cat ${ARTIFACT_LOCAL_PATH})"
+
+      - name: Checking out 'wire-server'
+        uses: actions/checkout@v2
+        if: ${{ steps.release-info-file.outputs.exists == 'true' }}
+        with:
+          repository: 'wireapp/wire-server'
+          fetch-depth: 1
+
+      - name: Changing Helm value of the webapp chart
+        id: change-helm-value
+        if: ${{ steps.release-info-file.outputs.exists == 'true' }}
+        shell: bash
+        run: |
+          sed --in-place --expression="s/  tag: .*/  tag: \"${{ fromJSON(steps.release-info-file.outputs.releaseInfo).imageTag }}\"/" ./charts/webapp/values.yaml
+          git add ./charts/webapp/values.yaml
+          echo "::set-output name=releaseUrl::${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${{ fromJSON(steps.release-info-file.outputs.releaseInfo).releaseName }}"
+
+      - name: Creating Pull Request
+        id: create-pr
+        if: ${{ steps.release-info-file.outputs.exists == 'true' }}
+        uses: peter-evans/create-pull-request@v3
+        with:
+          draft: false
+          token: ${{ secrets.ZEBOT_GH_TOKEN }}
+          author: 'Zebot <zebot@users.noreply.github.com>'
+          branch: charts-update-webapp-image-tag-${{ github.run_number }}
+          commit-message: 'chore: [charts] Update webapp version'
+          title: 'Update webapp version in Helm chart [skip ci]'
+          body: |
+            Image tag: `${{ fromJSON(steps.release-info-file.outputs.releaseInfo).imageTag }}`
+            Release: [`${{ fromJSON(steps.release-info-file.outputs.releaseInfo).releaseName }}`](${{ steps.change-helm-value.outputs.releaseUrl }})
+
+      - name: Printing Pull Request URL
+        if: ${{ steps.release-info-file.outputs.exists == 'true' }}
+        shell: bash
+        run: |
+          echo "PR: ${{ steps.create-pr.outputs.pull-request-url }}"
+
+
   build_desktop_binaries:
     name: Build desktop binaries
     needs: test_build_deploy
@@ -450,24 +528,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Set environment variables
-        shell: bash
-        run: |
-          echo "TAG=$(git tag --points-at ${{github.sha}})" >> $GITHUB_ENV
-          echo "PR_LAST_COMMIT_MESSAGE=$(git log --format=%B -n 1 ${{github.event.after}} | head -n 1)" >> $GITHUB_ENV
-
-      - name: Set BUILD_DESKTOP
-        shell: bash
-        run: |
-          echo "BUILD_DESKTOP=${{contains(env.TAG, 'staging') || contains(env.TAG, 'production') || contains(env.PR_LAST_COMMIT_MESSAGE, '+Desktop')}}" >> $GITHUB_ENV
-
       - name: Delete WebApp artifacts
-        if: env.BUILD_DESKTOP == 'true'
         uses: geekyeggo/delete-artifact@v1
         with:
-          name: webapp-dist
+          failOnError: false
+          name: |
+            webapp-dist
+            release-info.json


### PR DESCRIPTION
This change-set is meant to keep the webapp Helm chart in wire-server
up-to-date. To accomplish that, it adds two new blocks of steps (one
of which actually incorporates a new job).

(1) following the naming scheme in ./bin/push_docker.js:59, a step
assembles the image tag name (not the release tag) - and so the
naming clash begins. A second one write the information to an 'artifact'.
This way, its possible to access the information from another job.

(2) this new job reads the image tag from the artifact and opens a
new PR over at wire-server. This PR is supposed to only update the
webapp chart - more precisely it only changes the value of 'image.tag'
in wire-server/charts/webapp/values.yaml

Finally, the artifact is removed by the general clean up job 'cleanup_artifacts'.

Furthermore, the change-set simplifies cleanup with the help of setting
'failOnError', which wont cause the workflow to fail, if a certain
artifact does not exist.