### PR TITLE
runfix: address broken inputs when removing devices acc-210

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -74,13 +74,13 @@ exports[`stricter compilation`] = {
       [226, 8, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.\\n  Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'RefObject<HTMLInputElement>\'.", "193432436"],
       [228, 10, 20, "Object is possibly \'undefined\'.", "3805711124"]
     ],
-    "src/script/auth/component/ClientItem.tsx:1621350644": [
+    "src/script/auth/component/ClientItem.tsx:1403845945": [
       [149, 9, 21, "Object is possibly \'undefined\'.", "4077427211"],
       [151, 8, 21, "Object is possibly \'undefined\'.", "4077427211"],
       [152, 8, 21, "Object is possibly \'undefined\'.", "4077427211"],
       [155, 23, 21, "Object is possibly \'undefined\'.", "4077427211"],
       [236, 28, 12, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3597007453"],
-      [274, 20, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"]
+      [277, 20, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"]
     ],
     "src/script/auth/component/ClientList.tsx:3233905927": [
       [56, 4, 8, "Type \'string | null\' is not assignable to type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "1055803537"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -74,13 +74,13 @@ exports[`stricter compilation`] = {
       [226, 8, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.\\n  Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'RefObject<HTMLInputElement>\'.", "193432436"],
       [228, 10, 20, "Object is possibly \'undefined\'.", "3805711124"]
     ],
-    "src/script/auth/component/ClientItem.tsx:2070370025": [
+    "src/script/auth/component/ClientItem.tsx:1621350644": [
       [149, 9, 21, "Object is possibly \'undefined\'.", "4077427211"],
       [151, 8, 21, "Object is possibly \'undefined\'.", "4077427211"],
       [152, 8, 21, "Object is possibly \'undefined\'.", "4077427211"],
       [155, 23, 21, "Object is possibly \'undefined\'.", "4077427211"],
-      [226, 28, 12, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3597007453"],
-      [255, 20, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"]
+      [236, 28, 12, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3597007453"],
+      [274, 20, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"]
     ],
     "src/script/auth/component/ClientList.tsx:3233905927": [
       [56, 4, 8, "Type \'string | null\' is not assignable to type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "1055803537"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -80,7 +80,7 @@ exports[`stricter compilation`] = {
       [152, 8, 21, "Object is possibly \'undefined\'.", "4077427211"],
       [155, 23, 21, "Object is possibly \'undefined\'.", "4077427211"],
       [226, 28, 12, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3597007453"],
-      [255, 20, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.\\n  Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'RefObject<HTMLInputElement>\'.", "193432436"]
+      [255, 20, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"]
     ],
     "src/script/auth/component/ClientList.tsx:3233905927": [
       [56, 4, 8, "Type \'string | null\' is not assignable to type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "1055803537"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -74,13 +74,13 @@ exports[`stricter compilation`] = {
       [226, 8, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.\\n  Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'RefObject<HTMLInputElement>\'.", "193432436"],
       [228, 10, 20, "Object is possibly \'undefined\'.", "3805711124"]
     ],
-    "src/script/auth/component/ClientItem.tsx:2108822439": [
+    "src/script/auth/component/ClientItem.tsx:2070370025": [
       [149, 9, 21, "Object is possibly \'undefined\'.", "4077427211"],
       [151, 8, 21, "Object is possibly \'undefined\'.", "4077427211"],
       [152, 8, 21, "Object is possibly \'undefined\'.", "4077427211"],
       [155, 23, 21, "Object is possibly \'undefined\'.", "4077427211"],
-      [220, 28, 12, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3597007453"],
-      [249, 20, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.\\n  Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'RefObject<HTMLInputElement>\'.", "193432436"]
+      [226, 28, 12, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3597007453"],
+      [255, 20, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.\\n  Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'RefObject<HTMLInputElement>\'.", "193432436"]
     ],
     "src/script/auth/component/ClientList.tsx:3233905927": [
       [56, 4, 8, "Type \'string | null\' is not assignable to type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "1055803537"],
@@ -305,7 +305,7 @@ exports[`stricter compilation`] = {
       [132, 16, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"],
       [134, 16, 5, "Type \'string | null\' is not assignable to type \'string | number | readonly string[] | undefined\'.\\n  Type \'null\' is not assignable to type \'string | number | readonly string[] | undefined\'.", "189936718"]
     ],
-    "src/script/auth/page/ClientManager.tsx:4245719798": [
+    "src/script/auth/page/ClientManager.tsx:2167154494": [
       [37, 35, 44, "Argument of type \'string | null\' is not assignable to parameter of type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "2692881484"]
     ],
     "src/script/auth/page/ConversationJoin.tsx:2738577097": [

--- a/.betterer.results
+++ b/.betterer.results
@@ -74,13 +74,13 @@ exports[`stricter compilation`] = {
       [226, 8, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.\\n  Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'RefObject<HTMLInputElement>\'.", "193432436"],
       [228, 10, 20, "Object is possibly \'undefined\'.", "3805711124"]
     ],
-    "src/script/auth/component/ClientItem.tsx:281272235": [
+    "src/script/auth/component/ClientItem.tsx:2108822439": [
       [149, 9, 21, "Object is possibly \'undefined\'.", "4077427211"],
       [151, 8, 21, "Object is possibly \'undefined\'.", "4077427211"],
       [152, 8, 21, "Object is possibly \'undefined\'.", "4077427211"],
       [155, 23, 21, "Object is possibly \'undefined\'.", "4077427211"],
       [220, 28, 12, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3597007453"],
-      [249, 20, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"]
+      [249, 20, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.\\n  Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'RefObject<HTMLInputElement>\'.", "193432436"]
     ],
     "src/script/auth/component/ClientList.tsx:3233905927": [
       [56, 4, 8, "Type \'string | null\' is not assignable to type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "1055803537"],

--- a/src/script/auth/component/ClientItem.tsx
+++ b/src/script/auth/component/ClientItem.tsx
@@ -25,7 +25,7 @@ import {
   Form,
   Input,
   Line,
-  RoundIconButton,
+  IconButton,
   Small,
   Text,
   TrashIcon,
@@ -189,6 +189,7 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
   const height = animationPosition * 70;
   const marginTop = animationPosition * 16;
   const paddingHorizontal = animationPosition * 2;
+  const isOpen = requirePassword && (isSelected || isAnimating);
 
   return (
     <ContainerXS>
@@ -212,11 +213,16 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
           }}
           data-uie-name="go-remove-device"
         >
-          <div style={{display: 'flex', flexDirection: 'row'}}>
-            <div style={{flexBasis: '32px', margin: 'auto'}}>
+          <FlexBox>
+            <div
+              style={{
+                flexBasis: '32px',
+                margin: isOpen ? '12px 0 0 0' : 'auto',
+              }}
+            >
               <DeviceIcon color="#323639" />
             </div>
-            <div style={{flexGrow: 1}}>
+            <div style={{flexGrow: 1, marginTop: isOpen ? '12px' : 0}}>
               <Text bold block color="#323639" data-uie-name="device-header-model">
                 {formatName(client.model, client.class)}
               </Text>
@@ -224,7 +230,7 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
               <Small block>{formatDate(client.time)}</Small>
             </div>
             {!requirePassword && (
-              <RoundIconButton
+              <IconButton
                 aria-label={t('modalAccountRemoveDeviceAction')}
                 data-uie-name="do-remove-device"
                 formNoValidate
@@ -233,15 +239,15 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
                 type="submit"
               >
                 <TrashIcon />
-              </RoundIconButton>
+              </IconButton>
             )}
-          </div>
-          <Line color="rgba(51, 55, 58, .04)" style={{backgroundColor: 'transparent', margin: '4px 0 0 0'}} />
+          </FlexBox>
+          <Line color="rgba(51, 55, 58, .04)" style={{backgroundColor: 'transparent', margin: '4px 0 0 32px'}} />
         </ContainerXS>
-        {requirePassword && (isSelected || isAnimating) && (
+        {isOpen && (
           <ContainerXS style={{overflow: 'hidden', padding: `${paddingHorizontal}px 0`}}>
             <Form>
-              <FlexBox css={{alignItems: 'center', margin: '10px 10px 10px 0', maxHeight: height}}>
+              <FlexBox css={{alignItems: 'center', margin: '10px 16px 10px 48px', maxHeight: height}}>
                 <FlexBox css={{flexGrow: 1, marginRight: '12px'}}>
                   <Input
                     id="remove-device-password"
@@ -249,6 +255,7 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
                     data-uie-name="remove-device-password"
                     ref={passwordInput}
                     name="password"
+                    label={t('modalAccountRemoveDevicePlaceholder')}
                     onChange={onPasswordChange}
                     pattern=".{1,1024}"
                     placeholder={_(clientItemStrings.passwordPlaceholder)}
@@ -257,17 +264,17 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
                     value={password}
                   />
                 </FlexBox>
-                <RoundIconButton
+                <IconButton
                   aria-label={t('modalAccountRemoveDeviceAction')}
                   data-uie-name="do-remove-device"
                   disabled={!password || !isValidPassword}
                   formNoValidate
-                  css={{marginBottom: 20}}
+                  css={{margin: '0 8px'}}
                   onClick={handleSubmit}
                   type="submit"
                 >
                   <TrashIcon />
-                </RoundIconButton>
+                </IconButton>
               </FlexBox>
             </Form>
           </ContainerXS>

--- a/src/script/auth/component/ClientItem.tsx
+++ b/src/script/auth/component/ClientItem.tsx
@@ -185,7 +185,7 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
     setIsValidPassword(true);
   };
 
-  const spacing = {
+  const animatedCardSpacing = {
     l: 32,
     m: 16,
     s: 12,

--- a/src/script/auth/component/ClientItem.tsx
+++ b/src/script/auth/component/ClientItem.tsx
@@ -24,16 +24,16 @@ import {
   DeviceIcon,
   Form,
   Input,
-  InputBlock,
-  InputSubmitCombo,
   Line,
   RoundIconButton,
   Small,
   Text,
   TrashIcon,
+  FlexBox,
 } from '@wireapp/react-ui-kit';
 import React, {useEffect, useState} from 'react';
 import {useIntl} from 'react-intl';
+import {t} from 'Util/LocalizerUtil';
 import {splitFingerprint} from 'Util/StringUtil';
 import {clientItemStrings} from '../../strings';
 import {ValidationError} from '../module/action/ValidationError';
@@ -186,7 +186,7 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
   };
 
   const animationPosition = animationStep / CONFIG.animationSteps;
-  const height = animationPosition * 56;
+  const height = animationPosition * 70;
   const marginTop = animationPosition * 16;
   const paddingHorizontal = animationPosition * 2;
 
@@ -197,8 +197,8 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
           ['&:focus-within']: {
             boxShadow: `0 0 0 1px ${COLOR.BLUE}`,
           },
-          backgroundColor: selected ? '#DCE0E3' : '',
-          borderRadius: '4px',
+          backgroundColor: selected ? '#FFF' : '',
+          borderRadius: '12px',
           transition: 'background-color .35s linear',
         }}
         data-uie-value={client.model}
@@ -225,7 +225,7 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
             </div>
             {!requirePassword && (
               <RoundIconButton
-                backgroundColor={COLOR.RED}
+                aria-label={t('modalAccountRemoveDeviceAction')}
                 data-uie-name="do-remove-device"
                 formNoValidate
                 onClick={handlePasswordlessClientDeletion}
@@ -241,8 +241,8 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
         {requirePassword && (isSelected || isAnimating) && (
           <ContainerXS style={{overflow: 'hidden', padding: `${paddingHorizontal}px 0`}}>
             <Form>
-              <InputBlock style={{margin: '12px'}}>
-                <InputSubmitCombo style={{background: 'white', boxShadow: 'none', marginBottom: '0'}}>
+              <FlexBox css={{alignItems: 'center', margin: '10px 10px 10px 0', maxHeight: height}}>
+                <FlexBox css={{flexGrow: 1, marginRight: '12px'}}>
                   <Input
                     id="remove-device-password"
                     autoComplete="section-login password"
@@ -253,23 +253,22 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
                     pattern=".{1,1024}"
                     placeholder={_(clientItemStrings.passwordPlaceholder)}
                     required
-                    style={{background: 'transparent'}}
                     type="password"
                     value={password}
                   />
-                  <RoundIconButton
-                    backgroundColor={COLOR.RED}
-                    data-uie-name="do-remove-device"
-                    disabled={!password || !isValidPassword}
-                    formNoValidate
-                    onClick={handleSubmit}
-                    style={{marginBottom: '-4px'}}
-                    type="submit"
-                  >
-                    <TrashIcon />
-                  </RoundIconButton>
-                </InputSubmitCombo>
-              </InputBlock>
+                </FlexBox>
+                <RoundIconButton
+                  aria-label={t('modalAccountRemoveDeviceAction')}
+                  data-uie-name="do-remove-device"
+                  disabled={!password || !isValidPassword}
+                  formNoValidate
+                  css={{marginBottom: 20}}
+                  onClick={handleSubmit}
+                  type="submit"
+                >
+                  <TrashIcon />
+                </RoundIconButton>
+              </FlexBox>
             </Form>
           </ContainerXS>
         )}

--- a/src/script/auth/component/ClientItem.tsx
+++ b/src/script/auth/component/ClientItem.tsx
@@ -198,7 +198,7 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
 
   const animationPosition = animationStep / CONFIG.animationSteps;
   const smoothHeight = animationPosition * inputContainerHeight;
-  const smoothMarginTop = animationPosition * spacing.m;
+  const smoothMarginTop = animationPosition * animatedCardSpacing.m;
   const isOpen = requirePassword && (isSelected || isAnimating);
 
   return (
@@ -219,14 +219,14 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
           style={{
             cursor: requirePassword ? 'pointer' : 'auto',
             margin: `${smoothMarginTop}px 0 0 0`,
-            padding: `0 ${spacing.m}px`,
+            padding: `0 ${animatedCardSpacing.m}px`,
           }}
           data-uie-name="go-remove-device"
         >
           <FlexBox>
             <div
               style={{
-                flexBasis: spacing.l,
+                flexBasis: animatedCardSpacing.l,
                 margin: isOpen ? `${18 - smoothMarginTop / 2}px 0 0 0` : 'auto',
               }}
             >
@@ -254,7 +254,10 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
           </FlexBox>
           <Line
             color="rgba(51, 55, 58, .04)"
-            style={{backgroundColor: 'transparent', margin: `${spacing.xxs}px 0 0 ${spacing.l}px`}}
+            style={{
+              backgroundColor: 'transparent',
+              margin: `${animatedCardSpacing.xxs}px 0 0 ${animatedCardSpacing.l}px`,
+            }}
           />
         </ContainerXS>
         {isOpen && (
@@ -263,11 +266,11 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
               <FlexBox
                 css={{
                   alignItems: 'center',
-                  margin: `${spacing.s}px ${spacing.m}px 0px ${spacing.xl}px`,
+                  margin: `${animatedCardSpacing.s}px ${animatedCardSpacing.m}px 0px ${animatedCardSpacing.xl}px`,
                   maxHeight: smoothHeight,
                 }}
               >
-                <FlexBox css={{flexGrow: 1, marginRight: `${spacing.s}px`}}>
+                <FlexBox css={{flexGrow: 1, marginRight: `${animatedCardSpacing.s}px`}}>
                   <Input
                     id="remove-device-password"
                     autoComplete="section-login password"
@@ -288,7 +291,7 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
                   data-uie-name="do-remove-device"
                   disabled={!password || !isValidPassword}
                   formNoValidate
-                  css={{margin: `0 ${spacing.xs}px`}}
+                  css={{margin: `0 ${animatedCardSpacing.xs}px`}}
                   onClick={handleSubmit}
                   type="submit"
                 >
@@ -300,9 +303,9 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
         )}
       </ContainerXS>
       {validationError && selected ? (
-        <div style={{margin: `${spacing.m}px 0 0 0`}}>{parseValidationErrors(validationError)}</div>
+        <div style={{margin: `${animatedCardSpacing.m}px 0 0 0`}}>{parseValidationErrors(validationError)}</div>
       ) : clientError && selected ? (
-        <div style={{margin: `${spacing.m}px 0 0 0`}} data-uie-name="error-message">
+        <div style={{margin: `${animatedCardSpacing.m}px 0 0 0`}} data-uie-name="error-message">
           {parseError(clientError)}
         </div>
       ) : null}

--- a/src/script/auth/component/ClientItem.tsx
+++ b/src/script/auth/component/ClientItem.tsx
@@ -197,7 +197,7 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
           ['&:focus-within']: {
             boxShadow: `0 0 0 1px ${COLOR.BLUE}`,
           },
-          backgroundColor: selected ? 'white' : '',
+          backgroundColor: selected ? '#DCE0E3' : '',
           borderRadius: '4px',
           transition: 'background-color .35s linear',
         }}
@@ -225,7 +225,7 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
             </div>
             {!requirePassword && (
               <RoundIconButton
-                color={COLOR.RED}
+                backgroundColor={COLOR.RED}
                 data-uie-name="do-remove-device"
                 formNoValidate
                 onClick={handlePasswordlessClientDeletion}
@@ -239,10 +239,10 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
           <Line color="rgba(51, 55, 58, .04)" style={{backgroundColor: 'transparent', margin: '4px 0 0 0'}} />
         </ContainerXS>
         {requirePassword && (isSelected || isAnimating) && (
-          <ContainerXS style={{maxHeight: `${height}px`, overflow: 'hidden', padding: `${paddingHorizontal}px 0`}}>
+          <ContainerXS style={{overflow: 'hidden', padding: `${paddingHorizontal}px 0`}}>
             <Form>
-              <InputBlock>
-                <InputSubmitCombo style={{background: 'transparent', boxShadow: 'none', marginBottom: '0'}}>
+              <InputBlock style={{margin: '12px'}}>
+                <InputSubmitCombo style={{background: 'white', boxShadow: 'none', marginBottom: '0'}}>
                   <Input
                     id="remove-device-password"
                     autoComplete="section-login password"
@@ -258,7 +258,7 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
                     value={password}
                   />
                   <RoundIconButton
-                    color={COLOR.RED}
+                    backgroundColor={COLOR.RED}
                     data-uie-name="do-remove-device"
                     disabled={!password || !isValidPassword}
                     formNoValidate

--- a/src/script/auth/component/ClientItem.tsx
+++ b/src/script/auth/component/ClientItem.tsx
@@ -185,10 +185,20 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
     setIsValidPassword(true);
   };
 
+  const spacing = {
+    l: 32,
+    m: 16,
+    s: 12,
+    xl: 48,
+    xs: 8,
+    xxs: 4,
+  };
+
+  const inputContainerHeight = 104;
+
   const animationPosition = animationStep / CONFIG.animationSteps;
-  const height = animationPosition * 70;
-  const marginTop = animationPosition * 16;
-  const paddingHorizontal = animationPosition * 2;
+  const smoothHeight = animationPosition * inputContainerHeight;
+  const smoothMarginTop = animationPosition * spacing.m;
   const isOpen = requirePassword && (isSelected || isAnimating);
 
   return (
@@ -208,21 +218,21 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
           onClick={(event: React.MouseEvent<HTMLDivElement>) => requirePassword && wrappedOnClick(event)}
           style={{
             cursor: requirePassword ? 'pointer' : 'auto',
-            margin: `${marginTop}px 0 0 0`,
-            padding: '5px 16px 0 16px',
+            margin: `${smoothMarginTop}px 0 0 0`,
+            padding: `0 ${spacing.m}px`,
           }}
           data-uie-name="go-remove-device"
         >
           <FlexBox>
             <div
               style={{
-                flexBasis: '32px',
-                margin: isOpen ? '12px 0 0 0' : 'auto',
+                flexBasis: spacing.l,
+                margin: isOpen ? `${18 - smoothMarginTop / 2}px 0 0 0` : 'auto',
               }}
             >
               <DeviceIcon color="#323639" />
             </div>
-            <div style={{flexGrow: 1, marginTop: isOpen ? '12px' : 0}}>
+            <div style={{flexGrow: 1, marginTop: isOpen ? smoothMarginTop : 0}}>
               <Text bold block color="#323639" data-uie-name="device-header-model">
                 {formatName(client.model, client.class)}
               </Text>
@@ -242,13 +252,22 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
               </IconButton>
             )}
           </FlexBox>
-          <Line color="rgba(51, 55, 58, .04)" style={{backgroundColor: 'transparent', margin: '4px 0 0 32px'}} />
+          <Line
+            color="rgba(51, 55, 58, .04)"
+            style={{backgroundColor: 'transparent', margin: `${spacing.xxs}px 0 0 ${spacing.l}px`}}
+          />
         </ContainerXS>
         {isOpen && (
-          <ContainerXS style={{overflow: 'hidden', padding: `${paddingHorizontal}px 0`}}>
+          <ContainerXS style={{overflow: 'hidden'}}>
             <Form>
-              <FlexBox css={{alignItems: 'center', margin: '10px 16px 10px 48px', maxHeight: height}}>
-                <FlexBox css={{flexGrow: 1, marginRight: '12px'}}>
+              <FlexBox
+                css={{
+                  alignItems: 'center',
+                  margin: `${spacing.s}px ${spacing.m}px 0px ${spacing.xl}px`,
+                  maxHeight: smoothHeight,
+                }}
+              >
+                <FlexBox css={{flexGrow: 1, marginRight: `${spacing.s}px`}}>
                   <Input
                     id="remove-device-password"
                     autoComplete="section-login password"
@@ -269,7 +288,7 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
                   data-uie-name="do-remove-device"
                   disabled={!password || !isValidPassword}
                   formNoValidate
-                  css={{margin: '0 8px'}}
+                  css={{margin: `0 ${spacing.xs}px`}}
                   onClick={handleSubmit}
                   type="submit"
                 >
@@ -281,9 +300,9 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
         )}
       </ContainerXS>
       {validationError && selected ? (
-        <div style={{margin: '16px 0 0 0'}}>{parseValidationErrors(validationError)}</div>
+        <div style={{margin: `${spacing.m}px 0 0 0`}}>{parseValidationErrors(validationError)}</div>
       ) : clientError && selected ? (
-        <div style={{margin: '16px 0 0 0'}} data-uie-name="error-message">
+        <div style={{margin: `${spacing.m}px 0 0 0`}} data-uie-name="error-message">
           {parseError(clientError)}
         </div>
       ) : null}

--- a/src/script/auth/page/ClientManager.tsx
+++ b/src/script/auth/page/ClientManager.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {ContainerXS, H1, Link, Muted, useTimeout} from '@wireapp/react-ui-kit';
+import {Button, ButtonVariant, ContainerXS, H1, Muted, useTimeout} from '@wireapp/react-ui-kit';
 import React, {useEffect} from 'react';
 import {useIntl} from 'react-intl';
 import {connect} from 'react-redux';
@@ -74,9 +74,14 @@ const ClientManager = ({doGetAllClients, doLogout}: Props & ConnectedProps & Dis
           {_(clientManagerStrings.subhead, {brandName: Config.getConfig().BRAND_NAME})}
         </Muted>
         <ClientList />
-        <Link onClick={logout} style={{alignSelf: 'center', margin: '48px 0 80px 0'}} data-uie-name="go-sign-out">
+        <Button
+          variant={ButtonVariant.SECONDARY}
+          onClick={logout}
+          style={{alignSelf: 'center', margin: '48px 0 80px 0'}}
+          data-uie-name="go-sign-out"
+        >
           {_(clientManagerStrings.logout)}
-        </Link>
+        </Button>
       </ContainerXS>
     </Page>
   );


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-210" title="ACC-210" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-210</a>  [web] Usability of deleting a device on login (when device limit is reached) can be improved
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----


# What's new in this PR?

### Issues

- Inputs in the remove device screen are way too narrow
![3306c1a8-46b6-4250-b961-df51e37a355d](https://user-images.githubusercontent.com/78490891/178987147-fe3a7bb1-5094-42e6-b410-15edfd8ae88f.png)

### Solutions

- adjust style according to [new mockup](https://www.figma.com/file/OrP9jAJdfttfvsm3nxnihP/Accessibility-Quick-Wins-(Web%2FDesktop)?node-id=2711%3A17289)
- (Changes to inputs border radius need to be adressed in the ui-kit)

![image](https://user-images.githubusercontent.com/78490891/179210229-3653e349-a3bf-41ae-8766-07cc9cbb5035.png)

