### PR TITLE
runfix: Ensure conversation is MLS before checking it is established

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -2449,6 +2449,7 @@ export class ConversationRepository {
       eventData.users?.map(user => user.qualified_id) || eventData.user_ids.map(userId => ({domain: '', id: userId}));
 
     if (
+      conversationEntity.groupId &&
       !mlsConversationState.getState().isEstablished(conversationEntity.id) &&
       (await this.core.service!.conversation.isMLSConversationEstablished(conversationEntity.groupId))
     ) {

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -101,7 +101,7 @@ export class Conversation {
   public readonly connection: ko.Observable<ConnectionEntity>;
   // TODO(Federation): Currently the 'creator' just refers to a user id but it has to become a qualified id
   public creator: string;
-  public groupId: string = '';
+  public groupId?: string;
   public epoch: number = -1;
   public readonly isUsingMLSProtocol: boolean;
   public readonly display_name: ko.PureComputed<string>;


### PR DESCRIPTION
regression introduced by #13611 