### PR TITLE
fix(accessibility): wrong ko attributes #ACC-21

### DIFF
--- a/src/page/template/panel/add-participants.htm
+++ b/src/page/template/panel/add-participants.htm
@@ -2,7 +2,7 @@
   <!-- ko if: isVisible() -->
     <div class="panel__header">
       <button class="icon-button" type="button" 
-        data-bind="clickOrDrag: onGoBack, title: t('accessibility.rightPanel.GoBack'), 'aria-label': t('accessibility.rightPanel.GoBack')" 
+        data-bind="clickOrDrag: onGoBack, attr: {  title: t('accessibility.rightPanel.GoBack'), 'aria-label': t('accessibility.rightPanel.GoBack') }" 
         data-uie-name="go-back-add-participants">
       <arrow-left-icon aria-hidden="true"></arrow-left-icon>
       </button>

--- a/src/page/template/panel/add-participants.htm
+++ b/src/page/template/panel/add-participants.htm
@@ -7,7 +7,7 @@
       <arrow-left-icon aria-hidden="true"></arrow-left-icon>
       </button>
       <h3 class="panel__header__title" data-bind="text: headerText" data-uie-name="status-people-selected"></h3>
-      <button class="right-panel-close icon-button" type="button" data-bind="clickOrDrag: onClose, title: t('accessibility.rightPanel.close'), 'aria-label': t('accessibility.rightPanel.close')"
+      <button class="right-panel-close icon-button" type="button" data-bind="clickOrDrag: onClose, attr: { title: t('accessibility.rightPanel.close'), 'aria-label': t('accessibility.rightPanel.close')}"
         data-uie-name="do-close">
         <close-icon aria-hidden="true"></close-icon>
       </button>

--- a/src/page/template/panel/conversation-details.htm
+++ b/src/page/template/panel/conversation-details.htm
@@ -5,7 +5,7 @@
 >
   <!-- ko if: isVisible() -->
     <div class="panel__header panel__header--reverse">
-      <button class="right-panel-close icon-button" type="button" data-bind="clickOrDrag: onClose, title: t('accessibility.rightPanel.close'), 'aria-label': t('accessibility.rightPanel.close')"
+      <button class="right-panel-close icon-button" type="button" data-bind="clickOrDrag: onClose, attr: { title: t('accessibility.rightPanel.close'), 'aria-label': t('accessibility.rightPanel.close')}"
       data-uie-name="do-close">
         <close-icon aria-hidden="true"></close-icon>
       </button>

--- a/src/page/template/panel/conversation-participants.htm
+++ b/src/page/template/panel/conversation-participants.htm
@@ -7,7 +7,7 @@
         <arrow-left-icon aria-hidden="true"></arrow-left-icon>
       </button>
       <h3 class="panel__header__title" data-bind="text: t('conversationParticipantsTitle')"></h3>
-      <button class="right-panel-close icon-button" type="button" data-bind="clickOrDrag: onClose, title: t('accessibility.rightPanel.close'), 'aria-label': t('accessibility.rightPanel.close')"
+      <button class="right-panel-close icon-button" type="button" data-bind="clickOrDrag: onClose, attr: { title: t('accessibility.rightPanel.close'), 'aria-label': t('accessibility.rightPanel.close')}"
       data-uie-name="do-close">
         <close-icon aria-hidden="true"></close-icon>
       </button>

--- a/src/page/template/panel/conversation-participants.htm
+++ b/src/page/template/panel/conversation-participants.htm
@@ -2,7 +2,7 @@
   <!-- ko if: isVisible() -->
     <div class="panel__header">
       <button class="icon-button" type="button" 
-        data-bind="clickOrDrag: onGoBack, title: t('accessibility.rightPanel.GoBack'), 'aria-label': t('accessibility.rightPanel.GoBack')" 
+        data-bind="clickOrDrag: onGoBack, attr: { title: t('accessibility.rightPanel.GoBack'), 'aria-label': t('accessibility.rightPanel.GoBack') }" 
         data-uie-name="go-back-conversation-participants">
         <arrow-left-icon aria-hidden="true"></arrow-left-icon>
       </button>

--- a/src/page/template/panel/group-participant-service.htm
+++ b/src/page/template/panel/group-participant-service.htm
@@ -2,7 +2,7 @@
   <!-- ko if: isVisible() -->
     <div class="panel__header">
       <button type="button" class="icon-button" 
-      data-bind="clickOrDrag: onGoBack, title: t('accessibility.rightPanel.GoBack'), 'aria-label': t('accessibility.rightPanel.GoBack')"
+      data-bind="clickOrDrag: onGoBack, attr: {title: t('accessibility.rightPanel.GoBack'), 'aria-label': t('accessibility.rightPanel.GoBack') }"
       data-uie-name="go-back-group-participant">
         <arrow-left-icon aria-hidden="true"></arrow-left-icon>
       </button>

--- a/src/page/template/panel/group-participant-user.htm
+++ b/src/page/template/panel/group-participant-user.htm
@@ -2,11 +2,11 @@
   <!-- ko if: isVisible() -->
     <div class="panel__header">
       <button type="button" class="icon-button" 
