### PR TITLE
fix(call): Fix broken ability to mute participants in a call as an admin (SQCALL-541)

### DIFF
--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -1068,6 +1068,7 @@ export class CallingRepository {
   ) => {
     const conversation = this.conversationState.findConversation(conversationId);
     const content = typeof payload === 'string' ? payload : JSON.stringify(payload);
+
     const message = await this.messageRepository.sendCallingMessage(conversation, content, options);
     if (message.state === PayloadBundleState.CANCELLED) {
       // If the user has cancelled message sending because of a degradation warning, we abort the call
@@ -1075,11 +1076,34 @@ export class CallingRepository {
     }
   };
 
-  readonly sendModeratorMute = (conversationId: QualifiedId, recipients: Record<UserId, ClientId[]>) => {
+  readonly convertParticipantsToCallingMessageRecepients = (
+    participants: Participant[],
+  ): UserClients | QualifiedUserClients => {
+    const isFederated = this.core.backendFeatures.federationEndpoints;
+
+    if (isFederated) {
+      return participants.reduce((participants, participant) => {
+        participants[participant.user.domain] ||= {};
+        participants[participant.user.domain][participant.user.id] = [participant.clientId];
+        return participants;
+      }, {} as QualifiedUserClients);
+    }
+
+    const recipients: UserClients = {};
+    for (const participant of participants) {
+      recipients[participant.user.id] = [participant.clientId];
+    }
+
+    return recipients;
+  };
+
+  readonly sendModeratorMute = (conversationId: QualifiedId, participants: Participant[]) => {
+    const recipients = this.convertParticipantsToCallingMessageRecepients(participants);
     this.sendCallingMessage(conversationId, {type: CALL_MESSAGE_TYPE.REMOTE_MUTE}, {nativePush: true, recipients});
   };
 
-  readonly sendModeratorKick = (conversationId: QualifiedId, recipients: Record<UserId, ClientId[]>) => {
+  readonly sendModeratorKick = (conversationId: QualifiedId, participants: Participant[]) => {
+    const recipients = this.convertParticipantsToCallingMessageRecepients(participants);
     this.sendCallingMessage(conversationId, {type: CALL_MESSAGE_TYPE.REMOTE_KICK}, {nativePush: true, recipients});
   };
 

--- a/src/script/components/list/ConversationListCallingCell.tsx
+++ b/src/script/components/list/ConversationListCallingCell.tsx
@@ -47,7 +47,7 @@ import {CallState, MuteState} from '../../calling/CallState';
 import {useFadingScrollbar} from '../../ui/fadingScrollbar';
 import {CallActions, CallViewTab} from '../../view_model/CallingViewModel';
 import {showContextMenu, ContextMenuEntry} from '../../ui/ContextMenu';
-import type {ClientId, Participant, UserId} from '../../calling/Participant';
+import type {Participant} from '../../calling/Participant';
 import ClassifiedBar from 'Components/input/ClassifiedBar';
 
 export interface CallingCellProps {
@@ -152,8 +152,7 @@ const ConversationListCallingCell: React.FC<CallingCellProps> = ({
     event.preventDefault();
 
     const muteParticipant = {
-      click: () =>
-        callingRepository.sendModeratorMute(conversation.qualifiedId, {[participant.user.id]: [participant.clientId]}),
+      click: () => callingRepository.sendModeratorMute(conversation.qualifiedId, [participant]),
       icon: 'mic-off-icon',
       identifier: `moderator-mute-participant`,
       isDisabled: participant.isMuted(),
@@ -162,13 +161,10 @@ const ConversationListCallingCell: React.FC<CallingCellProps> = ({
 
     const muteOthers: ContextMenuEntry = {
       click: () => {
-        const recipients = participants
-          .filter(p => p !== participant)
-          .reduce((acc, {user, clientId}) => {
-            acc[user.id] = [...(acc[user.id] || []), clientId];
-            return acc;
-          }, {} as Record<UserId, ClientId[]>);
-        callingRepository.sendModeratorMute(conversation.qualifiedId, recipients);
+        callingRepository.sendModeratorMute(
+          conversation.qualifiedId,
+          participants.filter(p => p !== participant),
+        );
       },
       icon: 'mic-off-icon',
       identifier: 'moderator-mute-others',


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCALL-541" title="SQCALL-541" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQCALL-541</a>  [Web] Moderation: Muting other call participants stopped working
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³
