### PR TITLE
chore: add regressiontest for punycode links (WEBAPP-6078)

### DIFF
--- a/test/unit_tests/util/messageRendererSpec.js
+++ b/test/unit_tests/util/messageRendererSpec.js
@@ -242,6 +242,18 @@ describe('renderMessage', () => {
     );
   });
 
+  it('conversts unicode links to punycode', () => {
+    expect(renderMessage('https://müller.de')).toBe(
+      // if this test fails because the rendering of the url was changed to no longer display unicode characters urlescaped,
+      // then the output should be the same as the second test, to make the user aware of the fact that it is a punycode url aka "url open info popup"
+      `<a href="https://xn--mller-kva.de" target="_blank" rel="nofollow noopener noreferrer">https://m%C3%BCller.de</a>`,
+    );
+
+    expect(renderMessage('[https://müller.de](https://müller.de)')).toBe(
+      `<a href="https://xn--mller-kva.de" target="_blank" rel="nofollow noopener noreferrer" data-md-link=\"true\" data-uie-name=\"markdown-link\">https://müller.de</a>`,
+    );
+  });
+
   describe('Mentions', () => {
     const tests = [
       {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WEBAPP-6078" title="WEBAPP-6078" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WEBAPP-6078</a>  Regular links can contain punycode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Adds a regression test to make sure, the output of punycode links stays the same