### PR TITLE
runfix(core): Lighter log level when promise queue times out

### DIFF
--- a/src/script/util/PromiseQueue.ts
+++ b/src/script/util/PromiseQueue.ts
@@ -91,7 +91,7 @@ export class PromiseQueue {
       this.interval = window.setInterval(() => {
         if (!this.paused) {
           const logObject = {pendingEntry: queueEntry, queueState: this.queue};
-          this.logger.error('Promise queue failed, unblocking queue', logObject);
+          this.logger.warn(`Promise queue timed-out after ${this.timeout}ms, unblocking queue`, logObject);
           this.resume();
         }
       }, this.timeout);


### PR DESCRIPTION
Since a promise timing out is actually not cancelling the job that it's doing, it's ok to just log a warn instead of an error