### PR TITLE
fix: sidebar focus not clearly visible(ACC-204)

### DIFF
--- a/src/style/list/list.less
+++ b/src/style/list/list.less
@@ -146,8 +146,21 @@ body.theme-dark {
     text-align: left;
     transition: background-color 0.15s ease-in-out;
 
-    &:hover {
+    &:hover,
+    &:focus-visible,
+    &--active:focus-visible {
       background: @white;
+      color: @black;
+    }
+
+    &:focus-visible,
+    &--active:focus-visible {
+      outline: 1px solid var(--accent-color);
+      outline-offset: -2px;
+
+      .left-column-icon > svg {
+        fill: @black;
+      }
     }
 
     &--active,
@@ -246,13 +259,24 @@ body.theme-dark {
   }
 
   .left-list-item-button {
-    &:hover {
-      background: @gray-95;
+    &:hover,
+    &:focus-visible,
+    &--active:focus-visible {
+      background: @black;
+      color: @white;
     }
+    &:focus-visible,
+    &--active:focus-visible {
+      outline: 1px solid var(--accent-color);
+      outline-offset: -2px;
 
+      .left-column-icon > svg {
+        fill: @white;
+      }
+    }
     &--active,
     &--active:hover {
-      background-color: var(--accent-color-600) !important;
+      background-color: var(--accent-color-600);
       color: var(--black);
 
       .left-column-icon > svg {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-204" title="ACC-204" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-204</a>  Sidebar focus is not visible
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

Sidebar elements focus is not clearly indicated. Sidebar element hover and focus state was wrong.

### Solutions

create an outline to be clearly visible on focus. Fix hover states as described in the mock.

### Testing

#### How to Test

- sidebar focus and hover state should match the mock. Sidebar focus should be clearly indicated.

----
##### References
1. https://www.figma.com/file/OrP9jAJdfttfvsm3nxnihP/Accessibility-Quick-Wins-(Web%2FDesktop)?node-id=293%3A2964
