### PR TITLE
runfix(core): Read domain from client when encrypting with legacy CryptoRepo [FS-110]

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@wireapp/antiscroll-2": "1.0.2",
     "@wireapp/avs": "7.2.91",
-    "@wireapp/core": "17.24.0",
+    "@wireapp/core": "17.24.2",
     "@wireapp/react-ui-kit": "7.54.0",
     "@wireapp/store-engine-dexie": "1.6.7",
     "@wireapp/store-engine-sqleet": "1.7.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2911,10 +2911,10 @@
     logdown "3.3.1"
     rimraf "3.0.2"
 
-"@wireapp/core@17.24.0":
-  version "17.24.0"
-  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-17.24.0.tgz#ff2b8a6cbff9879c454883f6c5a36323a61453d4"
-  integrity sha512-hx2S663XRVGCC45zBPQzuVQPpp4Fgc4oocv9Q5BZStG71ey1mlrW21u2/AXWkc3nxjPYBxG/b0Wd8W67eu2lnQ==
+"@wireapp/core@17.24.2":
+  version "17.24.2"
+  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-17.24.2.tgz#5fa3918a3247f50321702c1626d56a0f0a98e099"
+  integrity sha512-FEulTmi4xV8mQ2j1MpRaaPvkDI/gVGTe8ZE+WObGWKmVtBIWkbzRBnmumcx4rECKScrwkgoMqGkh8yi66Kx3xQ==
   dependencies:
     "@types/long" "4.0.1"
     "@types/node" "~14"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of [semantic commits messages](https://sparkbox.com/foundry/semantic_commit_messages) supported in [Wire's Github Workflow](https://github.com/wireapp/.github#usage).
  - [x] contains a reference [JIRA](https://wearezeta.atlassian.net) issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ . E.g. `feature(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Issues

Still a few messages are sent/received through the deprecated CryptographyRepository in federated env.
We need to account for domain (if present) in those case. 

### Dependencies

- [x] https://github.com/wireapp/wire-web-packages/pull/4176
