### PR TITLE
chore: Bump @wireapp/avs from 8.2.8 to 8.2.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@emotion/react": "11.9.0",
     "@wireapp/antiscroll-2": "1.3.1",
-    "@wireapp/avs": "8.2.8",
+    "@wireapp/avs": "8.2.16",
     "@wireapp/core": "31.3.5",
     "@wireapp/react-ui-kit": "8.14.8",
     "@wireapp/store-engine-dexie": "1.7.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2992,10 +2992,10 @@
     tough-cookie "4.0.0"
     ws "7.5.3"
 
-"@wireapp/avs@8.2.8":
-  version "8.2.8"
-  resolved "https://registry.yarnpkg.com/@wireapp/avs/-/avs-8.2.8.tgz#58b9a129eca375305e66aadd6f2970fd77e77c38"
-  integrity sha512-G3Fe+Jn8hT89nMxQzYnoxcv/eBj9ahh18+zY7HPzVrYarzwsrfk1SiWh2S5mtC5pzBYPOsU1vZEKd2grXGQCuA==
+"@wireapp/avs@8.2.16":
+  version "8.2.16"
+  resolved "https://registry.yarnpkg.com/@wireapp/avs/-/avs-8.2.16.tgz#be282255aeeff7da4b7b41b1f591049e37c7c517"
+  integrity sha512-yXYC2u+8jZPoNFHdjD/81tapsm7IegMXic1ZREangtxrlJ+yPRxEVzvxrN+qivrbnI5TPKk+uXx3EJncJP0xOg==
 
 "@wireapp/cbor@4.7.3":
   version "4.7.3"
@@ -9322,6 +9322,11 @@ nanoid@^3.1.25:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.2.0.tgz#62667522da6673971cca916a6d3eff3f415ff80c"
   integrity sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==
 
+nanoid@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
+  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
+
 native-request@^1.0.5:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/native-request/-/native-request-1.0.8.tgz#8f66bf606e0f7ea27c0e5995eb2f5d03e33ae6fb"
@@ -11869,6 +11874,11 @@ source-map-js@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
   integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
+
+source-map-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
 source-map-support@0.5.13:
   version "0.5.13"


### PR DESCRIPTION
This version of avs has a fix for random `You missed a call` system messages

<img width="631" alt="image" src="https://user-images.githubusercontent.com/63250054/193072193-b9f2398c-823c-4b8b-bd19-90d9d3f96567.png">
