### PR TITLE
fix: giphy modal is not accessible by screen reader(ACC-54)

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -98,6 +98,7 @@
   "accessibility.openConversation": "Open {{name}} conversation",
   "accessibility.rightPanel.GoBack": "Go back",
   "accessibility.rightPanel.close": "Close conversation info",
+  "accessibility.giphyModal.close": "Close conversation info",
   "accountForm.emailPersonalPlaceholder": "you@email.com",
   "accountForm.emailTeamPlaceholder": "you@yourcompany.com",
   "accountForm.namePlaceholder": "Name",

--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -99,6 +99,7 @@
   "accessibility.rightPanel.GoBack": "Go back",
   "accessibility.rightPanel.close": "Close conversation info",
   "accessibility.giphyModal.close": "Close conversation info",
+  "accessibility.giphyModal.loading": "Loading giphy",
   "accountForm.emailPersonalPlaceholder": "you@email.com",
   "accountForm.emailTeamPlaceholder": "you@yourcompany.com",
   "accountForm.namePlaceholder": "Name",

--- a/src/page/template/modal/giphy.htm
+++ b/src/page/template/modal/giphy.htm
@@ -1,4 +1,4 @@
-<div id="giphy-modal" data-bind="with: $root.giphy" class="giphy-modal modal modal-large">
+<div id="giphy-modal" role="dialog" aria-labelledby="giphy-name" data-bind="with: $root.giphy" class="giphy-modal modal modal-large" tabindex="0">
   <div class="modal-content">
     <div class="giphy-modal-header modal-header">
       <!-- ko if: isStateResult() -->
@@ -10,12 +10,14 @@
       <!-- ko ifnot: isResultState() || isStateNoSearchResults() -->
         <span class="giphy-modal-header-button"></span>
       <!-- /ko -->
-      <span class="label-xs" data-bind="text: query" data-uie-name="giphy-query"></span>
-      <span class="button-icon icon-close pull-right" data-bind="click: clickOnClose" data-uie-name="do-close"></span>
+      <span id="giphy-name" class="label-xs" data-bind="text: query" data-uie-name="giphy-query"></span>
+      <button type="button" class="icon-button" data-bind="click: clickOnClose, attr: {'aria-label': t('accessibility.giphyModal.close')}" data-uie-name="do-close-giphy-modal">
+        <close-icon aria-hidden="true"></close-icon>
+      </button>
     </div>
-    <div class="giphy-modal-center modal-center">
+    <div class="giphy-modal-center modal-center" tabindex="0">
       <div class="gif-container-spinner" data-bind="visible: isStateLoading()">
-        <div class="icon-spinner spin"></div>
+        <div class="icon-spinner spin" aria-live="polite" data-bind="attr:{ 'aria-busy': isStateLoading(), 'aria-label': loadingTxt() }"></div>
       </div>
       <div class="gif-container"
            data-bind="foreach: gifs, visible: isResultState(), css: {'gif-container-grid': gifs().length > 1}">
@@ -37,13 +39,15 @@
         <span class="gif-container-error-message" data-bind="text: t('extensionsGiphyNoGifs')"></span>
       </div>
     </div>
-    <div class="giphy-modal-footer modal-footer">
-      <div class="button button-inverted"
-           data-bind="click: clickOnTryAnother, text: t('extensionsGiphyButtonMore'), css: {'button-disabled': gifs().length === 0}"
-           data-uie-name="do-try-another"></div>
-      <div class="button"
-           data-bind="click: clickToSend, text: t('extensionsGiphyButtonOk'), css: {'button-disabled': !selectedGif()}"
-           data-uie-name="do-send-gif"></div>
-    </div>
+    <footer class="giphy-modal-footer modal-footer">
+      <button type="button" class="button button-inverted"
+        data-bind="click: clickOnTryAnother, text: t('extensionsGiphyButtonMore'), attr:{ 'aria-disabled': !hasGifs()},
+        css: {'button-disabled': !hasGifs()}"
+        data-uie-name="do-try-another"></button>
+      <button type="button" class="button"
+        data-bind="click: clickToSend, text: t('extensionsGiphyButtonOk'), attr:{ 'aria-disabled': !selectedGif()},
+        css: {'button-disabled': !selectedGif()}"
+        data-uie-name="do-send-gif"></button>
+    </footer>
   </div>
 </div>

