### PR TITLE
feat(core): Restore message sending queueing [FS-418]

### DIFF
--- a/src/script/conversation/MessageRepository.test.ts
+++ b/src/script/conversation/MessageRepository.test.ts
@@ -68,13 +68,15 @@ function buildMessageRepository(): [MessageRepository, MessageRepositoryDependen
   const clientState = new ClientState();
   clientState.currentClient(new ClientEntity(true, ''));
   const core = container.resolve(Core);
+  const messageSender = new MessageSender();
+  messageSender.pauseQueue(false);
   core.initServices({} as any);
   /* eslint-disable sort-keys-fix/sort-keys-fix */
   const dependencies = {
     conversationRepository: () => ({} as ConversationRepository),
     cryptographyRepository: new CryptographyRepository({} as any),
     eventRepository: new EventRepository(new EventService({} as any), {} as any, {} as any, {} as any, {} as any),
-    messageSender: {} as MessageSender,
+    messageSender,
     propertiesRepository: new PropertiesRepository({} as any, {} as any),
     serverTimeHandler: serverTimeHandler,
     userRepository: {} as UserRepository,
@@ -220,7 +222,7 @@ describe('MessageRepository', () => {
   describe('resetSession', () => {
     it('resets the session with another device', async () => {
       const [messageRepository, {cryptographyRepository, core}] = buildMessageRepository();
-      spyOn(core.service!.conversation, 'send');
+      jest.spyOn(core.service!.conversation, 'send').mockResolvedValue({} as any);
       spyOn(cryptographyRepository, 'deleteSession');
       const conversation = generateConversation();
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-418" title="FS-418" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-418</a>  [Web] cleanup of legacy created by M2 sprint
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Message queue was lost when messages started being sent with @wireapp/core. Queueing messages will allow loadtime to increase (avoiding confirmation messages to be sent while the app is loading)
