### PR TITLE
fix(services): Revert "Disable applock when feature is not enforced in the team anymore (SQSERVICES-1064)"

### DIFF
--- a/src/script/page/AppLock.tsx
+++ b/src/script/page/AppLock.tsx
@@ -149,10 +149,8 @@ const AppLock: React.FC<AppLockProps> = ({
   }, [state, isVisible]);
 
   const showAppLock = () => {
-    if (isAppLockEnabled) {
-      setState(appLockState.hasPassphrase() ? APPLOCK_STATE.LOCKED : APPLOCK_STATE.SETUP);
-      setIsVisible(true);
-    }
+    setState(appLockState.hasPassphrase() ? APPLOCK_STATE.LOCKED : APPLOCK_STATE.SETUP);
+    setIsVisible(true);
   };
 
   const onUnlock = async (event: React.FormEvent) => {

--- a/src/script/user/AppLockRepository.ts
+++ b/src/script/user/AppLockRepository.ts
@@ -37,6 +37,9 @@ export class AppLockRepository {
     const hasPassphrase = !!this.getStoredPassphrase();
     this.appLockState.hasPassphrase(hasPassphrase);
     this.appLockState.isActivatedInPreferences(this.getStoredEnabled() === 'true');
+    if (this.appLockState.isAppLockEnforced()) {
+      this.setEnabled(true);
+    }
     if (hasPassphrase) {
       this.startPassphraseObserver();
     }
@@ -58,6 +61,7 @@ export class AppLockRepository {
 
   private readonly handleDisabledOnTeam = (isDisabled: boolean): void => {
     if (isDisabled) {
+      this.setEnabled(false);
       this.removeCode();
     }
   };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1064" title="SQSERVICES-1064" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1064</a>  [Web] When mandatory App Lock is disabled (after being enforced), you are still required to enter passphrase to unlock
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Reverts wireapp/wire-webapp#12428