### PR TITLE
refactor: rewrite key handler to not accept spacebar acc-178

### DIFF
--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -44,7 +44,7 @@ import {User} from '../../../entity/User';
 import {ACCESS_STATE} from '../../../conversation/AccessState';
 import Icon from 'Components/Icon';
 import {t} from 'Util/LocalizerUtil';
-import {onEscKey, offEscKey, handleKeyDown} from 'Util/KeyboardUtil';
+import {onEscKey, offEscKey, KEY} from 'Util/KeyboardUtil';
 import {
   ACCESS_TYPES,
   teamPermissionsForAccessState,
@@ -340,7 +340,9 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
                   setGroupName(trimmedName);
                 }}
                 onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
-                  handleKeyDown(event, clickOnNext);
+                  if (event.key === KEY.ENTER) {
+                    clickOnNext();
+                  }
                 }}
                 value={groupName}
                 isError={nameError.length > 0}

--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -44,7 +44,7 @@ import {User} from '../../../entity/User';
 import {ACCESS_STATE} from '../../../conversation/AccessState';
 import Icon from 'Components/Icon';
 import {t} from 'Util/LocalizerUtil';
-import {onEscKey, offEscKey, KEY} from 'Util/KeyboardUtil';
+import {onEscKey, offEscKey, handleEnterDown} from 'Util/KeyboardUtil';
 import {
   ACCESS_TYPES,
   teamPermissionsForAccessState,
@@ -340,9 +340,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
                   setGroupName(trimmedName);
                 }}
                 onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
-                  if (event.key === KEY.ENTER) {
-                    clickOnNext();
-                  }
+                  handleEnterDown(event, clickOnNext);
                 }}
                 value={groupName}
                 isError={nameError.length > 0}

--- a/src/script/util/KeyboardUtil.ts
+++ b/src/script/util/KeyboardUtil.ts
@@ -143,6 +143,13 @@ export const handleKeyDown = (event: React.KeyboardEvent<HTMLElement> | Keyboard
   return true;
 };
 
+export const handleEnterDown = (event: React.KeyboardEvent<HTMLElement> | KeyboardEvent, callback: () => void) => {
+  if (event.key === KEY.ENTER) {
+    callback();
+  }
+  return true;
+};
+
 const handleDebugKey = () => {
   const removeDebugInfo = (els: NodeListOf<HTMLElement>) => els.forEach(el => el.parentNode.removeChild(el));
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-178" title="ACC-178" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-178</a>  [Web] No autofocus on group name input when creating a group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


----

# What's new in this PR?

### Issues

handleKeyDown validates input on spacebar press

### Solutions

Change the handler to only validate input on enter press