### PR TITLE
runfix: Fix hidding conversation when legal hold is enabled

### DIFF
--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -89,9 +89,7 @@ export class ContentViewModel {
 
     const showMostRecentConversation = () => {
       const mostRecentConversation = this.conversationState.getMostRecentConversation();
-      if (mostRecentConversation) {
-        navigate(generateConversationUrl(mostRecentConversation));
-      }
+      this.showConversation(mostRecentConversation, {});
     };
 
     this.userState.connectRequests.subscribe(requests => {


### PR DESCRIPTION
Switching to urls for showing most recent conversation was premature. 
We need deeper understanding of the mechanisms at hand here. 

Was broken since #14086 