### PR TITLE
refactor: Harmonize conversation cell locators

### DIFF
--- a/src/page/template/list/conversations.htm
+++ b/src/page/template/list/conversations.htm
@@ -101,8 +101,8 @@
           <!-- ko foreach: {data: unarchivedConversations, as: 'conversation', noChildContext: true} -->
           <li class="conversation-recent-view-list-item">
             <conversation-list-cell
-              data-uie-name="item-conversation"
               params="
+                dataUieName: 'item-conversation',
                 onClick: makeOnClick(conversation.id, conversation.domain),
                 rightClick: (_, event) => listViewModel.onContextMenu(conversation, event),
                 conversation: conversation,

--- a/src/script/components/list/ConversationListCell.tsx
+++ b/src/script/components/list/ConversationListCell.tsx
@@ -235,6 +235,6 @@ export default ConversationListCell;
 
 registerReactComponent('conversation-list-cell', {
   bindings:
-    'offsetTop: ko.unwrap(offsetTop), index: ko.unwrap(index), showJoinButton: ko.unwrap(showJoinButton), conversation, is_selected, isVisibleFunc, onJoinCall, rightClick, onClick',
+    'offsetTop: ko.unwrap(offsetTop), index: ko.unwrap(index), showJoinButton: ko.unwrap(showJoinButton), conversation, is_selected, isVisibleFunc, onJoinCall, rightClick, onClick, dataUieName',
   component: ConversationListCell,
 });


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

This is to harmonize how conversation list cell are detected by automation. As of now we have 2 different selectors. 

`[data-uie-name='conversation-item'] [data-ui-value=...]`

And

`[data-uie-name='conversation-item'][data-ui-value=...]` (notice the space that disappears in this one). 

We would like to only have the second one available

It's needed for #12676 