### PR TITLE
runfix: use accent color for self mention acc-155

### DIFF
--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -102,8 +102,9 @@
     }
 
     &.self-mention {
-      background-color: fade(@w-yellow, 48%);
-      color: var(--background);
+      padding: 3px 0 4px 0;
+      background-color: var(--accent-color-selection);
+      color: var(--main-color);
     }
 
     &:not(.self-mention) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-155" title="ACC-155" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-155</a>  [Web][Dark Mode] Selected Text highlight in message Input UI doesn't have enough contrast with background
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
#### Changes

- use accent color instead of yellow for self mentions

![image](https://user-images.githubusercontent.com/78490891/191003995-71383f81-82c9-4249-9cf6-d6b266f2f159.png)
