### PR TITLE
refactor: Avoid rerendering when using fadingScrollbars

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -905,12 +905,12 @@ exports[`stricter compilation`] = {
       [127, 11, 33, "Object is possibly \'null\'.", "1545610583"],
       [132, 11, 33, "Object is possibly \'null\'.", "1545610583"]
     ],
-    "src/script/components/list/ConversationListCallingCell.tsx:3482388709": [
-      [115, 90, 6, "Argument of type \'number | undefined\' is not assignable to parameter of type \'REASON\'.\\n  Type \'undefined\' is not assignable to type \'REASON\'.", "2124277697"],
-      [128, 67, 8, "No overload matches this call.\\n  Overload 1 of 2, \'(...items: ConcatArray<User>[]): User[]\', gave the following error.\\n    Type \'User | undefined\' is not assignable to type \'User\'.\\n      Type \'undefined\' is not assignable to type \'User\'.\\n  Overload 2 of 2, \'(...items: (User | ConcatArray<User>)[]): User[]\', gave the following error.\\n    Type \'User | undefined\' is not assignable to type \'User\'.\\n      Type \'undefined\' is not assignable to type \'User\'.", "2198230984"],
-      [148, 28, 12, "Type \'undefined\' cannot be used as an index type.", "3398917396"],
-      [173, 10, 7, "Type \'(false | ContextMenuEntry | { click: () => void; icon: string; identifier: string; isDisabled: boolean; label: string; })[]\' is not assignable to type \'ContextMenuEntry[]\'.\\n  Type \'false | ContextMenuEntry | { click: () => void; icon: string; identifier: string; isDisabled: boolean; label: string; }\' is not assignable to type \'ContextMenuEntry\'.\\n    Type \'false\' has no properties in common with type \'ContextMenuEntry\'.", "4061926391"],
-      [306, 16, 20, "Type \'Participant | null\' is not assignable to type \'Participant\'.\\n  Type \'null\' is not assignable to type \'Participant\'.", "942864568"]
+    "src/script/components/list/ConversationListCallingCell.tsx:233908179": [
+      [111, 90, 6, "Argument of type \'number | undefined\' is not assignable to parameter of type \'REASON\'.\\n  Type \'undefined\' is not assignable to type \'REASON\'.", "2124277697"],
+      [124, 67, 8, "No overload matches this call.\\n  Overload 1 of 2, \'(...items: ConcatArray<User>[]): User[]\', gave the following error.\\n    Type \'User | undefined\' is not assignable to type \'User\'.\\n      Type \'undefined\' is not assignable to type \'User\'.\\n  Overload 2 of 2, \'(...items: (User | ConcatArray<User>)[]): User[]\', gave the following error.\\n    Type \'User | undefined\' is not assignable to type \'User\'.\\n      Type \'undefined\' is not assignable to type \'User\'.", "2198230984"],
+      [144, 28, 12, "Type \'undefined\' cannot be used as an index type.", "3398917396"],
+      [169, 10, 7, "Type \'(false | ContextMenuEntry | { click: () => void; icon: string; identifier: string; isDisabled: boolean; label: string; })[]\' is not assignable to type \'ContextMenuEntry[]\'.\\n  Type \'false | ContextMenuEntry | { click: () => void; icon: string; identifier: string; isDisabled: boolean; label: string; }\' is not assignable to type \'ContextMenuEntry\'.\\n    Type \'false\' has no properties in common with type \'ContextMenuEntry\'.", "4061926391"],
+      [302, 16, 20, "Type \'Participant | null\' is not assignable to type \'Participant\'.\\n  Type \'null\' is not assignable to type \'Participant\'.", "942864568"]
     ],
     "src/script/components/list/ConversationListCell.tsx:931164040": [
       [121, 8, 3, "Type \'(node: HTMLElement) => void\' is not assignable to type \'LegacyRef<HTMLLIElement> | undefined\'.\\n  Type \'(node: HTMLElement) => void\' is not assignable to type \'(instance: HTMLLIElement | null) => void\'.\\n    Types of parameters \'node\' and \'instance\' are incompatible.\\n      Type \'HTMLLIElement | null\' is not assignable to type \'HTMLElement\'.\\n        Type \'null\' is not assignable to type \'HTMLElement\'.", "193432436"],
@@ -2020,19 +2020,19 @@ exports[`stricter compilation`] = {
       [34, 41, 22, "Cannot invoke an object which is possibly \'undefined\'.", "1980738780"],
       [41, 21, 12, "Argument of type \'string | undefined\' is not assignable to parameter of type \'Matcher\'.\\n  Type \'undefined\' is not assignable to type \'Matcher\'.", "2075561852"]
     ],
-    "src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx:1032054856": [
-      [77, 90, 10, "Type \'undefined\' is not assignable to type \'boolean\'.", "3231345145"],
-      [141, 8, 14, "Type \'(device: ClientEntity) => Promise<string | undefined>\' is not assignable to type \'(device: ClientEntity) => Promise<string>\'.\\n  Type \'Promise<string | undefined>\' is not assignable to type \'Promise<string>\'.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "223037395"],
-      [148, 73, 37, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "3769528030"]
+    "src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx:235527860": [
+      [76, 90, 10, "Type \'undefined\' is not assignable to type \'boolean\'.", "3231345145"],
+      [138, 8, 14, "Type \'(device: ClientEntity) => Promise<string | undefined>\' is not assignable to type \'(device: ClientEntity) => Promise<string>\'.\\n  Type \'Promise<string | undefined>\' is not assignable to type \'Promise<string>\'.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "223037395"],
+      [145, 73, 37, "Argument of type \'Conversation | undefined\' is not assignable to parameter of type \'Conversation\'.\\n  Type \'undefined\' is not assignable to type \'Conversation\'.", "3769528030"]
     ],
     "src/script/page/message-list/InputBarControls/InputBarControls.test.tsx:2517377529": [
       [33, 2, 12, "Type \'undefined\' is not assignable to type \'Conversation\'.", "1670678216"]
     ],
-    "src/script/page/message-list/MentionSuggestions/MentionSuggestions.tsx:1339790850": [
-      [56, 44, 11, "Object is possibly \'null\'.", "2551690754"],
-      [72, 69, 11, "Argument of type \'HTMLInputElement | null\' is not assignable to parameter of type \'HTMLInputElement\'.\\n  Type \'null\' is not assignable to type \'HTMLInputElement\'.", "2551690754"],
-      [112, 49, 11, "Argument of type \'HTMLInputElement | null\' is not assignable to parameter of type \'HTMLInputElement\'.\\n  Type \'null\' is not assignable to type \'HTMLInputElement\'.", "2551690754"],
-      [115, 14, 3, "Type \'((node: Element) => void) | undefined\' is not assignable to type \'Ref<HTMLDivElement> | undefined\'.\\n  Type \'(node: Element) => void\' is not assignable to type \'Ref<HTMLDivElement> | undefined\'.\\n    Type \'(node: Element) => void\' is not assignable to type \'(instance: HTMLDivElement | null) => void\'.\\n      Types of parameters \'node\' and \'instance\' are incompatible.\\n        Type \'HTMLDivElement | null\' is not assignable to type \'Element\'.\\n          Type \'null\' is not assignable to type \'Element\'.", "193432436"]
+    "src/script/page/message-list/MentionSuggestions/MentionSuggestions.tsx:1071161103": [
+      [54, 44, 11, "Object is possibly \'null\'.", "2551690754"],
+      [70, 69, 11, "Argument of type \'HTMLInputElement | null\' is not assignable to parameter of type \'HTMLInputElement\'.\\n  Type \'null\' is not assignable to type \'HTMLInputElement\'.", "2551690754"],
+      [110, 49, 11, "Argument of type \'HTMLInputElement | null\' is not assignable to parameter of type \'HTMLInputElement\'.\\n  Type \'null\' is not assignable to type \'HTMLInputElement\'.", "2551690754"],
+      [113, 14, 3, "Type \'((node: Element) => void) | undefined\' is not assignable to type \'Ref<HTMLDivElement> | undefined\'.\\n  Type \'(node: Element) => void\' is not assignable to type \'Ref<HTMLDivElement> | undefined\'.\\n    Type \'(node: Element) => void\' is not assignable to type \'(instance: HTMLDivElement | null) => void\'.\\n      Types of parameters \'node\' and \'instance\' are incompatible.\\n        Type \'HTMLDivElement | null\' is not assignable to type \'Element\'.\\n          Type \'null\' is not assignable to type \'Element\'.", "193432436"]
     ],
     "src/script/page/message-list/MessageTimerButton.test.ts:254586997": [
       [33, 46, 29, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "4019893960"],
@@ -2614,10 +2614,10 @@ exports[`stricter compilation`] = {
       [33, 39, 22, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "3474761039"],
       [34, 38, 21, "Argument of type \'Element | null\' is not assignable to parameter of type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "327517530"]
     ],
-    "src/script/view_model/panel/TimedMessagesPanel.tsx:852651488": [
-      [52, 57, 18, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Partial<Record<\\"globalMessageTimer\\", Subscribable<any>>>\'.\\n  Type \'null\' is not assignable to type \'Partial<Record<\\"globalMessageTimer\\", Subscribable<any>>>\'.", "2242649668"],
-      [82, 44, 10, "Argument of type \'number | null\' is not assignable to parameter of type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "1022360174"],
-      [83, 83, 10, "Argument of type \'number | null\' is not assignable to parameter of type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "1022360174"]
+    "src/script/view_model/panel/TimedMessagesPanel.tsx:985707612": [
+      [49, 57, 18, "Argument of type \'Conversation | null\' is not assignable to parameter of type \'Partial<Record<\\"globalMessageTimer\\", Subscribable<any>>>\'.\\n  Type \'null\' is not assignable to type \'Partial<Record<\\"globalMessageTimer\\", Subscribable<any>>>\'.", "2242649668"],
+      [79, 44, 10, "Argument of type \'number | null\' is not assignable to parameter of type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "1022360174"],
+      [80, 83, 10, "Argument of type \'number | null\' is not assignable to parameter of type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "1022360174"]
     ]
   }`
 };

--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -51,8 +51,7 @@ import {
   teamPermissionsForAccessState,
   toggleFeature,
 } from '../../../conversation/ConversationAccessPermission';
-import useEffectRef from 'Util/useEffectRef';
-import {useFadingScrollbar} from '../../../ui/fadingScrollbar';
+import {initFadingScrollbar} from '../../../ui/fadingScrollbar';
 import {Config} from '../../../Config';
 import {isProtocolOption, ProtocolOption} from '../../../guards/Protocol';
 
@@ -99,8 +98,6 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
   const [groupCreationState, setGroupCreationState] = useState<GroupCreationModalState>(
     GroupCreationModalState.DEFAULT,
   );
-  const [scrollbarRef, setScrollbarRef] = useEffectRef<HTMLDivElement>();
-  useFadingScrollbar(scrollbarRef);
 
   const maxNameLength = ConversationRepository.CONFIG.GROUP.MAX_NAME_LENGTH;
   const maxSize = ConversationRepository.CONFIG.GROUP.MAX_SIZE;
@@ -326,7 +323,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
           )}
 
           {stateIsParticipants && (
-            <div className="group-creation__list" ref={setScrollbarRef}>
+            <div className="group-creation__list" ref={initFadingScrollbar}>
               {contacts.length > 0 && (
                 <UserSearchableList
                   users={contacts}

--- a/src/script/components/list/ConversationListCallingCell.tsx
+++ b/src/script/components/list/ConversationListCallingCell.tsx
@@ -33,7 +33,6 @@ import Duration from 'Components/calling/Duration';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 import {sortUsersByPriority} from 'Util/StringUtil';
-import useEffectRef from 'Util/useEffectRef';
 
 import type {Call} from '../../calling/Call';
 import type {CallingRepository} from '../../calling/CallingRepository';
@@ -44,7 +43,7 @@ import {generateConversationUrl} from '../../router/routeGenerator';
 import {createNavigate, createNavigateKeyboard} from '../../router/routerBindings';
 import {TeamState} from '../../team/TeamState';
 import {CallState, MuteState} from '../../calling/CallState';
-import {useFadingScrollbar} from '../../ui/fadingScrollbar';
+import {initFadingScrollbar} from '../../ui/fadingScrollbar';
 import {CallActions, CallViewTab} from '../../view_model/CallingViewModel';
 import {showContextMenu, ContextMenuEntry} from '../../ui/ContextMenu';
 import type {Participant} from '../../calling/Participant';
@@ -77,9 +76,6 @@ const ConversationListCallingCell: React.FC<CallingCellProps> = ({
   teamState = container.resolve(TeamState),
   callState = container.resolve(CallState),
 }) => {
-  const [scrollbarRef, setScrollbarRef] = useEffectRef<HTMLDivElement>();
-  useFadingScrollbar(scrollbarRef);
-
   const {reason, state, isCbrEnabled, startedAt, participants, maximizedParticipant, muteState} =
     useKoSubscribableChildren(call, [
       'reason',
@@ -448,7 +444,7 @@ const ConversationListCallingCell: React.FC<CallingCellProps> = ({
                   'call-ui__participant-list__wrapper--active': showParticipants,
                 })}
               >
-                <div ref={setScrollbarRef} className="call-ui__participant-list__container">
+                <div ref={initFadingScrollbar} className="call-ui__participant-list__container">
                   <ul className="call-ui__participant-list" data-uie-name="list-call-ui-participants">
                     {participants
                       .slice()

--- a/src/script/page/LeftSidebar/panels/ListWrapper.tsx
+++ b/src/script/page/LeftSidebar/panels/ListWrapper.tsx
@@ -17,15 +17,14 @@
  *
  */
 
-import React, {ReactElement, useEffect} from 'react';
+import React, {ReactElement} from 'react';
 
 import {css} from '@emotion/react';
 import {throttle} from 'underscore';
 import {isScrollable, isScrolledBottom, isScrolledTop} from 'Util/scroll-helpers';
 import Icon from 'Components/Icon';
 import {t} from 'Util/LocalizerUtil';
-import useEffectRef from 'Util/useEffectRef';
-import {useFadingScrollbar} from '../../../ui/fadingScrollbar';
+import {initFadingScrollbar} from '../../../ui/fadingScrollbar';
 
 type LeftListWrapperProps = {
   /** A react element that will be inserted after the header but before the list */
@@ -64,9 +63,6 @@ const ListWrapper: React.FC<LeftListWrapperProps> = ({
   before,
   headerUieName,
 }) => {
-  const [scrollbarRef, setScrollbarRef] = useEffectRef<HTMLDivElement>();
-  useFadingScrollbar(scrollbarRef);
-
   const calculateBorders = throttle((element: HTMLElement) => {
     window.requestAnimationFrame(() => {
       if (element.offsetHeight <= 0 || !isScrollable(element)) {
@@ -79,16 +75,13 @@ const ListWrapper: React.FC<LeftListWrapperProps> = ({
     });
   }, 100);
 
-  useEffect(() => {
-    if (!scrollbarRef) {
-      return undefined;
+  function initBorderedScroll(element: HTMLElement | null) {
+    if (!element) {
+      return;
     }
-    const onScroll = (event: Event) => calculateBorders(event.target as HTMLElement);
-    calculateBorders(scrollbarRef);
-    scrollbarRef.addEventListener('scroll', onScroll);
-
-    return () => scrollbarRef.removeEventListener('scroll', onScroll);
-  }, [scrollbarRef]);
+    calculateBorders(element);
+    element.addEventListener('scroll', () => calculateBorders(element));
+  }
 
   return (
     <div id={id} className={`left-list-${id} ${id}`} css={style}>
@@ -113,7 +106,13 @@ const ListWrapper: React.FC<LeftListWrapperProps> = ({
         )}
       </section>
       {before ?? null}
-      <section css={scrollStyle} ref={setScrollbarRef}>
+      <section
+        css={scrollStyle}
+        ref={element => {
+          initBorderedScroll(element);
+          initFadingScrollbar(element);
+        }}
+      >
         {children}
       </section>
       {footer ?? null}

--- a/src/script/page/MainContent/panels/Collection/CollectionDetails.tsx
+++ b/src/script/page/MainContent/panels/Collection/CollectionDetails.tsx
@@ -20,8 +20,7 @@
 import React, {Fragment} from 'react';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {Conversation} from '../../../../entity/Conversation';
-import {useFadingScrollbar} from '../../../../ui/fadingScrollbar';
-import useEffectRef from 'Util/useEffectRef';
+import {initFadingScrollbar} from '../../../../ui/fadingScrollbar';
 
 import {ContentMessage} from 'src/script/entity/message/ContentMessage';
 import {isToday, isThisYear, formatLocale} from 'Util/TimeUtil';
@@ -57,8 +56,6 @@ const groupByDate = (messages: ContentMessage[]): GroupedCollection => {
 
 const CollectionDetails: React.FC<CollectionDetailsProps> = ({conversation, messages, onClose = noop}) => {
   const {display_name} = useKoSubscribableChildren(conversation, ['display_name']);
-  const [scrollbarRef, setScrollbarRef] = useEffectRef<HTMLDivElement>();
-  useFadingScrollbar(scrollbarRef);
 
   return (
     <div id="collection-details" className="collection-details content">
@@ -76,7 +73,7 @@ const CollectionDetails: React.FC<CollectionDetailsProps> = ({conversation, mess
       </div>
 
       <div className="content-list-wrapper">
-        <div className="content-list collection-list" ref={setScrollbarRef}>
+        <div className="content-list collection-list" ref={initFadingScrollbar}>
           <div className="collection-images">
             {groupByDate(messages).map(([groupName, groupMessages]) => {
               return (

--- a/src/script/page/MainContent/panels/preferences/components/PreferencesPage.tsx
+++ b/src/script/page/MainContent/panels/preferences/components/PreferencesPage.tsx
@@ -18,8 +18,7 @@
  */
 
 import React from 'react';
-import useEffectRef from 'Util/useEffectRef';
-import {useFadingScrollbar} from '../../../../../ui/fadingScrollbar';
+import {initFadingScrollbar} from '../../../../../ui/fadingScrollbar';
 
 interface PreferencesPageProps {
   children: React.ReactNode;
@@ -27,13 +26,10 @@ interface PreferencesPageProps {
 }
 
 const PreferencesPage: React.FC<PreferencesPageProps> = ({title, children}) => {
-  const [scrollbarRef, setScrollbarRef] = useEffectRef<HTMLDivElement>();
-  useFadingScrollbar(scrollbarRef);
-
   return (
     <div style={{display: 'flex', flexDirection: 'column', height: '100vh'}}>
       <h2 className="preferences-titlebar">{title}</h2>
-      <div className="preferences-content" ref={setScrollbarRef}>
+      <div className="preferences-content" ref={initFadingScrollbar}>
         {children}
       </div>
     </div>

--- a/src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx
@@ -29,8 +29,7 @@ import {t} from 'Util/LocalizerUtil';
 import VerifiedIcon from 'Components/VerifiedIcon';
 import Icon from 'Components/Icon';
 import {CryptographyRepository} from 'src/script/cryptography/CryptographyRepository';
-import {useFadingScrollbar} from '../../../../../ui/fadingScrollbar';
-import useEffectRef from 'Util/useEffectRef';
+import {initFadingScrollbar} from '../../../../../ui/fadingScrollbar';
 import DetailedDevice from './components/DetailedDevice';
 import DeviceDetailsPreferences from './DeviceDetailsPreferences';
 import {Conversation} from '../../../../../entity/Conversation';
@@ -130,10 +129,8 @@ const DevicesPreferences: React.FC<DevicesPreferencesProps> = ({
   const {clients, currentClient} = useKoSubscribableChildren(clientState, ['clients', 'currentClient']);
   const {self} = useKoSubscribableChildren(userState, ['self']);
   const isSSO = self?.isNoPasswordSSO;
-  const [scrollbarRef, setScrollbarRef] = useEffectRef<HTMLDivElement>();
   const getFingerprint = (device: ClientEntity) =>
     cryptographyRepository.getRemoteFingerprint(self.qualifiedId, device.id);
-  useFadingScrollbar(scrollbarRef);
 
   if (selectedDevice) {
     return (
@@ -154,7 +151,7 @@ const DevicesPreferences: React.FC<DevicesPreferencesProps> = ({
   return (
     <div id="preferences-devices" className="preferences-page preferences-devices">
       <h2 className="preferences-titlebar">{t('preferencesDevices')}</h2>
-      <div className="preferences-content" ref={setScrollbarRef}>
+      <div className="preferences-content" ref={initFadingScrollbar}>
         <fieldset className="preferences-section" data-uie-name="preferences-device-current">
           <legend className="preferences-header">{t('preferencesDevicesCurrent')}</legend>
           <DetailedDevice device={currentClient} fingerprint={cryptographyRepository.getLocalFingerprint()} />

--- a/src/script/page/message-list/MentionSuggestions/MentionSuggestions.tsx
+++ b/src/script/page/message-list/MentionSuggestions/MentionSuggestions.tsx
@@ -24,7 +24,7 @@ import {KEY} from 'Util/KeyboardUtil';
 import {clamp} from 'Util/NumberUtil';
 import useEffectRef from 'Util/useEffectRef';
 
-import {useFadingScrollbar} from '../../../ui/fadingScrollbar';
+import {initFadingScrollbar} from '../../../ui/fadingScrollbar';
 import MentionSuggestionsItem from './MentionSuggestionsItem';
 import {User} from '../../../entity/User';
 
@@ -38,8 +38,6 @@ const MentionSuggestionList: React.FunctionComponent<MentionSuggestionListProps>
   onSelectionValidated,
   targetInputSelector,
 }) => {
-  const [scrollbarRef, setScrollbarRef] = useEffectRef<HTMLDivElement>();
-  useFadingScrollbar(scrollbarRef);
   const [selectedSuggestionIndex, setSelectedSuggestionIndex] = useState(0);
   const [selectedItem, setSelectedItem] = useEffectRef();
   useEffect(
@@ -99,7 +97,7 @@ const MentionSuggestionList: React.FunctionComponent<MentionSuggestionListProps>
       className="conversation-input-bar-mention-suggestion"
       style={{bottom, overflowY: 'auto'}}
       data-uie-name="list-mention-suggestions"
-      ref={setScrollbarRef}
+      ref={initFadingScrollbar}
     >
       <div className="mention-suggestion-list">
         {suggestions

--- a/src/script/ui/fadingScrollbar.ts
+++ b/src/script/ui/fadingScrollbar.ts
@@ -17,83 +17,77 @@
  *
  */
 
-import {useLayoutEffect} from 'react';
 import {debounce} from 'underscore';
 
-export const useFadingScrollbar = (element?: HTMLElement): void => {
-  useLayoutEffect(() => {
-    if (!element) {
-      return undefined;
+export const initFadingScrollbar = (element: HTMLElement | null): void => {
+  if (!element) {
+    return;
+  }
+  const animationSpeed = 0.05;
+
+  function parseColor(color: string) {
+    const el = document.body.appendChild(document.createElement('thiselementdoesnotexist'));
+    el.style.color = color;
+    const col = getComputedStyle(el).color;
+    document.body.removeChild(el);
+    const [, r, g, b, a = 1] = /rgba?\((\d+), *(\d+), *(\d+),? *(\d*\.?\d*)?\)/.exec(col) ?? [0, 0, 0, 0, 1];
+    return [+r, +g, +b, +a];
+  }
+
+  const initialColor = parseColor(window.getComputedStyle(element).getPropertyValue('--scrollbar-color'));
+  const currentColor = initialColor.slice();
+  let state = 'idle';
+  let animating = false;
+
+  function setAnimationState(newState: string) {
+    state = newState;
+    if (!animating) {
+      animate();
     }
-    const animationSpeed = 0.05;
+  }
 
-    function parseColor(color: string) {
-      const el = document.body.appendChild(document.createElement('thiselementdoesnotexist'));
-      el.style.color = color;
-      const col = getComputedStyle(el).color;
-      document.body.removeChild(el);
-      const [, r, g, b, a = 1] = /rgba?\((\d+), *(\d+), *(\d+),? *(\d*\.?\d*)?\)/.exec(col) ?? [0, 0, 0, 0, 1];
-      return [+r, +g, +b, +a];
+  function animate() {
+    switch (state) {
+      case 'fadein':
+        fadeStep(animationSpeed);
+        break;
+      case 'fadeout':
+        fadeStep(-animationSpeed);
+        break;
+
+      default:
+        animating = false;
+        return;
     }
+    animating = true;
+    window.requestAnimationFrame(animate);
+  }
 
-    const initialColor = parseColor(window.getComputedStyle(element).getPropertyValue('--scrollbar-color'));
-    const currentColor = initialColor.slice();
-    let state = 'idle';
-    let animating = false;
-
-    function setAnimationState(newState: string) {
-      state = newState;
-      if (!animating) {
-        animate();
-      }
+  const fadeStep = (delta: number) => {
+    const initialAlpha = initialColor[3];
+    const currentAlpha = currentColor[3];
+    const hasAppeared = delta > 0 && currentAlpha >= initialAlpha;
+    const hasDisappeared = delta < 0 && currentAlpha <= 0;
+    if (hasAppeared || hasDisappeared) {
+      return setAnimationState('idle');
     }
+    currentColor[3] += delta;
+    element.style.setProperty('--scrollbar-color', `rgba(${currentColor})`);
+  };
+  const fadeIn = () => setAnimationState('fadein');
+  const fadeOut = () => setAnimationState('fadeout');
+  const debouncedFadeOut = debounce(fadeOut, 1000);
+  const fadeInIdle = () => {
+    fadeIn();
+    debouncedFadeOut();
+  };
 
-    function animate() {
-      switch (state) {
-        case 'fadein':
-          fadeStep(animationSpeed);
-          break;
-        case 'fadeout':
-          fadeStep(-animationSpeed);
-          break;
+  const events = {
+    mouseenter: fadeIn,
+    mouseleave: fadeOut,
+    mousemove: fadeInIdle,
+    scroll: fadeInIdle,
+  };
 
-        default:
-          animating = false;
-          return;
-      }
-      animating = true;
-      window.requestAnimationFrame(animate);
-    }
-
-    const fadeStep = (delta: number) => {
-      const initialAlpha = initialColor[3];
-      const currentAlpha = currentColor[3];
-      const hasAppeared = delta > 0 && currentAlpha >= initialAlpha;
-      const hasDisappeared = delta < 0 && currentAlpha <= 0;
-      if (hasAppeared || hasDisappeared) {
-        return setAnimationState('idle');
-      }
-      currentColor[3] += delta;
-      element.style.setProperty('--scrollbar-color', `rgba(${currentColor})`);
-    };
-    const fadeIn = () => setAnimationState('fadein');
-    const fadeOut = () => setAnimationState('fadeout');
-    const debouncedFadeOut = debounce(fadeOut, 1000);
-    const fadeInIdle = () => {
-      fadeIn();
-      debouncedFadeOut();
-    };
-
-    const events = {
-      mouseenter: fadeIn,
-      mouseleave: fadeOut,
-      mousemove: fadeInIdle,
-      scroll: fadeInIdle,
-    };
-
-    Object.entries(events).forEach(([eventName, handler]) => element.addEventListener(eventName, handler));
-
-    return () =>
-      Object.entries(events).forEach(([eventName, handler]) => element.removeEventListener(eventName, handler));
-  }, [element]);
+  Object.entries(events).forEach(([eventName, handler]) => element.addEventListener(eventName, handler));
 };

--- a/src/script/ui/fadingScrollbar.ts
+++ b/src/script/ui/fadingScrollbar.ts
@@ -64,14 +64,15 @@ export const initFadingScrollbar = (element: HTMLElement | null): void => {
   }
 
   const fadeStep = (delta: number) => {
-    const initialAlpha = initialColor[3];
-    const currentAlpha = currentColor[3];
+    const alphaChanelIndex = 3;
+    const initialAlpha = initialColor[alphaChanelIndex];
+    const currentAlpha = currentColor[alphaChanelIndex];
     const hasAppeared = delta > 0 && currentAlpha >= initialAlpha;
     const hasDisappeared = delta < 0 && currentAlpha <= 0;
     if (hasAppeared || hasDisappeared) {
       return setAnimationState('idle');
     }
-    currentColor[3] += delta;
+    currentColor[alphaChanelIndex] += delta;
     element.style.setProperty('--scrollbar-color', `rgba(${currentColor})`);
   };
   const fadeIn = () => setAnimationState('fadein');

--- a/src/script/ui/fadingScrollbar.ts
+++ b/src/script/ui/fadingScrollbar.ts
@@ -19,11 +19,15 @@
 
 import {debounce} from 'underscore';
 
+const config = {
+  ANIMATION_SPEED: 0.05,
+  DEBOUNCE_THRESHOLD: 1000,
+};
+
 export const initFadingScrollbar = (element: HTMLElement | null): void => {
   if (!element) {
     return;
   }
-  const animationSpeed = 0.05;
 
   function parseColor(color: string) {
     const el = document.body.appendChild(document.createElement('thiselementdoesnotexist'));
@@ -49,10 +53,10 @@ export const initFadingScrollbar = (element: HTMLElement | null): void => {
   function animate() {
     switch (state) {
       case 'fadein':
-        fadeStep(animationSpeed);
+        fadeStep(config.ANIMATION_SPEED);
         break;
       case 'fadeout':
-        fadeStep(-animationSpeed);
+        fadeStep(-config.ANIMATION_SPEED);
         break;
 
       default:
@@ -77,7 +81,7 @@ export const initFadingScrollbar = (element: HTMLElement | null): void => {
   };
   const fadeIn = () => setAnimationState('fadein');
   const fadeOut = () => setAnimationState('fadeout');
-  const debouncedFadeOut = debounce(fadeOut, 1000);
+  const debouncedFadeOut = debounce(fadeOut, config.DEBOUNCE_THRESHOLD);
   const fadeInIdle = () => {
     fadeIn();
     debouncedFadeOut();

--- a/src/script/view_model/panel/NotificationsPanel.tsx
+++ b/src/script/view_model/panel/NotificationsPanel.tsx
@@ -21,10 +21,9 @@ import React, {useState, useRef, useEffect, FC} from 'react';
 import {container} from 'tsyringe';
 
 import {t} from 'Util/LocalizerUtil';
-import useEffectRef from 'Util/useEffectRef';
 import {registerReactComponent, useKoSubscribableChildren} from 'Util/ComponentUtil';
 
-import {useFadingScrollbar} from '../../ui/fadingScrollbar';
+import {initFadingScrollbar} from '../../ui/fadingScrollbar';
 import {NOTIFICATION_STATE, getNotificationText} from '../../conversation/NotificationSetting';
 import {ViewModelRepositories} from '../MainViewModel';
 import PanelHeader from './PanelHeader';
@@ -52,8 +51,6 @@ const NotificationsPanel: FC<NotificationsPanelProps> = ({
   const saveOptionNotificationPreference = (value: number) => {
     repositories.conversation.setNotificationState(activeConversation!, value);
   };
-  const [scrollbarRef, setScrollbarRef] = useEffectRef<HTMLDivElement>();
-  useFadingScrollbar(scrollbarRef);
 
   const [settings] = useState(
     Object.values(NOTIFICATION_STATE).map(status => ({
@@ -91,7 +88,7 @@ const NotificationsPanel: FC<NotificationsPanelProps> = ({
         ref={btnRef}
         handleBlur={() => setBtnFocus(false)}
       />
-      <div className="panel__content" ref={setScrollbarRef}>
+      <div className="panel__content" ref={initFadingScrollbar}>
         <fieldset className="notification-section">
           <PreferencesRadio
             name="preferences-options-notifications"

--- a/src/script/view_model/panel/ParticipantDevicesPanel.tsx
+++ b/src/script/view_model/panel/ParticipantDevicesPanel.tsx
@@ -20,13 +20,12 @@
 import React from 'react';
 
 import {registerReactComponent} from 'Util/ComponentUtil';
-import useEffectRef from 'Util/useEffectRef';
 import UserDevices, {UserDevicesState, useUserDevicesHistory} from 'Components/UserDevices';
 
 import type {User} from '../../entity/User';
 import {ViewModelRepositories} from '../MainViewModel';
 import PanelHeader from './PanelHeader';
-import {useFadingScrollbar} from '../../ui/fadingScrollbar';
+import {initFadingScrollbar} from '../../ui/fadingScrollbar';
 
 interface ParticipantDevicesPanelProps {
   onClose: () => void;
@@ -36,8 +35,6 @@ interface ParticipantDevicesPanelProps {
 }
 
 const ParticipantDevicesPanel: React.FC<ParticipantDevicesPanelProps> = ({repositories, onClose, onGoBack, user}) => {
-  const [scrollbarRef, setScrollbarRef] = useEffectRef<HTMLDivElement>();
-  useFadingScrollbar(scrollbarRef);
   const history = useUserDevicesHistory();
   return (
     <>
@@ -53,7 +50,7 @@ const ParticipantDevicesPanel: React.FC<ParticipantDevicesPanelProps> = ({reposi
         goBackUie="go-back-participant-devices"
       />
 
-      <div className="panel__content" ref={setScrollbarRef}>
+      <div className="panel__content" ref={initFadingScrollbar}>
         <UserDevices
           clientRepository={repositories.client}
           cryptographyRepository={repositories.cryptography}

--- a/src/script/view_model/panel/TimedMessagesPanel.tsx
+++ b/src/script/view_model/panel/TimedMessagesPanel.tsx
@@ -18,12 +18,11 @@
  */
 
 import React, {useEffect, useState} from 'react';
-import {useFadingScrollbar} from '../../ui/fadingScrollbar';
+import {initFadingScrollbar} from '../../ui/fadingScrollbar';
 import {container} from 'tsyringe';
 import {registerReactComponent, useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 import {formatDuration} from 'Util/TimeUtil';
-import useEffectRef from 'Util/useEffectRef';
 
 import {ConversationState} from '../../conversation/ConversationState';
 import {EphemeralTimings} from '../../ephemeral/EphemeralTimings';
@@ -46,8 +45,6 @@ const TimedMessagesPanel: React.FC<TimedMessagesPanelProps> = ({onClose, onGoBac
   const conversationState = container.resolve(ConversationState);
   const [currentMessageTimer, setCurrentMessageTimer] = useState(0);
   const [messageTimes, setMessageTimes] = useState<MessageTime[]>([]);
-  const [scrollbarRef, setScrollbarRef] = useEffectRef<HTMLDivElement>();
-  useFadingScrollbar(scrollbarRef);
 
   const {activeConversation} = useKoSubscribableChildren(conversationState, ['activeConversation']);
   const {globalMessageTimer} = useKoSubscribableChildren(activeConversation, ['globalMessageTimer']);
@@ -92,7 +89,7 @@ const TimedMessagesPanel: React.FC<TimedMessagesPanelProps> = ({onClose, onGoBac
         title={t('timedMessagesTitle')}
         goBackUie="go-back-timed-messages-options"
       />
-      <div ref={setScrollbarRef} className="panel__content">
+      <div ref={initFadingScrollbar} className="panel__content">
         {messageTimes.map(({text, isCustom, value}) => (
           <label
             key={value}


### PR DESCRIPTION
The `useEffectRef` is creating a re-render and show be avoided as much as possible. 

Instead we could use callback ref (see https://reactjs.org/docs/refs-and-the-dom.html#callback-refs) and just give a function that will init the DOM specific triggers that we want without re-rendering. 

The same can be done everywhere we use `useEffectRef` and we should migrate those in the near future and totally get rid of the `useEffectRef`