### PR TITLE
runfix(core): Fix qualifiedId in legal hold events

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1747,7 +1747,7 @@ export class ConversationRepository {
       timestamp = conversation.getLatestTimestamp(servertime);
     }
     const legalHoldUpdateMessage = EventBuilder.buildLegalHoldMessage(
-      conversationId || conversationEntity,
+      conversationId || {domain: conversationEntity.domain, id: conversationEntity.id},
       userId,
       timestamp,
       legalHoldStatus,


### PR DESCRIPTION
We were injecting the full conversation entity into the database (which lead to database errors). Now we just inject the id and domain needed