### PR TITLE
runfix(core): Add user fully qualified handle in federated icon [FS-272]

### DIFF
--- a/src/script/components/message.ts
+++ b/src/script/components/message.ts
@@ -333,7 +333,7 @@ const normalTemplate: string = `
           <external-icon class="message-header-icon-external with-tooltip with-tooltip--external" data-bind="attr: {'data-tooltip': t('rolePartner')}" data-uie-name="sender-external"></external-icon>
         <!-- /ko -->
         <!-- ko if: message.user().isFederated -->
-          <federation-icon class="message-header-icon-guest with-tooltip with-tooltip--external" data-bind="attr: {'data-tooltip': t('conversationFederationIndicator')}" data-uie-name="sender-federated"></federation-icon>
+          <federation-icon class="message-header-icon-guest with-tooltip with-tooltip--external" data-bind="attr: {'data-tooltip': message.user().handle}" data-uie-name="sender-federated"></federation-icon>
         <!-- /ko -->
         <!-- ko if: message.user().isDirectGuest() -->
           <guest-icon class="message-header-icon-guest with-tooltip with-tooltip--external" data-bind="attr: {'data-tooltip': t('conversationGuestIndicator')}" data-uie-name="sender-guest"></guest-icon>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-272" title="FS-272" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/secure/viewavatar?size=medium&avatarId=10803&avatarType=issuetype" />FS-272</a>  [Web] Tooltip on federated icon should show users qualified username
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

This aligns the behavior of the federated icon in the chat with the design specs

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
