### PR TITLE
runfix: Audio asset collection arrangement

### DIFF
--- a/src/page/template/content/collection-details.htm
+++ b/src/page/template/content/collection-details.htm
@@ -26,7 +26,7 @@
             <file-asset class="collection-file" params="message: messageEntity, header: true"></file-asset>
           <!-- /ko -->
           <!-- ko if: messageEntity.getFirstAsset().isAudio() -->
-            <audio-asset params="message: messageEntity, header: true, className: 'collection-file'"></audio-asset>
+            <audio-asset class="collection-file" params="message: messageEntity, header: true"></audio-asset>
           <!-- /ko -->
           <!-- ko if: messageEntity.getFirstAsset().isVideo() -->
             <file-asset class="collection-file" params="message: messageEntity, header: true"></file-asset>

--- a/src/page/template/content/collection.htm
+++ b/src/page/template/content/collection.htm
@@ -56,7 +56,7 @@
                 <!-- /ko -->
               </header>
               <div class="collection-images" data-bind="foreach: {data: audio.slice(0, 4), as: 'messageEntity'}">
-                <audio-asset params="message: messageEntity, header: true, className: 'collection-file'"></audio-asset>
+                <audio-asset class="collection-file" params="message: messageEntity, header: true"></audio-asset>
               </div>
             </section>
           <!-- /ko -->


### PR DESCRIPTION
Current:
![image](https://user-images.githubusercontent.com/1138344/127826221-045fd337-6d6c-4e2d-8c66-8bd72fa46d46.png)

Expected:
Every audio asset should be on a new line