### PR TITLE
feat: add unmute self when in call by pressing spacebar

### DIFF
--- a/src/script/components/calling/CallingOverlayContainer.tsx
+++ b/src/script/components/calling/CallingOverlayContainer.tsx
@@ -38,7 +38,7 @@ import {CallViewTab} from '../../view_model/CallingViewModel';
 import ChooseScreen, {Screen} from './ChooseScreen';
 import FullscreenVideoCall from './FullscreenVideoCall';
 import {LEAVE_CALL_REASON} from '../../calling/enum/LeaveCallReason';
-import {PushToTalkHandler} from './PushToTalkHandler';
+import PushToTalkHandler from './PushToTalkHandler';
 
 export interface CallingContainerProps {
   readonly callingRepository: CallingRepository;

--- a/src/script/components/calling/CallingOverlayContainer.tsx
+++ b/src/script/components/calling/CallingOverlayContainer.tsx
@@ -34,11 +34,11 @@ import {LEAVE_CALL_REASON} from '../../calling/enum/LeaveCallReason';
 import {Participant} from '../../calling/Participant';
 import {useVideoGrid} from '../../calling/videoGridHandler';
 import {ConversationState} from '../../conversation/ConversationState';
-import {useKeyPress} from '../../hooks/useKeypress';
 import {ElectronDesktopCapturerSource} from '../../media/MediaDevicesHandler';
 import {MediaRepository} from '../../media/MediaRepository';
 import {Multitasking} from '../../notification/NotificationRepository';
 import {CallViewTab} from '../../view_model/CallingViewModel';
+import {PushToTalkHandler} from './PushToTalkHandler';
 
 export interface CallingContainerProps {
   readonly callingRepository: CallingRepository;
@@ -72,24 +72,7 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
     muteState,
   } = useKoSubscribableChildren(joinedCall!, ['maximizedParticipant', 'state', 'muteState']);
 
-  const [isSpacebarPressUnmuted, setIsSpacebarPressUnmuted] = React.useState(false);
   const isMuted = muteState !== MuteState.NOT_MUTED;
-
-  const spacebarPress: boolean = useKeyPress(' ');
-
-  useEffect(() => {
-    if (joinedCall) {
-      const isUnmuteAllowed =
-        joinedCall.muteState() === MuteState.SELF_MUTED || joinedCall.muteState() === MuteState.REMOTE_MUTED;
-      if (!spacebarPress && isSpacebarPressUnmuted) {
-        callingRepository.muteCall(joinedCall, true);
-        setIsSpacebarPressUnmuted(false);
-      } else if (spacebarPress && isUnmuteAllowed) {
-        callingRepository.muteCall(joinedCall, false);
-        setIsSpacebarPressUnmuted(true);
-      }
-    }
-  }, [spacebarPress, joinedCall, callingRepository, isSpacebarPressUnmuted]);
 
   useEffect(() => {
     if (currentCallState === CALL_STATE.MEDIA_ESTAB && joinedCall?.initialType === CALL_TYPE.VIDEO) {
@@ -219,6 +202,10 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
           screens={selectableScreens as unknown as Screen[]}
           windows={selectableWindows as unknown as Screen[]}
         />
+      )}
+
+      {joinedCall && Number.isInteger(joinedCall.muteState()) && (
+        <PushToTalkHandler call={joinedCall} callingRepository={callingRepository} />
       )}
     </Fragment>
   );

--- a/src/script/components/calling/CallingOverlayContainer.tsx
+++ b/src/script/components/calling/CallingOverlayContainer.tsx
@@ -38,7 +38,7 @@ import {CallViewTab} from '../../view_model/CallingViewModel';
 import ChooseScreen, {Screen} from './ChooseScreen';
 import FullscreenVideoCall from './FullscreenVideoCall';
 import {LEAVE_CALL_REASON} from '../../calling/enum/LeaveCallReason';
-import {useKeyPress} from '../../hooks/useKeypress';
+import {PushToTalkHandler} from './PushToTalkHandler';
 
 export interface CallingContainerProps {
   readonly callingRepository: CallingRepository;
@@ -72,24 +72,7 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
     muteState,
   } = useKoSubscribableChildren(joinedCall, ['maximizedParticipant', 'state', 'muteState']);
 
-  const [isSpacebarPressUnmuted, setIsSpacebarPressUnmuted] = React.useState(false);
   const isMuted = muteState !== MuteState.NOT_MUTED;
-
-  const spacebarPress: boolean = useKeyPress(' ');
-
-  useEffect(() => {
-    if (joinedCall) {
-      const isUnmuteAllowed =
-        joinedCall.muteState() === MuteState.SELF_MUTED || joinedCall.muteState() === MuteState.REMOTE_MUTED;
-      if (!spacebarPress && isSpacebarPressUnmuted) {
-        callingRepository.muteCall(joinedCall, true);
-        setIsSpacebarPressUnmuted(false);
-      } else if (spacebarPress && isUnmuteAllowed) {
-        callingRepository.muteCall(joinedCall, false);
-        setIsSpacebarPressUnmuted(true);
-      }
-    }
-  }, [spacebarPress, joinedCall, callingRepository, isSpacebarPressUnmuted]);
 
   useEffect(() => {
     if (currentCallState === CALL_STATE.MEDIA_ESTAB && joinedCall.initialType === CALL_TYPE.VIDEO) {
@@ -222,6 +205,10 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
           screens={selectableScreens as unknown as Screen[]}
           windows={selectableWindows as unknown as Screen[]}
         />
+      )}
+
+      {joinedCall && Number.isInteger(joinedCall.muteState()) && (
+        <PushToTalkHandler call={joinedCall} callingRepository={callingRepository} />
       )}
     </Fragment>
   );

--- a/src/script/components/calling/CallingOverlayContainer.tsx
+++ b/src/script/components/calling/CallingOverlayContainer.tsx
@@ -38,6 +38,7 @@ import {CallViewTab} from '../../view_model/CallingViewModel';
 import ChooseScreen, {Screen} from './ChooseScreen';
 import FullscreenVideoCall from './FullscreenVideoCall';
 import {LEAVE_CALL_REASON} from '../../calling/enum/LeaveCallReason';
+import {useKeyPress} from '../../hooks/useKeypress';
 
 export interface CallingContainerProps {
   readonly callingRepository: CallingRepository;
@@ -71,7 +72,24 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
     muteState,
   } = useKoSubscribableChildren(joinedCall, ['maximizedParticipant', 'state', 'muteState']);
 
+  const [isSpacebarPressUnmuted, setIsSpacebarPressUnmuted] = React.useState(false);
   const isMuted = muteState !== MuteState.NOT_MUTED;
+
+  const spacebarPress: boolean = useKeyPress(' ');
+
+  useEffect(() => {
+    if (joinedCall) {
+      const isUnmuteAllowed =
+        joinedCall.muteState() === MuteState.SELF_MUTED || joinedCall.muteState() === MuteState.REMOTE_MUTED;
+      if (!spacebarPress && isSpacebarPressUnmuted) {
+        callingRepository.muteCall(joinedCall, true);
+        setIsSpacebarPressUnmuted(false);
+      } else if (spacebarPress && isUnmuteAllowed) {
+        callingRepository.muteCall(joinedCall, false);
+        setIsSpacebarPressUnmuted(true);
+      }
+    }
+  }, [spacebarPress, joinedCall, callingRepository, isSpacebarPressUnmuted]);
 
   useEffect(() => {
     if (currentCallState === CALL_STATE.MEDIA_ESTAB && joinedCall.initialType === CALL_TYPE.VIDEO) {

--- a/src/script/components/calling/PushToTalkHandler.tsx
+++ b/src/script/components/calling/PushToTalkHandler.tsx
@@ -1,0 +1,50 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {useEffect, useState} from 'react';
+import {CallingRepository} from '../../calling/CallingRepository';
+import {Call} from '../../calling/Call';
+import {MuteState} from '../../calling/CallState';
+import {useKeyPress} from '../../hooks/useKeypress';
+
+interface PushToTalkContainerProps {
+  callingRepository: CallingRepository;
+  call: Call;
+}
+
+const PushToTalkHandler = ({callingRepository, call}: PushToTalkContainerProps) => {
+  const spacePress: boolean = useKeyPress(' ');
+  const [unmuted, setUnmuted] = useState(false);
+
+  useEffect(() => {
+    const isUnmuteAllowed = call.muteState() === MuteState.SELF_MUTED || call.muteState() === MuteState.REMOTE_MUTED;
+    if (!spacePress && unmuted) {
+      callingRepository.muteCall(call, true);
+      setUnmuted(false);
+    } else if (spacePress && isUnmuteAllowed) {
+      callingRepository.muteCall(call, false);
+      setUnmuted(true);
+    }
+    return () => undefined;
+  }, [spacePress, callingRepository, unmuted, call]);
+
+  return null;
+};
+
+export {PushToTalkHandler};

--- a/src/script/components/calling/PushToTalkHandler.tsx
+++ b/src/script/components/calling/PushToTalkHandler.tsx
@@ -17,34 +17,34 @@
  *
  */
 
-import {useEffect, useState} from 'react';
+import {useEffect, useRef} from 'react';
 import {CallingRepository} from '../../calling/CallingRepository';
 import {Call} from '../../calling/Call';
 import {MuteState} from '../../calling/CallState';
 import {useKeyPress} from '../../hooks/useKeypress';
 
-interface PushToTalkContainerProps {
+interface PushToTalkHandlerProps {
   callingRepository: CallingRepository;
   call: Call;
 }
 
-const PushToTalkHandler = ({callingRepository, call}: PushToTalkContainerProps) => {
-  const spacePress: boolean = useKeyPress(' ');
-  const [unmuted, setUnmuted] = useState(false);
+const PushToTalkHandler: React.FC<PushToTalkHandlerProps> = ({callingRepository, call}) => {
+  const spacePress = useKeyPress(' ');
+  const isUnmuted = useRef(false);
 
   useEffect(() => {
     const isUnmuteAllowed = call.muteState() === MuteState.SELF_MUTED || call.muteState() === MuteState.REMOTE_MUTED;
-    if (!spacePress && unmuted) {
+    if (!spacePress && isUnmuted.current) {
       callingRepository.muteCall(call, true);
-      setUnmuted(false);
+      isUnmuted.current = false;
     } else if (spacePress && isUnmuteAllowed) {
       callingRepository.muteCall(call, false);
-      setUnmuted(true);
+      isUnmuted.current = true;
     }
     return () => undefined;
-  }, [spacePress, callingRepository, unmuted, call]);
+  }, [spacePress, callingRepository, call]);
 
   return null;
 };
 
-export {PushToTalkHandler};
+export default PushToTalkHandler;

--- a/src/script/components/calling/PushToTalkHandler.tsx
+++ b/src/script/components/calling/PushToTalkHandler.tsx
@@ -17,32 +17,32 @@
  *
  */
 
-import {useEffect, useState} from 'react';
+import {useEffect, useRef} from 'react';
 import {CallingRepository} from '../../calling/CallingRepository';
 import {Call} from '../../calling/Call';
 import {MuteState} from '../../calling/CallState';
 import {useKeyPress} from '../../hooks/useKeypress';
 
-interface PushToTalkContainerProps {
+interface PushToTalkHandlerProps {
   callingRepository: CallingRepository;
   call: Call;
 }
 
-const PushToTalkHandler = ({callingRepository, call}: PushToTalkContainerProps) => {
-  const spacePress: boolean = useKeyPress(' ');
-  const [unmuted, setUnmuted] = useState(false);
+const PushToTalkHandler: React.FC<PushToTalkHandlerProps> = ({callingRepository, call}) => {
+  const spacePress = useKeyPress(' ');
+  const isUnmuted = useRef(false);
 
   useEffect(() => {
     const isUnmuteAllowed = call.muteState() === MuteState.SELF_MUTED || call.muteState() === MuteState.REMOTE_MUTED;
-    if (!spacePress && unmuted) {
+    if (!spacePress && isUnmuted.current) {
       callingRepository.muteCall(call, true);
-      setUnmuted(false);
+      isUnmuted.current = false;
     } else if (spacePress && isUnmuteAllowed) {
       callingRepository.muteCall(call, false);
-      setUnmuted(true);
+      isUnmuted.current = true;
     }
     return () => undefined;
-  }, [spacePress, callingRepository, unmuted, call]);
+  }, [spacePress, callingRepository, call]);
 
   return null;
 };

--- a/src/script/hooks/useKeypress.ts
+++ b/src/script/hooks/useKeypress.ts
@@ -1,0 +1,50 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {useState, useEffect} from 'react';
+
+function useKeyPress(targetKey: string): boolean {
+  // State for keeping track of whether key is pressed
+  const [keyPressed, setKeyPressed] = useState(false);
+  // If pressed key is our target key then set to true
+  function downHandler({key}: KeyboardEvent): void {
+    if (key === targetKey) {
+      setKeyPressed(true);
+    }
+  }
+  // If released key is our target key then set to false
+  const upHandler = ({key}: KeyboardEvent): void => {
+    if (key === targetKey) {
+      setKeyPressed(false);
+    }
+  };
+  // Add event listeners
+  useEffect(() => {
+    window.addEventListener('keydown', downHandler);
+    window.addEventListener('keyup', upHandler);
+    // Remove event listeners on cleanup
+    return () => {
+      window.removeEventListener('keydown', downHandler);
+      window.removeEventListener('keyup', upHandler);
+    };
+  }, []); // Empty array ensures that effect is only run on mount and unmount
+  return keyPressed;
+}
+
+export {useKeyPress};


### PR DESCRIPTION
- This feature adds an event listener for SPACEBAR. 
- When being in an active call and muted (while being allowed to unmute), pressing and holding the SPACEBAR will unmute the user.
- Releasing the SPACEBAR will mute the user again.

This is a working draft and needs probably more information for our users like:
- Option in the Call Settings to deactivate the feature?
- Explanation for the user or a notification that the feature exists?
- Graphical response for the user while pressing the spacebar to make it more obvious they are unmuted?