### PR TITLE
fix(core): Be sure to await team member leave events before sending message

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -220,18 +220,20 @@ export class ConversationRepository {
         if (removedTeamUserIds.length) {
           // If we have found some users that were removed from the conversation, we need to check if those users were also completely removed from the team
           const usersWithoutClients = await this.userRepository.getUserListFromBackend(removedTeamUserIds);
-          usersWithoutClients
-            .filter(user => user.deleted)
-            .forEach(user =>
-              this.teamMemberLeave(
-                this.teamState.team().id,
-                {
-                  domain: this.teamState.teamDomain(),
-                  id: user.id,
-                },
-                new Date(time).getTime() - 1,
+          await Promise.all(
+            usersWithoutClients
+              .filter(user => user.deleted)
+              .map(user =>
+                this.teamMemberLeave(
+                  this.teamState.team().id,
+                  {
+                    domain: this.teamState.teamDomain(),
+                    id: user.id,
+                  },
+                  new Date(time).getTime() - 1,
+                ),
               ),
-            );
+          );
         }
 
         let shouldWarnLegalHold = false;
@@ -1568,18 +1570,19 @@ export class ConversationRepository {
     isoDate = this.serverTimeHandler.toServerTimestamp(),
   ) => {
     const userEntity = await this.userRepository.getUserById(userId);
-    this.conversationState
+    const eventInjections = this.conversationState
       .conversations()
       .filter(conversationEntity => {
         const conversationInTeam = conversationEntity.team_id === teamId;
         const userIsParticipant = UserFilter.isParticipant(conversationEntity, userId);
         return conversationInTeam && userIsParticipant && !conversationEntity.removed_from_conversation();
       })
-      .forEach(conversationEntity => {
+      .map(conversationEntity => {
         const leaveEvent = EventBuilder.buildTeamMemberLeave(conversationEntity, userEntity, isoDate);
-        this.eventRepository.injectEvent(leaveEvent);
+        return this.eventRepository.injectEvent(leaveEvent);
       });
     userEntity.isDeleted = true;
+    return Promise.all(eventInjections);
   };
 
   /**


### PR DESCRIPTION

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

This should fix system message ordering between `team.member_leave` and `verification`. (because we did not await for member leave events to have been processed)

Because we did not wait for the complete `team.member_leave` event to be inject, the message would be sent before we actually interpreted this event and eventually triggered a `verification` message.