### PR TITLE
fix(core): Inject team member leave event before last sent message

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -223,10 +223,14 @@ export class ConversationRepository {
           usersWithoutClients
             .filter(user => user.deleted)
             .forEach(user =>
-              this.teamMemberLeave(this.teamState.team().id, {
-                domain: this.teamState.teamDomain(),
-                id: user.id,
-              }),
+              this.teamMemberLeave(
+                this.teamState.team().id,
+                {
+                  domain: this.teamState.teamDomain(),
+                  id: user.id,
+                },
+                new Date(time).getTime() - 1,
+              ),
             );
         }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Since team member leave events are triggered after the message has been sent, we need to inject it with a specific timestamp (before the timestamp at which the message was sent)