### PR TITLE
runfix(core): Do not silent degradation warning for read-receipt in unverified conversations

### DIFF
--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -1059,7 +1059,7 @@ export class MessageRepository {
       recipients: [{domain: messageEntity.fromDomain, id: messageEntity.from}],
       // We first try to send the message targetting the sending user.
       // In case there is a mismatch, the app will update local clients but will not send the message and will not show the degradation warning
-      silentDegradationWarning: true,
+      silentDegradationWarning: conversationEntity.verification_state() !== ConversationVerificationState.UNVERIFIED,
 
       targetMode: MessageTargetMode.USERS,
     };

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -1057,8 +1057,8 @@ export class MessageRepository {
     const sendingOptions = {
       nativePush: false,
       recipients: [{domain: messageEntity.fromDomain, id: messageEntity.from}],
-      // We first try to send the message targetting the sending user.
-      // In case there is a mismatch, the app will update local clients but will not send the message and will not show the degradation warning
+      // When not in a verified conversation (verified or degraded) we want the regular sending flow (send and reencrypt if there are mismatches)
+      // When in a verified (or degraded) conversation we want to prevent encrypting for unverified devices, we will then silent the degradation modal and force sending to only the devices that are verified
       silentDegradationWarning: conversationEntity.verification_state() !== ConversationVerificationState.UNVERIFIED,
 
       targetMode: MessageTargetMode.USERS,


### PR DESCRIPTION

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In case of an unverified conversation, we do not want to send to only verified devices but all the devices for read-receipts. 

