### PR TITLE
fix: load polyfills on top

### DIFF
--- a/src/script/auth/main.tsx
+++ b/src/script/auth/main.tsx
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2022 Wire Swiss GmbH
+ * Copyright (C) 2018 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/script/auth/main.tsx
+++ b/src/script/auth/main.tsx
@@ -17,8 +17,9 @@
  *
  */
 
-// Polyfill "Object.entries" & "Object.values"
 import React from 'react';
+
+// Polyfill "Object.entries" & "Object.values"
 
 import 'core-js/full/object';
 import 'core-js/full/reflect';
@@ -72,7 +73,7 @@ function runApp(): void {
   render(Root);
   if (module.hot) {
     module.hot.accept('./page/Root', () => {
-      render(require('./page/Root').default);
+      render(require('./page/Root').Root);
     });
   }
 }

--- a/src/script/auth/main.tsx
+++ b/src/script/auth/main.tsx
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2018 Wire Swiss GmbH
+ * Copyright (C) 2022 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,12 +17,13 @@
  *
  */
 
-import React from 'react';
-
 // Polyfill "Object.entries" & "Object.values"
-
 import 'core-js/full/object';
 import 'core-js/full/reflect';
+
+// eslint-disable-next-line import/order
+import React from 'react';
+
 import cookieStore from 'js-cookie';
 import {createRoot} from 'react-dom/client';
 import {Provider, ConnectedComponent} from 'react-redux';

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -18,10 +18,12 @@
  */
 
 // Polyfill for "tsyringe" dependency injection
+// eslint-disable-next-line import/order
+import 'core-js/full/reflect';
+
 import {Context} from '@wireapp/api-client/lib/auth';
 import {ClientClassification, ClientType} from '@wireapp/api-client/lib/client/';
 import {amplify} from 'amplify';
-import 'core-js/full/reflect';
 import Dexie from 'dexie';
 import ko from 'knockout';
 import platform from 'platform';

--- a/src/script/main/index.tsx
+++ b/src/script/main/index.tsx
@@ -17,8 +17,11 @@
  *
  */
 
-import {ClientType} from '@wireapp/api-client/lib/client/';
+// eslint-disable-next-line import/order
 import 'core-js/full/reflect';
+
+// eslint-disable-next-line import/order
+import {ClientType} from '@wireapp/api-client/lib/client/';
 import {createRoot} from 'react-dom/client';
 
 import {Runtime} from '@wireapp/commons';

--- a/test/helper/TestFactory.js
+++ b/test/helper/TestFactory.js
@@ -20,10 +20,11 @@
 // @ts-check
 
 /* eslint no-undef: "off" */
+import 'core-js/full/reflect';
 
 // Polyfill for "tsyringe" dependency injection
 import {ClientClassification, ClientType} from '@wireapp/api-client/lib/client/';
-import 'core-js/full/reflect';
+
 import ko from 'knockout';
 import {container} from 'tsyringe';
 


### PR DESCRIPTION
Eslint import/order suggests putting React and possibly other packages on top of the imports. 
We need to take care manually that polyfills and needed unassigned imports are included before our assigned imports.
Eslint will not autofix unassigned imports, so we can put them where we would like to have them and ignore the imort/order rule in the file.