### PR TITLE
refactor(core): Use core to send pings

### DIFF
--- a/src/page/template/content/conversation/input-bar.htm
+++ b/src/page/template/content/conversation/input-bar.htm
@@ -111,7 +111,7 @@
               <!-- /ko -->
 
               <span class="controls-right-button button-icon-large"
-                    data-bind="click: clickToPing, disabled: disableControls, attr: {'title': pingTooltip}, css: {'disabled': pingDisabled() || disableControls()}"
+                    data-bind="click: clickToPing, disabled: pingDisabled(), attr: {'title': pingTooltip}, css: {'disabled': pingDisabled()}"
                     data-uie-name="do-ping">
                 <ping-icon></ping-icon>
               </span>

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -419,11 +419,7 @@ class App {
       telemetry.addStatistic(AppInitStatisticsValue.CLIENT_TYPE, clientEntity.type);
 
       await cryptographyRepository.initCryptobox();
-      if (Config.getConfig().FEATURE.FEDERATION_DOMAIN && Config.getConfig().FEATURE.ENABLE_FEDERATION) {
-        // We just want to initialize the core for federated backend (for now only those use the core)
-        // We can remove the condition once normal backends start using the core to send messages
-        cryptographyRepository.initCore(context.clientType);
-      }
+      cryptographyRepository.initCore(context.clientType);
       loadingView.updateProgress(10);
       telemetry.timeStep(AppInitTimingsStep.INITIALIZED_CRYPTOGRAPHY);
 

--- a/src/script/view_model/content/InputBarViewModel.ts
+++ b/src/script/view_model/content/InputBarViewModel.ts
@@ -519,7 +519,7 @@ export class InputBarViewModel {
   readonly clickToPing = (): void => {
     if (this.conversationEntity() && !this.pingDisabled()) {
       this.pingDisabled(true);
-      this.messageRepository.sendKnock(this.conversationEntity()).then(() => {
+      this.messageRepository.sendPing(this.conversationEntity()).then(() => {
         window.setTimeout(() => this.pingDisabled(false), InputBarViewModel.CONFIG.PING_TIMEOUT);
       });
     }


### PR DESCRIPTION
This would be the very first message we send with the core in the webapp. 
This means that both federated and regular env will use the core to send those messages. Which also means we need to initiate the core for every client. 