### PR TITLE
runfix: tweak auth page visuals

### DIFF
--- a/src/script/auth/component/AccountForm.tsx
+++ b/src/script/auth/component/AccountForm.tsx
@@ -20,7 +20,7 @@
 import React from 'react';
 
 import {ValidationUtil} from '@wireapp/commons';
-import {Button, Checkbox, CheckboxLabel, Form, Input, InputBlock, Small} from '@wireapp/react-ui-kit';
+import {Button, Checkbox, CheckboxLabel, Form, Input, Small} from '@wireapp/react-ui-kit';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {connect} from 'react-redux';
 import {AnyAction, Dispatch} from 'redux';
@@ -143,77 +143,75 @@ const AccountFormComponent = ({account, ...props}: Props & ConnectedProps & Disp
   return (
     <Form onSubmit={handleSubmit} style={{display: 'flex', flexDirection: 'column'}}>
       <div>
-        <InputBlock>
-          <Input
-            name="name"
-            id="name"
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-              inputs.name.current.setCustomValidity('');
-              setRegistrationData({...registrationData, name: event.target.value});
-              setValidInputs({...validInputs, name: true});
-            }}
-            ref={inputs.name}
-            markInvalid={!validInputs.name}
-            value={registrationData.name}
-            autoComplete="section-create-team username"
-            placeholder={_(accountFormStrings.namePlaceholder)}
-            onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
-              if (event.key === KEY.ENTER) {
-                inputs.email.current.focus();
-              }
-            }}
-            maxLength={64}
-            minLength={2}
-            pattern=".{2,64}"
-            required
-            data-uie-name="enter-name"
-          />
-          <Input
-            name="email"
-            id="email"
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-              inputs.email.current.setCustomValidity('');
-              setRegistrationData({...registrationData, email: event.target.value});
-              setValidInputs({...validInputs, email: true});
-            }}
-            ref={inputs.email}
-            markInvalid={!validInputs.email}
-            value={registrationData.email}
-            autoComplete="section-create-team email"
-            placeholder={_(
-              props.isPersonalFlow
-                ? accountFormStrings.emailPersonalPlaceholder
-                : accountFormStrings.emailTeamPlaceholder,
-            )}
-            onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
-              if (event.key === KEY.ENTER) {
-                inputs.password.current.focus();
-              }
-            }}
-            maxLength={128}
-            type="email"
-            required
-            data-uie-name="enter-email"
-          />
-          <Input
-            name="password"
-            id="password"
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-              inputs.password.current.setCustomValidity('');
-              setRegistrationData({...registrationData, password: event.target.value});
-              setValidInputs({...validInputs, password: true});
-            }}
-            ref={inputs.password}
-            markInvalid={!validInputs.password}
-            value={registrationData.password}
-            autoComplete="section-create-team new-password"
-            type="password"
-            placeholder={_(accountFormStrings.passwordPlaceholder)}
-            pattern={ValidationUtil.getNewPasswordPattern(Config.getConfig().NEW_PASSWORD_MINIMUM_LENGTH)}
-            required
-            data-uie-name="enter-password"
-          />
-        </InputBlock>
+        <Input
+          name="name"
+          id="name"
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+            inputs.name.current.setCustomValidity('');
+            setRegistrationData({...registrationData, name: event.target.value});
+            setValidInputs({...validInputs, name: true});
+          }}
+          ref={inputs.name}
+          markInvalid={!validInputs.name}
+          value={registrationData.name}
+          autoComplete="section-create-team username"
+          placeholder={_(accountFormStrings.namePlaceholder)}
+          onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
+            if (event.key === KEY.ENTER) {
+              inputs.email.current.focus();
+            }
+          }}
+          maxLength={64}
+          minLength={2}
+          pattern=".{2,64}"
+          required
+          data-uie-name="enter-name"
+        />
+        <Input
+          name="email"
+          id="email"
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+            inputs.email.current.setCustomValidity('');
+            setRegistrationData({...registrationData, email: event.target.value});
+            setValidInputs({...validInputs, email: true});
+          }}
+          ref={inputs.email}
+          markInvalid={!validInputs.email}
+          value={registrationData.email}
+          autoComplete="section-create-team email"
+          placeholder={_(
+            props.isPersonalFlow
+              ? accountFormStrings.emailPersonalPlaceholder
+              : accountFormStrings.emailTeamPlaceholder,
+          )}
+          onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
+            if (event.key === KEY.ENTER) {
+              inputs.password.current.focus();
+            }
+          }}
+          maxLength={128}
+          type="email"
+          required
+          data-uie-name="enter-email"
+        />
+        <Input
+          name="password"
+          id="password"
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+            inputs.password.current.setCustomValidity('');
+            setRegistrationData({...registrationData, password: event.target.value});
+            setValidInputs({...validInputs, password: true});
+          }}
+          ref={inputs.password}
+          markInvalid={!validInputs.password}
+          value={registrationData.password}
+          autoComplete="section-create-team new-password"
+          type="password"
+          placeholder={_(accountFormStrings.passwordPlaceholder)}
+          pattern={ValidationUtil.getNewPasswordPattern(Config.getConfig().NEW_PASSWORD_MINIMUM_LENGTH)}
+          required
+          data-uie-name="enter-password"
+        />
         <Small
           style={{
             display: validationErrors.length ? 'none' : 'block',

--- a/src/script/auth/component/LoginForm.tsx
+++ b/src/script/auth/component/LoginForm.tsx
@@ -20,14 +20,13 @@
 import React, {useRef, useState} from 'react';
 
 import {LoginData} from '@wireapp/api-client/src/auth';
-import {Input, Loading, Button, Link, LinkVariant} from '@wireapp/react-ui-kit';
+import {Input, Loading, Button} from '@wireapp/react-ui-kit';
 import {useIntl} from 'react-intl';
 
 import {isValidEmail, isValidPhoneNumber, isValidUsername} from 'Util/ValidationUtil';
 
 import {Config} from '../../Config';
 import {loginStrings} from '../../strings';
-import {EXTERNAL_ROUTE} from '../externalRoute';
 import {ValidationError} from '../module/action/ValidationError';
 
 interface LoginFormProps {
@@ -112,20 +111,11 @@ const LoginForm = ({isFetching, onSubmit}: LoginFormProps) => {
         required
         data-uie-name="enter-password"
       />
-      <Link
-        variant={LinkVariant.PRIMARY}
-        href={EXTERNAL_ROUTE.WIRE_ACCOUNT_PASSWORD_RESET}
-        target="_blank"
-        data-uie-name="go-forgot-password"
-      >
-        {_(loginStrings.forgotPassword)}
-      </Link>
 
       {isFetching ? (
         <Loading size={32} />
       ) : (
         <Button
-          style={{marginTop: '16px'}}
           block
           type="submit"
           disabled={!email || !password}

--- a/src/script/auth/component/PhoneLoginForm.tsx
+++ b/src/script/auth/component/PhoneLoginForm.tsx
@@ -20,7 +20,17 @@
 import React, {useRef, useState} from 'react';
 
 import {LoginData} from '@wireapp/api-client/src/auth';
-import {ArrowIcon, Input, InputBlock, InputSubmitCombo, Loading, RoundIconButton, Select} from '@wireapp/react-ui-kit';
+import {
+  ArrowIcon,
+  Input,
+  InputBlock,
+  InputSubmitCombo,
+  Loading,
+  QUERY,
+  RoundIconButton,
+  Select,
+  useMatchMedia,
+} from '@wireapp/react-ui-kit';
 import {useIntl} from 'react-intl';
 
 import {COUNTRY_CODES, getCountryByCode, getCountryCode} from 'Util/CountryCodes';
@@ -50,6 +60,9 @@ const PhoneLoginForm = ({isFetching, onSubmit}: LoginFormProps) => {
     ...countryList,
   ];
   const currentSelectValue = expandedCountryList.find(selectedCountry => selectedCountry.value === country);
+
+  const isTiny = useMatchMedia('max-width: 480px');
+  const isMobile = useMatchMedia(QUERY.mobile);
 
   const onCountryCodeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const {value} = event.target;
@@ -101,7 +114,7 @@ const PhoneLoginForm = ({isFetching, onSubmit}: LoginFormProps) => {
             id="enter-phone"
             name="phone-login"
             onChange={onPhoneNumberChange}
-            style={{width: 260}}
+            style={{width: isTiny ? 'calc(100vw - 200px)' : isMobile ? 'calc(100vw - 250px)' : '280px'}}
             ref={phoneInput}
             markInvalid={!validInput}
             value={phoneNumber}
@@ -116,7 +129,6 @@ const PhoneLoginForm = ({isFetching, onSubmit}: LoginFormProps) => {
             <Loading size={32} />
           ) : (
             <RoundIconButton
-              style={{marginLeft: 16}}
               disabled={!phoneNumber}
               type="submit"
               formNoValidate

--- a/src/script/auth/page/CreateAccount.tsx
+++ b/src/script/auth/page/CreateAccount.tsx
@@ -75,6 +75,9 @@ const CreateAccount = ({}: Props) => {
           <Column />
         </Columns>
       </Container>
+      <IsMobile>
+        <div style={{minWidth: 48}} />
+      </IsMobile>
     </Page>
   );
 };

--- a/src/script/auth/page/CreatePersonalAccount.tsx
+++ b/src/script/auth/page/CreatePersonalAccount.tsx
@@ -98,6 +98,9 @@ const CreatePersonalAccountComponent = ({
       ) : (
         pageContent
       )}
+      <IsMobile>
+        <div style={{minWidth: 48}} />
+      </IsMobile>
     </Page>
   );
 };

--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -42,6 +42,7 @@ import {
   Muted,
   Text,
   LinkVariant,
+  Link,
 } from '@wireapp/react-ui-kit';
 import {StatusCodes} from 'http-status-codes';
 import {useIntl} from 'react-intl';
@@ -60,6 +61,7 @@ import {loginStrings, verifyStrings} from '../../strings';
 import {AppAlreadyOpen} from '../component/AppAlreadyOpen';
 import {LoginForm} from '../component/LoginForm';
 import {RouterLink} from '../component/RouterLink';
+import {EXTERNAL_ROUTE} from '../externalRoute';
 import {actionRoot} from '../module/action/';
 import {BackendError} from '../module/action/BackendError';
 import {LabeledError} from '../module/action/LabeledError';
@@ -348,6 +350,15 @@ const LoginComponent = ({
                         )}
                       </Form>
                     </div>
+                    <Link
+                      variant={LinkVariant.PRIMARY}
+                      style={{paddingTop: '24px', textAlign: 'center'}}
+                      href={EXTERNAL_ROUTE.WIRE_ACCOUNT_PASSWORD_RESET}
+                      target="_blank"
+                      data-uie-name="go-forgot-password"
+                    >
+                      {_(loginStrings.forgotPassword)}
+                    </Link>
                     {Config.getConfig().FEATURE.ENABLE_PHONE_LOGIN && (
                       <RouterLink
                         variant={LinkVariant.PRIMARY}

--- a/src/script/auth/page/PhoneLogin.tsx
+++ b/src/script/auth/page/PhoneLogin.tsx
@@ -152,6 +152,9 @@ const PhoneLoginComponent = ({
           <Column />
         </Columns>
       </Container>
+      <IsMobile>
+        <div style={{minWidth: 48}} />
+      </IsMobile>
     </Page>
   );
 };

--- a/src/script/auth/page/SingleSignOn.tsx
+++ b/src/script/auth/page/SingleSignOn.tsx
@@ -279,6 +279,11 @@ const SingleSignOnComponent = ({hasDefaultSSOCode}: Props & ConnectedProps & Dis
           <Column />
         </Columns>
       </Container>
+      {!hasDefaultSSOCode && (
+        <IsMobile>
+          <div style={{minWidth: 48}} />
+        </IsMobile>
+      )}
     </Page>
   );
 };


### PR DESCRIPTION
### Issues

- QA tests are failing because of the position of "Forgot Password"
- Spinner isn't rendering correctly
- Some missing margins in mobile view
- The "Phone Login Situation" (see below)

### Solutions

- Revert position of "forgot password to the previous one"
- Add missing margins

#### The Phone Login Situation

The phone login input uses the `InputSubmitCombo` component from the ui-kit and is pretty broken.
That `InputSubmitCombo` has been removed from the rest of the auth page, but there's no replacement design here.

The "fix" is dirty and uses a nested ternary operator, but any more time spend on it feels like it would be wasted (unpopular feature + design needs to change)

before:
![Peek 2022-10-20 15-11](https://user-images.githubusercontent.com/78490891/196958017-b66ba428-6b7e-4afe-835f-7b0d05eeaf37.gif)
after:
![Peek 2022-10-20 15-04](https://user-images.githubusercontent.com/78490891/196958082-f65e59df-630b-4c32-8e4a-685acbc8de18.gif)


