### PR TITLE
runfix: render modals in main instead of body acc-201

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2428,7 +2428,7 @@ exports[`stricter compilation`] = {
       [166, 51, 4, "Argument of type \'string | null\' is not assignable to parameter of type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "2087822780"],
       [204, 71, 22, "Argument of type \'Token[] | null\' is not assignable to parameter of type \'Token[]\'.\\n  Type \'null\' is not assignable to type \'Token[]\'.", "525880250"]
     ],
-    "src/script/util/renderModal.ts:2732089643": [
+    "src/script/util/renderModal.ts:1796177515": [
       [29, 4, 14, "Type \'undefined\' is not assignable to type \'HTMLDivElement\'.", "4001065193"]
     ],
     "src/script/util/test/TestPage.tsx:1772987669": [

--- a/src/script/util/renderModal.ts
+++ b/src/script/util/renderModal.ts
@@ -26,7 +26,7 @@ let reactRoot: Root;
 const cleanUp = () => {
   if (modalContainer) {
     reactRoot.unmount();
-    document.getElementById('wire-main').removeChild(modalContainer);
+    document.getElementById('wire-main')?.removeChild(modalContainer);
     modalContainer = undefined;
   }
 };
@@ -40,7 +40,7 @@ const renderModal =
   (props: T) => {
     cleanUp();
     modalContainer = document.createElement('div');
-    document.getElementById('wire-main').appendChild(modalContainer);
+    document.getElementById('wire-main')?.appendChild(modalContainer);
 
     reactRoot = createRoot(modalContainer);
     const onClose = () => {

--- a/src/script/util/renderModal.ts
+++ b/src/script/util/renderModal.ts
@@ -26,7 +26,7 @@ let reactRoot: Root;
 const cleanUp = () => {
   if (modalContainer) {
     reactRoot.unmount();
-    document.body.removeChild(modalContainer);
+    document.getElementById('wire-main').removeChild(modalContainer);
     modalContainer = undefined;
   }
 };
@@ -40,7 +40,7 @@ const renderModal =
   (props: T) => {
     cleanUp();
     modalContainer = document.createElement('div');
-    document.body.appendChild(modalContainer);
+    document.getElementById('wire-main').appendChild(modalContainer);
 
     reactRoot = createRoot(modalContainer);
     const onClose = () => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-201" title="ACC-201" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-201</a>  [Web] The button to add a service to a conversation is almost invisible
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

---
# What's new in this PR?

### Issues

- Button in the service modal has illegible text
![81e216c1-4368-4339-8c03-14b6ea963b4a](https://user-images.githubusercontent.com/78490891/178001942-fddd6a25-a686-4786-8f27-127151df12c1.png)

### Causes (Optional)

- The new renderModal Util renders modals in the body instead of #wire-main. Accent color variables are only accessible in #wire-main.

### Solutions

- Render the modals in #wire-main.
![image](https://user-images.githubusercontent.com/78490891/178002589-a0a9b9ea-6aba-428b-9aa9-ef1d49ef6cf9.png)

