### PR TITLE
runfix: Load base conversation when temporary guest leaves preferences

### DIFF
--- a/src/script/view_model/ListViewModel.ts
+++ b/src/script/view_model/ListViewModel.ts
@@ -297,6 +297,7 @@ export class ListViewModel {
       case ListState.PREFERENCES:
         this.contentViewModel.switchContent(ContentState.PREFERENCES_ACCOUNT);
         break;
+      case ListState.TEMPORARY_GUEST:
       case ListState.CONVERSATIONS:
         if (loadPreviousContent) {
           this.contentViewModel.loadPreviousContent();


### PR DESCRIPTION
When a temporary guest leaves the preference page, we need to trigger the loading of the previous conversation that they were viewing