### PR TITLE
fix: wrong error message displayed when microphone disconnected (SER-153)

### DIFF
--- a/src/script/media/MediaStreamHandler.ts
+++ b/src/script/media/MediaStreamHandler.ts
@@ -173,7 +173,11 @@ export class MediaStreamHandler {
         if (
           audio === true &&
           video !== true &&
-          [MEDIA_STREAM_ERROR.NOT_READABLE_ERROR, MEDIA_STREAM_ERROR.NOT_ALLOWED_ERROR].includes(name)
+          [
+            MEDIA_STREAM_ERROR.NOT_READABLE_ERROR,
+            MEDIA_STREAM_ERROR.NOT_ALLOWED_ERROR,
+            MEDIA_STREAM_ERROR.NOT_FOUND_ERROR,
+          ].includes(name)
         ) {
           throw new NoAudioInputError(error);
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SER-153" title="SER-153" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />SER-153</a>  Login & Signup
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When microphone is disconnected, trying to audio call will give "No camera access" error

### Causes (Optional)

Missing value in media error handling (MediaStreamHandler, getMediaStream method) would not return NoAudioInputError when it should

### Solutions

Added missing value to error check (MEDIA_STREAM_ERROR.NOT_FOUND_ERROR)

### Dependencies (Optional)



Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Plug in/out mic/camera and try making video/audio calls

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
