### PR TITLE
fix(core): Send simple userId when reseting sessions on non-federated env

### DIFF
--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -974,7 +974,7 @@ export class MessageRepository {
     await this.core.service!.conversation.send({
       conversationDomain: conversation.isFederated() ? conversation.domain : undefined,
       payloadBundle: sessionReset,
-      userIds: [userId],
+      userIds: conversation.isFederated() ? [userId] : [userId.id],
     });
   }
 


### PR DESCRIPTION

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Since #12182 session reset are sent via the core. But the userIds given to the core are not the expected format for non-federated envs. 

This fixes the format of the userIds given to the core. 

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
