### PR TITLE
fix: separating and fixing add participants panel

### DIFF
--- a/src/script/view_model/panel/AddParticipantsViewModel.ts
+++ b/src/script/view_model/panel/AddParticipantsViewModel.ts
@@ -62,7 +62,6 @@ export class AddParticipantsViewModel extends BasePanelViewModel {
   selectedService: ko.Observable<ServiceEntity>;
   state: ko.Observable<string>;
   isTeamOnly: ko.PureComputed<boolean>;
-  isServicesEnabled: ko.PureComputed<boolean>;
   showIntegrations: ko.PureComputed<boolean>;
   enableAddAction: ko.PureComputed<boolean>;
   isStateAddPeople: ko.PureComputed<boolean>;
@@ -106,14 +105,12 @@ export class AddParticipantsViewModel extends BasePanelViewModel {
     this.state = ko.observable(AddParticipantsViewModel.STATE.ADD_PEOPLE);
 
     this.isTeamOnly = ko.pureComputed(() => this.activeConversation() && this.activeConversation().isTeamOnly());
-    this.isServicesEnabled = ko.pureComputed(
-      () =>
-        this.activeConversation() &&
-        (this.activeConversation().isServicesRoom() || this.activeConversation().isGuestAndServicesRoom()),
-    );
 
     this.showIntegrations = ko.pureComputed(() => {
       if (this.activeConversation()) {
+        const isServicesEnabled =
+          this.activeConversation().isServicesRoom() || this.activeConversation().isGuestAndServicesRoom();
+
         const firstUserEntity = this.activeConversation().firstUserEntity();
         const hasBotUser = firstUserEntity && firstUserEntity.isService;
         const allowIntegrations = this.activeConversation().isGroup() || hasBotUser;
@@ -122,7 +119,7 @@ export class AddParticipantsViewModel extends BasePanelViewModel {
           allowIntegrations &&
           this.activeConversation().inTeam() &&
           !this.isTeamOnly() &&
-          this.isServicesEnabled()
+          isServicesEnabled
         );
       }
       return undefined;


### PR DESCRIPTION
fixing a regression test issue on the add participants panel inside of conversations. 
this is related to the separation of guests and services

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

_Briefly describe the issue you have solved or implemented with this pull request. If the PR contains multiple issues, use a bullet list._

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
