### PR TITLE
runfix: audio file previews don't match on sender and receiver side [FS-1021]

### DIFF
--- a/src/script/cryptography/CryptographyMapper.ts
+++ b/src/script/cryptography/CryptographyMapper.ts
@@ -361,7 +361,7 @@ export class CryptographyMapper {
   _mapAssetMetaData(original: Asset.IOriginal): MappedAssetMetaData | undefined {
     const audioData = original.audio;
     if (audioData) {
-      const loudnessArray = audioData.normalizedLoudness ? audioData.normalizedLoudness.buffer : new ArrayBuffer(0);
+      const loudnessArray = audioData.normalizedLoudness || new ArrayBuffer(0);
       const durationInSeconds = audioData.durationInMillis
         ? Number(audioData.durationInMillis) / TIME_IN_MILLIS.SECOND
         : 0;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1021" title="FS-1021" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1021</a>  [Web] When sending soundfiles, only the sender has the wave view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- for proteus conversations audio file previews display differently on sender and receiver side.
- for MLS conversations audio file previews do not appear at all on receiver side.

Proteus:
![before-proteus](https://user-images.githubusercontent.com/45733298/197523788-adb23162-20ec-40af-bf35-fb78caf02c10.png)

MLS:
![before-mls](https://user-images.githubusercontent.com/45733298/197523826-6a673123-572c-41ed-86a1-64198e21f027.png)



### Solutions

Instead of reading `.buffer` property from `audioData.normalizedLoudness`, we pass it straight to `new Uint8Array` constructor.

Proteus:
![after-proteus](https://user-images.githubusercontent.com/45733298/197524285-96f5d6c0-aa2e-47cc-8865-981a605a90e4.png)

MLS:
![after-mls](https://user-images.githubusercontent.com/45733298/197524306-eac34443-2abc-4f11-9cbc-cd7dca14388c.png)


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
