### PR TITLE
runfix: reset audioElement media after stopping [FS-1116]

### DIFF
--- a/src/script/audio/AudioRepository.ts
+++ b/src/script/audio/AudioRepository.ts
@@ -206,6 +206,7 @@ export class AudioRepository {
     if (!audioElement?.paused) {
       this.logger.info(`Stopping sound '${audioId}'`);
       audioElement.pause();
+      audioElement.load();
     }
   };
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1116" title="FS-1116" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1116</a>  [Web] User is able to play calling sound after ending a call.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Issue (funny one):

User was able to play calling audio sound after the call was ended (and probably some other sounds also) by using keyboard play shortcut or menu top-bar.

https://user-images.githubusercontent.com/45733298/198037606-0588d8bc-49c3-4b24-8c3b-aeaa8e02879c.mp4

## Cause
The reason behind the issue was the stop method we are using for stopping sound effects. The stop method uses `audio.pause()` method, so macOS want to do wire user a favour and let them play paused audio.

## Solution
The solution is to simply call `audio.load()` method after `audio.pause()`. Regarding to [MDN doc](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/load) this methods resets the media element to the initial state (not playing) and removes audio from macOS's quick access pause-play functionality.
<img width="764" alt="Screenshot 2022-10-26 at 15 16 35" src="https://user-images.githubusercontent.com/45733298/198039369-46e3ee2f-fb10-4ce8-99e3-5c3d68947f49.png">
