### PR TITLE
refactor(core): Remove unused encryption primitives [FS-418]

### DIFF
--- a/src/script/cryptography/CryptographyRepository.test.ts
+++ b/src/script/cryptography/CryptographyRepository.test.ts
@@ -29,73 +29,12 @@ import {CONVERSATION_EVENT, ConversationOtrMessageAddEvent} from '@wireapp/api-c
 import {ClientEvent} from 'src/script/event/Client';
 import {TestFactory} from '../../../test/helper/TestFactory';
 import {CryptographyError} from 'src/script/error/CryptographyError';
-import {entities} from '../../../test/api/payloads';
 
 describe('CryptographyRepository', () => {
   const testFactory = new TestFactory();
 
   beforeAll(async () => {
     await testFactory.exposeCryptographyActors(false);
-  });
-
-  describe('encryptGenericMessage', () => {
-    const jane_roe = {
-      clients: {
-        phone_id: '55cdd1dbe3c2ed74',
-      },
-      id: entities.user.jane_roe.id,
-    };
-    const john_doe = {
-      clients: {
-        desktop_id: 'b29034060fed476e',
-        phone_id: '4b0a0fbf418d264c',
-      },
-      id: entities.user.john_doe.id,
-    };
-
-    it('encrypts a generic message', () => {
-      spyOn(testFactory.cryptography_repository['cryptographyService'], 'getUsersPreKeys').and.callFake(
-        (recipients: Record<string, string[]>) =>
-          new Promise(resolve => {
-            const prekey_map: Record<string, any> = {};
-
-            for (const user_id in recipients) {
-              if (recipients.hasOwnProperty(user_id)) {
-                const client_ids = recipients[user_id];
-
-                prekey_map[user_id] = prekey_map[user_id] || {};
-
-                client_ids.forEach(client_id => {
-                  prekey_map[user_id][client_id] = {
-                    id: 65535,
-                    key: 'pQABARn//wKhAFgg3OpuTCUwDZMt1fklZB4M+fjDx/3fyx78gJ6j3H3dM2YDoQChAFggQU1orulueQHLv5YDYqEYl3D4O0zA9d+TaGGXXaBJmK0E9g==',
-                  };
-                });
-              }
-            }
-
-            resolve(prekey_map);
-          }),
-      );
-
-      const generic_message = new GenericMessage({
-        [GENERIC_MESSAGE_TYPE.TEXT]: new Text({content: 'Unit test'}),
-        messageId: createRandomUuid(),
-      });
-
-      const recipients = {
-        [john_doe.id]: [john_doe.clients.phone_id, john_doe.clients.desktop_id],
-        [jane_roe.id]: [jane_roe.clients.phone_id],
-      };
-
-      return testFactory.cryptography_repository.encryptGenericMessage(recipients, generic_message).then(payload => {
-        expect(payload.recipients).toBeTruthy();
-        expect(Object.keys(payload.recipients).length).toBe(2);
-        expect(Object.keys(payload.recipients[john_doe.id]).length).toBe(2);
-        expect(Object.keys(payload.recipients[jane_roe.id]).length).toBe(1);
-        expect(payload.recipients[jane_roe.id][jane_roe.clients.phone_id]).toEqual(jasmine.any(String));
-      });
-    });
   });
 
   describe('getRemoteFingerprint', () => {

--- a/src/script/cryptography/CryptographyService.ts
+++ b/src/script/cryptography/CryptographyService.ts
@@ -18,8 +18,7 @@
  */
 
 import type {ClientPreKey, PreKey} from '@wireapp/api-client/src/auth/';
-import type {UserClients} from '@wireapp/api-client/src/conversation/';
-import type {QualifiedId, UserPreKeyBundleMap} from '@wireapp/api-client/src/user/';
+import type {QualifiedId} from '@wireapp/api-client/src/user/';
 import {APIClient} from '../service/APIClientSingleton';
 import {container} from 'tsyringe';
 import {Config} from '../Config';
@@ -39,17 +38,6 @@ export class CryptographyService {
     return Config.getConfig().FEATURE.ENABLE_FEDERATION
       ? this.apiClient.user.api.getClientPreKey(userId, clientId, true)
       : this.apiClient.user.api.getClientPreKey(userId.id, clientId);
-  }
-
-  /**
-   * Gets a pre-key for each client of a user client map.
-   * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/users/getMultiPrekeyBundles
-   *
-   * @param recipients User client map to request pre-keys for
-   * @returns Resolves with a pre-key for each client of the given map
-   */
-  getUsersPreKeys(recipients: UserClients): Promise<UserPreKeyBundleMap> {
-    return this.apiClient.user.api.postMultiPreKeyBundles(recipients);
   }
 
   /**


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-418" title="FS-418" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-418</a>  [Web] cleanup of legacy created by M2 sprint
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Now that all the encryption is done on the @wireapp/core side (since #12454 ), the webapp does not need those encryption primitives anymore. 