### PR TITLE
fix: Avoid account data failure when image could not be loaded [FS-996]

### DIFF
--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -268,8 +268,12 @@ export class TeamRepository {
       let imageDataUrl;
 
       if (imageResource) {
-        const imageBlob = imageResource ? await this.assetRepository.load(imageResource) : undefined;
-        imageDataUrl = imageBlob ? await loadDataUrl(imageBlob) : undefined;
+        try {
+          const imageBlob = imageResource ? await this.assetRepository.load(imageResource) : undefined;
+          imageDataUrl = imageBlob ? await loadDataUrl(imageBlob) : undefined;
+        } catch (error) {
+          this.logger.warn(`Account image could not be loaded`, error);
+        }
       }
 
       const accountInfo: AccountInfo = {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-996" title="FS-996" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-996</a>  [destkop] App sidebar doesn't show on on certain accounts
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The method `sendAccountInfo` is called to update electron with the account info for the current user. 
Among other data, it loads the image that should go with the user (either the user's own profile picture, or the team's avatar if it's a team account). 

In case this image loading fails, the entire `sendAccountInfo` fails and the electron app doesn't get notified with the current user info... And thus doesn't show the side bar. 

This should make the webapp resilient to image not being able to load