### PR TITLE
runfix: reset audio after pausing [FS-1116]

### DIFF
--- a/src/script/audio/AudioRepository.ts
+++ b/src/script/audio/AudioRepository.ts
@@ -207,6 +207,7 @@ export class AudioRepository {
     if (!audioElement?.paused) {
       this.logger.info(`Stopping sound '${audioId}'`);
       audioElement.pause();
+      audioElement.load();
     }
   };
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1116" title="FS-1116" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1116</a>  [Web] User is able to play calling sound after ending a call.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This fix was already implemented some time ago (13 days) but it got lost (probably during some `acc`->`dev` merges). 

See https://github.com/wireapp/wire-webapp/pull/13978 for full description. 