### PR TITLE
runfix: Avoid handling MLS protocol messages [FS-1003]

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.9.0",
     "@wireapp/antiscroll-2": "1.3.1",
     "@wireapp/avs": "8.2.8",
-    "@wireapp/core": "31.3.3",
+    "@wireapp/core": "31.3.4",
     "@wireapp/react-ui-kit": "8.14.8",
     "@wireapp/store-engine-dexie": "1.7.6",
     "@wireapp/store-engine-sqleet": "1.8.6",

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -59,7 +59,7 @@ import {
   sortUsersByPriority,
   fixWebsocketString,
 } from 'Util/StringUtil';
-import {ClientEvent} from '../event/Client';
+import {ClientEvent, CONVERSATION as CLIENT_CONVERSATION_EVENT} from '../event/Client';
 import {NOTIFICATION_HANDLING_STATE} from '../event/NotificationHandlingState';
 import {EventRepository} from '../event/EventRepository';
 import {
@@ -1947,7 +1947,7 @@ export class ConversationRepository {
       return Promise.reject(new Error('Conversation Repository Event Handling: Event missing'));
     }
 
-    const ignoredEvents = [CONVERSATION_EVENT.MLS_MESSAGE_ADD];
+    const ignoredEvents: (CONVERSATION_EVENT | CLIENT_CONVERSATION_EVENT)[] = [CONVERSATION_EVENT.MLS_MESSAGE_ADD];
     if (ignoredEvents.includes(eventJson?.type)) {
       return Promise.resolve();
     }

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1947,6 +1947,11 @@ export class ConversationRepository {
       return Promise.reject(new Error('Conversation Repository Event Handling: Event missing'));
     }
 
+    const ignoredEvents = [CONVERSATION_EVENT.MLS_MESSAGE_ADD];
+    if (ignoredEvents.includes(eventJson?.type)) {
+      return Promise.resolve();
+    }
+
     const {conversation, qualified_conversation, data: eventData, type} = eventJson;
     // data.conversationId is always the conversationId that should be read first. If not found we can fallback to qualified_conversation or conversation
     const conversationId: QualifiedId = eventData?.conversationId

--- a/yarn.lock
+++ b/yarn.lock
@@ -3148,19 +3148,19 @@
     logdown "3.3.1"
     rimraf "3.0.2"
 
-"@wireapp/core-crypto@0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@wireapp/core-crypto/-/core-crypto-0.5.1.tgz#78d640e14c5519d8b2e035f5a97654482e652037"
-  integrity sha512-9xKUTTxbDYzbAlcdnV1L1f89wYsR58pJU9Or4gYqgd2KV8AZKPlFsxAvNbsXSWbaXGrqK6Wzu7dNAV9AqMmDEA==
+"@wireapp/core-crypto@0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@wireapp/core-crypto/-/core-crypto-0.5.2.tgz#73f7787529d80fee68a42881003a5bded40486d9"
+  integrity sha512-D/lnVk/omd2xltMOpWjWkWfv/AHYzD0EepKLOqTq456coi5lwHNWja0niuFc6cBccXXrlkv3mh/ClDf2lGPvvg==
 
-"@wireapp/core@31.3.3":
-  version "31.3.3"
-  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-31.3.3.tgz#535b7785cd9551785ff0f2bd08fb1e827ebcc4f1"
-  integrity sha512-SzL5k+kzY6KrHwPLJ+lYN1A4IaOOuleix/GaP3nVKSAicmqKm72GU7G4jfnYKR1PjDl9li4lEpCIVh3EMyx3Gg==
+"@wireapp/core@31.3.4":
+  version "31.3.4"
+  resolved "https://registry.yarnpkg.com/@wireapp/core/-/core-31.3.4.tgz#4bd4e4fe4c610550176094c2010c553ee7e3d42b"
+  integrity sha512-APaob8IIBGTneYCNFNjjlQ+HekU7P4AViIMD0JE0v8r6b1D70pe/feZ633qeIRKBOhEy+ZgPIMHZXZloX4SYiw==
   dependencies:
     "@wireapp/api-client" "^20.6.3"
     "@wireapp/commons" "^4.4.6"
-    "@wireapp/core-crypto" "0.5.1"
+    "@wireapp/core-crypto" "0.5.2"
     "@wireapp/cryptobox" "12.8.0"
     "@wireapp/promise-queue" "^1.3.0"
     "@wireapp/store-engine-dexie" "^1.7.6"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1003" title="FS-1003" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1003</a>  [WEB] Added again user after had left MLS convo, can't send MLS messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

MLS protocol messages are forwarded to core-crypto and should only be handled by this library. 
At the conversation level we should only handle content messages

This created a problem with people leaving conversation. 
Leaving a conversation generates a lot of MLS protocol messages that, from the webapp point of view, are sent from a participant that is no longer in the conversation. 
This triggered the webapp to update the list of participants and eventually re-add the person that just left in the local conversation. 