### PR TITLE
fix(call): Avoid memory leak on camera switch (SQCALL-436)

### DIFF
--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -896,11 +896,10 @@ export class CallingRepository {
     }
   }
 
-  public async refreshVideoInput(): Promise<MediaStream> {
+  public async refreshVideoInput() {
     const stream = await this.mediaStreamHandler.requestMediaStream(false, true, false, false);
     this.stopMediaSource(MediaType.VIDEO);
     this.changeMediaSource(stream, MediaType.VIDEO);
-    return stream;
   }
 
   public async refreshAudioInput(): Promise<MediaStream> {
@@ -962,6 +961,8 @@ export class CallingRepository {
       if (videoTracks.length > 0) {
         selfParticipant.setVideoStream(new MediaStream(videoTracks), true);
         this.wCall.replaceTrack(this.serializeQualifiedId(call.conversationId), videoTracks[0]);
+        // Remove the previous video stream
+        this.mediaStreamHandler.releaseTracksFromStream(mediaStream);
       }
     }
   }

--- a/src/script/page/preferences/AVPreferences.tsx
+++ b/src/script/page/preferences/AVPreferences.tsx
@@ -61,6 +61,7 @@ const AVPreferences: React.FC<AVPreferencesProps> = ({
         <CameraPreferences
           {...{devicesHandler, streamHandler}}
           refreshStream={() => callingRepository.refreshVideoInput()}
+          hasActiveCameraStream={callingRepository.hasActiveCameraStream()}
         />
       )}
       <CallOptions {...{constraintsHandler, propertiesRepository}} />

--- a/src/script/view_model/CallingViewModel.ts
+++ b/src/script/view_model/CallingViewModel.ts
@@ -196,6 +196,7 @@ export class CallingViewModel {
       },
       switchCameraInput: (call: Call, deviceId: string) => {
         this.mediaDevicesHandler.currentDeviceId.videoInput(deviceId);
+        this.callingRepository.refreshVideoInput();
       },
       switchScreenInput: (call: Call, deviceId: string) => {
         this.mediaDevicesHandler.currentDeviceId.screenInput(deviceId);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCALL-436" title="SQCALL-436" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQCALL-436</a>  [Web] Camera capture does not stop after call when there was a switch between cameras
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Reported bug: Camera capture does not stop after call when there was a switch between cameras

### Causes (Optional)

Memory leak on not deleting old video stream

### Solutions

This PR removes the stream correctly 

