### PR TITLE
runfix: allow scrolling of right sidebar at maximum zoom [ACC-63]

### DIFF
--- a/src/style/common/variables.less
+++ b/src/style/common/variables.less
@@ -175,6 +175,7 @@
 @conversation-list-width: 300px;
 
 @right-width: 304px;
+@panel-content-min-height: 150px;
 
 body {
   --preferences-width: 560px;

--- a/src/style/components/list/participant-item.less
+++ b/src/style/components/list/participant-item.less
@@ -17,6 +17,8 @@
  *
  */
 
+@participant-max-width: 180px;
+
 .participant-item-wrapper {
   position: relative;
   display: block;
@@ -112,6 +114,7 @@
 
       &__text {
         display: flex;
+        max-width: @participant-max-width;
         min-width: 0; // this will ensure that ellipses is working
         height: @avatar-diameter-m;
         flex-direction: column;

--- a/src/style/panel/panel.less
+++ b/src/style/panel/panel.less
@@ -32,6 +32,7 @@
     display: flex;
     height: 100%;
     flex-direction: column;
+    overflow-y: overlay;
 
     &--move-out--left,
     &--move-out--right,
@@ -101,6 +102,7 @@
     position: relative;
     display: flex;
     width: @panel-width;
+    min-height: @panel-content-min-height;
     flex-direction: column;
     overflow-x: hidden;
     overflow-y: auto;

--- a/src/style/panel/panel.less
+++ b/src/style/panel/panel.less
@@ -32,6 +32,7 @@
     display: flex;
     height: 100%;
     flex-direction: column;
+    overflow-x: hidden;
     overflow-y: overlay;
 
     &--move-out--left,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-63" title="ACC-63" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-63</a>  Conversations View
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Issues

- participant icon gets misaligned when the name is too long
- When you try to add participants to a group, the participant list get squashed at max zoom
![Peek 2022-10-19 15-41](https://user-images.githubusercontent.com/78490891/196707974-04d080a4-e601-475f-b4d7-3b7c99809608.gif)

### Solution

- add a max-width to participant text
- allow vertical overflow to scroll on the right sidebar
![Peek 2022-10-19 15-06](https://user-images.githubusercontent.com/78490891/196699577-803fc980-7d4d-484b-9395-773426761cc6.gif)
