### PR TITLE
fix: Avoid loading undefined image on user background [FS-505]

### DIFF
--- a/src/script/page/left-sidebar/Background.tsx
+++ b/src/script/page/left-sidebar/Background.tsx
@@ -47,9 +47,10 @@ const UserBackground: React.FC<BackgroundProps> = ({selfUser, assetRepository}) 
     });
   }, [avatar]);
 
+  const style: React.CSSProperties = avatarUrl ? {backgroundImage: `url(${avatarUrl})`} : undefined;
   return (
     <div className="background">
-      <div className="background-image" style={{backgroundImage: `url(${avatarUrl})`}}></div>
+      <div className="background-image" style={style}></div>
       <div className="background-darken"></div>
     </div>
   );


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-505" title="FS-505" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-505</a>  [Web] Log error after logging in
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Fixes a call to `/undefined` when the application was loading. 