### PR TITLE
feat(core): Remove call to old conversations endpoint for federated backends

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@wireapp/antiscroll-2": "1.0.2",
     "@wireapp/avs": "7.2.91",
-    "@wireapp/core": "17.16.4",
+    "@wireapp/core": "17.16.6",
     "@wireapp/react-ui-kit": "7.54.0",
     "@wireapp/store-engine-dexie": "1.6.7",
     "@wireapp/store-engine-sqleet": "1.7.11",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@wireapp/antiscroll-2": "1.0.2",
     "@wireapp/avs": "7.2.91",
-    "@wireapp/core": "17.16.6",
+    "@wireapp/core": "17.16.8",
     "@wireapp/react-ui-kit": "7.54.0",
     "@wireapp/store-engine-dexie": "1.6.7",
     "@wireapp/store-engine-sqleet": "1.7.11",

--- a/src/script/conversation/ConversationService.ts
+++ b/src/script/conversation/ConversationService.ts
@@ -95,16 +95,11 @@ export class ConversationService {
    * @returns Resolves with the conversation information
    */
   async getAllConversations(): Promise<BackendConversation[]> {
-    const conversations = await this.apiClient.conversation.api.getAllConversations();
+    const domain = Config.getConfig().FEATURE.FEDERATION_DOMAIN;
+    const conversationApi = this.apiClient.conversation.api;
+    const isFederatedBackend = Config.getConfig().FEATURE.ENABLE_FEDERATION === true && domain;
 
-    if (Config.getConfig().FEATURE.ENABLE_FEDERATION === true && Config.getConfig().FEATURE.FEDERATION_DOMAIN) {
-      const remoteConversations = await this.apiClient.conversation.api.getRemoteConversations(
-        Config.getConfig().FEATURE.FEDERATION_DOMAIN,
-      );
-      conversations.push(...remoteConversations);
-    }
-
-    return conversations;
+    return isFederatedBackend ? conversationApi.getConversationList(domain) : conversationApi.getAllConversations();
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2920,10 +2920,10 @@
   resolved "https://registry.yarnpkg.com/@wireapp/antiscroll-2/-/antiscroll-2-1.0.2.tgz#71a78d294ee0c88f42d50477ab61fa39272f5bca"
   integrity sha512-9KeB3yh9k01PjpuuRQsve4yY3+OVS2/hp9j+N13Is5wYCZRkUzZVCs8w9CyA/C6J5o9ukH0EzT7uurysWuhn/A==
 
-"@wireapp/api-client@13.8.2":
-  version "13.8.2"
-  resolved "https://registry.yarnpkg.com/@wireapp/api-client/-/api-client-13.8.2.tgz#aa48bf8dfff5e75d9084269f26444b42887ef524"
-  integrity sha512-lzIlUh87e04SJ4GrQdEli9ZqAfSeKnJMB/DOvd8YsjIdj1Z14o1P0UuDxgrgN+aCBOCM1AEkW6RGYo2ejOp5Mw==
+"@wireapp/api-client@13.9.1":
+  version "13.9.1"
+  resolved "https://registry.yarnpkg.com/@wireapp/api-client/-/api-client-13.9.1.tgz#9c5d16e1b2c1ce9c90d38961885c48ca6e1d4107"
+  integrity sha512-CKfVy3XJfQjkex6auX1JSjxLvErdGRN01IP/DFo5EF+Ho5fCm4ahGzr4yBUpp/iRmEgolY6SjL8Xwd5FLgOnaA==
   dependencies:
     "@types/node" "~14"
     "@types/spark-md5" "3.0.2"
@@ -2977,14 +2977,14 @@
     logdown "3.3.1"
     rimraf "3.0.2"
 
-"@wireapp/core@17.16.4":
-  version "17.16.4"
-  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-17.16.4.tgz#99037e1b8b4d863b205e8174653789e8cbb2a0e9"
-  integrity sha512-V3/lJs0kjKklStepN+3zKKqGVpDCHiK/S7K5JJPecGJ+vyZBf5x+6MROFLVE+IMNAc+Ax05atntFCPJyKryobg==
+"@wireapp/core@17.16.6":
+  version "17.16.6"
+  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-17.16.6.tgz#b8d78efafad6993b583e79538983d401f8ac3c3e"
+  integrity sha512-FKoXupZTMPdPdsN8OMZhLRsQ3Z1hCTEaaa2KdZJLLUWipA9hpVjvEfKQLvIxap+VKm6SzDqrnFHm5JBNPwTijA==
   dependencies:
     "@types/long" "4.0.1"
     "@types/node" "~14"
-    "@wireapp/api-client" "13.8.2"
+    "@wireapp/api-client" "13.9.1"
     "@wireapp/cryptobox" "12.7.1"
     bazinga64 "5.9.7"
     hash.js "1.1.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2920,15 +2920,15 @@
   resolved "https://registry.yarnpkg.com/@wireapp/antiscroll-2/-/antiscroll-2-1.0.2.tgz#71a78d294ee0c88f42d50477ab61fa39272f5bca"
   integrity sha512-9KeB3yh9k01PjpuuRQsve4yY3+OVS2/hp9j+N13Is5wYCZRkUzZVCs8w9CyA/C6J5o9ukH0EzT7uurysWuhn/A==
 
-"@wireapp/api-client@13.9.1":
-  version "13.9.1"
-  resolved "https://registry.yarnpkg.com/@wireapp/api-client/-/api-client-13.9.1.tgz#9c5d16e1b2c1ce9c90d38961885c48ca6e1d4107"
-  integrity sha512-CKfVy3XJfQjkex6auX1JSjxLvErdGRN01IP/DFo5EF+Ho5fCm4ahGzr4yBUpp/iRmEgolY6SjL8Xwd5FLgOnaA==
+"@wireapp/api-client@14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/api-client/-/api-client-14.0.0.tgz#3c9ae880274b61dfd65dfe164697988a7d9f013b"
+  integrity sha512-AY/uRt/Coa+yV+sOflP3QkyhOaGmosl9eFyGWvrY8uRLdjeIENE4IrTkTGsTTZ0h7U8EoIDEVYrgoAPOzEKChQ==
   dependencies:
     "@types/node" "~14"
     "@types/spark-md5" "3.0.2"
     "@types/tough-cookie" "4.0.1"
-    "@wireapp/commons" "4.2.12"
+    "@wireapp/commons" "4.2.13"
     "@wireapp/priority-queue" "1.6.37"
     "@wireapp/protocol-messaging" "1.35.0"
     axios "0.21.4"
@@ -2950,15 +2950,15 @@
   resolved "https://registry.yarnpkg.com/@wireapp/cbor/-/cbor-4.7.2.tgz#cf890cbd1af6f684fd06c704e96b3186bd0672f3"
   integrity sha512-SfWI1pfwPLpYDC2gkQIOtVFA51x1LFbWoZ5qPp9wit5l3x1CWIpmGK3g1F06XXJn/HeRHJawwp28pzzH58h2iQ==
 
-"@wireapp/commons@4.2.12":
-  version "4.2.12"
-  resolved "https://registry.yarnpkg.com/@wireapp/commons/-/commons-4.2.12.tgz#2121cd9e40fa6252d18e18830f615d90e80e74c4"
-  integrity sha512-wbSpRUkdTgOs/F8tazPqo3iBjp/5xTA4VY44MOQW7c8hMZuVxJbENrJW6w8ZbipiaJO3jXsYS01cXF2TfIvLdA==
+"@wireapp/commons@4.2.13":
+  version "4.2.13"
+  resolved "https://registry.yarnpkg.com/@wireapp/commons/-/commons-4.2.13.tgz#a2b8d51ecd0604cb714c6281256608a476c7f86e"
+  integrity sha512-9iCXslLrc78Duu7h+ciGxSswzqeXN1zfPrDhOkaMVoqIDLJ0MjUHlZMOqq8eL7Sdiq/J00YUN419OVFs77+kKQ==
   dependencies:
     "@types/fs-extra" "9.0.12"
     "@types/node" "~14"
     "@types/platform" "1.3.4"
-    ansi-regex "5.0.0"
+    ansi-regex "5.0.1"
     fs-extra "10.0.0"
     logdown "3.3.1"
     platform "1.3.6"
@@ -2977,14 +2977,14 @@
     logdown "3.3.1"
     rimraf "3.0.2"
 
-"@wireapp/core@17.16.6":
-  version "17.16.6"
-  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-17.16.6.tgz#b8d78efafad6993b583e79538983d401f8ac3c3e"
-  integrity sha512-FKoXupZTMPdPdsN8OMZhLRsQ3Z1hCTEaaa2KdZJLLUWipA9hpVjvEfKQLvIxap+VKm6SzDqrnFHm5JBNPwTijA==
+"@wireapp/core@17.16.8":
+  version "17.16.8"
+  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-17.16.8.tgz#5f5e610f0ad9bd520fdb234bc67c4533ef955d67"
+  integrity sha512-3mcFDn8W8PpSOV1Ctlh2VwlxD2iyFL8KJbAbV8DN1g4a1eBTfpRXcZKbfPfeWxu03izjR7UclwaJYSVnkgYCrQ==
   dependencies:
     "@types/long" "4.0.1"
     "@types/node" "~14"
-    "@wireapp/api-client" "13.9.1"
+    "@wireapp/api-client" "14.0.0"
     "@wireapp/cryptobox" "12.7.1"
     bazinga64 "5.9.7"
     hash.js "1.1.7"
@@ -3313,10 +3313,10 @@ ansi-html-community@0.0.8:
   resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
   integrity sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==
 
-ansi-regex@5.0.0, ansi-regex@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
-  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+ansi-regex@5.0.1, ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -3333,10 +3333,10 @@ ansi-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
-ansi-regex@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
-  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+ansi-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
+  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
 ansi-styles@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
As discussed with backend, there is no need to query the old converation endpoint AND the new one. The new one already includes both local and remote conversations. 