### PR TITLE
fix(services): Disable applock when feature is disabled in team (SQSERVICES-1064)

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -432,6 +432,7 @@
   "extensionsGiphyMessage": "{{tag}} • via giphy.com",
   "extensionsGiphyNoGifs": "Oops, no gifs",
   "extensionsGiphyRandom": "Random",
+  "featureConfigChangeModalApplock": "Your team doesn't need app lock anymore. From now, you can access Wire without any extra steps.",
   "featureConfigChangeModalAudioVideoDescriptionItemCameraDisabled": "Camera in calls is disabled",
   "featureConfigChangeModalAudioVideoDescriptionItemCameraEnabled": "Camera in calls is enabled",
   "featureConfigChangeModalAudioVideoHeadline": "There has been a change in {{brandName}}",

--- a/src/script/page/AppLock.tsx
+++ b/src/script/page/AppLock.tsx
@@ -115,7 +115,7 @@ const AppLock: React.FC<AppLockProps> = ({
   useEffect(() => {
     if (isAppLockEnabled) {
       showAppLock();
-    } else {
+    } else if (appLockState.hasPassphrase()) {
       appLockRepository.removeCode();
       amplify.publish(WebAppEvents.WARNING.MODAL, ModalsViewModel.TYPE.ACKNOWLEDGE, {
         text: {
@@ -155,12 +155,10 @@ const AppLock: React.FC<AppLockProps> = ({
     };
   }, [state, isVisible]);
 
-  const showAppLock = useCallback(() => {
-    if (isAppLockEnabled) {
-      setState(appLockState.hasPassphrase() ? APPLOCK_STATE.LOCKED : APPLOCK_STATE.SETUP);
-      setIsVisible(true);
-    }
-  }, [isAppLockEnabled]);
+  const showAppLock = () => {
+    setState(appLockState.hasPassphrase() ? APPLOCK_STATE.LOCKED : APPLOCK_STATE.SETUP);
+    setIsVisible(true);
+  };
 
   const onUnlock = async (event: React.FormEvent) => {
     event.preventDefault();

--- a/src/script/page/AppLock.tsx
+++ b/src/script/page/AppLock.tsx
@@ -16,6 +16,7 @@ import {ClientState} from '../client/ClientState';
 import {AppLockState} from '../user/AppLockState';
 import {AppLockRepository} from '../user/AppLockRepository';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
+import {ModalsViewModel} from '../view_model/ModalsViewModel';
 
 export enum APPLOCK_STATE {
   FORGOT = 'applock.forgot',
@@ -116,6 +117,11 @@ const AppLock: React.FC<AppLockProps> = ({
       showAppLock();
     } else {
       appLockRepository.removeCode();
+      amplify.publish(WebAppEvents.WARNING.MODAL, ModalsViewModel.TYPE.ACKNOWLEDGE, {
+        text: {
+          title: t('featureConfigChangeModalAudioVideoHeadline', {brandName: Config.getConfig().BRAND_NAME}),
+        },
+      });
     }
   }, [isAppLockEnabled]);
 
@@ -128,7 +134,7 @@ const AppLock: React.FC<AppLockProps> = ({
         window.removeEventListener('focus', clearAppLockTimeout);
       };
     }
-    return undefined;
+    return clearAppLockTimeout();
   }, [isAppLockActivated, clearAppLockTimeout, startAppLockTimeout]);
 
   useEffect(() => {
@@ -148,12 +154,12 @@ const AppLock: React.FC<AppLockProps> = ({
     };
   }, [state, isVisible]);
 
-  const showAppLock = () => {
+  const showAppLock = useCallback(() => {
     if (isAppLockEnabled) {
       setState(appLockState.hasPassphrase() ? APPLOCK_STATE.LOCKED : APPLOCK_STATE.SETUP);
       setIsVisible(true);
     }
-  };
+  }, [isAppLockEnabled]);
 
   const onUnlock = async (event: React.FormEvent) => {
     event.preventDefault();

--- a/src/script/page/AppLock.tsx
+++ b/src/script/page/AppLock.tsx
@@ -149,8 +149,10 @@ const AppLock: React.FC<AppLockProps> = ({
   }, [state, isVisible]);
 
   const showAppLock = () => {
-    setState(appLockState.hasPassphrase() ? APPLOCK_STATE.LOCKED : APPLOCK_STATE.SETUP);
-    setIsVisible(true);
+    if (isAppLockEnabled) {
+      setState(appLockState.hasPassphrase() ? APPLOCK_STATE.LOCKED : APPLOCK_STATE.SETUP);
+      setIsVisible(true);
+    }
   };
 
   const onUnlock = async (event: React.FormEvent) => {

--- a/src/script/page/AppLock.tsx
+++ b/src/script/page/AppLock.tsx
@@ -119,6 +119,7 @@ const AppLock: React.FC<AppLockProps> = ({
       appLockRepository.removeCode();
       amplify.publish(WebAppEvents.WARNING.MODAL, ModalsViewModel.TYPE.ACKNOWLEDGE, {
         text: {
+          htmlMessage: t('featureConfigChangeModalApplock'),
           title: t('featureConfigChangeModalAudioVideoHeadline', {brandName: Config.getConfig().BRAND_NAME}),
         },
       });

--- a/src/script/user/AppLockRepository.ts
+++ b/src/script/user/AppLockRepository.ts
@@ -37,9 +37,6 @@ export class AppLockRepository {
     const hasPassphrase = !!this.getStoredPassphrase();
     this.appLockState.hasPassphrase(hasPassphrase);
     this.appLockState.isActivatedInPreferences(this.getStoredEnabled() === 'true');
-    if (this.appLockState.isAppLockEnforced()) {
-      this.setEnabled(true);
-    }
     if (hasPassphrase) {
       this.startPassphraseObserver();
     }
@@ -61,7 +58,6 @@ export class AppLockRepository {
 
   private readonly handleDisabledOnTeam = (isDisabled: boolean): void => {
     if (isDisabled) {
-      this.setEnabled(false);
       this.removeCode();
     }
   };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1064" title="SQSERVICES-1064" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1064</a>  [Web] When mandatory App Lock is disabled (after being enforced), you are still required to enter passphrase to unlock
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

