### PR TITLE
feat: remove ping keyboard shorcut

### DIFF
--- a/src/script/ui/Shortcut.ts
+++ b/src/script/ui/Shortcut.ts
@@ -112,20 +112,6 @@ const SHORTCUT_MAP: Record<string, Shortcut> = {
       },
     },
   },
-  [ShortcutType.PING]: {
-    event: WebAppEvents.SHORTCUT.PING,
-    shortcut: {
-      electron: {
-        macos: 'command + k',
-        menu: true,
-        pc: 'ctrl + k',
-      },
-      webapp: {
-        macos: 'command + alt + k',
-        pc: 'ctrl + alt + k',
-      },
-    },
-  },
   [ShortcutType.PEOPLE]: {
     event: WebAppEvents.SHORTCUT.PEOPLE,
     shortcut: {


### PR DESCRIPTION
# What's new in this PR?

Like wireapp/wire-desktop#5703, accidental pings have been an issue in the Wire web client as well. This PR will remove the keyboard shortcut.

> Whilst a useful feature, having it bound to a shortcut, even more so one that's commonly used by other apps for non-intrusive behaviour, leads to a lot of frustrating accidental triggers.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

### Testing

#### How to Test

I have not tested this, but the code does not seem to me as though it would be called into from elsewhere so removing an entry from the shortcut map should not cause bugs.

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
