### PR TITLE
runfix: Conversation read message and right-sidebar opening

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -292,7 +292,7 @@ const ConversationList: FC<ConversationListProps> = ({
   const getInViewportCallback = (
     conversationEntity: ConversationEntity,
     messageEntity: Message,
-  ): (() => void) | undefined => {
+  ): (() => void) | null => {
     const messageTimestamp = messageEntity.timestamp();
     const callbacks: Function[] = [];
 
@@ -325,7 +325,7 @@ const ConversationList: FC<ConversationListProps> = ({
     const isUnreadMessage = messageTimestamp > conversationEntity.last_read_timestamp();
     const isNotOwnMessage = !messageEntity.user().isMe;
 
-    let shouldSendReadReceipt = true;
+    let shouldSendReadReceipt = false;
 
     if (messageEntity.expectsReadConfirmation) {
       if (conversationEntity.is1to1()) {
@@ -350,7 +350,7 @@ const ConversationList: FC<ConversationListProps> = ({
     }
 
     if (!callbacks.length) {
-      return undefined;
+      return null;
     }
 
     return () => {

--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -292,7 +292,7 @@ const ConversationList: FC<ConversationListProps> = ({
   const getInViewportCallback = (
     conversationEntity: ConversationEntity,
     messageEntity: Message,
-  ): (() => void) | null => {
+  ): (() => void) | undefined => {
     const messageTimestamp = messageEntity.timestamp();
     const callbacks: Function[] = [];
 
@@ -350,7 +350,7 @@ const ConversationList: FC<ConversationListProps> = ({
     }
 
     if (!callbacks.length) {
-      return null;
+      return undefined;
     }
 
     return () => {

--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -80,6 +80,7 @@ import {EventRepository} from '../../event/EventRepository';
 import {MentionEntity} from '../../message/MentionEntity';
 import {MessageHasher} from '../../message/MessageHasher';
 import {QuoteEntity} from '../../message/QuoteEntity';
+import {useAppMainState} from '../../page/state';
 import {SearchRepository} from '../../search/SearchRepository';
 import {StorageRepository} from '../../storage';
 import {TeamState} from '../../team/TeamState';
@@ -169,6 +170,10 @@ const InputBar = ({
   const [selectionEnd, setSelectionEnd] = useState<number>(0);
   const [pingDisabled, setIsPingDisabled] = useState<boolean>(false);
   const [editedMention, setEditedMention] = useState<{startIndex: number; term: string} | undefined>(undefined);
+
+  const {rightSidebar} = useAppMainState.getState();
+  const currentState = rightSidebar.history.at(-1);
+  const isRightSidebarOpen = !!currentState;
 
   const availabilityIsNone = availability === Availability.Type.NONE;
   const showAvailabilityTooltip = firstUserEntity && inTeam && is1to1 && !availabilityIsNone;
@@ -851,7 +856,10 @@ const InputBar = ({
   };
 
   return (
-    <div id="conversation-input-bar" className="conversation-input-bar">
+    <div
+      id="conversation-input-bar"
+      className={cx('conversation-input-bar', {'is-right-panel-open': isRightSidebarOpen})}
+    >
       {classifiedDomains && !isConnectionRequest && (
         <ClassifiedBar users={participatingUserEts} classifiedDomains={classifiedDomains} />
       )}

--- a/src/script/components/MessagesList/Message/index.tsx
+++ b/src/script/components/MessagesList/Message/index.tsx
@@ -25,6 +25,7 @@ import React, {
 } from 'react';
 
 import {QualifiedId} from '@wireapp/api-client/src/user';
+import cx from 'classnames';
 
 import {InViewport} from 'Components/utils/InViewport';
 import {ServiceEntity} from 'src/script/integration/ServiceEntity';
@@ -73,7 +74,7 @@ export interface MessageParams extends MessageActions {
     deleteMessageEveryone: (conversation: Conversation, message: BaseMessage) => void;
   };
   messageRepository: MessageRepository;
-  onVisible?: () => void;
+  onVisible?: (() => void) | null;
   previousMessage?: BaseMessage;
   selfId: QualifiedId;
   shouldShowInvitePeople: boolean;
@@ -125,7 +126,7 @@ const Message: React.FC<
   );
   return (
     <div
-      className={`message ${isMarked ? 'message-marked' : ''}`}
+      className={cx('message', {'message-marked': isMarked})}
       ref={messageElementRef}
       data-uie-uid={message.id}
       data-uie-value={message.super_type}
@@ -133,7 +134,7 @@ const Message: React.FC<
       data-uie-send-status={status}
       data-uie-name="item-message"
     >
-      <div className={`message-header message-timestamp ${getTimestampClass()}`}>
+      <div className={cx('message-header message-timestamp', getTimestampClass())}>
         <div className="message-header-icon">
           <span className="message-unread-dot"></span>
         </div>

--- a/src/script/components/MessagesList/Message/index.tsx
+++ b/src/script/components/MessagesList/Message/index.tsx
@@ -74,7 +74,7 @@ export interface MessageParams extends MessageActions {
     deleteMessageEveryone: (conversation: Conversation, message: BaseMessage) => void;
   };
   messageRepository: MessageRepository;
-  onVisible?: (() => void) | null;
+  onVisible?: () => void;
   previousMessage?: BaseMessage;
   selfId: QualifiedId;
   shouldShowInvitePeople: boolean;

--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -55,7 +55,7 @@ interface MessagesListParams {
   cancelConnectionRequest: (message: MemberMessage) => void;
   conversation: Conversation;
   conversationRepository: ConversationRepository;
-  getVisibleCallback: (conversationEntity: Conversation, messageEntity: MessageEntity) => (() => void) | null;
+  getVisibleCallback: (conversationEntity: Conversation, messageEntity: MessageEntity) => (() => void) | undefined;
   initialMessage?: MessageEntity;
   invitePeople: (convesation: Conversation) => void;
   messageActions: {

--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -55,7 +55,7 @@ interface MessagesListParams {
   cancelConnectionRequest: (message: MemberMessage) => void;
   conversation: Conversation;
   conversationRepository: ConversationRepository;
-  getVisibleCallback: (conversationEntity: Conversation, messageEntity: MessageEntity) => (() => void) | undefined;
+  getVisibleCallback: (conversationEntity: Conversation, messageEntity: MessageEntity) => (() => void) | null;
   initialMessage?: MessageEntity;
   invitePeople: (convesation: Conversation) => void;
   messageActions: {
@@ -268,6 +268,7 @@ const MessagesList: FC<MessagesListParams> = ({
           const isLastDeliveredMessage = lastDeliveredMessage?.id === message.id;
 
           const visibleCallback = getVisibleCallback(conversation, message);
+
           const key = `${message.id || 'message'}-${message.timestamp()}`;
 
           return (

--- a/src/script/components/TitleBar/TitleBar.tsx
+++ b/src/script/components/TitleBar/TitleBar.tsx
@@ -183,9 +183,7 @@ export const TitleBar: React.FC<TitleBarProps> = ({
     };
   }, [isActivatedAccount, showAddParticipant, showDetails]);
 
-  const onClickCollectionButton = () => {
-    amplify.publish(WebAppEvents.CONTENT.SWITCH, ContentState.COLLECTION);
-  };
+  const onClickCollectionButton = () => amplify.publish(WebAppEvents.CONTENT.SWITCH, ContentState.COLLECTION);
 
   const onClickDetails = () => showDetails(false);
 
@@ -195,7 +193,10 @@ export const TitleBar: React.FC<TitleBarProps> = ({
   };
 
   return (
-    <ul id="conversation-title-bar" className="conversation-title-bar">
+    <ul
+      id="conversation-title-bar"
+      className={cx('conversation-title-bar', {'is-right-panel-open': isRightSidebarOpen})}
+    >
       <li className="conversation-title-bar-library">
         {smBreakpoint && (
           <IconButton

--- a/src/script/page/AppMain.tsx
+++ b/src/script/page/AppMain.tsx
@@ -68,7 +68,7 @@ const AppContainer: FC<AppContainerProps> = ({root}) => {
     const isDifferentState = currentState !== panelState;
     const isDifferentParams = newParamId !== currentParamId;
 
-    if (isDifferentState && isDifferentParams) {
+    if (isDifferentState || isDifferentParams) {
       goTo(panelState, params);
 
       return;

--- a/src/style/foundation/framework.less
+++ b/src/style/foundation/framework.less
@@ -63,6 +63,11 @@
     #conversation-input-bar,
     #conversation-title-bar {
       width: 100%;
+      transition: width @animation-timing-fast @ease-out-quart;
+
+      &.is-right-panel-open {
+        width: calc(100% - @right-width);
+      }
     }
   }
 


### PR DESCRIPTION
- Fix for opening Right Sidebar on clikc invite pepole.
- Add animations while right sidebar is opened - right sidebar overlapping title-bar and input-bar
- Propably fix for readed messages, more details in comment in there (Conversation.tsx)