### PR TITLE
runfix: TextInput and nth-child tests

### DIFF
--- a/src/script/components/TextInput/TextInput.tsx
+++ b/src/script/components/TextInput/TextInput.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React, {ForwardRefRenderFunction, useEffect, useRef} from 'react';
+import React, {forwardRef, useEffect} from 'react';
 
 import {CheckIcon, COLOR} from '@wireapp/react-ui-kit';
 
@@ -50,100 +50,108 @@ export interface UserInputProps {
 
 const SUCCESS_DISMISS_TIMEOUT = 2500;
 
-const TextInputComponent: ForwardRefRenderFunction<HTMLInputElement, UserInputProps> = ({
-  autoFocus,
-  disabled,
-  errorMessage,
-  isError,
-  isSuccess,
-  label,
-  name,
-  onCancel,
-  onChange,
-  onBlur,
-  onKeyDown,
-  onSuccessDismissed,
-  placeholder,
-  value,
-  uieName,
-  errorUieName,
-  inputWrapperRef,
-  setIsEditing,
-}: UserInputProps) => {
-  const isFilled = Boolean(value);
-  const textInputRef = useRef<HTMLInputElement>(null);
+const TextInput = forwardRef<HTMLInputElement, UserInputProps>(
+  (
+    {
+      autoFocus,
+      disabled,
+      errorMessage,
+      isError,
+      isSuccess,
+      label,
+      name,
+      onCancel,
+      onChange,
+      onBlur,
+      onKeyDown,
+      onSuccessDismissed,
+      placeholder,
+      value,
+      uieName,
+      errorUieName,
+      inputWrapperRef,
+      setIsEditing,
+    },
+    textInputRef,
+  ) => {
+    const isFilled = Boolean(value);
 
-  useEffect(() => {
-    if (isSuccess && onSuccessDismissed) {
-      setTimeout(() => {
-        onSuccessDismissed();
-      }, SUCCESS_DISMISS_TIMEOUT);
+    useEffect(() => {
+      if (isSuccess && onSuccessDismissed) {
+        setTimeout(() => {
+          onSuccessDismissed();
+        }, SUCCESS_DISMISS_TIMEOUT);
+      }
+    }, [isSuccess, onSuccessDismissed]);
+
+    let changedColor = undefined;
+    if (isError) {
+      changedColor = 'var(--text-input-alert) !important';
     }
-  }, [isSuccess, onSuccessDismissed]);
+    if (isSuccess) {
+      changedColor = 'var(--text-input-success) !important';
+    }
 
-  let changedColor = undefined;
-  if (isError) {
-    changedColor = 'var(--text-input-alert) !important';
-  }
-  if (isSuccess) {
-    changedColor = 'var(--text-input-success) !important';
-  }
+    return (
+      <div css={containerCSS} ref={inputWrapperRef}>
+        {isError && errorMessage && (
+          <span className="label" css={errorMessageCSS} data-uie-name={errorUieName}>
+            {errorMessage}
+          </span>
+        )}
 
-  return (
-    <div css={containerCSS} ref={inputWrapperRef}>
-      {isError && errorMessage && (
-        <span className="label" css={errorMessageCSS} data-uie-name={errorUieName}>
-          {errorMessage}
-        </span>
-      )}
+        {/* eslint jsx-a11y/no-autofocus : "off" */}
+        <input
+          autoFocus={autoFocus}
+          className="text-input"
+          css={getInputCSS(disabled, changedColor)}
+          disabled={disabled}
+          id={name}
+          name={name}
+          value={value}
+          onChange={onChange}
+          onBlur={onBlur}
+          onKeyDown={onKeyDown}
+          placeholder={placeholder}
+          ref={textInputRef}
+          data-uie-name={uieName}
+        />
 
-      {/* eslint jsx-a11y/no-autofocus : "off" */}
-      <input
-        autoFocus={autoFocus}
-        className="text-input"
-        css={getInputCSS(disabled, changedColor)}
-        disabled={disabled}
-        id={name}
-        name={name}
-        value={value}
-        onChange={onChange}
-        onBlur={onBlur}
-        onKeyDown={onKeyDown}
-        placeholder={placeholder}
-        ref={textInputRef}
-        data-uie-name={uieName}
-      />
-      <label className="label-medium" css={getLabelCSS(changedColor)} htmlFor={name}>
-        {label}
-      </label>
-      {isFilled && !isSuccess && !isError && (
-        <button
-          type="button"
-          css={cancelButtonCSS}
-          onClick={() => {
-            onCancel();
-            textInputRef.current?.focus();
-          }}
-          aria-label={t('accessibility.userProfileDeleteEntry')}
-          onKeyDown={(event: React.KeyboardEvent<HTMLButtonElement>): void => {
-            if (event.shiftKey && isTabKey(event)) {
-              // shift+tab from clear button should focus on the input field
-              setIsEditing?.(true);
-            } else if (isTabKey(event)) {
-              // tab from clear button should close the editable field
-              setIsEditing?.(false);
-            }
-          }}
-        >
-          <Icon.Close css={{fill: 'var(--text-input-background)', height: 8, width: 8}} />
-        </button>
-      )}
-      {isSuccess && !isError && <CheckIcon css={getIconCSS(changedColor)} color={COLOR.TEXT} />}
-      {isError && <Icon.ExclamationMark css={getIconCSS(changedColor)} color={COLOR.TEXT} />}
-    </div>
-  );
-};
+        <label className="label-medium" css={getLabelCSS(changedColor)} htmlFor={name}>
+          {label}
+        </label>
 
-const TextInput = React.forwardRef(TextInputComponent);
+        {isFilled && !isSuccess && !isError && (
+          <button
+            type="button"
+            css={cancelButtonCSS}
+            onClick={() => {
+              onCancel();
+              if (textInputRef && 'current' in textInputRef) {
+                textInputRef.current?.focus();
+              }
+            }}
+            aria-label={t('accessibility.userProfileDeleteEntry')}
+            onKeyDown={(event: React.KeyboardEvent<HTMLButtonElement>): void => {
+              if (event.shiftKey && isTabKey(event)) {
+                // shift+tab from clear button should focus on the input field
+                setIsEditing?.(true);
+              } else if (isTabKey(event)) {
+                // tab from clear button should close the editable field
+                setIsEditing?.(false);
+              }
+            }}
+          >
+            <Icon.Close css={{fill: 'var(--text-input-background)', height: 8, width: 8}} />
+          </button>
+        )}
+        {isSuccess && !isError && <CheckIcon css={getIconCSS(changedColor)} color={COLOR.TEXT} />}
+        {isError && <Icon.ExclamationMark css={getIconCSS(changedColor)} color={COLOR.TEXT} />}
+      </div>
+    );
+  },
+);
+
+TextInput.displayName = 'TextInput';
 
 export {TextInput};

--- a/src/script/page/AccentColorPicker.tsx
+++ b/src/script/page/AccentColorPicker.tsx
@@ -73,29 +73,29 @@ const AccentColorPicker: React.FunctionComponent<AccentColorPickerProps> = ({use
                   data-uie-name="do-set-accent-color"
                   data-uie-value={id}
                   css={{
-                    '& + label > span:first-child': {
+                    '& + label > span:first-of-type': {
                       color: color,
                       cursor: 'pointer',
                       display: 'inline-block',
                       position: 'relative',
                     },
-                    '& + label > span:first-child::after': {
+                    '& + label > span:first-of-type::after': {
                       ...CSS_SQUARE(10),
                       background: 'currentColor',
                       transform: 'translate(-50%, -50%)',
                     },
-                    '& + label > span:first-child::before': {
+                    '& + label > span:first-of-type::before': {
                       ...CSS_SQUARE(16),
                       transform: 'translate(-50%, -50%)',
                     },
-                    '& + label > span:first-child::before, & + label > span:first-child::after': {
+                    '& + label > span:first-of-type::before, & + label > span:first-of-type::after': {
                       borderRadius: '50%',
                       content: '""',
                       display: 'inline-block',
                       position: 'absolute',
                       transition: 'all 0.15s ease-out',
                     },
-                    '&:checked + label > span:first-child::before': {
+                    '&:checked + label > span:first-of-type::before': {
                       border: '1px solid currentColor',
                     },
                     '&:focus-visible + label': {

--- a/src/script/page/MainContent/panels/preferences/accountPreferences/AccountInput.tsx
+++ b/src/script/page/MainContent/panels/preferences/accountPreferences/AccountInput.tsx
@@ -82,7 +82,7 @@ const AccountInput: FC<AccountInputProps> = ({
   valueUie,
   ...rest
 }) => {
-  const inputWrapperRef = useRef<HTMLDivElement>(null);
+  const inputWrapperRef = useRef<HTMLInputElement | null>(null);
 
   const [input, setInput] = useState<string>('');
   const [isEditing, setIsEditing] = useState(false);
@@ -187,7 +187,7 @@ const AccountInput: FC<AccountInputProps> = ({
           label={label}
           name={valueUie ? valueUie : fieldName}
           value={input}
-          inputWrapperRef={inputWrapperRef}
+          ref={inputWrapperRef}
           onChange={({target}) => updateInput(target.value)}
           onCancel={() => {
             updateInput('');


### PR DESCRIPTION
Fixed a lot of warnings with wrong implementation of ref in TextInput component.

![image](https://user-images.githubusercontent.com/13432884/196370257-36c9de0e-38eb-4f71-827c-0cf8c0939167.png)

Also changed :first-child to :first-of-type ( on ss more details ):
![image](https://user-images.githubusercontent.com/13432884/196370558-93bbaff3-3aa6-4514-a686-f0d446b4334c.png)

Also more details about :first-of-type you can find there: https://css-tricks.com/almanac/selectors/f/first-of-type/ :)