### PR TITLE
runfix: address changes to call UI camera switcher acc-81

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -934,8 +934,8 @@ exports[`stricter compilation`] = {
       [177, 10, 20, "Type \'undefined\' is not assignable to type \'Participant\'.", "942864568"],
       [180, 10, 9, "Type \'undefined\' is not assignable to type \'MuteState\'.", "3616862203"]
     ],
-    "src/script/components/calling/FullscreenVideoCall.tsx:677417589": [
-      [401, 50, 4, "Argument of type \'null\' is not assignable to parameter of type \'Participant\'.", "2087897566"]
+    "src/script/components/calling/FullscreenVideoCall.tsx:2795856065": [
+      [406, 50, 4, "Argument of type \'null\' is not assignable to parameter of type \'Participant\'.", "2087897566"]
     ],
     "src/script/components/calling/GroupVideoGrid.test.ts:1931211751": [
       [35, 55, 22, "Object is possibly \'null\'.", "1458310722"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -789,9 +789,9 @@ exports[`stricter compilation`] = {
     "src/script/components/MessagesList/Message/ContentMessage/index.test.tsx:305658061": [
       [58, 6, 15, "Type \'undefined\' is not assignable to type \'Message\'.", "1976601247"]
     ],
-    "src/script/components/MessagesList/Message/ContentMessage/index.tsx:1379302737": [
-      [101, 45, 13, "Type \'(user: User) => void\' is not assignable to type \'(participant: User | ServiceEntity, target: Node) => void\'.\\n  Types of parameters \'user\' and \'participant\' are incompatible.\\n    Type \'User | ServiceEntity\' is not assignable to type \'User\'.\\n      Type \'ServiceEntity\' is not assignable to type \'User\'.", "2891534203"],
-      [174, 12, 13, "Type \'((message: ContentMessage, assetId: string) => void) | undefined\' is not assignable to type \'(message: ContentMessage, assetId: string) => void\'.\\n  Type \'undefined\' is not assignable to type \'(message: ContentMessage, assetId: string) => void\'.", "2671775388"]
+    "src/script/components/MessagesList/Message/ContentMessage/index.tsx:3077288377": [
+      [104, 10, 13, "Type \'(user: User) => void\' is not assignable to type \'(participant: User | ServiceEntity, target: Node) => void\'.\\n  Types of parameters \'user\' and \'participant\' are incompatible.\\n    Type \'User | ServiceEntity\' is not assignable to type \'User\'.\\n      Type \'ServiceEntity\' is not assignable to type \'User\'.", "2891534203"],
+      [179, 12, 13, "Type \'((message: ContentMessage, assetId: string) => void) | undefined\' is not assignable to type \'(message: ContentMessage, assetId: string) => void\'.\\n  Type \'undefined\' is not assignable to type \'(message: ContentMessage, assetId: string) => void\'.", "2671775388"]
     ],
     "src/script/components/MessagesList/Message/DecryptErrorMessage.test.tsx:629592445": [
       [36, 53, 36, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "885356606"]
@@ -934,8 +934,8 @@ exports[`stricter compilation`] = {
       [177, 10, 20, "Type \'undefined\' is not assignable to type \'Participant\'.", "942864568"],
       [180, 10, 9, "Type \'undefined\' is not assignable to type \'MuteState\'.", "3616862203"]
     ],
-    "src/script/components/calling/FullscreenVideoCall.tsx:1656063968": [
-      [406, 50, 4, "Argument of type \'null\' is not assignable to parameter of type \'Participant\'.", "2087897566"]
+    "src/script/components/calling/FullscreenVideoCall.tsx:677417589": [
+      [401, 50, 4, "Argument of type \'null\' is not assignable to parameter of type \'Participant\'.", "2087897566"]
     ],
     "src/script/components/calling/GroupVideoGrid.test.ts:1931211751": [
       [35, 55, 22, "Object is possibly \'null\'.", "1458310722"],

--- a/src/script/components/MessagesList/Message/ContentMessage/index.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/index.tsx
@@ -99,7 +99,12 @@ const ContentMessageComponent: React.FC<ContentMessageProps> = ({
   const avatarSection = shouldShowAvatar() ? (
     <div className="message-header">
       <div className="message-header-icon">
-        <Avatar participant={message.user()} onAvatarClick={onClickAvatar} avatarSize={AVATAR_SIZE.X_SMALL} />
+        <Avatar
+          tabIndex={0}
+          participant={message.user()}
+          onAvatarClick={onClickAvatar}
+          avatarSize={AVATAR_SIZE.X_SMALL}
+        />
       </div>
       <div className="message-header-label">
         <span className={`message-header-label-sender ${message.accent_color()}`} data-uie-name="sender-name">

--- a/src/script/components/avatar/UserAvatar.tsx
+++ b/src/script/components/avatar/UserAvatar.tsx
@@ -79,16 +79,14 @@ const UserAvatar: React.FunctionComponent<UserAvatarProps> = ({
     >
       <AvatarBackground backgroundColor={backgroundColor} />
       <AvatarInitials avatarSize={avatarSize} initials={participant.initials()} />
-      <div tabIndex={0} role="button">
-        <AvatarImage
-          avatarSize={avatarSize}
-          avatarAlt={avatarImgAlt}
-          backgroundColor={backgroundColor}
-          isGrey={isImageGrey}
-          mediumPicture={mediumPictureResource}
-          previewPicture={previewPictureResource}
-        />
-      </div>
+      <AvatarImage
+        avatarSize={avatarSize}
+        avatarAlt={avatarImgAlt}
+        backgroundColor={backgroundColor}
+        isGrey={isImageGrey}
+        mediumPicture={mediumPictureResource}
+        previewPicture={previewPictureResource}
+      />
       {!noBadge && shouldShowBadge(avatarSize, state) && <AvatarBadge state={state} />}
       {!isImageGrey && <AvatarBorder />}
     </AvatarWrapper>

--- a/src/script/components/calling/DeviceToggleButton.tsx
+++ b/src/script/components/calling/DeviceToggleButton.tsx
@@ -61,24 +61,28 @@ const DeviceToggleButton: React.FC<DeviceToggleButtonProps> = ({currentDevice, d
           marginTop: 8,
         }}
       >
-        {devices.map(device => (
-          <span
-            key={device}
-            className="device-toggle-button-indicator-dot"
-            data-uie-name="device-toggle-button-indicator-dot"
-            data-uie-value={device === currentDevice ? 'active' : 'inactive'}
-            css={{
-              '&:not(:last-child)': {marginRight: 5},
-              backgroundColor: device === currentDevice ? 'var(--accent-color)' : 'var(--app-bg-secondary)',
-              border: device === currentDevice ? '1px solid var(--accent-color)' : '1px solid var(--foreground)',
-              borderRadius: '50%',
-              color: '#fff',
-              display: 'inline-block',
-              height: 10,
-              width: 10,
-            }}
-          />
-        ))}
+        {devices.map(device => {
+          const isCurrentDevice = device === currentDevice;
+
+          return (
+            <span
+              key={device}
+              className="device-toggle-button-indicator-dot"
+              data-uie-name="device-toggle-button-indicator-dot"
+              data-uie-value={isCurrentDevice ? 'active' : 'inactive'}
+              css={{
+                '&:not(:last-child)': {marginRight: 5},
+                backgroundColor: isCurrentDevice ? 'var(--accent-color)' : 'var(--app-bg-secondary)',
+                border: isCurrentDevice ? '1px solid var(--accent-color)' : '1px solid var(--foreground)',
+                borderRadius: '50%',
+                color: '#fff',
+                display: 'inline-block',
+                height: 10,
+                width: 10,
+              }}
+            />
+          );
+        })}
       </div>
     </div>
   );

--- a/src/script/components/calling/DeviceToggleButton.tsx
+++ b/src/script/components/calling/DeviceToggleButton.tsx
@@ -68,13 +68,14 @@ const DeviceToggleButton: React.FC<DeviceToggleButtonProps> = ({currentDevice, d
             data-uie-name="device-toggle-button-indicator-dot"
             data-uie-value={device === currentDevice ? 'active' : 'inactive'}
             css={{
-              '&:not(:last-child)': {marginRight: 8},
-              backgroundColor: device === currentDevice ? 'currentColor' : 'var(--foreground-fade-24)',
+              '&:not(:last-child)': {marginRight: 5},
+              backgroundColor: device === currentDevice ? 'var(--accent-color)' : 'var(--app-bg-secondary)',
+              border: device === currentDevice ? '1px solid var(--accent-color)' : '1px solid var(--foreground)',
               borderRadius: '50%',
               color: '#fff',
               display: 'inline-block',
-              height: 8,
-              width: 8,
+              height: 10,
+              width: 10,
             }}
           />
         ))}

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -256,7 +256,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
               <Icon.ArrowNext css={{position: 'relative', right: 4, transform: 'rotate(180deg)'}} />
             </button>
           )}
-          <div css={{bottom: 110, display: 'flex', justifyContent: 'center', position: 'absolute', width: '100%'}}>
+          <div css={{bottom: 108, display: 'flex', justifyContent: 'center', position: 'absolute', width: '100%'}}>
             <Pagination
               totalPages={totalPages}
               currentPage={currentPage}
@@ -333,11 +333,15 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                       <Icon.CameraOff width={16} height={16} />
                     )}
 
-                    {showSwitchCamera ? (
+                    <span id="video-label" className="video-controls__button__label">
+                      {t('videoCallOverlayCamera')}
+                    </span>
+
+                    {showSwitchCamera && (
                       <DeviceToggleButton
                         styles={css`
                           position: absolute;
-                          bottom: -16px;
+                          bottom: -38px;
                           left: 50%;
                           transform: translateX(-50%);
                         `}
@@ -345,10 +349,6 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                         devices={availableCameras}
                         onChooseDevice={deviceId => switchCameraInput(call, deviceId)}
                       />
-                    ) : (
-                      <span id="video-label" className="video-controls__button__label">
-                        {t('videoCallOverlayCamera')}
-                      </span>
                     )}
                   </div>
                 </li>

--- a/src/script/components/calling/Pagination.tsx
+++ b/src/script/components/calling/Pagination.tsx
@@ -27,6 +27,20 @@ export interface PaginationProps {
   wrapperStyles?: CSSObject;
 }
 
+const paginationItemStyles: CSSObject = {
+  '&:hover': {
+    border: '1px solid var(--accent-color)',
+  },
+  ':last-child': {
+    marginRight: 4,
+  },
+  borderRadius: '50%',
+  cursor: 'pointer',
+  height: 12,
+  marginLeft: 4,
+  width: 12,
+};
+
 const Pagination: React.FC<PaginationProps> = ({totalPages, currentPage, onChangePage, wrapperStyles = {}}) => {
   const pages = new Array(totalPages).fill(null).map((_, index) => index);
 
@@ -37,7 +51,7 @@ const Pagination: React.FC<PaginationProps> = ({totalPages, currentPage, onChang
         backgroundColor: 'var(--border-color)',
         borderRadius: 12,
         display: 'flex',
-        height: 16,
+        height: 22,
         justifyContent: 'center',
         ...wrapperStyles,
       }}
@@ -52,16 +66,9 @@ const Pagination: React.FC<PaginationProps> = ({totalPages, currentPage, onChang
           type="button"
           className="button-reset-default"
           css={{
-            ':last-child': {
-              marginRight: 4,
-            },
+            ...paginationItemStyles,
             backgroundColor: currentPage === page ? 'var(--accent-color)' : 'var(--app-bg-secondary)',
             border: currentPage === page ? 'solid 1px var(--accent-color)' : 'solid 1px var(--foreground)',
-            borderRadius: 8,
-            cursor: 'pointer',
-            height: 8,
-            marginLeft: 4,
-            width: 8,
           }}
         />
       ))}

--- a/src/style/foundation/video-calling.less
+++ b/src/style/foundation/video-calling.less
@@ -44,7 +44,7 @@
 }
 
 .video-element-remote {
-  height: calc(100% - 175px);
+  height: calc(100% - 179px);
   // fade in animation
   animation: video-fade-in @animation-timing-slower @ease-out-quart forwards;
   opacity: 0;

--- a/src/style/foundation/video-calling.less
+++ b/src/style/foundation/video-calling.less
@@ -155,11 +155,13 @@
         body.theme-dark & {
           background-color: #ff928d;
         }
-      }
-      &:active {
-        border: 1px solid var(--accent-color);
-        body.theme-dark & {
-          border: 1px solid var(--accent-color);
+        &:active {
+          border: 1px solid #74000b;
+          background-color: var(--red-500);
+          body.theme-dark & {
+            border: 1px solid #ffc9c6;
+            background-color: var(--red-500);
+          }
         }
       }
     }

--- a/src/style/foundation/video-calling.less
+++ b/src/style/foundation/video-calling.less
@@ -145,6 +145,7 @@
     }
 
     &--red {
+      border: 1px solid var(--red-500);
       background-color: var(--red-500);
       svg > path {
         fill: var(--app-bg-secondary);
@@ -153,6 +154,12 @@
         background-color: #9b000f;
         body.theme-dark & {
           background-color: #ff928d;
+        }
+      }
+      &:active {
+        border: 1px solid var(--accent-color);
+        body.theme-dark & {
+          border: 1px solid var(--accent-color);
         }
       }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-81" title="ACC-81" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-81</a>  Calling UI fullscreen view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----

### Issues

- The camera switcher pagination was not addressed during the call-ui changes
- The user pagination's size was not correct
- Avatars are available to keyboard navigation in the call-ui

### Solutions

- Address the pagination changes
- Expand the height of the call-ui to accomodate the camera-switcher
- Move the tab index from the avatar component to the chat window index.tsx

![Screenshot from 2022-08-19 13-47-52](https://user-images.githubusercontent.com/78490891/185612029-94ad7420-ecdd-43cc-a6dc-cdca4df8a266.png)
![Screenshot from 2022-08-19 13-48-11](https://user-images.githubusercontent.com/78490891/185612038-a00676e4-1770-49fa-b4c1-20dc9ec3f042.png)

