### PR TITLE
chore: Cleanup unneeded koReact components

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -916,7 +916,7 @@ exports[`stricter compilation`] = {
       [121, 8, 3, "Type \'(node: HTMLElement) => void\' is not assignable to type \'LegacyRef<HTMLLIElement> | undefined\'.\\n  Type \'(node: HTMLElement) => void\' is not assignable to type \'(instance: HTMLLIElement | null) => void\'.\\n    Types of parameters \'node\' and \'instance\' are incompatible.\\n      Type \'HTMLLIElement | null\' is not assignable to type \'HTMLElement\'.\\n        Type \'null\' is not assignable to type \'HTMLElement\'.", "193432436"],
       [151, 23, 8, "Object is possibly \'undefined\'.", "2198230984"]
     ],
-    "src/script/components/list/ParticipantItem.tsx:3591469056": [
+    "src/script/components/list/ParticipantItem.tsx:1338044247": [
       [111, 94, 15, "Argument of type \'Participant | undefined\' is not assignable to parameter of type \'Partial<Record<\\"isMuted\\" | \\"isActivelySpeaking\\" | \\"sharesScreen\\" | \\"sharesCamera\\", Subscribable<any>>>\'.\\n  Type \'undefined\' is not assignable to type \'Partial<Record<\\"isMuted\\" | \\"isActivelySpeaking\\" | \\"sharesScreen\\" | \\"sharesCamera\\", Subscribable<any>>>\'.", "420345688"]
     ],
     "src/script/components/modal.ts:282599833": [

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/LinkPreviewAssetComponent.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/LinkPreviewAssetComponent.tsx
@@ -23,7 +23,7 @@ import cx from 'classnames';
 import {safeWindowOpen} from 'Util/SanitizationUtil';
 import {cleanURL} from 'Util/UrlUtil';
 import {isTweetUrl} from 'Util/ValidationUtil';
-import {registerReactComponent, useKoSubscribableChildren} from 'Util/ComponentUtil';
+import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 
 import Image from 'Components/Image';
@@ -127,5 +127,3 @@ const LinkPreviewAssetComponent: React.FC<LinkPreviewAssetProps> = ({header = fa
 };
 
 export default LinkPreviewAssetComponent;
-
-registerReactComponent('link-preview-asset', LinkPreviewAssetComponent);

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset.tsx
@@ -26,7 +26,7 @@ import type {ContentMessage} from '../../../../../entity/message/ContentMessage'
 import type {FileAsset} from '../../../../../entity/message/FileAsset';
 import {useAssetTransfer} from './AbstractAssetTransferStateTracker';
 import {TeamState} from '../../../../../team/TeamState';
-import {registerReactComponent, useKoSubscribableChildren} from 'Util/ComponentUtil';
+import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import SeekBar from './controls/SeekBar';
 import MediaButton from './controls/MediaButton';
 import {t} from 'Util/LocalizerUtil';
@@ -219,4 +219,3 @@ const VideoAsset: React.FC<VideoAssetProps> = ({
 };
 
 export default VideoAsset;
-registerReactComponent('video-asset', VideoAsset);

--- a/src/script/components/TextInput/TextInput.tsx
+++ b/src/script/components/TextInput/TextInput.tsx
@@ -18,7 +18,6 @@
  */
 
 import React, {useEffect} from 'react';
-import {registerReactComponent} from 'Util/ComponentUtil';
 import Icon from 'Components/Icon';
 import {CheckIcon, COLOR} from '@wireapp/react-ui-kit';
 import {
@@ -130,5 +129,3 @@ const TextInput: React.ForwardRefRenderFunction<HTMLDivElement, UserInputProps> 
 const TextInputForwarded = React.forwardRef(TextInput);
 
 export default TextInputForwarded;
-
-registerReactComponent('text-input', TextInputForwarded);

--- a/src/script/components/asset/RestrictedFile.tsx
+++ b/src/script/components/asset/RestrictedFile.tsx
@@ -20,7 +20,6 @@
 import React from 'react';
 import {FileAsset} from 'src/script/entity/message/FileAsset';
 
-import {registerReactComponent} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 import {trimFileExtension} from 'Util/util';
 
@@ -50,5 +49,3 @@ const RestrictedFile: React.FC<RestrictedFileProps> = ({asset}) => {
 };
 
 export default RestrictedFile;
-
-registerReactComponent('file-restricted', RestrictedFile);

--- a/src/script/components/calling/ParticipantMicOnIcon.tsx
+++ b/src/script/components/calling/ParticipantMicOnIcon.tsx
@@ -19,7 +19,6 @@
 
 import React from 'react';
 import {keyframes} from '@emotion/react';
-import {registerReactComponent} from 'Util/ComponentUtil';
 import SVGProvider from '../../auth/util/SVGProvider';
 
 const fadeAnimation = keyframes`
@@ -66,5 +65,3 @@ const ParticipantMicOnIcon: React.FC<ParticipantMicOnIconProps> = ({
 };
 
 export default ParticipantMicOnIcon;
-
-registerReactComponent('participant-mic-on-icon', ParticipantMicOnIcon);

--- a/src/script/components/list/ParticipantItem.tsx
+++ b/src/script/components/list/ParticipantItem.tsx
@@ -20,7 +20,7 @@
 import React from 'react';
 import cx from 'classnames';
 
-import {registerReactComponent, useKoSubscribableChildren} from 'Util/ComponentUtil';
+import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import Avatar, {AVATAR_SIZE} from 'Components/Avatar';
 import {UserlistMode} from 'Components/UserList';
 import {t} from 'Util/LocalizerUtil';
@@ -274,5 +274,3 @@ const ParticipantItem = <UserType extends User | ServiceEntity>(
 };
 
 export default ParticipantItem;
-
-registerReactComponent('participant-item', ParticipantItem);


### PR DESCRIPTION
Remove some of the `registerReactComponent` that are not consumed anymore (because of the migration to react, they are exclusively consumed in React land and never in knockout land)