### PR TITLE
refactor: cleanup the conversationState

### DIFF
--- a/src/script/components/userDevices/DeviceDetails.tsx
+++ b/src/script/components/userDevices/DeviceDetails.tsx
@@ -89,7 +89,7 @@ const DeviceDetails: React.FC<DeviceDetailsProps> = ({
 
   const clickToResetSession = () => {
     const _resetProgress = () => window.setTimeout(() => setIsResettingSession(false), MotionDuration.LONG);
-    const conversation = user.isMe ? conversationState.self_conversation() : conversationState.activeConversation();
+    const conversation = user.isMe ? conversationState.selfConversation() : conversationState.activeConversation();
     setIsResettingSession(true);
     if (conversation) {
       messageRepository

--- a/src/script/conversation/ConversationLabelRepository.ts
+++ b/src/script/conversation/ConversationLabelRepository.ts
@@ -88,7 +88,7 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
 
   constructor(
     private readonly allConversations: ko.ObservableArray<Conversation>,
-    private readonly conversations: ko.ObservableArray<Conversation>,
+    private readonly conversations: ko.PureComputed<Conversation[]>,
     private readonly propertiesService: PropertiesService,
   ) {
     super();

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -62,6 +62,7 @@ describe('ConversationRepository', () => {
   const testFactory = new TestFactory();
 
   let conversation_et: Conversation;
+  let selfConversation: Conversation;
   let self_user_et;
   let server: sinon.SinonFakeServer;
   let storage_service: StorageService;
@@ -86,16 +87,17 @@ describe('ConversationRepository', () => {
     return conversation;
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     server = sinon.fakeServer.create();
     server.autoRespond = true;
 
-    return testFactory.exposeConversationActors().then((conversation_repository: ConversationRepository) => {
+    return testFactory.exposeConversationActors().then(async (conversation_repository: ConversationRepository) => {
       amplify.publish(WebAppEvents.EVENT.NOTIFICATION_HANDLING_STATE, NOTIFICATION_HANDLING_STATE.WEB_SOCKET);
       storage_service = conversation_repository['conversationService']['storageService'];
 
       spyOn(testFactory.event_repository, 'injectEvent').and.returnValue(Promise.resolve({}));
-      conversation_et = _generateConversation(CONVERSATION_TYPE.SELF);
+      conversation_et = _generateConversation(CONVERSATION_TYPE.REGULAR);
+      selfConversation = _generateConversation(CONVERSATION_TYPE.SELF);
       conversation_et.id = payload.conversations.knock.post.conversation;
 
       const ping_url = `${Config.getConfig().BACKEND_REST}/conversations/${conversation_et.id}/knock`;
@@ -114,6 +116,7 @@ describe('ConversationRepository', () => {
       const mark_as_read_url = `${Config.getConfig().BACKEND_REST}/conversations/${conversation_et.id}/self`;
       server.respondWith('PUT', mark_as_read_url, [HTTP_STATUS.OK, {}, '']);
 
+      await conversation_repository['saveConversation'](selfConversation);
       return conversation_repository['saveConversation'](conversation_et);
     });
   });
@@ -301,7 +304,7 @@ describe('ConversationRepository', () => {
 
       result = testFactory.conversation_repository.getGroupsByName('e', false);
 
-      expect(result.length).toBe(3);
+      expect(result.length).toBe(4);
 
       result = testFactory.conversation_repository.getGroupsByName('Rene', false);
 
@@ -706,7 +709,7 @@ describe('ConversationRepository', () => {
     describe('conversation.member-join', () => {
       let memberJoinEvent: ConversationMemberJoinEvent;
 
-      beforeEach(() => {
+      beforeEach(async () => {
         spyOn(testFactory.conversation_repository as any, 'onMemberJoin').and.callThrough();
         spyOn(testFactory.conversation_repository, 'updateParticipatingUserEntities').and.callThrough();
         spyOn(testFactory.user_repository, 'getUsersById').and.returnValue(Promise.resolve([]));
@@ -904,14 +907,14 @@ describe('ConversationRepository', () => {
 
       it('should not hide message if sender is not self user', async () => {
         const messageHiddenEvent: MessageHiddenEvent = {
-          conversation: conversation_et.id,
+          conversation: selfConversation.id,
           data: {
             conversation_id: conversation_et.id,
             message_id: messageId,
           },
           from: createRandomUuid(),
           id: createRandomUuid(),
-          qualified_conversation: {domain: '', id: conversation_et.id},
+          qualified_conversation: selfConversation.qualifiedId,
           time: new Date().toISOString(),
           type: ClientEvent.CONVERSATION.MESSAGE_HIDDEN,
         };
@@ -932,14 +935,14 @@ describe('ConversationRepository', () => {
       it('should hide message if sender is self user', () => {
         spyOn(testFactory.event_service, 'deleteEvent');
         const messageHiddenEvent: MessageHiddenEvent = {
-          conversation: conversation_et.id,
+          conversation: selfConversation.id,
           data: {
             conversation_id: conversation_et.id,
             message_id: messageId,
           },
           from: selfUser.id,
           id: createRandomUuid(),
-          qualified_conversation: {domain: '', id: conversation_et.id},
+          qualified_conversation: selfConversation.qualifiedId,
           time: new Date().toISOString(),
           type: ClientEvent.CONVERSATION.MESSAGE_HIDDEN,
         };
@@ -954,7 +957,7 @@ describe('ConversationRepository', () => {
         });
       });
 
-      it('should not hide message if not send via self conversation', () => {
+      it('should not hide message if not send via self conversation', async () => {
         spyOn(testFactory.event_service, 'deleteEvent');
         const messageHiddenEvent: MessageHiddenEvent = {
           conversation: createRandomUuid(),
@@ -972,10 +975,12 @@ describe('ConversationRepository', () => {
         expect(conversation_et.getMessage(messageId)).toBeDefined();
         spyOn(testFactory.conversation_repository['userState'], 'self').and.returnValue(selfUser);
 
-        return testFactory.conversation_repository['onMessageHidden'](messageHiddenEvent).then(() => {
-          expect(testFactory.conversation_repository['onMessageHidden']).toHaveBeenCalled();
-          expect(testFactory.event_service.deleteEvent).toHaveBeenCalledTimes(1);
+        await expect(
+          testFactory.conversation_repository['handleConversationEvent'](messageHiddenEvent),
+        ).rejects.toMatchObject({
+          type: ConversationError.TYPE.WRONG_CONVERSATION,
         });
+        expect(testFactory.event_service.deleteEvent).not.toHaveBeenCalled();
       });
 
       it('syncs message deletion with the database', () => {
@@ -1119,12 +1124,12 @@ describe('ConversationRepository', () => {
     });
 
     it('should know all users participating in a conversation (including the self user)', () => {
-      const [, users] = testFactory.conversation_repository['conversationState'].conversations();
+      const [, , users] = testFactory.conversation_repository['conversationState'].conversations();
       return testFactory.conversation_repository
         .getAllUsersInConversation({domain: '', id: users.id})
         .then(user_ets => {
           expect(user_ets.length).toBe(3);
-          expect(testFactory.conversation_repository['conversationState'].conversations().length).toBe(4);
+          expect(testFactory.conversation_repository['conversationState'].conversations().length).toBe(5);
         });
     });
   });
@@ -1191,7 +1196,7 @@ describe('ConversationRepository', () => {
       testFactory.conversation_repository['saveConversation'](deletedGroup);
       await testFactory.conversation_repository.checkForDeletedConversations();
 
-      expect(testFactory.conversation_repository['conversationState'].conversations().length).toBe(2);
+      expect(testFactory.conversation_repository['conversationState'].conversations().length).toBe(3);
     });
   });
 

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -139,7 +139,7 @@ describe('ConversationRepository', () => {
         expect(
           _findConversation(
             self_conversation_et,
-            testFactory.conversation_repository['conversationState'].filtered_conversations,
+            testFactory.conversation_repository['conversationState'].filteredConversations,
           ),
         ).toBeUndefined();
       });
@@ -159,7 +159,7 @@ describe('ConversationRepository', () => {
         expect(
           _findConversation(
             blocked_conversation_et,
-            testFactory.conversation_repository['conversationState'].filtered_conversations,
+            testFactory.conversation_repository['conversationState'].filteredConversations,
           ),
         ).toBeUndefined();
       });
@@ -179,7 +179,7 @@ describe('ConversationRepository', () => {
         expect(
           _findConversation(
             cancelled_conversation_et,
-            testFactory.conversation_repository['conversationState'].filtered_conversations,
+            testFactory.conversation_repository['conversationState'].filteredConversations,
           ),
         ).toBeUndefined();
       });
@@ -199,7 +199,7 @@ describe('ConversationRepository', () => {
         expect(
           _findConversation(
             pending_conversation_et,
-            testFactory.conversation_repository['conversationState'].filtered_conversations,
+            testFactory.conversation_repository['conversationState'].filteredConversations,
           ),
         ).toBeUndefined();
       });
@@ -429,7 +429,7 @@ describe('ConversationRepository', () => {
         expect(
           _findConversation(
             _conversation,
-            testFactory.conversation_repository['conversationState'].filtered_conversations,
+            testFactory.conversation_repository['conversationState'].filteredConversations,
           ),
         ).toBeUndefined();
       });

--- a/src/script/conversation/ConversationVerificationStateHandler.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler.ts
@@ -193,7 +193,7 @@ export class ConversationVerificationStateHandler {
     userIds: QualifiedId[],
   ): {conversationEntity: Conversation; userIds: QualifiedId[]}[] {
     return this.conversationState
-      .filtered_conversations()
+      .filteredConversations()
       .map((conversationEntity: Conversation) => {
         if (!conversationEntity.removed_from_conversation()) {
           const userIdsInConversation = conversationEntity

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -969,7 +969,7 @@ export class MessageRepository {
    */
   public async deleteMessage(conversation: Conversation, message: Message): Promise<void> {
     try {
-      const selfConversation = this.conversationState.self_conversation();
+      const selfConversation = this.conversationState.selfConversation();
       if (!selfConversation) {
         throw new Error('cannot delete message as selfConversation is not defined');
       }
@@ -997,7 +997,7 @@ export class MessageRepository {
    */
   public async updateClearedTimestamp(conversation: Conversation): Promise<void> {
     const timestamp = conversation.getLastKnownTimestamp(this.serverTimeHandler.toServerTimestamp());
-    const selfConversation = this.conversationState.self_conversation();
+    const selfConversation = this.conversationState.selfConversation();
     if (!selfConversation) {
       throw new Error('cannot clear conversation as selfConversation is not defined');
     }
@@ -1241,7 +1241,7 @@ export class MessageRepository {
    * @param conversation Conversation to be marked as read
    */
   public async markAsRead(conversation: Conversation) {
-    const selfConversation = this.conversationState.self_conversation();
+    const selfConversation = this.conversationState.selfConversation();
     if (!selfConversation) {
       throw new Error('cannot mark as read as selfConversation is not defined');
     }
@@ -1262,7 +1262,7 @@ export class MessageRepository {
    * @param countlyId Countly new ID
    */
   public async sendCountlySync(countlyId: string) {
-    const selfConversation = this.conversationState.self_conversation();
+    const selfConversation = this.conversationState.selfConversation();
     if (!selfConversation) {
       throw new Error('cannot mark as read as selfConversation is not defined');
     }

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -419,7 +419,7 @@ export class App {
 
       await teamRepository.initTeam();
 
-      const conversationEntities = await conversationRepository.getConversations();
+      const conversationEntities = await conversationRepository.loadConversations();
 
       if (supportsMLS()) {
         // We send external proposal to all the MLS conversations that are in an unknown state (not established nor pendingWelcome)
@@ -476,7 +476,6 @@ export class App {
       telemetry.addStatistic(AppInitStatisticsValue.NOTIFICATIONS, notificationsCount, 100);
 
       eventTrackerRepository.init(propertiesRepository.properties.settings.privacy.telemetry_sharing);
-      await conversationRepository.initializeConversations();
       onProgress(97.5, t('initUpdatedFromNotifications', this.config.BRAND_NAME));
 
       const clientEntities = await clientRepository.updateClientsForSelf();
@@ -512,8 +511,7 @@ export class App {
       if (error instanceof BaseError) {
         this._appInitFailure(error, isReload);
       }
-
-      return undefined;
+      throw error;
     }
   }
 

--- a/src/script/page/LeftSidebar/panels/Archive.tsx
+++ b/src/script/page/LeftSidebar/panels/Archive.tsx
@@ -51,8 +51,8 @@ const Archive: React.FC<ArchiveProps> = ({
   onClose,
   conversationState = container.resolve(ConversationState),
 }) => {
-  const {conversations_archived: conversations} = useKoSubscribableChildren(conversationState, [
-    'conversations_archived',
+  const {archivedConversations: conversations} = useKoSubscribableChildren(conversationState, [
+    'archivedConversations',
   ]);
 
   const onClickConversation = async (conversation: Conversation) => {

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -94,8 +94,10 @@ const Conversations: React.FC<ConversationsProps> = ({
   const {classifiedDomains} = useKoSubscribableChildren(teamState, ['classifiedDomains']);
   const {connectRequests} = useKoSubscribableChildren(userState, ['connectRequests']);
   const {activeConversation} = useKoSubscribableChildren(conversationState, ['activeConversation']);
-  const {conversations_archived: archivedConversations, conversations_unarchived: conversations} =
-    useKoSubscribableChildren(conversationState, ['conversations_archived', 'conversations_unarchived']);
+  const {archivedConversations, unarchivedConversations: conversations} = useKoSubscribableChildren(conversationState, [
+    'archivedConversations',
+    'unarchivedConversations',
+  ]);
   const {notifications} = useKoSubscribableChildren(preferenceNotificationRepository, ['notifications']);
 
   const {filterEstablishedConversations} = useMLSConversationState();

--- a/src/script/page/LeftSidebar/panels/Conversations/GroupedConversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/GroupedConversations.tsx
@@ -76,8 +76,8 @@ const GroupedConversations: React.FC<GroupedConversationsProps> = ({
   callState = container.resolve(CallState),
 }) => {
   const {conversationLabelRepository} = conversationRepository;
-  const {conversations_unarchived: conversations} = useKoSubscribableChildren(conversationState, [
-    'conversations_unarchived',
+  const {unarchivedConversations: conversations} = useKoSubscribableChildren(conversationState, [
+    'unarchivedConversations',
   ]);
 
   useKoSubscribableChildren(callState, ['activeCalls']);

--- a/src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx
@@ -153,7 +153,7 @@ const DevicesPreferences: React.FC<DevicesPreferencesProps> = ({
         }}
         onClose={() => setSelectedDevice(undefined)}
         onVerify={(device, verified) => verifyDevice(self.qualifiedId, device, verified)}
-        onResetSession={device => resetSession(self.qualifiedId, device, conversationState.self_conversation())}
+        onResetSession={device => resetSession(self.qualifiedId, device, conversationState.selfConversation())}
       />
     );
   }

--- a/src/script/page/useWindowTitle.ts
+++ b/src/script/page/useWindowTitle.ts
@@ -49,10 +49,10 @@ export const useWindowTitle = () => {
   const [updateWindowTitle, setUpdateWindowTitle] = useState(false);
 
   const {connectRequests: connectionRequests} = useKoSubscribableChildren(userState, ['connectRequests']);
-  const {activeConversation, conversations_unarchived: unarchivedConversations} = useKoSubscribableChildren(
-    conversationState,
-    ['activeConversation', 'conversations_unarchived'],
-  );
+  const {activeConversation, unarchivedConversations} = useKoSubscribableChildren(conversationState, [
+    'activeConversation',
+    'unarchivedConversations',
+  ]);
   const unreadConversations = unarchivedConversations.filter(conversationEntity => conversationEntity.hasUnread());
 
   const updateFavicon = useCallback(

--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -56,7 +56,7 @@ interface ShowConversationOptions {
 }
 
 interface ShowConversationOverload {
-  (conversation: Conversation, options: ShowConversationOptions): Promise<void>;
+  (conversation: Conversation | undefined, options: ShowConversationOptions): Promise<void>;
   (conversationId: string, options: ShowConversationOptions, domain: string | null): Promise<void>;
 }
 
@@ -93,7 +93,7 @@ export class ContentViewModel {
 
       const isStateRequests = contentState === ContentState.CONNECTION_REQUESTS;
       if (isStateRequests && !requests.length) {
-        this.showConversation(this.conversationRepository.getMostRecentConversation(), {});
+        this.showConversation(this.conversationState.getMostRecentConversation(), {});
       }
     });
 
@@ -102,7 +102,7 @@ export class ContentViewModel {
         this.conversationState.activeConversation()?.connection().status() ===
         ConnectionStatus.MISSING_LEGAL_HOLD_CONSENT
       ) {
-        this.showConversation(this.conversationRepository.getMostRecentConversation(), {});
+        this.showConversation(this.conversationState.getMostRecentConversation(), {});
       }
     });
 
@@ -154,7 +154,7 @@ export class ContentViewModel {
    * @param domain Domain name
    */
   readonly showConversation: ShowConversationOverload = async (
-    conversation: Conversation | string,
+    conversation: Conversation | string | undefined,
     options: ShowConversationOptions,
     domain: string | null = null,
   ) => {

--- a/src/script/view_model/ListViewModel.ts
+++ b/src/script/view_model/ListViewModel.ts
@@ -123,7 +123,7 @@ export class ListViewModel {
       const hasConnectRequests = !!this.userState.connectRequests().length;
       const states: (string | Conversation)[] = hasConnectRequests ? [ContentState.CONNECTION_REQUESTS] : [];
 
-      return states.concat(this.conversationState.conversations_unarchived());
+      return states.concat(this.conversationState.unarchivedConversations());
     });
 
     this._initSubscriptions();
@@ -306,7 +306,7 @@ export class ListViewModel {
 
   readonly showTemporaryGuest = (): void => {
     this.switchList(ListState.TEMPORARY_GUEST);
-    const conversationEntity = this.conversationRepository.getMostRecentConversation();
+    const conversationEntity = this.conversationState.getMostRecentConversation();
     amplify.publish(WebAppEvents.CONVERSATION.SHOW, conversationEntity, {});
   };
 
@@ -465,7 +465,7 @@ export class ListViewModel {
 
   readonly clickToUnarchive = (conversationEntity: Conversation): void => {
     this.conversationRepository.unarchiveConversation(conversationEntity, true, 'manual un-archive').then(() => {
-      if (!this.conversationState.conversations_archived().length) {
+      if (!this.conversationState.archivedConversations().length) {
         this.switchList(ListState.CONVERSATIONS);
       }
     });


### PR DESCRIPTION
This cleans the conversationState and improve the `selfConversation` detection. 

Previously the selfConversation was found using the userId. Now we use the type of the conversation to know which one is the selfConversation. This is way better semantic and the id of the conversation will probably change with MLS