### PR TITLE
refactor: Use @wireapp/core to delete clients [FS-552]

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.9.0",
     "@wireapp/antiscroll-2": "1.3.1",
     "@wireapp/avs": "8.1.8",
-    "@wireapp/core": "25.1.0",
+    "@wireapp/core": "25.3.0",
     "@wireapp/react-ui-kit": "8.0.0",
     "@wireapp/store-engine-dexie": "1.6.9",
     "@wireapp/store-engine-sqleet": "1.7.14",

--- a/src/script/client/ClientRepository.ts
+++ b/src/script/client/ClientRepository.ts
@@ -287,10 +287,9 @@ export class ClientRepository {
    * @param password Password entered by user
    * @returns Resolves with the remaining user devices
    */
-  async deleteClient(clientId: string, password: string): Promise<ClientEntity[]> {
+  async deleteClient(clientId: string, password?: string): Promise<ClientEntity[]> {
     const selfUser = this.selfUser();
-    await this.clientService.deleteClient(clientId, password);
-    await this.deleteClientFromDb(selfUser.qualifiedId, clientId);
+    await this.core.service.client.deleteClient(clientId, password);
     selfUser.removeClient(clientId);
     amplify.publish(WebAppEvents.USER.CLIENT_REMOVED, selfUser.qualifiedId, clientId);
     return this.clientState.clients();

--- a/src/script/client/ClientService.ts
+++ b/src/script/client/ClientService.ts
@@ -18,7 +18,7 @@
  */
 
 import type {
-  NewClient,
+  CreateClientPayload,
   RegisteredClient,
   QualifiedUserClientMap,
   ClientCapabilityData,
@@ -132,7 +132,7 @@ export class ClientService {
    * @param newClient Client payload
    * @returns Resolves with the registered client information
    */
-  postClients(newClient: NewClient): Promise<RegisteredClient> {
+  postClients(newClient: CreateClientPayload): Promise<RegisteredClient> {
     return this.apiClient.api.client.postClient(newClient);
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3021,10 +3021,10 @@
   resolved "https://registry.yarnpkg.com/@wireapp/antiscroll-2/-/antiscroll-2-1.3.1.tgz#bcb66f72c6dadc306e43235256b768ed3f89039c"
   integrity sha512-vWmWYAzSdyxs+xlgSPGtiNSTCM1z0nxM+jSPa/xz1/kuFKy80BrJP5xaGwNNLljBAz8ymlSPUUZlylUd0tFr1Q==
 
-"@wireapp/api-client@19.0.0":
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/@wireapp/api-client/-/api-client-19.0.0.tgz#dff631cf61a3dac1bdeae632e145e8472c44fe8d"
-  integrity sha512-PNVnkkf1KxChm/KoMyxH/q+4XKEEJQ89iWYlohd0MO0Zb6ShIBsE7sx46nG5BSFSsMQoqWgPnl2HXl7xxSvmHA==
+"@wireapp/api-client@19.2.0":
+  version "19.2.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/api-client/-/api-client-19.2.0.tgz#ec2fb8e2c2f2e8cd0ae603945fee49223cf000a8"
+  integrity sha512-MmQuZjqsAg2+owMcCyyCfsePYe7Mz7IP+8Ek/SZ9Ua4REp1JzntvXNBRePa/5UHalDKO8E0HOKnqkWKGU8cMGw==
   dependencies:
     "@types/node" "~14"
     "@types/spark-md5" "3.0.2"
@@ -3078,14 +3078,14 @@
     logdown "3.3.1"
     rimraf "3.0.2"
 
-"@wireapp/core@25.1.0":
-  version "25.1.0"
-  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-25.1.0.tgz#3475e12e6f110151b6f2ed67dbb6403145f54a31"
-  integrity sha512-YqqCzRGMTzUAumfx1yYK99h/25RN+ztZQHU8oGHyxcrcaYdNRi+u0et0I2ieNRkbYr5dMMGdcNk4NsCojQ9dfw==
+"@wireapp/core@25.3.0":
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-25.3.0.tgz#1e727e73de432508a4ff50e70fee3d67ec497d22"
+  integrity sha512-d+OQ/tTMuG9oL4n/+a9dA7CCRWlpH3iYYG5+0Rh3eew1ithAC6NFX0dDlp+XUrapLRk+zkTUUCBctuPCf4Z+oQ==
   dependencies:
     "@types/long" "4.0.1"
     "@types/node" "~14"
-    "@wireapp/api-client" "19.0.0"
+    "@wireapp/api-client" "19.2.0"
     "@wireapp/cryptobox" "12.8.0"
     bazinga64 "5.10.0"
     hash.js "1.1.7"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-552" title="FS-552" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-552</a>  [Web] Register new client with MLS
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
With the integration of MLS we need to move all that is related to `clients` and `messages` to the core. 

This PR will let the core handle clients deletion (on backend and local db). In the future handling deletion of MLS clients will be completely transparent to the webapp