### PR TITLE
feat(services): Support new screen sharing api on electron 18 (SQSERVICES-1568)

### DIFF
--- a/src/script/media/MediaDevicesHandler.ts
+++ b/src/script/media/MediaDevicesHandler.ts
@@ -32,6 +32,7 @@ declare global {
       getSources(options: ElectronGetSourcesOptions, callback: ElectronDesktopCapturerCallback): void;
       // Electron > 4
       getSources(options: ElectronGetSourcesOptions): Promise<ElectronDesktopCapturerSource[]>;
+      getDesktopSources(options: ElectronGetSourcesOptions): Promise<ElectronDesktopCapturerSource[]>;
     };
   }
 }
@@ -265,6 +266,14 @@ export class MediaDevicesHandler {
     };
 
     const getSourcesWrapper = (options: ElectronGetSourcesOptions): Promise<ElectronDesktopCapturerSource[]> => {
+      /**
+       * Electron.desktopCapturer.getSources() is not available from electron 17 anymore
+       * for further info please visit:
+       * https://www.electronjs.org/docs/latest/breaking-changes#removed-desktopcapturergetsources-in-the-renderer
+       */
+      if (window.desktopCapturer.getDesktopSources) {
+        return window.desktopCapturer.getDesktopSources(options);
+      }
       if (window.desktopCapturer.getSources.constructor.name === 'AsyncFunction') {
         // Electron > 4
         return window.desktopCapturer.getSources(options);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1568" title="SQSERVICES-1568" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1568</a>  [wire-desktop] Electron 18: Screensharing does not work due to permission denied
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

This PR is needed to enable screen sharing on upgrading to electron 18 in https://github.com/wireapp/wire-desktop/pull/5710