### PR TITLE
runfix: correct text color in active sidebar

### DIFF
--- a/src/style/list/conversation-list-cell.less
+++ b/src/style/list/conversation-list-cell.less
@@ -121,7 +121,7 @@
     font-weight: @font-weight-medium;
 
     &--active {
-      color: var(--white);
+      color: var(--app-bg-secondary);
     }
   }
 }
@@ -135,7 +135,7 @@
   font-weight: @font-weight-medium;
 
   &--active {
-    color: var(--white);
+    color: var(--app-bg-secondary);
   }
 }
 
@@ -191,7 +191,7 @@ body.theme-dark {
 
   &--active {
     &::before {
-      border-top-color: var(--white);
+      border-top-color: var(--app-bg-secondary);
     }
   }
 }


### PR DESCRIPTION
----

### Issues

- Some text is white in dark mode on an active sidebar (should be black)

![Screenshot from 2022-08-18 11-12-15](https://user-images.githubusercontent.com/78490891/185358566-c01e79b3-14c8-4d93-b49f-40aa3e121d99.png)

### Solutions

![image](https://user-images.githubusercontent.com/78490891/185358242-bcd85c64-8777-4fbe-a89c-69ae29928b39.png)
