### PR TITLE
runfix: Init apiClient version before initializing the app

### DIFF
--- a/src/script/components/AppContainer/AppContainer.tsx
+++ b/src/script/components/AppContainer/AppContainer.tsx
@@ -36,7 +36,7 @@ interface AppProps {
 }
 
 export const AppContainer: FC<AppProps> = ({config, clientType}) => {
-  const app = new App(container.resolve(Core), container.resolve(APIClient));
+  const app = new App(container.resolve(Core), container.resolve(APIClient), config);
   const mainView = new MainViewModel(app.repository);
 
   return (

--- a/src/script/components/AppContainer/AppContainer.tsx
+++ b/src/script/components/AppContainer/AppContainer.tsx
@@ -40,7 +40,7 @@ export const AppContainer: FC<AppProps> = ({config, clientType}) => {
   const mainView = new MainViewModel(app.repository);
 
   return (
-    <AppLoader init={onProgress => app.initApp(clientType, config, onProgress)}>
+    <AppLoader init={onProgress => app.initApp(clientType, onProgress)}>
       {selfUser => <AppMain app={app} selfUser={selfUser} mainView={mainView} />}
     </AppLoader>
   );

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -52,7 +52,7 @@ import {CacheRepository} from '../cache/CacheRepository';
 import {CallingRepository} from '../calling/CallingRepository';
 import {ClientRepository} from '../client/ClientRepository';
 import {ClientService} from '../client/ClientService';
-import {Config, Configuration} from '../Config';
+import {Config} from '../Config';
 import {ConnectionRepository} from '../connection/ConnectionRepository';
 import {ConnectionService} from '../connection/ConnectionService';
 import {ConversationRepository} from '../conversation/ConversationRepository';
@@ -349,13 +349,7 @@ export class App {
    * @param config
    * @param onProgress
    */
-  async initApp(
-    clientType: ClientType,
-    config: Configuration,
-    onProgress: (progress: number, message?: string) => void,
-  ) {
-    await this.apiClient.useVersion(config.SUPPORTED_API_VERSIONS);
-
+  async initApp(clientType: ClientType, onProgress: (progress: number, message?: string) => void) {
     // add body information
     const osCssClass = Runtime.isMacOS() ? 'os-mac' : 'os-pc';
     const platformCssClass = Runtime.isDesktopApp() ? 'platform-electron' : 'platform-web';

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -52,7 +52,7 @@ import {CacheRepository} from '../cache/CacheRepository';
 import {CallingRepository} from '../calling/CallingRepository';
 import {ClientRepository} from '../client/ClientRepository';
 import {ClientService} from '../client/ClientService';
-import {Config} from '../Config';
+import {Configuration} from '../Config';
 import {ConnectionRepository} from '../connection/ConnectionRepository';
 import {ConnectionService} from '../connection/ConnectionService';
 import {ConversationRepository} from '../conversation/ConversationRepository';
@@ -167,7 +167,12 @@ export class App {
    * @param core
    * @param apiClient Configured backend client
    */
-  constructor(private readonly core: Core, private readonly apiClient: APIClient) {
+  constructor(
+    private readonly core: Core,
+    private readonly apiClient: APIClient,
+    private readonly config: Configuration,
+  ) {
+    this.config = config;
     this.apiClient.on(APIClient.TOPIC.ON_LOGOUT, () => this.logout(SIGN_OUT_REASON.SESSION_EXPIRED, false));
     this.logger = getLogger('App');
 
@@ -176,7 +181,7 @@ export class App {
     this.service = this._setupServices();
     this.repository = this._setupRepositories();
 
-    if (Config.getConfig().FEATURE.ENABLE_DEBUG) {
+    if (config.FEATURE.ENABLE_DEBUG) {
       import('Util/DebugUtil').then(({DebugUtil}) => {
         this.debug = new DebugUtil(this.repository);
         this.util = {debug: this.debug}; // Alias for QA
@@ -456,7 +461,7 @@ export class App {
 
       await eventRepository.connectWebSocket(this.core, ({done, total}) => {
         const baseMessage = t('initDecryption');
-        const extraInfo = Config.getConfig().FEATURE.SHOW_LOADING_INFORMATION
+        const extraInfo = this.config.FEATURE.SHOW_LOADING_INFORMATION
           ? ` ${t('initProgress', {number1: done.toString(), number2: total.toString()})}`
           : '';
 
@@ -469,7 +474,7 @@ export class App {
 
       eventTrackerRepository.init(propertiesRepository.properties.settings.privacy.telemetry_sharing);
       await conversationRepository.initializeConversations();
-      onProgress(97.5, t('initUpdatedFromNotifications', Config.getConfig().BRAND_NAME));
+      onProgress(97.5, t('initUpdatedFromNotifications', this.config.BRAND_NAME));
 
       const clientEntities = await clientRepository.updateClientsForSelf();
 

--- a/src/script/main/index.tsx
+++ b/src/script/main/index.tsx
@@ -22,6 +22,7 @@ import 'core-js/full/reflect';
 import {ClientType} from '@wireapp/api-client/lib/client/';
 import {Runtime} from '@wireapp/commons';
 import {createRoot} from 'react-dom/client';
+import {container} from 'tsyringe';
 
 import {AppContainer} from 'Components/AppContainer/AppContainer';
 import {enableLogging} from 'Util/LoggerUtil';
@@ -32,10 +33,14 @@ import {doRedirect} from './app';
 
 import {SIGN_OUT_REASON} from '../auth/SignOutReason';
 import {Config} from '../Config';
+import {APIClient} from '../service/APIClientSingleton';
 import {StorageKey} from '../storage';
 
 document.addEventListener('DOMContentLoaded', async () => {
+  const apiClient = container.resolve(APIClient);
   const config = Config.getConfig();
+  await apiClient.useVersion(config.SUPPORTED_API_VERSIONS);
+
   enableLogging(config.FEATURE.ENABLE_DEBUG);
   exposeWrapperGlobals();
 


### PR DESCRIPTION
We need to make sure the api version is set before we do anything to bootstrap the app. 
