### PR TITLE
runfix: prevent button group from displaying incorrectly

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -926,7 +926,7 @@ exports[`stricter compilation`] = {
       [177, 10, 20, "Type \'undefined\' is not assignable to type \'Participant\'.", "942864568"],
       [180, 10, 9, "Type \'undefined\' is not assignable to type \'MuteState\'.", "3616862203"]
     ],
-    "src/script/components/calling/FullscreenVideoCall.tsx:3088091976": [
+    "src/script/components/calling/FullscreenVideoCall.tsx:2602936459": [
       [406, 50, 4, "Argument of type \'null\' is not assignable to parameter of type \'Participant\'.", "2087897566"]
     ],
     "src/script/components/calling/GroupVideoGrid.test.ts:1931211751": [

--- a/.betterer.results
+++ b/.betterer.results
@@ -926,7 +926,7 @@ exports[`stricter compilation`] = {
       [177, 10, 20, "Type \'undefined\' is not assignable to type \'Participant\'.", "942864568"],
       [180, 10, 9, "Type \'undefined\' is not assignable to type \'MuteState\'.", "3616862203"]
     ],
-    "src/script/components/calling/FullscreenVideoCall.tsx:2602936459": [
+    "src/script/components/calling/FullscreenVideoCall.tsx:1476535855": [
       [406, 50, 4, "Argument of type \'null\' is not assignable to parameter of type \'Participant\'.", "2087897566"]
     ],
     "src/script/components/calling/GroupVideoGrid.test.ts:1931211751": [

--- a/src/script/components/calling/ButtonGroup.tsx
+++ b/src/script/components/calling/ButtonGroup.tsx
@@ -55,7 +55,7 @@ const buttonGroupWrapperStyles: CSSObject = {
   },
   display: 'flex',
   justifyContent: 'center',
-  width: '145px',
+  minWidth: '145px',
 };
 
 const buttonGroupItemStyles: CSSObject = {

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -398,7 +398,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                 </button>
               </li>
             </div>
-            <div css={{display: 'flex', minWidth: '145px'}}>
+            <div css={{display: 'flex', minWidth: '157px'}}>
               {participants.length > 2 && (
                 <ButtonGroup
                   items={Object.values(CallViewTabs)}

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -398,7 +398,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                 </button>
               </li>
             </div>
-            <div css={{display: 'flex', minWidth: '157px'}}>
+            <div css={{display: 'flex', justifyContent: 'flex-end', minWidth: '157px'}}>
               {participants.length > 2 && (
                 <ButtonGroup
                   items={Object.values(CallViewTabs)}

--- a/src/style/foundation/video-calling.less
+++ b/src/style/foundation/video-calling.less
@@ -117,7 +117,7 @@
 
   &__item__minimize {
     display: flex;
-    width: 145px;
+    min-width: 157px;
     justify-content: center;
   }
 

--- a/src/style/foundation/video-calling.less
+++ b/src/style/foundation/video-calling.less
@@ -110,15 +110,14 @@
 
     display: flex;
     width: 100%;
-    justify-content: space-around;
-    padding-top: 32px;
+    justify-content: space-between;
+    padding: 32px 40px 0 40px;
     margin: 0;
   }
 
   &__item__minimize {
     display: flex;
     min-width: 157px;
-    justify-content: center;
   }
 
   &__button {


### PR DESCRIPTION
- button groups was getting squished if the number of participant got in the double digit
- address a design review to have the outside button stays at the same distance of the edge

![image](https://user-images.githubusercontent.com/78490891/187229934-c907bcc1-557b-4499-82bd-0d1bccf0b9cf.png)

