### PR TITLE
runfix: prevent horizontal scrolling on left sidebar

### DIFF
--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -54,7 +54,6 @@
   .label-small-medium;
   display: flex;
   width: 100%;
-  min-width: 76px;
   height: 100%;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
----
### Issue
- On mac OS, elements of the footer do not fit the sidebar's width
![Wire 2022-11-04 at 13-00-52](https://user-images.githubusercontent.com/78490891/199978576-81b2d6fa-976b-4b9a-8d50-446c1c4c2687.gif)

### Cause
- The min-witdh of the footer buttons is too high, leaving only a few pixels of leeway, system font on mac OS makes the conversation button juuust too wide

### Solution 
- I don't see any reason to keep a min width on the footer buttons, their width is responsive anyway.