### PR TITLE
runfix(core): Consume and send qualified ids in mentions [FS-290]

### DIFF
--- a/src/page/template/content/conversation/message-list.htm
+++ b/src/page/template/content/conversation/message-list.htm
@@ -22,7 +22,7 @@
           conversation: conversation,
           shouldShowAvatar: !shouldHideUserAvatar(message),
           shouldShowInvitePeople: showInvitePeople(),
-          selfId: selfUser().id,
+          selfId: selfUser().qualifiedId,
           isMarked: focusedMessage() === message.id,
           isSelfTemporaryGuest: selfUser().isTemporaryGuest(),
           isLastDeliveredMessage: isLastDeliveredMessage(message),

--- a/src/script/components/message.ts
+++ b/src/script/components/message.ts
@@ -25,6 +25,7 @@ import {container} from 'tsyringe';
 import {AVATAR_SIZE} from 'Components/Avatar';
 import {t} from 'Util/LocalizerUtil';
 import {includesOnlyEmojis} from 'Util/EmojiUtil';
+import {QualifiedId} from '@wireapp/api-client/src/user';
 
 import {EphemeralStatusType} from '../message/EphemeralStatusType';
 import {showContextMenu as showContext, ContextMenuEntry} from '../ui/ContextMenu';
@@ -91,7 +92,7 @@ interface MessageParams {
   onContentUpdated: () => void;
   onLike: (message: ContentMessage, button?: boolean) => void;
   onMessageMarked: (element: HTMLElement) => void;
-  selfId: ko.Observable<string>;
+  selfId: ko.Observable<QualifiedId>;
   shouldShowAvatar: ko.Observable<boolean>;
   shouldShowInvitePeople: ko.Observable<boolean>;
   teamState?: TeamState;
@@ -124,7 +125,7 @@ class Message {
   onLike: (message: ContentMessage, button?: boolean) => void;
   AVATAR_SIZE: typeof AVATAR_SIZE;
   previewSubscription: ko.Subscription;
-  selfId: ko.Observable<string>;
+  selfId: ko.Observable<QualifiedId>;
   shouldShowAvatar: ko.Observable<boolean>;
   shouldShowInvitePeople: ko.Observable<boolean>;
   StatusType: typeof StatusType;

--- a/src/script/components/message/MessageQuote.tsx
+++ b/src/script/components/message/MessageQuote.tsx
@@ -25,6 +25,7 @@ import {WebAppEvents} from '@wireapp/webapp-events';
 import {isBeforeToday, formatDateNumeral, formatTimeShort} from 'Util/TimeUtil';
 import {includesOnlyEmojis} from 'Util/EmojiUtil';
 
+import {QualifiedId} from '@wireapp/api-client/src/user';
 import {QuoteEntity} from '../../message/QuoteEntity';
 import {ConversationError} from '../../error/ConversationError';
 import type {Conversation} from '../../entity/Conversation';
@@ -49,7 +50,7 @@ export interface QuoteProps {
   handleClickOnMessage: (message: ContentMessage, event: React.MouseEvent) => boolean;
   messageRepository: MessageRepository;
   quote: QuoteEntity;
-  selfId: string;
+  selfId: QualifiedId;
   showDetail: (message: ContentMessage, event: React.MouseEvent) => void;
   showUserDetails: (user: User) => void;
 }
@@ -132,7 +133,7 @@ interface QuotedMessageProps {
   focusMessage: (id: string) => void;
   handleClickOnMessage: (message: ContentMessage | Text, event: React.MouseEvent) => boolean;
   quotedMessage: ContentMessage;
-  selfId: string;
+  selfId: QualifiedId;
   showDetail: (message: ContentMessage, event: React.MouseEvent) => void;
   showUserDetails: (user: User) => void;
 }

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -287,7 +287,12 @@ export class MessageRepository {
     const textPayload = this.messageBuilder
       .createText({conversationId: conversation.id, text: message})
       .withMentions(
-        mentions.map(mention => ({length: mention.length, start: mention.startIndex, userId: mention.userId})),
+        mentions.map(mention => ({
+          length: mention.length,
+          qualifiedUserId: mention.userQualifiedId,
+          start: mention.startIndex,
+          userId: mention.userId,
+        })),
       )
       .withReadConfirmation(this.expectReadReceipt(conversation))
       .withQuote(quoteData)

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -401,7 +401,9 @@ export class Conversation {
           const isPing = messageEntity.isPing();
           const isMessage = messageEntity.isContent();
           const isSelfMentioned =
-            isMessage && this.selfUser() && (messageEntity as ContentMessage).isUserMentioned(this.selfUser().id);
+            isMessage &&
+            this.selfUser() &&
+            (messageEntity as ContentMessage).isUserMentioned(this.selfUser().qualifiedId);
           const isSelfQuoted =
             isMessage && this.selfUser() && (messageEntity as ContentMessage).isUserQuoted(this.selfUser().id);
 

--- a/src/script/entity/message/ContentMessage.ts
+++ b/src/script/entity/message/ContentMessage.ts
@@ -174,7 +174,7 @@ export class ContentMessage extends Message {
    * @returns `true` if the user was mentioned or quoted, `false` otherwise.
    */
   isUserTargeted(userId: QualifiedId): boolean {
-    return this.isUserMentioned(userId) || this.isUserQuoted(userId.id);
+    return userId && (this.isUserMentioned(userId) || this.isUserQuoted(userId.id));
   }
 
   /**

--- a/src/script/entity/message/ContentMessage.ts
+++ b/src/script/entity/message/ContentMessage.ts
@@ -20,6 +20,7 @@
 import ko from 'knockout';
 
 import {copyText} from 'Util/ClipboardUtil';
+import {QualifiedId} from '@wireapp/api-client/src/user';
 import {t} from 'Util/LocalizerUtil';
 import {formatLocale, formatTimeShort} from 'Util/TimeUtil';
 import type {QuoteEntity} from '../../message/QuoteEntity';
@@ -154,7 +155,7 @@ export class ContentMessage extends Message {
    * @param userId The user id to check
    * @returns `true` if the message mentions the user, `false` otherwise.
    */
-  isUserMentioned(userId: string): boolean {
+  isUserMentioned(userId: QualifiedId): boolean {
     return this.hasAssetText()
       ? this.assets().some(assetEntity => assetEntity.isText() && assetEntity.isUserMentioned(userId))
       : false;
@@ -172,8 +173,8 @@ export class ContentMessage extends Message {
    * @param userId The user id to check
    * @returns `true` if the user was mentioned or quoted, `false` otherwise.
    */
-  isUserTargeted(userId: string): boolean {
-    return this.isUserMentioned(userId) || this.isUserQuoted(userId);
+  isUserTargeted(userId: QualifiedId): boolean {
+    return this.isUserMentioned(userId) || this.isUserQuoted(userId.id);
   }
 
   /**

--- a/src/script/entity/message/Text.ts
+++ b/src/script/entity/message/Text.ts
@@ -21,6 +21,7 @@ import ko from 'knockout';
 
 import {renderMessage} from 'Util/messageRenderer';
 
+import {QualifiedId} from '@wireapp/api-client/src/user';
 import {AssetType} from '../../assets/AssetType';
 import {containsOnlyLink} from '../../links/LinkPreviewHelpers';
 import {mediaParser} from '../../media/MediaParser';
@@ -53,12 +54,12 @@ export class Text extends Asset {
   }
 
   // Process text before rendering it
-  render(selfId: string, themeColor?: string): string {
+  render(selfId: QualifiedId, themeColor?: string): string {
     const message = renderMessage(this.text, selfId, this.mentions());
     return !this.previews().length ? mediaParser.renderMediaEmbeds(message, themeColor) : message;
   }
 
-  isUserMentioned(userId: string): boolean {
+  isUserMentioned(userId: QualifiedId): boolean {
     return this.mentions().some(mentionEntity => mentionEntity.targetsUser(userId));
   }
 }

--- a/src/script/message/MentionEntity.ts
+++ b/src/script/message/MentionEntity.ts
@@ -17,7 +17,9 @@
  *
  */
 
-import {Mention} from '@wireapp/protocol-messaging';
+import {Mention, IMention} from '@wireapp/protocol-messaging';
+import {matchQualifiedIds} from 'Util/QualifiedId';
+import {QualifiedId} from '@wireapp/api-client/src/user';
 
 import {isUUID} from 'Util/ValidationUtil';
 
@@ -51,9 +53,13 @@ export class MentionEntity {
     this.userId = userId;
   }
 
-  targetsUser(userId: string): boolean {
+  targetsUser(userId: QualifiedId): boolean {
     const isTypeUserId = this.type === PROTO_MESSAGE_TYPE.MENTION_TYPE_USER_ID;
-    return isTypeUserId && this.userId === userId;
+    return isTypeUserId && matchQualifiedIds(this.userQualifiedId, userId);
+  }
+
+  get userQualifiedId(): QualifiedId {
+    return {domain: this.domain || '', id: this.userId};
   }
 
   // Index of first char outside of mention
@@ -116,20 +122,24 @@ export class MentionEntity {
     return true;
   }
 
-  toJSON(): {length: number; startIndex: number; userId: string} {
+  toJSON() {
     return {
       length: this.length,
       startIndex: this.startIndex,
       userId: this.userId,
+      userQualifiedId: this.domain ? this.userQualifiedId : undefined,
     };
   }
 
   toProto(): Mention {
-    const protoMention = new Mention({length: this.length, start: this.startIndex});
+    const options: IMention = {length: this.length, start: this.startIndex};
     const isUserIdMention = this.type === PROTO_MESSAGE_TYPE.MENTION_TYPE_USER_ID;
     if (isUserIdMention) {
-      protoMention[PROTO_MESSAGE_TYPE.MENTION_TYPE_USER_ID] = this.userId;
+      options.userId = this.userId;
+      if (this.domain) {
+        options.qualifiedUserId = this.userQualifiedId;
+      }
     }
-    return protoMention;
+    return new Mention(options);
   }
 }

--- a/src/script/notification/NotificationRepository.ts
+++ b/src/script/notification/NotificationRepository.ts
@@ -223,7 +223,7 @@ export class NotificationRepository {
     }
 
     const isUserBusy = this.selfUser().availability() === Availability.Type.BUSY;
-    const isSelfMentionOrReply = messageEntity.isContent() && messageEntity.isUserTargeted(this.selfUser().id);
+    const isSelfMentionOrReply = messageEntity.isContent() && messageEntity.isUserTargeted(this.selfUser().qualifiedId);
     const isCallMessage = messageEntity.super_type === SuperType.CALL;
 
     if (isUserBusy && !isSelfMentionOrReply && !isCallMessage && !isComposite) {
@@ -231,7 +231,11 @@ export class NotificationRepository {
     }
 
     const notifyInConversation = conversationEntity
-      ? NotificationRepository.shouldNotifyInConversation(conversationEntity, messageEntity, this.selfUser().id)
+      ? NotificationRepository.shouldNotifyInConversation(
+          conversationEntity,
+          messageEntity,
+          this.selfUser().qualifiedId,
+        )
       : true;
 
     if (notifyInConversation) {
@@ -305,7 +309,7 @@ export class NotificationRepository {
         if (assetEntity.isText()) {
           let notificationText;
 
-          if (assetEntity.isUserMentioned(this.selfUser().id)) {
+          if (assetEntity.isUserMentioned(this.selfUser().qualifiedId)) {
             notificationText = t('notificationMention', assetEntity.text, {}, true);
           } else if (messageEntity.isUserQuoted(this.selfUser().id)) {
             notificationText = t('notificationReply', assetEntity.text, {}, true);
@@ -423,7 +427,7 @@ export class NotificationRepository {
    */
   private createBodyObfuscated(messageEntity: ContentMessage): string {
     if (messageEntity.isContent()) {
-      const isSelfMentioned = messageEntity.isUserMentioned(this.selfUser().id);
+      const isSelfMentioned = messageEntity.isUserMentioned(this.selfUser().qualifiedId);
 
       if (isSelfMentioned) {
         return t('notificationObfuscatedMention');
@@ -647,7 +651,7 @@ export class NotificationRepository {
     const conversationId = this.getConversationId(connectionEntity, conversationEntity);
 
     const containsSelfMention =
-      messageEntity.isContent() && (messageEntity as ContentMessage).isUserMentioned(this.selfUser().id);
+      messageEntity.isContent() && (messageEntity as ContentMessage).isUserMentioned(this.selfUser().qualifiedId);
     if (containsSelfMention) {
       const showOptions = {exposeMessage: messageEntity, openFirstSelfMention: true};
       return () => amplify.publish(WebAppEvents.CONVERSATION.SHOW, conversationEntity, showOptions);
@@ -888,7 +892,7 @@ export class NotificationRepository {
   static shouldNotifyInConversation(
     conversationEntity: Conversation,
     messageEntity: ContentMessage,
-    userId: string,
+    userId: QualifiedId,
   ): boolean {
     if (messageEntity.isComposite()) {
       return true;

--- a/src/script/util/messageRenderer.ts
+++ b/src/script/util/messageRenderer.ts
@@ -24,6 +24,7 @@ import {escape} from 'underscore';
 
 import {replaceInRange} from './StringUtil';
 
+import {QualifiedId} from '@wireapp/api-client/src/user';
 import type {MentionEntity} from '../message/MentionEntity';
 
 interface MentionText {
@@ -94,7 +95,7 @@ function modifyMarkdownLinks(markdown: string): string {
 
 markdownit.normalizeLinkText = text => text;
 
-export const renderMessage = (message: string, selfId: string, mentionEntities: MentionEntity[] = []) => {
+export const renderMessage = (message: string, selfId: QualifiedId, mentionEntities: MentionEntity[] = []) => {
   const createMentionHash = (mention: MentionEntity) => `@@${window.btoa(JSON.stringify(mention)).replace(/=/g, '')}`;
   const renderMention = (mentionData: MentionText) => {
     const elementClasses = mentionData.isSelfMentioned ? ' self-mention' : '';
@@ -219,7 +220,7 @@ export const renderMessage = (message: string, selfId: string, mentionEntities: 
 };
 
 export const getRenderedTextContent = (text: string): string => {
-  const renderedMessage = renderMessage(text, '');
+  const renderedMessage = renderMessage(text, {domain: '', id: ''});
   const messageWithLinebreaks = renderedMessage.replace(/<br>/g, '\n');
   const strippedMessage = messageWithLinebreaks.replace(/<.+?>/g, '');
   return markdownit.utils.unescapeAll(strippedMessage);

--- a/test/unit_tests/notification/NotificationRepositorySpec.js
+++ b/test/unit_tests/notification/NotificationRepositorySpec.js
@@ -754,14 +754,14 @@ describe('NotificationRepository', () => {
     let conversationEntity;
     let messageEntity;
 
-    const userId = createRandomUuid();
+    const userId = {domain: '', id: createRandomUuid()};
     const shouldNotifyInConversation = NotificationRepository.shouldNotifyInConversation;
 
     function generateTextAsset(selfMentioned = false) {
-      const mentionId = selfMentioned ? userId : createRandomUuid();
+      const mentionId = selfMentioned ? userId.id : createRandomUuid();
 
       const textEntity = new Text(createRandomUuid(), '@Gregor can you take a look?');
-      const mentionEntity = new MentionEntity(0, 7, mentionId);
+      const mentionEntity = new MentionEntity(0, 7, mentionId, userId.domain);
       textEntity.mentions([mentionEntity]);
 
       return textEntity;

--- a/test/unit_tests/notification/NotificationRepositorySpec.js
+++ b/test/unit_tests/notification/NotificationRepositorySpec.js
@@ -338,9 +338,7 @@ describe('NotificationRepository', () => {
     });
 
     it('filters content and ping messages when user is "busy"', () => {
-      spyOn(testFactory.notification_repository, 'selfUser').and.callFake(() => {
-        return {...testFactory.user_repository['userState'].self(), availability: () => Availability.Type.BUSY};
-      });
+      spyOn(testFactory.notification_repository['selfUser'](), 'availability').and.returnValue(Availability.Type.BUSY);
       testFactory.notification_repository.permissionState(PermissionStatusState.GRANTED);
 
       const ignoredMessages = Object.entries(allMessageTypes)
@@ -357,9 +355,7 @@ describe('NotificationRepository', () => {
     });
 
     it('allows mentions, calls and composite when user is "busy"', () => {
-      spyOn(testFactory.notification_repository, 'selfUser').and.callFake(() => {
-        return {...testFactory.user_repository['userState'].self(), availability: () => Availability.Type.BUSY};
-      });
+      spyOn(testFactory.notification_repository['selfUser'](), 'availability').and.returnValue(Availability.Type.BUSY);
       testFactory.notification_repository.permissionState(PermissionStatusState.GRANTED);
 
       const notifiedMessages = Object.entries(allMessageTypes)

--- a/test/unit_tests/notification/NotificationRepositorySpec.js
+++ b/test/unit_tests/notification/NotificationRepositorySpec.js
@@ -814,7 +814,7 @@ describe('NotificationRepository', () => {
     it('returns the correct value for self replies', () => {
       messageEntity.addAsset(generateTextAsset());
 
-      const quoteEntity = new QuoteEntity({messageId: createRandomUuid(), userId});
+      const quoteEntity = new QuoteEntity({messageId: createRandomUuid(), userId: userId.id});
       messageEntity.quote(quoteEntity);
 
       conversationEntity.mutedState(NOTIFICATION_STATE.MENTIONS_AND_REPLIES);

--- a/test/unit_tests/util/messageRendererSpec.js
+++ b/test/unit_tests/util/messageRendererSpec.js
@@ -265,7 +265,7 @@ describe('renderMessage', () => {
 
       // eslint-disable-next-line jest/valid-title
       it(testCase, () => {
-        const result = renderMessage(text, 'self-id', mentionEntities);
+        const result = renderMessage(text, {domain: '', id: 'self-id'}, mentionEntities);
 
         expect(result).toEqual(expected);
       });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-290" title="FS-290" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/secure/viewavatar?size=medium&avatarId=10803&avatarType=issuetype" />FS-290</a>  [Web] On iOS, we are not getting domain in protobuf mention qualified id object.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues


This adds the user's qualified id in the protobuf payload when sending mentions. 
It also fully checks qualifiedId when receiving a mention