### PR TITLE
chore: Simplify version generation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -87,24 +87,7 @@ module.exports = grunt => {
   grunt.registerTask('build_prod', ['build', 'shell:dist_bundle', 'compress']);
 
   grunt.registerTask('set_version', () => {
-    grunt.task.run('gitinfo');
-    const target = grunt.config('gitinfo.local.branch.current.name');
-    grunt.log.ok(`Version target set to ${target}`);
-
-    let user = grunt.config('gitinfo.local.branch.current.currentUser');
-    if (user) {
-      user = user.substring(0, user.indexOf(' ')).toLowerCase();
-    }
-
-    let version = format(new Date(), 'yyyy.MM.dd.HH.mm');
-
-    if (user) {
-      version = `${version}-${user}`;
-    }
-    if (target) {
-      version = `${version}-${target}`;
-    }
-
+    const version = format(new Date(), 'yyyy.MM.dd.HH.mm');
     grunt.log.ok(`Version set to ${version}`);
     grunt.file.write(path.join('server/dist/version'), version);
   });

--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
     "grunt-contrib-compress": "2.0.0",
     "grunt-contrib-copy": "1.0.0",
     "grunt-contrib-watch": "1.1.0",
-    "grunt-gitinfo": "0.1.9",
     "grunt-include-replace": "5.0.0",
     "grunt-open": "0.2.4",
     "grunt-postcss": "0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4845,7 +4845,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async@npm:0.9.x, async@npm:~0.9.0":
+"async@npm:0.9.x":
   version: 0.9.2
   resolution: "async@npm:0.9.2"
   checksum: 87dbf129292b8a6c32a4e07f43f462498162aa86f404a7e11f978dbfdf75cfb163c26833684bb07b9d436083cd604cbbf730a57bfcbe436c6ae1ed266cdc56bb
@@ -8691,13 +8691,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"getobject@npm:~0.1.0":
-  version: 0.1.0
-  resolution: "getobject@npm:0.1.0"
-  checksum: d0a057114846e2b1c9e17c01cff75072f43e8df84410412acbd10290bd3f537d41ddbfffe44ea8055fe3078861019f7b98d78526eadbd4b17f945d6e8fc0d086
-  languageName: node
-  linkType: hard
-
 "getobject@npm:~1.0.0":
   version: 1.0.0
   resolution: "getobject@npm:1.0.0"
@@ -9060,19 +9053,6 @@ __metadata:
     lodash: ^4.17.10
     tiny-lr: ^1.1.1
   checksum: 04f3e8b0ccf2556a6d23e3663fb1d24da780ab23de33dfafe9dc70073014e66f5f48a1d8b02c8d42d4a17f0f20fd83074c91d3ab844e97b8e72579bdfbc947aa
-  languageName: node
-  linkType: hard
-
-"grunt-gitinfo@npm:0.1.9":
-  version: 0.1.9
-  resolution: "grunt-gitinfo@npm:0.1.9"
-  dependencies:
-    async: ~0.9.0
-    getobject: ~0.1.0
-    lodash: ^4.17.14
-  peerDependencies:
-    grunt: ">=0.4.0"
-  checksum: 817d447eab3e685efc5384d9f6ac0327ddbb92abb177350826a8353f1502b13c6273a7890dc2ab6c625aff631769d56b8a5fde2a030e3e45d33150206d3fb143
   languageName: node
   linkType: hard
 
@@ -17859,7 +17839,6 @@ __metadata:
     grunt-contrib-compress: 2.0.0
     grunt-contrib-copy: 1.0.0
     grunt-contrib-watch: 1.1.0
-    grunt-gitinfo: 0.1.9
     grunt-include-replace: 5.0.0
     grunt-open: 0.2.4
     grunt-postcss: 0.9.0


### PR DESCRIPTION
This was broken for a little while (the git info did not work for a while). 
This remove the unnecessary calls for this (see. https://app.wire.com/version)