### PR TITLE
runfix: fix for firefox ephemeral message progress icon [FS-1022]

### DIFF
--- a/src/style/components/ephemeral-timer.less
+++ b/src/style/components/ephemeral-timer.less
@@ -17,7 +17,7 @@
  *
  */
 
-@strokewidth: 4;
+@strokewidth: 4px;
 @strokelength: @strokewidth * pi();
 
 .ephemeral-timer {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1022" title="FS-1022" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1022</a>  [Web] Firefox: Progress dot for ephemeral messages does not update 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fixed ephemeral message progress icon animation on Firefox browser. The value of `--offset` firefox variable did not include `px`. Firefox doesn't seem to support values without units.

before


https://user-images.githubusercontent.com/45733298/197181612-a490b63a-85d8-4689-9845-170b6c1793ba.mov


after

https://user-images.githubusercontent.com/45733298/197181631-d1cc0bc9-a5a4-4a95-87c2-5c7402b50592.mov


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
