### PR TITLE
fix(core): Add domain to user search requests [FS-225]

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@wireapp/antiscroll-2": "1.0.2",
     "@wireapp/avs": "7.2.91",
-    "@wireapp/core": "17.27.3",
+    "@wireapp/core": "17.27.4",
     "@wireapp/react-ui-kit": "7.54.0",
     "@wireapp/store-engine-dexie": "1.6.7",
     "@wireapp/store-engine-sqleet": "1.7.11",

--- a/src/script/search/SearchRepository.ts
+++ b/src/script/search/SearchRepository.ts
@@ -169,8 +169,7 @@ export class SearchRepository {
     isHandle?: boolean,
     maxResults = SearchRepository.CONFIG.MAX_SEARCH_RESULTS,
   ): Promise<User[]> {
-    const domain = query.includes('@') ? query.substr(query.lastIndexOf('@') + 1) : undefined;
-    const name = domain ? query.substr(0, query.indexOf('@')) : query;
+    const [name, domain] = query.replace(/^@/, '').split('@');
 
     const matchedUserIdsFromDirectorySearch: QualifiedId[] = await this.searchService
       .getContacts(name, SearchRepository.CONFIG.MAX_DIRECTORY_RESULTS, domain)

--- a/src/script/search/SearchRepository.ts
+++ b/src/script/search/SearchRepository.ts
@@ -169,15 +169,15 @@ export class SearchRepository {
     isHandle?: boolean,
     maxResults = SearchRepository.CONFIG.MAX_SEARCH_RESULTS,
   ): Promise<User[]> {
+    const domain = query.includes('@') ? query.substr(query.lastIndexOf('@') + 1) : undefined;
+    const name = domain ? query.substr(0, query.indexOf('@')) : query;
+
     const matchedUserIdsFromDirectorySearch: QualifiedId[] = await this.searchService
-      .getContacts(query, SearchRepository.CONFIG.MAX_DIRECTORY_RESULTS)
+      .getContacts(name, SearchRepository.CONFIG.MAX_DIRECTORY_RESULTS, domain)
       .then(({documents}) => documents.map(match => ({domain: match.qualified_id?.domain || null, id: match.id})));
 
     const userIds: QualifiedId[] = [...matchedUserIdsFromDirectorySearch];
     const userEntities = await this.userRepository.getUsersById(userIds);
-
-    const domain = query.includes('@') ? query.substr(query.lastIndexOf('@') + 1) : undefined;
-    const name = domain ? query.substr(0, query.indexOf('@')) : query;
 
     if (validateHandle(name, domain)) {
       const apiUser = await this.userRepository.getUserByHandle({domain, handle: name});

--- a/src/script/search/SearchService.ts
+++ b/src/script/search/SearchService.ts
@@ -25,8 +25,8 @@ import {APIClient} from '../service/APIClientSingleton';
 export class SearchService {
   constructor(private readonly apiClient = container.resolve(APIClient)) {}
 
-  async getContacts(query: string, numberOfRequestedUser: number): Promise<SearchResult> {
-    const request = await this.apiClient.user.api.getSearchContacts(query, numberOfRequestedUser);
+  async getContacts(query: string, numberOfRequestedUser: number, domain?: string): Promise<SearchResult> {
+    const request = await this.apiClient.user.api.getSearchContacts(query, numberOfRequestedUser, domain);
     return request.response;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2854,10 +2854,10 @@
   resolved "https://registry.yarnpkg.com/@wireapp/antiscroll-2/-/antiscroll-2-1.0.2.tgz#71a78d294ee0c88f42d50477ab61fa39272f5bca"
   integrity sha512-9KeB3yh9k01PjpuuRQsve4yY3+OVS2/hp9j+N13Is5wYCZRkUzZVCs8w9CyA/C6J5o9ukH0EzT7uurysWuhn/A==
 
-"@wireapp/api-client@15.5.0":
-  version "15.5.0"
-  resolved "https://registry.yarnpkg.com/@wireapp/api-client/-/api-client-15.5.0.tgz#5ceb2d07eb8bfe137178dd9fb1d806dbe24d665c"
-  integrity sha512-SNDdsyYIdubf8518LguuSeBt2vo6X//RCJEm9V8YFeEOMQv7iqnA6nOS3Edl+ejm+A6AvgWa4RPYtP01FUnh9g==
+"@wireapp/api-client@15.6.0":
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/api-client/-/api-client-15.6.0.tgz#5d6bad06ae10f05dfc03931752a5d7fa3ae21687"
+  integrity sha512-ekgo/vjJ25Qq5VT0CKTqYh32giYfqBEJfz8yooLA+NjIwWFKwfYxMYXfdg273xWGtWEwop/6LQrdP4eNhdMMDA==
   dependencies:
     "@types/node" "~14"
     "@types/spark-md5" "3.0.2"
@@ -2911,14 +2911,14 @@
     logdown "3.3.1"
     rimraf "3.0.2"
 
-"@wireapp/core@17.27.3":
-  version "17.27.3"
-  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-17.27.3.tgz#88fb35fa5c4de98e3e8d9bc1f717e99316e7c48c"
-  integrity sha512-lDV+NDWgPakRIbPY6tYPcrfkA56PjytTaHGVii0z9Pt49caxBSquohu/osg11Zf7i+7givR5KXZiIUQ/NTTtfw==
+"@wireapp/core@17.27.4":
+  version "17.27.4"
+  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-17.27.4.tgz#355703ace7a155bd3665441dbebeb1b95cb10baa"
+  integrity sha512-FmyC3PIi13D9MrYLUhdUp0EdtJVVbyGdV8SNxdlGaBfPxnY9QljsiSgwyv/pI0MB/2dNC/KQzrLFFVY5prdEFA==
   dependencies:
     "@types/long" "4.0.1"
     "@types/node" "~14"
-    "@wireapp/api-client" "15.5.0"
+    "@wireapp/api-client" "15.6.0"
     "@wireapp/cryptobox" "12.7.1"
     bazinga64 "5.9.7"
     hash.js "1.1.7"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ . E.g. `feature(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Issues
When searching for federated users, we send the username and the domain in the `query` param of the search API.
We should split them and send the domain as a different param.

### Dependencies (Optional)

- [ ] https://github.com/wireapp/wire-web-packages/pull/4180

