### PR TITLE
chore: Fix React warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@wireapp/antiscroll-2": "1.3.1",
     "@wireapp/avs": "8.2.8",
     "@wireapp/core": "31.3.0",
-    "@wireapp/react-ui-kit": "8.14.7",
+    "@wireapp/react-ui-kit": "8.14.8",
     "@wireapp/store-engine-dexie": "1.7.6",
     "@wireapp/store-engine-sqleet": "1.8.6",
     "@wireapp/webapp-events": "0.14.6",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@wireapp/antiscroll-2": "1.3.1",
     "@wireapp/avs": "8.2.8",
     "@wireapp/core": "31.3.0",
-    "@wireapp/react-ui-kit": "8.13.8",
+    "@wireapp/react-ui-kit": "8.14.7",
     "@wireapp/store-engine-dexie": "1.7.6",
     "@wireapp/store-engine-sqleet": "1.8.6",
     "@wireapp/webapp-events": "0.14.6",

--- a/src/script/auth/component/UnsupportedBrowser.test.tsx
+++ b/src/script/auth/component/UnsupportedBrowser.test.tsx
@@ -17,38 +17,18 @@
  *
  */
 
-import {ReactWrapper} from 'enzyme';
-import {initialRootState, RootState, Api} from '../module/reducer';
+import {initialRootState} from '../module/reducer';
 import {mockStoreFactory} from '../util/test/mockStoreFactory';
-import {mountComponent} from '../util/test/TestUtil';
-import UnsupportedBrowser, {UnsupportedBrowserProps} from './UnsupportedBrowser';
+import UnsupportedBrowser from './UnsupportedBrowser';
 import {TypeUtil} from '@wireapp/commons';
-import {MockStoreEnhanced} from 'redux-mock-store';
-import {ThunkDispatch} from 'redux-thunk';
-import {AnyAction} from 'redux';
-import {History} from 'history';
 import {Config, Configuration} from '../../Config';
 import {Runtime} from '@wireapp/commons';
+import {mountComponentReact16} from '../util/test/TestUtil';
 
 jest.mock('../util/SVGProvider');
 
-class UnsupportedBrowserPage {
-  private readonly driver: ReactWrapper;
-
-  constructor(
-    store: MockStoreEnhanced<TypeUtil.RecursivePartial<RootState>, ThunkDispatch<RootState, Api, AnyAction>>,
-    props?: UnsupportedBrowserProps,
-    history?: History<any>,
-  ) {
-    this.driver = mountComponent(<UnsupportedBrowser {...props} />, store, history);
-  }
-
-  getOnlyDesktopMessage = () => this.driver.find('[data-uie-name="element-unsupported-desktop-only"]');
-  getGeneralUnsupprtedMessage = () => this.driver.find('[data-uie-name="element-unsupported-general"]');
-  getText = () => this.driver.text();
-
-  update = () => this.driver.update();
-}
+const desktopMessageId = 'element-unsupported-desktop-only';
+const generalMessageId = 'element-unsupported-general';
 
 describe('UnsupportedBrowser', () => {
   // @SF.Channel @TSFI.UserInterface @S1
@@ -62,18 +42,17 @@ describe('UnsupportedBrowser', () => {
         },
       });
 
-    const unsupportedPage = new UnsupportedBrowserPage(
-      mockStoreFactory()({
-        ...initialRootState,
-        runtimeState: {
-          hasCookieSupport: true,
-          hasIndexedDbSupport: true,
-          isSupportedBrowser: false,
-        },
-      }),
-    );
+    const store = mockStoreFactory()({
+      ...initialRootState,
+      runtimeState: {
+        hasCookieSupport: true,
+        hasIndexedDbSupport: true,
+        isSupportedBrowser: false,
+      },
+    });
+    const {getByTestId} = mountComponentReact16(<UnsupportedBrowser />, store);
 
-    expect(unsupportedPage.getOnlyDesktopMessage().exists()).toBe(true);
+    expect(getByTestId(desktopMessageId)).not.toBe(null);
   });
 
   it('renders content in desktop application when ENABLE_ENFORCE_DESKTOP_APPLICATION_ONLY is true', async () => {
@@ -88,20 +67,19 @@ describe('UnsupportedBrowser', () => {
 
     const expectedContent = 'content';
 
-    const unsupportedPage = new UnsupportedBrowserPage(
-      mockStoreFactory()({
-        ...initialRootState,
-        runtimeState: {
-          hasCookieSupport: true,
-          hasIndexedDbSupport: true,
-          isSupportedBrowser: true,
-        },
-      }),
-      {children: 'content'},
-    );
+    const store = mockStoreFactory()({
+      ...initialRootState,
+      runtimeState: {
+        hasCookieSupport: true,
+        hasIndexedDbSupport: true,
+        isSupportedBrowser: true,
+      },
+    });
+    const props = {children: 'content'};
+    const {queryByTestId, getByText} = mountComponentReact16(<UnsupportedBrowser {...props} />, store);
 
-    expect(unsupportedPage.getOnlyDesktopMessage().exists()).toBe(false);
-    expect(unsupportedPage.getText()).toContain(expectedContent);
+    expect(queryByTestId(desktopMessageId)).toBe(null);
+    expect(getByText(expectedContent)).not.toBe(null);
   });
 
   it('shows general unsupported browser message', async () => {
@@ -113,17 +91,16 @@ describe('UnsupportedBrowser', () => {
         },
       });
 
-    const unsupportedPage = new UnsupportedBrowserPage(
-      mockStoreFactory()({
-        ...initialRootState,
-        runtimeState: {
-          hasCookieSupport: true,
-          hasIndexedDbSupport: true,
-          isSupportedBrowser: false,
-        },
-      }),
-    );
+    const store = mockStoreFactory()({
+      ...initialRootState,
+      runtimeState: {
+        hasCookieSupport: true,
+        hasIndexedDbSupport: true,
+        isSupportedBrowser: false,
+      },
+    });
+    const {getByTestId} = mountComponentReact16(<UnsupportedBrowser />, store);
 
-    expect(unsupportedPage.getGeneralUnsupprtedMessage().exists()).toBe(true);
+    expect(getByTestId(generalMessageId)).not.toBe(null);
   });
 });

