### PR TITLE
feat: Always try to map asset v4 when possible [FS-1001]

### DIFF
--- a/src/script/assets/AssetMapper.ts
+++ b/src/script/assets/AssetMapper.ts
@@ -37,9 +37,7 @@ export const mapProfileAssets = (userId: QualifiedId, assets: APIClientUserAsset
     .filter(asset => asset.type === 'image')
     .reduce((mappedAssets, asset) => {
       const domain = asset.domain ?? userId.domain;
-      const assetRemoteData = domain
-        ? AssetRemoteData.v4(asset.key, domain, new Uint8Array())
-        : AssetRemoteData.v3(asset.key, new Uint8Array());
+      const assetRemoteData = AssetRemoteData.v3(asset.key, domain, new Uint8Array());
       return !sizeMap[asset.size] ? mappedAssets : {...mappedAssets, [sizeMap[asset.size]]: assetRemoteData};
     }, {});
 };

--- a/src/script/assets/AssetRemoteData.ts
+++ b/src/script/assets/AssetRemoteData.ts
@@ -60,6 +60,10 @@ export class AssetRemoteData {
     this.cancelDownload = () => {};
   }
 
+  /**
+   * Will generate a v3 or v4 (depending on the given domain) asset payload.
+   * Assets v3 and v4 only differ by the domain, so it doesn't make sense to split those into 2 different methods
+   */
   static v3(
     assetKey: string,
     assetDomain?: string,

--- a/src/script/assets/AssetRemoteData.ts
+++ b/src/script/assets/AssetRemoteData.ts
@@ -23,7 +23,7 @@ export type AssetUrlData = AssetUrlDataVersion1 | AssetUrlDataVersion2 | AssetUr
 
 export interface AssetUrlDataVersion3 {
   assetKey: string;
-  assetToken: string;
+  assetToken?: string;
   forceCaching: boolean;
   version: 3;
 }
@@ -60,46 +60,28 @@ export class AssetRemoteData {
     this.cancelDownload = () => {};
   }
 
-  static v4(
-    assetKey: string,
-    assetDomain: string,
-    otrKey?: Uint8Array,
-    sha256?: Uint8Array,
-    assetToken?: string,
-    forceCaching: boolean = false,
-  ) {
-    return new AssetRemoteData(
-      assetKey,
-      {
-        assetDomain,
-        assetKey,
-        assetToken,
-        forceCaching,
-        version: 4,
-      },
-      otrKey,
-      sha256,
-    );
-  }
-
   static v3(
     assetKey: string,
+    assetDomain?: string,
     otrKey?: Uint8Array,
     sha256?: Uint8Array,
     assetToken?: string,
     forceCaching: boolean = false,
   ) {
-    return new AssetRemoteData(
+    const baseProperties: AssetUrlDataVersion3 = {
       assetKey,
-      {
-        assetKey,
-        assetToken,
-        forceCaching,
-        version: 3,
-      },
-      otrKey,
-      sha256,
-    );
+      assetToken,
+      forceCaching,
+      version: 3,
+    };
+    const urlData = assetDomain
+      ? ({
+          ...baseProperties,
+          assetDomain,
+          version: 4,
+        } as AssetUrlDataVersion4)
+      : baseProperties;
+    return new AssetRemoteData(assetKey, urlData, otrKey, sha256);
   }
 
   static v2(

--- a/src/script/assets/AssetRemoteData.ts
+++ b/src/script/assets/AssetRemoteData.ts
@@ -23,7 +23,7 @@ export type AssetUrlData = AssetUrlDataVersion1 | AssetUrlDataVersion2 | AssetUr
 
 export interface AssetUrlDataVersion3 {
   assetKey: string;
-  assetToken?: string;
+  assetToken: string;
   forceCaching: boolean;
   version: 3;
 }

--- a/src/script/team/TeamEntity.ts
+++ b/src/script/team/TeamEntity.ts
@@ -50,7 +50,7 @@ export class TeamEntity {
     } catch (error) {}
 
     if (hasIcon) {
-      return teamDomain ? AssetRemoteData.v4(this.icon, teamDomain) : AssetRemoteData.v3(this.icon);
+      return AssetRemoteData.v3(this.icon, teamDomain);
     }
   }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1001" title="FS-1001" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1001</a>  [Web] Old images do not display when using API V2
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Context

asset v3 and v4 are very similar, the only difference is that v4 has a domain. 
When dealing with old assets (that were uploaded in a chat before we used domain for assets), we try to map them to v3 but on backend they are now seen as v4. 
We should then try to always set a domain to any asset we see (even if the payload doesn't have a domain). 
Falling back to the conversation domain when the asset doesn't have a domain should do the trick

### Solution

merging back together asset v3 and v4 allows for simpler flow and the switch between v3 and v4 is actually done internally. 
