### PR TITLE
feat: Upgrade to Electron 13

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@wireapp/react-ui-kit": "7.55.0",
     "@wireapp/store-engine-dexie": "1.6.7",
     "@wireapp/store-engine-sqleet": "1.7.12",
-    "@wireapp/webapp-events": "0.11.3",
+    "@wireapp/webapp-events": "0.12.0",
     "amplify": "git+https://git@github.com/wireapp/amplify",
     "classnames": "2.3.1",
     "core-js": "2.6.10",

--- a/src/script/auth/page/SingleSignOn.tsx
+++ b/src/script/auth/page/SingleSignOn.tsx
@@ -32,6 +32,7 @@ import {
   Overlay,
   Text,
 } from '@wireapp/react-ui-kit';
+import {WebAppEvents} from '@wireapp/webapp-events';
 import React, {useRef, useState} from 'react';
 import {useIntl} from 'react-intl';
 import {connect} from 'react-redux';
@@ -145,11 +146,11 @@ const SingleSignOn = ({hasDefaultSSOCode}: Props & ConnectedProps & DispatchProp
       setIsOverlayOpen(true);
 
       const closeSSOWindow = () => {
-        amplify.publish('BARDIA_CLOSE_SSO');
+        amplify.publish(WebAppEvents.LIFECYCLE.SSO_WINDOW_CLOSE);
         ssoWindowRef.current?.close();
       };
 
-      amplify.subscribe('BARDIA_SSO_WINDOW_CLOSED', () => {
+      amplify.subscribe(WebAppEvents.LIFECYCLE.SSO_WINDOW_CLOSED, () => {
         onChildWindowClose();
         reject(new BackendError({code: 500, label: BackendError.LABEL.SSO_USER_CANCELLED_ERROR}));
       });
@@ -190,7 +191,7 @@ const SingleSignOn = ({hasDefaultSSOCode}: Props & ConnectedProps & DispatchProp
   };
 
   const focusChildWindow = () => {
-    amplify.publish('BARDIA_FOCUS_SSO');
+    amplify.publish(WebAppEvents.LIFECYCLE.SSO_WINDOW_FOCUS);
     ssoWindowRef.current?.focus();
   };
 

--- a/src/script/auth/page/SingleSignOn.tsx
+++ b/src/script/auth/page/SingleSignOn.tsx
@@ -149,6 +149,11 @@ const SingleSignOn = ({hasDefaultSSOCode}: Props & ConnectedProps & DispatchProp
         ssoWindowRef.current?.close();
       };
 
+      amplify.subscribe('BARDIA_SSO_WINDOW_CLOSED', () => {
+        onChildWindowClose();
+        reject(new BackendError({code: 500, label: BackendError.LABEL.SSO_USER_CANCELLED_ERROR}));
+      });
+
       if (ssoWindowRef.current) {
         timerId = window.setInterval(() => {
           if (ssoWindowRef.current && ssoWindowRef.current.closed) {

--- a/src/script/auth/page/SingleSignOn.tsx
+++ b/src/script/auth/page/SingleSignOn.tsx
@@ -39,7 +39,6 @@ import {AnyAction, Dispatch} from 'redux';
 import useReactRouter from 'use-react-router';
 import {getLogger} from 'Util/Logger';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
-import {Runtime} from '@wireapp/commons';
 
 import {Config} from '../../Config';
 import {ssoLoginStrings} from '../../strings';
@@ -146,11 +145,8 @@ const SingleSignOn = ({hasDefaultSSOCode}: Props & ConnectedProps & DispatchProp
       setIsOverlayOpen(true);
 
       const closeSSOWindow = () => {
-        if (Runtime.isDesktopApp()) {
-          amplify.publish('BARDIA_CLOSE_SSO');
-        } else {
-          ssoWindowRef.current?.close();
-        }
+        amplify.publish('BARDIA_CLOSE_SSO');
+        ssoWindowRef.current?.close();
       };
 
       if (ssoWindowRef.current) {
@@ -189,11 +185,8 @@ const SingleSignOn = ({hasDefaultSSOCode}: Props & ConnectedProps & DispatchProp
   };
 
   const focusChildWindow = () => {
-    if (Runtime.isDesktopApp()) {
-      amplify.publish('BARDIA_FOCUS_SSO');
-    } else {
-      ssoWindowRef.current?.focus();
-    }
+    amplify.publish('BARDIA_FOCUS_SSO');
+    ssoWindowRef.current?.focus();
   };
 
   const backArrow = (

--- a/src/script/auth/page/SingleSignOnForm.tsx
+++ b/src/script/auth/page/SingleSignOnForm.tsx
@@ -204,6 +204,7 @@ const SingleSignOnForm = ({
         history.push(ROUTE.HISTORY_INFO);
       }
     } catch (error) {
+      console.info('bardia error', error);
       setIsLoading(false);
       switch (error.label) {
         case BackendError.LABEL.TOO_MANY_CLIENTS: {

--- a/src/script/auth/page/SingleSignOnForm.tsx
+++ b/src/script/auth/page/SingleSignOnForm.tsx
@@ -204,7 +204,6 @@ const SingleSignOnForm = ({
         history.push(ROUTE.HISTORY_INFO);
       }
     } catch (error) {
-      console.info('bardia error', error);
       setIsLoading(false);
       switch (error.label) {
         case BackendError.LABEL.TOO_MANY_CLIENTS: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3160,10 +3160,10 @@
   dependencies:
     "@types/node" "~14"
 
-"@wireapp/webapp-events@0.11.3":
-  version "0.11.3"
-  resolved "https://registry.yarnpkg.com/@wireapp/webapp-events/-/webapp-events-0.11.3.tgz#132fa7463e7bfd0229581a3ed1f8bc5a1e65bd89"
-  integrity sha512-ZyLvBJ/gSjVTwOkFqJ6wIfHaNBj3W3JR6bUjb5sNpgvr3eTN0FoGFov+iX6w9gRoYBpSWM1HTQ7p9Y1lmMV5lg==
+"@wireapp/webapp-events@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/webapp-events/-/webapp-events-0.12.0.tgz#ba821bc9f77af67600a19b4102458d7d1c671060"
+  integrity sha512-cw1VmJpRPCl3AfaTZDvdBW+5y7kTa+xZFbRzA/FN3oFFq1iDzRdIVj9q1NWwTihym8gC2YUubcRAAMaOS6vZDw==
 
 "@wireapp/websql@0.0.17":
   version "0.0.17"


### PR DESCRIPTION
Upgrading to Electron 13 has a major blocker which is `window.open`, on current version calling this function returns a window object which we keep in a react ref in order to be able to later close the window manually or focus on it, but from Electron 12 and above this function does not return a window object any more which i'm not sure is it a spec change in the Electron or is it because of our customizations but either way right now we are unable to close the window on electron cause we can not access the window object, so i've added some messaging that we do this on the electron wrapper instead of webapp.

think of it as:
Previously:
Webapp -> successful SSO login -> window object -> closing sso window
Now:
Webapp -> successful SSO login -> sending close message to electron -> closing sso window