### PR TITLE
runfix: Reset active conversation state when leave conversation view

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -68,7 +68,7 @@ import {UserState} from '../../user/UserState';
 
 type ReadMessageBuffer = {conversation: ConversationEntity; message: Message};
 
-interface ConversationListProps {
+interface ConversationProps {
   readonly initialMessage?: Message;
   readonly teamState: TeamState;
   readonly userState: UserState;
@@ -76,7 +76,7 @@ interface ConversationListProps {
   isRightSidebarOpen?: boolean;
 }
 
-const ConversationList: FC<ConversationListProps> = ({
+export const Conversation: FC<ConversationProps> = ({
   initialMessage,
   teamState,
   userState,
@@ -103,6 +103,11 @@ const ConversationList: FC<ConversationListProps> = ({
 
   // To be changed when design chooses a breakpoint, the conditional can be integrated to the ui-kit directly
   const smBreakpoint = useMatchMedia('max-width: 640px');
+
+  useEffect(() => {
+    // Reset active conversation state when component is unmounted
+    return () => conversationState.activeConversation(undefined);
+  }, [conversationState]);
 
   useEffect(() => {
     if (readMessagesBuffer.length) {
@@ -458,5 +463,3 @@ const ConversationList: FC<ConversationListProps> = ({
     </div>
   );
 };
-
-export {ConversationList};

--- a/src/script/page/MainContent/MainContent.tsx
+++ b/src/script/page/MainContent/MainContent.tsx
@@ -24,7 +24,7 @@ import {CSSTransition, SwitchTransition} from 'react-transition-group';
 import {container} from 'tsyringe';
 
 import {ConnectRequests} from 'Components/ConnectRequests';
-import {ConversationList} from 'Components/Conversation';
+import {Conversation} from 'Components/Conversation';
 import {HistoryExport} from 'Components/HistoryExport';
 import {HistoryImport} from 'Components/HistoryImport';
 import {Icon} from 'Components/Icon';
@@ -206,7 +206,7 @@ const MainContent: FC<MainContentProps> = ({
             )}
 
             {contentState === ContentState.CONVERSATION && (
-              <ConversationList
+              <Conversation
                 initialMessage={initialMessage}
                 teamState={teamState}
                 userState={userState}

--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -72,7 +72,7 @@ export class ContentViewModel {
   logger: Logger;
   readonly isFederated?: boolean;
   mainViewModel: MainViewModel;
-  previousConversation: Conversation | undefined;
+  previousConversation?: Conversation;
   userRepository: UserRepository;
   initialMessage?: Message;
 


### PR DESCRIPTION
When leaving the conversation view, we should reset the active conversation to trigger the release of all the components that are instantiated with this conversation