### PR TITLE
fix: address hover and focus state of sidebar call-ui acc-80

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -974,7 +974,7 @@ exports[`stricter compilation`] = {
       [127, 11, 33, "Object is possibly \'null\'.", "1545610583"],
       [132, 11, 33, "Object is possibly \'null\'.", "1545610583"]
     ],
-    "src/script/components/list/ConversationListCallingCell.tsx:2856634286": [
+    "src/script/components/list/ConversationListCallingCell.tsx:1825680799": [
       [115, 90, 6, "Argument of type \'number | undefined\' is not assignable to parameter of type \'REASON\'.\\n  Type \'undefined\' is not assignable to type \'REASON\'.", "2124277697"],
       [128, 67, 8, "No overload matches this call.\\n  Overload 1 of 2, \'(...items: ConcatArray<User>[]): User[]\', gave the following error.\\n    Type \'User | undefined\' is not assignable to type \'User\'.\\n      Type \'undefined\' is not assignable to type \'User\'.\\n  Overload 2 of 2, \'(...items: (User | ConcatArray<User>)[]): User[]\', gave the following error.\\n    Type \'User | undefined\' is not assignable to type \'User\'.\\n      Type \'undefined\' is not assignable to type \'User\'.", "2198230984"],
       [148, 28, 12, "Type \'undefined\' cannot be used as an index type.", "3398917396"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -974,7 +974,7 @@ exports[`stricter compilation`] = {
       [127, 11, 33, "Object is possibly \'null\'.", "1545610583"],
       [132, 11, 33, "Object is possibly \'null\'.", "1545610583"]
     ],
-    "src/script/components/list/ConversationListCallingCell.tsx:4274181005": [
+    "src/script/components/list/ConversationListCallingCell.tsx:2856634286": [
       [115, 90, 6, "Argument of type \'number | undefined\' is not assignable to parameter of type \'REASON\'.\\n  Type \'undefined\' is not assignable to type \'REASON\'.", "2124277697"],
       [128, 67, 8, "No overload matches this call.\\n  Overload 1 of 2, \'(...items: ConcatArray<User>[]): User[]\', gave the following error.\\n    Type \'User | undefined\' is not assignable to type \'User\'.\\n      Type \'undefined\' is not assignable to type \'User\'.\\n  Overload 2 of 2, \'(...items: (User | ConcatArray<User>)[]): User[]\', gave the following error.\\n    Type \'User | undefined\' is not assignable to type \'User\'.\\n      Type \'undefined\' is not assignable to type \'User\'.", "2198230984"],
       [148, 28, 12, "Type \'undefined\' cannot be used as an index type.", "3398917396"],
@@ -985,9 +985,9 @@ exports[`stricter compilation`] = {
       [121, 8, 3, "Type \'(node: HTMLElement) => void\' is not assignable to type \'LegacyRef<HTMLLIElement> | undefined\'.\\n  Type \'(node: HTMLElement) => void\' is not assignable to type \'(instance: HTMLLIElement | null) => void\'.\\n    Types of parameters \'node\' and \'instance\' are incompatible.\\n      Type \'HTMLLIElement | null\' is not assignable to type \'HTMLElement\'.\\n        Type \'null\' is not assignable to type \'HTMLElement\'.", "193432436"],
       [151, 23, 8, "Object is possibly \'undefined\'.", "2198230984"]
     ],
-    "src/script/components/list/ParticipantItem.tsx:3591469056": [
-      [86, 43, 18, "Argument of type \'HTMLDivElement | undefined\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLElement\'.", "4082577534"],
-      [111, 94, 15, "Argument of type \'Participant | undefined\' is not assignable to parameter of type \'Partial<Record<\\"isMuted\\" | \\"isActivelySpeaking\\" | \\"sharesScreen\\" | \\"sharesCamera\\", Subscribable<any>>>\'.\\n  Type \'undefined\' is not assignable to type \'Partial<Record<\\"isMuted\\" | \\"isActivelySpeaking\\" | \\"sharesScreen\\" | \\"sharesCamera\\", Subscribable<any>>>\'.", "420345688"]
+    "src/script/components/list/ParticipantItem.tsx:2055801931": [
+      [87, 43, 18, "Argument of type \'HTMLDivElement | undefined\' is not assignable to parameter of type \'HTMLElement\'.\\n  Type \'undefined\' is not assignable to type \'HTMLElement\'.", "4082577534"],
+      [112, 94, 15, "Argument of type \'Participant | undefined\' is not assignable to parameter of type \'Partial<Record<\\"isMuted\\" | \\"isActivelySpeaking\\" | \\"sharesScreen\\" | \\"sharesCamera\\", Subscribable<any>>>\'.\\n  Type \'undefined\' is not assignable to type \'Partial<Record<\\"isMuted\\" | \\"isActivelySpeaking\\" | \\"sharesScreen\\" | \\"sharesCamera\\", Subscribable<any>>>\'.", "420345688"]
     ],
     "src/script/components/modal.ts:282599833": [
       [56, 9, 5, "Property \'large\' does not exist on type \'{} | Config\'.\\n  Property \'large\' does not exist on type \'{}\'.", "173484696"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -974,7 +974,7 @@ exports[`stricter compilation`] = {
       [127, 11, 33, "Object is possibly \'null\'.", "1545610583"],
       [132, 11, 33, "Object is possibly \'null\'.", "1545610583"]
     ],
-    "src/script/components/list/ConversationListCallingCell.tsx:3482388709": [
+    "src/script/components/list/ConversationListCallingCell.tsx:4274181005": [
       [115, 90, 6, "Argument of type \'number | undefined\' is not assignable to parameter of type \'REASON\'.\\n  Type \'undefined\' is not assignable to type \'REASON\'.", "2124277697"],
       [128, 67, 8, "No overload matches this call.\\n  Overload 1 of 2, \'(...items: ConcatArray<User>[]): User[]\', gave the following error.\\n    Type \'User | undefined\' is not assignable to type \'User\'.\\n      Type \'undefined\' is not assignable to type \'User\'.\\n  Overload 2 of 2, \'(...items: (User | ConcatArray<User>)[]): User[]\', gave the following error.\\n    Type \'User | undefined\' is not assignable to type \'User\'.\\n      Type \'undefined\' is not assignable to type \'User\'.", "2198230984"],
       [148, 28, 12, "Type \'undefined\' cannot be used as an index type.", "3398917396"],

--- a/src/script/components/list/ConversationListCallingCell.tsx
+++ b/src/script/components/list/ConversationListCallingCell.tsx
@@ -454,7 +454,7 @@ const ConversationListCallingCell: React.FC<CallingCellProps> = ({
                       .slice()
                       .sort((participantA, participantB) => sortUsersByPriority(participantA.user, participantB.user))
                       .map(participant => (
-                        <li key={participant.clientId}>
+                        <li key={participant.clientId} className="call-ui__participant-list__participant">
                           <ParticipantItem
                             key={participant.clientId}
                             participant={participant.user}

--- a/src/script/components/list/ConversationListCallingCell.tsx
+++ b/src/script/components/list/ConversationListCallingCell.tsx
@@ -148,7 +148,7 @@ const ConversationListCallingCell: React.FC<CallingCellProps> = ({
   const [showParticipants, setShowParticipants] = useState(false);
   const isModerator = roles[selfUser?.id] === DefaultConversationRoleName.WIRE_ADMIN;
 
-  const getParticipantContext = (event: React.MouseEvent<HTMLDivElement>, participant: Participant) => {
+  const getParticipantContext = (event: React.MouseEvent<HTMLDivElement> | MouseEvent, participant: Participant) => {
     event.preventDefault();
 
     const muteParticipant = {
@@ -172,7 +172,7 @@ const ConversationListCallingCell: React.FC<CallingCellProps> = ({
     };
 
     const entries: ContextMenuEntry[] = [!participant.user.isMe && muteParticipant, muteOthers].filter(Boolean);
-    showContextMenu(event.nativeEvent, entries, 'participant-moderator-menu');
+    showContextMenu(event, entries, 'participant-moderator-menu');
   };
 
   const handleMinimizedKeydown = useCallback(
@@ -466,6 +466,7 @@ const ConversationListCallingCell: React.FC<CallingCellProps> = ({
                             external={teamState.isExternal(participant.user.id)}
                             onContextMenu={isModerator ? event => getParticipantContext(event, participant) : undefined}
                             showDropdown={isModerator}
+                            noInteraction
                           />
                         </li>
                       ))}

--- a/src/script/components/list/ConversationListCallingCell.tsx
+++ b/src/script/components/list/ConversationListCallingCell.tsx
@@ -148,7 +148,7 @@ const ConversationListCallingCell: React.FC<CallingCellProps> = ({
   const [showParticipants, setShowParticipants] = useState(false);
   const isModerator = roles[selfUser?.id] === DefaultConversationRoleName.WIRE_ADMIN;
 
-  const getParticipantContext = (event: React.MouseEvent<HTMLDivElement> | MouseEvent, participant: Participant) => {
+  const getParticipantContext = (event: React.MouseEvent<HTMLDivElement>, participant: Participant) => {
     event.preventDefault();
 
     const muteParticipant = {

--- a/src/script/components/list/ParticipantItem.tsx
+++ b/src/script/components/list/ParticipantItem.tsx
@@ -25,7 +25,7 @@ import Avatar, {AVATAR_SIZE} from 'Components/Avatar';
 import {UserlistMode} from 'Components/UserList';
 import {t} from 'Util/LocalizerUtil';
 import {capitalizeFirstChar} from 'Util/StringUtil';
-import {noop} from 'Util/util';
+import {noop, setContextMenuPosition} from 'Util/util';
 
 import {User} from '../../entity/User';
 import {ServiceEntity} from '../../integration/ServiceEntity';
@@ -37,6 +37,7 @@ import AvailabilityState from 'Components/AvailabilityState';
 import ParticipantMicOnIcon from 'Components/calling/ParticipantMicOnIcon';
 import Icon from 'Components/Icon';
 import useEffectRef from 'Util/useEffectRef';
+import {KEY} from 'Util/KeyboardUtil';
 
 export interface ParticipantItemProps<UserType> extends Omit<React.HTMLProps<HTMLDivElement>, 'onClick' | 'onKeyDown'> {
   badge?: boolean;
@@ -132,6 +133,13 @@ const ParticipantItem = <UserType extends User | ServiceEntity>(
     return (participant as User).handle;
   })();
 
+  const handleContextKeyDown = (event: React.KeyboardEvent) => {
+    if ([KEY.SPACE, KEY.ENTER].includes(event.key)) {
+      const newEvent = setContextMenuPosition(event);
+      onContextMenu(newEvent as unknown as React.MouseEvent<HTMLDivElement>);
+    }
+  };
+
   return (
     <div
       className={cx('participant-item-wrapper', {
@@ -142,8 +150,8 @@ const ParticipantItem = <UserType extends User | ServiceEntity>(
       role="button"
       tabIndex={0}
       onContextMenu={onContextMenu}
-      onClick={noInteraction ? noop : event => onClick(participant, event.nativeEvent)}
-      onKeyDown={noInteraction ? noop : event => onKeyDown(participant, event.nativeEvent)}
+      onClick={noInteraction ? onContextMenu : event => onClick(participant, event.nativeEvent)}
+      onKeyDown={noInteraction ? handleContextKeyDown : event => onKeyDown(participant, event.nativeEvent)}
       aria-label={t('accessibility.openConversation', participantName)}
     >
       <div
@@ -197,6 +205,7 @@ const ParticipantItem = <UserType extends User | ServiceEntity>(
               </div>
               {showDropdown && (
                 <button
+                  tabIndex={-1}
                   className="participant-item__content__chevron"
                   onClick={event => onContextMenu(event as unknown as React.MouseEvent<HTMLDivElement>)}
                   type="button"

--- a/src/style/components/list/participant-item.less
+++ b/src/style/components/list/participant-item.less
@@ -132,10 +132,6 @@
         opacity: 0;
         transition: opacity 0.25s ease-in-out;
 
-        // :hover > &, :focus > &, :focus-visible > & {
-        //   opacity: 1;
-        // }
-
         svg {
           width: 8px;
           path {

--- a/src/style/components/list/participant-item.less
+++ b/src/style/components/list/participant-item.less
@@ -41,8 +41,13 @@
   }
 
   &:hover,
-  &:focus {
+  &:focus,
+  &:focus-visible {
     background: var(--app-bg-secondary);
+
+    .participant-item__content__chevron {
+      opacity: 1;
+    }
 
     &::after {
       border-bottom: none;
@@ -120,12 +125,16 @@
       &__chevron {
         .button-reset-default;
         display: flex;
+        width: 16px;
+        height: 16px;
+        align-items: center;
+        justify-content: center;
         opacity: 0;
         transition: opacity 0.25s ease-in-out;
 
-        :hover > & {
-          opacity: 1;
-        }
+        // :hover > &, :focus > &, :focus-visible > & {
+        //   opacity: 1;
+        // }
 
         svg {
           width: 8px;
@@ -211,7 +220,7 @@ body.theme-dark {
     }
   }
   &:last-of-type > .participant-item-wrapper {
-    border-radius: 0 0 0 8px;
+    border-radius: 0 0 8px 8px;
   }
 }
 

--- a/src/style/components/list/participant-item.less
+++ b/src/style/components/list/participant-item.less
@@ -20,6 +20,7 @@
 .participant-item-wrapper {
   position: relative;
   display: block;
+  margin: 1px;
 
   &[role='button'] {
     .button-reset-default();
@@ -39,10 +40,9 @@
     content: '';
   }
 
-  &:hover {
-    .participant-item {
-      background: var(--gray-20);
-    }
+  &:hover,
+  &:focus {
+    background: var(--app-bg-secondary);
 
     &::after {
       border-bottom: none;
@@ -200,11 +200,18 @@ body.theme-dark {
       border-bottom-color: var(--gray-90);
     }
   }
+}
 
-  .participant-item-wrapper:hover {
-    .participant-item {
-      background: var(--gray-95);
+.call-ui__participant-list__participant {
+  & > .participant-item-wrapper[role='button'] {
+    &:hover,
+    &:focus,
+    &:focus-visible {
+      background-color: var(--disabled-call-button-bg);
     }
+  }
+  &:last-of-type > .participant-item-wrapper {
+    border-radius: 0 0 0 8px;
   }
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-80" title="ACC-80" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-80</a>  Calling UI conversation view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

- add correct hover and focus state to call-ui sidebar
- remove focus from dropdown arrow
- open context menu when targeting the sidebar item (mouse or keyboard.)

![image](https://user-images.githubusercontent.com/78490891/186694821-c494dfdb-73c6-4e29-9ad3-d0bef33ac731.png)

