### PR TITLE
fix(core): Do not update message timestamp when link preview is sent

### DIFF
--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -248,7 +248,10 @@ export class MessageRepository {
    * @see https://github.com/wireapp/wire-docs/tree/master/src/understand/federation
    * @see https://docs.wire.com/understand/federation/index.html
    */
-  private async sendText({conversation, message, mentions = [], linkPreview, quote, messageId}: TextMessagePayload) {
+  private async sendText(
+    {conversation, message, mentions = [], linkPreview, quote, messageId}: TextMessagePayload,
+    options?: {syncTimestamp?: boolean},
+  ) {
     const baseMessage = MessageBuilder.createText({
       ...this.createCommonMessagePayload(conversation),
       messageId,
@@ -256,7 +259,7 @@ export class MessageRepository {
     });
     const textMessage = this.decorateTextMessage(conversation, baseMessage, {linkPreview, mentions, quote});
 
-    return this.sendAndInjectGenericCoreMessage(textMessage, conversation);
+    return this.sendAndInjectGenericCoreMessage(textMessage, conversation, options);
   }
 
   private async sendEdit({
@@ -385,12 +388,15 @@ export class MessageRepository {
     const linkPreview = await getLinkPreviewFromString(textPayload.message);
     if (linkPreview) {
       // If we detect a link preview, then we go on and send a new message (that will override the initial message) containing the link preview
-      await this.sendText({
-        ...textPayload,
-        linkPreview: linkPreview.image
-          ? await this.core.service!.linkPreview.uploadLinkPreviewImage(linkPreview as LinkPreviewContent)
-          : linkPreview,
-      });
+      await this.sendText(
+        {
+          ...textPayload,
+          linkPreview: linkPreview.image
+            ? await this.core.service!.linkPreview.uploadLinkPreviewImage(linkPreview as LinkPreviewContent)
+            : linkPreview,
+        },
+        {syncTimestamp: false},
+      );
     }
   }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Since quotes are verified with a hash from the message text + the message timestamp, we need the timestamps to be stable. 

When sending a linkPreview we should prevent the timestamp to be updated (so that the receiving side also has the same timestamp).