### PR TITLE
runfix: Make sure last event date is saved when joining conversation

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.9.0",
     "@wireapp/antiscroll-2": "1.3.1",
     "@wireapp/avs": "8.1.17",
-    "@wireapp/core": "27.3.4",
+    "@wireapp/core": "27.3.5",
     "@wireapp/react-ui-kit": "8.1.0",
     "@wireapp/store-engine-dexie": "1.6.10",
     "@wireapp/store-engine-sqleet": "1.7.14",

--- a/src/script/auth/module/action/NotificationAction.ts
+++ b/src/script/auth/module/action/NotificationAction.ts
@@ -42,7 +42,7 @@ export class NotificationAction {
 
   setLastEventDate = (lastEventDate: Date): ThunkAction => {
     return async (dispatch, getState, {core}) => {
-      core.service.notification.setLastEventDate(lastEventDate);
+      await core.service.notification.setLastEventDate(lastEventDate);
     };
   };
 }

--- a/src/script/auth/page/ConversationJoin.tsx
+++ b/src/script/auth/page/ConversationJoin.tsx
@@ -149,6 +149,10 @@ const ConversationJoin = ({
         entropyData && new Uint8Array(entropyData.filter(Boolean).flat()),
       );
       const conversationEvent = await doJoinConversationByCode(conversationKey, conversationCode);
+      /* When we join a conversation, we create the join event before loading the webapp.
+       * That means that when the webapp loads and tries to fetch the notificationStream is will get the join event once again and will try to handle it
+       * Here we set the core's lastEventDate so that it knows that this duplicated event should be skipped
+       */
       await setLastEventDate(new Date(conversationEvent.time));
 
       routeToApp(conversationEvent.conversation, conversationEvent.qualified_conversation.domain);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3111,10 +3111,10 @@
     logdown "3.3.1"
     rimraf "3.0.2"
 
-"@wireapp/core@27.3.4":
-  version "27.3.4"
-  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-27.3.4.tgz#e5f43ed0cbb523a381e9d2a6c50612a5dfa58c0b"
-  integrity sha512-OwcBa3xwbsM6RSlQeUhy1OCF5ppi/eNzJvovB2zq/anBIwMO35BZk+k+oMyq0jjIml7OWJkM5jwu2GDH/OFEDw==
+"@wireapp/core@27.3.5":
+  version "27.3.5"
+  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-27.3.5.tgz#f2f2c59416366c4621e27f08d56c363291bec7f8"
+  integrity sha512-+CNZBLu7Cfxdso66rDuBSSR0wKvC6CFm9PdvPz9h5DsmnGj26bwXb5lOKTimSGI9PoUhfaCFK9JJ3wPkBOfICw==
   dependencies:
     "@types/long" "4.0.1"
     "@types/node" "~14"


### PR DESCRIPTION
When joining a conversation, we create the `conversation join` event before loading the webapp. 
In order to avoid handling this event from the notification stream later on when the webapp loads, we need to keep track of the `conversation join` event time and let the core skip this event when it loads

- [ ] needs https://github.com/wireapp/wire-web-packages/pull/4289