### PR TITLE
runfix(core): Fix memberUpdateEvent parsing

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -2391,10 +2391,10 @@ export class ConversationRepository {
    */
   private onMemberUpdate(
     conversationEntity: Conversation,
-    eventJson: Pick<ConversationMemberUpdateEvent, 'data' | 'from'>,
+    eventJson: Pick<ConversationMemberUpdateEvent, 'data' | 'from'> & {conversation?: string},
   ) {
-    const {data: eventData, from} = eventJson;
-    const conversationId = conversationEntity.qualifiedId;
+    const {conversation, data: eventData, from} = eventJson;
+    const conversationId = {domain: '', id: conversation || '' /* TODO(federation) add domain on the sender side */};
 
     const isConversationRoleUpdate = !!eventData.conversation_role;
     if (isConversationRoleUpdate) {
@@ -2414,7 +2414,7 @@ export class ConversationRepository {
     const isBackendEvent = eventData.otr_archived_ref || eventData.otr_muted_ref;
     const selfConversation = this.conversationState.self_conversation();
     const inSelfConversation = selfConversation && matchQualifiedIds(selfConversation, conversationId);
-    if (!inSelfConversation && conversationId && !isBackendEvent) {
+    if (!inSelfConversation && conversation && !isBackendEvent) {
       throw new ConversationError(
         ConversationError.TYPE.WRONG_CONVERSATION,
         ConversationError.MESSAGE.WRONG_CONVERSATION,


### PR DESCRIPTION
There is a bit of confusion regarding what is `event.conversation` and `event.data.conversation`. 

`event.conversation` => the destination conversation (to which the message was sent)
`event.data.conversation` => the conversation that is affected by the event

We need the distinction because when updating a member we send a message to the `selfConversation` but the message affects a different conversation (the conversation in which the user was updated). 

My last changes broke this distinction. This PR fixes it