### PR TITLE
fix(services): Do not double escape links in open link modal (SQSERVICES-1491)

### DIFF
--- a/src/script/view_model/content/MessageListViewModel.ts
+++ b/src/script/view_model/content/MessageListViewModel.ts
@@ -336,7 +336,7 @@ export class MessageListViewModel {
           text: t('modalOpenLinkAction'),
         },
         text: {
-          message: t('modalOpenLinkMessage', href),
+          message: t('modalOpenLinkMessage', href, {}, true),
           title: t('modalOpenLinkTitle'),
         },
       });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1491" title="SQSERVICES-1491" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1491</a>  Escaping issue in markdown
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³
