### PR TITLE
runfix: remove applock keyboard trap acc-75

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2065,12 +2065,11 @@ exports[`stricter compilation`] = {
       [106, 37, 12, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1912908196"],
       [178, 35, 12, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1912908196"]
     ],
-    "src/script/page/AppLock.tsx:218288677": [
-      [165, 28, 36, "Argument of type \'Element | null\' is not assignable to parameter of type \'Node\'.\\n  Type \'null\' is not assignable to type \'Node\'.", "3019440182"],
-      [169, 26, 30, "Argument of type \'Element | null\' is not assignable to parameter of type \'Node\'.\\n  Type \'null\' is not assignable to type \'Node\'.", "1790131128"],
-      [197, 59, 37, "Object is possibly \'null\'.", "3700925542"],
-      [218, 94, 4, "Argument of type \'unknown\' is not assignable to parameter of type \'StatusCodes\'.", "2087770728"],
-      [221, 19, 7, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<string>\'.", "1236122734"]
+    "src/script/page/AppLock.tsx:877948654": [
+      [162, 28, 36, "Argument of type \'Element | null\' is not assignable to parameter of type \'Node\'.\\n  Type \'null\' is not assignable to type \'Node\'.", "3019440182"],
+      [166, 26, 30, "Argument of type \'Element | null\' is not assignable to parameter of type \'Node\'.\\n  Type \'null\' is not assignable to type \'Node\'.", "1790131128"],
+      [215, 94, 4, "Argument of type \'unknown\' is not assignable to parameter of type \'StatusCodes\'.", "2087770728"],
+      [218, 19, 7, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<string>\'.", "1236122734"]
     ],
     "src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx:3232925700": [
       [104, 10, 15, "Type \'(conversation: Conversation) => boolean\' is not assignable to type \'(conversationId: QualifiedId) => boolean\'.\\n  Types of parameters \'conversation\' and \'conversationId\' are incompatible.\\n    Type \'QualifiedId\' is missing the following properties from type \'Conversation\': teamState, archivedState, incomingMessages, isManaged, and 118 more.", "1629494677"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -2068,6 +2068,7 @@ exports[`stricter compilation`] = {
     "src/script/page/AppLock.tsx:877948654": [
       [162, 28, 36, "Argument of type \'Element | null\' is not assignable to parameter of type \'Node\'.\\n  Type \'null\' is not assignable to type \'Node\'.", "3019440182"],
       [166, 26, 30, "Argument of type \'Element | null\' is not assignable to parameter of type \'Node\'.\\n  Type \'null\' is not assignable to type \'Node\'.", "1790131128"],
+      [194, 59, 37, "Object is possibly \'null\'.", "3700925542"],
       [215, 94, 4, "Argument of type \'unknown\' is not assignable to parameter of type \'StatusCodes\'.", "2087770728"],
       [218, 19, 7, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<string>\'.", "1236122734"]
     ],

--- a/src/script/page/AppLock.tsx
+++ b/src/script/page/AppLock.tsx
@@ -83,9 +83,6 @@ const AppLock: React.FC<AppLockProps> = ({
     'isAppLockEnforced',
   ]);
 
-  const focusElement = (input: HTMLInputElement) => setTimeout(() => input?.focus());
-  const forceFocus = ({target}: React.FocusEvent<HTMLInputElement>) => focusElement(target);
-
   const {current: appObserver} = useRef(
     new MutationObserver(mutationRecords => {
       const [{attributeName}] = mutationRecords;
@@ -294,7 +291,10 @@ const AppLock: React.FC<AppLockProps> = ({
             <div className="modal__text modal__label" data-uie-name="label-applock-unlock-text">
               {t('modalAppLockPasscode')}
             </div>
+            {/* eslint jsx-a11y/no-autofocus : "off" */}
             <input
+              aria-label={t('modalAppLockSetupTitle')}
+              autoFocus
               className="modal__input"
               type="password"
               value={setupPassphrase}
@@ -302,8 +302,6 @@ const AppLock: React.FC<AppLockProps> = ({
               data-uie-status={isSetupPassphraseValid ? 'valid' : 'invalid'}
               data-uie-name="input-applock-set-a"
               autoComplete="new-password"
-              onBlur={forceFocus}
-              ref={focusElement}
             />
             <div
               className={`modal__passcode__info ${isSetupPassphraseLength ? 'modal__passcode__info--valid' : ''}`}
@@ -381,6 +379,8 @@ const AppLock: React.FC<AppLockProps> = ({
               {t('modalAppLockPasscode')}
             </div>
             <input
+              aria-label={t('modalAppLockSetupChangeTitle')}
+              autoFocus
               className="modal__input"
               type="password"
               value={setupPassphrase}
@@ -388,8 +388,6 @@ const AppLock: React.FC<AppLockProps> = ({
               data-uie-status={isSetupPassphraseValid ? 'valid' : 'invalid'}
               data-uie-name="input-applock-set-a"
               autoComplete="new-password"
-              onBlur={forceFocus}
-              ref={focusElement}
             />
             <div className={`modal__passcode__info ${isSetupPassphraseLength ? 'modal__passcode__info--valid' : ''}`}>
               {t('modalAppLockSetupLong', {
@@ -427,6 +425,8 @@ const AppLock: React.FC<AppLockProps> = ({
               {t('modalAppLockPasscode')}
             </div>
             <input
+              aria-label={t('modalAppLockLockedTitle')}
+              autoFocus
               className="modal__input"
               type="password"
               id={Math.random().toString()}
@@ -434,8 +434,6 @@ const AppLock: React.FC<AppLockProps> = ({
               onKeyDown={clearUnlockError}
               data-uie-name="input-applock-unlock"
               autoComplete="new-password"
-              onBlur={forceFocus}
-              ref={focusElement}
             />
             <div className="modal__input__error" data-uie-name="label-applock-unlock-error">
               {unlockError}
@@ -510,6 +508,8 @@ const AppLock: React.FC<AppLockProps> = ({
         {state === APPLOCK_STATE.WIPE_PASSWORD && (
           <form onSubmit={onWipeDatabase}>
             <input
+              aria-label={t('modalAppLockWipePasswordTitle')}
+              autoFocus
               className="modal__input"
               type="password"
               name="password"
@@ -517,8 +517,6 @@ const AppLock: React.FC<AppLockProps> = ({
               placeholder={t('modalAppLockWipePasswordPlaceholder')}
               onKeyDown={clearWipeError}
               data-uie-name="input-applock-wipe"
-              onBlur={forceFocus}
-              ref={focusElement}
             />
             <div className="modal__input__error" style={{height: 20}} data-uie-name="label-applock-wipe-error">
               {wipeError}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-75" title="ACC-75" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-75</a>  9.2.1.2 No keyboard traps
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----

# What's new in this PR?

### Issues

- The AppLock modal has a deliberate hard keyboard trap in the password input

### Solutions

- Replace the keyboard trap by React autoFocus prop, and add the correct aria-labels to the inputs

![image](https://user-images.githubusercontent.com/78490891/178557693-3ed7c19b-edac-4c72-81cf-3969467dcd81.png)


