### PR TITLE
fix: dark mode checkbox border colour(ACC-194)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1359,6 +1359,8 @@ exports[`stricter compilation`] = {
       [225, 10, 12, "Object is possibly \'undefined\'.", "1670678216"],
       [320, 6, 18, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "1508601427"],
       [334, 43, 15, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1177570679"],
+      [399, 14, 14, "Property \'creator_client\' does not exist on type \'NewConversation & { conversation_role: string; }\'.", "2928040639"],
+      [400, 14, 10, "Property \'selfUserId\' does not exist on type \'NewConversation & { conversation_role: string; }\'.", "1576755397"],
       [467, 8, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'BackendClientError\'.", "165548477"],
       [507, 10, 13, "Object is of type \'unknown\'.", "2758364324"],
       [513, 8, 13, "Argument of type \'unknown\' is not assignable to parameter of type \'Error | undefined\'.", "2758364324"],
@@ -1412,6 +1414,7 @@ exports[`stricter compilation`] = {
       [93, 54, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"]
     ],
     "src/script/conversation/ConversationService.ts:3614282690": [
+      [330, 55, 14, "Argument of type \'QualifiedId\' is not assignable to parameter of type \'string\'.", "2597408709"],
       [348, 4, 92, "Type \'Promise<T | undefined>\' is not assignable to type \'Promise<T>\'.\\n  Type \'T | undefined\' is not assignable to type \'T\'.\\n    \'T\' could be instantiated with an arbitrary type which could be unrelated to \'T | undefined\'.", "1764067179"]
     ],
     "src/script/conversation/ConversationState.ts:3761486215": [

--- a/.betterer.results
+++ b/.betterer.results
@@ -1359,8 +1359,6 @@ exports[`stricter compilation`] = {
       [225, 10, 12, "Object is possibly \'undefined\'.", "1670678216"],
       [320, 6, 18, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "1508601427"],
       [334, 43, 15, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1177570679"],
-      [399, 14, 14, "Property \'creator_client\' does not exist on type \'NewConversation & { conversation_role: string; }\'.", "2928040639"],
-      [400, 14, 10, "Property \'selfUserId\' does not exist on type \'NewConversation & { conversation_role: string; }\'.", "1576755397"],
       [467, 8, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'BackendClientError\'.", "165548477"],
       [507, 10, 13, "Object is of type \'unknown\'.", "2758364324"],
       [513, 8, 13, "Argument of type \'unknown\' is not assignable to parameter of type \'Error | undefined\'.", "2758364324"],
@@ -1414,7 +1412,6 @@ exports[`stricter compilation`] = {
       [93, 54, 4, "Argument of type \'null\' is not assignable to parameter of type \'string | undefined\'.", "2087897566"]
     ],
     "src/script/conversation/ConversationService.ts:3614282690": [
-      [330, 55, 14, "Argument of type \'QualifiedId\' is not assignable to parameter of type \'string\'.", "2597408709"],
       [348, 4, 92, "Type \'Promise<T | undefined>\' is not assignable to type \'Promise<T>\'.\\n  Type \'T | undefined\' is not assignable to type \'T\'.\\n    \'T\' could be instantiated with an arbitrary type which could be unrelated to \'T | undefined\'.", "1764067179"]
     ],
     "src/script/conversation/ConversationState.ts:3761486215": [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@wireapp/antiscroll-2": "1.3.1",
     "@wireapp/avs": "8.1.17",
     "@wireapp/core": "28.3.0",
-    "@wireapp/react-ui-kit": "8.7.0",
+    "@wireapp/react-ui-kit": "file:.yalc/@wireapp/react-ui-kit",
     "@wireapp/store-engine-dexie": "1.6.10",
     "@wireapp/store-engine-sqleet": "1.7.14",
     "@wireapp/webapp-events": "0.13.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@wireapp/antiscroll-2": "1.3.1",
     "@wireapp/avs": "8.1.17",
     "@wireapp/core": "28.3.0",
-    "@wireapp/react-ui-kit": "file:.yalc/@wireapp/react-ui-kit",
+    "@wireapp/react-ui-kit": "8.7.3",
     "@wireapp/store-engine-dexie": "1.6.10",
     "@wireapp/store-engine-sqleet": "1.7.14",
     "@wireapp/webapp-events": "0.13.2",

--- a/src/style/foundation/themes.less
+++ b/src/style/foundation/themes.less
@@ -146,7 +146,7 @@ body.theme-dark {
   @checkbox-background-selected: @blue-dark-500;
   @checkbox-background-disabled: @gray-90;
   @checkbox-background-disabled-selected: @gray-80;
-  @checkbox-border: @gray-80;
+  @checkbox-border: @gray-60;
   @checkbox-border-hover: @blue-dark-500;
   @checkbox-border-disabled: @gray-70;
   @checkbox-alert: @red-dark-500;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3280,10 +3280,10 @@
   dependencies:
     protobufjs "6.10.2"
 
-"@wireapp/react-ui-kit@8.7.0":
-  version "8.7.0"
-  resolved "https://registry.yarnpkg.com/@wireapp/react-ui-kit/-/react-ui-kit-8.7.0.tgz#7bd99e17ed847dffc7507862c2760c490c34dde9"
-  integrity sha512-15rTtYjFRrBk5cNT5qzGZXsOPhwGGzuY9neMHxQnyeUSA5XCi+pr5moBsjYZ/WluukwSQef4srJOlfUd1eKfEg==
+"@wireapp/react-ui-kit@8.7.3":
+  version "8.7.3"
+  resolved "https://registry.yarnpkg.com/@wireapp/react-ui-kit/-/react-ui-kit-8.7.3.tgz#1d974b0d462594feac83737c564ad901c56ff998"
+  integrity sha512-dahNq3UUQbES1+uAVuLn6dYqjaO3zCzVSwlw89+ZB4xRUTj1YnmHOf0VPpQFLaR8pzBnfkc0/ZgZ7PjytMEpZQ==
   dependencies:
     "@emotion/react" "11.9.0"
     "@types/color" "3.0.2"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-194" title="ACC-194" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-194</a>  All checkboxes under the “copy profile” option in “accounts” focus is not clearly visible
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

- checkbox border colour and background colour same made the checkbox invisble

### Solutions

- use checkbox colour as specified in the mock

### Testing

#### How to Test

- create account auth screen checkbox for terms and condition should be visible.

