### PR TITLE
fix: address ts errors in link preview generation [SQCORE-1270]

### DIFF
--- a/src/script/conversation/linkPreviews/index.ts
+++ b/src/script/conversation/linkPreviews/index.ts
@@ -115,12 +115,12 @@ function toLinkPreviewData(openGraphData: OpenGraphResult, url: string, offset: 
   const {site_name, title, description} = openGraphData;
 
   const truncatedTitle = truncate(deArrayify(title), Config.getConfig().MAXIMUM_LINK_PREVIEW_CHARS);
-  const truncatedDescription = truncate(deArrayify(description), Config.getConfig().MAXIMUM_LINK_PREVIEW_CHARS);
+  const truncatedDescription = truncate(deArrayify(description ?? ''), Config.getConfig().MAXIMUM_LINK_PREVIEW_CHARS);
 
   let tweet;
   if (deArrayify(site_name) === 'Twitter' && isTweetUrl(deArrayify(url))) {
     const author = deArrayify(title).replace('on Twitter', '').trim();
-    const username = deArrayify(url).match(/com\/([^/]*)\//)[1];
+    const username = deArrayify(url).match(/com\/([^/]*)\//)?.[1];
     tweet = {
       author,
       username,
@@ -129,7 +129,7 @@ function toLinkPreviewData(openGraphData: OpenGraphResult, url: string, offset: 
 
   return {
     image,
-    permanantUrl: deArrayify(openGraphData.url),
+    permanantUrl: deArrayify(openGraphData.url) ?? '',
     title: tweet ? truncatedDescription : truncatedTitle,
     tweet,
     url,
@@ -154,7 +154,9 @@ async function fetchOpenGraphData(link: string): Promise<OpenGraphResult | undef
     }
     return undefined;
   } catch (error) {
-    logger.warn(`Error while fetching OpenGraph data: ${error.message}`);
+    if (error instanceof Error) {
+      logger.warn(`Error while fetching OpenGraph data: ${error.message}`);
+    }
     throw new LinkPreviewError(LinkPreviewError.TYPE.UNSUPPORTED_TYPE, LinkPreviewError.MESSAGE.UNSUPPORTED_TYPE);
   }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCORE-1270" title="SQCORE-1270" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQCORE-1270</a>  [Web] Desktop: Uncaught error when link preview is generated for certain links
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Some link preview do not have a description. In which case our link preview parsing will crash. 
Only fixing the strict typescript issues will address this problem.