### PR TITLE
fix(call): Own thumbnail tile has no background (SQCALL-433)

### DIFF
--- a/src/style/components/group-video-grid.less
+++ b/src/style/components/group-video-grid.less
@@ -191,10 +191,10 @@
     overflow: hidden;
     width: 160px;
     height: 120px;
+    background-color: #54585a;
     border-radius: 4px;
     box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.16);
     line-height: 0;
-    background-color: #54585a;
 
     &-video {
       width: 100%;

--- a/src/style/components/group-video-grid.less
+++ b/src/style/components/group-video-grid.less
@@ -194,6 +194,7 @@
     border-radius: 4px;
     box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.16);
     line-height: 0;
+    background-color: #54585a;
 
     &-video {
       width: 100%;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCALL-433" title="SQCALL-433" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQCALL-433</a>  [Web] Own thumbnail tile has no background
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

