### PR TITLE
runfix: Make message keys unique in the message list

### DIFF
--- a/src/script/components/MessagesList/index.tsx
+++ b/src/script/components/MessagesList/index.tsx
@@ -162,7 +162,7 @@ const MessagesList: React.FC<MessagesListParams> = ({
     const visibleCallback = getVisibleCallback(conversation, message);
     return (
       <Message
-        key={message.id}
+        key={message.id + message.timestamp}
         onVisible={visibleCallback}
         message={message}
         previousMessage={previousMessage}


### PR DESCRIPTION
Since some messages can have no `id`, we need to create a key that is more unique