### PR TITLE
fix: correct button alignment in HistoryInfo

### DIFF
--- a/src/script/auth/page/HistoryInfo.tsx
+++ b/src/script/auth/page/HistoryInfo.tsx
@@ -70,14 +70,8 @@ const HistoryInfo = ({hasHistory, clients, currentSelfClient, isNewCurrentSelfCl
             }}
           />
         </Paragraph>
-        {!hasHistory && (
-          <Paragraph center style={{marginBottom: 40}}>
-            <Link href={Config.getConfig().URL.SUPPORT.HISTORY} target="_blank" data-uie-name="do-history-learn-more">
-              {_(historyInfoStrings.learnMore)}
-            </Link>
-          </Paragraph>
-        )}
         <Button
+          style={{margin: 'auto', width: 200}}
           type="button"
           onClick={onContinue}
           data-uie-name="do-history-confirm"
@@ -89,6 +83,13 @@ const HistoryInfo = ({hasHistory, clients, currentSelfClient, isNewCurrentSelfCl
         >
           {_(historyInfoStrings.ok)}
         </Button>
+        {!hasHistory && (
+          <Paragraph center style={{marginTop: 40}}>
+            <Link href={Config.getConfig().URL.SUPPORT.HISTORY} target="_blank" data-uie-name="do-history-learn-more">
+              {_(historyInfoStrings.learnMore)}
+            </Link>
+          </Paragraph>
+        )}
       </ContainerXS>
     </Page>
   );


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

# What's new in this PR?

### Issues

Button in HistoryInfo isn't centered

### Solutions

Center the Button


##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
