### PR TITLE
chore: fine tune sourcemap generation for dev

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,6 @@
     },
     "resolveJsonModule": true,
     "rootDirs": ["src/script"],
-    "sourceMap": true,
     "target": "es2017",
     "typeRoots": ["src/types", "node_modules/@types", "node_modules/amplify/typings"],
     "strict": true

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -69,7 +69,6 @@ module.exports = {
           {
             loader: 'css-loader',
             options: {
-              sourceMap: true,
               url: false,
             },
           },
@@ -81,12 +80,7 @@ module.exports = {
               },
             },
           },
-          {
-            loader: 'less-loader',
-            options: {
-              sourceMap: true,
-            },
-          },
+          {loader: 'less-loader'},
         ],
       },
     ],

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -27,6 +27,7 @@ const srcScript = 'src/script/';
 
 module.exports = {
   ...commonConfig,
+  devtool: 'eval-source-map',
   entry: {
     ...commonConfig.entry,
     app: ['webpack-hot-middleware/client?reload=true', path.resolve(__dirname, srcScript, 'main/app.ts')],
@@ -34,8 +35,8 @@ module.exports = {
   },
   mode: 'development',
   plugins: [...commonConfig.plugins, new webpack.HotModuleReplacementPlugin()],
-  resolve: {...commonConfig.resolve, alias: {...commonConfig.resolve.alias}},
   snapshot: {
+    // This will make sure that changes in the node_modules will be detected and recompiled automatically (when using yalc for example)
     managedPaths: [],
   },
 };


### PR DESCRIPTION
SourceMaps are expensive to generate. This will fine tune the source map generation for dev. 
This trim ~50ms of rebuild time on my Mac M2 computer. 

see https://webpack.js.org/configuration/devtool/ for explanation