### PR TITLE
runfix: prevent overflow for av select at minimum screen width

### DIFF
--- a/src/style/components/input-level.less
+++ b/src/style/components/input-level.less
@@ -18,6 +18,7 @@
  */
 
 @input-level-bullet-size: 16px;
+@input-level-bullet-size-sm: 12px;
 
 .input-level {
   display: flex;
@@ -32,6 +33,10 @@
     border-radius: @input-level-bullet-size / 2;
     background-color: #fff;
     transition: all 0.16s;
+
+    @media (max-width: @screen-sm) {
+      .circle(@input-level-bullet-size-sm);
+    }
 
     &--active {
       background-color: currentColor;


### PR DESCRIPTION

### Issue

- Microphone select does not display correctly at 320px width
![Screenshot from 2022-10-18 15-47-55](https://user-images.githubusercontent.com/78490891/196450870-fa5616fd-7633-403b-b2a9-fbddc41e4adb.png)

### Solution

- Adjust the size of in level bullets at the lowest breakpoint
![Screenshot from 2022-10-18 15-46-05](https://user-images.githubusercontent.com/78490891/196451180-07ab84e2-b507-422e-9144-6eb0bab67b08.png)
