### PR TITLE
runfix: correct text selection and avatar bg colors acc-77

### DIFF
--- a/src/script/components/avatar/GroupAvatar.tsx
+++ b/src/script/components/avatar/GroupAvatar.tsx
@@ -36,14 +36,14 @@ const GroupAvatar: React.FC<GroupAvatarProps> = ({users, isLight = false, classN
       className={className}
       css={{
         ...CSS_SQUARE(32),
-        border: isLight ? '1px solid var(--gray-50)' : '1px solid hsla(0, 0%, 100%, 0.12)',
+        border: '1px solid var(--text-input-placeholder)',
         borderRadius: 6,
       }}
     >
       <div
         css={{
           ...CSS_SQUARE(28),
-          backgroundColor: '#34383B',
+          backgroundColor: 'var(--app-bg)',
           borderRadius: 5,
           display: 'flex',
           flexWrap: 'wrap',

--- a/src/style/common/accent-color.less
+++ b/src/style/common/accent-color.less
@@ -193,6 +193,7 @@ each(.colors(), .(@color-key, @color-name) {
   @accent-color-highlight-inversed: '@{name}-800';
   @accent-color-border: '@{name}-500';
   @accent-color-focus: '@{name}-400';
+  @accent-color-selection: '@{name}-300';
   @icon-primary-active-fill: '@{name}-500';
   @icon-secondary-active-border: 'accent_colors-0';
   @button-primary-hover: '@{name}-600';
@@ -216,6 +217,7 @@ each(.colors(), .(@color-key, @color-name) {
     --accent-color-highlight-inversed: @@accent-color-highlight-inversed;
     --accent-color-border: @@accent-color-border;
     --accent-color-focus: @@accent-color-focus;
+    --accent-color-selection: @@accent-color-selection;
     --accent-color-fade-16: fade(@@accent-color, 16%);
     --accent-color-fade-24: fade(@@accent-color, 24%);
     --accent-color-darken-16: darken(@@accent-color, 16%);
@@ -235,6 +237,7 @@ each(.colors(), .(@color-key, @color-name) {
     @accent-color-highlight-inversed-dark: '@{name}-50';
     @accent-color-border-dark: '@{name}-dark-600';
     @accent-color-focus-dark: '@{name}-dark-600';
+    @accent-color-selection-dark: '@{name}-dark-700';
     @icon-primary-active-fill-dark: 'w-white';
     @icon-secondary-active-border-dark: '@{name}-dark-800' ;
     @button-primary-hover-dark: '@{name}-dark-400';
@@ -257,6 +260,7 @@ each(.colors(), .(@color-key, @color-name) {
       --accent-color-highlight-inversed: @@accent-color-highlight-inversed-dark;
       --accent-color-border: @@accent-color-border-dark;
       --accent-color-focus: @@accent-color-focus-dark;
+      --accent-color-selection: @@accent-color-selection-dark;
       each(@color-index, {
         @accent-color: '@{name}-dark-@{value}';
         --accent-color-@{value}: @@accent-color;
@@ -270,10 +274,10 @@ each(.colors(), .(@color-key, @color-name) {
 })
   .accent-selection() {
   &::-moz-selection {
-    background-color: var(--accent-color-fade-24);
+    background-color: var(--accent-color-selection);
   }
   &::selection {
-    background-color: var(--accent-color-fade-24);
+    background-color: var(--accent-color-selection);
   }
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-77" title="ACC-77" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-77</a>  Update conversations view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
### Changes
 
#### Address conversation view design review : 
- Use higher contrast accent for selection highlight
- Use different group conversation avatar bg in light mode

#### Before:
![image](https://user-images.githubusercontent.com/78490891/189317878-5717fc7e-3a8a-44db-bca4-7a87beccaa34.png)

#### After:
![Screenshot from 2022-09-09 11-22-54](https://user-images.githubusercontent.com/78490891/189318048-497dc4f1-947f-4a2f-8551-26a27aa3241b.png)
