### PR TITLE
runfix: Fix conversation join url redirection

### DIFF
--- a/server/routes/RedirectRoutes.ts
+++ b/server/routes/RedirectRoutes.ts
@@ -35,7 +35,7 @@ export const RedirectRoutes = (config: ServerConfig) => [
   router.get('/join/?', (req, res) => {
     const key = req.query.key;
     const code = req.query.code;
-    res.redirect(HTTP_STATUS.MOVED_TEMPORARILY, `/auth/?join_key=${key}&join_code=${code}#join-conversation`);
+    res.redirect(HTTP_STATUS.MOVED_TEMPORARILY, `/auth/?join_key=${key}&join_code=${code}#/join-conversation`);
   }),
   router.get('/browser/?', (req, res, next) => {
     if (config.SERVER.DEVELOPMENT) {


### PR DESCRIPTION
This URL was wrongly defined from the start. 
For some reasons the previous version of react-router was less strict about it. 
But with the upgrade to react-router 6+ the trailing slash is required 