### PR TITLE
runfix: remove excessive padding for long titles acc-159

### DIFF
--- a/src/style/content/conversation/title-bar.less
+++ b/src/style/content/conversation/title-bar.less
@@ -16,6 +16,9 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  *
  */
+#show-participants {
+  min-width: 0; //needed for the truncation of long titles to work properly in flex-boxes
+}
 
 .conversation-title-bar {
   .flex-center;
@@ -34,8 +37,8 @@
 
   display: flex;
   height: 100%;
-  flex-direction: column;
   flex-grow: 1;
+  margin-left: 10px;
   cursor: pointer;
   user-select: none;
 
@@ -70,7 +73,6 @@ body.theme-dark {
 .conversation-title-bar-icons,
 .conversation-title-bar-library {
   display: flex;
-  width: 112px;
   height: 100%;
   align-items: center;
 }

--- a/src/style/list/conversation-list-cell.less
+++ b/src/style/list/conversation-list-cell.less
@@ -53,6 +53,9 @@
     .conversation-list-cell-right {
       border-bottom: 0 !important;
     }
+    .call-ui__button--join {
+      outline: 1px solid var(--main-color);
+    }
   }
 }
 

--- a/src/style/list/conversation-list-cell.less
+++ b/src/style/list/conversation-list-cell.less
@@ -54,7 +54,7 @@
       border-bottom: 0 !important;
     }
     .call-ui__button--join {
-      outline: 1px solid var(--main-color);
+      outline: 1px solid var(--app-bg-secondary);
     }
   }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-159" title="ACC-159" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-159</a>  [Webapp] Calling and Conversation UI Issues
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----

# What's new in this PR?

### Issues

Long titles do not truncate properly and there's too much padding to the left

![image](https://user-images.githubusercontent.com/78490891/175295657-18924235-f466-431a-a0ab-f25a4355ea0c.png)


### Solutions

Flexboxes break the normal behavior of truncating text, the fix is to set the parent element's min-margin to 0
The fixed width of the icons wrapper div adds excessive padding

![Screenshot from 2022-06-23 13-11-16](https://user-images.githubusercontent.com/78490891/175296209-92f91919-f8ca-475f-b515-246cbb13d63c.png)

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
