### PR TITLE
fix(core): Avoid losing data when serializing client notifications

### DIFF
--- a/src/script/notification/PreferenceNotificationRepository.test.ts
+++ b/src/script/notification/PreferenceNotificationRepository.test.ts
@@ -66,12 +66,13 @@ describe('PreferenceNotificationRepository', () => {
     amplify.unsubscribeAll(WebAppEvents.USER.CLIENT_ADDED);
     const preferenceNotificationRepository = new PreferenceNotificationRepository(userObservable);
     const newClientData = new ClientEntity(true, '');
+    const {type, id, domain, model, time} = newClientData;
 
     amplify.publish(WebAppEvents.USER.CLIENT_ADDED, user.qualifiedId, newClientData);
 
     expect(preferenceNotificationRepository.notifications().length).toBe(1);
     expect(preferenceNotificationRepository.notifications()[0]).toEqual({
-      data: newClientData,
+      data: {domain, id, model, time, type},
       type: PreferenceNotificationRepository.CONFIG.NOTIFICATION_TYPES.NEW_CLIENT,
     });
   });

--- a/src/script/notification/PreferenceNotificationRepository.ts
+++ b/src/script/notification/PreferenceNotificationRepository.ts
@@ -20,17 +20,25 @@
 import {amplify} from 'amplify';
 import ko from 'knockout';
 import {groupBy} from 'underscore';
-import {USER_EVENT, UserEvent} from '@wireapp/api-client/src/event/';
+import {USER_EVENT, UserEvent} from '@wireapp/api-client/src/event';
+import type {QualifiedId} from '@wireapp/api-client/src/user';
+import {ClientType} from '@wireapp/api-client/src/client';
 import {WebAppEvents} from '@wireapp/webapp-events';
 import {loadValue, resetStoreValue, storeValue} from 'Util/StorageUtil';
 import type {ClientEntity} from '../client/ClientEntity';
 import type {User} from '../entity/User';
 import {PropertiesRepository} from '../properties/PropertiesRepository';
-import type {QualifiedId} from '@wireapp/api-client/src/user/';
 import {matchQualifiedIds} from 'Util/QualifiedId';
 
+export type ClientNotificationData = {
+  domain?: string;
+  id: string;
+  model: string;
+  time: string;
+  type: ClientType;
+};
 export interface Notification {
-  data: ClientEntity | boolean;
+  data: ClientNotificationData | boolean;
   type: string;
 }
 
@@ -70,8 +78,9 @@ export class PreferenceNotificationRepository {
 
     amplify.subscribe(WebAppEvents.USER.CLIENT_ADDED, (user: QualifiedId, clientEntity?: ClientEntity) => {
       if (clientEntity && !clientEntity.isLegalHold() && matchQualifiedIds(user, selfUserObservable())) {
+        const {id, domain, type, time, model} = clientEntity;
         this.notifications.push({
-          data: clientEntity,
+          data: {domain, id, model, time, type},
           type: PreferenceNotificationRepository.CONFIG.NOTIFICATION_TYPES.NEW_CLIENT,
         });
       }
@@ -103,7 +112,7 @@ export class PreferenceNotificationRepository {
         typeof clientEntity !== 'boolean' &&
         clientEntity.id === clientId &&
         (!domain || clientEntity.domain === domain);
-      return isExpectedId && (clientEntity as ClientEntity).isPermanent();
+      return isExpectedId && clientEntity.type === ClientType.PERMANENT;
     });
   }
 

--- a/src/script/notification/PreferenceNotificationRepository.ts
+++ b/src/script/notification/PreferenceNotificationRepository.ts
@@ -108,10 +108,13 @@ export class PreferenceNotificationRepository {
 
   onClientRemove(_userId: string, clientId: string, domain: string | null): void {
     this.notifications.remove(({data: clientEntity}) => {
-      const isExpectedId =
-        typeof clientEntity !== 'boolean' &&
-        clientEntity.id === clientId &&
-        (!domain || clientEntity.domain === domain);
+      if (typeof clientEntity === 'boolean') {
+        return false;
+      }
+      const isExpectedId = matchQualifiedIds(
+        {domain: clientEntity.domain, id: clientEntity.id},
+        {domain, id: clientId},
+      );
       return isExpectedId && clientEntity.type === ClientType.PERMANENT;
     });
   }

--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -62,9 +62,12 @@ import '../page/preferences/AccountPreferences';
 import '../page/preferences/OptionPreferences';
 import '../page/preferences/AVPreferences';
 import '../page/preferences/AboutPreferences';
-import {PreferenceNotificationRepository, Notification} from '../notification/PreferenceNotificationRepository';
+import {
+  PreferenceNotificationRepository,
+  Notification,
+  ClientNotificationData,
+} from '../notification/PreferenceNotificationRepository';
 import {modals} from '../view_model/ModalsViewModel';
-import {ClientEntity} from '../client/ClientEntity';
 
 interface ShowConversationOptions {
   exposeMessage?: Message;
@@ -434,7 +437,7 @@ export class ContentViewModel {
           modals.showModal(
             ModalsViewModel.TYPE.ACCOUNT_NEW_DEVICES,
             {
-              data: aggregatedNotifications.map(notification => notification.data) as ClientEntity[],
+              data: aggregatedNotifications.map(notification => notification.data) as ClientNotificationData[],
               preventClose: true,
               secondaryAction: {
                 action: () => {

--- a/src/script/view_model/ModalsViewModel.ts
+++ b/src/script/view_model/ModalsViewModel.ts
@@ -29,7 +29,7 @@ import {formatLocale} from 'Util/TimeUtil';
 import {onEscKey, offEscKey, isEnterKey, isSpaceKey} from 'Util/KeyboardUtil';
 
 import {Config} from '../Config';
-import type {ClientEntity} from '../client/ClientEntity';
+import {ClientNotificationData} from '../notification/PreferenceNotificationRepository';
 
 interface Content {
   checkboxLabel: string;
@@ -63,7 +63,7 @@ export interface ModalOptions {
   close?: Function;
   closeOnConfirm?: boolean;
   /** Content needed for visualization on modal */
-  data?: ClientEntity[] | boolean;
+  data?: ClientNotificationData[] | boolean;
   hideSecondary?: boolean;
   /** Set to `true` to disable autoclose behavior */
   preventClose?: boolean;
@@ -219,7 +219,7 @@ export class ModalsViewModel {
         content.primaryAction = {...primaryAction, text: t('modalAcknowledgeAction')};
         content.secondaryAction = {...secondaryAction, text: t('modalAccountNewDevicesSecondary')};
         content.messageText = t('modalAccountNewDevicesMessage');
-        const deviceList = (data as unknown as ClientEntity[])
+        const deviceList = (data as ClientNotificationData[])
           .map(device => {
             const deviceTime = formatLocale(device.time || new Date(), 'PP, p');
             const deviceModel = `${t('modalAccountNewDevicesFrom')} ${escape(device.model)}`;


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When storing new clients notifications, we serialize a `ClientEntity` and call the `isPermanent()` function on the other side. But during the serialization we lose the prototype of the `ClientEntity` and end-up only with the raw data. 
In order to prevent this, this PR adds a new type that restricts the data we store and allow ourself to use later on