### PR TITLE
fix: active heart icon is grey, make it red(ACC-160)

### DIFF
--- a/src/style/common/like.less
+++ b/src/style/common/like.less
@@ -54,7 +54,7 @@
 
 .like-button-liked {
   > span {
-    color: var(--gray-70) !important;
+    color: @red-500 !important;
 
     &:last-child {
       .like-transform-mixin(1);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-160" title="ACC-160" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-160</a>  [Webapp] Incorrect Message Action Buttons States
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
- The **PR Description**
  - The "active heart” icon should be red again, currently it is grey
----

# What's new in this PR?

### Issues

-  The "active heart” icon should be red again, currently it is grey

### Solutions

- changed the liked message colour to be red

### Testing

#### How to Test

- like a message, it should be grey. hover and focus colour depends on user profile theme colour. 


