### PR TITLE
runfix: prevent modals to close on key press

### DIFF
--- a/src/script/components/ModalComponent.tsx
+++ b/src/script/components/ModalComponent.tsx
@@ -138,7 +138,7 @@ const ModalComponent: React.FC<ModalComponentProps> = ({
       style={{display: displayNone ? 'none' : 'flex'}}
       tabIndex={0}
       role="button"
-      onKeyDown={onBgClick}
+      onKeyDown={noop}
       {...rest}
     >
       {showLoading ? (


### PR DESCRIPTION
----

# What's new in this PR?

### Issues

- Invite modal closes on any key press

### Causes (Optional)

- The onBgClick property of modal components is triggered on click and on key presses. The onKeyDown event was only added to fix linting issue related to accessibility but is not needed.

### Solutions

- replace `onKeyDown={onBgClick}` by `onKeyDown={noop}`