### PR TITLE
feat(core): Debounce search queries

### DIFF
--- a/src/script/components/userList.ts
+++ b/src/script/components/userList.ts
@@ -208,13 +208,16 @@ ko.components.register('user-list', {
       remoteTeamMembers(nonExternalMembers);
     }
 
+    const debouncedFilter = ko
+      .pureComputed(filter)
+      .extend({rateLimit: {method: 'notifyWhenChangesStop', timeout: 300}});
     // Filter all list items if a filter is provided
     const filteredUserEntities = ko.pureComputed(() => {
       const connectedUsers = this.conversationState.connectedUsers();
       let resultUsers = userEntities();
-      const normalizedQuery = SearchRepository.normalizeQuery(filter());
+      const normalizedQuery = SearchRepository.normalizeQuery(debouncedFilter());
       if (normalizedQuery) {
-        const trimmedQuery = filter().trim();
+        const trimmedQuery = debouncedFilter().trim();
         const isHandle = trimmedQuery.startsWith('@') && validateHandle(normalizedQuery);
         if (!skipSearch) {
           const SEARCHABLE_FIELDS = SearchRepository.CONFIG.SEARCHABLE_FIELDS;


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ . E.g. `feature(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Issues

When typing in the search input field (StartUI, add participant or create conversation fields) a query per character would be sent. 
This limits the rate at which we send those queries to only when the user stops typing for 300ms. 