### PR TITLE
feat: Give external crypto primitives to core when available [FS-566]

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.9.0",
     "@wireapp/antiscroll-2": "1.3.1",
     "@wireapp/avs": "8.1.17",
-    "@wireapp/core": "27.4.1",
+    "@wireapp/core": "27.6.0",
     "@wireapp/react-ui-kit": "8.6.0",
     "@wireapp/store-engine-dexie": "1.6.10",
     "@wireapp/store-engine-sqleet": "1.7.14",

--- a/src/script/service/CoreSingleton.ts
+++ b/src/script/service/CoreSingleton.ts
@@ -47,6 +47,11 @@ export class Core extends Account {
       },
       enableMLS: Config.getConfig().FEATURE.ENABLE_MLS,
       nbPrekeys: 100,
+      /*
+       * When in an electron context, the window.secretsCrypto will be populated by the renderer process.
+       * We then give those crypto primitives to the core that will use them when encrypting MLS secrets.
+       * When in an browser context, then this secrtesCrypto will be undefined and the core will then use it's internal encryption system
+       */
       secretsCrypto: window.secretsCrypto,
     });
   }

--- a/src/script/service/CoreSingleton.ts
+++ b/src/script/service/CoreSingleton.ts
@@ -50,7 +50,7 @@ export class Core extends Account {
       /*
        * When in an electron context, the window.secretsCrypto will be populated by the renderer process.
        * We then give those crypto primitives to the core that will use them when encrypting MLS secrets.
-       * When in an browser context, then this secrtesCrypto will be undefined and the core will then use it's internal encryption system
+       * When in an browser context, then this secretsCrypto will be undefined and the core will then use it's internal encryption system
        */
       secretsCrypto: window.secretsCrypto,
     });

--- a/src/script/service/CoreSingleton.ts
+++ b/src/script/service/CoreSingleton.ts
@@ -25,6 +25,15 @@ import {createStorageEngine, DatabaseTypes} from './StoreEngineProvider';
 import {isTemporaryClientAndNonPersistent} from 'Util/util';
 import {Config} from '../Config';
 
+declare global {
+  interface Window {
+    secretsCrypto?: {
+      decrypt: (value: Uint8Array) => Promise<Uint8Array>;
+      encrypt: (encrypted: Uint8Array) => Promise<Uint8Array>;
+    };
+  }
+}
+
 @singleton()
 export class Core extends Account {
   constructor(apiClient = container.resolve(APIClient)) {
@@ -38,6 +47,7 @@ export class Core extends Account {
       },
       enableMLS: Config.getConfig().FEATURE.ENABLE_MLS,
       nbPrekeys: 100,
+      secretsCrypto: window.secretsCrypto,
     });
   }
   get storage() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3064,10 +3064,10 @@
   resolved "https://registry.yarnpkg.com/@wireapp/antiscroll-2/-/antiscroll-2-1.3.1.tgz#bcb66f72c6dadc306e43235256b768ed3f89039c"
   integrity sha512-vWmWYAzSdyxs+xlgSPGtiNSTCM1z0nxM+jSPa/xz1/kuFKy80BrJP5xaGwNNLljBAz8ymlSPUUZlylUd0tFr1Q==
 
-"@wireapp/api-client@19.7.0":
-  version "19.7.0"
-  resolved "https://registry.yarnpkg.com/@wireapp/api-client/-/api-client-19.7.0.tgz#bce79862d401ae2d49c85e7103b312eb14a9a8b2"
-  integrity sha512-oti0hdolvDFhHkELcoX/LthRuhSvzuUiO08UE7I+vDuGaKw5Fg+G01jUWaRiZTciQBFt0fIyghbGpM+S+0g83Q==
+"@wireapp/api-client@19.7.2":
+  version "19.7.2"
+  resolved "https://registry.yarnpkg.com/@wireapp/api-client/-/api-client-19.7.2.tgz#38d833d565b1bb6d1afbc9bafe65a29fcf0f9fa8"
+  integrity sha512-BCFIf1VMsUvu2qXS7KCWHbpUk6yFXtItodXcwIMM0LFfUJeXmOlr3kIozTCtmJwblHDyMKIwNK5mzN45R32Sqw==
   dependencies:
     "@types/node" "~14"
     "@types/spark-md5" "3.0.2"
@@ -3121,20 +3121,21 @@
     logdown "3.3.1"
     rimraf "3.0.2"
 
-"@wireapp/core@27.4.1":
-  version "27.4.1"
-  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-27.4.1.tgz#ef89d0c3ac334cf933e48343c38bec80d2a9b1bd"
-  integrity sha512-h5Bv2wS62qXzT5qestSaF3hEKdquysHVmX8OyK0LsOk1RPrJ+edGr1jity2flYqxmwL/gl4X/jqFv+2+cTuYhA==
+"@wireapp/core@27.6.0":
+  version "27.6.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-27.6.0.tgz#acd859cc8a8ee5396fdb4078fa3c4bb739f98f6a"
+  integrity sha512-7MXPQC5ZgII7t25ga06yZfmY8jvEgvIjgXVXlClRl5DEweuLBdwVgSMRbI7V7M0pqTrawD3yVcE+9fi1mL+95w==
   dependencies:
     "@open-wc/webpack-import-meta-loader" "0.4.7"
     "@otak/core-crypto" "0.2.0-beta-3"
     "@types/long" "4.0.1"
     "@types/node" "~14"
-    "@wireapp/api-client" "19.7.0"
+    "@wireapp/api-client" "19.7.2"
     "@wireapp/cryptobox" "12.8.0"
     bazinga64 "5.10.0"
     hash.js "1.1.7"
     http-status-codes "2.1.4"
+    idb "7.0.2"
     logdown "3.3.1"
     long "4.0.0"
     protobufjs "6.11.3"
@@ -7223,6 +7224,11 @@ iconv-lite@0.4.24, iconv-lite@~0.4.13:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+idb@7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/idb/-/idb-7.0.2.tgz#7a067e20dd16539938e456814b7d714ba8db3892"
+  integrity sha512-jjKrT1EnyZewQ/gCBb/eyiYrhGzws2FeY92Yx8qT9S9GeQAmo4JFVIiWRIfKW/6Ob9A+UDAOW9j9jn58fy2HIg==
 
 idb@^6.1.4:
   version "6.1.5"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-566" title="FS-566" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-566</a>  [Web] Core crypto keystore protected by node-keytar or safestorage API in Electron wrapper
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This is in an effort to use native method to encrypt secrets when the webapp is used inside of electron. 

## Solution
When the app is running inside electron, the electron wrapper will publish a `secretsCrypto` object against `window` that can be used to encrypt/decrypt. 
If the webapp detects this published `secretsCrypto` it will then give it to the core and the core will rely on those crypto primitives to encrypt whatever secret is needed to be stored. 

## Dependencies
needs:
- [x] https://github.com/wireapp/wire-desktop/pull/5812
- [x] https://github.com/wireapp/wire-web-packages/pull/4302