### PR TITLE
runfix: prevent right sidebar from squishing input and titlebar

### DIFF
--- a/src/style/foundation/framework.less
+++ b/src/style/foundation/framework.less
@@ -65,8 +65,10 @@
       width: 100%;
       transition: width @animation-timing-fast @ease-out-quart;
 
-      &.is-right-panel-open {
-        width: calc(100% - @right-width);
+      @media (min-width: 1000px) {
+        &.is-right-panel-open {
+          width: calc(100% - @right-width);
+        }
       }
     }
   }


### PR DESCRIPTION
----
### Issue

- Right sidebar squishes input and titlebar when it should overlay

![Peek 2022-10-21 17-11](https://user-images.githubusercontent.com/78490891/197230672-7c979165-2c6f-4a8b-99ac-14ac18555430.gif)

### Solution

- Prevent squishing below the overlay breakpoint

![Peek 2022-10-21 17-12](https://user-images.githubusercontent.com/78490891/197231037-837c5cfa-a1f4-426c-b568-f3f9199e85b4.gif)

#### Note
That breakpoint is 5 years old and not part of the recent responsive changes