### PR TITLE
runfix(core): Silent degradation warning when sending confirmation message

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -185,7 +185,7 @@ export class ConversationRepository {
     this.eventService = eventRepository.eventService;
     // we register a client mismatch handler agains the message repository so that we can react to missing members
     // FIXME this should be temporary. In the near future we want the core to handle clients/mismatch/verification. So the webapp won't need this logic at all
-    this.messageRepository.setClientMismatchHandler(async (mismatch, conversationId) => {
+    this.messageRepository.setClientMismatchHandler(async (mismatch, conversationId, silent) => {
       const deleted = isQualifiedUserClients(mismatch.deleted)
         ? flattenQualifiedUserClients(mismatch.deleted)
         : flattenUserClients(mismatch.deleted);
@@ -216,7 +216,7 @@ export class ConversationRepository {
           conversation.verification_state(ConversationVerificationState.DEGRADED);
         }
       }
-      return this.messageRepository.requestUserSendingPermission(conversation);
+      return silent ? false : this.messageRepository.requestUserSendingPermission(conversation);
     });
 
     this.logger = getLogger('ConversationRepository');


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Confirmation messages are sent when a message is received. If we get a mismatch error at this point and the conversation is verified (a user has a new client we do not know of), we should not show the degradation warning to the user. 

### Causes (Optional)

Since we now send confirmation message with the core, this logic was not ported back to core message sending. 

### Solutions

This PR add a `silentDegradationWarning` flag that allows sending a message that might create a mismatch but will just stop sending instead of warn the user. 
