### PR TITLE
runfix(core): Do not send domain search request if domain is not valid

### DIFF
--- a/src/script/search/SearchRepository.ts
+++ b/src/script/search/SearchRepository.ts
@@ -170,7 +170,10 @@ export class SearchRepository {
     isHandle?: boolean,
     maxResults = SearchRepository.CONFIG.MAX_SEARCH_RESULTS,
   ): Promise<User[]> {
-    const [name, domain] = Config.getConfig().FEATURE.ENABLE_FEDERATION ? query.replace(/^@/, '').split('@') : [query];
+    const [rawName, rawDomain] = Config.getConfig().FEATURE.ENABLE_FEDERATION
+      ? query.replace(/^@/, '').split('@')
+      : [query];
+    const [name, domain] = validateHandle(rawName, rawDomain) ? [rawName, rawDomain] : [query];
 
     const matchedUserIdsFromDirectorySearch: QualifiedId[] = await this.searchService
       .getContacts(name, SearchRepository.CONFIG.MAX_DIRECTORY_RESULTS, domain)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sending a search request with an invalid domain (say `bella.wire.`) will trigger a weird backend error. 
Instead we should validate the handle+domain beforehand and avoid sending requests that are invalid. 