### PR TITLE
runfix(core): Do not send domain search request on non-federated env

### DIFF
--- a/src/script/search/SearchRepository.ts
+++ b/src/script/search/SearchRepository.ts
@@ -27,6 +27,7 @@ import type {UserRepository} from '../user/UserRepository';
 import type {User} from '../entity/User';
 import type {QualifiedId} from '@wireapp/api-client/src/user/';
 import {matchQualifiedIds} from 'Util/QualifiedId';
+import {Config} from '../Config';
 
 export class SearchRepository {
   logger: Logger;
@@ -169,7 +170,7 @@ export class SearchRepository {
     isHandle?: boolean,
     maxResults = SearchRepository.CONFIG.MAX_SEARCH_RESULTS,
   ): Promise<User[]> {
-    const [name, domain] = query.replace(/^@/, '').split('@');
+    const [name, domain] = Config.getConfig().FEATURE.ENABLE_FEDERATION ? query.replace(/^@/, '').split('@') : [query];
 
     const matchedUserIdsFromDirectorySearch: QualifiedId[] = await this.searchService
       .getContacts(name, SearchRepository.CONFIG.MAX_DIRECTORY_RESULTS, domain)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ . E.g. `feature(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Issues

This will not allow non-federated env to send domain-qualified search requests
fixes regression introduced by #12169 
