### PR TITLE
runfix: Update active call UI when call changed

### DIFF
--- a/src/script/calling/CallingRepository.test.ts
+++ b/src/script/calling/CallingRepository.test.ts
@@ -75,7 +75,7 @@ describe('CallingRepository', () => {
   });
 
   afterEach(() => {
-    callingRepository['callState'].activeCalls([]);
+    callingRepository['callState'].calls([]);
   });
 
   afterAll(() => {
@@ -143,7 +143,7 @@ describe('CallingRepository', () => {
       declinedCall.state(CALL_STATE.INCOMING);
       declinedCall.reason(REASON.STILL_ONGOING);
 
-      callingRepository['callState'].activeCalls([incomingCall, activeCall, declinedCall]);
+      callingRepository['callState'].calls([incomingCall, activeCall, declinedCall]);
 
       expect(callingRepository['callState'].joinedCall()).toBe(activeCall);
     });
@@ -360,10 +360,10 @@ describe('CallingRepository ISO', () => {
         type: CALL.E_CALL,
       };
 
-      expect(callingRepo['callState'].activeCalls().length).toBe(0);
+      expect(callingRepo['callState'].calls().length).toBe(0);
 
       callingRepo.onIncomingCall(call => {
-        expect(callingRepo['callState'].activeCalls().length).toBe(1);
+        expect(callingRepo['callState'].calls().length).toBe(1);
 
         done();
       });
@@ -439,7 +439,7 @@ describe.skip('E2E audio call', () => {
         }, 30);
       }
     });
-    activeCallsSub = client['callState'].activeCalls.subscribe(calls => {
+    activeCallsSub = client['callState'].calls.subscribe(calls => {
       if (calls.length === 0) {
         onCallClosed();
       }

--- a/src/script/calling/CallingRepository.test.ts
+++ b/src/script/calling/CallingRepository.test.ts
@@ -93,7 +93,7 @@ describe('CallingRepository', () => {
         {currentAvailableDeviceId: mediaDevices} as MediaDevicesHandler,
       );
       activeCall.state(CALL_STATE.MEDIA_ESTAB);
-      spyOn(callingRepository['callState'], 'activeCalls').and.returnValue([activeCall]);
+      spyOn(callingRepository['callState'], 'calls').and.returnValue([activeCall]);
       spyOn(amplify, 'publish').and.returnValue(undefined);
       const conversationId = createConversationId();
       const conversationType = CONV_TYPE.ONEONONE;

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -232,26 +232,24 @@ const Conversations: React.FC<ConversationsProps> = ({
 
   const callingView = (
     <>
-      {activeCalls
-        .filter(call => !call.reason())
-        .map(call => {
-          const conversation = conversationState.findConversation(call.conversationId);
-          const callingViewModel = listViewModel.callingViewModel;
-          const callingRepository = callingViewModel.callingRepository;
-          return (
-            <div className="calling-cell" key={conversation.id}>
-              <ConversationListCallingCell
-                call={call}
-                callActions={callingViewModel.callActions}
-                callingRepository={callingRepository}
-                conversation={conversation}
-                hasAccessToCamera={callingViewModel.hasAccessToCamera()}
-                isSelfVerified={selfUser.is_verified()}
-                multitasking={callingViewModel.multitasking}
-              />
-            </div>
-          );
-        })}
+      {activeCalls.map(call => {
+        const conversation = conversationState.findConversation(call.conversationId);
+        const callingViewModel = listViewModel.callingViewModel;
+        const callingRepository = callingViewModel.callingRepository;
+        return (
+          <div className="calling-cell" key={conversation.id}>
+            <ConversationListCallingCell
+              call={call}
+              callActions={callingViewModel.callActions}
+              callingRepository={callingRepository}
+              conversation={conversation}
+              hasAccessToCamera={callingViewModel.hasAccessToCamera()}
+              isSelfVerified={selfUser.is_verified()}
+              multitasking={callingViewModel.multitasking}
+            />
+          </div>
+        );
+      })}
     </>
   );
 

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
@@ -19,7 +19,6 @@
 
 import {css} from '@emotion/core';
 import React from 'react';
-import {REASON as CALL_REASON, STATE as CALL_STATE} from '@wireapp/avs';
 import {t} from 'Util/LocalizerUtil';
 import {ListViewModel} from '../../../../view_model/ListViewModel';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
@@ -56,7 +55,7 @@ export const ConversationsList: React.FC<{
   conversationRepository,
   callState,
 }) => {
-  const {activeCalls} = useKoSubscribableChildren(callState, ['activeCalls']);
+  const {joinableCalls} = useKoSubscribableChildren(callState, ['joinableCalls']);
 
   const isActiveConversation = (conversation: Conversation) => conversationState.isActiveConversation(conversation);
 
@@ -67,17 +66,13 @@ export const ConversationsList: React.FC<{
   const isShowingConnectionRequests = contentState === ContentViewModel.STATE.CONNECTION_REQUESTS;
 
   const hasJoinableCall = (conversation: Conversation) => {
-    const call = activeCalls.find((callInstance: Call) =>
+    const call = joinableCalls.find((callInstance: Call) =>
       matchQualifiedIds(callInstance.conversationId, conversation.qualifiedId),
     );
     if (!call) {
       return false;
     }
-    return (
-      !conversation.removed_from_conversation() &&
-      call.state() === CALL_STATE.INCOMING &&
-      call.reason() !== CALL_REASON.ANSWERED_ELSEWHERE
-    );
+    return !conversation.removed_from_conversation();
   };
 
   const conversationView =

--- a/src/script/view_model/CallingViewModel.ts
+++ b/src/script/view_model/CallingViewModel.ts
@@ -103,7 +103,7 @@ export class CallingViewModel {
   ) {
     this.isSelfVerified = ko.pureComputed(() => selfUser().is_verified());
     this.activeCalls = ko.pureComputed(() =>
-      this.callState.activeCalls().filter(call => {
+      this.callState.calls().filter(call => {
         const conversation = this.conversationState.findConversation(call.conversationId);
         if (!conversation || conversation.removed_from_conversation()) {
           return false;


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Since we moved the conversation list to react, some observable changes did not trigger UI updates (when a call was active or not). 
We need to add new observables to tackle this problem, have ko observe the change and bring them back to react. 