### PR TITLE
runfix: Address emoji picker styles

### DIFF
--- a/src/script/components/Emoji/EmojiItem.styles.ts
+++ b/src/script/components/Emoji/EmojiItem.styles.ts
@@ -1,0 +1,48 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {CSSObject} from '@emotion/react';
+
+export const symbolStyle: CSSObject = {
+  fontSize: '1.1em',
+  paddingRight: '12px',
+};
+
+export const nameStyle: CSSObject = {
+  '&::first-letter': {
+    textTransform: 'capitalize',
+  },
+};
+
+export const itemStyle: CSSObject = {
+  '&.selected': {
+    backgroundColor: 'var(--foreground-fade-16)',
+  },
+  '&:first-of-type': {
+    borderRadius: '4px 4px 0 0', // to match parent border-radius
+  },
+  '&:last-of-type': {
+    borderRadius: '0 0 4px 4px', // to match parent border-radius
+  },
+  alignItems: 'flex-start',
+  display: 'flex',
+  flexDirection: 'row',
+  padding: '10px 12px',
+  width: '100%',
+};

--- a/src/script/components/Emoji/EmojiItem.tsx
+++ b/src/script/components/Emoji/EmojiItem.tsx
@@ -39,7 +39,6 @@ const EmojiItem: FC<EmojiItemProps> = ({emoji, onClick, onMouseEnter, selectedEm
     onMouseEnter={onMouseEnter}
     onClick={onClick}
     aria-label={emoji.name}
-    tabIndex={0}
   >
     <span css={symbolStyle}>{emoji.icon}</span>
     <span css={nameStyle}>{emoji.name}</span>

--- a/src/script/components/Emoji/EmojiItem.tsx
+++ b/src/script/components/Emoji/EmojiItem.tsx
@@ -21,6 +21,7 @@ import {FC} from 'react';
 
 import cx from 'classnames';
 
+import {itemStyle, symbolStyle, nameStyle} from './EmojiItem.styles';
 import {EmojiListItem} from './useEmoji';
 
 interface EmojiItemProps {
@@ -33,15 +34,15 @@ interface EmojiItemProps {
 const EmojiItem: FC<EmojiItemProps> = ({emoji, onClick, onMouseEnter, selectedEmoji = false}) => (
   <button
     type="button"
-    className={cx('button-reset-default emoji', {selected: selectedEmoji})}
-    css={{alignItems: 'flex-start', display: 'flex', flexDirection: 'column', width: '100%'}}
+    className={cx('button-reset-default', {selected: selectedEmoji})}
+    css={itemStyle}
     onMouseEnter={onMouseEnter}
     onClick={onClick}
     aria-label={emoji.name}
     tabIndex={0}
   >
-    <span className="symbol">{emoji.icon}</span>
-    <span className="name">{emoji.name}</span>
+    <span css={symbolStyle}>{emoji.icon}</span>
+    <span css={nameStyle}>{emoji.name}</span>
   </button>
 );
 

--- a/src/style/content/conversation/input-bar.less
+++ b/src/style/content/conversation/input-bar.less
@@ -280,42 +280,6 @@
   font-size: 12px;
   font-weight: @font-weight-regular;
   line-height: @line-height-xl;
-
-  .emoji {
-    cursor: pointer;
-
-    &:first-child {
-      border-radius: 4px 4px 0 0; // to match parent border-radius
-    }
-
-    &:last-child {
-      border-radius: 0 0 4px 4px; // to match parent border-radius
-    }
-
-    &.selected {
-      background-color: var(--foreground-fade-16);
-    }
-
-    .symbol {
-      position: absolute;
-      display: inline-block;
-      padding-left: 12px;
-      font-size: @font-size-sm;
-      text-align: center;
-      vertical-align: middle;
-    }
-
-    .name {
-      display: inline-block;
-      padding-right: 16px;
-      margin-left: 40px;
-      vertical-align: middle;
-
-      &::first-letter {
-        text-transform: capitalize;
-      }
-    }
-  }
 }
 
 .input-bar__reply {


### PR DESCRIPTION
This PR fixes the display of the emoji picker than was broken since https://github.com/wireapp/wire-webapp/pull/13493

It also modernizes the styles and migrate them to css-in-js

Before 
![image](https://user-images.githubusercontent.com/1090716/199782657-0fc4bd98-c962-4c8c-b47d-9b1cf31b4fd9.png)

After 
![image](https://user-images.githubusercontent.com/1090716/199782763-3df7e88e-6358-4c2d-9ea1-8ad76e4411bb.png)
