### PR TITLE
chore: Remove electron config build

### DIFF
--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -316,10 +316,6 @@ jobs:
           conversation: 'b2cc7120-4154-4be4-b0c0-45a8c361c4d1'
           send_text: '${{env.COMMITTER}} broke the "${{env.BRANCH_NAME}}" branch on "${{github.repository}}" with [${{env.TITLE}}](${{env.COMMIT_URL}}) 🌵'
 
-      - name: Build config.js file for desktop
-        if: env.BUILD_DESKTOP == 'true'
-        run: node electron/bin/build-config.js
-
       - name: Upload WebApp artifacts
         if: env.BUILD_DESKTOP == 'true'
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Should have been removed with https://github.com/wireapp/wire-webapp/pull/12860