### PR TITLE
fix: rendering of 404 page (SQCORE-1347)

### DIFF
--- a/server/templates/error.html
+++ b/server/templates/error.html
@@ -11,11 +11,11 @@
     <link rel="icon" href="/image/meta/wire-icon-64.png" sizes="64x64" type="image/png">
     <title>Wire Error</title>
     <link rel="stylesheet" href="/style/support.css">
-    <meta property="og:title" content="Wire for Web – modern, private communications in your browsers.">
-    <meta property="og:description" name="description" content="Crystal clear voice, video and group chats. No advertising. Always encrypted.">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://app.wire.com">
-    <meta property="og:image" content="https://lh3.googleusercontent.com/ElqTCcY1N0c3EAX27MRFoXynZlbTaJD2KEqYNXAPn5YQPZa6Bvsux4NCgEMoUhazdIWWelAU__Kzmr55j55EsgM=s1024">
+    <meta property="og:title" content="{{@config.OPEN_GRAPH.TITLE}}" />
+    <meta property="og:description" name="description" content="{{@config.OPEN_GRAPH.DESCRIPTION}}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="{{@config.APP_BASE}}" />
+    <meta property="og:image" content="{{@config.OPEN_GRAPH.IMAGE_URL}}" />
   </head>
 
   <body>

--- a/src/style/support.less
+++ b/src/style/support.less
@@ -47,11 +47,11 @@ html {
 svg {
   width: 32px;
   height: 26.5px;
-  fill: #fff;
+  fill: #000;
 }
 
 a {
-  color: #fff;
+  color: #000;
   text-decoration: none;
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCORE-1347" title="SQCORE-1347" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQCORE-1347</a>  [webapp] 404 page does not render correctly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some text on the 404 page is rendered in white (on a white background)

### Solutions

Set font color to black.

### Testing

#### How to Test

open a non existing page on the webapp (e.g. https://wire-webapp-staging.wire.com/404) and make sure all text is readable and a Wire logo is shown.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
