### PR TITLE
runfix: Avoid crashing when accessing localStorage with cookies disabled

### DIFF
--- a/src/script/mls/mlsConversationState/conversationStateStorage.ts
+++ b/src/script/mls/mlsConversationState/conversationStateStorage.ts
@@ -17,12 +17,14 @@
  *
  */
 
+import {getStorage} from 'Util/localStorage';
 import {MLSConversationState} from './mlsConversationState';
 
 const storageKey = 'mlsConversationsState';
+const storage = getStorage();
 
 export const loadState = (): MLSConversationState => {
-  const storedState = localStorage.getItem(storageKey);
+  const storedState = storage?.getItem(storageKey);
   if (!storedState) {
     return {
       established: new Set(),
@@ -37,8 +39,5 @@ export const loadState = (): MLSConversationState => {
 };
 
 export const saveState = ({established, pendingWelcome}: MLSConversationState) => {
-  localStorage.setItem(
-    storageKey,
-    JSON.stringify({established: [...established], pendingWelcome: [...pendingWelcome]}),
-  );
+  storage?.setItem(storageKey, JSON.stringify({established: [...established], pendingWelcome: [...pendingWelcome]}));
 };

--- a/src/script/util/LoggerUtil.ts
+++ b/src/script/util/LoggerUtil.ts
@@ -17,29 +17,18 @@
  *
  */
 
-export function enableLogging(force = false, search = window.location.search): void {
-  let localStorage;
+import {getStorage} from './localStorage';
 
-  try {
-    /**
-     * If users disable cookies in their browsers, they won't have access to the localStorage API.
-     * The following check will fix this error:
-     * > Failed to read the 'localStorage' property from 'Window': Access is denied for this document
-     * (note: Some version of Firefox do not throw an error but, instead, return a null object, we also need to account for that scenario)
-     */
-    localStorage = window.localStorage;
-  } catch (error) {}
-  if (!localStorage) {
-    return;
-  }
+export function enableLogging(force = false, search = window.location.search): void {
+  const storage = getStorage();
 
   const namespace = new URLSearchParams(search).get('enableLogging');
 
   if (namespace) {
-    localStorage.setItem('debug', namespace);
+    storage?.setItem('debug', namespace);
   } else if (force) {
-    localStorage.setItem('debug', '*');
+    storage?.setItem('debug', '*');
   } else {
-    localStorage.removeItem('debug');
+    storage?.removeItem('debug');
   }
 }

--- a/src/script/util/localStorage.ts
+++ b/src/script/util/localStorage.ts
@@ -1,0 +1,37 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+/**
+ * Gives back the browser's instance of localstorage if present.
+ * Will prevent failing if localStorage is not accessible because cookies are disabled
+ * @returns {any}
+ */
+export function getStorage() {
+  try {
+    /**
+     * If users disable cookies in their browsers, they won't have access to the localStorage API.
+     * The following check will fix this error:
+     * > Failed to read the 'localStorage' property from 'Window': Access is denied for this document
+     * (note: Some version of Firefox do not throw an error but, instead, return a null object, we also need to account for that scenario)
+     */
+    return window.localStorage;
+  } catch (error) {
+    return undefined;
+  }
+}


### PR DESCRIPTION
When cookies are disabled, `window.localStorage` cannot be accessed and throws an error.
The storage util prevent this