### PR TITLE
runfix: Display notification status in right sidebar

### DIFF
--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
@@ -166,7 +166,8 @@ const ConversationDetails: FC<ConversationDetailsProps> = ({
 
   const guestOptionsText = isTeamOnly ? t('conversationDetailsOff') : t('conversationDetailsOn');
   const servicesOptionsText = isServicesRoom ? t('conversationDetailsOn') : t('conversationDetailsOff');
-  const notificationStatusText = notificationState ? getNotificationText(notificationState) : '';
+
+  const notificationStatusText = getNotificationText(notificationState);
   const timedMessagesText =
     hasTimer && globalMessageTimer ? formatDuration(globalMessageTimer).text : t('ephemeralUnitsNone');
 


### PR DESCRIPTION
When Notification status is 0, code not checks this status, because 0 is falsy value.
We have always notificationStatus so we don't need to check if exist.

Previous:
![image](https://user-images.githubusercontent.com/13432884/198232513-a2987784-5c63-4167-95fb-f6ba250fd8f2.png)

Now:
![image](https://user-images.githubusercontent.com/13432884/198232414-45cfd2dc-e8f2-43a5-a57f-494c8ae31198.png)
