### PR TITLE
refactor: Use core to initialize api version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.10.5",
     "@wireapp/antiscroll-2": "1.3.1",
     "@wireapp/avs": "8.2.17",
-    "@wireapp/core": "36.3.1",
+    "@wireapp/core": "36.4.0",
     "@wireapp/react-ui-kit": "9.0.2",
     "@wireapp/store-engine-dexie": "2.0.0",
     "@wireapp/store-engine-sqleet": "1.8.9",

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -356,6 +356,7 @@ export class App {
    */
   async initApp(clientType: ClientType, onProgress: (progress: number, message?: string) => void) {
     // add body information
+    await this.core.useAPIVersion(this.config.SUPPORTED_API_VERSIONS, this.config.ENABLE_DEV_BACKEND_API);
     const osCssClass = Runtime.isMacOS() ? 'os-mac' : 'os-pc';
     const platformCssClass = Runtime.isDesktopApp() ? 'platform-electron' : 'platform-web';
     document.body.classList.add(osCssClass, platformCssClass);

--- a/src/script/main/index.tsx
+++ b/src/script/main/index.tsx
@@ -22,7 +22,6 @@ import 'core-js/full/reflect';
 import {ClientType} from '@wireapp/api-client/lib/client/';
 import {Runtime} from '@wireapp/commons';
 import {createRoot} from 'react-dom/client';
-import {container} from 'tsyringe';
 
 import {AppContainer} from 'Components/AppContainer/AppContainer';
 import {enableLogging} from 'Util/LoggerUtil';
@@ -33,13 +32,10 @@ import {doRedirect} from './app';
 
 import {SIGN_OUT_REASON} from '../auth/SignOutReason';
 import {Config} from '../Config';
-import {APIClient} from '../service/APIClientSingleton';
 import {StorageKey} from '../storage';
 
 document.addEventListener('DOMContentLoaded', async () => {
-  const apiClient = container.resolve(APIClient);
   const config = Config.getConfig();
-  await apiClient.useVersion(config.SUPPORTED_API_VERSIONS);
 
   enableLogging(config.FEATURE.ENABLE_DEBUG);
   exposeWrapperGlobals();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4594,9 +4594,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:36.3.1":
-  version: 36.3.1
-  resolution: "@wireapp/core@npm:36.3.1"
+"@wireapp/core@npm:36.4.0":
+  version: 36.4.0
+  resolution: "@wireapp/core@npm:36.4.0"
   dependencies:
     "@wireapp/api-client": ^22.3.0
     "@wireapp/commons": ^5.0.0
@@ -4613,7 +4613,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.12
-  checksum: 0a0ff81ca3b8cbe177adbff6a95a494ed7bc78f2644f4bdfc0a5b107330162b20f4a1931091cdf775a3c3bbab83eff1de4a83535d527228cbb3450418347c691
+  checksum: 3469efa32c505ccf48de778eb82758576bcbfc5f62e841cf7c3ee994b51702f4796ffa6a3eede62ded8f1a0e2ecd55a2b3e34492d4adb0e18b18a4398c5eb9bc
   languageName: node
   linkType: hard
 
@@ -16615,7 +16615,7 @@ __metadata:
     "@wireapp/antiscroll-2": 1.3.1
     "@wireapp/avs": 8.2.17
     "@wireapp/copy-config": 2.0.0
-    "@wireapp/core": 36.3.1
+    "@wireapp/core": 36.4.0
     "@wireapp/eslint-config": 2.0.0
     "@wireapp/prettier-config": 0.5.0
     "@wireapp/react-ui-kit": 9.0.2


### PR DESCRIPTION
Will prevent having mismatch between the configuration of the APIClient and the core. 
If the core is responsible for updating the api version used, then it will also know what version is used and what features are available

needs:
- [x] https://github.com/wireapp/wire-web-packages/pull/4602