### PR TITLE
fix: Use avs to parse incoming call events [SQCALL-583]

### DIFF
--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -608,6 +608,18 @@ export class CallingRepository {
             this.abortCall(conversationId, LEAVE_CALL_REASON.ABORTED_BECAUSE_FAILED_TO_UPDATE_MISSING_CLIENTS);
           }
         }
+        break;
+      }
+      case CALL_MESSAGE_TYPE.REMOTE_MUTE: {
+        const call = this.findCall(conversationId);
+        if (call) {
+          this.muteCall(call, true, MuteState.REMOTE_MUTED);
+        }
+        break;
+      }
+      case CALL_MESSAGE_TYPE.REMOTE_KICK: {
+        this.leaveCall(conversationId, LEAVE_CALL_REASON.REMOTE_KICK);
+        break;
       }
     }
 

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -292,18 +292,12 @@ export class CallingRepository {
     return wUser;
   }
 
-  private readonly handleMissedCall = (
-    convid: string,
-    timestamp: number,
-    userid: string,
-    clientid: string,
-    video_call: number,
-    arg: number,
-  ) => {
+  private readonly handleMissedCall = (conversationId: string, timestamp: number, userId: string) => {
+    const callDuration = 0;
     this.injectDeactivateEvent(
-      this.parseQualifiedId(convid),
-      this.parseQualifiedId(userid),
-      0,
+      this.parseQualifiedId(conversationId),
+      this.parseQualifiedId(userId),
+      callDuration,
       REASON.CANCELED,
       new Date(timestamp * 1000).toISOString(),
       EventSource.INJECTED,
@@ -1307,13 +1301,13 @@ export class CallingRepository {
   private readonly incomingCall = (
     convId: SerializedConversationId,
     timestamp: number,
-    userIdStr: UserId,
+    userId: UserId,
     clientId: string,
     hasVideo: number,
     shouldRing: number,
     conversationType: CONV_TYPE,
   ) => {
-    const userId = this.parseQualifiedId(userIdStr);
+    const qualifiedUserId = this.parseQualifiedId(userId);
     const conversationId = this.parseQualifiedId(convId);
     const conversation = this.conversationState.findConversation(conversationId);
     if (!conversation || !this.selfUser || !this.selfClientId) {
@@ -1334,7 +1328,7 @@ export class CallingRepository {
     const isVideoCall = hasVideo ? CALL_TYPE.VIDEO : CALL_TYPE.NORMAL;
     const isMuted = Config.getConfig().FEATURE.CONFERENCE_AUTO_MUTE && conversationType === CONV_TYPE.CONFERENCE;
     const call = new Call(
-      userId,
+      qualifiedUserId,
       conversation.qualifiedId,
       conversationType,
       selfParticipant,
@@ -1350,7 +1344,7 @@ export class CallingRepository {
     if (canRing && isVideoCall) {
       this.warmupMediaStreams(call, true, true);
     }
-    this.injectActivateEvent(conversationId, userId, new Date(timestamp * 1000).toISOString());
+    this.injectActivateEvent(conversationId, qualifiedUserId, new Date(timestamp * 1000).toISOString());
 
     this.storeCall(call);
     this.incomingCallCallback(call);

--- a/src/script/event/EventRepository.ts
+++ b/src/script/event/EventRepository.ts
@@ -662,6 +662,7 @@ export class EventRepository {
    * @returns `true` if event is handled within it's lifetime, otherwise throws error
    */
   private validateCallEventLifetime(event: EventRecord): boolean {
+    return true;
     const {content = {}, conversation: conversationId, time, type} = event;
     const forcedEventTypes = [CALL_MESSAGE_TYPE.CANCEL, CALL_MESSAGE_TYPE.GROUP_LEAVE];
 

--- a/src/script/event/EventRepository.ts
+++ b/src/script/event/EventRepository.ts
@@ -26,7 +26,6 @@ import {container} from 'tsyringe';
 import {getLogger, Logger} from 'Util/Logger';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
 
-import {CALL_MESSAGE_TYPE} from '../calling/enum/CallMessageType';
 import {AssetTransferState} from '../assets/AssetTransferState';
 
 import {EVENT_TYPE} from './EventType';
@@ -445,12 +444,6 @@ export class EventRepository {
         this.updateLastEventDate(eventDate as string);
       }
     }
-
-    const isCallEvent = event.type === ClientEvent.CALL.E_CALL;
-    if (isCallEvent) {
-      this.validateCallEventLifetime(event);
-    }
-
     return this.distributeEvent(event, source);
   }
 
@@ -653,40 +646,5 @@ export class EventRepository {
     const baseErrorMessage = 'Event validation failed:';
     this.logger.warn(`${baseLogMessage} ${logMessage || errorMessage}`, event);
     throw new EventError(EventError.TYPE.VALIDATION_FAILED, `${baseErrorMessage} ${errorMessage}`);
-  }
-
-  /**
-   * Check if call event is handled within its valid lifespan.
-   *
-   * @param event Event to validate
-   * @returns `true` if event is handled within it's lifetime, otherwise throws error
-   */
-  private validateCallEventLifetime(event: EventRecord): boolean {
-    return true;
-    const {content = {}, conversation: conversationId, time, type} = event;
-    const forcedEventTypes = [CALL_MESSAGE_TYPE.CANCEL, CALL_MESSAGE_TYPE.GROUP_LEAVE];
-
-    const correctedTimestamp = this.serverTimeHandler.toServerTimestamp();
-    const thresholdTimestamp = new Date(time).getTime() + EventRepository.CONFIG.E_CALL_EVENT_LIFETIME;
-
-    const isForcedEventType = forcedEventTypes.includes((content as {type: CALL_MESSAGE_TYPE}).type);
-    const eventWithinThreshold = correctedTimestamp < thresholdTimestamp;
-    const stateIsWebSocket = this.notificationHandlingState() === NOTIFICATION_HANDLING_STATE.WEB_SOCKET;
-
-    const isValidEvent = isForcedEventType || eventWithinThreshold || stateIsWebSocket;
-    if (isValidEvent) {
-      return true;
-    }
-
-    const eventIsoDate = new Date(time).toISOString();
-    const logMessage = `Ignored outdated calling event '${type}' (${eventIsoDate}) in conversation '${conversationId}'`;
-    const logObject = {
-      eventJson: JSON.stringify(event),
-      eventObject: event,
-      eventTime: eventIsoDate,
-      localTime: new Date(correctedTimestamp).toISOString(),
-    };
-    this.logger.info(logMessage, logObject);
-    throw new EventError(EventError.TYPE.OUTDATED_E_CALL_EVENT, EventError.MESSAGE.OUTDATED_E_CALL_EVENT);
   }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCALL-583" title="SQCALL-583" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQCALL-583</a>  Webapp bypasses AVS by parsing calling messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

We were still manually parsing calling events in the webapp. 
Those events should be opaque to us and we should use avs's callbacks instead to react to calling events. 

This PR fixes a few of those events. 