### PR TITLE
fix: Check if errors are backend errors

### DIFF
--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -105,6 +105,7 @@ import {TeamState} from '../team/TeamState';
 import {ConversationState} from './ConversationState';
 import {ClientState} from '../client/ClientState';
 import {UserType} from '../tracking/attribute';
+import {isBackendError} from 'Util/TypePredicateUtil';
 
 type ConversationEvent = {conversation: string; id: string};
 type EventJson = any;
@@ -1203,7 +1204,8 @@ export class MessageRepository {
       payload.native_push = options.nativePush;
       return await this.sendEncryptedMessage(eventInfoEntity, payload);
     } catch (error) {
-      const isRequestTooLarge = error.code === HTTP_STATUS.REQUEST_TOO_LONG;
+      const isRequestTooLarge = isBackendError(error) && error.code === HTTP_STATUS.REQUEST_TOO_LONG;
+
       if (isRequestTooLarge) {
         return this.sendExternalGenericMessage(eventInfoEntity);
       }

--- a/src/script/util/TypePredicateUtil.test.ts
+++ b/src/script/util/TypePredicateUtil.test.ts
@@ -1,0 +1,48 @@
+import {isAxiosError, isBackendError} from 'Util/TypePredicateUtil';
+import type {AxiosError} from 'axios';
+import {BackendError, BackendErrorLabel} from '@wireapp/api-client/src/http/';
+
+describe('TypePredicateUtil', () => {
+  describe('isAxiosError', () => {
+    it('recognizes axios error structures', () => {
+      const error: AxiosError = {
+        config: {},
+        isAxiosError: true,
+        message: 'Server Error',
+        name: 'AxiosError',
+        toJSON: jest.fn(),
+      };
+
+      const actual = isAxiosError(error);
+      expect(actual).toBeTruthy();
+    });
+
+    it('does not fail when an error is undefined', () => {
+      const actual = isAxiosError(undefined);
+      expect(actual).toBeFalsy();
+    });
+
+    it('does not fail when an error is a string', () => {
+      const actual = isAxiosError('Server Error');
+      expect(actual).toBeFalsy();
+    });
+  });
+
+  describe('isBackendError', () => {
+    it('recognizes Wire backend errors', () => {
+      const error = new BackendError('Server Error', BackendErrorLabel.SERVER_ERROR);
+      const actual = isBackendError(error);
+      expect(actual).toBeTruthy();
+    });
+
+    it('does not fail when an error is undefined', () => {
+      const actual = isBackendError(undefined);
+      expect(actual).toBeFalsy();
+    });
+
+    it('does not fail when an error is a string', () => {
+      const actual = isBackendError('Server Error');
+      expect(actual).toBeFalsy();
+    });
+  });
+});

--- a/src/script/util/TypePredicateUtil.ts
+++ b/src/script/util/TypePredicateUtil.ts
@@ -21,9 +21,9 @@ import type {BackendError} from '@wireapp/api-client/src/http/';
 import {AxiosError} from 'axios';
 
 export function isAxiosError(errorCandidate: any): errorCandidate is AxiosError {
-  return errorCandidate.isAxiosError === true;
+  return errorCandidate && errorCandidate.isAxiosError === true;
 }
 
 export function isBackendError(errorCandidate: any): errorCandidate is BackendError {
-  return typeof errorCandidate.label === 'string' && typeof errorCandidate.message === 'string';
+  return errorCandidate && typeof errorCandidate.label === 'string' && typeof errorCandidate.message === 'string';
 }


### PR DESCRIPTION
Errors are by default of `any` type, so they can be `undefined` or of type `string` which will cause a check on `error.code` to fail.