### PR TITLE
runfix: Handle multi-user feature config state comparison

### DIFF
--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -463,11 +463,20 @@ export class TeamRepository {
     }
   };
 
-  private readonly loadPreviousFeatureConfig = (): FeatureList =>
-    JSON.parse(window.localStorage.getItem(TeamRepository.LOCAL_STORAGE_FEATURE_CONFIG_KEY));
+  private readonly loadPreviousFeatureConfig = (): FeatureList | void => {
+    const featureConfigs: {[selfId: string]: FeatureList} = JSON.parse(
+      window.localStorage.getItem(TeamRepository.LOCAL_STORAGE_FEATURE_CONFIG_KEY),
+    );
+    if (featureConfigs && featureConfigs[this.userState.self().id]) {
+      return featureConfigs[this.userState.self().id];
+    }
+  };
 
   private readonly saveFeatureConfig = (featureConfigList: FeatureList): void =>
-    window.localStorage.setItem(TeamRepository.LOCAL_STORAGE_FEATURE_CONFIG_KEY, JSON.stringify(featureConfigList));
+    window.localStorage.setItem(
+      TeamRepository.LOCAL_STORAGE_FEATURE_CONFIG_KEY,
+      JSON.stringify({[this.userState.self().id]: featureConfigList}),
+    );
 
   private onMemberLeave(eventJson: TeamMemberLeaveEvent): void {
     const {


### PR DESCRIPTION
If a user logs into two different accounts sequentially on the same webapp instance the feature config would be compared to the feature config state of the previous account. This PR scopes the feature config state to a specific account.