### PR TITLE
runfix: Disable typing indicator for federated environments

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1711,10 +1711,26 @@ export class ConversationRepository {
   }
 
   public async sendTypingStart(conversationEntity: Conversation) {
+    /*
+      Currently typing endpoint is not implemented on backend for federated environments
+      @todo: remove this condition when backend is ready and api-client in packages is updated to support domain in typing endpoint
+    */
+    const isFederated = this.core.backendFeatures?.isFederated;
+    if (isFederated) {
+      return;
+    }
     this.core.service!.conversation.sendTypingStart(conversationEntity.id);
   }
 
   public async sendTypingStop(conversationEntity: Conversation) {
+    /*
+      Currently typing endpoint is not implemented on backend for federated environments
+      @todo: remove this condition when backend is ready and api-client in packages is updated to support domain in typing endpoint
+    */
+    const isFederated = this.core.backendFeatures?.isFederated;
+    if (isFederated) {
+      return;
+    }
     this.core.service!.conversation.sendTypingStop(conversationEntity.id);
   }
 


### PR DESCRIPTION
Currently typing endpoint is not implemented on backend for federated environments