### PR TITLE
runfix: correct left sidebar width

### DIFF
--- a/src/script/components/ConnectRequests/index.tsx
+++ b/src/script/components/ConnectRequests/index.tsx
@@ -50,7 +50,7 @@ const ConnectRequests: FC<ConnectRequestsProps> = ({
   const {connectRequests} = useKoSubscribableChildren(userState, ['connectRequests']);
 
   // To be changed when design chooses a breakpoint, the conditional can be integrated to the ui-kit directly
-  const smBreakpoint = useMatchMedia('max-width: 620px');
+  const smBreakpoint = useMatchMedia('max-width: 640px');
 
   const {setCurrentView} = useAppMainState(state => state.responsiveView);
 

--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -101,7 +101,7 @@ const ConversationList: FC<ConversationListProps> = ({
   const {activeCalls} = useKoSubscribableChildren(callState, ['activeCalls']);
 
   // To be changed when design chooses a breakpoint, the conditional can be integrated to the ui-kit directly
-  const smBreakpoint = useMatchMedia('max-width: 620px');
+  const smBreakpoint = useMatchMedia('max-width: 640px');
 
   useEffect(() => {
     if (readMessagesBuffer.length) {

--- a/src/script/components/TitleBar/TitleBar.tsx
+++ b/src/script/components/TitleBar/TitleBar.tsx
@@ -137,7 +137,7 @@ export const TitleBar: React.FC<TitleBarProps> = ({
 
   // To be changed when design chooses a breakpoint, the conditional can be integrated to the ui-kit directly
   const mdBreakpoint = useMatchMedia('max-width: 768px');
-  const smBreakpoint = useMatchMedia('max-width: 620px');
+  const smBreakpoint = useMatchMedia('max-width: 640px');
 
   const {setCurrentView: setView} = useAppMainState(state => state.responsiveView);
 

--- a/src/script/page/AppMain.tsx
+++ b/src/script/page/AppMain.tsx
@@ -76,7 +76,7 @@ const AppContainer: FC<AppContainerProps> = ({root}) => {
   };
 
   // To be changed when design chooses a breakpoint, the conditional can be integrated to the ui-kit directly
-  const smBreakpoint = useMatchMedia('max-width: 620px');
+  const smBreakpoint = useMatchMedia('max-width: 640px');
 
   const {currentView} = useAppMainState(state => state.responsiveView);
   const isLeftSidebarVisible = currentView == ViewType.LEFT_SIDEBAR;

--- a/src/script/page/MainContent/panels/preferences/components/PreferencesPage.tsx
+++ b/src/script/page/MainContent/panels/preferences/components/PreferencesPage.tsx
@@ -32,7 +32,7 @@ interface PreferencesPageProps {
 
 const PreferencesPage: React.FC<PreferencesPageProps> = ({title, children}) => {
   // To be changed when design chooses a breakpoint, the conditional can be integrated to the ui-kit directly
-  const smBreakpoint = useMatchMedia('max-width: 620px');
+  const smBreakpoint = useMatchMedia('max-width: 640px');
 
   const {currentView, setCurrentView} = useAppMainState(state => state.responsiveView);
   const isCentralColumn = currentView == ViewType.CENTRAL_COLUMN;

--- a/src/style/common/variables.less
+++ b/src/style/common/variables.less
@@ -172,7 +172,7 @@
 @teams-width: 78px;
 
 @conversation-list-color: #fff;
-@conversation-list-width: 300px;
+@conversation-list-width: 320px;
 
 @right-width: 304px;
 @panel-content-min-height: 150px;

--- a/src/style/foundation/framework.less
+++ b/src/style/foundation/framework.less
@@ -110,7 +110,7 @@
   }
 
   // @media (max-width: calc(@screen-sm-min*2)) {
-  @media (max-width: 620px) {
+  @media (max-width: 640px) {
     .left-column {
       width: 100%;
     }

--- a/src/style/foundation/framework.less
+++ b/src/style/foundation/framework.less
@@ -109,8 +109,7 @@
     top: 64px;
   }
 
-  // @media (max-width: calc(@screen-sm-min*2)) {
-  @media (max-width: 640px) {
+  @media (max-width: calc(@screen-sm-min*2)) {
     .left-column {
       width: 100%;
     }


### PR DESCRIPTION
----
### Issue

- A change in sidebar's width introduces horizontal scrolling after archiving convos
![image](https://user-images.githubusercontent.com/78490891/199759297-8e95c5b1-f930-4ce7-8dc3-ff7f4417cd3d.png)

### Solution

- revert sidebar's width to the original 320px


#### Additionally

- The temporary breakpoint for the sidebar collapse needs to be changed (sidebar-width + 320px)
- The width was changed unintentionally