### PR TITLE
runfix: Dismiss reconnection warning when notification stream is parsed [SQCORE-1312]

### DIFF
--- a/src/script/event/EventRepository.ts
+++ b/src/script/event/EventRepository.ts
@@ -155,6 +155,7 @@ export class EventRepository {
         amplify.publish(WebAppEvents.CONNECTION.ONLINE);
         amplify.publish(WebAppEvents.WARNING.DISMISS, Warnings.TYPE.NO_INTERNET);
         amplify.publish(WebAppEvents.WARNING.DISMISS, Warnings.TYPE.CONNECTIVITY_RECONNECT);
+        amplify.publish(WebAppEvents.WARNING.DISMISS, Warnings.TYPE.CONNECTIVITY_RECOVERY);
       }
     }
   };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCORE-1312" title="SQCORE-1312" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQCORE-1312</a>  After losing connection and reconnecting, the yellow loader never disapears
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Introduced since #13087 