### PR TITLE
chore: Turn web chapter into code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @AndyLnd @bennycode @ffflorian @thisisamir98 @Yserz

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @AndyLnd @bennycode @ffflorian @thisisamir98 @Yserz
+* @wireapp/web

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @wireapp/web
+* @wireapp/web @otto-the-bot


### PR DESCRIPTION
We need this code change to activate the following check in our repo:

![image](https://user-images.githubusercontent.com/469989/122057634-24013680-cdeb-11eb-9732-5811b9341e2e.png)
