### PR TITLE
refactor(core): Create optimized react-ko component creator

### DIFF
--- a/src/page/template/content/connect-requests.htm
+++ b/src/page/template/content/connect-requests.htm
@@ -4,7 +4,7 @@
       <div class="connect-request" data-bind="attr: {'data-uie-uid': id}" data-uie-name="connect-request">
         <div class="connect-request-name ellipsis" data-bind="text: name()"></div>
         <div class="connect-request-username label-username" data-bind="text: handle"></div>
-        <participant-avatar class="connect-request-avatar avatar-no-filter cursor-default" params="participant: $data, size: $parent.AVATAR_SIZE.X_LARGE, noBadge: true, noFilter: true"></participant-avatar>
+        <participant-avatar class="connect-request-avatar avatar-no-filter cursor-default" params="participant: $data, avatarSize: $parent.AVATAR_SIZE.X_LARGE, noBadge: true, noFilter: true"></participant-avatar>
         <div class="button-group">
           <div class="button button-inverted" data-bind="click: $parent.clickOnIgnore, text: t('connectionRequestIgnore')" data-uie-name="do-ignore"></div>
           <div class="button" data-bind="click: $parent.clickOnAccept, text: t('connectionRequestConnect')" data-uie-name="do-accept"></div>

--- a/src/page/template/content/conversation/input-bar.htm
+++ b/src/page/template/content/conversation/input-bar.htm
@@ -62,7 +62,7 @@
     <!-- ko if: conversationEntity() && !conversationEntity().connection().isOutgoingRequest() -->
       <div class="controls-left">
         <!-- ko if: input().length -->
-          <participant-avatar class="cursor-default" params="participant: selfUser, size: participantAvatarSize"></participant-avatar>
+          <participant-avatar class="cursor-default" params="participant: selfUser, avatarSize: participantAvatarSize"></participant-avatar>
         <!-- /ko -->
       </div>
 

--- a/src/page/template/list/conversations.htm
+++ b/src/page/template/list/conversations.htm
@@ -57,7 +57,7 @@
         <div class="conversation-list-cell-left">
           <!-- ko if: connectRequests().length === 1 -->
           <div class="avatar-halo">
-            <participant-avatar params="participant: connectRequests()[0], size: participantAvatarSize">
+            <participant-avatar params="participant: connectRequests()[0], avatarSize: participantAvatarSize">
             </participant-avatar>
           </div>
           <!-- /ko -->

--- a/src/page/template/modal/service-modal.htm
+++ b/src/page/template/modal/service-modal.htm
@@ -9,7 +9,7 @@
       </div>
       <div class="modal__body service-modal__body">
         <div class="service-modal__details">
-          <participant-avatar params="participant: service, size: avatarSize"></participant-avatar>
+          <participant-avatar params="participant: service, avatarSize: avatarSize"></participant-avatar>
           <div class="service-modal__details__content">
             <div class="service-modal__name" data-bind="text: service().name" data-uie-name="status-service-name"></div>
             <div

--- a/src/script/components/Avatar.tsx
+++ b/src/script/components/Avatar.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 
 import {User} from '../entity/User';
 import {ServiceEntity} from '../integration/ServiceEntity';
-import {registerReactComponent, useKoSubscribableChildren} from 'Util/ComponentUtil';
+import {registerStaticReactComponent, useKoSubscribableChildren} from 'Util/ComponentUtil';
 
 import UserAvatar from './avatar/UserAvatar';
 import ServiceAvatar from './avatar/ServiceAvatar';
