### PR TITLE
runfix: add focus trap to modals acc-178

### DIFF
--- a/src/script/components/ModalComponent.tsx
+++ b/src/script/components/ModalComponent.tsx
@@ -18,7 +18,7 @@
  */
 
 import {CSSObject} from '@emotion/react';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useId, useRef, useState} from 'react';
 import {noop, preventFocusOutside} from 'Util/util';
 import Icon from './Icon';
 
@@ -88,9 +88,10 @@ const ModalComponent: React.FC<ModalComponentProps> = ({
   const [displayNone, setDisplayNone] = useState<boolean>(!isShown);
   const hasVisibleClass = isShown && !displayNone;
   const isMounting = useRef<boolean>(true);
+  const trapId = useId();
 
   const onKeyDown = (event: KeyboardEvent): void => {
-    preventFocusOutside(event, 'trap');
+    preventFocusOutside(event, trapId);
   };
 
   useEffect(() => {
@@ -141,13 +142,14 @@ const ModalComponent: React.FC<ModalComponentProps> = ({
         <Icon.Loading width="48" height="48" css={{path: {fill: 'var(--modal-bg)'}}} />
       ) : (
         <div
+          id={trapId}
           onClick={event => event.stopPropagation()}
           role="button"
           tabIndex={-1}
           onKeyDown={noop}
           css={hasVisibleClass ? ModalContentVisibleStyles : ModalContentStyles}
         >
-          {hasVisibleClass ? <div id="trap">{children}</div> : null}
+          {hasVisibleClass ? children : null}
         </div>
       )}
     </div>

--- a/src/script/components/ModalComponent.tsx
+++ b/src/script/components/ModalComponent.tsx
@@ -19,7 +19,7 @@
 
 import {CSSObject} from '@emotion/react';
 import React, {useEffect, useRef, useState} from 'react';
-import {noop} from 'Util/util';
+import {noop, preventFocusOutside} from 'Util/util';
 import Icon from './Icon';
 
 interface ModalComponentProps {
@@ -88,6 +88,22 @@ const ModalComponent: React.FC<ModalComponentProps> = ({
   const [displayNone, setDisplayNone] = useState<boolean>(!isShown);
   const hasVisibleClass = isShown && !displayNone;
   const isMounting = useRef<boolean>(true);
+
+  const onKeyDown = (event: KeyboardEvent): void => {
+    preventFocusOutside(event, 'trap');
+  };
+
+  useEffect(() => {
+    if (isShown) {
+      document.addEventListener('keydown', onKeyDown);
+    } else {
+      document.removeEventListener('keydown', onKeyDown);
+    }
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [isShown]);
+
   useEffect(() => {
     let timeoutId = 0;
     const mounting = isMounting.current;
@@ -128,10 +144,10 @@ const ModalComponent: React.FC<ModalComponentProps> = ({
           onClick={event => event.stopPropagation()}
           role="button"
           tabIndex={-1}
-          onKeyDown={event => event.stopPropagation()}
+          onKeyDown={noop}
           css={hasVisibleClass ? ModalContentVisibleStyles : ModalContentStyles}
         >
-          {hasVisibleClass ? children : null}
+          {hasVisibleClass ? <div id="trap">{children}</div> : null}
         </div>
       )}
     </div>

--- a/src/script/components/ModalComponent.tsx
+++ b/src/script/components/ModalComponent.tsx
@@ -18,7 +18,7 @@
  */
 
 import {CSSObject} from '@emotion/react';
-import React, {useEffect, useId, useRef, useState} from 'react';
+import React, {useEffect, useId, useRef, useState, useCallback} from 'react';
 import {noop, preventFocusOutside} from 'Util/util';
 import Icon from './Icon';
 
@@ -90,20 +90,23 @@ const ModalComponent: React.FC<ModalComponentProps> = ({
   const isMounting = useRef<boolean>(true);
   const trapId = useId();
 
-  const onKeyDown = (event: KeyboardEvent): void => {
-    preventFocusOutside(event, trapId);
-  };
+  const trapFocus = useCallback(
+    (event: KeyboardEvent): void => {
+      preventFocusOutside(event, trapId);
+    },
+    [trapId],
+  );
 
   useEffect(() => {
     if (isShown) {
-      document.addEventListener('keydown', onKeyDown);
+      document.addEventListener('keydown', trapFocus);
     } else {
-      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('keydown', trapFocus);
     }
     return () => {
-      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('keydown', trapFocus);
     };
-  }, [isShown]);
+  }, [isShown, onkeydown]);
 
   useEffect(() => {
     let timeoutId = 0;

--- a/src/script/util/util.ts
+++ b/src/script/util/util.ts
@@ -351,6 +351,10 @@ export const preventFocusOutside = (event: KeyboardEvent, parentId: string): voi
   const parent = document.getElementById(parentId);
   const focusableContent = [...parent.querySelectorAll(focusableElements)];
   const focusedItemIndex = focusableContent.indexOf(document.activeElement);
+  if (event.shiftKey && focusedItemIndex != 0) {
+    (focusableContent[focusedItemIndex - 1] as HTMLElement)?.focus();
+    return;
+  }
   if (event.shiftKey && focusedItemIndex === 0) {
     (focusableContent[focusableContent.length - 1] as HTMLElement)?.focus();
     return;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-178" title="ACC-178" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-178</a>  [Web] No autofocus on group name input when creating a group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----

# What's new in this PR?

### Issues

- Focus needs to be trapped inside modals for accessibility reasons
- Shift Tabbing doesn't work in preventFocusOutside

### Solutions

- Use the preventFocusOutside function from Util
- Hard code shift-tabbing into preventFocusOutside
![Peek 2022-06-29 16-02](https://user-images.githubusercontent.com/78490891/176456134-cf5b1c23-f9e2-47f1-a197-4bd6a3053bbf.gif)


