### PR TITLE
runfix: Add app instance to window object

### DIFF
--- a/src/script/components/AppContainer/AppContainer.tsx
+++ b/src/script/components/AppContainer/AppContainer.tsx
@@ -37,6 +37,7 @@ interface AppProps {
 
 export const AppContainer: FC<AppProps> = ({config, clientType}) => {
   const app = new App(container.resolve(Core), container.resolve(APIClient), config);
+  // Publishing application on the global scope for debug and testing purposes.
   window.wire.app = app;
   const mainView = new MainViewModel(app.repository);
 

--- a/src/script/components/AppContainer/AppContainer.tsx
+++ b/src/script/components/AppContainer/AppContainer.tsx
@@ -37,6 +37,7 @@ interface AppProps {
 
 export const AppContainer: FC<AppProps> = ({config, clientType}) => {
   const app = new App(container.resolve(Core), container.resolve(APIClient), config);
+  window.wire.app = app;
   const mainView = new MainViewModel(app.repository);
 
   return (


### PR DESCRIPTION
Publishing application on the global scope for debug and testing purposes