### PR TITLE
fix: Don't automatically open links in replies

### DIFF
--- a/src/script/view_model/content/MessageListViewModel.ts
+++ b/src/script/view_model/content/MessageListViewModel.ts
@@ -555,7 +555,7 @@ export class MessageListViewModel {
   };
 
   readonly handleClickOnMessage = (messageEntity: ContentMessage | Text, event: MouseEvent): boolean => {
-    if (event.which === 3) {
+    if (event.button === 2) {
       // Default browser behavior on right click
       return true;
     }
@@ -563,6 +563,7 @@ export class MessageListViewModel {
     const emailTarget = (event.target as HTMLElement).closest<HTMLAnchorElement>('[data-email-link]');
     if (emailTarget) {
       safeMailOpen(emailTarget.href);
+      event.preventDefault();
       return false;
     }
 
@@ -581,6 +582,7 @@ export class MessageListViewModel {
           title: t('modalOpenLinkTitle'),
         },
       });
+      event.preventDefault();
       return false;
     }
 


### PR DESCRIPTION
We recently introduced a regression where a link in a reply would show the "external link" warning but already open the link either way.
This was due to the migration to react, as we need to preventDefault events there (knockout just needs a falsy return value to cancel the default automatically)
Also `UIEvent.which` is deprecated, so i changed it to `UIEvent.button`.