### PR TITLE
runfix: prevent sidebar header to overlap with button

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -115,6 +115,8 @@ const Conversations: React.FC<ConversationsProps> = ({
 
   const {setCurrentView} = useAppMainState(state => state.responsiveView);
 
+  const showLegalHold = isOnLegalHold || hasPendingLegalHold;
+
   const onClickPreferences = () => {
     setCurrentView(ViewType.LEFT_SIDEBAR);
     switchList(ListState.PREFERENCES);
@@ -170,6 +172,7 @@ const Conversations: React.FC<ConversationsProps> = ({
           <button
             type="button"
             className="left-list-header-availability"
+            css={{...(showLegalHold && {gridColumn: '2/3'})}}
             onClick={event => AvailabilityContextMenu.show(event.nativeEvent, 'left-list-availability-menu')}
             onBlur={event => {
               // on blur conversation list should get the focus
@@ -184,7 +187,7 @@ const Conversations: React.FC<ConversationsProps> = ({
             />
           </button>
 
-          {(isOnLegalHold || hasPendingLegalHold) && (
+          {showLegalHold && (
             <LegalHoldDot
               isPending={hasPendingLegalHold}
               dataUieName={hasPendingLegalHold ? 'status-legal-hold-pending' : 'status-legal-hold'}

--- a/src/style/components/legal-hold-dot.less
+++ b/src/style/components/legal-hold-dot.less
@@ -24,6 +24,7 @@
   padding: 8px;
 
   cursor: default;
+  grid-column: 3 / span 2;
 
   &--interactive {
     cursor: pointer;

--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -99,8 +99,7 @@
   .button-reset-default;
   .button-icon-large;
   .focus-border-radius;
-  position: absolute;
-  left: 10px;
+  position: relative;
   outline-offset: 0.2rem;
 }
 

--- a/src/style/list/list.less
+++ b/src/style/list/list.less
@@ -49,7 +49,6 @@
   display: grid;
   height: @content-title-bar-height;
   flex-shrink: 0;
-  justify-content: space-between;
   border-bottom: 1px solid var(--sidebar-border-color);
   grid-template-columns: 50px 1fr 50px 50px;
 }

--- a/src/style/list/list.less
+++ b/src/style/list/list.less
@@ -45,13 +45,13 @@
 }
 
 .left-list-header {
-  .flex-center;
   position: relative;
+  display: grid;
   height: @content-title-bar-height;
   flex-shrink: 0;
-  justify-content: center;
-  padding: 0 12px;
+  justify-content: space-between;
   border-bottom: 1px solid var(--sidebar-border-color);
+  grid-template-columns: 50px 1fr 50px 50px;
 }
 
 body.theme-dark {
@@ -65,11 +65,11 @@ body.theme-dark {
   .button-reset-default;
   position: relative;
   overflow: hidden;
-  max-width: 208px;
   height: 100%;
   flex: 1;
   justify-content: center;
   cursor: pointer;
+  grid-column: 2 / span 2;
 
   &:focus-visible {
     .focus-border-radius;
@@ -88,20 +88,15 @@ body.theme-dark {
 .left-list-header-text {
   .ellipsis-nowrap;
   .heading-h3;
-
   display: inline-block;
-  max-width: @conversation-list-width - 40px;
-  flex-grow: 1;
+
+  align-self: center;
+  grid-column: 2 / span 2;
   text-align: center;
 }
 
 .left-list-header-close-button {
   .button-reset-default;
-  position: absolute;
-  top: 50%;
-  right: 16px;
-  padding: 8px;
-  transform: translateY(-50%);
 }
 
 .left-list-center {


### PR DESCRIPTION
----

### Issue

- sidebar header is overlapping with preferences button when legal hold is active

![Screenshot from 2022-10-18 11-29-12](https://user-images.githubusercontent.com/78490891/196416945-f89cb55b-7ff2-4f68-9b1d-080085f0d3ca.png)


### Solution

- remove the use of absolute positioning for buttons in the sidebar header and use css grid instead

![image](https://user-images.githubusercontent.com/78490891/196417502-0306c59a-fe20-4afe-b0c3-32e0c907d682.png)
