### PR TITLE
fix(ci): avoid failing check on Jira ticket not found

### DIFF
--- a/.github/workflows/jira-lint-and-link.yml
+++ b/.github/workflows/jira-lint-and-link.yml
@@ -13,4 +13,4 @@ jobs:
           jira-token: ${{ secrets.JIRA_TOKEN }}
           jira-base-url: https://wearezeta.atlassian.net
           skip-branches: '^(production-release|main|master|release\/v\d+)$' #optional
-          fail-when-jira-issue-not-found: true
+          fail-when-jira-issue-not-found: false


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

PRs with missing Jira ticket ID's are failing the check and that's a bit annoying. We prefer the color green. 

### Solutions

Don't fail the check if a Jira ticket ID is missing

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
