### PR TITLE
runfix(core): Do match mentions when message is rendered without userId

### DIFF
--- a/src/script/util/messageRenderer.ts
+++ b/src/script/util/messageRenderer.ts
@@ -95,7 +95,7 @@ function modifyMarkdownLinks(markdown: string): string {
 
 markdownit.normalizeLinkText = text => text;
 
-export const renderMessage = (message: string, selfId: QualifiedId, mentionEntities: MentionEntity[] = []) => {
+export const renderMessage = (message: string, selfId: QualifiedId | null, mentionEntities: MentionEntity[] = []) => {
   const createMentionHash = (mention: MentionEntity) => `@@${window.btoa(JSON.stringify(mention)).replace(/=/g, '')}`;
   const renderMention = (mentionData: MentionText) => {
     const elementClasses = mentionData.isSelfMentioned ? ' self-mention' : '';
@@ -122,7 +122,7 @@ export const renderMessage = (message: string, selfId: QualifiedId, mentionEntit
       const mentionKey = createMentionHash(mention);
       mentionTexts[mentionKey] = {
         domain: mention.domain,
-        isSelfMentioned: mention.targetsUser(selfId),
+        isSelfMentioned: selfId && mention.targetsUser(selfId),
         text: mentionText,
         userId: mention.userId,
       };

--- a/src/script/util/messageRenderer.ts
+++ b/src/script/util/messageRenderer.ts
@@ -122,7 +122,7 @@ export const renderMessage = (message: string, selfId: QualifiedId | null, menti
       const mentionKey = createMentionHash(mention);
       mentionTexts[mentionKey] = {
         domain: mention.domain,
-        isSelfMentioned: selfId && mention.targetsUser(selfId),
+        isSelfMentioned: !!selfId && mention.targetsUser(selfId),
         text: mentionText,
         userId: mention.userId,
       };

--- a/test/unit_tests/util/messageRendererSpec.js
+++ b/test/unit_tests/util/messageRendererSpec.js
@@ -270,6 +270,19 @@ describe('renderMessage', () => {
         expect(result).toEqual(expected);
       });
     });
+
+    it('does not try to match mention to self id if no userId given', () => {
+      const expected =
+        'hey <span class="message-mention" data-uie-name="label-other-mention" data-user-id="pain-id"><span class="mention-at-sign">@</span>user</span>';
+      const mentions = [{length: 5, startIndex: 4, userId: 'pain-id'}];
+      const mentionEntities = mentions.map(mention => {
+        const mentionEntity = new MentionEntity(mention.startIndex, mention.length, mention.userId);
+        return mentionEntity;
+      });
+      const result = renderMessage('hey @user', null, mentionEntities);
+
+      expect(result).toEqual(expected);
+    });
   });
 });
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Fixes a bug introduced by #12230 