### PR TITLE
runfix: remove close button from locked state acc-172

### DIFF
--- a/src/script/page/AppLock.tsx
+++ b/src/script/page/AppLock.tsx
@@ -272,7 +272,7 @@ const AppLock: React.FC<AppLockProps> = ({
   return (
     <ModalComponent isShown={isVisible} showLoading={isLoading} onClosed={onClosed} data-uie-name="applock-modal">
       <div className="modal__header">
-        {!isAppLockEnforced && (
+        {!isAppLockEnforced && !APPLOCK_STATE.LOCKED && (
           <button type="button" className="modal__header__button" onClick={onCancelAppLock} data-uie-name="do-close">
             <span aria-hidden="true">
               <Icon.Close />

--- a/src/style/common/modal.less
+++ b/src/style/common/modal.less
@@ -194,9 +194,6 @@
   }
 }
 
-.modal-account-new-devices {
-}
-
 // mixings
 .modal-content-anim-close {
   opacity: 0;
@@ -412,11 +409,11 @@
   }
 
   &__input {
-    width: calc(100% + 16px);
+    width: calc(100% - 8px);
     height: 48px;
     padding-left: 12px;
     border: none;
-    margin: 0 -8px;
+    margin: 0 4px;
     background-color: var(--app-bg-secondary);
     border-radius: 4px;
     color: currentColor;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-172" title="ACC-172" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-172</a>  [Web] It is possible to circumvent app lock
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors


# What's new in this PR?

### Issues

User can simply close the applock modal when it requires a passcode if applock is not enforced in team settings.

### Solutions

Add a condition for the close button so it doesn't appear when the app is locked, regardless of team settings.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
