### PR TITLE
fix: issue with ui during 2fa too many clients flow

### DIFF
--- a/src/script/auth/component/ClientItem.tsx
+++ b/src/script/auth/component/ClientItem.tsx
@@ -62,18 +62,24 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
   const [password, setPassword] = useState('');
   const [isValidPassword, setIsValidPassword] = useState(true);
   const [validationError, setValidationError] = useState<ValidationError | null>(null);
+  const [isOpen, setIsOpen] = useState(requirePassword && (isSelected || isAnimating));
 
   useEffect(() => {
     if (!selected && isSelected) {
       setIsAnimating(true);
       setIsSelected(false);
+      setIsOpen(false);
       requestAnimationFrame(() => executeAnimateOut());
     } else if (selected && !isSelected) {
       setIsAnimating(true);
       setIsSelected(true);
+      setIsOpen(true);
       requestAnimationFrame(() => executeAnimateIn());
+    } else if (selected && isSelected) {
+      setIsOpen(true);
     } else {
       setAnimationStep(0);
+      setIsOpen(false);
     }
   }, [selected]);
 
@@ -203,7 +209,6 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
   const animationPosition = animationStep / CONFIG.animationSteps;
   const smoothHeight = animationPosition * inputContainerHeight;
   const smoothMarginTop = animationPosition * animatedCardSpacing.m;
-  const isOpen = requirePassword && (isSelected || isAnimating);
 
   return (
     <ContainerXS>

--- a/src/script/auth/component/ClientList.tsx
+++ b/src/script/auth/component/ClientList.tsx
@@ -46,6 +46,7 @@ const ClientList = ({
   doRemoveClient,
   getLocalStorage,
   resetAuthError,
+  resetClientError,
   removeLocalStorage,
 }: Props & ConnectedProps & DispatchProps) => {
   const navigate = useNavigate();
@@ -58,6 +59,7 @@ const ClientList = ({
     const selectedClientId = isSelectedClient ? null : clientId;
     setCurrentlySelectedClient(selectedClientId);
     resetAuthError();
+    resetClientError();
   };
 
   const removeClient = async (clientId: string, password?: string) => {
@@ -67,12 +69,12 @@ const ClientList = ({
       await doRemoveClient(clientId, password);
       const persist = await getLocalStorage(LocalStorageAction.LocalStorageKey.AUTH.PERSIST);
       await doInitializeClient(persist ? ClientType.PERMANENT : ClientType.TEMPORARY, password, SFAcode, entropy);
+      removeLocalStorage(QUERY_KEY.CONVERSATION_CODE);
+      removeLocalStorage(QUERY_KEY.JOIN_EXPIRES);
       return navigate(ROUTE.HISTORY_INFO);
     } catch (error) {
       logger.error(error);
     } finally {
-      removeLocalStorage(QUERY_KEY.CONVERSATION_CODE);
-      removeLocalStorage(QUERY_KEY.JOIN_EXPIRES);
       setShowLoading(false);
     }
   };
@@ -122,6 +124,7 @@ const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) =>
       getLocalStorage: ROOT_ACTIONS.localStorageAction.getLocalStorage,
       removeLocalStorage: ROOT_ACTIONS.localStorageAction.deleteLocalStorage,
       resetAuthError: ROOT_ACTIONS.authAction.resetAuthError,
+      resetClientError: ROOT_ACTIONS.clientAction.resetClientError,
     },
     dispatch,
   );

--- a/src/script/auth/module/action/ClientAction.ts
+++ b/src/script/auth/module/action/ClientAction.ts
@@ -103,6 +103,12 @@ export class ClientAction {
       model: deviceModel,
     };
   };
+
+  resetClientError = (): ThunkAction => {
+    return async dispatch => {
+      dispatch(ClientActionCreator.resetError());
+    };
+  };
 }
 
 export const clientAction = new ClientAction();

--- a/src/script/auth/page/ClientManager.tsx
+++ b/src/script/auth/page/ClientManager.tsx
@@ -35,7 +35,7 @@ interface Props extends React.HTMLProps<HTMLDivElement> {}
 const ClientManager = ({doGetAllClients, doLogout}: Props & ConnectedProps & DispatchProps) => {
   const {formatMessage: _} = useIntl();
   const SFAcode = localStorage.getItem(QUERY_KEY.CONVERSATION_CODE);
-  const timeRemaining = JSON.parse(localStorage.getItem(QUERY_KEY.JOIN_EXPIRES))?.data ?? Date.now();
+  const timeRemaining = JSON.parse(localStorage.getItem(QUERY_KEY.JOIN_EXPIRES) ?? '')?.data ?? Date.now();
 
   // Automatically log the user out if ten minutes passes and they are a 2fa user.
   const {startTimeout} = useTimeout(


### PR DESCRIPTION
Fixes three issues with the 2 factor too many clients flow:
1. wrong password shows a broken open frame after rerender
<img width="585" alt="Screenshot 2022-10-07 at 18 02 29" src="https://user-images.githubusercontent.com/37285713/194598314-4f3fb87e-820e-4486-a44c-f2c37d318d96.png">

2. wrong password also is clearing the 2fa password since we were removing it in the finally, should be removed before the catch. 

3. clicking on another client after a wrong password error also shows the error on the other client. 
<img width="604" alt="Screenshot 2022-10-07 at 18 02 35" src="https://user-images.githubusercontent.com/37285713/194598504-263fdfa0-5810-482b-bde9-ff9bf9316f25.png">
