### PR TITLE
runfix: address responsive design in authentication screen [ACC-66]

### DIFF
--- a/src/script/auth/component/LoginForm.tsx
+++ b/src/script/auth/component/LoginForm.tsx
@@ -20,13 +20,14 @@
 import React, {useRef, useState} from 'react';
 
 import {LoginData} from '@wireapp/api-client/src/auth';
-import {Input, Loading, Button} from '@wireapp/react-ui-kit';
+import {Input, Loading, Button, Link, LinkVariant} from '@wireapp/react-ui-kit';
 import {useIntl} from 'react-intl';
 
 import {isValidEmail, isValidPhoneNumber, isValidUsername} from 'Util/ValidationUtil';
 
 import {Config} from '../../Config';
 import {loginStrings} from '../../strings';
+import {EXTERNAL_ROUTE} from '../externalRoute';
 import {ValidationError} from '../module/action/ValidationError';
 
 interface LoginFormProps {
@@ -111,11 +112,20 @@ const LoginForm = ({isFetching, onSubmit}: LoginFormProps) => {
         required
         data-uie-name="enter-password"
       />
+      <Link
+        variant={LinkVariant.PRIMARY}
+        href={EXTERNAL_ROUTE.WIRE_ACCOUNT_PASSWORD_RESET}
+        target="_blank"
+        data-uie-name="go-forgot-password"
+      >
+        {_(loginStrings.forgotPassword)}
+      </Link>
 
       {isFetching ? (
         <Loading size={32} />
       ) : (
         <Button
+          style={{marginTop: '16px'}}
           block
           type="submit"
           disabled={!email || !password}

--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -375,6 +375,9 @@ const LoginComponent = ({
           </Columns>
         </Container>
       )}
+      <IsMobile>
+        <div style={{minWidth: 48}} />
+      </IsMobile>
     </Page>
   );
 };

--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -37,11 +37,11 @@ import {
   H2,
   Label,
   IsMobile,
-  Link,
   TextLink,
   Loading,
   Muted,
   Text,
+  LinkVariant,
 } from '@wireapp/react-ui-kit';
 import {StatusCodes} from 'http-status-codes';
 import {useIntl} from 'react-intl';
@@ -60,7 +60,6 @@ import {loginStrings, verifyStrings} from '../../strings';
 import {AppAlreadyOpen} from '../component/AppAlreadyOpen';
 import {LoginForm} from '../component/LoginForm';
 import {RouterLink} from '../component/RouterLink';
-import {EXTERNAL_ROUTE} from '../externalRoute';
 import {actionRoot} from '../module/action/';
 import {BackendError} from '../module/action/BackendError';
 import {LabeledError} from '../module/action/LabeledError';
@@ -349,24 +348,16 @@ const LoginComponent = ({
                         )}
                       </Form>
                     </div>
-                    <Columns>
-                      <Column>
-                        <Link
-                          href={EXTERNAL_ROUTE.WIRE_ACCOUNT_PASSWORD_RESET}
-                          target="_blank"
-                          data-uie-name="go-forgot-password"
-                        >
-                          {_(loginStrings.forgotPassword)}
-                        </Link>
-                      </Column>
-                      {Config.getConfig().FEATURE.ENABLE_PHONE_LOGIN && (
-                        <Column>
-                          <RouterLink to={ROUTE.LOGIN_PHONE} data-uie-name="go-sign-in-phone">
-                            {_(loginStrings.phoneLogin)}
-                          </RouterLink>
-                        </Column>
-                      )}
-                    </Columns>
+                    {Config.getConfig().FEATURE.ENABLE_PHONE_LOGIN && (
+                      <RouterLink
+                        variant={LinkVariant.PRIMARY}
+                        style={{paddingTop: '12px', textAlign: 'center'}}
+                        to={ROUTE.LOGIN_PHONE}
+                        data-uie-name="go-sign-in-phone"
+                      >
+                        {_(loginStrings.phoneLogin)}
+                      </RouterLink>
+                    )}
                   </>
                 )}
               </ContainerXS>

--- a/src/script/auth/page/SetAccountType.tsx
+++ b/src/script/auth/page/SetAccountType.tsx
@@ -90,7 +90,9 @@ const SetAccountType = ({}: Props) => {
             </Column>
           </IsMobile>
           <Column style={{flexBasis: 384, flexGrow: 0, padding: 0}}>
-            <Logo scale={1.68} data-uie-name="ui-wire-logo" />
+            <Column>
+              <Logo scale={1.68} data-uie-name="ui-wire-logo" />
+            </Column>
             <Columns style={{margin: '70px auto'}}>
               <Column style={{marginLeft: isMacOsWrapper ? 0 : 16}}>
                 <RouterLink to={ROUTE.CREATE_ACCOUNT} data-uie-name="go-register-personal">

--- a/src/script/auth/page/SetAccountType.tsx
+++ b/src/script/auth/page/SetAccountType.tsx
@@ -69,6 +69,13 @@ const SetAccountType = ({}: Props) => {
 
   return (
     <Page>
+      {(Config.getConfig().FEATURE.ENABLE_DOMAIN_DISCOVERY ||
+        Config.getConfig().FEATURE.ENABLE_SSO ||
+        Config.getConfig().FEATURE.ENABLE_ACCOUNT_REGISTRATION) && (
+        <IsMobile>
+          <div style={{margin: 16}}>{backArrow}</div>
+        </IsMobile>
+      )}
       {!Config.getConfig().FEATURE.ENABLE_ACCOUNT_REGISTRATION && (
         <Navigate to={pathWithParams(ROUTE.INDEX)} replace data-uie-name="redirect-login" />
       )}
@@ -150,6 +157,9 @@ const SetAccountType = ({}: Props) => {
           <Column />
         </Columns>
       </Container>
+      <IsMobile>
+        <div style={{minWidth: 48}} />
+      </IsMobile>
     </Page>
   );
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-66" title="ACC-66" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-66</a>  Auth app
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Issue

- The back arrow does not appear on the 'create account" screen on mobile breakpoints
- The login screen is lacking a right margin on mobile breakpoints
- Links still use the old design (and forgot password should be over the login button)

![Screenshot from 2022-10-18 17-51-02](https://user-images.githubusercontent.com/78490891/196482085-8df01ba2-697c-4d42-95c3-45cab709ff15.png)
![Screenshot from 2022-10-18 17-51-13](https://user-images.githubusercontent.com/78490891/196482114-4016cfea-2fc7-4a02-b48c-36cd4321ce6c.png)

### After changes
![Screenshot from 2022-10-18 18-19-06](https://user-images.githubusercontent.com/78490891/196487353-42aeade2-b7e7-4a61-aa26-5022a952773b.png)

![Screenshot from 2022-10-18 17-50-09](https://user-images.githubusercontent.com/78490891/196482351-c4d0653a-01eb-4df8-893c-909bf076c50c.png)
