### PR TITLE
build: Add new stage to deploy acc branch to wire-webapp-qa environment 

### DIFF
--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -239,7 +239,7 @@ jobs:
           aws_access_key: ${{secrets.WEBTEAM_AWS_ACCESS_KEY_ID}}
           aws_secret_key: ${{secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY}}
           deployment_package: ${{env.AWS_BUILD_ZIP_PATH}}
-          environment_name: wire-webapp-qa
+          environment_name: wire-webapp-acc
           region: eu-central-1
           use_existing_version_if_available: true
           version_description: ${{github.sha}}

--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -2,12 +2,12 @@ name: CI
 
 on:
   push:
-    branches: [master, dev, edge, avs, mobile]
+    branches: [master, dev, edge, avs, mobile, acc]
     tags:
       - '*staging*'
       - '*production*'
   pull_request:
-    branches: [master, dev, edge, avs, mobile]
+    branches: [master, dev, edge, avs, mobile, acc]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -223,6 +223,23 @@ jobs:
           aws_secret_key: ${{secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY}}
           deployment_package: ${{env.AWS_BUILD_ZIP_PATH}}
           environment_name: wire-webapp-mobile
+          region: eu-central-1
+          use_existing_version_if_available: true
+          version_description: ${{github.sha}}
+          version_label: ${{github.run_id}}
+          wait_for_deployment: false
+          wait_for_environment_recovery: ${{env.DEPLOYMENT_RECOVERY_TIMEOUT_SECONDS}}
+
+      # Stage 7: https://wire-webapp-qa.zinfra.io/
+      - name: Deploy acc build to Elastic Beanstalk
+        if: env.BRANCH_NAME == 'acc'
+        uses: einaregilsson/beanstalk-deploy@v20
+        with:
+          application_name: ${{env.AWS_APPLICATION_NAME}}
+          aws_access_key: ${{secrets.WEBTEAM_AWS_ACCESS_KEY_ID}}
+          aws_secret_key: ${{secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY}}
+          deployment_package: ${{env.AWS_BUILD_ZIP_PATH}}
+          environment_name: wire-webapp-qa
           region: eu-central-1
           use_existing_version_if_available: true
           version_description: ${{github.sha}}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Accessibility changes prevent dev branch from being bumped and releasable

### Solutions

Separate dev and acc branch with acc branch deploying to wire-webapp-qa. See [Proposal](https://wearezeta.atlassian.net/wiki/spaces/QA/pages/619315842/Proposal+Build+structure+improvements+for+webapp)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
