### PR TITLE
runfix: solve stale isFederated value issue

### DIFF
--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -70,11 +70,14 @@ export class ContentViewModel {
   messageRepository: MessageRepository;
   sidebarId: string;
   logger: Logger;
-  readonly isFederated?: boolean;
   mainViewModel: MainViewModel;
   previousConversation?: Conversation;
   userRepository: UserRepository;
   initialMessage?: Message;
+
+  get isFederated() {
+    return this.mainViewModel.isFederated;
+  }
 
   constructor(mainViewModel: MainViewModel, public repositories: ViewModelRepositories) {
     this.userState = container.resolve(UserState);
@@ -86,7 +89,6 @@ export class ContentViewModel {
     this.conversationRepository = repositories.conversation;
     this.userRepository = repositories.user;
     this.messageRepository = repositories.message;
-    this.isFederated = mainViewModel.isFederated;
     this.logger = getLogger('ContentViewModel');
 
     const showMostRecentConversation = () => {

--- a/src/script/view_model/ListViewModel.ts
+++ b/src/script/view_model/ListViewModel.ts
@@ -60,7 +60,6 @@ export class ListViewModel {
 
   readonly isActivatedAccount: ko.PureComputed<boolean>;
   readonly lastUpdate: ko.Observable<number>;
-  readonly isFederated: boolean;
   readonly repositories: ViewModelRepositories;
 
   public readonly mainViewModel: MainViewModel;
@@ -76,13 +75,16 @@ export class ListViewModel {
   public readonly selfUser: ko.Observable<User>;
   private readonly visibleListItems: ko.PureComputed<(string | Conversation)[]>;
 
+  get isFederated() {
+    return this.mainViewModel.isFederated;
+  }
+
   constructor(mainViewModel: MainViewModel, repositories: ViewModelRepositories) {
     this.userState = container.resolve(UserState);
     this.teamState = container.resolve(TeamState);
     this.conversationState = container.resolve(ConversationState);
 
     this.mainViewModel = mainViewModel;
-    this.isFederated = mainViewModel.isFederated;
     this.repositories = repositories;
     this.conversationRepository = repositories.conversation;
     this.callingRepository = repositories.calling;

--- a/src/script/view_model/MainViewModel.ts
+++ b/src/script/view_model/MainViewModel.ts
@@ -90,10 +90,10 @@ export class MainViewModel {
   multitasking: Multitasking;
   selfUser: ko.Observable<User>;
   userRepository: UserRepository;
-  isFederated: boolean;
   messageEntity: Message | undefined;
   showLikes: boolean;
   highlightedUsers: User[];
+  private readonly core = container.resolve(Core);
   private readonly userState: UserState;
 
   static get CONFIG() {
@@ -105,12 +105,15 @@ export class MainViewModel {
     };
   }
 
+  get isFederated() {
+    return this.core.backendFeatures.isFederated;
+  }
+
   constructor(repositories: ViewModelRepositories) {
     this.userRepository = repositories.user;
     this.logger = getLogger('MainViewModel');
 
     this.userState = container.resolve(UserState);
-    this.isFederated = container.resolve(Core).backendFeatures.isFederated;
 
     this.multitasking = {
       isMinimized: ko.observable(true),


### PR DESCRIPTION
Use getters for accessing `isFederated` value from `backendFeatures` so we're always accessing fresh value. Not a very elegant way, but should fix some of the regression errors.