### PR TITLE
runfix(core): Stop file sending when metadata sending is canceled by user

### DIFF
--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -485,6 +485,12 @@ export class MessageRepository {
     try {
       const uploadStarted = Date.now();
       const injectedEvent = await this.sendAssetMetadata(conversationEntity, file, asImage);
+      if (injectedEvent.state === PayloadBundleState.CANCELLED) {
+        throw new ConversationError(
+          ConversationError.TYPE.DEGRADED_CONVERSATION_CANCELLATION,
+          ConversationError.MESSAGE.DEGRADED_CONVERSATION_CANCELLATION,
+        );
+      }
       messageId = injectedEvent.id;
       await this.sendAssetRemotedata(conversationEntity, file, messageId, asImage);
       const uploadDuration = (Date.now() - uploadStarted) / TIME_IN_MILLIS.SECOND;


### PR DESCRIPTION

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Since #12264 we send file metadata with the core. But this broke the degradation flow. 
We should stop the sending process when the conversation degrades and the user decides to cancel sending. 