### PR TITLE
runfix: Enable ephemeral for pings

### DIFF
--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -229,7 +229,7 @@ export class MessageRepository {
       legalHoldStatus: conversation.legalHoldStatus(),
     });
 
-    return this.sendAndInjectMessage(ping, conversation, {playPingAudio: true});
+    return this.sendAndInjectMessage(ping, conversation, {enableEphemeral: true, playPingAudio: true});
   }
 
   /**


### PR DESCRIPTION
With the migration to the newest version of the `core` the `pings` were never wrapped into ephemeral messages (see https://github.com/wireapp/wire-webapp/pull/13838)