### PR TITLE
chore: Use github native concurrency param to cancel workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,16 +6,15 @@ on:
   pull_request:
     branches: [master, dev, edge, avs, mobile]
 
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{github.token}}
-
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/sync_translations.yml
+++ b/.github/workflows/sync_translations.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: '0 8 * * *'
 
+concurrency:
+  group: translations-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sync_translations:
     runs-on: ubuntu-latest
@@ -13,9 +17,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
 
       - name: Yarn cache
         uses: c-hive/gha-yarn-cache@v2.1.0

--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [master, dev, edge, avs, mobile]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test_build_deploy:
     runs-on: ubuntu-latest
@@ -69,11 +73,6 @@ jobs:
           contains(env.TITLE || env.PR_LAST_COMMIT_MESSAGE, '[skip ci]') ||
           contains(env.TITLE || env.PR_LAST_COMMIT_MESSAGE, '[ci skip]')
         uses: andymckay/cancel-action@0.2
-
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{github.token}}
 
       - name: Yarn cache
         uses: c-hive/gha-yarn-cache@v2.1.0


### PR DESCRIPTION
Lately, canceling CI builds were broken. 
I discovered there was now a native way to cancel github workflow

see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency