### PR TITLE
chore: Align node version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
   },
   "engines": {
     "yarn": ">= 1.0.0",
-    "node": ">=15 <17"
+    "node": ">=16"
   },
   "license": "GPL-3.0",
   "lint-staged": {


### PR DESCRIPTION
### Description

Since we need node 16 to get the right mock for crypto (see https://github.com/wireapp/wire-webapp/pull/12587) we can adjust our minimal requirement. 

Since we don't use advances API of node, we can also safely let any recent node version available