### PR TITLE
feat(core): Make link preview asset compatible with federation [FS-299]

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@wireapp/antiscroll-2": "1.0.2",
     "@wireapp/avs": "8.0.7",
-    "@wireapp/core": "20.6.2",
+    "@wireapp/core": "20.7.0",
     "@wireapp/react-ui-kit": "7.55.0",
     "@wireapp/store-engine-dexie": "1.6.7",
     "@wireapp/store-engine-sqleet": "1.7.12",

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -331,8 +331,8 @@ export class MessageRepository {
     quoteEntity?: QuoteEntity,
   ): Promise<void> {
     const textPayload = {
-      conversation: conversation,
-      mentions: mentions,
+      conversation,
+      mentions,
       message: textMessage,
       messageId: createRandomUuid(), // We set the id explicitely in order to be able to override the message if we generate a link preview
       quote: quoteEntity,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2930,10 +2930,10 @@
     logdown "3.3.1"
     rimraf "3.0.2"
 
-"@wireapp/core@20.6.2":
-  version "20.6.2"
-  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-20.6.2.tgz#4215df911b2a277f6bb0d43e200f155114994475"
-  integrity sha512-AyHkHxd2GV4BdtPfUtnwt0fC7zlnIfggZfNWAjDEgG9rsBaPhvuhj6QOaYgng1tidVZdvNMMe0dFpGndbDOl7w==
+"@wireapp/core@20.7.0":
+  version "20.7.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-20.7.0.tgz#4adbf29992459903595a33d1bff2d91747258dc0"
+  integrity sha512-pRfDsQ6IH03zP+K9nW3QbiDTnX0eMBTFDLOej+MW9tGXmOS0if4gF6RaEPCv7f3vqXtOEgblRqfrANIyzNM3gg==
   dependencies:
     "@types/long" "4.0.1"
     "@types/node" "~14"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-299" title="FS-299" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />FS-299</a>  [Web] As a user, I like to share link previews in conversations with members from federated backends
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Will enable link preview images for federated envs