### PR TITLE
runfix: correct active panel button colors acc-175

### DIFF
--- a/src/style/common/mixins.less
+++ b/src/style/common/mixins.less
@@ -384,7 +384,7 @@
   background-color: var(--accent-color-500) !important;
 
   body.theme-dark & {
-    background-color: var(--accent-color-700) !important;
+    background-color: var(--accent-color-600) !important;
   }
 }
 

--- a/src/style/content/conversation/title-bar.less
+++ b/src/style/content/conversation/title-bar.less
@@ -43,7 +43,12 @@
     margin: 4px 16px 0 0;
   }
 }
-
+body.theme-dark {
+  .conversation-title-bar-indication-badge {
+    background-color: var(--accent-color-600);
+    color: var(--black) !important;
+  }
+}
 .conversation-title-bar-indication-badge {
   .text-white;
 

--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -79,14 +79,22 @@
       background-color: var(--gray-95);
       outline: 1px solid var(--gray-90);
     }
+    &.active {
+      .button-active();
+      color: var(--black);
+
+      svg {
+        fill: var(--black);
+      }
+    }
   }
 
   &.active {
     .button-active();
-    color: var(--black);
+    color: var(--white);
 
     svg {
-      fill: var(--black);
+      fill: var(--white);
     }
   }
 }

--- a/src/style/list/list.less
+++ b/src/style/list/list.less
@@ -155,7 +155,7 @@ body.theme-dark {
     &--active,
     &--active:hover {
       border-bottom-width: 0 !important;
-      background-color: var(--accent-color-500);
+      background-color: var(--accent-color);
       color: @white;
 
       .left-column-icon > svg {

--- a/src/style/list/start-ui.less
+++ b/src/style/list/start-ui.less
@@ -130,6 +130,11 @@
 }
 
 body.theme-dark {
+  .start-ui-import {
+    .button-reset-default;
+    background-color: var(--accent-color-600);
+    color: var(--black);
+  }
   .start-ui-list-tabs {
     border-bottom-color: var(--gray-70);
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-175" title="ACC-175" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-175</a>  Dark Mode | Active Panel Items have the wrong color
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-161" title="ACC-161" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-161</a>  [Webapp] Incorrect Text Color for Info Banner in Dark Mode
  </td></table>

----
# What's new in this PR?

### Issues

Active panel button color in dark mode was assigned to light mode also
Color value of some active items were stil incorrect
### Solutions

restore the correct style for the light mode
make sure dark mode accent is set to 600
set text color to black for warning badge and people invite in dark mode

![image](https://user-images.githubusercontent.com/78490891/174036999-4e3eb70b-c40b-43d3-b83a-a2a16e48d02a.png)
![image](https://user-images.githubusercontent.com/78490891/174037219-f0356d4b-f686-4ad4-87ad-98822a1a976e.png)
![image](https://user-images.githubusercontent.com/78490891/174037132-0da16dde-5b23-45fc-8444-38d804fd973a.png)


----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
