### PR TITLE
fix: reorder people tab for group button

### DIFF
--- a/src/script/page/LeftSidebar/panels/StartUI/PeopleTab.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/PeopleTab.tsx
@@ -234,37 +234,6 @@ export const PeopleTab: React.FC<{
         </div>
       )}
 
-      {!hasFederationError && !hasResults && (
-        <>
-          {!canSearchUnconnectedUsers ? (
-            <div className="start-ui-no-search-results__content">
-              <span className="start-ui-no-search-results__icon">
-                <Icon.Message />
-              </span>
-              <p className="start-ui-no-search-results__text" data-uie-name="label-no-search-result">
-                {t('searchNoMatchesPartner')}
-              </p>
-            </div>
-          ) : isFederated ? (
-            <div className="start-ui-fed-wrapper">
-              <span className="start-ui-fed-wrapper__icon">
-                <Icon.Profile />
-              </span>
-              <div className="start-ui-fed-wrapper__text">{t('searchTrySearchFederation')}</div>
-              <div className="start-ui-fed-wrapper__button">
-                {/*@todo: re-enable when federation article is available
-                <button type="button" data-bind="click: () => {}" data-uie-name="do-search-learn-more">
-                  {t('searchTrySearchLearnMore')}
-                </button>
-          */}
-              </div>
-            </div>
-          ) : (
-            <p className="start-ui-no-search-results">{t('searchTrySearch')}</p>
-          )}
-        </>
-      )}
-
       {searchQuery.length === 0 && (
         <>
           <ul className="start-ui-list left-list-items">
@@ -325,6 +294,36 @@ export const PeopleTab: React.FC<{
                 </div>
               </div>
             </div>
+          )}
+        </>
+      )}
+      {!hasFederationError && !hasResults && (
+        <>
+          {!canSearchUnconnectedUsers ? (
+            <div className="start-ui-no-search-results__content">
+              <span className="start-ui-no-search-results__icon">
+                <Icon.Message />
+              </span>
+              <p className="start-ui-no-search-results__text" data-uie-name="label-no-search-result">
+                {t('searchNoMatchesPartner')}
+              </p>
+            </div>
+          ) : isFederated ? (
+            <div className="start-ui-fed-wrapper">
+              <span className="start-ui-fed-wrapper__icon">
+                <Icon.Profile />
+              </span>
+              <div className="start-ui-fed-wrapper__text">{t('searchTrySearchFederation')}</div>
+              <div className="start-ui-fed-wrapper__button">
+                {/*@todo: re-enable when federation article is available
+                <button type="button" data-bind="click: () => {}" data-uie-name="do-search-learn-more">
+                  {t('searchTrySearchLearnMore')}
+                </button>
+          */}
+              </div>
+            </div>
+          ) : (
+            <p className="start-ui-no-search-results">{t('searchTrySearch')}</p>
           )}
         </>
       )}

--- a/src/style/list/start-ui.less
+++ b/src/style/list/start-ui.less
@@ -332,10 +332,10 @@ body.theme-dark .start-ui-list-header {
 
 .start-ui-fed-wrapper {
   display: flex;
-  height: 100%;
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  margin-top: 72px;
 
   &__icon {
     opacity: 0.24;


### PR DESCRIPTION
On federation (and possibly other edge cases), the buttons to join a group are hidden below the message that you have no connections. 
<img width="1504" alt="Wire 2022-09-16 at 3_34 PM" src="https://user-images.githubusercontent.com/37285713/190662465-6fd3b899-8fce-468e-9343-b3ba289e1108.png">

It appears this is caused by an incorrect ordering of items in the column (and a 100% height)


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

_Briefly describe the issue you have solved or implemented with this pull request. If the PR contains multiple issues, use a bullet list._

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
