### PR TITLE
runfix: Add close button on AppLock modal [SQSERVICES-1562]

### DIFF
--- a/src/script/page/AppLock.tsx
+++ b/src/script/page/AppLock.tsx
@@ -36,6 +36,7 @@ import {AppLockRepository} from '../user/AppLockRepository';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {ModalsViewModel} from '../view_model/ModalsViewModel';
 import {createRoot} from 'react-dom/client';
+import Icon from 'Components/Icon';
 
 export enum APPLOCK_STATE {
   FORGOT = 'applock.forgot',
@@ -272,6 +273,13 @@ const AppLock: React.FC<AppLockProps> = ({
   return (
     <ModalComponent isShown={isVisible} showLoading={isLoading} onClosed={onClosed} data-uie-name="applock-modal">
       <div className="modal__header">
+        {!isAppLockEnforced && (
+          <button type="button" className="modal__header__button" onClick={onCancelAppLock} data-uie-name="do-close">
+            <span aria-hidden="true">
+              <Icon.Close />
+            </span>
+          </button>
+        )}
         <h2 className="modal__header__title" data-uie-name="applock-modal-header">
           {headerText()}
         </h2>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1562" title="SQSERVICES-1562" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1562</a>  [Web] User cannot close App Lock setup modal
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
continuation of #13028 