### PR TITLE
runfix(core): Strip domain when searching for local users

### DIFF
--- a/src/script/view_model/list/StartUIViewModel.ts
+++ b/src/script/view_model/list/StartUIViewModel.ts
@@ -421,7 +421,7 @@ export class StartUIViewModel {
     const SEARCHABLE_FIELDS = SearchRepository.CONFIG.SEARCHABLE_FIELDS;
     const searchFields = isHandle ? [SEARCHABLE_FIELDS.USERNAME] : undefined;
 
-    // If the user typed a domain, we will just ignore it when search for the user locally
+    // If the user typed a domain, we will just ignore it when searchng for the user locally
     const domainFreeQuery = normalizedQuery.replace(/@.*/, '');
     const contactResults = this.searchRepository.searchUserInSet(domainFreeQuery, localSearchSources, searchFields);
     const connectedUsers = this.conversationState.connectedUsers();

--- a/src/script/view_model/list/StartUIViewModel.ts
+++ b/src/script/view_model/list/StartUIViewModel.ts
@@ -422,7 +422,7 @@ export class StartUIViewModel {
     const searchFields = isHandle ? [SEARCHABLE_FIELDS.USERNAME] : undefined;
 
     // If the user typed a domain, we will just ignore it when searchng for the user locally
-    const domainFreeQuery = normalizedQuery.replace(/@.*/, '');
+    const [domainFreeQuery] = normalizedQuery.split('@');
     const contactResults = this.searchRepository.searchUserInSet(domainFreeQuery, localSearchSources, searchFields);
     const connectedUsers = this.conversationState.connectedUsers();
     const filteredResults = contactResults.filter(

--- a/src/script/view_model/list/StartUIViewModel.ts
+++ b/src/script/view_model/list/StartUIViewModel.ts
@@ -421,7 +421,9 @@ export class StartUIViewModel {
     const SEARCHABLE_FIELDS = SearchRepository.CONFIG.SEARCHABLE_FIELDS;
     const searchFields = isHandle ? [SEARCHABLE_FIELDS.USERNAME] : undefined;
 
-    const contactResults = this.searchRepository.searchUserInSet(normalizedQuery, localSearchSources, searchFields);
+    // If the user typed a domain, we will just ignore it when search for the user locally
+    const domainFreeQuery = normalizedQuery.replace(/@.*/, '');
+    const contactResults = this.searchRepository.searchUserInSet(domainFreeQuery, localSearchSources, searchFields);
     const connectedUsers = this.conversationState.connectedUsers();
     const filteredResults = contactResults.filter(
       user =>


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When searching for a local user using the federated domain (eg. `user1@domain.com`) the matcher tries to use the `@...` part as if it was part of the username. 
In this PR we then strip the domain part before matching against local users. 