### PR TITLE
fix: Use team domain when generating team icon [FS-996]

### DIFF
--- a/src/script/team/TeamEntity.ts
+++ b/src/script/team/TeamEntity.ts
@@ -42,7 +42,7 @@ export class TeamEntity {
     this.name = ko.observable('');
   }
 
-  getIconResource(): AssetRemoteData | void {
+  getIconResource(teamDomain?: string): AssetRemoteData | void {
     let hasIcon = false;
 
     try {
@@ -50,7 +50,7 @@ export class TeamEntity {
     } catch (error) {}
 
     if (hasIcon) {
-      return AssetRemoteData.v3(this.icon);
+      return teamDomain ? AssetRemoteData.v4(this.icon, teamDomain) : AssetRemoteData.v3(this.icon);
     }
   }
 }

--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -263,7 +263,7 @@ export class TeamRepository {
   async sendAccountInfo(isDesktop = Runtime.isDesktopApp()): Promise<AccountInfo | void> {
     if (isDesktop) {
       const imageResource = this.teamState.isTeam()
-        ? this.teamState.team().getIconResource()
+        ? this.teamState.team().getIconResource(this.teamState.teamDomain())
         : this.userState.self().previewPictureResource();
       let imageDataUrl;
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-996" title="FS-996" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-996</a>  [destkop] App sidebar doesn't show on on certain accounts
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
With the arrival of asset V4, if the server is operating on a particular domain, we need to map the domain in all assets. 
The Team Icon was missing that piece of logic and thus the team's logo could load