### PR TITLE
runfix: Update team info when opening preferences

### DIFF
--- a/src/script/page/LeftSidebar/LeftSidebar.tsx
+++ b/src/script/page/LeftSidebar/LeftSidebar.tsx
@@ -54,6 +54,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
   selfUser,
 }) => {
   const {conversationRepository, propertiesRepository} = listViewModel;
+  const repositories = listViewModel.contentViewModel.repositories;
   const {state} = useKoSubscribableChildren(listViewModel, ['state']);
   let content = <span></span>;
   const switchList = (list: ListState) => listViewModel.switchList(list);
@@ -74,7 +75,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
       content = (
         <Conversations
           listViewModel={listViewModel}
-          preferenceNotificationRepository={listViewModel.contentViewModel.repositories.preferenceNotification}
+          preferenceNotificationRepository={repositories.preferenceNotification}
           conversationRepository={conversationRepository}
           propertiesRepository={propertiesRepository}
           switchList={switchList}
@@ -86,7 +87,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
       content = (
         <Preferences
           contentViewModel={listViewModel.contentViewModel}
-          listViewModel={listViewModel}
+          teamRepository={repositories.team}
           onClose={goHome}
         ></Preferences>
       );

--- a/src/script/page/LeftSidebar/panels/Preferences.test.tsx
+++ b/src/script/page/LeftSidebar/panels/Preferences.test.tsx
@@ -21,7 +21,6 @@ import React from 'react';
 import ko from 'knockout';
 import {render} from '@testing-library/react';
 import Preferences from './Preferences';
-import {ListViewModel} from 'src/script/view_model/ListViewModel';
 import {ContentViewModel} from 'src/script/view_model/ContentViewModel';
 
 import {Runtime} from '@wireapp/commons';
@@ -31,10 +30,8 @@ describe('Preferences', () => {
     contentViewModel: {
       state: ko.observable(''),
     } as ContentViewModel,
-    listViewModel: {
-      state: ko.observable(''),
-    } as ListViewModel,
     onClose: jest.fn(),
+    teamRepository: {getTeam: jest.fn()},
   };
 
   it('renders the right preferences items', () => {

--- a/src/script/page/LeftSidebar/panels/Preferences.tsx
+++ b/src/script/page/LeftSidebar/panels/Preferences.tsx
@@ -17,21 +17,20 @@
  *
  */
 
-import React from 'react';
+import React, {useEffect} from 'react';
 import {t} from 'Util/LocalizerUtil';
 
 import {Runtime} from '@wireapp/commons';
 import Icon from 'Components/Icon';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
-import {ListViewModel} from '../../../view_model/ListViewModel';
 import {ContentViewModel} from '../../../view_model/ContentViewModel';
 import ListWrapper from './ListWrapper';
+import {TeamRepository} from '../../../team/TeamRepository';
 
 type PreferencesProps = {
   contentViewModel: ContentViewModel;
-  isTemporaryGuest?: boolean;
-  listViewModel: ListViewModel;
   onClose: () => void;
+  teamRepository: TeamRepository;
 };
 
 const PreferenceItem: React.FC<{
@@ -58,8 +57,13 @@ const PreferenceItem: React.FC<{
   );
 };
 
-const Preferences: React.FC<PreferencesProps> = ({listViewModel, contentViewModel, onClose}) => {
+const Preferences: React.FC<PreferencesProps> = ({contentViewModel, teamRepository, onClose}) => {
   const {state: contentState} = useKoSubscribableChildren(contentViewModel, ['state']);
+
+  useEffect(() => {
+    // Update local team
+    teamRepository.getTeam();
+  }, []);
 
   const isDesktop = Runtime.isDesktopApp();
   const supportsCalling = Runtime.isSupportingLegacyCalling();

--- a/src/script/page/LeftSidebar/panels/Preferences.tsx
+++ b/src/script/page/LeftSidebar/panels/Preferences.tsx
@@ -30,7 +30,7 @@ import {TeamRepository} from '../../../team/TeamRepository';
 type PreferencesProps = {
   contentViewModel: ContentViewModel;
   onClose: () => void;
-  teamRepository: TeamRepository;
+  teamRepository: Pick<TeamRepository, 'getTeam'>;
 };
 
 const PreferenceItem: React.FC<{


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Restore a bug where team is not updated when loading the preferences 