### PR TITLE
fix(core): Regression fixes with qualified ids

### DIFF
--- a/src/script/entity/message/MemberMessage.ts
+++ b/src/script/entity/message/MemberMessage.ts
@@ -30,6 +30,7 @@ import {User} from '../User';
 import {SystemMessage} from './SystemMessage';
 import {Config} from '../../Config';
 import {QualifiedIdOptional} from '../../conversation/EventBuilder';
+import {isQualifiedId} from 'Util/TypePredicateUtil';
 
 export class MemberMessage extends SystemMessage {
   public allTeamMembers: User[];
@@ -344,7 +345,9 @@ export class MemberMessage extends SystemMessage {
   }
 
   isUserAffected(userId: QualifiedIdOptional): boolean {
-    return !!this.userIds().find(user => user.id === userId.id && user.domain == userId.domain);
+    return !!this.userIds().find(user =>
+      isQualifiedId(user) ? user.id === userId.id && user.domain == userId.domain : userId.id === user,
+    );
   }
 
   guestCount(): number {

--- a/src/script/entity/message/VerificationMessage.ts
+++ b/src/script/entity/message/VerificationMessage.ts
@@ -22,11 +22,13 @@ import ko from 'knockout';
 import {SuperType} from '../../message/SuperType';
 import {VerificationMessageType} from '../../message/VerificationMessageType';
 import type {User} from '../User';
+import {QualifiedUserId} from '@wireapp/protocol-messaging';
+import {isQualifiedId} from 'Util/TypePredicateUtil';
 import {Message} from './Message';
 
 export class VerificationMessage extends Message {
   public readonly userEntities: ko.ObservableArray<User>;
-  public userIds: ko.ObservableArray<string>;
+  public userIds: ko.ObservableArray<QualifiedUserId | string>;
   public verificationMessageType: ko.Observable<VerificationMessageType>;
   public readonly isSelfClient: ko.PureComputed<boolean>;
 
@@ -37,10 +39,15 @@ export class VerificationMessage extends Message {
     this.affect_order(false);
 
     this.verificationMessageType = ko.observable();
-    this.userIds = ko.observableArray();
+    this.userIds = ko.observableArray<QualifiedUserId | string>();
 
     this.userEntities = ko.observableArray();
 
-    this.isSelfClient = ko.pureComputed(() => this.userIds()?.length === 1 && this.userIds()[0] === this.user().id);
+    this.isSelfClient = ko.pureComputed(() => {
+      const messageUserId = this.userIds()?.length === 1 && this.userIds()[0];
+      return isQualifiedId(messageUserId)
+        ? messageUserId.id === this.user().id && messageUserId.domain === this.user().domain
+        : messageUserId === this.user().id;
+    });
   }
 }

--- a/test/unit_tests/event/preprocessor/ServiceMiddlewareSpec.js
+++ b/test/unit_tests/event/preprocessor/ServiceMiddlewareSpec.js
@@ -88,6 +88,26 @@ describe('ServiceMiddleware', () => {
           expect(decoratedEvent.data.has_service).not.toBeDefined();
         });
       });
+
+      it('adds meta when services are present in the event with qualified user ids', () => {
+        const event = {
+          data: {
+            users: [
+              {qualified_id: {domain: null, id: 'not-a-service'}},
+              {qualified_id: {domain: null, id: 'a-service'}},
+            ],
+          },
+          type: CONVERSATION_EVENT.MEMBER_JOIN,
+        };
+
+        spyOn(serviceMiddleware['userState'], 'self').and.returnValue({id: 'self-id'});
+        const userEntities = [{}, {isService: true}];
+        spyOn(testFactory.user_repository, 'getUsersById').and.returnValue(Promise.resolve(userEntities));
+
+        return serviceMiddleware.processEvent(event).then(decoratedEvent => {
+          expect(decoratedEvent.data.has_service).toBe(true);
+        });
+      });
     });
 
     describe('conversation.one2one-creation events', () => {


### PR DESCRIPTION
This includes fixes for:
- new device system message action
- un-archiving conversation when user is re-added to the conversation
- detecting services in a system message

The problem always lies with detecting the user with the given id (we need to account for unqualified and qualified ids)