### PR TITLE
runfix: correct input bar background color for replies and pasted files

### DIFF
--- a/src/style/content/conversation/input-bar.less
+++ b/src/style/content/conversation/input-bar.less
@@ -221,7 +221,7 @@
   animation-fill-mode: forwards;
   animation-name: paste-fade-in;
   animation-timing-function: @ease-out-expo;
-  background-color: var(--app-bg-secondary);
+  background-color: var(--input-bar-bg);
   opacity: 0;
 }
 
@@ -323,7 +323,7 @@
   width: 100%;
   padding: 12px 16px 0 30px;
   animation: reply-box 0.15s ease-out;
-  background-color: var(--app-bg-secondary);
+  background-color: var(--input-bar-bg);
   fill: var(--main-color);
 
   .close-icon {


### PR DESCRIPTION
----

### Issues

- Background color of replies and pasted files is different from input bar's in dark mode
 
![image](https://user-images.githubusercontent.com/78490891/199699685-fa0ea88d-3387-47c6-8cb9-7e38b821c4e8.png)
![Screenshot from 2022-11-03 11-27-35](https://user-images.githubusercontent.com/78490891/199699770-660819b2-6a04-4a90-b2ae-704ac57e97eb.png)

### Correction

![image](https://user-images.githubusercontent.com/78490891/199699928-79b1f549-4caf-483f-a1e9-2862be69d727.png)
![image](https://user-images.githubusercontent.com/78490891/199700020-96044ae6-a2f2-41fb-aabc-84633e449c90.png)
