### PR TITLE
chore(wire-server): Include changelog entry

### DIFF
--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -385,6 +385,8 @@ jobs:
         run: |
           sed --in-place --expression="s/  tag: .*/  tag: \"${{ fromJSON(steps.release-info-file.outputs.releaseInfo).imageTag }}\"/" ./charts/webapp/values.yaml
           git add ./charts/webapp/values.yaml
+          echo "Upgrade webapp version to ${{ fromJSON(steps.release-info-file.outputs.releaseInfo).imageTag }}" > ./changelog.d/0-release-notes/webapp-upgrade
+          git add ./changelog.d/0-release-notes/webapp-upgrade
           echo "::set-output name=releaseUrl::${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${{ fromJSON(steps.release-info-file.outputs.releaseInfo).releaseName }}"
 
       - name: Creating Pull Request


### PR DESCRIPTION
We recently added a changelog process on wire-server. This adds a file on the automatic PRs with a changelog description that is then picked up with the rest of our current process. This is for the helm charts of the webapp, also currently located inside the wire-server repo. These are used as the defaults for on-premise installations.

The same would need to be done on the similar code active on team-settings and account pages.