### PR TITLE
feat: limit entropy generator only to windows machines [SQSERVICES-1478]

### DIFF
--- a/src/script/Config.ts
+++ b/src/script/Config.ts
@@ -19,6 +19,7 @@
 
 import {ValidationUtil} from '@wireapp/commons';
 import {createRandomUuid} from 'Util/util';
+import {Runtime} from '@wireapp/commons';
 const env = window.wire.env;
 
 export const ACCENT_ID = {
@@ -41,7 +42,10 @@ export class Configuration {
   readonly BRAND_NAME = env.BRAND_NAME || 'Wire';
   readonly COUNTLY_API_KEY = env.COUNTLY_API_KEY;
   readonly ENVIRONMENT = env.ENVIRONMENT || 'production';
-  readonly FEATURE = env.FEATURE;
+  readonly FEATURE = {
+    ...env.FEATURE,
+    ENABLE_EXTRA_CLIENT_ENTROPY: env.FEATURE.ENABLE_EXTRA_CLIENT_ENTROPY && Runtime.isWindows(),
+  };
   readonly MAX_GROUP_PARTICIPANTS = env.MAX_GROUP_PARTICIPANTS || 500;
   readonly MAX_VIDEO_PARTICIPANTS = env.MAX_VIDEO_PARTICIPANTS || 4;
   readonly NEW_PASSWORD_MINIMUM_LENGTH = env.NEW_PASSWORD_MINIMUM_LENGTH || ValidationUtil.DEFAULT_PASSWORD_MIN_LENGTH;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1478" title="SQSERVICES-1478" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1478</a>  [web] Entropy is included for all clients but should only display for Windows. 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
