### PR TITLE
chore: upgrade @wireapp/core version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.9.0",
     "@wireapp/antiscroll-2": "1.3.1",
     "@wireapp/avs": "8.2.8",
-    "@wireapp/core": "30.7.1",
+    "@wireapp/core": "30.8.0",
     "@wireapp/react-ui-kit": "8.13.8",
     "@wireapp/store-engine-dexie": "1.6.10",
     "@wireapp/store-engine-sqleet": "1.7.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3234,10 +3234,10 @@
   resolved "https://registry.yarnpkg.com/@wireapp/core-crypto/-/core-crypto-0.4.0.tgz#62ae0b4976753a454d478b141cd4f08e5a8be95a"
   integrity sha512-GIrzcbTdZ66dVXh+T56mhsoepTov6H5aQst40WFTGT20EnjubI5bV+w/PE8kegTRQcmDnZL2WQUQExDEwGK5aw==
 
-"@wireapp/core@30.7.1":
-  version "30.7.1"
-  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-30.7.1.tgz#ee27653b199ae7f843307dffdbe7904f60486580"
-  integrity sha512-Cva2227fmfjrue9BdbRERBpayHPyUOdE1cXtyStOdK1Srkgqp5vNng2oqyxFGRaX+6zA1kKJMFwC3zEo0E3n2g==
+"@wireapp/core@30.8.0":
+  version "30.8.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-30.8.0.tgz#731fa1912347f00e54e222a097abe2b6148f8454"
+  integrity sha512-965tmos7VaXR8mIq3myU9EavkLLgaVtFC8ZcwvM21MRGbVKktysGzQttYKiDja/nEzbE4y5ZvscXO8aB2Sb11A==
   dependencies:
     "@open-wc/webpack-import-meta-loader" "0.4.7"
     "@types/long" "4.0.1"


### PR DESCRIPTION
Bump `@wireapp/core` package's version to include:
- https://github.com/wireapp/wire-web-packages/pull/4394
- https://github.com/wireapp/wire-web-packages/pull/4395
