### PR TITLE
runfix(core): Restore dynamic binding of conversationListCell component

### DIFF
--- a/src/script/components/list/ConversationListCell.tsx
+++ b/src/script/components/list/ConversationListCell.tsx
@@ -22,7 +22,7 @@ import cx from 'classnames';
 
 import {noop} from 'Util/util';
 import {t} from 'Util/LocalizerUtil';
-import {registerStaticReactComponent, useKoSubscribableChildren} from 'Util/ComponentUtil';
+import {registerReactComponent, useKoSubscribableChildren} from 'Util/ComponentUtil';
 import useEffectRef from 'Util/useEffectRef';
 
 import {AVATAR_SIZE} from 'Components/Avatar';
@@ -222,4 +222,9 @@ const ConversationListCell: React.FC<ConversationListCellProps> = ({
 };
 
 export default ConversationListCell;
-registerStaticReactComponent('conversation-list-cell', ConversationListCell);
+
+registerReactComponent('conversation-list-cell', {
+  bindings:
+    'offsetTop: ko.unwrap(offsetTop), index: ko.unwrap(index), showJoinButton: ko.unwrap(showJoinButton), conversation, is_selected, isVisibleFunc, onJoinCall, rightClick, onClick',
+  component: ConversationListCell,
+});


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The `ConversationListCell` component is expecting a direct observable parameter to be updated from KO (the `showJoinButton`). Thus we cannot convert it to a static react component. 