### PR TITLE
fix(services): Disable app lock if disabled team wide (SQSERVICES-356)

### DIFF
--- a/src/script/page/AppLock.tsx
+++ b/src/script/page/AppLock.tsx
@@ -15,7 +15,7 @@ import {SIGN_OUT_REASON} from '../auth/SignOutReason';
 import {ClientState} from '../client/ClientState';
 import {AppLockState} from '../user/AppLockState';
 import {AppLockRepository} from '../user/AppLockRepository';
-import {useKoSubscribable} from 'Util/ComponentUtil';
+import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 
 export enum APPLOCK_STATE {
   FORGOT = 'applock.forgot',
@@ -57,8 +57,10 @@ const AppLock: React.FC<AppLockProps> = ({
   const [setupPassphrase, setSetupPassphrase] = useState('');
   const [inactivityTimeoutId, setInactivityTimeoutId] = useState<number>();
   const [scheduledTimeoutId, setScheduledTimeoutId] = useState<number>();
-  const isAppLockActivated = useKoSubscribable(appLockState.isAppLockActivated);
-  const isAppLockEnabled = useKoSubscribable(appLockState.isAppLockEnabled);
+  const {isAppLockActivated, isAppLockEnabled} = useKoSubscribableChildren(appLockState, [
+    'isAppLockActivated',
+    'isAppLockEnabled',
+  ]);
 
   const focusElement = (input: HTMLInputElement) => setTimeout(() => input?.focus());
   const forceFocus = ({target}: React.FocusEvent<HTMLInputElement>) => focusElement(target);

--- a/src/script/user/AppLockRepository.ts
+++ b/src/script/user/AppLockRepository.ts
@@ -43,6 +43,9 @@ export class AppLockRepository {
     if (hasPassphrase) {
       this.startPassphraseObserver();
     }
+
+    this.appLockState.isAppLockDisabledOnTeam.subscribe(this.handleDisabledOnTeam);
+    this.handleDisabledOnTeam(this.appLockState.isAppLockDisabledOnTeam());
   }
 
   getStoredPassphrase = (): string => window.localStorage.getItem(this.getPassphraseStorageKey());
@@ -53,6 +56,13 @@ export class AppLockRepository {
     const storageKey = this.getPassphraseStorageKey();
     if (key === storageKey) {
       window.localStorage.setItem(storageKey, oldValue);
+    }
+  };
+
+  private readonly handleDisabledOnTeam = (isDisabled: boolean): void => {
+    if (isDisabled) {
+      this.setEnabled(false);
+      this.removeCode();
     }
   };
 

--- a/src/script/user/AppLockState.ts
+++ b/src/script/user/AppLockState.ts
@@ -36,8 +36,13 @@ export class AppLockState {
   public readonly isAppLockEnabled: ko.PureComputed<boolean>;
   public readonly hasPassphrase: ko.Observable<boolean>;
   public readonly isActivatedInPreferences: ko.Observable<boolean>;
+  public readonly isAppLockDisabledOnTeam: ko.PureComputed<boolean>;
 
   constructor(teamState = container.resolve(TeamState)) {
+    this.isAppLockDisabledOnTeam = ko.pureComputed(
+      () => teamState.isTeam() && teamState.teamFeatures()?.appLock?.status !== FeatureStatus.ENABLED,
+    );
+
     this.isAppLockAvailable = ko.pureComputed(() =>
       teamState.isTeam() ? teamState.teamFeatures()?.appLock?.status === FeatureStatus.ENABLED : defaultEnabled,
     );


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-356" title="SQSERVICES-356" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/secure/viewavatar?size=medium&avatarId=10803&avatarType=issuetype" />SQSERVICES-356</a>  [WebApp] Applock is not disabled on client after team settings change
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
