### PR TITLE
runfix: correct issues related to responsive view in left sidebar [ACC-62]

### DIFF
--- a/src/script/components/ConnectRequests/index.tsx
+++ b/src/script/components/ConnectRequests/index.tsx
@@ -19,10 +19,12 @@
 
 import {FC, useContext, useEffect, useRef} from 'react';
 
+import {Button, ButtonVariant, IconButton, IconButtonVariant, useMatchMedia} from '@wireapp/react-ui-kit';
 import {container} from 'tsyringe';
 
 import {Avatar, AVATAR_SIZE} from 'Components/Avatar';
 import {ClassifiedBar} from 'Components/input/ClassifiedBar';
+import {useAppMainState, ViewType} from 'src/script/page/state';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 
@@ -46,6 +48,11 @@ const ConnectRequests: FC<ConnectRequestsProps> = ({
   const mainViewModel = useContext(RootContext);
   const {classifiedDomains} = useKoSubscribableChildren(teamState, ['classifiedDomains']);
   const {connectRequests} = useKoSubscribableChildren(userState, ['connectRequests']);
+
+  // To be changed when design chooses a breakpoint, the conditional can be integrated to the ui-kit directly
+  const smBreakpoint = useMatchMedia('max-width: 620px');
+
+  const {setCurrentView} = useAppMainState(state => state.responsiveView);
 
   const scrollToBottom = (behavior: ScrollBehavior = 'auto') => {
     if (connectRequestsRefEnd.current) {
@@ -91,6 +98,16 @@ const ConnectRequests: FC<ConnectRequestsProps> = ({
     <div className="connect-request-wrapper">
       <div id="connect-requests" className="connect-requests" style={{overflowY: 'scroll'}}>
         <div className="connect-requests-inner" style={{overflowY: 'hidden'}}>
+          {smBreakpoint && (
+            <div css={{width: '100%'}}>
+              <IconButton
+                variant={IconButtonVariant.SECONDARY}
+                className="connect-requests-icon-back icon-back"
+                css={{marginBottom: 0}}
+                onClick={() => setCurrentView(ViewType.LEFT_SIDEBAR)}
+              />
+            </div>
+          )}
           {connectRequests.map(connectRequest => (
             <div
               key={connectRequest.id}
@@ -112,24 +129,23 @@ const ConnectRequests: FC<ConnectRequestsProps> = ({
                 noFilter
               />
 
-              <div className="button-group">
-                <button
-                  className="button button-inverted"
+              <div className="connect-request-button-group">
+                <Button
+                  variant={ButtonVariant.SECONDARY}
                   data-uie-name="do-ignore"
                   aria-label={t('connectionRequestIgnore')}
                   onClick={() => onIgnoreClick(connectRequest)}
                 >
                   {t('connectionRequestIgnore')}
-                </button>
+                </Button>
 
-                <button
-                  className="button"
+                <Button
                   onClick={() => onAcceptClick(connectRequest)}
                   data-uie-name="do-accept"
                   aria-label={t('connectionRequestConnect')}
                 >
                   {t('connectionRequestConnect')}
-                </button>
+                </Button>
               </div>
             </div>
           ))}

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
@@ -42,7 +42,7 @@ import {generateConversationUrl} from '../../../../router/routeGenerator';
 import {createNavigate} from '../../../../router/routerBindings';
 import {ContentState} from '../../../../view_model/ContentViewModel';
 import {ListViewModel} from '../../../../view_model/ListViewModel';
-import {useAppMainState} from '../../../state';
+import {useAppMainState, ViewType} from '../../../state';
 
 export const ConversationsList: React.FC<{
   callState: CallState;
@@ -89,7 +89,10 @@ export const ConversationsList: React.FC<{
     return !conversation.removed_from_conversation();
   };
 
+  const {setCurrentView} = useAppMainState(state => state.responsiveView);
+
   const onConnectionRequestClick = () => {
+    setCurrentView(ViewType.CENTRAL_COLUMN);
     listViewModel.contentViewModel.switchContent(ContentState.CONNECTION_REQUESTS);
   };
 

--- a/src/style/content/connect-requests.less
+++ b/src/style/content/connect-requests.less
@@ -77,3 +77,9 @@
   margin-top: 24px;
   margin-bottom: 32px;
 }
+
+.connect-request-button-group {
+  display: flex;
+  width: @scree-sm-min;
+  justify-content: space-around;
+}

--- a/src/style/content/connect-requests.less
+++ b/src/style/content/connect-requests.less
@@ -80,6 +80,6 @@
 
 .connect-request-button-group {
   display: flex;
-  width: @scree-sm-min;
+  width: @screen-sm-min;
   justify-content: space-around;
 }

--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -109,21 +109,12 @@
   &--badge::after {
     .dot-md;
     position: absolute;
-    top: 5px;
-    right: 5px;
+    top: 10px;
+    right: 10px;
     background-color: currentColor;
     color: inherit;
     content: '';
   }
-}
-
-.conversations-settings-badge {
-  .dot-md;
-
-  position: absolute;
-  top: 5px;
-  right: 5px;
-  content: '';
 }
 
 .conversations-hint {

--- a/src/style/list/list.less
+++ b/src/style/list/list.less
@@ -24,7 +24,6 @@
   bottom: 0;
   left: 0;
   display: flex;
-  width: @conversation-list-width;
   flex-direction: column;
 
   .team-mode & {

--- a/src/style/list/list.less
+++ b/src/style/list/list.less
@@ -91,6 +91,7 @@ body.theme-dark {
 
   align-self: center;
   grid-column: 2 / span 2;
+  justify-self: center;
   text-align: center;
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-62" title="ACC-62" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-62</a>  Sidebar
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
### Issues

- View doesn't change when accepting contact requests
- Preferences notification dot isn't correctly aligned
- Username is not centered in sidebar header for normal accounts
- start-ui (contact view) doesn't use the full width in responsive view

![image](https://user-images.githubusercontent.com/78490891/197210440-421c91e4-118c-413d-89e0-3b9c6ec0ccbf.png)

### Solutions

- Change view when clicking contact request and add back arrow to contact request view (change button design to ui-kit while we're at it)
- Align notification dot and center username
- remove width of left list container

![image](https://user-images.githubusercontent.com/78490891/197211315-9511b118-aa95-4564-9a3c-4f6df64f40b7.png)
![image](https://user-images.githubusercontent.com/78490891/197211430-0db3bc41-cc45-46ec-8b93-3bf24d50a477.png)
