### PR TITLE
fix(call): Set AVS to mute false when start a call (SQCALL-551)

### DIFF
--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -694,6 +694,12 @@ export class CallingRepository {
           : Promise.resolve(true);
       const success = await loadPreviewPromise;
       if (success) {
+        /**
+         * Since we might have been on a conference call before, which was started as muted, then we've hung up and started an outgoing call,
+         * we are stuck in muted state so we should call the AVS function setMute(this.wUser, 0) before initiating the call to fix this
+         * Further info: https://wearezeta.atlassian.net/browse/SQCALL-551
+         */
+        this.wCall.setMute(this.wUser, 0);
         this.wCall.start(this.wUser, convId, callType, conversationType, this.callState.cbrEncoding());
         this.sendCallingEvent(EventName.CALLING.INITIATED_CALL, call);
         this.sendCallingEvent(EventName.CONTRIBUTED, call, {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCALL-551" title="SQCALL-551" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQCALL-551</a>  1:1 call, other person cannot hear me
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³
