### PR TITLE
fix: Target lastRead and Countly messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.9.0",
     "@wireapp/antiscroll-2": "1.3.1",
     "@wireapp/avs": "8.1.8",
-    "@wireapp/core": "25.3.0",
+    "@wireapp/core": "26.0.0",
     "@wireapp/react-ui-kit": "8.0.0",
     "@wireapp/store-engine-dexie": "1.6.9",
     "@wireapp/store-engine-sqleet": "1.7.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3078,10 +3078,10 @@
     logdown "3.3.1"
     rimraf "3.0.2"
 
-"@wireapp/core@25.3.0":
-  version "25.3.0"
-  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-25.3.0.tgz#1e727e73de432508a4ff50e70fee3d67ec497d22"
-  integrity sha512-d+OQ/tTMuG9oL4n/+a9dA7CCRWlpH3iYYG5+0Rh3eew1ithAC6NFX0dDlp+XUrapLRk+zkTUUCBctuPCf4Z+oQ==
+"@wireapp/core@26.0.0":
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-26.0.0.tgz#f3b9f5385489a05983648451f55b33c7cbdf4d5a"
+  integrity sha512-ERU730rPou+XSHUVwpayMq8NX+RxOBkyhR9DowVrJALJ+Nl49woyh3Tw5SN0/6dUxqIKqEyAd87YXmBzH3555g==
   dependencies:
     "@types/long" "4.0.1"
     "@types/node" "~14"


### PR DESCRIPTION
Since the migration to the core, we provided no users to target the message for lastRead and Countly payloads. This meant that the core was trying to find which users to send to and ended up downloading the full user list and generating payload for those ... Including the self device.

This fixes it by passing an explicit list of users to send the message to from the webapp
