### PR TITLE
runfix: address eslint jsx-a11y warnings (#ACC-183 and #ACC-184)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,10 +44,6 @@
     "jest/no-disabled-tests": "warn",
     "jest/no-conditional-expect": "warn",
     "sort-keys-fix/sort-keys-fix": "warn",
-    "jsx-a11y/click-events-have-key-events": "warn",
-    "jsx-a11y/no-static-element-interactions": "warn",
-    "jsx-a11y/anchor-is-valid": "warn",
-    "jsx-a11y/no-noninteractive-element-interactions": "warn",
     "jsx-a11y/media-has-caption": "warn",
     "react/react-in-jsx-scope": "off"
   },

--- a/src/script/components/CopyToClipboard.tsx
+++ b/src/script/components/CopyToClipboard.tsx
@@ -19,24 +19,30 @@
 
 import React from 'react';
 import {registerReactComponent} from 'Util/ComponentUtil';
+import {handleKeyDown} from 'Util/KeyboardUtil';
 
 export interface CopyToClipboardProps {
   text: string;
 }
 
 const CopyToClipboard: React.FC<CopyToClipboardProps> = ({text}) => {
+  const onClick = ({currentTarget}: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    if (window.getSelection) {
+      const selectionRange = document.createRange();
+      selectionRange.selectNode(currentTarget);
+      window.getSelection().removeAllRanges();
+      window.getSelection().addRange(selectionRange);
+    }
+  };
+
   return (
     <div
+      role="button"
+      tabIndex={0}
       data-uie-name="copy-to-clipboard"
       className="copy-to-clipboard"
-      onClick={({currentTarget}) => {
-        if (window.getSelection) {
-          const selectionRange = document.createRange();
-          selectionRange.selectNode(currentTarget);
-          window.getSelection().removeAllRanges();
-          window.getSelection().addRange(selectionRange);
-        }
-      }}
+      onClick={onClick}
+      onKeyDown={e => handleKeyDown(e, onClick.bind(null, e))}
     >
       {text}
     </div>

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageFooterLike.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageFooterLike.tsx
@@ -45,6 +45,7 @@ const MessageFooterLike: React.FC<MessageFooterLikeProps> = ({message, is1to1Con
         <MessageLike className="like-button" message={message} onLike={onLike} />
       </div>
       <button
+        type="button"
         className={cx('button-reset-default', 'message-footer-label', {
           'cursor-pointer': !is1to1Conversation,
         })}

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageFooterLike.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageFooterLike.tsx
@@ -44,8 +44,8 @@ const MessageFooterLike: React.FC<MessageFooterLikeProps> = ({message, is1to1Con
       <div className="message-footer-icon">
         <MessageLike className="like-button" message={message} onLike={onLike} />
       </div>
-      <div
-        className={cx('message-footer-label', {
+      <button
+        className={cx('button-reset-default', 'message-footer-label', {
           'cursor-pointer': !is1to1Conversation,
         })}
         onClick={is1to1Conversation ? null : () => onClickLikes(message)}
@@ -53,7 +53,7 @@ const MessageFooterLike: React.FC<MessageFooterLikeProps> = ({message, is1to1Con
         <span className="message-footer-text" data-uie-name="message-liked-names" data-uie-value={reactionsUserIds}>
           {likeCaption}
         </span>
-      </div>
+      </button>
     </div>
   );
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageQuote.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageQuote.tsx
@@ -42,6 +42,7 @@ import FileAssetComponent from './asset/FileAssetComponent';
 import LocationAsset from './asset/LocationAsset';
 import useEffectRef from 'Util/useEffectRef';
 import {Text} from 'src/script/entity/message/Text';
+import {handleKeyDown} from 'Util/KeyboardUtil';
 
 export interface QuoteProps {
   conversation: Conversation;
@@ -181,9 +182,13 @@ const QuotedMessage: React.FC<QuotedMessageProps> = ({
   return (
     <>
       <div className="message-quote__sender">
-        <span onClick={() => showUserDetails(quotedUser)} data-uie-name="label-name-quote">
+        <button
+          className="button-reset-default"
+          onClick={() => showUserDetails(quotedUser)}
+          data-uie-name="label-name-quote"
+        >
           {headerSenderName}
-        </span>
+        </button>
         {was_edited && (
           <span data-uie-name="message-edited-quote" title={quotedMessage.displayEditedTimestamp()}>
             <Icon.Edit />
@@ -206,19 +211,22 @@ const QuotedMessage: React.FC<QuotedMessageProps> = ({
           {asset.isText() && (
             <>
               <div
+                role="button"
+                tabIndex={0}
                 className={cx('message-quote__text', {
                   'message-quote__text--full': showFullText,
                   'message-quote__text--large': includesOnlyEmojis(asset.text),
                 })}
                 ref={setTextQuoteElement}
                 onClick={event => handleClickOnMessage(asset, event)}
+                onKeyDown={event => handleKeyDown(event, handleClickOnMessage.bind(this, asset, event))}
                 dangerouslySetInnerHTML={{__html: asset.render(selfId)}}
                 dir="auto"
                 data-uie-name="media-text-quote"
               />
               {canShowMore && (
-                <div
-                  className="message-quote__text__show-more"
+                <button
+                  className="button-reset-default message-quote__text__show-more"
                   onClick={() => setShowFullText(!showFullText)}
                   data-uie-name="do-show-more-quote"
                 >
@@ -228,7 +236,7 @@ const QuotedMessage: React.FC<QuotedMessageProps> = ({
                       'upside-down': showFullText,
                     })}
                   />
-                </div>
+                </button>
               )}
             </>
           )}
@@ -257,8 +265,8 @@ const QuotedMessage: React.FC<QuotedMessageProps> = ({
           {asset.isLocation() && <LocationAsset asset={asset} data-uie-name="media-location-quote" />}
         </React.Fragment>
       ))}
-      <div
-        className="message-quote__timestamp"
+      <button
+        className="button-reset-default message-quote__timestamp"
         onClick={() => {
           if (quotedMessage) {
             focusMessage(quotedMessage.id);
@@ -269,7 +277,7 @@ const QuotedMessage: React.FC<QuotedMessageProps> = ({
         {isBeforeToday(timestamp)
           ? t('replyQuoteTimeStampDate', formatDateNumeral(timestamp))
           : t('replyQuoteTimeStampTime', formatTimeShort(timestamp))}
-      </div>
+      </button>
     </>
   );
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageQuote.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageQuote.tsx
@@ -183,6 +183,7 @@ const QuotedMessage: React.FC<QuotedMessageProps> = ({
     <>
       <div className="message-quote__sender">
         <button
+          type="button"
           className="button-reset-default"
           onClick={() => showUserDetails(quotedUser)}
           data-uie-name="label-name-quote"
@@ -226,6 +227,7 @@ const QuotedMessage: React.FC<QuotedMessageProps> = ({
               />
               {canShowMore && (
                 <button
+                  type="button"
                   className="button-reset-default message-quote__text__show-more"
                   onClick={() => setShowFullText(!showFullText)}
                   data-uie-name="do-show-more-quote"
@@ -266,6 +268,7 @@ const QuotedMessage: React.FC<QuotedMessageProps> = ({
         </React.Fragment>
       ))}
       <button
+        type="button"
         className="button-reset-default message-quote__timestamp"
         onClick={() => {
           if (quotedMessage) {

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/AssetLoader.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/AssetLoader.tsx
@@ -20,6 +20,7 @@
 import React from 'react';
 
 import Icon from '../../../../Icon';
+import {handleKeyDown} from 'Util/KeyboardUtil';
 
 export interface AssetLoaderProps {
   large?: boolean;
@@ -38,7 +39,14 @@ const AssetLoader: React.FC<AssetLoaderProps> = ({large, loadProgress, onCancel}
   };
 
   return (
-    <div className="media-button" onClick={onClick} data-uie-name="status-loading-media">
+    <div
+      role="button"
+      tabIndex={0}
+      className="media-button"
+      onClick={onClick}
+      onKeyDown={e => handleKeyDown(e, onClick.bind(null, e))}
+      data-uie-name="status-loading-media"
+    >
       <svg aria-hidden="true" viewBox={viewBox} data-uie-name="asset-loader-svg">
         <circle
           className="accent-stroke"

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/LinkPreviewAssetComponent.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/LinkPreviewAssetComponent.tsx
@@ -30,6 +30,7 @@ import Image from 'Components/Image';
 import AssetHeader from './AssetHeader';
 import type {ContentMessage} from '../../../../../entity/message/ContentMessage';
 import type {Text} from '../../../../../entity/message/Text';
+import {handleKeyDown} from 'Util/KeyboardUtil';
 
 export interface LinkPreviewAssetProps {
   /** Does the asset have a visible header? */
@@ -73,7 +74,13 @@ const LinkPreviewAssetComponent: React.FC<LinkPreviewAssetProps> = ({header = fa
       </div>
     </div>
   ) : (
-    <div className="link-preview-asset" onClick={onClick}>
+    <div
+      role="button"
+      tabIndex={0}
+      className="link-preview-asset"
+      onClick={onClick}
+      onKeyDown={e => handleKeyDown(e, onClick)}
+    >
       <div className="link-preview-image-container">
         {preview && previewImage ? (
           <Image className="link-preview-image" asset={previewImage} data-uie-name="link-preview-image" />

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MessageButton.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MessageButton.tsx
@@ -46,6 +46,7 @@ const MessageButton: React.FC<MessageButtonProps> = ({id, label, message, onClic
   return (
     <>
       <button
+        type="button"
         className={classNames('message-button', {
           'message-button--selected': isSelected,
         })}

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/controls/MediaButton.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/controls/MediaButton.tsx
@@ -76,6 +76,7 @@ const MediaButton: React.FC<MediaButtonProps> = ({
     >
       {isUploaded && !isPlaying && mediaElement && (
         <button
+          type="button"
           className="button-reset-default media-button media-button-play icon-play"
           onClick={play}
           data-uie-name="do-play-media"
@@ -83,6 +84,7 @@ const MediaButton: React.FC<MediaButtonProps> = ({
       )}
       {isUploaded && isPlaying && (
         <button
+          type="button"
           className="button-reset-default media-button media-button-pause icon-pause"
           onClick={pause}
           data-uie-name="do-pause-media"

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/controls/MediaButton.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/controls/MediaButton.tsx
@@ -75,10 +75,18 @@ const MediaButton: React.FC<MediaButtonProps> = ({
       })}
     >
       {isUploaded && !isPlaying && mediaElement && (
-        <div className="media-button media-button-play icon-play" onClick={play} data-uie-name="do-play-media" />
+        <button
+          className="button-reset-default media-button media-button-play icon-play"
+          onClick={play}
+          data-uie-name="do-play-media"
+        />
       )}
       {isUploaded && isPlaying && (
-        <div className="media-button media-button-pause icon-pause" onClick={pause} data-uie-name="do-pause-media" />
+        <button
+          className="button-reset-default media-button media-button-pause icon-pause"
+          onClick={pause}
+          data-uie-name="do-pause-media"
+        />
       )}
       {isDownloading && <AssetLoader large={large} loadProgress={unwrappedAsset.downloadProgress} onCancel={cancel} />}
       {isUploading && <AssetLoader large={large} loadProgress={uploadProgress} onCancel={cancel} />}

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
@@ -41,6 +41,7 @@ import {StatusType} from '../../../../../message/StatusType';
 import {includesOnlyEmojis} from 'Util/EmojiUtil';
 import {ContentMessage} from 'src/script/entity/message/ContentMessage';
 import {MessageActions} from '../..';
+import {handleKeyDown} from 'Util/KeyboardUtil';
 
 const ContentAsset = ({
   asset,
@@ -64,14 +65,17 @@ const ContentAsset = ({
         <>
           {(asset as Text).should_render_text() && (
             <div
+              role="button"
+              tabIndex={0}
               className={`text ${includesOnlyEmojis((asset as Text).text) ? 'text-large' : ''} ${
                 status === StatusType.SENDING ? 'text-foreground' : ''
               } ${isObfuscated ? 'ephemeral-message-obfuscated' : ''}`}
               dangerouslySetInnerHTML={{__html: (asset as Text).render(selfId, message.accent_color())}}
               onClick={event => onClickMessage(asset as Text, event)}
+              onKeyDown={event => handleKeyDown(event, onClickMessage.bind(this, asset as Text, event))}
               onAuxClick={event => onClickMessage(asset as Text, event)}
               dir="auto"
-            ></div>
+            />
           )}
           {(asset as Text).previews().map(preview => (
             <div key={preview.url} className="message-asset">

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
@@ -72,7 +72,7 @@ const ContentAsset = ({
               } ${isObfuscated ? 'ephemeral-message-obfuscated' : ''}`}
               dangerouslySetInnerHTML={{__html: (asset as Text).render(selfId, message.accent_color())}}
               onClick={event => onClickMessage(asset as Text, event)}
-              onKeyDown={event => handleKeyDown(event, onClickMessage.bind(this, asset as Text, event))}
+              onKeyDown={event => handleKeyDown(event, onClickMessage.bind(null, asset as Text, event))}
               onAuxClick={event => onClickMessage(asset as Text, event)}
               dir="auto"
             />

--- a/src/script/components/MessagesList/Message/DecryptErrorMessage.tsx
+++ b/src/script/components/MessagesList/Message/DecryptErrorMessage.tsx
@@ -79,6 +79,7 @@ const DecryptErrorMessage: React.FC<DecryptErrorMessageProps> = ({message, onCli
               <Icon.Loading className="accent-fill" data-uie-name="status-loading" />
             ) : (
               <button
+                type="button"
                 className="button-reset-default message-header-decrypt-reset-session-action button-label accent-text"
                 onClick={() => onClickResetSession(message)}
                 data-uie-name="do-reset-encryption-session"

--- a/src/script/components/MessagesList/Message/DecryptErrorMessage.tsx
+++ b/src/script/components/MessagesList/Message/DecryptErrorMessage.tsx
@@ -78,13 +78,13 @@ const DecryptErrorMessage: React.FC<DecryptErrorMessageProps> = ({message, onCli
             {isResettingSession ? (
               <Icon.Loading className="accent-fill" data-uie-name="status-loading" />
             ) : (
-              <span
-                className="message-header-decrypt-reset-session-action button-label accent-text"
+              <button
+                className="button-reset-default message-header-decrypt-reset-session-action button-label accent-text"
                 onClick={() => onClickResetSession(message)}
                 data-uie-name="do-reset-encryption-session"
               >
                 {t('conversationUnableToDecryptResetSession')}
-              </span>
+              </button>
             )}
           </div>
         )}

--- a/src/script/components/MessagesList/Message/LegalHoldMessage.tsx
+++ b/src/script/components/MessagesList/Message/LegalHoldMessage.tsx
@@ -48,9 +48,9 @@ const LegalHoldMessage: React.FC<LegalHoldMessageProps> = ({
         {message.isActivationMessage ? (
           <>
             <span data-uie-name="status-legalhold-activated">{t('legalHoldActivated')}</span>
-            <span className="message-header-label__learn-more" onClick={showLegalHold}>
+            <button className="button-reset-default message-header-label__learn-more" onClick={showLegalHold}>
               {t('legalHoldActivatedLearnMore')}
-            </span>
+            </button>
           </>
         ) : (
           <span className="message-header-label" data-uie-name="status-legalhold-deactivated">

--- a/src/script/components/MessagesList/Message/LegalHoldMessage.tsx
+++ b/src/script/components/MessagesList/Message/LegalHoldMessage.tsx
@@ -48,7 +48,11 @@ const LegalHoldMessage: React.FC<LegalHoldMessageProps> = ({
         {message.isActivationMessage ? (
           <>
             <span data-uie-name="status-legalhold-activated">{t('legalHoldActivated')}</span>
-            <button className="button-reset-default message-header-label__learn-more" onClick={showLegalHold}>
+            <button
+              type="button"
+              className="button-reset-default message-header-label__learn-more"
+              onClick={showLegalHold}
+            >
               {t('legalHoldActivatedLearnMore')}
             </button>
           </>

--- a/src/script/components/MessagesList/Message/MemberMessage.tsx
+++ b/src/script/components/MessagesList/Message/MemberMessage.tsx
@@ -112,7 +112,6 @@ const MemberMessage: React.FC<MemberMessageProps> = ({
               <h2 className="message-group-creation-header-name">{name}</h2>
             </div>
           )}
-
           {hasUsers && (
             <div className="message-header">
               <div className="message-header-icon message-header-icon--svg text-foreground">
@@ -140,17 +139,16 @@ const MemberMessage: React.FC<MemberMessageProps> = ({
               {t('conversationServicesWarning')}
             </div>
           )}
-
           {isGroupCreation && shouldShowInvitePeople && (
             <div className="message-member-footer">
               <div>{t('guestRoomConversationHead')}</div>
-              <div
+              <button
                 onClick={onClickInvitePeople}
-                className="message-member-footer-button"
+                className="button-reset-default message-member-footer-button"
                 data-uie-name="do-invite-people"
               >
                 {t('guestRoomConversationButton')}
-              </div>
+              </button>
             </div>
           )}
           {isGroupCreation && isSelfTemporaryGuest && (
@@ -170,7 +168,6 @@ const MemberMessage: React.FC<MemberMessageProps> = ({
               </div>
             </div>
           )}
-
           {isMemberLeave && user.isMe && isSelfTemporaryGuest && (
             <div className="message-member-footer">
               <div className="message-member-footer-description">{t('temporaryGuestLeaveDescription')}</div>

--- a/src/script/components/MessagesList/Message/MemberMessage.tsx
+++ b/src/script/components/MessagesList/Message/MemberMessage.tsx
@@ -143,6 +143,7 @@ const MemberMessage: React.FC<MemberMessageProps> = ({
             <div className="message-member-footer">
               <div>{t('guestRoomConversationHead')}</div>
               <button
+                type="button"
                 onClick={onClickInvitePeople}
                 className="button-reset-default message-member-footer-button"
                 data-uie-name="do-invite-people"

--- a/src/script/components/MessagesList/Message/ReadReceiptStatus.test.tsx
+++ b/src/script/components/MessagesList/Message/ReadReceiptStatus.test.tsx
@@ -29,7 +29,7 @@ class ReadReceiptStatusPage extends TestPage<ReadReceiptStatusProps> {
     super(ReadReceiptStatus, props);
   }
 
-  getReadReceiptStatus = () => this.get('span[data-uie-name="status-message-read-receipts"]');
+  getReadReceiptStatus = () => this.get('button[data-uie-name="status-message-read-receipts"]');
   getReadReceiptStatusCount = () => this.get('span[data-uie-name="status-message-read-receipt-count"]');
   getReadReceiptStatusDelivered = () => this.get('span[data-uie-name="status-message-read-receipt-delivered"]');
   getReadIcon = () => this.get('[data-uie-name=status-message-read-receipts]');

--- a/src/script/components/MessagesList/Message/ReadReceiptStatus.tsx
+++ b/src/script/components/MessagesList/Message/ReadReceiptStatus.tsx
@@ -68,6 +68,7 @@ const ReadReceiptStatus: React.FC<ReadReceiptStatusProps> = ({
       )}
       {showEyeIndicator && (
         <button
+          type="button"
           className={cx('button-reset-default', 'message-status-read', {
             'message-status-read--clickable': !is1to1Conversation,
             'message-status-read--visible': isLastDeliveredMessage,

--- a/src/script/components/MessagesList/Message/ReadReceiptStatus.tsx
+++ b/src/script/components/MessagesList/Message/ReadReceiptStatus.tsx
@@ -67,8 +67,8 @@ const ReadReceiptStatus: React.FC<ReadReceiptStatusProps> = ({
         </span>
       )}
       {showEyeIndicator && (
-        <span
-          className={cx('message-status-read', {
+        <button
+          className={cx('button-reset-default', 'message-status-read', {
             'message-status-read--clickable': !is1to1Conversation,
             'message-status-read--visible': isLastDeliveredMessage,
             'with-tooltip with-tooltip--receipt': readReceiptTooltip,
@@ -81,7 +81,7 @@ const ReadReceiptStatus: React.FC<ReadReceiptStatusProps> = ({
           <span className="message-status-read__count" data-uie-name="status-message-read-receipt-count">
             {readReceiptText}
           </span>
-        </span>
+        </button>
       )}
     </>
   );

--- a/src/script/components/MessagesList/Message/VerificationMessage.tsx
+++ b/src/script/components/MessagesList/Message/VerificationMessage.tsx
@@ -69,11 +69,15 @@ const VerificationMessage: React.FC<VerificationMessageProps> = ({message}) => {
           <>
             <span className="message-header-sender-name">{unsafeSenderName}</span>
             <span className="ellipsis">{t('conversationDeviceUnverified')}</span>
-            <span className="message-verification-action accent-text" onClick={showDevice} data-uie-name="go-devices">
+            <button
+              className="button-reset-default message-verification-action accent-text"
+              onClick={showDevice}
+              data-uie-name="go-devices"
+            >
               {isSelfClient
                 ? t('conversationDeviceYourDevices')
                 : t('conversationDeviceUserDevices', userEntities[0]?.name())}
-            </span>
+            </button>
           </>
         )}
         {isTypeNewDevice && (
@@ -82,18 +86,26 @@ const VerificationMessage: React.FC<VerificationMessageProps> = ({message}) => {
             <span className="ellipsis">
               {hasMultipleUsers ? t('conversationDeviceStartedUsingMany') : t('conversationDeviceStartedUsingOne')}
             </span>
-            <span className="message-verification-action accent-text" onClick={showDevice} data-uie-name="go-devices">
+            <button
+              className="button-reset-default message-verification-action accent-text"
+              onClick={showDevice}
+              data-uie-name="go-devices"
+            >
               {hasMultipleUsers ? t('conversationDeviceNewDeviceMany') : t('conversationDeviceNewDeviceOne')}
-            </span>
+            </button>
           </>
         )}
         {isTypeNewMember && (
           <>
             <span className="ellipsis">{t('conversationDeviceNewPeopleJoined')}</span>
             &nbsp;
-            <span className="message-verification-action accent-text" onClick={showDevice} data-uie-name="go-devices">
+            <button
+              className="button-reset-default message-verification-action accent-text"
+              onClick={showDevice}
+              data-uie-name="go-devices"
+            >
               {t('conversationDeviceNewPeopleJoinedVerify')}
-            </span>
+            </button>
           </>
         )}
         <hr className="message-header-line" />

--- a/src/script/components/MessagesList/Message/VerificationMessage.tsx
+++ b/src/script/components/MessagesList/Message/VerificationMessage.tsx
@@ -70,6 +70,7 @@ const VerificationMessage: React.FC<VerificationMessageProps> = ({message}) => {
             <span className="message-header-sender-name">{unsafeSenderName}</span>
             <span className="ellipsis">{t('conversationDeviceUnverified')}</span>
             <button
+              type="button"
               className="button-reset-default message-verification-action accent-text"
               onClick={showDevice}
               data-uie-name="go-devices"
@@ -87,6 +88,7 @@ const VerificationMessage: React.FC<VerificationMessageProps> = ({message}) => {
               {hasMultipleUsers ? t('conversationDeviceStartedUsingMany') : t('conversationDeviceStartedUsingOne')}
             </span>
             <button
+              type="button"
               className="button-reset-default message-verification-action accent-text"
               onClick={showDevice}
               data-uie-name="go-devices"
@@ -100,6 +102,7 @@ const VerificationMessage: React.FC<VerificationMessageProps> = ({message}) => {
             <span className="ellipsis">{t('conversationDeviceNewPeopleJoined')}</span>
             &nbsp;
             <button
+              type="button"
               className="button-reset-default message-verification-action accent-text"
               onClick={showDevice}
               data-uie-name="go-devices"

--- a/src/script/components/MessagesList/Message/memberMessage/ConnectedMessage.tsx
+++ b/src/script/components/MessagesList/Message/memberMessage/ConnectedMessage.tsx
@@ -62,6 +62,7 @@ const ConnectedMessage: React.FC<ConnectedMessageProps> = ({
       />
       {isOutgoingRequest && (
         <button
+          type="button"
           className="button-reset-default message-connected-cancel accent-text"
           onClick={onClickCancelRequest}
           data-uie-name="do-cancel-request"

--- a/src/script/components/MessagesList/Message/memberMessage/ConnectedMessage.tsx
+++ b/src/script/components/MessagesList/Message/memberMessage/ConnectedMessage.tsx
@@ -61,13 +61,13 @@ const ConnectedMessage: React.FC<ConnectedMessageProps> = ({
         className="message-connected-avatar cursor-default"
       />
       {isOutgoingRequest && (
-        <div
-          className="message-connected-cancel accent-text"
+        <button
+          className="button-reset-default message-connected-cancel accent-text"
           onClick={onClickCancelRequest}
           data-uie-name="do-cancel-request"
         >
           {t('conversationConnectionCancelRequest')}
-        </div>
+        </button>
       )}
       {showServicesWarning && (
         <div className="message-services-warning" data-uie-name="label-services-warning">

--- a/src/script/components/calling/DeviceToggleButton.tsx
+++ b/src/script/components/calling/DeviceToggleButton.tsx
@@ -19,6 +19,7 @@
 
 import React from 'react';
 import {css, SerializedStyles} from '@emotion/react';
+import {handleKeyDown} from 'Util/KeyboardUtil';
 export interface DeviceToggleButtonProps {
   currentDevice: string;
   devices: string[];
@@ -49,9 +50,12 @@ const DeviceToggleButton: React.FC<DeviceToggleButtonProps> = ({currentDevice, d
       `}
     >
       <div
+        role="button"
+        tabIndex={0}
         className="device-toggle-button-indicator"
         data-uie-name="device-toggle-button-indicator"
         onClick={selectNextDevice}
+        onKeyDown={e => handleKeyDown(e, selectNextDevice.bind(null, e))}
         css={{
           display: 'flex',
           marginTop: 8,

--- a/src/script/components/userDevices/DeviceCard.tsx
+++ b/src/script/components/userDevices/DeviceCard.tsx
@@ -28,6 +28,7 @@ import type {ClientEntity} from '../../client/ClientEntity';
 import Icon from '../Icon';
 import LegalHoldDot from '../LegalHoldDot';
 import VerifiedIcon from '../VerifiedIcon';
+import {handleKeyDown} from 'Util/KeyboardUtil';
 
 export interface DeviceCardProps {
   click?: (device: ClientEntity) => void;
@@ -58,8 +59,11 @@ const DeviceCard: React.FC<DeviceCardProps> = ({
 
   return (
     <div
+      role={clickable && 'button'}
+      tabIndex={clickable ? 0 : -1}
       className={cx('device-card', {'device-card__no-hover': !clickable})}
       onClick={clickOnDevice}
+      onKeyDown={e => handleKeyDown(e, clickOnDevice)}
       data-uie-uid={id}
       data-uie-name="device-card"
     >

--- a/src/script/components/userDevices/DeviceDetails.tsx
+++ b/src/script/components/userDevices/DeviceDetails.tsx
@@ -97,18 +97,18 @@ const DeviceDetails: React.FC<DeviceDetailsProps> = ({
 
   return (
     <div className={cx('participant-devices__header', {'participant-devices__header--padding': !noPadding})}>
-      <div
-        className="participant-devices__link participant-devices__show-self-fingerprint accent-text"
+      <button
+        className="button-reset-default participant-devices__link participant-devices__show-self-fingerprint accent-text"
         onClick={clickToShowSelfFingerprint}
       >
         {t('participantDevicesDetailShowMyDevice')}
-      </div>
+      </button>
       <div
         className="panel__info-text"
         dangerouslySetInnerHTML={{
           __html: user ? t('participantDevicesDetailHeadline', {user: userName}) : '',
         }}
-      ></div>
+      />
       <a
         className="participant-devices__link accent-text"
         href={getPrivacyHowUrl()}
@@ -147,14 +147,14 @@ const DeviceDetails: React.FC<DeviceDetailsProps> = ({
             style={{display: isResettingSession ? 'initial' : 'none'}}
             data-uie-name="status-loading"
           />
-          <span
-            className="button-label accent-text ellipsis"
+          <button
+            className="button-reset-default button-label participant-devices__reset-session accent-text ellipsis"
             onClick={clickToResetSession}
             style={{display: isResettingSession ? 'none' : 'initial'}}
             data-uie-name="do-reset-session"
           >
             {t('participantDevicesDetailResetSession')}
-          </span>
+          </button>
         </div>
       </div>
     </div>

--- a/src/script/components/userDevices/DeviceDetails.tsx
+++ b/src/script/components/userDevices/DeviceDetails.tsx
@@ -98,6 +98,7 @@ const DeviceDetails: React.FC<DeviceDetailsProps> = ({
   return (
     <div className={cx('participant-devices__header', {'participant-devices__header--padding': !noPadding})}>
       <button
+        type="button"
         className="button-reset-default participant-devices__link participant-devices__show-self-fingerprint accent-text"
         onClick={clickToShowSelfFingerprint}
       >
@@ -148,6 +149,7 @@ const DeviceDetails: React.FC<DeviceDetailsProps> = ({
             data-uie-name="status-loading"
           />
           <button
+            type="button"
             className="button-reset-default button-label participant-devices__reset-session accent-text ellipsis"
             onClick={clickToResetSession}
             style={{display: isResettingSession ? 'none' : 'initial'}}

--- a/src/script/components/userDevices/SelfFingerprint.tsx
+++ b/src/script/components/userDevices/SelfFingerprint.tsx
@@ -53,6 +53,7 @@ const SelfFingerprint: React.FC<SelfFingerprintProps> = ({
       </div>
       <div>
         <button
+          type="button"
           className="button-reset-default participant-devices__link accent-text"
           onClick={() => amplify.publish(WebAppEvents.PREFERENCES.MANAGE_DEVICES)}
         >

--- a/src/script/components/userDevices/SelfFingerprint.tsx
+++ b/src/script/components/userDevices/SelfFingerprint.tsx
@@ -52,12 +52,12 @@ const SelfFingerprint: React.FC<SelfFingerprintProps> = ({
         <DeviceId deviceId={fingerprintLocal} />
       </div>
       <div>
-        <span
-          className="participant-devices__link accent-text"
+        <button
+          className="button-reset-default participant-devices__link accent-text"
           onClick={() => amplify.publish(WebAppEvents.PREFERENCES.MANAGE_DEVICES)}
         >
           {t('participantDevicesSelfAllDevices')}
-        </span>
+        </button>
       </div>
     </div>
   );

--- a/src/script/page/AccentColorPicker.tsx
+++ b/src/script/page/AccentColorPicker.tsx
@@ -61,17 +61,7 @@ const AccentColorPicker: React.FunctionComponent<AccentColorPickerProps> = ({use
             const isChecked = accentId === id;
 
             return (
-              <div
-                data-uie-name="element-accent-color-label"
-                data-uie-value={id}
-                key={id}
-                css={{
-                  alignItems: 'center',
-                  display: 'flex',
-                  flexDirection: 'column',
-                  justifyContent: 'center',
-                }}
-              >
+              <div data-uie-name="element-accent-color-label" data-uie-value={id} key={id}>
                 <input
                   id={String(id)}
                   type="radio"
@@ -81,51 +71,63 @@ const AccentColorPicker: React.FunctionComponent<AccentColorPickerProps> = ({use
                   data-uie-name="do-set-accent-color"
                   data-uie-value={id}
                   css={{
-                    '& + span': {
+                    '& + label > span:first-child': {
                       color: color,
                       cursor: 'pointer',
                       display: 'inline-block',
                       position: 'relative',
                     },
-                    '& + span::after': {
+                    '& + label > span:first-child::after': {
                       ...CSS_SQUARE(10),
                       background: 'currentColor',
                       left: '-5px',
                       top: '-5px',
                     },
-                    '& + span::before': {
+                    '& + label > span:first-child::before': {
                       ...CSS_SQUARE(16),
                       left: '-8px',
                       top: '-8px',
                     },
-                    '& + span::before, & + span::after': {
+                    '& + label > span:first-child::before, & + label > span:first-child::after': {
                       borderRadius: '50%',
                       content: '""',
                       display: 'inline-block',
                       position: 'absolute',
                       transition: 'all 0.15s ease-out',
                     },
-                    '&:checked + span::after': {
+                    '&:checked + label > span:first-child::after': {
                       left: '-5px',
                       top: '-5px',
                     },
-                    '&:checked + span::before': {
+                    '&:checked + label > span:first-child::before': {
                       border: '1px solid currentColor',
                     },
-                    '&:focus + span::before': {
+                    '&:focus + label > span:first-child::before': {
                       ...CSS_SQUARE(16),
                       outline: '1px solid Highlight',
                     },
                     opacity: 0,
                   }}
                 />
-                <span onClick={() => doSetAccentColor(id)} />
                 <label
                   htmlFor={String(id)}
-                  onClick={() => doSetAccentColor(id)}
-                  style={{cursor: 'pointer', fontSize: '11px', marginTop: '14px', textTransform: 'capitalize'}}
+                  style={{
+                    alignItems: 'center',
+                    cursor: 'pointer',
+                    display: 'flex',
+                    flexDirection: 'column',
+                  }}
                 >
-                  {name}
+                  <span />
+                  <span
+                    style={{
+                      fontSize: '11px',
+                      marginTop: '14px',
+                      textTransform: 'capitalize',
+                    }}
+                  >
+                    {name}
+                  </span>
                 </label>
               </div>
             );

--- a/src/script/page/AppLock.tsx
+++ b/src/script/page/AppLock.tsx
@@ -442,6 +442,7 @@ const AppLock: React.FC<AppLockProps> = ({
             </div>
 
             <button
+              type="button"
               className="button-reset-default block modal__cta"
               data-uie-name="go-forgot-passphrase"
               onClick={onClickForgot}
@@ -467,6 +468,7 @@ const AppLock: React.FC<AppLockProps> = ({
               {t('modalAppLockForgotMessage')}
             </div>
             <button
+              type="button"
               className="button-reset-default block modal__cta"
               onClick={onClickWipe}
               data-uie-name="go-wipe-database"

--- a/src/script/page/AppLock.tsx
+++ b/src/script/page/AppLock.tsx
@@ -290,7 +290,7 @@ const AppLock: React.FC<AppLockProps> = ({
               className="modal__text"
               dangerouslySetInnerHTML={{__html: t('modalAppLockSetupMessage', {}, {br: '<br><br>'})}}
               data-uie-name="label-applock-set-text"
-            ></div>
+            />
             <div className="modal__text modal__label" data-uie-name="label-applock-unlock-text">
               {t('modalAppLockPasscode')}
             </div>
@@ -376,7 +376,7 @@ const AppLock: React.FC<AppLockProps> = ({
                 ),
               }}
               data-uie-name="label-applock-set-text"
-            ></div>
+            />
             <div className="modal__text modal__label" data-uie-name="label-applock-unlock-text">
               {t('modalAppLockPasscode')}
             </div>
@@ -441,9 +441,13 @@ const AppLock: React.FC<AppLockProps> = ({
               {unlockError}
             </div>
 
-            <div className="modal__cta" data-uie-name="go-forgot-passphrase" onClick={onClickForgot}>
+            <button
+              className="button-reset-default block modal__cta"
+              data-uie-name="go-forgot-passphrase"
+              onClick={onClickForgot}
+            >
               {t('modalAppLockLockedForgotCTA')}
-            </div>
+            </button>
 
             <div className="modal__buttons">
               <button
@@ -462,9 +466,13 @@ const AppLock: React.FC<AppLockProps> = ({
             <div className="modal__text" data-uie-name="label-applock-forgot-text">
               {t('modalAppLockForgotMessage')}
             </div>
-            <div className="modal__cta" onClick={onClickWipe} data-uie-name="go-wipe-database">
+            <button
+              className="button-reset-default block modal__cta"
+              onClick={onClickWipe}
+              data-uie-name="go-wipe-database"
+            >
               {t('modalAppLockForgotWipeCTA')}
-            </div>
+            </button>
             <div className="modal__buttons">
               <button
                 onClick={onGoBack}

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
@@ -37,6 +37,7 @@ import GroupAvatar from 'Components/avatar/GroupAvatar';
 import {ContentViewModel} from '../../../../view_model/ContentViewModel';
 import {ConverationViewStyle} from './Conversations';
 import {User} from 'src/script/entity/User';
+import {handleKeyDown} from 'Util/KeyboardUtil';
 
 export const ConversationsList: React.FC<{
   callState: CallState;
@@ -73,6 +74,10 @@ export const ConversationsList: React.FC<{
       return false;
     }
     return !conversation.removed_from_conversation();
+  };
+
+  const onConnectionRequestClick = () => {
+    listViewModel.contentViewModel.switchContent(ContentViewModel.STATE.CONNECTION_REQUESTS);
   };
 
   const conversationView =
@@ -114,34 +119,39 @@ export const ConversationsList: React.FC<{
 
   const connectionRequests =
     connectRequests.length === 0 ? null : (
-      <li
-        className={`conversation-list-cell ${isShowingConnectionRequests ? 'conversation-list-cell-active' : ''}`}
-        onClick={() => listViewModel.contentViewModel.switchContent(ContentViewModel.STATE.CONNECTION_REQUESTS)}
-      >
-        <div className="conversation-list-cell-left">
-          {connectRequests.length === 1 ? (
-            <div className="avatar-halo">
-              <Avatar participant={connectRequests[0]} avatarSize={AVATAR_SIZE.SMALL} />
-            </div>
-          ) : (
-            <GroupAvatar users={connectRequests} />
-          )}
-        </div>
+      <li>
+        <div
+          role="button"
+          tabIndex={0}
+          className={`conversation-list-cell ${isShowingConnectionRequests ? 'conversation-list-cell-active' : ''}`}
+          onClick={onConnectionRequestClick}
+          onKeyDown={e => handleKeyDown(e, onConnectionRequestClick)}
+        >
+          <div className="conversation-list-cell-left">
+            {connectRequests.length === 1 ? (
+              <div className="avatar-halo">
+                <Avatar participant={connectRequests[0]} avatarSize={AVATAR_SIZE.SMALL} />
+              </div>
+            ) : (
+              <GroupAvatar users={connectRequests} />
+            )}
+          </div>
 
-        <div className="conversation-list-cell-center">
-          <span
-            className={`conversation-list-cell-name ${isShowingConnectionRequests ? 'accent-text' : ''}`}
-            data-uie-name="item-pending-requests"
-          >
-            {connectionText}
-          </span>
-        </div>
+          <div className="conversation-list-cell-center">
+            <span
+              className={`conversation-list-cell-name ${isShowingConnectionRequests ? 'accent-text' : ''}`}
+              data-uie-name="item-pending-requests"
+            >
+              {connectionText}
+            </span>
+          </div>
 
-        <div className="conversation-list-cell-right">
-          <span
-            className="conversation-list-cell-badge cell-badge-dark icon-pending"
-            data-uie-name="status-pending"
-          ></span>
+          <div className="conversation-list-cell-right">
+            <span
+              className="conversation-list-cell-badge cell-badge-dark icon-pending"
+              data-uie-name="status-pending"
+            />
+          </div>
         </div>
       </li>
     );

--- a/src/script/page/LeftSidebar/panels/StartUI/components/groupList/GroupListItem.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/components/groupList/GroupListItem.tsx
@@ -25,6 +25,7 @@ import type {Conversation} from '../../../../../../entity/Conversation';
 import {generateConversationUrl} from '../../../../../../router/routeGenerator';
 import {Router} from '../../../../../../router/Router';
 import GroupAvatar from 'Components/avatar/GroupAvatar';
+import {handleKeyDown} from 'Util/KeyboardUtil';
 
 export interface GroupListItemProps {
   assetRepository: AssetRepository;
@@ -40,16 +41,21 @@ const GroupListItem: React.FC<GroupListItemProps> = ({assetRepository, click, gr
     is1to1,
   } = useKoSubscribableChildren(group, ['display_name', 'participating_user_ets', 'is1to1']);
 
+  const onClick = () => {
+    click(group);
+    router.navigate(generateConversationUrl(group.id, group.domain));
+  };
+
   return (
     <div
+      role="button"
+      tabIndex={0}
       key={group.id}
       data-uie-name="item-group"
       className="search-list-item"
       data-uie-uid={`${group.id}`}
-      onClick={() => {
-        click(group);
-        router.navigate(generateConversationUrl(group.id, group.domain));
-      }}
+      onClick={onClick}
+      onKeyDown={e => handleKeyDown(e, onClick)}
       data-uie-value={displayName}
     >
       <div className="search-list-item-image">

--- a/src/script/page/MainContent/panels/preferences/avPreferences/CameraPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/avPreferences/CameraPreferences.tsx
@@ -146,6 +146,7 @@ const CameraPreferences: React.FC<CameraPreferencesProps> = ({
                 }}
               />
               <button
+                type="button"
                 className="button-reset-default preferences-av-video-disabled__try-again"
                 onClick={requestStream}
                 data-uie-name="do-try-again-preferences-av"

--- a/src/script/page/MainContent/panels/preferences/avPreferences/CameraPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/avPreferences/CameraPreferences.tsx
@@ -63,7 +63,7 @@ const CameraPreferences: React.FC<CameraPreferencesProps> = ({
   const requestStream = async () => {
     setIsRequesting(true);
     try {
-      // we should be able to change camera from prefrences page in middle of the call
+      // we should be able to change camera from preferences page in middle of the call
       if (hasActiveCameraStream) {
         const refreshedStream = await refreshStream();
         if (!refreshedStream) {
@@ -126,7 +126,7 @@ const CameraPreferences: React.FC<CameraPreferencesProps> = ({
 
       {isRequesting ? (
         <div className="preferences-av-video-disabled">
-          <div className="icon-spinner spin accent-text"></div>
+          <div className="icon-spinner spin accent-text" />
         </div>
       ) : (
         <>
@@ -144,14 +144,14 @@ const CameraPreferences: React.FC<CameraPreferencesProps> = ({
                       "<a href='https://support.wire.com/hc/articles/202935412' data-uie-name='go-no-camera-faq' target='_blank' rel='noopener noreferrer'>",
                   }),
                 }}
-              ></div>
-              <div
-                className="preferences-av-video-disabled__try-again"
+              />
+              <button
+                className="button-reset-default preferences-av-video-disabled__try-again"
                 onClick={requestStream}
                 data-uie-name="do-try-again-preferences-av"
               >
                 {t('preferencesAVTryAgain')}
-              </div>
+              </button>
             </div>
           )}
         </>

--- a/src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx
@@ -35,6 +35,7 @@ import DetailedDevice from './components/DetailedDevice';
 import DeviceDetailsPreferences from './DeviceDetailsPreferences';
 import {Conversation} from '../../../../../entity/Conversation';
 import {FormattedId} from './components/FormattedId';
+import {handleKeyDown} from 'Util/KeyboardUtil';
 
 interface DevicesPreferencesProps {
   clientState: ClientState;
@@ -55,7 +56,13 @@ const Device: React.FC<{
   const {isVerified} = useKoSubscribableChildren(device.meta, ['isVerified']);
 
   return (
-    <div className="preferences-devices-card" onClick={() => onSelect(device)}>
+    <div
+      role="button"
+      tabIndex={0}
+      className="preferences-devices-card"
+      onClick={() => onSelect(device)}
+      onKeyDown={e => handleKeyDown(e, onSelect.bind(null, device))}
+    >
       <div className="preferences-devices-card-data">
         <div className="preferences-devices-card-icon" data-uie-value={device.id} data-uie-name="device-id">
           <VerifiedIcon data-uie-name={`user-device-${isVerified ? '' : 'not-'}verified`} isVerified={isVerified} />
@@ -87,7 +94,7 @@ const Device: React.FC<{
             <Icon.Delete />
           </button>
         )}
-        <div className="icon-forward preferences-devices-card-action__forward" data-uie-name="go-device-details"></div>
+        <div className="icon-forward preferences-devices-card-action__forward" data-uie-name="go-device-details" />
       </div>
     </div>
   );

--- a/src/script/page/message-list/MentionSuggestions/MentionSuggestionsItem.tsx
+++ b/src/script/page/message-list/MentionSuggestions/MentionSuggestionsItem.tsx
@@ -25,6 +25,7 @@ import Icon from 'Components/Icon';
 import Avatar, {AVATAR_SIZE} from 'Components/Avatar';
 
 import {User} from '../../../entity/User';
+import {handleKeyDown} from 'Util/KeyboardUtil';
 
 type MentionSuggestionsItemProps = {
   isSelected: boolean;
@@ -41,12 +42,18 @@ const MentionSuggestionsItem: React.ForwardRefRenderFunction<HTMLDivElement, Men
     suggestion,
     ['name', 'expirationRemainingText', 'isTemporaryGuest', 'isExternal', 'isDirectGuest'],
   );
+
+  const onClick = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    event.preventDefault();
+    onSuggestionClick();
+  };
+
   return (
     <div
-      onClick={event => {
-        event.preventDefault();
-        onSuggestionClick();
-      }}
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={e => handleKeyDown(e, onClick.bind(null, e))}
       onMouseEnter={onMouseEnter}
       className={cx('mention-suggestion-list__item', {'mention-suggestion-list__item--highlighted': isSelected})}
       data-uie-name="item-mention-suggestion"

--- a/src/script/view_model/WarningsContainer.tsx
+++ b/src/script/view_model/WarningsContainer.tsx
@@ -154,7 +154,7 @@ const WarningsContainer: React.FC = () => {
               ),
             }}
           />
-          <button className="warning-bar-close icon-close button-icon button-reset-default" onClick={closeWarning} />
+          <CloseWarningButton onClick={closeWarning} />
         </div>
       )}
       {visibleWarning === type.DENIED_CAMERA && (
@@ -170,10 +170,7 @@ const WarningsContainer: React.FC = () => {
               {t('warningLearnMore')}
             </a>
           </div>
-          <button
-            className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
-            onClick={closeWarning}
-          />
+          <CloseWarningButton onClick={closeWarning} />
         </div>
       )}
       {visibleWarning === type.REQUEST_MICROPHONE && (
@@ -182,10 +179,7 @@ const WarningsContainer: React.FC = () => {
             <Icon.MicOn className="warning-bar-icon" />
             <span dangerouslySetInnerHTML={{__html: t('warningPermissionRequestMicrophone', {}, {icon: ''})}} />
           </div>
-          <button
-            className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
-            onClick={closeWarning}
-          />
+          <CloseWarningButton onClick={closeWarning} />
         </div>
       )}
       {visibleWarning === type.DENIED_MICROPHONE && (
@@ -201,10 +195,7 @@ const WarningsContainer: React.FC = () => {
               {t('warningLearnMore')}
             </a>
           </div>
-          <button
-            className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
-            onClick={closeWarning}
-          />
+          <CloseWarningButton onClick={closeWarning} />
         </div>
       )}
       {visibleWarning === type.REQUEST_SCREEN && (
@@ -219,7 +210,7 @@ const WarningsContainer: React.FC = () => {
               ),
             }}
           />
-          <button className="warning-bar-close icon-close button-icon button-reset-default" onClick={closeWarning} />
+          <CloseWarningButton onClick={closeWarning} />
         </div>
       )}
       {visibleWarning === type.DENIED_SCREEN && (
@@ -235,10 +226,7 @@ const WarningsContainer: React.FC = () => {
               {t('warningLearnMore')}
             </a>
           </div>
-          <button
-            className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
-            onClick={closeWarning}
-          />
+          <CloseWarningButton onClick={closeWarning} />
         </div>
       )}
       {visibleWarning === type.NOT_FOUND_CAMERA && (
@@ -254,10 +242,7 @@ const WarningsContainer: React.FC = () => {
               {t('warningLearnMore')}
             </a>
           </div>
-          <button
-            className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
-            onClick={closeWarning}
-          />
+          <CloseWarningButton onClick={closeWarning} />
         </div>
       )}
       {visibleWarning === type.NOT_FOUND_MICROPHONE && (
@@ -273,10 +258,7 @@ const WarningsContainer: React.FC = () => {
               {t('warningLearnMore')}
             </a>
           </div>
-          <button
-            className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
-            onClick={closeWarning}
-          />
+          <CloseWarningButton onClick={closeWarning} />
         </div>
       )}
       {visibleWarning === type.REQUEST_NOTIFICATION && (
@@ -291,11 +273,7 @@ const WarningsContainer: React.FC = () => {
               ),
             }}
           />
-          <button
-            className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
-            onClick={closeWarning}
-            data-uie-name="do-close-warning"
-          />
+          <CloseWarningButton onClick={closeWarning} />
         </div>
       )}
       {visibleWarning === type.UNSUPPORTED_INCOMING_CALL && (
@@ -330,10 +308,7 @@ const WarningsContainer: React.FC = () => {
               <span>{t('warningCallUpgradeBrowser')}</span>
             </div>
           )}
-          <button
-            className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
-            onClick={closeWarning}
-          />
+          <CloseWarningButton onClick={closeWarning} />
         </div>
       )}
       {visibleWarning === type.UNSUPPORTED_OUTGOING_CALL && (
@@ -368,10 +343,7 @@ const WarningsContainer: React.FC = () => {
               <span>{t('warningCallUpgradeBrowser')}</span>
             </div>
           )}
-          <button
-            className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
-            onClick={closeWarning}
-          />
+          <CloseWarningButton onClick={closeWarning} />
         </div>
       )}
       {visibleWarning === type.CONNECTIVITY_RECONNECT && (
@@ -422,6 +394,16 @@ const WarningsContainer: React.FC = () => {
     </div>
   );
 };
+
+interface CloseWarningButtonProps {
+  onClick: () => void;
+}
+const CloseWarningButton = ({onClick}: CloseWarningButtonProps) => (
+  <button
+    className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
+    onClick={onClick}
+  />
+);
 
 const TYPE = {
   CALL_QUALITY_POOR: 'call_quality_poor',

--- a/src/script/view_model/WarningsContainer.tsx
+++ b/src/script/view_model/WarningsContainer.tsx
@@ -136,6 +136,15 @@ const WarningsContainer: React.FC = () => {
     };
   });
 
+  const closeButton = (
+    <button
+      type="button"
+      data-uie-name="do-close-warning"
+      className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
+      onClick={closeWarning}
+    />
+  );
+
   if (warnings.length === 0) {
     return null;
   }
@@ -154,7 +163,7 @@ const WarningsContainer: React.FC = () => {
               ),
             }}
           />
-          <CloseWarningButton onClick={closeWarning} />
+          {closeButton}
         </div>
       )}
       {visibleWarning === type.DENIED_CAMERA && (
@@ -170,7 +179,7 @@ const WarningsContainer: React.FC = () => {
               {t('warningLearnMore')}
             </a>
           </div>
-          <CloseWarningButton onClick={closeWarning} />
+          {closeButton}
         </div>
       )}
       {visibleWarning === type.REQUEST_MICROPHONE && (
@@ -179,7 +188,7 @@ const WarningsContainer: React.FC = () => {
             <Icon.MicOn className="warning-bar-icon" />
             <span dangerouslySetInnerHTML={{__html: t('warningPermissionRequestMicrophone', {}, {icon: ''})}} />
           </div>
-          <CloseWarningButton onClick={closeWarning} />
+          {closeButton}
         </div>
       )}
       {visibleWarning === type.DENIED_MICROPHONE && (
@@ -195,7 +204,7 @@ const WarningsContainer: React.FC = () => {
               {t('warningLearnMore')}
             </a>
           </div>
-          <CloseWarningButton onClick={closeWarning} />
+          {closeButton}
         </div>
       )}
       {visibleWarning === type.REQUEST_SCREEN && (
@@ -210,7 +219,7 @@ const WarningsContainer: React.FC = () => {
               ),
             }}
           />
-          <CloseWarningButton onClick={closeWarning} />
+          {closeButton}
         </div>
       )}
       {visibleWarning === type.DENIED_SCREEN && (
@@ -226,7 +235,7 @@ const WarningsContainer: React.FC = () => {
               {t('warningLearnMore')}
             </a>
           </div>
-          <CloseWarningButton onClick={closeWarning} />
+          {closeButton}
         </div>
       )}
       {visibleWarning === type.NOT_FOUND_CAMERA && (
@@ -242,7 +251,7 @@ const WarningsContainer: React.FC = () => {
               {t('warningLearnMore')}
             </a>
           </div>
-          <CloseWarningButton onClick={closeWarning} />
+          {closeButton}
         </div>
       )}
       {visibleWarning === type.NOT_FOUND_MICROPHONE && (
@@ -258,7 +267,7 @@ const WarningsContainer: React.FC = () => {
               {t('warningLearnMore')}
             </a>
           </div>
-          <CloseWarningButton onClick={closeWarning} />
+          {closeButton}
         </div>
       )}
       {visibleWarning === type.REQUEST_NOTIFICATION && (
@@ -273,7 +282,7 @@ const WarningsContainer: React.FC = () => {
               ),
             }}
           />
-          <CloseWarningButton onClick={closeWarning} />
+          {closeButton}
         </div>
       )}
       {visibleWarning === type.UNSUPPORTED_INCOMING_CALL && (
@@ -308,7 +317,7 @@ const WarningsContainer: React.FC = () => {
               <span>{t('warningCallUpgradeBrowser')}</span>
             </div>
           )}
-          <CloseWarningButton onClick={closeWarning} />
+          {closeButton}
         </div>
       )}
       {visibleWarning === type.UNSUPPORTED_OUTGOING_CALL && (
@@ -343,7 +352,7 @@ const WarningsContainer: React.FC = () => {
               <span>{t('warningCallUpgradeBrowser')}</span>
             </div>
           )}
-          <CloseWarningButton onClick={closeWarning} />
+          {closeButton}
         </div>
       )}
       {visibleWarning === type.CONNECTIVITY_RECONNECT && (
@@ -395,18 +404,6 @@ const WarningsContainer: React.FC = () => {
     </div>
   );
 };
-
-interface CloseWarningButtonProps {
-  onClick: () => void;
-}
-const CloseWarningButton = ({onClick}: CloseWarningButtonProps) => (
-  <button
-    type="button"
-    data-uie-name="do-close-warning"
-    className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
-    onClick={onClick}
-  />
-);
 
 const TYPE = {
   CALL_QUALITY_POOR: 'call_quality_poor',

--- a/src/script/view_model/WarningsContainer.tsx
+++ b/src/script/view_model/WarningsContainer.tsx
@@ -154,7 +154,7 @@ const WarningsContainer: React.FC = () => {
               ),
             }}
           />
-          <span className="warning-bar-close icon-close button-icon" onClick={closeWarning} />
+          <button className="warning-bar-close icon-close button-icon button-reset-default" onClick={closeWarning} />
         </div>
       )}
       {visibleWarning === type.DENIED_CAMERA && (
@@ -170,16 +170,22 @@ const WarningsContainer: React.FC = () => {
               {t('warningLearnMore')}
             </a>
           </div>
-          <span className="warning-bar-close icon-close button-round button-round-dark" onClick={closeWarning} />
+          <button
+            className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
+            onClick={closeWarning}
+          />
         </div>
       )}
       {visibleWarning === type.REQUEST_MICROPHONE && (
         <div className="warning-bar warning-bar-feature">
           <div className="warning-bar-message">
-            <Icon.MicOn className="warning-bar-icon"></Icon.MicOn>
+            <Icon.MicOn className="warning-bar-icon" />
             <span dangerouslySetInnerHTML={{__html: t('warningPermissionRequestMicrophone', {}, {icon: ''})}} />
           </div>
-          <span className="warning-bar-close icon-close button-round button-round-dark" onClick={closeWarning} />
+          <button
+            className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
+            onClick={closeWarning}
+          />
         </div>
       )}
       {visibleWarning === type.DENIED_MICROPHONE && (
@@ -195,7 +201,10 @@ const WarningsContainer: React.FC = () => {
               {t('warningLearnMore')}
             </a>
           </div>
-          <span className="warning-bar-close icon-close button-round button-round-dark" onClick={closeWarning} />
+          <button
+            className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
+            onClick={closeWarning}
+          />
         </div>
       )}
       {visibleWarning === type.REQUEST_SCREEN && (
@@ -210,7 +219,7 @@ const WarningsContainer: React.FC = () => {
               ),
             }}
           />
-          <span className="warning-bar-close icon-close button-icon" onClick={closeWarning} />
+          <button className="warning-bar-close icon-close button-icon button-reset-default" onClick={closeWarning} />
         </div>
       )}
       {visibleWarning === type.DENIED_SCREEN && (
@@ -226,7 +235,10 @@ const WarningsContainer: React.FC = () => {
               {t('warningLearnMore')}
             </a>
           </div>
-          <span className="warning-bar-close icon-close button-round button-round-dark" onClick={closeWarning} />
+          <button
+            className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
+            onClick={closeWarning}
+          />
         </div>
       )}
       {visibleWarning === type.NOT_FOUND_CAMERA && (
@@ -242,7 +254,10 @@ const WarningsContainer: React.FC = () => {
               {t('warningLearnMore')}
             </a>
           </div>
-          <span className="warning-bar-close icon-close button-round button-round-dark" onClick={closeWarning} />
+          <button
+            className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
+            onClick={closeWarning}
+          />
         </div>
       )}
       {visibleWarning === type.NOT_FOUND_MICROPHONE && (
@@ -258,7 +273,10 @@ const WarningsContainer: React.FC = () => {
               {t('warningLearnMore')}
             </a>
           </div>
-          <span className="warning-bar-close icon-close button-round button-round-dark" onClick={closeWarning} />
+          <button
+            className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
+            onClick={closeWarning}
+          />
         </div>
       )}
       {visibleWarning === type.REQUEST_NOTIFICATION && (
@@ -272,9 +290,9 @@ const WarningsContainer: React.FC = () => {
                 {icon: "<span class='warning-bar-icon icon-envelope'></span>"},
               ),
             }}
-          ></div>
-          <span
-            className="warning-bar-close icon-close button-round button-round-dark"
+          />
+          <button
+            className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
             onClick={closeWarning}
             data-uie-name="do-close-warning"
           />
@@ -312,7 +330,10 @@ const WarningsContainer: React.FC = () => {
               <span>{t('warningCallUpgradeBrowser')}</span>
             </div>
           )}
-          <span className="warning-bar-close icon-close button-round button-round-dark" onClick={closeWarning} />
+          <button
+            className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
+            onClick={closeWarning}
+          />
         </div>
       )}
       {visibleWarning === type.UNSUPPORTED_OUTGOING_CALL && (
@@ -347,14 +368,17 @@ const WarningsContainer: React.FC = () => {
               <span>{t('warningCallUpgradeBrowser')}</span>
             </div>
           )}
-          <span className="warning-bar-close icon-close button-round button-round-dark" onClick={closeWarning} />
+          <button
+            className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
+            onClick={closeWarning}
+          />
         </div>
       )}
       {visibleWarning === type.CONNECTIVITY_RECONNECT && (
         <div className="warning-bar warning-bar-connection">
           <div className="warning-bar-message">
             <span>{t('warningConnectivityConnectionLost', brandName)}</span>
-            <Icon.Loading className="warning-bar-spinner" data-uie-name="status-loading"></Icon.Loading>
+            <Icon.Loading className="warning-bar-spinner" data-uie-name="status-loading" />
           </div>
         </div>
       )}
@@ -365,7 +389,7 @@ const WarningsContainer: React.FC = () => {
           </div>
         </div>
       )}
-      {visibleWarning === type.CONNECTIVITY_RECOVERY && <div className="warning-bar warning-bar-progress"></div>}
+      {visibleWarning === type.CONNECTIVITY_RECOVERY && <div className="warning-bar warning-bar-progress" />}
       {visibleWarning === type.NO_INTERNET && (
         <div className="warning-bar warning-bar-connection">
           <div className="warning-bar-message">{t('warningConnectivityNoInternet')}</div>
@@ -385,15 +409,13 @@ const WarningsContainer: React.FC = () => {
               {t('warningLifecycleUpdateNotes')}
             </a>
             &nbsp;·&nbsp;
-            <a
-              className="warning-bar-link"
+            <button
+              className="warning-bar-link button-reset-default"
               onClick={() => amplify.publish(lifeCycleRefresh)}
-              rel="nofollow noopener noreferrer"
-              target="_blank"
               data-uie-name="do-update"
             >
               {t('warningLifecycleUpdateLink')}
-            </a>
+            </button>
           </div>
         </div>
       )}

--- a/src/script/view_model/WarningsContainer.tsx
+++ b/src/script/view_model/WarningsContainer.tsx
@@ -400,6 +400,7 @@ interface CloseWarningButtonProps {
 }
 const CloseWarningButton = ({onClick}: CloseWarningButtonProps) => (
   <button
+    data-uie-name="do-close-warning"
     className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
     onClick={onClick}
   />

--- a/src/script/view_model/WarningsContainer.tsx
+++ b/src/script/view_model/WarningsContainer.tsx
@@ -382,6 +382,7 @@ const WarningsContainer: React.FC = () => {
             </a>
             &nbsp;·&nbsp;
             <button
+              type="button"
               className="warning-bar-link button-reset-default"
               onClick={() => amplify.publish(lifeCycleRefresh)}
               data-uie-name="do-update"
@@ -400,6 +401,7 @@ interface CloseWarningButtonProps {
 }
 const CloseWarningButton = ({onClick}: CloseWarningButtonProps) => (
   <button
+    type="button"
     data-uie-name="do-close-warning"
     className="warning-bar-close icon-close button-round button-round-dark button-reset-default"
     onClick={onClick}

--- a/src/style/common/button.less
+++ b/src/style/common/button.less
@@ -254,6 +254,7 @@
   cursor: pointer;
   font-family: inherit;
   font-size: inherit;
+  text-transform: inherit;
 }
 
 // -- new design buttons --

--- a/src/style/common/button.less
+++ b/src/style/common/button.less
@@ -254,7 +254,6 @@
   cursor: pointer;
   font-family: inherit;
   font-size: inherit;
-  text-transform: inherit;
 }
 
 // -- new design buttons --

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -794,6 +794,7 @@
 
 .message-header-decrypt-reset-session-action {
   height: 12px;
+  font-size: 11px;
 }
 
 .message-header-decrypt-reset-session-spinner {

--- a/src/style/content/conversation/message-quote.less
+++ b/src/style/content/conversation/message-quote.less
@@ -68,6 +68,7 @@
     }
 
     &__show-more {
+      display: block;
       color: @w-blue;
       cursor: pointer;
       font-size: 12px;
@@ -101,6 +102,7 @@
   }
 
   &__timestamp {
+    display: block;
     margin-top: 4px;
     cursor: pointer;
     font-size: 12px;

--- a/src/style/foundation/warnings.less
+++ b/src/style/foundation/warnings.less
@@ -134,5 +134,6 @@
   &:active {
     color: #fff;
     text-decoration: underline;
+    text-transform: inherit;
   }
 }

--- a/src/style/panel/participant-devices.less
+++ b/src/style/panel/participant-devices.less
@@ -68,6 +68,7 @@
   }
 
   &__reset-session {
+    font-size: 11px;
     text-transform: uppercase;
   }
 

--- a/src/style/panel/participant-devices.less
+++ b/src/style/panel/participant-devices.less
@@ -67,6 +67,10 @@
     margin-bottom: 56px;
   }
 
+  &__reset-session {
+    text-transform: uppercase;
+  }
+
   &__single-client {
     margin-top: 40px;
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-183" title="ACC-183" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-183</a>  Fix all the  "jsx-a11y/click-events-have-key-events" errors
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some of the clickable elements (with `onClick` event) in different parts of our app are not accessible (no keyboard focus/actions).

### Solutions

- replace `span`s or `div`s with native `<button />` element, if it's not possible (clicked element contains other divs or other block elements):
- add `role="button"` and `tabIndex={0}` attributes to make element focusable and add `onKeyDown` event handler to enable user interact with the element using keyboard.


### Testing

#### Test Coverage

I've modified one test (`ReadReceiptStatus.test.tsx`) by replacing `span` with `button`.

### Notes

Following eslint warning are gone:
- `jsx-a11y/click-events-have-key-events`
- `jsx-a11y/no-static-element-interactions`

There are 3 components with `jsx-a11y/media-has-caption` warning tough:
- `AudioAsset.tsx`
- `VideoAsset.tsx`
- `Video.tsx`
Which we need to fix to get rid of all `jsx-a11y` warnings.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
