### PR TITLE
runfix: enable sending the same asset multiple times in a row

### DIFF
--- a/src/script/page/message-list/AssetUploadButton.test.tsx
+++ b/src/script/page/message-list/AssetUploadButton.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render, fireEvent} from '@testing-library/react';
+import {AssetUploadButton} from './AssetUploadButton';
+
+jest.mock('../../Config', () => ({
+  Config: {
+    getConfig: () => ({
+      ALLOWED_IMAGE_TYPES: ['image/gif', 'image/avif'],
+      FEATURE: {ALLOWED_FILE_UPLOAD_EXTENSIONS: ['*']},
+    }),
+  },
+}));
+
+const pngFile = new File(['(⌐□_□)'], 'chucknorris.png', {type: 'image/png'});
+
+describe('AssetUploadButton', () => {
+  it('Does call onSelectFiles with uploaded file', async () => {
+    const onSelectFiles = jest.fn();
+
+    const {getByTestId} = render(<AssetUploadButton onSelectFiles={onSelectFiles} />);
+
+    const fileInput = getByTestId('conversation-input-bar-files') as HTMLInputElement;
+    fireEvent.change(fileInput, {
+      target: {files: [pngFile]},
+    });
+
+    expect(onSelectFiles).toHaveBeenCalledWith([pngFile]);
+  });
+
+  it('Does reset file input after upload', async () => {
+    const onSelectFiles = jest.fn();
+
+    const {getByTestId} = render(<AssetUploadButton onSelectFiles={onSelectFiles} />);
+
+    const getFileInput = () => getByTestId('conversation-input-bar-files') as HTMLInputElement;
+    let fileInput = getFileInput();
+
+    fireEvent.change(fileInput, {
+      target: {files: [pngFile]},
+    });
+
+    expect(fileInput.files?.[0].name).toEqual(pngFile.name);
+    expect(onSelectFiles).toHaveBeenCalledWith([pngFile]);
+
+    //input did reset we grab new reference
+    fileInput = getFileInput();
+    expect(fileInput.files).toHaveLength(0);
+  });
+});

