### PR TITLE
runfix: Correctly display federated handle in conversation title [ACC-190]

### DIFF
--- a/src/style/content/conversation/title-bar.less
+++ b/src/style/content/conversation/title-bar.less
@@ -109,6 +109,7 @@ body.theme-dark {
 .conversation-title-bar-name-label {
   .heading-h3;
   overflow: hidden;
+  margin: 0.15em;
   text-overflow: ellipsis;
   &--wrapper {
     .flex-center;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-190" title="ACC-190" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-190</a>  User handle is cut off in conversation title in federated setups
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Before 
![image](https://user-images.githubusercontent.com/1090716/176407743-57ce3f1d-4ae3-402b-802e-8287713d2dfc.png)

After
![image](https://user-images.githubusercontent.com/1090716/176407811-461b535e-e3e4-4f31-9f62-c7b77aaae763.png)


in non-federated env, the design is unchanged
![image](https://user-images.githubusercontent.com/1090716/176407956-e4b2033b-c23c-4f15-b809-9c78a9c08c4d.png)
