### PR TITLE
runfix: Give fallback domain when showing user modal

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1995,7 +1995,7 @@ exports[`stricter compilation`] = {
     "src/script/main/SingleInstanceHandler.ts:305503035": [
       [118, 6, 27, "Cannot invoke an object which is possibly \'undefined\'.", "107936000"]
     ],
-    "src/script/main/app.ts:2246757944": [
+    "src/script/main/app.ts:1711472333": [
       [156, 2, 5, "Property \'debug\' has no initializer and is not definitely assigned in the constructor.", "164124116"],
       [157, 2, 4, "Property \'util\' has no initializer and is not definitely assigned in the constructor.", "2087972225"],
       [349, 87, 5, "Object is of type \'unknown\'.", "165548477"],
@@ -2005,7 +2005,6 @@ exports[`stricter compilation`] = {
       [485, 27, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'BaseError\'.", "165548477"],
       [503, 36, 11, "Object is possibly \'undefined\'.", "3663176296"],
       [699, 62, 6, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string | null\'.", "1127975365"],
-      [709, 19, 6, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1127975365"],
       [776, 12, 5, "Object is of type \'unknown\'.", "165548477"],
       [830, 81, 5, "Object is of type \'unknown\'.", "165548477"],
       [874, 37, 15, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string | URL\'.\\n  Type \'undefined\' is not assignable to type \'string | URL\'.", "1529230466"]

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -703,7 +703,7 @@ class App {
       '/preferences/av': () => mainView.list.openPreferencesAudioVideo(),
       '/preferences/devices': () => mainView.list.openPreferencesDevices(),
       '/preferences/options': () => mainView.list.openPreferencesOptions(),
-      '/user/:userId(/:domain)': (userId: string, domain?: string) => {
+      '/user/:userId(/:domain)': (userId: string, domain: string = this.apiClient.context!.domain ?? '') => {
         showUserModal({
           actionsViewModel: mainView.actions,
           onClose: () => router.navigate('/'),


### PR DESCRIPTION
With backend API v2, fetching a user requires the domain to be given. 
If the URL is not present in the url params, we then fallback to the domain configured in the apiClient