### PR TITLE
chore(calling): Bump @wireapp/avs from 8.1.7 to 8.1.8 (SQCALL-531)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@wireapp/antiscroll-2": "1.3.1",
-    "@wireapp/avs": "8.1.7",
+    "@wireapp/avs": "8.1.8",
     "@wireapp/core": "24.4.4",
     "@wireapp/react-ui-kit": "7.55.1",
     "@wireapp/store-engine-dexie": "1.6.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3048,10 +3048,10 @@
     tough-cookie "4.0.0"
     ws "7.5.3"
 
-"@wireapp/avs@8.1.7":
-  version "8.1.7"
-  resolved "https://registry.yarnpkg.com/@wireapp/avs/-/avs-8.1.7.tgz#3ea2ba5b9d9765e95b533eb4fb0437b24ccbe9b4"
-  integrity sha512-bA+5Js9hWZJhlbGeBtKFRulvdLBWpxH3Xz3hvbC81M3QMhmb3TtcJPMNV6tr197Ho8hkszCrxWNNAkz46xX1ng==
+"@wireapp/avs@8.1.8":
+  version "8.1.8"
+  resolved "https://registry.yarnpkg.com/@wireapp/avs/-/avs-8.1.8.tgz#ddece50fe123810db15b78f782654167356f7e5c"
+  integrity sha512-aqJ9hajAXjochD3AtJUV9jKTmS+54EaMsKjyZ1VLmgRfnQ4cByGMlC3o1Y+6szYwdvPwlwr15CWhGpSJJD8kWQ==
 
 "@wireapp/cbor@4.7.3":
   version "4.7.3"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCALL-531" title="SQCALL-531" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />SQCALL-531</a>  [Web] bump avs version to `8.1.8`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
