### PR TITLE
runfix: Align content messages and replies

### DIFF
--- a/src/style/content/conversation/message-quote.less
+++ b/src/style/content/conversation/message-quote.less
@@ -1,7 +1,7 @@
 .message-quote {
   position: relative;
   padding-right: @conversation-message-timestamp-width;
-  padding-left: 88px;
+  padding-left: @conversation-message-sender-width + 16;
   margin-bottom: 10px;
   font-size: 14px;
   line-height: 1.5em;
@@ -10,7 +10,7 @@
     position: absolute;
     top: 0;
     bottom: 0;
-    left: 72px;
+    left: @conversation-message-sender-width;
     display: block;
     width: 4px;
     height: 100%;


### PR DESCRIPTION
Quotes and content messages are misaligned since https://github.com/wireapp/wire-webapp/pull/12892

**Before**
![image](https://user-images.githubusercontent.com/1090716/172892597-fbb1215b-d6c0-4588-b3a4-914de4ae0399.png)


**After**
![image](https://user-images.githubusercontent.com/1090716/172892410-e578d06c-b1da-43c4-b7b8-658d99499977.png)

