### PR TITLE
fix: Login Page (Auth app) is missing lang attribute(ACC-48)

### DIFF
--- a/src/script/auth/page/Index.tsx
+++ b/src/script/auth/page/Index.tsx
@@ -24,6 +24,7 @@ import React, {useEffect, useState} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import useReactRouter from 'use-react-router';
 import {Config} from '../../Config';
+import '../../localization/Localizer';
 import {indexStrings, logoutReasonStrings} from '../../strings';
 import {QUERY_KEY, ROUTE} from '../route';
 import Page from './Page';


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-48" title="ACC-48" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-48</a>  Login Page (Auth app) is missing lang attribute
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
- Login Page (Auth app) is missing lang attribute

- **PR Description**
  - imported Localizer to run setAppLocale which will set lang attribute 
----

# What's new in this PR?

### Issues

- Login Page (Auth app) is missing lang attribute

### Solutions

- imported Localizer to run setAppLocale(IIFE) which will set the lang attribute at auth page
----

#### How to Test

- After landing at auth page lang attribute should be set and changing browser language page should update this after refreshing the page.


