### PR TITLE
runfix(core): Get connections on federated env

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@wireapp/antiscroll-2": "1.0.2",
     "@wireapp/avs": "7.2.91",
-    "@wireapp/core": "17.19.0",
+    "@wireapp/core": "17.19.2",
     "@wireapp/react-ui-kit": "7.54.0",
     "@wireapp/store-engine-dexie": "1.6.7",
     "@wireapp/store-engine-sqleet": "1.7.11",

--- a/src/page/template/modal/user-modal.htm
+++ b/src/page/template/modal/user-modal.htm
@@ -18,7 +18,7 @@
         <!-- /ko -->
         <!-- ko ifnot: user().isBlockedLegalHold() -->   
           <user-actions
-            params="user: user, actionsViewModel: actionsViewModel, onAction: onUserAction, isSelfActivated: isActivatedAccount()"
+            params="user: user, actionsViewModel: actionsViewModel, onAction: onUserAction, isSelfActivated: isActivatedAccount(), selfUser: userState.self"
           ></user-actions>
         <!-- /ko -->
       <!-- /ko -->

--- a/src/page/template/panel/group-participant-user.htm
+++ b/src/page/template/panel/group-participant-user.htm
@@ -27,7 +27,7 @@
         <div class="panel__action-item panel__info-text" data-bind="text: t('conversationDetailsGroupAdminInfo')"></div>
       <!-- /ko -->
       <enriched-fields params="user: selectedParticipant"></enriched-fields>
-      <user-actions params="user: selectedParticipant, conversation: activeConversation, actionsViewModel: actionsViewModel, onAction: onUserAction, isSelfActivated: isActivatedAccount(), conversationRoleRepository: conversationRoleRepository"></user-actions>
+      <user-actions params="user: selectedParticipant, conversation: activeConversation, actionsViewModel: actionsViewModel, onAction: onUserAction, isSelfActivated: isActivatedAccount(), conversationRoleRepository: conversationRoleRepository, selfUser: userState.self"></user-actions>
     </div>
   <!-- /ko -->
 </div>

--- a/src/script/components/panel/UserActions.test.ts
+++ b/src/script/components/panel/UserActions.test.ts
@@ -54,6 +54,7 @@ describe('UserActions', () => {
       conversationRoleRepository: conversationRoleRepository as ConversationRoleRepository,
       isSelfActivated: true,
       onAction: noop,
+      selfUser: user,
       user,
     });
 
@@ -74,6 +75,7 @@ describe('UserActions', () => {
       conversationRoleRepository: {} as ConversationRoleRepository,
       isSelfActivated: false,
       onAction: noop,
+      selfUser: user,
       user,
     });
 
@@ -93,6 +95,7 @@ describe('UserActions', () => {
       conversationRoleRepository: {} as ConversationRoleRepository,
       isSelfActivated: true,
       onAction: noop,
+      selfUser: new User('', null),
       user,
     });
 

--- a/src/script/components/panel/UserActions.tsx
+++ b/src/script/components/panel/UserActions.tsx
@@ -68,13 +68,15 @@ export interface UserActionsProps {
   conversationRoleRepository?: ConversationRoleRepository;
   isSelfActivated: boolean;
   onAction: (action: Actions) => void;
+  selfUser: User;
   user: User;
 }
 
