### PR TITLE
runfix: prevent av select overflow in between breakpoints

### DIFF
--- a/src/style/common/variables.less
+++ b/src/style/common/variables.less
@@ -291,7 +291,7 @@ body {
 @screen-sm-min: 320px;
 @screen-sm: 480px;
 @screen-md-min: 768px;
-@screen-lg-min: 920px;
+@screen-lg-min: 960px;
 
 @screen-height-sm: 420px;
 

--- a/src/style/components/input-level.less
+++ b/src/style/components/input-level.less
@@ -34,6 +34,12 @@
     background-color: #fff;
     transition: all 0.16s;
 
+    @media (max-width: calc(@conversation-list-width + @screen-sm)) {
+      .circle(@input-level-bullet-size-sm);
+    }
+    @media (max-width: calc(@screen-sm-min * 2)) {
+      .circle(@input-level-bullet-size);
+    }
     @media (max-width: @screen-sm) {
       .circle(@input-level-bullet-size-sm);
     }


### PR DESCRIPTION
----

### Issue
- Mic select overflows because of the input level dots at some breakpoints
- A change to the sidebar's width needs to be reflected in the responsive breakpoint for preferences

![Peek 2022-11-04 15-32](https://user-images.githubusercontent.com/78490891/200000675-aa19c12a-e1dc-4ab3-b00a-98c46e56e78a.gif)

### Solution
- Introduce media queries for the in-between breakpoints
- change the relevant breakpoint

![Peek 2022-11-04 15-31](https://user-images.githubusercontent.com/78490891/200000351-7954b535-cacd-4c6e-b288-64116b690c93.gif)
