### PR TITLE
fix: Subscribe to active speakers in minimized call view (SQCALL-477)

### DIFF
--- a/src/script/calling/Call.ts
+++ b/src/script/calling/Call.ts
@@ -192,8 +192,6 @@ export class Call {
     }
   }
 
-  getActiveSpeakers = () => this.activeSpeakers();
-
   addParticipant(participant: Participant): void {
     this.participants.push(participant);
     this.updatePages();

--- a/src/script/components/list/ConversationListCallingCell.tsx
+++ b/src/script/components/list/ConversationListCallingCell.tsx
@@ -136,6 +136,8 @@ const ConversationListCallingCell: React.FC<CallingCellProps> = ({
     hasActiveVideo: selfHasActiveVideo,
   } = useKoSubscribableChildren(selfParticipant, ['sharesScreen', 'sharesCamera', 'hasActiveVideo']);
 
+  const {activeSpeakers} = useKoSubscribableChildren(call, ['activeSpeakers']);
+
   const isOutgoingVideoCall = isOutgoing && selfSharesCamera;
   const isVideoUnsupported =
     !selfSharesCamera && !conversation?.supportsVideoCall(call.conversationType === CONV_TYPE.CONFERENCE);
@@ -259,9 +261,7 @@ const ConversationListCallingCell: React.FC<CallingCellProps> = ({
               onClick={isOngoing ? () => multitasking.isMinimized(false) : undefined}
             >
               <GroupVideoGrid
-                grid={
-                  activeCallViewTab === CallViewTab.ALL ? videoGrid : {grid: call.getActiveSpeakers(), thumbnail: null}
-                }
+                grid={activeCallViewTab === CallViewTab.ALL ? videoGrid : {grid: activeSpeakers, thumbnail: null}}
                 minimized
                 maximizedParticipant={maximizedParticipant}
                 selfParticipant={selfParticipant}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCALL-477" title="SQCALL-477" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQCALL-477</a>  [Web] Active speaker tiles in minimized call do not update automatically
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- **Description**
The speaker view in minimized call should update in the same way as if the call is maximized
----

# What's new in this PR?

### Issues

The call tiles do not update in real time when active speakers are changing.
The last active speaker can be shown even though there is no one talking for some minutes.
The view can be updated by maximizing the call or sometimes when the mute state of someone changes

### Causes (Optional)

We used to get active speakers by just calling the method getActiveSpeakers but as they are an observable we should subscribe to them with useKoSubscribableChildren

### Solutions
`useKoSubscribableChildren`