### PR TITLE
fix: messages bigger than viewport not being read (#SQSERVICES-1558)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -850,13 +850,13 @@ exports[`stricter compilation`] = {
       [93, 10, 23, "Type \'Observable<VerificationMessageType.NEW_DEVICE>\' is not assignable to type \'Observable<VerificationMessageType>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'VerificationMessageType\' is not assignable to type \'VerificationMessageType.NEW_DEVICE\'.", "3608773647"],
       [107, 10, 23, "Type \'Observable<VerificationMessageType.NEW_MEMBER>\' is not assignable to type \'Observable<VerificationMessageType>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'VerificationMessageType\' is not assignable to type \'VerificationMessageType.NEW_MEMBER\'.", "3608773647"]
     ],
-    "src/script/components/MessagesList/Message/index.tsx:1724729952": [
+    "src/script/components/MessagesList/Message/index.tsx:2435315203": [
       [87, 51, 15, "Argument of type \'Message | undefined\' is not assignable to parameter of type \'Message\'.\\n  Type \'undefined\' is not assignable to type \'Message\'.", "1976601247"],
       [91, 6, 14, "Cannot invoke an object which is possibly \'undefined\'.", "4289202771"],
       [91, 36, 7, "Type \'HTMLDivElement | undefined\' is not assignable to type \'HTMLElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLElement\'.", "4115912507"],
       [93, 6, 14, "Cannot invoke an object which is possibly \'undefined\'.", "4289202771"],
       [93, 22, 7, "Type \'HTMLDivElement | undefined\' is not assignable to type \'HTMLElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLElement\'.", "4115912507"],
-      [118, 6, 3, "Type \'MutableRefObject<HTMLDivElement | undefined>\' is not assignable to type \'LegacyRef<HTMLDivElement> | undefined\'.", "193432436"]
+      [118, 6, 3, "Type \'MutableRefObject<HTMLDivElement | undefined>\' is not assignable to type \'LegacyRef<HTMLDivElement> | undefined\'.\\n  Type \'MutableRefObject<HTMLDivElement | undefined>\' is not assignable to type \'RefObject<HTMLDivElement>\'.\\n    Types of property \'current\' are incompatible.\\n      Type \'HTMLDivElement | undefined\' is not assignable to type \'HTMLDivElement | null\'.\\n        Type \'undefined\' is not assignable to type \'HTMLDivElement | null\'.", "193432436"]
     ],
     "src/script/components/MessagesList/index.test.tsx:3039094850": [
       [41, 4, 14, "Type \'undefined\' is not assignable to type \'Message\'.", "1306210352"],
@@ -893,7 +893,7 @@ exports[`stricter compilation`] = {
       [128, 42, 8, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4039656867"],
       [144, 9, 13, "Type \'{ clickToShowSelfFingerprint: () => void; clientRepository: ClientRepository; cryptographyRepository: CryptographyRepository; logger: Logger; messageRepository: MessageRepository; noPadding: boolean; selectedClient: ClientEntity | undefined; user: User; }\' is not assignable to type \'DeviceDetailsProps\'.\\n  Types of property \'selectedClient\' are incompatible.\\n    Type \'ClientEntity | undefined\' is not assignable to type \'ClientEntity\'.\\n      Type \'undefined\' is not assignable to type \'ClientEntity\'.", "538994175"]
     ],
-    "src/script/components/UserList.tsx:541400935": [
+    "src/script/components/UserList.tsx:2117159562": [
       [97, 28, 12, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Partial<Record<\\"roles\\", Subscribable<any>>>\'.\\n  Type \'undefined\' is not assignable to type \'Partial<Record<\\"roles\\", Subscribable<any>>>\'.", "1670678216"]
     ],
     "src/script/components/UserSearchableList.tsx:1290904950": [
@@ -1082,10 +1082,6 @@ exports[`stricter compilation`] = {
     "src/script/components/toggle/ReceiptModeToggle.test.ts:3769197722": [
       [42, 11, 8, "Object is possibly \'null\'.", "2071428406"],
       [53, 11, 8, "Object is possibly \'null\'.", "2071428406"]
-    ],
-    "src/script/components/utils/InViewport.tsx:954388960": [
-      [68, 6, 21, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement | undefined\'.\\n  Type \'null\' is not assignable to type \'HTMLElement | undefined\'.", "2791404919"],
-      [78, 9, 3, "Type \'MutableRefObject<HTMLDivElement | undefined>\' is not assignable to type \'LegacyRef<HTMLDivElement> | undefined\'.\\n  Type \'MutableRefObject<HTMLDivElement | undefined>\' is not assignable to type \'RefObject<HTMLDivElement>\'.\\n    Types of property \'current\' are incompatible.\\n      Type \'HTMLDivElement | undefined\' is not assignable to type \'HTMLDivElement | null\'.\\n        Type \'undefined\' is not assignable to type \'HTMLDivElement | null\'.", "193432436"]
     ],
     "src/script/connection/ConnectionEntity.ts:2779957789": [
       [41, 4, 19, "Type \'null\' is not assignable to type \'QualifiedId\'.", "59414957"],
@@ -2558,7 +2554,7 @@ exports[`stricter compilation`] = {
       [51, 4, 22, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "2603921936"],
       [89, 31, 43, "Object is possibly \'null\'.", "1853768633"]
     ],
-    "src/script/view_model/bindings/CommonBindings.ts:3939643793": [
+    "src/script/view_model/bindings/CommonBindings.ts:4259167057": [
       [44, 6, 32, "Object is possibly \'null\'.", "3763860455"],
       [83, 63, 13, "Object is possibly \'null\'.", "115063321"],
       [83, 86, 13, "Object is possibly \'null\'.", "115063321"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -850,13 +850,13 @@ exports[`stricter compilation`] = {
       [93, 10, 23, "Type \'Observable<VerificationMessageType.NEW_DEVICE>\' is not assignable to type \'Observable<VerificationMessageType>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'VerificationMessageType\' is not assignable to type \'VerificationMessageType.NEW_DEVICE\'.", "3608773647"],
       [107, 10, 23, "Type \'Observable<VerificationMessageType.NEW_MEMBER>\' is not assignable to type \'Observable<VerificationMessageType>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'VerificationMessageType\' is not assignable to type \'VerificationMessageType.NEW_MEMBER\'.", "3608773647"]
     ],
-    "src/script/components/MessagesList/Message/index.tsx:360781890": [
+    "src/script/components/MessagesList/Message/index.tsx:1724729952": [
       [87, 51, 15, "Argument of type \'Message | undefined\' is not assignable to parameter of type \'Message\'.\\n  Type \'undefined\' is not assignable to type \'Message\'.", "1976601247"],
       [91, 6, 14, "Cannot invoke an object which is possibly \'undefined\'.", "4289202771"],
       [91, 36, 7, "Type \'HTMLDivElement | undefined\' is not assignable to type \'HTMLElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLElement\'.", "4115912507"],
       [93, 6, 14, "Cannot invoke an object which is possibly \'undefined\'.", "4289202771"],
       [93, 22, 7, "Type \'HTMLDivElement | undefined\' is not assignable to type \'HTMLElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLElement\'.", "4115912507"],
-      [112, 6, 3, "Type \'MutableRefObject<HTMLDivElement | undefined>\' is not assignable to type \'LegacyRef<HTMLDivElement> | undefined\'.", "193432436"]
+      [118, 6, 3, "Type \'MutableRefObject<HTMLDivElement | undefined>\' is not assignable to type \'LegacyRef<HTMLDivElement> | undefined\'.", "193432436"]
     ],
     "src/script/components/MessagesList/index.test.tsx:3039094850": [
       [41, 4, 14, "Type \'undefined\' is not assignable to type \'Message\'.", "1306210352"],
@@ -1083,9 +1083,9 @@ exports[`stricter compilation`] = {
       [42, 11, 8, "Object is possibly \'null\'.", "2071428406"],
       [53, 11, 8, "Object is possibly \'null\'.", "2071428406"]
     ],
-    "src/script/components/utils/InViewport.tsx:2602655444": [
-      [60, 6, 21, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "2791404919"],
-      [70, 9, 3, "Type \'MutableRefObject<HTMLDivElement | undefined>\' is not assignable to type \'LegacyRef<HTMLDivElement> | undefined\'.\\n  Type \'MutableRefObject<HTMLDivElement | undefined>\' is not assignable to type \'RefObject<HTMLDivElement>\'.\\n    Types of property \'current\' are incompatible.\\n      Type \'HTMLDivElement | undefined\' is not assignable to type \'HTMLDivElement | null\'.\\n        Type \'undefined\' is not assignable to type \'HTMLDivElement | null\'.", "193432436"]
+    "src/script/components/utils/InViewport.tsx:954388960": [
+      [68, 6, 21, "Argument of type \'HTMLElement | null\' is not assignable to parameter of type \'HTMLElement | undefined\'.\\n  Type \'null\' is not assignable to type \'HTMLElement | undefined\'.", "2791404919"],
+      [78, 9, 3, "Type \'MutableRefObject<HTMLDivElement | undefined>\' is not assignable to type \'LegacyRef<HTMLDivElement> | undefined\'.\\n  Type \'MutableRefObject<HTMLDivElement | undefined>\' is not assignable to type \'RefObject<HTMLDivElement>\'.\\n    Types of property \'current\' are incompatible.\\n      Type \'HTMLDivElement | undefined\' is not assignable to type \'HTMLDivElement | null\'.\\n        Type \'undefined\' is not assignable to type \'HTMLDivElement | null\'.", "193432436"]
     ],
     "src/script/connection/ConnectionEntity.ts:2779957789": [
       [41, 4, 19, "Type \'null\' is not assignable to type \'QualifiedId\'.", "59414957"],
@@ -2277,9 +2277,6 @@ exports[`stricter compilation`] = {
     ],
     "src/script/ui/resizeObserver.ts:1962447755": [
       [47, 48, 8, "Argument of type \'(element: Element) => void\' is not assignable to parameter of type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'element\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'Element\'.", "3760058444"]
-    ],
-    "src/script/ui/viewportObserver.ts:8326502": [
-      [109, 6, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'HTMLElement\'.", "2620553983"]
     ],
     "src/script/user/AppLockRepository.ts:968558871": [
       [48, 38, 59, "Type \'string | null\' is not assignable to type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "2029474882"],

--- a/src/script/components/MessagesList/Message/index.tsx
+++ b/src/script/components/MessagesList/Message/index.tsx
@@ -76,7 +76,7 @@ export interface MessageParams extends MessageActions {
 const Message: React.FC<
   MessageParams & {scrollTo?: (elm: {center?: boolean; element: HTMLElement}, isUnread?: boolean) => void}
 > = props => {
-  const {message, previousMessage, isMarked, lastReadTimestamp} = props;
+  const {message, previousMessage, isMarked, lastReadTimestamp, onVisible} = props;
   const messageElementRef = useRef<HTMLDivElement>();
   const {status, ephemeral_expires, timestamp} = useKoSubscribableChildren(message, [
     'status',
@@ -106,8 +106,8 @@ const Message: React.FC<
   };
 
   const content = <MessageWrapper {...props} hasMarker={markerType !== MessageMarkerType.NONE} />;
-  const wrappedContent = props.onVisible ? (
-    <InViewport allowBiggerThanViewport onVisible={props.onVisible}>
+  const wrappedContent = onVisible ? (
+    <InViewport allowBiggerThanViewport onVisible={onVisible}>
       {content}
     </InViewport>
   ) : (

--- a/src/script/components/MessagesList/Message/index.tsx
+++ b/src/script/components/MessagesList/Message/index.tsx
@@ -106,7 +106,13 @@ const Message: React.FC<
   };
 
   const content = <MessageWrapper {...props} hasMarker={markerType !== MessageMarkerType.NONE} />;
-  const wrappedContent = props.onVisible ? <InViewport onVisible={props.onVisible}>{content}</InViewport> : content;
+  const wrappedContent = props.onVisible ? (
+    <InViewport allowBiggerThanViewport onVisible={props.onVisible}>
+      {content}
+    </InViewport>
+  ) : (
+    content
+  );
   return (
     <div
       className={`message ${isMarked ? 'message-marked' : ''}`}

--- a/src/script/components/UserList.tsx
+++ b/src/script/components/UserList.tsx
@@ -239,7 +239,7 @@ const UserList: React.FC<UserListProps> = ({
       {content}
       {hasMoreUsers && (
         <InViewport
-          fullyInView={false}
+          requireFullyInView={false}
           onVisible={() => setMaxShownUsers(maxShownUsers + USER_CHUNK_SIZE)}
           key={`in-viewport-${Math.random()}`}
           style={{height: 10, transform: 'translateY(-60px)', width: 10}}

--- a/src/script/components/utils/InViewport.tsx
+++ b/src/script/components/utils/InViewport.tsx
@@ -24,11 +24,18 @@ import {viewportObserver} from '../../ui/viewportObserver';
 interface InViewportParams {
   children?: React.ReactNode;
   fullyInView?: boolean;
+  allowBiggerThanViewport?: boolean;
   onVisible: () => void;
   style?: React.CSSProperties;
 }
 
-const InViewport: React.FC<InViewportParams> = ({children, style, onVisible, fullyInView = true}) => {
+const InViewport: React.FC<InViewportParams> = ({
+  children,
+  style,
+  onVisible,
+  fullyInView = true,
+  allowBiggerThanViewport = false,
+}) => {
   const domNode = useRef<HTMLDivElement>();
 
   useEffect(() => {
@@ -58,6 +65,7 @@ const InViewport: React.FC<InViewportParams> = ({children, style, onVisible, ful
         triggerCallbackIfVisible();
       },
       fullyInView,
+      allowBiggerThanViewport,
       element.parentElement,
     );
     overlayedObserver.trackElement(element, isVisible => {

--- a/src/script/components/utils/InViewport.tsx
+++ b/src/script/components/utils/InViewport.tsx
@@ -22,10 +22,10 @@ import {overlayedObserver} from '../../ui/overlayedObserver';
 import {viewportObserver} from '../../ui/viewportObserver';
 
 interface InViewportParams {
-  children?: React.ReactNode;
-  fullyInView?: boolean;
-  allowBiggerThanViewport?: boolean;
   onVisible: () => void;
+  children?: React.ReactNode;
+  requireFullyInView?: boolean;
+  allowBiggerThanViewport?: boolean;
   style?: React.CSSProperties;
 }
 
@@ -33,10 +33,10 @@ const InViewport: React.FC<InViewportParams> = ({
   children,
   style,
   onVisible,
-  fullyInView = true,
+  requireFullyInView = true,
   allowBiggerThanViewport = false,
 }) => {
-  const domNode = useRef<HTMLDivElement>();
+  const domNode = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const element = domNode.current;
@@ -64,16 +64,16 @@ const InViewport: React.FC<InViewportParams> = ({
         inViewport = isInViewport;
         triggerCallbackIfVisible();
       },
-      fullyInView,
+      requireFullyInView,
       allowBiggerThanViewport,
-      element.parentElement,
+      element.parentElement || undefined,
     );
     overlayedObserver.trackElement(element, isVisible => {
       visible = isVisible;
       triggerCallbackIfVisible();
     });
     return () => releaseTrackers();
-  }, [onVisible]);
+  }, [allowBiggerThanViewport, requireFullyInView, onVisible]);
 
   return (
     <div ref={domNode} style={style}>

--- a/src/script/components/utils/InViewport.tsx
+++ b/src/script/components/utils/InViewport.tsx
@@ -64,9 +64,9 @@ const InViewport: React.FC<InViewportParams> = ({
         inViewport = isInViewport;
         triggerCallbackIfVisible();
       },
+      element.parentElement || undefined,
       requireFullyInView,
       allowBiggerThanViewport,
-      element.parentElement || undefined,
     );
     overlayedObserver.trackElement(element, isVisible => {
       visible = isVisible;

--- a/src/script/ui/viewportObserver.ts
+++ b/src/script/ui/viewportObserver.ts
@@ -91,9 +91,9 @@ const onElementInViewport = (
 const trackElement = (
   element: HTMLElement,
   onChange: Function,
+  container?: HTMLElement,
   requireFullyInView = false,
   allowBiggerThanViewport = false,
-  container?: HTMLElement,
 ): void => {
   if (element) {
     observedElements.set(element, {allowBiggerThanViewport, container, onChange, requireFullyInView});

--- a/src/script/view_model/bindings/CommonBindings.ts
+++ b/src/script/view_model/bindings/CommonBindings.ts
@@ -607,9 +607,8 @@ ko.bindingHandlers.in_viewport = {
         inViewport = isInViewport;
         triggerCallbackIfVisible();
       },
-      true,
-      false,
       container,
+      true,
     );
     overlayedObserver.trackElement(element, isVisible => {
       visible = isVisible;

--- a/src/script/view_model/bindings/CommonBindings.ts
+++ b/src/script/view_model/bindings/CommonBindings.ts
@@ -608,6 +608,7 @@ ko.bindingHandlers.in_viewport = {
         triggerCallbackIfVisible();
       },
       true,
+      false,
       container,
     );
     overlayedObserver.trackElement(element, isVisible => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1558" title="SQSERVICES-1558" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1558</a>  [Web]Number badge doesn't go away
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There is a bug where messages bigger than window's viewport are not being read. 

### Causes

Using `IntersectionObserver` we mark the messages as read when the whole message is visible in the viewport, so it does not work for messages higher that viewport. 

### Solutions

I suggest adding `allowBiggerThanViewport` boolean (optional, defaults to `false`) to the `<InViewport />` component's props. When its value is set to true, and observed element is higher than viewport, we treat this element as visible.

When element will be considered as visible:

`const isVisible = isIntersecting && (!fullyInView || isFullyInView() || isBiggerThanRoot());`

`isIntersecting`: The element must be partially visible (at least 1%), and:
- `!fullyInView` (`<InViewport />`'s prop) - we don't want the whole element to be visible, or
-  `isFullyInView()` - we want the whole element to be visible and it's fully in the view (doesn't work for higher messages)

after this PR is merged:

- `isBiggerThanRoot()` - we want the whole element to be visible, but we also allow it to be partially visible when it's bigger than viewport (only if `allowBiggerThanViewport` is set to `true`) 

This is how I check if element is bigger than viewport:
```ts
const isBiggerThanRoot = () => {
      return (
        allowBiggerThanViewport &&
        !!rootBounds &&
        (element.clientHeight > rootBounds.height || element.clientWidth > rootBounds.width)
      );
};
```

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
