### PR TITLE
runfix: tweak service modal style acc-201

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -340,7 +340,7 @@ exports[`stricter compilation`] = {
     ],
     "src/script/auth/page/Login.tsx:2293216844": [
       [172, 24, 16, "Argument of type \'Error[]\' is not assignable to parameter of type \'SetStateAction<never[]>\'.", "2735526245"],
-      [174, 50, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.\\n  Type \'undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
+      [174, 50, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
       [203, 56, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
       [205, 32, 11, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2331572484"],
       [210, 36, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<string>\'.", "165548477"],
@@ -1120,7 +1120,7 @@ exports[`stricter compilation`] = {
       [61, 4, 91, "Type \'number | null\' is not assignable to type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "187276181"],
       [72, 6, 41, "Type of computed property\'s value is \'(conversationEntity: Conversation, eventJson: ConversationMessageTimerUpdateEvent) => Promise<Conversation>\', which is not assignable to type \'(conversationEntity: Conversation) => void | Promise<void>\'.", "2358639438"],
       [77, 4, 18, "Type \'ObservableArray<never>\' is not assignable to type \'ObservableArray<ContentMessage>\'.\\n  Types of parameters \'value\' and \'value\' are incompatible.\\n    Type \'ContentMessage[] | null | undefined\' is not assignable to type \'never[] | null | undefined\'.\\n      Type \'ContentMessage[]\' is not assignable to type \'never[]\'.\\n        Type \'ContentMessage\' is not assignable to type \'never\'.", "2087948420"],
-      [84, 29, 16, "No overload matches this call.\\n  Overload 1 of 2, \'(id?: number | undefined): void\', gave the following error.\\n    Argument of type \'number | null\' is not assignable to parameter of type \'number | undefined\'.\\n  Overload 2 of 2, \'(intervalId: Timeout): void\', gave the following error.\\n    Argument of type \'number | null\' is not assignable to parameter of type \'Timeout\'.\\n      Type \'null\' is not assignable to type \'Timeout\'.", "1776967942"],
+      [84, 29, 16, "No overload matches this call.\\n  Overload 1 of 2, \'(id?: number | undefined): void\', gave the following error.\\n    Argument of type \'number | null\' is not assignable to parameter of type \'number | undefined\'.\\n  Overload 2 of 2, \'(intervalId: Timeout | undefined): void\', gave the following error.\\n    Argument of type \'number | null\' is not assignable to parameter of type \'Timeout | undefined\'.\\n      Type \'null\' is not assignable to type \'Timeout | undefined\'.", "1776967942"],
       [129, 38, 25, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1762572671"],
       [178, 34, 25, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1762572671"],
       [197, 34, 25, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1762572671"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -340,7 +340,7 @@ exports[`stricter compilation`] = {
     ],
     "src/script/auth/page/Login.tsx:2293216844": [
       [172, 24, 16, "Argument of type \'Error[]\' is not assignable to parameter of type \'SetStateAction<never[]>\'.", "2735526245"],
-      [174, 50, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
+      [174, 50, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.\\n  Type \'undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
       [203, 56, 10, "Type \'ClientType | undefined\' is not assignable to type \'ClientType\'.", "3013398820"],
       [205, 32, 11, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2331572484"],
       [210, 36, 5, "Argument of type \'unknown\' is not assignable to parameter of type \'SetStateAction<string>\'.", "165548477"],

--- a/src/script/components/Modals/ServiceModal/ServiceModal.tsx
+++ b/src/script/components/Modals/ServiceModal/ServiceModal.tsx
@@ -81,7 +81,11 @@ const ServiceModal: React.FC<ServiceModalProps> = ({
             </div>
 
             <div className="service-modal__footer">
-              <button className="service-modal__button" onClick={onOpenService} data-uie-name="do-service-confirm">
+              <button
+                className="service-modal__button modal__button--primary"
+                onClick={onOpenService}
+                data-uie-name="do-service-confirm"
+              >
                 {t('searchServiceConfirmButton')}
               </button>
             </div>

--- a/src/style/modal/service-modal.less
+++ b/src/style/modal/service-modal.less
@@ -1,10 +1,8 @@
 .service-modal {
   &__name {
+    .heading-h2;
     padding: 0;
     margin: 0;
-    font-size: 24px;
-    font-weight: @font-weight-regular;
-    line-height: 32px;
   }
 
   &__provider {
@@ -17,15 +15,12 @@
     display: flex;
     flex-direction: column;
     flex-grow: 1;
-    padding: 16px;
-    margin-top: -40px;
+    padding: 8px;
+    margin-top: -30px;
   }
 
   &__button {
-    .button;
-
     width: 100%;
-    height: 48px;
   }
 
   &__details {
@@ -37,9 +32,8 @@
   }
 
   &__description {
-    padding: 8px;
+    .text-light;
     margin-top: 16px;
-    font-size: 14px;
   }
 
   &__header {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-201" title="ACC-201" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-201</a>  [Web] The button to add a service to a conversation is almost invisible
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----

### Issues

![image](https://user-images.githubusercontent.com/78490891/179480628-f1103771-fce1-4760-865b-d8c1240504b8.png)

### Solutions

- assign the correct css classes to the button, title and paragraph

![image](https://user-images.githubusercontent.com/78490891/179480973-bd04eeeb-a34e-4f46-8067-ec782045cf41.png)
