### PR TITLE
feat(core): Enable message timer for federated environments [FS-229]

### DIFF
--- a/src/page/template/content/conversation/input-bar.htm
+++ b/src/page/template/content/conversation/input-bar.htm
@@ -96,7 +96,7 @@
             <!-- /ko -->
 
             <!-- ko ifnot: input().length -->
-              <message-timer-button params="conversation: conversationEntity, disabled: disableControls" data-bind="css: {'disabled': disableControls}"></message-timer-button>
+            <message-timer-button params="conversation: conversationEntity"></message-timer-button>
 
             <!-- ko if: isFileSharingSendingEnabled() -->
               <label id="conversation-input-bar-photo" class="controls-right-button button-icon-large" data-bind="css: {'disabled': disableControls}">

--- a/src/script/page/message-list/MessageTimerButton.tsx
+++ b/src/script/page/message-list/MessageTimerButton.tsx
@@ -40,17 +40,16 @@ export const MessageTimerButton: React.FC<MessageTimerButtonProps> = ({
   conversation,
   teamState = container.resolve(TeamState),
 }) => {
-  const {messageTimer, hasGlobalMessageTimer, isFederated} = useKoSubscribableChildren(conversation, [
+  const {messageTimer, hasGlobalMessageTimer} = useKoSubscribableChildren(conversation, [
     'messageTimer',
     'hasGlobalMessageTimer',
-    'isFederated',
   ]);
   const {isSelfDeletingMessagesEnabled, isSelfDeletingMessagesEnforced} = useKoSubscribableChildren(teamState, [
     'isSelfDeletingMessagesEnabled',
     'isSelfDeletingMessagesEnforced',
   ]);
   const hasMessageTimer = !!messageTimer;
-  const isTimerDisabled = isSelfDeletingMessagesEnforced || hasGlobalMessageTimer || isFederated;
+  const isTimerDisabled = isSelfDeletingMessagesEnforced || hasGlobalMessageTimer;
   const duration = hasMessageTimer ? formatDuration(messageTimer) : ({} as DurationUnit);
 
   // Click on ephemeral button


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

This enables the ephemeral timer button for federated envs. The logic for handling ephemeral is already fully working so nothing to do on that end. 

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
