### PR TITLE
fix(accessibility): modal focus on open #ACC-14

### DIFF
--- a/src/page/template/modal/group-creation.htm
+++ b/src/page/template/modal/group-creation.htm
@@ -1,5 +1,5 @@
 <div id="group-creation-modal" data-bind="with: $root.groupCreation" class="group-creation__modal">
-  <modal params="isShown: isShown, onClosed: afterHideModal, ariaLabelby: 'group-creation-label'">
+  <modal params="isShown: isShown, onClosed: afterHideModal, ariaLabelBy: 'group-creation-label'">
     <div class="modal__header">
       <!-- ko if: stateIsParticipants() -->
         <h2 id="group-creation-label" class="modal__header__title" data-bind="text: participantsHeaderText" data-uie-name="status-people-selected"></h2>

--- a/src/page/template/modals.htm
+++ b/src/page/template/modals.htm
@@ -4,7 +4,7 @@
     data-bind="attr: {'data-uie-name': content().modalUie}"
   >
     <div class="modal__header" data-uie-name="status-modal-title">
-      <div class="modal__header__title" data-bind="text: content().titleText"></div>
+      <div class="modal__header__title" id="modal-title" data-bind="text: content().titleText"></div>
       <!-- ko if: content().showClose -->
         <close-icon class="modal__header__button" data-bind="click: hide" data-uie-name="do-close"></close-icon>
       <!-- /ko -->
@@ -13,10 +13,10 @@
     <div class="modal__body" data-bind="fadingscrollbar">
       <div class="modal__text" data-uie-name="status-modal-text">
         <!-- ko if: content().messageHtml -->
-          <div data-bind="html: content().messageHtml"></div>
+          <div id="modal-desc" data-bind="html: content().messageHtml"></div>
         <!-- /ko -->
         <!-- ko if: content().messageText -->
-          <div data-bind="text: content().messageText"></div>
+          <div id="modal-desc" data-bind="text: content().messageText"></div>
         <!-- /ko -->
       </div>
       <!-- ko if: hasPassword() -->
@@ -44,10 +44,10 @@
       <!-- /ko -->
       <div class="modal__buttons" data-bind="css: {'modal__buttons--column': hasMultipleSecondary()}">
         <!-- ko foreach: {data: content().secondaryAction, as: 'secondary', noChildContext: true} -->
-          <input type="button" data-bind="value: secondary.text, click: () => doAction(secondary.action, true, true), css: {'modal__button--full': hasMultipleSecondary()}, attr: {'data-uie-name': secondary.uieName}" class="modal__button modal__button--secondary"></button>
+          <button type="button" data-bind="text: secondary.text, click: () => doAction(secondary.action, true, true), css: {'modal__button--full': hasMultipleSecondary()}, attr: {'data-uie-name': secondary.uieName}" class="modal__button modal__button--secondary"></button>
         <!-- /ko -->
         <!-- ko if: content().primaryAction.text -->
-          <input type="button" data-bind="value: content().primaryAction.text, click: () => doAction(confirm, content().closeOnConfirm), css: {'modal__button--full': hasMultipleSecondary()}, enable: actionEnabled()" class="modal__button modal__button--primary" data-uie-name="do-action"></inpu>
+          <button type="button" data-bind="text: content().primaryAction.text, click: () => doAction(confirm, content().closeOnConfirm), css: {'modal__button--full': hasMultipleSecondary()}, enable: actionEnabled()" class="modal__button modal__button--primary" data-uie-name="do-action"></button>
         <!-- /ko -->
       </div>
     </div>

--- a/src/page/template/modals.htm
+++ b/src/page/template/modals.htm
@@ -1,6 +1,6 @@
 <div id="modals">
   <modal
-    params="isShown: isModalVisible(), onBgClick: content().onBgClick, onClosed: onModalHidden"
+    params="isShown: isModalVisible(), onBgClick: content().onBgClick, onClosed: onModalHidden, ariaDescribedBy: 'modal-description'"
     data-bind="attr: {'data-uie-name': content().modalUie}"
   >
     <div class="modal__header" data-uie-name="status-modal-title">
@@ -13,10 +13,10 @@
     <div class="modal__body" data-bind="fadingscrollbar">
       <div class="modal__text" data-uie-name="status-modal-text">
         <!-- ko if: content().messageHtml -->
