### PR TITLE
fix: Delete ephemeral messages even when connectivity is down [SEC-198]

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -2841,9 +2841,12 @@ export class ConversationRepository {
         }
 
         const userIds = conversationEntity.isGroup()
-          ? [this.userState.self().qualifiedId, {domain: messageEntity.fromDomain, id: messageEntity.from}]
+          ? [this.userState.self().qualifiedId, {domain: messageEntity.fromDomain ?? '', id: messageEntity.from}]
           : undefined;
-        return this.messageRepository.deleteMessageForEveryone(conversationEntity, messageEntity, userIds);
+        return this.messageRepository.deleteMessageForEveryone(conversationEntity, messageEntity, {
+          optimiticRemoval: true,
+          targetedUsers: userIds,
+        });
       });
     }
   };

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -2844,7 +2844,7 @@ export class ConversationRepository {
           ? [this.userState.self().qualifiedId, {domain: messageEntity.fromDomain ?? '', id: messageEntity.from}]
           : undefined;
         return this.messageRepository.deleteMessageForEveryone(conversationEntity, messageEntity, {
-          optimiticRemoval: true,
+          optimisticRemoval: true,
           targetedUsers: userIds,
         });
       });

--- a/src/script/conversation/MessageRepository.test.ts
+++ b/src/script/conversation/MessageRepository.test.ts
@@ -46,6 +46,7 @@ import {ClientEntity} from '../client/ClientEntity';
 import {TeamState} from '../team/TeamState';
 import {ContentMessage} from '../entity/message/ContentMessage';
 import {PayloadBundleState} from '@wireapp/core/src/main/conversation';
+import {ConversationState} from './ConversationState';
 
 const selfUser = new User('selfid', '');
 selfUser.isMe = true;
@@ -69,6 +70,7 @@ type MessageRepositoryDependencies = {
   serverTimeHandler: ServerTimeHandler;
   userRepository: UserRepository;
   userState: UserState;
+  conversationState: ConversationState;
 };
 
 async function buildMessageRepository(): Promise<[MessageRepository, MessageRepositoryDependencies]> {
@@ -81,6 +83,10 @@ async function buildMessageRepository(): Promise<[MessageRepository, MessageRepo
   messageSender.pauseQueue(false);
   await core.initServices({} as any);
   /* eslint-disable sort-keys-fix/sort-keys-fix */
+  const conversationState = new ConversationState(userState);
+  const selfConversation = new Conversation(selfUser.id);
+  selfConversation.selfUser(selfUser);
+  conversationState.conversations([selfConversation]);
   const dependencies = {
     conversationRepository: () => ({} as ConversationRepository),
     cryptographyRepository: new CryptographyRepository({} as any),
@@ -93,6 +99,7 @@ async function buildMessageRepository(): Promise<[MessageRepository, MessageRepo
     userState,
     teamState: new TeamState(),
     clientState,
+    conversationState,
     core,
   };
   /* eslint-disable sort-keys-fix/sort-keys-fix */
@@ -237,7 +244,6 @@ describe('MessageRepository', () => {
           userIds: {selfid: [], user1: []},
         }),
       );
-      expect(eventRepository.eventService.deleteEvent).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -945,7 +945,7 @@ export class MessageRepository {
       targetedUsers?: QualifiedId[];
       /** will not wait for backend confirmation before actually deleting the message locally */
       optimiticRemoval?: boolean;
-    },
+    } = {},
   ): Promise<void> {
     const conversationId = conversation.id;
     const messageId = message.id;

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -961,6 +961,7 @@ export class MessageRepository {
       });
       await this.sendAndInjectGenericCoreMessage(payload, conversation, {
         recipients: userIds,
+        // if we want optimistic removal, we can rely on the injection system that will handle the event and remove the message even before the message is sent
         skipInjection: !options.optimiticRemoval,
       });
       if (!options.optimiticRemoval) {

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -944,7 +944,7 @@ export class MessageRepository {
     options: {
       targetedUsers?: QualifiedId[];
       /** will not wait for backend confirmation before actually deleting the message locally */
-      optimiticRemoval?: boolean;
+      optimisticRemoval?: boolean;
     } = {},
   ): Promise<void> {
     const conversationId = conversation.id;
@@ -962,9 +962,9 @@ export class MessageRepository {
       await this.sendAndInjectGenericCoreMessage(payload, conversation, {
         recipients: userIds,
         // if we want optimistic removal, we can rely on the injection system that will handle the event and remove the message even before the message is sent
-        skipInjection: !options.optimiticRemoval,
+        skipInjection: !options.optimisticRemoval,
       });
-      if (!options.optimiticRemoval) {
+      if (!options.optimisticRemoval) {
         this.deleteMessage(conversation, message);
       }
     } catch (error) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SEC-198" title="SEC-198" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />SEC-198</a>  [webapp] Expired messages are not scrambled when there is no internet connection at time of expiry
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### The problem

In the initial approach, we would delete the message locally **after** the http call to send the message has actually gone through. This is nice for when the user actually deletes a message (we actually want a visual confirmation that the message has been deleted), but for ephemeral messages, this is a problem since it means you will see the message for an indefinite time if the internet is down

### The solution

We can use the `injection` system that we have build it, it processes any event coming in optimistically. 
If the event is a `delete` event then the code will trigger the removal before the message is actually sent.