### PR TITLE
refactor(core): Fix missing conversation receipt mode typings

### DIFF
--- a/src/script/components/toggle/ReceiptModeToggle.test.ts
+++ b/src/script/components/toggle/ReceiptModeToggle.test.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {Confirmation} from '@wireapp/protocol-messaging';
+import {RECEIPT_MODE} from '@wireapp/api-client/src/conversation/data';
 
 import TestPage from 'Util/test/TestPage';
 
@@ -37,7 +37,7 @@ describe('ReceiptModeToggle', () => {
   it('checks the checkbox when receipts are turned on', () => {
     const receiptModeToggle = new ReceiptModeTogglePage({
       onReceiptModeChanged: () => {},
-      receiptMode: Confirmation.Type.DELIVERED,
+      receiptMode: RECEIPT_MODE.OFF,
     });
 
     const checkBox = receiptModeToggle.getCheckbox();
@@ -48,7 +48,7 @@ describe('ReceiptModeToggle', () => {
   it('unchecks the checkbox when receipts are turned off', () => {
     const receiptModeToggle = new ReceiptModeTogglePage({
       onReceiptModeChanged: () => {},
-      receiptMode: Confirmation.Type.READ,
+      receiptMode: RECEIPT_MODE.ON,
     });
 
     const checkBox = receiptModeToggle.getCheckbox();

--- a/src/script/components/toggle/ReceiptModeToggle.tsx
+++ b/src/script/components/toggle/ReceiptModeToggle.tsx
@@ -18,7 +18,7 @@
  */
 
 import React, {Fragment} from 'react';
-import {Confirmation} from '@wireapp/protocol-messaging';
+import {RECEIPT_MODE} from '@wireapp/api-client/src/conversation/data';
 
 import {registerReactComponent} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
@@ -26,13 +26,13 @@ import {t} from 'Util/LocalizerUtil';
 import Icon from '../Icon';
 
 export interface ReceiptModeToggleProps {
-  onReceiptModeChanged: (receiptMode: Confirmation.Type) => void;
-  receiptMode: Confirmation.Type;
+  onReceiptModeChanged: (receiptMode: RECEIPT_MODE) => void;
+  receiptMode: RECEIPT_MODE;
 }
 
 const ReceiptModeToggle: React.FC<ReceiptModeToggleProps> = ({receiptMode, onReceiptModeChanged}) => {
   const updateValue = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const newReceiptMode = event.target.checked ? Confirmation.Type.READ : Confirmation.Type.DELIVERED;
+    const newReceiptMode = event.target.checked ? RECEIPT_MODE.ON : RECEIPT_MODE.OFF;
     onReceiptModeChanged(newReceiptMode);
   };
 
@@ -46,7 +46,7 @@ const ReceiptModeToggle: React.FC<ReceiptModeToggleProps> = ({receiptMode, onRec
           <div className="panel__action-item__text">{t('receiptToggleLabel')}</div>
         </div>
         <input
-          checked={receiptMode !== Confirmation.Type.DELIVERED}
+          checked={receiptMode !== RECEIPT_MODE.OFF}
           className="slider-input"
           data-uie-name="toggle-receipt-mode-checkbox"
           id="receipt-toggle-input"

--- a/src/script/properties/PropertiesRepository.ts
+++ b/src/script/properties/PropertiesRepository.ts
@@ -19,9 +19,9 @@
 
 import ko from 'knockout';
 import {amplify} from 'amplify';
-import {Confirmation} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
 import {AudioPreference, NotificationPreference, WebappProperties} from '@wireapp/api-client/src/user/data/';
+import {RECEIPT_MODE} from '@wireapp/api-client/src/conversation/data';
 import {ConsentType} from '@wireapp/api-client/src/self/';
 
 import {Environment} from 'Util/Environment';
@@ -46,7 +46,7 @@ export class PropertiesRepository {
         key: 'WIRE_MARKETING_CONSENT',
       },
       WIRE_RECEIPT_MODE: {
-        defaultValue: Confirmation.Type.DELIVERED,
+        defaultValue: RECEIPT_MODE.OFF,
         key: 'WIRE_RECEIPT_MODE',
       },
     };
@@ -54,7 +54,7 @@ export class PropertiesRepository {
 
   private readonly logger: Logger;
   public readonly propertiesService: PropertiesService;
-  public readonly receiptMode: ko.Observable<Confirmation.Type>;
+  public readonly receiptMode: ko.Observable<RECEIPT_MODE>;
   private readonly selfService: SelfService;
   private readonly selfUser: ko.Observable<User>;
   public properties: WebappProperties;
@@ -234,7 +234,7 @@ export class PropertiesRepository {
   deleteProperty(key: string): void {
     switch (key) {
       case PropertiesRepository.CONFIG.WIRE_RECEIPT_MODE.key:
-        this.setProperty(key, Confirmation.Type.DELIVERED);
+        this.setProperty(key, RECEIPT_MODE.OFF);
         break;
       case PropertiesRepository.CONFIG.WIRE_MARKETING_CONSENT.key:
         this.setProperty(key, ConsentValue.NOT_GIVEN);
@@ -264,7 +264,7 @@ export class PropertiesRepository {
   updateProperty(key: string, value: any): Promise<void> | void {
     switch (key) {
       case PropertiesRepository.CONFIG.WIRE_RECEIPT_MODE.key:
-        if (value === Confirmation.Type.DELIVERED) {
+        if (value === RECEIPT_MODE.OFF) {
           return this.propertiesService.deletePropertiesByKey(key);
         }
         return this.propertiesService.putPropertiesByKey(key, value);

--- a/src/script/view_model/content/PreferencesAccountViewModel.ts
+++ b/src/script/view_model/content/PreferencesAccountViewModel.ts
@@ -21,7 +21,8 @@ import {WebappProperties} from '@wireapp/api-client/src/user/data/';
 import type {RichInfoField} from '@wireapp/api-client/src/user/RichInfo';
 import {Logger, Runtime} from '@wireapp/commons';
 import {AccentColorID} from '@wireapp/commons/src/main/util/AccentColor';
-import {Availability, Confirmation} from '@wireapp/protocol-messaging';
+import {Availability} from '@wireapp/protocol-messaging';
+import {RECEIPT_MODE} from '@wireapp/api-client/src/conversation/data';
 import {WebAppEvents} from '@wireapp/webapp-events';
 import {amplify} from 'amplify';
 import 'Components/AvailabilityState';
@@ -91,7 +92,7 @@ export class PreferencesAccountViewModel {
   teamName: ko.PureComputed<string>;
   optionPrivacy: ko.Observable<boolean>;
   optionTelemetrySharing: ko.Observable<boolean>;
-  optionReadReceipts: ko.Observable<Confirmation.Type>;
+  optionReadReceipts: ko.Observable<RECEIPT_MODE>;
   optionMarketingConsent: ko.Observable<boolean | ConsentValue>;
   AVATAR_SIZE: typeof AVATAR_SIZE;
   isMacOsWrapper: boolean;
@@ -537,7 +538,7 @@ export class PreferencesAccountViewModel {
 
   readonly onReadReceiptsChange = (_viewModel: unknown, event: ChangeEvent<HTMLInputElement>): boolean => {
     const isChecked = event.target.checked;
-    const mode = isChecked ? Confirmation.Type.READ : Confirmation.Type.DELIVERED;
+    const mode = isChecked ? RECEIPT_MODE.ON : RECEIPT_MODE.OFF;
     this.propertiesRepository.updateProperty(PropertiesRepository.CONFIG.WIRE_RECEIPT_MODE.key, mode);
     return true;
   };

--- a/test/unit_tests/user/UserRepositorySpec.js
+++ b/test/unit_tests/user/UserRepositorySpec.js
@@ -17,8 +17,8 @@
  *
  */
 
-import {Confirmation} from '@wireapp/protocol-messaging';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
+import {RECEIPT_MODE} from '@wireapp/api-client/src/conversation/data';
 
 import {ConsentValue} from 'src/script/user/ConsentValue';
 import {PropertiesRepository} from 'src/script/properties/PropertiesRepository';
@@ -126,7 +126,7 @@ describe('UserRepository', () => {
         const turnOnReceiptMode = {
           key: PropertiesRepository.CONFIG.WIRE_RECEIPT_MODE.key,
           type: 'user.properties-set',
-          value: Confirmation.Type.READ,
+          value: RECEIPT_MODE.ON,
         };
         const turnOffReceiptMode = {
           key: PropertiesRepository.CONFIG.WIRE_RECEIPT_MODE.key,
@@ -135,15 +135,15 @@ describe('UserRepository', () => {
         const source = EventRepository.SOURCE.WEB_SOCKET;
         const receiptMode = testFactory.user_repository.propertyRepository.receiptMode;
 
-        expect(receiptMode()).toBe(Confirmation.Type.DELIVERED);
+        expect(receiptMode()).toBe(RECEIPT_MODE.OFF);
 
         testFactory.user_repository.onUserEvent(turnOnReceiptMode, source);
 
-        expect(receiptMode()).toBe(Confirmation.Type.READ);
+        expect(receiptMode()).toBe(RECEIPT_MODE.ON);
 
         testFactory.user_repository.onUserEvent(turnOffReceiptMode, source);
 
-        expect(receiptMode()).toBe(Confirmation.Type.DELIVERED);
+        expect(receiptMode()).toBe(RECEIPT_MODE.OFF);
       });
     });
   });


### PR DESCRIPTION
Follow-up to https://github.com/wireapp/wire-webapp/pull/11748.