### PR TITLE
runfix: fix codeblock link parsing (FS-1066)

### DIFF
--- a/src/script/util/messageRenderer.ts
+++ b/src/script/util/messageRenderer.ts
@@ -71,28 +71,6 @@ markdownit.renderer.rules.paragraph_open = (tokens, idx) => {
 };
 markdownit.renderer.rules.paragraph_close = () => '';
 
-// https://github.com/markdown-it/markdown-it/issues/458#issuecomment-401221267
-function modifyMarkdownLinks(markdown: string): string {
-  const matches = markdownit.linkify.match(markdown);
-  if (!matches || matches.length === 0) {
-    return markdown;
-  }
-  const result = [];
-  let prevEndIndex = 0;
-  for (const match of matches) {
-    const startsWithProto = /^https?:\/\//i.test(match.raw);
-    const noStartBracket = match.index === 0 || markdown[match.index - 1] !== '<';
-    const noEndBracket = match.lastIndex === markdown.length || markdown[match.lastIndex] !== '>';
-    const shouldInsertBrackets = startsWithProto && noStartBracket && noEndBracket;
-
-    result.push(markdown.slice(prevEndIndex, match.index));
-    result.push(shouldInsertBrackets ? `<${match.raw}>` : match.raw);
-    prevEndIndex = match.lastIndex;
-  }
-  result.push(markdown.slice(prevEndIndex));
-  return result.join('');
-}
-
 markdownit.normalizeLinkText = text => text;
 
 export const renderMessage = (message: string, selfId: QualifiedId | null, mentionEntities: MentionEntity[] = []) => {
@@ -193,7 +171,6 @@ export const renderMessage = (message: string, selfId: QualifiedId | null, menti
     return self.renderToken(tokens, idx, options);
   };
   const originalTokens = markdownit.parse(mentionlessText, {});
-  mentionlessText = modifyMarkdownLinks(mentionlessText);
   const modifiedLinksTokens = markdownit.parse(mentionlessText, {});
   const fixCodeTokens = (modifiedTokens: Token[], originalTokens: Token[]) =>
     modifiedTokens.map((modifiedToken, index) => {

--- a/test/unit_tests/util/messageRendererSpec.js
+++ b/test/unit_tests/util/messageRendererSpec.js
@@ -203,7 +203,7 @@ describe('renderMessage', () => {
     );
   });
 
-  it('does not render a broken markdown link', () => {
+  it('escapes links with an xss attempt on their url', () => {
     expect(renderMessage(`[sometext](https://some.domain"><script>alert("oops")</script>)`)).toBe(
       `<a href=\"https://some.domain%22%3E%3Cscript%3Ealert(%22oops%22)%3C/script%3E\" target=\"_blank\" rel=\"nofollow noopener noreferrer\" data-md-link=\"true\" data-uie-name=\"markdown-link\">sometext</a>`,
     );

--- a/test/unit_tests/util/messageRendererSpec.js
+++ b/test/unit_tests/util/messageRendererSpec.js
@@ -205,7 +205,7 @@ describe('renderMessage', () => {
 
   it('does not render a broken markdown link', () => {
     expect(renderMessage(`[sometext](https://some.domain"><script>alert("oops")</script>)`)).toBe(
-      `[sometext](<a href="https://some.domain" target="_blank" rel="nofollow noopener noreferrer">https://some.domain</a>&quot;&gt;&lt;script&gt;alert(&quot;oops&quot;)&lt;/script&gt;)`,
+      `<a href=\"https://some.domain%22%3E%3Cscript%3Ealert(%22oops%22)%3C/script%3E\" target=\"_blank\" rel=\"nofollow noopener noreferrer\" data-md-link=\"true\" data-uie-name=\"markdown-link\">sometext</a>`,
     );
   });
 

--- a/test/unit_tests/util/messageRendererSpec.js
+++ b/test/unit_tests/util/messageRendererSpec.js
@@ -209,6 +209,13 @@ describe('renderMessage', () => {
     );
   });
 
+  it('does not add a < behind URLs within <code> tags 2', () => {
+    expect(renderMessage('` http://wire.com`\n`123`')).toBe('<code> http://wire.com</code><br><code>123</code>');
+  });
+  it('does not add a < behind URLs within <code> tags', () => {
+    expect(renderMessage('` http://wire.com`')).toBe('<code> http://wire.com</code>');
+  });
+
   it('escapes url params', () => {
     expect(renderMessage(`[sometext](https://some.domain?param1=a&param2=b)`)).toBe(
       `<a href="https://some.domain?param1=a&amp;param2=b" target="_blank" rel="nofollow noopener noreferrer" data-md-link="true" data-uie-name="markdown-link">sometext</a>`,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1066" title="FS-1066" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1066</a>  [Web] Link handling creates artifacts
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Issue described here: https://github.com/wireapp/wire-webapp/issues/10217. Hack for supporting links with underscores introduced a small bug in codeblock links.

### Causes (Optional)

In older versions of `markdown-it` library, there was a bug where [links with underscores (`_`) were not supported](https://github.com/markdown-it/markdown-it/issues/458). We were using [this hack](https://github.com/markdown-it/markdown-it/issues/458#issuecomment-401221267) as a workaround.

### Solutions

The `markdown-it` library seems to be supporting links with underscores now. So the solution is just removing the hack.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
