### PR TITLE
runfix: add convo protocol details back

### DIFF
--- a/src/script/components/panel/ConversationProtocolDetails/ConversationProtocolDetails.test.tsx
+++ b/src/script/components/panel/ConversationProtocolDetails/ConversationProtocolDetails.test.tsx
@@ -31,7 +31,7 @@ describe('ConversationProtocolDetails', () => {
 
     const {queryByText} = render(<ConversationProtocolDetails {...props} />);
 
-    expect(queryByText('mls')).not.toBeNull();
+    expect(queryByText('MLS')).not.toBeNull();
     expect(queryByText('MLS_128_DHKEMP256_AES128GCM_SHA256_P256')).not.toBeNull();
   });
 
@@ -42,6 +42,6 @@ describe('ConversationProtocolDetails', () => {
 
     const {queryByText} = render(<ConversationProtocolDetails {...props} />);
 
-    expect(queryByText('proteus')).not.toBeNull();
+    expect(queryByText('PROTEUS')).not.toBeNull();
   });
 });

--- a/src/script/components/panel/ConversationProtocolDetails/ConversationProtocolDetails.tsx
+++ b/src/script/components/panel/ConversationProtocolDetails/ConversationProtocolDetails.tsx
@@ -81,14 +81,14 @@ const wrapperStyles: CSSObject = {
 
 const ConversationProtocolDetails: React.FC<ConversationProtocolDetailsProps> = ({protocol, cipherSuite}) => {
   return (
-    <>
+    <div>
       <div className="conversation-details__list-head">{t('conversationDetailsProtocolDetails')}</div>
       <div css={wrapperStyles}>
         <div css={titleStyles}>Protocol</div>
         <div css={subTitleStyles} data-uie-name="protocol-name">
-          {protocol}
+          {protocol.toUpperCase()}
         </div>
-        {protocol.toLocaleLowerCase() === ConversationProtocol.MLS && cipherSuite && (
+        {protocol === ConversationProtocol.MLS && cipherSuite && (
           <>
             <div css={titleStyles}>Cipher Suite</div>
             <div css={subTitleStyles} data-uie-name="cipher-suite">
@@ -97,7 +97,7 @@ const ConversationProtocolDetails: React.FC<ConversationProtocolDetailsProps> = 
           </>
         )}
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
@@ -22,6 +22,7 @@ import {FC, useCallback, useEffect, useMemo, useState} from 'react';
 import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data/';
 
 import {Icon} from 'Components/Icon';
+import {ConversationProtocolDetails} from 'Components/panel/ConversationProtocolDetails/ConversationProtocolDetails';
 import {PanelActions} from 'Components/panel/PanelActions';
 import {ServiceDetails} from 'Components/panel/ServiceDetails';
 import {ServiceList} from 'Components/ServiceList';
@@ -409,6 +410,11 @@ const ConversationDetails: FC<ConversationDetailsProps> = ({
             <PanelActions items={conversationActions} />
           </>
         )}
+
+        <ConversationProtocolDetails
+          protocol={activeConversation.protocol}
+          cipherSuite={activeConversation.cipherSuite}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
Add ConversationProtocolDetails component back to the right sidebar after it was lost during knockout -> react migration.