### PR TITLE
runfix: correct font styles acc-156

### DIFF
--- a/src/style/common/typing.less
+++ b/src/style/common/typing.less
@@ -25,8 +25,8 @@
   font-weight: @font-weight-semibold;
 }
 .heading-h3 {
-  font-size: @font-size-small;
-  font-weight: @font-weight-medium;
+  font-size: @font-size-medium;
+  font-weight: @font-weight-semibold;
 }
 .heading-h4 {
   font-size: @font-size-xsmall;

--- a/src/style/components/list/conversation-list-calling-cell.less
+++ b/src/style/components/list/conversation-list-calling-cell.less
@@ -43,8 +43,8 @@
     }
 
     &--join {
+      font-size: @font-size-medium;
       font-weight: @font-weight-bold;
-      text-transform: uppercase;
     }
 
     &--participants {

--- a/src/style/components/list/participant-item.less
+++ b/src/style/components/list/participant-item.less
@@ -109,10 +109,10 @@
         display: flex;
         min-width: 0; // this will ensure that ellipses is working
         height: @avatar-diameter-m;
-        flex-direction: column;
         flex-grow: 1;
-        align-items: flex-start;
-        justify-content: center;
+        align-items: center;
+        justify-content: flex-start;
+        font-size: @font-size-medium!important;
         .text-medium;
       }
 

--- a/src/style/components/list/participant-item.less
+++ b/src/style/components/list/participant-item.less
@@ -112,8 +112,8 @@
         flex-grow: 1;
         align-items: center;
         justify-content: flex-start;
-        font-size: @font-size-medium!important;
-        .text-medium;
+        font-size: @font-size-medium;
+        font-weight: @font-weight-medium;
       }
 
       &__chevron {

--- a/src/style/content/conversation/title-bar.less
+++ b/src/style/content/conversation/title-bar.less
@@ -105,7 +105,7 @@ body.theme-dark {
 }
 
 .conversation-title-bar-name-label {
-  .label-bold-xs;
+  .heading-h3;
   overflow: hidden;
   text-overflow: ellipsis;
   &--wrapper {

--- a/src/style/list/conversation-list-cell.less
+++ b/src/style/list/conversation-list-cell.less
@@ -110,11 +110,12 @@
 
   .availability-state-label {
     .ellipsis-nowrap;
-    .text-medium;
-
     padding-bottom: 2px;
     margin-right: 4px;
     margin-bottom: -2px;
+
+    font-size: @font-size-medium;
+    font-weight: @font-weight-medium;
 
     &--active {
       color: var(--white);
@@ -124,11 +125,11 @@
 
 .conversation-list-cell-name {
   .ellipsis-nowrap;
-  .text-medium;
-
   padding-bottom: 2px;
   margin-right: 4px;
   margin-bottom: -2px;
+  font-size: @font-size-medium;
+  font-weight: @font-weight-medium;
 
   &--active {
     color: var(--white);

--- a/src/style/list/list.less
+++ b/src/style/list/list.less
@@ -77,7 +77,6 @@ body.theme-dark {
 
     display: inline-block;
     text-align: center;
-    text-transform: uppercase;
   }
 }
 
@@ -89,7 +88,6 @@ body.theme-dark {
   max-width: @conversation-list-width - 40px;
   flex-grow: 1;
   text-align: center;
-  text-transform: uppercase;
 }
 
 .left-list-header-close-button {

--- a/src/style/panel/panel.less
+++ b/src/style/panel/panel.less
@@ -370,7 +370,6 @@
 
     &__title {
       .heading-h3;
-      text-transform: uppercase;
 
       &:first-child {
         flex-grow: 1;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-156" title="ACC-156" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-156</a>  [Web] Incorrect Font Size
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

# What's new in this PR?

### Issues

Inconsistent font styles with the Figma file accross the board.
Tickets 156 focuses on the join button, header bar and conversation list
Names in the conversation list were not centered to their avatars

### Solutions

![image](https://user-images.githubusercontent.com/78490891/174278875-9abc9717-1718-4b91-83a6-7cdf8df04772.png)

![image](https://user-images.githubusercontent.com/78490891/174278581-a0613f9d-6dab-4911-b81c-dcc1a44d6236.png)

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