--- a/src/script/auth/component/UnsupportedBrowser.test.tsx
+++ b/src/script/auth/component/UnsupportedBrowser.test.tsx
@@ -23,7 +23,7 @@ import UnsupportedBrowser from './UnsupportedBrowser';
 import {TypeUtil} from '@wireapp/commons';
 import {Config, Configuration} from '../../Config';
 import {Runtime} from '@wireapp/commons';
-import {mountComponentReact16} from '../util/test/TestUtil';
+import {mountComponentReact18} from '../util/test/TestUtil';
 
 jest.mock('../util/SVGProvider');
 
@@ -50,7 +50,7 @@ describe('UnsupportedBrowser', () => {
         isSupportedBrowser: false,
       },
     });
-    const {getByTestId} = mountComponentReact16(<UnsupportedBrowser />, store);
+    const {getByTestId} = mountComponentReact18(<UnsupportedBrowser />, store);
 
     expect(getByTestId(desktopMessageId)).not.toBe(null);
   });
@@ -76,7 +76,7 @@ describe('UnsupportedBrowser', () => {
       },
     });
     const props = {children: 'content'};
-    const {queryByTestId, getByText} = mountComponentReact16(<UnsupportedBrowser {...props} />, store);
+    const {queryByTestId, getByText} = mountComponentReact18(<UnsupportedBrowser {...props} />, store);
 
     expect(queryByTestId(desktopMessageId)).toBe(null);
     expect(getByText(expectedContent)).not.toBe(null);
@@ -99,7 +99,7 @@ describe('UnsupportedBrowser', () => {
         isSupportedBrowser: false,
       },
     });
-    const {getByTestId} = mountComponentReact16(<UnsupportedBrowser />, store);
+    const {getByTestId} = mountComponentReact18(<UnsupportedBrowser />, store);
 
     expect(getByTestId(generalMessageId)).not.toBe(null);
   });

--- a/src/script/auth/util/test/TestUtil.tsx
+++ b/src/script/auth/util/test/TestUtil.tsx
@@ -17,6 +17,7 @@
  *
  */
 
+import {render} from '@testing-library/react';
 import {RecursivePartial} from '@wireapp/commons/src/main/util/TypeUtil';
 import {StyledApp, THEME_ID} from '@wireapp/react-ui-kit';
 import {mount} from 'enzyme';
@@ -43,8 +44,17 @@ export const withRouter = (component: React.ReactNode, history: History) => (
   <Router history={history}>{component}</Router>
 );
 