@@ -152,9 +152,4 @@ const Avatar: React.FunctionComponent<AvatarProps> = ({
 };
 
 export default Avatar;
-
-registerReactComponent('participant-avatar', {
-  component: Avatar,
-  template:
-    '<span data-bind="react: {participant: ko.unwrap(participant), avatarSize: size, onAvatarClick, noBadge, noFilter}"></span>',
-});
+registerStaticReactComponent('participant-avatar', Avatar);

--- a/src/script/components/CopyToClipboard.tsx
+++ b/src/script/components/CopyToClipboard.tsx
@@ -18,7 +18,7 @@
  */
 
 import React from 'react';
-import {registerReactComponent} from 'Util/ComponentUtil';
+import {registerStaticReactComponent} from 'Util/ComponentUtil';
 
 export interface CopyToClipboardProps {
   text: string;
@@ -44,8 +44,4 @@ const CopyToClipboard: React.FC<CopyToClipboardProps> = ({text}) => {
 };
 
 export default CopyToClipboard;
-
-registerReactComponent('copy-to-clipboard', {
-  bindings: 'text: ko.unwrap(text)',
-  component: CopyToClipboard,
-});
+registerStaticReactComponent('copy-to-clipboard', CopyToClipboard);

--- a/src/script/components/list/ConversationListCell.tsx
+++ b/src/script/components/list/ConversationListCell.tsx
@@ -22,7 +22,7 @@ import cx from 'classnames';
 
 import {noop} from 'Util/util';
 import {t} from 'Util/LocalizerUtil';
-import {registerReactComponent, useKoSubscribableChildren} from 'Util/ComponentUtil';
+import {registerStaticReactComponent, useKoSubscribableChildren} from 'Util/ComponentUtil';
 import useEffectRef from 'Util/useEffectRef';
 
 import {AVATAR_SIZE} from 'Components/Avatar';
@@ -222,9 +222,4 @@ const ConversationListCell: React.FC<ConversationListCellProps> = ({
 };
 
 export default ConversationListCell;
-
-registerReactComponent('conversation-list-cell', {
-  bindings:
-    'offsetTop: ko.unwrap(offsetTop), index: ko.unwrap(index), showJoinButton: ko.unwrap(showJoinButton), conversation, is_selected, isVisibleFunc, onJoinCall, rightClick, onClick',
-  component: ConversationListCell,
-});
+registerStaticReactComponent('conversation-list-cell', ConversationListCell);

--- a/src/script/components/message.ts
+++ b/src/script/components/message.ts
@@ -323,7 +323,7 @@ const normalTemplate: string = `
   <!-- ko if: shouldShowAvatar -->
     <div class="message-header">
       <div class="message-header-icon">
-        <participant-avatar class="cursor-pointer" params="participant: message.user, onAvatarClick: onClickAvatar, size: AVATAR_SIZE.X_SMALL"></participant-avatar>
+        <participant-avatar class="cursor-pointer" params="participant: message.user, onAvatarClick: onClickAvatar, avatarSize: AVATAR_SIZE.X_SMALL"></participant-avatar>
       </div>
       <div class="message-header-label">
         <span class="message-header-label-sender" data-bind='css: message.accent_color(), text: message.headerSenderName()' data-uie-name="sender-name"></span>

--- a/src/script/page/message-list/MessageTimerButton.tsx
+++ b/src/script/page/message-list/MessageTimerButton.tsx
@@ -23,7 +23,7 @@ import cx from 'classnames';
 import {t} from 'Util/LocalizerUtil';
 import {formatDuration, DurationUnit} from 'Util/TimeUtil';
 import Icon from 'Components/Icon';
-import {registerReactComponent, useKoSubscribableChildren} from 'Util/ComponentUtil';
+import {registerStaticReactComponent, useKoSubscribableChildren} from 'Util/ComponentUtil';
 
 import {EphemeralTimings} from '../../ephemeral/EphemeralTimings';
 import {showContextMenu} from '../../ui/ContextMenu';
@@ -111,8 +111,4 @@ export const MessageTimerButton: React.FC<MessageTimerButtonProps> = ({
 };
 
 export default MessageTimerButton;
-
-registerReactComponent('message-timer-button', {
-  component: MessageTimerButton,
-  template: '<span data-bind="react: {conversation: ko.unwrap(conversation)}"></span>',
-});
+registerStaticReactComponent('message-timer-button', MessageTimerButton);


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR create a new `registerStaticReactComponent` that allows registering a component that will not be update from the knockout world. 

The current `registerReactComponent` will get full state update from the ko world whenever an observable given parameter updates (The problematic line is here https://github.com/wireapp/wire-webapp/blob/4dad1eccdaa29482a9daefafc7827b80178d524f/src/script/view_model/bindings/ReactBindings.ts#L69)


# Benchmark

This is a small benchmark to highlight how many less update we do with this new component:

sending the same message in the exact same conversation with the same initial state. Screenshot taken from React devtools.
We can see a lot of avatar get updated in the `before` case (because ko forces an update to them). While in the `after` screenshot, only the avatars in the conversation get updated and are faster update (detected by react)

After (on current PR's branch)

![image](https://user-images.githubusercontent.com/1090716/153378502-4c8258ff-7470-4358-85d4-72991c6e8f99.png)

Before (on `dev` branch)

![image](https://user-images.githubusercontent.com/1090716/153379444-719587be-918a-484b-8025-f2b78f66c3ec.png)
