### PR TITLE
fix: Avoid account data failure when image could not be loaded (#13711)

### DIFF
--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -268,8 +268,12 @@ export class TeamRepository {
       let imageDataUrl;
 
       if (imageResource) {
-        const imageBlob = imageResource ? await this.assetRepository.load(imageResource) : undefined;
-        imageDataUrl = imageBlob ? await loadDataUrl(imageBlob) : undefined;
+        try {
+          const imageBlob = imageResource ? await this.assetRepository.load(imageResource) : undefined;
+          imageDataUrl = imageBlob ? await loadDataUrl(imageBlob) : undefined;
+        } catch (error) {
+          this.logger.warn(`Account image could not be loaded`, error);
+        }
       }
 
       const accountInfo: AccountInfo = {


### PR DESCRIPTION
This will fix a major bug that we currently have on production: a `x` button appearing on electron that, if clicked, will delete the entire account data. 

