### PR TITLE
runfix: Improve lazy loading of conversation participants

### DIFF
--- a/src/script/components/MessagesList/Message/index.tsx
+++ b/src/script/components/MessagesList/Message/index.tsx
@@ -111,7 +111,7 @@ const Message: React.FC<
 
   const content = <MessageWrapper {...props} hasMarker={markerType !== MessageMarkerType.NONE} />;
   const wrappedContent = onVisible ? (
-    <InViewport requireFullyInView allowBiggerThanViewport onVisible={onVisible}>
+    <InViewport requireFullyInView allowBiggerThanViewport checkOverlay onVisible={onVisible}>
       {content}
     </InViewport>
   ) : (

--- a/src/script/components/utils/InViewport.tsx
+++ b/src/script/components/utils/InViewport.tsx
@@ -25,12 +25,15 @@ interface InViewportParams {
   onVisible: () => void;
   requireFullyInView?: boolean;
   allowBiggerThanViewport?: boolean;
+  /** Will check if the element is overlayed by something else. Can be used to be absolutely sure the user could actually see the element */
+  checkOverlay?: boolean;
 }
 
 const InViewport: React.FC<InViewportParams & React.HTMLProps<HTMLDivElement>> = ({
   children,
   onVisible,
   requireFullyInView = false,
+  checkOverlay = false,
   allowBiggerThanViewport = false,
   ...props
 }) => {
@@ -43,9 +46,11 @@ const InViewport: React.FC<InViewportParams & React.HTMLProps<HTMLDivElement>> =
     }
 
     let inViewport = false;
-    let visible = false;
+    let visible = !checkOverlay;
     const releaseTrackers = () => {
-      overlayedObserver.removeElement(element);
+      if (checkOverlay) {
+        overlayedObserver.removeElement(element);
+      }
       viewportObserver.removeElement(element);
     };
 
@@ -66,12 +71,14 @@ const InViewport: React.FC<InViewportParams & React.HTMLProps<HTMLDivElement>> =
       requireFullyInView,
       allowBiggerThanViewport,
     );
-    overlayedObserver.trackElement(element, isVisible => {
-      visible = isVisible;
-      triggerCallbackIfVisible();
-    });
+    if (checkOverlay) {
+      overlayedObserver.trackElement(element, isVisible => {
+        visible = isVisible;
+        triggerCallbackIfVisible();
+      });
+    }
     return () => releaseTrackers();
-  }, [allowBiggerThanViewport, requireFullyInView, onVisible]);
+  }, [allowBiggerThanViewport, requireFullyInView, checkOverlay, onVisible]);
 
   return (
     <div ref={domNode} {...props} css={{minHeight: '1px'}}>

--- a/src/script/components/utils/InViewport.tsx
+++ b/src/script/components/utils/InViewport.tsx
@@ -25,7 +25,7 @@ interface InViewportParams {
   onVisible: () => void;
   requireFullyInView?: boolean;
   allowBiggerThanViewport?: boolean;
-  /** Will check if the element is overlayed by something else. Can be used to be absolutely sure the user could actually see the element */
+  /** Will check if the element is overlayed by something else. Can be used to be sure the user could actually see the element. Should not be used to do lazy loading as the overlayObserver has quite a long debounce time */
   checkOverlay?: boolean;
 }
 


### PR DESCRIPTION
This will add an option to be able not to check for overlay when using the `<InViewport>` components.

The overlay observer is quite inefficient and should not used to trigger lazy loading operations