### PR TITLE
feat: add new failure states for decryption failure cases (SQCORE-653)

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -264,6 +264,8 @@
   "connectionRequestConnect": "Connect",
   "connectionRequestIgnore": "Ignore",
   "conversationAssetDownloading": "Downloading…",
+  "conversationAssetFailedDecryptDownloading": "DOWNLOAD FAILED (CANNOT DECRYPT)",
+  "conversationAssetFailedHashDownloading": "DOWNLOAD FAILED (HASH DOES NOT MATCH)",
   "conversationAssetRestrictedAudioMessageHeadline": "Audio message",
   "conversationAssetUploadFailed": "Upload Failed",
   "conversationAssetUploading": "Uploading…",

--- a/src/script/assets/AssetTransferState.ts
+++ b/src/script/assets/AssetTransferState.ts
@@ -23,4 +23,6 @@ export enum AssetTransferState {
   UPLOAD_PENDING = 'upload-pending',
   UPLOADED = 'uploaded',
   UPLOADING = 'uploading',
+  DOWNLOAD_FAILED_DECRPYT = 'download-failed-decrypt',
+  DOWNLOAD_FAILED_HASH = 'download-failed-hash',
 }

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/FileAssetComponent.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/FileAssetComponent.tsx
@@ -67,6 +67,8 @@ const FileAssetComponent: React.FC<FileAssetProps> = ({
   const isFailedUpload = assetStatus === AssetTransferState.UPLOAD_FAILED;
   const isUploaded = assetStatus === AssetTransferState.UPLOADED;
   const isDownloading = assetStatus === AssetTransferState.DOWNLOADING;
+  const isFailedDownloadingDecrypt = assetStatus === AssetTransferState.DOWNLOAD_FAILED_DECRPYT;
+  const isFailedDownloadingHash = assetStatus === AssetTransferState.DOWNLOAD_FAILED_HASH;
   const isUploading = assetStatus === AssetTransferState.UPLOADING;
 
   if (isObfuscated) {
@@ -113,7 +115,9 @@ const FileAssetComponent: React.FC<FileAssetProps> = ({
 
               {isUploading && <AssetLoader loadProgress={uploadProgress || 0} onCancel={() => cancelUpload()} />}
 
-              {isFailedUpload && <div className="media-button media-button-error" />}
+              {(isFailedUpload || isFailedDownloadingDecrypt || isFailedDownloadingHash) && (
+                <div className="media-button media-button-error" />
+              )}
 
               <div className="file__desc">
                 <div className="label-bold-xs ellipsis" data-uie-name="file-name">
@@ -127,6 +131,12 @@ const FileAssetComponent: React.FC<FileAssetProps> = ({
                   {isUploading && <li data-uie-name="file-status">{t('conversationAssetUploading')}</li>}
                   {isFailedUpload && <li data-uie-name="file-status">{t('conversationAssetUploadFailed')}</li>}
                   {isDownloading && <li data-uie-name="file-status">{t('conversationAssetDownloading')}</li>}
+                  {isFailedDownloadingDecrypt && (
+                    <li data-uie-name="file-status">{t('conversationAssetFailedDecryptDownloading')}</li>
+                  )}
+                  {isFailedDownloadingHash && (
+                    <li data-uie-name="file-status">{t('conversationAssetFailedHashDownloading')}</li>
+                  )}
                 </ul>
               </div>
             </>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCORE-653" title="SQCORE-653" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />SQCORE-653</a>  [Web] Show error message in UI when transfered files have been manipulated (wrong hash or wrong used algorithm)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Webapp should show error states when a file cannot be downloaded because of an incorrect hash or decryption error. 
This is especially useful/ important as it could show that some bad actor has tried to manipulate a file. 

<img width="903" alt="Screenshot 2022-09-23 at 15 12 31" src="https://user-images.githubusercontent.com/37285713/191970407-43f28fb5-8241-42e8-90ff-634fa08dd2c9.png">
