### PR TITLE
runfix: Avoid releasing active conversation for conversation states

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -105,11 +105,6 @@ export const Conversation: FC<ConversationProps> = ({
   const smBreakpoint = useMatchMedia('max-width: 640px');
 
   useEffect(() => {
-    // Reset active conversation state when component is unmounted
-    return () => conversationState.activeConversation(undefined);
-  }, [conversationState]);
-
-  useEffect(() => {
     if (readMessagesBuffer.length) {
       const groupedMessagesTest = groupBy(
         readMessagesBuffer,

--- a/src/script/page/MainContent/MainContent.tsx
+++ b/src/script/page/MainContent/MainContent.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {FC, ReactNode, useContext, useState} from 'react';
+import {FC, ReactNode, useContext, useEffect, useState} from 'react';
 
 import cx from 'classnames';
 import {CSSTransition, SwitchTransition} from 'react-transition-group';
@@ -69,6 +69,14 @@ const MainContent: FC<MainContentProps> = ({
   const mainViewModel = useContext(RootContext);
 
   const {contentState} = useAppState();
+
+  useEffect(() => {
+    const stateWithConversation = [ContentState.WATERMARK, ContentState.COLLECTION, ContentState.CONVERSATION];
+    if (!stateWithConversation.includes(contentState) && conversationState.activeConversation()) {
+      // Reset active conversation for all states that do not require a loaded conversation
+      conversationState.activeConversation(undefined);
+    }
+  }, [contentState, conversationState]);
 
   if (!mainViewModel) {
     return null;

--- a/src/script/page/MainContent/MainContent.tsx
+++ b/src/script/page/MainContent/MainContent.tsx
@@ -59,6 +59,7 @@ interface MainContentProps {
   isRightSidebarOpen?: boolean;
   conversationState?: ConversationState;
 }
+const STATE_WITH_CONVERSATION = [ContentState.WATERMARK, ContentState.COLLECTION, ContentState.CONVERSATION];
 
 const MainContent: FC<MainContentProps> = ({
   openRightSidebar,
@@ -71,8 +72,7 @@ const MainContent: FC<MainContentProps> = ({
   const {contentState} = useAppState();
 
   useEffect(() => {
-    const stateWithConversation = [ContentState.WATERMARK, ContentState.COLLECTION, ContentState.CONVERSATION];
-    if (!stateWithConversation.includes(contentState) && conversationState.activeConversation()) {
+    if (!STATE_WITH_CONVERSATION.includes(contentState) && conversationState.activeConversation()) {
       // Reset active conversation for all states that do not require a loaded conversation
       conversationState.activeConversation(undefined);
     }


### PR DESCRIPTION
This condition was wrongly translated into the Conversation react hooks. 
It should not release the active conversation when loading the `collection` state