### PR TITLE
chore: Enable full debug log in dev mode

### DIFF
--- a/src/script/util/LoggerUtil.ts
+++ b/src/script/util/LoggerUtil.ts
@@ -38,7 +38,7 @@ export function enableLogging(force = false, search = window.location.search): v
   if (namespace) {
     localStorage.setItem('debug', namespace);
   } else if (force) {
-    localStorage.setItem('debug', '@wireapp/webapp*');
+    localStorage.setItem('debug', '*');
   } else {
     localStorage.removeItem('debug');
   }

--- a/test/unit_tests/util/LoggerUtilSpec.js
+++ b/test/unit_tests/util/LoggerUtilSpec.js
@@ -49,6 +49,6 @@ describe('enableLogging', () => {
 
     enableLogging(true, '');
 
-    expect(localStorage.getItem('debug')).toBe('@wireapp/webapp*');
+    expect(localStorage.getItem('debug')).toBe('*');
   });
 });


### PR DESCRIPTION
Since we started moving logic to the `core` we are missing more and more logs in the webapp in debug mode. 

This will enable all logs when `ENABLE_LOGGING` flag is on (this will allow us to see errors messages from the core). 