### PR TITLE
runfix: Avoid triggering close event on modal first render [SQCORE-1327]

### DIFF
--- a/src/script/components/ModalComponent.tsx
+++ b/src/script/components/ModalComponent.tsx
@@ -18,7 +18,7 @@
  */
 
 import {CSSObject} from '@emotion/react';
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {noop} from 'Util/util';
 import Icon from './Icon';
 
@@ -87,11 +87,20 @@ const ModalComponent: React.FC<ModalComponentProps> = ({
 }) => {
   const [displayNone, setDisplayNone] = useState<boolean>(!isShown);
   const hasVisibleClass = isShown && !displayNone;
+  const isFirstRender = useRef<boolean>(true);
   useEffect(() => {
     let timeoutId = 0;
+    const firstRender = isFirstRender.current;
+    isFirstRender.current = false;
     if (isShown) {
       return setDisplayNone(false);
     }
+
+    if (firstRender) {
+      // Avoid triggering the onClose event for the first render
+      return;
+    }
+
     timeoutId = window.setTimeout(() => {
       setDisplayNone(true);
       onClosed();

--- a/src/script/components/ModalComponent.tsx
+++ b/src/script/components/ModalComponent.tsx
@@ -87,17 +87,17 @@ const ModalComponent: React.FC<ModalComponentProps> = ({
 }) => {
   const [displayNone, setDisplayNone] = useState<boolean>(!isShown);
   const hasVisibleClass = isShown && !displayNone;
-  const isFirstRender = useRef<boolean>(true);
+  const isMounting = useRef<boolean>(true);
   useEffect(() => {
     let timeoutId = 0;
-    const firstRender = isFirstRender.current;
-    isFirstRender.current = false;
+    const mounting = isMounting.current;
+    isMounting.current = false;
     if (isShown) {
       return setDisplayNone(false);
     }
 
-    if (firstRender) {
-      // Avoid triggering the onClose event for the first render
+    if (mounting) {
+      // Avoid triggering the onClose event when component is mounting
       return;
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCORE-1327" title="SQCORE-1327" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQCORE-1327</a>  [Web] Blank app lock modal when refreshing page while app is locked
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

The problem is when the app lock modal is instantiated, it then creates the modal with `isVisible: false` which then triggers the ModalComponent `onClose` callback which resets the React state of the AppLock Component. 
For the initial rendering of the `ModalComponent` we do not need to trigger the `onClose` event (since the modal was never opened in the first place)