### PR TITLE
feat(core): Enable 1:1 calling for federated env [FS-14]

### DIFF
--- a/src/page/template/list/conversations.htm
+++ b/src/page/template/list/conversations.htm
@@ -85,7 +85,7 @@
         <!-- ko foreach: {data: unarchivedConversations, as: 'conversation', noChildContext: true} -->
         <conversation-list-cell
           data-uie-name="item-conversation"
-          params="onClick: makeOnClick(conversation.id, conversation.domain), rightClick: (_, event) => listViewModel.onContextMenu(conversation, event), conversation: conversation, showJoinButton: hasJoinableCall(conversation.id), is_selected: isSelectedConversation, onJoinCall: onJoinCall, index: $index, isVisibleFunc: isVisibleFunc"
+          params="onClick: makeOnClick(conversation.id, conversation.domain), rightClick: (_, event) => listViewModel.onContextMenu(conversation, event), conversation: conversation, showJoinButton: hasJoinableCall(conversation.qualifiedId), is_selected: isSelectedConversation, onJoinCall: onJoinCall, index: $index, isVisibleFunc: isVisibleFunc"
         >
         </conversation-list-cell>
         <!-- /ko -->

--- a/src/script/calling/Call.ts
+++ b/src/script/calling/Call.ts
@@ -26,8 +26,9 @@ import {CALL_MESSAGE_TYPE} from './enum/CallMessageType';
 import type {Participant, UserId, ClientId} from './Participant';
 import type {MediaDevicesHandler} from '../media/MediaDevicesHandler';
 import {Config} from '../Config';
+import {QualifiedId} from '@wireapp/api-client/src/user';
 
-export type ConversationId = string;
+export type SerializedConversationId = string;
 
 const NUMBER_OF_PARTICIPANTS_IN_ONE_PAGE = 9;
 
