### PR TITLE
runfix: Show isVerified user badge

### DIFF
--- a/src/script/components/UserList.tsx
+++ b/src/script/components/UserList.tsx
@@ -92,8 +92,6 @@ const UserList: React.FC<UserListProps> = ({
 
   const highlightedUserIds = highlightedUsers.map(user => user.id);
   const selfInTeam = userState.self().inTeam();
-  const {self} = useKoSubscribableChildren(userState, ['self']);
-  const {is_verified: isSelfVerified} = useKoSubscribableChildren(self, ['is_verified']);
   const isSelectEnabled = !!onSelectUser;
 
   // subscribe to roles changes in order to react to them
@@ -166,7 +164,6 @@ const UserList: React.FC<UserListProps> = ({
                       mode={mode}
                       external={teamState.isExternal(user.id)}
                       selfInTeam={selfInTeam}
-                      isSelfVerified={isSelfVerified}
                       onClick={onClickOrKeyPressed}
                       onKeyDown={onUserKeyPressed}
                       showArrow={showArrow}
@@ -201,7 +198,6 @@ const UserList: React.FC<UserListProps> = ({
                     mode={mode}
                     external={teamState.isExternal(user.id)}
                     selfInTeam={selfInTeam}
-                    isSelfVerified={isSelfVerified}
                     onClick={onClickOrKeyPressed}
                     onKeyDown={onUserKeyPressed}
                     showArrow={showArrow}
@@ -231,7 +227,6 @@ const UserList: React.FC<UserListProps> = ({
             mode={mode}
             external={teamState.isExternal(user.id)}
             selfInTeam={selfInTeam}
-            isSelfVerified={isSelfVerified}
             onClick={onClickOrKeyPressed}
             onKeyDown={onUserKeyPressed}
             showArrow={showArrow}

--- a/src/script/components/list/ParticipantItem.tsx
+++ b/src/script/components/list/ParticipantItem.tsx
@@ -47,7 +47,6 @@ export interface ParticipantItemProps<UserType> extends Omit<React.HTMLProps<HTM
   hideInfo?: boolean;
   highlighted?: boolean;
   isSelected?: boolean;
-  isSelfVerified?: boolean;
   mode?: UserlistMode;
   noInteraction?: boolean;
   noUnderline?: boolean;
@@ -71,7 +70,6 @@ const ParticipantItem = <UserType extends User | ServiceEntity>(
     hideInfo,
     highlighted = false,
     isSelected,
-    isSelfVerified = false,
     mode = UserlistMode.DEFAULT,
     noInteraction = false,
     noUnderline = false,
@@ -222,9 +220,7 @@ const ParticipantItem = <UserType extends User | ServiceEntity>(
               </span>
             )}
 
-            {isUser && isSelfVerified && isVerified && (
-              <Icon.Verified className="verified-icon" data-uie-name="status-verified" />
-            )}
+            {isUser && isVerified && <Icon.Verified className="verified-icon" data-uie-name="status-verified" />}
 
             {callParticipant && (
               <>

--- a/src/script/components/panel/UserDetails.tsx
+++ b/src/script/components/panel/UserDetails.tsx
@@ -35,18 +35,11 @@ export interface UserDetailsProps {
   badge?: string;
   classifiedDomains?: string[];
   isGroupAdmin?: boolean;
-  isSelfVerified: boolean;
   isVerified?: boolean;
   participant: User;
 }
 
-const UserDetails: React.FC<UserDetailsProps> = ({
-  badge,
-  participant,
-  isSelfVerified,
-  isGroupAdmin,
-  classifiedDomains,
-}) => {
+const UserDetails: React.FC<UserDetailsProps> = ({badge, participant, isGroupAdmin, classifiedDomains}) => {
   const user = useKoSubscribableChildren(participant, [
     'inTeam',
     'isGuest',
@@ -79,7 +72,8 @@ const UserDetails: React.FC<UserDetailsProps> = ({
             {user.name}
           </h2>
         )}
-        {isSelfVerified && user.is_verified && (
+
+        {user.is_verified && (
           <Icon.Verified
             className="panel-participant__head__verified-icon"
             data-uie-name="status-verified-participant"

--- a/src/script/page/RightSidebar/GroupParticipantUser/GroupParticipantUser.tsx
+++ b/src/script/page/RightSidebar/GroupParticipantUser/GroupParticipantUser.tsx
@@ -82,7 +82,6 @@ const GroupParticipantUser: FC<GroupParticipantUserProps> = ({
     'team',
   ]);
   const {isActivatedAccount, self: selfUser} = useKoSubscribableChildren(userState, ['isActivatedAccount', 'self']);
-  const {is_verified: isSelfVerified} = useKoSubscribableChildren(selfUser, ['is_verified']);
 
   const canChangeRole =
     conversationRoleRepository.canChangeParticipantRoles(activeConversation) && !currentUser.isMe && !isTemporaryGuest;
@@ -149,7 +148,6 @@ const GroupParticipantUser: FC<GroupParticipantUserProps> = ({
           participant={currentUser}
           badge={teamRepository.getRoleBadge(currentUser.id)}
           isGroupAdmin={isAdmin}
-          isSelfVerified={isSelfVerified}
           classifiedDomains={classifiedDomains}
         />
 


### PR DESCRIPTION
Fix for test: Guest room
Scenario: I want to see a verified shield in conversation details when all the devices are verified 0  - I see verified icon in conversation title bar.

![image](https://user-images.githubusercontent.com/13432884/196769854-d78bf378-6f23-49a8-b5aa-be2ca858d95d.png)

We checking multiple times same state and passing it to UserDetails, we passing also participant to UserDetails component, so we don't need pass isSelfVerified from top :)