### PR TITLE
feat(core): Conversation security clearance level bar [FS-386]

### DIFF
--- a/src/i18n/de-DE.json
+++ b/src/i18n/de-DE.json
@@ -207,6 +207,8 @@
   "conversationAssetUploadFailed": "Hochladen fehlgeschlagen",
   "conversationAssetUploading": "Hochladen…",
   "conversationAudioAssetRestricted": "Empfang von Audiodateien ist verboten",
+  "conversationClassified": "Sicherheitslevel: VS-NfD",
+  "conversationNotClassified": "Sicherheitslevel: Nicht eingestuft",
   "conversationConnectionAccepted": "Hinzugefügt",
   "conversationConnectionBlocked": "Blockiert",
   "conversationConnectionCancelRequest": "Kontaktanfrage abbrechen",

--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -219,6 +219,8 @@
   "conversationContextMenuLike": "Like",
   "conversationContextMenuReply": "Reply",
   "conversationContextMenuUnlike": "Unlike",
+  "conversationClassified": "Security level: VS-NfD",
+  "conversationNotClassified": "Security level: Not classified",
   "conversationCreateReceiptsEnabled": "Read receipts are on",
   "conversationCreateTeam": "with [showmore]all team members[/showmore]",
   "conversationCreateTeamGuest": "with [showmore]all team members and one guest[/showmore]",

--- a/src/page/template/content/conversation/input-bar.htm
+++ b/src/page/template/content/conversation/input-bar.htm
@@ -1,6 +1,8 @@
 <!--@formatter:off-->
 <div id="conversation-input-bar" class="conversation-input-bar" data-bind="with: $root.inputBar">
-  <classified-bar params="text: '', highContrast: false"></classified-bar>
+  <!-- ko if: classifiedDomains -->
+    <classified-bar params="users: conversationEntity().participating_user_ets, classifiedDomains: classifiedDomains"></classified-bar>
+  <!-- /ko -->
   <!-- ko if: isReplying() && !isEditing() -->
     <div class="input-bar__reply" data-uie-name="input-bar-reply-box">
       <close-icon data-bind="click: handleCancelReply" data-uie-name="do-close-reply-box"></close-icon>

--- a/src/page/template/content/conversation/input-bar.htm
+++ b/src/page/template/content/conversation/input-bar.htm
@@ -1,6 +1,6 @@
 <!--@formatter:off-->
 <div id="conversation-input-bar" class="conversation-input-bar" data-bind="with: $root.inputBar">
-
+  <classified-bar params="text: '', highContrast: false"></classified-bar>
   <!-- ko if: isReplying() && !isEditing() -->
     <div class="input-bar__reply" data-uie-name="input-bar-reply-box">
       <close-icon data-bind="click: handleCancelReply" data-uie-name="do-close-reply-box"></close-icon>

--- a/src/script/components/input/ClassifiedBar.test.ts
+++ b/src/script/components/input/ClassifiedBar.test.ts
@@ -20,8 +20,8 @@ describe('ClassifiedBar', () => {
     users => {
       const {getByText, queryByText} = render(ClassifiedBar({classifiedDomains, users}));
 
-      expect(getByText('Security level: VS-NfD')).not.toBe(null);
-      expect(queryByText('Security level: Not classified')).toBe(null);
+      expect(getByText('conversationClassified')).not.toBe(null);
+      expect(queryByText('conversationNotClassified')).toBe(null);
     },
   );
 
@@ -32,7 +32,7 @@ describe('ClassifiedBar', () => {
   ])('returns non-classified if a single user is from another domain', users => {
     const {queryByText, getByText} = render(ClassifiedBar({classifiedDomains, users}));
 
-    expect(queryByText('Security level: VS-NfD')).toBe(null);
-    expect(getByText('Security level: Not classified')).not.toBe(null);
+    expect(queryByText('conversationClassified')).toBe(null);
+    expect(getByText('conversationNotClassified')).not.toBe(null);
   });
 });

