### PR TITLE
runfix: Closing right sidebar

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -67,7 +67,7 @@ interface ConversationListProps {
   readonly initialMessage?: Message;
   readonly teamState: TeamState;
   readonly userState: UserState;
-  openRightSidebar: (panelState: PanelState, params: RightSidebarParams) => void;
+  openRightSidebar: (panelState: PanelState, params: RightSidebarParams, compareEntityId?: boolean) => void;
   isRightSidebarOpen?: boolean;
 }
 
@@ -159,9 +159,9 @@ const ConversationList: FC<ConversationListProps> = ({
     const serviceEntity = userEntity.isService && (await repositories.integration.getServiceFromUser(userEntity));
 
     if (serviceEntity) {
-      openRightSidebar(panelId, {entity: {...serviceEntity, id: userEntity.id}});
+      openRightSidebar(panelId, {entity: {...serviceEntity, id: userEntity.id}}, true);
     } else {
-      openRightSidebar(panelId, {entity: userEntity});
+      openRightSidebar(panelId, {entity: userEntity}, true);
     }
   };
 

--- a/src/script/components/TitleBar/TitleBar.tsx
+++ b/src/script/components/TitleBar/TitleBar.tsx
@@ -51,7 +51,7 @@ import {ViewModelRepositories} from '../../view_model/MainViewModel';
 export interface TitleBarProps {
   callActions: CallActions;
   conversation: Conversation;
-  openRightSidebar: (panelState: PanelState, params: RightSidebarParams) => void;
+  openRightSidebar: (panelState: PanelState, params: RightSidebarParams, compareEntityId?: boolean) => void;
   repositories: ViewModelRepositories;
   userState: UserState;
   teamState: TeamState;

--- a/src/script/page/AppMain.tsx
+++ b/src/script/page/AppMain.tsx
@@ -61,10 +61,11 @@ const AppContainer: FC<AppContainerProps> = ({root}) => {
   const {history, entity: currentEntity, clearHistory, goTo} = useAppMainState(state => state.rightSidebar);
   const currentState = history.at(-1);
 
-  const toggleRightSidebar = (panelState: PanelState, params: RightSidebarParams) => {
+  const toggleRightSidebar = (panelState: PanelState, params: RightSidebarParams, compareEntityId = false) => {
     const isDifferentState = currentState !== panelState;
+    const isDifferentId = compareEntityId && currentEntity?.id !== params?.entity?.id;
 
-    if (isDifferentState) {
+    if (isDifferentId || isDifferentState) {
       goTo(panelState, params);
 
       return;
@@ -87,9 +88,11 @@ const AppContainer: FC<AppContainerProps> = ({root}) => {
             {(!smBreakpoint || isLeftSidebarVisible) && (
               <LeftSidebar listViewModel={root.list} selfUser={selfUser} isActivatedAccount={isActivatedAccount} />
             )}
+
             {(!smBreakpoint || !isLeftSidebarVisible) && (
               <MainContent isRightSidebarOpen={!!currentState} openRightSidebar={toggleRightSidebar} />
             )}
+
             {currentState && (
               <RightSidebar
                 currentEntity={currentEntity}

--- a/src/script/page/MainContent/MainContent.tsx
+++ b/src/script/page/MainContent/MainContent.tsx
@@ -53,7 +53,7 @@ const Animated: FC<{children: ReactNode}> = ({children, ...rest}) => (
 );
 
 interface MainContentProps {
-  openRightSidebar: (panelState: PanelState, params: RightSidebarParams) => void;
+  openRightSidebar: (panelState: PanelState, params: RightSidebarParams, compareEntityId?: boolean) => void;
   isRightSidebarOpen?: boolean;
   conversationState?: ConversationState;
 }


### PR DESCRIPTION
Fix for toggle right sidebar when user click on user details.

Previous:
User click on different user when have open user - it closing right sidebar.

Now:
User click on different user when have open user - right sidebar changing details for clicked user.