### PR TITLE
runfix: Legal hold modal - empty userId

### DIFF
--- a/src/script/components/Modals/LegalHoldModal/LegalHoldModal.state.ts
+++ b/src/script/components/Modals/LegalHoldModal/LegalHoldModal.state.ts
@@ -146,7 +146,7 @@ const useLegalHoldModalState = create<LegalHoldModalState>((set, get) => ({
     set(state => ({
       ...state,
       conversation,
-      conversationId: conversation ? conversation?.id : 'self',
+      conversationId: conversation?.id || 'self',
       isInitialized: initialize,
       isLoading: true,
       isOpen: true,

--- a/src/script/components/Modals/LegalHoldModal/LegalHoldModal.tsx
+++ b/src/script/components/Modals/LegalHoldModal/LegalHoldModal.tsx
@@ -240,6 +240,8 @@ const LegalHoldModal: FC<LegalHoldModalProps> = ({
 
       if (!legalHoldUsers.length) {
         setIsModalOpen(false);
+
+        return;
       }
 
       setUsers(legalHoldUsers);
@@ -363,46 +365,50 @@ const LegalHoldModal: FC<LegalHoldModalProps> = ({
           </>
         )}
 
-        {!isRequestModal && !userDevices ? (
+        {!isRequest && (
           <>
-            <div className="legal-hold-modal__logo">
-              <LegalHoldDot large dataUieName="status-modal-legal-hold-icon" />
-            </div>
+            {!userDevices ? (
+              <>
+                <div className="legal-hold-modal__logo">
+                  <LegalHoldDot large dataUieName="status-modal-legal-hold-icon" />
+                </div>
 
-            <div className="legal-hold-modal__headline" data-uie-name="status-modal-title">
-              {t('legalHoldHeadline')}
-            </div>
+                <div className="legal-hold-modal__headline" data-uie-name="status-modal-title">
+                  {t('legalHoldHeadline')}
+                </div>
 
-            <p
-              className="legal-hold-modal__info"
-              data-uie-name="status-modal-text"
-              dangerouslySetInnerHTML={{
-                __html: isSelfInfo ? t('legalHoldDescriptionSelf') : t('legalHoldDescriptionOthers'),
-              }}
-            />
+                <p
+                  className="legal-hold-modal__info"
+                  data-uie-name="status-modal-text"
+                  dangerouslySetInnerHTML={{
+                    __html: isSelfInfo ? t('legalHoldDescriptionSelf') : t('legalHoldDescriptionOthers'),
+                  }}
+                />
 
-            <div className="legal-hold-modal__subjects">{t('legalHoldSubjects')}</div>
+                <div className="legal-hold-modal__subjects">{t('legalHoldSubjects')}</div>
 
-            <UserSearchableList
-              users={users}
-              userState={userState}
-              conversationRepository={conversationRepository}
-              searchRepository={searchRepository}
-              teamRepository={teamRepository}
-              onClick={setUserDevices}
-              noUnderline
-            />
+                <UserSearchableList
+                  users={users}
+                  userState={userState}
+                  conversationRepository={conversationRepository}
+                  searchRepository={searchRepository}
+                  teamRepository={teamRepository}
+                  onClick={setUserDevices}
+                  noUnderline
+                />
+              </>
+            ) : (
+              <UserDevices
+                clientRepository={clientRepository}
+                cryptographyRepository={cryptographyRepository}
+                messageRepository={messageRepository}
+                user={userDevices as User}
+                current={userDevicesHistory.current}
+                goTo={userDevicesHistory.goTo}
+                noPadding
+              />
+            )}
           </>
-        ) : (
-          <UserDevices
-            clientRepository={clientRepository}
-            cryptographyRepository={cryptographyRepository}
-            messageRepository={messageRepository}
-            user={userDevices as User}
-            current={userDevicesHistory.current}
-            goTo={userDevicesHistory.goTo}
-            noPadding
-          />
         )}
       </div>
     </ModalComponent>

--- a/src/script/components/UserDevices.tsx
+++ b/src/script/components/UserDevices.tsx
@@ -118,7 +118,7 @@ const UserDevices: React.FC<UserDevicesProps> = ({
           }
         }
       } catch (error) {
-        logger.error(`Unable to retrieve clients for user '${user?.id}': ${error.message || error}`);
+        logger.error(`Unable to retrieve clients for user '${user.id}': ${error.message || error}`);
       }
     })();
   }, [user]);
@@ -126,7 +126,7 @@ const UserDevices: React.FC<UserDevicesProps> = ({
   const clickOnDevice = (clientEntity: ClientEntity) => {
     setSelectedClient(clientEntity);
     const headline = user.isMe ? clientEntity.label || clientEntity.model : capitalizeFirstChar(clientEntity.class);
-    goTo(UserDevicesState.DEVICE_DETAILS, headline);
+    goTo(UserDevicesState.DEVICE_DETAILS, headline || '');
   };
 
   const clickToShowSelfFingerprint = () => {


### PR DESCRIPTION
Fix for: 
Browser log contained 1 errors:
SEVERE: https://wire-webapp-acc.zinfra.io/min/vendor.js?2022.10.19.13.28 1:2294601 "%c@wireapp/webapp/UserDevicesComponent%c [2022-10-19 13:43:34]" "color:#15256b; font-weight:bold;" "" "Unable to retrieve clients for user 'undefined': Error in $['qualified_users'][0]: parsing Qualified_UserId failed, expected Object, but encountered Null"

It's running UserDevices component when Show Request was called. Now we calling for UserDevices only when is Show Users was called.