--- a/src/script/ui/Modal.ts
+++ b/src/script/ui/Modal.ts
@@ -65,6 +65,12 @@ export class Modal {
     }
   }
 
+  focus(): void {
+    if (this.modal) {
+      this.modal.focus();
+    }
+  }
+
   hide(callback?: () => void): void {
     this.callOptional(this.beforeHideCallback);
 

--- a/src/script/view_model/content/GiphyViewModel.ts
+++ b/src/script/view_model/content/GiphyViewModel.ts
@@ -24,6 +24,7 @@ import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {Modal} from '../../ui/Modal';
 import {GiphyRepository, Gif} from '../../extension/GiphyRepository';
+import {t} from 'Util/LocalizerUtil';
 
 enum GiphyState {
   DEFAULT = '',
@@ -68,7 +69,9 @@ export class GiphyViewModel {
 
     this.isStateError = ko.pureComputed(() => [GiphyState.ERROR, GiphyState.NO_SEARCH_RESULT].includes(this.state()));
     this.isStateLoading = ko.pureComputed(() => this.state() === GiphyState.LOADING);
-    this.loadingTxt = ko.pureComputed(() => (this.state() === GiphyState.LOADING ? 'Loading gif' : ''));
+    this.loadingTxt = ko.pureComputed(() =>
+      this.state() === GiphyState.LOADING ? t('accessibility.giphyModal.loading') : '',
+    );
     this.isStateResult = ko.pureComputed(() => this.state() === GiphyState.RESULT);
     this.isStateResults = ko.pureComputed(() => this.state() === GiphyState.RESULTS);
     this.isStateNoSearchResults = ko.pureComputed(() => this.state() === GiphyState.NO_SEARCH_RESULT);

--- a/src/script/view_model/content/GiphyViewModel.ts
+++ b/src/script/view_model/content/GiphyViewModel.ts
@@ -44,6 +44,8 @@ export class GiphyViewModel {
   private readonly selectedGif: ko.Observable<Gif>;
   public isStateError: ko.PureComputed<boolean>;
   public isStateLoading: ko.PureComputed<boolean>;
+  public loadingTxt: ko.PureComputed<string>;
+  public hasGifs: ko.PureComputed<boolean>;
   public isStateResult: ko.PureComputed<boolean>;
   public isStateResults: ko.PureComputed<boolean>;
   public isResultState: ko.PureComputed<boolean>;
@@ -66,9 +68,11 @@ export class GiphyViewModel {
 
     this.isStateError = ko.pureComputed(() => [GiphyState.ERROR, GiphyState.NO_SEARCH_RESULT].includes(this.state()));
     this.isStateLoading = ko.pureComputed(() => this.state() === GiphyState.LOADING);
+    this.loadingTxt = ko.pureComputed(() => (this.state() === GiphyState.LOADING ? 'Loading gif' : ''));
     this.isStateResult = ko.pureComputed(() => this.state() === GiphyState.RESULT);
     this.isStateResults = ko.pureComputed(() => this.state() === GiphyState.RESULTS);
     this.isStateNoSearchResults = ko.pureComputed(() => this.state() === GiphyState.NO_SEARCH_RESULT);
+    this.hasGifs = ko.pureComputed(() => this.gifs().length > 0);
 
     this.isResultState = ko.pureComputed(() => {
       return [GiphyState.RESULT, GiphyState.RESULTS].includes(this.state());
@@ -148,6 +152,7 @@ export class GiphyViewModel {
     }
 
     this.modal.show();
+    this.modal.focus();
   };
 
   private readonly clearGifs = (): void => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-54" title="ACC-54" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />ACC-54</a>  Missing loader description (9.3.3.1 / 9.4.1.3)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

BREAKING CHANGE: giphy modal close icon, try another, send button has structural change/data-uie-name updated

----

- The **PR Description**
    - after opening the giphy modal, the modal gets focus now
    - all modal elements are keyboard reachable using tab
    - close button is accessible
    - modal loader is accessible now
    - footer buttons try another and send announce dimmed when disabled
    
----

# What's new in this PR?

### Issues

- giphy modal is not accessible by screen reader. Modal doesn't get focus when opened. Modal elements are not accessible either. 

### Solutions

- followed accessibility principles of a dialogue

### Testing

#### How to Test

- enable voiceover and open the giphy modal then navigate through using keyboard(tab).