-        data-bind="clickOrDrag: onGoBack, title: t('accessibility.rightPanel.GoBack'), 'aria-label': t('accessibility.rightPanel.GoBack')"
+        data-bind="clickOrDrag: onGoBack, attr: { title: t('accessibility.rightPanel.GoBack'), 'aria-label': t('accessibility.rightPanel.GoBack') }"
         data-uie-name="go-back-group-participant">
         <arrow-left-icon aria-hidden="true"></arrow-left-icon>
       </button>
-      <button type="button" class="icon-button" data-bind="clickOrDrag: onClose, title: t('accessibility.rightPanel.close'), 'aria-label': t('accessibility.rightPanel.close')" data-uie-name="do-close">
+      <button type="button" class="icon-button" data-bind="clickOrDrag: onClose, attr: { title: t('accessibility.rightPanel.close'), 'aria-label': t('accessibility.rightPanel.close') }" data-uie-name="do-close">
         <close-icon aria-hidden="true"></close-icon>
       </button>
     </div>

--- a/src/page/template/panel/guest-options.htm
+++ b/src/page/template/panel/guest-options.htm
@@ -2,7 +2,7 @@
   <!-- ko if: isVisible() -->
     <div class="panel__header">
       <button type="button" class="icon-button" 
-        data-bind="clickOrDrag: onGoBack, title: t('accessibility.rightPanel.GoBack'), 'aria-label': t('accessibility.rightPanel.GoBack')"
+        data-bind="clickOrDrag: onGoBack, attr: { title: t('accessibility.rightPanel.GoBack'), 'aria-label': t('accessibility.rightPanel.GoBack') }"
         data-uie-name="go-back-guest-options"
       >
         <arrow-left-icon aria-hidden="true"></arrow-left-icon>

--- a/src/page/template/panel/guest-options.htm
+++ b/src/page/template/panel/guest-options.htm
@@ -8,7 +8,8 @@
         <arrow-left-icon aria-hidden="true"></arrow-left-icon>
       </button>
       <h3 class="panel__header__title" data-bind="text: t('guestOptionsTitle')"></h3>
-      <button type="button" class="right-panel-close icon-button" data-bind="clickOrDrag: onClose, title: t('accessibility.rightPanel.close'), 'aria-label': t('accessibility.rightPanel.close')" data-uie-name="do-close">
+      <button class="right-panel-close icon-button" type="button" data-bind="clickOrDrag: onClose, attr: { title: t('accessibility.rightPanel.close'), 'aria-label': t('accessibility.rightPanel.close')}"
+      data-uie-name="do-close">
         <close-icon aria-hidden="true"></close-icon>
       </button>
     </div>

--- a/src/page/template/panel/message-details.htm
+++ b/src/page/template/panel/message-details.htm
@@ -6,7 +6,8 @@
   <!-- ko if: isVisible() -->
     <div class="panel__header">
       <h4 class="panel__header__title" data-bind="text: panelTitle()" data-uie-name="message-details-title"></h4>
-      <button type="button" class="right-panel-close icon-button" data-bind="clickOrDrag: onClose, title: t('accessibility.rightPanel.close'), 'aria-label': t('accessibility.rightPanel.close')" data-uie-name="do-close">
+      <button class="right-panel-close icon-button" type="button" data-bind="clickOrDrag: onClose, attr: { title: t('accessibility.rightPanel.close'), 'aria-label': t('accessibility.rightPanel.close')}"
+ data-uie-name="do-close">
         <close-icon aria-hidden="true"></close-icon>
       </button>
     </div>

--- a/src/page/template/panel/services-options.htm
+++ b/src/page/template/panel/services-options.htm
@@ -6,7 +6,7 @@
   <!-- ko if: isVisible() -->
   <div class="panel__header">
     <button type="button" class="icon-button"
-      data-bind="clickOrDrag: onGoBack, title: t('accessibility.rightPanel.GoBack'), 'aria-label': t('accessibility.rightPanel.GoBack')"
+      data-bind="clickOrDrag: onGoBack, attr: { title: t('accessibility.rightPanel.GoBack'), 'aria-label': t('accessibility.rightPanel.GoBack') }"
       data-uie-name="go-back-services-options">
         <arrow-left-icon aria-hidden="true"></arrow-left-icon>
     </button>

--- a/src/page/template/panel/services-options.htm
+++ b/src/page/template/panel/services-options.htm
@@ -11,7 +11,8 @@
         <arrow-left-icon aria-hidden="true"></arrow-left-icon>
     </button>
     <h4 class="panel__header__title" data-bind="text: t('servicesOptionsTitle')"></h4>
-    <button type="button" class="right-panel-close icon-button" data-bind="clickOrDrag: onClose, title: t('accessibility.rightPanel.close'), 'aria-label': t('accessibility.rightPanel.close')" data-uie-name="do-close">
+    <button class="right-panel-close icon-button" type="button" data-bind="clickOrDrag: onClose, attr: { title: t('accessibility.rightPanel.close'), 'aria-label': t('accessibility.rightPanel.close')}"
+    data-uie-name="do-close">
       <close-icon aria-hidden="true"></close-icon>
     </button>
   </div>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-21" title="ACC-21" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-21</a>  9.1.1.1 A - Fix alternative texts for controls
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Fix wrong ko attr usage
