### PR TITLE
fix: device removal and device details keyboard accessibility(ACC-249)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2098,10 +2098,10 @@ exports[`stricter compilation`] = {
       [34, 41, 22, "Cannot invoke an object which is possibly \'undefined\'.", "1980738780"],
       [41, 21, 12, "Argument of type \'string | undefined\' is not assignable to parameter of type \'Matcher\'.\\n  Type \'undefined\' is not assignable to type \'Matcher\'.", "2075561852"]
     ],
-    "src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx:3136549338": [
-      [67, 90, 10, "Type \'undefined\' is not assignable to type \'boolean\'.", "3231345145"],
-      [124, 8, 14, "Type \'(device: ClientEntity) => Promise<string | undefined>\' is not assignable to type \'(device: ClientEntity) => Promise<string>\'.\\n  Type \'Promise<string | undefined>\' is not assignable to type \'Promise<string>\'.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "223037395"],
-      [131, 73, 37, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "3769528030"]
+    "src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx:1032054856": [
+      [77, 90, 10, "Type \'undefined\' is not assignable to type \'boolean\'.", "3231345145"],
+      [141, 8, 14, "Type \'(device: ClientEntity) => Promise<string | undefined>\' is not assignable to type \'(device: ClientEntity) => Promise<string>\'.\\n  Type \'Promise<string | undefined>\' is not assignable to type \'Promise<string>\'.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "223037395"],
+      [148, 73, 37, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "3769528030"]
     ],
     "src/script/page/message-list/InputBarControls/InputBarControls.test.tsx:2517377529": [
       [33, 2, 12, "Type \'undefined\' is not assignable to type \'Conversation\'.", "1670678216"]

--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -903,6 +903,8 @@
   "participantDevicesDetailResetSession": "Reset session",
   "participantDevicesDetailShowMyDevice": "Show my device fingerprint",
   "participantDevicesDetailVerify": "Verified",
+  "preferencesDeviceNotVerified": "not verified",
+  "preferencesDevice": "Device",
   "participantDevicesHeader": "Devices",
   "participantDevicesHeadline": "{{brandName}} gives every device a unique fingerprint. Compare them with {{user}} and verify your conversation.",
   "participantDevicesLearnMore": "Learn more",

--- a/src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx
@@ -52,23 +52,37 @@ const Device: React.FC<{
   isSSO: boolean;
   onRemove: (device: ClientEntity) => void;
   onSelect: (device: ClientEntity) => void;
-}> = ({device, isSSO, onSelect, onRemove}) => {
+  deviceNumber: number;
+}> = ({device, isSSO, onSelect, onRemove, deviceNumber}) => {
   const {isVerified} = useKoSubscribableChildren(device.meta, ['isVerified']);
-
+  const deviceAriaLabel = `${t('preferencesDevice')} ${deviceNumber}, ${device.getName()}, ${
+    isVerified ? t('preferencesDevicesVerification') : t('preferencesDeviceNotVerified')
+  }, `;
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    onRemove(device);
+  };
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+  };
   return (
     <div
-      role="button"
-      tabIndex={0}
       className="preferences-devices-card"
       onClick={() => onSelect(device)}
       onKeyDown={e => handleKeyDown(e, onSelect.bind(null, device))}
+      tabIndex={0}
+      role="button"
     >
       <div className="preferences-devices-card-data">
         <div className="preferences-devices-card-icon" data-uie-value={device.id} data-uie-name="device-id">
           <VerifiedIcon data-uie-name={`user-device-${isVerified ? '' : 'not-'}verified`} isVerified={isVerified} />
         </div>
         <div className="preferences-devices-card-info">
-          <div className="preferences-devices-model" data-uie-name="preferences-device-active-model">
+          <div
+            className="preferences-devices-model"
+            data-uie-name="preferences-device-active-model"
+            aria-label={deviceAriaLabel}
+          >
             {device.getName()}
           </div>
           <div className="preferences-devices-id">
@@ -85,16 +99,19 @@ const Device: React.FC<{
             aria-label={t('preferencesDevicesRemove')}
             type="button"
             className={`preferences-devices-card-action__delete ${isSSO && 'svg-red'}`}
-            onClick={event => {
-              event.stopPropagation();
-              onRemove(device);
-            }}
+            onClick={handleClick}
+            onKeyDown={handleKeyPress}
             data-uie-name="do-device-remove"
           >
             <Icon.Delete />
           </button>
         )}
-        <div className="icon-forward preferences-devices-card-action__forward" data-uie-name="go-device-details" />
+        <button
+          className="icon-forward preferences-devices-card-action__forward"
+          data-uie-name="go-device-details"
+          aria-label={t('accessibility.headings.preferencesDeviceDetails')}
+          aria-hidden={true}
+        ></button>
       </div>
     </div>
   );
@@ -148,13 +165,14 @@ const DevicesPreferences: React.FC<DevicesPreferencesProps> = ({
         {clients.length > 0 && (
           <fieldset className="preferences-section">
             <legend className="preferences-header">{t('preferencesDevicesActive')}</legend>
-            {clients.map(device => (
+            {clients.map((device, index) => (
               <Device
                 device={device}
                 key={device.id}
                 isSSO={isSSO}
                 onSelect={setSelectedDevice}
                 onRemove={removeDevice}
+                deviceNumber={++index}
               />
             ))}
             <div className="preferences-detail">{t('preferencesDevicesActiveDetail')}</div>

--- a/src/style/common/typing.less
+++ b/src/style/common/typing.less
@@ -136,3 +136,11 @@
 .focus-border-radius {
   border-radius: 4px;
 }
+
+.focus-default {
+  &:focus-visible {
+    .focus-outline;
+    .focus-offset;
+    .focus-border-radius;
+  }
+}

--- a/src/style/content/preferences/devices.less
+++ b/src/style/content/preferences/devices.less
@@ -39,6 +39,8 @@
   padding-top: 8px;
   cursor: pointer;
 
+  .focus-default;
+
   .preferences-devices-card-action {
     display: flex;
     width: 56px;
@@ -48,9 +50,12 @@
     &__delete {
       .button-reset-default;
       padding: 8px;
+      .focus-default;
     }
     &__forward {
       margin-left: auto;
+      .button-reset-default;
+      .focus-default;
     }
   }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-249" title="ACC-249" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-249</a>  [Web]Device removal using keyboard takes the user to device details page instead of showing delete modal
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - device removal and device details keyboard accessibility

- The **PR Description**
  - device removal and device details keyboard accessibility
----

# What's new in this PR?

### Issues

- device removal takes user to device details.
- announce device list items as suggested in [ACC-21](https://docs.google.com/spreadsheets/d/1g5ENPrk7NivDOJy9vKoymXnDvu42G3rlR9oKzYslWBs/edit?pli=1#gid=0)

### Solutions

- add keyboard handlers

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

- - access the list and actions using keyboard