### PR TITLE
runfix: allow autofocus on group creation's text input acc-178

### DIFF
--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -44,7 +44,7 @@ import {User} from '../../../entity/User';
 import {ACCESS_STATE} from '../../../conversation/AccessState';
 import Icon from 'Components/Icon';
 import {t} from 'Util/LocalizerUtil';
-import {onEscKey, offEscKey, KEY} from 'Util/KeyboardUtil';
+import {onEscKey, offEscKey, handleKeyDown} from 'Util/KeyboardUtil';
 import {
   ACCESS_TYPES,
   teamPermissionsForAccessState,
@@ -339,9 +339,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
                   setGroupName(trimmedName);
                 }}
                 onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
-                  if (event.key === KEY.ENTER) {
-                    clickOnNext();
-                  }
+                  handleKeyDown(event, clickOnNext);
                 }}
                 value={groupName}
                 isError={nameError.length > 0}

--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -320,12 +320,12 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
             )}
           </div>
         )}
-
+        {/* eslint jsx-a11y/no-autofocus : "off" */}
         {stateIsPreferences && (
           <>
             <div className="modal-input-wrapper">
               <TextInputForwarded
-                autofocus
+                autoFocus
                 label={t('groupCreationPreferencesPlaceholder')}
                 placeholder={t('groupCreationPreferencesPlaceholder')}
                 uieName="enter-group-name"

--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -226,6 +226,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
   const participantsActionText = selectedContacts.length
     ? t('groupCreationParticipantsActionCreate')
     : t('groupCreationParticipantsActionSkip');
+  const isInputValid = groupNameLength && !nameError.length;
 
   return (
     <div id="group-creation-modal" className="group-creation__modal">
@@ -280,9 +281,9 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
                 id="group-go-next"
                 className={cx('group-creation__action', {
                   'accent-text': groupNameLength,
-                  enabled: groupNameLength && !nameError.length,
+                  enabled: isInputValid,
                 })}
-                disabled={!groupNameLength || nameError.length > 0}
+                disabled={!isInputValid}
                 type="button"
                 onClick={clickOnNext}
                 aria-label={t('groupCreationPreferencesAction')}

--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -44,7 +44,7 @@ import {User} from '../../../entity/User';
 import {ACCESS_STATE} from '../../../conversation/AccessState';
 import Icon from 'Components/Icon';
 import {t} from 'Util/LocalizerUtil';
-import {onEscKey, offEscKey} from 'Util/KeyboardUtil';
+import {onEscKey, offEscKey, KEY} from 'Util/KeyboardUtil';
 import {
   ACCESS_TYPES,
   teamPermissionsForAccessState,
@@ -282,6 +282,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
                   'accent-text': groupNameLength,
                   enabled: groupNameLength && !nameError.length,
                 })}
+                disabled={!groupNameLength || nameError.length > 0}
                 type="button"
                 onClick={clickOnNext}
                 aria-label={t('groupCreationPreferencesAction')}
@@ -324,6 +325,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
           <>
             <div className="modal-input-wrapper">
               <TextInputForwarded
+                autofocus
                 label={t('groupCreationPreferencesPlaceholder')}
                 placeholder={t('groupCreationPreferencesPlaceholder')}
                 uieName="enter-group-name"
@@ -335,6 +337,11 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
                   const {value} = event.target as HTMLInputElement;
                   const trimmedName = value.trim();
                   setGroupName(trimmedName);
+                }}
+                onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
+                  if (event.key === KEY.ENTER) {
+                    clickOnNext();
+                  }
                 }}
                 value={groupName}
                 isError={nameError.length > 0}

--- a/src/script/components/TextInput/TextInput.tsx
+++ b/src/script/components/TextInput/TextInput.tsx
@@ -31,7 +31,7 @@ import {
 } from 'Components/TextInput/TextInput.styles';
 
 export interface UserInputProps {
-  autofocus?: boolean;
+  autoFocus?: boolean;
   disabled?: boolean;
   errorMessage?: string;
   isError?: boolean;
@@ -53,7 +53,7 @@ const SUCCESS_DISMISS_TIMEOUT = 2500;
 
 const TextInput: React.ForwardRefRenderFunction<HTMLDivElement, UserInputProps> = (
   {
-    autofocus,
+    autoFocus,
     disabled,
     errorMessage,
     isError,
@@ -98,9 +98,9 @@ const TextInput: React.ForwardRefRenderFunction<HTMLDivElement, UserInputProps> 
         </span>
       )}
 
-      {/* eslint-disable */}
+      {/* eslint jsx-a11y/no-autofocus : "off" */}
       <input
-        autoFocus={autofocus}
+        autoFocus={autoFocus}
         className="text-input"
         css={getInputCSS(disabled, changedColor)}
         disabled={disabled}
@@ -113,7 +113,6 @@ const TextInput: React.ForwardRefRenderFunction<HTMLDivElement, UserInputProps> 
         placeholder={placeholder}
         data-uie-name={uieName}
       />
-      {/* eslint-enable */}
       <label className="label-medium" css={getLabelCSS(changedColor)} htmlFor={name}>
         {label}
       </label>

--- a/src/script/components/TextInput/TextInput.tsx
+++ b/src/script/components/TextInput/TextInput.tsx
@@ -31,6 +31,7 @@ import {
 } from 'Components/TextInput/TextInput.styles';
 
 export interface UserInputProps {
+  autofocus?: boolean;
   disabled?: boolean;
   errorMessage?: string;
   isError?: boolean;
@@ -52,6 +53,7 @@ const SUCCESS_DISMISS_TIMEOUT = 2500;
 
 const TextInput: React.ForwardRefRenderFunction<HTMLDivElement, UserInputProps> = (
   {
+    autofocus,
     disabled,
     errorMessage,
     isError,
@@ -96,7 +98,9 @@ const TextInput: React.ForwardRefRenderFunction<HTMLDivElement, UserInputProps> 
         </span>
       )}
 
+      {/* eslint-disable */}
       <input
+        autoFocus={autofocus}
         className="text-input"
         css={getInputCSS(disabled, changedColor)}
         disabled={disabled}
@@ -109,6 +113,7 @@ const TextInput: React.ForwardRefRenderFunction<HTMLDivElement, UserInputProps> 
         placeholder={placeholder}
         data-uie-name={uieName}
       />
+      {/* eslint-enable */}
       <label className="label-medium" css={getLabelCSS(changedColor)} htmlFor={name}>
         {label}
       </label>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-178" title="ACC-178" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-178</a>  [Web] No autofocus on group name input when creating a group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----

## Needs review on how to proceed

> **This issue has been pushed as high priority by Rahil and he confirms that we want the autofocus**

### Issues

- The input for group creation doesn't autofocus and pressing enter doesn't proceed

### Solutions

- Add the react autoFocus prop to the input
- Add an onkeydown event when pressing enter

### However

Autofocus shouldn't be used for accessibility reasons, is there a way to control focus that plays nice with screen readers?
Trying to solve the eslint issue by using refs and focus() feels like it's just ignoring the problem.

![Screenshot from 2022-06-21 15-54-35](https://user-images.githubusercontent.com/78490891/174824755-9d2ebf91-81c1-4990-a659-61a8e531c118.png)

### Compromise

We are discussing allowing the autoFocus React prop only on a case by case basis.

- It's important to rename the input prop "autofocus" to "autoFocus" so it's flagged by eslint in the parent component