### PR TITLE
runfix: prevent user handle cut-off in sidebars acc-177

### DIFF
--- a/src/style/components/list/participant-item.less
+++ b/src/style/components/list/participant-item.less
@@ -163,7 +163,8 @@
       &__info {
         .ellipsis;
         display: flex;
-        max-width: 100%;
+        width: 100%;
+        justify-content: flex-end;
         margin-top: 4px;
         font-size: 0;
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-177" title="ACC-177" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-177</a>  [Web] User handles are cut off in group participant list
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

### Issues

Handles are cut-off in sidebars

![381aa006-883a-4439-b63f-8993a3860999](https://user-images.githubusercontent.com/78490891/174770701-18dfddd1-46ad-4caf-9042-06ba61615a9b.png)

### Solutions

assign a width of 100% and justify to flex-end

![Screenshot from 2022-06-21 11-40-43](https://user-images.githubusercontent.com/78490891/174771284-ce0ba320-40af-416d-94b9-fa270c190b33.png)


----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
