### PR TITLE
runfix: mls device not able to logout [FS-1163]

### DIFF
--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -774,8 +774,7 @@ export class App {
     const _logoutOnBackend = async () => {
       this.logger.info(`Logout triggered by '${signOutReason}': Disconnecting user from the backend.`);
       try {
-        await this.core.logout(clearData);
-        _logout();
+        await _logout();
       } catch (e) {
         _redirectToLogin();
       }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1163" title="FS-1163" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1163</a>  [Web] impossible to logout of an MLS device
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
There was a bug where user on mls device was stuck on settings screen after trying to log out. We were calling `core.logout()` (calling `CoreCrypto.wipe()` under the hood) method twice what was throwing unhandled error. 
Extra call to `core.logout()` seems not to be needed as `_logout()` method calls it too.