+/**
+ * @deprecated use mountComponentReact16 instead
+ */
 export const mountComponent = (
   component: React.ReactNode,
   store: MockStoreEnhanced<RecursivePartial<RootState>, ThunkDispatch<RootState, Api, AnyAction>>,
   history: History = createMemoryHistory(),
 ) => mount(withRouter(withTheme(withStore(withIntl(component), store)), history));
+
+export const mountComponentReact16 = (
+  component: React.ReactNode,
+  store: MockStoreEnhanced<RecursivePartial<RootState>, ThunkDispatch<RootState, Api, AnyAction>>,
+  history: History = createMemoryHistory(),
+) => render(withRouter(withTheme(withStore(withIntl(component), store)), history));

--- a/src/script/auth/util/test/TestUtil.tsx
+++ b/src/script/auth/util/test/TestUtil.tsx
@@ -44,17 +44,23 @@ export const withRouter = (component: React.ReactNode, history: History) => (
   <Router history={history}>{component}</Router>
 );
 
+const wrapComponent = (
+  component: React.ReactNode,
+  store: MockStoreEnhanced<RecursivePartial<RootState>, ThunkDispatch<RootState, Api, AnyAction>>,
+  history: History = createMemoryHistory(),
+) => withRouter(withTheme(withStore(withIntl(component), store)), history);
+
 /**
- * @deprecated use mountComponentReact16 instead
+ * @deprecated use mountComponentReact16 instead to avoid "Warning: ReactDOM.render is no longer supported in React 18."
  */
 export const mountComponent = (
   component: React.ReactNode,
   store: MockStoreEnhanced<RecursivePartial<RootState>, ThunkDispatch<RootState, Api, AnyAction>>,
   history: History = createMemoryHistory(),
-) => mount(withRouter(withTheme(withStore(withIntl(component), store)), history));
+) => mount(wrapComponent(component, store, history));
 
-export const mountComponentReact16 = (
+export const mountComponentReact18 = (
   component: React.ReactNode,
   store: MockStoreEnhanced<RecursivePartial<RootState>, ThunkDispatch<RootState, Api, AnyAction>>,
   history: History = createMemoryHistory(),
-) => render(withRouter(withTheme(withStore(withIntl(component), store)), history));
+) => render(wrapComponent(component, store, history));

