### PR TITLE
feat: remove device 'reset session' button for mls conversations (FS-881)

### DIFF
--- a/src/script/components/userDevices/DeviceDetails.tsx
+++ b/src/script/components/userDevices/DeviceDetails.tsx
@@ -17,7 +17,6 @@
  *
  */
 
-import {ConversationProtocol} from '@wireapp/api-client/src/conversation/NewConversation';
 import React, {useEffect, useMemo, useState} from 'react';
 import {container} from 'tsyringe';
 import cx from 'classnames';
@@ -98,7 +97,7 @@ const DeviceDetails: React.FC<DeviceDetailsProps> = ({
     }
   };
 
-  const isMLSConversation = conversationState.activeConversation()?.protocol === ConversationProtocol.MLS;
+  const isMLSConversation = !!conversationState.activeConversation()?.isUsingMLSProtocol;
 
   return (
     <div className={cx('participant-devices__header', {'participant-devices__header--padding': !noPadding})}>

--- a/src/script/components/userDevices/DeviceDetails.tsx
+++ b/src/script/components/userDevices/DeviceDetails.tsx
@@ -98,7 +98,7 @@ const DeviceDetails: React.FC<DeviceDetailsProps> = ({
     }
   };
 
-  const isMlsConversation = conversationState.activeConversation()?.protocol === ConversationProtocol.MLS;
+  const isMLSConversation = conversationState.activeConversation()?.protocol === ConversationProtocol.MLS;
 
   return (
     <div className={cx('participant-devices__header', {'participant-devices__header--padding': !noPadding})}>
@@ -155,7 +155,7 @@ const DeviceDetails: React.FC<DeviceDetailsProps> = ({
             style={{display: isResettingSession ? 'initial' : 'none'}}
             data-uie-name="status-loading"
           />
-          {!isMlsConversation && (
+          {!isMLSConversation && (
             <button
               type="button"
               className="button-reset-default button-label participant-devices__reset-session accent-text ellipsis"

--- a/src/script/components/userDevices/DeviceDetails.tsx
+++ b/src/script/components/userDevices/DeviceDetails.tsx
@@ -17,6 +17,7 @@
  *
  */
 
+import {ConversationProtocol} from '@wireapp/api-client/src/conversation/NewConversation';
 import React, {useEffect, useMemo, useState} from 'react';
 import {container} from 'tsyringe';
 import cx from 'classnames';
@@ -97,6 +98,8 @@ const DeviceDetails: React.FC<DeviceDetailsProps> = ({
     }
   };
 
+  const isMlsConversation = conversationState.activeConversation()?.protocol === ConversationProtocol.MLS;
+
   return (
     <div className={cx('participant-devices__header', {'participant-devices__header--padding': !noPadding})}>
       <button
@@ -152,15 +155,17 @@ const DeviceDetails: React.FC<DeviceDetailsProps> = ({
             style={{display: isResettingSession ? 'initial' : 'none'}}
             data-uie-name="status-loading"
           />
-          <button
-            type="button"
-            className="button-reset-default button-label participant-devices__reset-session accent-text ellipsis"
-            onClick={clickToResetSession}
-            style={{display: isResettingSession ? 'none' : 'initial'}}
-            data-uie-name="do-reset-session"
-          >
-            {t('participantDevicesDetailResetSession')}
-          </button>
+          {!isMlsConversation && (
+            <button
+              type="button"
+              className="button-reset-default button-label participant-devices__reset-session accent-text ellipsis"
+              onClick={clickToResetSession}
+              style={{display: isResettingSession ? 'none' : 'initial'}}
+              data-uie-name="do-reset-session"
+            >
+              {t('participantDevicesDetailResetSession')}
+            </button>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-881" title="FS-881" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-881</a>  [Web] Protocol and Cyphersuite indication in the Group properties
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Removes device `reset session` button from mls conversations. This is a thing that was mentioned in ticket's [specification (parent ticket)](https://wearezeta.atlassian.net/browse/FS-699) and we've missed it while implementing displaying ciphersuite in conversation details panel.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
