### PR TITLE
chore: Only deploy production build on master branch

### DIFF
--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -115,7 +115,7 @@ jobs:
         run: yarn build:prod
 
       - name: Assembling release information
-        if: contains(env.TAG, 'production') && matrix.DISTRIBUTION == 'DISTRIBUTION_0'
+        if: contains(env.TAG, 'production') && matrix.DISTRIBUTION == 'DISTRIBUTION_0' && env.BRANCHE_NAME == 'master'
         # NOTE: always using 'master' config, since release version is only consumed at
         #       'production' stage for now
         shell: bash
@@ -219,7 +219,7 @@ jobs:
 
       # Stage 5: https://app.wire.com/
       - name: Deploy production build to Elastic Beanstalk
-        if: contains(env.TAG, 'production') && matrix.DISTRIBUTION == 'DISTRIBUTION_0'
+        if: contains(env.TAG, 'production') && matrix.DISTRIBUTION == 'DISTRIBUTION_0' && env.BRANCH_NAME == 'master'
         uses: einaregilsson/beanstalk-deploy@v14
         with:
           application_name: ${{env.AWS_APPLICATION_NAME}}
@@ -260,7 +260,7 @@ jobs:
           fi
 
       - name: Push production Docker image
-        if: contains(env.TAG, 'production')
+        if: contains(env.TAG, 'production') && env.BRANCH_NAME == 'master'
         env:
           DOCKER_PASSWORD: ${{secrets.WEBTEAM_QUAY_PASSWORD}}
           DOCKER_USERNAME: ${{secrets.WEBTEAM_QUAY_USERNAME}}
@@ -272,12 +272,12 @@ jobs:
           fi
 
       - name: Generate changelog for production release
-        if: contains(env.TAG, 'production') && matrix.DISTRIBUTION == 'DISTRIBUTION_0'
+        if: contains(env.TAG, 'production') && matrix.DISTRIBUTION == 'DISTRIBUTION_0' && env.BRANCH_NAME == 'master'
         run: yarn changelog:ci
 
       - name: Create GitHub production release
         id: create_release_production
-        if: contains(env.TAG, 'production') && matrix.DISTRIBUTION == 'DISTRIBUTION_0'
+        if: contains(env.TAG, 'production') && matrix.DISTRIBUTION == 'DISTRIBUTION_0' && env.BRANCH_NAME == 'master'
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{github.token}}
@@ -289,7 +289,7 @@ jobs:
           prerelease: false
 
       - name: Announce production release
-        if: contains(env.TAG, 'production') && matrix.DISTRIBUTION == 'DISTRIBUTION_0'
+        if: contains(env.TAG, 'production') && matrix.DISTRIBUTION == 'DISTRIBUTION_0' && env.BRANCH_NAME == 'master'
         uses: wireapp/github-action-wire-messenger@v2.0.0
         with:
           email: ${{secrets.WIRE_BOT_EMAIL}}
@@ -518,7 +518,7 @@ jobs:
           verbose: true
 
       - name: Attach desktop build to production release assets
-        if: contains(env.TAG, 'production')
+        if: contains(env.TAG, 'production') && env.BRANCH_NAME == 'master'
         uses: xresloader/upload-to-github-release@v1.3.0
         env:
           GITHUB_TOKEN: ${{github.token}}


### PR DESCRIPTION
There is a serious flow in our deployment script that can allow the `dev` branch to be deployed to the production env. 

Because we only check the tags, if a `production` tag is pushed to `dev` then the deploy script will trigger the production deployment even though we currently are on `dev`. 

This fixes the issue by checking the branch name before triggering the deployment. 