@@ -76,7 +77,7 @@ export class Call {
 
   constructor(
     public readonly initiator: UserId,
-    public readonly conversationId: ConversationId,
+    public readonly conversationId: QualifiedId,
     public readonly conversationType: CONV_TYPE,
     private readonly selfParticipant: Participant,
     callType: CALL_TYPE,

--- a/src/script/calling/CallState.ts
+++ b/src/script/calling/CallState.ts
@@ -24,6 +24,8 @@ import {STATE as CALL_STATE} from '@wireapp/avs';
 import {CallViewTab} from '../view_model/CallingViewModel';
 import {Config} from '../Config';
 import type {ElectronDesktopCapturerSource} from '../media/MediaDevicesHandler';
+import {matchQualifiedIds} from 'Util/QualifiedId';
+import {QualifiedId} from '@wireapp/api-client/src/user';
 
 export enum MuteState {
   NOT_MUTED,
@@ -36,7 +38,7 @@ export enum MuteState {
 export class CallState {
   public readonly activeCalls: ko.ObservableArray<Call> = ko.observableArray();
   public readonly muteState: ko.Observable<MuteState> = ko.observable(MuteState.NOT_MUTED);
-  public readonly acceptedVersionWarnings: ko.ObservableArray<string> = ko.observableArray<string>();
+  public readonly acceptedVersionWarnings: ko.ObservableArray<QualifiedId> = ko.observableArray<QualifiedId>();
   public readonly cbrEncoding: ko.Observable<number> = ko.observable(
     Config.getConfig().FEATURE.ENFORCE_CONSTANT_BITRATE ? 1 : 0,
   );
@@ -58,7 +60,9 @@ export class CallState {
 
     this.activeCalls.subscribe(activeCalls => {
       const activeCallIds = activeCalls.map(call => call.conversationId);
-      this.acceptedVersionWarnings.remove(acceptedId => !activeCallIds.includes(acceptedId));
+      this.acceptedVersionWarnings.remove(
+        acceptedId => !activeCallIds.some(callId => matchQualifiedIds(acceptedId, callId)),
+      );
     });
     this.isSpeakersViewActive = ko.pureComputed(() => this.activeCallViewTab() === CallViewTab.SPEAKERS);
 

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -712,9 +712,7 @@ export class CallingRepository {
         this.removeCall(call);
       }
       return call;
-    } catch (_error) {
-      console.error(_error);
-    }
+    } catch (_error) {}
   }
 
   private serializeQualifiedId(id: QualifiedId): string {

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -23,6 +23,7 @@ import type {WebappProperties} from '@wireapp/api-client/src/user/data';
 import type {QualifiedId} from '@wireapp/api-client/src/user';
 import type {CallConfigData} from '@wireapp/api-client/src/account/CallConfigData';
 import type {ClientMismatch, UserClients} from '@wireapp/api-client/src/conversation/';
+import {matchQualifiedIds} from 'Util/QualifiedId';
 import {
   CALL_TYPE,
   CONV_TYPE,
@@ -62,7 +63,7 @@ import {CallingEvent, EventBuilder} from '../conversation/EventBuilder';
 import {EventInfoEntity, MessageSendingOptions} from '../conversation/EventInfoEntity';
 import {EventRepository} from '../event/EventRepository';
 import {MediaType} from '../media/MediaType';
-import {Call, ConversationId} from './Call';
+import {Call, SerializedConversationId} from './Call';
 import {CallState, MuteState} from './CallState';
 import {ClientId, Participant, UserId} from './Participant';
 import {EventName} from '../tracking/EventName';
@@ -103,7 +104,7 @@ enum CALL_DIRECTION {
 }
 
 export class CallingRepository {
-  private readonly acceptVersionWarning: (conversationId: string) => void;
+  private readonly acceptVersionWarning: (conversationId: QualifiedId) => void;
   private readonly callLog: string[];
   private readonly logger: Logger;
   private avsVersion: number;
@@ -164,7 +165,7 @@ export class CallingRepository {
       }
     });
 
-    this.acceptVersionWarning = (conversationId: string) => {
+    this.acceptVersionWarning = (conversationId: QualifiedId) => {
       this.callState.acceptedVersionWarnings.push(conversationId);
       window.setTimeout(
         () => this.callState.acceptedVersionWarnings.remove(conversationId),
@@ -194,8 +195,8 @@ export class CallingRepository {
     }
   };
 
-  getStats(conversationId: ConversationId): Promise<{stats: RTCStatsReport; userid: UserId}[]> {
-    return this.wCall.getStats(conversationId);
+  getStats(conversationId: QualifiedId): Promise<{stats: RTCStatsReport; userid: UserId}[]> {
+    return this.wCall.getStats(this.serializeQualifiedId(conversationId));
   }
 
   async initAvs(selfUser: User, clientId: ClientId): Promise<{wCall: Wcall; wUser: number}> {
@@ -276,13 +277,13 @@ export class CallingRepository {
     this.callState.muteState(isMuted ? this.nextMuteState : MuteState.NOT_MUTED);
   };
 
-  private async pushClients(conversationId: ConversationId): Promise<void> {
-    const qualifiedConversationId: QualifiedId = {domain: '', id: conversationId};
+  private async pushClients(conversationId: QualifiedId): Promise<void> {
     try {
-      await this.apiClient.conversation.api.postOTRMessage(this.selfClientId, conversationId);
+      // TODO(federation), fix direct call to API (use MessageRepo for the federated/non-federated routing?)
+      await this.apiClient.conversation.api.postOTRMessage(this.selfClientId, conversationId.id);
     } catch (error) {
       const mismatch: ClientMismatch = (error as AxiosError).response!.data;
-      const localClients = await this.messageRepository.createRecipients(qualifiedConversationId);
+      const localClients = await this.messageRepository.createRecipients(conversationId);
 
       const makeClientList = (recipients: UserClients): ClientListEntry[] =>
         Object.entries(recipients).reduce(
@@ -317,7 +318,7 @@ export class CallingRepository {
         [GENERIC_MESSAGE_TYPE.CALLING]: new Calling({content: ''}),
         messageId: createRandomUuid(),
       });
-      const eventInfoEntity = new EventInfoEntity(genericMessage, qualifiedConversationId);
+      const eventInfoEntity = new EventInfoEntity(genericMessage, conversationId);
       eventInfoEntity.setType(GENERIC_MESSAGE_TYPE.CALLING);
       await this.messageRepository.clientMismatchHandler.onClientMismatch(eventInfoEntity, localMismatch);
 
@@ -326,16 +327,20 @@ export class CallingRepository {
       );
 
       const data: {clients: Clients} = {clients: flatten(clients)};
-      this.wCall.setClientsForConv(this.wUser, conversationId, JSON.stringify(data));
+      this.wCall.setClientsForConv(this.wUser, this.serializeQualifiedId(conversationId), JSON.stringify(data));
     }
   }
 
-  readonly updateCallQuality = (conversationId: string, userId: string, clientId: string, quality: number) => {
-    const call = this.findCall(conversationId);
+  private readonly updateCallQuality = (
+    conversationId: SerializedConversationId,
+    userId: string,
+    clientId: string,
+    quality: number,
+  ) => {
+    const call = this.findCall(this.parseQualifiedId(conversationId));
     if (!call) {
       return;
     }
-
     if (!this.poorCallQualityUsers[conversationId]) {
       this.poorCallQualityUsers[conversationId] = [];
     }
@@ -386,18 +391,20 @@ export class CallingRepository {
     this.incomingCallCallback = callback;
   }
 
-  findCall(conversationId: ConversationId): Call | undefined {
-    return this.callState.activeCalls().find((callInstance: Call) => callInstance.conversationId === conversationId);
+  findCall(conversationId: QualifiedId): Call | undefined {
+    return this.callState
+      .activeCalls()
+      .find((callInstance: Call) => matchQualifiedIds(callInstance.conversationId, conversationId));
   }
 
-  private findParticipant(conversationId: ConversationId, userId: UserId, clientId: ClientId): Participant | undefined {
+  private findParticipant(conversationId: QualifiedId, userId: UserId, clientId: ClientId): Participant | undefined {
     const call = this.findCall(conversationId);
     return call?.getParticipant(userId, clientId);
   }
 
   private storeCall(call: Call): void {
     this.callState.activeCalls.push(call);
-    const conversation = this.conversationState.findConversation({domain: '', id: call.conversationId});
+    const conversation = this.conversationState.findConversation(call.conversationId);
     if (conversation) {
       conversation.call(call);
     }
@@ -411,7 +418,7 @@ export class CallingRepository {
     if (index !== -1) {
       this.callState.activeCalls.splice(index, 1);
     }
-    const conversation = this.conversationState.findConversation({domain: '', id: call.conversationId});
+    const conversation = this.conversationState.findConversation(call.conversationId);
     if (conversation) {
       conversation.call(null);
     }
@@ -514,13 +521,9 @@ export class CallingRepository {
   // Inbound call events
   //##############################################################################
 
-  private async verificationPromise(conversationId: string, userId: string, isResponse: boolean): Promise<void> {
-    const qualifiedConversationId: QualifiedId = {
-      domain: '',
-      id: conversationId /*TODO(federation): get conversation domain*/,
-    };
-    const recipients = await this.messageRepository.createRecipients(qualifiedConversationId, false, [userId]);
-    const eventInfoEntity = new EventInfoEntity(undefined, qualifiedConversationId, {recipients});
+  private async verificationPromise(conversationId: QualifiedId, userId: string, isResponse: boolean): Promise<void> {
+    const recipients = await this.messageRepository.createRecipients(conversationId, false, [userId]);
+    const eventInfoEntity = new EventInfoEntity(undefined, conversationId, {recipients});
     eventInfoEntity.setType(GENERIC_MESSAGE_TYPE.CALLING);
     const consentType = isResponse
       ? ConversationRepository.CONSENT_TYPE.INCOMING_CALL
@@ -528,7 +531,7 @@ export class CallingRepository {
     await this.messageRepository.grantMessage(eventInfoEntity, consentType, [], false);
   }
 
-  private abortCall(conversationId: string): void {
+  private abortCall(conversationId: QualifiedId): void {
     const call = this.findCall(conversationId);
     if (call) {
       // we flag the call in order to prevent sending further messages
@@ -537,7 +540,7 @@ export class CallingRepository {
     this.leaveCall(conversationId);
   }
 
-  private warnOutdatedClient(conversationId: string) {
+  private warnOutdatedClient(conversationId: QualifiedId) {
     const brandName = Config.getConfig().BRAND_NAME;
     amplify.publish(
       WebAppEvents.WARNING.MODAL,
@@ -605,7 +608,7 @@ export class CallingRepository {
       contentStr.length,
       toSecond(currentTimestamp),
       toSecond(new Date(time).getTime()),
-      conversationId,
+      this.serializeQualifiedId(conversationId),
       userId,
       clientId,
     );
@@ -613,7 +616,7 @@ export class CallingRepository {
     if (res !== 0) {
       this.logger.warn(`recv_msg failed with code: ${res}`);
       if (
-        this.callState.acceptedVersionWarnings().every((acceptedId: string) => acceptedId !== conversationId) &&
+        this.callState.acceptedVersionWarnings().every(acceptedId => !matchQualifiedIds(acceptedId, conversationId)) &&
         res === ERROR.UNKNOWN_PROTOCOL &&
         event.content.type === 'CONFSTART'
       ) {
@@ -624,9 +627,9 @@ export class CallingRepository {
     return this.handleCallEventSaving(content.type, conversationId, userId, time, source);
   };
 
-  handleCallEventSaving(
+  private handleCallEventSaving(
     type: string,
-    conversationId: ConversationId,
+    conversationId: QualifiedId,
     userId: UserId,
     time: string,
     source: string,
@@ -640,7 +643,7 @@ export class CallingRepository {
         const ignoreNotificationStates = [CALL_STATE.MEDIA_ESTAB, CALL_STATE.ANSWERED, CALL_STATE.OUTGOING];
         if (!activeCall || !ignoreNotificationStates.includes(activeCall.state())) {
           // we want to ignore call start events that already have an active call (whether it's ringing or connected).
-          this.injectActivateEvent({domain: '', id: conversationId}, userId, time, source);
+          this.injectActivateEvent(conversationId, userId, time, source);
         }
         break;
     }
@@ -650,26 +653,23 @@ export class CallingRepository {
   // Call actions
   //##############################################################################
 
-  readonly toggleState = (withVideo: boolean): void => {
+  private readonly toggleState = (withVideo: boolean): void => {
     const conversationEntity = this.conversationState.activeConversation();
     if (conversationEntity) {
-      const isActiveCall = this.findCall(conversationEntity.id);
+      const isActiveCall = this.findCall(conversationEntity.qualifiedId);
       const isGroupCall = conversationEntity.isGroup() ? CONV_TYPE.GROUP : CONV_TYPE.ONEONONE;
       const callType = withVideo ? CALL_TYPE.VIDEO : CALL_TYPE.NORMAL;
       return (
         (isActiveCall
-          ? this.leaveCall(conversationEntity.id)
-          : this.startCall(conversationEntity.id, isGroupCall, callType)) && undefined
+          ? this.leaveCall(conversationEntity.qualifiedId)
+          : this.startCall(conversationEntity.qualifiedId, isGroupCall, callType)) && undefined
       );
     }
   };
 
-  async startCall(
-    conversationId: ConversationId,
-    conversationType: CONV_TYPE,
-    callType: CALL_TYPE,
-  ): Promise<void | Call> {
-    this.logger.log(`Starting a call of type "${callType}" in conversation ID "${conversationId}"...`);
+  async startCall(conversationId: QualifiedId, conversationType: CONV_TYPE, callType: CALL_TYPE): Promise<void | Call> {
+    const convId = this.serializeQualifiedId(conversationId);
+    this.logger.log(`Starting a call of type "${callType}" in conversation ID "${convId}"...`);
     try {
       await this.checkConcurrentJoinedCall(conversationId, CALL_STATE.OUTGOING);
       conversationType =
@@ -698,7 +698,7 @@ export class CallingRepository {
           : Promise.resolve(true);
       const success = await loadPreviewPromise;
       if (success) {
-        this.wCall.start(this.wUser, conversationId, callType, conversationType, this.callState.cbrEncoding());
+        this.wCall.start(this.wUser, convId, callType, conversationType, this.callState.cbrEncoding());
         this.sendCallingEvent(EventName.CALLING.INITIATED_CALL, call);
         this.sendCallingEvent(EventName.CONTRIBUTED, call, {
           [Segmentation.MESSAGE.ACTION]: callType === CALL_TYPE.VIDEO ? 'video_call' : 'audio_call',
@@ -708,7 +708,21 @@ export class CallingRepository {
         this.removeCall(call);
       }
       return call;
-    } catch (_error) {}
+    } catch (_error) {
+      console.error(_error);
+    }
+  }
+
+  private serializeQualifiedId(id: QualifiedId): string {
+    if (id.domain) {
+      return `${id.id}@${id.domain}`;
+    }
+    return id.id;
+  }
+
+  private parseQualifiedId(multiplexedId: string): QualifiedId {
+    const [id, domain = ''] = multiplexedId.split('@');
+    return {domain, id};
   }
 
   /**
@@ -725,7 +739,7 @@ export class CallingRepository {
         this.warmupMediaStreams(call, false, true);
       }
     }
-    this.wCall.setVideoSendState(this.wUser, call.conversationId, newState);
+    this.wCall.setVideoSendState(this.wUser, this.serializeQualifiedId(call.conversationId), newState);
   }
 
   /**
@@ -740,19 +754,23 @@ export class CallingRepository {
         [Segmentation.SCREEN_SHARE.DURATION]:
           Math.ceil((Date.now() - selfParticipant.startedScreenSharingAt()) / 5000) * 5,
       });
-      return this.wCall.setVideoSendState(this.wUser, call.conversationId, VIDEO_STATE.STOPPED);
+      return this.wCall.setVideoSendState(
+        this.wUser,
+        this.serializeQualifiedId(call.conversationId),
+        VIDEO_STATE.STOPPED,
+      );
     }
     try {
       const isGroup = [CONV_TYPE.CONFERENCE, CONV_TYPE.GROUP].includes(call.conversationType);
       const mediaStream = await this.getMediaStream({audio: true, screen: true}, isGroup);
       // https://stackoverflow.com/a/25179198/451634
       mediaStream.getVideoTracks()[0].onended = () => {
-        this.wCall.setVideoSendState(this.wUser, call.conversationId, VIDEO_STATE.STOPPED);
+        this.wCall.setVideoSendState(this.wUser, this.serializeQualifiedId(call.conversationId), VIDEO_STATE.STOPPED);
       };
       const selfParticipant = call.getSelfParticipant();
       selfParticipant.videoState(VIDEO_STATE.SCREENSHARE);
       selfParticipant.updateMediaStream(mediaStream, true);
-      this.wCall.setVideoSendState(this.wUser, call.conversationId, VIDEO_STATE.SCREENSHARE);
+      this.wCall.setVideoSendState(this.wUser, this.serializeQualifiedId(call.conversationId), VIDEO_STATE.SCREENSHARE);
       selfParticipant.startedScreenSharingAt(Date.now());
     } catch (error) {
       this.logger.info('Failed to get screen sharing stream', error);
@@ -775,7 +793,12 @@ export class CallingRepository {
         this.setMute(true);
       }
 
-      this.wCall.answer(this.wUser, call.conversationId, callType, this.callState.cbrEncoding());
+      this.wCall.answer(
+        this.wUser,
+        this.serializeQualifiedId(call.conversationId),
+        callType,
+        this.callState.cbrEncoding(),
+      );
 
       this.sendCallingEvent(EventName.CALLING.JOINED_CALL, call, {
         [Segmentation.CALL.DIRECTION]: this.getCallDirection(call),
@@ -785,8 +808,8 @@ export class CallingRepository {
     }
   }
 
-  rejectCall(conversationId: ConversationId): void {
-    this.wCall.reject(this.wUser, conversationId);
+  rejectCall(conversationId: QualifiedId): void {
+    this.wCall.reject(this.wUser, this.serializeQualifiedId(conversationId));
   }
 
   changeCallPage(newPage: number, call: Call): void {
@@ -805,17 +828,19 @@ export class CallingRepository {
     this.requestVideoStreams(call.conversationId, currentPageParticipants);
   }
 
-  requestVideoStreams(conversationId: string, participants: Participant[]) {
+  requestVideoStreams(conversationId: QualifiedId, participants: Participant[]) {
+    const convId = this.serializeQualifiedId(conversationId);
     const payload = {
       clients: participants.map(participant => ({clientid: participant.clientId, userid: participant.user.id})),
-      convid: conversationId,
+      convid: convId,
     };
-    this.wCall.requestVideoStreams(this.wUser, conversationId, VSTREAMS.LIST, JSON.stringify(payload));
+    this.wCall.requestVideoStreams(this.wUser, convId, VSTREAMS.LIST, JSON.stringify(payload));
   }
 
-  readonly leaveCall = (conversationId: ConversationId): void => {
-    delete this.poorCallQualityUsers[conversationId];
-    this.wCall.end(this.wUser, conversationId);
+  readonly leaveCall = (conversationId: QualifiedId): void => {
+    const conversationIdStr = this.serializeQualifiedId(conversationId);
+    delete this.poorCallQualityUsers[conversationIdStr];
+    this.wCall.end(this.wUser, conversationIdStr);
   };
 
   muteCall(call: Call, shouldMute: boolean, reason?: MuteState): void {
@@ -858,7 +883,7 @@ export class CallingRepository {
       if (requestedStreams.camera) {
         this.showNoCameraModal();
       }
-      this.wCall.setVideoSendState(this.wUser, call.conversationId, VIDEO_STATE.STOPPED);
+      this.wCall.setVideoSendState(this.wUser, this.serializeQualifiedId(call.conversationId), VIDEO_STATE.STOPPED);
     }
   }
 
@@ -904,7 +929,7 @@ export class CallingRepository {
       const audioTracks = mediaStream.getAudioTracks().map(track => track.clone());
       if (audioTracks.length > 0) {
         selfParticipant.setAudioStream(new MediaStream(audioTracks), true);
-        this.wCall.replaceTrack(call.conversationId, audioTracks[0]);
+        this.wCall.replaceTrack(this.serializeQualifiedId(call.conversationId), audioTracks[0]);
       }
     }
 
@@ -913,7 +938,7 @@ export class CallingRepository {
       const videoTracks = mediaStream.getVideoTracks().map(track => track.clone());
       if (videoTracks.length > 0) {
         selfParticipant.setVideoStream(new MediaStream(videoTracks), true);
-        this.wCall.replaceTrack(call.conversationId, videoTracks[0]);
+        this.wCall.replaceTrack(this.serializeQualifiedId(call.conversationId), videoTracks[0]);
       }
     }
   }
@@ -960,13 +985,14 @@ export class CallingRepository {
 
   private readonly sendMessage = (
     _context: number,
-    conversationId: ConversationId,
+    convId: SerializedConversationId,
     _userId: UserId,
     _clientId: ClientId,
     targets: string | null,
     _unused: null,
     payload: string,
   ): number => {
+    const conversationId = this.parseQualifiedId(convId);
     const call = this.findCall(conversationId);
     if (call?.blockMessages) {
       return 0;
@@ -975,7 +1001,6 @@ export class CallingRepository {
 
     if (typeof targets === 'string') {
       const parsedTargets: SendMessageTarget = JSON.parse(targets);
-      // TODO(federation): get domain from avs and generate QualifiedUserClients (instead of just UserClients)
       const recipients = this.mapTargets(parsedTargets);
       options = {
         nativePush: true,
@@ -989,15 +1014,11 @@ export class CallingRepository {
   };
 
   private readonly sendCallingMessage = async (
-    conversationId: ConversationId,
+    conversationId: QualifiedId,
     payload: string | Object,
     options?: MessageSendingOptions,
   ): Promise<void> => {
-    const qualifiedConversationId: QualifiedId = {
-      domain: '',
-      id: conversationId /*TODO(federation): get conversation domain*/,
-    };
-    const conversation = this.conversationState.findConversation(qualifiedConversationId);
+    const conversation = this.conversationState.findConversation(conversationId);
     const content = typeof payload === 'string' ? payload : JSON.stringify(payload);
     const message = await this.messageRepository.sendCallingMessage(conversation, content, options);
     if (message.state === PayloadBundleState.CANCELLED) {
@@ -1006,7 +1027,7 @@ export class CallingRepository {
     }
   };
 
-  readonly sendModeratorMute = (conversationId: ConversationId, recipients: Record<UserId, ClientId[]>) => {
+  readonly sendModeratorMute = (conversationId: QualifiedId, recipients: Record<UserId, ClientId[]>) => {
     this.sendCallingMessage(
       conversationId,
       {type: CALL_MESSAGE_TYPE.REMOTE_MUTE},
@@ -1018,7 +1039,7 @@ export class CallingRepository {
     );
   };
 
-  readonly sendModeratorKick = (conversationId: ConversationId, recipients: Record<UserId, ClientId[]>) => {
+  readonly sendModeratorKick = (conversationId: QualifiedId, recipients: Record<UserId, ClientId[]>) => {
     this.sendCallingMessage(
       conversationId,
       {type: CALL_MESSAGE_TYPE.REMOTE_KICK},
@@ -1062,8 +1083,9 @@ export class CallingRepository {
     return 0;
   };
 
-  private readonly callClosed = (reason: REASON, conversationId: ConversationId) => {
+  private readonly callClosed = (reason: REASON, convId: SerializedConversationId) => {
     amplify.publish(WebAppEvents.WARNING.DISMISS, Warnings.TYPE.CALL_QUALITY_POOR);
+    const conversationId = this.parseQualifiedId(convId);
     const call = this.findCall(conversationId);
     if (!call) {
       return;
@@ -1075,7 +1097,7 @@ export class CallingRepository {
     }
 
     if (reason === REASON.NOONE_JOINED || reason === REASON.EVERYONE_LEFT) {
-      const conversationEntity = this.conversationState.findConversation({domain: '', id: conversationId});
+      const conversationEntity = this.conversationState.findConversation(conversationId);
       const callingEvent = EventBuilder.buildCallingTimeoutEvent(
         reason,
         conversationEntity,
@@ -1117,7 +1139,7 @@ export class CallingRepository {
 
     if (!stillActiveState.includes(reason)) {
       this.injectDeactivateEvent(
-        {domain: '' /*TODO(federation): get conversation domain*/, id: call.conversationId},
+        call.conversationId,
         call.initiator,
         call.startedAt() ? Date.now() - call.startedAt() : 0,
         reason,
@@ -1134,7 +1156,7 @@ export class CallingRepository {
   };
 
   private readonly incomingCall = (
-    conversationId: ConversationId,
+    convId: SerializedConversationId,
     timestamp: number,
     userId: UserId,
     clientId: string,
@@ -1142,7 +1164,8 @@ export class CallingRepository {
     shouldRing: number,
     conversationType: CONV_TYPE,
   ) => {
-    const conversationEntity = this.conversationState.findConversation({domain: '', id: conversationId});
+    const conversationId = this.parseQualifiedId(convId);
+    const conversationEntity = this.conversationState.findConversation(conversationId);
     if (!conversationEntity) {
       return;
     }
@@ -1177,10 +1200,10 @@ export class CallingRepository {
     this.sendCallingEvent(EventName.CALLING.RECEIVED_CALL, call);
   };
 
-  private readonly updateCallState = (conversationId: ConversationId, state: CALL_STATE) => {
-    const call = this.findCall(conversationId);
+  private readonly updateCallState = (convId: SerializedConversationId, state: CALL_STATE) => {
+    const call = this.findCall(this.parseQualifiedId(convId));
     if (!call) {
-      this.logger.warn(`received state for call in conversation '${conversationId}' but no stored call found`);
+      this.logger.warn(`received state for call in conversation '${convId}' but no stored call found`);
       return;
     }
 
@@ -1230,8 +1253,8 @@ export class CallingRepository {
     this.changeCallPage(call.currentPage(), call);
   }
 
-  private readonly handleCallParticipantChanges = (conversationId: ConversationId, membersJson: string) => {
-    const call = this.findCall(conversationId);
+  private readonly handleCallParticipantChanges = (convId: SerializedConversationId, membersJson: string) => {
+    const call = this.findCall(this.parseQualifiedId(convId));
 
     if (!call) {
       return;
@@ -1244,12 +1267,12 @@ export class CallingRepository {
     this.updateParticipantVideoState(call, members);
   };
 
-  private readonly requestClients = (wUser: number, conversationId: ConversationId, _: number) => {
-    this.pushClients(conversationId);
+  private readonly requestClients = (wUser: number, convId: SerializedConversationId, _: number) => {
+    this.pushClients(this.parseQualifiedId(convId));
   };
 
   private readonly getCallMediaStream = async (
-    conversationId: ConversationId,
+    convId: SerializedConversationId,
     audio: boolean,
     camera: boolean,
     screen: boolean,
@@ -1258,7 +1281,7 @@ export class CallingRepository {
       // if a query is already occurring, we will return the result of this query
       return this.mediaStreamQuery;
     }
-    const call = this.findCall(conversationId);
+    const call = this.findCall(this.parseQualifiedId(convId));
     if (!call) {
       return Promise.reject();
     }
@@ -1324,8 +1347,8 @@ export class CallingRepository {
     return this.mediaStreamQuery;
   };
 
-  private readonly updateActiveSpeakers = (wuser: number, conversationId: string, rawJson: string) => {
-    const call = this.findCall(conversationId);
+  private readonly updateActiveSpeakers = (wuser: number, convId: string, rawJson: string) => {
+    const call = this.findCall(this.parseQualifiedId(convId));
     const activeSpeakers = JSON.parse(rawJson);
     if (call && activeSpeakers) {
       call.setActiveSpeakers(activeSpeakers);
@@ -1333,11 +1356,11 @@ export class CallingRepository {
   };
 
   private readonly updateCallAudioStreams = (
-    conversationId: string,
+    convId: SerializedConversationId,
     streamId: string,
     streams: readonly MediaStream[] | null,
   ): void => {
-    const call = this.findCall(conversationId);
+    const call = this.findCall(this.parseQualifiedId(convId));
     if (!call) {
       return;
     }
@@ -1356,14 +1379,14 @@ export class CallingRepository {
   };
 
   private readonly updateParticipantVideoStream = (
-    conversationId: ConversationId,
+    conversationId: SerializedConversationId,
     remoteUserId: UserId,
     remoteClientId: ClientId,
     streams: readonly MediaStream[] | null,
   ): void => {
-    let participant = this.findParticipant(conversationId, remoteUserId, remoteClientId);
+    let participant = this.findParticipant(this.parseQualifiedId(conversationId), remoteUserId, remoteClientId);
     if (!participant) {
-      const call = this.findCall(conversationId);
+      const call = this.findCall(this.parseQualifiedId(conversationId));
       if (call?.conversationType !== CONV_TYPE.ONEONONE) {
         return;
       }
@@ -1390,12 +1413,12 @@ export class CallingRepository {
   };
 
   private readonly videoStateChanged = (
-    conversationId: ConversationId,
+    convId: SerializedConversationId,
     userId: UserId,
     clientId: ClientId,
     state: VIDEO_STATE,
   ) => {
-    const call = this.findCall(conversationId);
+    const call = this.findCall(this.parseQualifiedId(convId));
     if (!call) {
       return;
     }
@@ -1446,7 +1469,7 @@ export class CallingRepository {
     call: Call,
     customSegmentations: Record<string, any> = {},
   ) => {
-    const conversationEntity = this.conversationState.findConversation({domain: '', id: call.conversationId});
+    const conversationEntity = this.conversationState.findConversation(call.conversationId);
     const participants = conversationEntity.participating_user_ets();
     const selfUserTeamId = call.getSelfParticipant().user.id;
     const guests = participants.filter(user => user.isGuest()).length;
@@ -1470,7 +1493,9 @@ export class CallingRepository {
    * @note Should only used by "window.onbeforeunload".
    */
   destroy(): void {
-    this.callState.activeCalls().forEach((call: Call) => this.wCall.end(this.wUser, call.conversationId));
+    this.callState
+      .activeCalls()
+      .forEach((call: Call) => this.wCall.end(this.wUser, this.serializeQualifiedId(call.conversationId)));
     this.wCall.destroy(this.wUser);
   }
 
@@ -1482,11 +1507,11 @@ export class CallingRepository {
     return this.apiClient.account.api.getCallConfig(limit);
   }
 
-  private checkConcurrentJoinedCall(conversationId: ConversationId, newCallState: CALL_STATE): Promise<void> {
+  private checkConcurrentJoinedCall(conversationId: QualifiedId, newCallState: CALL_STATE): Promise<void> {
     const idleCallStates = [CALL_STATE.INCOMING, CALL_STATE.NONE, CALL_STATE.UNKNOWN];
     const activeCall = this.callState
       .activeCalls()
-      .find(call => call.conversationId !== conversationId && !idleCallStates.includes(call.state()));
+      .find(call => !matchQualifiedIds(call.conversationId, conversationId) && !idleCallStates.includes(call.state()));
     if (!activeCall) {
       return Promise.resolve();
     }

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -560,7 +560,11 @@ export class CallingRepository {
    * Handle incoming calling events from backend.
    */
   onCallEvent = async (event: CallingEvent, source: string): Promise<void> => {
-    const {content, conversation: conversationId, from: userId, sender: clientId, time} = event;
+    const {content, conversation, qualified_conversation, from: userId, sender: clientId, time} = event;
+    const conversationId =
+      Config.getConfig().FEATURE.ENABLE_FEDERATION && qualified_conversation
+        ? qualified_conversation
+        : {domain: '', id: conversation};
     const currentTimestamp = this.serverTimeHandler.toServerTimestamp();
     const toSecond = (timestamp: number) => Math.floor(timestamp / 1000);
     const contentStr = JSON.stringify(content);
@@ -714,7 +718,7 @@ export class CallingRepository {
   }
 
   private serializeQualifiedId(id: QualifiedId): string {
-    if (id.domain) {
+    if (id.domain && Config.getConfig().FEATURE.ENABLE_FEDERATION) {
       return `${id.id}@${id.domain}`;
     }
     return id.id;

--- a/src/script/components/calling/CallingOverlayContainer.tsx
+++ b/src/script/components/calling/CallingOverlayContainer.tsx
@@ -157,7 +157,7 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
     });
   };
 
-  const conversation = conversationState.findConversation({domain: '', id: joinedCall?.conversationId});
+  const conversation = joinedCall && conversationState.findConversation(joinedCall.conversationId);
   if (!joinedCall || !conversation || conversation.removed_from_conversation()) {
     return null;
   }
@@ -166,11 +166,11 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
     <Fragment>
       {!isMinimized && !!videoGrid?.grid.length && (
         <FullscreenVideoCall
-          key={joinedCall.conversationId}
+          key={joinedCall.conversationId.id}
           videoGrid={videoGrid}
           call={joinedCall}
           activeCallViewTab={activeCallViewTab}
-          conversation={getConversationById({domain: '', id: joinedCall.conversationId})}
+          conversation={getConversationById(joinedCall.conversationId)}
           multitasking={multitasking}
           canShareScreen={callingRepository.supportsScreenSharing}
           maximizedParticipant={maximizedParticipant}

--- a/src/script/components/calling/fullscreenVideoCall.test.ts
+++ b/src/script/components/calling/fullscreenVideoCall.test.ts
@@ -46,7 +46,7 @@ describe('fullscreenVideoCall', () => {
     spyOn(conversation, 'supportsVideoCall').and.returnValue(true);
     const selfUser = new User('', null);
     selfUser.isMe = true;
-    const call = new Call('', '', 0, new Participant(selfUser, ''), 0, {
+    const call = new Call('', {domain: '', id: ''}, 0, new Participant(selfUser, ''), 0, {
       currentAvailableDeviceId: {
         audioOutput: ko.pureComputed(() => 'test'),
       },

--- a/src/script/components/list/ConversationListCallingCell.test.ts
+++ b/src/script/components/list/ConversationListCallingCell.test.ts
@@ -52,7 +52,7 @@ const createCall = (
   selfClientId = createRandomUuid(),
 ) => {
   const selfParticipant = new Participant(selfUser, selfClientId);
-  const call = new Call('', '', 0, selfParticipant, CALL_TYPE.NORMAL, {
+  const call = new Call('', {domain: '', id: ''}, 0, selfParticipant, CALL_TYPE.NORMAL, {
     currentAvailableDeviceId: {
       audioOutput: ko.pureComputed(() => 'test'),
     },

--- a/src/script/components/list/ConversationListCallingCell.tsx
+++ b/src/script/components/list/ConversationListCallingCell.tsx
@@ -149,7 +149,7 @@ const ConversationListCallingCell: React.FC<CallingCellProps> = ({
 
     const muteParticipant = {
       click: () =>
-        callingRepository.sendModeratorMute(conversation.id, {[participant.user.id]: [participant.clientId]}),
+        callingRepository.sendModeratorMute(conversation.qualifiedId, {[participant.user.id]: [participant.clientId]}),
       icon: 'mic-off-icon',
       identifier: `moderator-mute-participant`,
       isDisabled: participant.isMuted(),
@@ -164,7 +164,7 @@ const ConversationListCallingCell: React.FC<CallingCellProps> = ({
             acc[user.id] = [...(acc[user.id] || []), clientId];
             return acc;
           }, {} as Record<UserId, ClientId[]>);
-        callingRepository.sendModeratorMute(conversation.id, recipients);
+        callingRepository.sendModeratorMute(conversation.qualifiedId, recipients);
       },
       icon: 'mic-off-icon',
       identifier: 'moderator-mute-others',

--- a/src/script/components/list/GroupedConversations.tsx
+++ b/src/script/components/list/GroupedConversations.tsx
@@ -36,6 +36,7 @@ import {ConversationState} from '../../conversation/ConversationState';
 import {registerReactComponent, useKoSubscribableChildren} from 'Util/ComponentUtil';
 import GroupedConversationsFolder from './GroupedConversationsFolder';
 import {CallState} from '../../calling/CallState';
+import {QualifiedId} from '@wireapp/api-client/src/user';
 
 const useLabels = (conversationLabelRepository: ConversationLabelRepository) => {
   const {labels: conversationLabels} = useKoSubscribableChildren(conversationLabelRepository, ['labels']);
@@ -57,7 +58,7 @@ export interface GroupedConversationsProps {
   conversationRepository: ConversationRepository;
   conversationState: ConversationState;
   expandedFolders: string[];
-  hasJoinableCall: (conversationId: string) => boolean;
+  hasJoinableCall: (conversationId: QualifiedId) => boolean;
   isSelectedConversation: (conversationEntity: Conversation) => boolean;
   isVisibleFunc: (top: number, bottom: number) => boolean;
   listViewModel: ListViewModel;

--- a/src/script/components/list/GroupedConversationsFolder.tsx
+++ b/src/script/components/list/GroupedConversationsFolder.tsx
@@ -26,12 +26,13 @@ import {generateConversationUrl} from '../../router/routeGenerator';
 import {createNavigate} from '../../router/routerBindings';
 import {ListViewModel} from 'src/script/view_model/ListViewModel';
 import {Conversation} from 'src/script/entity/Conversation';
+import {QualifiedId} from '@wireapp/api-client/src/user';
 
 export interface GroupedConversationsFolderProps {
   expandedFolders: string[];
   folder: ConversationLabel;
   getOffsetTop: (folder: ConversationLabel, conversation: Conversation) => number;
-  hasJoinableCall: (conversationId: string) => boolean;
+  hasJoinableCall: (conversationId: QualifiedId) => boolean;
   isSelectedConversation: (conversationEntity: Conversation) => boolean;
   isVisibleFunc: (top: number, bottom: number) => boolean;
   listViewModel: ListViewModel;
@@ -67,7 +68,7 @@ const GroupedConversationsFolder: React.FC<GroupedConversationsFolderProps> = ({
               onClick={makeOnClick(conversation.id, conversation.domain)}
               rightClick={(_, event) => listViewModel.onContextMenu(conversation, event)}
               conversation={conversation}
-              showJoinButton={hasJoinableCall(conversation.id)}
+              showJoinButton={hasJoinableCall(conversation.qualifiedId)}
               is_selected={isSelectedConversation}
               onJoinCall={onJoinCall}
               offsetTop={getOffsetTop(folder, conversation)}

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -144,7 +144,7 @@ export class ConversationRepository {
   public readonly conversationRoleRepository: ConversationRoleRepository;
   private readonly event_mapper: EventMapper;
   private readonly eventService: EventService;
-  public leaveCall: (conversationId: string) => void;
+  public leaveCall: (conversationId: QualifiedId) => void;
   private readonly receiving_queue: PromiseQueue;
   private readonly logger: Logger;
   public readonly stateHandler: ConversationStateHandler;
@@ -1407,7 +1407,7 @@ export class ConversationRepository {
 
     if (leaveConversation) {
       conversationEntity.status(ConversationStatus.PAST_MEMBER);
-      this.leaveCall(conversationEntity.id);
+      this.leaveCall(conversationEntity.qualifiedId);
     }
 
     this.messageRepository.updateClearedTimestamp(conversationEntity);
@@ -2383,7 +2383,7 @@ export class ConversationRepository {
 
     if (removesSelfUser) {
       conversationEntity.status(ConversationStatus.PAST_MEMBER);
-      this.leaveCall(conversationEntity.id);
+      this.leaveCall(conversationEntity.qualifiedId);
       if (this.userState.self().isTemporaryGuest()) {
         eventJson.from = this.userState.self().id;
       }

--- a/src/script/conversation/EventBuilder.ts
+++ b/src/script/conversation/EventBuilder.ts
@@ -55,7 +55,7 @@ export interface ConversationEvent<T> extends BaseEvent {
 
 export interface CallingEvent {
   content: CallEntity;
-  conversation: string;
+  conversation: QualifiedId;
   from: string;
   sender: string;
   time?: string;
@@ -244,7 +244,7 @@ export const EventBuilder = {
   ): CallingEvent {
     return {
       content: callMessage,
-      conversation: conversationEntity.id,
+      conversation: conversationEntity.qualifiedId,
       from: userId,
       sender: clientId,
       type: ClientEvent.CALL.E_CALL,

--- a/src/script/conversation/EventBuilder.ts
+++ b/src/script/conversation/EventBuilder.ts
@@ -55,8 +55,9 @@ export interface ConversationEvent<T> extends BaseEvent {
 
 export interface CallingEvent {
   content: CallEntity;
-  conversation: QualifiedId;
+  conversation: string;
   from: string;
+  qualified_conversation?: QualifiedId;
   sender: string;
   time?: string;
   type: CALL;
@@ -244,8 +245,9 @@ export const EventBuilder = {
   ): CallingEvent {
     return {
       content: callMessage,
-      conversation: conversationEntity.qualifiedId,
+      conversation: conversationEntity.id,
       from: userId,
+      qualified_conversation: conversationEntity.qualifiedId,
       sender: clientId,
       type: ClientEvent.CALL.E_CALL,
     };

--- a/src/script/view_model/CallingViewModel.ts
+++ b/src/script/view_model/CallingViewModel.ts
@@ -47,6 +47,7 @@ import {TeamState} from '../team/TeamState';
 import {Config} from '../Config';
 import {safeWindowOpen} from 'Util/SanitizationUtil';
 import {ROLE} from '../user/UserPermission';
+import {QualifiedId} from '@wireapp/api-client/src/user';
 
 export interface CallActions {
   answer: (call: Call) => void;
@@ -100,7 +101,7 @@ export class CallingViewModel {
     this.isSelfVerified = ko.pureComputed(() => selfUser().is_verified());
     this.activeCalls = ko.pureComputed(() =>
       this.callState.activeCalls().filter(call => {
-        const conversation = this.conversationState.findConversation({domain: '', id: call.conversationId});
+        const conversation = this.conversationState.findConversation(call.conversationId);
         if (!conversation || conversation.removed_from_conversation()) {
           return false;
         }
@@ -134,7 +135,7 @@ export class CallingViewModel {
 
     const startCall = (conversationEntity: Conversation, callType: CALL_TYPE): void => {
       const convType = conversationEntity.isGroup() ? CONV_TYPE.GROUP : CONV_TYPE.ONEONONE;
-      this.callingRepository.startCall(conversationEntity.id, convType, callType).then(call => {
+      this.callingRepository.startCall(conversationEntity.qualifiedId, convType, callType).then(call => {
         if (!call) {
           return;
         }
@@ -303,8 +304,8 @@ export class CallingViewModel {
     return call.state() === CALL_STATE.MEDIA_ESTAB;
   }
 
-  getConversationById(conversationId: string): Conversation {
-    return this.conversationState.findConversation({domain: '', id: conversationId});
+  getConversationById(conversationId: QualifiedId): Conversation {
+    return this.conversationState.findConversation(conversationId);
   }
 
   hasAccessToCamera(): boolean {

--- a/src/script/view_model/ListViewModel.ts
+++ b/src/script/view_model/ListViewModel.ts
@@ -203,7 +203,7 @@ export class ListViewModel {
   };
 
   readonly answerCall = (conversationEntity: Conversation): void => {
-    const call = this.callingRepository.findCall(conversationEntity.id);
+    const call = this.callingRepository.findCall(conversationEntity.qualifiedId);
     if (!call) {
       return;
     }

--- a/src/script/view_model/content/TitleBarViewModel.ts
+++ b/src/script/view_model/content/TitleBarViewModel.ts
@@ -39,6 +39,7 @@ import {ConversationState} from '../../conversation/ConversationState';
 import {CallState} from '../../calling/CallState';
 import {TeamState} from '../../team/TeamState';
 import {ConversationFilter} from '../../conversation/ConversationFilter';
+import {matchQualifiedIds} from 'Util/QualifiedId';
 
 // Parent: ContentViewModel
 export function generateWarningBadgeKey({
@@ -120,7 +121,9 @@ export class TitleBarViewModel {
 
     this.hasCall = ko.pureComputed(() => {
       const hasEntities = this.conversationEntity() && !!this.callState.joinedCall();
-      return hasEntities ? this.conversationEntity().id === this.callState.joinedCall().conversationId : false;
+      return hasEntities
+        ? matchQualifiedIds(this.conversationEntity().qualifiedId, this.callState.joinedCall().conversationId)
+        : false;
     });
 
     this.badgeLabelCopy = ko.pureComputed(() => {
@@ -180,7 +183,7 @@ export class TitleBarViewModel {
 
   private readonly _startCall = (conversationEntity: Conversation, callType: CALL_TYPE): void => {
     const convType = conversationEntity.isGroup() ? CONV_TYPE.GROUP : CONV_TYPE.ONEONONE;
-    this.callingRepository.startCall(conversationEntity.id, convType, callType);
+    this.callingRepository.startCall(conversationEntity.qualifiedId, convType, callType);
   };
 
   readonly clickOnDetails = (): void => {

--- a/src/script/view_model/list/ConversationListViewModel.ts
+++ b/src/script/view_model/list/ConversationListViewModel.ts
@@ -54,6 +54,7 @@ import type {PreferenceNotificationRepository} from '../../notification/Preferen
 import type {PropertiesRepository} from '../../properties/PropertiesRepository';
 import type {User} from '../../entity/User';
 import {createNavigate} from '../../router/routerBindings';
+import {QualifiedId} from '@wireapp/api-client/src/user';
 
 export class ConversationListViewModel {
   readonly startTooltip: string;
@@ -253,12 +254,12 @@ export class ConversationListViewModel {
     this.contentViewModel.switchContent(ContentViewModel.STATE.CONNECTION_REQUESTS);
   };
 
-  readonly hasJoinableCall = (conversationId: string): boolean => {
+  readonly hasJoinableCall = (conversationId: QualifiedId): boolean => {
     const call = this.callingRepository.findCall(conversationId);
     if (!call) {
       return false;
     }
-    const conversation = this.conversationState.findConversation({domain: '', id: conversationId});
+    const conversation = this.conversationState.findConversation(conversationId);
     return (
       !conversation.removed_from_conversation() &&
       call.state() === CALL_STATE.INCOMING &&


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-14" title="FS-14" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/secure/viewavatar?size=medium&avatarId=10818&avatarType=issuetype" />FS-14</a>  [Web] As a user, I can place a call with a user in my contact list who is part of a federated backend
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Will enable 1:1 calling for federated envs. The idea is to give a serialized identifier to AVS, and parse this identifier on webapp side. 

AVS will have an id with this format `convid@domain` that will be parsed to `{id: 'convid', domain: 'domain'}`. Thus this doesn't need any update from AVS