### PR TITLE
runfix: Init the core as part of the App init [FS-647 FS-648]

### DIFF
--- a/src/script/auth/AuthRepository.ts
+++ b/src/script/auth/AuthRepository.ts
@@ -17,13 +17,9 @@
  *
  */
 
-import type {Context} from '@wireapp/api-client/src/auth/';
-import {ClientType} from '@wireapp/api-client/src/client/';
 import {container} from 'tsyringe';
 
 import {Logger, getLogger} from 'Util/Logger';
-import {loadValue} from 'Util/StorageUtil';
-import {StorageKey} from '../storage/StorageKey';
 import {APIClient} from '../service/APIClientSingleton';
 
 export class AuthRepository {
@@ -47,12 +43,6 @@ export class AuthRepository {
 
   constructor(private readonly apiClient = container.resolve(APIClient)) {
     this.logger = getLogger('AuthRepository');
-  }
-
-  init(): Promise<Context> {
-    const persist = loadValue(StorageKey.AUTH.PERSIST);
-    const clientType = persist ? ClientType.PERMANENT : ClientType.TEMPORARY;
-    return this.apiClient.init(clientType);
   }
 
   async logout(): Promise<void> {

--- a/src/script/storage/StorageService.ts
+++ b/src/script/storage/StorageService.ts
@@ -46,25 +46,15 @@ enum DEXIE_CRUD_EVENT {
 @singleton()
 export class StorageService {
   public db?: DexieDatabase;
-  private readonly hasHookSupport: boolean;
-  private readonly dbListeners: DatabaseListener[];
-  private readonly engine: CRUDEngine;
-  public readonly isTemporaryAndNonPersistent: boolean;
+  private readonly dbListeners: DatabaseListener[] = [];
+  private hasHookSupport: boolean;
+  private engine: CRUDEngine;
+  public isTemporaryAndNonPersistent: boolean;
   private readonly logger: Logger;
-  private readonly userId?: string;
   public dbName?: string;
 
-  constructor(engine: CRUDEngine) {
+  constructor() {
     this.logger = getLogger('StorageService');
-
-    this.dbName = undefined;
-    this.userId = undefined;
-
-    this.engine = engine;
-    this.hasHookSupport = this.engine instanceof IndexedDBEngine;
-    this.isTemporaryAndNonPersistent = this.engine instanceof SQLeetEngine;
-
-    this.dbListeners = [];
   }
 
   //##############################################################################
@@ -78,8 +68,11 @@ export class StorageService {
    * @param requestPersistentStorage if a persistent storage should be requested
    * @returns Resolves with the database name
    */
-  init(userId: string = this.userId, requestPersistentStorage: boolean = false): string {
+  init(engine: CRUDEngine): string {
+    this.engine = engine;
     this.dbName = this.engine.storeName;
+    this.hasHookSupport = this.engine instanceof IndexedDBEngine;
+    this.isTemporaryAndNonPersistent = this.engine instanceof SQLeetEngine;
 
     try {
       if (this.hasHookSupport) {

--- a/test/helper/TestFactory.js
+++ b/test/helper/TestFactory.js
@@ -90,11 +90,11 @@ export class TestFactory {
    * @returns {Promise<StorageRepository>} The storage repository.
    */
   async exposeStorageActors() {
-    const engine = await createStorageEngine('test', DatabaseTypes.PERMANENT);
-    container.registerInstance(StorageService, new StorageService(engine));
+    container.registerInstance(StorageService, new StorageService());
     this.storage_service = container.resolve(StorageService);
     if (!this.storage_service.db) {
-      this.storage_service.init(entities.user.john_doe.id, false);
+      const engine = await createStorageEngine('test', DatabaseTypes.PERMANENT);
+      this.storage_service.init(engine);
     }
     this.storage_repository = singleton(StorageRepository, this.storage_service);
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-647" title="FS-647" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-647</a>  [Web] Automatic login when all devices are deleted
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

In order to have proper error handling from the app.init function, we to include the `core.init` function in the `initApp` function. 

But since we need the storage engine (created by the core) in the `StorageService` at build time, this was not possible before.

This PR allows this by moving the moment we give the `StorageService` to when the `core` is actually initiated instead of in the constructor of the `StorageService`. 