### PR TITLE
fix: timeout device manager

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -229,7 +229,7 @@
   "chooseHandle.subhead": "Your username helps people find you.",
   "clientItem.passwordPlaceholder": "Password",
   "clientManager.headline": "Remove a device",
-  "clientManager.logout": "Log out",
+  "clientManager.logout": "Cancel process",
   "clientManager.subhead": "Remove one of your other devices to start using {brandName} on this one.",
   "collectionSectionAudio": "Audio messages",
   "collectionSectionFiles": "Files",

--- a/src/script/auth/component/ClientList.tsx
+++ b/src/script/auth/component/ClientList.tsx
@@ -71,6 +71,7 @@ const ClientList = ({
       logger.error(error);
     } finally {
       removeLocalStorage(QUERY_KEY.CONVERSATION_CODE);
+      removeLocalStorage(QUERY_KEY.JOIN_EXPIRES);
       setShowLoading(false);
     }
   };

--- a/src/script/auth/component/ClientList.tsx
+++ b/src/script/auth/component/ClientList.tsx
@@ -60,8 +60,8 @@ const ClientList = ({
   };
 
   const removeClient = async (clientId: string, password?: string) => {
-    const SFAcode = ((await getLocalStorage(QUERY_KEY.CONVERSATION_CODE)) as string) ?? undefined;
     try {
+      const SFAcode = (await getLocalStorage(QUERY_KEY.CONVERSATION_CODE)) ?? undefined;
       setShowLoading(true);
       await doRemoveClient(clientId, password);
       const persist = getLocalStorage(LocalStorageAction.LocalStorageKey.AUTH.PERSIST);

--- a/src/script/auth/page/ClientManager.tsx
+++ b/src/script/auth/page/ClientManager.tsx
@@ -35,6 +35,8 @@ interface Props extends React.HTMLProps<HTMLDivElement> {}
 const ClientManager = ({doGetAllClients, doLogout}: Props & ConnectedProps & DispatchProps) => {
   const {formatMessage: _} = useIntl();
   const SFAcode = localStorage.getItem(QUERY_KEY.CONVERSATION_CODE);
+  const timeRemaining = JSON.parse(localStorage.getItem(QUERY_KEY.JOIN_EXPIRES))?.data ?? Date.now();
+
   useEffect(() => {
     doGetAllClients();
     if (SFAcode) {
@@ -49,10 +51,14 @@ const ClientManager = ({doGetAllClients, doLogout}: Props & ConnectedProps & Dis
   };
 
   // Automatically log the user out if ten minutes passes and they are a 2fa user.
-  const {startTimeout} = useTimeout(() => {
-    localStorage.removeItem(QUERY_KEY.CONVERSATION_CODE);
-    logout();
-  }, 1000 * 60 * 10);
+  const {startTimeout} = useTimeout(
+    () => {
+      localStorage.removeItem(QUERY_KEY.CONVERSATION_CODE);
+      localStorage.removeItem(QUERY_KEY.JOIN_EXPIRES);
+      logout();
+    },
+    timeRemaining - Date.now() > 0 ? timeRemaining - Date.now() : 0,
+  );
 
   return (
     <Page>

--- a/src/script/auth/page/ClientManager.tsx
+++ b/src/script/auth/page/ClientManager.tsx
@@ -22,33 +22,37 @@ import React, {useEffect} from 'react';
 import {useIntl} from 'react-intl';
 import {connect} from 'react-redux';
 import {AnyAction, Dispatch} from 'redux';
-import useReactRouter from 'use-react-router';
 import {Config} from '../../Config';
 import {clientManagerStrings} from '../../strings';
 import ClientList from '../component/ClientList';
 import {actionRoot as ROOT_ACTIONS} from '../module/action/';
 import {RootState, bindActionCreators} from '../module/reducer';
-import {ROUTE} from '../route';
+import {QUERY_KEY} from '../route';
 import Page from './Page';
 
 interface Props extends React.HTMLProps<HTMLDivElement> {}
 
 const ClientManager = ({doGetAllClients, doLogout}: Props & ConnectedProps & DispatchProps) => {
   const {formatMessage: _} = useIntl();
-  const {history} = useReactRouter();
+  const SFAcode = localStorage.getItem(QUERY_KEY.CONVERSATION_CODE);
   useEffect(() => {
     doGetAllClients();
+    if (SFAcode) {
+      startTimeout();
+    }
   }, []);
 
   const logout = async () => {
     try {
       await doLogout();
-      history.push(ROUTE.INDEX);
     } catch (error) {}
   };
 
-  // Automatically log the user out if ten minutes passes.
-  useTimeout(logout, 1000 * 60 * 10);
+  // Automatically log the user out if ten minutes passes and they are a 2fa user.
+  const {startTimeout} = useTimeout(() => {
+    localStorage.removeItem(QUERY_KEY.CONVERSATION_CODE);
+    logout();
+  }, 1000 * 60 * 10);
 
   return (
     <Page>

--- a/src/script/auth/page/ClientManager.tsx
+++ b/src/script/auth/page/ClientManager.tsx
@@ -37,6 +37,16 @@ const ClientManager = ({doGetAllClients, doLogout}: Props & ConnectedProps & Dis
   const SFAcode = localStorage.getItem(QUERY_KEY.CONVERSATION_CODE);
   const timeRemaining = JSON.parse(localStorage.getItem(QUERY_KEY.JOIN_EXPIRES))?.data ?? Date.now();
 
+  // Automatically log the user out if ten minutes passes and they are a 2fa user.
+  const {startTimeout} = useTimeout(
+    () => {
+      localStorage.removeItem(QUERY_KEY.CONVERSATION_CODE);
+      localStorage.removeItem(QUERY_KEY.JOIN_EXPIRES);
+      logout();
+    },
+    timeRemaining - Date.now() > 0 ? timeRemaining - Date.now() : 0,
+  );
+
   useEffect(() => {
     doGetAllClients();
     if (SFAcode) {
@@ -49,16 +59,6 @@ const ClientManager = ({doGetAllClients, doLogout}: Props & ConnectedProps & Dis
       await doLogout();
     } catch (error) {}
   };
-
-  // Automatically log the user out if ten minutes passes and they are a 2fa user.
-  const {startTimeout} = useTimeout(
-    () => {
-      localStorage.removeItem(QUERY_KEY.CONVERSATION_CODE);
-      localStorage.removeItem(QUERY_KEY.JOIN_EXPIRES);
-      logout();
-    },
-    timeRemaining - Date.now() > 0 ? timeRemaining - Date.now() : 0,
-  );
 
   return (
     <Page>

--- a/src/script/auth/page/ClientManager.tsx
+++ b/src/script/auth/page/ClientManager.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {ContainerXS, H1, Link, Muted} from '@wireapp/react-ui-kit';
+import {ContainerXS, H1, Link, Muted, useTimeout} from '@wireapp/react-ui-kit';
 import React, {useEffect} from 'react';
 import {useIntl} from 'react-intl';
 import {connect} from 'react-redux';
@@ -39,12 +39,16 @@ const ClientManager = ({doGetAllClients, doLogout}: Props & ConnectedProps & Dis
   useEffect(() => {
     doGetAllClients();
   }, []);
+
   const logout = async () => {
     try {
       await doLogout();
       history.push(ROUTE.INDEX);
     } catch (error) {}
   };
+
+  // Automatically log the user out if ten minutes passes.
+  useTimeout(logout, 1000 * 60 * 10);
 
   return (
     <Page>

--- a/src/script/auth/page/InitialInvite.tsx
+++ b/src/script/auth/page/InitialInvite.tsx
@@ -48,6 +48,7 @@ import * as LanguageSelector from '../module/selector/LanguageSelector';
 import {pathWithParams} from '../util/urlUtil';
 import Page from './Page';
 import Exception from '../component/Exception';
+import {QUERY_KEY} from '../route';
 
 interface Props extends React.HTMLProps<HTMLDivElement> {}
 
@@ -59,6 +60,7 @@ const InitialInvite = ({
   invite,
   isTeamFlow,
   doFlushDatabase,
+  removeLocalStorage,
 }: Props & ConnectedProps & DispatchProps) => {
   const {formatMessage: _} = useIntl();
   const emailInput = React.useRef<HTMLInputElement>();
@@ -67,6 +69,8 @@ const InitialInvite = ({
 
   const onInviteDone = async () => {
     await doFlushDatabase();
+    // Remove local storage item for 2FA logout if token expires.
+    removeLocalStorage(QUERY_KEY.JOIN_EXPIRES);
     window.location.replace(pathWithParams(EXTERNAL_ROUTE.WEBAPP));
   };
 
@@ -203,6 +207,7 @@ const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) =>
     {
       doFlushDatabase: ROOT_ACTIONS.authAction.doFlushDatabase,
       invite: ROOT_ACTIONS.invitationAction.invite,
+      removeLocalStorage: ROOT_ACTIONS.localStorageAction.deleteLocalStorage,
       resetInviteErrors: ROOT_ACTIONS.invitationAction.resetInviteErrors,
     },
     dispatch,

--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -204,6 +204,7 @@ const Login = ({
             const login: LoginData = {...formLoginData, clientType: loginData.clientType};
             setTwoFactorLoginData(login);
             doSendTwoFactorCode(login.email);
+            doSetLocalStorage(QUERY_KEY.JOIN_EXPIRES, Date.now() + 1000 * 60 * 10);
             break;
           }
           case BackendError.LABEL.CODE_AUTHENTICATION_FAILED: {

--- a/src/script/strings.ts
+++ b/src/script/strings.ts
@@ -855,7 +855,7 @@ export const clientManagerStrings = defineMessages({
     id: 'clientManager.headline',
   },
   logout: {
-    defaultMessage: 'Log out',
+    defaultMessage: 'Cancel process',
     id: 'clientManager.logout',
   },
   subhead: {


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1524
fixing one edge case where the user could be blocked if taking too long to delete a device and they also have a 2fa code (2fa code expires after 10 mins)

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

_Briefly describe the issue you have solved or implemented with this pull request. If the PR contains multiple issues, use a bullet list._

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
