### PR TITLE
chore: Update crowdin/github-action to 1.4.8

### DIFF
--- a/.github/workflows/sync_translations.yml
+++ b/.github/workflows/sync_translations.yml
@@ -11,10 +11,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Add /github/workspace as a safe directory to read git config from (see https://github.blog/2022-04-12-git-security-vulnerability-announced/)
-      - name: Set safe config reading directory
-        run: git config --global --add safe.directory /github/workspace
-
       - name: Checkout
         uses: actions/checkout@v2.3.4
 
@@ -36,7 +32,7 @@ jobs:
         run: yarn translate:merge
 
       - name: Download translations
-        uses: crowdin/github-action@1.3.3
+        uses: crowdin/github-action@1.4.8
         env:
           GITHUB_TOKEN: ${{secrets.OTTO_THE_BOT_GH_TOKEN}}
           CROWDIN_PROJECT_ID: 342359


### PR DESCRIPTION
To address issue with new git security vulnerability discovered on the 12/04/2022
see https://github.blog/2022-04-12-git-security-vulnerability-announced/