### PR TITLE
feat: Register Self and Team MLS conversations on app load [FS-1007 FS-1006]

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@types/eslint": "^8.4.10",
     "@wireapp/antiscroll-2": "1.3.1",
     "@wireapp/avs": "8.2.17",
-    "@wireapp/core": "37.1.0",
+    "@wireapp/core": "37.1.1",
     "@wireapp/react-ui-kit": "9.0.2",
     "@wireapp/store-engine-dexie": "2.0.3",
     "@wireapp/store-engine-sqleet": "1.8.9",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@types/eslint": "^8.4.10",
     "@wireapp/antiscroll-2": "1.3.1",
     "@wireapp/avs": "8.2.17",
-    "@wireapp/core": "37.0.3",
+    "@wireapp/core": "37.1.0",
     "@wireapp/react-ui-kit": "9.0.2",
     "@wireapp/store-engine-dexie": "2.0.3",
     "@wireapp/store-engine-sqleet": "1.8.9",

--- a/src/script/conversation/ConversationSelectors.ts
+++ b/src/script/conversation/ConversationSelectors.ts
@@ -1,0 +1,30 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation/';
+
+import {Conversation} from '../entity/Conversation';
+
+export function isSelfConversation(conversation: Conversation): boolean {
+  return conversation.type() === CONVERSATION_TYPE.SELF;
+}
+
+export function isTeamConversation(conversation: Conversation): boolean {
+  return conversation.type() === CONVERSATION_TYPE.GLOBAL_TEAM;
+}

--- a/src/script/conversation/ConversationSelectors.ts
+++ b/src/script/conversation/ConversationSelectors.ts
@@ -17,9 +17,15 @@
  *
  */
 
