### PR TITLE
fix(accessibility): message-like-button #ACC-11

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/MessageLike.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageLike.tsx
@@ -33,7 +33,7 @@ const MessageLike: React.FC<MessageLikeProps> = ({message, onLike, className}) =
   const {is_liked: isLiked} = useKoSubscribableChildren(message, ['is_liked']);
 
   return (
-    <span
+    <button
       className={cx(className, {
         'like-button-liked': isLiked,
       })}
@@ -42,11 +42,13 @@ const MessageLike: React.FC<MessageLikeProps> = ({message, onLike, className}) =
       }}
       data-uie-name="do-like-message"
       data-uie-value={isLiked}
+      aria-label={isLiked ? 'Liked' : 'Like'}
       onClick={() => onLike(message)}
+      type="button"
     >
       <span className="icon-like-small"></span>
       <span className="icon-liked-small"></span>
-    </span>
+    </button>
   );
 };
 

--- a/src/style/common/button.less
+++ b/src/style/common/button.less
@@ -247,3 +247,10 @@
 .svg-button {
   cursor: pointer;
 }
+
+.button-reset-default {
+  padding: 0;
+  border: 0;
+  background-color: transparent;
+  cursor: pointer;
+}

--- a/src/style/common/like.less
+++ b/src/style/common/like.less
@@ -23,6 +23,7 @@
 
 .like-button {
   .circle(24px);
+  .button-reset-default;
 
   position: relative;
   cursor: pointer;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-11" title="ACC-11" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-11</a>  9.4.1.2 Fix message-like component
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Transform clickable span to button and add missing aria-label. 
