### PR TITLE
runfix: Let antiscroll react to component resize (SQCALL-432)

### DIFF
--- a/src/script/view_model/bindings/CommonBindings.ts
+++ b/src/script/view_model/bindings/CommonBindings.ts
@@ -454,7 +454,6 @@ ko.bindingHandlers.fadingscrollbar = {
  */
 ko.bindingHandlers.antiscroll = {
   init(element, valueAccessor) {
-    let trigger_subscription: ko.Subscription;
     ($(element) as any).antiscroll({
       autoHide: true,
       autoWrap: true,
@@ -462,31 +461,26 @@ ko.bindingHandlers.antiscroll = {
       notHorizontal: true,
     });
 
-    const parent_element = $(element).parent();
-    const antiscroll = parent_element.data('antiscroll');
+    const parentElement = $(element).parent();
+    const antiscroll = parentElement.data('antiscroll');
 
     if (antiscroll) {
-      const trigger_value = valueAccessor();
-      if (ko.isObservable(trigger_value)) {
-        trigger_subscription = trigger_value.subscribe(() => {
+      const observer = new ResizeObserver(throttle(() => antiscroll.rebuild(), 100));
+      observer.observe(parentElement[0], {box: 'border-box'});
+      observer.observe(element, {box: 'border-box'});
+
+      let triggerSubscription: ko.Subscription;
+      const triggerValue = valueAccessor();
+      if (ko.isObservable(triggerValue)) {
+        triggerSubscription = triggerValue.subscribe(() => {
           antiscroll.rebuild();
         });
       }
 
-      const resize_event = `resize.${Date.now()}`;
-      $(window).on(
-        resize_event,
-        throttle(() => {
-          antiscroll.rebuild();
-        }, 100),
-      );
-
       ko.utils.domNodeDisposal.addDisposeCallback(element, () => {
         antiscroll.destroy();
-        $(window).off(resize_event);
-        if (trigger_subscription) {
-          trigger_subscription.dispose();
-        }
+        observer.disconnect();
+        triggerSubscription?.dispose();
       });
     }
   },


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCALL-432" title="SQCALL-432" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQCALL-432</a>  [Web] Conversation list is cut off during call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

