### PR TITLE
runfix: Do not crash when device date is invalid

### DIFF
--- a/src/script/components/Modals/PrimaryModal/PrimaryModalState.ts
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModalState.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isValid} from 'date-fns';
 import create from 'zustand';
 
 import {replaceLink, t} from 'Util/LocalizerUtil';
@@ -155,9 +156,10 @@ const updateCurrentModalContent = (type: PrimaryModalType, options: ModalOptions
       content.messageText = t('modalAccountNewDevicesMessage');
       const deviceList = (data as ClientNotificationData[])
         .map(device => {
-          const deviceTime = formatLocale(device.time || new Date(), 'PP, p');
+          const deviceTime = isValid(device.time) ? device.time : new Date();
+          const formattedDate = formatLocale(deviceTime, 'PP, p');
           const deviceModel = `${t('modalAccountNewDevicesFrom')} ${escape(device.model)}`;
-          return `<div>${deviceTime} - UTC</div><div>${deviceModel}</div>`;
+          return `<div>${formattedDate} - UTC</div><div>${deviceModel}</div>`;
         })
         .join('');
       content.messageHtml = `<div class="modal__content__device-list">${deviceList}</div>`;

--- a/src/script/page/MainContent/panels/preferences/devices/components/DetailedDevice.tsx
+++ b/src/script/page/MainContent/panels/preferences/devices/components/DetailedDevice.tsx
@@ -19,6 +19,8 @@
 
 import React from 'react';
 
+import {isValid} from 'date-fns';
+
 import {ClientEntity} from 'src/script/client/ClientEntity';
 import {t} from 'Util/LocalizerUtil';
 import {splitFingerprint} from 'Util/StringUtil';
@@ -46,7 +48,7 @@ const DetailedDevice: React.FC<DeviceProps> = ({device, fingerprint}) => {
         </span>
       </p>
 
-      {device.time !== undefined && (
+      {device.time !== undefined && isValid(device.time) && (
         <div className="preferences-devices-activated">
           <p
             dangerouslySetInnerHTML={{


### PR DESCRIPTION
In some case we could get a device that has an invalid date (which result in the time being `?`). In this case the app completely crash. 
This prevents the crash. 