### PR TITLE
fix: Show expiration message when logout is detected [SQCORE-1272]

### DIFF
--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -190,7 +190,7 @@ class App {
     private readonly core: Core,
     private readonly apiClient: APIClient,
   ) {
-    this.apiClient.on(APIClient.TOPIC.ON_LOGOUT, () => this.logout(SIGN_OUT_REASON.NOT_SIGNED_IN, false));
+    this.apiClient.on(APIClient.TOPIC.ON_LOGOUT, () => this.logout(SIGN_OUT_REASON.SESSION_EXPIRED, false));
     this.logger = getLogger('App');
     this.appContainer = appContainer;
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCORE-1272" title="SQCORE-1272" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQCORE-1272</a>  [Web] Desktop: No reason shown on welcome page when logout reason is a password reset
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Regression Introduced by https://github.com/wireapp/wire-webapp/pull/8738

this `logout` event from the apiClient is triggered when the access token is not valid anymore. So the reason should have been `EXPIRED` and not `NOT_SIGNED_IN` in the original PR