### PR TITLE
chore: select federation backend via parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -230,7 +230,7 @@
     "release:production": "git checkout master && git pull && ts-node ./bin/release_tag.ts production",
     "start": "yarn build:server && grunt build && concurrently \"yarn watch:server\" \"grunt watch\"",
     "watch:server": "tsc-watch -P server/tsconfig.json --onSuccess \"yarn start:server:dev\"",
-    "start:server:dev": "cross-env NODE_ENV=development node ./server/dist/index.js",
+    "start:server:dev": "cross-env NODE_ENV=development node ./server/dist/index.js $FEDERATION",
     "stylelint": "prettier --ignore-path .prettierignore --write \"**/*.less\" && stylelint --ignore-path .gitignore \"**/*.less\"",
     "test": "yarn test:types && yarn test:server && yarn test:electron && yarn test:app",
     "test:app": "jest --forceExit",

--- a/package.json
+++ b/package.json
@@ -230,7 +230,7 @@
     "release:production": "git checkout master && git pull && ts-node ./bin/release_tag.ts production",
     "start": "yarn build:server && grunt build && concurrently \"yarn watch:server\" \"grunt watch\"",
     "watch:server": "tsc-watch -P server/tsconfig.json --onSuccess \"yarn start:server:dev\"",
-    "start:server:dev": "cross-env NODE_ENV=development node ./server/dist/index.js $FEDERATION",
+    "start:server:dev": "cross-env NODE_ENV=development node ./server/dist/index.js",
     "stylelint": "prettier --ignore-path .prettierignore --write \"**/*.less\" && stylelint --ignore-path .gitignore \"**/*.less\"",
     "test": "yarn test:types && yarn test:server && yarn test:electron && yarn test:app",
     "test:app": "jest --forceExit",

--- a/server/index.ts
+++ b/server/index.ts
@@ -21,7 +21,7 @@ import {config} from './config';
 import {Server} from './Server';
 import {formatDate} from './util/TimeUtil';
 
-const federation = process.argv[2];
+const federation = process.env.FEDERATION;
 
 if (federation) {
   config.SERVER.APP_BASE = `https://local.${federation}.wire.link:8081`;

--- a/server/index.ts
+++ b/server/index.ts
@@ -21,6 +21,16 @@ import {config} from './config';
 import {Server} from './Server';
 import {formatDate} from './util/TimeUtil';
 
+const federation = process.argv[2];
+
+if (federation) {
+  config.SERVER.APP_BASE = `https://local.${federation}.wire.link:8081`;
+  config.CLIENT.BACKEND_REST = `https://nginz-https.${federation}.wire.link`;
+  config.CLIENT.BACKEND_WS = `wss://nginz-ssl.${federation}.wire.link`;
+  config.CLIENT.FEATURE.ENABLE_FEDERATION = true;
+  config.CLIENT.FEATURE.FEDERATION_DOMAIN = `${federation}.wire.link`;
+}
+
 const server = new Server(config);
 
 server


### PR DESCRIPTION
This makes it possible to run the server pointing to different federated backends without the need to edit the .env file

**Usage:**
`FEDERATION=anta yarn start`
`FEDERATION=bella yarn start`
`FEDERATION=chala yarn start`
