### PR TITLE
fix(core): Target only specific client when reseting session

### DIFF
--- a/src/script/conversation/MessageRepository.test.ts
+++ b/src/script/conversation/MessageRepository.test.ts
@@ -55,6 +55,7 @@ import {ConversationService} from './ConversationService';
 import {EventService} from '../event/EventService';
 import {Core} from '../service/CoreSingleton';
 import {container} from 'tsyringe';
+import {ClientEntity} from '../client/ClientEntity';
 
 describe('MessageRepository', () => {
   const testFactory = new TestFactory();
@@ -357,9 +358,11 @@ describe('MessageRepository', () => {
     let cryptographyRepository: CryptographyRepository;
     beforeEach(() => {
       const userState = new UserState();
+      userState.self(new User('', ''));
       const teamState = new TeamState(userState);
       const conversationState = new ConversationState(userState, teamState);
       const clientState = new ClientState();
+      clientState.currentClient(new ClientEntity(true, ''));
       cryptographyRepository = testFactory.cryptography_repository as CryptographyRepository;
       messageRepository = new MessageRepository(
         {} as ClientRepository,
@@ -371,7 +374,6 @@ describe('MessageRepository', () => {
         {} as ServerTimeHandler,
         {} as UserRepository,
         {} as ConversationService,
-        {} as LinkPreviewRepository,
         {} as AssetRepository,
         userState,
         teamState,
@@ -383,11 +385,10 @@ describe('MessageRepository', () => {
 
     it('resets the session with another device', async () => {
       spyOn(core.service!.conversation, 'send');
-      console.log(cryptographyRepository);
       spyOn(cryptographyRepository, 'deleteSession');
       const conversation = generateConversation();
 
-      const userId = {id: 'user1', domain: 'domain1'};
+      const userId = {domain: 'domain1', id: 'user1'};
       const clientId = 'client1';
       await messageRepository.resetSession(userId, clientId, conversation);
       expect(cryptographyRepository.deleteSession).toHaveBeenCalledWith(userId, clientId);

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -767,16 +767,14 @@ export class MessageRepository {
    * @returns Resolves after sending the session reset
    */
   private async sendSessionReset(userId: QualifiedId, clientId: string, conversation: Conversation) {
-    const sessionReset = MessageBuilder.createSessionReset({
-      ...this.createCommonMessagePayload(conversation),
-    });
+    const sessionReset = MessageBuilder.createSessionReset(this.createCommonMessagePayload(conversation));
 
     const userClient = {[userId.id]: [clientId]};
     await this.conversationService.send({
       conversationDomain: conversation.isFederated() ? conversation.domain : undefined,
       payloadBundle: sessionReset,
-      userIds: conversation.isFederated() ? {[userId.domain]: userClient} : userClient,
-      targetMode: MessageTargetMode.USERS_CLIENTS, // we target this message to the specific client of the user (no need for mismatch handling here)
+      targetMode: MessageTargetMode.USERS_CLIENTS,
+      userIds: conversation.isFederated() ? {[userId.domain]: userClient} : userClient, // we target this message to the specific client of the user (no need for mismatch handling here)
     });
   }
 

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -771,10 +771,12 @@ export class MessageRepository {
       ...this.createCommonMessagePayload(conversation),
     });
 
+    const userClient = {[userId.id]: [clientId]};
     await this.conversationService.send({
       conversationDomain: conversation.isFederated() ? conversation.domain : undefined,
       payloadBundle: sessionReset,
-      userIds: conversation.isFederated() ? [userId] : [userId.id],
+      userIds: conversation.isFederated() ? {[userId.domain]: userClient} : userClient,
+      targetMode: MessageTargetMode.USERS_CLIENTS, // we target this message to the specific client of the user (no need for mismatch handling here)
     });
   }
 


### PR DESCRIPTION
Since #12182  ([this line](https://github.com/wireapp/wire-webapp/pull/12182/files#diff-8a277356da1eb1435094433268c1e8cf7392c374f617174bd0a6e60ea52ea4ebL993)) session reset messages as sent to the full list of devices of the other user. 
This PR only targets the device we want to reset. 