### PR TITLE
runfix(core): Do not show federated badge for connection requests [FS-276]

### DIFF
--- a/src/script/view_model/content/TitleBarViewModel.ts
+++ b/src/script/view_model/content/TitleBarViewModel.ts
@@ -124,7 +124,7 @@ export class TitleBarViewModel {
     });
 
     this.badgeLabelCopy = ko.pureComputed(() => {
-      if (this.conversationEntity().is1to1()) {
+      if (this.conversationEntity().is1to1() || this.conversationEntity().isRequest()) {
         return '';
       }
       const hasExternal = this.conversationEntity().hasExternal();


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-276" title="FS-276" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/secure/viewavatar?size=medium&avatarId=10803&avatarType=issuetype" />FS-276</a>  [Web] Connection requests should not display the federated badge
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The federated badge is shown in connection requests. We need to filter out showing this badge for connection requests

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
