### PR TITLE
fix: adjust color of active panel items in dark mode

### DIFF
--- a/src/style/common/mixins.less
+++ b/src/style/common/mixins.less
@@ -384,7 +384,6 @@
   background-color: var(--accent-color-500) !important;
 
   body.theme-dark & {
-    border: 1px solid var(--accent-color-600) !important;
     background-color: var(--accent-color-700) !important;
   }
 }

--- a/src/style/list/conversation-list-cell.less
+++ b/src/style/list/conversation-list-cell.less
@@ -152,6 +152,11 @@ body.theme-dark {
   .conversation-list-cell-description {
     color: var(--gray-20);
   }
+  .conversation-list-cell-name {
+    &--active {
+      color: var(--black);
+    }
+  }
 }
 
 .conversation-list-cell-badge {

--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -83,10 +83,10 @@
 
   &.active {
     .button-active();
-    color: var(--white);
+    color: var(--black);
 
     svg {
-      fill: var(--white);
+      fill: var(--black);
     }
   }
 }

--- a/src/style/list/list.less
+++ b/src/style/list/list.less
@@ -254,9 +254,12 @@ body.theme-dark {
 
     &--active,
     &--active:hover {
-      border: 1px solid var(--accent-color-600) !important;
-      background-color: var(--accent-color-700) !important;
-      color: @white;
+      background-color: var(--accent-color-600) !important;
+      color: var(--black);
+
+      .left-column-icon > svg {
+        fill: var(--black);
+      }
     }
   }
 }


### PR DESCRIPTION
<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-175" title="ACC-175" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-175</a>  Dark Mode | Active Panel Items have the wrong color
  </td></table>

----
#### PR Submission Checklist for internal contributors

# What's new in this PR?

### Issues

![Wire 2022-06-14 at 15-02-29](https://user-images.githubusercontent.com/78490891/173622882-6616c8c9-7761-4d79-bff8-4cd7dc6897de.png)

### Solutions

Adjust color of active panel items in .less files
![Screenshot from 2022-06-14 18-01-11](https://user-images.githubusercontent.com/78490891/173623330-1936ebeb-09c3-4353-aed7-b60067f23651.png)
![Screenshot from 2022-06-14 18-02-21](https://user-images.githubusercontent.com/78490891/173623540-ba83f606-ad70-441c-a437-d34592e7bc9f.png)

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
