### PR TITLE
runfix: tweak modals style issues acc-77

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -340,7 +340,7 @@ exports[`stricter compilation`] = {
     ],
     "src/script/auth/page/Login.tsx:877256236": [
       [172, 24, 16, "Argument of type \'Error[]\' is not assignable to parameter of type \'SetStateAction<never[]>\'.", "2735526245"],
-      [174, 50, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
+      [174, 50, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.\\n  Type \'undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
       [203, 56, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
       [205, 32, 11, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2331572484"],
       [210, 36, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<string>\'.", "165548477"],
@@ -2061,7 +2061,7 @@ exports[`stricter compilation`] = {
       [106, 37, 12, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1912908196"],
       [178, 35, 12, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1912908196"]
     ],
-    "src/script/page/AppLock.tsx:2707199433": [
+    "src/script/page/AppLock.tsx:588408162": [
       [163, 28, 36, "Argument of type \'Element | null\' is not assignable to parameter of type \'Node\'.\\n  Type \'null\' is not assignable to type \'Node\'.", "3019440182"],
       [167, 26, 30, "Argument of type \'Element | null\' is not assignable to parameter of type \'Node\'.\\n  Type \'null\' is not assignable to type \'Node\'.", "1790131128"],
       [195, 59, 37, "Object is possibly \'null\'.", "3700925542"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -2064,6 +2064,7 @@ exports[`stricter compilation`] = {
     "src/script/page/AppLock.tsx:588408162": [
       [163, 28, 36, "Argument of type \'Element | null\' is not assignable to parameter of type \'Node\'.\\n  Type \'null\' is not assignable to type \'Node\'.", "3019440182"],
       [167, 26, 30, "Argument of type \'Element | null\' is not assignable to parameter of type \'Node\'.\\n  Type \'null\' is not assignable to type \'Node\'.", "1790131128"],
+      [195, 59, 37, "Object is possibly \'null\'.", "3700925542"],
       [216, 94, 4, "Argument of type \'unknown\' is not assignable to parameter of type \'StatusCodes\'.", "2087770728"],
       [219, 19, 7, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<string>\'.", "1236122734"]
     ],

--- a/.betterer.results
+++ b/.betterer.results
@@ -340,7 +340,7 @@ exports[`stricter compilation`] = {
     ],
     "src/script/auth/page/Login.tsx:877256236": [
       [172, 24, 16, "Argument of type \'Error[]\' is not assignable to parameter of type \'SetStateAction<never[]>\'.", "2735526245"],
-      [174, 50, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.\\n  Type \'undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
+      [174, 50, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
       [203, 56, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
       [205, 32, 11, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2331572484"],
       [210, 36, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<string>\'.", "165548477"],
@@ -2064,7 +2064,6 @@ exports[`stricter compilation`] = {
     "src/script/page/AppLock.tsx:588408162": [
       [163, 28, 36, "Argument of type \'Element | null\' is not assignable to parameter of type \'Node\'.\\n  Type \'null\' is not assignable to type \'Node\'.", "3019440182"],
       [167, 26, 30, "Argument of type \'Element | null\' is not assignable to parameter of type \'Node\'.\\n  Type \'null\' is not assignable to type \'Node\'.", "1790131128"],
-      [195, 59, 37, "Object is possibly \'null\'.", "3700925542"],
       [216, 94, 4, "Argument of type \'unknown\' is not assignable to parameter of type \'StatusCodes\'.", "2087770728"],
       [219, 19, 7, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<string>\'.", "1236122734"]
     ],

--- a/src/page/template/modals.htm
+++ b/src/page/template/modals.htm
@@ -7,7 +7,7 @@
     <div class="modal__header" data-uie-name="status-modal-title">
       <h2 class="modal__header__title" id="modal-title" data-bind="text: content().titleText"></h2>
       <button type="button" class="modal__header__button" data-bind="click: hide" data-uie-name="do-close">
-        <close-icon class="modal__header__button" aria-hidden="true"></close-icon>
+        <close-icon class="modal__header__icon" aria-hidden="true"></close-icon>
       </button>
     </div>
     <div class="modal__body" data-bind="fadingscrollbar">

--- a/src/script/page/AppLock.tsx
+++ b/src/script/page/AppLock.tsx
@@ -272,7 +272,7 @@ const AppLock: React.FC<AppLockProps> = ({
       <div className="modal__header">
         {!isAppLockEnforced && !isAppLockActivated && (
           <button type="button" className="modal__header__button" onClick={onCancelAppLock} data-uie-name="do-close">
-            <span aria-hidden="true">
+            <span className="modal__header__icon" aria-hidden="true">
               <Icon.Close />
             </span>
           </button>

--- a/src/style/common/checkbox.less
+++ b/src/style/common/checkbox.less
@@ -28,11 +28,17 @@
 //
 .checkbox {
   display: inline-block;
+  padding-left: 2px;
 
   input[type='checkbox'] {
     position: absolute;
     left: @offscreen-left;
     opacity: 0;
+
+    &:focus-visible + label {
+      outline: 1px solid var(--accent-color);
+      outline-offset: 0.4rem;
+    }
 
     &:checked + label {
       &::after {
@@ -86,8 +92,8 @@
     }
 
     &::before {
-      border: 1.5px solid var(--gray-80);
-      background-color: var(--gray-20);
+      border: 1.5px solid var(--checkbox-border);
+      background-color: var(--checkbox-background);
     }
 
     > div {

--- a/src/style/common/modal.less
+++ b/src/style/common/modal.less
@@ -154,6 +154,9 @@
 
     .modal-checkbox {
       margin-right: 4px;
+      & input {
+        .checkbox;
+      }
     }
   }
 
@@ -314,10 +317,20 @@
       align-items: center;
       justify-content: center;
       cursor: pointer;
+
+      &:hover {
+        fill: var(--accent-color);
+      }
+
       &__left {
         right: unset;
         left: -6px;
       }
+    }
+    &__icon {
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     &--list {
@@ -337,7 +350,7 @@
   }
 
   &__body {
-    overflow-y: auto;
+    overflow: visible;
   }
 
   &__buttons {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-77" title="ACC-77" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-77</a>  Update conversations view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
### Issues

- Close Icon focus state looks broken
- Buttons outlines get clipped
- Checkboxes have wrong color in dark mode
![Peek 2022-07-15 18-25](https://user-images.githubusercontent.com/78490891/179266286-f4a3a5eb-0eea-4c5a-bc27-f0ee6c346496.gif)

### Solutions
![Peek 2022-07-15 18-24](https://user-images.githubusercontent.com/78490891/179266341-920b5cb2-80aa-46fb-a360-387dfae1aa46.gif)

