### PR TITLE
feat(core): Migrate existing session id in a federated env [FS-471]

### DIFF
--- a/src/script/main/sessionIdMigrator.ts
+++ b/src/script/main/sessionIdMigrator.ts
@@ -1,0 +1,56 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+import {Table} from 'dexie';
+
+/**
+ * Will migrate all the session ids in the database to fully qualified ids (from 'user-id@device-id` to  `domain@user-id@device-id`)
+ * Will only occur once for an instance of the webapp (a flag is stored in order not to re-do the migration at each loadtime)
+ *
+ * @param sessionTable The indexedDB table where the sessions are stored
+ * @param defaultDomain The domain to add to the unqualified session ids
+ */
+export async function migrateToQualifiedSessionIds(sessionTable: Table, defaultDomain: string) {
+  const flag = 'migratedToQualifiedSessionId';
+  if (localStorage.getItem(flag)) {
+    // We already have migrated the session ids to fully qualified ids
+    return;
+  }
+  const isFullyQualified = /^[^@]+@[A-F0-9-]+@/i;
+  const updatedSessions = (await sessionTable.toArray())
+    .filter(session => !isFullyQualified.test(session.id))
+    .reduce<{newSessions: {id: string}[]; oldIds: string[]}>(
+      (acc, session) => {
+        return {
+          newSessions: [...acc.newSessions, {...session, id: `${defaultDomain}@${session.id}`}],
+          oldIds: [...acc.oldIds, session.id],
+        };
+      },
+      {newSessions: [], oldIds: []},
+    );
+
+  // In order to change primaryKeys, we need to first delete all the record and re-add them with the new key
+  await sessionTable.bulkDelete(updatedSessions.oldIds);
+  await sessionTable.bulkAdd(
+    updatedSessions.newSessions,
+    updatedSessions.newSessions.map(({id}) => id),
+  );
+
+  // Keep track that we already migrated this batch so that we do not need to do it again
+  localStorage.setItem(flag, '1');
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-471" title="FS-471" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />FS-471</a>  [Web] Migrate existing session in DB to qualified sessions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When loading the app in a federated env first the first time, it will migrate all the existing session to fully qualified sessions. 

from `user-id@device-id` to `domain@user-id@device-id`.