### PR TITLE
runfix(core): Fix helmet default config from images with V5

### DIFF
--- a/server/Server.ts
+++ b/server/Server.ts
@@ -121,6 +121,7 @@ class Server {
     this.app.disable('x-powered-by');
     this.app.use(
       helmet({
+        crossOriginEmbedderPolicy: false,
         frameguard: {action: 'deny'},
       }),
     );


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Since #12430 (and helmet v5) the default CORS config is stricter than before and doesn't let the browser display images from other domains. (see. https://github.com/helmetjs/helmet/blob/main/CHANGELOG.md#500---2022-01-02)