### PR TITLE
runfix: cleanup releasing the loaded conversation

### DIFF
--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -250,6 +250,7 @@ const MessagesList: FC<MessagesListParams> = ({
         onLoading(false);
       }, 10);
     });
+    return () => conversation.release();
   }, [conversation, initialMessage]);
 
   useLayoutEffect(() => {

--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -107,6 +107,13 @@ export class ConversationState {
   }
 
   /**
+   * returns true if the conversation should be visible to the user
+   * @param conversation the conversation to check visibility
+   */
+  isVisible(conversation: Conversation): boolean {
+    return this.visibleConversations().some(conv => matchQualifiedIds(conv.qualifiedId, conversation.qualifiedId));
+  }
+  /**
    * Get unarchived conversation with the most recent event.
    * @param allConversations Search all conversations
    * @returns Most recent conversation

--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -40,7 +40,7 @@ export class ConversationState {
   /**
    * current conversation that is being viewed
    */
-  public readonly activeConversation = ko.observable<Conversation | null>(null);
+  public readonly activeConversation = ko.observable<Conversation | undefined>();
   /**
    * ordered list of conversations that are actives. This is basically the conversations we want to show to the user
    */
@@ -110,8 +110,11 @@ export class ConversationState {
    * returns true if the conversation should be visible to the user
    * @param conversation the conversation to check visibility
    */
-  isVisible(conversation: Conversation): boolean {
-    return this.visibleConversations().some(conv => matchQualifiedIds(conv.qualifiedId, conversation.qualifiedId));
+  isVisible(conversation?: Conversation): conversation is Conversation {
+    return (
+      !!conversation &&
+      this.visibleConversations().some(conv => matchQualifiedIds(conv.qualifiedId, conversation.qualifiedId))
+    );
   }
   /**
    * Get unarchived conversation with the most recent event.

--- a/src/script/page/useAppState.ts
+++ b/src/script/page/useAppState.ts
@@ -68,7 +68,6 @@ type AppState = {
   listState: ListState;
   setListState: (listState: ListState) => void;
   previousContentState: ContentState | null;
-  setPreviousContentState: (contentState: ContentState | null) => void;
   unreadMessagesCount: number;
   setUnreadMessagesCount: (unreadMessagesCount: number) => void;
 };
@@ -77,20 +76,18 @@ const useAppState = create<AppState>((set, get) => ({
   contentState: ContentState.WATERMARK,
   listState: ListState.CONVERSATIONS,
   previousContentState: null,
-  setContentState: (contentState: ContentState) =>
+  setContentState: (contentState: ContentState) => {
+    const previousContentState = get().contentState;
     set(state => ({
       ...state,
       contentState,
-    })),
+      previousContentState,
+    }));
+  },
   setListState: (listState: ListState) =>
     set(state => ({
       ...state,
       listState,
-    })),
-  setPreviousContentState: (contentState: ContentState | null) =>
-    set(state => ({
-      ...state,
-      previousContentState: contentState,
     })),
   setUnreadMessagesCount: (unreadMessagesCount: number) =>
     set(state => ({

--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -72,7 +72,7 @@ export class ContentViewModel {
   logger: Logger;
   readonly isFederated?: boolean;
   mainViewModel: MainViewModel;
-  previousConversation: Conversation | null = null;
+  previousConversation: Conversation | undefined;
   userRepository: UserRepository;
   initialMessage?: Message;
 
@@ -224,7 +224,7 @@ export class ContentViewModel {
       this.previousConversation = this.conversationState.activeConversation();
 
       if (openNotificationSettings) {
-        rightSidebar.goTo(PanelState.NOTIFICATIONS, {entity: this.conversationState.activeConversation()});
+        rightSidebar.goTo(PanelState.NOTIFICATIONS, {entity: this.conversationState.activeConversation() ?? null});
       }
     } catch (error) {
       const isConversationNotFound = error.type === ConversationError.TYPE.CONVERSATION_NOT_FOUND;
@@ -264,7 +264,7 @@ export class ContentViewModel {
         this.switchContent(ContentState.CONNECTION_REQUESTS);
       }
 
-      if (this.previousConversation && this.conversationState.isVisible(this.previousConversation)) {
+      if (this.conversationState.isVisible(this.previousConversation)) {
         navigate(generateConversationUrl(this.previousConversation));
         return;
       }


### PR DESCRIPTION
This cleans up the process of releasing the current loaded conversation when switching content. 

It basically leverage the React `useEffect` feature to detect a change in the current conversation and releases the previous conversation when unmounting or switching conversation inside of the component