### PR TITLE
fix: centre align auth screen checkbox(ACC-207)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -45,7 +45,7 @@ exports[`stricter compilation`] = {
     "src/script/auth/AuthRepository.ts:219478500": [
       [52, 60, 5, "Object is of type \'unknown\'.", "165548477"]
     ],
-    "src/script/auth/component/AccountForm.tsx:3824179626": [
+    "src/script/auth/component/AccountForm.tsx:1149474091": [
       [90, 8, 16, "Object is possibly \'undefined\'.", "3859911866"],
       [90, 33, 16, "Object is possibly \'undefined\'.", "3859911866"],
       [92, 11, 16, "Object is possibly \'undefined\'.", "3859911866"],
@@ -338,7 +338,7 @@ exports[`stricter compilation`] = {
       [115, 16, 5, "Object is of type \'unknown\'.", "165548477"],
       [168, 18, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"]
     ],
-    "src/script/auth/page/Login.tsx:2417473152": [
+    "src/script/auth/page/Login.tsx:3700032385": [
       [172, 24, 16, "Argument of type \'Error[]\' is not assignable to parameter of type \'SetStateAction<never[]>\'.", "2735526245"],
       [174, 50, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
       [203, 56, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
@@ -348,7 +348,7 @@ exports[`stricter compilation`] = {
       [234, 32, 24, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3055772661"],
       [294, 24, 14, "Type \'(code: string) => void\' is not assignable to type \'(completeCode?: string | undefined) => void\'.\\n  Types of parameters \'code\' and \'completeCode\' are incompatible.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "2059828224"]
     ],
-    "src/script/auth/page/PhoneLogin.tsx:2964526712": [
+    "src/script/auth/page/PhoneLogin.tsx:2188590841": [
       [86, 19, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<undefined>\'.", "165548477"],
       [90, 19, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<undefined>\'.", "165548477"]
     ],
@@ -399,7 +399,7 @@ exports[`stricter compilation`] = {
       [73, 10, 19, "Type \'undefined\' is not assignable to type \'(event: Event) => void\'.", "568100674"],
       [129, 6, 20, "Type \'Window | null\' is not assignable to type \'Window | undefined\'.\\n  Type \'null\' is not assignable to type \'Window | undefined\'.", "2747308432"]
     ],
-    "src/script/auth/page/SingleSignOnForm.tsx:2490051983": [
+    "src/script/auth/page/SingleSignOnForm.tsx:2724281134": [
       [80, 59, 4, "Argument of type \'null\' is not assignable to parameter of type \'ClientType | (() => ClientType)\'.", "2087897566"],
       [159, 30, 23, "Object is possibly \'undefined\'.", "1793578893"],
       [160, 4, 23, "Object is possibly \'undefined\'.", "1793578893"],
@@ -1511,7 +1511,10 @@ exports[`stricter compilation`] = {
     ],
     "src/script/conversation/MessageRepository.ts:3425977142": [
       [746, 52, 8, "No overload matches this call.\\n  Overload 1 of 4, \'(value: string | number | Date): Date\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number | Date\'.\\n  Overload 2 of 4, \'(value: string | number): Date\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number\'.", "1948180668"],
+      [759, 10, 7, "Argument of type \'{ groupId: string; onStart: (message: GenericMessage) => boolean | void | Promise<boolean>; onSuccess: (genericMessage: GenericMessage, sentTime?: string | undefined) => Promise<...>; payload: OtrMessage; protocol: ConversationProtocol; }\' is not assignable to parameter of type \'{ payloadBundle: OtrMessage; userIds?: string[] | UserClients | QualifiedId[] | QualifiedUserClients | undefined; callbacks?: MessageSendingCallbacks | undefined; } & MessageSendingOptions\'.\\n  Object literal may only specify known properties, and \'groupId\' does not exist in type \'{ payloadBundle: OtrMessage; userIds?: string[] | UserClients | QualifiedId[] | QualifiedUserClients | undefined; callbacks?: MessageSendingCallbacks | undefined; } & MessageSendingOptions\'.", "3065364087"],
+      [773, 8, 30, "Argument of type \'{ conversationDomain: string | undefined; nativePush: boolean; onClientMismatch: (mismatch: ClientMismatch | MessageSendingStatus) => Promise<...> | undefined; ... 5 more ...; userIds: UserClients | QualifiedUserClients; }\' is not assignable to parameter of type \'{ payloadBundle: OtrMessage; userIds?: string[] | UserClients | QualifiedId[] | QualifiedUserClients | undefined; callbacks?: MessageSendingCallbacks | undefined; } & MessageSendingOptions\'.\\n  Object literal may only specify known properties, and \'onStart\' does not exist in type \'{ payloadBundle: OtrMessage; userIds?: string[] | UserClients | QualifiedId[] | QualifiedUserClients | undefined; callbacks?: MessageSendingCallbacks | undefined; } & MessageSendingOptions\'.", "2451661254"],
       [811, 102, 5, "Object is of type \'unknown\'.", "165548477"],
+      [836, 8, 21, "Argument of type \'{ conversationDomain: string | undefined; payload: ResetSessionMessage; protocol: ConversationProtocol; targetMode: MessageTargetMode.USERS_CLIENTS; userIds: { ...; } | { ...; }; }\' is not assignable to parameter of type \'{ payloadBundle: OtrMessage; userIds?: string[] | UserClients | QualifiedId[] | QualifiedUserClients | undefined; callbacks?: MessageSendingCallbacks | undefined; } & MessageSendingOptions\'.\\n  Object literal may only specify known properties, and \'payload\' does not exist in type \'{ payloadBundle: OtrMessage; userIds?: string[] | UserClients | QualifiedId[] | QualifiedUserClients | undefined; callbacks?: MessageSendingCallbacks | undefined; } & MessageSendingOptions\'.", "4257357402"],
       [955, 80, 4, "Object is possibly \'undefined\'.", "2087973204"],
       [966, 37, 5, "Object is of type \'unknown\'.", "165548477"],
       [1173, 81, 4, "Argument of type \'User | undefined\' is not assignable to parameter of type \'QualifiedEntity\'.\\n  Type \'undefined\' is not assignable to type \'QualifiedEntity\'.", "2087973204"],
@@ -2109,7 +2112,7 @@ exports[`stricter compilation`] = {
       [70, 6, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
       [104, 40, 43, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1072333434"]
     ],
-    "src/script/page/MainContent/panels/preferences/accountPreferences/AvatarInput.tsx:919643938": [
+    "src/script/page/MainContent/panels/preferences/accountPreferences/AvatarInput.tsx:2284917208": [
       [50, 69, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
       [91, 4, 16, "Object is possibly \'null\'.", "4019370437"],
       [116, 23, 14, "Argument of type \'File | null\' is not assignable to parameter of type \'File\'.\\n  Type \'null\' is not assignable to type \'File\'.", "1073819172"]
@@ -2132,10 +2135,10 @@ exports[`stricter compilation`] = {
       [34, 41, 22, "Cannot invoke an object which is possibly \'undefined\'.", "1980738780"],
       [41, 21, 12, "Argument of type \'string | undefined\' is not assignable to parameter of type \'Matcher\'.\\n  Type \'undefined\' is not assignable to type \'Matcher\'.", "2075561852"]
     ],
-    "src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx:3136549338": [
-      [67, 90, 10, "Type \'undefined\' is not assignable to type \'boolean\'.", "3231345145"],
-      [124, 8, 14, "Type \'(device: ClientEntity) => Promise<string | undefined>\' is not assignable to type \'(device: ClientEntity) => Promise<string>\'.\\n  Type \'Promise<string | undefined>\' is not assignable to type \'Promise<string>\'.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "223037395"],
-      [131, 73, 37, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "3769528030"]
+    "src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx:1995369812": [
+      [70, 90, 10, "Type \'undefined\' is not assignable to type \'boolean\'.", "3231345145"],
+      [135, 8, 14, "Type \'(device: ClientEntity) => Promise<string | undefined>\' is not assignable to type \'(device: ClientEntity) => Promise<string>\'.\\n  Type \'Promise<string | undefined>\' is not assignable to type \'Promise<string>\'.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "223037395"],
+      [142, 73, 37, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "3769528030"]
     ],
     "src/script/page/message-list/InputBarControls/InputBarControls.test.tsx:2517377529": [
       [33, 2, 12, "Type \'undefined\' is not assignable to type \'Conversation\'.", "1670678216"]
@@ -2231,6 +2234,7 @@ exports[`stricter compilation`] = {
       [80, 4, 22, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "1357312573"],
       [96, 13, 38, "Object is possibly \'undefined\'.", "3672246717"],
       [97, 10, 37, "Object is possibly \'undefined\'.", "1981238082"],
+      [116, 67, 3, "Property \'mls\' does not exist on type \'FeatureList\'. Did you mean \'MLS\'?", "193413975"],
       [121, 4, 22, "Type \'PureComputed<boolean | undefined>\' is not assignable to type \'PureComputed<boolean>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'boolean | undefined\' is not assignable to type \'boolean\'.", "32795343"],
       [122, 4, 33, "Type \'PureComputed<number | undefined>\' is not assignable to type \'PureComputed<number>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'number | undefined\' is not assignable to type \'number\'.\\n      Type \'undefined\' is not assignable to type \'number\'.", "3833026544"]
     ],
@@ -2775,9 +2779,9 @@ exports[`stricter compilation`] = {
       [38, 54, 29, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1262202094"],
       [76, 20, 77, "Argument of type \'Element | null\' is not assignable to parameter of type \'Document | Node | Element | Window\'.", "1971299222"]
     ],
-    "src/script/view_model/panel/NotificationsPanel.tsx:3967190560": [
+    "src/script/view_model/panel/NotificationsPanel.tsx:3185514146": [
       [46, 56, 18, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Partial<Record<\\"notificationState\\", Subscribable<any>>>\'.\\n  Type \'null\' is not assignable to type \'Partial<Record<\\"notificationState\\", Subscribable<any>>>\'.", "2242649668"],
-      [78, 77, 18, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'null\' is not assignable to type \'Conversation\'.", "2242649668"]
+      [79, 77, 18, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'null\' is not assignable to type \'Conversation\'.", "2242649668"]
     ],
     "src/script/view_model/panel/PanelHeader.test.ts:4232255009": [
       [33, 39, 22, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "3474761039"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -45,7 +45,7 @@ exports[`stricter compilation`] = {
     "src/script/auth/AuthRepository.ts:219478500": [
       [52, 60, 5, "Object is of type \'unknown\'.", "165548477"]
     ],
-    "src/script/auth/component/AccountForm.tsx:1149474091": [
+    "src/script/auth/component/AccountForm.tsx:259264838": [
       [90, 8, 16, "Object is possibly \'undefined\'.", "3859911866"],
       [90, 33, 16, "Object is possibly \'undefined\'.", "3859911866"],
       [92, 11, 16, "Object is possibly \'undefined\'.", "3859911866"],
@@ -338,9 +338,9 @@ exports[`stricter compilation`] = {
       [115, 16, 5, "Object is of type \'unknown\'.", "165548477"],
       [168, 18, 3, "Type \'MutableRefObject<HTMLInputElement | undefined>\' is not assignable to type \'((instance: HTMLInputElement | null) => void) | RefObject<HTMLInputElement> | null | undefined\'.", "193432436"]
     ],
-    "src/script/auth/page/Login.tsx:3700032385": [
+    "src/script/auth/page/Login.tsx:877256236": [
       [172, 24, 16, "Argument of type \'Error[]\' is not assignable to parameter of type \'SetStateAction<never[]>\'.", "2735526245"],
-      [174, 50, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.\\n  Type \'undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
+      [174, 50, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
       [203, 56, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
       [205, 32, 11, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2331572484"],
       [210, 36, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<string>\'.", "165548477"],
@@ -348,7 +348,7 @@ exports[`stricter compilation`] = {
       [234, 32, 24, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "3055772661"],
       [294, 24, 14, "Type \'(code: string) => void\' is not assignable to type \'(completeCode?: string | undefined) => void\'.\\n  Types of parameters \'code\' and \'completeCode\' are incompatible.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "2059828224"]
     ],
-    "src/script/auth/page/PhoneLogin.tsx:2188590841": [
+    "src/script/auth/page/PhoneLogin.tsx:2040611796": [
       [86, 19, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<undefined>\'.", "165548477"],
       [90, 19, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<undefined>\'.", "165548477"]
     ],
@@ -399,7 +399,7 @@ exports[`stricter compilation`] = {
       [73, 10, 19, "Type \'undefined\' is not assignable to type \'(event: Event) => void\'.", "568100674"],
       [129, 6, 20, "Type \'Window | null\' is not assignable to type \'Window | undefined\'.\\n  Type \'null\' is not assignable to type \'Window | undefined\'.", "2747308432"]
     ],
-    "src/script/auth/page/SingleSignOnForm.tsx:2724281134": [
+    "src/script/auth/page/SingleSignOnForm.tsx:3538322659": [
       [80, 59, 4, "Argument of type \'null\' is not assignable to parameter of type \'ClientType | (() => ClientType)\'.", "2087897566"],
       [159, 30, 23, "Object is possibly \'undefined\'.", "1793578893"],
       [160, 4, 23, "Object is possibly \'undefined\'.", "1793578893"],
@@ -1511,10 +1511,7 @@ exports[`stricter compilation`] = {
     ],
     "src/script/conversation/MessageRepository.ts:3425977142": [
       [746, 52, 8, "No overload matches this call.\\n  Overload 1 of 4, \'(value: string | number | Date): Date\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number | Date\'.\\n  Overload 2 of 4, \'(value: string | number): Date\', gave the following error.\\n    Argument of type \'string | undefined\' is not assignable to parameter of type \'string | number\'.", "1948180668"],
-      [759, 10, 7, "Argument of type \'{ groupId: string; onStart: (message: GenericMessage) => boolean | void | Promise<boolean>; onSuccess: (genericMessage: GenericMessage, sentTime?: string | undefined) => Promise<...>; payload: OtrMessage; protocol: ConversationProtocol; }\' is not assignable to parameter of type \'{ payloadBundle: OtrMessage; userIds?: string[] | UserClients | QualifiedId[] | QualifiedUserClients | undefined; callbacks?: MessageSendingCallbacks | undefined; } & MessageSendingOptions\'.\\n  Object literal may only specify known properties, and \'groupId\' does not exist in type \'{ payloadBundle: OtrMessage; userIds?: string[] | UserClients | QualifiedId[] | QualifiedUserClients | undefined; callbacks?: MessageSendingCallbacks | undefined; } & MessageSendingOptions\'.", "3065364087"],
-      [773, 8, 30, "Argument of type \'{ conversationDomain: string | undefined; nativePush: boolean; onClientMismatch: (mismatch: ClientMismatch | MessageSendingStatus) => Promise<...> | undefined; ... 5 more ...; userIds: UserClients | QualifiedUserClients; }\' is not assignable to parameter of type \'{ payloadBundle: OtrMessage; userIds?: string[] | UserClients | QualifiedId[] | QualifiedUserClients | undefined; callbacks?: MessageSendingCallbacks | undefined; } & MessageSendingOptions\'.\\n  Object literal may only specify known properties, and \'onStart\' does not exist in type \'{ payloadBundle: OtrMessage; userIds?: string[] | UserClients | QualifiedId[] | QualifiedUserClients | undefined; callbacks?: MessageSendingCallbacks | undefined; } & MessageSendingOptions\'.", "2451661254"],
       [811, 102, 5, "Object is of type \'unknown\'.", "165548477"],
-      [836, 8, 21, "Argument of type \'{ conversationDomain: string | undefined; payload: ResetSessionMessage; protocol: ConversationProtocol; targetMode: MessageTargetMode.USERS_CLIENTS; userIds: { ...; } | { ...; }; }\' is not assignable to parameter of type \'{ payloadBundle: OtrMessage; userIds?: string[] | UserClients | QualifiedId[] | QualifiedUserClients | undefined; callbacks?: MessageSendingCallbacks | undefined; } & MessageSendingOptions\'.\\n  Object literal may only specify known properties, and \'payload\' does not exist in type \'{ payloadBundle: OtrMessage; userIds?: string[] | UserClients | QualifiedId[] | QualifiedUserClients | undefined; callbacks?: MessageSendingCallbacks | undefined; } & MessageSendingOptions\'.", "4257357402"],
       [955, 80, 4, "Object is possibly \'undefined\'.", "2087973204"],
       [966, 37, 5, "Object is of type \'unknown\'.", "165548477"],
       [1173, 81, 4, "Argument of type \'User | undefined\' is not assignable to parameter of type \'QualifiedEntity\'.\\n  Type \'undefined\' is not assignable to type \'QualifiedEntity\'.", "2087973204"],
@@ -2112,7 +2109,7 @@ exports[`stricter compilation`] = {
       [70, 6, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
       [104, 40, 43, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1072333434"]
     ],
-    "src/script/page/MainContent/panels/preferences/accountPreferences/AvatarInput.tsx:2284917208": [
+    "src/script/page/MainContent/panels/preferences/accountPreferences/AvatarInput.tsx:919643938": [
       [50, 69, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
       [91, 4, 16, "Object is possibly \'null\'.", "4019370437"],
       [116, 23, 14, "Argument of type \'File | null\' is not assignable to parameter of type \'File\'.\\n  Type \'null\' is not assignable to type \'File\'.", "1073819172"]
@@ -2135,10 +2132,10 @@ exports[`stricter compilation`] = {
       [34, 41, 22, "Cannot invoke an object which is possibly \'undefined\'.", "1980738780"],
       [41, 21, 12, "Argument of type \'string | undefined\' is not assignable to parameter of type \'Matcher\'.\\n  Type \'undefined\' is not assignable to type \'Matcher\'.", "2075561852"]
     ],
-    "src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx:1995369812": [
-      [70, 90, 10, "Type \'undefined\' is not assignable to type \'boolean\'.", "3231345145"],
-      [135, 8, 14, "Type \'(device: ClientEntity) => Promise<string | undefined>\' is not assignable to type \'(device: ClientEntity) => Promise<string>\'.\\n  Type \'Promise<string | undefined>\' is not assignable to type \'Promise<string>\'.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "223037395"],
-      [142, 73, 37, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "3769528030"]
+    "src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx:3136549338": [
+      [67, 90, 10, "Type \'undefined\' is not assignable to type \'boolean\'.", "3231345145"],
+      [124, 8, 14, "Type \'(device: ClientEntity) => Promise<string | undefined>\' is not assignable to type \'(device: ClientEntity) => Promise<string>\'.\\n  Type \'Promise<string | undefined>\' is not assignable to type \'Promise<string>\'.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "223037395"],
+      [131, 73, 37, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "3769528030"]
     ],
     "src/script/page/message-list/InputBarControls/InputBarControls.test.tsx:2517377529": [
       [33, 2, 12, "Type \'undefined\' is not assignable to type \'Conversation\'.", "1670678216"]
@@ -2234,7 +2231,6 @@ exports[`stricter compilation`] = {
       [80, 4, 22, "Type \'Observable<false>\' is not assignable to type \'Observable<boolean>\'.", "1357312573"],
       [96, 13, 38, "Object is possibly \'undefined\'.", "3672246717"],
       [97, 10, 37, "Object is possibly \'undefined\'.", "1981238082"],
-      [116, 67, 3, "Property \'mls\' does not exist on type \'FeatureList\'. Did you mean \'MLS\'?", "193413975"],
       [121, 4, 22, "Type \'PureComputed<boolean | undefined>\' is not assignable to type \'PureComputed<boolean>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'boolean | undefined\' is not assignable to type \'boolean\'.", "32795343"],
       [122, 4, 33, "Type \'PureComputed<number | undefined>\' is not assignable to type \'PureComputed<number>\'.\\n  The types returned by \'peek()\' are incompatible between these types.\\n    Type \'number | undefined\' is not assignable to type \'number\'.\\n      Type \'undefined\' is not assignable to type \'number\'.", "3833026544"]
     ],
@@ -2779,9 +2775,9 @@ exports[`stricter compilation`] = {
       [38, 54, 29, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1262202094"],
       [76, 20, 77, "Argument of type \'Element | null\' is not assignable to parameter of type \'Document | Node | Element | Window\'.", "1971299222"]
     ],
-    "src/script/view_model/panel/NotificationsPanel.tsx:3185514146": [
+    "src/script/view_model/panel/NotificationsPanel.tsx:3967190560": [
       [46, 56, 18, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Partial<Record<\\"notificationState\\", Subscribable<any>>>\'.\\n  Type \'null\' is not assignable to type \'Partial<Record<\\"notificationState\\", Subscribable<any>>>\'.", "2242649668"],
-      [79, 77, 18, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'null\' is not assignable to type \'Conversation\'.", "2242649668"]
+      [78, 77, 18, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'null\' is not assignable to type \'Conversation\'.", "2242649668"]
     ],
     "src/script/view_model/panel/PanelHeader.test.ts:4232255009": [
       [33, 39, 22, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "3474761039"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -340,7 +340,7 @@ exports[`stricter compilation`] = {
     ],
     "src/script/auth/page/Login.tsx:3700032385": [
       [172, 24, 16, "Argument of type \'Error[]\' is not assignable to parameter of type \'SetStateAction<never[]>\'.", "2735526245"],
-      [174, 50, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
+      [174, 50, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.\\n  Type \'undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
       [203, 56, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
       [205, 32, 11, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2331572484"],
       [210, 36, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<string>\'.", "165548477"],

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@wireapp/antiscroll-2": "1.3.1",
     "@wireapp/avs": "8.2.2",
     "@wireapp/core": "28.4.2",
-    "@wireapp/react-ui-kit": "8.8.1",
+    "@wireapp/react-ui-kit": "8.8.2",
     "@wireapp/store-engine-dexie": "1.6.10",
     "@wireapp/store-engine-sqleet": "1.7.14",
     "@wireapp/webapp-events": "0.13.2",

--- a/src/script/auth/component/AccountForm.tsx
+++ b/src/script/auth/component/AccountForm.tsx
@@ -231,6 +231,7 @@ const AccountForm = ({account, ...props}: Props & ConnectedProps & DispatchProps
           setValidInputs({...validInputs, terms: true});
         }}
         markInvalid={!validInputs.terms}
+        alignCenter={true}
         name="accept"
         id="accept"
         required

--- a/src/script/auth/component/AccountForm.tsx
+++ b/src/script/auth/component/AccountForm.tsx
@@ -231,7 +231,7 @@ const AccountForm = ({account, ...props}: Props & ConnectedProps & DispatchProps
           setValidInputs({...validInputs, terms: true});
         }}
         markInvalid={!validInputs.terms}
-        alignCenter={true}
+        alignCenter
         name="accept"
         id="accept"
         required

--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -332,7 +332,7 @@ const Login = ({
                             checked={loginData.clientType === ClientType.TEMPORARY}
                             data-uie-name="enter-public-computer-sign-in"
                             style={{justifyContent: 'center', marginTop: '12px'}}
-                            alignCenter={true}
+                            alignCenter
                           >
                             <CheckboxLabel htmlFor="enter-public-computer-sign-in">
                               {_(loginStrings.publicComputer)}

--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -332,6 +332,7 @@ const Login = ({
                             checked={loginData.clientType === ClientType.TEMPORARY}
                             data-uie-name="enter-public-computer-sign-in"
                             style={{justifyContent: 'center', marginTop: '12px'}}
+                            alignCenter={true}
                           >
                             <CheckboxLabel htmlFor="enter-public-computer-sign-in">
                               {_(loginStrings.publicComputer)}

--- a/src/script/auth/page/PhoneLogin.tsx
+++ b/src/script/auth/page/PhoneLogin.tsx
@@ -137,7 +137,7 @@ const PhoneLogin = ({
                       checked={loginData.clientType === ClientType.TEMPORARY}
                       data-uie-name="enter-public-computer-phone-sign-in"
                       style={{justifyContent: 'center', marginTop: '12px'}}
-                      alignCenter={true}
+                      alignCenter
                     >
                       <CheckboxLabel>{_(loginStrings.publicComputer)}</CheckboxLabel>
                     </Checkbox>

--- a/src/script/auth/page/PhoneLogin.tsx
+++ b/src/script/auth/page/PhoneLogin.tsx
@@ -137,6 +137,7 @@ const PhoneLogin = ({
                       checked={loginData.clientType === ClientType.TEMPORARY}
                       data-uie-name="enter-public-computer-phone-sign-in"
                       style={{justifyContent: 'center', marginTop: '12px'}}
+                      alignCenter={true}
                     >
                       <CheckboxLabel>{_(loginStrings.publicComputer)}</CheckboxLabel>
                     </Checkbox>

--- a/src/script/auth/page/SingleSignOnForm.tsx
+++ b/src/script/auth/page/SingleSignOnForm.tsx
@@ -311,7 +311,7 @@ const SingleSignOnForm = ({
           }
           checked={clientType === ClientType.TEMPORARY}
           data-uie-name="enter-public-computer-sso-sign-in"
-          alignCenter={true}
+          alignCenter
           style={{justifyContent: 'center', marginTop: '36px'}}
         >
           <CheckboxLabel htmlFor="">{_(loginStrings.publicComputer)}</CheckboxLabel>

--- a/src/script/auth/page/SingleSignOnForm.tsx
+++ b/src/script/auth/page/SingleSignOnForm.tsx
@@ -311,6 +311,7 @@ const SingleSignOnForm = ({
           }
           checked={clientType === ClientType.TEMPORARY}
           data-uie-name="enter-public-computer-sso-sign-in"
+          alignCenter={true}
           style={{justifyContent: 'center', marginTop: '36px'}}
         >
           <CheckboxLabel htmlFor="">{_(loginStrings.publicComputer)}</CheckboxLabel>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3304,10 +3304,10 @@
   dependencies:
     protobufjs "6.10.2"
 
-"@wireapp/react-ui-kit@8.8.1":
-  version "8.8.1"
-  resolved "https://registry.yarnpkg.com/@wireapp/react-ui-kit/-/react-ui-kit-8.8.1.tgz#9ba0bce3bc32e531b7310b95487980b795a61848"
-  integrity sha512-kJTI+P3Aty5PsBPdE+O4RsMTAyxbAdZk1sIyv7NnexPWRQcvMZ4/ldZ16I7b4I6vqVFGv3/J5pEbrEtWaRlveA==
+"@wireapp/react-ui-kit@8.8.2":
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/@wireapp/react-ui-kit/-/react-ui-kit-8.8.2.tgz#0f4d4ad2d018624b1817ab823a47fb918b7df67a"
+  integrity sha512-LFiKIiSXX5YRxvy8cs6jsgHaeItdf/7LdYMH6w18roTqd1BPf+efvVIV1pU0DnwaDU+NJVUENkTKAyqUPWfbag==
   dependencies:
     "@emotion/react" "11.9.0"
     "@types/color" "3.0.2"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-207" title="ACC-207" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-207</a>  [Web] Option to login with public computer is not centered on login page
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

# What's new in this PR?

auth screen checkbox should be centre aligned.

### Issues

auth screen checkbox were not centre aligned

### Solutions

- use a flag to determine if 100% width is required

### Testing

#### How to Test

open login/create account screen, the checkbox should be centre aligned.