### PR TITLE
feat: Always send proteus messages as protobuf

### DIFF
--- a/src/script/conversation/MessageRepository.test.ts
+++ b/src/script/conversation/MessageRepository.test.ts
@@ -130,6 +130,7 @@ describe('MessageRepository', () => {
         ...commonSendResponse,
         conversationDomain: undefined,
         nativePush: true,
+        sendAsProtobuf: true,
         payload: expect.objectContaining({
           content: expect.objectContaining({hotKnock: false}),
           conversation: conversation.id,
@@ -157,6 +158,7 @@ describe('MessageRepository', () => {
         ...commonSendResponse,
         conversationDomain: undefined,
         nativePush: true,
+        sendAsProtobuf: true,
         payload: expect.objectContaining({
           content: expect.objectContaining({text: 'new text', originalMessageId: originalMessage.id}),
           conversation: conversation.id,
@@ -181,6 +183,7 @@ describe('MessageRepository', () => {
         ...commonSendResponse,
         conversationDomain: undefined,
         nativePush: true,
+        sendAsProtobuf: true,
         payload: expect.objectContaining({
           content: expect.objectContaining({text: 'hello there'}),
           conversation: conversation.id,

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -775,6 +775,7 @@ export class MessageRepository {
         onSuccess: handleSuccess,
         payload,
         protocol: ConversationProtocol.PROTEUS,
+        sendAsProtobuf: true,
         targetMode,
         userIds: this.generateRecipients(conversation, recipients, skipSelf),
       }),
@@ -836,8 +837,11 @@ export class MessageRepository {
         conversationDomain: this.core.backendFeatures.federationEndpoints ? conversation.domain : undefined,
         payload: sessionReset,
         protocol: ConversationProtocol.PROTEUS,
+        sendAsProtobuf: true,
+
         targetMode: MessageTargetMode.USERS_CLIENTS,
-        userIds: this.core.backendFeatures.federationEndpoints ? {[userId.domain]: userClient} : userClient, // we target this message to the specific client of the user (no need for mismatch handling here)
+        // we target this message to the specific client of the user (no need for mismatch handling here)
+        userIds: this.core.backendFeatures.federationEndpoints ? {[userId.domain]: userClient} : userClient,
       }),
     );
   }
@@ -1092,7 +1096,7 @@ export class MessageRepository {
       ? this.createQualifiedRecipients(users)
       : this.createRecipients(users);
 
-    this.core.service!.broadcast.broadcastGenericMessage(genericMessage, recipients, false, mismatch => {
+    this.core.service!.broadcast.broadcastGenericMessage(genericMessage, recipients, true, mismatch => {
       this.onClientMismatch?.(mismatch);
     });
   };


### PR DESCRIPTION
Now that protobuf has been battle tested (with the federated envs) and we know it works, let's give it a try for all other messages (non federated ones). 

This will allow us to remove a lot of code from the `core` (see https://github.com/wireapp/wire-web-packages/pull/4382) 