### PR TITLE
runfix: reposition user handle under the username acc-177

### DIFF
--- a/src/script/components/list/ParticipantItem.tsx
+++ b/src/script/components/list/ParticipantItem.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React, {Fragment} from 'react';
+import React from 'react';
 import cx from 'classnames';
 
 import {registerReactComponent, useKoSubscribableChildren} from 'Util/ComponentUtil';
@@ -177,25 +177,23 @@ const ParticipantItem = <UserType extends User | ServiceEntity>(
                   )}
                   {isSelf && <div className="participant-item__content__self-indicator">{selfString}</div>}
                 </div>
-                <div className="participant-item__content__info">
-                  {contentInfoText && (
-                    <Fragment>
-                      <span
-                        className={cx('participant-item__content__username label-username-notext', {
-                          'label-username': hasUsernameInfo,
-                        })}
-                        data-uie-name="status-username"
-                      >
-                        {contentInfoText}
+                {contentInfoText && (
+                  <div className="participant-item__content__info">
+                    <span
+                      className={cx('participant-item__content__username label-username-notext', {
+                        'label-username': hasUsernameInfo,
+                      })}
+                      data-uie-name="status-username"
+                    >
+                      {contentInfoText}
+                    </span>
+                    {hasUsernameInfo && badge && (
+                      <span className="participant-item__content__badge" data-uie-name="status-partner">
+                        {badge}
                       </span>
-                      {hasUsernameInfo && badge && (
-                        <span className="participant-item__content__badge" data-uie-name="status-partner">
-                          {badge}
-                        </span>
-                      )}
-                    </Fragment>
-                  )}
-                </div>
+                    )}
+                  </div>
+                )}
               </div>
               {showDropdown && (
                 <button

--- a/src/style/components/list/participant-item.less
+++ b/src/style/components/list/participant-item.less
@@ -109,9 +109,10 @@
         display: flex;
         min-width: 0; // this will ensure that ellipses is working
         height: @avatar-diameter-m;
+        flex-direction: column;
         flex-grow: 1;
-        align-items: center;
-        justify-content: flex-start;
+        align-items: flex-start;
+        justify-content: center;
         font-size: @font-size-medium;
         font-weight: @font-weight-medium;
       }
@@ -164,7 +165,6 @@
         .ellipsis;
         display: flex;
         width: 100%;
-        justify-content: flex-end;
         margin-top: 4px;
         font-size: 0;
 

--- a/src/style/components/list/participant-item.less
+++ b/src/style/components/list/participant-item.less
@@ -157,6 +157,12 @@
         white-space: nowrap;
       }
 
+      &__username {
+        .ellipsis;
+        max-width: 100%;
+        white-space: nowrap;
+      }
+
       &__self-indicator {
         margin-left: 4px;
       }
@@ -170,11 +176,6 @@
 
         * {
           .subline;
-        }
-
-        &__username {
-          .ellipsis;
-          display: block;
         }
       }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-177" title="ACC-177" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-177</a>  [Web] User handles are cut off in group participant list
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


----

# What's new in this PR?

### Issues
![image](https://user-images.githubusercontent.com/78490891/175310987-63ce1f34-7c92-41d8-ad98-574a676cedd1.png)

- fixing this issue reverts the fix to the username not being properly center in the call UI
- A too long user handle does not truncate properly

### Solutions

- Change flex-direction to column on the relevant wrapper div and adjust align-items and justify-content accordingly
- Solve the call-UI centering issue by preventing an empty div from rendering
- Adjust css for .participant-item__content__username. (there's no distinction between name and username anymore, I kept the 2 classes but the distinction might be obsolete)

![Screenshot from 2022-06-23 15-22-49](https://user-images.githubusercontent.com/78490891/175311542-e0ba9d71-9045-446c-9fb4-2c8bf35fe47d.png)




----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
