### PR TITLE
runfix: Scroll to new elements when switching conversation

### DIFF
--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -173,6 +173,10 @@ const MessagesList: FC<MessagesListParams> = ({
   const focusedElement = useRef<FocusedElement | null>(null);
   const conversationLastReadTimestamp = useRef(conversation.last_read_timestamp());
 
+  useEffect(() => {
+    conversationLastReadTimestamp.current = conversation.last_read_timestamp();
+  }, [conversation]);
+
   const updateScroll = (container: Element | null) => {
     const scrollingContainer = container?.parentElement;
 

--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -173,10 +173,6 @@ const MessagesList: FC<MessagesListParams> = ({
   const focusedElement = useRef<FocusedElement | null>(null);
   const conversationLastReadTimestamp = useRef(conversation.last_read_timestamp());
 
-  useEffect(() => {
-    conversationLastReadTimestamp.current = conversation.last_read_timestamp();
-  }, [conversation]);
-
   const updateScroll = (container: Element | null) => {
     const scrollingContainer = container?.parentElement;
 
@@ -247,6 +243,7 @@ const MessagesList: FC<MessagesListParams> = ({
   useEffect(() => {
     onLoading(true);
     setLoaded(false);
+    conversationLastReadTimestamp.current = conversation.last_read_timestamp();
     loadConversation(conversation, initialMessage).then(() => {
       setTimeout(() => {
         setLoaded(true);

--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -242,6 +242,7 @@ const MessagesList: FC<MessagesListParams> = ({
 
   useEffect(() => {
     onLoading(true);
+    setLoaded(false);
     loadConversation(conversation, initialMessage).then(() => {
       setTimeout(() => {
         setLoaded(true);


### PR DESCRIPTION
There are actually 2 problems that are fixed by this PR. 
The reason for both problems is the same: The `<MessageList>` component always stays on the DOM. 

Previously, it was removed from the DOM and re-added (and thus we would get a fresh new state from it).
Now it's living "forever" in the DOM and is just updated with new conversation when we switch between conversations. 

This fix with reset default states when conversation are switched