### PR TITLE
runfix: correct focus states of toggle dots acc-81

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -953,7 +953,7 @@ exports[`stricter compilation`] = {
     "src/script/components/calling/chooseScreen.test.ts:1945034304": [
       [64, 23, 30, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1127551965"]
     ],
-    "src/script/components/calling/deviceToggleButton.test.ts:3520291628": [
+    "src/script/components/calling/deviceToggleButton.test.ts:3262402387": [
       [31, 35, 16, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "733554636"]
     ],
     "src/script/components/calling/fullscreenVideoCall.test.tsx:2299129286": [

--- a/src/script/components/calling/DeviceToggleButton.tsx
+++ b/src/script/components/calling/DeviceToggleButton.tsx
@@ -42,60 +42,60 @@ const DeviceToggleButton: React.FC<DeviceToggleButtonProps> = ({currentDevice, d
       data-uie-name="device-toggle-button"
       css={css`
         align-items: center;
-        flex-direction: column;
         color: #fff;
         cursor: pointer;
         display: inline-flex;
         ${styles};
       `}
     >
-      <div
-        role="button"
-        tabIndex={0}
-        className="device-toggle-button-indicator"
-        data-uie-name="device-toggle-button-indicator"
-        onClick={selectNextDevice}
-        onKeyDown={e => handleKeyDown(e, selectNextDevice.bind(null, e))}
-        css={{
-          display: 'flex',
-          marginTop: 8,
-        }}
-      >
-        {devices.map(device => {
-          const isCurrentDevice = device === currentDevice;
+      {devices.map(device => {
+        const isCurrentDevice = device === currentDevice;
 
-          return (
-            <span
-              key={device}
-              className="device-toggle-button-indicator-dot"
-              data-uie-name="device-toggle-button-indicator-dot"
-              data-uie-value={isCurrentDevice ? 'active' : 'inactive'}
-              css={{
-                '&:hover': {
-                  backgroundColor: isCurrentDevice ? 'var(--toggle-button-hover-bg)' : 'var(--app-bg)',
-                  border: isCurrentDevice
-                    ? '1px solid var(--toggle-button-hover-bg)'
-                    : '1px solid var(--toggle-button-unselected-hover-border)',
-                },
-                /* eslint-disable sort-keys-fix/sort-keys-fix */
-                '&:active': {
-                  /* eslint-enable sort-keys-fix/sort-keys-fix */
-                  backgroundColor: isCurrentDevice ? 'var(--accent-color)' : 'var(--toggle-button-unselected-bg)',
-                  border: '1px solid var(--accent-color)',
-                },
-                '&:not(:last-child)': {marginRight: 5},
-                backgroundColor: isCurrentDevice ? 'var(--accent-color)' : 'var(--app-bg-secondary)',
-                border: isCurrentDevice ? '1px solid var(--accent-color)' : '1px solid var(--foreground)',
-                borderRadius: '50%',
-                color: '#fff',
-                display: 'inline-block',
-                height: 10,
-                width: 10,
-              }}
-            />
-          );
-        })}
-      </div>
+        return (
+          <div
+            role="button"
+            tabIndex={0}
+            key={device}
+            className="device-toggle-button-indicator-dot"
+            data-uie-name="device-toggle-button-indicator-dot"
+            data-uie-value={isCurrentDevice ? 'active' : 'inactive'}
+            onClick={selectNextDevice}
+            onKeyDown={e => handleKeyDown(e, selectNextDevice.bind(null, e))}
+            css={{
+              '&:focus-visible': {
+                backgroundColor: isCurrentDevice
+                  ? 'var(--toggle-button-hover-bg)'
+                  : 'var(--toggle-button-unselected-hover-bg)',
+                border: '1px solid var(--accent-color)',
+                outline: 'none',
+              },
+              '&:hover': {
+                backgroundColor: isCurrentDevice
+                  ? 'var(--toggle-button-hover-bg)'
+                  : 'var(--toggle-button-unselected-hover-bg)',
+                border: isCurrentDevice
+                  ? '1px solid var(--toggle-button-hover-bg)'
+                  : '1px solid var(--toggle-button-unselected-hover-border)',
+              },
+              /* eslint-disable sort-keys-fix/sort-keys-fix */
+              '&:active': {
+                /* eslint-enable sort-keys-fix/sort-keys-fix */
+                backgroundColor: isCurrentDevice ? 'var(--accent-color)' : 'var(--toggle-button-unselected-bg)',
+                border: '1px solid var(--accent-color)',
+              },
+              '&:not(:last-child)': {marginRight: 5},
+              backgroundColor: isCurrentDevice ? 'var(--accent-color)' : 'var(--app-bg-secondary)',
+              border: isCurrentDevice ? '1px solid var(--accent-color)' : '1px solid var(--foreground)',
+              borderRadius: '50%',
+              color: '#fff',
+              display: 'flex',
+              height: 10,
+              marginTop: 8,
+              width: 10,
+            }}
+          />
+        );
+      })}
     </div>
   );
 };

--- a/src/script/components/calling/DeviceToggleButton.tsx
+++ b/src/script/components/calling/DeviceToggleButton.tsx
@@ -52,11 +52,9 @@ const DeviceToggleButton: React.FC<DeviceToggleButtonProps> = ({currentDevice, d
         const isCurrentDevice = device === currentDevice;
 
         return (
-          <div
-            role="button"
-            tabIndex={0}
+          <button
             key={device}
-            className="device-toggle-button-indicator-dot"
+            className="device-toggle-button-indicator-dot button-reset-default"
             data-uie-name="device-toggle-button-indicator-dot"
             data-uie-value={isCurrentDevice ? 'active' : 'inactive'}
             onClick={selectNextDevice}

--- a/src/script/components/calling/Pagination.tsx
+++ b/src/script/components/calling/Pagination.tsx
@@ -67,8 +67,17 @@ const Pagination: React.FC<PaginationProps> = ({totalPages, currentPage, onChang
             className="button-reset-default"
             css={{
               ...paginationItemStyles,
+              '&:focus-visible': {
+                backgroundColor: isCurrentPage
+                  ? 'var(--toggle-button-hover-bg)'
+                  : 'var(--toggle-button-unselected-hover-bg)',
+                border: '1px solid var(--accent-color)',
+                outline: 'none',
+              },
               '&:hover': {
-                backgroundColor: isCurrentPage ? 'var(--toggle-button-hover-bg)' : 'var(--app-bg)',
+                backgroundColor: isCurrentPage
+                  ? 'var(--toggle-button-hover-bg)'
+                  : 'var(--toggle-button-unselected-hover-bg)',
                 border: isCurrentPage
                   ? '1px solid var(--toggle-button-hover-bg)'
                   : '1px solid var(--toggle-button-unselected-hover-border)',

--- a/src/script/components/calling/deviceToggleButton.test.ts
+++ b/src/script/components/calling/deviceToggleButton.test.ts
@@ -25,9 +25,9 @@ class DeviceToggleButtonPage extends TestPage<DeviceToggleButtonProps> {
     super(DeviceToggleButton, props);
   }
 
-  getDots = () => this.getAll('span[data-uie-name="device-toggle-button-indicator-dot"]');
-  getActiveDot = () => this.get('span[data-uie-value="active"]');
-  getButton = () => this.get('div[data-uie-name="device-toggle-button-indicator"]');
+  getDots = () => this.getAll('button[data-uie-name="device-toggle-button-indicator-dot"]');
+  getActiveDot = () => this.get('button[data-uie-value="active"]');
+  getButton = () => this.get('button[data-uie-name="device-toggle-button-indicator-dot"]');
 
   clickOnButton = () => this.click(this.getButton());
 }

--- a/src/style/common/mixins.less
+++ b/src/style/common/mixins.less
@@ -42,7 +42,7 @@
   .setColorFade(foreground, @foreground);
   .setColorFade(background, @background);
   .setVariables(app-bg sidebar-bg sidebar-border-color main-color border-color app-bg-secondary conversation-list-bg-opacity);
-  .setVariables(group-video-bg group-video-tile-bg inactive-call-button-bg inactive-call-button-border inactive-call-button-hover-bg inactive-call-button-hover-border disabled-call-button-bg disabled-call-button-border disabled-call-button-svg button-group-left-hover button-group-right-hover toggle-button-unselected-hover-border);
+  .setVariables(group-video-bg group-video-tile-bg inactive-call-button-bg inactive-call-button-border inactive-call-button-hover-bg inactive-call-button-hover-border disabled-call-button-bg disabled-call-button-border disabled-call-button-svg button-group-left-hover button-group-right-hover toggle-button-unselected-hover-border toggle-button-unselected-hover-bg);
   .setVariables(modal-bg modal-border-color);
   .setVariables(preference-account-input-bg);
   .setVariables(text-input-editing text-input-background text-input-border text-input-border-hover text-input-placeholder text-input-color text-input-alert text-input-disabled text-input-label text-input-success);

--- a/src/style/foundation/themes.less
+++ b/src/style/foundation/themes.less
@@ -53,6 +53,7 @@ body.theme-default {
   @button-group-left-hover: var(--gray-20);
   @button-group-right-hover: var(--gray-90);
   @toggle-button-unselected-hover-border: var(--gray-80);
+  @toggle-button-unselected-hover-bg: var(--gray-30);
 
   // ----------------------------------------------------------------------------
   // Modal
@@ -145,6 +146,7 @@ body.theme-dark {
   @button-group-left-hover: var(--gray-100);
   @button-group-right-hover: var(--gray-30);
   @toggle-button-unselected-hover-border: var(--gray-50);
+  @toggle-button-unselected-hover-bg: var(--gray-90);
 
   // ----------------------------------------------------------------------------
   // Modal


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-81" title="ACC-81" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-81</a>  Calling UI fullscreen view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

- assign the correct style for focus state of pagination and device select toggle dots
- refactor device toggle button to allow proper keyboard navigation