-          <div id="modal-desc" data-bind="html: content().messageHtml"></div>
+          <div id="modal-description" data-bind="html: content().messageHtml"></div>
         <!-- /ko -->
         <!-- ko if: content().messageText -->
-          <div id="modal-desc" data-bind="text: content().messageText"></div>
+          <div id="modal-description" data-bind="text: content().messageText"></div>
         <!-- /ko -->
       </div>
       <!-- ko if: hasPassword() -->

--- a/src/script/components/modal.ts
+++ b/src/script/components/modal.ts
@@ -33,7 +33,7 @@ interface ModalParams {
 
 ko.components.register('modal', {
   template: `
-    <div class="modal" data-bind="style: {display: displayNone() ? 'none': 'flex', zIndex: 10000001}, attr: id ? {id: id, 'aria-labelledby': ariaLabelby} : {}" role="dialog" aria-modal="true" tabindex="-1">
+    <div class="modal" data-bind="style: {display: displayNone() ? 'none': 'flex', zIndex: 10000001}, attr: id ? {id: id, 'aria-labelledby': ariaLabelby} : {}" tabIndex="-1" aria-labelledby="modal-title" aria-describedby="modal-desc" aria-modal="true" role="dialog" aria-modal="true">
       <!-- ko if: showLoading() -->
         <loading-icon class="modal__loading"></loading-icon>
       <!-- /ko -->
@@ -65,6 +65,9 @@ ko.components.register('modal', {
     const maintainFocus = (): void => {
       if (!this.displayNone()) {
         document.addEventListener('keydown', onKeyDown);
+        window.setTimeout(() => {
+          document.getElementById(this.id).focus();
+        });
       }
     };
 

--- a/src/script/components/modal.ts
+++ b/src/script/components/modal.ts
@@ -23,7 +23,8 @@ import {isTabKey} from 'Util/KeyboardUtil';
 import {noop, createRandomUuid} from 'Util/util';
 
 interface ModalParams {
-  ariaLabelby?: string;
+  ariaDescribedBy?: string;
+  ariaLabelBy?: string;
   isShown: ko.Observable<boolean>;
   large?: boolean;
   onBgClick?: () => void;
@@ -33,7 +34,7 @@ interface ModalParams {
 
 ko.components.register('modal', {
   template: `
-    <div class="modal" data-bind="style: {display: displayNone() ? 'none': 'flex', zIndex: 10000001}, attr: id ? {id: id, 'aria-labelledby': ariaLabelby} : {}" tabIndex="-1" aria-labelledby="modal-title" aria-describedby="modal-desc" aria-modal="true" role="dialog" aria-modal="true">
+    <div class="modal" data-bind="style: {display: displayNone() ? 'none': 'flex', zIndex: 10000001}, attr: {id: id, 'aria-labelledby': ariaLabelBy, 'aria-describedby': ariaDescribedBy}" tabIndex="-1" aria-modal="true" role="dialog" aria-modal="true">
       <!-- ko if: showLoading() -->
         <loading-icon class="modal__loading"></loading-icon>
       <!-- /ko -->
@@ -48,14 +49,16 @@ ko.components.register('modal', {
   viewModel: function ({
     isShown,
     large,
-    ariaLabelby,
+    ariaLabelBy,
+    ariaDescribedBy,
     onBgClick = noop,
     onClosed = noop,
     showLoading = ko.observable(false),
   }: ModalParams): void {
     this.large = large;
     this.id = createRandomUuid();
-    this.ariaLabelby = ariaLabelby;
+    this.ariaLabelBy = ariaLabelBy;
+    this.ariaDescribedBy = ariaDescribedBy;
     this.onBgClick = () => ko.unwrap(onBgClick)();
     this.displayNone = ko.observable(!ko.unwrap(isShown));
     this.hasVisibleClass = ko.computed(() => isShown() && !this.displayNone()).extend({rateLimit: 20});

--- a/src/style/common/modal.less
+++ b/src/style/common/modal.less
@@ -350,6 +350,7 @@
   }
 
   &__button {
+    .button-reset-default;
     display: inline-block;
     width: calc(50% - 8px);
     height: 40px;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-14" title="ACC-14" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-14</a>  9.2.4.3 Fix focus staying on the popup's background
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Added focus modal on open and add `label`, `describedby` for proper screen reader behavior. Switch from inputs to buttons. 
