### PR TITLE
chore: add yalc to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ CHANGELOG.md
 node_modules
 npm-debug.log
 yarn-error.log
+.yalc
+yalc.lock


### PR DESCRIPTION


# What's new in this PR?

### Issues

Yalc outside of gitignore makes it cumbersome to use yalc with the ui-kit

### Solutions

add .yalc and yalc.lock to .gitignore
