### PR TITLE
runfix: add outline to join button when the cell is active acc-156

### DIFF
--- a/src/style/list/conversation-list-cell.less
+++ b/src/style/list/conversation-list-cell.less
@@ -53,6 +53,9 @@
     .conversation-list-cell-right {
       border-bottom: 0 !important;
     }
+    .call-ui__button--join {
+      outline: 1px solid var(--main-color);
+    }
   }
 }
 

--- a/src/style/list/conversation-list-cell.less
+++ b/src/style/list/conversation-list-cell.less
@@ -54,7 +54,7 @@
       border-bottom: 0 !important;
     }
     .call-ui__button--join {
-      outline: 1px solid var(--main-color);
+      outline: 1px solid var(--app-bg-secondary);
     }
   }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-156" title="ACC-156" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-156</a>  [Web] Incorrect Font Size
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----

# What's new in this PR?

### Issues

Join button merges with an active cell if he color is set to green

![Screenshot from 2022-06-17 11-11-34](https://user-images.githubusercontent.com/78490891/175269888-425f656c-a4fd-46cb-a1e4-03839ee6b5f0.png)

### Solutions

add an outline to the join button when the cell is active
![image](https://user-images.githubusercontent.com/78490891/175271586-f8d1a7d5-2528-4de8-88a3-1fda6c6ad8cf.png)
![image](https://user-images.githubusercontent.com/78490891/175271675-3e838460-9394-4aec-8aac-56ed74dda8bf.png)



----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
