### PR TITLE
chore: Remove references of non-existing keys in app-config

### DIFF
--- a/bin/push_docker.js
+++ b/bin/push_docker.js
@@ -37,17 +37,10 @@ const releaseParam = process.argv[4] || '';
 const commitSha = process.env.GITHUB_SHA || 'COMMIT_ID';
 const commitShaLength = 7;
 const commitShortSha = commitSha.substring(0, commitShaLength - 1);
-const configurationEntry = distributionParam
-  ? `wire-web-config-default-${distributionParam}`
-  : `wire-web-config-default-${currentBranch === 'master' ? 'master' : 'staging'}`;
-const dependencies = {
-  ...appConfigPkg.dependencies,
-  ...appConfigPkg.devDependencies,
-  ...appConfigPkg.peerDependencies,
-  ...appConfigPkg.optionalDependencies,
-};
-
-const configVersion = dependencies[configurationEntry].split('#')[1];
+const configurationEntry = `wire-web-config-default-${
+  distributionParam ? distributionParam : currentBranch === 'master' ? 'master' : 'staging'
+}`;
+const configVersion = appConfigPkg.dependencies[configurationEntry].split('#')[1];
 const dockerRegistryDomain = 'quay.io';
 const repository = `${dockerRegistryDomain}/wire/webapp${distributionParam ? `-${distributionParam}` : ''}`;
 


### PR DESCRIPTION
As a result of a discussion in 'wire-account' [1], this change set ports
the proposed changes - simply for reasons of consistency, and:

  [...] because 'app-config/package.json' only contains the 'dependencies'
  field, not all the others like 'devDependencies' or 'peerDependencies'.

[1] https://github.com/wireapp/wire-account/pull/2865#discussion_r644025507