### PR TITLE
runfix: Show legal hold request modal when view mounts

### DIFF
--- a/src/script/page/MainContent/MainContent.tsx
+++ b/src/script/page/MainContent/MainContent.tsx
@@ -28,6 +28,7 @@ import {Conversation} from 'Components/Conversation';
 import {HistoryExport} from 'Components/HistoryExport';
 import {HistoryImport} from 'Components/HistoryImport';
 import {Icon} from 'Components/Icon';
+import {useLegalHoldModalState} from 'Components/Modals/LegalHoldModal/LegalHoldModal.state';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 import {incomingCssClass, removeAnimationsClass} from 'Util/util';
@@ -68,6 +69,9 @@ const MainContent: FC<MainContentProps> = ({
   const [uploadedFile, setUploadedFile] = useState<File | null>(null);
   const mainViewModel = useContext(RootContext);
 
+  const teamState = container.resolve(TeamState);
+  const userState = container.resolve(UserState);
+
   const {contentState, isShowingConversation} = useAppState();
 
   useEffect(() => {
@@ -77,6 +81,13 @@ const MainContent: FC<MainContentProps> = ({
     }
   }, [contentState, conversationState]);
 
+  useEffect(() => {
+    if (teamState.supportsLegalHold()) {
+      const {showRequestModal} = useLegalHoldModalState.getState();
+      showRequestModal(true);
+    }
+  }, [teamState]);
+
   if (!mainViewModel) {
     return null;
   }
@@ -85,9 +96,6 @@ const MainContent: FC<MainContentProps> = ({
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const {activeConversation} = useKoSubscribableChildren(conversationState, ['activeConversation']);
-
-  const teamState = container.resolve(TeamState);
-  const userState = container.resolve(UserState);
 
   const statesTitle: Partial<Record<ContentState, string>> = {
     [ContentState.CONNECTION_REQUESTS]: t('accessibility.headings.connectionRequests'),

--- a/src/script/page/MainContent/MainContent.tsx
+++ b/src/script/page/MainContent/MainContent.tsx
@@ -71,6 +71,7 @@ const MainContent: FC<MainContentProps> = ({
 
   const teamState = container.resolve(TeamState);
   const userState = container.resolve(UserState);
+  const {showRequestModal} = useLegalHoldModalState();
 
   const {contentState, isShowingConversation} = useAppState();
 
@@ -82,11 +83,11 @@ const MainContent: FC<MainContentProps> = ({
   }, [contentState, conversationState]);
 
   useEffect(() => {
+    // Show legal hold on mount when legal hold is enabled for team
     if (teamState.supportsLegalHold()) {
-      const {showRequestModal} = useLegalHoldModalState.getState();
       showRequestModal(true);
     }
-  }, [teamState]);
+  }, [teamState, showRequestModal]);
 
   if (!mainViewModel) {
     return null;

--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -600,7 +600,8 @@ export class TeamRepository {
       return accumulator;
     }, this.teamState.memberInviters());
 
-    const supportsLegalHold = memberArray.some(member => member.hasOwnProperty('legalholdStatus'));
+    const supportsLegalHold =
+      this.teamState.supportsLegalHold() || memberArray.some(member => member.hasOwnProperty('legalholdStatus'));
     this.teamState.supportsLegalHold(supportsLegalHold);
     this.teamState.memberRoles(memberRoles);
     this.teamState.memberInviters(memberInvites);

--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -24,7 +24,6 @@ import {container} from 'tsyringe';
 
 import {WebAppEvents} from '@wireapp/webapp-events';
 
-import {useLegalHoldModalState} from 'Components/Modals/LegalHoldModal/LegalHoldModal.state';
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
 import {t} from 'Util/LocalizerUtil';
 import {getLogger, Logger} from 'Util/Logger';
@@ -117,11 +116,6 @@ export class ContentViewModel {
     });
 
     this._initSubscriptions();
-
-    if (this.teamState.supportsLegalHold()) {
-      const {showRequestModal} = useLegalHoldModalState.getState();
-      showRequestModal(true);
-    }
   }
 
   private _initSubscriptions() {

--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -45,7 +45,6 @@ import {useAppMainState} from '../page/state';
 import {ContentState, useAppState} from '../page/useAppState';
 import {generateConversationUrl} from '../router/routeGenerator';
 import {navigate} from '../router/Router';
-import {TeamState} from '../team/TeamState';
 import type {UserRepository} from '../user/UserRepository';
 import {UserState} from '../user/UserState';
 
@@ -62,7 +61,6 @@ interface ShowConversationOverload {
 
 export class ContentViewModel {
   private readonly userState: UserState;
-  private readonly teamState: TeamState;
   private readonly conversationState: ConversationState;
 
   conversationRepository: ConversationRepository;
@@ -80,7 +78,6 @@ export class ContentViewModel {
 
   constructor(mainViewModel: MainViewModel, public repositories: ViewModelRepositories) {
     this.userState = container.resolve(UserState);
-    this.teamState = container.resolve(TeamState);
     this.conversationState = container.resolve(ConversationState);
 
     this.sidebarId = 'left-column';


### PR DESCRIPTION
Right now we try to trigger the legal hold request modal too early (before the team is loaded). 
We need to trigger it once the team is loaded and the app ready to be view. 

Triggering it when the main content loads is the perfect moment to do so 