### PR TITLE
runfix: address design review of preferences margins [ACC-64]

### DIFF
--- a/src/style/content/preferences.less
+++ b/src/style/content/preferences.less
@@ -50,7 +50,11 @@ body.theme-dark {
   overflow-x: hidden;
 
   @media (max-width: @screen-md-min) {
-    padding: 10px;
+    padding: 40px;
+  }
+
+  @media (max-width: @screen-sm) {
+    padding: 20px;
   }
 
   input {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-64" title="ACC-64" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-64</a>  Settings View
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
### Issue

- There's too little padding for preference content, especially at the higher width of responsive view
![image](https://user-images.githubusercontent.com/78490891/198575498-077eb923-5c3d-4583-b684-414eba6ba40e.png)

### Solution

- adjust padding and add a breakpoint 
![Screenshot from 2022-10-28 13-18-27](https://user-images.githubusercontent.com/78490891/198575640-97b58368-9fca-4766-8ee9-8a25786a66da.png)
