### PR TITLE
runfix: restore close button from applock passcode setup

### DIFF
--- a/src/script/page/AppLock.tsx
+++ b/src/script/page/AppLock.tsx
@@ -272,7 +272,7 @@ const AppLock: React.FC<AppLockProps> = ({
   return (
     <ModalComponent isShown={isVisible} showLoading={isLoading} onClosed={onClosed} data-uie-name="applock-modal">
       <div className="modal__header">
-        {!isAppLockEnforced && !APPLOCK_STATE.LOCKED && (
+        {!isAppLockEnforced && !isAppLockActivated && (
           <button type="button" className="modal__header__button" onClick={onCancelAppLock} data-uie-name="do-close">
             <span aria-hidden="true">
               <Icon.Close />


### PR DESCRIPTION
----

### Issues

I somehow overlooked that the close button was removed from the setup passcode modal and not only the enter passcode one.

### Solutions

use !isAppLockActivated instead of !APPLOCK_STATE.LOCKED as a condition seems to do the trick.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
