### PR TITLE
chore: Put eslint jsx-a11y/interactive-supports-focus rule to error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,7 +46,6 @@
     "sort-keys-fix/sort-keys-fix": "warn",
     "jsx-a11y/click-events-have-key-events": "warn",
     "jsx-a11y/no-static-element-interactions": "warn",
-    "jsx-a11y/interactive-supports-focus": "warn",
     "jsx-a11y/anchor-is-valid": "warn",
     "jsx-a11y/no-noninteractive-element-interactions": "warn",
     "jsx-a11y/media-has-caption": "warn",


### PR DESCRIPTION
Since all the [jsx-a11y/interactive-supports-focus](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/interactive-supports-focus.md) errors have been fixed, we can now put the rule to `error` instead of `warn`