### PR TITLE
fix(core): Allow empty domain webapp to verify conversations with domains

### DIFF
--- a/src/script/conversation/ConversationVerificationStateHandler.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler.ts
@@ -207,7 +207,9 @@ export class ConversationVerificationStateHandler {
           const userIdsInConversation = conversationEntity.participating_user_ids().concat(selfUser);
           const matchingUserIds = userIdsInConversation.filter(userIdInConversation =>
             userIds.find(
-              userId => userId.id === userIdInConversation.id && userId.domain == userIdInConversation.domain,
+              userId =>
+                userId.id === userIdInConversation.id &&
+                (!userId.domain || userId.domain === userIdInConversation.domain),
             ),
           );
 


### PR DESCRIPTION
If we are in a situation where:
- the backend is on the latest version (with domains)
- the frontend doesn't have any federation_domain config

We need to skip domain verification 