### PR TITLE
runfix: display read status separator at correct screen width

### DIFF
--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -596,12 +596,14 @@
 .message-status-read {
   left: 83px;
   &::before {
-    position: absolute;
-    display: flex;
-    width: 16px;
-    align-items: center;
-    justify-content: center;
-    content: '';
+    display: none;
+    @media (min-width: @screen-md-min) {
+      display: flex;
+      width: 16px;
+      align-items: center;
+      justify-content: center;
+      content: '';
+    }
   }
 }
 


### PR DESCRIPTION
#### Issue

- Read status separator (a dash on the right of the eye icon) is never shown
![image](https://user-images.githubusercontent.com/78490891/202439085-e23a4f62-9893-455e-bc84-f6fa51e6b8e3.png)


#### Change

- Make sure it shows when hover info displays horizontally
![Peek 2022-11-17 12-46](https://user-images.githubusercontent.com/78490891/202438668-ca6424ce-3024-49c6-a3ee-4822c439db3e.gif)
