### PR TITLE
runfix(core): Ensure asset message has same id as preview message

### DIFF
--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -558,7 +558,7 @@ export class MessageRepository {
       asset: asset,
       conversationId: conversation.id,
       from: this.userState.self().id,
-      originalMessageId: messageId,
+      messageId,
     };
     const metadata = asImage ? ((await buildMetadata(file)) as ImageMetadata) : undefined;
     const assetMessage = metadata
@@ -569,6 +569,7 @@ export class MessageRepository {
       : MessageBuilder.createFileData({
           ...commonPayload,
           file: {data: Buffer.from(await file.arrayBuffer())},
+          originalMessageId: messageId,
         });
     return this.sendAndInjectGenericCoreMessage(assetMessage, conversation);
   }


### PR DESCRIPTION
This ensures the placeholder message gets replaced when the real asset is sent
