### PR TITLE
runfix(core): Make sure customInfo is unwrapped before given to React

### DIFF
--- a/src/script/components/list/ParticipantItem.tsx
+++ b/src/script/components/list/ParticipantItem.tsx
@@ -266,6 +266,6 @@ export default ParticipantItem;
 
 registerReactComponent<ParticipantItemProps>('participant-item', {
   bindings:
-    'badge, callParticipant, showArrow, highlighted, noInteraction, noUnderline, canSelect, customInfo, external: ko.unwrap(external), hideInfo, isSelected: ko.unwrap(isSelected), isSelfVerified: ko.unwrap(isSelfVerified), mode, participant, selfInTeam',
+    'badge, callParticipant, showArrow, highlighted, noInteraction, noUnderline, canSelect, customInfo: ko.unwrap(customInfo), external: ko.unwrap(external), hideInfo, isSelected: ko.unwrap(isSelected), isSelfVerified: ko.unwrap(isSelfVerified), mode, participant, selfInTeam',
   component: ParticipantItem,
 });


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Since #12394 the value passed as `customInfo` in the `ParticipantItem` for read receipts is not unwrapped by KO. We need to unwrap it before giving it to react