### PR TITLE
fix: Remove leaving participants from activeSpeaker view (SQCALL-455)

### DIFF
--- a/src/script/calling/Call.ts
+++ b/src/script/calling/Call.ts
@@ -209,6 +209,7 @@ export class Call {
 
   removeParticipant(participant: Participant): void {
     this.participants.remove(participant);
+    this.activeSpeakers.remove(participant);
     this.updatePages();
   }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCALL-455" title="SQCALL-455" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQCALL-455</a>  User that quit the call is still shown as active speaker
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
