### PR TITLE
chore: Fix translation download job

### DIFF
--- a/.github/workflows/sync_translations.yml
+++ b/.github/workflows/sync_translations.yml
@@ -5,6 +5,7 @@ on:
     branches: [dev]
   schedule:
     - cron: '0 8 * * *'
+  workflow_dispatch:
 
 concurrency:
   group: translations-${{ github.ref }}
@@ -36,6 +37,7 @@ jobs:
         uses: crowdin/github-action@1.4.8
         env:
           GITHUB_TOKEN: ${{secrets.OTTO_THE_BOT_GH_TOKEN}}
+          GITHUB_ACTOR: otto-the-bot
           CROWDIN_PROJECT_ID: 342359
           INPUT_DEBUG_MODE: false
         with:


### PR DESCRIPTION
Mostly aligns the translation download job with the one on Team Settings (see https://github.com/wireapp/wire-team-settings/blob/dev/.github/workflows/download_translations.yml)