### PR TITLE
runfix: Improve updating local clients list from backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.9.0",
     "@wireapp/antiscroll-2": "1.3.1",
     "@wireapp/avs": "8.2.8",
-    "@wireapp/core": "30.5.1",
+    "@wireapp/core": "30.6.0",
     "@wireapp/react-ui-kit": "8.13.8",
     "@wireapp/store-engine-dexie": "1.6.10",
     "@wireapp/store-engine-sqleet": "1.7.14",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.9.0",
     "@wireapp/antiscroll-2": "1.3.1",
     "@wireapp/avs": "8.2.8",
-    "@wireapp/core": "30.6.0",
+    "@wireapp/core": "30.6.1",
     "@wireapp/react-ui-kit": "8.13.8",
     "@wireapp/store-engine-dexie": "1.6.10",
     "@wireapp/store-engine-sqleet": "1.7.14",

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -595,7 +595,6 @@ export class CallingRepository {
             ? await this.core.service!.conversation.fetchAllParticipantsClients(id, domain)
             : await this.core.service!.conversation.getAllParticipantsClients(id, domain);
           // We warn the message repository that a mismatch has happened outside of its lifecycle (eventually triggering a conversation degradation)
-          // We warn the message repository that a mismatch has happened outside of its lifecycle (eventually triggering a conversation degradation)
           const shouldContinue = await this.messageRepository.updateMissingClients(
             conversationEntity,
             allClients,

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -305,7 +305,9 @@ export class CallingRepository {
       return false;
     }
     const {id, domain} = call.conversationId;
-    const allClients = await this.core.service!.conversation.getAllParticipantsClients(id, domain);
+    const allClients = conversation.isUsingMLSProtocol
+      ? await this.core.service!.conversation.fetchAllParticipantsClients(id, domain)
+      : await this.core.service!.conversation.getAllParticipantsClients(id, domain);
     const qualifiedClients = isQualifiedUserClients(allClients)
       ? flattenQualifiedUserClients(allClients)
       : flattenUserClients(allClients);
@@ -589,7 +591,9 @@ export class CallingRepository {
       case CALL_MESSAGE_TYPE.CONFKEY: {
         if (source !== EventRepository.SOURCE.STREAM) {
           const {id, domain} = conversationId;
-          const allClients = await this.core.service!.conversation.getAllParticipantsClients(id, domain);
+          const allClients = conversationEntity.isUsingMLSProtocol
+            ? await this.core.service!.conversation.fetchAllParticipantsClients(id, domain)
+            : await this.core.service!.conversation.getAllParticipantsClients(id, domain);
           // We warn the message repository that a mismatch has happened outside of its lifecycle (eventually triggering a conversation degradation)
           // We warn the message repository that a mismatch has happened outside of its lifecycle (eventually triggering a conversation degradation)
           const shouldContinue = await this.messageRepository.updateMissingClients(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3177,10 +3177,10 @@
   resolved "https://registry.yarnpkg.com/@wireapp/antiscroll-2/-/antiscroll-2-1.3.1.tgz#bcb66f72c6dadc306e43235256b768ed3f89039c"
   integrity sha512-vWmWYAzSdyxs+xlgSPGtiNSTCM1z0nxM+jSPa/xz1/kuFKy80BrJP5xaGwNNLljBAz8ymlSPUUZlylUd0tFr1Q==
 
-"@wireapp/api-client@20.3.0":
-  version "20.3.0"
-  resolved "https://registry.yarnpkg.com/@wireapp/api-client/-/api-client-20.3.0.tgz#3c8bd36411f184b48f6bd82ea04aca0a06b217c7"
-  integrity sha512-au0XUVyK5nGnk2NA6Mmdj1UlbHw1dLXZorXEX8TeFeSWBSuOVpD6Ss6MFsAIqYvvitgA9az+9znJv6Ytkdux+Q==
+"@wireapp/api-client@20.3.1":
+  version "20.3.1"
+  resolved "https://registry.yarnpkg.com/@wireapp/api-client/-/api-client-20.3.1.tgz#d06ac6f261c17f90fdb40764249400901b752083"
+  integrity sha512-9VmA8BLCIpRGS0kovjD37seaktf5kMto6Hj+2aSaXr71J/lGFqzKsIXgMbk7rtfJxDer+kZgAgV8EOwye0x4CA==
   dependencies:
     "@types/node" "~14"
     "@types/spark-md5" "3.0.2"
@@ -3234,16 +3234,16 @@
     logdown "3.3.1"
     rimraf "3.0.2"
 
-"@wireapp/core@30.6.0":
-  version "30.6.0"
-  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-30.6.0.tgz#fa8dff8ee89195cd4540f1e5d257274906c5ee13"
-  integrity sha512-b/gX98StcUdusaGUi2xphTpEZKtBwLa+lu73FrDocVRX+kr1ZL2r/3S32UMXR0J1/lipRh3D1SYDPq64xyosKA==
+"@wireapp/core@30.6.1":
+  version "30.6.1"
+  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-30.6.1.tgz#e917db6c0ab0841e2a88e5a4165bad32d4139e6e"
+  integrity sha512-qJmMD6mXD98gPA5O7KQuA7G6eRmyfj3CgA0yGkvOrhFYacT5GX7LVJNINETaUkTExtNuSJUuYoHNGHmHukQbiA==
   dependencies:
     "@open-wc/webpack-import-meta-loader" "0.4.7"
     "@otak/core-crypto" "0.3.0-es2017"
     "@types/long" "4.0.1"
     "@types/node" "~14"
-    "@wireapp/api-client" "20.3.0"
+    "@wireapp/api-client" "20.3.1"
     "@wireapp/commons" "4.3.0"
     "@wireapp/cryptobox" "12.8.0"
     "@wireapp/store-engine-dexie" "1.6.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3177,16 +3177,16 @@
   resolved "https://registry.yarnpkg.com/@wireapp/antiscroll-2/-/antiscroll-2-1.3.1.tgz#bcb66f72c6dadc306e43235256b768ed3f89039c"
   integrity sha512-vWmWYAzSdyxs+xlgSPGtiNSTCM1z0nxM+jSPa/xz1/kuFKy80BrJP5xaGwNNLljBAz8ymlSPUUZlylUd0tFr1Q==
 
-"@wireapp/api-client@20.2.1":
-  version "20.2.1"
-  resolved "https://registry.yarnpkg.com/@wireapp/api-client/-/api-client-20.2.1.tgz#443b9c2fc6af5d45fbea52d17d6759ea44650900"
-  integrity sha512-WHpZqm5d5FLO3wSUoikC99QPrdwttvLGZQSwwozrhLeWBg0sLqO0IeN73lAE3mFbOh1fihJNI2RC5eWl/ttHOw==
+"@wireapp/api-client@20.3.0":
+  version "20.3.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/api-client/-/api-client-20.3.0.tgz#3c8bd36411f184b48f6bd82ea04aca0a06b217c7"
+  integrity sha512-au0XUVyK5nGnk2NA6Mmdj1UlbHw1dLXZorXEX8TeFeSWBSuOVpD6Ss6MFsAIqYvvitgA9az+9znJv6Ytkdux+Q==
   dependencies:
     "@types/node" "~14"
     "@types/spark-md5" "3.0.2"
     "@types/tough-cookie" "4.0.1"
     "@wireapp/commons" "4.3.0"
-    "@wireapp/priority-queue" "1.6.39"
+    "@wireapp/priority-queue" "1.7.0"
     "@wireapp/protocol-messaging" "1.37.0"
     axios "0.21.4"
     axios-retry "3.1.9"
@@ -3234,16 +3234,16 @@
     logdown "3.3.1"
     rimraf "3.0.2"
 
-"@wireapp/core@30.5.1":
-  version "30.5.1"
-  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-30.5.1.tgz#ea3487ae9eb9538eeed78ec74e6c3b26da663f44"
-  integrity sha512-WPG/XktSRy5HmuEeLC3k8xQkdRyIdZAmZ6fc3CjpGEb8Lm7BmjEIk74RQFzsFdB/QCtSaEc75uf7YMBerwT96g==
+"@wireapp/core@30.6.0":
+  version "30.6.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-30.6.0.tgz#fa8dff8ee89195cd4540f1e5d257274906c5ee13"
+  integrity sha512-b/gX98StcUdusaGUi2xphTpEZKtBwLa+lu73FrDocVRX+kr1ZL2r/3S32UMXR0J1/lipRh3D1SYDPq64xyosKA==
   dependencies:
     "@open-wc/webpack-import-meta-loader" "0.4.7"
     "@otak/core-crypto" "0.3.0-es2017"
     "@types/long" "4.0.1"
     "@types/node" "~14"
-    "@wireapp/api-client" "20.2.1"
+    "@wireapp/api-client" "20.3.0"
     "@wireapp/commons" "4.3.0"
     "@wireapp/cryptobox" "12.8.0"
     "@wireapp/store-engine-dexie" "1.6.10"
@@ -3290,10 +3290,10 @@
   dependencies:
     "@types/node" "~14"
 
-"@wireapp/priority-queue@1.6.39":
-  version "1.6.39"
-  resolved "https://registry.yarnpkg.com/@wireapp/priority-queue/-/priority-queue-1.6.39.tgz#ebf887bc74ae1331bc9ad3612fcc7dcaf7e47e0c"
-  integrity sha512-Rsv0DixzhEwETALKEk0BRlQ4w0W2/oNtYpcTxpcCGOLZee9aqag3ETFo2LLnvGjCv14Q95FkGrzpvRT8yo2SVQ==
+"@wireapp/priority-queue@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/priority-queue/-/priority-queue-1.7.0.tgz#0a710e95ae63333e0946054c193a30aa080097bd"
+  integrity sha512-KE3dilt231KSyVT1wo40XXGFyQZTbxh9eoCmuwdBUdXT11R9i/ES91hk/v/7oh/t18G3EEn2nTcDwCWCY2FGJA==
   dependencies:
     "@types/node" "~14"
 


### PR DESCRIPTION
The `getAllParticipantClients` from the core packages needs more changes to have aligned behavior with the previous one. 
Rolling back to the previous method to avoid missed local clients updates