### PR TITLE
runfix: add autofocus to group creation input acc-178

### DIFF
--- a/src/script/components/TextInput/TextInput.tsx
+++ b/src/script/components/TextInput/TextInput.tsx
@@ -31,6 +31,7 @@ import {
 } from 'Components/TextInput/TextInput.styles';
 
 export interface UserInputProps {
+  autoFocus?: boolean;
   disabled?: boolean;
   errorMessage?: string;
   isError?: boolean;
@@ -52,6 +53,7 @@ const SUCCESS_DISMISS_TIMEOUT = 2500;
 
 const TextInput: React.ForwardRefRenderFunction<HTMLDivElement, UserInputProps> = (
   {
+    autoFocus,
     disabled,
     errorMessage,
     isError,
@@ -96,7 +98,9 @@ const TextInput: React.ForwardRefRenderFunction<HTMLDivElement, UserInputProps> 
         </span>
       )}
 
+      {/* eslint-disable */}
       <input
+        autoFocus={autoFocus}
         className="text-input"
         css={getInputCSS(disabled, changedColor)}
         disabled={disabled}
@@ -109,6 +113,7 @@ const TextInput: React.ForwardRefRenderFunction<HTMLDivElement, UserInputProps> 
         placeholder={placeholder}
         data-uie-name={uieName}
       />
+      {/* eslint-enable */}
       <label className="label-medium" css={getLabelCSS(changedColor)} htmlFor={name}>
         {label}
       </label>

--- a/src/script/page/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/page/Modals/GroupCreation/GroupCreationModal.tsx
@@ -44,7 +44,7 @@ import {User} from '../../../entity/User';
 import {ACCESS_STATE} from '../../../conversation/AccessState';
 import Icon from 'Components/Icon';
 import {t} from 'Util/LocalizerUtil';
-import {onEscKey, offEscKey} from 'Util/KeyboardUtil';
+import {onEscKey, offEscKey, KEY} from 'Util/KeyboardUtil';
 import {
   ACCESS_TYPES,
   teamPermissionsForAccessState,
@@ -319,11 +319,12 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
             )}
           </div>
         )}
-
+        {/* eslint-disable */}
         {stateIsPreferences && (
           <>
             <div className="modal-input-wrapper">
               <TextInputForwarded
+                autoFocus
                 label={t('groupCreationPreferencesPlaceholder')}
                 placeholder={t('groupCreationPreferencesPlaceholder')}
                 uieName="enter-group-name"
@@ -336,11 +337,17 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
                   const trimmedName = value.trim();
                   setGroupName(trimmedName);
                 }}
+                onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
+                  if (event.key === KEY.ENTER) {
+                    clickOnNext();
+                  }
+                }}
                 value={groupName}
                 isError={nameError.length > 0}
                 errorMessage={nameError}
               />
             </div>
+            {/* eslint-enable */}
             {isTeam && (
               <>
                 <div


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-178" title="ACC-178" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-178</a>  [Web] No autofocus on group name input when creating a group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----

## Needs review on how to proceed

### Issues

The input for group creation doesn't autofocus and pressing enter doesn't proceed

### Solutions

add the react autoFocus prop to the input

### However

Autofocus shouldn't be used for accessibility reasons, is there a way to control focus that plays nice with screen readers?
Trying to solve the eslint issue by using refs and focus() feels like it's just ignoring the problem.

![Screenshot from 2022-06-21 15-54-35](https://user-images.githubusercontent.com/78490891/174824755-9d2ebf91-81c1-4990-a659-61a8e531c118.png)


----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
