### PR TITLE
chore: Fix cakeinpanic/jira-description-action version

### DIFF
--- a/.github/workflows/jira-lint-and-link.yml
+++ b/.github/workflows/jira-lint-and-link.yml
@@ -6,10 +6,11 @@ jobs:
   add-jira-description:
     runs-on: ubuntu-latest
     steps:
-      - uses: cakeinpanic/jira-description-action@v1.2
+      - uses: cakeinpanic/jira-description-action@v0.3.2
         name: jira-description-action
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           jira-token: ${{ secrets.JIRA_TOKEN }}
           jira-base-url: https://wearezeta.atlassian.net
           skip-branches: '^(production-release|main|master|release\/v\d+)$' #optional
+          fail-when-jira-issue-not-found: false


### PR DESCRIPTION
This reverts commit 4678e30a4d6f5d390af387a3a5b57cf3fa043ba1.

v1.2 was released by mistake, see https://github.com/cakeinpanic/jira-description-action/issues/26