### PR TITLE
runfix: Correctly stack modals and fix memory issue in renderElement

### DIFF
--- a/src/page/template/wire-main.htm
+++ b/src/page/template/wire-main.htm
@@ -18,9 +18,6 @@
           #include('modal/legal-hold.htm')
         </div>
     </div>
-
-    #include('modals.htm')
-
     <!-- /ko -->
 
     <app-lock-container params="clientRepository: $root.content.repositories.client"></app-lock-container>
@@ -31,4 +28,7 @@
       mediaRepository: $root.content.repositories.media,
       ">
     </calling-overlay-container>
+    <!-- The order of these elements matter to show proper modals stack upon each other -->
+    <div id="user-modal-container"></div>
+    <div id="primary-modal-container"></div>
 </main>

--- a/src/script/components/Modals/PrimaryModal/index.ts
+++ b/src/script/components/Modals/PrimaryModal/index.ts
@@ -26,7 +26,7 @@ export {usePrimaryModalState, removeCurrentModal} from './PrimaryModalState';
 
 const PrimaryModal = {
   init: () => {
-    renderElement(PrimaryModalComponent)({});
+    renderElement(PrimaryModalComponent, 'primary-modal-container')({});
     showNextModalInQueue();
   },
   show: addNewModalToQueue,

--- a/src/script/components/Modals/UserModal/UserModal.tsx
+++ b/src/script/components/Modals/UserModal/UserModal.tsx
@@ -167,4 +167,4 @@ const UserModalComponent: React.FC<UserModalProps> = ({
 
 export default UserModalComponent;
 
-export const showUserModal = renderElement<UserModalProps>(UserModalComponent);
+export const showUserModal = renderElement<UserModalProps>(UserModalComponent, 'user-modal-container');

--- a/src/script/util/renderElement.ts
+++ b/src/script/util/renderElement.ts
@@ -20,21 +20,21 @@
 import React from 'react';
 import {createRoot, Root} from 'react-dom/client';
 
-const roots: Record<
+const roots = new Map<
   string,
   {
     elementContainer: HTMLDivElement | undefined;
     reactRoot: Root;
   }
-> = {};
+>();
 
 export const cleanUpElement = (elementId: string) => {
-  const root = roots[elementId];
+  const root = roots.get(elementId);
   if (root && root.elementContainer) {
     root.reactRoot.unmount();
     document.getElementById(elementId)?.removeChild(root.elementContainer);
     root.elementContainer = undefined;
-    delete roots[elementId];
+    roots.delete(elementId);
   }
 };
 
@@ -71,10 +71,10 @@ const renderElement =
     document.getElementById(currentElementId)?.appendChild(elementContainer);
     const reactRoot = createRoot(elementContainer);
 
-    roots[currentElementId] = {
+    roots.set(currentElementId, {
       elementContainer,
       reactRoot,
-    };
+    });
 
     const onClose = () => {
       cleanUpElement(currentElementId);

--- a/src/script/util/renderElement.ts
+++ b/src/script/util/renderElement.ts
@@ -20,14 +20,21 @@
 import React from 'react';
 import {createRoot, Root} from 'react-dom/client';
 
-let elementContainer: HTMLDivElement | undefined;
-let reactRoot: Root;
+const roots: Record<
+  string,
+  {
+    elementContainer: HTMLDivElement | undefined;
+    reactRoot: Root;
+  }
+> = {};
 
 export const cleanUpElement = (elementId: string) => {
-  if (elementContainer) {
-    reactRoot.unmount();
-    document.getElementById(elementId)?.removeChild(elementContainer);
-    elementContainer = undefined;
+  const root = roots[elementId];
+  if (root && root.elementContainer) {
+    root.reactRoot.unmount();
+    document.getElementById(elementId)?.removeChild(root.elementContainer);
+    root.elementContainer = undefined;
+    delete roots[elementId];
   }
 };
 
@@ -55,12 +62,20 @@ const renderElement =
     const currentElementId = parentElementId;
 
     cleanUpElement(currentElementId);
-    elementContainer = document.createElement('div');
+    const elementContainer = document.createElement('div');
+
     if (style) {
       elementContainer.setAttribute('style', generateStyleString(style));
     }
+
     document.getElementById(currentElementId)?.appendChild(elementContainer);
-    reactRoot = createRoot(elementContainer);
+    const reactRoot = createRoot(elementContainer);
+
+    roots[currentElementId] = {
+      elementContainer,
+      reactRoot,
+    };
+
     const onClose = () => {
       cleanUpElement(currentElementId);
       props.onClose?.();


### PR DESCRIPTION
The order of how we render modals matters! some times for example in the flow of searching a user and trying to unblock them we show stack modals (user-modal & confirm-modal from primary modals) 
By calling `renderElement` we just append the modal to the wire-main in an unordered way so to fix it we need separate roots for these modals so they would be rendered in their own containers with an order. 

Also, the `renderElement` utility turns out to be using the same variables `elementContainer` & `reactRoot` for every call which is a memory bug actually, fixed by changing it to a Map!