### PR TITLE
chore: upgrade @wireapp/core

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.9.0",
     "@wireapp/antiscroll-2": "1.3.1",
     "@wireapp/avs": "8.1.17",
-    "@wireapp/core": "27.3.2",
+    "@wireapp/core": "27.3.3",
     "@wireapp/react-ui-kit": "8.1.0",
     "@wireapp/store-engine-dexie": "1.6.10",
     "@wireapp/store-engine-sqleet": "1.7.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3111,10 +3111,10 @@
     logdown "3.3.1"
     rimraf "3.0.2"
 
-"@wireapp/core@27.3.2":
-  version "27.3.2"
-  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-27.3.2.tgz#fe9e5b7e3d7ba0452ecc95f3413fd8e3fd42c990"
-  integrity sha512-ZEWF6+e3bku6/AHTWYFcWnLXAzNCcNVMP50Fmq3mWBlw8KFwTMBIhVTbIV2RwqvKnZiPgQQZhhUgpaau3Q9orA==
+"@wireapp/core@27.3.3":
+  version "27.3.3"
+  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-27.3.3.tgz#6b9b53b663837daa07fd02135f851b5662b9c54e"
+  integrity sha512-S2ea4YydWAG0YaAKZFgPXT/koUq9ohXCYmHg7aEJ94GEfZmFWUX1dRseyFEfvFvaGVyuZ5z5qRxzmmp3vdg1vA==
   dependencies:
     "@types/long" "4.0.1"
     "@types/node" "~14"


### PR DESCRIPTION
Will fix decryption errors when computer reconnects to the internet after a little while (enough for the access token to expire)
see https://github.com/wireapp/wire-web-packages/pull/4285