### PR TITLE
chore: mock @wireapp/core-crypto

### DIFF
--- a/src/__mocks__/@wireapp/core-crypto.js
+++ b/src/__mocks__/@wireapp/core-crypto.js
@@ -1,0 +1,20 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+module.exports = {};


### PR DESCRIPTION
For now core-crypto is only exported as an es module, which doesn't play well with jest/node resolvers. 

We would need to investigate a proper way to load this dependency, but for now, as a temporary solution, we will just mock it