### PR TITLE
fix(core): Avoid handling known clients when mismatch happens

### DIFF
--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -575,7 +575,7 @@ export class CallingRepository {
           const allClients = await this.core.service!.conversation.getAllParticipantsClients(id, domain);
           // We warn the message repository that a mismatch has happened outside of its lifecycle (eventually triggering a conversation degradation)
           const shouldContinue = await this.messageRepository.updateMissingClients(
-            conversationId,
+            this.conversationState.findConversation(conversationId),
             allClients,
             CONSENT_TYPE.INCOMING_CALL,
           );

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -229,16 +229,16 @@ export class MessageRepository {
   private async findMissingClients(conversation: Conversation, remoteClients: UserClients | QualifiedUserClients) {
     const localClients = await this.generateRecipients(conversation);
 
-    const filterKnownClients = (remoteClients: UserClients, localClients: UserClients) => {
-      return Object.entries(remoteClients).reduce<UserClients>((missing, [userId, clients]) => {
-        const missingClients = getDifference(localClients[userId] || [], clients);
+    const filterKnownClients = (clients: UserClients, knownClients: UserClients) => {
+      return Object.entries(clients).reduce<UserClients>((missing, [userId, clients]) => {
+        const missingClients = getDifference(knownClients[userId] || [], clients);
         return missingClients.length ? {...missing, [userId]: missingClients} : missing;
       }, {});
     };
 
-    const filterKnownQualifiedClients = (remoteClients: QualifiedUserClients, localClients: QualifiedUserClients) => {
-      return Object.entries(remoteClients).reduce<QualifiedUserClients>((missing, [domain, userClients]) => {
-        const missingUserClients = filterKnownClients(userClients, localClients[domain]);
+    const filterKnownQualifiedClients = (clients: QualifiedUserClients, knownClients: QualifiedUserClients) => {
+      return Object.entries(clients).reduce<QualifiedUserClients>((missing, [domain, userClients]) => {
+        const missingUserClients = filterKnownClients(userClients, knownClients[domain]);
         return Object.keys(missingUserClients).length ? {...missing, [domain]: missingUserClients} : missing;
       }, {});
     };

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -509,7 +509,7 @@ export class Conversation {
   }
 
   get qualifiedId(): QualifiedId {
-    return {domain: this.domain, id: this.id};
+    return {domain: this.isFederated() ? this.domain : '', id: this.id};
   }
 
   private hasInitializedUsers() {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In order to avoid handling and requesting a lot of clients to the backend when we start a conf call, we need to first filter the clients we know locally. 