### PR TITLE
fix: keyboard trapping at conversation title(ACC-75)

### DIFF
--- a/src/script/view_model/content/TitleBarViewModel.ts
+++ b/src/script/view_model/content/TitleBarViewModel.ts
@@ -198,8 +198,8 @@ export class TitleBarViewModel {
     this.showDetails(false);
   };
 
-  readonly pressOnDetails = (event: KeyboardEvent): void => {
-    handleKeyDown(event, this.clickOnDetails);
+  readonly pressOnDetails = (event: KeyboardEvent): boolean => {
+    return handleKeyDown(event, this.clickOnDetails);
   };
 
   readonly clickOnCollectionButton = (): void => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-75" title="ACC-75" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-75</a>  tabbing/focusing issues left
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# fix for keyboard trapping at conversation title

 - This should fix the issue @anette.giesa commented at ACC-75

# What's new in this PR?

### Issues

There are still keyboard traps. For example the user is stuck and can’t tab forward when reaching the conversation title.

### Solutions

- return true from handle key events function of conversation title so that tab events are not swallowed which was preventing moving forward. 

### Testing

#### How to Test

- Pressing tab key should proceed further from conversation title.
- Pressing enter key should open the right menu with personal details.