### PR TITLE
runfix: Always pass qualified id to postMembers method

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1995,7 +1995,7 @@ exports[`stricter compilation`] = {
     "src/script/main/SingleInstanceHandler.ts:305503035": [
       [118, 6, 27, "Cannot invoke an object which is possibly \'undefined\'.", "107936000"]
     ],
-    "src/script/main/app.ts:4190299091": [
+    "src/script/main/app.ts:3587239796": [
       [156, 2, 5, "Property \'debug\' has no initializer and is not definitely assigned in the constructor.", "164124116"],
       [157, 2, 4, "Property \'util\' has no initializer and is not definitely assigned in the constructor.", "2087972225"],
       [349, 87, 5, "Object is of type \'unknown\'.", "165548477"],
@@ -2004,9 +2004,9 @@ exports[`stricter compilation`] = {
       [418, 65, 19, "Argument of type \'import(\\"wire-webapp/node_modules/@wireapp/api-client/src/client/ClientType\\").ClientType | undefined\' is not assignable to parameter of type \'string | number\'.\\n  Type \'undefined\' is not assignable to type \'string | number\'.", "1723063280"],
       [485, 27, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'BaseError\'.", "165548477"],
       [503, 36, 11, "Object is possibly \'undefined\'.", "3663176296"],
-      [776, 12, 5, "Object is of type \'unknown\'.", "165548477"],
-      [830, 81, 5, "Object is of type \'unknown\'.", "165548477"],
-      [874, 37, 15, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string | URL\'.\\n  Type \'undefined\' is not assignable to type \'string | URL\'.", "1529230466"]
+      [778, 12, 5, "Object is of type \'unknown\'.", "165548477"],
+      [832, 81, 5, "Object is of type \'unknown\'.", "165548477"],
+      [876, 37, 15, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string | URL\'.\\n  Type \'undefined\' is not assignable to type \'string | URL\'.", "1529230466"]
     ],
     "src/script/media/MediaConstraintsHandler.test.ts:456751395": [
       [43, 47, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -93,7 +93,7 @@ exports[`stricter compilation`] = {
       [93, 20, 6, "Object is possibly \'null\'.", "1537472717"]
     ],
     "src/script/auth/component/LinkButton.tsx:522804603": [
-      [32, 8, 67, "Type \'(theme: Theme) => CSSObject\' is not assignable to type \'Interpolation<Theme>\'.\\n  Type \'(theme: Theme) => CSSObject\' is not assignable to type \'FunctionInterpolation<Theme>\'.\\n    Types of parameters \'theme\' and \'props\' are incompatible.\\n      Type \'Theme\' is missing the following properties from type \'Theme\': general, Input", "530872600"]
+      [32, 8, 67, "Type \'(theme: Theme) => CSSObject\' is not assignable to type \'Interpolation<Theme>\'.\\n  Type \'(theme: Theme) => CSSObject\' is not assignable to type \'FunctionInterpolation<Theme>\'.\\n    Types of parameters \'theme\' and \'props\' are incompatible.\\n      Type \'Theme\' is missing the following properties from type \'Theme\': general, Input, select, checkbox", "530872600"]
     ],
     "src/script/auth/component/LoginForm.tsx:1467603633": [
       [49, 4, 18, "Object is possibly \'undefined\'.", "3955986040"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -93,7 +93,7 @@ exports[`stricter compilation`] = {
       [93, 20, 6, "Object is possibly \'null\'.", "1537472717"]
     ],
     "src/script/auth/component/LinkButton.tsx:522804603": [
-      [32, 8, 67, "Type \'(theme: Theme) => CSSObject\' is not assignable to type \'Interpolation<Theme>\'.\\n  Type \'(theme: Theme) => CSSObject\' is not assignable to type \'FunctionInterpolation<Theme>\'.\\n    Types of parameters \'theme\' and \'props\' are incompatible.\\n      Type \'Theme\' is missing the following properties from type \'Theme\': general, Input, select, checkbox", "530872600"]
+      [32, 8, 67, "Type \'(theme: Theme) => CSSObject\' is not assignable to type \'Interpolation<Theme>\'.\\n  Type \'(theme: Theme) => CSSObject\' is not assignable to type \'FunctionInterpolation<Theme>\'.\\n    Types of parameters \'theme\' and \'props\' are incompatible.\\n      Type \'Theme\' is missing the following properties from type \'Theme\': general, Input", "530872600"]
     ],
     "src/script/auth/component/LoginForm.tsx:1467603633": [
       [49, 4, 18, "Object is possibly \'undefined\'.", "3955986040"],
@@ -1351,7 +1351,7 @@ exports[`stricter compilation`] = {
       [1182, 12, 35, "Object is possibly \'undefined\'.", "901544345"],
       [1184, 13, 35, "Object is possibly \'undefined\'.", "901544345"]
     ],
-    "src/script/conversation/ConversationRepository.ts:3174583672": [
+    "src/script/conversation/ConversationRepository.ts:500063414": [
       [179, 8, 29, "Argument of type \'(User | undefined)[] | undefined\' is not assignable to parameter of type \'User[] | undefined\'.\\n  Type \'(User | undefined)[]\' is not assignable to type \'User[]\'.", "1506995572"],
       [185, 75, 13, "No overload matches this call.\\n  Overload 1 of 4, \'(value: string | number | Date): Date\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number | Date\'.\\n  Overload 2 of 4, \'(value: string | number): Date\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number\'.", "2642562490"],
       [204, 16, 24, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2322605270"],
@@ -1411,7 +1411,7 @@ exports[`stricter compilation`] = {
       [65, 6, 27, "Object is possibly \'undefined\'.", "2595125417"],
       [93, 54, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"]
     ],
-    "src/script/conversation/ConversationService.ts:112701748": [
+    "src/script/conversation/ConversationService.ts:3614282690": [
       [348, 4, 92, "Type \'Promise<T | undefined>\' is not assignable to type \'Promise<T>\'.\\n  Type \'T | undefined\' is not assignable to type \'T\'.\\n    \'T\' could be instantiated with an arbitrary type which could be unrelated to \'T | undefined\'.", "1764067179"]
     ],
     "src/script/conversation/ConversationState.ts:3761486215": [
@@ -1995,7 +1995,7 @@ exports[`stricter compilation`] = {
     "src/script/main/SingleInstanceHandler.ts:305503035": [
       [118, 6, 27, "Cannot invoke an object which is possibly \'undefined\'.", "107936000"]
     ],
-    "src/script/main/app.ts:1711472333": [
+    "src/script/main/app.ts:4190299091": [
       [156, 2, 5, "Property \'debug\' has no initializer and is not definitely assigned in the constructor.", "164124116"],
       [157, 2, 4, "Property \'util\' has no initializer and is not definitely assigned in the constructor.", "2087972225"],
       [349, 87, 5, "Object is of type \'unknown\'.", "165548477"],
@@ -2004,7 +2004,6 @@ exports[`stricter compilation`] = {
       [418, 65, 19, "Argument of type \'import(\\"wire-webapp/node_modules/@wireapp/api-client/src/client/ClientType\\").ClientType | undefined\' is not assignable to parameter of type \'string | number\'.\\n  Type \'undefined\' is not assignable to type \'string | number\'.", "1723063280"],
       [485, 27, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'BaseError\'.", "165548477"],
       [503, 36, 11, "Object is possibly \'undefined\'.", "3663176296"],
-      [699, 62, 6, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string | null\'.", "1127975365"],
       [776, 12, 5, "Object is of type \'unknown\'.", "165548477"],
       [830, 81, 5, "Object is of type \'unknown\'.", "165548477"],
       [874, 37, 15, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string | URL\'.\\n  Type \'undefined\' is not assignable to type \'string | URL\'.", "1529230466"]

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.9.0",
     "@wireapp/antiscroll-2": "1.3.1",
     "@wireapp/avs": "8.1.17",
-    "@wireapp/core": "28.2.0",
+    "@wireapp/core": "28.3.0",
     "@wireapp/react-ui-kit": "8.7.0",
     "@wireapp/store-engine-dexie": "1.6.10",
     "@wireapp/store-engine-sqleet": "1.7.14",

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1352,7 +1352,7 @@ export class ConversationRepository {
     const userIds = userEntities.map(userEntity => userEntity.qualifiedId);
 
     try {
-      const response = await this.conversation_service.postMembers(conversationEntity.id, userIds);
+      const response = await this.conversation_service.postMembers(conversationEntity.qualifiedId, userIds);
       if (response) {
         this.eventRepository.injectEvent(response, EventRepository.SOURCE.BACKEND_RESPONSE);
       }

--- a/src/script/conversation/ConversationService.ts
+++ b/src/script/conversation/ConversationService.ts
@@ -327,7 +327,7 @@ export class ConversationService {
    * @param userIds IDs of users to be added to the conversation
    * @returns Resolves with the server response
    */
-  postMembers(conversationId: string, userIds: QualifiedId[]): Promise<ConversationMemberJoinEvent> {
+  postMembers(conversationId: QualifiedId, userIds: QualifiedId[]): Promise<ConversationMemberJoinEvent> {
     return this.apiClient.api.conversation.postMembers(conversationId, userIds);
   }
 

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -696,14 +696,16 @@ class App {
     }
 
     const router = new Router({
-      '/conversation/:conversationId(/:domain)': (conversationId: string, domain?: string) =>
-        mainView.content.showConversation(conversationId, {}, domain),
+      '/conversation/:conversationId(/:domain)': (
+        conversationId: string,
+        domain: string = this.apiClient.context?.domain ?? '',
+      ) => mainView.content.showConversation(conversationId, {}, domain),
       '/preferences/about': () => mainView.list.openPreferencesAbout(),
       '/preferences/account': () => mainView.list.openPreferencesAccount(),
       '/preferences/av': () => mainView.list.openPreferencesAudioVideo(),
       '/preferences/devices': () => mainView.list.openPreferencesDevices(),
       '/preferences/options': () => mainView.list.openPreferencesOptions(),
-      '/user/:userId(/:domain)': (userId: string, domain: string = this.apiClient.context!.domain ?? '') => {
+      '/user/:userId(/:domain)': (userId: string, domain: string = this.apiClient.context?.domain ?? '') => {
         showUserModal({
           actionsViewModel: mainView.actions,
           onClose: () => router.navigate('/'),

--- a/src/script/team/TeamService.ts
+++ b/src/script/team/TeamService.ts
@@ -107,12 +107,7 @@ export class TeamService {
         [FEATURE_KEY.SSO]: {
           status: FeatureStatus.ENABLED,
         },
-        [FEATURE_KEY.MLS]: {
-          config: {
-            allowList: [],
-          },
-          status: FeatureStatus.DISABLED,
-        },
+        [FEATURE_KEY.MLS]: undefined,
         [FEATURE_KEY.VALIDATE_SAML_EMAILS]: {
           status: FeatureStatus.ENABLED,
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3145,10 +3145,10 @@
   resolved "https://registry.yarnpkg.com/@wireapp/antiscroll-2/-/antiscroll-2-1.3.1.tgz#bcb66f72c6dadc306e43235256b768ed3f89039c"
   integrity sha512-vWmWYAzSdyxs+xlgSPGtiNSTCM1z0nxM+jSPa/xz1/kuFKy80BrJP5xaGwNNLljBAz8ymlSPUUZlylUd0tFr1Q==
 
-"@wireapp/api-client@19.9.0":
-  version "19.9.0"
-  resolved "https://registry.yarnpkg.com/@wireapp/api-client/-/api-client-19.9.0.tgz#92e5d026bd2e302a98cf095b53c2d71f11705a10"
-  integrity sha512-g/YOdbuh9/x5/SAy31r6GRkqwI9K/dmqz0MOxYvbiwtXpq7eZB1c1IT78GBONwLKD4/TX+cOPqOa1hJ09dAWEA==
+"@wireapp/api-client@19.11.0":
+  version "19.11.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/api-client/-/api-client-19.11.0.tgz#cee107273c6b8e160c2eae5cbf443f852415a362"
+  integrity sha512-0EfJt3nPyQvAFaSkaZ0AVg3C4Ee2qybnjsDv5rMClo8busGgrIW5MzLH7Cf05ZA2zcME/O8UW4VrQSYd3hGe3g==
   dependencies:
     "@types/node" "~14"
     "@types/spark-md5" "3.0.2"
@@ -3202,16 +3202,16 @@
     logdown "3.3.1"
     rimraf "3.0.2"
 
-"@wireapp/core@28.2.0":
-  version "28.2.0"
-  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-28.2.0.tgz#72bc962a19b3c230a66de49d3353a13912097e4d"
-  integrity sha512-6hhGyRDWHDPDmKqcVpIdQxxOBlGsE0NWtK9a8gh+Isl34G83wL/lvVz/mOrCR48GW9v9C0ofmsFgMzUhpOUS8A==
+"@wireapp/core@28.3.0":
+  version "28.3.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-28.3.0.tgz#6f408731f476ba0d5ed92216f2fd5005e707a771"
+  integrity sha512-CmMnUVTViiEKqJsVhK8n0E8ubiUF3INTILDymcG6d2B0OOgcaF/qtG5Cjabg7e0QgojZ8eLXVkPMJzl/5ULPbA==
   dependencies:
     "@open-wc/webpack-import-meta-loader" "0.4.7"
     "@otak/core-crypto" "0.3.0-beta-1"
     "@types/long" "4.0.1"
     "@types/node" "~14"
-    "@wireapp/api-client" "19.9.0"
+    "@wireapp/api-client" "19.11.0"
     "@wireapp/cryptobox" "12.8.0"
     bazinga64 "5.10.0"
     hash.js "1.1.7"


### PR DESCRIPTION
With backend API v2, the `POST /conversation/:id/members` has become qualified `POST /conversation/:domain/:id/members`. We need to pass it qualified ids

Needs :
- [ ] https://github.com/wireapp/wire-web-packages/pull/4312