### PR TITLE
runfix: Avoid creating default device on SSO first login

### DIFF
--- a/src/script/auth/module/action/AuthAction.ts
+++ b/src/script/auth/module/action/AuthAction.ts
@@ -171,7 +171,8 @@ export class AuthAction {
     ) => {
       dispatch(AuthActionCreator.startLogin());
       try {
-        await core.init(clientType);
+        // we first init the core without initializing the client for now (this will be done later on)
+        await core.init(clientType, undefined, false);
         await this.persistAuthData(clientType, core, dispatch, localStorageAction);
         await dispatch(selfAction.fetchSelf());
         await dispatch(cookieAction.setCookie(COOKIE_NAME_APP_OPENED, {appInstanceId: getConfig().APP_INSTANCE_ID}));


### PR DESCRIPTION
Since https://github.com/wireapp/wire-web-packages/pull/4264 we do not automatically create a default device for the user when calling the `init` method of the core. It now throws an error. 
We need to explicitly say that we do not want to initialize the client. 

The real client will be init a few lines below.

My guest is that we currently have users that have a device called `@wireapp/core` instead of the browser's name. 
So good that this error now surfaces 