### PR TITLE
runfix: Improve end of user list detection

### DIFF
--- a/src/script/components/UserList.tsx
+++ b/src/script/components/UserList.tsx
@@ -86,6 +86,8 @@ const UserList: React.FC<UserListProps> = ({
 }) => {
   const [maxShownUsers, setMaxShownUsers] = useState(USER_CHUNK_SIZE);
 
+  const hasMoreUsers = !truncate && users.length > maxShownUsers;
+
   const highlightedUserIds = highlightedUsers.map(user => user.id);
   const selfInTeam = userState.self().inTeam();
   const {self} = useKoSubscribableChildren(userState, ['self']);
@@ -234,14 +236,13 @@ const UserList: React.FC<UserListProps> = ({
   return (
     <>
       {content}
-      {users.length > maxShownUsers && (
+      {hasMoreUsers && (
         <InViewport
           fullyInView={false}
           onVisible={() => setMaxShownUsers(maxShownUsers + USER_CHUNK_SIZE)}
           key={`in-viewport-${Math.random()}`}
-        >
-          <div css={{height: 100}}></div>
-        </InViewport>
+          style={{transform: 'translateY(-60px)'}}
+        />
       )}
     </>
   );

--- a/src/script/components/utils/InViewport.tsx
+++ b/src/script/components/utils/InViewport.tsx
@@ -23,9 +23,10 @@ import {viewportObserver} from '../../ui/viewportObserver';
 interface InViewportParams {
   fullyInView?: boolean;
   onVisible: () => void;
+  style?: React.CSSProperties;
 }
 
-const InViewport: React.FC<InViewportParams> = ({children, onVisible, fullyInView = true}) => {
+const InViewport: React.FC<InViewportParams> = ({children, style, onVisible, fullyInView = true}) => {
   const domNode = useRef<HTMLDivElement>();
 
   useEffect(() => {
@@ -64,7 +65,11 @@ const InViewport: React.FC<InViewportParams> = ({children, onVisible, fullyInVie
     return () => releaseTrackers();
   }, [onVisible]);
 
-  return <div ref={domNode}>{children}</div>;
+  return (
+    <div ref={domNode} style={style}>
+      {children}
+    </div>
+  );
 };
 
 export default InViewport;


### PR DESCRIPTION
This will trigger the load of extra users a little earlier than when the end of the list is reached
And it will also prevent the InViewport trigger to be added if the list is voluntarily truncated