### PR TITLE
chore: Use browserslist config for all transpilers

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,4 @@
+chrome >= 51
+firefox >= 60
+edge >= 15
+opera >= 43

--- a/babel.config.js
+++ b/babel.config.js
@@ -21,9 +21,6 @@ const presetEnvConfig = {
   corejs: 'core-js>=3.a',
   debug: false,
   modules: false,
-  targets: {
-    browsers: ['chrome >= 51', 'firefox >= 60', 'edge >= 15', 'opera >= 43'],
-  },
   useBuiltIns: 'usage',
 };
 

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -77,15 +77,7 @@ module.exports = {
             loader: 'postcss-loader',
             options: {
               postcssOptions: {
-                plugins: [
-                  [
-                    'autoprefixer',
-                    {
-                      browsers: ['Chrome >= 51', 'Edge >= 14', 'Firefox >= 52', 'Opera >= 40'],
-                    },
-                  ],
-                  [require('cssnano')()],
-                ],
+                plugins: [['autoprefixer'], [require('cssnano')()]],
               },
             },
           },


### PR DESCRIPTION
Will harmonize our config for supporting browser into a single file. 
This config will apply to babel, autoprefixer or any transpiler that helps with supporting old browsers :) 

It will also remove this warning
![image](https://user-images.githubusercontent.com/1090716/199545091-57fbadf1-1d2b-437e-8e7b-7a9ad78ff3e4.png)
