### PR TITLE
runfix(core): Correctly parse asset domain for video preview image

### DIFF
--- a/src/script/cryptography/CryptographyMapper.ts
+++ b/src/script/cryptography/CryptographyMapper.ts
@@ -327,6 +327,7 @@ export class CryptographyMapper {
 
       data = {
         ...data,
+        preview_domain: remote.assetDomain,
         preview_key: remote.assetId,
         preview_otr_key: new Uint8Array(remote.otrKey),
         preview_sha256: new Uint8Array(remote.sha256),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When receiving a video with a preview image embed, the domain of the preview image is not mapped and the image doesn't show up in the conversation. 
This PR parses the domain of the image