### PR TITLE
runfix: Use base-toggle component for admin toggle [ACC-118]

### DIFF
--- a/src/page/template/panel/group-participant-user.htm
+++ b/src/page/template/panel/group-participant-user.htm
@@ -24,11 +24,15 @@
       <!-- ko if: canChangeRole() -->
         <div class="panel__action-item conversation-details__admin" data-uie-name="toggle-admin">
           <group-admin-icon aria-hidden="true" class="panel__action-item__icon"></group-admin-icon>
-          <div class="panel__action-item__text" data-bind="text: t('conversationDetailsGroupAdmin')"></div>
-          <div class="slider">
-            <input class="slider-input" type="checkbox" name="toggle" id="toggle" data-bind="checked: isAdmin">
-            <label class="button-label" for="toggle" data-bind="click: onToggleAdmin, attr: {'data-uie-value': isAdmin() ? 'checked': 'unchecked'}, css:{'disabled': selectedParticipant().isFederated}" data-uie-name="do-toggle-admin"></label>
-          </div>
+          <base-toggle
+            class="modal-style"
+            params="
+              isChecked: isAdmin(),
+              setIsChecked: onToggleAdmin,
+              toggleName: t('conversationDetailsGroupAdmin'),
+              toggleId: 'admin',
+              isDisabled: selectedParticipant().isFederated"
+          ></base-toggle>
         </div>
         <div class="panel__action-item panel__info-text" data-bind="text: t('conversationDetailsGroupAdminInfo')"></div>
       <!-- /ko -->

--- a/src/style/panel/conversation-details.less
+++ b/src/style/panel/conversation-details.less
@@ -43,6 +43,15 @@
     margin: 8px 0;
   }
 
+  &__admin {
+    base-toggle {
+      width: 100%;
+    }
+    .base-toggle {
+      margin-bottom: 0;
+    }
+  }
+
   &__name {
     .heading-h2;
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-118" title="ACC-118" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-118</a>  [Web] Missing toggles
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Fixes automation issues