### PR TITLE
refactor(core): Pass on conversation when mismatch happens

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -173,8 +173,7 @@ export class ConversationRepository {
     this.eventService = eventRepository.eventService;
     // we register a client mismatch handler agains the message repository so that we can react to missing members
     // FIXME this should be temporary. In the near future we want the core to handle clients/mismatch/verification. So the webapp won't need this logic at all
-    this.messageRepository.setClientMismatchHandler(async (mismatch, conversationId, silent, consentType) => {
-      const conversation = conversationId ? await this.getConversationById(conversationId) : undefined;
+    this.messageRepository.setClientMismatchHandler(async (mismatch, conversation, silent, consentType) => {
       const {missingClients, deletedClients, emptyUsers, missingUserIds} = extractClientDiff(
         mismatch,
         conversation?.allUserEntities,

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -176,10 +176,10 @@ export class ConversationRepository {
     this.messageRepository.setClientMismatchHandler(async (mismatch, conversation, silent, consentType) => {
       const {missingClients, deletedClients, emptyUsers, missingUserIds} = extractClientDiff(
         mismatch,
-        conversation?.allUserEntities,
+        conversation.allUserEntities,
       );
 
-      if (conversation && missingUserIds.length) {
+      if (missingUserIds.length) {
         // add/remove users from the conversation (if any)
         await this.addMissingMember(conversation, missingUserIds, new Date(mismatch.time).getTime() - 1);
       }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Since we always have the live conversation object when handling a mismatch, there is no need to refetch it again. 
This PR injects the full conversation into the handler. 