### PR TITLE
fix(core): Always place next timestamp after last known timestamp

### DIFF
--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -686,9 +686,11 @@ export class Conversation {
   getNextTimestamp(): number {
     const sentMessages = this.messages().filter(message => message?.status() !== StatusType.SENDING);
     if (sentMessages.length === 0) {
-      return this.getLastKnownTimestamp();
+      return this.getLastKnownTimestamp() + 1;
     }
-    return sentMessages[sentMessages.length - 1].timestamp() + 1;
+    const lastMessageTimestamp = sentMessages[sentMessages.length - 1].timestamp();
+    // The next timestamp can never be before the last known timestamp, so we need to take the max between the last message and the last known server timestamp
+    return Math.max(lastMessageTimestamp, this.getLastKnownTimestamp()) + 1;
   }
 
   getLatestTimestamp(currentTimestamp: number): number {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When trying to inject a system message, we try to get the best timestamp to inject to. The `getNextTimestamp` method gives such a timestamp. But there are cases where this method could return a value that is before the last server timestamp. 
This PR fixes this and does a max between the last message timestamp and the last conversation known server timestamp