--- a/src/script/page/message-list/AssetUploadButton.test.tsx
+++ b/src/script/page/message-list/AssetUploadButton.test.tsx
@@ -32,12 +32,12 @@ jest.mock('../../Config', () => ({
 const pngFile = new File(['(⌐□_□)'], 'chucknorris.png', {type: 'image/png'});
 
 describe('AssetUploadButton', () => {
-  it('Does call onSelectFiles with uploaded file', async () => {
+  it('Does call onSelectFiles with uploaded file', () => {
     const onSelectFiles = jest.fn();
 
-    const {getByTestId} = render(<AssetUploadButton onSelectFiles={onSelectFiles} />);
+    const {container} = render(<AssetUploadButton onSelectFiles={onSelectFiles} />);
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
 
-    const fileInput = getByTestId('conversation-input-bar-files') as HTMLInputElement;
     fireEvent.change(fileInput, {
       target: {files: [pngFile]},
     });
@@ -45,23 +45,22 @@ describe('AssetUploadButton', () => {
     expect(onSelectFiles).toHaveBeenCalledWith([pngFile]);
   });
 
-  it('Does reset file input after upload', async () => {
+  it('Does reset a form with input after upload', () => {
     const onSelectFiles = jest.fn();
 
-    const {getByTestId} = render(<AssetUploadButton onSelectFiles={onSelectFiles} />);
+    const {container} = render(<AssetUploadButton onSelectFiles={onSelectFiles} />);
 
-    const getFileInput = () => getByTestId('conversation-input-bar-files') as HTMLInputElement;
-    let fileInput = getFileInput();
+    const form = container.querySelector('form');
+    jest.spyOn(form!, 'reset');
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
 
     fireEvent.change(fileInput, {
       target: {files: [pngFile]},
     });
 
-    expect(fileInput.files?.[0].name).toEqual(pngFile.name);
     expect(onSelectFiles).toHaveBeenCalledWith([pngFile]);
-
-    //input did reset we grab new reference
-    fileInput = getFileInput();
-    expect(fileInput.files).toHaveLength(0);
+    expect(fileInput.files?.[0].name).toEqual(pngFile.name);
+    expect(form!.reset).toHaveBeenCalled();
   });
 });

--- a/src/script/page/message-list/AssetUploadButton.tsx
+++ b/src/script/page/message-list/AssetUploadButton.tsx
@@ -1,0 +1,69 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {useState, useRef} from 'react';
+import {Config} from '../../Config';
+import {t} from 'Util/LocalizerUtil';
+import Icon from 'Components/Icon';
+
+interface AssetUploadButtonProps {
+  onSelectFiles: (files: File[]) => void;
+}
+
+export const AssetUploadButton = ({onSelectFiles}: AssetUploadButtonProps) => {
+  const [inputKey, setInputKey] = useState(Date.now());
+  const acceptedFileTypes = Config.getConfig().FEATURE.ALLOWED_FILE_UPLOAD_EXTENSIONS.join(',');
+  const fileRef = useRef<HTMLInputElement>(null!);
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const {files} = event.target;
+
+    if (!files) {
+      return;
+    }
+
+    onSelectFiles(Array.from(files));
+
+    //reset file input's value by re-rendering the component
+    setInputKey(Date.now());
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label={t('tooltipConversationFile')}
+      title={t('tooltipConversationFile')}
+      className="conversation-button controls-right-button no-radius file-button"
+      onClick={() => fileRef.current?.click()}
+      data-uie-name="do-share-file"
+    >
+      <Icon.Attachment />
+      <input
+        key={inputKey}
+        ref={fileRef}
+        accept={acceptedFileTypes ?? null}
+        id="conversation-input-bar-files"
+        data-uie-name="conversation-input-bar-files"
+        tabIndex={-1}
+        onChange={handleFileChange}
+        type="file"
+      />
+    </button>
+  );
+};

--- a/src/script/page/message-list/AssetUploadButton.tsx
+++ b/src/script/page/message-list/AssetUploadButton.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {useState, useRef} from 'react';
+import {useRef} from 'react';
 import {Config} from '../../Config';
 import {t} from 'Util/LocalizerUtil';
 import Icon from 'Components/Icon';
@@ -27,9 +27,9 @@ interface AssetUploadButtonProps {
 }
 
 export const AssetUploadButton = ({onSelectFiles}: AssetUploadButtonProps) => {
-  const [inputKey, setInputKey] = useState(Date.now());
   const acceptedFileTypes = Config.getConfig().FEATURE.ALLOWED_FILE_UPLOAD_EXTENSIONS.join(',');
   const fileRef = useRef<HTMLInputElement>(null!);
+  const formRef = useRef<HTMLFormElement>(null);
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const {files} = event.target;
@@ -40,30 +40,30 @@ export const AssetUploadButton = ({onSelectFiles}: AssetUploadButtonProps) => {
 
     onSelectFiles(Array.from(files));
 
-    //reset file input's value by re-rendering the component
-    setInputKey(Date.now());
+    //reset file input's value resetting form wrapper
+    formRef.current?.reset();
   };
 
   return (
-    <button
-      type="button"
-      aria-label={t('tooltipConversationFile')}
-      title={t('tooltipConversationFile')}
-      className="conversation-button controls-right-button no-radius file-button"
-      onClick={() => fileRef.current?.click()}
-      data-uie-name="do-share-file"
-    >
-      <Icon.Attachment />
-      <input
-        key={inputKey}
-        ref={fileRef}
-        accept={acceptedFileTypes ?? null}
-        id="conversation-input-bar-files"
-        data-uie-name="conversation-input-bar-files"
-        tabIndex={-1}
-        onChange={handleFileChange}
-        type="file"
-      />
-    </button>
+    <form ref={formRef}>
+      <button
+        type="button"
+        aria-label={t('tooltipConversationFile')}
+        title={t('tooltipConversationFile')}
+        className="conversation-button controls-right-button no-radius file-button"
+        onClick={() => fileRef.current?.click()}
+        data-uie-name="do-share-file"
+      >
+        <Icon.Attachment />
+        <input
+          ref={fileRef}
+          accept={acceptedFileTypes ?? null}
+          id="conversation-input-bar-files"
+          tabIndex={-1}
+          onChange={handleFileChange}
+          type="file"
+        />
+      </button>
+    </form>
   );
 };

--- a/src/script/page/message-list/InputBarControls/ControlButtons.tsx
+++ b/src/script/page/message-list/InputBarControls/ControlButtons.tsx
@@ -61,6 +61,15 @@ const ControlButtons: React.FC<ControlButtonsProps> = ({
 
   const pingTooltip = t('tooltipConversationPing');
 
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const {files} = event.target;
+    if (!files) {
+      return;
+    }
+    onSelectFiles(Array.from(files));
+    event.target.value = '';
+  };
+
   if (isEditing) {
     return (
       <li>
@@ -134,7 +143,7 @@ const ControlButtons: React.FC<ControlButtonsProps> = ({
                   accept={acceptedFileTypes ?? null}
                   id="conversation-input-bar-files"
                   tabIndex={-1}
-                  onChange={({target: {files}}) => files && onSelectFiles(Array.from(files))}
+                  onChange={handleFileChange}
                   type="file"
                 />
               </button>

--- a/src/script/page/message-list/InputBarControls/ControlButtons.tsx
+++ b/src/script/page/message-list/InputBarControls/ControlButtons.tsx
@@ -23,6 +23,7 @@ import MessageTimerButton from '../MessageTimerButton';
 import {t} from 'Util/LocalizerUtil';
 import {Conversation} from 'src/script/entity/Conversation';
 import {Config} from '../../../Config';
+import {AssetUploadButton} from '../AssetUploadButton';
 
 export type ControlButtonsProps = {
   input: string;
@@ -54,21 +55,10 @@ const ControlButtons: React.FC<ControlButtonsProps> = ({
   onClickGif,
 }) => {
   const acceptedImageTypes = Config.getConfig().ALLOWED_IMAGE_TYPES.join(',');
-  const acceptedFileTypes = Config.getConfig().FEATURE.ALLOWED_FILE_UPLOAD_EXTENSIONS.join(',');
 
   const imageRef = useRef<HTMLInputElement>(null!);
-  const fileRef = useRef<HTMLInputElement>(null!);
 
   const pingTooltip = t('tooltipConversationPing');
-
-  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const {files} = event.target;
-    if (!files) {
-      return;
-    }
-    onSelectFiles(Array.from(files));
-    event.target.value = '';
-  };
 
   if (isEditing) {
     return (
@@ -128,25 +118,7 @@ const ControlButtons: React.FC<ControlButtonsProps> = ({
             </li>
 
             <li>
-              <button
-                type="button"
-                aria-label={t('tooltipConversationFile')}
-                title={t('tooltipConversationFile')}
-                className="conversation-button controls-right-button no-radius file-button"
-                onClick={() => fileRef.current?.click()}
-                data-uie-name="do-share-file"
-              >
-                <Icon.Attachment />
-
-                <input
-                  ref={fileRef}
-                  accept={acceptedFileTypes ?? null}
-                  id="conversation-input-bar-files"
-                  tabIndex={-1}
-                  onChange={handleFileChange}
-                  type="file"
-                />
-              </button>
+              <AssetUploadButton onSelectFiles={onSelectFiles} />
             </li>
           </>
         )}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

User was not able to send the same asset two (or more) times in a row. 

The reason behind the issue was that the file input we are using to upload assets was not resetting after uploading a file, so when trying to upload the same file twice, `onChange` event was not triggered (input's `value` field was not changing).

The solution is to wrap the component with `<form>` element, and use it's native `.reset()` method. 

Before:
![asset-before](https://user-images.githubusercontent.com/45733298/197718876-d35a6991-f840-40ab-8e75-2fbd2f93f566.gif)

After:
![asset-after](https://user-images.githubusercontent.com/45733298/197718893-1c3ac16b-428e-45a3-90e4-0c1f70cba1ce.gif)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
