### PR TITLE
runfix: Force React to reset MessageList when conversation are switched

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -415,6 +415,7 @@ export const Conversation: FC<ConversationProps> = ({
           })}
 
           <MessagesList
+            key={activeConversation.id}
             conversation={activeConversation}
             selfUser={selfUser}
             initialMessage={initialMessage}

--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -240,11 +240,6 @@ const MessagesList: FC<MessagesListParams> = ({
   }, [messagesContainer, filteredMessagesLength]);
 
   useEffect(() => {
-    // We need to reset the remembered scroll position when switching conversation in order to compute the correct position for the new conversation
-    scrollHeight.current = 0;
-  }, [conversation]);
-
-  useEffect(() => {
     onLoading(true);
     setLoaded(false);
     conversationLastReadTimestamp.current = conversation.last_read_timestamp();


### PR DESCRIPTION
Since the `MessageList` has quite a lot of internal state that is dependent on the current conversation UI state, it's safer, and probably will make things easier to maintain, to ask React to completely re-mount the component from scratch