### PR TITLE
runfix: remove capitalization of preference's titlebars

### DIFF
--- a/src/style/content/preferences.less
+++ b/src/style/content/preferences.less
@@ -24,7 +24,6 @@
 }
 
 .preferences-titlebar {
-  .label-bold-xs;
   .heading-h3;
   .flex-center;
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

# What's new in this PR?

### Issues

The preferences titlebars are capitalized, they shouldn't be in the new design

### Solutions

Remove the class that capitalizes the titlebars

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
