### PR TITLE
runfix(core): Fix how array difference is computed with custom matcher [FS-259]

### DIFF
--- a/src/script/util/ArrayUtil.ts
+++ b/src/script/util/ArrayUtil.ts
@@ -39,7 +39,7 @@ export function chunk<T>(array: T[] | Float32Array, size: number) {
  */
 export const getDifference = <T>(array1: T[] = [], array2: T[] = [], matcher?: (t1: T, t2: T) => boolean): T[] => {
   if (matcher) {
-    return array2.filter(el1 => !array1.find(el2 => matcher(el1, el2)));
+    return array2.filter(el1 => !array1.some(el2 => matcher(el1, el2)));
   }
   return array2.filter(element => !array1.includes(element));
 };

--- a/src/script/util/ArrayUtil.ts
+++ b/src/script/util/ArrayUtil.ts
@@ -39,7 +39,7 @@ export function chunk<T>(array: T[] | Float32Array, size: number) {
  */
 export const getDifference = <T>(array1: T[] = [], array2: T[] = [], matcher?: (t1: T, t2: T) => boolean): T[] => {
   if (matcher) {
-    return array2.filter(el1 => array1.find(el2 => !matcher(el1, el2)));
+    return array2.filter(el1 => !array1.find(el2 => matcher(el1, el2)));
   }
   return array2.filter(element => !array1.includes(element));
 };


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of [semantic commits messages](https://sparkbox.com/foundry/semantic_commit_messages) supported in [Wire's Github Workflow](https://github.com/wireapp/.github#usage).
  - [x] contains a reference [JIRA](https://wearezeta.atlassian.net) issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ . E.g. `feature(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Issues

When sending messages in a newly created conversation by a connected users, we would wrongly detect new users because the `getDifferences` is broken (thus showing a system message that says that a new user joined). 

Fixing the `getDifferences` util will fix the problem