### PR TITLE
chore: Base tag information on script input rather than branch name

### DIFF
--- a/bin/push_docker.js
+++ b/bin/push_docker.js
@@ -21,24 +21,16 @@
 
 const child = require('child_process');
 const appConfigPkg = require('../app-config/package.json');
-const {execSync} = require('child_process');
 
 require('dotenv').config();
 
-let currentBranch = '';
-
-try {
-  currentBranch = execSync('git rev-parse HEAD').toString().trim();
-} catch (error) {}
-
 const distributionParam = process.argv[2] || '';
 const stageParam = process.argv[3] || '';
-const releaseParam = process.argv[4] || '';
+const versionParam = process.argv[4] || '';
 const commitSha = process.env.GITHUB_SHA || 'COMMIT_ID';
-const commitShaLength = 7;
-const commitShortSha = commitSha.substring(0, commitShaLength - 1);
+const commitShortSha = commitSha.substring(0, 7);
 const configurationEntry = `wire-web-config-default-${
-  distributionParam ? distributionParam : currentBranch === 'master' ? 'master' : 'staging'
+  distributionParam ? distributionParam : stageParam === 'production' ? 'master' : 'staging'
 }`;
 const configVersion = appConfigPkg.dependencies[configurationEntry].split('#')[1];
 const dockerRegistryDomain = 'quay.io';
@@ -48,8 +40,8 @@ const tags = [];
 if (stageParam) {
   tags.push(`${repository}:${stageParam}`);
 }
-if (releaseParam) {
-  tags.push(`${repository}:${releaseParam}-${configVersion}-${commitShortSha}`);
+if (stageParam === 'production') {
+  tags.push(`${repository}:${versionParam}-${configVersion}-${commitShortSha}`);
 }
 
 const dockerCommands = [

--- a/bin/push_docker.js
+++ b/bin/push_docker.js
@@ -30,7 +30,7 @@ const versionParam = process.argv[4] || '';
 const commitSha = process.env.GITHUB_SHA || 'COMMIT_ID';
 const commitShortSha = commitSha.substring(0, 7);
 const configurationEntry = `wire-web-config-default-${
-  distributionParam ? distributionParam : stageParam === 'production' ? 'master' : 'staging'
+  distributionParam || stageParam === 'production' ? 'master' : 'staging'
 }`;
 const configVersion = appConfigPkg.dependencies[configurationEntry].split('#')[1];
 const dockerRegistryDomain = 'quay.io';


### PR DESCRIPTION
The container image tag information are now solely defined by the script input.
Due to the fact that branch information are not available during the release
process (because it indicated by a tag), it make sense to rather base the tag
determination on the stageParam, which is set i the respective pipeline step.

This also allows to further simplify the script assembling that tag and pushing
the images. Alongside, some variables have been renamed to clarify the meaning
of their values.
The pipelines uses 7 characters while the script only used 6 (second param of
substring behaves exclusive). This has been aligned.

*Owner: @arianvp*