### PR TITLE
runfix: use default protocol when user can't choose (FS-1026)

### DIFF
--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -88,7 +88,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
 
   const enableMLSToggle = isMLSFeatureEnabled && isMLSEnabledForTeam && isProtocolToggleEnabledForUser;
 
-  //if user is not able to choose mls (team does not allow or feature flag is off), use proteus as default
+  //if feature flag is set to false or mls is disabled for current team use proteus as default
   const defaultProtocol =
     isMLSFeatureEnabled && isMLSEnabledForTeam
       ? teamState.teamFeatures().mls?.config.defaultProtocol

--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -78,17 +78,21 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
   userState = container.resolve(UserState),
   teamState = container.resolve(TeamState),
 }) => {
-  const {isTeam, isMLSEnabled: isMLSEnabledForTeamUser} = useKoSubscribableChildren(teamState, [
-    'isTeam',
-    'isMLSEnabled',
-  ]);
+  const {
+    isTeam,
+    isMLSEnabled: isMLSEnabledForTeam,
+    isProtocolToggleEnabledForUser,
+  } = useKoSubscribableChildren(teamState, ['isTeam', 'isMLSEnabled', 'isProtocolToggleEnabledForUser']);
 
-  const enableMLSToggle = isMLSEnabledForTeamUser && Config.getConfig().FEATURE.ENABLE_MLS;
+  const isMLSFeatureEnabled = Config.getConfig().FEATURE.ENABLE_MLS;
+
+  const enableMLSToggle = isMLSFeatureEnabled && isMLSEnabledForTeam && isProtocolToggleEnabledForUser;
 
   //if user is not able to choose mls (team does not allow or feature flag is off), use proteus as default
-  const defaultProtocol = enableMLSToggle
-    ? teamState.teamFeatures().mls?.config.defaultProtocol
-    : ConversationProtocol.PROTEUS;
+  const defaultProtocol =
+    isMLSFeatureEnabled && isMLSEnabledForTeam
+      ? teamState.teamFeatures().mls?.config.defaultProtocol
+      : ConversationProtocol.PROTEUS;
 
   const protocolOptions: ProtocolOption[] = [ConversationProtocol.PROTEUS, ConversationProtocol.MLS].map(protocol => ({
     label: `${t(`modalCreateGroupProtocolSelect.${protocol}`)}${

--- a/src/script/team/TeamState.ts
+++ b/src/script/team/TeamState.ts
@@ -42,6 +42,7 @@ export class TeamState {
   public readonly isFileSharingReceivingEnabled: ko.PureComputed<boolean>;
   public readonly isVideoCallingEnabled: ko.PureComputed<boolean>;
   public readonly isMLSEnabled: ko.PureComputed<boolean>;
+  public readonly isProtocolToggleEnabledForUser: ko.PureComputed<boolean>;
   public readonly isGuestLinkEnabled: ko.PureComputed<boolean>;
   public readonly isSelfDeletingMessagesEnabled: ko.PureComputed<boolean>;
   public readonly isSelfDeletingMessagesEnforced: ko.PureComputed<boolean>;
@@ -114,12 +115,13 @@ export class TeamState {
       // TODO connect to video calling feature config
       () => true || this.teamFeatures()?.videoCalling?.status === FeatureStatus.ENABLED,
     );
-    this.isMLSEnabled = ko.pureComputed(
-      () =>
-        (this.teamFeatures()?.mls?.config.protocolToggleUsers.includes(this.userState.self().id) &&
-          this.teamFeatures()?.mls?.status === FeatureStatus.ENABLED) ??
-        false,
+
+    this.isMLSEnabled = ko.pureComputed(() => this.teamFeatures()?.mls?.status === FeatureStatus.ENABLED ?? false);
+
+    this.isProtocolToggleEnabledForUser = ko.pureComputed(
+      () => this.teamFeatures()?.mls?.config.protocolToggleUsers.includes(this.userState.self().id) ?? false,
     );
+
     this.isConferenceCallingEnabled = ko.pureComputed(
       () => this.teamFeatures()?.conferenceCalling?.status === FeatureStatus.ENABLED,
     );


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1026" title="FS-1026" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1026</a>  [WEB] User can't create group convo after MLS feature flag on env off
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

There's still a bug with group creation and choosing a default protocol:
Protocol was always set to proteus when user was not able to change default one (settings in TM). 
The expected behaviour is: 

1. select **default** protocol if:
  - `FEATURE_ENABLE_MLS` flag on client is set to `"true"`
  - mls mode is enabled for team management

2. allow user to change the default protocol via protocol select component in group creation modal if:
  - `FEATURE_ENABLE_MLS` flag on client is set to `"true"`,
  - mls mode is enabled for team management,
  - user is added to a group of users who have access to changing protocol

I've split two statements in `TeamState.ts` that we're merged before: 
- is mls enable for the current team
- is user added to a list of users who have access for changing default protocol (enabling protocol select in group creation modal)
----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
