### PR TITLE
runfix: restore removed data-uie-name

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2104,7 +2104,7 @@ exports[`stricter compilation`] = {
       [92, 79, 34, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.", "212151669"],
       [120, 6, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"]
     ],
-    "src/script/page/MainContent/panels/preferences/accountPreferences/AccountInput.tsx:3749980777": [
+    "src/script/page/MainContent/panels/preferences/accountPreferences/AccountInput.tsx:3399271415": [
       [182, 10, 4, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2087876002"],
       [183, 10, 5, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "189936718"],
       [189, 30, 5, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "178805363"]

--- a/src/script/page/MainContent/panels/preferences/accountPreferences/AccountInput.tsx
+++ b/src/script/page/MainContent/panels/preferences/accountPreferences/AccountInput.tsx
@@ -148,7 +148,7 @@ const AccountInput: React.FC<AccountInputProps> = ({
                 css={{
                   margin: '0.5rem',
                 }}
-                data-uie-name={`${iconUiePrefix}-icon-check`}
+                data-uie-name={`go-edit-${fieldName}`}
                 onClick={() => {
                   setIsEditingExternal?.(true);
                   setIsEditing(true);


### PR DESCRIPTION
----

# What's new in this PR?

### Issues

- Tests are failing

### Causes (Optional)

- Copied the wrong data-uie-name while changing the edit button in account preferences

### Solutions

- Restore the correct data-uie-name
