### PR TITLE
feat(core): Generate explicit UserClients for federated messages 

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@wireapp/antiscroll-2": "1.0.2",
     "@wireapp/avs": "7.2.91",
-    "@wireapp/core": "17.21.1",
+    "@wireapp/core": "17.22.0",
     "@wireapp/react-ui-kit": "7.54.0",
     "@wireapp/store-engine-dexie": "1.6.7",
     "@wireapp/store-engine-sqleet": "1.7.11",

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -1336,7 +1336,6 @@ export class MessageRepository {
       for (const client of user.devices()) {
         userClients[user.domain][user.id].push(client.id);
       }
-      userClients[user.domain][user.id].pop();
       return userClients;
     }, {} as QualifiedUserClients);
   }

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -39,9 +39,9 @@ import {
   LinkPreview,
   DataTransfer,
 } from '@wireapp/protocol-messaging';
-import {ReactionType, MessageSendingCallbacks} from '@wireapp/core/src/main/conversation/';
+import {ReactionType, MessageSendingCallbacks} from '@wireapp/core/src/main/conversation';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
-import {ClientMismatch, NewOTRMessage, UserClients} from '@wireapp/api-client/src/conversation/';
+import {ClientMismatch, NewOTRMessage, QualifiedUserClients, UserClients} from '@wireapp/api-client/src/conversation';
 import {QualifiedId, RequestCancellationError, User as APIClientUser} from '@wireapp/api-client/src/user/';
 import {WebAppEvents} from '@wireapp/webapp-events';
 import {AudioMetaData, VideoMetaData, ImageMetaData} from '@wireapp/core/src/main/conversation/content/';
@@ -110,6 +110,7 @@ import {BackendErrorLabel} from '@wireapp/api-client/src/http';
 import {Config} from '../Config';
 import {Core} from '../service/CoreSingleton';
 import {OtrMessage} from '@wireapp/core/src/main/conversation/message/OtrMessage';
+import {User} from '../entity/User';
 
 type ConversationEvent = {conversation: string; id?: string};
 type EventJson = any;
@@ -808,7 +809,7 @@ export class MessageRepository {
     },
   ) {
     const users = conversation.allUserEntities;
-    const userIds = conversation.isFederated() ? users.map(user => user.qualifiedId) : users.map(user => user.id);
+    const userIds = conversation.isFederated() ? this.createQualifiedRecipients(users) : users.map(user => user.id);
     const injectOptimisticEvent: MessageSendingCallbacks['onStart'] = genericMessage => {
       if (playPingAudio) {
         amplify.publish(WebAppEvents.AUDIO.PLAY, AudioType.OUTGOING_PING);
@@ -1326,6 +1327,18 @@ export class MessageRepository {
         throw error;
       }
     }
+  }
+
+  private createQualifiedRecipients(users: User[]): QualifiedUserClients {
+    return users.reduce((userClients, user) => {
+      userClients[user.domain] ||= {};
+      userClients[user.domain][user.id] ||= [];
+      for (const client of user.devices()) {
+        userClients[user.domain][user.id].push(client.id);
+      }
+      userClients[user.domain][user.id].pop();
+      return userClients;
+    }, {} as QualifiedUserClients);
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2911,10 +2911,10 @@
     logdown "3.3.1"
     rimraf "3.0.2"
 
-"@wireapp/core@17.21.1":
-  version "17.21.1"
-  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-17.21.1.tgz#85a6feb510755f873291253e3c94b6afb17b6997"
-  integrity sha512-/bRIDeK1XKwAsuJKOH2im/godh+fQzbWPf2CUe/NIhxfyH9tasqi2EJbwFD7CwjJB68oJut+CHLX4wCR38KaWg==
+"@wireapp/core@17.22.0":
+  version "17.22.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-17.22.0.tgz#28b1ff17d4a1c779d7fa7dd9b1776c0593c6d3a3"
+  integrity sha512-Psn99/oFGAG7EbTwONywZXEi2YpOKX2fRBx1XGasRmvJyxNBr625UYcd5hPr/9kMpYDVHB5829RDHl3LJ2sGGQ==
   dependencies:
     "@types/long" "4.0.1"
     "@types/node" "~14"


### PR DESCRIPTION
This will tell the core to send messages to specific clients rather that letting the core fetch all the clients of all the users. 

In the near future that will allow us to trigger client mismatch and let the webapp know that a client is missing.