-import {CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation/';
+import {CONVERSATION_TYPE, ConversationProtocol} from '@wireapp/api-client/lib/conversation/';
 
 import {Conversation} from '../entity/Conversation';
+
+export type MLSConversation = Conversation & {groupId: string};
+
+export function isMLSConversation(conversation: Conversation): conversation is MLSConversation {
+  return !!conversation.groupId && conversation.protocol === ConversationProtocol.MLS;
+}
 
 export function isSelfConversation(conversation: Conversation): boolean {
   return conversation.type() === CONVERSATION_TYPE.SELF;

--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -18,13 +18,14 @@
  */
 
 import {ConnectionStatus} from '@wireapp/api-client/lib/connection/';
-import {CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation/';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import ko from 'knockout';
 import {container, singleton} from 'tsyringe';
 
 import {matchQualifiedIds} from 'Util/QualifiedId';
 import {sortGroupsByLastEvent} from 'Util/util';
+
+import {isMLSConversation, isSelfConversation} from './ConversationSelectors';
 
 import {Conversation} from '../entity/Conversation';
 import {User} from '../entity/User';
@@ -48,6 +49,7 @@ export class ConversationState {
   public readonly filteredConversations: ko.PureComputed<Conversation[]>;
   public readonly archivedConversations: ko.PureComputed<Conversation[]>;
   public readonly selfConversation: ko.PureComputed<Conversation | undefined>;
+  public readonly selfMLSConversation: ko.PureComputed<Conversation | undefined>;
   public readonly connectedUsers: ko.PureComputed<User[]>;
 
   public readonly sortedConversations: ko.PureComputed<Conversation[]>;
@@ -58,7 +60,10 @@ export class ConversationState {
   ) {
     this.sortedConversations = ko.pureComputed(() => this.filteredConversations().sort(sortGroupsByLastEvent));
     this.selfConversation = ko.pureComputed(() =>
-      this.conversations().find(conversation => conversation.type() === CONVERSATION_TYPE.SELF),
+      this.conversations().find(conversation => !isMLSConversation(conversation) && isSelfConversation(conversation)),
+    );
+    this.selfMLSConversation = ko.pureComputed(() =>
+      this.conversations().find(conversation => isMLSConversation(conversation) && isSelfConversation(conversation)),
     );
 
     this.visibleConversations = ko.pureComputed(() => {

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -140,6 +140,7 @@ export class Conversation {
   public readonly isLeavable: ko.PureComputed<boolean>;
   public readonly isMutable: ko.PureComputed<boolean>;
   public readonly isRequest: ko.PureComputed<boolean>;
+  /** @deprecated use isSelfConversation from conversationSelectors */
   public readonly isSelf: ko.PureComputed<boolean>;
   public readonly isTeamOnly: ko.PureComputed<boolean>;
   public readonly last_event_timestamp: ko.Observable<number>;

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -83,7 +83,7 @@ import {IntegrationRepository} from '../integration/IntegrationRepository';
 import {IntegrationService} from '../integration/IntegrationService';
 import {startNewVersionPolling} from '../lifecycle/newVersionHandler';
 import {MediaRepository} from '../media/MediaRepository';
-import {initMLSConversations} from '../mls';
+import {initMLSConversations, registerUninitializedConversations} from '../mls';
 import {NotificationRepository} from '../notification/NotificationRepository';
 import {PreferenceNotificationRepository} from '../notification/PreferenceNotificationRepository';
 import {PermissionRepository} from '../permission/PermissionRepository';
@@ -449,6 +449,11 @@ export class App {
         onProgress(25 + 50 * (done / total), `${baseMessage}${extraInfo}`);
       });
       const notificationsCount = eventRepository.notificationsTotal;
+
+      if (supportsMLS()) {
+        // Once all the messages have been processed and the message sending queue freed we can now add the potential `self` and `team` conversations
+        await registerUninitializedConversations(conversationEntities, selfUser, clientEntity().id, this.core);
+      }
 
       telemetry.timeStep(AppInitTimingsStep.UPDATED_FROM_NOTIFICATIONS);
       telemetry.addStatistic(AppInitStatisticsValue.NOTIFICATIONS, notificationsCount, 100);

--- a/src/script/mls/MLSConversations.test.ts
+++ b/src/script/mls/MLSConversations.test.ts
@@ -89,5 +89,27 @@ describe('MLSConversations', () => {
 
       expect(core.service!.mls.registerConversation).toHaveBeenCalledTimes(2);
     });
+
+    it('does not register self and team conversation that have epoch > 0', async () => {
+      const core = mockCore();
+      const nbProteusConversations = 5 + Math.ceil(Math.random() * 10);
+      const nbMLSConversations = 5 + Math.ceil(Math.random() * 10);
+
+      const proteusConversations = createConversations(nbProteusConversations, ConversationProtocol.PROTEUS);
+      const selfConversation = createConversation(ConversationProtocol.MLS);
+      selfConversation.epoch = 1;
+      selfConversation.type(CONVERSATION_TYPE.SELF);
+
+      const teamConversation = createConversation(ConversationProtocol.MLS);
+      teamConversation.epoch = 2;
+      teamConversation.type(CONVERSATION_TYPE.GLOBAL_TEAM);
+
+      const mlsConversations = createConversations(nbMLSConversations);
+      const conversations = [...proteusConversations, teamConversation, ...mlsConversations, selfConversation];
+
+      await initMLSConversations(conversations, new User(), core, {} as any);
+
+      expect(core.service!.mls.registerConversation).toHaveBeenCalledTimes(0);
+    });
   });
 });

--- a/src/script/mls/MLSConversations.test.ts
+++ b/src/script/mls/MLSConversations.test.ts
@@ -47,6 +47,7 @@ function mockCore() {
     service: {mls: {registerConversation: jest.fn()}},
   } as unknown as Account;
 }
+
 describe('MLSConversations', () => {
   beforeEach(() => {
     jest.spyOn(mlsConversationState.getState(), 'sendExternalToPendingJoin').mockReturnValue(undefined);
@@ -64,7 +65,7 @@ describe('MLSConversations', () => {
       await initMLSConversations(conversations, new User(), new Account(), {} as any);
 
       expect(mlsConversationState.getState().sendExternalToPendingJoin).toHaveBeenCalledWith(
-        conversations,
+        mlsConversations,
         expect.any(Function),
         expect.any(Function),
       );
@@ -77,9 +78,11 @@ describe('MLSConversations', () => {
 
       const proteusConversations = createConversations(nbProteusConversations, ConversationProtocol.PROTEUS);
       const selfConversation = createConversation(ConversationProtocol.MLS);
+      selfConversation.epoch = 0;
       selfConversation.type(CONVERSATION_TYPE.SELF);
 
       const teamConversation = createConversation(ConversationProtocol.MLS);
+      teamConversation.epoch = 0;
       teamConversation.type(CONVERSATION_TYPE.GLOBAL_TEAM);
 
       const mlsConversations = createConversations(nbMLSConversations);

--- a/src/script/mls/MLSConversations.test.ts
+++ b/src/script/mls/MLSConversations.test.ts
@@ -29,16 +29,24 @@ import {mlsConversationState} from './mlsConversationState';
 import {Conversation} from '../entity/Conversation';
 import {User} from '../entity/User';
 
-function createConversation(protocol: ConversationProtocol) {
+function createConversation(protocol: ConversationProtocol, type?: CONVERSATION_TYPE) {
   const conversation = new Conversation(randomUUID(), '', protocol);
   if (protocol === ConversationProtocol.MLS) {
     conversation.groupId = `groupid-${randomUUID()}`;
+    conversation.epoch = 0;
+  }
+  if (type) {
+    conversation.type(type);
   }
   return conversation;
 }
 
-function createConversations(nbConversations: number, protocol: ConversationProtocol = ConversationProtocol.MLS) {
-  return Array.from(new Array(nbConversations)).map(() => createConversation(protocol));
+function createConversations(
+  nbConversations: number,
+  protocol: ConversationProtocol = ConversationProtocol.MLS,
+  type?: CONVERSATION_TYPE,
+) {
+  return Array.from(new Array(nbConversations)).map(() => createConversation(protocol, type));
 }
 
 function mockCore() {
@@ -77,13 +85,9 @@ describe('MLSConversations', () => {
       const nbMLSConversations = 5 + Math.ceil(Math.random() * 10);
 
       const proteusConversations = createConversations(nbProteusConversations, ConversationProtocol.PROTEUS);
-      const selfConversation = createConversation(ConversationProtocol.MLS);
-      selfConversation.epoch = 0;
-      selfConversation.type(CONVERSATION_TYPE.SELF);
+      const selfConversation = createConversation(ConversationProtocol.MLS, CONVERSATION_TYPE.SELF);
 
-      const teamConversation = createConversation(ConversationProtocol.MLS);
-      teamConversation.epoch = 0;
-      teamConversation.type(CONVERSATION_TYPE.GLOBAL_TEAM);
+      const teamConversation = createConversation(ConversationProtocol.MLS, CONVERSATION_TYPE.GLOBAL_TEAM);
 
       const mlsConversations = createConversations(nbMLSConversations);
       const conversations = [...proteusConversations, teamConversation, ...mlsConversations, selfConversation];

--- a/src/script/mls/MLSConversations.test.ts
+++ b/src/script/mls/MLSConversations.test.ts
@@ -23,7 +23,7 @@ import {randomUUID} from 'crypto';
 
 import {Account} from '@wireapp/core';
 
-import {initMLSConversations} from './MLSConversations';
+import {initMLSConversations, registerUninitializedConversations} from './MLSConversations';
 import {mlsConversationState} from './mlsConversationState';
 
 import {Conversation} from '../entity/Conversation';
@@ -88,7 +88,7 @@ describe('MLSConversations', () => {
       const mlsConversations = createConversations(nbMLSConversations);
       const conversations = [...proteusConversations, teamConversation, ...mlsConversations, selfConversation];
 
-      await initMLSConversations(conversations, new User(), core, {} as any);
+      await registerUninitializedConversations(conversations, new User(), 'client-1', core);
 
       expect(core.service!.mls.registerConversation).toHaveBeenCalledTimes(2);
     });

--- a/src/script/mls/MLSConversations.ts
+++ b/src/script/mls/MLSConversations.ts
@@ -98,7 +98,9 @@ async function registerUninitializedConversations(
     conversation => conversation.epoch === 0 && (isSelfConversation(conversation) || isTeamConversation(conversation)),
   );
 
-  uninitializedConversations.forEach(conversation => {
-    core.service?.mls.registerConversation(conversation.groupId, [selfUser]);
-  });
+  await Promise.all(
+    uninitializedConversations.map(conversation =>
+      core.service?.mls.registerConversation(conversation.groupId, [selfUser]),
+    ),
+  );
 }

--- a/src/script/mls/MLSConversations.ts
+++ b/src/script/mls/MLSConversations.ts
@@ -62,8 +62,9 @@ export async function initMLSConversations(
     userAuthorize: () => true,
   });
 
-  await registerUninitializedConversations(conversations, selfUser, core);
-  await joinNewConversations(conversations, core);
+  const mlsConversations = conversations.filter(isMLSConversation);
+  await registerUninitializedConversations(mlsConversations, selfUser, core);
+  await joinNewConversations(mlsConversations, core);
 }
 
 /**
@@ -72,7 +73,7 @@ export async function initMLSConversations(
  * @param conversations - all the conversations that the user is part of
  * @param core - the instance of the core
  */
-async function joinNewConversations(conversations: Conversation[], core: Account): Promise<void> {
+async function joinNewConversations(conversations: MLSConversation[], core: Account): Promise<void> {
   // We send external proposal to all the MLS conversations that are in an unknown state (not established nor pendingWelcome)
   await mlsConversationState.getState().sendExternalToPendingJoin(
     conversations,
@@ -89,15 +90,12 @@ async function joinNewConversations(conversations: Conversation[], core: Account
  * @param core instance of the core
  */
 async function registerUninitializedConversations(
-  conversations: Conversation[],
+  conversations: MLSConversation[],
   selfUser: User,
   core: Account,
 ): Promise<void> {
   const uninitializedConversations = conversations.filter(
-    (conversation): conversation is MLSConversation =>
-      isMLSConversation(conversation) &&
-      conversation.epoch === 0 &&
-      (isSelfConversation(conversation) || isTeamConversation(conversation)),
+    conversation => conversation.epoch === 0 && (isSelfConversation(conversation) || isTeamConversation(conversation)),
   );
 
   uninitializedConversations.forEach(conversation => {

--- a/src/script/mls/MLSConversations.ts
+++ b/src/script/mls/MLSConversations.ts
@@ -95,7 +95,9 @@ async function registerUninitializedConversations(
 ): Promise<void> {
   const uninitializedConversations = conversations.filter(
     (conversation): conversation is MLSConversation =>
-      isMLSConversation(conversation) && (isSelfConversation(conversation) || isTeamConversation(conversation)),
+      isMLSConversation(conversation) &&
+      conversation.epoch === 0 &&
+      (isSelfConversation(conversation) || isTeamConversation(conversation)),
   );
 
   uninitializedConversations.forEach(conversation => {

--- a/src/script/properties/PropertiesRepository.ts
+++ b/src/script/properties/PropertiesRepository.ts
@@ -79,6 +79,7 @@ export class PropertiesRepository {
           replace_inline: true,
         },
         interface: {
+          font_size: '',
           theme: 'default',
           view_folders: false,
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4167,9 +4167,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^22.5.0":
-  version: 22.5.0
-  resolution: "@wireapp/api-client@npm:22.5.0"
+"@wireapp/api-client@npm:^22.6.0":
+  version: 22.6.0
+  resolution: "@wireapp/api-client@npm:22.6.0"
   dependencies:
     "@wireapp/commons": ^5.0.3
     "@wireapp/priority-queue": ^2.0.3
@@ -4182,7 +4182,7 @@ __metadata:
     spark-md5: 3.0.2
     tough-cookie: 4.1.2
     ws: 8.10.0
-  checksum: 175c20690002ba770b3c0e8a26ef4cec48d97de1c33702c94752bde76ec8b86e8afdf78000dfa5d77a6f49a3d06ee7f9df374d76483f23289e0a9a324ec0f6ef
+  checksum: 50699512cc2ac2abbc1db31529d460efc1ed062f0582208f8539eae1a1466f747b182470cc8e29def6473bf3287b0a0388de8b6aa12ddcac688aa2a566f5b6d5
   languageName: node
   linkType: hard
 
@@ -4235,11 +4235,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:37.0.3":
-  version: 37.0.3
-  resolution: "@wireapp/core@npm:37.0.3"
+"@wireapp/core@npm:37.1.0":
+  version: 37.1.0
+  resolution: "@wireapp/core@npm:37.1.0"
   dependencies:
-    "@wireapp/api-client": ^22.5.0
+    "@wireapp/api-client": ^22.6.0
     "@wireapp/commons": ^5.0.3
     "@wireapp/core-crypto": 0.6.0-pre.4
     "@wireapp/cryptobox": 12.8.0
@@ -4254,7 +4254,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.12
-  checksum: e3a1e69cd34c687800b29f9e60181dc2ad28132a62e69c87b6e03e550ce3a400107bfe7b3e6a145383378b0a381bffb1cb6051602c8ac26130658a571f9c4492
+  checksum: c3c815ad3cd8b50a3665103584cd98e12e6525279e3497dd5cb20eb1ece0badd1a02c2dc3276ecb89849339f501243798c5af95c4f06282fbe1faf2014b6be92
   languageName: node
   linkType: hard
 
@@ -16526,7 +16526,7 @@ __metadata:
     "@wireapp/antiscroll-2": 1.3.1
     "@wireapp/avs": 8.2.17
     "@wireapp/copy-config": 2.0.3
-    "@wireapp/core": 37.0.3
+    "@wireapp/core": 37.1.0
     "@wireapp/eslint-config": 2.1.0
     "@wireapp/prettier-config": 0.5.2
     "@wireapp/react-ui-kit": 9.0.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -4167,9 +4167,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^22.6.0":
-  version: 22.6.0
-  resolution: "@wireapp/api-client@npm:22.6.0"
+"@wireapp/api-client@npm:^22.6.1":
+  version: 22.6.1
+  resolution: "@wireapp/api-client@npm:22.6.1"
   dependencies:
     "@wireapp/commons": ^5.0.3
     "@wireapp/priority-queue": ^2.0.3
@@ -4182,7 +4182,7 @@ __metadata:
     spark-md5: 3.0.2
     tough-cookie: 4.1.2
     ws: 8.10.0
-  checksum: 50699512cc2ac2abbc1db31529d460efc1ed062f0582208f8539eae1a1466f747b182470cc8e29def6473bf3287b0a0388de8b6aa12ddcac688aa2a566f5b6d5
+  checksum: a1cbc2cc80f44dfc88886a89425acda0f91834ec2182dafa6ef9dab030b3963e5db9847553661213e305a3b355090cb2cda3dcafc622bc693f1c85c93bd9817c
   languageName: node
   linkType: hard
 
@@ -4235,11 +4235,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:37.1.0":
-  version: 37.1.0
-  resolution: "@wireapp/core@npm:37.1.0"
+"@wireapp/core@npm:37.1.1":
+  version: 37.1.1
+  resolution: "@wireapp/core@npm:37.1.1"
   dependencies:
-    "@wireapp/api-client": ^22.6.0
+    "@wireapp/api-client": ^22.6.1
     "@wireapp/commons": ^5.0.3
     "@wireapp/core-crypto": 0.6.0-pre.4
     "@wireapp/cryptobox": 12.8.0
@@ -4254,7 +4254,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.12
-  checksum: c3c815ad3cd8b50a3665103584cd98e12e6525279e3497dd5cb20eb1ece0badd1a02c2dc3276ecb89849339f501243798c5af95c4f06282fbe1faf2014b6be92
+  checksum: 19994abdec60930ad75bf46888f1bcf8e2e3db1f80457d43f48e30fae3709d4fe600453213d87f44ac9403251f25565b9683731f2bd1b1053c561da8d371138c
   languageName: node
   linkType: hard
 
@@ -16526,7 +16526,7 @@ __metadata:
     "@wireapp/antiscroll-2": 1.3.1
     "@wireapp/avs": 8.2.17
     "@wireapp/copy-config": 2.0.3
-    "@wireapp/core": 37.1.0
+    "@wireapp/core": 37.1.1
     "@wireapp/eslint-config": 2.1.0
     "@wireapp/prettier-config": 0.5.2
     "@wireapp/react-ui-kit": 9.0.2


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1007" title="FS-1007" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-1007</a>  [web] join the MLS TeamGroup conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

The `self` and `team` conversations have a special case when they are at epoch 0: they should be registered against coreCrypto. 

Because those conversations are created by backend, there are no commit that will be received by the current device, so we need to manually create those commits and send them to backend