### PR TITLE
runfix(core): Revert changes to sending regular ping messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@wireapp/antiscroll-2": "1.0.2",
     "@wireapp/avs": "7.2.91",
-    "@wireapp/core": "17.20.0",
+    "@wireapp/core": "17.20.2",
     "@wireapp/react-ui-kit": "7.54.0",
     "@wireapp/store-engine-dexie": "1.6.7",
     "@wireapp/store-engine-sqleet": "1.7.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2964,10 +2964,10 @@
     logdown "3.3.1"
     rimraf "3.0.2"
 
-"@wireapp/core@17.20.0":
-  version "17.20.0"
-  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-17.20.0.tgz#ed26b22c997cb9992fbf54b2c42533364d35659a"
-  integrity sha512-Bot7Rd0IuAC0ckQZAEbgMhkfRe2WP1j0XahXURS6V/T0cb4DtZG0uZEO67fib6axkQnbZUHhL0ai0CPE5JVT4g==
+"@wireapp/core@17.20.2":
+  version "17.20.2"
+  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-17.20.2.tgz#9d5a31dd0659540e5d8b0adb7f7666bdf5c3b12c"
+  integrity sha512-wyErqAQO+ucdX4mVeXtsBeKeAWmdC4y+brBdBNr2Za+aSxbiNrM8ieRb5xohutd6Fn4aaIjrAY7i9e2uXowr6g==
   dependencies:
     "@types/long" "4.0.1"
     "@types/node" "~14"


### PR DESCRIPTION
This reverts changes to ping messages that were made in #12043 

We did learn a lot from this experiment though. It has made us aware that the core could not handle proper mismatch UI reactions yet and we will need to implement those in the core first