--- a/src/script/auth/util/test/TestUtil.tsx
+++ b/src/script/auth/util/test/TestUtil.tsx
@@ -51,7 +51,7 @@ const wrapComponent = (
 ) => withRouter(withTheme(withStore(withIntl(component), store)), history);
 
 /**
- * @deprecated use mountComponentReact16 instead to avoid "Warning: ReactDOM.render is no longer supported in React 18."
+ * @deprecated use mountComponentReact18 instead to avoid "Warning: ReactDOM.render is no longer supported in React 18."
  */
 export const mountComponent = (
   component: React.ReactNode,

--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -38,7 +38,7 @@ import {registerReactComponent, useKoSubscribableChildren} from 'Util/ComponentU
 import ModalComponent from 'Components/ModalComponent';
 import SearchInput from 'Components/SearchInput';
 import UserSearchableList from 'Components/UserSearchableList';
-import TextInputForwarded from 'Components/TextInput/TextInput';
+import TextInput from 'Components/TextInput/TextInput';
 import BaseToggle from 'Components/toggle/BaseToggle';
 import InfoToggle from 'Components/toggle/InfoToggle';
 import {User} from '../../../entity/User';
@@ -353,7 +353,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
           {stateIsPreferences && (
             <>
               <div className="modal-input-wrapper">
-                <TextInputForwarded
+                <TextInput
                   autoFocus
                   label={t('groupCreationPreferencesPlaceholder')}
                   placeholder={t('groupCreationPreferencesPlaceholder')}

--- a/src/script/components/TextInput/TextInput.tsx
+++ b/src/script/components/TextInput/TextInput.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React, {ForwardRefRenderFunction, useEffect, useRef} from 'react';
+import React, {useEffect, useRef} from 'react';
 import Icon from 'Components/Icon';
 import {CheckIcon, COLOR} from '@wireapp/react-ui-kit';
 import {cancelButtonCSS, containerCSS, errorMessageCSS, getIconCSS, getInputCSS, getLabelCSS} from './TextInput.styles';
@@ -47,7 +47,7 @@ export interface UserInputProps {
 
 const SUCCESS_DISMISS_TIMEOUT = 2500;
 
-const TextInput: ForwardRefRenderFunction<HTMLInputElement, UserInputProps> = ({
+const TextInput: React.FC<UserInputProps> = ({
   autoFocus,
   disabled,
   errorMessage,
@@ -141,6 +141,4 @@ const TextInput: ForwardRefRenderFunction<HTMLInputElement, UserInputProps> = ({
   );
 };
 
-const TextInputForwarded = React.forwardRef(TextInput);
-
-export default TextInputForwarded;
+export default TextInput;

--- a/src/script/components/TextInput/TextInput.tsx
+++ b/src/script/components/TextInput/TextInput.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React, {useEffect, useRef} from 'react';
+import React, {forwardRef, useEffect, useRef} from 'react';
 import Icon from 'Components/Icon';
 import {CheckIcon, COLOR} from '@wireapp/react-ui-kit';
 import {cancelButtonCSS, containerCSS, errorMessageCSS, getIconCSS, getInputCSS, getLabelCSS} from './TextInput.styles';
@@ -41,32 +41,33 @@ export interface UserInputProps {
   value?: string;
   uieName?: string;
   errorUieName?: string;
-  inputWrapperRef?: React.RefObject<HTMLDivElement>;
   setIsEditing?: (x: boolean) => void;
 }
 
 const SUCCESS_DISMISS_TIMEOUT = 2500;
 
-const TextInput: React.FC<UserInputProps> = ({
-  autoFocus,
-  disabled,
-  errorMessage,
-  isError,
-  isSuccess,
-  label,
-  name,
-  onCancel,
-  onChange,
-  onBlur,
-  onKeyDown,
-  onSuccessDismissed,
-  placeholder,
-  value,
-  uieName,
-  errorUieName,
-  inputWrapperRef,
-  setIsEditing,
-}: UserInputProps) => {
+const TextInput: React.ForwardRefRenderFunction<HTMLDivElement, UserInputProps> = (
+  {
+    autoFocus,
+    disabled,
+    errorMessage,
+    isError,
+    isSuccess,
+    label,
+    name,
+    onCancel,
+    onChange,
+    onBlur,
+    onKeyDown,
+    onSuccessDismissed,
+    placeholder,
+    value,
+    uieName,
+    errorUieName,
+    setIsEditing,
+  }: UserInputProps,
+  ref,
+) => {
   const isFilled = Boolean(value);
   const textInputRef = useRef<HTMLInputElement>(null);
 
@@ -87,7 +88,7 @@ const TextInput: React.FC<UserInputProps> = ({
   }
 
   return (
-    <div css={containerCSS} ref={inputWrapperRef}>
+    <div css={containerCSS} ref={ref}>
       {isError && errorMessage && (
         <span className="label" css={errorMessageCSS} data-uie-name={errorUieName}>
           {errorMessage}
@@ -140,5 +141,4 @@ const TextInput: React.FC<UserInputProps> = ({
     </div>
   );
 };
-
-export default TextInput;
+export default forwardRef(TextInput);

--- a/src/script/page/MainContent/panels/preferences/accountPreferences/AccountInput.tsx
+++ b/src/script/page/MainContent/panels/preferences/accountPreferences/AccountInput.tsx
@@ -184,7 +184,7 @@ const AccountInput: FC<AccountInputProps> = ({
           label={label}
           name={valueUie ? valueUie : fieldName}
           value={input}
-          inputWrapperRef={inputWrapperRef}
+          ref={inputWrapperRef}
           onChange={({target}) => updateInput(target.value)}
           onCancel={() => {
             updateInput('');

--- a/test/helper/UserGenerator.ts
+++ b/test/helper/UserGenerator.ts
@@ -44,7 +44,7 @@ export class UserGenerator {
       ],
       handle: faker.internet.userName(),
       id: createRandomUuid(),
-      name: faker.name.findName(),
+      name: faker.name.fullName(),
     };
 
     return new UserMapper(serverTimeHandler).mapUserFromJson(template);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2281,25 +2281,6 @@
   dependencies:
     classnames "*"
 
-"@types/color-convert@*":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/color-convert/-/color-convert-2.0.0.tgz#8f5ee6b9e863dcbee5703f5a517ffb13d3ea4e22"
-  integrity sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==
-  dependencies:
-    "@types/color-name" "*"
-
-"@types/color-name@*":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
-  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
-
-"@types/color@3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@types/color/-/color-3.0.2.tgz#3779043e782f562aa9157b5fc6bd07e14fd8e7f3"
-  integrity sha512-INiJl6sfNn8iyC5paxVzqiVUEj2boIlFki02uRTAkKwAj++7aAF+ZfEv/XrIeBa0XI/fTZuDHW8rEEcEVnON+Q==
-  dependencies:
-    "@types/color-convert" "*"
-
 "@types/dexie-batch@0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@types/dexie-batch/-/dexie-batch-0.4.3.tgz#0535449aeb91d7ab1a78a29047f97067a8665871"
@@ -3235,14 +3216,13 @@
   dependencies:
     protobufjs "6.11.3"
 
-"@wireapp/react-ui-kit@8.13.8":
-  version "8.13.8"
-  resolved "https://registry.yarnpkg.com/@wireapp/react-ui-kit/-/react-ui-kit-8.13.8.tgz#60e2c021b94f45b6a97094ffbee1b031a84a2d0a"
-  integrity sha512-cJu9h96QgKX6Q02hgjCrSHp/TNROw0dJvT0do+bMMHrMSDcXFCTq41hv2wcISvMR29RN1gYWau0h/g4hwV0yzw==
+"@wireapp/react-ui-kit@8.14.7":
+  version "8.14.7"
+  resolved "https://registry.yarnpkg.com/@wireapp/react-ui-kit/-/react-ui-kit-8.14.7.tgz#03f9b7f348c32cbe4c75afc685a43dc2c676abd9"
+  integrity sha512-/gOmXAabETuBxqDmhY77mwXElSYLPS6iSvU3+/wSlXL30tX7UkKYhY545rcWSZjdaEvwLXMP802OkTMvz8/G3Q==
   dependencies:
     "@emotion/react" "11.9.0"
-    "@types/color" "3.0.2"
-    bazinga64 "5.10.0"
+    bazinga64 "5.11.6"
     color "3.1.3"
     emotion-normalize "11.0.1"
     react-select "5.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2281,6 +2281,25 @@
   dependencies:
     classnames "*"
 
+"@types/color-convert@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/color-convert/-/color-convert-2.0.0.tgz#8f5ee6b9e863dcbee5703f5a517ffb13d3ea4e22"
+  integrity sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==
+  dependencies:
+    "@types/color-name" "*"
+
+"@types/color-name@*":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
+  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+"@types/color@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/color/-/color-3.0.2.tgz#3779043e782f562aa9157b5fc6bd07e14fd8e7f3"
+  integrity sha512-INiJl6sfNn8iyC5paxVzqiVUEj2boIlFki02uRTAkKwAj++7aAF+ZfEv/XrIeBa0XI/fTZuDHW8rEEcEVnON+Q==
+  dependencies:
+    "@types/color-convert" "*"
+
 "@types/dexie-batch@0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@types/dexie-batch/-/dexie-batch-0.4.3.tgz#0535449aeb91d7ab1a78a29047f97067a8665871"
@@ -3216,12 +3235,13 @@
   dependencies:
     protobufjs "6.11.3"
 
-"@wireapp/react-ui-kit@8.14.7":
-  version "8.14.7"
-  resolved "https://registry.yarnpkg.com/@wireapp/react-ui-kit/-/react-ui-kit-8.14.7.tgz#03f9b7f348c32cbe4c75afc685a43dc2c676abd9"
-  integrity sha512-/gOmXAabETuBxqDmhY77mwXElSYLPS6iSvU3+/wSlXL30tX7UkKYhY545rcWSZjdaEvwLXMP802OkTMvz8/G3Q==
+"@wireapp/react-ui-kit@8.14.8":
+  version "8.14.8"
+  resolved "https://registry.yarnpkg.com/@wireapp/react-ui-kit/-/react-ui-kit-8.14.8.tgz#3d77e557020d490baa4f2ae303aa949ba73bcf54"
+  integrity sha512-VLm7JS6vtG/SbYNHOZnJBOfbORpuEmImZZnpG/Fego9cItl6p/oocPUQ2r9lp79bv58qsZtD4BiuUBNDwHsmtw==
   dependencies:
     "@emotion/react" "11.9.0"
+    "@types/color" "3.0.2"
     bazinga64 "5.11.6"
     color "3.1.3"
     emotion-normalize "11.0.1"


### PR DESCRIPTION
Will fix 2 React warnings:
- The improve use of `forwardRef` in the TextInput component (the `ref` parameters was never used)
- migrating a few tests to `testing-library` to avoid the `mount` error when running the tests

And one test warning:
- use of deprecated `faker.user.findName()` 