### PR TITLE
runfix: Improve csp headers when object-src is defined

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -59,7 +59,6 @@ const defaultCSP = {
   imgSrc: ["'self'", 'blob:', 'data:', 'https://*.giphy.com'],
   manifestSrc: ["'self'"],
   mediaSrc: ["'self'", 'blob:', 'data:'],
-  objectSrc: ["'none'"],
   prefetchSrc: ["'self'"],
   scriptSrc: ["'self'", "'unsafe-eval'"],
   styleSrc: ["'self'", "'unsafe-inline'"],
@@ -88,6 +87,7 @@ function parseCommaSeparatedList(list: string = ''): string[] {
 }
 
 function mergedCSP(): Record<string, Iterable<string>> {
+  const objectSrc = parseCommaSeparatedList(process.env.CSP_EXTRA_OBJECT_SRC);
   const csp = {
     connectSrc: [
       ...defaultCSP.connectSrc,
@@ -101,7 +101,7 @@ function mergedCSP(): Record<string, Iterable<string>> {
     imgSrc: [...defaultCSP.imgSrc, ...parseCommaSeparatedList(process.env.CSP_EXTRA_IMG_SRC)],
     manifestSrc: [...defaultCSP.manifestSrc, ...parseCommaSeparatedList(process.env.CSP_EXTRA_MANIFEST_SRC)],
     mediaSrc: [...defaultCSP.mediaSrc, ...parseCommaSeparatedList(process.env.CSP_EXTRA_MEDIA_SRC)],
-    objectSrc: [...defaultCSP.objectSrc, ...parseCommaSeparatedList(process.env.CSP_EXTRA_OBJECT_SRC)],
+    objectSrc: objectSrc.length > 0 ? objectSrc : ["'none'"],
     prefetchSrc: [...defaultCSP.prefetchSrc, ...parseCommaSeparatedList(process.env.CSP_EXTRA_PREFETCH_SRC)],
     scriptSrc: [...defaultCSP.scriptSrc, ...parseCommaSeparatedList(process.env.CSP_EXTRA_SCRIPT_SRC)],
     styleSrc: [...defaultCSP.styleSrc, ...parseCommaSeparatedList(process.env.CSP_EXTRA_STYLE_SRC)],


### PR DESCRIPTION
When there are `objectSrc` values defined, the `none` keyword should not be there