### PR TITLE
runfix: use proteus as default protocol when user can't choose (FS-1026)

### DIFF
--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -83,10 +83,10 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
     'isMLSEnabled',
   ]);
 
-  const enableMlsToggle = isMLSEnabledForTeamUser && Config.getConfig().FEATURE.ENABLE_MLS;
+  const enableMLSToggle = isMLSEnabledForTeamUser && Config.getConfig().FEATURE.ENABLE_MLS;
 
   //if user is not able to choose mls (team does not allow or feature flag is off), use proteus as default
-  const defaultProtocol = enableMlsToggle
+  const defaultProtocol = enableMLSToggle
     ? teamState.teamFeatures().mls?.config.defaultProtocol
     : ConversationProtocol.PROTEUS;
 
@@ -184,7 +184,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
           groupName,
           isTeam ? accessState : undefined,
           {
-            protocol: enableMlsToggle ? selectedProtocol.value : defaultProtocol,
+            protocol: enableMLSToggle ? selectedProtocol.value : defaultProtocol,
             receipt_mode: enableReadReceipts ? RECEIPT_MODE.ON : RECEIPT_MODE.OFF,
           },
         );
@@ -423,7 +423,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
                     isDisabled={false}
                     name={t('readReceiptsToggleName')}
                   />
-                  {enableMlsToggle && (
+                  {enableMLSToggle && (
                     <>
                       <Select
                         id="select-protocol"

--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -78,7 +78,18 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
   userState = container.resolve(UserState),
   teamState = container.resolve(TeamState),
 }) => {
-  const defaultProtocol = teamState.teamFeatures().mls?.config.defaultProtocol;
+  const {isTeam, isMLSEnabled: isMLSEnabledForTeamUser} = useKoSubscribableChildren(teamState, [
+    'isTeam',
+    'isMLSEnabled',
+  ]);
+
+  const enableMlsToggle = isMLSEnabledForTeamUser && Config.getConfig().FEATURE.ENABLE_MLS;
+
+  //if user is not able to choose mls (team does not allow or feature flag is off), use proteus as default
+  const defaultProtocol = enableMlsToggle
+    ? teamState.teamFeatures().mls?.config.defaultProtocol
+    : ConversationProtocol.PROTEUS;
+
   const protocolOptions: ProtocolOption[] = [ConversationProtocol.PROTEUS, ConversationProtocol.MLS].map(protocol => ({
     label: `${t(`modalCreateGroupProtocolSelect.${protocol}`)}${
       protocol === defaultProtocol ? t(`modalCreateGroupProtocolSelect.default`) : ''
@@ -106,8 +117,6 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
   const maxSize = ConversationRepository.CONFIG.GROUP.MAX_SIZE;
 
   const onEscape = () => setIsShown(false);
-  const {isTeam, isMLSEnabled} = useKoSubscribableChildren(teamState, ['isTeam', 'isMLSEnabled']);
-  const enableMlsToggle = isMLSEnabled && Config.getConfig().FEATURE.ENABLE_MLS;
 
   useEffect(() => {
     const showCreateGroup = (_: string, userEntity: User) => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1026" title="FS-1026" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1026</a>  [WEB] User can't create group convo after MLS feature flag on env off
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

There was a bug where user was not able to create a proteus conversation when `FEATURE_ENABLE_MLS` feature flag was not set but user's team had mls mode enabled and default protocol set to `MLS`. 

Because protocol toggle was not visible (lack of feature flag) in group creation modal, user was not able to choose the protocol, and the default one was chosen (the one that was being set in TM - `MLS`). 

This led to some errors in our client as it was trying to create mls conversation without feature flag on (`coreCryptoClient` was not initialised in `MLSService`).

The solution is to check if user is not able to choose protocol (team does not allow `MLS` or feature flag is off) and use proteus as default. Pseudo code would be:

```js
const defaultProtocol = FEATURE_ENABLE_MLS && isMLSEnabledOnTM ? getDefaultFromTM() : useProteus()
```

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
