### PR TITLE
chore: add 'betterer' to prevent ts strict regressions (#WEBAPP-7144)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1,0 +1,3018 @@
+// BETTERER RESULTS V2.
+// 
+// If this file contains merge conflicts, use `betterer merge` to automatically resolve them:
+// https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
+//
+exports[`stricter compilation`] = {
+  value: `{
+    "src/script/Config.ts:3231864459": [
+      [51, 4, 40, "\'ACCOUNT_BASE\' is specified more than once, so this usage will be overwritten.", "2150385420"],
+      [52, 4, 15, "\'MOBILE_BASE\' is specified more than once, so this usage will be overwritten.", "437120469"],
+      [53, 4, 12, "\'PRICING\' is specified more than once, so this usage will be overwritten.", "1004628660"],
+      [54, 4, 65, "\'PRIVACY_POLICY\' is specified more than once, so this usage will be overwritten.", "3718416051"],
+      [55, 4, 799, "\'SUPPORT\' is specified more than once, so this usage will be overwritten.", "1733685078"],
+      [69, 4, 36, "\'TEAMS_BASE\' is specified more than once, so this usage will be overwritten.", "1602627884"],
+      [70, 4, 47, "\'TEAMS_BILLING\' is specified more than once, so this usage will be overwritten.", "1546117942"],
+      [71, 4, 79, "\'TEAMS_CREATE\' is specified more than once, so this usage will be overwritten.", "3896973981"],
+      [72, 4, 84, "\'TERMS_OF_USE_PERSONAL\' is specified more than once, so this usage will be overwritten.", "4120462090"],
+      [73, 4, 78, "\'TERMS_OF_USE_TEAMS\' is specified more than once, so this usage will be overwritten.", "2894167402"],
+      [74, 4, 32, "\'WEBSITE_BASE\' is specified more than once, so this usage will be overwritten.", "41464345"],
+      [75, 4, 61, "\'WHATS_NEW\' is specified more than once, so this usage will be overwritten.", "608611251"]
+    ],
+    "src/script/assets/AssetCrypto.test.ts:2635946620": [
+      [38, 55, 4, "Argument of type \'null\' is not assignable to parameter of type \'ArrayBuffer\'.", "2087897566"]
+    ],
+    "src/script/assets/AssetMapper.ts:137626173": [
+      [49, 10, 6, "Type \'AssetRemoteData | undefined\' is not assignable to type \'AssetRemoteData\'.\\n  Type \'undefined\' is not assignable to type \'AssetRemoteData\'.", "1468438424"],
+      [49, 31, 7, "Type \'AssetRemoteData | undefined\' is not assignable to type \'AssetRemoteData\'.\\n  Type \'undefined\' is not assignable to type \'AssetRemoteData\'.", "1793644015"]
+    ],
+    "src/script/assets/AssetRemoteData.ts:2909057294": [
+      [75, 8, 10, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2264616494"],
+      [95, 8, 10, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2264616494"]
+    ],
+    "src/script/assets/AssetRepository.ts:839388141": [
+      [101, 27, 5, "Object is of type \'unknown\'.", "165548477"],
+      [276, 4, 81, "Type \'UploadStatus | undefined\' is not assignable to type \'UploadStatus\'.\\n  Type \'undefined\' is not assignable to type \'UploadStatus\'.", "613717832"]
+    ],
+    "src/script/audio/AudioRepository.ts:12311176": [
+      [92, 6, 26, "Cannot invoke an object which is possibly \'undefined\'.", "1352108271"],
+      [116, 44, 42, "Argument of type \'(audioId: AudioType) => void\' is not assignable to parameter of type \'(value: string, index: number, array: string[]) => void\'.\\n  Types of parameters \'audioId\' and \'value\' are incompatible.\\n    Type \'string\' is not assignable to type \'AudioType\'.", "2195180610"],
+      [175, 66, 5, "Object is of type \'unknown\'.", "165548477"]
+    ],
+    "src/script/audio/AudioState.ts:2637326876": [
+      [28, 4, 20, "Type \'Observable<AudioPreference.ALL>\' is not assignable to type \'Observable<AudioPreference>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'AudioPreference\' is not assignable to type \'AudioPreference.ALL\'.", "889323520"]
+    ],
+    "src/script/auth/AuthRepository.ts:219478500": [
+      [52, 60, 5, "Object is of type \'unknown\'.", "165548477"]
+    ],
+    "src/script/auth/component/AccountForm.tsx:3824179626": [
+      [90, 8, 16, "Object is possibly \'undefined\'.", "3859911866"],
+      [90, 33, 16, "Object is possibly \'undefined\'.", "3859911866"],
+      [92, 11, 16, "Object is possibly \'undefined\'.", "3859911866"],
+      [93, 20, 87, "Argument of type \'ValidationError | null\' is not assignable to parameter of type \'Error\'.\\n  Type \'null\' is not assignable to type \'Error\'.", "612674422"],
+      [93, 58, 16, "Object is possibly \'undefined\'.", "3859911866"],
+      [93, 81, 16, "Object is possibly \'undefined\'.", "3859911866"],
+      [95, 33, 16, "Object is possibly \'undefined\'.", "3859911866"],
+      [98, 24, 6, "Argument of type \'Error[]\' is not assignable to parameter of type \'SetStateAction<never[]>\'.\\n  Type \'Error[]\' is not assignable to type \'never[]\'.\\n    Type \'Error\' is not assignable to type \'never\'.", "1168132398"],
+      [108, 19, 5, "Object is of type \'unknown\'.", "165548477"],
+      [109, 16, 5, "Object is of type \'unknown\'.", "165548477"],
+      [114, 12, 20, "Object is possibly \'undefined\'.", "4048796933"],
+      [114, 51, 5, "Object is of type \'unknown\'.", "165548477"],
+      [120, 12, 20, "Object is possibly \'undefined\'.", "4048796933"],
+      [120, 51, 5, "Object is of type \'unknown\'.", "165548477"],
+      [121, 12, 23, "Object is possibly \'undefined\'.", "23329910"],
+      [121, 54, 5, "Object is of type \'unknown\'.", "165548477"],
+      [127, 14, 5, "Object is of type \'unknown\'.", "165548477"],
+      [147, 14, 19, "Object is possibly \'undefined\'.", "3911565646"],
+      [151, 12, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"],
+      [158, 16, 20, "Object is possibly \'undefined\'.", "4048796933"],
+      [171, 14, 20, "Object is possibly \'undefined\'.", "4048796933"],
+      [175, 12, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"],
+      [186, 16, 23, "Object is possibly \'undefined\'.", "23329910"],
+      [198, 14, 23, "Object is possibly \'undefined\'.", "23329910"],
+      [202, 12, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"],
+      [226, 8, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.\\n  Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'RefObject<HTMLInputElement>\'.", "193432436"],
+      [228, 10, 20, "Object is possibly \'undefined\'.", "3805711124"]
+    ],
+    "src/script/auth/component/AppAlreadyOpen.tsx:1094893852": [
+      [78, 60, 14, "Argument of type \'({ isAppAlreadyOpen, fullscreen, removeCookie }: AppAlreadyOpenProps) => false | EmotionJSX.Element\' is not assignable to parameter of type \'ComponentType<never>\'.\\n  Type \'({ isAppAlreadyOpen, fullscreen, removeCookie }: AppAlreadyOpenProps) => false | EmotionJSX.Element\' is not assignable to type \'FunctionComponent<never>\'.\\n    Type \'false | Element\' is not assignable to type \'ReactElement<any, any> | null\'.", "158714422"]
+    ],
+    "src/script/auth/component/ClientItem.tsx:281272235": [
+      [149, 9, 21, "Object is possibly \'undefined\'.", "4077427211"],
+      [151, 8, 21, "Object is possibly \'undefined\'.", "4077427211"],
+      [152, 8, 21, "Object is possibly \'undefined\'.", "4077427211"],
+      [155, 23, 21, "Object is possibly \'undefined\'.", "4077427211"],
+      [220, 28, 12, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3597007453"],
+      [249, 20, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"]
+    ],
+    "src/script/auth/component/ClientList.tsx:3233905927": [
+      [56, 4, 8, "Type \'string | null\' is not assignable to type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "1055803537"],
+      [67, 31, 7, "This condition will always return true since this \'Promise<any>\' is always defined.", "2364942655"],
+      [93, 10, 11, "Type \'false | Error\' is not assignable to type \'Error\'.\\n  Type \'boolean\' is not assignable to type \'Error\'.", "674912356"]
+    ],
+    "src/script/auth/component/EntropyCanvas.tsx:2599807788": [
+      [65, 16, 10, "Type \'[number, number] | null\' is not assignable to type \'[number, number]\'.\\n  Type \'null\' is not assignable to type \'[number, number]\'.", "3284027968"],
+      [65, 28, 4, "Type \'null\' is not assignable to type \'[number, number]\'.", "2087897566"],
+      [93, 20, 6, "Object is possibly \'null\'.", "1537472717"]
+    ],
+    "src/script/auth/component/LinkButton.tsx:522804603": [
+      [32, 8, 67, "Type \'(theme: Theme) => CSSObject\' is not assignable to type \'Interpolation<Theme>\'.\\n  Type \'(theme: Theme) => CSSObject\' is not assignable to type \'FunctionInterpolation<Theme>\'.\\n    Types of parameters \'theme\' and \'props\' are incompatible.\\n      Type \'Theme\' is missing the following properties from type \'Theme\': general, Input", "530872600"]
+    ],
+    "src/script/auth/component/LoginForm.tsx:1467603633": [
+      [49, 4, 18, "Object is possibly \'undefined\'.", "3955986040"],
+      [49, 31, 18, "Object is possibly \'undefined\'.", "3955986040"],
+      [52, 9, 18, "Object is possibly \'undefined\'.", "3955986040"],
+      [54, 8, 91, "Argument of type \'ValidationError | null\' is not assignable to parameter of type \'Error\'.\\n  Type \'null\' is not assignable to type \'Error\'.", "2109761846"],
+      [54, 46, 18, "Object is possibly \'undefined\'.", "3955986040"],
+      [54, 71, 18, "Object is possibly \'undefined\'.", "3955986040"],
+      [57, 23, 18, "Object is possibly \'undefined\'.", "3955986040"],
+      [58, 9, 21, "Object is possibly \'undefined\'.", "4077427211"],
+      [60, 8, 97, "Argument of type \'ValidationError | null\' is not assignable to parameter of type \'Error\'.\\n  Type \'null\' is not assignable to type \'Error\'.", "2075038454"],
+      [60, 46, 21, "Object is possibly \'undefined\'.", "4077427211"],
+      [60, 74, 21, "Object is possibly \'undefined\'.", "4077427211"],
+      [64, 26, 21, "Object is possibly \'undefined\'.", "4077427211"],
+      [85, 8, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"],
+      [102, 8, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"]
+    ],
+    "src/script/auth/component/PhoneLoginForm.tsx:1266572804": [
+      [89, 12, 3, "Type \'MutableRefObject<undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.\\n  Type \'MutableRefObject<undefined>\' is not assignable to type \'RefObject<HTMLInputElement>\'.\\n    Types of property \'current\' are incompatible.\\n      Type \'undefined\' is not assignable to type \'HTMLInputElement | null\'.", "193432436"],
+      [99, 12, 3, "Type \'MutableRefObject<undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"]
+    ],
+    "src/script/auth/component/RouterLink.tsx:4241768683": [
+      [26, 59, 43, "Type \'(theme: Theme) => CSSObject\' is not assignable to type \'Interpolation<Theme>\'.\\n  Type \'(theme: Theme) => CSSObject\' is not assignable to type \'FunctionInterpolation<Theme>\'.\\n    Types of parameters \'theme\' and \'props\' are incompatible.\\n      Type \'import(\\"wire-webapp/node_modules/@emotion/react/types/index\\").Theme\' is not assignable to type \'import(\\"wire-webapp/node_modules/@wireapp/react-ui-kit/src/Layout/Theme\\").Theme\'.", "1560990654"]
+    ],
+    "src/script/auth/component/WirelessContainer.tsx:3024259460": [
+      [56, 71, 25, "Cannot invoke an object which is possibly \'undefined\'.", "1570949058"],
+      [76, 69, 25, "Cannot invoke an object which is possibly \'undefined\'.", "1570949058"]
+    ],
+    "src/script/auth/localeConfig.ts:2649740668": [
+      [47, 2, 59, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "576197098"]
+    ],
+    "src/script/auth/main.tsx:2888819071": [
+      [65, 13, 31, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'Element | DocumentFragment\'.\\n  Type \'null\' is not assignable to type \'Element | DocumentFragment\'.", "223522320"],
+      [69, 9, 4, "Argument of type \'ConnectedComponent<FC<RootProps & { isAuthenticated: boolean; isFetchingSSOSettings: boolean; language: string; } & { doGetSSOSettings: () => Promise<void>; safelyRemoveCookie: (name: string, value: string) => Promise<...>; startPolling: (name?: string | undefined, interval?: number | undefined, asJSON?: boolean | u...\' is not assignable to parameter of type \'ConnectedComponent<FunctionComponent<{}>, any>\'.\\n  Type \'ComponentClass<Omit<RootProps & { isAuthenticated: boolean; isFetchingSSOSettings: boolean; language: string; } & { doGetSSOSettings: () => Promise<void>; safelyRemoveCookie: (name: string, value: string) => Promise<...>; startPolling: (name?: string | undefined, interval?: number | undefined, asJSON?: boolean | und...\' is not assignable to type \'ConnectedComponent<FunctionComponent<{}>, any>\'.\\n    Type \'ComponentClass<Omit<RootProps & { isAuthenticated: boolean; isFetchingSSOSettings: boolean; language: string; } & { doGetSSOSettings: () => Promise<void>; safelyRemoveCookie: (name: string, value: string) => Promise<...>; startPolling: (name?: string | undefined, interval?: number | undefined, asJSON?: boolean | und...\' is not assignable to type \'ComponentClass<any, any> & NonReactStatics<FunctionComponent<{}>, {}> & { WrappedComponent: FunctionComponent<{}>; }\'.\\n      Type \'ComponentClass<Omit<RootProps & { isAuthenticated: boolean; isFetchingSSOSettings: boolean; language: string; } & { doGetSSOSettings: () => Promise<void>; safelyRemoveCookie: (name: string, value: string) => Promise<...>; startPolling: (name?: string | undefined, interval?: number | undefined, asJSON?: boolean | und...\' is not assignable to type \'{ WrappedComponent: FunctionComponent<{}>; }\'.\\n        Types of property \'WrappedComponent\' are incompatible.\\n          Type \'FC<RootProps & { isAuthenticated: boolean; isFetchingSSOSettings: boolean; language: string; } & { doGetSSOSettings: () => Promise<void>; safelyRemoveCookie: (name: string, value: string) => Promise<...>; startPolling: (name?: string | undefined, interval?: number | undefined, asJSON?: boolean | undefined) => Promis...\' is not assignable to type \'FunctionComponent<{}>\'.\\n            Types of parameters \'props\' and \'props\' are incompatible.\\n              Type \'{}\' is not assignable to type \'RootProps & { isAuthenticated: boolean; isFetchingSSOSettings: boolean; language: string; } & { doGetSSOSettings: () => Promise<void>; safelyRemoveCookie: (name: string, value: string) => Promise<...>; startPolling: (name?: string | undefined, interval?: number | undefined, asJSON?: boolean | undefined) => Promise<....\'.\\n                Type \'{}\' is not assignable to type \'{ isAuthenticated: boolean; isFetchingSSOSettings: boolean; language: string; }\'.", "2089387715"]
+    ],
+    "src/script/auth/module/action/AuthAction.ts:3569464432": [
+      [126, 12, 5, "Object is of type \'unknown\'.", "165548477"],
+      [132, 49, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [146, 60, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [159, 59, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [181, 12, 5, "Object is of type \'unknown\'.", "165548477"],
+      [184, 49, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [269, 27, 18, "Object is possibly \'undefined\'.", "1666073462"],
+      [270, 6, 17, "Object is possibly \'undefined\'.", "2392383015"],
+      [271, 6, 17, "Object is possibly \'undefined\'.", "2392383015"],
+      [272, 6, 17, "Object is possibly \'undefined\'.", "2392383015"],
+      [273, 6, 17, "Object is possibly \'undefined\'.", "2392383015"],
+      [273, 31, 17, "Object is possibly \'undefined\'.", "2392383015"],
+      [285, 54, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [300, 27, 18, "Object is possibly \'undefined\'.", "1666073462"],
+      [312, 58, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [344, 58, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [378, 49, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [390, 61, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [409, 56, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [430, 48, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [444, 48, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"]
+    ],
+    "src/script/auth/module/action/BackendError.ts:3652889880": [
+      [28, 4, 10, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3983565867"],
+      [29, 4, 12, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1494865734"]
+    ],
+    "src/script/auth/module/action/ClientAction.ts:1102551119": [
+      [36, 57, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [49, 56, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [73, 60, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [100, 6, 11, "Type \'undefined\' is not assignable to type \'string\'.", "1193824839"]
+    ],
+    "src/script/auth/module/action/ConversationAction.ts:3179619467": [
+      [32, 71, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [46, 72, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"]
+    ],
+    "src/script/auth/module/action/CookieAction.ts:2952107553": [
+      [37, 57, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [51, 57, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [67, 53, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [81, 56, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [92, 56, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [103, 53, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [117, 53, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"]
+    ],
+    "src/script/auth/module/action/InvitationAction.ts:4153062423": [
+      [57, 82, 6, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1747314229"],
+      [60, 57, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"]
+    ],
+    "src/script/auth/module/action/LocalStorageAction.ts:1941616717": [
+      [44, 65, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [59, 65, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [72, 68, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"]
+    ],
+    "src/script/auth/module/action/NotificationAction.ts:261962671": [
+      [27, 33, 12, "Object is possibly \'undefined\'.", "3283681133"],
+      [30, 62, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [44, 12, 12, "Object is possibly \'undefined\'.", "3283681133"]
+    ],
+    "src/script/auth/module/action/SelfAction.ts:2089396225": [
+      [43, 51, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [57, 51, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [74, 53, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [96, 52, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [109, 57, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [122, 54, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [136, 12, 5, "Object is of type \'unknown\'.", "165548477"],
+      [140, 58, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"]
+    ],
+    "src/script/auth/module/action/UserAction.ts:2835118030": [
+      [38, 60, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"]
+    ],
+    "src/script/auth/module/action/ValidationError.ts:3871046799": [
+      [72, 11, 82, "Object is possibly \'undefined\'.", "1780944499"],
+      [92, 11, 86, "Object is possibly \'undefined\'.", "2194479222"]
+    ],
+    "src/script/auth/module/action/WebSocketAction.ts:3134213674": [
+      [53, 83, 5, "Object is of type \'unknown\'.", "165548477"]
+    ],
+    "src/script/auth/module/action/creator/CookieActionCreator.ts:3301665892": [
+      [137, 14, 6, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1544311649"],
+      [150, 14, 6, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1544311649"]
+    ],
+    "src/script/auth/module/reducer/authReducer.ts:182177111": [
+      [61, 4, 9, "Type \'null\' is not assignable to type \'number\'.", "1561043785"],
+      [62, 4, 6, "Type \'null\' is not assignable to type \'UserAsset[]\'.", "1332497414"],
+      [63, 4, 5, "Type \'null\' is not assignable to type \'string\'.", "165454089"],
+      [64, 4, 10, "Type \'null\' is not assignable to type \'string\'.", "1013483035"],
+      [65, 4, 15, "Type \'null\' is not assignable to type \'string\'.", "3770638438"],
+      [66, 4, 5, "Type \'null\' is not assignable to type \'string\'.", "173467459"],
+      [67, 4, 6, "Type \'null\' is not assignable to type \'string\'.", "1422303533"],
+      [68, 4, 4, "Type \'null\' is not assignable to type \'string\'.", "2087876002"],
+      [69, 4, 8, "Type \'null\' is not assignable to type \'string\'.", "1569157018"],
+      [70, 4, 5, "Type \'null\' is not assignable to type \'string\'.", "187940249"],
+      [71, 4, 10, "Type \'null\' is not assignable to type \'string\'.", "1244982411"],
+      [72, 4, 4, "Type \'null\' is not assignable to type \'TeamData\'.", "2087956856"],
+      [75, 2, 11, "Type \'null\' is not assignable to type \'string\'.", "974154622"],
+      [76, 2, 7, "Type \'null\' is not assignable to type \'Uint8Array | undefined\'.", "4061937486"],
+      [77, 2, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"],
+      [87, 4, 16, "Type \'undefined\' is not assignable to type \'string\'.", "2775896460"],
+      [100, 8, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"],
+      [121, 8, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"],
+      [152, 8, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"],
+      [178, 72, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"],
+      [181, 49, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"],
+      [184, 64, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"],
+      [187, 24, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"],
+      [190, 24, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"],
+      [198, 8, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"],
+      [203, 24, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"]
+    ],
+    "src/script/auth/module/reducer/clientReducer.ts:981784269": [
+      [34, 2, 13, "Type \'null\' is not assignable to type \'RegisteredClient\'.", "107809045"],
+      [35, 2, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"],
+      [37, 2, 10, "Type \'null\' is not assignable to type \'boolean\'.", "1547819645"],
+      [38, 2, 11, "Type \'null\' is not assignable to type \'boolean\'.", "549268378"],
+      [60, 8, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"],
+      [81, 8, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"],
+      [99, 24, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"]
+    ],
+    "src/script/auth/module/reducer/conversationReducer.ts:3111817881": [
+      [28, 2, 5, "Type \'null\' is not assignable to type \'Error & { label?: string | undefined; }\'.\\n  Type \'null\' is not assignable to type \'Error\'.", "165548477"],
+      [42, 8, 5, "Type \'null\' is not assignable to type \'Error & { label?: string | undefined; }\'.", "165548477"]
+    ],
+    "src/script/auth/module/reducer/cookieReducer.ts:2680697582": [
+      [32, 2, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"],
+      [47, 8, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"],
+      [59, 8, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"],
+      [71, 8, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"],
+      [83, 8, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"]
+    ],
+    "src/script/auth/module/reducer/inviteReducer.ts:1673100957": [
+      [30, 2, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"],
+      [48, 8, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"],
+      [61, 24, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"]
+    ],
+    "src/script/auth/module/reducer/selfReducer.ts:2545020496": [
+      [34, 2, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"],
+      [38, 21, 2, "Type \'null\' is not assignable to type \'string\'.", "5861160"],
+      [38, 31, 6, "Type \'null\' is not assignable to type \'string\'.", "1422303533"],
+      [38, 45, 4, "Type \'null\' is not assignable to type \'string\'.", "2087876002"],
+      [38, 57, 4, "Type \'null\' is not assignable to type \'string | undefined\'.", "2087956856"],
+      [65, 8, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"],
+      [78, 8, 5, "Type \'null\' is not assignable to type \'Error\'.", "165548477"]
+    ],
+    "src/script/auth/module/selector/AuthSelector.ts:941636495": [
+      [33, 2, 5, "Type \'undefined\' is not assignable to type \'string\'.", "165454089"],
+      [34, 2, 10, "Type \'undefined\' is not assignable to type \'string\'.", "1013483035"],
+      [35, 2, 15, "Type \'undefined\' is not assignable to type \'string\'.", "3770638438"],
+      [36, 2, 5, "Type \'undefined\' is not assignable to type \'string\'.", "173467459"],
+      [37, 2, 6, "Type \'undefined\' is not assignable to type \'string\'.", "1422303533"],
+      [38, 2, 4, "Type \'undefined\' is not assignable to type \'string\'.", "2087876002"],
+      [39, 2, 8, "Type \'undefined\' is not assignable to type \'string\'.", "1569157018"],
+      [40, 2, 5, "Type \'undefined\' is not assignable to type \'string\'.", "187940249"],
+      [41, 2, 10, "Type \'undefined\' is not assignable to type \'string\'.", "1244982411"],
+      [42, 2, 4, "Type \'undefined\' is not assignable to type \'TeamData\'.", "2087956856"],
+      [47, 2, 7, "Type \'undefined\' is not assignable to type \'boolean\'.", "2643464100"],
+      [48, 2, 7, "Type \'undefined\' is not assignable to type \'string\'.", "3920213849"],
+      [49, 2, 4, "Type \'undefined\' is not assignable to type \'string\'.", "2087846158"],
+      [50, 2, 2, "Type \'undefined\' is not assignable to type \'string\'.", "5861160"],
+      [51, 2, 4, "Type \'undefined\' is not assignable to type \'string\'.", "2087876002"]
+    ],
+    "src/script/auth/module/selector/SelfSelector.ts:104386324": [
+      [29, 2, 2, "Type \'undefined\' is not assignable to type \'string\'.", "5861160"],
+      [30, 2, 6, "Type \'undefined\' is not assignable to type \'string\'.", "1422303533"],
+      [31, 2, 4, "Type \'undefined\' is not assignable to type \'string\'.", "2087876002"]
+    ],
+    "src/script/auth/page/CheckPassword.tsx:1850762464": [
+      [71, 9, 21, "Object is possibly \'undefined\'.", "4077427211"],
+      [72, 6, 15, "Type \'ValidationError | null\' is not assignable to type \'Error\'.\\n  Type \'null\' is not assignable to type \'Error\'.", "1905002070"],
+      [73, 8, 21, "Object is possibly \'undefined\'.", "4077427211"],
+      [74, 8, 21, "Object is possibly \'undefined\'.", "4077427211"],
+      [77, 26, 21, "Object is possibly \'undefined\'.", "4077427211"],
+      [79, 10, 15, "Variable \'validationError\' is used before being assigned.", "1905002070"],
+      [82, 32, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.\\n  Type \'undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
+      [82, 66, 8, "Type \'string | null\' is not assignable to type \'string | number | undefined\'.\\n  Type \'null\' is not assignable to type \'string | number | undefined\'.", "1569157018"],
+      [87, 17, 5, "Argument of type \'ValidationError\' is not assignable to parameter of type \'SetStateAction<null>\'.\\n  Type \'ValidationError\' provides no match for the signature \'(prevState: null): null\'.", "165548477"],
+      [90, 14, 5, "Object is of type \'unknown\'.", "165548477"],
+      [99, 19, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<null>\'.", "165548477"],
+      [103, 19, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<null>\'.", "165548477"],
+      [132, 16, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"],
+      [134, 16, 5, "Type \'string | null\' is not assignable to type \'string | number | readonly string[] | undefined\'.\\n  Type \'null\' is not assignable to type \'string | number | readonly string[] | undefined\'.", "189936718"]
+    ],
+    "src/script/auth/page/ClientManager.tsx:4245719798": [
+      [37, 35, 44, "Argument of type \'string | null\' is not assignable to parameter of type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "2692881484"]
+    ],
+    "src/script/auth/page/ConversationJoin.tsx:2738577097": [
+      [121, 20, 9, "Argument of type \'boolean | \\"\\"\' is not assignable to parameter of type \'SetStateAction<boolean | undefined>\'.\\n  Type \'\\"\\"\' is not assignable to type \'SetStateAction<boolean | undefined>\'.", "984770170"],
+      [138, 19, 11, "Object is possibly \'undefined\'.", "3519972619"],
+      [151, 63, 15, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4110106687"],
+      [158, 49, 40, "Object is possibly \'undefined\'.", "2139501078"],
+      [160, 10, 5, "Object is of type \'unknown\'.", "165548477"],
+      [161, 16, 5, "Object is of type \'unknown\'.", "165548477"],
+      [164, 14, 5, "Object is of type \'unknown\'.", "165548477"],
+      [186, 4, 17, "Object is possibly \'undefined\'.", "2878566579"],
+      [186, 30, 17, "Object is possibly \'undefined\'.", "2878566579"],
+      [187, 9, 17, "Object is possibly \'undefined\'.", "2878566579"],
+      [188, 61, 17, "Object is possibly \'undefined\'.", "2878566579"],
+      [236, 30, 10, "Type \'boolean | undefined\' is not assignable to type \'never\'.\\n  Type \'undefined\' is not assignable to type \'never\'.", "1476830426"],
+      [256, 22, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"],
+      [294, 28, 10, "Type \'boolean | undefined\' is not assignable to type \'never\'.\\n  Type \'undefined\' is not assignable to type \'never\'.", "1476830426"],
+      [311, 75, 15, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4110106687"],
+      [312, 61, 40, "Object is possibly \'undefined\'.", "2139501078"]
+    ],
+    "src/script/auth/page/CustomEnvironmentRedirect.tsx:135692577": [
+      [44, 22, 16, "Argument of type \'string\' is not assignable to parameter of type \'SetStateAction<null>\'.", "1895785526"]
+    ],
+    "src/script/auth/page/EntropyContainer.tsx:1487902934": [
+      [36, 46, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'boolean | (() => boolean)\'.", "2620553983"]
+    ],
+    "src/script/auth/page/InitialInvite.tsx:2052648555": [
+      [97, 4, 18, "Object is possibly \'undefined\'.", "3955986040"],
+      [97, 31, 18, "Object is possibly \'undefined\'.", "3955986040"],
+      [98, 4, 18, "Object is possibly \'undefined\'.", "3955986040"],
+      [99, 9, 18, "Object is possibly \'undefined\'.", "3955986040"],
+      [100, 15, 75, "Argument of type \'ValidationError | null\' is not assignable to parameter of type \'SetStateAction<null>\'.\\n  Type \'ValidationError\' is not assignable to type \'SetStateAction<null>\'.", "2665964110"],
+      [100, 62, 18, "Object is possibly \'undefined\'.", "3955986040"],
+      [103, 29, 18, "Object is possibly \'undefined\'.", "3955986040"],
+      [105, 8, 18, "Object is possibly \'undefined\'.", "3955986040"],
+      [107, 12, 5, "Object is of type \'unknown\'.", "165548477"],
+      [108, 18, 5, "Object is of type \'unknown\'.", "165548477"],
+      [115, 16, 5, "Object is of type \'unknown\'.", "165548477"],
+      [168, 18, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"]
+    ],
+    "src/script/auth/page/Login.tsx:2417473152": [
+      [172, 24, 16, "Argument of type \'Error[]\' is not assignable to parameter of type \'SetStateAction<never[]>\'.", "2735526245"],
+      [174, 50, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
+      [203, 56, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
+      [205, 32, 11, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2331572484"],
+      [210, 36, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<string>\'.", "165548477"],
+      [234, 32, 18, "Object is possibly \'undefined\'.", "1981014711"],
+      [234, 32, 24, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3055772661"],
+      [269, 11, 14, "Type \'{}\' is not assignable to type \'never\'.", "158714422"],
+      [294, 24, 14, "Type \'(code: string) => void\' is not assignable to type \'(completeCode?: string | undefined) => void\'.\\n  Types of parameters \'code\' and \'completeCode\' are incompatible.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "2059828224"]
+    ],
+    "src/script/auth/page/PhoneLogin.tsx:2964526712": [
+      [86, 19, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<undefined>\'.", "165548477"],
+      [90, 19, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<undefined>\'.", "165548477"],
+      [108, 9, 14, "Type \'{}\' is not assignable to type \'never\'.", "158714422"]
+    ],
+    "src/script/auth/page/Root.tsx:3928022086": [
+      [130, 16, 9, "No overload matches this call.\\n  Overload 1 of 2, \'(props: (RouteProps<string, { [x: string]: string | undefined; }> & OmitNative<{}, keyof RouteProps<string, { [x: string]: string | undefined; }>>) | Readonly<...>): Route<...>\', gave the following error.\\n    Type \'false | ConnectedComponent<({ teamName, enterTeamCreationFlow, resetInviteErrors, pushAccountRegistrationData, authError, }: Props & { authError: Error; teamName: string; } & { enterTeamCreationFlow: () => Promise<void>; pushAccountRegistrationData: (registration: Partial<RegistrationDataState>) => Promise<...>; res...\' is not assignable to type \'ComponentType<any> | ComponentType<RouteComponentProps<any, StaticContext, unknown>> | undefined\'.\\n      Type \'false\' is not assignable to type \'ComponentType<any> | ComponentType<RouteComponentProps<any, StaticContext, unknown>> | undefined\'.\\n  Overload 2 of 2, \'(props: RouteProps<string, { [x: string]: string | undefined; }> & OmitNative<{}, keyof RouteProps<string, { [x: string]: string | undefined; }>>, context: any): Route<...>\', gave the following error.\\n    Type \'false | ConnectedComponent<({ teamName, enterTeamCreationFlow, resetInviteErrors, pushAccountRegistrationData, authError, }: Props & { authError: Error; teamName: string; } & { enterTeamCreationFlow: () => Promise<void>; pushAccountRegistrationData: (registration: Partial<RegistrationDataState>) => Promise<...>; res...\' is not assignable to type \'ComponentType<any> | ComponentType<RouteComponentProps<any, StaticContext, unknown>> | undefined\'.", "4247110506"],
+      [173, 16, 9, "No overload matches this call.\\n  Overload 1 of 2, \'(props: (RouteProps<string, { [x: string]: string | undefined; }> & OmitNative<{}, keyof RouteProps<string, { [x: string]: string | undefined; }>>) | Readonly<...>): Route<...>\', gave the following error.\\n    Type \'false | ConnectedComponent<({ account, authError, currentFlow, entropyData, doRegisterPersonal, doRegisterTeam, doSendActivationCode, }: Props & { account: RegistrationDataState; authError: Error; currentFlow: string; entropyData: Uint8Array | undefined; } & { ...; }) => Element, Omit<...> & ConnectProps>\' is not assignable to type \'ComponentType<any> | ComponentType<RouteComponentProps<any, StaticContext, unknown>> | undefined\'.\\n      Type \'false\' is not assignable to type \'ComponentType<any> | ComponentType<RouteComponentProps<any, StaticContext, unknown>> | undefined\'.\\n  Overload 2 of 2, \'(props: RouteProps<string, { [x: string]: string | undefined; }> & OmitNative<{}, keyof RouteProps<string, { [x: string]: string | undefined; }>>, context: any): Route<...>\', gave the following error.\\n    Type \'false | ConnectedComponent<({ account, authError, currentFlow, entropyData, doRegisterPersonal, doRegisterTeam, doSendActivationCode, }: Props & { account: RegistrationDataState; authError: Error; currentFlow: string; entropyData: Uint8Array | undefined; } & { ...; }) => Element, Omit<...> & ConnectProps>\' is not assignable to type \'ComponentType<any> | ComponentType<RouteComponentProps<any, StaticContext, unknown>> | undefined\'.", "4247110506"],
+      [177, 16, 9, "No overload matches this call.\\n  Overload 1 of 2, \'(props: (RouteProps<string, { [x: string]: string | undefined; }> & OmitNative<{}, keyof RouteProps<string, { [x: string]: string | undefined; }>>) | Readonly<...>): Route<...>\', gave the following error.\\n    Type \'false | ConnectedComponent<({ isPersonalFlow, enterPersonalCreationFlow }: Props & { isPersonalFlow: boolean; } & { enterPersonalCreationFlow: () => Promise<void>; }) => Element, Omit<Props & { isPersonalFlow: boolean; } & { ...; }, \\"enterPersonalCreationFlow\\" | \\"isPersonalFlow\\"> & ConnectProps>\' is not assignable to type \'ComponentType<any> | ComponentType<RouteComponentProps<any, StaticContext, unknown>> | undefined\'.\\n      Type \'false\' is not assignable to type \'ComponentType<any> | ComponentType<RouteComponentProps<any, StaticContext, unknown>> | undefined\'.\\n  Overload 2 of 2, \'(props: RouteProps<string, { [x: string]: string | undefined; }> & OmitNative<{}, keyof RouteProps<string, { [x: string]: string | undefined; }>>, context: any): Route<...>\', gave the following error.\\n    Type \'false | ConnectedComponent<({ isPersonalFlow, enterPersonalCreationFlow }: Props & { isPersonalFlow: boolean; } & { enterPersonalCreationFlow: () => Promise<void>; }) => Element, Omit<Props & { isPersonalFlow: boolean; } & { ...; }, \\"enterPersonalCreationFlow\\" | \\"isPersonalFlow\\"> & ConnectProps>\' is not assignable to type \'ComponentType<any> | ComponentType<RouteComponentProps<any, StaticContext, unknown>> | undefined\'.", "4247110506"],
+      [181, 16, 9, "No overload matches this call.\\n  Overload 1 of 2, \'(props: (RouteProps<string, { [x: string]: string | undefined; }> & OmitNative<{}, keyof RouteProps<string, { [x: string]: string | undefined; }>>) | Readonly<...>): Route<...>\', gave the following error.\\n    Type \'false | (({}: Props) => Element)\' is not assignable to type \'ComponentType<any> | ComponentType<RouteComponentProps<any, StaticContext, unknown>> | undefined\'.\\n      Type \'false\' is not assignable to type \'ComponentType<any> | ComponentType<RouteComponentProps<any, StaticContext, unknown>> | undefined\'.\\n  Overload 2 of 2, \'(props: RouteProps<string, { [x: string]: string | undefined; }> & OmitNative<{}, keyof RouteProps<string, { [x: string]: string | undefined; }>>, context: any): Route<...>\', gave the following error.\\n    Type \'false | (({}: Props) => Element)\' is not assignable to type \'ComponentType<any> | ComponentType<RouteComponentProps<any, StaticContext, unknown>> | undefined\'.", "4247110506"]
+    ],
+    "src/script/auth/page/SetEmail.tsx:2334731788": [
+      [50, 4, 16, "Object is possibly \'undefined\'.", "3859911866"],
+      [50, 29, 16, "Object is possibly \'undefined\'.", "3859911866"],
+      [51, 4, 16, "Object is possibly \'undefined\'.", "3859911866"],
+      [52, 9, 16, "Object is possibly \'undefined\'.", "3859911866"],
+      [53, 6, 15, "Type \'ValidationError | null\' is not assignable to type \'Error\'.\\n  Type \'null\' is not assignable to type \'Error\'.", "1905002070"],
+      [53, 62, 16, "Object is possibly \'undefined\'.", "3859911866"],
+      [53, 85, 16, "Object is possibly \'undefined\'.", "3859911866"],
+      [55, 20, 16, "Object is possibly \'undefined\'.", "3859911866"],
+      [57, 10, 15, "Variable \'validationError\' is used before being assigned.", "1905002070"],
+      [60, 23, 16, "Object is possibly \'undefined\'.", "3859911866"],
+      [63, 15, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<undefined>\'.", "165548477"],
+      [85, 14, 18, "Object is possibly \'undefined\'.", "3955986040"],
+      [87, 23, 4, "Argument of type \'null\' is not assignable to parameter of type \'SetStateAction<undefined>\'.", "2087897566"],
+      [92, 12, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"]
+    ],
+    "src/script/auth/page/SetHandle.tsx:663801276": [
+      [79, 17, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<null>\'.", "165548477"],
+      [91, 10, 5, "Object is of type \'unknown\'.", "165548477"],
+      [92, 8, 5, "Object is of type \'unknown\'.", "165548477"],
+      [94, 15, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<null>\'.", "165548477"]
+    ],
+    "src/script/auth/page/SetPassword.tsx:2776380433": [
+      [57, 4, 16, "Object is possibly \'undefined\'.", "3859911866"],
+      [58, 9, 16, "Object is possibly \'undefined\'.", "3859911866"],
+      [59, 6, 15, "Type \'ValidationError | null\' is not assignable to type \'Error\'.\\n  Type \'null\' is not assignable to type \'Error\'.", "1905002070"],
+      [59, 62, 16, "Object is possibly \'undefined\'.", "3859911866"],
+      [59, 85, 16, "Object is possibly \'undefined\'.", "3859911866"],
+      [61, 23, 16, "Object is possibly \'undefined\'.", "3859911866"],
+      [63, 10, 15, "Variable \'validationError\' is used before being assigned.", "1905002070"],
+      [69, 15, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<undefined>\'.", "165548477"],
+      [94, 14, 21, "Object is possibly \'undefined\'.", "4077427211"],
+      [95, 23, 4, "Argument of type \'null\' is not assignable to parameter of type \'SetStateAction<undefined>\'.", "2087897566"],
+      [99, 12, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"]
+    ],
+    "src/script/auth/page/SingleSignOn.tsx:2263489110": [
+      [71, 10, 7, "Type \'undefined\' is not assignable to type \'number\'.", "1978261647"],
+      [72, 10, 27, "Type \'undefined\' is not assignable to type \'(event: MessageEvent<any>) => void\'.", "667134498"],
+      [73, 10, 19, "Type \'undefined\' is not assignable to type \'(event: Event) => void\'.", "568100674"],
+      [129, 6, 20, "Type \'Window | null\' is not assignable to type \'Window | undefined\'.\\n  Type \'null\' is not assignable to type \'Window | undefined\'.", "2747308432"],
+      [243, 9, 14, "Type \'{}\' is not assignable to type \'never\'.", "158714422"]
+    ],
+    "src/script/auth/page/SingleSignOnForm.tsx:2490051983": [
+      [80, 59, 4, "Argument of type \'null\' is not assignable to parameter of type \'ClientType | (() => ClientType)\'.", "2087897566"],
+      [159, 30, 23, "Object is possibly \'undefined\'.", "1793578893"],
+      [160, 4, 23, "Object is possibly \'undefined\'.", "1793578893"],
+      [162, 4, 23, "Object is possibly \'undefined\'.", "1793578893"],
+      [162, 36, 23, "Object is possibly \'undefined\'.", "1793578893"],
+      [163, 35, 23, "Object is possibly \'undefined\'.", "1793578893"],
+      [165, 46, 23, "Object is possibly \'undefined\'.", "1793578893"],
+      [165, 76, 23, "Object is possibly \'undefined\'.", "1793578893"],
+      [168, 30, 23, "Object is possibly \'undefined\'.", "1793578893"],
+      [170, 4, 23, "Object is possibly \'undefined\'.", "1793578893"],
+      [184, 10, 4, "Argument of type \'null\' is not assignable to parameter of type \'string[] | undefined\'.", "2087897566"],
+      [213, 14, 5, "Object is of type \'unknown\'.", "165548477"],
+      [220, 22, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<null>\'.", "165548477"],
+      [228, 22, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<null>\'.", "165548477"],
+      [230, 25, 5, "Object is of type \'unknown\'.", "165548477"],
+      [230, 40, 5, "Object is of type \'unknown\'.", "165548477"],
+      [233, 83, 5, "No overload matches this call.\\n  Overload 1 of 2, \'(o: ArrayLike<unknown> | { [s: string]: unknown; }): [string, unknown][]\', gave the following error.\\n    Argument of type \'unknown\' is not assignable to parameter of type \'ArrayLike<unknown> | { [s: string]: unknown; }\'.\\n  Overload 2 of 2, \'(o: {}): [string, any][]\', gave the following error.\\n    Argument of type \'unknown\' is not assignable to parameter of type \'{}\'.", "165548477"],
+      [269, 12, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"]
+    ],
+    "src/script/auth/page/TeamName.tsx:158592421": [
+      [83, 4, 21, "Object is possibly \'undefined\'.", "173618382"],
+      [83, 34, 21, "Object is possibly \'undefined\'.", "173618382"],
+      [84, 9, 21, "Object is possibly \'undefined\'.", "173618382"],
+      [85, 15, 77, "Argument of type \'ValidationError | null\' is not assignable to parameter of type \'SetStateAction<null>\'.", "190261043"],
+      [85, 61, 21, "Object is possibly \'undefined\'.", "173618382"],
+      [91, 12, 7, "Type \'undefined\' is not assignable to type \'boolean\'.", "2643464100"],
+      [92, 12, 7, "Type \'undefined\' is not assignable to type \'string\'.", "3920213849"],
+      [93, 12, 4, "Type \'undefined\' is not assignable to type \'string\'.", "2087846158"],
+      [94, 12, 2, "Type \'undefined\' is not assignable to type \'string\'.", "5861160"],
+      [95, 18, 21, "Object is possibly \'undefined\'.", "173618382"],
+      [103, 4, 21, "Object is possibly \'undefined\'.", "173618382"],
+      [143, 24, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"]
+    ],
+    "src/script/auth/page/VerifyEmailCode.tsx:4216359015": [
+      [73, 61, 11, "Argument of type \'Uint8Array | undefined\' is not assignable to parameter of type \'Uint8Array\'.\\n  Type \'undefined\' is not assignable to type \'Uint8Array\'.", "432650366"],
+      [109, 45, 14, "Type \'(email_code: string) => Promise<void>\' is not assignable to type \'(completeCode?: string | undefined) => void\'.\\n  Types of parameters \'email_code\' and \'completeCode\' are incompatible.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "2059828224"]
+    ],
+    "src/script/auth/page/VerifyPhoneCode.tsx:423749632": [
+      [63, 17, 5, "Object is of type \'unknown\'.", "165548477"],
+      [64, 16, 5, "Object is of type \'unknown\'.", "165548477"],
+      [69, 21, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<ValidationError | null>\'.", "165548477"],
+      [81, 32, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
+      [90, 14, 5, "Object is of type \'unknown\'.", "165548477"],
+      [98, 19, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<ValidationError | null>\'.", "165548477"],
+      [102, 19, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<ValidationError | null>\'.", "165548477"],
+      [117, 45, 14, "Type \'(code: string) => Promise<void>\' is not assignable to type \'(completeCode?: string | undefined) => void\'.\\n  Types of parameters \'code\' and \'completeCode\' are incompatible.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "2059828224"]
+    ],
+    "src/script/auth/util/AccentColor.ts:2522707954": [
+      [72, 60, 44, "Type \'AccentColor | undefined\' is not assignable to type \'AccentColor\'.\\n  Type \'undefined\' is not assignable to type \'AccentColor\'.", "3153955984"]
+    ],
+    "src/script/auth/util/errorUtil.tsx:2764331984": [
+      [45, 70, 5, "Property \'label\' does not exist on type \'never\'.", "173467459"],
+      [45, 88, 5, "Property \'label\' does not exist on type \'never\'.", "173467459"],
+      [46, 51, 5, "Property \'label\' does not exist on type \'never\'.", "173467459"],
+      [47, 59, 5, "Property \'label\' does not exist on type \'never\'.", "173467459"]
+    ],
+    "src/script/auth/util/urlUtil.ts:2936167840": [
+      [61, 2, 17, "Type \'Window | null\' is not assignable to type \'Window\'.\\n  Type \'null\' is not assignable to type \'Window\'.", "211185092"]
+    ],
+    "src/script/backup/BackupRepository.ts:3449491466": [
+      [128, 53, 5, "Object is of type \'unknown\'.", "165548477"],
+      [157, 39, 18, "Argument of type \'Table<any, string> | undefined\' is not assignable to parameter of type \'Table<any, string>\'.\\n  Type \'undefined\' is not assignable to type \'Table<any, string>\'.", "3343706341"],
+      [178, 39, 11, "Argument of type \'Table<any, string> | undefined\' is not assignable to parameter of type \'Table<any, string>\'.\\n  Type \'undefined\' is not assignable to type \'Table<any, string>\'.", "1200531428"],
+      [244, 53, 5, "Object is of type \'unknown\'.", "165548477"],
+      [262, 61, 26, "Object is possibly \'undefined\'.", "3260126685"],
+      [265, 54, 19, "Object is possibly \'undefined\'.", "4084348636"]
+    ],
+    "src/script/calling/Call.ts:2505878078": [
+      [45, 18, 5, "Type \'Observable<STATE.UNKNOWN>\' is not assignable to type \'Observable<STATE>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'STATE\' is not assignable to type \'STATE.UNKNOWN\'.", "195031250"],
+      [46, 18, 9, "Type \'Observable<MuteState.NOT_MUTED>\' is not assignable to type \'Observable<MuteState>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'MuteState\' is not assignable to type \'MuteState.NOT_MUTED\'.", "3616862203"],
+      [53, 18, 14, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<Participant>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'Participant[] | null | undefined\' is not assignable to type \'never[] | null | undefined\'.\\n      Type \'Participant[]\' is not assignable to type \'never[]\'.\\n        Type \'Participant\' is not assignable to type \'never\'.", "2557058977"],
+      [101, 4, 99, "Type \'Participant | undefined\' is not assignable to type \'Participant\'.\\n  Type \'undefined\' is not assignable to type \'Participant\'.", "4122831026"],
+      [105, 28, 12, "Type \'null\' is not assignable to type \'HTMLAudioElement\'.", "1230365389"],
+      [183, 64, 12, "Object is possibly \'undefined\'.", "3794430747"],
+      [183, 83, 12, "Object is possibly \'undefined\'.", "3794430744"],
+      [190, 26, 14, "No overload matches this call.\\n  Overload 1 of 3, \'(value: Participant[] | null | undefined): ObservableArray<Participant>\', gave the following error.\\n    Argument of type \'(Participant | undefined)[]\' is not assignable to parameter of type \'Participant[]\'.\\n      Type \'Participant | undefined\' is not assignable to type \'Participant\'.\\n        Type \'undefined\' is not assignable to type \'Participant\'.\\n  Overload 2 of 3, \'(value: Participant[]): any\', gave the following error.\\n    Argument of type \'(Participant | undefined)[]\' is not assignable to parameter of type \'Participant[]\'.", "2557058977"]
+    ],
+    "src/script/calling/CallState.ts:2918606106": [
+      [45, 18, 22, "Type \'Observable<CallViewTab>\' is not assignable to type \'Observable<string>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'string\' is not assignable to type \'CallViewTab\'.", "2571314215"],
+      [46, 11, 17, "Type \'Observable<never[]>\' is not assignable to type \'Observable<ElectronDesktopCapturerSource[]>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'ElectronDesktopCapturerSource[]\' is not assignable to type \'never[]\'.", "3442699224"],
+      [47, 11, 17, "Type \'Observable<never[]>\' is not assignable to type \'Observable<ElectronDesktopCapturerSource[]>\'.", "2673893080"],
+      [51, 18, 17, "Type \'Observable<CallViewTab>\' is not assignable to type \'Observable<string>\'.", "1323835793"]
+    ],
+    "src/script/calling/CallingRepository.test.ts:1041588344": [
+      [129, 68, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'CONV_TYPE\'.", "2620553983"],
+      [134, 66, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'CONV_TYPE\'.", "2620553983"],
+      [139, 68, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'CONV_TYPE\'.", "2620553983"],
+      [155, 60, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'CONV_TYPE\'.", "2620553983"],
+      [180, 8, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'CONV_TYPE\'.", "2620553983"],
+      [244, 70, 15, "Argument of type \'(done: DoneCallback) => Promise<void>\' is not assignable to parameter of type \'ProvidesCallback | undefined\'.\\n  Type \'(done: DoneCallback) => Promise<void>\' is not assignable to type \'(cb: DoneCallback) => void | undefined\'.\\n    Type \'Promise<void>\' is not assignable to type \'void\'.", "4060847195"],
+      [383, 4, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'UserRepository\'.", "2620553983"],
+      [549, 4, 7, "Argument of type \'(context: any, conversationId: string, userId: string, clientId: string, destinationUserId: string, destinationClientId: string, payload: string) => number\' is not assignable to parameter of type \'WcallSendHandler\'.\\n  Types of parameters \'destinationUserId\' and \'targets\' are incompatible.\\n    Type \'string | null\' is not assignable to type \'string\'.\\n      Type \'null\' is not assignable to type \'string\'.", "2532445472"]
+    ],
+    "src/script/calling/CallingRepository.ts:3192332915": [
+      [121, 10, 10, "Property \'avsVersion\' has no initializer and is not definitely assigned in the constructor.", "3071787355"],
+      [127, 10, 12, "Property \'selfClientId\' has no initializer and is not definitely assigned in the constructor.", "3576844301"],
+      [128, 10, 8, "Property \'selfUser\' has no initializer and is not definitely assigned in the constructor.", "2198230984"],
+      [131, 10, 13, "Property \'nextMuteState\' has no initializer and is not definitely assigned in the constructor.", "2281376764"],
+      [215, 11, 10, "Object is possibly \'undefined\'.", "4011988536"],
+      [269, 6, 16, "Argument of type \'(_context: number, convId: SerializedConversationId, _userId: UserId, _clientId: ClientId, targets: string | null, _unused: null, payload: string) => number\' is not assignable to parameter of type \'WcallSendHandler\'.\\n  Types of parameters \'_unused\' and \'unused\' are incompatible.\\n    Type \'string | null\' is not assignable to type \'null\'.\\n      Type \'string\' is not assignable to type \'null\'.", "1986800474"],
+      [311, 4, 10, "Object is possibly \'undefined\'.", "4011988536"],
+      [311, 33, 10, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "4011779659"],
+      [317, 10, 60, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "440161276"],
+      [417, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'Call\'.", "2087897566"],
+      [489, 20, 50, "Object is possibly \'undefined\'.", "3990698706"],
+      [576, 12, 55, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "1654076048"],
+      [600, 16, 10, "Object is possibly \'undefined\'.", "4011988536"],
+      [601, 6, 10, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "4011779659"],
+      [605, 24, 4, "No overload matches this call.\\n  Overload 1 of 4, \'(value: string | number | Date): Date\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number | Date\'.\\n  Overload 2 of 4, \'(value: string | number): Date\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number\'.", "2087961072"],
+      [622, 38, 12, "Argument of type \'import(\\"wire-webapp/src/script/calling/enum/CallMessageType\\").CALL_MESSAGE_TYPE | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3390204570"],
+      [701, 8, 10, "Object is possibly \'undefined\'.", "4011988536"],
+      [701, 27, 10, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "4011779659"],
+      [702, 8, 10, "Object is possibly \'undefined\'.", "4011988536"],
+      [702, 25, 10, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "4011779659"],
+      [745, 4, 10, "Object is possibly \'undefined\'.", "4011988536"],
+      [745, 33, 10, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "4011779659"],
+      [760, 13, 10, "Object is possibly \'undefined\'.", "4011988536"],
+      [761, 8, 10, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "4011779659"],
+      [771, 8, 10, "Object is possibly \'undefined\'.", "4011988536"],
+      [771, 37, 10, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "4011779659"],
+      [776, 6, 10, "Object is possibly \'undefined\'.", "4011988536"],
+      [776, 35, 10, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "4011779659"],
+      [800, 6, 10, "Object is possibly \'undefined\'.", "4011988536"],
+      [801, 8, 10, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "4011779659"],
+      [819, 4, 10, "Object is possibly \'undefined\'.", "4011988536"],
+      [819, 22, 10, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "4011779659"],
+      [847, 4, 10, "Object is possibly \'undefined\'.", "4011988536"],
+      [847, 35, 10, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "4011779659"],
+      [853, 4, 10, "Object is possibly \'undefined\'.", "4011988536"],
+      [853, 19, 10, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "4011779659"],
+      [870, 4, 10, "Object is possibly \'undefined\'.", "4011988536"],
+      [870, 23, 10, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "4011779659"],
+      [878, 54, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.", "170201683"],
+      [900, 6, 10, "Object is possibly \'undefined\'.", "4011988536"],
+      [900, 35, 10, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "4011779659"],
+      [949, 4, 40, "Type \'Call | undefined\' is not assignable to type \'Call\'.\\n  Type \'undefined\' is not assignable to type \'Call\'.", "2135604529"],
+      [960, 8, 10, "Object is possibly \'undefined\'.", "4011988536"],
+      [970, 8, 10, "Object is possibly \'undefined\'.", "4011988536"],
+      [1077, 68, 12, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "1670678216"],
+      [1127, 6, 10, "Object is possibly \'undefined\'.", "4011988536"],
+      [1138, 8, 10, "Object is possibly \'undefined\'.", "4011988536"],
+      [1138, 32, 10, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "4011779659"],
+      [1141, 8, 10, "Object is possibly \'undefined\'.", "4011988536"],
+      [1141, 32, 10, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "4011779659"],
+      [1165, 8, 18, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "1508601427"],
+      [1180, 60, 16, "Object is possibly \'undefined\'.", "2328737116"],
+      [1207, 40, 16, "Object is possibly \'undefined\'.", "2328737116"],
+      [1343, 51, 40, "Argument of type \'User | undefined\' is not assignable to parameter of type \'User\'.\\n  Type \'undefined\' is not assignable to type \'User\'.", "882916431"],
+      [1380, 21, 4, "Argument of type \'Call | undefined\' is not assignable to parameter of type \'Call\'.\\n  Type \'undefined\' is not assignable to type \'Call\'.", "2087764327"],
+      [1406, 6, 93, "No overload matches this call.\\n  Overload 1 of 3, \'(callbackfn: (previousValue: [string, MediaStream | undefined], currentValue: [string, MediaStream | undefined], currentIndex: number, array: [string, MediaStream | undefined][]) => [...], initialValue: [...]): [...]\', gave the following error.\\n    Argument of type \'(accumulator: MediaStreamQuery, [type, isCached]: [keyof MediaStreamQuery, MediaStream]) => MediaStreamQuery\' is not assignable to parameter of type \'(previousValue: [string, MediaStream | undefined], currentValue: [string, MediaStream | undefined], currentIndex: number, array: [string, MediaStream | undefined][]) => [...]\'.\\n      Types of parameters \'accumulator\' and \'previousValue\' are incompatible.\\n        Type \'[string, MediaStream | undefined]\' has no properties in common with type \'MediaStreamQuery\'.\\n  Overload 2 of 3, \'(callbackfn: (previousValue: MediaStreamQuery, currentValue: [string, MediaStream | undefined], currentIndex: number, array: [string, MediaStream | undefined][]) => MediaStreamQuery, initialValue: MediaStreamQuery): MediaStreamQuery\', gave the following error.\\n    Argument of type \'(accumulator: MediaStreamQuery, [type, isCached]: [keyof MediaStreamQuery, MediaStream]) => MediaStreamQuery\' is not assignable to parameter of type \'(previousValue: MediaStreamQuery, currentValue: [string, MediaStream | undefined], currentIndex: number, array: [string, MediaStream | undefined][]) => MediaStreamQuery\'.\\n      Types of parameters \'__1\' and \'currentValue\' are incompatible.\\n        Type \'[string, MediaStream | undefined]\' is not assignable to type \'[keyof MediaStreamQuery, MediaStream]\'.\\n          Type at position 0 in source is not compatible with type at position 0 in target.\\n            Type \'string\' is not assignable to type \'keyof MediaStreamQuery\'.", "2143539252"],
+      [1417, 39, 30, "Element implicitly has an \'any\' type because index expression is not of type \'number\'.", "4024502179"],
+      [1435, 27, 6, "Property \'screen\' does not exist on type \'[string, MediaStream | undefined]\'.", "2165256457"],
+      [1438, 54, 14, "Type \'[string, MediaStream | undefined]\' has no properties in common with type \'MediaStreamQuery\'.", "3540397998"],
+      [1445, 42, 14, "Type \'[string, MediaStream | undefined]\' has no properties in common with type \'MediaStreamQuery\'.", "3540397998"],
+      [1510, 36, 40, "Argument of type \'User | undefined\' is not assignable to parameter of type \'User\'.\\n  Type \'undefined\' is not assignable to type \'User\'.", "882916431"],
+      [1591, 25, 18, "Object is possibly \'undefined\'.", "1508601427"],
+      [1600, 61, 18, "Object is possibly \'undefined\'.", "1508601427"],
+      [1601, 57, 18, "Object is possibly \'undefined\'.", "1508601427"],
+      [1616, 31, 10, "Object is possibly \'undefined\'.", "4011988536"],
+      [1616, 46, 10, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "4011779659"],
+      [1617, 4, 10, "Object is possibly \'undefined\'.", "4011988536"],
+      [1617, 23, 10, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "4011779659"]
+    ],
+    "src/script/calling/Participant.ts:1539597594": [
+      [46, 4, 15, "Type \'Observable<VIDEO_STATE.STOPPED>\' is not assignable to type \'Observable<VIDEO_STATE>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'VIDEO_STATE\' is not assignable to type \'VIDEO_STATE.STOPPED\'.", "4277239019"],
+      [61, 4, 23, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'boolean\' is not assignable to type \'false\'.", "2555908354"],
+      [62, 4, 27, "Type \'Observable<number | undefined>\' is not assignable to type \'Observable<number>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'number | undefined\' is not assignable to type \'number\'.\\n      Type \'undefined\' is not assignable to type \'number\'.", "3324051133"],
+      [63, 4, 12, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "3089409914"],
+      [64, 4, 19, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "2641705914"],
+      [71, 23, 18, "Argument of type \'MediaStream | undefined\' is not assignable to parameter of type \'MediaStream\'.\\n  Type \'undefined\' is not assignable to type \'MediaStream\'.", "2024190982"],
+      [76, 23, 18, "Argument of type \'MediaStream | undefined\' is not assignable to parameter of type \'MediaStream\'.\\n  Type \'undefined\' is not assignable to type \'MediaStream\'.", "2270688449"],
+      [91, 65, 18, "Object is possibly \'undefined\'.", "2024190982"],
+      [92, 65, 18, "Object is possibly \'undefined\'.", "2270688449"],
+      [97, 23, 18, "Argument of type \'MediaStream | undefined\' is not assignable to parameter of type \'MediaStream\'.\\n  Type \'undefined\' is not assignable to type \'MediaStream\'.", "2270688449"],
+      [102, 23, 18, "Argument of type \'MediaStream | undefined\' is not assignable to parameter of type \'MediaStream\'.\\n  Type \'undefined\' is not assignable to type \'MediaStream\'.", "2024190982"]
+    ],
+    "src/script/calling/videoGridHandler.ts:1921469395": [
+      [65, 2, 12, "Type \'Grid | undefined\' is not assignable to type \'Grid\'.\\n  Type \'undefined\' is not assignable to type \'Grid\'.", "3234966220"]
+    ],
+    "src/script/client/ClientEntity.ts:1079007296": [
+      [56, 4, 11, "Type \'string | null\' is not assignable to type \'string | undefined\'.", "2914658029"],
+      [70, 6, 10, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "3231345145"],
+      [108, 4, 56, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2872449191"]
+    ],
+    "src/script/client/ClientMapper.ts:508685249": [
+      [54, 58, 30, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "653879435"],
+      [56, 6, 28, "Cannot invoke an object which is possibly \'undefined\'.", "1515665510"],
+      [56, 35, 30, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.", "863083372"],
+      [97, 8, 18, "Type \'T[Extract<keyof T, string>] | undefined\' is not assignable to type \'T[Extract<keyof T, string>]\'.\\n  Type \'undefined\' is not assignable to type \'T[Extract<keyof T, string>]\'.", "1321920442"]
+    ],
+    "src/script/client/ClientRepository.test.ts:4081872359": [
+      [35, 6, 6, "Type \'undefined\' is not assignable to type \'string\'.", "1765117785"],
+      [39, 13, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [42, 19, 30, "Object is possibly \'undefined\'.", "3948412077"],
+      [49, 6, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [62, 12, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [66, 35, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [98, 28, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [104, 13, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [111, 28, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [119, 13, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [129, 28, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [131, 41, 16, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "4228495289"],
+      [136, 13, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [146, 12, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [150, 19, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [160, 6, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [160, 65, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'ClientEntity\'.", "2620553983"],
+      [171, 6, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [173, 26, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [186, 6, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [188, 26, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [195, 33, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [208, 6, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [209, 26, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [222, 6, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [223, 26, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [229, 33, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [236, 21, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [236, 80, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'ClientEntity\'.", "2620553983"],
+      [241, 6, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [242, 6, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [242, 62, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [243, 21, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [251, 6, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [252, 21, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [260, 6, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [261, 21, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [267, 33, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [273, 6, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [274, 33, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [274, 108, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
+      [280, 6, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [281, 33, 29, "Object is possibly \'undefined\'.", "3944650061"],
+      [281, 82, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'QualifiedId\'.", "2620553983"]
+    ],
+    "src/script/client/ClientRepository.ts:3960554774": [
+      [71, 4, 13, "Type \'Observable<undefined>\' is not assignable to type \'Observable<User>\'.\\n  Types of property \'equalityComparer\' are incompatible.\\n    Type \'(a: undefined, b: undefined) => boolean\' is not assignable to type \'(a: User, b: User) => boolean\'.\\n      Types of parameters \'a\' and \'a\' are incompatible.\\n        Type \'User\' is not assignable to type \'undefined\'.", "311178912"],
+      [112, 60, 29, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4105403112"],
+      [115, 78, 19, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string | null\'.", "3263048159"],
+      [156, 73, 19, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string | null\'.", "3263048159"],
+      [187, 4, 12, "Object is possibly \'undefined\'.", "123060899"],
+      [201, 4, 28, "Cannot invoke an object which is possibly \'undefined\'.", "1515665510"],
+      [256, 33, 5, "Object is of type \'unknown\'.", "165548477"],
+      [258, 64, 5, "Object is of type \'unknown\'.", "165548477"],
+      [258, 78, 5, "Object is of type \'unknown\'.", "165548477"],
+      [271, 6, 45, "Type \'ClientType.PERMANENT | ClientType.TEMPORARY | undefined\' is not assignable to type \'ClientType.PERMANENT | ClientType.TEMPORARY\'.\\n  Type \'undefined\' is not assignable to type \'ClientType.PERMANENT | ClientType.TEMPORARY\'.", "2864978427"],
+      [291, 10, 17, "Object is possibly \'undefined\'.", "985697541"],
+      [371, 66, 23, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4244912389"],
+      [372, 32, 6, "Type \'string | undefined\' is not assignable to type \'string | null\'.", "1127975365"],
+      [458, 52, 23, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4244912389"]
+    ],
+    "src/script/client/ClientState.ts:2521520538": [
+      [26, 2, 7, "Property \'clients\' has no initializer and is not definitely assigned in the constructor.", "3676208751"],
+      [31, 4, 18, "Type \'Observable<ClientEntity | undefined>\' is not assignable to type \'Observable<ClientEntity>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'ClientEntity | undefined\' is not assignable to type \'ClientEntity\'.\\n      Type \'undefined\' is not assignable to type \'ClientEntity\'.", "2551882557"]
+    ],
+    "src/script/components/AvailabilityState.tsx:2012314105": [
+      [75, 6, 7, "Cannot invoke an object which is possibly \'undefined\'.", "4055953994"]
+    ],
+    "src/script/components/Avatar.test.tsx:1834172511": [
+      [38, 37, 31, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "4162123045"],
+      [43, 39, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [60, 39, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [86, 39, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [98, 39, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"]
+    ],
+    "src/script/components/Avatar.tsx:3497736425": [
+      [97, 33, 30, "Argument of type \'ParentNode | null\' is not assignable to parameter of type \'Node\'.\\n  Type \'null\' is not assignable to type \'Node\'.", "3446886669"]
+    ],
+    "src/script/components/Checkbox/Checkbox.styles.ts:4183813824": [
+      [22, 2, 9, "Type \'{ cursor: false | \\"pointer\\"; }\' is not assignable to type \'CSSInterpolation\'.\\n  Types of property \'cursor\' are incompatible.\\n    Type \'false | \\"pointer\\"\' is not assignable to type \'Cursor | (Cursor | undefined)[] | Cursor[] | undefined\'.\\n      Type \'false\' is not assignable to type \'Cursor | (Cursor | undefined)[] | Cursor[] | undefined\'.", "1736274335"],
+      [25, 2, 13, "Type \'{ borderColor: false | \\"var(--accent-color-500)\\"; }\' is not assignable to type \'CSSInterpolation\'.\\n  Types of property \'borderColor\' are incompatible.\\n    Type \'false | \\"var(--accent-color-500)\\"\' is not assignable to type \'BorderColor | (BorderColor | undefined)[] | BorderColor[] | undefined\'.\\n      Type \'false\' is not assignable to type \'BorderColor | (BorderColor | undefined)[] | BorderColor[] | undefined\'.", "3854155997"],
+      [34, 2, 16, "Type \'{ borderColor: false | \\"var(--accent-color-500)\\"; }\' is not assignable to type \'CSSInterpolation\'.\\n  Types of property \'borderColor\' are incompatible.\\n    Type \'false | \\"var(--accent-color-500)\\"\' is not assignable to type \'BorderColor | (BorderColor | undefined)[] | BorderColor[] | undefined\'.", "2405411068"],
+      [37, 2, 38, "Type \'{ backgroundColor: false | \\"var(--accent-color-600)\\"; borderColor: \\"var(--accent-color-600)\\"; outline: string; }\' is not assignable to type \'CSSInterpolation\'.\\n  Types of property \'backgroundColor\' are incompatible.\\n    Type \'false | \\"var(--accent-color-600)\\"\' is not assignable to type \'BackgroundColor | (BackgroundColor | undefined)[] | BackgroundColor[] | undefined\'.\\n      Type \'false\' is not assignable to type \'BackgroundColor | (BackgroundColor | undefined)[] | BackgroundColor[] | undefined\'.", "876827402"],
+      [52, 2, 29, "Type \'{ \'& + svg\': { background?: string | undefined; borderColor?: \\"var(--accent-color-600)\\" | undefined; }; \'&:active + svg\': { borderColor: false | \\"var(--accent-color-600)\\"; }; \'&:focus + svg, &:focus-visible + svg\': { ...; }; }\' is not assignable to type \'CSSInterpolation\'.\\n  Types of property \'\'&:active + svg\'\' are incompatible.\\n    Type \'{ borderColor: false | \\"var(--accent-color-600)\\"; }\' is not assignable to type \'CSSInterpolation\'.\\n      Types of property \'borderColor\' are incompatible.\\n        Type \'false | \\"var(--accent-color-600)\\"\' is not assignable to type \'BorderColor | (BorderColor | undefined)[] | BorderColor[] | undefined\'.\\n          Type \'false\' is not assignable to type \'BorderColor | (BorderColor | undefined)[] | BorderColor[] | undefined\'.", "1050489042"]
+    ],
+    "src/script/components/CopyToClipboard.test.ts:2298079608": [
+      [35, 11, 28, "Object is possibly \'null\'.", "1881734620"],
+      [40, 4, 13, "Object is possibly \'null\'.", "2433726607"],
+      [41, 4, 13, "Object is possibly \'null\'.", "2433726607"],
+      [47, 24, 7, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "4115912507"],
+      [49, 11, 13, "Object is possibly \'null\'.", "2433726607"],
+      [50, 11, 13, "Object is possibly \'null\'.", "2433726607"]
+    ],
+    "src/script/components/CopyToClipboard.tsx:1568430381": [
+      [32, 6, 21, "Object is possibly \'null\'.", "3831905776"],
+      [33, 6, 21, "Object is possibly \'null\'.", "3831905776"],
+      [44, 58, 1, "No overload matches this call.\\n  Overload 1 of 6, \'(this: (this: null, arg0: MouseEvent<HTMLDivElement, MouseEvent>) => void, thisArg: null, arg0: MouseEvent<HTMLDivElement, MouseEvent>): () => void\', gave the following error.\\n    Argument of type \'KeyboardEvent<HTMLDivElement>\' is not assignable to parameter of type \'MouseEvent<HTMLDivElement, MouseEvent>\'.\\n  Overload 2 of 6, \'(this: (this: null, ...args: MouseEvent<HTMLDivElement, MouseEvent>[]) => void, thisArg: null, ...args: MouseEvent<HTMLDivElement, MouseEvent>[]): (...args: MouseEvent<...>[]) => void\', gave the following error.\\n    Argument of type \'KeyboardEvent<HTMLDivElement>\' is not assignable to parameter of type \'MouseEvent<HTMLDivElement, MouseEvent>\'.", "177600"]
+    ],
+    "src/script/components/Icon.tsx:3124821771": [
+      [44, 11, 5, "Property \'width\' does not exist on type \'{ [key: string]: string; } | undefined\'.", "191264035"],
+      [44, 18, 6, "Property \'height\' does not exist on type \'{ [key: string]: string; } | undefined\'.", "1581003770"],
+      [44, 28, 19, "Object is possibly \'null\'.", "3003021604"],
+      [44, 39, 7, "Argument of type \'string | null\' is not assignable to parameter of type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "985028253"],
+      [53, 12, 3, "Type \'{ \\"aria-hidden\\": \\"true\\"; dangerouslySetInnerHTML: { __html: string; }; className?: string | undefined; color?: string | undefined; height: any; id?: string | undefined; lang?: string | undefined; ... 463 more ...; key?: Key | ... 1 more ... | undefined; }\' is not assignable to type \'SVGProps<SVGSVGElement> & { css?: Interpolation<Theme>; }\'.\\n  Type \'{ \\"aria-hidden\\": \\"true\\"; dangerouslySetInnerHTML: { __html: string; }; className?: string | undefined; color?: string | undefined; height: any; id?: string | undefined; lang?: string | undefined; ... 463 more ...; key?: Key | ... 1 more ... | undefined; }\' is not assignable to type \'SVGProps<SVGSVGElement>\'.\\n    Types of property \'viewBox\' are incompatible.\\n      Type \'string | null\' is not assignable to type \'string | undefined\'.\\n        Type \'null\' is not assignable to type \'string | undefined\'.", "193432711"]
+    ],
+    "src/script/components/Image.tsx:2138055581": [
+      [51, 43, 18, "Argument of type \'HTMLDivElement | undefined\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLElement\'.", "4082577534"]
+    ],
+    "src/script/components/LoadingBar.test.tsx:2152103384": [
+      [34, 11, 31, "Object is possibly \'null\'.", "1466818312"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/MessageFooterLike.test.tsx:1554184736": [
+      [33, 39, 22, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1768242196"],
+      [34, 31, 14, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "3477072529"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/MessageFooterLike.tsx:2085723443": [
+      [51, 8, 7, "Type \'(() => void) | null\' is not assignable to type \'MouseEventHandler<HTMLButtonElement> | undefined\'.\\n  Type \'null\' is not assignable to type \'MouseEventHandler<HTMLButtonElement> | undefined\'.", "4055953994"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/MessageQuote.tsx:3969532892": [
+      [68, 53, 11, "Argument of type \'Error | undefined\' is not assignable to parameter of type \'string | Error | (() => string | Error)\'.\\n  Type \'undefined\' is not assignable to type \'string | Error | (() => string | Error)\'.", "2014657417"],
+      [118, 10, 13, "Type \'ContentMessage | undefined\' is not assignable to type \'ContentMessage\'.\\n  Type \'undefined\' is not assignable to type \'ContentMessage\'.", "2555417520"],
+      [121, 10, 20, "Type \'(message: ContentMessage, event: MouseEvent<Element, MouseEvent>) => void\' is not assignable to type \'(message: Text | ContentMessage, event: MouseEvent<Element, MouseEvent>) => void\'.\\n  Types of parameters \'message\' and \'message\' are incompatible.\\n    Type \'Text | ContentMessage\' is not assignable to type \'ContentMessage\'.\\n      Type \'Text\' is missing the following properties from type \'ContentMessage\': isLikedProvisional, reactions_user_ets, assets, is_liked, and 75 more.", "2936827179"],
+      [220, 16, 3, "Type \'(node: Element) => void\' is not assignable to type \'LegacyRef<HTMLDivElement> | undefined\'.\\n  Type \'(node: Element) => void\' is not assignable to type \'(instance: HTMLDivElement | null) => void\'.", "193432436"],
+      [222, 57, 45, "No overload matches this call.\\n  Overload 1 of 6, \'(this: (this: undefined, arg0: Text, arg1: MouseEvent<Element, MouseEvent>) => void, thisArg: undefined, arg0: Text, arg1: MouseEvent<Element, MouseEvent>): () => void\', gave the following error.\\n    Argument of type \'KeyboardEvent<HTMLDivElement>\' is not assignable to parameter of type \'MouseEvent<Element, MouseEvent>\'.\\n      Type \'KeyboardEvent<HTMLDivElement>\' is missing the following properties from type \'MouseEvent<Element, MouseEvent>\': button, buttons, clientX, clientY, and 7 more.\\n  Overload 2 of 6, \'(this: (this: undefined, ...args: Text[]) => void, thisArg: undefined, ...args: Text[]): (...args: Text[]) => void\', gave the following error.\\n    The \'this\' context of type \'(message: Text | ContentMessage, event: MouseEvent<Element, MouseEvent>) => void\' is not assignable to method\'s \'this\' of type \'(this: undefined, ...args: Text[]) => void\'.\\n      Types of parameters \'event\' and \'args\' are incompatible.\\n        Type \'Text\' is missing the following properties from type \'MouseEvent<Element, MouseEvent>\': altKey, button, buttons, clientX, and 28 more.", "3928016927"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/asset/AbstractAssetTransferStateTracker.ts:1402358935": [
+      [41, 24, 14, "Object is possibly \'undefined\'.", "2156033467"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/asset/AssetHeader.test.tsx:2147033157": [
+      [32, 22, 56, "Object is possibly \'null\'.", "2110829367"],
+      [33, 18, 51, "Object is possibly \'null\'.", "4019120793"],
+      [43, 46, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/asset/AssetLoader.test.tsx:2902218927": [
+      [29, 33, 16, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "4136845134"],
+      [30, 21, 49, "Object is possibly \'null\'.", "1165956046"],
+      [67, 24, 31, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "3939317679"],
+      [73, 24, 33, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "4029481972"],
+      [79, 24, 31, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "3431654221"],
+      [85, 24, 33, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "4048303894"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/asset/AssetLoader.tsx:2401435474": [
+      [46, 58, 1, "No overload matches this call.\\n  Overload 1 of 6, \'(this: (this: null, arg0: MouseEvent<HTMLDivElement, MouseEvent>) => void, thisArg: null, arg0: MouseEvent<HTMLDivElement, MouseEvent>): () => void\', gave the following error.\\n    Argument of type \'KeyboardEvent<HTMLDivElement>\' is not assignable to parameter of type \'MouseEvent<HTMLDivElement, MouseEvent>\'.\\n  Overload 2 of 6, \'(this: (this: null, ...args: MouseEvent<HTMLDivElement, MouseEvent>[]) => void, thisArg: null, ...args: MouseEvent<HTMLDivElement, MouseEvent>[]): (...args: MouseEvent<...>[]) => void\', gave the following error.\\n    Argument of type \'KeyboardEvent<HTMLDivElement>\' is not assignable to parameter of type \'MouseEvent<HTMLDivElement, MouseEvent>\'.", "177600"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/asset/AudioAsset.tsx:1986822260": [
+      [65, 42, 12, "Object is possibly \'undefined\'.", "1230365389"],
+      [66, 33, 28, "Object is possibly \'undefined\'.", "1981948963"],
+      [76, 47, 4, "Argument of type \'Blob | undefined\' is not assignable to parameter of type \'Blob | MediaSource\'.\\n  Type \'undefined\' is not assignable to type \'Blob | MediaSource\'.", "2087735462"],
+      [96, 33, 8, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "504498865"],
+      [125, 20, 14, "Type \'number | undefined\' is not assignable to type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "2156033467"],
+      [134, 38, 12, "Type \'HTMLAudioElement | undefined\' is not assignable to type \'HTMLAudioElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLAudioElement\'.", "1230365389"],
+      [138, 26, 12, "Type \'HTMLAudioElement | undefined\' is not assignable to type \'HTMLMediaElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLMediaElement\'.", "780920223"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/asset/FileAssetComponent.test.tsx:1016943020": [
+      [34, 22, 39, "Object is possibly \'null\'.", "1572638209"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/asset/FileAssetComponent.tsx:2719195984": [
+      [43, 6, 18, "Type \'({ message, hasHeader, teamState, }: FileAssetProps) => false | Element\' is not assignable to type \'FC<FileAssetProps>\'.\\n  Type \'false | Element\' is not assignable to type \'ReactElement<any, any> | null\'.", "3519699612"],
+      [62, 22, 14, "Object is possibly \'undefined\'.", "2156033467"],
+      [62, 44, 14, "Object is possibly \'undefined\'.", "2156033467"],
+      [106, 31, 12, "Type \'number | undefined\' is not assignable to type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "3813716702"],
+      [109, 45, 12, "Type \'number | undefined\' is not assignable to type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "3813716702"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset.test.ts:3331662495": [
+      [54, 19, 17, "Object is possibly \'null\'.", "901686138"],
+      [80, 21, 17, "Object is possibly \'null\'.", "901686138"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset.tsx:3794627806": [
+      [51, 43, 18, "Argument of type \'HTMLDivElement | undefined\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLElement\'.", "4082577534"],
+      [110, 27, 12, "Type \'number | undefined\' is not assignable to type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "3813716702"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/asset/LinkPreviewAssetComponent.test.ts:3000844988": [
+      [116, 11, 21, "Object is possibly \'null\'.", "3265536666"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/asset/LocationAsset.test.ts:1073403253": [
+      [31, 22, 21, "Object is possibly \'null\'.", "3932109547"],
+      [49, 11, 12, "Object is possibly \'null\'.", "2001318815"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/asset/MessageButton.test.tsx:865057470": [
+      [33, 49, 24, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "531434894"],
+      [41, 6, 13, "Type \'Observable<string>\' is not assignable to type \'Observable<string | undefined>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "3232332006"],
+      [43, 6, 16, "Type \'Observable<string>\' is not assignable to type \'Observable<string | undefined>\'.", "4149311735"],
+      [44, 6, 15, "Type \'Observable<string>\' is not assignable to type \'Observable<string | undefined>\'.", "4105372853"],
+      [53, 11, 24, "Object is possibly \'null\'.", "1746716537"],
+      [59, 6, 13, "Type \'Observable<string>\' is not assignable to type \'Observable<string | undefined>\'.", "3232332006"],
+      [61, 6, 16, "Type \'Observable<string>\' is not assignable to type \'Observable<string | undefined>\'.", "4149311735"],
+      [62, 6, 15, "Type \'Observable<string>\' is not assignable to type \'Observable<string | undefined>\'.", "4105372853"],
+      [71, 11, 40, "Object is possibly \'null\'.", "95183934"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset.tsx:48342831": [
+      [45, 6, 10, "Type \'({ message, isQuote, teamState, assetRepository, }: VideoAssetProps) => false | Element\' is not assignable to type \'FC<VideoAssetProps>\'.\\n  Type \'false | Element\' is not assignable to type \'ReactElement<any, any> | null\'.", "1844198436"],
+      [56, 59, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | (() => string)\'.", "2087897566"],
+      [57, 51, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | (() => string)\'.", "2087897566"],
+      [70, 105, 4, "Argument of type \'Blob | undefined\' is not assignable to parameter of type \'Blob | MediaSource\'.", "2087735462"],
+      [83, 8, 12, "Object is possibly \'undefined\'.", "2287620778"],
+      [89, 49, 4, "Argument of type \'Blob | undefined\' is not assignable to parameter of type \'Blob | MediaSource\'.", "2087735462"],
+      [105, 4, 12, "Object is possibly \'undefined\'.", "2287620778"],
+      [139, 40, 4, "Argument of type \'true\' is not assignable to parameter of type \'SetStateAction<null>\'.", "2087932467"],
+      [143, 53, 12, "Object is possibly \'undefined\'.", "2287620778"],
+      [143, 77, 12, "Object is possibly \'undefined\'.", "2287620778"],
+      [144, 57, 12, "Object is possibly \'undefined\'.", "2287620778"],
+      [144, 81, 12, "Object is possibly \'undefined\'.", "2287620778"],
+      [169, 28, 14, "Type \'number | undefined\' is not assignable to type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "2156033467"],
+      [182, 28, 14, "Type \'number | undefined\' is not assignable to type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "2156033467"],
+      [192, 28, 12, "Type \'HTMLVideoElement | undefined\' is not assignable to type \'HTMLMediaElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLMediaElement\'.", "780920223"],
+      [198, 43, 13, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "3979215185"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/asset/controls/AudioSeekBar.test.ts:540025694": [
+      [63, 32, 26, "Object is possibly \'null\'.", "2291412725"],
+      [86, 22, 3, "Argument of type \'Element | null\' is not assignable to parameter of type \'Document | Node | Element | Window\'.\\n  Type \'null\' is not assignable to type \'Document | Node | Element | Window\'.", "193432711"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/asset/controls/AudioSeekBar.tsx:1617658655": [
+      [49, 29, 19, "No overload matches this call.\\n  Overload 1 of 4, \'(iterable: ArrayLike<number> | Iterable<number>): number[]\', gave the following error.\\n    Argument of type \'number[] | undefined\' is not assignable to parameter of type \'ArrayLike<number> | Iterable<number>\'.\\n      Type \'undefined\' is not assignable to type \'ArrayLike<number> | Iterable<number>\'.\\n  Overload 2 of 4, \'(arrayLike: ArrayLike<number>): number[]\', gave the following error.\\n    Argument of type \'number[] | undefined\' is not assignable to parameter of type \'ArrayLike<number>\'.\\n      Type \'undefined\' is not assignable to type \'ArrayLike<number>\'.", "2734492113"],
+      [86, 53, 15, "Object is possibly \'undefined\'.", "3322187904"],
+      [87, 63, 15, "Object is possibly \'undefined\'.", "3322187904"],
+      [109, 6, 3, "Type \'MutableRefObject<SVGSVGElement | undefined>\' is not assignable to type \'LegacyRef<SVGSVGElement> | undefined\'.\\n  Type \'MutableRefObject<SVGSVGElement | undefined>\' is not assignable to type \'RefObject<SVGSVGElement>\'.\\n    Types of property \'current\' are incompatible.\\n      Type \'SVGSVGElement | undefined\' is not assignable to type \'SVGSVGElement | null\'.\\n        Type \'undefined\' is not assignable to type \'SVGSVGElement | null\'.", "193432436"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/asset/controls/MediaButton.test.tsx:2611082281": [
+      [33, 39, 20, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "2187624904"],
+      [34, 40, 21, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "2102968254"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/asset/controls/MediaButton.tsx:3223205614": [
+      [92, 51, 12, "Type \'number | undefined\' is not assignable to type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "3813716702"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/asset/controls/SeekBar.test.tsx:4106938805": [
+      [30, 4, 17, "Object is possibly \'null\'.", "780973491"],
+      [30, 4, 46, "Object is possibly \'null\'.", "4284107"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx:1156661443": [
+      [74, 55, 47, "No overload matches this call.\\n  Overload 1 of 6, \'(this: (this: null, arg0: Text, arg1: MouseEvent<Element, MouseEvent>) => void, thisArg: null, arg0: Text, arg1: MouseEvent<Element, MouseEvent>): () => void\', gave the following error.\\n    Argument of type \'KeyboardEvent<HTMLDivElement>\' is not assignable to parameter of type \'MouseEvent<Element, MouseEvent>\'.\\n  Overload 2 of 6, \'(this: (this: null, ...args: Text[]) => void, thisArg: null, ...args: Text[]): (...args: Text[]) => void\', gave the following error.\\n    The \'this\' context of type \'(message: Text | ContentMessage, event: MouseEvent<Element, MouseEvent>) => void\' is not assignable to method\'s \'this\' of type \'(this: null, ...args: Text[]) => void\'.\\n      Types of parameters \'event\' and \'args\' are incompatible.\\n        Type \'Text\' is not assignable to type \'MouseEvent<Element, MouseEvent>\'.", "250432903"],
+      [117, 48, 8, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3685798518"],
+      [119, 10, 2, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "5861160"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/index.test.tsx:305658061": [
+      [58, 6, 15, "Type \'undefined\' is not assignable to type \'Message\'.", "1976601247"]
+    ],
+    "src/script/components/MessagesList/Message/ContentMessage/index.tsx:1379302737": [
+      [101, 45, 13, "Type \'(user: User) => void\' is not assignable to type \'(participant: User | ServiceEntity, target: Node) => void\'.\\n  Types of parameters \'user\' and \'participant\' are incompatible.\\n    Type \'User | ServiceEntity\' is not assignable to type \'User\'.\\n      Type \'ServiceEntity\' is not assignable to type \'User\'.", "2891534203"],
+      [174, 12, 13, "Type \'((message: ContentMessage, assetId: string) => void) | undefined\' is not assignable to type \'(message: ContentMessage, assetId: string) => void\'.\\n  Type \'undefined\' is not assignable to type \'(message: ContentMessage, assetId: string) => void\'.", "2671775388"]
+    ],
+    "src/script/components/MessagesList/Message/DecryptErrorMessage.test.tsx:629592445": [
+      [36, 53, 36, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "885356606"],
+      [43, 4, 20, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "2918866304"]
+    ],
+    "src/script/components/MessagesList/Message/DeleteMessage.test.tsx:2152816266": [
+      [41, 43, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [58, 11, 46, "Object is possibly \'null\'.", "1127157571"]
+    ],
+    "src/script/components/MessagesList/Message/DeleteMessage.tsx:1494469525": [
+      [39, 33, 25, "Object is possibly \'null\'.", "1746015084"],
+      [48, 10, 13, "Type \'(user: User) => void\' is not assignable to type \'(participant: User | ServiceEntity, target: Node) => void\'.\\n  Types of parameters \'user\' and \'participant\' are incompatible.\\n    Type \'User | ServiceEntity\' is not assignable to type \'User\'.\\n      Type \'ServiceEntity\' is missing the following properties from type \'User\': expirationIsUrgent, isDeleted, isMe, isSingleSignOn, and 49 more.", "2891534203"],
+      [60, 10, 9, "Type \'number | null\' is not assignable to type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "2548743275"]
+    ],
+    "src/script/components/MessagesList/Message/EphemeralTimer.test.ts:1942988828": [
+      [43, 35, 6, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1547361719"],
+      [51, 35, 6, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1547361719"]
+    ],
+    "src/script/components/MessagesList/Message/MemberMessage.test.tsx:819448386": [
+      [56, 56, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"]
+    ],
+    "src/script/components/MessagesList/Message/MemberMessage.tsx:210312751": [
+      [79, 73, 4, "Argument of type \'null\' is not assignable to parameter of type \'Element | undefined\'.", "2087897566"],
+      [121, 19, 3, "Type \'(node: Element) => void\' is not assignable to type \'LegacyRef<HTMLDivElement> | undefined\'.", "193432436"]
+    ],
+    "src/script/components/MessagesList/Message/MessageWrapper.tsx:4264065369": [
+      [157, 8, 15, "Type \'Message | undefined\' is not assignable to type \'Message\'.\\n  Type \'undefined\' is not assignable to type \'Message\'.", "1976601247"],
+      [165, 8, 13, "Type \'(message: CompositeMessage, buttonId: string) => void\' is not assignable to type \'(message: ContentMessage, assetId: string) => void\'.\\n  Types of parameters \'message\' and \'message\' are incompatible.\\n    Type \'ContentMessage\' is missing the following properties from type \'CompositeMessage\': errorButtonId, errorMessage, selectedButtonId, waitingButtonId, and 3 more.", "2671775388"]
+    ],
+    "src/script/components/MessagesList/Message/PingMessage.test.tsx:1695534491": [
+      [36, 4, 12, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<ReadReceipt>\'.", "3173113880"],
+      [58, 11, 36, "Object is possibly \'null\'.", "2457040434"]
+    ],
+    "src/script/components/MessagesList/Message/ReadReceiptStatus.test.tsx:246482947": [
+      [36, 44, 27, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "3518150560"],
+      [42, 4, 12, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<ReadReceipt>\'.", "3173113880"],
+      [54, 8, 12, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<ReadReceipt>\'.", "3173113880"],
+      [67, 8, 12, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<ReadReceipt>\'.", "3173113880"],
+      [121, 13, 49, "Object is possibly \'null\'.", "2963204748"],
+      [151, 8, 15, "Type \'null\' is not assignable to type \'((message: Message) => void) | undefined\'.", "2393653541"],
+      [156, 13, 49, "Object is possibly \'null\'.", "2963204748"]
+    ],
+    "src/script/components/MessagesList/Message/ReadReceiptStatus.tsx:3083018950": [
+      [77, 47, 15, "Cannot invoke an object which is possibly \'undefined\'.", "2393653541"]
+    ],
+    "src/script/components/MessagesList/Message/VerificationMessage.test.tsx:3256909500": [
+      [44, 4, 12, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<User>\'.", "3158614633"],
+      [45, 4, 7, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<string | QualifiedUserId>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'(string | QualifiedUserId)[] | null | undefined\' is not assignable to type \'never[] | null | undefined\'.\\n      Type \'(string | QualifiedUserId)[]\' is not assignable to type \'never[]\'.\\n        Type \'string | QualifiedUserId\' is not assignable to type \'never\'.\\n          Type \'string\' is not assignable to type \'never\'.", "2414311946"],
+      [46, 4, 23, "Type \'Observable<undefined>\' is not assignable to type \'Observable<VerificationMessageType>\'.\\n  Types of property \'equalityComparer\' are incompatible.\\n    Type \'(a: undefined, b: undefined) => boolean\' is not assignable to type \'(a: VerificationMessageType, b: VerificationMessageType) => boolean\'.\\n      Types of parameters \'a\' and \'a\' are incompatible.\\n        Type \'VerificationMessageType\' is not assignable to type \'undefined\'.", "3608773647"],
+      [57, 10, 23, "Type \'Observable<VerificationMessageType.VERIFIED>\' is not assignable to type \'Observable<VerificationMessageType>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'VerificationMessageType\' is not assignable to type \'VerificationMessageType.VERIFIED\'.", "3608773647"],
+      [79, 10, 23, "Type \'Observable<VerificationMessageType.UNVERIFIED>\' is not assignable to type \'Observable<VerificationMessageType>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'VerificationMessageType\' is not assignable to type \'VerificationMessageType.UNVERIFIED\'.", "3608773647"],
+      [93, 10, 23, "Type \'Observable<VerificationMessageType.NEW_DEVICE>\' is not assignable to type \'Observable<VerificationMessageType>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'VerificationMessageType\' is not assignable to type \'VerificationMessageType.NEW_DEVICE\'.", "3608773647"],
+      [107, 10, 23, "Type \'Observable<VerificationMessageType.NEW_MEMBER>\' is not assignable to type \'Observable<VerificationMessageType>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'VerificationMessageType\' is not assignable to type \'VerificationMessageType.NEW_MEMBER\'.", "3608773647"]
+    ],
+    "src/script/components/MessagesList/Message/index.tsx:360781890": [
+      [87, 51, 15, "Argument of type \'Message | undefined\' is not assignable to parameter of type \'Message\'.\\n  Type \'undefined\' is not assignable to type \'Message\'.", "1976601247"],
+      [91, 6, 14, "Cannot invoke an object which is possibly \'undefined\'.", "4289202771"],
+      [91, 36, 7, "Type \'HTMLDivElement | undefined\' is not assignable to type \'HTMLElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLElement\'.", "4115912507"],
+      [93, 6, 14, "Cannot invoke an object which is possibly \'undefined\'.", "4289202771"],
+      [93, 22, 7, "Type \'HTMLDivElement | undefined\' is not assignable to type \'HTMLElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLElement\'.", "4115912507"],
+      [112, 6, 3, "Type \'MutableRefObject<HTMLDivElement | undefined>\' is not assignable to type \'LegacyRef<HTMLDivElement> | undefined\'.", "193432436"]
+    ],
+    "src/script/components/MessagesList/index.test.tsx:3039094850": [
+      [41, 4, 14, "Type \'undefined\' is not assignable to type \'Message\'.", "1306210352"],
+      [47, 4, 17, "Type \'undefined\' is not assignable to type \'MessageRepository\'.", "1843982700"]
+    ],
+    "src/script/components/MessagesList/index.tsx:3202191129": [
+      [113, 57, 21, "Type \'HTMLDivElement | null\' does not satisfy the constraint \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "723935770"],
+      [153, 20, 17, "Argument of type \'HTMLDivElement | null | undefined\' is not assignable to parameter of type \'Element | undefined\'.\\n  Type \'null\' is not assignable to type \'Element | undefined\'.", "3615360346"],
+      [153, 58, 17, "Argument of type \'HTMLDivElement | null | undefined\' is not assignable to parameter of type \'Element | null\'.\\n  Type \'undefined\' is not assignable to type \'Element | null\'.", "3615360346"],
+      [155, 20, 32, "Argument of type \'HTMLElement | null | undefined\' is not assignable to parameter of type \'Element | undefined\'.\\n  Type \'null\' is not assignable to type \'Element | undefined\'.", "3459359081"],
+      [155, 73, 17, "Argument of type \'HTMLDivElement | null | undefined\' is not assignable to parameter of type \'Element | null\'.", "3615360346"],
+      [201, 23, 17, "Argument of type \'HTMLDivElement | null | undefined\' is not assignable to parameter of type \'Element | null\'.", "3615360346"]
+    ],
+    "src/script/components/Modals/GroupCreation/GroupCreationModal.tsx:2991720581": [
+      [92, 21, 12, "Argument of type \'HTMLDivElement | undefined\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLElement\'.", "652464040"]
+    ],
+    "src/script/components/Modals/ServiceModal/ServiceModal.tsx:1305631526": [
+      [45, 4, 7, "Cannot invoke an object which is possibly \'undefined\'.", "4055961042"]
+    ],
+    "src/script/components/Modals/UserModal/UserModal.test.tsx:2720850156": [
+      [45, 6, 6, "Type \'null\' is not assignable to type \'QualifiedId\'.", "1765117785"],
+      [49, 11, 29, "Object is possibly \'null\'.", "3523845355"]
+    ],
+    "src/script/components/Modals/UserModal/UserModal.tsx:2112661617": [
+      [72, 57, 4, "Argument of type \'User | null\' is not assignable to parameter of type \'Partial<Record<\\"isBlockedLegalHold\\", Subscribable<any>>>\'.\\n  Type \'null\' is not assignable to type \'Partial<Record<\\"isBlockedLegalHold\\", Subscribable<any>>>\'.", "2087973204"]
+    ],
+    "src/script/components/SearchInput.test.tsx:3374298949": [
+      [32, 38, 15, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "2173439052"],
+      [41, 36, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [41, 57, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [41, 78, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [41, 99, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [51, 20, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [52, 20, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [53, 20, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [54, 20, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"]
+    ],
+    "src/script/components/SearchInput.tsx:3792000228": [
+      [53, 4, 20, "Object is possibly \'undefined\'.", "2860176586"],
+      [54, 4, 20, "Object is possibly \'undefined\'.", "1100706242"],
+      [54, 37, 20, "Object is possibly \'undefined\'.", "2860176586"],
+      [66, 38, 3, "Type \'MutableRefObject<HTMLDivElement | undefined>\' is not assignable to type \'LegacyRef<HTMLDivElement> | undefined\'.", "193432436"],
+      [83, 12, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'LegacyRef<HTMLInputElement> | undefined\'.\\n  Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'RefObject<HTMLInputElement>\'.\\n    Types of property \'current\' are incompatible.\\n      Type \'HTMLInputElement | undefined\' is not assignable to type \'HTMLInputElement | null\'.\\n        Type \'undefined\' is not assignable to type \'HTMLInputElement | null\'.", "193432436"]
+    ],
+    "src/script/components/TextInput/TextInput.styles.ts:1761831861": [
+      [55, 2, 9, "Type \'{ borderColor: false | \\"var(--text-input-border-hover)\\"; }\' is not assignable to type \'CSSInterpolation\'.\\n  Types of property \'borderColor\' are incompatible.\\n    Type \'false | \\"var(--text-input-border-hover)\\"\' is not assignable to type \'BorderColor | (BorderColor | undefined)[] | BorderColor[] | undefined\'.\\n      Type \'false\' is not assignable to type \'BorderColor | (BorderColor | undefined)[] | BorderColor[] | undefined\'.", "1736274335"],
+      [58, 2, 36, "Type \'{ \'& + label\': { color: false | \\"var(--accent-color-500)\\"; }; borderColor: false | \\"var(--accent-color-500)\\"; }\' is not assignable to type \'CSSInterpolation\'.\\n  Types of property \'\'& + label\'\' are incompatible.\\n    Type \'{ color: false | \\"var(--accent-color-500)\\"; }\' is not assignable to type \'CSSInterpolation\'.\\n      Types of property \'color\' are incompatible.\\n        Type \'false | \\"var(--accent-color-500)\\"\' is not assignable to type \'Color | (Color | undefined)[] | Color[] | undefined\'.\\n          Type \'false\' is not assignable to type \'Color | (Color | undefined)[] | Color[] | undefined\'.", "507716502"]
+    ],
+    "src/script/components/TextInput/TextInput.tsx:1217040429": [
+      [104, 35, 12, "Argument of type \'string | null\' is not assignable to parameter of type \'string | undefined\'.\\n  Type \'null\' is not assignable to type \'string | undefined\'.", "4008345754"],
+      [115, 55, 12, "Argument of type \'string | null\' is not assignable to parameter of type \'string | undefined\'.", "4008345754"],
+      [123, 59, 12, "Argument of type \'string | null\' is not assignable to parameter of type \'string | undefined\'.", "4008345754"],
+      [124, 56, 12, "Argument of type \'string | null\' is not assignable to parameter of type \'string | undefined\'.", "4008345754"]
+    ],
+    "src/script/components/UserDevices.tsx:1074292287": [
+      [120, 74, 5, "Object is of type \'unknown\'.", "165548477"],
+      [128, 42, 8, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4039656867"],
+      [144, 9, 13, "Type \'{ clickToShowSelfFingerprint: () => void; clientRepository: ClientRepository; cryptographyRepository: CryptographyRepository; logger: Logger; messageRepository: MessageRepository; noPadding: boolean; selectedClient: ClientEntity | undefined; user: User; }\' is not assignable to type \'DeviceDetailsProps\'.\\n  Types of property \'selectedClient\' are incompatible.\\n    Type \'ClientEntity | undefined\' is not assignable to type \'ClientEntity\'.\\n      Type \'undefined\' is not assignable to type \'ClientEntity\'.", "538994175"]
+    ],
+    "src/script/components/UserList.tsx:541400935": [
+      [97, 28, 12, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Partial<Record<\\"roles\\", Subscribable<any>>>\'.\\n  Type \'undefined\' is not assignable to type \'Partial<Record<\\"roles\\", Subscribable<any>>>\'.", "1670678216"]
+    ],
+    "src/script/components/UserSearchableList.tsx:1290904950": [
+      [73, 32, 11, "Argument of type \'{ filter?: Observable<string> | undefined; highlightedUsers?: Observable<User[]> | undefined; selected?: ObservableArray<User> | undefined; users: ObservableArray<...>; } | undefined\' is not assignable to parameter of type \'Partial<Record<\\"filter\\" | \\"selected\\" | \\"users\\" | \\"highlightedUsers\\", Subscribable<any>>>\'.\\n  Type \'undefined\' is not assignable to type \'Partial<Record<\\"filter\\" | \\"selected\\" | \\"users\\" | \\"highlightedUsers\\", Subscribable<any>>>\'.", "965633731"],
+      [151, 8, 13, "Object is possibly \'undefined\'.", "3172385806"],
+      [153, 34, 13, "Type \'User[] | undefined\' must have a \'[Symbol.iterator]()\' method that returns an iterator.", "3172385806"]
+    ],
+    "src/script/components/asset/RestrictedFile.tsx:3277010298": [
+      [31, 37, 16, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2539792794"]
+    ],
+    "src/script/components/avatar/AvatarImage.test.tsx:132044584": [
+      [46, 39, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [71, 39, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [96, 39, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [122, 39, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"]
+    ],
+    "src/script/components/avatar/GroupAvatar.test.ts:2643749063": [
+      [33, 36, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [34, 36, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [35, 36, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [36, 36, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [46, 11, 30, "Object is possibly \'null\'.", "2093565968"]
+    ],
+    "src/script/components/avatar/TemporaryGuest.test.tsx:963341365": [
+      [42, 39, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [56, 39, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [67, 11, 34, "Object is possibly \'null\'.", "882755595"],
+      [71, 39, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [85, 39, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"]
+    ],
+    "src/script/components/avatar/UserAvatar.test.tsx:322543618": [
+      [39, 39, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [49, 11, 24, "Object is possibly \'null\'.", "568765553"],
+      [53, 39, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [63, 11, 24, "Object is possibly \'null\'.", "568765553"],
+      [67, 39, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [80, 39, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [93, 39, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"]
+    ],
+    "src/script/components/calling/ButtonGroup.test.ts:3889884856": [
+      [32, 43, 24, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "323337895"],
+      [33, 41, 22, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "674875776"],
+      [48, 11, 24, "Object is possibly \'null\'.", "3345041766"],
+      [62, 11, 24, "Object is possibly \'null\'.", "3345041766"],
+      [63, 11, 29, "Object is possibly \'null\'.", "373716495"],
+      [66, 11, 29, "Object is possibly \'null\'.", "373716495"]
+    ],
+    "src/script/components/calling/CallingOverlayContainer.tsx:3950008160": [
+      [70, 32, 10, "Argument of type \'Call | undefined\' is not assignable to parameter of type \'Partial<Record<\\"state\\" | \\"muteState\\" | \\"maximizedParticipant\\", Subscribable<any>>>\'.\\n  Type \'undefined\' is not assignable to type \'Partial<Record<\\"state\\" | \\"muteState\\" | \\"maximizedParticipant\\", Subscribable<any>>>\'.", "4286110980"],
+      [75, 55, 10, "Object is possibly \'undefined\'.", "4286110980"],
+      [83, 33, 10, "Argument of type \'Call | undefined\' is not assignable to parameter of type \'Call\'.\\n  Type \'undefined\' is not assignable to type \'Call\'.", "4286110980"],
+      [91, 4, 58, "Type \'Conversation | undefined\' is not assignable to type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "3582593161"],
+      [176, 10, 20, "Type \'undefined\' is not assignable to type \'Participant\'.", "942864568"],
+      [179, 10, 9, "Type \'undefined\' is not assignable to type \'MuteState\'.", "3616862203"]
+    ],
+    "src/script/components/calling/DeviceToggleButton.tsx:46682170": [
+      [57, 69, 1, "No overload matches this call.\\n  Overload 1 of 6, \'(this: (this: null, arg0: MouseEvent<HTMLDivElement, MouseEvent>) => void, thisArg: null, arg0: MouseEvent<HTMLDivElement, MouseEvent>): () => void\', gave the following error.\\n    Argument of type \'KeyboardEvent<HTMLDivElement>\' is not assignable to parameter of type \'MouseEvent<HTMLDivElement, MouseEvent>\'.\\n  Overload 2 of 6, \'(this: (this: null, ...args: MouseEvent<HTMLDivElement, MouseEvent>[]) => void, thisArg: null, ...args: MouseEvent<HTMLDivElement, MouseEvent>[]): (...args: MouseEvent<...>[]) => void\', gave the following error.\\n    Argument of type \'KeyboardEvent<HTMLDivElement>\' is not assignable to parameter of type \'MouseEvent<HTMLDivElement, MouseEvent>\'.", "177600"]
+    ],
+    "src/script/components/calling/FullscreenVideoCall.tsx:3337270414": [
+      [245, 46, 4, "Argument of type \'null\' is not assignable to parameter of type \'Participant\'.", "2087897566"]
+    ],
+    "src/script/components/calling/GroupVideoGrid.test.ts:1931211751": [
+      [35, 55, 22, "Object is possibly \'null\'.", "1458310722"],
+      [40, 32, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [48, 6, 20, "Type \'null\' is not assignable to type \'Participant\'.", "942864568"],
+      [55, 11, 32, "Object is possibly \'null\'.", "4265756850"],
+      [59, 38, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [60, 38, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [65, 8, 20, "Type \'null\' is not assignable to type \'Participant\'.", "942864568"],
+      [80, 11, 32, "Object is possibly \'null\'.", "4265756850"],
+      [86, 32, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [95, 6, 20, "Type \'null\' is not assignable to type \'Participant\'.", "942864568"],
+      [105, 32, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [115, 6, 20, "Type \'null\' is not assignable to type \'Participant\'.", "942864568"],
+      [126, 32, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [136, 6, 20, "Type \'null\' is not assignable to type \'Participant\'.", "942864568"]
+    ],
+    "src/script/components/calling/GroupVideoGrid.tsx:610569498": [
+      [83, 46, 14, "Argument of type \'Participant | null\' is not assignable to parameter of type \'Partial<Record<\\"videoStream\\" | \\"hasActiveVideo\\" | \\"sharesScreen\\", Subscribable<any>>>\'.\\n  Type \'null\' is not assignable to type \'Partial<Record<\\"videoStream\\" | \\"hasActiveVideo\\" | \\"sharesScreen\\", Subscribable<any>>>\'.", "446802655"],
+      [92, 30, 4, "Argument of type \'null\' is not assignable to parameter of type \'Participant\'.", "2087897566"],
+      [100, 28, 11, "Argument of type \'Participant | undefined\' is not assignable to parameter of type \'Participant\'.\\n  Type \'undefined\' is not assignable to type \'Participant\'.", "2457692186"]
+    ],
+    "src/script/components/calling/chooseScreen.test.ts:1945034304": [
+      [64, 23, 30, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1127551965"]
+    ],
+    "src/script/components/calling/deviceToggleButton.test.ts:3520291628": [
+      [31, 35, 16, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "733554636"]
+    ],
+    "src/script/components/calling/fullscreenVideoCall.test.tsx:3312717523": [
+      [34, 34, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [58, 21, 11, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "2107724227"],
+      [110, 60, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [111, 60, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [112, 60, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [113, 60, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"]
+    ],
+    "src/script/components/input/ClassifiedBar.test.ts:3396080197": [
+      [31, 31, 22, "Argument of type \'ReactElement<any, any> | null\' is not assignable to parameter of type \'ReactElement<any, string | JSXElementConstructor<any>>\'.\\n  Type \'null\' is not assignable to type \'ReactElement<any, string | JSXElementConstructor<any>>\'.", "3914530936"],
+      [39, 46, 41, "Argument of type \'ReactElement<any, any> | null\' is not assignable to parameter of type \'ReactElement<any, string | JSXElementConstructor<any>>\'.\\n  Type \'null\' is not assignable to type \'ReactElement<any, string | JSXElementConstructor<any>>\'.", "68552590"],
+      [51, 44, 41, "Argument of type \'ReactElement<any, any> | null\' is not assignable to parameter of type \'ReactElement<any, string | JSXElementConstructor<any>>\'.\\n  Type \'null\' is not assignable to type \'ReactElement<any, string | JSXElementConstructor<any>>\'.", "68552590"]
+    ],
+    "src/script/components/list/ConversationListCallingCell.test.ts:3589252036": [
+      [51, 42, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [74, 54, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [127, 11, 33, "Object is possibly \'null\'.", "1545610583"],
+      [132, 11, 33, "Object is possibly \'null\'.", "1545610583"]
+    ],
+    "src/script/components/list/ConversationListCallingCell.tsx:1743640908": [
+      [80, 21, 12, "Argument of type \'HTMLDivElement | undefined\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLElement\'.", "652464040"],
+      [115, 90, 6, "Argument of type \'number | undefined\' is not assignable to parameter of type \'REASON\'.\\n  Type \'undefined\' is not assignable to type \'REASON\'.", "2124277697"],
+      [128, 67, 8, "No overload matches this call.\\n  Overload 1 of 2, \'(...items: ConcatArray<User>[]): User[]\', gave the following error.\\n    Type \'User | undefined\' is not assignable to type \'User\'.\\n      Type \'undefined\' is not assignable to type \'User\'.\\n  Overload 2 of 2, \'(...items: (User | ConcatArray<User>)[]): User[]\', gave the following error.\\n    Type \'User | undefined\' is not assignable to type \'User\'.\\n      Type \'undefined\' is not assignable to type \'User\'.", "2198230984"],
+      [148, 28, 12, "Type \'undefined\' cannot be used as an index type.", "3398917396"],
+      [173, 10, 7, "Type \'(false | ContextMenuEntry | { click: () => void; icon: string; identifier: string; isDisabled: boolean; label: string; })[]\' is not assignable to type \'ContextMenuEntry[]\'.\\n  Type \'false | ContextMenuEntry | { click: () => void; icon: string; identifier: string; isDisabled: boolean; label: string; }\' is not assignable to type \'ContextMenuEntry\'.\\n    Type \'false\' has no properties in common with type \'ContextMenuEntry\'.", "4061926391"],
+      [306, 16, 20, "Type \'Participant | null\' is not assignable to type \'Participant\'.\\n  Type \'null\' is not assignable to type \'Participant\'.", "942864568"]
+    ],
+    "src/script/components/list/ConversationListCell.tsx:2515616563": [
+      [128, 8, 3, "Type \'(node: HTMLElement) => void\' is not assignable to type \'LegacyRef<HTMLLIElement> | undefined\'.\\n  Type \'(node: HTMLElement) => void\' is not assignable to type \'(instance: HTMLLIElement | null) => void\'.\\n    Types of parameters \'node\' and \'instance\' are incompatible.\\n      Type \'HTMLLIElement | null\' is not assignable to type \'HTMLElement\'.\\n        Type \'null\' is not assignable to type \'HTMLElement\'.", "193432436"],
+      [158, 23, 8, "Object is possibly \'undefined\'.", "2198230984"]
+    ],
+    "src/script/components/list/ParticipantItem.tsx:3591469056": [
+      [86, 43, 18, "Argument of type \'HTMLDivElement | undefined\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLElement\'.", "4082577534"],
+      [111, 94, 15, "Argument of type \'Participant | undefined\' is not assignable to parameter of type \'Partial<Record<\\"isMuted\\" | \\"isActivelySpeaking\\" | \\"sharesScreen\\" | \\"sharesCamera\\", Subscribable<any>>>\'.\\n  Type \'undefined\' is not assignable to type \'Partial<Record<\\"isMuted\\" | \\"isActivelySpeaking\\" | \\"sharesScreen\\" | \\"sharesCamera\\", Subscribable<any>>>\'.", "420345688"]
+    ],
+    "src/script/components/modal.ts:282599833": [
+      [54, 4, 11, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "2565900128"],
+      [56, 9, 5, "Property \'large\' does not exist on type \'{} | Config\'.\\n  Property \'large\' does not exist on type \'{}\'.", "173484696"],
+      [57, 9, 2, "Property \'id\' does not exist on type \'{} | Config\'.\\n  Property \'id\' does not exist on type \'{}\'.", "5861160"],
+      [58, 9, 11, "Property \'ariaLabelBy\' does not exist on type \'{} | Config\'.\\n  Property \'ariaLabelBy\' does not exist on type \'{}\'.", "2719191011"],
+      [59, 9, 15, "Property \'ariaDescribedBy\' does not exist on type \'{} | Config\'.\\n  Property \'ariaDescribedBy\' does not exist on type \'{}\'.", "2192860460"],
+      [60, 9, 9, "Property \'onBgClick\' does not exist on type \'{} | Config\'.\\n  Property \'onBgClick\' does not exist on type \'{}\'.", "1270597711"],
+      [61, 9, 11, "Property \'displayNone\' does not exist on type \'{} | Config\'.\\n  Property \'displayNone\' does not exist on type \'{}\'.", "2033428597"],
+      [62, 9, 15, "Property \'hasVisibleClass\' does not exist on type \'{} | Config\'.\\n  Property \'hasVisibleClass\' does not exist on type \'{}\'.", "2672704031"],
+      [62, 64, 11, "Property \'displayNone\' does not exist on type \'{} | Config\'.\\n  Property \'displayNone\' does not exist on type \'{}\'.", "2033428597"],
+      [63, 9, 11, "Property \'showLoading\' does not exist on type \'{} | Config\'.\\n  Property \'showLoading\' does not exist on type \'{}\'.", "2565900128"],
+      [67, 16, 11, "Property \'displayNone\' does not exist on type \'{} | Config\'.\\n  Property \'displayNone\' does not exist on type \'{}\'.", "2033428597"],
+      [70, 10, 32, "Object is possibly \'null\'.", "941564926"],
+      [70, 39, 2, "Property \'id\' does not exist on type \'{} | Config\'.\\n  Property \'id\' does not exist on type \'{}\'.", "5861160"],
+      [77, 38, 2, "Property \'id\' does not exist on type \'{} | Config\'.\\n  Property \'id\' does not exist on type \'{}\'.", "5861160"],
+      [80, 43, 11, "Property \'displayNone\' does not exist on type \'{} | Config\'.\\n  Property \'displayNone\' does not exist on type \'{}\'.", "2033428597"],
+      [86, 20, 11, "Property \'displayNone\' does not exist on type \'{} | Config\'.\\n  Property \'displayNone\' does not exist on type \'{}\'.", "2033428597"],
+      [90, 13, 11, "Property \'displayNone\' does not exist on type \'{} | Config\'.\\n  Property \'displayNone\' does not exist on type \'{}\'.", "2033428597"],
+      [95, 9, 7, "Property \'dispose\' does not exist on type \'{} | Config\'.\\n  Property \'dispose\' does not exist on type \'{}\'.", "2810921618"],
+      [98, 11, 15, "Property \'hasVisibleClass\' does not exist on type \'{} | Config\'.\\n  Property \'hasVisibleClass\' does not exist on type \'{}\'.", "2672704031"]
+    ],
+    "src/script/components/panel/EnrichedFields.tsx:57735554": [
+      [77, 6, 14, "Type \'({ onFieldsLoaded, showDomain, richProfileRepository, user, }: EnrichedFieldsProps) => false | Element\' is not assignable to type \'FC<EnrichedFieldsProps>\'.\\n  Type \'false | Element\' is not assignable to type \'ReactElement<any, any> | null\'.\\n    Type \'boolean\' is not assignable to type \'ReactElement<any, any>\'.", "3281877902"]
+    ],
+    "src/script/components/panel/PanelActions/PanelActions.test.ts:3957570535": [
+      [30, 55, 30, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "923794636"],
+      [43, 11, 15, "Object is possibly \'null\'.", "3285363318"],
+      [63, 11, 15, "Object is possibly \'null\'.", "3285363318"]
+    ],
+    "src/script/components/panel/PanelActions/PanelActions.tsx:1779366507": [
+      [39, 7, 5, "Object is possibly \'undefined\'.", "179721187"]
+    ],
+    "src/script/components/panel/ServiceDetails.test.ts:1343420477": [
+      [43, 11, 24, "Object is possibly \'null\'.", "1690512676"],
+      [44, 11, 28, "Object is possibly \'null\'.", "449714402"],
+      [45, 11, 31, "Object is possibly \'null\'.", "27546597"]
+    ],
+    "src/script/components/panel/UserActions.test.ts:3686258051": [
+      [46, 30, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [68, 30, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [88, 30, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [98, 29, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"]
+    ],
+    "src/script/components/panel/UserActions.tsx:2911491574": [
+      [127, 8, 15, "Type \'false | { click: () => void; icon: string; identifier: string; label: string; }\' is not assignable to type \'MenuItem\'.\\n  Type \'boolean\' is not assignable to type \'MenuItem\'.", "2657483110"],
+      [137, 8, 17, "Type \'false | { click: () => Promise<void>; icon: string; identifier: string; label: string; } | undefined\' is not assignable to type \'MenuItem\'.\\n  Type \'undefined\' is not assignable to type \'MenuItem\'.", "1208863187"],
+      [141, 4, 26, "Object is possibly \'undefined\'.", "3771314110"],
+      [151, 8, 20, "Type \'false | { click: () => Promise<void>; icon: string; identifier: string; label: string; }\' is not assignable to type \'MenuItem\'.\\n  Type \'boolean\' is not assignable to type \'MenuItem\'.", "2848461319"],
+      [162, 8, 23, "Type \'false | { click: () => Promise<void>; icon: string; identifier: string; label: string; }\' is not assignable to type \'MenuItem\'.\\n  Type \'boolean\' is not assignable to type \'MenuItem\'.", "2628002562"],
+      [174, 8, 23, "Type \'false | { click: () => Promise<void>; icon: string; identifier: string; label: string; }\' is not assignable to type \'MenuItem\'.\\n  Type \'boolean\' is not assignable to type \'MenuItem\'.", "3037255418"],
+      [185, 8, 23, "Type \'false | { click: () => Promise<void>; icon: string; identifier: string; label: string; }\' is not assignable to type \'MenuItem\'.\\n  Type \'boolean\' is not assignable to type \'MenuItem\'.", "3602563140"],
+      [199, 8, 21, "Type \'false | { click: () => Promise<void>; icon: string; identifier: string; label: string; }\' is not assignable to type \'MenuItem\'.\\n  Type \'boolean\' is not assignable to type \'MenuItem\'.", "4077601278"],
+      [222, 8, 9, "Type \'false | { click: () => Promise<void>; icon: string; identifier: string; label: string; }\' is not assignable to type \'MenuItem\'.\\n  Type \'boolean\' is not assignable to type \'MenuItem\'.", "3954618525"],
+      [234, 8, 11, "Type \'false | { click: () => Promise<void>; icon: string; identifier: string; label: string; }\' is not assignable to type \'MenuItem\'.\\n  Type \'boolean\' is not assignable to type \'MenuItem\'.", "3143138118"],
+      [246, 8, 26, "Type \'false | { click: () => Promise<void>; icon: string; identifier: string; label: string; } | undefined\' is not assignable to type \'MenuItem\'.\\n  Type \'undefined\' is not assignable to type \'MenuItem\'.", "679169961"],
+      [250, 4, 26, "Object is possibly \'undefined\'.", "3771314110"]
+    ],
+    "src/script/components/panel/UserDetails.test.ts:1738837932": [
+      [43, 53, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [52, 11, 21, "Object is possibly \'null\'.", "2859301736"],
+      [53, 11, 25, "Object is possibly \'null\'.", "3046884217"],
+      [62, 58, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [64, 4, 30, "Cannot invoke an object which is possibly \'undefined\'.", "1790663291"],
+      [73, 53, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [81, 11, 25, "Object is possibly \'null\'.", "3098493970"],
+      [86, 53, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [97, 11, 35, "Object is possibly \'null\'.", "3072447641"]
+    ],
+    "src/script/components/toggle/BaseToggle.test.tsx:917864535": [
+      [43, 25, 25, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "2875532638"]
+    ],
+    "src/script/components/toggle/BaseToggle.tsx:4077699567": [
+      [64, 12, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'LegacyRef<HTMLInputElement> | undefined\'.", "193432436"],
+      [77, 40, 16, "Object is possibly \'undefined\'.", "4019370437"]
+    ],
+    "src/script/components/toggle/InfoToggle.test.tsx:1025969366": [
+      [48, 11, 31, "Object is possibly \'null\'.", "756876288"],
+      [49, 21, 21, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1763299350"]
+    ],
+    "src/script/components/toggle/ReceiptModeToggle.test.ts:3769197722": [
+      [42, 11, 8, "Object is possibly \'null\'.", "2071428406"],
+      [53, 11, 8, "Object is possibly \'null\'.", "2071428406"]
+    ],
+    "src/script/components/toggle/ReceiptModeToggle.tsx:3019625326": [
+      [57, 10, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'LegacyRef<HTMLInputElement> | undefined\'.", "193432436"]
+    ],
+    "src/script/components/userDevices/DeviceCard.test.ts:2605028463": [
+      [54, 10, 10, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "3231345145"],
+      [68, 10, 10, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "3231345145"],
+      [83, 10, 10, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "3231345145"],
+      [97, 10, 10, "Type \'Observable<true>\' is not assignable to type \'Observable<boolean>\'.", "3231345145"],
+      [112, 10, 10, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "3231345145"]
+    ],
+    "src/script/components/userDevices/DeviceCard.tsx:2886933329": [
+      [61, 6, 4, "Type \'false | \\"button\\"\' is not assignable to type \'AriaRole | undefined\'.\\n  Type \'false\' is not assignable to type \'AriaRole | undefined\'.", "2088305233"],
+      [88, 49, 10, "Cannot invoke an object which is possibly \'undefined\'.", "3231345145"]
+    ],
+    "src/script/components/userDevices/DeviceDetails.tsx:3950414303": [
+      [92, 57, 12, "Argument of type \'Conversation | null | undefined\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "1670678216"],
+      [124, 18, 8, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1602964848"]
+    ],
+    "src/script/components/utils/InViewport.tsx:2602655444": [
+      [60, 6, 21, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "2791404919"],
+      [70, 9, 3, "Type \'MutableRefObject<HTMLDivElement | undefined>\' is not assignable to type \'LegacyRef<HTMLDivElement> | undefined\'.\\n  Type \'MutableRefObject<HTMLDivElement | undefined>\' is not assignable to type \'RefObject<HTMLDivElement>\'.\\n    Types of property \'current\' are incompatible.\\n      Type \'HTMLDivElement | undefined\' is not assignable to type \'HTMLDivElement | null\'.\\n        Type \'undefined\' is not assignable to type \'HTMLDivElement | null\'.", "193432436"]
+    ],
+    "src/script/connection/ConnectionEntity.ts:2779957789": [
+      [41, 4, 19, "Type \'null\' is not assignable to type \'QualifiedId\'.", "59414957"],
+      [42, 4, 9, "Type \'null\' is not assignable to type \'string\'.", "1162435291"],
+      [43, 4, 15, "Type \'null\' is not assignable to type \'string\'.", "3261786582"],
+      [44, 4, 12, "Type \'null\' is not assignable to type \'string\'.", "1494865734"],
+      [45, 4, 11, "Type \'Observable<ConnectionStatus.UNKNOWN>\' is not assignable to type \'Observable<ConnectionStatus>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'ConnectionStatus\' is not assignable to type \'ConnectionStatus.UNKNOWN\'.", "3642829209"],
+      [46, 4, 11, "Type \'null\' is not assignable to type \'QualifiedId\'.", "3570480945"]
+    ],
+    "src/script/connection/ConnectionMapper.ts:1601471521": [
+      [63, 4, 24, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3077613709"]
+    ],
+    "src/script/connection/ConnectionRepository.ts:4139441225": [
+      [188, 10, 5, "Object is of type \'unknown\'.", "165548477"],
+      [201, 89, 5, "Object is of type \'unknown\'.", "165548477"],
+      [241, 72, 5, "Object is of type \'unknown\'.", "165548477"],
+      [309, 72, 5, "Object is of type \'unknown\'.", "165548477"]
+    ],
+    "src/script/conversation/AbstractConversationEventHandler.ts:2160548461": [
+      [55, 4, 57, "Type \'void | Promise<void>\' is not assignable to type \'Promise<void>\'.\\n  Type \'void\' is not assignable to type \'Promise<void>\'.", "1935544587"],
+      [55, 50, 9, "Expected 1 arguments, but got 2.", "1945995409"]
+    ],
+    "src/script/conversation/ConversationAccessPermission.ts:4078826543": [
+      [77, 8, 29, "Type \'[string, number] | undefined\' must have a \'[Symbol.iterator]()\' method that returns an iterator.", "3545949443"],
+      [137, 9, 95, "Argument of type \'(bit: \\"1\\" | \\"0\\", i: number) => string | undefined\' is not assignable to parameter of type \'(value: string, index: number, array: string[]) => string | undefined\'.\\n  Types of parameters \'bit\' and \'value\' are incompatible.\\n    Type \'string\' is not assignable to type \'\\"1\\" | \\"0\\"\'.", "2336737203"]
+    ],
+    "src/script/conversation/ConversationCellState.ts:2607123593": [
+      [191, 8, 17, "Object is possibly \'undefined\'.", "1821064255"],
+      [241, 6, 17, "Object is possibly \'undefined\'.", "1821064255"],
+      [250, 28, 17, "Object is possibly \'undefined\'.", "1821064255"],
+      [293, 23, 29, "Object is possibly \'undefined\'.", "2539326033"],
+      [300, 50, 29, "Argument of type \'User | undefined\' is not assignable to parameter of type \'QualifiedEntity\'.\\n  Type \'undefined\' is not assignable to type \'QualifiedEntity\'.", "2539326033"],
+      [379, 4, 65, "Type \'boolean | undefined\' is not assignable to type \'boolean\'.", "368272031"]
+    ],
+    "src/script/conversation/ConversationEphemeralHandler.ts:1544789085": [
+      [61, 4, 91, "Type \'number | null\' is not assignable to type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "187276181"],
+      [72, 6, 41, "Type of computed property\'s value is \'(conversationEntity: Conversation, eventJson: ConversationMessageTimerUpdateEvent) => Promise<Conversation>\', which is not assignable to type \'(conversationEntity: Conversation) => void | Promise<void>\'.", "2358639438"],
+      [77, 4, 18, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<ContentMessage>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'ContentMessage[] | null | undefined\' is not assignable to type \'never[] | null | undefined\'.\\n      Type \'ContentMessage[]\' is not assignable to type \'never[]\'.\\n        Type \'ContentMessage\' is not assignable to type \'never\'.", "2087948420"],
+      [84, 29, 16, "No overload matches this call.\\n  Overload 1 of 2, \'(id?: number | undefined): void\', gave the following error.\\n    Argument of type \'number | null\' is not assignable to parameter of type \'number | undefined\'.\\n  Overload 2 of 2, \'(intervalId: Timeout): void\', gave the following error.\\n    Argument of type \'number | null\' is not assignable to parameter of type \'Timeout\'.\\n      Type \'null\' is not assignable to type \'Timeout\'.", "1776967942"],
+      [129, 38, 25, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1762572671"],
+      [178, 34, 25, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1762572671"],
+      [197, 34, 25, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1762572671"],
+      [245, 34, 25, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1762572671"]
+    ],
+    "src/script/conversation/ConversationFilter.test.ts:451886162": [
+      [35, 8, 6, "Type \'undefined\' is not assignable to type \'CONVERSATION_ACCESS[]\'.", "1314097761"],
+      [37, 8, 11, "Type \'undefined\' is not assignable to type \'(CONVERSATION_ACCESS_ROLE | ACCESS_ROLE_V2[]) & (CONVERSATION_ACCESS_ROLE | undefined)\'.", "186257802"],
+      [43, 8, 15, "Type \'null\' is not assignable to type \'number\'.", "32466162"],
+      [44, 8, 20, "Type \'null\' is not assignable to type \'number\'.", "162671298"],
+      [56, 8, 16, "Type \'undefined\' is not assignable to type \'QualifiedId[]\'.", "3008406851"],
+      [57, 8, 12, "Type \'null\' is not assignable to type \'RECEIPT_MODE\'.", "1234422597"],
+      [60, 8, 7, "Type \'undefined\' is not assignable to type \'string\'.", "1826788170"],
+      [88, 8, 15, "Type \'null\' is not assignable to type \'number\'.", "32466162"],
+      [89, 8, 20, "Type \'null\' is not assignable to type \'number\'.", "162671298"],
+      [97, 8, 13, "Type \'null\' is not assignable to type \'number | undefined\'.", "2449554358"],
+      [102, 8, 16, "Type \'undefined\' is not assignable to type \'QualifiedId[]\'.", "3008406851"],
+      [103, 8, 12, "Type \'null\' is not assignable to type \'RECEIPT_MODE\'.", "1234422597"],
+      [109, 8, 7, "Type \'null\' is not assignable to type \'string\'.", "1826788170"]
+    ],
+    "src/script/conversation/ConversationLabelRepository.ts:2667135542": [
+      [93, 4, 11, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<ConversationLabel>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'ConversationLabel[] | null | undefined\' is not assignable to type \'never[] | null | undefined\'.\\n      Type \'ConversationLabel[]\' is not assignable to type \'never[]\'.\\n        Type \'ConversationLabel\' is not assignable to type \'never\'.", "2608654840"],
+      [118, 8, 13, "Type \'ObservableArray<Conversation | undefined>\' is not assignable to type \'ObservableArray<Conversation>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'(Conversation | undefined)[]\' is not assignable to type \'Conversation[]\'.\\n      Type \'Conversation | undefined\' is not assignable to type \'Conversation\'.\\n        Type \'undefined\' is not assignable to type \'Conversation\'.", "3592773563"],
+      [142, 49, 5, "Object is of type \'unknown\'.", "165548477"],
+      [164, 55, 59, "Type \'ConversationLabel | undefined\' is not assignable to type \'ConversationLabel\'.\\n  Type \'undefined\' is not assignable to type \'ConversationLabel\'.", "1891492718"],
+      [165, 66, 44, "Type \'ConversationLabel | undefined\' is not assignable to type \'ConversationLabel\'.\\n  Type \'undefined\' is not assignable to type \'ConversationLabel\'.", "3545764513"],
+      [207, 15, 45, "Object is possibly \'undefined\'.", "2733869551"]
+    ],
+    "src/script/conversation/ConversationMapper.test.ts:3872739284": [
+      [59, 86, 9, "Type \'undefined\' is not assignable to type \'ConversationDatabaseData\'.", "2620553983"],
+      [187, 8, 18, "Type \'undefined\' is not assignable to type \'Conversation\'.", "1508601427"],
+      [195, 6, 18, "Type \'undefined\' is not assignable to type \'Conversation\'.", "1508601427"],
+      [320, 8, 15, "Type \'null\' is not assignable to type \'number | undefined\'.", "32466162"],
+      [321, 8, 20, "Type \'null\' is not assignable to type \'number | undefined\'.", "162671298"],
+      [365, 8, 13, "Type \'null\' is not assignable to type \'number | undefined\'.", "2449554358"],
+      [420, 48, 18, "Object is possibly \'undefined\'.", "3207599164"],
+      [456, 49, 18, "Object is possibly \'undefined\'.", "3207599164"],
+      [467, 49, 18, "Object is possibly \'undefined\'.", "3207599164"],
+      [467, 49, 40, "No overload matches this call.\\n  Overload 1 of 4, \'(value: string | number | Date): Date\', gave the following error.\\n    Argument of type \'string | null\' is not assignable to parameter of type \'string | number | Date\'.\\n  Overload 2 of 4, \'(value: string | number): Date\', gave the following error.\\n    Argument of type \'string | null\' is not assignable to parameter of type \'string | number\'.", "489961534"],
+      [470, 54, 18, "Object is possibly \'undefined\'.", "3207599164"],
+      [472, 53, 18, "Object is possibly \'undefined\'.", "3207599164"],
+      [472, 53, 37, "No overload matches this call.\\n  Overload 1 of 4, \'(value: string | number | Date): Date\', gave the following error.\\n    Argument of type \'string | null\' is not assignable to parameter of type \'string | number | Date\'.\\n  Overload 2 of 4, \'(value: string | number): Date\', gave the following error.\\n    Argument of type \'string | null\' is not assignable to parameter of type \'string | number\'.", "963650325"],
+      [528, 6, 18, "Object is possibly \'undefined\'.", "3207599164"],
+      [528, 36, 18, "Object is possibly \'undefined\'.", "3207599164"],
+      [537, 49, 18, "Object is possibly \'undefined\'.", "3207599164"],
+      [550, 49, 18, "Object is possibly \'undefined\'.", "3207599164"],
+      [550, 49, 40, "No overload matches this call.\\n  Overload 1 of 4, \'(value: string | number | Date): Date\', gave the following error.\\n    Argument of type \'string | null\' is not assignable to parameter of type \'string | number | Date\'.\\n  Overload 2 of 4, \'(value: string | number): Date\', gave the following error.\\n    Argument of type \'string | null\' is not assignable to parameter of type \'string | number\'.", "489961534"],
+      [553, 54, 18, "Object is possibly \'undefined\'.", "3207599164"],
+      [555, 53, 18, "Object is possibly \'undefined\'.", "3207599164"],
+      [555, 53, 37, "No overload matches this call.\\n  Overload 1 of 4, \'(value: string | number | Date): Date\', gave the following error.\\n    Argument of type \'string | null\' is not assignable to parameter of type \'string | number | Date\'.\\n  Overload 2 of 4, \'(value: string | number): Date\', gave the following error.\\n    Argument of type \'string | null\' is not assignable to parameter of type \'string | number\'.", "963650325"],
+      [569, 6, 18, "Object is possibly \'undefined\'.", "3207599164"],
+      [569, 34, 18, "Object is possibly \'undefined\'.", "3207599164"],
+      [611, 65, 4, "Argument of type \'null\' is not assignable to parameter of type \'RECEIPT_MODE\'.", "2087897566"]
+    ],
+    "src/script/conversation/ConversationMapper.ts:1643825803": [
+      [91, 45, 49, "Argument of type \'([key, value]: [keyof Conversation, string]) => void\' is not assignable to parameter of type \'(value: [string, any], index: number, array: [string, any][]) => void\'.\\n  Types of parameters \'__0\' and \'value\' are incompatible.\\n    Type \'[string, any]\' is not assignable to type \'[keyof Conversation, string]\'.\\n      Type at position 0 in source is not compatible with type at position 0 in target.\\n        Type \'string\' is not assignable to type \'keyof Conversation\'.", "2065920092"],
+      [133, 39, 24, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.", "81006062"],
+      [166, 36, 21, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "3907016453"],
+      [185, 41, 26, "No overload matches this call.\\n  Overload 1 of 4, \'(value: string | number | Date): Date\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number | Date\'.\\n      Type \'undefined\' is not assignable to type \'string | number | Date\'.\\n  Overload 2 of 4, \'(value: string | number): Date\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number\'.", "582302494"],
+      [191, 38, 23, "No overload matches this call.\\n  Overload 1 of 4, \'(value: string | number | Date): Date\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number | Date\'.\\n  Overload 2 of 4, \'(value: string | number): Date\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number\'.", "4035274933"],
+      [274, 11, 25, "Object is possibly \'undefined\'.", "4293153287"],
+      [275, 11, 94, "Argument of type \'(remoteConversationData: ConversationBackendData & {    receipt_mode: number;}, index: number) => ConversationDatabaseData\' is not assignable to parameter of type \'(value: Conversation, index: number, array: Conversation[]) => ConversationDatabaseData\'.\\n  Types of parameters \'remoteConversationData\' and \'value\' are incompatible.\\n    Type \'Conversation\' is not assignable to type \'Conversation & { receipt_mode: number; }\'.\\n      Type \'Conversation\' is not assignable to type \'{ receipt_mode: number; }\'.\\n        Types of property \'receipt_mode\' are incompatible.\\n          Type \'import(\\"wire-webapp/node_modules/@wireapp/api-client/src/conversation/data/ConversationReceiptModeUpdateData\\").RECEIPT_MODE | undefined\' is not assignable to type \'number\'.\\n            Type \'undefined\' is not assignable to type \'number\'.", "310849300"],
+      [319, 10, 24, "Type \'(QualifiedId | undefined)[]\' is not assignable to type \'QualifiedId[]\'.\\n  Type \'QualifiedId | undefined\' is not assignable to type \'QualifiedId\'.\\n    Type \'undefined\' is not assignable to type \'QualifiedId\'.", "125758031"],
+      [323, 61, 13, "Object is possibly \'undefined\'.", "1863462798"],
+      [324, 10, 13, "Object is possibly \'undefined\'.", "1863462798"],
+      [329, 70, 13, "Object is possibly \'undefined\'.", "1863462798"],
+      [330, 12, 13, "Object is possibly \'undefined\'.", "1863462798"],
+      [366, 49, 26, "No overload matches this call.\\n  Overload 1 of 4, \'(value: string | number | Date): Date\', gave the following error.\\n    Argument of type \'string | null\' is not assignable to parameter of type \'string | number | Date\'.\\n      Type \'null\' is not assignable to type \'string | number | Date\'.\\n  Overload 2 of 4, \'(value: string | number): Date\', gave the following error.\\n    Argument of type \'string | null\' is not assignable to parameter of type \'string | number\'.\\n      Type \'null\' is not assignable to type \'string | number\'.", "582302494"],
+      [370, 10, 33, "Type \'boolean | undefined\' is not assignable to type \'boolean\'.", "2524769620"],
+      [375, 46, 23, "No overload matches this call.\\n  Overload 1 of 4, \'(value: string | number | Date): Date\', gave the following error.\\n    Argument of type \'string | null\' is not assignable to parameter of type \'string | number | Date\'.\\n  Overload 2 of 4, \'(value: string | number): Date\', gave the following error.\\n    Argument of type \'string | null\' is not assignable to parameter of type \'string | number\'.", "4035274933"],
+      [380, 10, 30, "Type \'import(\\"wire-webapp/node_modules/@wireapp/api-client/src/conversation/MutedStatus\\").MutedStatus | null\' is not assignable to type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "127436159"],
+      [386, 14, 19, "No overload matches this call.\\n  Overload 1 of 2, \'(...items: ConcatArray<ConversationDatabaseData>[]): ConversationDatabaseData[]\', gave the following error.\\n    Argument of type \'(ConversationDatabaseData | undefined)[]\' is not assignable to parameter of type \'ConcatArray<ConversationDatabaseData>\'.\\n      The types returned by \'slice(...)\' are incompatible between these types.\\n        Type \'(ConversationDatabaseData | undefined)[]\' is not assignable to type \'ConversationDatabaseData[]\'.\\n          Type \'ConversationDatabaseData | undefined\' is not assignable to type \'ConversationDatabaseData\'.\\n            Type \'undefined\' is not assignable to type \'ConversationDatabaseData\'.\\n              Type \'undefined\' is not assignable to type \'ConversationRecord\'.\\n  Overload 2 of 2, \'(...items: (ConversationDatabaseData | ConcatArray<ConversationDatabaseData>)[]): ConversationDatabaseData[]\', gave the following error.\\n    Argument of type \'(ConversationDatabaseData | undefined)[]\' is not assignable to parameter of type \'ConversationDatabaseData | ConcatArray<ConversationDatabaseData>\'.\\n      Type \'(ConversationDatabaseData | undefined)[]\' is not assignable to type \'ConcatArray<ConversationDatabaseData>\'.", "482451192"]
+    ],
+    "src/script/conversation/ConversationRepository.test.ts:787280384": [
+      [92, 42, 13, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "1690980598"],
+      [119, 4, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [126, 13, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [130, 12, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [137, 12, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [146, 13, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [150, 12, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [157, 12, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [166, 13, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [170, 12, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [177, 12, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [186, 13, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [190, 12, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [197, 12, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [205, 21, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [228, 8, 4, "Type \'null\' is not assignable to type \'string | undefined\'.", "2087876002"],
+      [236, 6, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [239, 27, 28, "Object is possibly \'undefined\'.", "2623105571"],
+      [244, 12, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [249, 13, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [264, 36, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [280, 8, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [281, 8, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [282, 8, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [283, 8, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [288, 19, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [292, 15, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [296, 15, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [300, 15, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [304, 15, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [310, 21, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [316, 21, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [324, 41, 13, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "3975720788"],
+      [324, 103, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [326, 12, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [352, 70, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
+      [353, 33, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [367, 35, 505, "Conversion of type \'{ creator: string; id: string; members: { others: never[]; self: { hidden_ref: null; id: string; otr_archived_ref: null; otr_muted_ref: null; otr_muted_status: 0; service: null; status_ref: string; status_time: string; }; }; name: null; type: 0; }\' to type \'ConversationDatabaseData\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Type \'{ creator: string; id: string; members: { others: never[]; self: { hidden_ref: null; id: string; otr_archived_ref: null; otr_muted_ref: null; otr_muted_status: 0; service: null; status_ref: string; status_time: string; }; }; name: null; type: 0; }\' is missing the following properties from type \'ConversationRecord\': access, access_role, archived_state, archived_timestamp, and 19 more.", "1362948183"],
+      [388, 46, 21, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "1873507912"],
+      [394, 13, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [395, 8, 34, "Argument of type \'(_conversation: Conversation) => void\' is not assignable to parameter of type \'(value: Conversation | undefined) => void | PromiseLike<void>\'.\\n  Types of parameters \'_conversation\' and \'value\' are incompatible.\\n    Type \'Conversation | undefined\' is not assignable to type \'Conversation\'.\\n      Type \'undefined\' is not assignable to type \'Conversation\'.", "34751641"],
+      [396, 17, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [397, 17, 32, "Object is possibly \'undefined\'.", "3571799462"],
+      [405, 6, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [407, 13, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [408, 15, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [409, 15, 32, "Object is possibly \'undefined\'.", "3571799462"],
+      [410, 15, 13, "Object is possibly \'undefined\'.", "2708044599"],
+      [417, 13, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [418, 15, 13, "Object is possibly \'undefined\'.", "2708044599"],
+      [420, 28, 13, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "2708044599"],
+      [420, 43, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [425, 12, 13, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "2708044599"],
+      [426, 12, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [446, 49, 18, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "2794143312"],
+      [449, 49, 21, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "1873507912"],
+      [452, 12, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [454, 13, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [455, 15, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [524, 31, 871, "Conversion of type \'{ access: CONVERSATION_ACCESS.PRIVATE[]; accessRole: CONVERSATION_ACCESS_ROLE.ACTIVATED; creator: string; id: string; members: { others: { id: string; status: 0; }[]; self: { ...; }; }; name: null; team: null; type: 2; }\' to type \'ConversationDatabaseData\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Type \'{ access: CONVERSATION_ACCESS.PRIVATE[]; accessRole: CONVERSATION_ACCESS_ROLE.ACTIVATED; creator: string; id: string; members: { others: { id: string; status: 0; }[]; self: { ...; }; }; name: null; team: null; type: 2; }\' is missing the following properties from type \'ConversationRecord\': access_role, archived_state, archived_timestamp, cleared_timestamp, and 18 more.", "2902648306"],
+      [557, 14, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [589, 15, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [592, 12, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [593, 19, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [597, 14, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [597, 14, 77, "Object is possibly \'null\'.", "2683947211"],
+      [601, 19, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [605, 14, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [605, 14, 77, "Object is possibly \'null\'.", "2683947211"],
+      [619, 51, 18, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "970899399"],
+      [622, 51, 33, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "2464318121"],
+      [662, 12, 13, "Type \'null\' is not assignable to type \'number | undefined\'.", "2449554358"],
+      [668, 12, 12, "Type \'null\' is not assignable to type \'RECEIPT_MODE | undefined\'.", "1234422597"],
+      [669, 12, 4, "Type \'null\' is not assignable to type \'string | undefined\'.", "2087956856"],
+      [679, 15, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [680, 17, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [681, 17, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [689, 15, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [690, 17, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [691, 17, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [704, 51, 33, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "2464318121"],
+      [705, 43, 14, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "4200913383"],
+      [720, 14, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [722, 15, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [723, 17, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [724, 17, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [753, 15, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [758, 53, 18, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "4226246646"],
+      [780, 14, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [784, 10, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [788, 15, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [790, 15, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [794, 41, 13, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "4004503856"],
+      [809, 14, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [812, 15, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [813, 17, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [814, 17, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [815, 17, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [820, 41, 13, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "4004503856"],
+      [838, 14, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [841, 15, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [842, 17, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [843, 17, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [844, 17, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [849, 41, 13, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "4004503856"],
+      [868, 14, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [871, 15, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [872, 17, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [873, 17, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [874, 17, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [886, 15, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [911, 14, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [914, 10, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [918, 15, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [923, 41, 13, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "4004503856"],
+      [939, 14, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [941, 15, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [942, 17, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [943, 17, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [948, 41, 13, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "4004503856"],
+      [963, 14, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [965, 15, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [966, 17, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [967, 17, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [984, 14, 22, "Object is possibly \'undefined\'.", "3445893770"],
+      [986, 8, 22, "Object is possibly \'undefined\'.", "3445893770"],
+      [988, 15, 22, "Object is possibly \'undefined\'.", "3445893770"],
+      [1001, 6, 22, "Type \'ConversationRepository | undefined\' is not assignable to type \'ConversationRepository\'.\\n  Type \'undefined\' is not assignable to type \'ConversationRepository\'.", "3445893770"],
+      [1054, 26, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [1057, 61, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [1060, 49, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [1063, 49, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [1071, 26, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [1105, 8, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [1106, 8, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [1107, 8, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [1112, 24, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [1113, 13, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [1117, 17, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [1126, 49, 21, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "1873507912"],
+      [1129, 13, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [1132, 17, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [1141, 6, 30, "Object is possibly \'undefined\'.", "3408729068"],
+      [1148, 25, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [1156, 6, 30, "Object is possibly \'undefined\'.", "3408729068"],
+      [1163, 25, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [1173, 46, 21, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "1873507912"],
+      [1180, 6, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [1181, 6, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [1182, 12, 35, "Object is possibly \'undefined\'.", "901544345"],
+      [1184, 13, 35, "Object is possibly \'undefined\'.", "901544345"]
+    ],
+    "src/script/conversation/ConversationRepository.ts:1817913264": [
+      [177, 8, 29, "Argument of type \'(User | undefined)[] | undefined\' is not assignable to parameter of type \'User[] | undefined\'.\\n  Type \'(User | undefined)[]\' is not assignable to type \'User[]\'.", "1506995572"],
+      [183, 75, 13, "No overload matches this call.\\n  Overload 1 of 4, \'(value: string | number | Date): Date\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number | Date\'.\\n  Overload 2 of 4, \'(value: string | number): Date\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number\'.", "2642562490"],
+      [202, 16, 24, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2322605270"],
+      [207, 25, 13, "No overload matches this call.\\n  Overload 1 of 4, \'(value: string | number | Date): Date\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number | Date\'.\\n  Overload 2 of 4, \'(value: string | number): Date\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number\'.", "2642562490"],
+      [223, 10, 12, "Object is possibly \'undefined\'.", "1670678216"],
+      [318, 6, 18, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "1508601427"],
+      [332, 43, 15, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1177570679"],
+      [456, 8, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'BackendClientError\'.", "165548477"],
+      [496, 10, 13, "Object is of type \'unknown\'.", "2758364324"],
+      [502, 8, 13, "Argument of type \'unknown\' is not assignable to parameter of type \'Error | undefined\'.", "2758364324"],
+      [522, 9, 25, "Object is possibly \'undefined\'.", "4293153287"],
+      [643, 78, 9, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "2548743275"],
+      [830, 26, 24, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2322605270"],
+      [889, 37, 5, "Object is of type \'unknown\'.", "165548477"],
+      [891, 80, 5, "Object is of type \'unknown\'.", "165548477"],
+      [1018, 6, 50, "Type \'Conversation | undefined\' is not assignable to type \'false | Conversation\'.\\n  Type \'undefined\' is not assignable to type \'false | Conversation\'.", "4161336519"],
+      [1028, 37, 5, "Object is of type \'unknown\'.", "165548477"],
+      [1053, 30, 5, "Object is of type \'unknown\'.", "165548477"],
+      [1091, 73, 6, "Type \'null\' is not assignable to type \'string\'.", "1127975365"],
+      [1110, 22, 5, "Object is of type \'unknown\'.", "165548477"],
+      [1136, 14, 5, "Object is of type \'unknown\'.", "165548477"],
+      [1214, 4, 88, "Type \'Promise<Conversation | undefined>[]\' is not assignable to type \'Promise<Conversation>[]\'.\\n  Type \'Promise<Conversation | undefined>\' is not assignable to type \'Promise<Conversation>\'.\\n    Type \'Conversation | undefined\' is not assignable to type \'Conversation\'.\\n      Type \'undefined\' is not assignable to type \'Conversation\'.", "909551372"],
+      [1348, 47, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'BackendClientError\'.", "165548477"],
+      [1608, 101, 5, "Object is of type \'unknown\'.", "165548477"],
+      [1707, 44, 9, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "2548743275"],
+      [1806, 18, 12, "Object is possibly \'undefined\'.", "1670678216"],
+      [1886, 12, 39, "Argument of type \'(conversationEntity: Conversation) => Conversation\' is not assignable to parameter of type \'((value: Conversation) => Conversation | PromiseLike<Conversation>) & ((value: null) => Conversation | PromiseLike<...>)\'.\\n  Type \'(conversationEntity: Conversation) => Conversation\' is not assignable to type \'(value: null) => Conversation | PromiseLike<Conversation>\'.\\n    Types of parameters \'conversationEntity\' and \'value\' are incompatible.\\n      Type \'null\' is not assignable to type \'Conversation\'.", "3862325245"],
+      [1982, 52, 9, "Argument of type \'IncomingEvent\' is not assignable to parameter of type \'MappedEvent\'.\\n  Type \'ConversationCodeDeleteEvent\' is not assignable to type \'MappedEvent\'.\\n    Type \'ConversationCodeDeleteEvent\' is not assignable to type \'{ data?: MappedEventData | undefined; type: CONVERSATION_EVENT | CONVERSATION; }\'.\\n      Types of property \'data\' are incompatible.\\n        Type \'null\' is not assignable to type \'MappedEventData | undefined\'.", "1945995409"],
+      [1987, 6, 9, "Argument of type \'IncomingEvent\' is not assignable to parameter of type \'MappedEvent\'.", "1945995409"],
+      [2206, 60, 13, "Argument of type \'ContentMessage | MemberMessage | CallMessage | VerificationMessage | LegalHoldMessage | ... 9 more ... | undefined\' is not assignable to parameter of type \'Message\'.", "2065728181"],
+      [2207, 12, 35, "Argument of type \'(messageEntity: MemberMessage) => { conversationEntity: Conversation; }\' is not assignable to parameter of type \'(value: Message) => { conversationEntity: Conversation; } | PromiseLike<{ conversationEntity: Conversation; }>\'.\\n  Types of parameters \'messageEntity\' and \'value\' are incompatible.\\n    Type \'Message\' is missing the following properties from type \'MemberMessage\': allTeamMembers, exceedsMaxVisibleUsers, hasUsers, hiddenUserCount, and 34 more.", "3695844397"],
+      [2235, 8, 6, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1127975365"],
+      [2253, 26, 5, "Object is of type \'unknown\'.", "165548477"],
+      [2258, 4, 17, "Type \'undefined\' is not assignable to type \'{ conversationEntity: Conversation; }\'.", "4204377774"],
+      [2275, 6, 16, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1831201559"],
+      [2284, 70, 13, "Argument of type \'ContentMessage | MemberMessage | CallMessage | VerificationMessage | LegalHoldMessage | ... 9 more ... | undefined\' is not assignable to parameter of type \'Message\'.\\n  Type \'undefined\' is not assignable to type \'Message\'.", "2065728181"],
+      [2323, 12, 6, "Type \'string | null\' is not assignable to type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "1127975365"],
+      [2357, 73, 16, "Argument of type \'(QualifiedId | undefined)[]\' is not assignable to parameter of type \'QualifiedId[]\'.", "2829605732"],
+      [2436, 14, 9, "Type \'undefined\' cannot be used as an index type.", "665809274"],
+      [2461, 60, 9, "Argument of type \'ConversationMemberUpdateData\' is not assignable to parameter of type \'Partial<SelfStatusUpdateDatabaseData>\'.\\n  Types of property \'otr_muted_ref\' are incompatible.\\n    Type \'string | null | undefined\' is not assignable to type \'string | undefined\'.", "1946204345"],
+      [2575, 74, 42, "Object is possibly \'undefined\'.", "4089489462"],
+      [2613, 51, 4, "Property \'type\' does not exist on type \'never\'.", "2087944093"],
+      [2629, 25, 5, "Object is of type \'unknown\'.", "165548477"],
+      [2656, 25, 5, "Object is of type \'unknown\'.", "165548477"],
+      [2709, 98, 7, "Argument of type \'{ domain: string | undefined; id: string; }[] | undefined\' is not assignable to parameter of type \'QualifiedId[] | undefined\'.\\n  Type \'{ domain: string | undefined; id: string; }[]\' is not assignable to type \'QualifiedId[]\'.\\n    Type \'{ domain: string | undefined; id: string; }\' is not assignable to type \'QualifiedId\'.\\n      Types of property \'domain\' are incompatible.\\n        Type \'string | undefined\' is not assignable to type \'string\'.\\n          Type \'undefined\' is not assignable to type \'string\'.", "2414311946"],
+      [2716, 42, 13, "Argument of type \'ContentMessage | MemberMessage | CallMessage | VerificationMessage | LegalHoldMessage | ... 9 more ... | undefined\' is not assignable to parameter of type \'Message\'.", "2065728181"],
+      [2818, 64, 6, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1127975365"],
+      [2840, 6, 6, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1127975365"],
+      [2879, 58, 8, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1234247995"]
+    ],
+    "src/script/conversation/ConversationRoleRepository.test.ts:4040891269": [
+      [36, 6, 27, "Argument of type \'TeamRepository | undefined\' is not assignable to parameter of type \'TeamRepository\'.\\n  Type \'undefined\' is not assignable to type \'TeamRepository\'.", "2595125417"],
+      [38, 6, 27, "Object is possibly \'undefined\'.", "2644272773"],
+      [39, 6, 27, "Object is possibly \'undefined\'.", "2595125417"],
+      [46, 6, 27, "Object is possibly \'undefined\'.", "2595125417"],
+      [54, 41, 26, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "4107340324"],
+      [65, 6, 27, "Object is possibly \'undefined\'.", "2595125417"],
+      [93, 54, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"]
+    ],
+    "src/script/conversation/ConversationService.ts:112701748": [
+      [348, 4, 92, "Type \'Promise<T | undefined>\' is not assignable to type \'Promise<T>\'.\\n  Type \'T | undefined\' is not assignable to type \'T\'.\\n    \'T\' could be instantiated with an arbitrary type which could be unrelated to \'T | undefined\'.", "1764067179"]
+    ],
+    "src/script/conversation/ConversationState.ts:3761486215": [
+      [49, 4, 18, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<Conversation>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'Conversation[] | null | undefined\' is not assignable to type \'never[] | null | undefined\'.\\n      Type \'Conversation[]\' is not assignable to type \'never[]\'.\\n        Type \'Conversation\' is not assignable to type \'never\'.", "3125413011"],
+      [50, 4, 27, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<Conversation>\'.", "984920682"],
+      [51, 4, 26, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<Conversation>\'.", "1791791444"],
+      [52, 4, 29, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<Conversation>\'.", "1232424273"]
+    ],
+    "src/script/conversation/ConversationStateHandler.ts:402674568": [
+      [49, 6, 34, "Type of computed property\'s value is \'(conversationEntity: Conversation, eventJson: ConversationEvent<Partial<ConversationAccessV2UpdateData & ConversationAccessUpdateData>>) => void\', which is not assignable to type \'(conversationEntity: Conversation) => void | Promise<void>\'.", "141947257"],
+      [51, 6, 32, "Type of computed property\'s value is \'(conversationEntity: Conversation, eventJson: ConversationEvent<ConversationCode>) => void\', which is not assignable to type \'(conversationEntity: Conversation) => void | Promise<void>\'.", "2297092144"],
+      [68, 44, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
+      [79, 32, 52, "Argument of type \'\\"modalConversationOptionsAllowGuestMessage\\" | \\"modalConversationOptionsAllowServiceMessage\\" | \\"modalConversationOptionsAllowundefinedMessage\\"\' is not assignable to parameter of type \'StringIdentifer\'.\\n  Type \'\\"modalConversationOptionsAllowundefinedMessage\\"\' is not assignable to type \'StringIdentifer\'. Did you mean \'\\"modalConversationOptionsAllowServiceMessage\\"\'?", "584687952"],
+      [81, 32, 54, "Argument of type \'\\"modalConversationOptionsDisableGuestMessage\\" | \\"modalConversationOptionsDisableServiceMessage\\" | \\"modalConversationOptionsDisableundefinedMessage\\"\' is not assignable to parameter of type \'StringIdentifer\'.\\n  Type \'\\"modalConversationOptionsDisableundefinedMessage\\"\' is not assignable to type \'StringIdentifer\'. Did you mean \'\\"modalConversationOptionsDisableServiceMessage\\"\'?", "2151912957"],
+      [90, 22, 53, "Argument of type \'\\"modalConversationOptionsToggleGuestMessage\\" | \\"modalConversationOptionsToggleServiceMessage\\" | \\"modalConversationOptionsToggleundefinedMessage\\"\' is not assignable to parameter of type \'StringIdentifer\'.\\n  Type \'\\"modalConversationOptionsToggleundefinedMessage\\"\' is not assignable to type \'StringIdentifer\'. Did you mean \'\\"modalConversationOptionsToggleServiceMessage\\"\'?", "605985499"],
+      [98, 25, 5, "Object is of type \'unknown\'.", "165548477"],
+      [120, 36, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
+      [131, 58, 11, "Argument of type \'CONVERSATION_ACCESS[] | undefined\' is not assignable to parameter of type \'CONVERSATION_ACCESS[]\'.\\n  Type \'undefined\' is not assignable to type \'CONVERSATION_ACCESS[]\'.", "160859537"],
+      [135, 34, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"]
+    ],
+    "src/script/conversation/ConversationVerificationStateHandler.test.ts:2666026360": [
+      [48, 42, 13, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "1690980598"],
+      [56, 52, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [58, 55, 28, "Cannot invoke an object which is possibly \'undefined\'.", "1515665510"],
+      [62, 43, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [63, 43, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [66, 6, 23, "Cannot invoke an object which is possibly \'undefined\'.", "1497309756"],
+      [70, 6, 23, "Cannot invoke an object which is possibly \'undefined\'.", "3101468415"],
+      [105, 6, 28, "Cannot invoke an object which is possibly \'undefined\'.", "3077965475"],
+      [115, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [127, 6, 28, "Cannot invoke an object which is possibly \'undefined\'.", "3077965475"],
+      [137, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [153, 6, 26, "Cannot invoke an object which is possibly \'undefined\'.", "625087166"],
+      [162, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [171, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [183, 6, 26, "Cannot invoke an object which is possibly \'undefined\'.", "625087166"],
+      [192, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [201, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [210, 52, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [212, 6, 28, "Cannot invoke an object which is possibly \'undefined\'.", "3077965475"],
+      [226, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [232, 52, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [234, 6, 28, "Cannot invoke an object which is possibly \'undefined\'.", "3077965475"],
+      [248, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [254, 6, 23, "Cannot invoke an object which is possibly \'undefined\'.", "1497309756"]
+    ],
+    "src/script/conversation/EventBuilder.test.ts:3015092617": [
+      [33, 6, 12, "Type \'undefined\' is not assignable to type \'EventMapper\'.", "2093608813"],
+      [34, 6, 15, "Type \'undefined\' is not assignable to type \'Conversation\'.", "4110128166"],
+      [35, 6, 12, "Type \'undefined\' is not assignable to type \'User\'.", "2792000409"],
+      [38, 48, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [53, 36, 26, "Object is possibly \'undefined\'.", "1493205124"],
+      [68, 36, 26, "Object is possibly \'undefined\'.", "1493205124"],
+      [77, 11, 13, "Object is possibly \'undefined\'.", "2065728181"],
+      [78, 11, 13, "Object is possibly \'undefined\'.", "2065728181"],
+      [78, 36, 26, "Object is possibly \'undefined\'.", "1493205124"],
+      [79, 11, 13, "Object is possibly \'undefined\'.", "2065728181"],
+      [95, 11, 13, "Object is possibly \'undefined\'.", "2065728181"],
+      [96, 11, 13, "Object is possibly \'undefined\'.", "2065728181"]
+    ],
+    "src/script/conversation/EventBuilder.ts:154152099": [
+      [222, 12, 29, "Object is possibly \'undefined\'.", "2539326033"],
+      [233, 12, 29, "Object is possibly \'undefined\'.", "2539326033"],
+      [284, 12, 29, "Object is possibly \'undefined\'.", "2539326033"],
+      [336, 23, 29, "Object is possibly \'undefined\'.", "2539326033"],
+      [342, 19, 29, "Object is possibly \'undefined\'.", "2539326033"],
+      [432, 32, 29, "Object is possibly \'undefined\'.", "2539326033"],
+      [444, 12, 29, "Object is possibly \'undefined\'.", "2539326033"],
+      [454, 12, 29, "Object is possibly \'undefined\'.", "2539326033"]
+    ],
+    "src/script/conversation/EventMapper.ts:2506079831": [
+      [92, 96, 5, "Object is of type \'unknown\'.", "165548477"],
+      [160, 31, 11, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3188681863"],
+      [163, 51, 10, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3610690941"],
+      [170, 6, 22, "Type \'number | undefined\' is not assignable to type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "152976819"],
+      [174, 6, 22, "Type \'number | undefined\' is not assignable to type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "152976819"],
+      [177, 4, 17, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1128866980"],
+      [344, 4, 26, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2611213113"],
+      [345, 4, 16, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1858936470"],
+      [451, 56, 9, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "2548743275"],
+      [525, 4, 20, "Type \'MemberLeaveReason | undefined\' is not assignable to type \'MemberLeaveReason\'.\\n  Type \'undefined\' is not assignable to type \'MemberLeaveReason\'.", "642569791"],
+      [732, 27, 3, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "193424690"],
+      [735, 47, 7, "Argument of type \'Uint8Array | undefined\' is not assignable to parameter of type \'Uint8Array\'.\\n  Type \'undefined\' is not assignable to type \'Uint8Array\'.", "861760996"],
+      [743, 29, 11, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3188681863"],
+      [745, 29, 11, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3188681863"],
+      [746, 45, 10, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3610690941"],
+      [763, 11, 14, "Property \'content_length\' does not exist on type \'AssetData | undefined\'.", "2383733551"],
+      [763, 27, 12, "Property \'content_type\' does not exist on type \'AssetData | undefined\'.", "3523308779"],
+      [763, 41, 2, "Property \'id\' does not exist on type \'AssetData | undefined\'.", "5861160"],
+      [763, 54, 4, "Property \'info\' does not exist on type \'AssetData | undefined\'.", "2087826411"],
+      [774, 11, 3, "Property \'key\' does not exist on type \'AssetData | undefined\'.", "193424690"],
+      [774, 16, 7, "Property \'otr_key\' does not exist on type \'AssetData | undefined\'.", "861760996"],
+      [774, 25, 6, "Property \'sha256\' does not exist on type \'AssetData | undefined\'.", "2174157102"],
+      [774, 33, 5, "Property \'token\' does not exist on type \'AssetData | undefined\'.", "183304158"],
+      [774, 40, 6, "Property \'domain\' does not exist on type \'AssetData | undefined\'.", "1127975365"],
+      [817, 72, 10, "Argument of type \'string | null | undefined\' is not assignable to parameter of type \'string | undefined\'.\\n  Type \'null\' is not assignable to type \'string | undefined\'.", "2264616494"],
+      [818, 59, 10, "Argument of type \'string | null | undefined\' is not assignable to parameter of type \'string | undefined\'.", "2264616494"],
+      [857, 10, 36, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string | null\'.", "3484704420"],
+      [865, 78, 5, "Object is of type \'unknown\'.", "165548477"],
+      [884, 68, 11, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2853998291"]
+    ],
+    "src/script/conversation/MessageRepository.ts:2506682268": [
+      [754, 58, 8, "No overload matches this call.\\n  Overload 1 of 4, \'(value: string | number | Date): Date\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number | Date\'.\\n  Overload 2 of 4, \'(value: string | number): Date\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number\'.", "1948180668"],
+      [797, 102, 5, "Object is of type \'unknown\'.", "165548477"],
+      [940, 80, 4, "Object is possibly \'undefined\'.", "2087973204"],
+      [951, 37, 5, "Object is of type \'unknown\'.", "165548477"],
+      [1158, 81, 4, "Argument of type \'User | undefined\' is not assignable to parameter of type \'QualifiedEntity\'.\\n  Type \'undefined\' is not assignable to type \'QualifiedEntity\'.", "2087973204"],
+      [1160, 36, 4, "Object is possibly \'undefined\'.", "2087973204"],
+      [1163, 39, 5, "Argument of type \'(User | undefined)[]\' is not assignable to parameter of type \'User[]\'.", "183638951"],
+      [1164, 30, 5, "Argument of type \'(User | undefined)[]\' is not assignable to parameter of type \'User[]\'.", "183638951"],
+      [1209, 68, 24, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2322605270"],
+      [1241, 39, 42, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "4089489462"],
+      [1258, 39, 42, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "4089489462"]
+    ],
+    "src/script/conversation/linkPreviews/helpers.test.ts:1000221294": [
+      [84, 11, 4, "Object is possibly \'undefined\'.", "2087656645"],
+      [85, 11, 4, "Object is possibly \'undefined\'.", "2087656645"],
+      [91, 11, 4, "Object is possibly \'undefined\'.", "2087656645"],
+      [92, 11, 4, "Object is possibly \'undefined\'.", "2087656645"],
+      [98, 11, 4, "Object is possibly \'undefined\'.", "2089009317"],
+      [99, 11, 4, "Object is possibly \'undefined\'.", "2089009317"],
+      [105, 11, 12, "Object is possibly \'undefined\'.", "929375728"],
+      [106, 11, 12, "Object is possibly \'undefined\'.", "929375728"],
+      [112, 11, 4, "Object is possibly \'undefined\'.", "2089009317"],
+      [113, 11, 4, "Object is possibly \'undefined\'.", "2089009317"]
+    ],
+    "src/script/conversation/linkPreviews/index.test.ts:3225052035": [
+      [113, 13, 10, "Object is possibly \'undefined\'.", "444608935"],
+      [114, 13, 10, "Object is possibly \'undefined\'.", "444608935"]
+    ],
+    "src/script/conversation/linkPreviews/index.ts:3906640483": [
+      [117, 40, 23, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "493358700"],
+      [122, 21, 39, "Object is possibly \'null\'.", "3082036576"],
+      [131, 4, 12, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "399682992"],
+      [156, 56, 5, "Object is of type \'unknown\'.", "165548477"]
+    ],
+    "src/script/conversation/userClientsUtils.ts:356115482": [
+      [28, 47, 21, "No overload matches this call.\\n  Overload 1 of 2, \'(o: ArrayLike<unknown> | { [s: string]: unknown; }): unknown[]\', gave the following error.\\n    Argument of type \'object | null\' is not assignable to parameter of type \'ArrayLike<unknown> | { [s: string]: unknown; }\'.\\n      Type \'null\' is not assignable to type \'ArrayLike<unknown> | { [s: string]: unknown; }\'.\\n  Overload 2 of 2, \'(o: {}): any[]\', gave the following error.\\n    Argument of type \'object | null\' is not assignable to parameter of type \'{}\'.\\n      Type \'null\' is not assignable to type \'{}\'.", "4151921890"]
+    ],
+    "src/script/cryptography/CryptographyMapper.ts:2912131072": [
+      [145, 51, 20, "Argument of type \'IAsset | null | undefined\' is not assignable to parameter of type \'(IImageAsset | IAsset) & Partial<{ expectsReadConfirmation: boolean; legalHoldStatus: LegalHoldStatus; }>\'.\\n  Type \'undefined\' is not assignable to type \'(IImageAsset | IAsset) & Partial<{ expectsReadConfirmation: boolean; legalHoldStatus: LegalHoldStatus; }>\'.", "4167911361"],
+      [191, 51, 20, "Argument of type \'IImageAsset | null | undefined\' is not assignable to parameter of type \'(IImageAsset | IAsset) & Partial<{ expectsReadConfirmation: boolean; legalHoldStatus: LegalHoldStatus; }>\'.\\n  Type \'undefined\' is not assignable to type \'(IImageAsset | IAsset) & Partial<{ expectsReadConfirmation: boolean; legalHoldStatus: LegalHoldStatus; }>\'.", "4177607510"],
+      [197, 51, 20, "Argument of type \'IKnock | null | undefined\' is not assignable to parameter of type \'(IImageAsset | IAsset) & Partial<{ expectsReadConfirmation: boolean; legalHoldStatus: LegalHoldStatus; }>\'.\\n  Type \'undefined\' is not assignable to type \'(IImageAsset | IAsset) & Partial<{ expectsReadConfirmation: boolean; legalHoldStatus: LegalHoldStatus; }>\'.", "4184406259"],
+      [208, 54, 23, "Argument of type \'ILocation | null | undefined\' is not assignable to parameter of type \'(IImageAsset | IAsset) & Partial<{ expectsReadConfirmation: boolean; legalHoldStatus: LegalHoldStatus; }>\'.\\n  Type \'undefined\' is not assignable to type \'(IImageAsset | IAsset) & Partial<{ expectsReadConfirmation: boolean; legalHoldStatus: LegalHoldStatus; }>\'.", "4165194764"],
+      [219, 50, 19, "Argument of type \'IText | null | undefined\' is not assignable to parameter of type \'(IImageAsset | IAsset) & Partial<{ expectsReadConfirmation: boolean; legalHoldStatus: LegalHoldStatus; }>\'.\\n  Type \'undefined\' is not assignable to type \'(IImageAsset | IAsset) & Partial<{ expectsReadConfirmation: boolean; legalHoldStatus: LegalHoldStatus; }>\'.", "1297199116"],
+      [225, 55, 24, "Argument of type \'IComposite | null | undefined\' is not assignable to parameter of type \'(IImageAsset | IAsset) & Partial<{ expectsReadConfirmation: boolean; legalHoldStatus: LegalHoldStatus; }>\'.\\n  Type \'undefined\' is not assignable to type \'(IImageAsset | IAsset) & Partial<{ expectsReadConfirmation: boolean; legalHoldStatus: LegalHoldStatus; }>\'.", "2918936900"],
+      [270, 15, 8, "Property \'mentions\' does not exist on type \'IText | null | undefined\'.", "1350167884"],
+      [270, 40, 7, "Property \'content\' does not exist on type \'IText | null | undefined\'.", "3716929964"],
+      [277, 43, 12, "Parameter \'protoMention\' implicitly has an \'any\' type.", "3153561129"],
+      [312, 10, 4, "Type \'string | null\' is not assignable to type \'string | undefined\'.", "2087876002"],
+      [328, 11, 4, "Variable \'data\' is used before being assigned.", "2087377941"],
+      [329, 8, 14, "Type \'string | null | undefined\' is not assignable to type \'string | undefined\'.", "1588166864"],
+      [329, 24, 6, "Object is possibly \'null\' or \'undefined\'.", "2124712353"],
+      [330, 8, 11, "Type \'string | null | undefined\' is not assignable to type \'string | undefined\'.", "3188681863"],
+      [330, 21, 6, "Object is possibly \'null\' or \'undefined\'.", "2124712353"],
+      [331, 40, 6, "Object is possibly \'null\' or \'undefined\'.", "2124712353"],
+      [332, 39, 6, "Object is possibly \'null\' or \'undefined\'.", "2124712353"],
+      [333, 8, 13, "Type \'string | null | undefined\' is not assignable to type \'string | undefined\'.", "2111557739"],
+      [333, 23, 6, "Object is possibly \'null\' or \'undefined\'.", "2124712353"],
+      [339, 6, 4, "Variable \'data\' is used before being assigned.", "2087377941"],
+      [344, 11, 4, "Variable \'data\' is used before being assigned.", "2087377941"],
+      [345, 8, 6, "Type \'string | null | undefined\' is not assignable to type \'string | undefined\'.", "1127975365"],
+      [345, 16, 8, "Object is possibly \'undefined\'.", "533230503"],
+      [346, 8, 3, "Type \'string | null | undefined\' is not assignable to type \'string | undefined\'.", "193424690"],
+      [346, 13, 8, "Object is possibly \'undefined\'.", "533230503"],
+      [347, 32, 8, "Object is possibly \'undefined\'.", "533230503"],
+      [348, 31, 8, "Object is possibly \'undefined\'.", "533230503"],
+      [350, 8, 5, "Type \'string | null | undefined\' is not assignable to type \'string | undefined\'.", "183304158"],
+      [350, 15, 8, "Object is possibly \'undefined\'.", "533230503"],
+      [353, 17, 4, "Variable \'data\' is used before being assigned.", "2087377941"],
+      [356, 12, 4, "Variable \'data\' is used before being assigned.", "2087377941"],
+      [451, 25, 24, "Object is possibly \'null\' or \'undefined\'.", "1179641534"],
+      [485, 62, 5, "Object is of type \'unknown\'.", "165548477"],
+      [551, 28, 31, "Object is possibly \'null\' or \'undefined\'.", "723833724"]
+    ],
+    "src/script/cryptography/CryptographyRepository.test.ts:468271473": [
+      [26, 4, 35, "Object is possibly \'undefined\'.", "2744578530"],
+      [39, 32, 35, "Object is possibly \'undefined\'.", "2744578530"]
+    ],
+    "src/script/cryptography/CryptographyRepository.ts:1877355837": [
+      [180, 100, 5, "Object is of type \'unknown\'.", "165548477"]
+    ],
+    "src/script/entity/Conversation.test.ts:2104519903": [
+      [49, 6, 15, "Type \'null\' is not assignable to type \'Conversation\'.", "4110128166"],
+      [50, 6, 10, "Type \'null\' is not assignable to type \'User\'.", "964073551"],
+      [52, 56, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [60, 53, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [146, 8, 18, "Type \'undefined\' is not assignable to type \'Message\'.", "3099154241"],
+      [182, 13, 15, "Object is possibly \'undefined\'.", "3656134677"],
+      [183, 13, 15, "Object is possibly \'undefined\'.", "3656134677"],
+      [196, 13, 15, "Object is possibly \'undefined\'.", "3656134677"],
+      [197, 13, 15, "Object is possibly \'undefined\'.", "3656134677"],
+      [306, 60, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [307, 58, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [348, 8, 12, "Type \'undefined\' is not assignable to type \'User\'.", "2792000409"],
+      [351, 34, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [364, 35, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [383, 35, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [408, 40, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [412, 13, 40, "Object is possibly \'undefined\'.", "1814521512"],
+      [429, 13, 40, "Object is possibly \'undefined\'.", "1814521512"],
+      [447, 13, 40, "Object is possibly \'undefined\'.", "1814521512"],
+      [496, 54, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [516, 48, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [547, 35, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [551, 42, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [568, 6, 34, "Cannot invoke an object which is possibly \'undefined\'.", "893582186"],
+      [570, 56, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [574, 35, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [584, 6, 34, "Cannot invoke an object which is possibly \'undefined\'.", "893582186"],
+      [586, 40, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [591, 35, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [595, 39, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [605, 6, 34, "Cannot invoke an object which is possibly \'undefined\'.", "893582186"],
+      [607, 40, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [612, 35, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [616, 39, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [628, 58, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [634, 54, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [646, 60, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [701, 54, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [714, 60, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [795, 8, 10, "Type \'undefined\' is not assignable to type \'string\'.", "3990992796"],
+      [904, 8, 9, "Type \'undefined\' is not assignable to type \'number\'.", "2548743275"],
+      [905, 8, 14, "Type \'undefined\' is not assignable to type \'ContentMessage\'.", "770131143"],
+      [906, 8, 21, "Type \'undefined\' is not assignable to type \'PingMessage\'.", "3552399181"],
+      [907, 8, 15, "Type \'undefined\' is not assignable to type \'PingMessage\'.", "1424040496"],
+      [908, 8, 11, "Type \'undefined\' is not assignable to type \'PingMessage\'.", "3938011998"],
+      [909, 8, 18, "Type \'undefined\' is not assignable to type \'ContentMessage\'.", "2146105736"],
+      [912, 56, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [1138, 58, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [1142, 36, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
+      [1167, 36, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"]
+    ],
+    "src/script/entity/Conversation.ts:2585477540": [
+      [104, 18, 24, "Property \'enforcedTeamMessageTimer\' has no initializer and is not definitely assigned in the constructor.", "3799921350"],
+      [179, 4, 16, "Type \'Observable<PERSONAL | TEAM | OTHER | undefined>\' is not assignable to type \'Observable<ACCESS_STATE>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'PERSONAL | TEAM | OTHER | undefined\' is not assignable to type \'ACCESS_STATE\'.", "3665501182"],
+      [180, 4, 15, "Type \'Observable<string | undefined>\' is not assignable to type \'Observable<string>\'.", "761254596"],
+      [181, 4, 12, "Type \'undefined\' is not assignable to type \'string\'.", "2242477105"],
+      [182, 4, 9, "Type \'Observable<string | undefined>\' is not assignable to type \'Observable<string>\'.", "1162129866"],
+      [183, 4, 12, "Type \'undefined\' is not assignable to type \'string\'.", "1264629218"],
+      [184, 4, 9, "Type \'Observable<CONVERSATION_TYPE | undefined>\' is not assignable to type \'Observable<CONVERSATION_TYPE>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'CONVERSATION_TYPE | undefined\' is not assignable to type \'CONVERSATION_TYPE\'.", "1162754997"],
+      [186, 4, 14, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "3558292847"],
+      [187, 4, 15, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "1584403895"],
+      [189, 4, 27, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<User>\'.", "957208303"],
+      [190, 4, 27, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<QualifiedId>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'QualifiedId[] | null | undefined\' is not assignable to type \'never[] | null | undefined\'.\\n      Type \'QualifiedId[]\' is not assignable to type \'never[]\'.\\n        Type \'QualifiedId\' is not assignable to type \'never\'.", "957203187"],
+      [199, 4, 12, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "3072930663"],
+      [211, 4, 23, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "1079595184"],
+      [213, 4, 15, "Type \'PureComputed<boolean | \\"\\">\' is not assignable to type \'PureComputed<boolean>\'.", "1095670353"],
+      [229, 4, 19, "Type \'PureComputed<boolean | undefined>\' is not assignable to type \'PureComputed<boolean>\'.", "2748887882"],
+      [233, 4, 13, "Type \'PureComputed<boolean | undefined>\' is not assignable to type \'PureComputed<boolean>\'.", "1137010663"],
+      [258, 4, 23, "Type \'Observable<ConversationVerificationState.UNVERIFIED>\' is not assignable to type \'Observable<ConversationVerificationState>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'ConversationVerificationState\' is not assignable to type \'ConversationVerificationState.UNVERIFIED\'.", "1872259068"],
+      [267, 4, 9, "Type \'Observable<Call | null>\' is not assignable to type \'Observable<Call>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'Call | null\' is not assignable to type \'Call\'.\\n      Type \'null\' is not assignable to type \'Call\'.", "1162313103"],
+      [279, 61, 15, "Object is possibly \'undefined\'.", "3866385313"],
+      [285, 35, 15, "Object is possibly \'undefined\'.", "3866385313"],
+      [301, 54, 10, "Object is possibly \'undefined\'.", "50227919"],
+      [304, 4, 20, "Type \'Observable<LegalHoldStatus.DISABLED>\' is not assignable to type \'Observable<LegalHoldStatus>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'LegalHoldStatus\' is not assignable to type \'LegalHoldStatus.DISABLED\'.", "135203605"],
+      [308, 84, 10, "Object is possibly \'undefined\'.", "50227919"],
+      [325, 18, 15, "Object is possibly \'undefined\'.", "3866385313"],
+      [331, 12, 15, "Object is possibly \'undefined\'.", "3866385313"],
+      [344, 4, 11, "Type \'Observable<ConversationStatus.CURRENT_MEMBER>\' is not assignable to type \'Observable<ConversationStatus>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'ConversationStatus\' is not assignable to type \'ConversationStatus.CURRENT_MEMBER\'.", "3642829209"],
+      [354, 4, 22, "Type \'Observable<number | null>\' is not assignable to type \'Observable<number>\'.", "3241402412"],
+      [355, 4, 23, "Type \'Observable<number | null>\' is not assignable to type \'Observable<number>\'.", "2493965002"],
+      [357, 4, 16, "Type \'Observable<RECEIPT_MODE.OFF>\' is not assignable to type \'Observable<RECEIPT_MODE>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'RECEIPT_MODE\' is not assignable to type \'RECEIPT_MODE.OFF\'.", "245090354"],
+      [368, 4, 17, "Type \'PureComputed<number | false>\' is not assignable to type \'PureComputed<number>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'number | false\' is not assignable to type \'number\'.\\n      Type \'boolean\' is not assignable to type \'number\'.", "515474049"],
+      [387, 4, 26, "Type \'Observable<true>\' is not assignable to type \'Observable<boolean>\'.", "1584405110"],
+      [419, 62, 15, "Object is possibly \'undefined\'.", "3866385313"],
+      [421, 91, 15, "Object is possibly \'undefined\'.", "3866385313"],
+      [647, 28, 54, "Argument of type \'string | null\' is not assignable to parameter of type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "3385179653"],
+      [688, 4, 53, "Type \'ContentMessage | undefined\' is not assignable to type \'ContentMessage\'.\\n  Type \'undefined\' is not assignable to type \'ContentMessage\'.", "1980005351"],
+      [739, 9, 15, "Object is possibly \'undefined\'.", "3866385313"],
+      [762, 4, 88, "No overload matches this call.\\n  Overload 1 of 2, \'(item: Message | ContentMessage | MemberMessage): (Message | ContentMessage | MemberMessage)[]\', gave the following error.\\n    Argument of type \'(message_et: Message | ContentMessage | MemberMessage) => boolean | \\"\\"\' is not assignable to parameter of type \'Message | ContentMessage | MemberMessage\'.\\n  Overload 2 of 2, \'(removeFunction: (item: Message | ContentMessage | MemberMessage) => boolean): (Message | ContentMessage | MemberMessage)[]\', gave the following error.\\n    Type \'string | boolean\' is not assignable to type \'boolean\'.", "302417194"],
+      [803, 72, 15, "Object is possibly \'undefined\'.", "3866385313"],
+      [950, 45, 15, "No overload matches this call.\\n  Overload 1 of 2, \'(...items: ConcatArray<User>[]): User[]\', gave the following error.\\n    Argument of type \'User | undefined\' is not assignable to parameter of type \'ConcatArray<User>\'.\\n      Type \'undefined\' is not assignable to type \'ConcatArray<User>\'.\\n  Overload 2 of 2, \'(...items: (User | ConcatArray<User>)[]): User[]\', gave the following error.\\n    Argument of type \'User | undefined\' is not assignable to parameter of type \'User | ConcatArray<User>\'.\\n      Type \'undefined\' is not assignable to type \'User | ConcatArray<User>\'.", "3866385313"],
+      [957, 45, 15, "No overload matches this call.\\n  Overload 1 of 2, \'(...items: ConcatArray<User>[]): User[]\', gave the following error.\\n    Argument of type \'User | undefined\' is not assignable to parameter of type \'ConcatArray<User>\'.\\n      Type \'undefined\' is not assignable to type \'ConcatArray<User>\'.\\n  Overload 2 of 2, \'(...items: (User | ConcatArray<User>)[]): User[]\', gave the following error.\\n    Argument of type \'User | undefined\' is not assignable to parameter of type \'User | ConcatArray<User>\'.", "3866385313"],
+      [972, 48, 21, "Object is possibly \'undefined\'.", "2518032411"],
+      [977, 6, 6, "Type \'CONVERSATION_ACCESS[] | undefined\' is not assignable to type \'CONVERSATION_ACCESS[]\'.\\n  Type \'undefined\' is not assignable to type \'CONVERSATION_ACCESS[]\'.", "1314097761"],
+      [978, 6, 11, "Type \'CONVERSATION_ACCESS_ROLE | ACCESS_ROLE_V2[] | undefined\' is not assignable to type \'CONVERSATION_ACCESS_ROLE | ACCESS_ROLE_V2[]\'.\\n  Type \'undefined\' is not assignable to type \'CONVERSATION_ACCESS_ROLE | ACCESS_ROLE_V2[]\'.", "186257802"]
+    ],
+    "src/script/entity/User.test.ts:1823754266": [
+      [91, 27, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"]
+    ],
+    "src/script/entity/User.ts:3591817769": [
+      [132, 4, 17, "Type \'Observable<undefined>\' is not assignable to type \'Observable<string>\'.\\n  Types of property \'equalityComparer\' are incompatible.\\n    Type \'(a: undefined, b: undefined) => boolean\' is not assignable to type \'(a: string, b: string) => boolean\'.\\n      Types of parameters \'a\' and \'a\' are incompatible.\\n        Type \'string\' is not assignable to type \'undefined\'.", "2198912395"],
+      [140, 4, 10, "Type \'Observable<string | undefined>\' is not assignable to type \'Observable<string>\'.", "3993952993"],
+      [141, 4, 10, "Type \'Observable<string | undefined>\' is not assignable to type \'Observable<string>\'.", "4016447089"],
+      [174, 4, 11, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "2812049175"],
+      [175, 4, 12, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "3072930663"],
+      [179, 4, 21, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "4210022876"],
+      [180, 4, 17, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "3163265562"],
+      [181, 4, 13, "Type \'Observable<ROLE.NONE>\' is not assignable to type \'Observable<ROLE>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'ROLE\' is not assignable to type \'ROLE.NONE\'.", "3077682660"],
+      [191, 47, 25, "Cannot invoke an object which is possibly \'undefined\'.", "3264425299"],
+      [204, 4, 17, "Type \'Observable<Type.NONE>\' is not assignable to type \'Observable<Type>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'Type\' is not assignable to type \'Type.NONE\'.", "1506870780"],
+      [208, 4, 23, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "703960067"],
+      [212, 4, 14, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "4158763232"],
+      [248, 57, 13, "No overload matches this call.\\n  Overload 1 of 4, \'(value: string | number | Date): Date\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number | Date\'.\\n  Overload 2 of 4, \'(value: string | number): Date\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number\'.", "3452993210"],
+      [248, 93, 13, "No overload matches this call.\\n  Overload 1 of 4, \'(value: string | number | Date): Date\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number | Date\'.\\n  Overload 2 of 4, \'(value: string | number): Date\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number\'.", "3563212121"]
+    ],
+    "src/script/entity/message/Asset.ts:2714709642": [
+      [36, 9, 4, "Property \'size\' has no initializer and is not definitely assigned in the constructor.", "2088346912"],
+      [68, 67, 14, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1931590284"],
+      [79, 67, 14, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1931590284"]
+    ],
+    "src/script/entity/message/CallMessage.ts:2179419971": [
+      [38, 4, 20, "Type \'TERMINATION_REASON | undefined\' is not assignable to type \'TERMINATION_REASON\'.\\n  Type \'undefined\' is not assignable to type \'TERMINATION_REASON\'.", "773642052"]
+    ],
+    "src/script/entity/message/ContentMessage.ts:2244220679": [
+      [56, 4, 11, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<FileAsset | Asset | MediumImage | Text>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'(FileAsset | Asset | MediumImage | Text)[] | null | undefined\' is not assignable to type \'never[] | null | undefined\'.\\n      Type \'(FileAsset | Asset | MediumImage | Text)[]\' is not assignable to type \'never[]\'.\\n        Type \'FileAsset | Asset | MediumImage | Text\' is not assignable to type \'never\'.", "3137859118"],
+      [59, 4, 21, "Type \'Observable<number | null>\' is not assignable to type \'Observable<number>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'number | null\' is not assignable to type \'number\'.\\n      Type \'null\' is not assignable to type \'number\'.", "1015589921"],
+      [71, 4, 10, "Type \'Observable<QuoteEntity | undefined>\' is not assignable to type \'Observable<QuoteEntity>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'QuoteEntity | undefined\' is not assignable to type \'QuoteEntity\'.\\n      Type \'undefined\' is not assignable to type \'QuoteEntity\'.", "4017089943"],
+      [72, 4, 17, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<ReadReceipt>\'.", "1540688880"],
+      [74, 4, 23, "Type \'Observable<boolean | null>\' is not assignable to type \'Observable<boolean>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'boolean | null\' is not assignable to type \'boolean\'.", "1490518748"],
+      [80, 34, 4, "Argument of type \'null\' is not assignable to parameter of type \'boolean\'.", "2087897566"]
+    ],
+    "src/script/entity/message/DecryptErrorMessage.ts:3460253006": [
+      [63, 4, 9, "Type \'PureComputed<string | undefined>\' is not assignable to type \'PureComputed<string>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "1161926893"],
+      [74, 4, 25, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "4236151592"]
+    ],
+    "src/script/entity/message/FileAsset.ts:2276294258": [
+      [45, 9, 14, "Property \'conversationId\' has no initializer and is not definitely assigned in the constructor.", "2597408709"],
+      [46, 9, 14, "Property \'correlation_id\' has no initializer and is not definitely assigned in the constructor.", "1441381135"],
+      [54, 4, 11, "Type \'Observable<AssetTransferState | undefined>\' is not assignable to type \'Observable<AssetTransferState>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'AssetTransferState | undefined\' is not assignable to type \'AssetTransferState\'.", "3642829209"],
+      [64, 4, 22, "Type \'Observable<AssetRemoteData | undefined>\' is not assignable to type \'Observable<AssetRemoteData>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'AssetRemoteData | undefined\' is not assignable to type \'AssetRemoteData\'.\\n      Type \'undefined\' is not assignable to type \'AssetRemoteData\'.", "1979595329"],
+      [65, 4, 21, "Type \'Observable<AssetRemoteData | undefined>\' is not assignable to type \'Observable<AssetRemoteData>\'.", "2294021202"],
+      [81, 4, 25, "Type \'Observable<NotUploaded | undefined>\' is not assignable to type \'Observable<NotUploaded>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'NotUploaded | undefined\' is not assignable to type \'NotUploaded\'.", "890696937"]
+    ],
+    "src/script/entity/message/MediumImage.ts:426001127": [
+      [41, 4, 13, "Type \'Observable<AssetRemoteData | undefined>\' is not assignable to type \'Observable<AssetRemoteData>\'.", "752547655"]
+    ],
+    "src/script/entity/message/MemberMessage.ts:3711207890": [
+      [53, 9, 6, "Property \'reason\' has no initializer and is not definitely assigned in the constructor.", "2124277697"],
+      [76, 4, 17, "Type \'Observable<never[]>\' is not assignable to type \'Observable<User[]>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'User[]\' is not assignable to type \'never[]\'.", "437902945"],
+      [83, 4, 19, "Type \'undefined\' is not assignable to type \'User[]\'.", "3619181810"],
+      [116, 100, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"]
+    ],
+    "src/script/entity/message/Message.ts:306209129": [
+      [53, 10, 19, "Property \'messageTimerStarted\' has no initializer and is not definitely assigned in the constructor.", "4092792040"],
+      [63, 9, 8, "Property \'reaction\' has no initializer and is not definitely assigned in the constructor.", "2663965068"],
+      [96, 4, 15, "Type \'SuperType | undefined\' is not assignable to type \'SuperType\'.\\n  Type \'undefined\' is not assignable to type \'SuperType\'.", "3885844715"],
+      [102, 4, 22, "Type \'Observable<false>\' is not assignable to type \'Observable<string | number | boolean>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'string | number | boolean\' is not assignable to type \'false\'.", "2558403805"],
+      [128, 4, 17, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<ReadReceipt>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'ReadReceipt[] | null | undefined\' is not assignable to type \'never[] | null | undefined\'.\\n      Type \'ReadReceipt[]\' is not assignable to type \'never[]\'.\\n        Type \'ReadReceipt\' is not assignable to type \'never\'.", "1540688880"],
+      [136, 4, 11, "Type \'Observable<StatusType.UNSPECIFIED>\' is not assignable to type \'Observable<StatusType>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'StatusType\' is not assignable to type \'StatusType.UNSPECIFIED\'.", "3642829209"],
+      [138, 43, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [140, 4, 12, "Type \'Observable<true>\' is not assignable to type \'Observable<boolean>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'boolean\' is not assignable to type \'true\'.", "4071713891"],
+      [142, 4, 17, "Type \'Observable<true>\' is not assignable to type \'Observable<boolean>\'.", "1239229967"],
+      [149, 75, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"]
+    ],
+    "src/script/entity/message/SystemMessage.ts:3060794215": [
+      [25, 9, 7, "Property \'caption\' has no initializer and is not definitely assigned in the constructor.", "3511518411"]
+    ],
+    "src/script/entity/message/VerificationMessage.ts:1055991539": [
+      [40, 4, 28, "Type \'Observable<VerificationMessageType | undefined>\' is not assignable to type \'Observable<VerificationMessageType>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'VerificationMessageType | undefined\' is not assignable to type \'VerificationMessageType\'.", "1551103719"],
+      [47, 27, 13, "Argument of type \'string | false | QualifiedUserId\' is not assignable to parameter of type \'string | QualifiedId\'.\\n  Type \'boolean\' is not assignable to type \'string | QualifiedId\'.", "2678465042"]
+    ],
+    "src/script/error/BackendClientError.ts:4157618261": [
+      [29, 4, 10, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3983565867"]
+    ],
+    "src/script/event/EventRepository.test.ts:3843097520": [
+      [90, 25, 26, "No overload matches this call.\\n  Overload 1 of 2, \'(o: {}): string[]\', gave the following error.\\n    Argument of type \'ReadReceipt[] | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 2, \'(o: object): string[]\', gave the following error.\\n    Argument of type \'ReadReceipt[] | undefined\' is not assignable to parameter of type \'object\'.\\n      Type \'undefined\' is not assignable to type \'object\'.", "792500112"],
+      [96, 6, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [98, 15, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [99, 25, 55, "Argument of type \'Promise<EventRecord<any>>\' is not assignable to parameter of type \'never\'.", "526597759"],
+      [104, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [108, 15, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [109, 15, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [114, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [118, 15, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [119, 15, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [124, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [128, 15, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [129, 15, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [143, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [144, 15, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [145, 15, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [159, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [160, 15, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [161, 15, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [175, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [176, 15, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [177, 15, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [216, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [217, 15, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [218, 15, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [241, 15, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [242, 28, 11, "Parameter \'saved_event\' implicitly has an \'any\' type.", "3147593107"],
+      [242, 28, 43, "Argument of type \'(saved_event: any) => Promise<any>\' is not assignable to parameter of type \'() => never\'.", "1450607298"],
+      [246, 17, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [248, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [249, 15, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [257, 15, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [258, 28, 46, "Argument of type \'() => Promise<EventRecord<any>>\' is not assignable to parameter of type \'() => never\'.\\n  Type \'Promise<EventRecord<any>>\' is not assignable to type \'never\'.", "270173584"],
+      [260, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [265, 17, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [273, 15, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [274, 28, 46, "Argument of type \'() => Promise<EventRecord<any>>\' is not assignable to parameter of type \'() => never\'.\\n  Type \'Promise<EventRecord<any>>\' is not assignable to type \'never\'.", "270173584"],
+      [276, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [281, 17, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [289, 15, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [290, 28, 46, "Argument of type \'() => Promise<EventRecord<any>>\' is not assignable to parameter of type \'() => never\'.\\n  Type \'Promise<EventRecord<any>>\' is not assignable to type \'never\'.", "270173584"],
+      [292, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [297, 17, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [304, 15, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [305, 28, 46, "Argument of type \'() => Promise<EventRecord<any>>\' is not assignable to parameter of type \'() => never\'.\\n  Type \'Promise<EventRecord<any>>\' is not assignable to type \'never\'.", "270173584"],
+      [307, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [312, 17, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [320, 15, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [321, 28, 46, "Argument of type \'() => Promise<EventRecord<any>>\' is not assignable to parameter of type \'() => never\'.\\n  Type \'Promise<EventRecord<any>>\' is not assignable to type \'never\'.", "270173584"],
+      [323, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [328, 17, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [335, 15, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [336, 28, 46, "Argument of type \'() => Promise<EventRecord<any>>\' is not assignable to parameter of type \'() => never\'.\\n  Type \'Promise<EventRecord<any>>\' is not assignable to type \'never\'.", "270173584"],
+      [341, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [346, 17, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [352, 17, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [352, 76, 35, "Argument of type \'() => Promise<EventRecord<any>>\' is not assignable to parameter of type \'() => never\'.\\n  Type \'Promise<EventRecord<any>>\' is not assignable to type \'never\'.", "3585529426"],
+      [354, 15, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [355, 28, 46, "Argument of type \'() => Promise<EventRecord<any>>\' is not assignable to parameter of type \'() => never\'.\\n  Type \'Promise<EventRecord<any>>\' is not assignable to type \'never\'.", "270173584"],
+      [362, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [363, 15, 11, "Object is possibly \'undefined\'.", "3147593107"],
+      [364, 15, 11, "Object is possibly \'undefined\'.", "3147593107"],
+      [365, 15, 11, "Object is possibly \'undefined\'.", "3147593107"],
+      [366, 15, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [372, 17, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [372, 76, 40, "Argument of type \'() => Promise<EventRecord<any>>\' is not assignable to parameter of type \'() => never\'.\\n  Type \'Promise<EventRecord<any>>\' is not assignable to type \'never\'.", "2477440726"],
+      [374, 15, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [375, 28, 40, "Argument of type \'() => Promise<EventRecord<any>>\' is not assignable to parameter of type \'() => never\'.\\n  Type \'Promise<EventRecord<any>>\' is not assignable to type \'never\'.", "2477440726"],
+      [379, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [382, 17, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [383, 17, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [395, 15, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [396, 28, 48, "Argument of type \'(conversationId: string, messageId: string) => Promise<undefined> | Promise<EventRecord<any>>\' is not assignable to parameter of type \'() => never\'.", "270597142"],
+      [400, 15, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [401, 28, 40, "Argument of type \'(ev: EventRecord) => Promise<EventRecord<any>>\' is not assignable to parameter of type \'() => never\'.", "130762840"],
+      [406, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [406, 86, 32, "Argument of type \'(updatedEvent: EventRecord) => void\' is not assignable to parameter of type \'(value: EventRecord<any> | undefined) => void | PromiseLike<void>\'.\\n  Types of parameters \'updatedEvent\' and \'value\' are incompatible.\\n    Type \'EventRecord<any> | undefined\' is not assignable to type \'EventRecord<any>\'.\\n      Type \'undefined\' is not assignable to type \'EventRecord<any>\'.", "1291289374"],
+      [407, 15, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [408, 15, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [417, 15, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [418, 28, 53, "Argument of type \'() => Promise<EventRecord<any>>\' is not assignable to parameter of type \'() => never\'.\\n  Type \'Promise<EventRecord<any>>\' is not assignable to type \'never\'.", "3901075106"],
+      [420, 15, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [421, 28, 50, "Argument of type \'(updates: EventRecord) => Promise<EventRecord<any>>\' is not assignable to parameter of type \'() => never\'.", "2498929304"],
+      [431, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [431, 75, 32, "Argument of type \'(updatedEvent: EventRecord) => void\' is not assignable to parameter of type \'(value: EventRecord<any> | undefined) => void | PromiseLike<void>\'.\\n  Types of parameters \'updatedEvent\' and \'value\' are incompatible.\\n    Type \'EventRecord<any> | undefined\' is not assignable to type \'EventRecord<any>\'.\\n      Type \'undefined\' is not assignable to type \'EventRecord<any>\'.", "1291289374"],
+      [436, 27, 22, "No overload matches this call.\\n  Overload 1 of 2, \'(o: {}): string[]\', gave the following error.\\n    Argument of type \'UserReactionMap | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 2, \'(o: object): string[]\', gave the following error.\\n    Argument of type \'UserReactionMap | undefined\' is not assignable to parameter of type \'object\'.\\n      Type \'undefined\' is not assignable to type \'object\'.", "3237744360"],
+      [437, 15, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [448, 17, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [448, 76, 34, "Argument of type \'() => Promise<{ data: any; category?: number | undefined; client?: { time: string; } | undefined; connection?: { lastUpdate: string; } | undefined; content?: string | undefined; conversation: string; ... 24 more ...; waiting_button_id?: string | undefined; }>\' is not assignable to parameter of type \'() => never\'.\\n  Type \'Promise<{ data: any; category?: number | undefined; client?: { time: string; } | undefined; connection?: { lastUpdate: string; } | undefined; content?: string | undefined; conversation: string; edited_time?: string | undefined; ... 23 more ...; waiting_button_id?: string | undefined; }>\' is not assignable to type \'never\'.", "2413977172"],
+      [450, 15, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [451, 28, 40, "Argument of type \'(ev: EventRecord) => Promise<EventRecord<any>>\' is not assignable to parameter of type \'() => never\'.", "130762840"],
+      [455, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [455, 79, 32, "Argument of type \'(updatedEvent: EventRecord) => void\' is not assignable to parameter of type \'(value: EventRecord<any> | undefined) => void | PromiseLike<void>\'.\\n  Types of parameters \'updatedEvent\' and \'value\' are incompatible.\\n    Type \'EventRecord<any> | undefined\' is not assignable to type \'EventRecord<any>\'.\\n      Type \'undefined\' is not assignable to type \'EventRecord<any>\'.", "1291289374"],
+      [456, 15, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [457, 15, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [465, 17, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [467, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [469, 17, 12, "Object is possibly \'undefined\'.", "373016604"],
+      [470, 17, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [480, 8, 27, "Object is possibly \'undefined\'.", "2644272773"],
+      [483, 38, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [484, 40, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [493, 40, 36, "Argument of type \'() => Promise<{ from: string; type: CONVERSATION; category?: number | undefined; client?: { time: string; } | undefined; connection?: { lastUpdate: string; } | undefined; content?: string | undefined; ... 24 more ...; waiting_button_id?: string | undefined; }>\' is not assignable to parameter of type \'() => never\'.\\n  Type \'Promise<{ from: string; type: CONVERSATION; category?: number | undefined; client?: { time: string; } | undefined; connection?: { lastUpdate: string; } | undefined; content?: string | undefined; ... 24 more ...; waiting_button_id?: string | undefined; }>\' is not assignable to type \'never\'.", "2692316574"],
+      [494, 42, 24, "Argument of type \'() => Promise<number>\' is not assignable to parameter of type \'() => never\'.\\n  Type \'Promise<number>\' is not assignable to type \'never\'.", "731841138"],
+      [496, 33, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [500, 15, 10, "Object is possibly \'undefined\'.", "3453834508"],
+      [501, 15, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [513, 17, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [513, 76, 36, "Argument of type \'() => Promise<{ type: CONVERSATION; category?: number | undefined; client?: { time: string; } | undefined; connection?: { lastUpdate: string; } | undefined; content?: string | undefined; ... 25 more ...; waiting_button_id?: string | undefined; }>\' is not assignable to parameter of type \'() => never\'.\\n  Type \'Promise<{ type: CONVERSATION; category?: number | undefined; client?: { time: string; } | undefined; connection?: { lastUpdate: string; } | undefined; content?: string | undefined; ... 25 more ...; waiting_button_id?: string | undefined; }>\' is not assignable to type \'never\'.", "2692316574"],
+      [514, 17, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [514, 78, 24, "Argument of type \'() => Promise<number>\' is not assignable to parameter of type \'() => never\'.\\n  Type \'Promise<number>\' is not assignable to type \'never\'.", "731841138"],
+      [516, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [518, 17, 10, "Object is possibly \'undefined\'.", "3453834508"],
+      [519, 17, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [533, 15, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [535, 17, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [535, 76, 36, "Argument of type \'() => Promise<EventRecord<any>>\' is not assignable to parameter of type \'() => never\'.\\n  Type \'Promise<EventRecord<any>>\' is not assignable to type \'never\'.", "2692316574"],
+      [537, 15, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [538, 28, 45, "Argument of type \'() => Promise<EventRecord<any>>\' is not assignable to parameter of type \'() => never\'.\\n  Type \'Promise<EventRecord<any>>\' is not assignable to type \'never\'.", "368568095"],
+      [540, 31, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [544, 13, 10, "Object is possibly \'undefined\'.", "3453834508"],
+      [545, 13, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [558, 15, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [559, 28, 13, "Parameter \'eventToUpdate\' implicitly has an \'any\' type.", "964362851"],
+      [559, 28, 47, "Argument of type \'(eventToUpdate: any) => Promise<any>\' is not assignable to parameter of type \'() => never\'.", "666953218"],
+      [560, 17, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [560, 76, 40, "Argument of type \'() => Promise<{ type: CONVERSATION; category?: number | undefined; client?: { time: string; } | undefined; connection?: { lastUpdate: string; } | undefined; content?: string | undefined; ... 25 more ...; waiting_button_id?: string | undefined; }>\' is not assignable to parameter of type \'() => never\'.\\n  Type \'Promise<{ type: CONVERSATION; category?: number | undefined; client?: { time: string; } | undefined; connection?: { lastUpdate: string; } | undefined; content?: string | undefined; ... 25 more ...; waiting_button_id?: string | undefined; }>\' is not assignable to type \'never\'.", "1106270881"],
+      [562, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [564, 17, 12, "Object is possibly \'undefined\'.", "373016604"],
+      [565, 17, 12, "Object is possibly \'undefined\'.", "373016604"],
+      [566, 17, 25, "Object is possibly \'undefined\'.", "47328231"],
+      [581, 15, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [582, 28, 13, "Parameter \'eventToUpdate\' implicitly has an \'any\' type.", "964362851"],
+      [582, 28, 47, "Argument of type \'(eventToUpdate: any) => Promise<any>\' is not assignable to parameter of type \'() => never\'.", "666953218"],
+      [583, 17, 25, "No overload matches this call.\\n  Overload 1 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.\\n  Overload 2 of 4, \'(object: {}, method: never): SpyInstance<never, never>\', gave the following error.\\n    Argument of type \'EventService | undefined\' is not assignable to parameter of type \'{}\'.\\n      Type \'undefined\' is not assignable to type \'{}\'.", "47328231"],
+      [583, 76, 40, "Argument of type \'() => Promise<{ type: CONVERSATION; category?: number | undefined; client?: { time: string; } | undefined; connection?: { lastUpdate: string; } | undefined; content?: string | undefined; ... 25 more ...; waiting_button_id?: string | undefined; }>\' is not assignable to parameter of type \'() => never\'.\\n  Type \'Promise<{ type: CONVERSATION; category?: number | undefined; client?: { time: string; } | undefined; connection?: { lastUpdate: string; } | undefined; content?: string | undefined; ... 25 more ...; waiting_button_id?: string | undefined; }>\' is not assignable to type \'never\'.", "1106270881"],
+      [585, 13, 28, "Object is possibly \'undefined\'.", "3381709752"],
+      [586, 8, 32, "Argument of type \'(updatedEvent: EventRecord) => void\' is not assignable to parameter of type \'(value: EventRecord<any> | undefined) => void | PromiseLike<void>\'.\\n  Types of parameters \'updatedEvent\' and \'value\' are incompatible.\\n    Type \'EventRecord<any> | undefined\' is not assignable to type \'EventRecord<any>\'.\\n      Type \'undefined\' is not assignable to type \'EventRecord<any>\'.", "1291289374"],
+      [588, 17, 25, "Object is possibly \'undefined\'.", "47328231"]
+    ],
+    "src/script/event/EventRepository.ts:2800868471": [
+      [106, 4, 30, "Type \'Observable<NOTIFICATION_HANDLING_STATE.STREAM>\' is not assignable to type \'Observable<NOTIFICATION_HANDLING_STATE>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'NOTIFICATION_HANDLING_STATE\' is not assignable to type \'NOTIFICATION_HANDLING_STATE.STREAM\'.", "3724439608"],
+      [161, 60, 5, "Object is possibly \'undefined\'.", "165702089"],
+      [161, 76, 5, "Object is of type \'unknown\'.", "165548477"],
+      [228, 10, 13, "Object is of type \'unknown\'.", "3310660798"],
+      [229, 49, 13, "Object is of type \'unknown\'.", "3310660798"],
+      [243, 13, 6, "Object is possibly \'undefined\'.", "1543056028"],
+      [248, 13, 10, "Object is possibly \'undefined\'.", "1089446899"],
+      [261, 48, 25, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3511045606"],
+      [272, 40, 20, "Object is possibly \'undefined\'.", "3111726366"],
+      [538, 28, 12, "Object is possibly \'undefined\'.", "2257332645"],
+      [538, 53, 12, "Object is possibly \'undefined\'.", "2257332645"],
+      [539, 59, 12, "Object is possibly \'undefined\'.", "2257332645"],
+      [553, 41, 13, "Object is possibly \'undefined\'.", "1529837131"],
+      [557, 69, 11, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3842816886"],
+      [560, 8, 100, "Type \'EventRecord<any> | undefined\' is not assignable to type \'EventRecord<any>\'.\\n  Type \'undefined\' is not assignable to type \'EventRecord<any>\'.", "1834623770"],
+      [560, 59, 25, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2126983834"],
+      [560, 86, 13, "Object is possibly \'undefined\'.", "1529837131"],
+      [564, 78, 13, "Object is possibly \'undefined\'.", "1529837131"],
+      [607, 52, 20, "Object is possibly \'undefined\'.", "2445000522"]
+    ],
+    "src/script/event/EventService.ts:414809804": [
+      [46, 79, 9, "Object is possibly \'undefined\'.", "1946021483"],
+      [46, 103, 9, "No overload matches this call.\\n  Overload 1 of 2, \'(that: string, locales?: string | string[] | undefined, options?: CollatorOptions | undefined): number\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.\\n  Overload 2 of 2, \'(that: string): number\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "1946194504"],
+      [77, 86, 9, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "761523947"],
+      [81, 8, 5, "Object is of type \'unknown\'.", "165548477"],
+      [110, 97, 5, "Object is of type \'unknown\'.", "165548477"],
+      [140, 6, 156, "Type \'EventRecord<any> | undefined\' is not assignable to type \'EventRecord<any>\'.\\n  Type \'undefined\' is not assignable to type \'EventRecord<any>\'.", "608859508"],
+      [145, 99, 5, "Object is of type \'unknown\'.", "165548477"],
+      [185, 52, 15, "Object is possibly \'undefined\'.", "1303905750"],
+      [185, 86, 15, "Object is possibly \'undefined\'.", "1303905750"],
+      [240, 100, 5, "Object is of type \'unknown\'.", "165548477"],
+      [338, 92, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
+      [352, 74, 17, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2867884739"],
+      [382, 4, 11, "Object is possibly \'undefined\'.", "370216726"],
+      [383, 4, 11, "Object is possibly \'undefined\'.", "370216726"]
+    ],
+    "src/script/event/EventServiceNoCompound.ts:1388827788": [
+      [64, 54, 15, "Object is possibly \'undefined\'.", "1303905750"]
+    ],
+    "src/script/event/preprocessor/ServiceMiddleware.ts:3271199821": [
+      [80, 58, 9, "Argument of type \'MemberJoinEvent | undefined\' is not assignable to parameter of type \'MemberJoinEvent\'.\\n  Type \'undefined\' is not assignable to type \'MemberJoinEvent\'.", "1946204345"],
+      [103, 51, 10, "Object is possibly \'undefined\'.", "4128218071"]
+    ],
+    "src/script/extension/GiphyRepository.ts:4288041442": [
+      [46, 10, 13, "Property \'currentOffset\' has no initializer and is not definitely assigned in the constructor.", "3944906049"],
+      [75, 42, 18, "Object is possibly \'undefined\'.", "3219551329"],
+      [89, 67, 15, "Object is possibly \'undefined\'.", "3911174730"]
+    ],
+    "src/script/externalRoute.ts:1170782870": [
+      [77, 2, 55, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2013931483"],
+      [78, 64, 51, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2860866952"],
+      [81, 2, 111, "Type \'string | false\' is not assignable to type \'string\'.\\n  Type \'boolean\' is not assignable to type \'string\'.", "685592872"],
+      [82, 46, 35, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3510242108"],
+      [83, 46, 35, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3510297418"],
+      [84, 51, 40, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3597061715"],
+      [88, 4, 17, "Type \'undefined\' is not assignable to type \'string\'.", "4204377774"]
+    ],
+    "src/script/hooks/usePausableInterval.ts:4028999421": [
+      [38, 6, 21, "Cannot invoke an object which is possibly \'undefined\'.", "4185327969"]
+    ],
+    "src/script/hooks/usePausableTimeout.ts:3967169248": [
+      [38, 6, 20, "Cannot invoke an object which is possibly \'undefined\'.", "2491310661"]
+    ],
+    "src/script/hooks/useRelativeTimestamp.tsx:4133986382": [
+      [65, 79, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.", "170515051"],
+      [69, 47, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.", "170515051"]
+    ],
+    "src/script/integration/IntegrationRepository.ts:1781170224": [
+      [72, 4, 13, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<ServiceEntity>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'ServiceEntity[] | null | undefined\' is not assignable to type \'never[] | null | undefined\'.\\n      Type \'ServiceEntity[]\' is not assignable to type \'never[]\'.\\n        Type \'ServiceEntity\' is not assignable to type \'never\'.", "4242441731"],
+      [85, 56, 17, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2786638268"],
+      [86, 26, 14, "Object is possibly \'undefined\'.", "2727665343"],
+      [101, 4, 50, "Type \'ServiceEntity | undefined\' is not assignable to type \'ServiceEntity\'.\\n  Type \'undefined\' is not assignable to type \'ServiceEntity\'.", "3311380496"],
+      [101, 31, 10, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4118455337"],
+      [238, 77, 24, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2322605270"],
+      [249, 57, 5, "Object is of type \'unknown\'.", "165548477"]
+    ],
+    "src/script/integration/ServiceEntity.ts:2862427254": [
+      [58, 4, 26, "Type \'Observable<AssetRemoteData | undefined>\' is not assignable to type \'Observable<AssetRemoteData>\'.", "2039859734"],
+      [59, 4, 27, "Type \'Observable<AssetRemoteData | undefined>\' is not assignable to type \'Observable<AssetRemoteData>\'.", "4198396353"]
+    ],
+    "src/script/legal-hold/LegalHoldEvaluator.ts:1567725998": [
+      [45, 43, 23, "Argument of type \'User | undefined\' is not assignable to parameter of type \'User\'.\\n  Type \'undefined\' is not assignable to type \'User\'.", "153688682"],
+      [56, 2, 49, "Type \'boolean | undefined\' is not assignable to type \'boolean\'.", "265606130"],
+      [61, 11, 16, "Object is possibly \'undefined\'.", "332022202"]
+    ],
+    "src/script/main/SingleInstanceHandler.ts:305503035": [
+      [118, 6, 27, "Cannot invoke an object which is possibly \'undefined\'.", "107936000"]
+    ],
+    "src/script/main/app.ts:2246757944": [
+      [156, 2, 5, "Property \'debug\' has no initializer and is not definitely assigned in the constructor.", "164124116"],
+      [157, 2, 4, "Property \'util\' has no initializer and is not definitely assigned in the constructor.", "2087972225"],
+      [349, 87, 5, "Object is of type \'unknown\'.", "165548477"],
+      [408, 10, 41, "Object is possibly \'undefined\'.", "1596662938"],
+      [409, 10, 30, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "286595218"],
+      [418, 65, 19, "Argument of type \'import(\\"wire-webapp/node_modules/@wireapp/api-client/src/client/ClientType\\").ClientType | undefined\' is not assignable to parameter of type \'string | number\'.\\n  Type \'undefined\' is not assignable to type \'string | number\'.", "1723063280"],
+      [485, 27, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'BaseError\'.", "165548477"],
+      [503, 36, 11, "Object is possibly \'undefined\'.", "3663176296"],
+      [699, 62, 6, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string | null\'.", "1127975365"],
+      [709, 19, 6, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1127975365"],
+      [776, 12, 5, "Object is of type \'unknown\'.", "165548477"],
+      [830, 81, 5, "Object is of type \'unknown\'.", "165548477"],
+      [874, 37, 15, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string | URL\'.\\n  Type \'undefined\' is not assignable to type \'string | URL\'.", "1529230466"]
+    ],
+    "src/script/media/MediaConstraintsHandler.test.ts:456751395": [
+      [43, 47, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"]
+    ],
+    "src/script/media/MediaConstraintsHandler.ts:977701651": [
+      [118, 22, 11, "Argument of type \'string | null\' is not assignable to parameter of type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "2484436277"]
+    ],
+    "src/script/media/MediaDevicesHandler.ts:2288366914": [
+      [94, 6, 10, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<ElectronDesktopCapturerSource | MediaDeviceInfo>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'(ElectronDesktopCapturerSource | MediaDeviceInfo)[] | null | undefined\' is not assignable to type \'never[] | null | undefined\'.\\n      Type \'(ElectronDesktopCapturerSource | MediaDeviceInfo)[]\' is not assignable to type \'never[]\'.\\n        Type \'ElectronDesktopCapturerSource | MediaDeviceInfo\' is not assignable to type \'never\'.\\n          Type \'ElectronDesktopCapturerSource\' is not assignable to type \'never\'.", "3972973829"],
+      [95, 6, 11, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<ElectronDesktopCapturerSource | MediaDeviceInfo>\'.", "2173601068"],
+      [96, 6, 11, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<ElectronDesktopCapturerSource | MediaDeviceInfo>\'.", "3890886687"],
+      [97, 6, 10, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<ElectronDesktopCapturerSource | MediaDeviceInfo>\'.", "3876799330"],
+      [101, 6, 10, "Type \'Observable<null | undefined>\' is not assignable to type \'Observable<string>\'.\\n  Types of property \'equalityComparer\' are incompatible.\\n    Type \'(a: null | undefined, b: null | undefined) => boolean\' is not assignable to type \'(a: string, b: string) => boolean\'.\\n      Types of parameters \'a\' and \'a\' are incompatible.\\n        Type \'string\' is not assignable to type \'null | undefined\'.", "3972973829"],
+      [102, 6, 11, "Type \'Observable<null | undefined>\' is not assignable to type \'Observable<string>\'.", "2173601068"],
+      [103, 6, 11, "Type \'Observable<null | undefined>\' is not assignable to type \'Observable<string>\'.", "3890886687"],
+      [104, 6, 10, "Type \'Observable<null | undefined>\' is not assignable to type \'Observable<string>\'.", "3876799330"],
+      [273, 10, 22, "Object is possibly \'undefined\'.", "520485411"],
+      [274, 15, 22, "Object is possibly \'undefined\'.", "520485411"],
+      [276, 10, 22, "Object is possibly \'undefined\'.", "520485411"],
+      [278, 15, 22, "Object is possibly \'undefined\'.", "520485411"],
+      [282, 8, 22, "Object is possibly \'undefined\'.", "520485411"]
+    ],
+    "src/script/media/MediaEmbeds.test.ts:94533359": [
+      [688, 58, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"],
+      [689, 58, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"]
+    ],
+    "src/script/media/MediaEmbeds.ts:3626459359": [
+      [122, 65, 21, "Argument of type \'string | null\' is not assignable to parameter of type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "3195064474"]
+    ],
+    "src/script/media/MediaParser.ts:2612415638": [
+      [56, 69, 10, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4239794921"]
+    ],
+    "src/script/media/MediaStreamHandler.ts:731304856": [
+      [68, 33, 5, "Object is of type \'unknown\'.", "165548477"]
+    ],
+    "src/script/message/QuoteEntity.ts:2585694251": [
+      [60, 42, 9, "No overload matches this call.\\n  The last overload gave the following error.\\n    Argument of type \'ArrayBuffer | undefined\' is not assignable to parameter of type \'ArrayBufferLike\'.\\n      Type \'undefined\' is not assignable to type \'ArrayBufferLike\'.", "1162062559"]
+    ],
+    "src/script/notification/NotificationRepository.ts:2433616700": [
+      [145, 4, 28, "Type \'Observable<NotificationPreference.ON>\' is not assignable to type \'Observable<NotificationPreference>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'NotificationPreference\' is not assignable to type \'NotificationPreference.ON\'.", "703631336"],
+      [153, 4, 20, "Type \'Observable<PermissionState | PermissionStatusState>\' is not assignable to type \'Observable<PermissionState | PermissionStatusState | NotificationPermission>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'PermissionState | PermissionStatusState | NotificationPermission\' is not assignable to type \'PermissionState | PermissionStatusState\'.", "2835088081"]
+    ],
+    "src/script/notification/PreferenceNotificationRepository.test.ts:318347950": [
+      [31, 44, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"]
+    ],
+    "src/script/notification/PreferenceNotificationRepository.ts:1031470059": [
+      [82, 29, 5, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "174572682"],
+      [82, 36, 4, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2087961072"],
+      [82, 42, 4, "Type \'ClientType.PERMANENT | ClientType.TEMPORARY | undefined\' is not assignable to type \'ClientType\'.\\n  Type \'undefined\' is not assignable to type \'ClientType\'.", "2087944093"],
+      [114, 9, 6, "Type \'string | undefined\' is not assignable to type \'string | null\'.", "1127975365"]
+    ],
+    "src/script/page/AccentColorPicker.test.tsx:2337834610": [
+      [52, 10, 5, "Type \'HTMLInputElement | null\' is not assignable to type \'HTMLInputElement\'.\\n  Type \'null\' is not assignable to type \'HTMLInputElement\'.", "178805363"],
+      [93, 12, 5, "Type \'HTMLInputElement | null\' is not assignable to type \'HTMLInputElement\'.\\n  Type \'null\' is not assignable to type \'HTMLInputElement\'.", "178805363"]
+    ],
+    "src/script/page/AccentColorPicker.tsx:609208269": [
+      [56, 38, 34, "Argument of type \'(key: keyof typeof ACCENT_ID) => EmotionJSX.Element\' is not assignable to parameter of type \'(value: string, index: number, array: string[]) => Element\'.\\n  Types of parameters \'key\' and \'value\' are incompatible.\\n    Type \'string\' is not assignable to type \'\\"AMBER\\" | \\"BLUE\\" | \\"GREEN\\" | \\"PURPLE\\" | \\"RED\\" | \\"TURQUOISE\\"\'.", "2706456082"]
+    ],
+    "src/script/page/AppLock.test.ts:262111532": [
+      [50, 59, 22, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "316356198"],
+      [52, 33, 14, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "3534045292"],
+      [106, 37, 12, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1912908196"],
+      [178, 35, 12, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1912908196"]
+    ],
+    "src/script/page/AppLock.tsx:218288677": [
+      [165, 28, 36, "Argument of type \'Element | null\' is not assignable to parameter of type \'Node\'.\\n  Type \'null\' is not assignable to type \'Node\'.", "3019440182"],
+      [169, 26, 30, "Argument of type \'Element | null\' is not assignable to parameter of type \'Node\'.\\n  Type \'null\' is not assignable to type \'Node\'.", "1790131128"],
+      [197, 59, 37, "Object is possibly \'null\'.", "3700925542"],
+      [218, 94, 4, "Argument of type \'unknown\' is not assignable to parameter of type \'StatusCodes\'.", "2087770728"],
+      [221, 19, 7, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<string>\'.", "1236122734"]
+    ],
+    "src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx:591295102": [
+      [256, 45, 12, "Object is possibly \'undefined\'.", "1670678216"],
+      [262, 14, 12, "Type \'Conversation | undefined\' is not assignable to type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "1670678216"]
+    ],
+    "src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx:3232925700": [
+      [104, 10, 15, "Type \'(conversation: Conversation) => boolean\' is not assignable to type \'(conversationId: QualifiedId) => boolean\'.\\n  Types of parameters \'conversation\' and \'conversationId\' are incompatible.\\n    Type \'QualifiedId\' is missing the following properties from type \'Conversation\': teamState, archivedState, incomingMessages, isManaged, and 118 more.", "1629494677"]
+    ],
+    "src/script/page/LeftSidebar/panels/Conversations/GroupedConversationHeader.test.ts:3219319072": [
+      [62, 11, 11, "Object is possibly \'null\'.", "3168726921"]
+    ],
+    "src/script/page/LeftSidebar/panels/Conversations/GroupedConversations.tsx:3926241606": [
+      [106, 25, 2, "Property \'id\' does not exist on type \'0 | ConversationLabel\'.\\n  Property \'id\' does not exist on type \'0\'.", "5861160"],
+      [106, 38, 13, "Property \'conversations\' does not exist on type \'0 | ConversationLabel\'.\\n  Property \'conversations\' does not exist on type \'0\'.", "3592773563"],
+      [107, 10, 6, "Type \'0 | ConversationLabel\' is not assignable to type \'ConversationLabel\'.\\n  Type \'number\' is not assignable to type \'ConversationLabel\'.", "1353197619"]
+    ],
+    "src/script/page/LeftSidebar/panels/ListWrapper.tsx:4099755336": [
+      [67, 21, 12, "Argument of type \'HTMLDivElement | undefined\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLElement\'.", "652464040"],
+      [87, 44, 8, "No overload matches this call.\\n  Overload 1 of 2, \'(type: \\"scroll\\", listener: (this: HTMLDivElement, ev: Event) => any, options?: boolean | AddEventListenerOptions | undefined): void\', gave the following error.\\n    Argument of type \'(event: MouseEvent) => void\' is not assignable to parameter of type \'(this: HTMLDivElement, ev: Event) => any\'.\\n      Types of parameters \'event\' and \'ev\' are incompatible.\\n        Type \'Event\' is not assignable to type \'MouseEvent\'.\\n  Overload 2 of 2, \'(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions | undefined): void\', gave the following error.\\n    Argument of type \'(event: MouseEvent) => void\' is not assignable to parameter of type \'EventListenerOrEventListenerObject\'.", "1317952297"],
+      [89, 60, 8, "No overload matches this call.\\n  Overload 1 of 2, \'(type: \\"scroll\\", listener: (this: HTMLDivElement, ev: Event) => any, options?: boolean | EventListenerOptions | undefined): void\', gave the following error.\\n    Argument of type \'(event: MouseEvent) => void\' is not assignable to parameter of type \'(this: HTMLDivElement, ev: Event) => any\'.\\n      Types of parameters \'event\' and \'ev\' are incompatible.\\n        Type \'Event\' is missing the following properties from type \'MouseEvent\': altKey, button, buttons, clientX, and 21 more.\\n  Overload 2 of 2, \'(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions | undefined): void\', gave the following error.\\n    Argument of type \'(event: MouseEvent) => void\' is not assignable to parameter of type \'EventListenerOrEventListenerObject\'.\\n      Type \'(event: MouseEvent) => void\' is not assignable to type \'EventListener\'.\\n        Types of parameters \'event\' and \'evt\' are incompatible.\\n          Type \'Event\' is not assignable to type \'MouseEvent\'.", "1317952297"]
+    ],
+    "src/script/page/LeftSidebar/panels/StartUI/ServicesTab.tsx:702522318": [
+      [44, 18, 7, "Argument of type \'ServiceEntity[] | undefined\' is not assignable to parameter of type \'SetStateAction<ServiceEntity[]>\'.\\n  Type \'undefined\' is not assignable to type \'SetStateAction<ServiceEntity[]>\'.", "1366156959"]
+    ],
+    "src/script/page/LeftSidebar/panels/StartUI/components/GroupList.test.tsx:87150494": [
+      [34, 63, 38, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "495210063"]
+    ],
+    "src/script/page/LeftSidebar/panels/StartUI/components/topPeople/TopContact.tsx:3148560411": [
+      [53, 8, 11, "Cannot invoke an object which is possibly \'undefined\'.", "110900827"],
+      [55, 48, 11, "Object is possibly \'undefined\'.", "110900827"],
+      [55, 48, 11, "No overload matches this call.\\n  Overload 1 of 6, \'(this: (this: undefined, arg0: User, arg1: MouseEvent<Element, MouseEvent>) => void, thisArg: undefined, arg0: User, arg1: MouseEvent<Element, MouseEvent>): () => void\', gave the following error.\\n    The \'this\' context of type \'((userEntity: User, event: MouseEvent<Element, MouseEvent>) => void) | undefined\' is not assignable to method\'s \'this\' of type \'(this: undefined, arg0: User, arg1: MouseEvent<Element, MouseEvent>) => void\'.\\n      Type \'undefined\' is not assignable to type \'(this: undefined, arg0: User, arg1: MouseEvent<Element, MouseEvent>) => void\'.\\n  Overload 2 of 6, \'(this: (this: undefined, ...args: User[]) => void, thisArg: undefined, ...args: User[]): (...args: User[]) => void\', gave the following error.\\n    The \'this\' context of type \'((userEntity: User, event: MouseEvent<Element, MouseEvent>) => void) | undefined\' is not assignable to method\'s \'this\' of type \'(this: undefined, ...args: User[]) => void\'.\\n      Type \'undefined\' is not assignable to type \'(this: undefined, ...args: User[]) => void\'.", "110900827"]
+    ],
+    "src/script/page/MainContent/MainContent.tsx:3648818950": [
+      [85, 28, 12, "Type \'Conversation | null\' is not assignable to type \'Conversation\'.\\n  Type \'null\' is not assignable to type \'Conversation\'.", "1670678216"]
+    ],
+    "src/script/page/MainContent/panels/Collection/Collection.test.tsx:1028939995": [
+      [122, 12, 5, "Type \'HTMLInputElement | null\' is not assignable to type \'HTMLInputElement\'.\\n  Type \'null\' is not assignable to type \'HTMLInputElement\'.", "178805363"]
+    ],
+    "src/script/page/MainContent/panels/Collection/CollectionDetails.tsx:4259170832": [
+      [60, 21, 12, "Argument of type \'HTMLDivElement | undefined\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLElement\'.", "652464040"]
+    ],
+    "src/script/page/MainContent/panels/Collection/FullSearch.tsx:1879516049": [
+      [99, 10, 10, "Object is possibly \'undefined\'.", "1962587969"],
+      [100, 26, 10, "Object is possibly \'undefined\'.", "1962587969"],
+      [109, 25, 11, "Object is possibly \'undefined\'.", "2591652326"],
+      [126, 12, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'LegacyRef<HTMLInputElement> | undefined\'.", "193432436"]
+    ],
+    "src/script/page/MainContent/panels/Collection/utils.tsx:3873364785": [
+      [27, 13, 16, "Object is possibly \'undefined\'.", "3400861264"],
+      [27, 59, 16, "Object is possibly \'undefined\'.", "3400861264"],
+      [29, 13, 16, "Object is possibly \'undefined\'.", "3400861264"],
+      [31, 13, 16, "Object is possibly \'undefined\'.", "3400861264"],
+      [34, 8, 16, "Object is possibly \'undefined\'.", "3400861264"]
+    ],
+    "src/script/page/MainContent/panels/preferences/AccountPreferences.tsx:273564411": [
+      [92, 79, 34, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.", "212151669"],
+      [120, 6, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"]
+    ],
+    "src/script/page/MainContent/panels/preferences/OptionPreferences.tsx:3886393057": [
+      [107, 10, 8, "Type \'(audioPreference: AudioPreference) => void\' is not assignable to type \'(newValue: string) => void\'.\\n  Types of parameters \'audioPreference\' and \'newValue\' are incompatible.\\n    Type \'string\' is not assignable to type \'AudioPreference\'.", "707514658"],
+      [135, 14, 8, "Type \'(notificationsPreference: NotificationPreference) => void\' is not assignable to type \'(newValue: string) => void\'.\\n  Types of parameters \'notificationsPreference\' and \'newValue\' are incompatible.\\n    Type \'string\' is not assignable to type \'NotificationPreference\'.", "707514658"]
+    ],
+    "src/script/page/MainContent/panels/preferences/accountPreferences/AccountInput.tsx:1546355455": [
+      [188, 10, 4, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2087876002"],
+      [189, 10, 5, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "189936718"],
+      [195, 30, 5, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "178805363"]
+    ],
+    "src/script/page/MainContent/panels/preferences/accountPreferences/AccountSecuritySection.tsx:851375994": [
+      [70, 6, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
+      [104, 40, 43, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1072333434"]
+    ],
+    "src/script/page/MainContent/panels/preferences/accountPreferences/AvailabilityButtons.tsx:2655666562": [
+      [123, 29, 10, "Cannot invoke an object which is possibly \'undefined\'.", "2097453872"],
+      [125, 21, 17, "Type \'undefined\' cannot be used as an index type.", "2478873583"]
+    ],
+    "src/script/page/MainContent/panels/preferences/accountPreferences/AvatarInput.tsx:919643938": [
+      [50, 69, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
+      [91, 4, 16, "Object is possibly \'null\'.", "4019370437"],
+      [116, 23, 14, "Argument of type \'File | null\' is not assignable to parameter of type \'File\'.\\n  Type \'null\' is not assignable to type \'File\'.", "1073819172"]
+    ],
+    "src/script/page/MainContent/panels/preferences/accountPreferences/DataUsageSection.tsx:1594199724": [
+      [70, 8, 7, "Type \'boolean | undefined\' is not assignable to type \'boolean\'.", "3837137090"],
+      [82, 10, 7, "Type \'boolean | undefined\' is not assignable to type \'boolean\'.", "3837137090"]
+    ],
+    "src/script/page/MainContent/panels/preferences/accountPreferences/EmailInput.tsx:542696972": [
+      [56, 10, 5, "Object is of type \'unknown\'.", "165548477"],
+      [59, 10, 5, "Object is of type \'unknown\'.", "165548477"]
+    ],
+    "src/script/page/MainContent/panels/preferences/accountPreferences/FileInput.tsx:2008057001": [
+      [27, 6, 9, "Type \'ForwardRefExoticComponent<Pick<FileInputProps, \\"start\\" | \\"hidden\\" | \\"color\\" | \\"content\\" | \\"size\\" | \\"style\\" | \\"default\\" | \\"wrap\\" | \\"open\\" | \\"height\\" | \\"translate\\" | \\"width\\" | \\"multiple\\" | ... 348 more ... | \\"onFileChange\\"> & RefAttributes<...>>\' is not assignable to type \'FC<FileInputProps>\'.\\n  Types of parameters \'props\' and \'props\' are incompatible.\\n    Type \'FileInputProps\' is not assignable to type \'Pick<FileInputProps, \\"start\\" | \\"hidden\\" | \\"color\\" | \\"content\\" | \\"size\\" | \\"style\\" | \\"default\\" | \\"wrap\\" | \\"open\\" | \\"height\\" | \\"translate\\" | \\"width\\" | \\"multiple\\" | ... 348 more ... | \\"onFileChange\\"> & RefAttributes<...>\'.\\n      Type \'FileInputProps\' is not assignable to type \'RefAttributes<HTMLInputElement>\'.\\n        Types of property \'ref\' are incompatible.\\n          Type \'LegacyRef<HTMLInputElement> | undefined\' is not assignable to type \'Ref<HTMLInputElement> | undefined\'.\\n            Type \'string\' is not assignable to type \'Ref<HTMLInputElement> | undefined\'.", "3080892789"],
+      [34, 12, 12, "Object is possibly \'null\'.", "3895849327"],
+      [35, 25, 12, "Argument of type \'FileList | null\' is not assignable to parameter of type \'FileList\'.\\n  Type \'null\' is not assignable to type \'FileList\'.", "3895849327"],
+      [37, 12, 12, "Type \'null\' is not assignable to type \'string\'.", "3877145201"]
+    ],
+    "src/script/page/MainContent/panels/preferences/accountPreferences/HistoryBackupSection.tsx:3752447778": [
+      [36, 4, 20, "Object is possibly \'null\'.", "2235498147"]
+    ],
+    "src/script/page/MainContent/panels/preferences/accountPreferences/UsernameInput.tsx:3610323435": [
+      [39, 55, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | (() => string)\'.", "2087897566"],
+      [41, 61, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | (() => string)\'.", "2087897566"],
+      [42, 61, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | (() => string)\'.", "2087897566"],
+      [49, 27, 4, "Argument of type \'null\' is not assignable to parameter of type \'SetStateAction<string>\'.", "2087897566"],
+      [85, 20, 4, "Argument of type \'null\' is not assignable to parameter of type \'SetStateAction<string>\'.", "2087897566"],
+      [95, 22, 4, "Argument of type \'null\' is not assignable to parameter of type \'SetStateAction<string>\'.", "2087897566"],
+      [99, 30, 5, "Object is of type \'unknown\'.", "165548477"]
+    ],
+    "src/script/page/MainContent/panels/preferences/avPreferences/CameraPreferences.tsx:147485328": [
+      [80, 82, 5, "Object is of type \'unknown\'.", "165548477"],
+      [81, 16, 4, "Argument of type \'null\' is not assignable to parameter of type \'SetStateAction<MediaStream | undefined>\'.", "2087897566"],
+      [93, 6, 22, "Type \'MediaStream | undefined\' is not assignable to type \'MediaProvider | null\'.\\n  Type \'undefined\' is not assignable to type \'MediaProvider | null\'.", "3365227987"]
+    ],
+    "src/script/page/MainContent/panels/preferences/avPreferences/DeviceSelect.tsx:2574448848": [
+      [63, 10, 2, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "5861160"],
+      [65, 10, 11, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "988383179"]
+    ],
+    "src/script/page/MainContent/panels/preferences/avPreferences/MicrophonePreferences.tsx:490834589": [
+      [64, 82, 5, "Object is of type \'unknown\'.", "165548477"],
+      [65, 16, 4, "Argument of type \'null\' is not assignable to parameter of type \'SetStateAction<MediaStream | undefined>\'.", "2087897566"],
+      [109, 84, 11, "Type \'MediaStream | undefined\' is not assignable to type \'MediaStream\'.\\n  Type \'undefined\' is not assignable to type \'MediaStream\'.", "4175552125"]
+    ],
+    "src/script/page/MainContent/panels/preferences/components/PreferencesCheckbox.tsx:2721392659": [
+      [49, 10, 7, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3123876731"]
+    ],
+    "src/script/page/MainContent/panels/preferences/components/PreferencesPage.tsx:928517848": [
+      [30, 21, 12, "Argument of type \'HTMLDivElement | undefined\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLElement\'.", "652464040"]
+    ],
+    "src/script/page/MainContent/panels/preferences/devices/DeviceDetailsPreferences.test.tsx:2030460021": [
+      [34, 41, 22, "Cannot invoke an object which is possibly \'undefined\'.", "1980738780"],
+      [41, 21, 12, "Argument of type \'string | undefined\' is not assignable to parameter of type \'Matcher\'.\\n  Type \'undefined\' is not assignable to type \'Matcher\'.", "2075561852"]
+    ],
+    "src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx:3136549338": [
+      [67, 90, 10, "Type \'undefined\' is not assignable to type \'boolean\'.", "3231345145"],
+      [118, 21, 12, "Argument of type \'HTMLDivElement | undefined\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLElement\'.", "652464040"],
+      [124, 8, 14, "Type \'(device: ClientEntity) => Promise<string | undefined>\' is not assignable to type \'(device: ClientEntity) => Promise<string>\'.\\n  Type \'Promise<string | undefined>\' is not assignable to type \'Promise<string>\'.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "223037395"],
+      [131, 73, 37, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "3769528030"]
+    ],
+    "src/script/page/MainContent/panels/preferences/devices/components/DetailedDevice.tsx:3712575264": [
+      [46, 78, 11, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number\'.\\n  Type \'undefined\' is not assignable to type \'string | number\'.", "1754256582"]
+    ],
+    "src/script/page/message-list/InputBarControls/ControlButtons.tsx:59214157": [
+      [113, 63, 18, "No overload matches this call.\\n  Overload 1 of 4, \'(iterable: Iterable<File> | ArrayLike<File>): File[]\', gave the following error.\\n    Argument of type \'FileList | null\' is not assignable to parameter of type \'Iterable<File> | ArrayLike<File>\'.\\n      Type \'null\' is not assignable to type \'Iterable<File> | ArrayLike<File>\'.\\n  Overload 2 of 4, \'(arrayLike: ArrayLike<File>): File[]\', gave the following error.\\n    Argument of type \'FileList | null\' is not assignable to parameter of type \'ArrayLike<File>\'.\\n      Type \'null\' is not assignable to type \'ArrayLike<File>\'.", "2593443629"],
+      [135, 62, 18, "No overload matches this call.\\n  Overload 1 of 4, \'(iterable: Iterable<File> | ArrayLike<File>): File[]\', gave the following error.\\n    Argument of type \'FileList | null\' is not assignable to parameter of type \'Iterable<File> | ArrayLike<File>\'.\\n  Overload 2 of 4, \'(arrayLike: ArrayLike<File>): File[]\', gave the following error.\\n    Argument of type \'FileList | null\' is not assignable to parameter of type \'ArrayLike<File>\'.\\n      Type \'null\' is not assignable to type \'ArrayLike<File>\'.", "2593443629"]
+    ],
+    "src/script/page/message-list/InputBarControls/InputBarControls.test.tsx:2517377529": [
+      [33, 2, 12, "Type \'undefined\' is not assignable to type \'Conversation\'.", "1670678216"]
+    ],
+    "src/script/page/message-list/MentionSuggestions/MentionSuggestions.tsx:1339790850": [
+      [41, 21, 12, "Argument of type \'HTMLDivElement | undefined\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLElement\'.", "652464040"],
+      [56, 44, 11, "Object is possibly \'null\'.", "2551690754"],
+      [72, 69, 11, "Argument of type \'HTMLInputElement | null\' is not assignable to parameter of type \'HTMLInputElement\'.\\n  Type \'null\' is not assignable to type \'HTMLInputElement\'.", "2551690754"],
+      [112, 49, 11, "Argument of type \'HTMLInputElement | null\' is not assignable to parameter of type \'HTMLInputElement\'.\\n  Type \'null\' is not assignable to type \'HTMLInputElement\'.", "2551690754"],
+      [115, 14, 3, "Type \'((node: Element) => void) | undefined\' is not assignable to type \'Ref<HTMLDivElement> | undefined\'.\\n  Type \'(node: Element) => void\' is not assignable to type \'Ref<HTMLDivElement> | undefined\'.\\n    Type \'(node: Element) => void\' is not assignable to type \'(instance: HTMLDivElement | null) => void\'.\\n      Types of parameters \'node\' and \'instance\' are incompatible.\\n        Type \'HTMLDivElement | null\' is not assignable to type \'Element\'.\\n          Type \'null\' is not assignable to type \'Element\'.", "193432436"]
+    ],
+    "src/script/page/message-list/MentionSuggestions/MentionSuggestionsItem.tsx:1404765977": [
+      [55, 58, 1, "No overload matches this call.\\n  Overload 1 of 6, \'(this: (this: null, arg0: MouseEvent<HTMLDivElement, MouseEvent>) => void, thisArg: null, arg0: MouseEvent<HTMLDivElement, MouseEvent>): () => void\', gave the following error.\\n    Argument of type \'KeyboardEvent<HTMLDivElement>\' is not assignable to parameter of type \'MouseEvent<HTMLDivElement, MouseEvent>\'.\\n      Type \'KeyboardEvent<HTMLDivElement>\' is missing the following properties from type \'MouseEvent<HTMLDivElement, MouseEvent>\': button, buttons, clientX, clientY, and 7 more.\\n  Overload 2 of 6, \'(this: (this: null, ...args: MouseEvent<HTMLDivElement, MouseEvent>[]) => void, thisArg: null, ...args: MouseEvent<HTMLDivElement, MouseEvent>[]): (...args: MouseEvent<...>[]) => void\', gave the following error.\\n    Argument of type \'KeyboardEvent<HTMLDivElement>\' is not assignable to parameter of type \'MouseEvent<HTMLDivElement, MouseEvent>\'.", "177600"]
+    ],
+    "src/script/page/message-list/MessageTimerButton.test.ts:254586997": [
+      [33, 46, 29, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "4019893960"],
+      [96, 11, 47, "Object is possibly \'null\'.", "512435431"],
+      [123, 11, 51, "Object is possibly \'null\'.", "4189896900"],
+      [124, 11, 52, "Object is possibly \'null\'.", "146485961"],
+      [125, 11, 47, "Object is possibly \'null\'.", "512435431"],
+      [148, 11, 51, "Object is possibly \'null\'.", "4189896900"],
+      [149, 11, 52, "Object is possibly \'null\'.", "146485961"],
+      [150, 11, 47, "Object is possibly \'null\'.", "512435431"],
+      [174, 11, 51, "Object is possibly \'null\'.", "4189896900"],
+      [175, 11, 52, "Object is possibly \'null\'.", "146485961"],
+      [176, 11, 47, "Object is possibly \'null\'.", "512435431"],
+      [198, 11, 47, "Object is possibly \'null\'.", "512435431"]
+    ],
+    "src/script/page/message-list/MessageTimerButton.tsx:3316852480": [
+      [38, 13, 18, "Type \'({ conversation, teamState, }: MessageTimerButtonProps) => false | Element\' is not assignable to type \'FC<MessageTimerButtonProps>\'.\\n  Type \'false | Element\' is not assignable to type \'ReactElement<any, any> | null\'.", "3252704543"]
+    ],
+    "src/script/permission/PermissionRepository.ts:3072861882": [
+      [45, 6, 23, "Type of computed property\'s value is \'Observable<PermissionStatusState.PROMPT>\', which is not assignable to type \'Observable<PermissionState | PermissionStatusState>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'PermissionState | PermissionStatusState\' is not assignable to type \'PermissionStatusState.PROMPT\'.", "2132945991"],
+      [46, 6, 29, "Type of computed property\'s value is \'Observable<PermissionStatusState.PROMPT>\', which is not assignable to type \'Observable<PermissionState | PermissionStatusState>\'.", "3793420497"],
+      [47, 6, 27, "Type of computed property\'s value is \'Observable<PermissionStatusState.PROMPT>\', which is not assignable to type \'Observable<PermissionState | PermissionStatusState>\'.", "952378264"],
+      [48, 6, 30, "Type of computed property\'s value is \'Observable<PermissionStatusState.PROMPT>\', which is not assignable to type \'Observable<PermissionState | PermissionStatusState>\'.", "338556256"]
+    ],
+    "src/script/properties/PropertiesRepository.ts:274184231": [
+      [97, 4, 13, "Type \'Observable<User | undefined>\' is not assignable to type \'Observable<User>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'User | undefined\' is not assignable to type \'User\'.\\n      Type \'undefined\' is not assignable to type \'User\'.", "311178912"],
+      [100, 4, 21, "Type \'Observable<ConsentValue>\' is not assignable to type \'Observable<boolean | ConsentValue>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'boolean | ConsentValue\' is not assignable to type \'ConsentValue\'.", "1820233671"]
+    ],
+    "src/script/router/Router.ts:4158324241": [
+      [50, 38, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"]
+    ],
+    "src/script/search/SearchRepository.ts:142898156": [
+      [92, 44, 4, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "2087773917"],
+      [103, 13, 140, "Argument of type \'(property: keyof User) => any\' is not assignable to parameter of type \'(value: string, index: number, array: string[]) => any\'.\\n  Types of parameters \'property\' and \'value\' are incompatible.\\n    Type \'string\' is not assignable to type \'keyof User\'.", "2023942255"],
+      [114, 59, 16, "No overload matches this call.\\n  Overload 1 of 2, \'(...items: ConcatArray<never>[]): never[]\', gave the following error.\\n    Argument of type \'{ user: User; weight: any; }\' is not assignable to parameter of type \'ConcatArray<never>\'.\\n      Object literal may only specify known properties, and \'user\' does not exist in type \'ConcatArray<never>\'.\\n  Overload 2 of 2, \'(...items: ConcatArray<never>[]): never[]\', gave the following error.\\n    Argument of type \'{ user: User; weight: any; }\' is not assignable to parameter of type \'ConcatArray<never>\'.\\n      Object literal may only specify known properties, and \'user\' does not exist in type \'ConcatArray<never>\'.", "3870214084"],
+      [119, 20, 6, "Property \'weight\' does not exist on type \'never\'.", "2011919237"],
+      [119, 39, 6, "Property \'weight\' does not exist on type \'never\'.", "2011919237"],
+      [120, 25, 4, "Property \'user\' does not exist on type \'never\'.", "2087973204"],
+      [120, 47, 4, "Property \'user\' does not exist on type \'never\'.", "2087973204"],
+      [122, 23, 6, "Property \'weight\' does not exist on type \'never\'.", "2011919237"],
+      [122, 40, 6, "Property \'weight\' does not exist on type \'never\'.", "2011919237"],
+      [124, 28, 4, "Property \'user\' does not exist on type \'never\'.", "2087973204"],
+      [133, 44, 5, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "189936718"]
+    ],
+    "src/script/storage/StorageSchemata.ts:4126568932": [
+      [124, 8, 7, "Type \'(transaction: Transaction, database: Dexie) => void\' is not assignable to type \'(transaction: Transaction, database?: Dexie | undefined) => void\'.\\n  Types of parameters \'database\' and \'database\' are incompatible.\\n    Type \'Dexie | undefined\' is not assignable to type \'Dexie\'.\\n      Type \'undefined\' is not assignable to type \'Dexie\'.", "2225706901"],
+      [304, 8, 7, "Type \'(transaction: Transaction, database: Dexie) => void\' is not assignable to type \'(transaction: Transaction, database?: Dexie | undefined) => void\'.\\n  Types of parameters \'database\' and \'database\' are incompatible.\\n    Type \'Dexie | undefined\' is not assignable to type \'Dexie\'.\\n      Type \'undefined\' is not assignable to type \'Dexie\'.", "2225706901"]
+    ],
+    "src/script/storage/StorageService.ts:2898776693": [
+      [49, 10, 14, "Property \'hasHookSupport\' has no initializer and is not definitely assigned in the constructor.", "2732954963"],
+      [50, 10, 6, "Property \'engine\' has no initializer and is not definitely assigned in the constructor.", "1163760011"],
+      [51, 9, 27, "Property \'isTemporaryAndNonPersistent\' has no initializer and is not definitely assigned in the constructor.", "2204664357"],
+      [79, 28, 7, "Argument of type \'DexieDatabase | undefined\' is not assignable to parameter of type \'DexieDatabase\'.\\n  Type \'undefined\' is not assignable to type \'DexieDatabase\'.", "1929661355"],
+      [83, 76, 5, "Object is of type \'unknown\'.", "165548477"],
+      [108, 8, 25, "No overload matches this call.\\n  The last overload gave the following error.\\n    Argument of type \'DEXIE_CRUD_EVENT.UPDATING\' is not assignable to parameter of type \'\\"deleting\\"\'.", "746988678"],
+      [116, 8, 8, "No overload matches this call.\\n  The last overload gave the following error.\\n    Argument of type \'(this: DeletingHookContext<any, IndexableType>, primaryKey: string, obj: Object, transaction: Transaction) => void\' is not assignable to parameter of type \'(this: DeletingHookContext<any, IndexableType>, primKey: IndexableType, obj: any, transaction: Transaction) => any\'.\\n      Types of parameters \'primaryKey\' and \'primKey\' are incompatible.\\n        Type \'IndexableType\' is not assignable to type \'string\'.\\n          Type \'number\' is not assignable to type \'string\'.", "1594753575"],
+      [117, 91, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'Object\'.", "2620553983"],
+      [278, 39, 7, "Object is possibly \'undefined\'.", "1929661355"],
+      [386, 38, 7, "Object is possibly \'undefined\'.", "1929661355"]
+    ],
+    "src/script/team/TeamEntity.ts:781860466": [
+      [48, 6, 7, "Type \'string | boolean\' is not assignable to type \'boolean\'.\\n  Type \'string\' is not assignable to type \'boolean\'.", "814555284"]
+    ],
+    "src/script/team/TeamRepository.ts:2238095787": [
+      [204, 4, 159, "Type \'(User | undefined)[]\' is not assignable to type \'User[]\'.\\n  Type \'User | undefined\' is not assignable to type \'User\'.\\n    Type \'undefined\' is not assignable to type \'User\'.", "587279576"],
+      [210, 53, 24, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2322605270"],
+      [304, 4, 9, "Type \'(string | undefined)[]\' is not assignable to type \'string[]\'.\\n  Type \'string | undefined\' is not assignable to type \'string\'.\\n    Type \'undefined\' is not assignable to type \'string\'.", "3264882315"],
+      [325, 53, 13, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3345044032"],
+      [334, 66, 9, "Argument of type \'{ domain: string; id: string | undefined; }[]\' is not assignable to parameter of type \'QualifiedId[]\'.\\n  Type \'{ domain: string; id: string | undefined; }\' is not assignable to type \'QualifiedId\'.\\n    Types of property \'id\' are incompatible.\\n      Type \'string | undefined\' is not assignable to type \'string\'.\\n        Type \'undefined\' is not assignable to type \'string\'.", "3264882315"],
+      [468, 28, 45, "Object is possibly \'undefined\'.", "1991114915"],
+      [469, 23, 40, "Object is possibly \'undefined\'.", "841513102"],
+      [536, 6, 76, "Argument of type \'string | null\' is not assignable to parameter of type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "563963699"],
+      [588, 34, 14, "No overload matches this call.\\n  Overload 1 of 2, \'(...items: ConcatArray<never>[]): never[]\', gave the following error.\\n    Argument of type \'TeamMemberEntity | TeamMemberEntity[]\' is not assignable to parameter of type \'ConcatArray<never>\'.\\n      Type \'TeamMemberEntity\' is missing the following properties from type \'ConcatArray<never>\': length, join, slice\\n  Overload 2 of 2, \'(...items: ConcatArray<never>[]): never[]\', gave the following error.\\n    Argument of type \'TeamMemberEntity | TeamMemberEntity[]\' is not assignable to parameter of type \'ConcatArray<never>\'.\\n      Type \'TeamMemberEntity\' is not assignable to type \'ConcatArray<never>\'.", "3525779144"],
+      [590, 56, 6, "Property \'userId\' does not exist on type \'never\'.", "1765117785"],
+      [592, 45, 11, "Property \'permissions\' does not exist on type \'never\'.", "524793117"],
+      [597, 25, 6, "Property \'userId\' does not exist on type \'never\'.", "1765117785"],
+      [597, 42, 11, "Property \'permissions\' does not exist on type \'never\'.", "524793117"],
+      [597, 87, 11, "Property \'permissions\' does not exist on type \'never\'.", "524793117"],
+      [602, 25, 6, "Property \'userId\' does not exist on type \'never\'.", "1765117785"],
+      [602, 42, 9, "Property \'invitedBy\' does not exist on type \'never\'.", "1955064691"],
+      [606, 64, 14, "Property \'hasOwnProperty\' does not exist on type \'never\'.", "547572878"]
+    ],
+    "src/script/team/TeamState.ts:3690188753": [
+      [59, 4, 9, "Type \'Observable<TeamEntity | undefined>\' is not assignable to type \'Observable<TeamEntity>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'TeamEntity | undefined\' is not assignable to type \'TeamEntity\'.\\n      Type \'undefined\' is not assignable to type \'TeamEntity\'.", "1162784912"],
+      [62, 4, 18, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "173607415"],
+      [68, 4, 17, "Type \'Observable<FeatureList | undefined>\' is not assignable to type \'Observable<FeatureList>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'FeatureList | undefined\' is not assignable to type \'FeatureList\'.\\n      Type \'undefined\' is not assignable to type \'FeatureList\'.", "54583831"],
+      [80, 4, 22, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "1357312573"],
+      [96, 13, 38, "Object is possibly \'undefined\'.", "3672246717"],
+      [97, 10, 37, "Object is possibly \'undefined\'.", "1981238082"],
+      [121, 4, 22, "Type \'PureComputed<boolean | undefined>\' is not assignable to type \'PureComputed<boolean>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'boolean | undefined\' is not assignable to type \'boolean\'.", "32795343"],
+      [122, 4, 33, "Type \'PureComputed<number | undefined>\' is not assignable to type \'PureComputed<number>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'number | undefined\' is not assignable to type \'number\'.\\n      Type \'undefined\' is not assignable to type \'number\'.", "3833026544"]
+    ],
+    "src/script/telemetry/app_init/AppInitTimings.ts:2827224089": [
+      [51, 31, 9, "Object is possibly \'undefined\'.", "2472707299"]
+    ],
+    "src/script/time/serverTimeHandler.ts:469728213": [
+      [39, 14, 49, "Conversion of type \'Observable<undefined>\' to type \'Observable<number>\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Types of property \'equalityComparer\' are incompatible.\\n    Type \'(a: undefined, b: undefined) => boolean\' is not comparable to type \'(a: number, b: number) => boolean\'.\\n      Types of parameters \'a\' and \'a\' are incompatible.\\n        Type \'number\' is not comparable to type \'undefined\'.", "1339088109"]
+    ],
+    "src/script/tracking/EventTrackingRepository.ts:471863585": [
+      [47, 10, 15, "Property \'countlyDeviceId\' has no initializer and is not definitely assigned in the constructor.", "3024684198"],
+      [170, 23, 16, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.", "3019303906"]
+    ],
+    "src/script/tracking/Helpers.ts:3850783506": [
+      [47, 10, 30, "Object is possibly \'undefined\'.", "3185682702"]
+    ],
+    "src/script/ui/ContextMenu.tsx:2048719779": [
+      [53, 4, 9, "Type \'undefined\' is not assignable to type \'HTMLDivElement\'.", "1873118818"],
+      [81, 68, 14, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1122698020"],
+      [96, 30, 8, "Argument of type \'ContextMenuEntry | undefined\' is not assignable to parameter of type \'ContextMenuEntry\'.\\n  Type \'undefined\' is not assignable to type \'ContextMenuEntry\'.", "2198592556"],
+      [102, 43, 8, "Argument of type \'ContextMenuEntry | undefined\' is not assignable to parameter of type \'ContextMenuEntry\'.\\n  Type \'undefined\' is not assignable to type \'ContextMenuEntry\'.", "2198592556"],
+      [134, 29, 3, "Type \'Dispatch<SetStateAction<HTMLUListElement | undefined>>\' is not assignable to type \'LegacyRef<HTMLUListElement> | undefined\'.\\n  Type \'Dispatch<SetStateAction<HTMLUListElement | undefined>>\' is not assignable to type \'(instance: HTMLUListElement | null) => void\'.\\n    Types of parameters \'value\' and \'instance\' are incompatible.\\n      Type \'HTMLUListElement | null\' is not assignable to type \'SetStateAction<HTMLUListElement | undefined>\'.\\n        Type \'null\' is not assignable to type \'SetStateAction<HTMLUListElement | undefined>\'.", "193432436"],
+      [148, 30, 11, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2169853657"]
+    ],
+    "src/script/ui/Modal.ts:2744470243": [
+      [35, 4, 10, "Type \'HTMLElement | null\' is not assignable to type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "3985246182"],
+      [36, 4, 17, "Type \'(() => void) | undefined\' is not assignable to type \'() => void\'.\\n  Type \'undefined\' is not assignable to type \'() => void\'.", "2437998084"],
+      [37, 4, 23, "Type \'(() => void) | undefined\' is not assignable to type \'() => void\'.\\n  Type \'undefined\' is not assignable to type \'() => void\'.", "1878779325"]
+    ],
+    "src/script/ui/Shortcut.ts:4030248185": [
+      [166, 26, 10, "Object is possibly \'undefined\'.", "3955554463"],
+      [169, 80, 10, "Object is possibly \'undefined\'.", "3955554463"],
+      [171, 6, 10, "Object is possibly \'undefined\'.", "3955554463"]
+    ],
+    "src/script/ui/overlayedObserver.ts:1307956702": [
+      [28, 4, 22, "Type \'undefined\' is not assignable to type \'number\'.", "553548977"],
+      [37, 6, 9, "Cannot invoke an object which is possibly \'undefined\'.", "4219368682"],
+      [56, 2, 95, "Type \'boolean | null\' is not assignable to type \'boolean\'.", "1265679455"],
+      [81, 4, 22, "Type \'undefined\' is not assignable to type \'number\'.", "553548977"]
+    ],
+    "src/script/ui/resizeObserver.ts:1962447755": [
+      [47, 48, 8, "Argument of type \'(element: Element) => void\' is not assignable to parameter of type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'element\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'Element\'.", "3760058444"]
+    ],
+    "src/script/ui/viewportObserver.ts:8326502": [
+      [109, 6, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'HTMLElement\'.", "2620553983"]
+    ],
+    "src/script/user/AppLockRepository.ts:968558871": [
+      [48, 38, 59, "Type \'string | null\' is not assignable to type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "2029474882"],
+      [50, 35, 56, "Type \'string | null\' is not assignable to type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "4278102955"],
+      [55, 46, 8, "Argument of type \'string | null\' is not assignable to parameter of type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "2452599369"]
+    ],
+    "src/script/user/AppLockState.ts:4063056116": [
+      [49, 4, 22, "Type \'PureComputed<boolean | undefined>\' is not assignable to type \'PureComputed<boolean>\'.", "32795343"],
+      [55, 4, 33, "Type \'PureComputed<number | undefined>\' is not assignable to type \'PureComputed<number>\'.", "3833026544"],
+      [60, 4, 18, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "3934899707"],
+      [61, 4, 29, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "4114033765"]
+    ],
+    "src/script/user/UserHandleGenerator.ts:608562243": [
+      [67, 35, 6, "No overload matches this call.\\n  Overload 1 of 4, \'(iterable: Iterable<unknown> | ArrayLike<unknown>, mapfn: (v: unknown, k: number) => number, thisArg?: any): number[]\', gave the following error.\\n    Type \'number | undefined\' is not assignable to type \'number\'.\\n      Type \'undefined\' is not assignable to type \'number\'.\\n  Overload 2 of 4, \'(arrayLike: ArrayLike<unknown>, mapfn: (v: unknown, k: number) => number, thisArg?: any): number[]\', gave the following error.\\n    Type \'number | undefined\' is not assignable to type \'number\'.\\n      Type \'undefined\' is not assignable to type \'number\'.", "1433765721"]
+    ],
+    "src/script/user/UserMapper.test.ts:250567312": [
+      [83, 42, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'User | Self\'.", "2620553983"],
+      [137, 47, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'(User | Self)[]\'.", "2620553983"],
+      [158, 13, 15, "Object is possibly \'undefined\'.", "52415216"],
+      [167, 13, 15, "Object is possibly \'undefined\'.", "52415216"],
+      [176, 13, 15, "Object is possibly \'undefined\'.", "52415216"],
+      [221, 13, 15, "Object is possibly \'undefined\'.", "52415216"],
+      [222, 13, 15, "Object is possibly \'undefined\'.", "52415216"]
+    ],
+    "src/script/user/UserMapper.ts:450957740": [
+      [47, 4, 63, "Type \'User | undefined\' is not assignable to type \'User\'.\\n  Type \'undefined\' is not assignable to type \'User\'.", "55227688"],
+      [47, 50, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [51, 62, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [52, 4, 10, "Object is possibly \'undefined\'.", "50227919"],
+      [57, 6, 10, "Object is possibly \'undefined\'.", "50227919"],
+      [60, 4, 18, "Type \'User | undefined\' is not assignable to type \'User\'.\\n  Type \'undefined\' is not assignable to type \'User\'.", "1723739806"],
+      [96, 6, 13, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1154411948"],
+      [135, 8, 15, "Object is possibly \'undefined\'.", "696735433"],
+      [141, 55, 16, "Argument of type \'Picture[] | undefined\' is not assignable to parameter of type \'Picture[]\'.\\n  Type \'undefined\' is not assignable to type \'Picture[]\'.", "1145520518"]
+    ],
+    "src/script/user/UserPermission.ts:1999060110": [
+      [173, 2, 395, "Type \'Record<string, (role: ROLE) => boolean>\' is not assignable to type \'Record<string, (role?: ROLE | undefined) => boolean>\'.\\n  \'string\' index signatures are incompatible.\\n    Type \'(role: ROLE) => boolean\' is not assignable to type \'(role?: ROLE | undefined) => boolean\'.", "3736070641"]
+    ],
+    "src/script/user/UserRepository.ts:3686698449": [
+      [172, 55, 6, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1127975365"],
+      [217, 24, 6, "Type \'string | null\' is not assignable to type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "1127975365"],
+      [228, 32, 6, "Type \'string | null\' is not assignable to type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "1127975365"],
+      [228, 75, 2, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "5861160"],
+      [252, 28, 16, "Argument of type \'ConnectionEntity | undefined\' is not assignable to parameter of type \'ConnectionEntity\'.\\n  Type \'undefined\' is not assignable to type \'ConnectionEntity\'.", "3456520104"],
+      [263, 10, 7, "Type \'{ domain: string | undefined; id: string; }[]\' is not assignable to type \'QualifiedId[]\'.\\n  Type \'{ domain: string | undefined; id: string; }\' is not assignable to type \'QualifiedId\'.\\n    Types of property \'domain\' are incompatible.\\n      Type \'string | undefined\' is not assignable to type \'string\'.\\n        Type \'undefined\' is not assignable to type \'string\'.", "2414311946"],
+      [339, 4, 20, "Type \'(ClientEntity | undefined)[]\' is not assignable to type \'ClientEntity[]\'.\\n  Type \'ClientEntity | undefined\' is not assignable to type \'ClientEntity\'.\\n    Type \'undefined\' is not assignable to type \'ClientEntity\'.", "724989886"],
+      [447, 12, 5, "Object is of type \'unknown\'.", "165548477"],
+      [520, 53, 5, "Object is of type \'unknown\'.", "165548477"],
+      [530, 23, 16, "Object is possibly \'undefined\'.", "1145520518"],
+      [531, 21, 15, "Object is possibly \'undefined\'.", "696735433"],
+      [536, 57, 16, "Argument of type \'Picture[] | undefined\' is not assignable to parameter of type \'Picture[]\'.\\n  Type \'undefined\' is not assignable to type \'Picture[]\'.", "1145520518"],
+      [555, 27, 5, "Object is of type \'unknown\'.", "165548477"],
+      [558, 89, 5, "Object is of type \'unknown\'.", "165548477"],
+      [658, 27, 17, "Type \'User | undefined\' is not assignable to type \'User\'.\\n  Type \'undefined\' is not assignable to type \'User\'.", "3641955066"],
+      [673, 101, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"],
+      [723, 69, 5, "Object is of type \'unknown\'.", "165548477"],
+      [742, 24, 5, "Object is of type \'unknown\'.", "165548477"],
+      [770, 60, 5, "Object is of type \'unknown\'.", "165548477"],
+      [770, 77, 5, "Object is of type \'unknown\'.", "165548477"],
+      [817, 64, 5, "Object is of type \'unknown\'.", "165548477"],
+      [817, 81, 5, "Object is of type \'unknown\'.", "165548477"]
+    ],
+    "src/script/user/UserState.ts:1636460432": [
+      [44, 4, 9, "Type \'Observable<User | undefined>\' is not assignable to type \'Observable<User>\'.", "1162883985"],
+      [45, 4, 10, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<User>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'User[] | null | undefined\' is not assignable to type \'never[] | null | undefined\'.\\n      Type \'User[]\' is not assignable to type \'never[]\'.\\n        Type \'User\' is not assignable to type \'never\'.", "4012712079"],
+      [62, 4, 11, "Type \'Observable<boolean | undefined>\' is not assignable to type \'PureComputed<boolean> | Observable<boolean>\'.\\n  Type \'Observable<boolean | undefined>\' is not assignable to type \'Observable<boolean>\'.\\n    The types returned by \'peek()\' are incompatible between these types.\\n      Type \'boolean | undefined\' is not assignable to type \'boolean\'.", "2825893770"]
+    ],
+    "src/script/util/ArrayUtil.ts:1796804857": [
+      [109, 47, 42, "Type \'undefined\' cannot be used as an index type.", "3231080782"]
+    ],
+    "src/script/util/ClipboardUtil.ts:3834718542": [
+      [33, 22, 21, "Object is possibly \'null\'.", "3831905776"],
+      [33, 57, 21, "Object is possibly \'null\'.", "3831905776"],
+      [43, 6, 16, "Object is possibly \'null\'.", "548905036"],
+      [44, 6, 16, "Object is possibly \'null\'.", "548905036"]
+    ],
+    "src/script/util/ComponentUtil.test.ts:2336697613": [
+      [48, 44, 73, "Argument of type \'({ obj }: { obj: any; }) => UnwrappedValues<any, Subscribables<any>>\' is not assignable to parameter of type \'(initialProps: unknown) => UnwrappedValues<any, Subscribables<any>>\'.\\n  Types of parameters \'__0\' and \'initialProps\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'{ obj: any; }\'.", "2621166550"]
+    ],
+    "src/script/util/DebugUtil.ts:3949008751": [
+      [119, 35, 9, "Object is possibly \'undefined\'.", "3919057299"],
+      [129, 4, 9, "Object is possibly \'undefined\'.", "3919057299"],
+      [177, 21, 43, "Object is possibly \'null\'.", "1853768633"],
+      [189, 29, 43, "Object is possibly \'null\'.", "1853768633"],
+      [210, 14, 44, "No overload matches this call.\\n  Overload 1 of 2, \'(predicate: (value: BackendEvent, index: number, array: BackendEvent[]) => value is ConversationOtrMessageAddEvent, thisArg?: any): ConversationOtrMessageAddEvent[]\', gave the following error.\\n    Argument of type \'(event: ConversationOtrMessageAddEvent) => boolean\' is not assignable to parameter of type \'(value: BackendEvent, index: number, array: BackendEvent[]) => value is ConversationOtrMessageAddEvent\'.\\n      Types of parameters \'event\' and \'value\' are incompatible.\\n        Type \'BackendEvent\' is not assignable to type \'ConversationOtrMessageAddEvent\'.\\n          Type \'ConversationAccessUpdateEvent\' is not assignable to type \'ConversationOtrMessageAddEvent\'.\\n            Types of property \'data\' are incompatible.\\n              Type \'ConversationAccessUpdateData\' is missing the following properties from type \'ConversationOtrMessageAddData\': recipient, sender, text\\n  Overload 2 of 2, \'(predicate: (value: BackendEvent, index: number, array: BackendEvent[]) => unknown, thisArg?: any): BackendEvent[]\', gave the following error.\\n    Argument of type \'(event: ConversationOtrMessageAddEvent) => boolean\' is not assignable to parameter of type \'(value: BackendEvent, index: number, array: BackendEvent[]) => unknown\'.\\n      Types of parameters \'event\' and \'value\' are incompatible.\\n        Type \'BackendEvent\' is not assignable to type \'ConversationOtrMessageAddEvent\'.", "1988627528"],
+      [231, 79, 28, "Argument of type \'QualifiedId | undefined\' is not assignable to parameter of type \'QualifiedId\'.\\n  Type \'undefined\' is not assignable to type \'QualifiedId\'.", "3076846587"],
+      [252, 28, 37, "Object is possibly \'undefined\'.", "1392610785"],
+      [323, 8, 3, "Object is possibly \'null\'.", "193416522"],
+      [324, 8, 3, "Object is possibly \'null\'.", "193416522"],
+      [325, 8, 3, "Object is possibly \'null\'.", "193416522"],
+      [326, 8, 3, "Object is possibly \'null\'.", "193416522"],
+      [333, 4, 37, "Cannot invoke an object which is possibly \'null\'.", "1296197002"],
+      [333, 42, 4, "Argument of type \'null\' is not assignable to parameter of type \'Event\'.", "2087897566"],
+      [342, 18, 12, "Object is possibly \'null\'.", "1670678216"],
+      [348, 24, 12, "Object is possibly \'null\'.", "1670678216"],
+      [352, 16, 12, "Object is possibly \'null\'.", "1670678216"],
+      [366, 26, 12, "Object is possibly \'null\'.", "1670678216"],
+      [368, 25, 12, "Object is possibly \'null\'.", "1670678216"]
+    ],
+    "src/script/util/EmojiUtil.ts:2636485232": [
+      [29, 18, 26, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "2839450053"]
+    ],
+    "src/script/util/FileTypeUtil.ts:2165001675": [
+      [48, 68, 29, "Object is possibly \'null\'.", "3648478764"]
+    ],
+    "src/script/util/KeyboardUtil.ts:3567597689": [
+      [153, 78, 13, "Object is possibly \'null\'.", "2879944190"],
+      [159, 6, 21, "Type \'string | undefined\' is not assignable to type \'string | null\'.\\n  Type \'undefined\' is not assignable to type \'string | null\'.", "3866716832"]
+    ],
+    "src/script/util/PromiseQueue.ts:2903873298": [
+      [64, 22, 7, "Object is possibly \'undefined\'.", "717644789"],
+      [67, 18, 7, "Object is possibly \'undefined\'.", "717644789"],
+      [69, 19, 7, "Object is possibly \'undefined\'.", "717644789"],
+      [153, 8, 9, "Type \'(value: T | PromiseLike<T>) => void\' is not assignable to type \'PromiseResolveFn\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'T | PromiseLike<T>\'.", "1585311161"],
+      [183, 25, 10, "Argument of type \'{ fn: PromiseFn<T>; rejectFn: (reason?: any) => void; resolveFn: (value: T | PromiseLike<T>) => void; }\' is not assignable to parameter of type \'QueueEntry<any>\'.\\n  Types of property \'resolveFn\' are incompatible.\\n    Type \'(value: T | PromiseLike<T>) => void\' is not assignable to type \'PromiseResolveFn\'.\\n      Types of parameters \'value\' and \'value\' are incompatible.\\n        Type \'unknown\' is not assignable to type \'T | PromiseLike<T>\'.", "2928457408"]
+    ],
+    "src/script/util/SanitizationUtil.ts:998997544": [
+      [63, 2, 17, "Type \'Window | null\' is not assignable to type \'Window\'.\\n  Type \'null\' is not assignable to type \'Window\'.", "211185092"]
+    ],
+    "src/script/util/TimeUtil.ts:2937722238": [
+      [196, 14, 7, "Object is possibly \'undefined\'.", "2520100294"],
+      [197, 17, 7, "Object is possibly \'undefined\'.", "2520100294"],
+      [218, 19, 5, "Object is possibly \'undefined\'.", "177734518"],
+      [223, 71, 7, "Object is possibly \'undefined\'.", "770838456"]
+    ],
+    "src/script/util/TypedEventTarget.ts:158498822": [
+      [24, 9, 16, "Property \'addEventListener\' in type \'TypedEventTarget<EventDef>\' is not assignable to the same property in base type \'EventTarget\'.\\n  Type \'<T extends EventDef[\\"type\\"]>(type: T, listener: ((e: Event & EventDef) => void) | null) => void\' is not assignable to type \'(type: string, callback: EventListenerOrEventListenerObject | null, options?: boolean | AddEventListenerOptions | undefined) => void\'.\\n    Types of parameters \'listener\' and \'callback\' are incompatible.\\n      Type \'EventListenerOrEventListenerObject | null\' is not assignable to type \'((e: Event & EventDef) => void) | null\'.\\n        Type \'EventListenerObject\' is not assignable to type \'(e: Event & EventDef) => void\'.\\n          Type \'EventListenerObject\' provides no match for the signature \'(e: Event & EventDef): void\'.", "1663469078"],
+      [25, 33, 8, "Argument of type \'((e: Event & EventDef) => void) | null\' is not assignable to parameter of type \'EventListenerOrEventListenerObject | null\'.\\n  Type \'(e: Event & EventDef) => void\' is not assignable to type \'EventListenerOrEventListenerObject | null\'.\\n    Type \'(e: Event & EventDef) => void\' is not assignable to type \'EventListener\'.\\n      Types of parameters \'e\' and \'evt\' are incompatible.\\n        Type \'Event\' is not assignable to type \'Event & EventDef\'.\\n          Type \'Event\' is not assignable to type \'EventDef\'.\\n            \'Event\' is assignable to the constraint of type \'EventDef\', but \'EventDef\' could be instantiated with a different subtype of constraint \'{ type: any; }\'.", "732556603"],
+      [28, 9, 19, "Property \'removeEventListener\' in type \'TypedEventTarget<EventDef>\' is not assignable to the same property in base type \'EventTarget\'.\\n  Type \'(type: EventDef[\\"type\\"], listener: (e: Event & EventDef) => void) => void\' is not assignable to type \'(type: string, callback: EventListenerOrEventListenerObject | null, options?: boolean | EventListenerOptions | undefined) => void\'.\\n    Types of parameters \'listener\' and \'callback\' are incompatible.\\n      Type \'EventListenerOrEventListenerObject | null\' is not assignable to type \'(e: Event & EventDef) => void\'.\\n        Type \'null\' is not assignable to type \'(e: Event & EventDef) => void\'.", "2229065745"],
+      [29, 36, 8, "Argument of type \'(e: Event & EventDef) => void\' is not assignable to parameter of type \'EventListenerOrEventListenerObject | null\'.\\n  Type \'(e: Event & EventDef) => void\' is not assignable to type \'EventListener\'.\\n    Types of parameters \'e\' and \'evt\' are incompatible.\\n      Type \'Event\' is not assignable to type \'Event & EventDef\'.", "732556603"]
+    ],
+    "src/script/util/ephemeralValueStore.ts:2413706131": [
+      [68, 2, 6, "Type \'ServiceWorker | null\' is not assignable to type \'ServiceWorker\'.\\n  Type \'null\' is not assignable to type \'ServiceWorker\'.", "2022943379"]
+    ],
+    "src/script/util/messageRenderer.ts:3293515046": [
+      [51, 22, 17, "Object is possibly \'undefined\'.", "2874537081"],
+      [51, 22, 17, "Cannot invoke an object which is possibly \'undefined\'.", "2874537081"],
+      [52, 2, 15, "Object is possibly \'null\'.", "3502905644"],
+      [62, 8, 10, "Type \'[number, number] | null\' must have a \'[Symbol.iterator]()\' method that returns an iterator.", "3658085274"],
+      [67, 45, 19, "Object is possibly \'null\'.", "298984248"],
+      [142, 38, 14, "Argument of type \'\\"\\" | string[]\' is not assignable to parameter of type \'string[] | undefined\'.\\n  Type \'string\' is not assignable to type \'string[]\'.", "592874915"],
+      [156, 20, 4, "Object is possibly \'null\'.", "2087822780"],
+      [157, 27, 4, "Object is possibly \'null\'.", "2087822780"],
+      [164, 6, 10, "Object is possibly \'undefined\'.", "393830728"],
+      [165, 6, 10, "Object is possibly \'undefined\'.", "393830728"],
+      [166, 51, 4, "Argument of type \'string | null\' is not assignable to parameter of type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "2087822780"],
+      [204, 71, 22, "Argument of type \'Token[] | null\' is not assignable to parameter of type \'Token[]\'.\\n  Type \'null\' is not assignable to type \'Token[]\'.", "525880250"]
+    ],
+    "src/script/util/renderModal.ts:2732089643": [
+      [29, 4, 14, "Type \'undefined\' is not assignable to type \'HTMLDivElement\'.", "4001065193"]
+    ],
+    "src/script/util/test/TestPage.tsx:1772987669": [
+      [28, 4, 10, "Type \'T | undefined\' is not assignable to type \'T\'.\\n  \'T\' could be instantiated with an arbitrary type which could be unrelated to \'T | undefined\'.", "4016349795"],
+      [29, 4, 14, "Type \'FC<T> | ComponentClass<T, any>\' is not assignable to type \'FC<{}> | ComponentClass<{}, any>\'.\\n  Type \'FC<T>\' is not assignable to type \'FC<{}> | ComponentClass<{}, any>\'.\\n    Type \'FunctionComponent<T>\' is not assignable to type \'FC<{}>\'.\\n      Types of parameters \'props\' and \'props\' are incompatible.\\n        Type \'{}\' is not assignable to type \'T\'.\\n          \'T\' could be instantiated with an arbitrary type which could be unrelated to \'{}\'.", "2825119042"]
+    ],
+    "src/script/util/test/mock/LocalStorageMock.ts:763526660": [
+      [30, 4, 15, "Type \'null\' is not assignable to type \'string\'.", "729139267"]
+    ],
+    "src/script/util/util.ts:981707972": [
+      [48, 40, 34, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.", "212151669"],
+      [102, 34, 13, "Argument of type \'string | ArrayBuffer | null\' is not assignable to parameter of type \'string | ArrayBuffer | PromiseLike<string | ArrayBuffer>\'.\\n  Type \'null\' is not assignable to type \'string | ArrayBuffer | PromiseLike<string | ArrayBuffer>\'.", "3216273927"],
+      [120, 41, 8, "Type \'string | null\' is not assignable to type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "3750463409"],
+      [190, 9, 29, "Object is possibly \'null\'.", "3854968340"],
+      [328, 21, 4, "\'this\' implicitly has type \'any\' because it does not have a type annotation.", "2087959715"],
+      [351, 31, 6, "Object is possibly \'null\'.", "1898500505"],
+      [352, 52, 22, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1093908406"]
+    ],
+    "src/script/view_model/ActionsViewModel.ts:125543468": [
+      [117, 82, 22, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "4075697524"],
+      [181, 67, 5, "Object is of type \'unknown\'.", "165548477"],
+      [181, 83, 5, "Object is of type \'unknown\'.", "165548477"],
+      [195, 8, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"]
+    ],
+    "src/script/view_model/CallingViewModel.ts:3603774031": [
+      [87, 11, 17, "Property \'activeCallViewTab\' has no initializer and is not definitely assigned in the constructor.", "1323835793"],
+      [319, 4, 63, "Type \'Conversation | undefined\' is not assignable to type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "62763745"]
+    ],
+    "src/script/view_model/ContentViewModel.ts:1667610503": [
+      [273, 65, 6, "Type \'string | null\' is not assignable to type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "1127975365"],
+      [310, 68, 13, "Argument of type \'Message | undefined\' is not assignable to parameter of type \'Message\'.\\n  Type \'undefined\' is not assignable to type \'Message\'.", "2065728181"],
+      [316, 10, 6, "Type \'Conversation | null\' is not assignable to type \'PanelEntity\'.", "1164306878"],
+      [320, 37, 5, "Object is of type \'unknown\'.", "165548477"],
+      [330, 10, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
+      [413, 50, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'Conversation\'.", "2620553983"],
+      [441, 12, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
+      [450, 20, 29, "Object is possibly \'undefined\'.", "1398699454"],
+      [453, 12, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"]
+    ],
+    "src/script/view_model/ImageDetailViewViewModel.ts:1576396674": [
+      [58, 4, 11, "Type \'undefined\' is not assignable to type \'string\'.", "3652784592"],
+      [60, 4, 15, "Type \'undefined\' is not assignable to type \'Modal\'.", "4236294625"],
+      [61, 4, 13, "Type \'Observable<string | undefined>\' is not assignable to type \'Observable<string>\'.", "236598504"],
+      [63, 4, 17, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "3331382116"],
+      [65, 4, 23, "Type \'Observable<Conversation | undefined>\' is not assignable to type \'Observable<Conversation>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'Conversation | undefined\' is not assignable to type \'Conversation\'.\\n      Type \'undefined\' is not assignable to type \'Conversation\'.", "2356679995"],
+      [67, 4, 18, "Type \'Observable<ContentMessage | undefined>\' is not assignable to type \'Observable<ContentMessage>\'.", "3462443997"],
+      [93, 18, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
+      [95, 23, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'ContentMessage\'.", "2620553983"],
+      [96, 4, 11, "Type \'undefined\' is not assignable to type \'string\'.", "3652784592"],
+      [146, 20, 22, "Object is possibly \'undefined\'.", "670361899"],
+      [146, 72, 22, "Object is possibly \'undefined\'.", "670361899"]
+    ],
+    "src/script/view_model/ListViewModel.ts:4038366115": [
+      [119, 4, 10, "Type \'Observable<ListState>\' is not assignable to type \'Observable<string>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'string\' is not assignable to type \'ListState\'.", "4014904506"],
+      [120, 4, 15, "Type \'Observable<number | undefined>\' is not assignable to type \'Observable<number>\'.", "3261786582"],
+      [121, 4, 17, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "3342042619"],
+      [185, 8, 6, "Type \'Conversation | null\' is not assignable to type \'PanelEntity\'.", "1164306878"],
+      [433, 48, 18, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'null\' is not assignable to type \'Conversation\'.", "1508601427"],
+      [453, 44, 18, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'null\' is not assignable to type \'Conversation\'.", "1508601427"],
+      [461, 49, 18, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'null\' is not assignable to type \'Conversation\'.", "1508601427"]
+    ],
+    "src/script/view_model/LoadingViewModel.ts:748248502": [
+      [34, 4, 12, "Type \'HTMLElement | null\' is not assignable to type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "2937706259"],
+      [60, 21, 14, "Object is possibly \'undefined\'.", "3120882432"],
+      [61, 21, 14, "Object is possibly \'undefined\'.", "3120882432"]
+    ],
+    "src/script/view_model/MainViewModel.ts:4084606447": [
+      [153, 6, 11, "Type \'Observable<true>\' is not assignable to type \'Observable<boolean>\'.", "2107724227"],
+      [158, 4, 16, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "2689308885"],
+      [215, 4, 30, "Object is possibly \'null\'.", "1790131128"],
+      [223, 24, 3, "Object is possibly \'null\'.", "193410244"],
+      [235, 27, 3, "Object is possibly \'null\'.", "193410244"],
+      [237, 29, 3, "Object is possibly \'null\'.", "193410244"],
+      [243, 10, 5, "Object is possibly \'null\'.", "187702867"],
+      [244, 28, 5, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "187702867"],
+      [245, 28, 8, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "277626740"],
+      [246, 28, 5, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "178805363"],
+      [250, 12, 3, "Object is possibly \'null\'.", "193410244"],
+      [252, 12, 7, "Object is possibly \'null\'.", "652303743"],
+      [254, 12, 3, "Object is possibly \'null\'.", "193410244"],
+      [256, 12, 7, "Object is possibly \'null\'.", "652303743"],
+      [265, 6, 5, "Object is possibly \'null\'.", "187702867"],
+      [268, 25, 5, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "187702867"],
+      [270, 27, 8, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "277626740"],
+      [271, 27, 5, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "178805363"],
+      [274, 25, 5, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "187702867"],
+      [276, 27, 8, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "277626740"],
+      [277, 27, 5, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "178805363"],
+      [283, 25, 5, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "187702867"],
+      [284, 25, 8, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "277626740"],
+      [285, 25, 5, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "178805363"],
+      [288, 27, 5, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "187702867"],
+      [290, 29, 8, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "277626740"],
+      [291, 29, 5, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "178805363"],
+      [294, 27, 5, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "187702867"],
+      [296, 29, 8, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "277626740"],
+      [297, 29, 5, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "178805363"]
+    ],
+    "src/script/view_model/ModalsViewModel.ts:508741377": [
+      [80, 2, 11, "Type \'null\' is not assignable to type \'string\'.", "974495764"],
+      [132, 4, 18, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "3358619369"],
+      [135, 4, 15, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "1894281975"],
+      [138, 4, 14, "Type \'Observable<string | null>\' is not assignable to type \'Observable<string>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'string | null\' is not assignable to type \'string\'.\\n      Type \'null\' is not assignable to type \'string\'.", "209694601"],
+      [172, 13, 4, "Property \'type\' does not exist on type \'{ id: string; options: ModalOptions; type: ModalType; } | undefined\'.", "2087944093"],
+      [172, 19, 7, "Property \'options\' does not exist on type \'{ id: string; options: ModalOptions; type: ModalType; } | undefined\'.", "717644789"],
+      [172, 28, 2, "Property \'id\' does not exist on type \'{ id: string; options: ModalOptions; type: ModalType; } | undefined\'.", "5861160"],
+      [242, 8, 19, "Type \'string | false | undefined\' is not assignable to type \'string | undefined\'.\\n  Type \'boolean\' is not assignable to type \'string\'.", "1717244404"],
+      [270, 56, 23, "No overload matches this call.\\n  Overload 1 of 2, \'(...items: ConcatArray<never>[]): never[]\', gave the following error.\\n    Argument of type \'Action\' is not assignable to parameter of type \'ConcatArray<never>\'.\\n      Type \'Action\' is missing the following properties from type \'ConcatArray<never>\': length, join, slice\\n  Overload 2 of 2, \'(...items: ConcatArray<never>[]): never[]\', gave the following error.\\n    Argument of type \'Action\' is not assignable to parameter of type \'ConcatArray<never>\'.", "1386143110"],
+      [272, 16, 9, "Spread types may only be created from object types.", "2308002069"],
+      [275, 17, 7, "Argument of type \'{ checkboxLabel: string | undefined; closeFn: Function; closeOnConfirm: boolean; currentType: ModalType; inputPlaceholder: string | undefined; messageHtml: string | undefined; ... 6 more ...; titleText: string | undefined; }\' is not assignable to parameter of type \'Content\'.\\n  Types of property \'checkboxLabel\' are incompatible.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "3716929964"],
+      [277, 19, 2, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "5861160"],
+      [293, 34, 29, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "1283406094"],
+      [336, 19, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"]
+    ],
+    "src/script/view_model/PanelViewModel.ts:1100221187": [
+      [69, 2, 13, "Property \'currentEntity\' has no initializer and is not definitely assigned in the constructor.", "32305655"],
+      [139, 4, 23, "Type \'Observable<Conversation | null>\' is not assignable to type \'Observable<Conversation>\'.", "2356679995"],
+      [142, 4, 16, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "2985846665"],
+      [143, 4, 10, "Type \'Observable<string | undefined>\' is not assignable to type \'Observable<string>\'.", "4014904506"],
+      [145, 4, 17, "Type \'Observable<string | undefined>\' is not assignable to type \'Observable<string>\'.", "2911337818"],
+      [213, 15, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
+      [215, 4, 18, "Type \'undefined\' is not assignable to type \'PanelEntity\'.", "2173061407"],
+      [276, 22, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
+      [296, 24, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
+      [297, 34, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
+      [309, 6, 15, "Type \'Element | null\' is not assignable to type \'Element | undefined\'.\\n  Type \'null\' is not assignable to type \'Element | undefined\'.", "2931287914"]
+    ],
+    "src/script/view_model/WarningsContainer.tsx:374721783": [
+      [55, 4, 3, "Object is possibly \'null\'.", "193410244"],
+      [56, 4, 3, "Object is possibly \'null\'.", "193410244"]
+    ],
+    "src/script/view_model/WindowTitleViewModel.ts:2939646455": [
+      [48, 4, 17, "Type \'Observable<ContentState>\' is not assignable to type \'Observable<string>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'string\' is not assignable to type \'ContentState\'.", "3516467027"],
+      [51, 4, 22, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "2603921936"],
+      [89, 31, 43, "Object is possibly \'null\'.", "1853768633"]
+    ],
+    "src/script/view_model/bindings/CommonBindings.ts:3939643793": [
+      [44, 6, 32, "Object is possibly \'null\'.", "3763860455"],
+      [83, 63, 13, "Object is possibly \'null\'.", "115063321"],
+      [83, 86, 13, "Object is possibly \'null\'.", "115063321"],
+      [97, 31, 38, "Type \'File | null\' is not assignable to type \'BlobPart\'.\\n  Type \'null\' is not assignable to type \'BlobPart\'.", "2527675968"],
+      [254, 24, 4, "\'this\' implicitly has type \'any\' because it does not have a type annotation.", "2087959715"],
+      [279, 10, 40, "Object is possibly \'null\'.", "525534827"],
+      [280, 29, 4, "\'this\' implicitly has type \'any\' because it does not have a type annotation.", "2087959715"],
+      [285, 30, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | number | string[] | ((this: EventTarget, index: number, value: string) => string)\'.", "2087897566"],
+      [327, 10, 5, "Type \'undefined\' is not assignable to type \'HTMLImageElement\'.", "178823234"],
+      [336, 10, 12, "Type \'undefined\' is not assignable to type \'((this: GlobalEventHandlers, ev: Event) => any) | null\'.", "1696577579"],
+      [379, 6, 3, "Object is possibly \'null\'.", "193416522"],
+      [380, 6, 3, "Object is possibly \'null\'.", "193416522"],
+      [381, 13, 3, "Object is possibly \'null\'.", "193416522"],
+      [523, 8, 12, "Type \'undefined\' is not assignable to type \'number\'.", "2583042145"]
+    ],
+    "src/script/view_model/bindings/ConversationListBindings.ts:3095649748": [
+      [29, 0, 32, "Type \'{ init(element: HTMLElement): void; update(element: HTMLElement, valueAccessor: PureComputed<string> | ObservableArray<Conversation>): void; }\' is not assignable to type \'BindingHandler<any>\'.\\n  Types of property \'update\' are incompatible.\\n    Type \'(element: HTMLElement, valueAccessor: PureComputed<string> | ObservableArray<Conversation>) => void\' is not assignable to type \'(element: any, valueAccessor: () => any, allBindings: AllBindings, viewModel: any, bindingContext: BindingContext<any>) => void\'.\\n      Types of parameters \'valueAccessor\' and \'valueAccessor\' are incompatible.\\n        Type \'() => any\' is not assignable to type \'PureComputed<string> | ObservableArray<Conversation>\'.\\n          Type \'() => any\' is missing the following properties from type \'PureComputed<string>\': equalityComparer, peek, dispose, isActive, and 7 more.", "1716760283"]
+    ],
+    "src/script/view_model/bindings/MessageListBindings.ts:3261685299": [
+      [129, 48, 8, "No overload matches this call.\\n  Overload 1 of 2, \'(type: \\"scroll\\", listener: (this: HTMLElement, ev: Event) => any, options?: boolean | AddEventListenerOptions | undefined): void\', gave the following error.\\n    Argument of type \'({ target: element }: Event & {    target: HTMLElement;}) => void\' is not assignable to parameter of type \'(this: HTMLElement, ev: Event) => any\'.\\n      Types of parameters \'__0\' and \'ev\' are incompatible.\\n        Type \'Event\' is not assignable to type \'Event & { target: HTMLElement; }\'.\\n          Type \'Event\' is not assignable to type \'{ target: HTMLElement; }\'.\\n            Types of property \'target\' are incompatible.\\n              Type \'EventTarget | null\' is not assignable to type \'HTMLElement\'.\\n                Type \'null\' is not assignable to type \'HTMLElement\'.\\n  Overload 2 of 2, \'(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions | undefined): void\', gave the following error.\\n    Argument of type \'({ target: element }: Event & {    target: HTMLElement;}) => void\' is not assignable to parameter of type \'EventListenerOrEventListenerObject\'.\\n      Type \'({ target: element }: Event & {    target: HTMLElement;}) => void\' is not assignable to type \'EventListener\'.\\n        Types of parameters \'__0\' and \'evt\' are incompatible.\\n          Type \'Event\' is not assignable to type \'Event & { target: HTMLElement; }\'.", "1317952297"],
+      [133, 53, 8, "No overload matches this call.\\n  Overload 1 of 2, \'(type: \\"scroll\\", listener: (this: HTMLElement, ev: Event) => any, options?: boolean | EventListenerOptions | undefined): void\', gave the following error.\\n    Argument of type \'({ target: element }: Event & {    target: HTMLElement;}) => void\' is not assignable to parameter of type \'(this: HTMLElement, ev: Event) => any\'.\\n      Types of parameters \'__0\' and \'ev\' are incompatible.\\n        Type \'Event\' is not assignable to type \'Event & { target: HTMLElement; }\'.\\n  Overload 2 of 2, \'(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions | undefined): void\', gave the following error.\\n    Argument of type \'({ target: element }: Event & {    target: HTMLElement;}) => void\' is not assignable to parameter of type \'EventListenerOrEventListenerObject\'.", "1317952297"],
+      [158, 49, 4, "Argument of type \'Blob | undefined\' is not assignable to parameter of type \'Blob | MediaSource\'.", "2087735462"]
+    ],
+    "src/script/view_model/bindings/VideoCallingBindings.ts:456425467": [
+      [23, 2, 6, "Type \'(element: HTMLMediaElement, valueAccessor: Observable<MediaStream>) => void\' is not assignable to type \'(element: any, valueAccessor: () => any, allBindings: AllBindings, viewModel: any, bindingContext: BindingContext<any>) => void\'.\\n  Types of parameters \'valueAccessor\' and \'valueAccessor\' are incompatible.\\n    Type \'() => any\' is missing the following properties from type \'Observable<MediaStream>\': equalityComparer, peek, valueHasMutated, valueWillMutate, and 5 more.", "1759213236"],
+      [31, 2, 6, "Type \'(element: HTMLMediaElement, valueAccessor: Observable<MediaStream>) => void\' is not assignable to type \'(element: any, valueAccessor: () => any, allBindings: AllBindings, viewModel: any, bindingContext: BindingContext<any>) => void\'.\\n  Types of parameters \'valueAccessor\' and \'valueAccessor\' are incompatible.\\n    Type \'() => any\' is not assignable to type \'Observable<MediaStream>\'.", "1759213236"]
+    ],
+    "src/script/view_model/content/ConnectRequestsViewModel.ts:1733765070": [
+      [54, 56, 43, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "4107348197"]
+    ],
+    "src/script/view_model/content/EmojiInputViewModel.ts:1071561715": [
+      [49, 10, 13, "Property \'suppressKeyUp\' has no initializer and is not definitely assigned in the constructor.", "1816102502"],
+      [167, 8, 48, "Argument of type \'string[]\' is not assignable to parameter of type \'number[]\'.\\n  Type \'string\' is not assignable to type \'number\'.", "4095030990"],
+      [291, 20, 9, "Object is possibly \'null\'.", "3834073445"],
+      [292, 8, 9, "Argument of type \'number | null\' is not assignable to parameter of type \'number | undefined\'.\\n  Type \'null\' is not assignable to type \'number | undefined\'.", "3834073445"],
+      [301, 38, 9, "Object is possibly \'null\'.", "3834073445"],
+      [319, 41, 9, "Argument of type \'number | null\' is not assignable to parameter of type \'number | undefined\'.", "3834073445"],
+      [320, 37, 9, "Argument of type \'number | null\' is not assignable to parameter of type \'number | undefined\'.", "3834073445"],
+      [370, 60, 4, "Property \'icon\' does not exist on type \'never\'.", "2087846158"],
+      [372, 27, 5, "Argument of type \'{ icon: string; name: string; }\' is not assignable to parameter of type \'never\'.", "165439585"],
+      [377, 54, 4, "Property \'name\' does not exist on type \'never\'.", "2087876002"],
+      [378, 54, 4, "Property \'name\' does not exist on type \'never\'.", "2087876002"],
+      [381, 54, 4, "Property \'name\' does not exist on type \'never\'.", "2087876002"],
+      [381, 67, 4, "Property \'name\' does not exist on type \'never\'.", "2087876002"],
+      [387, 41, 4, "Property \'icon\' does not exist on type \'never\'.", "2087846158"],
+      [387, 80, 4, "Property \'name\' does not exist on type \'never\'.", "2087876002"],
+      [402, 31, 22, "Object is possibly \'undefined\'.", "4272920130"],
+      [431, 38, 9, "Argument of type \'number | null\' is not assignable to parameter of type \'number | undefined\'.", "3834073445"]
+    ],
+    "src/script/view_model/content/GiphyViewModel.ts:931654924": [
+      [57, 4, 10, "Type \'undefined\' is not assignable to type \'Modal\'.", "3985246182"],
+      [58, 4, 10, "Type \'Observable<GiphyState.DEFAULT>\' is not assignable to type \'Observable<GiphyState>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'GiphyState\' is not assignable to type \'GiphyState.DEFAULT\'.", "4014904506"],
+      [61, 4, 15, "Type \'Observable<Gif | undefined>\' is not assignable to type \'Observable<Gif>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'Gif | undefined\' is not assignable to type \'Gif\'.\\n      Type \'undefined\' is not assignable to type \'Gif\'.", "2624948332"],
+      [67, 4, 16, "Type \'Observable<Gif | undefined>\' is not assignable to type \'Observable<Gif>\'.", "2966715820"],
+      [112, 24, 19, "No overload matches this call.\\n  The last overload gave the following error.\\n    Argument of type \'EventTarget | null\' is not assignable to parameter of type \'PlainObject<any>\'.\\n      Type \'null\' is not assignable to type \'PlainObject<any>\'.", "3586053823"],
+      [113, 31, 6, "Property \'parent\' does not exist on type \'JQueryStatic\'.", "1898500505"],
+      [116, 10, 4, "\'this\' implicitly has type \'any\' because it does not have a type annotation.", "2087959715"],
+      [120, 10, 4, "\'this\' implicitly has type \'any\' because it does not have a type annotation.", "2087959715"],
+      [125, 25, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'Gif\'.", "2620553983"],
+      [138, 23, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'Gif\'.", "2620553983"],
+      [151, 8, 10, "Type \'undefined\' is not assignable to type \'Modal\'.", "3985246182"],
+      [162, 21, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'Gif\'.", "2620553983"]
+    ],
+    "src/script/view_model/content/HistoryExportViewModel.ts:1810820018": [
+      [72, 4, 13, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "1143683791"],
+      [89, 4, 16, "Type \'Observable<Blob | null>\' is not assignable to type \'Observable<Blob>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'Blob | null\' is not assignable to type \'Blob\'.\\n      Type \'null\' is not assignable to type \'Blob\'.", "340013420"],
+      [128, 19, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"]
+    ],
+    "src/script/view_model/content/HistoryImportViewModel.ts:2154234816": [
+      [61, 4, 10, "Type \'Observable<Error | null>\' is not assignable to type \'Observable<Error>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'Error | null\' is not assignable to type \'Error\'.\\n      Type \'null\' is not assignable to type \'Error\'.", "3994891413"],
+      [115, 15, 4, "Argument of type \'null\' is not assignable to parameter of type \'Error\'.", "2087897566"],
+      [136, 19, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'Error\'.", "165548477"],
+      [151, 15, 4, "Argument of type \'null\' is not assignable to parameter of type \'Error\'.", "2087897566"]
+    ],
+    "src/script/view_model/content/InputBarViewModel.ts:1163668652": [
+      [105, 11, 11, "Property \'pingTooltip\' has no initializer and is not definitely assigned in the constructor.", "2111945888"],
+      [111, 11, 18, "Property \'acceptedImageTypes\' has no initializer and is not definitely assigned in the constructor.", "1132622984"],
+      [112, 11, 16, "Property \'allowedFileTypes\' has no initializer and is not definitely assigned in the constructor.", "31684880"],
+      [114, 11, 13, "Property \'inputFileAttr\' has no initializer and is not definitely assigned in the constructor.", "1682828358"],
+      [138, 4, 16, "Type \'null\' is not assignable to type \'HTMLDivElement\'.", "2981580189"],
+      [139, 4, 13, "Type \'null\' is not assignable to type \'HTMLTextAreaElement\'.", "2203991591"],
+      [140, 4, 24, "Type \'PureComputed<boolean | null>\' is not assignable to type \'PureComputed<boolean>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'boolean | null\' is not assignable to type \'boolean\'.", "902354832"],
+      [143, 9, 25, "Object is possibly \'null\'.", "2329039674"],
+      [144, 10, 25, "Object is possibly \'null\'.", "2329039674"],
+      [155, 4, 22, "Type \'Observable<ContentMessage | undefined>\' is not assignable to type \'Observable<ContentMessage>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'ContentMessage | undefined\' is not assignable to type \'ContentMessage\'.\\n      Type \'undefined\' is not assignable to type \'ContentMessage\'.", "127474017"],
+      [156, 4, 23, "Type \'Observable<ContentMessage | undefined>\' is not assignable to type \'Observable<ContentMessage>\'.", "2477632015"],
+      [159, 4, 22, "Type \'PureComputed<string[] | undefined>\' is not assignable to type \'PureComputed<string[]>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'string[] | undefined\' is not assignable to type \'string[]\'.\\n      Type \'undefined\' is not assignable to type \'string[]\'.", "1145910007"],
+      [163, 32, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'ContentMessage\'.", "2620553983"],
+      [197, 4, 15, "Type \'Observable<File | undefined>\' is not assignable to type \'Observable<File>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'File | undefined\' is not assignable to type \'File\'.\\n      Type \'undefined\' is not assignable to type \'File\'.", "2328486812"],
+      [198, 4, 25, "Type \'Observable<string | undefined>\' is not assignable to type \'Observable<string>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "4170687229"],
+      [199, 4, 19, "Type \'Observable<string | undefined>\' is not assignable to type \'Observable<string>\'.", "3727263643"],
+      [201, 4, 17, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "2409749581"],
+      [203, 4, 18, "Type \'Observable<undefined>\' is not assignable to type \'Observable<{ startIndex: number; term: string; }>\'.\\n  Types of property \'equalityComparer\' are incompatible.\\n    Type \'(a: undefined, b: undefined) => boolean\' is not assignable to type \'(a: { startIndex: number; term: string; }, b: { startIndex: number; term: string; }) => boolean\'.\\n      Types of parameters \'a\' and \'a\' are incompatible.\\n        Type \'{ startIndex: number; term: string; }\' is not assignable to type \'undefined\'.", "1081038602"],
+      [237, 25, 25, "Object is possibly \'null\'.", "2329039674"],
+      [251, 34, 12, "Object is possibly \'undefined\'.", "2098887158"],
+      [253, 14, 12, "Object is possibly \'undefined\'.", "2098887158"],
+      [255, 34, 12, "Object is possibly \'undefined\'.", "2098887158"],
+      [282, 27, 25, "Object is possibly \'null\'.", "2329039674"],
+      [292, 21, 25, "Object is possibly \'null\'.", "2329039674"],
+      [301, 38, 25, "Object is possibly \'null\'.", "2329039674"],
+      [302, 32, 25, "Object is possibly \'null\'.", "2329039674"],
+      [333, 32, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"],
+      [334, 26, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"],
+      [337, 4, 27, "Type \'PureComputed<boolean | 0>\' is not assignable to type \'PureComputed<boolean>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'number | boolean\' is not assignable to type \'boolean\'.", "2411177522"],
+      [341, 8, 18, "Object is possibly \'null\'.", "1508601427"],
+      [342, 9, 18, "Object is possibly \'null\'.", "1508601427"],
+      [346, 38, 36, "Argument of type \'(conversationEntity: Conversation) => Promise<void>\' is not assignable to parameter of type \'SubscriptionCallback<Conversation | null, void>\'.\\n  Types of parameters \'conversationEntity\' and \'val\' are incompatible.\\n    Type \'Conversation | null\' is not assignable to type \'Conversation\'.\\n      Type \'null\' is not assignable to type \'Conversation\'.", "946019828"],
+      [349, 29, 25, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'null\' is not assignable to type \'Conversation\'.", "2329039674"],
+      [377, 20, 4, "Argument of type \'null\' is not assignable to parameter of type \'File\'.", "2087897566"],
+      [487, 23, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'{ startIndex: number; term: string; }\'.", "2620553983"],
+      [496, 27, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'ContentMessage\'.", "2620553983"],
+      [497, 28, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'ContentMessage\'.", "2620553983"],
+      [504, 28, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'ContentMessage\'.", "2620553983"],
+      [518, 20, 4, "Argument of type \'null\' is not assignable to parameter of type \'File\'.", "2087897566"],
+      [528, 38, 25, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'null\' is not assignable to type \'Conversation\'.", "2329039674"],
+      [545, 40, 25, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'null\' is not assignable to type \'Conversation\'.", "2329039674"],
+      [651, 8, 12, "No overload matches this call.\\n  The last overload gave the following error.\\n    Argument of type \'EventTarget | null\' is not assignable to parameter of type \'PlainObject<any>\'.\\n      Type \'null\' is not assignable to type \'PlainObject<any>\'.", "3718352182"],
+      [651, 22, 5, "Property \'focus\' does not exist on type \'JQueryStatic\'.", "171175241"],
+      [662, 29, 25, "Object is possibly \'null\'.", "2329039674"],
+      [672, 28, 4, "Argument of type \'null\' is not assignable to parameter of type \'File\'.", "2087897566"],
+      [683, 26, 20, "Object is possibly \'null\'.", "181029819"],
+      [721, 4, 17, "Type \'undefined\' is not assignable to type \'{ startIndex: number; term: string; }\'.", "4204377774"],
+      [771, 6, 12, "Type \'null\' is not assignable to type \'MentionEntity\'.", "3224621615"],
+      [774, 6, 12, "Type \'null\' is not assignable to type \'MentionEntity\'.", "3224621615"],
+      [800, 4, 95, "Type \'MentionEntity | undefined\' is not assignable to type \'MentionEntity\'.\\n  Type \'undefined\' is not assignable to type \'MentionEntity\'.", "1173598365"],
+      [820, 37, 18, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'null\' is not assignable to type \'Conversation\'.", "1508601427"],
+      [826, 4, 467, "Type \'Promise<QuoteEntity | OutgoingQuote | undefined>\' is not assignable to type \'Promise<OutgoingQuote | undefined>\'.\\n  Type \'QuoteEntity | OutgoingQuote | undefined\' is not assignable to type \'OutgoingQuote | undefined\'.\\n    Type \'QuoteEntity\' is not assignable to type \'OutgoingQuote\'.\\n      Type \'QuoteEntity\' is not assignable to type \'{ hash: Uint8Array; }\'.\\n        Types of property \'hash\' are incompatible.\\n          Type \'ArrayBuffer | undefined\' is not assignable to type \'Uint8Array\'.\\n            Type \'undefined\' is not assignable to type \'Uint8Array\'.", "3474749203"],
+      [848, 8, 25, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'null\' is not assignable to type \'Conversation\'.", "2329039674"],
+      [862, 61, 25, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'null\' is not assignable to type \'Conversation\'.", "2329039674"],
+      [866, 23, 25, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'null\' is not assignable to type \'Conversation\'.", "2329039674"],
+      [877, 20, 4, "Argument of type \'null\' is not assignable to parameter of type \'File\'.", "2087897566"],
+      [889, 42, 25, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'null\' is not assignable to type \'Conversation\'.", "2329039674"],
+      [899, 12, 25, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'null\' is not assignable to type \'Conversation\'.", "2329039674"],
+      [928, 41, 25, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'null\' is not assignable to type \'Conversation\'.", "2329039674"]
+    ],
+    "src/script/view_model/content/LegalHoldModalViewModel.ts:3913530676": [
+      [72, 4, 14, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "2246514233"],
+      [73, 4, 16, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "4203184287"],
+      [75, 4, 15, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "1690488901"],
+      [76, 4, 10, "Type \'Observable<never[]>\' is not assignable to type \'Observable<User[]>\'.", "4012712079"],
+      [77, 4, 16, "Type \'Observable<User | undefined>\' is not assignable to type \'Observable<User>\'.", "3229850487"],
+      [79, 4, 21, "Type \'Observable<true>\' is not assignable to type \'Observable<boolean>\'.", "2630150188"],
+      [82, 4, 14, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "333392401"],
+      [83, 4, 21, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "3098275876"],
+      [84, 4, 18, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "3456688653"],
+      [86, 4, 19, "Type \'null\' is not assignable to type \'string\'.", "59414957"],
+      [95, 23, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'User\'.", "2620553983"],
+      [128, 79, 15, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2249385622"],
+      [143, 50, 11, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2028249029"],
+      [153, 4, 19, "Type \'null\' is not assignable to type \'string\'.", "59414957"],
+      [178, 66, 15, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2249385622"],
+      [195, 28, 7, "Argument of type \'unknown\' is not assignable to parameter of type \'string\'.", "1236122734"],
+      [239, 21, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'User\'.", "2620553983"]
+    ],
+    "src/script/view_model/content/MessageListViewModel.ts:1895857150": [
+      [94, 19, 12, "Property \'conversation\' does not exist on type \'{ conversation: Conversation; message: Message; } | undefined\'.", "1670678216"],
+      [94, 33, 7, "Property \'message\' does not exist on type \'{ conversation: Conversation; message: Message; } | undefined\'.", "1236122734"],
+      [138, 4, 107, "Type \'number | boolean\' is not assignable to type \'boolean\'.\\n  Type \'number\' is not assignable to type \'boolean\'.", "3357851046"],
+      [162, 37, 18, "Object is possibly \'null\'.", "1508601427"],
+      [162, 68, 18, "Object is possibly \'null\'.", "1508601427"],
+      [166, 8, 6, "Type \'Conversation | null\' is not assignable to type \'PanelEntity\'.\\n  Type \'null\' is not assignable to type \'PanelEntity\'.", "1164306878"],
+      [188, 9, 6, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1127975365"],
+      [200, 39, 19, "No overload matches this call.\\n  The last overload gave the following error.\\n    Argument of type \'EventTarget | null\' is not assignable to parameter of type \'PlainObject<any>\'.\\n      Type \'null\' is not assignable to type \'PlainObject<any>\'.", "3586053823"],
+      [200, 60, 8, "Property \'hasClass\' does not exist on type \'JQueryStatic\'.", "1121770737"],
+      [209, 14, 13, "Object is possibly \'undefined\'.", "2217428334"],
+      [209, 57, 13, "Object is possibly \'undefined\'.", "2217428334"],
+      [222, 83, 18, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'null\' is not assignable to type \'Conversation\'.", "1508601427"],
+      [356, 68, 6, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1127975365"],
+      [359, 14, 5, "Object is of type \'unknown\'.", "165548477"]
+    ],
+    "src/script/view_model/content/TitleBarViewModel.ts:1298048855": [
+      [116, 4, 23, "Type \'Observable<Conversation | null>\' is not assignable to type \'Observable<Conversation>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'Conversation | null\' is not assignable to type \'Conversation\'.\\n      Type \'null\' is not assignable to type \'Conversation\'.", "2356679995"],
+      [132, 67, 27, "Object is possibly \'undefined\'.", "4125423766"]
+    ],
+    "src/script/view_model/panel/AddParticipantsViewModel.ts:978446956": [
+      [100, 4, 27, "Type \'Observable<true>\' is not assignable to type \'Observable<boolean>\'.", "527027962"],
+      [102, 4, 21, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<User>\'.", "2199671479"],
+      [103, 4, 20, "Type \'Observable<ServiceEntity | undefined>\' is not assignable to type \'Observable<ServiceEntity>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'ServiceEntity | undefined\' is not assignable to type \'ServiceEntity\'.\\n      Type \'undefined\' is not assignable to type \'ServiceEntity\'.", "3275208665"],
+      [108, 4, 21, "Type \'PureComputed<boolean | undefined>\' is not assignable to type \'PureComputed<boolean>\'.", "3187656643"],
+      [196, 25, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'ServiceEntity\'.", "2620553983"]
+    ],
+    "src/script/view_model/panel/BasePanelViewModel.ts:1781850387": [
+      [57, 4, 23, "Type \'Observable<Conversation | null>\' is not assignable to type \'Observable<Conversation>\'.", "233634092"]
+    ],
+    "src/script/view_model/panel/ConversationDetailsViewModel.ts:1232323692": [
+      [137, 4, 20, "Type \'Observable<ServiceEntity | undefined>\' is not assignable to type \'Observable<ServiceEntity>\'.", "3275208665"],
+      [158, 21, 36, "Argument of type \'User | undefined\' is not assignable to parameter of type \'User\'.\\n  Type \'undefined\' is not assignable to type \'User\'.", "1354386287"],
+      [179, 4, 18, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "2548422508"],
+      [201, 4, 21, "Type \'PureComputed<boolean | \\"\\">\' is not assignable to type \'PureComputed<boolean>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'string | boolean\' is not assignable to type \'boolean\'.", "1116588846"],
+      [209, 4, 23, "Type \'PureComputed<boolean | \\"\\">\' is not assignable to type \'PureComputed<boolean>\'.", "1139188355"]
+    ],
+    "src/script/view_model/panel/ConversationParticipantsViewModel.ts:2997455980": [
+      [53, 21, 36, "Argument of type \'User | undefined\' is not assignable to parameter of type \'User\'.\\n  Type \'undefined\' is not assignable to type \'User\'.", "1354386287"],
+      [61, 4, 21, "Type \'Observable<never[]>\' is not assignable to type \'Observable<User[]>\'.", "3284804734"],
+      [71, 46, 6, "Type \'null\' is not assignable to type \'PanelEntity\'.", "1164306878"]
+    ],
+    "src/script/view_model/panel/GroupParticipantServiceViewModel.ts:516410094": [
+      [52, 4, 24, "Type \'Observable<undefined>\' is not assignable to type \'Observable<User>\'.", "3514586203"],
+      [53, 4, 20, "Type \'Observable<undefined>\' is not assignable to type \'Observable<ServiceEntity>\'.\\n  Types of property \'equalityComparer\' are incompatible.\\n    Type \'(a: undefined, b: undefined) => boolean\' is not assignable to type \'(a: ServiceEntity, b: ServiceEntity) => boolean\'.\\n      Types of parameters \'a\' and \'a\' are incompatible.\\n        Type \'ServiceEntity\' is not assignable to type \'undefined\'.", "3275208665"],
+      [55, 4, 14, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "878538421"],
+      [93, 25, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'ServiceEntity\'.", "2620553983"]
+    ],
+    "src/script/view_model/panel/GroupParticipantUserViewModel.ts:3122532612": [
+      [74, 4, 24, "Type \'Observable<undefined>\' is not assignable to type \'Observable<User>\'.", "3514586203"]
+    ],
+    "src/script/view_model/panel/GuestsAndServicesViewModel.ts:292948775": [
+      [76, 4, 17, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "1480297283"],
+      [77, 4, 19, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "3910055221"],
+      [93, 4, 23, "Type \'PureComputed<boolean | undefined>\' is not assignable to type \'PureComputed<boolean>\'.", "2493661698"]
+    ],
+    "src/script/view_model/panel/MessageDetailsViewModel.ts:906474120": [
+      [71, 4, 19, "Type \'Observable<true>\' is not assignable to type \'Observable<boolean>\'.", "1452458508"],
+      [72, 4, 14, "Type \'Observable<string | undefined>\' is not assignable to type \'Observable<string>\'.", "116181579"],
+      [102, 13, 14, "Object is possibly \'undefined\'.", "116180423"],
+      [114, 63, 14, "Object is possibly \'undefined\'.", "116180423"],
+      [120, 12, 7, "Type \'{ domain: string | undefined; id: string; }[]\' is not assignable to type \'QualifiedId[]\'.\\n  Type \'{ domain: string | undefined; id: string; }\' is not assignable to type \'QualifiedId\'.\\n    Types of property \'domain\' are incompatible.\\n      Type \'string | undefined\' is not assignable to type \'string\'.\\n        Type \'undefined\' is not assignable to type \'string\'.", "2414311946"],
+      [130, 41, 14, "Object is possibly \'undefined\'.", "116180423"],
+      [136, 39, 14, "Object is possibly \'undefined\'.", "116180423"],
+      [175, 4, 17, "Type \'PureComputed<string | false>\' is not assignable to type \'PureComputed<string | undefined>\'.\\n  Types of property \'equalityComparer\' are incompatible.\\n    Type \'(a: string | false | undefined, b: string | false) => boolean\' is not assignable to type \'(a: string | undefined, b: string | undefined) => boolean\'.\\n      Types of parameters \'b\' and \'b\' are incompatible.\\n        Type \'string | undefined\' is not assignable to type \'string | false\'.\\n          Type \'undefined\' is not assignable to type \'string | false\'.", "3727029621"]
+    ],
+    "src/script/view_model/panel/NotificationsPanel.test.ts:989279192": [
+      [38, 54, 29, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1262202094"],
+      [76, 20, 77, "Argument of type \'Element | null\' is not assignable to parameter of type \'Document | Node | Element | Window\'.", "1971299222"]
+    ],
+    "src/script/view_model/panel/NotificationsPanel.tsx:3967190560": [
+      [46, 56, 18, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Partial<Record<\\"notificationState\\", Subscribable<any>>>\'.\\n  Type \'null\' is not assignable to type \'Partial<Record<\\"notificationState\\", Subscribable<any>>>\'.", "2242649668"],
+      [49, 21, 12, "Argument of type \'HTMLDivElement | undefined\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLElement\'.", "652464040"],
+      [78, 77, 18, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'null\' is not assignable to type \'Conversation\'.", "2242649668"]
+    ],
+    "src/script/view_model/panel/PanelHeader.test.ts:4232255009": [
+      [33, 39, 22, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "3474761039"],
+      [34, 38, 21, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "327517530"]
+    ],
+    "src/script/view_model/panel/ParticipantDevicesPanel.tsx:2126168348": [
+      [39, 21, 12, "Argument of type \'HTMLDivElement | undefined\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLElement\'.", "652464040"]
+    ],
+    "src/script/view_model/panel/TimedMessagesPanel.tsx:852651488": [
+      [49, 21, 12, "Argument of type \'HTMLDivElement | undefined\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLElement\'.", "652464040"],
+      [52, 57, 18, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Partial<Record<\\"globalMessageTimer\\", Subscribable<any>>>\'.\\n  Type \'null\' is not assignable to type \'Partial<Record<\\"globalMessageTimer\\", Subscribable<any>>>\'.", "2242649668"],
+      [82, 44, 10, "Argument of type \'number | null\' is not assignable to parameter of type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "1022360174"],
+      [83, 83, 10, "Argument of type \'number | null\' is not assignable to parameter of type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "1022360174"]
+    ]
+  }`
+};

--- a/.betterer.ts
+++ b/.betterer.ts
@@ -1,0 +1,8 @@
+import {typescript} from '@betterer/typescript';
+
+export default {
+  'stricter compilation': () =>
+    typescript('./tsconfig.json', {
+      strict: true,
+    }).include('./src/**/*.{ts,tsx}'),
+};

--- a/.betterer.ts
+++ b/.betterer.ts
@@ -1,3 +1,22 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
 import {typescript} from '@betterer/typescript';
 
 export default {

--- a/.github/workflows/betterer.yml
+++ b/.github/workflows/betterer.yml
@@ -1,0 +1,25 @@
+name: 'Betterer - strict TS'
+on: [push]
+
+jobs:
+  betterer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Use latest Node.js v16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+
+      - name: Yarn cache
+        uses: c-hive/gha-yarn-cache@v2.1.0
+
+      - name: Install JS dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Test TS regression
+        run: yarn betterer ci

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ CHANGELOG.md
 node_modules
 npm-debug.log
 yarn-error.log
+.betterer.cache

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx --no-install lint-staged
-yarn betterer precommit
+yarn betterer precommit --cache

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx --no-install lint-staged
+yarn betterer precommit

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "@babel/preset-env": "7.18.2",
     "@babel/preset-react": "7.17.12",
     "@babel/preset-typescript": "7.17.12",
+    "@betterer/cli": "^5.3.6",
+    "@betterer/typescript": "5.3.6",
     "@faker-js/faker": "6.3.1",
     "@formatjs/cli": "4.8.4",
     "@koush/wrtc": "0.5.3",
@@ -237,7 +239,9 @@
     "translate:extract": "i18next-scanner 'src/{page,script}/**/*.{js,html,htm}'",
     "translate:merge": "formatjs extract --format './bin/translations_extract_formatter.js' --out-file './src/i18n/en-US.json' './src/script/strings.ts'",
     "translate:upload": "yarn translate:merge && ts-node ./bin/translations_upload.ts",
-    "translate:download": "ts-node ./bin/translations_download.ts"
+    "translate:download": "ts-node ./bin/translations_download.ts",
+    "betterer": "betterer",
+    "betterer:conflict": "betterer merge"
   },
   "version": "0.18.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,6 +25,13 @@
   dependencies:
     "@babel/highlight" "^7.16.7"
 
+"@babel/code-frame@^7.10.3":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
+  integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
+  dependencies:
+    "@babel/highlight" "^7.18.6"
+
 "@babel/compat-data@^7.13.11", "@babel/compat-data@^7.14.7", "@babel/compat-data@^7.17.10":
   version "7.17.10"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.17.10.tgz#711dc726a492dfc8be8220028b1b92482362baab"
@@ -322,6 +329,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
   integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
 
+"@babel/helper-validator-identifier@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
+  integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
+
 "@babel/helper-validator-option@^7.14.5", "@babel/helper-validator-option@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz#b203ce62ce5fe153899b617c08957de860de4d23"
@@ -352,6 +364,15 @@
   integrity sha512-aKpPMfLvGO3Q97V0qhw/V2SWNWlwfJknuwAunU7wZLSfrM4xTBvg7E5opUVi1kJTBKihE38CPg4nBiqX83PWYw==
   dependencies:
     "@babel/helper-validator-identifier" "^7.16.7"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
+"@babel/highlight@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.18.6.tgz#81158601e93e2563795adcbfbdf5d64be3f2ecdf"
+  integrity sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.18.6"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
@@ -1167,6 +1188,107 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@betterer/betterer@^5.3.6":
+  version "5.3.6"
+  resolved "https://registry.yarnpkg.com/@betterer/betterer/-/betterer-5.3.6.tgz#1793aeb45284d69beb2490a2db05273f7904fc1a"
+  integrity sha512-FpdVFdrSWLSPZRssuneI0uhqtbzbnQzBYz9hU8Nvl9v1XOILvMuD+lZOywlY9aPsLXuZmzQyxdlY7txHqN6jvg==
+  dependencies:
+    "@betterer/constraints" "^5.3.0"
+    "@betterer/errors" "^5.3.0"
+    "@betterer/logger" "^5.3.4"
+    "@betterer/reporter" "^5.3.6"
+    "@phenomnomnominal/debug" "^0.2.5"
+    "@phenomnomnominal/worker-require" "^0.0.34"
+    chokidar "^3.3.1"
+    djb2a "^1.2.0"
+    fast-memoize "^2.5.2"
+    lines-and-columns "^2.0.3"
+    minimatch "^5.0.1"
+    prettier "^2.3.2"
+    simple-git "^3.6.0"
+    ts-node "^10.2.1"
+    tslib "^2.3.1"
+  optionalDependencies:
+    typescript ">=2.7"
+
+"@betterer/cli@^5.3.6":
+  version "5.3.6"
+  resolved "https://registry.yarnpkg.com/@betterer/cli/-/cli-5.3.6.tgz#dced55e2bac2422af4e8657d7292aa45ec09140d"
+  integrity sha512-OgBNPuCnd1/gV9KG2sFhwkHv+kPWdxnVb5xY5SMmo9NK780KIm2GANv1bYQzWoqCDiOdbRl/OCDlvNDV1pb7/g==
+  dependencies:
+    "@betterer/betterer" "^5.3.6"
+    "@betterer/errors" "^5.3.0"
+    "@betterer/render" "^5.3.4"
+    "@betterer/tasks" "^5.3.6"
+    "@phenomnomnominal/tsquery" "^4.1.1"
+    "@phenomnomnominal/tstemplate" "^0.1.0"
+    "@phenomnomnominal/worker-require" "^0.0.34"
+    chalk "^4.1.2"
+    commander "^8.3.0"
+    find-up "^5.0.0"
+    jest-diff "^27.1.0"
+    prettier "^2.3.2"
+    tslib "^2.3.1"
+
+"@betterer/constraints@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@betterer/constraints/-/constraints-5.3.0.tgz#6009aa179f7995a70c45af2f7a519af62b2e38df"
+  integrity sha512-YmaX30/S4PoYDqGspRmUBeBE1KkLbnSQCndqPar7ZH6sWOIo29d67B7as6ODEmwpJf+GGYfmrGtTJd5c69hTng==
+  dependencies:
+    tslib "^2.3.1"
+
+"@betterer/errors@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@betterer/errors/-/errors-5.3.0.tgz#d84aad0df650598cfbf35de20fca89a356b5be9d"
+  integrity sha512-Z4uCvA2oSuyEHNgIgMUo+WqIP/xwy40mGmkM/cJXLWWQOTOfzELa5CNgyz4t4XNebojko2bja8n2zaXlTUzViw==
+
+"@betterer/logger@^5.3.4":
+  version "5.3.4"
+  resolved "https://registry.yarnpkg.com/@betterer/logger/-/logger-5.3.4.tgz#c746de14d5b919a96adbc830724ee44d90aa3c6d"
+  integrity sha512-Ns4KsZ5G0F5BsBF8K0VkmAUfEGKhgog9kv8QCKuZQQNcPAX5cESIYSeEs5H4bcMDqsk0dW/sQRt/7rZWGlrFSg==
+  dependencies:
+    "@babel/code-frame" "^7.10.3"
+    jest-diff "^27.0.6"
+    lines-and-columns "^2.0.3"
+    tslib "^2.3.1"
+
+"@betterer/render@^5.3.4":
+  version "5.3.4"
+  resolved "https://registry.yarnpkg.com/@betterer/render/-/render-5.3.4.tgz#1e668202b006bb71bca5ee316c114cef85ae4812"
+  integrity sha512-zc91zlLxWafGxG25/kUsCDmxLvQhUb4PNIq4MRU/VpnncyhdelMY5OxaIAxu9IXhJFoC6FRJhL3I7eGdND64zQ==
+
+"@betterer/reporter@^5.3.6":
+  version "5.3.6"
+  resolved "https://registry.yarnpkg.com/@betterer/reporter/-/reporter-5.3.6.tgz#a2f1e72fd4016f6abf63e68dbcfbd77a8b4f8850"
+  integrity sha512-6KTwgjfWi6MKav22utjd97NtVANfxRnWDdMMo10t9mto0Ez71XuOf/Xt0D+2cZ8mhXMfOOCZbzbqQ6+IaTCSlQ==
+  dependencies:
+    "@betterer/betterer" "^5.3.6"
+    "@betterer/errors" "^5.3.0"
+    "@betterer/logger" "^5.3.4"
+    "@betterer/render" "^5.3.4"
+    "@betterer/tasks" "^5.3.6"
+    tslib "^2.3.1"
+
+"@betterer/tasks@^5.3.6":
+  version "5.3.6"
+  resolved "https://registry.yarnpkg.com/@betterer/tasks/-/tasks-5.3.6.tgz#e862e69e09157c5445bad552a0ee8b7b51161136"
+  integrity sha512-UBx+My23z/q4deq5WPGNPDO/8OoK7epPpQftgaD8r1UXeD10aaV8BmjQ70Yjw/EQWDqVBBkDdbwmwspMOHjoMA==
+  dependencies:
+    "@betterer/errors" "^5.3.0"
+    "@betterer/logger" "^5.3.4"
+    "@betterer/render" "^5.3.4"
+    chalk "^4.1.2"
+    tslib "^2.3.1"
+
+"@betterer/typescript@5.3.6":
+  version "5.3.6"
+  resolved "https://registry.yarnpkg.com/@betterer/typescript/-/typescript-5.3.6.tgz#fa446839d9c579f9dc505ebecc9ac1ae82060837"
+  integrity sha512-3A8PHjQ+z5TgM07gpt2zQWcowZKZdtLrqvPv5tIX51w0nrcEojBo9zey+6+YRZC2SuBzUql8XpEc+eF9nBkauw==
+  dependencies:
+    "@betterer/betterer" "^5.3.6"
+    "@betterer/errors" "^5.3.0"
+    tslib "^2.3.1"
+
 "@cspell/cspell-bundled-dicts@^5.20.0":
   version "5.20.0"
   resolved "https://registry.yarnpkg.com/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-5.20.0.tgz#294106a2660baf825494535019a0d2230c3cc0c1"
@@ -1963,6 +2085,37 @@
   version "0.2.0-beta-3"
   resolved "https://registry.yarnpkg.com/@otak/core-crypto/-/core-crypto-0.2.0-beta-3.tgz#1863e9b4152e7db4c96e245cffdfef0ddade670a"
   integrity sha512-KWh9a1Zi+NRgMnouquQVkmuONq630LP9YUcNtuhM39kIfSg6XRFUhIyPhidCb9QGb2zPylls1pHjxrsjHOUcvg==
+
+"@phenomnomnominal/debug@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@phenomnomnominal/debug/-/debug-0.2.5.tgz#cf7931acd4fa1782b47641b67d5cd49e5ae8c844"
+  integrity sha512-5yAKsIqcvKUiTYfsEXTt6wiNW2jWVEpa6ej8RSPSRV681av1APBK+2BpEIdOo9DAmq2bwq45Ry3zi/wxBjndaQ==
+  dependencies:
+    callsite "^1.0.0"
+    esprima "^4.0.1"
+    esquery "^1.3.1"
+    tslib "^2.0.3"
+
+"@phenomnomnominal/tsquery@^4.1.1":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@phenomnomnominal/tsquery/-/tsquery-4.2.0.tgz#7742ff4af12ce673b0b601ba5515c934f1876b14"
+  integrity sha512-hR2U3uVcrrdkuG30ItQ+uFDs4ncZAybxWG0OjTE8ptPzVoU7GVeXpy+vMU8zX9EbmjGeITPw/su5HjYQyAH8bA==
+  dependencies:
+    esquery "^1.0.1"
+
+"@phenomnomnominal/tstemplate@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@phenomnomnominal/tstemplate/-/tstemplate-0.1.0.tgz#125b2617fa8cead47433bbf34ba7ef4e30a7c0f2"
+  integrity sha512-/v+GIVNFHAz4+nQtgy9e5ZAXK3xj6TbP5s9JTpnFuqkcLB+gB2lJ6x/nsDhkKhzR6o4REuzhsYoWYnXqKC/UnQ==
+
+"@phenomnomnominal/worker-require@^0.0.34":
+  version "0.0.34"
+  resolved "https://registry.yarnpkg.com/@phenomnomnominal/worker-require/-/worker-require-0.0.34.tgz#1b11ed024f28cbea741dfad255d077d2d957903a"
+  integrity sha512-2GoVa1PRjrCjOpbMdzsZMQzkx/yFKqWizZc+ZNYSWE+Ym8BG+qAGDcWehUmUmGqy22wS13qitdVt6sR/DAWkIw==
+  dependencies:
+    callsite "^1.0.0"
+    comlink "^4.3.0"
+    tslib "^1.10.0"
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -3518,6 +3671,14 @@ anymatch@^3.0.3:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+anymatch@~3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
+  integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
+
 append-buffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/append-buffer/-/append-buffer-1.0.2.tgz#d8220cf466081525efea50614f3de6514dfa58f1"
@@ -3945,6 +4106,11 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
+binary-extensions@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
+  integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
 bl@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489"
@@ -3989,7 +4155,7 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^3.0.2:
+braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -4089,6 +4255,11 @@ caller-path@^2.0.0:
   integrity sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=
   dependencies:
     caller-callsite "^2.0.0"
+
+callsite@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
+  integrity sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==
 
 callsites@^2.0.0:
   version "2.0.0"
@@ -4243,6 +4414,21 @@ cheerio@^1.0.0-rc.3:
     htmlparser2 "^6.0.0"
     parse5 "^6.0.0"
     parse5-htmlparser2-tree-adapter "^6.0.0"
+
+chokidar@^3.3.1:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
+  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 chownr@^2.0.0:
   version "2.0.0"
@@ -4492,6 +4678,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+comlink@^4.3.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/comlink/-/comlink-4.3.1.tgz#0c6b9d69bcd293715c907c33fe8fc45aecad13c5"
+  integrity sha512-+YbhUdNrpBZggBAHWcgQMLPLH1KDF3wJpeqrCKieWQ8RL7atmgsgTQko1XEBK6PsecfopWNntopJ+ByYG1lRaA==
 
 commander@8, commander@^8.3.0:
   version "8.3.0"
@@ -5221,6 +5412,11 @@ discontinuous-range@1.0.0:
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
   integrity sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=
 
+djb2a@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/djb2a/-/djb2a-1.2.0.tgz#a441d5f49b90b78aac52d2c44f5a6c49b3d1724b"
+  integrity sha512-rXrJYOPCGvHPYw8R2u/zczFTG3xXNqklrtT17vTPm8n/4a16PKEhrfgMwJ9Zyuz96PJwZzHuK2ChQO/SSChuKA==
+
 doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
@@ -5909,7 +6105,7 @@ esprima@^4.0.0, esprima@^4.0.1:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.4.0:
+esquery@^1.0.1, esquery@^1.3.1, esquery@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
   integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
@@ -6081,6 +6277,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fast-memoize@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/fast-memoize/-/fast-memoize-2.5.2.tgz#79e3bb6a4ec867ea40ba0e7146816f6cdce9b57e"
+  integrity sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==
 
 fastest-levenshtein@^1.0.12:
   version "1.0.12"
@@ -6389,7 +6590,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@^2.3.2, fsevents@~2.3.1:
+fsevents@^2.3.2, fsevents@~2.3.1, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -6556,7 +6757,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@^5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -7406,6 +7607,13 @@ is-bigint@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.1.tgz#6923051dfcbc764278540b9ce0e6b3213aa5ebc2"
   integrity sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==
 
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
+
 is-boolean-object@^1.0.1, is-boolean-object@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.0.tgz#e2aaad3a3a8fca34c28f6eee135b156ed2587ff0"
@@ -7534,7 +7742,7 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -7950,7 +8158,7 @@ jest-config@^27.5.1:
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
-jest-diff@^27.5.1:
+jest-diff@^27.0.6, jest-diff@^27.1.0, jest-diff@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.5.1.tgz#a07f5011ac9e6643cf8a95a462b7b1ecf6680def"
   integrity sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==
@@ -8635,6 +8843,11 @@ lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
+
+lines-and-columns@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-2.0.3.tgz#b2f0badedb556b747020ab8ea7f0373e22efac1b"
+  integrity sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==
 
 linkify-it@4.0.1:
   version "4.0.1"
@@ -9449,7 +9662,7 @@ normalize-path@^2.1.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
-normalize-path@^3.0.0:
+normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -9983,15 +10196,15 @@ picomatch@^2.0.4, picomatch@^2.2.2:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
+picomatch@^2.2.1, picomatch@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
 picomatch@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.3.tgz#465547f359ccc206d3c48e46a1bcb89bf7ee619d"
   integrity sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==
-
-picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
 pidtree@^0.5.0:
   version "0.5.0"
@@ -10719,7 +10932,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.7.1:
+prettier@2.7.1, prettier@^2.3.2:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
@@ -11098,6 +11311,13 @@ readdir-glob@^1.0.0:
   integrity sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==
   dependencies:
     minimatch "^3.0.4"
+
+readdirp@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
+  dependencies:
+    picomatch "^2.2.1"
 
 realistic-structured-clone@^2.0.1:
   version "2.0.2"
@@ -11735,7 +11955,7 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
-simple-git@3.10.0:
+simple-git@3.10.0, simple-git@^3.6.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.10.0.tgz#f20031dd121d3c49e215ef0186a102bece3f89b2"
   integrity sha512-2w35xrS5rVtAW0g67LqtxCZN5cdddz/woQRfS0OJXaljXEoTychZ4jnE+CQgra/wX4ZvHeiChTUMenCwfIYEYw==
@@ -12664,7 +12884,7 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
-ts-node@10.8.1:
+ts-node@10.8.1, ts-node@^10.2.1:
   version "10.8.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.8.1.tgz#ea2bd3459011b52699d7e88daa55a45a1af4f066"
   integrity sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==
@@ -12708,6 +12928,11 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.0.3, tslib@^2.3.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tslib@^2.1.0:
   version "2.3.1"
@@ -12788,6 +13013,11 @@ typescript@4.6.4, typescript@^4.5:
   version "4.6.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
+
+typescript@>=2.7:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 typeson-registry@^1.0.0-alpha.20:
   version "1.0.0-alpha.38"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WEBAPP-7144" title="WEBAPP-7144" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WEBAPP-7144</a>  Have a job that checks that the number of strict typescript errors is going down
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Our goal is to make our code compiled with TypeScript **strict** mode. As our codebase is pretty big and currently includes about 2300 ts strict errors (null checks, possible undefineds, etc.) It's not possible to just enable the `strict` mode.

We want to prevent us from pushing more typescript `strict` errors.

### Solutions

I've found pretty cool tool called [Betterer](https://phenomnomnominal.github.io/betterer/), which let us keep track of ts compile errors, and saves them as a snapshot. The tool does not allow to increase the number of specified errors, but each time we reduce the number, the snapshot gets updated 😄 


### Setup

Here is the recommended workflow by tool's authors: https://phenomnomnominal.github.io/betterer/docs/workflow. It seems to match our requirements. How it would basically work:

- there is pre-commit husky hook added which will run after `lint-staged`, so it won't allow us to push if we've added any more ts strict errors.
- there is a ci action that will run and make sure our snapshot is in sync with the errors.
- in case we got any merge conflicts in snapshot file, there is a `yarn betterer:conflict` script which should fix it
- in case something bad happens to the snapshot file, we can force its update with `yarn betterer -u`


### Notes

I've never used this tool before, and I need your opinion. I've tested it out locally and works great!

Our codebase is pretty big and `betterer` command can take long time (about 16s for me) on the first run, but thanks to `--cache` option added  next runs should be much faster.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