--- a/src/script/components/input/ClassifiedBar.test.ts
+++ b/src/script/components/input/ClassifiedBar.test.ts
@@ -1,0 +1,38 @@
+import {User} from 'src/script/entity/User';
+import {createRandomUuid} from 'Util/util';
+import ClassifiedBar from './ClassifiedBar';
+import {render} from '@testing-library/react';
+
+describe('ClassifiedBar', () => {
+  const classifiedDomains = ['same.domain', 'classified.domain', 'other-classified.domain'];
+  const sameDomainUser = new User(createRandomUuid(), 'same.domain');
+  const classifiedDomainUser = new User(createRandomUuid(), 'classified.domain');
+  const otherDomainUser = new User(createRandomUuid(), 'other.domain');
+
+  it.each([[[sameDomainUser]], [[sameDomainUser, otherDomainUser]]])('is empty if no domains are given', users => {
+    const {container} = render(ClassifiedBar({users}));
+
+    expect(container.querySelector('[data-uie-name=classified-label]')).toBe(null);
+  });
+
+  it.each([[[sameDomainUser]], [[classifiedDomainUser]], [[sameDomainUser, classifiedDomainUser]]])(
+    'returns classified if all users in the classified domains',
+    users => {
+      const {getByText, queryByText} = render(ClassifiedBar({classifiedDomains, users}));
+
+      expect(getByText('Security level: VS-NfD')).not.toBe(null);
+      expect(queryByText('Security level: Not classified')).toBe(null);
+    },
+  );
+
+  it.each([
+    [[sameDomainUser, otherDomainUser]],
+    [[classifiedDomainUser, otherDomainUser]],
+    [[sameDomainUser, classifiedDomainUser, otherDomainUser]],
+  ])('returns non-classified if a single user is from another domain', users => {
+    const {queryByText, getByText} = render(ClassifiedBar({classifiedDomains, users}));
+
+    expect(queryByText('Security level: VS-NfD')).toBe(null);
+    expect(getByText('Security level: Not classified')).not.toBe(null);
+  });
+});

--- a/src/script/components/input/ClassifiedBar.tsx
+++ b/src/script/components/input/ClassifiedBar.tsx
@@ -1,0 +1,54 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import React from 'react';
+import {CSSObject} from '@emotion/core';
+import {registerReactComponent} from 'Util/ComponentUtil';
+
+interface ClassifiedBarProps {
+  text?: string;
+  highContrast?: boolean;
+}
+
+const barStyle = (highContrast: boolean): CSSObject => ({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  width: '100%',
+  height: 32,
+  fontSize: 16,
+  fontWeight: 600,
+  textTransform: 'uppercase',
+  backgroundColor: `var(--${highContrast ? 'background' : 'app-bg-secondary'})`,
+  color: `var(--${highContrast ? 'app-bg' : 'background'})`,
+  borderColor: 'var(--foreground)',
+  borderWidth: '1px 0',
+  borderStyle: highContrast ? 'none' : 'solid',
+});
+
+const ClassifiedBar: React.FC<ClassifiedBarProps> = ({text, highContrast = false}) => {
+  return text ? <div css={barStyle(highContrast)}>{text}</div> : null;
+};
+
+export default ClassifiedBar;
+
+registerReactComponent('classified-bar', {
+  component: ClassifiedBar,
+  template: '<div data-bind="react: {text: ko.unwrap(text), highContrast: ko.unwrap(highContrast)}"></div>',
+});

--- a/src/script/components/input/ClassifiedBar.tsx
+++ b/src/script/components/input/ClassifiedBar.tsx
@@ -43,7 +43,11 @@ const barStyle = (highContrast: boolean): CSSObject => ({
 });
 
 const ClassifiedBar: React.FC<ClassifiedBarProps> = ({text, highContrast = false}) => {
-  return text ? <div css={barStyle(highContrast)}>{text}</div> : null;
+  return text ? (
+    <div data-uie-name="classified-label" css={barStyle(highContrast)}>
+      {text}
+    </div>
+  ) : null;
 };
 
 export default ClassifiedBar;

