### PR TITLE
feat : pass a darkMode boolean to the theme

### DIFF
--- a/src/script/page/MainContent/MainContent.tsx
+++ b/src/script/page/MainContent/MainContent.tsx
@@ -70,7 +70,9 @@ const MainContent: React.FC<LeftSidebarProps> = ({
     general: {
       backgroundColor: 'var(--app-bg)',
       color: 'var(--main-color)',
-      themeColor: 'var(--accent-color)',
+      contrastTextColor: 'var(--text-input-background)',
+      disabledColor: 'var(--text-input-placeholder)',
+      primaryColor: 'var(--accent-color)',
     },
   };
 

--- a/src/script/page/MainContent/MainContent.tsx
+++ b/src/script/page/MainContent/MainContent.tsx
@@ -70,9 +70,12 @@ const MainContent: React.FC<LeftSidebarProps> = ({
     general: {
       backgroundColor: 'var(--app-bg)',
       color: 'var(--main-color)',
+      primaryColor: 'var(--accent-color)',
+    },
+    select: {
       contrastTextColor: 'var(--text-input-background)',
       disabledColor: 'var(--text-input-placeholder)',
-      primaryColor: 'var(--accent-color)',
+      fillColor: 'var(--checkbox-fill-color)',
     },
   };
 

--- a/src/script/page/MainContent/MainContent.tsx
+++ b/src/script/page/MainContent/MainContent.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import {CSSTransition, SwitchTransition} from 'react-transition-group';
 import {registerReactComponent, useKoSubscribableChildren} from 'Util/ComponentUtil';
 
@@ -35,6 +35,8 @@ import {container} from 'tsyringe';
 import {ClientState} from '../../client/ClientState';
 import {UserState} from '../../user/UserState';
 import {StyledApp} from '@wireapp/react-ui-kit';
+import {amplify} from 'amplify';
+import {WebAppEvents} from '@wireapp/webapp-events';
 
 // Ko imported components
 import '../message-list/InputBarControls';
@@ -58,6 +60,21 @@ const MainContent: React.FC<LeftSidebarProps> = ({
   const {state} = useKoSubscribableChildren(contentViewModel, ['state']);
   const {activeConversation} = useKoSubscribableChildren(conversationState, ['activeConversation']);
   const repositories = contentViewModel.repositories;
+  const currentTheme = repositories.properties?.properties.settings.interface.theme;
+
+  const [darkMode, setDarkMode] = useState<boolean>(currentTheme === 'dark');
+
+  const updateTheme = (theme: string) => {
+    setDarkMode(theme === 'dark');
+  };
+
+  useEffect(() => {
+    amplify.subscribe(WebAppEvents.PROPERTIES.UPDATE.INTERFACE.THEME, updateTheme);
+
+    return () => {
+      amplify.unsubscribe(WebAppEvents.PROPERTIES.UPDATE.INTERFACE.THEME, updateTheme);
+    };
+  }, []);
 
   const isFederated = contentViewModel.isFederated;
 
@@ -67,6 +84,7 @@ const MainContent: React.FC<LeftSidebarProps> = ({
       backgroundColorDisabled: 'var(--app-bg)',
       placeholderColor: 'var(--text-input-label)',
     },
+    darkMode: darkMode,
     general: {
       backgroundColor: 'var(--app-bg)',
       color: 'var(--main-color)',

--- a/src/script/page/MainContent/panels/preferences/AVPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/AVPreferences.tsx
@@ -30,6 +30,7 @@ import CameraPreferences from './avPreferences/CameraPreferences';
 import MicrophonePreferences from './avPreferences/MicrophonePreferences';
 import AudioOutPreferences from './avPreferences/AudioOutPreferences';
 import PreferencesPage from './components/PreferencesPage';
+import {Checkbox} from '@wireapp/react-ui-kit';
 
 interface AVPreferencesProps {
   callingRepository: CallingRepository;
@@ -50,6 +51,7 @@ const AVPreferences: React.FC<AVPreferencesProps> = ({
 
   return (
     <PreferencesPage title={t('preferencesAV')}>
+      <Checkbox></Checkbox>
       {deviceSupport.audioInput && (
         <MicrophonePreferences
           {...{devicesHandler, streamHandler}}

--- a/src/style/common/mixins.less
+++ b/src/style/common/mixins.less
@@ -45,7 +45,7 @@
   .setVariables(modal-bg modal-border-color);
   .setVariables(preference-account-input-bg);
   .setVariables(text-input-editing text-input-background text-input-border text-input-border-hover text-input-placeholder text-input-color text-input-alert text-input-disabled text-input-label text-input-success);
-  .setVariables(checkbox-background checkbox-background-selected checkbox-background-disabled checkbox-background-disabled-selected checkbox-border checkbox-border-hover checkbox-border-disabled);
+  .setVariables(checkbox-background checkbox-background-selected checkbox-background-disabled checkbox-background-disabled-selected checkbox-border checkbox-border-hover checkbox-border-disabled checkbox-fill-color);
   .setVariables(message-quote-bg);
   .setVariables(group-creation-modal-teamname-input-bg);
 }

--- a/src/style/foundation/themes.less
+++ b/src/style/foundation/themes.less
@@ -73,6 +73,7 @@ body.theme-default {
   @checkbox-border: @gray-80;
   @checkbox-border-hover: @blue-500;
   @checkbox-border-disabled: @gray-60;
+  @checkbox-fill-color: '%23FFF';
 
   // ----------------------------------------------------------------------------
   // Message Quote Vertical Bar
@@ -148,6 +149,7 @@ body.theme-dark {
   @checkbox-border: @gray-80;
   @checkbox-border-hover: @blue-dark-500;
   @checkbox-border-disabled: @gray-80;
+  @checkbox-fill-color: '%23000';
 
   // ----------------------------------------------------------------------------
   // Message Quote Vertical Bar

--- a/src/style/foundation/themes.less
+++ b/src/style/foundation/themes.less
@@ -73,7 +73,7 @@ body.theme-default {
   @checkbox-border: @gray-80;
   @checkbox-border-hover: @blue-500;
   @checkbox-border-disabled: @gray-60;
-  @checkbox-fill-color: '%23FFF';
+  @checkbox-fill-color: 'black';
 
   // ----------------------------------------------------------------------------
   // Message Quote Vertical Bar
@@ -149,7 +149,7 @@ body.theme-dark {
   @checkbox-border: @gray-80;
   @checkbox-border-hover: @blue-dark-500;
   @checkbox-border-disabled: @gray-80;
-  @checkbox-fill-color: '%23000';
+  @checkbox-fill-color: 'white';
 
   // ----------------------------------------------------------------------------
   // Message Quote Vertical Bar


### PR DESCRIPTION
I couldn't find a way to pass css variables to inline svgs in the ui-kit
pass a darkMode boolean instead