### PR TITLE
runfix: Targets ephemeral message deletion to the sender of the message [FS-1023]

### DIFF
--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -963,9 +963,10 @@ export class MessageRepository {
         recipients: userIds,
         // if we want optimistic removal, we can rely on the injection system that will handle the event and remove the message even before the message is sent
         skipInjection: !options.optimisticRemoval,
+        targetMode: MessageTargetMode.USERS,
       });
       if (!options.optimisticRemoval) {
-        this.deleteMessage(conversation, message);
+        this.deleteMessageById(conversation, message.id);
       }
     } catch (error) {
       const isConversationNotFound = error.code === HTTP_STATUS.NOT_FOUND;

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -963,7 +963,8 @@ export class MessageRepository {
         recipients: userIds,
         // if we want optimistic removal, we can rely on the injection system that will handle the event and remove the message even before the message is sent
         skipInjection: !options.optimisticRemoval,
-        targetMode: MessageTargetMode.USERS,
+        // If there are recipients to the message, we only want to target those users (case of ephemeral messages that should be deleted in the sender's client and the user's own clients)
+        targetMode: userIds ? MessageTargetMode.USERS : undefined,
       });
       if (!options.optimisticRemoval) {
         this.deleteMessageById(conversation, message.id);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1023" title="FS-1023" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1023</a>  [Web] Ephemeral message gets deleted for me if timer expires for somebody else
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

As of now, the webapp broacast the message deletion to all the participants of the conversation (by not using the target property of the message sending method).
With the targetted behavior we will only send the message back to the sender and our own clients

Bug was introduced while migrating message deletion to the core (in order to have it for MLS converations)
https://github.com/wireapp/wire-webapp/pull/13703/files#diff-8a277356da1eb1435094433268c1e8cf7392c374f617174bd0a6e60ea52ea4ebR958