### PR TITLE
runfix(core): remove irrelevant sessionId contruction condition

### DIFF
--- a/src/script/util/StorageUtil.ts
+++ b/src/script/util/StorageUtil.ts
@@ -48,12 +48,8 @@ export function constructClientPrimaryKey(userId: QualifiedId, clientId: string)
 }
 
 export function constructUserPrimaryKey({id, domain}: QualifiedId): string {
-  /**
-   * For backward compatibility: We store clients with participants from our own domain without a domain in the session ID (legacy session ID format).
-   * All other clients (from users on a different domain/remote backends) will be saved with a domain in their primary key.
-   */
-  if (Config.getConfig().FEATURE.ENABLE_FEDERATION && Config.getConfig().FEATURE.FEDERATION_DOMAIN !== domain) {
-    return domain ? `${domain}@${id}` : id;
+  if (Config.getConfig().FEATURE.ENABLE_FEDERATION && domain) {
+    return `${domain}@${id}`;
   }
 
   return id;


### PR DESCRIPTION
We initially had a condition to not generate fully qualified session ids for users:
- on a **federated** env
- that are on the **same backend** as the user receiving the message. 

Removing this condition will generate the right sessionId and be able to find to corresponding session and decrypt the message