-function createPlaceholder1to1Conversation(user: User) {
+function createPlaceholder1to1Conversation(user: User, selfUser: User) {
   const {id, domain} = user.connection().conversationId;
   const conversation = new Conversation(id, domain);
   conversation.name(user.name());
+  conversation.selfUser(selfUser);
   conversation.type(CONVERSATION_TYPE.CONNECT);
   conversation.participating_user_ids([user.qualifiedId]);
   conversation.participating_user_ets([user]);
@@ -91,6 +93,7 @@ const UserActions: React.FC<UserActionsProps> = ({
   conversation,
   onAction,
   conversationRoleRepository,
+  selfUser,
 }) => {
   const isNotMe = !user.isMe && isSelfActivated;
 
@@ -191,7 +194,7 @@ const UserActions: React.FC<UserActionsProps> = ({
            *
            * Before generalizing this, we need to account for special cases (probably with team users...). At the end of the federation feature we will probably have a pretty good idea what are the special cases
            */
-          const newConversation = createPlaceholder1to1Conversation(user);
+          const newConversation = createPlaceholder1to1Conversation(user, selfUser);
           const savedConversation = await actionsViewModel.saveConversation(newConversation);
           actionsViewModel.open1to1Conversation(savedConversation);
         } else {
@@ -263,5 +266,5 @@ export default UserActions;
 registerReactComponent('user-actions', {
   component: UserActions,
   template:
-    '<div data-bind="react: {user: ko.unwrap(user), isSelfActivated: ko.unwrap(isSelfActivated), onAction, conversationRoleRepository, conversation: ko.unwrap(conversation), actionsViewModel}"></div>',
+    '<div data-bind="react: {user: ko.unwrap(user), isSelfActivated: ko.unwrap(isSelfActivated), onAction, conversationRoleRepository, conversation: ko.unwrap(conversation), actionsViewModel, selfUser: ko.unwrap(selfUser)}"></div>',
 });

--- a/src/script/connection/ConnectionRepository.ts
+++ b/src/script/connection/ConnectionRepository.ts
@@ -99,7 +99,7 @@ export class ConnectionRepository {
 
     // Try to find existing connection
     let connectionEntity = this.getConnectionByUserId(
-      connectionData.qualified_to || {id: connectionData.to, domain: ''},
+      connectionData.qualified_to || {domain: '', id: connectionData.to},
     );
     const previousStatus = connectionEntity?.status();
 
@@ -234,9 +234,9 @@ export class ConnectionRepository {
    *
    * @returns Promise that resolves when all connections have been retrieved and mapped
    */
-  async getConnections(): Promise<ConnectionEntity[]> {
+  async getConnections(useFederation: boolean = false): Promise<ConnectionEntity[]> {
     try {
-      const connectionData = await this.connectionService.getConnections();
+      const connectionData = await this.connectionService.getConnections(useFederation);
       const newConnectionEntities = ConnectionMapper.mapConnectionsFromJson(connectionData);
       return newConnectionEntities.length
         ? await this.updateConnections(newConnectionEntities)

--- a/src/script/connection/ConnectionService.ts
+++ b/src/script/connection/ConnectionService.ts
@@ -38,8 +38,10 @@ export class ConnectionService {
    * @param userId User ID to start from
    * @returns Promise that resolves with user connections
    */
-  getConnections(): Promise<Connection[]> {
-    return this.apiClient.connection.api.getAllConnections();
+  getConnections(useFederation: boolean = false): Promise<Connection[]> {
+    return useFederation
+      ? this.apiClient.connection.api.getConnectionList()
+      : this.apiClient.connection.api.getAllConnections();
   }
 
   /**

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1095,7 +1095,6 @@ export class ConversationRepository {
       .then(conversationEntity => {
         if (!conversationEntity) {
           if (connectionEntity.isConnected() || connectionEntity.isOutgoingRequest()) {
-            // TODO(Federation): Federated 1:1 connections are not yet implemented by the backend.
             return this.fetchConversationById(qualifiedId);
           }
         }

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -430,7 +430,9 @@ class App {
       await teamRepository.initTeam();
 
       const conversationEntities = await conversationRepository.getConversations();
-      const connectionEntities = await connectionRepository.getConnections();
+      const connectionEntities = await connectionRepository.getConnections(
+        Config.getConfig().FEATURE.ENABLE_FEDERATION,
+      );
       loadingView.updateProgress(25, t('initReceivedUserData'));
 
       telemetry.timeStep(AppInitTimingsStep.RECEIVED_USER_DATA);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2907,10 +2907,10 @@
   resolved "https://registry.yarnpkg.com/@wireapp/antiscroll-2/-/antiscroll-2-1.0.2.tgz#71a78d294ee0c88f42d50477ab61fa39272f5bca"
   integrity sha512-9KeB3yh9k01PjpuuRQsve4yY3+OVS2/hp9j+N13Is5wYCZRkUzZVCs8w9CyA/C6J5o9ukH0EzT7uurysWuhn/A==
 
-"@wireapp/api-client@15.1.0":
-  version "15.1.0"
-  resolved "https://registry.yarnpkg.com/@wireapp/api-client/-/api-client-15.1.0.tgz#bcdbd527aa530b2806a960d375a7c0fd746038ec"
-  integrity sha512-HNeHAGS6/Rdg0RbhRfLscHMFvLotmul6POkJpYKFLppC0mulK+MSaZ9otgho5lRhEySA9uzDiKBGrt+HYMkGgA==
+"@wireapp/api-client@15.2.0":
+  version "15.2.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/api-client/-/api-client-15.2.0.tgz#f933063d8a75d80c181c83ddd35f86a62c5b710b"
+  integrity sha512-FJWTwanBkQG0PxB782i4XFIV9ial9+kkRXqNH4OQP+kAyhqgh76G2OU6BQkde41+lh0y0/xPFbVW5PVDX7iS6A==
   dependencies:
     "@types/node" "~14"
     "@types/spark-md5" "3.0.2"
@@ -2964,14 +2964,14 @@
     logdown "3.3.1"
     rimraf "3.0.2"
 
-"@wireapp/core@17.19.0":
-  version "17.19.0"
-  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-17.19.0.tgz#82f56b391dc1f33e071acdb7234b7ac01787ac23"
-  integrity sha512-/8cvv2NiYlgA0u2LyeDbXhvW/Ya1b7yPHF/eebBAbPVc/p4caFeSuxMPr+O7QdhTXXwFRZh8/pBfZ0XX/J2eGg==
+"@wireapp/core@17.19.2":
+  version "17.19.2"
+  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-17.19.2.tgz#813fc3991e3ef858f75b413d1f69fff02f110e7c"
+  integrity sha512-mG/6Y+X9SRugFsk9VyIssiE7knLoPjGyBskPVPPY9VrkaSCCmJYEsGkaNdW/K+uXdjm6u4e1QNTk3ptqM2IF5Q==
   dependencies:
     "@types/long" "4.0.1"
     "@types/node" "~14"
-    "@wireapp/api-client" "15.1.0"
+    "@wireapp/api-client" "15.2.0"
     "@wireapp/cryptobox" "12.7.1"
     bazinga64 "5.9.7"
     hash.js "1.1.7"


### PR DESCRIPTION
This fixes 2 things:
- the endpoint we query to fetch the connections at load time (it was still the old endpoint, missing the remote connections)
- attaches the selfUser when creating the placeholder conversation upon sending a connection request to someone