### PR TITLE
runfix: show expand option for collections over limit [FS-1025]

### DIFF
--- a/src/script/page/MainContent/panels/Collection/Collection.test.tsx
+++ b/src/script/page/MainContent/panels/Collection/Collection.test.tsx
@@ -101,6 +101,9 @@ describe('Collection', () => {
   });
 
   it('displays collection details when a section is selected', async () => {
+    const imageMessages = new Array(14).fill(null).map(() => createImageMessage());
+    mockConversationRepository.getEventsForCategory.mockResolvedValueOnce(imageMessages);
+
     const {getAllByText, getByText} = render(
       <Collection conversation={conversation} conversationRepository={mockConversationRepository as any} />,
     );
@@ -114,13 +117,13 @@ describe('Collection', () => {
 
   it('should display search results when term is typed', async () => {
     jest.useFakeTimers();
-    const {getAllByText, queryByText, container} = render(
+    const {getAllByText, queryByText, getByTestId} = render(
       <Collection conversation={conversation} conversationRepository={mockConversationRepository as any} />,
     );
 
     await waitFor(() => getAllByText('CollectionItem'));
     await act(async () => {
-      const input: HTMLInputElement = container.querySelector('[data-uie-name=full-search-header-input]');
+      const input = getByTestId('full-search-header-input');
       fireEvent.change(input, {target: {value: 'term'}});
       jest.advanceTimersByTime(500);
       await waitFor(() => expect(mockConversationRepository.searchInConversation).toHaveBeenCalled());

--- a/src/script/page/MainContent/panels/Collection/Collection.test.tsx
+++ b/src/script/page/MainContent/panels/Collection/Collection.test.tsx
@@ -101,7 +101,8 @@ describe('Collection', () => {
   });
 
   it('displays collection details when a section is selected', async () => {
-    const imageMessages = new Array(14).fill(null).map(() => createImageMessage());
+    const IMAGE_COLLECTION_LENGTH = 13;
+    const imageMessages = new Array(IMAGE_COLLECTION_LENGTH).fill(null).map(createImageMessage);
     mockConversationRepository.getEventsForCategory.mockResolvedValueOnce(imageMessages);
 
     const {getAllByText, getByText} = render(

--- a/src/script/page/MainContent/panels/Collection/CollectionSection.test.tsx
+++ b/src/script/page/MainContent/panels/Collection/CollectionSection.test.tsx
@@ -1,0 +1,82 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render, fireEvent} from '@testing-library/react';
+
+import CollectionSection from './CollectionSection';
+import {ContentMessage} from '../../../../entity/message/ContentMessage';
+import {createRandomUuid} from 'Util/util';
+
+const NUMBER_OF_ASSETS = 5;
+
+const messages = new Array(NUMBER_OF_ASSETS).fill(null).map(() => new ContentMessage(createRandomUuid()));
+
+const getDefaultProps = ({limit}: {limit: number}) => ({
+  label: 'cool collection',
+  limit,
+  messages,
+  onSelect: jest.fn(),
+  uieName: 'cool-collection',
+});
+
+describe('CollectionSection', () => {
+  it('does not show show all button when under or equal a limit', async () => {
+    const props = getDefaultProps({limit: NUMBER_OF_ASSETS + 1});
+    const {queryByText, rerender} = render(
+      <CollectionSection {...props}>
+        <span className={`collection-header-icon icon-library`}></span>
+      </CollectionSection>,
+    );
+
+    props.limit = NUMBER_OF_ASSETS;
+    expect(queryByText('collectionShowAll')).toBeNull();
+
+    rerender(
+      <CollectionSection {...props}>
+        <span className={`collection-header-icon icon-library`}></span>
+      </CollectionSection>,
+    );
+
+    expect(queryByText('collectionShowAll')).toBeNull();
+  });
+
+  it('does show show all button when over a limit', async () => {
+    const {getByText} = render(
+      <CollectionSection {...getDefaultProps({limit: NUMBER_OF_ASSETS - 1})}>
+        <span className={`collection-header-icon icon-library`}></span>
+      </CollectionSection>,
+    );
+
+    expect(getByText('collectionShowAll')).toBeDefined();
+  });
+
+  it('triggers onSelect callback on show all button click', async () => {
+    const props = getDefaultProps({limit: NUMBER_OF_ASSETS - 1});
+    const {getByText} = render(
+      <CollectionSection {...props}>
+        <span className={`collection-header-icon icon-library`}></span>
+      </CollectionSection>,
+    );
+
+    const button = getByText('collectionShowAll');
+    fireEvent.click(button);
+
+    expect(props.onSelect).toHaveBeenCalled();
+  });
+});

--- a/src/script/page/MainContent/panels/Collection/CollectionSection.test.tsx
+++ b/src/script/page/MainContent/panels/Collection/CollectionSection.test.tsx
@@ -27,7 +27,7 @@ const NUMBER_OF_ASSETS = 5;
 
 const messages = new Array(NUMBER_OF_ASSETS).fill(null).map(() => new ContentMessage(createRandomUuid()));
 
-const getDefaultProps = ({limit}: {limit: number}) => ({
+const getDefaultProps = (limit: number) => ({
   label: 'cool collection',
   limit,
   messages,
@@ -37,10 +37,10 @@ const getDefaultProps = ({limit}: {limit: number}) => ({
 
 describe('CollectionSection', () => {
   it('does not show show all button when under or equal a limit', async () => {
-    const props = getDefaultProps({limit: NUMBER_OF_ASSETS + 1});
+    const props = getDefaultProps(NUMBER_OF_ASSETS + 1);
     const {queryByText, rerender} = render(
       <CollectionSection {...props}>
-        <span className={`collection-header-icon icon-library`}></span>
+        <span />
       </CollectionSection>,
     );
 
@@ -49,7 +49,7 @@ describe('CollectionSection', () => {
 
     rerender(
       <CollectionSection {...props}>
-        <span className={`collection-header-icon icon-library`}></span>
+        <span />
       </CollectionSection>,
     );
 
@@ -58,8 +58,8 @@ describe('CollectionSection', () => {
 
   it('does show show all button when over a limit', async () => {
     const {getByText} = render(
-      <CollectionSection {...getDefaultProps({limit: NUMBER_OF_ASSETS - 1})}>
-        <span className={`collection-header-icon icon-library`}></span>
+      <CollectionSection {...getDefaultProps(NUMBER_OF_ASSETS - 1)}>
+        <span />
       </CollectionSection>,
     );
 
@@ -67,10 +67,10 @@ describe('CollectionSection', () => {
   });
 
   it('triggers onSelect callback on show all button click', async () => {
-    const props = getDefaultProps({limit: NUMBER_OF_ASSETS - 1});
+    const props = getDefaultProps(NUMBER_OF_ASSETS - 1);
     const {getByText} = render(
       <CollectionSection {...props}>
-        <span className={`collection-header-icon icon-library`}></span>
+        <span />
       </CollectionSection>,
     );
 

--- a/src/script/page/MainContent/panels/Collection/CollectionSection.tsx
+++ b/src/script/page/MainContent/panels/Collection/CollectionSection.tsx
@@ -42,7 +42,7 @@ const CollectionSection: React.FC<{
         {children}
         <span className="label-bold-xs">{label}</span>
         {hasExtra && (
-          <button className="collection-header-all accent-text" onClick={() => onSelect()}>
+          <button className="collection-header-all accent-text" onClick={onSelect}>
             <span data-uie-name="collection-show-all">{t('collectionShowAll', messages.length)}</span>
             &nbsp;<span className="icon-forward font-size-xxs"></span>
           </button>

--- a/src/script/page/MainContent/panels/Collection/CollectionSection.tsx
+++ b/src/script/page/MainContent/panels/Collection/CollectionSection.tsx
@@ -33,7 +33,7 @@ const CollectionSection: React.FC<{
   if (messages.length === 0) {
     return null;
   }
-  const hasExtra = true || messages.length > limit;
+  const hasExtra = messages.length > limit;
   const topMessages = messages.slice(0, limit);
 
   return (


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1025" title="FS-1025" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1025</a>  [Web] File collection shows 'Show all' button before file limit is reached
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Display `Show all` button only in the case of preexisting limit. I assume this `true ||` was a leftover after react migration. 