### PR TITLE
fix(core): Do not update original message timestamp when assets are uploaded

### DIFF
--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -550,7 +550,7 @@ export class MessageRepository {
           file: {data: Buffer.from(await file.arrayBuffer())},
           originalMessageId: messageId,
         });
-    return this.sendAndInjectGenericCoreMessage(assetMessage, conversation);
+    return this.sendAndInjectGenericCoreMessage(assetMessage, conversation, {syncTimestamp: false});
   }
 
   /**


### PR DESCRIPTION
This will prevent the message timestamp to be updated and message replies hash to validate. (will fix replying to an asset message)