### PR TITLE
runfix: show full call ui in sidebar for temporary guests

### DIFF
--- a/src/script/page/LeftSidebar/panels/TemporatyGuestConversations.tsx
+++ b/src/script/page/LeftSidebar/panels/TemporatyGuestConversations.tsx
@@ -81,7 +81,8 @@ const TemporaryGuestConversations: React.FC<TemporaryGuestConversations> = ({
               data-uie-value={conversation.display_name()}
               call={call}
               conversation={conversation}
-              temporaryUserStyle={true}
+              temporaryUserStyle
+              isFullUi
               isSelfVerified={false}
               callActions={callingViewModel.callActions}
               callingRepository={callingViewModel.callingRepository}


### PR DESCRIPTION
----

### Issue

- The calling cell for temporary guests is missing the video tile and most of the call controls

### Cause

- The calling cell component have a new variant that only display the answering call controls

### Solution

- The component was missing the prop that displays the entire call ui