### PR TITLE
runfix: prevent sidebar's search field from cutting off

### DIFF
--- a/src/style/components/search-input.less
+++ b/src/style/components/search-input.less
@@ -19,6 +19,7 @@
 
 .search-outer {
   overflow: hidden;
+  min-height: 48px;
   padding: 0 12px;
 }
 


### PR DESCRIPTION
### Change

- assign a min-width to the search field to prevent it from cutting off when too many participants are present