### PR TITLE
fix(services): Stop escaping characters when using links with special characters (SQSERVICES-1342)

### DIFF
--- a/src/script/util/messageRenderer.ts
+++ b/src/script/util/messageRenderer.ts
@@ -153,7 +153,7 @@ export const renderMessage = (message: string, selfId: QualifiedId | null, menti
         ),
       );
     const link = tokens[idx];
-    const href = cleanString(link.attrGet('href'));
+    const href = link.attrGet('href');
     const isEmail = href.startsWith('mailto:');
     const isWireDeepLink = href.toLowerCase().startsWith('wire://');
     const nextToken = tokens[idx + 1];
@@ -175,9 +175,9 @@ export const renderMessage = (message: string, selfId: QualifiedId | null, menti
     if (!isWireDeepLink && !['autolink', 'linkify'].includes(link.markup)) {
       const title = link.attrGet('title');
       if (title) {
-        link.attrSet('title', cleanString(title));
+        link.attrSet('title', title);
       }
-      link.attrSet('href', cleanString(href));
+      link.attrSet('href', href);
       if (nextToken?.type === 'text') {
         nextToken.content = text;
       }

--- a/test/unit_tests/util/messageRendererSpec.js
+++ b/test/unit_tests/util/messageRendererSpec.js
@@ -193,7 +193,37 @@ describe('renderMessage', () => {
     );
 
     expect(renderMessage("[email](mailto:'\\);alert\\('pwned'\\)//)")).toBe(
-      '<a href="mailto:&amp;amp;#x27;);alert(&amp;amp;#x27;pwned&amp;amp;#x27;)//" data-email-link="true" data-md-link="true" data-uie-name="markdown-link">email</a>',
+      '<a href="mailto:\');alert(\'pwned\')//" data-email-link="true" data-md-link="true" data-uie-name="markdown-link">email</a>',
+    );
+  });
+
+  it('renders a link from markdown notation with a title', () => {
+    expect(renderMessage('[sometext](https://some.domain "this is a title")')).toBe(
+      `<a href="https://some.domain" title="this is a title" target="_blank" rel="nofollow noopener noreferrer" data-md-link="true" data-uie-name="markdown-link">sometext</a>`,
+    );
+  });
+
+  it('does not render a broken markdown link', () => {
+    expect(renderMessage(`[sometext](https://some.domain"><script>alert("oops")</script>)`)).toBe(
+      `[sometext](<a href="https://some.domain" target="_blank" rel="nofollow noopener noreferrer">https://some.domain</a>&quot;&gt;&lt;script&gt;alert(&quot;oops&quot;)&lt;/script&gt;)`,
+    );
+  });
+
+  it('escapes url params', () => {
+    expect(renderMessage(`[sometext](https://some.domain?param1=a&param2=b)`)).toBe(
+      `<a href="https://some.domain?param1=a&amp;param2=b" target="_blank" rel="nofollow noopener noreferrer" data-md-link="true" data-uie-name="markdown-link">sometext</a>`,
+    );
+  });
+
+  it('escapes links with html charachters on their title', () => {
+    expect(renderMessage(`[sometext](https://some.domain "<this> &' >that<")`)).toBe(
+      `<a href="https://some.domain" title="&lt;this&gt; &amp;' &gt;that&lt;" target="_blank" rel="nofollow noopener noreferrer" data-md-link="true" data-uie-name="markdown-link">sometext</a>`,
+    );
+  });
+
+  it('escapes links with an xss attempt on their title', () => {
+    expect(renderMessage(`[sometext](https://some.domain '"><script>alert("oops")</script>')`)).toBe(
+      `<a href="https://some.domain" title="&quot;&gt;&lt;script&gt;alert(&quot;oops&quot;)&lt;/script&gt;" target="_blank" rel="nofollow noopener noreferrer" data-md-link="true" data-uie-name="markdown-link">sometext</a>`,
     );
   });
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1342" title="SQSERVICES-1342" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1342</a>  [Web] Fix escaping characters when using links with special characters
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

