### PR TITLE
fix(core): Avoid displaying domain twice in the Account preferences [SQSERVICES-1245]

### DIFF
--- a/src/script/page/preferences/AccountPreferences.tsx
+++ b/src/script/page/preferences/AccountPreferences.tsx
@@ -168,14 +168,6 @@ const AccountPreferences: React.FC<AccountPreferencesProps> = ({
             {isTeam && (
               <AccountInput label={t('preferencesAccountTeam')} value={teamName} readOnly data-uie-name="status-team" />
             )}
-            {isFederated && (
-              <AccountInput
-                label={t('preferencesAccountDomain')}
-                value={domain}
-                readOnly
-                data-uie-name="status-domain"
-              />
-            )}
             {richFields.map(({type, value}) => (
               <AccountInput
                 key={type}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1245" title="SQSERVICES-1245" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1245</a>  WEB: Domain name is showing twice on profile section 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Since domain is already handled by our richField hook, we do not need to manually add it in the profile
