### PR TITLE
runfix(core): Add classified bar for Call UI and user profile [FS-386]

### DIFF
--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -42,6 +42,7 @@ import DeviceToggleButton from './DeviceToggleButton';
 import Duration from './Duration';
 import GroupVideoGrid from './GroupVideoGrid';
 import Pagination from './Pagination';
+import ClassifiedBar from 'Components/input/ClassifiedBar';
 
 export interface FullscreenVideoCallProps {
   activeCallViewTab: string;
@@ -141,7 +142,10 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
     participants,
   } = useKoSubscribableChildren(call, ['activeSpeakers', 'currentPage', 'pages', 'startedAt', 'participants']);
   const {display_name: conversationName} = useKoSubscribableChildren(conversation, ['display_name']);
-  const {isVideoCallingEnabled} = useKoSubscribableChildren(teamState, ['isVideoCallingEnabled']);
+  const {isVideoCallingEnabled, classifiedDomains} = useKoSubscribableChildren(teamState, [
+    'isVideoCallingEnabled',
+    'classifiedDomains',
+  ]);
 
   const {videoInput: currentCameraDevice} = useKoSubscribableChildren(mediaDevicesHandler.currentDeviceId, [
     DeviceTypes.VIDEO_INPUT,
@@ -197,6 +201,13 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
         <div data-uie-name="video-timer" className="video-timer label-xs">
           <Duration startedAt={startedAt} />
         </div>
+        {classifiedDomains && (
+          <ClassifiedBar
+            users={conversation.participating_user_ets()}
+            classifiedDomains={classifiedDomains}
+            style={{display: 'inline-block', lineHeight: '1.5em', margin: '1em 0', padding: '0 1em', width: 'auto'}}
+          />
+        )}
       </div>
 
       {!isChoosingScreen && (

--- a/src/script/components/panel/UserDetails.tsx
+++ b/src/script/components/panel/UserDetails.tsx
@@ -149,5 +149,5 @@ export default UserDetails;
 registerReactComponent('panel-user-details', {
   component: UserDetails,
   template:
-    '<div data-bind="react: {badge: ko.unwrap(badge), isGroupAdmin: ko.unwrap(isGroupAdmin), isSelfVerified: ko.unwrap(isSelfVerified), isVerified: ko.unwrap(isVerified), participant: ko.unwrap(participant)}"></div>',
+    '<div data-bind="react: {badge: ko.unwrap(badge), isGroupAdmin: ko.unwrap(isGroupAdmin), isSelfVerified: ko.unwrap(isSelfVerified), isVerified: ko.unwrap(isVerified), participant: ko.unwrap(participant), classifiedDomains: ko.unwrap(classifiedDomains)}"></div>',
 });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-386" title="FS-386" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />FS-386</a>  [Web] As a user, I like to be aware of the security clearance of a conversation (only for BUND at this point).
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Adds the classified bar for:
- maximized call UI
- user profile view