### PR TITLE
fix(services): Remove extra dot indicator next to guest and services badge (SQSERVICES-1513)

### DIFF
--- a/src/style/content/conversation/title-bar.less
+++ b/src/style/content/conversation/title-bar.less
@@ -19,13 +19,14 @@
 
 .conversation-title-bar {
   .flex-center;
-
   position: relative;
   width: 100%;
   height: @content-title-bar-height;
   padding: 0 8px;
   margin: 0;
   background-color: var(--sidebar-bg);
+
+  list-style-type: none;
 }
 
 .conversation-title-bar-name {

--- a/src/style/content/conversation/title-bar.less
+++ b/src/style/content/conversation/title-bar.less
@@ -25,7 +25,6 @@
   padding: 0 8px;
   margin: 0;
   background-color: var(--sidebar-bg);
-
   list-style-type: none;
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1513" title="SQSERVICES-1513" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1513</a>  [Web] White dot next to banner
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³