--- a/src/script/components/input/ClassifiedBar.tsx
+++ b/src/script/components/input/ClassifiedBar.tsx
@@ -21,6 +21,7 @@ import React from 'react';
 import {CSSObject} from '@emotion/core';
 import {registerReactComponent} from 'Util/ComponentUtil';
 import {User} from 'src/script/entity/User';
+import {t} from 'Util/LocalizerUtil';
 
 function isClassified(users: User[], classifiedDomains: string[]): boolean {
   if (users.some(user => !classifiedDomains.includes(user.domain))) {
@@ -40,8 +41,8 @@ const barStyle = (highContrast: boolean): CSSObject => ({
   borderColor: 'var(--foreground)',
   borderStyle: highContrast ? 'none' : 'solid',
   borderWidth: '1px 0',
-  display: 'flex',
   color: `var(--${highContrast ? 'app-bg' : 'background'})`,
+  display: 'flex',
   fontSize: 16,
   fontWeight: 600,
   height: 32,
@@ -55,7 +56,7 @@ const ClassifiedBar: React.FC<ClassifiedBarProps> = ({users, classifiedDomains})
     return undefined;
   }
   const classified = isClassified(users, classifiedDomains);
-  const text = classified ? 'Security level: VS-NfD' : 'Security level: Not classified';
+  const text = classified ? t('conversationClassified') : t('conversationNotClassified');
   const highContrast = classified;
   return (
     <div data-uie-name="classified-label" css={barStyle(highContrast)}>

--- a/src/script/components/input/ClassifiedBar.tsx
+++ b/src/script/components/input/ClassifiedBar.tsx
@@ -20,39 +20,53 @@
 import React from 'react';
 import {CSSObject} from '@emotion/core';
 import {registerReactComponent} from 'Util/ComponentUtil';
+import {User} from 'src/script/entity/User';
+
+function isClassified(users: User[], classifiedDomains: string[]): boolean {
+  if (users.some(user => !classifiedDomains.includes(user.domain))) {
+    return false;
+  }
+  return true;
+}
 
 interface ClassifiedBarProps {
-  text?: string;
-  highContrast?: boolean;
+  classifiedDomains?: string[];
+  users: User[];
 }
 
 const barStyle = (highContrast: boolean): CSSObject => ({
-  display: 'flex',
-  justifyContent: 'center',
   alignItems: 'center',
-  width: '100%',
-  height: 32,
+  backgroundColor: `var(--${highContrast ? 'background' : 'app-bg-secondary'})`,
+  borderColor: 'var(--foreground)',
+  borderStyle: highContrast ? 'none' : 'solid',
+  borderWidth: '1px 0',
+  display: 'flex',
+  color: `var(--${highContrast ? 'app-bg' : 'background'})`,
   fontSize: 16,
   fontWeight: 600,
+  height: 32,
+  justifyContent: 'center',
   textTransform: 'uppercase',
-  backgroundColor: `var(--${highContrast ? 'background' : 'app-bg-secondary'})`,
-  color: `var(--${highContrast ? 'app-bg' : 'background'})`,
-  borderColor: 'var(--foreground)',
-  borderWidth: '1px 0',
-  borderStyle: highContrast ? 'none' : 'solid',
+  width: '100%',
 });
 
-const ClassifiedBar: React.FC<ClassifiedBarProps> = ({text, highContrast = false}) => {
-  return text ? (
+const ClassifiedBar: React.FC<ClassifiedBarProps> = ({users, classifiedDomains}) => {
+  if (typeof classifiedDomains === 'undefined') {
+    return undefined;
+  }
+  const classified = isClassified(users, classifiedDomains);
+  const text = classified ? 'Security level: VS-NfD' : 'Security level: Not classified';
+  const highContrast = classified;
+  return (
     <div data-uie-name="classified-label" css={barStyle(highContrast)}>
       {text}
     </div>
-  ) : null;
+  );
 };
 
 export default ClassifiedBar;
 
 registerReactComponent('classified-bar', {
   component: ClassifiedBar,
-  template: '<div data-bind="react: {text: ko.unwrap(text), highContrast: ko.unwrap(highContrast)}"></div>',
+  template: '<div data-bind="react: {users: ko.unwrap(users), classifiedDomains: ko.unwrap(classifiedDomains)}"></div>',
 });

--- a/src/script/team/TeamState.ts
+++ b/src/script/team/TeamState.ts
@@ -36,6 +36,7 @@ export class TeamState {
   public readonly supportsLegalHold: ko.Observable<boolean>;
   public readonly teamName: ko.PureComputed<string>;
   public readonly teamFeatures: ko.Observable<FeatureList>;
+  public readonly classifiedDomains: ko.PureComputed<string[] | undefined>;
   public readonly isConferenceCallingEnabled: ko.PureComputed<boolean>;
   public readonly isFileSharingSendingEnabled: ko.PureComputed<boolean>;
   public readonly isFileSharingReceivingEnabled: ko.PureComputed<boolean>;
@@ -89,6 +90,12 @@ export class TeamState {
     this.isFileSharingReceivingEnabled = ko.pureComputed(() => {
       const status = this.teamFeatures()?.fileSharing?.status;
       return status ? status === FeatureStatus.ENABLED : true;
+    });
+
+    this.classifiedDomains = ko.pureComputed(() => {
+      return this.teamFeatures()?.classifiedDomains.status === FeatureStatus.ENABLED
+        ? this.teamFeatures().classifiedDomains.config.domains
+        : undefined;
     });
 
     this.isSelfDeletingMessagesEnabled = ko.pureComputed(

--- a/src/script/view_model/content/InputBarViewModel.ts
+++ b/src/script/view_model/content/InputBarViewModel.ts
@@ -102,6 +102,7 @@ export class InputBarViewModel {
   readonly richTextInput: ko.PureComputed<string>;
   readonly inputPlaceholder: ko.PureComputed<string>;
   readonly showGiphyButton: ko.PureComputed<boolean>;
+  readonly classifiedDomains: ko.PureComputed<string[]>;
   readonly isFileSharingSendingEnabled: ko.PureComputed<boolean>;
   readonly pingTooltip: string;
   readonly hasLocalEphemeralTimer: ko.PureComputed<boolean>;
@@ -151,6 +152,7 @@ export class InputBarViewModel {
     this.replyMessageEntity = ko.observable();
 
     this.isFileSharingSendingEnabled = this.teamState.isFileSharingSendingEnabled;
+    this.classifiedDomains = this.teamState.classifiedDomains;
 
     const handleRepliedMessageDeleted = (messageId: string) => {
       if (this.replyMessageEntity()?.id === messageId) {

--- a/src/script/view_model/content/InputBarViewModel.ts
+++ b/src/script/view_model/content/InputBarViewModel.ts
@@ -27,6 +27,7 @@ import ko from 'knockout';
 import {afterRender, formatBytes} from 'Util/util';
 import {allowsAllFiles, hasAllowedExtension, getFileExtensionOrName} from 'Util/FileTypeUtil';
 import {AVATAR_SIZE} from 'Components/Avatar';
+import 'Components/input/ClassifiedBar';
 import {KEY, isFunctionKey, insertAtCaret} from 'Util/KeyboardUtil';
 import {renderMessage} from 'Util/messageRenderer';
 import {t} from 'Util/LocalizerUtil';


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-386" title="FS-386" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />FS-386</a>  [Web] As a user, I like to be aware of the security clearance of a conversation (only for BUND at this point).
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
