### PR TITLE
runfix: Reset all conversation components on conversation switch

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -378,6 +378,7 @@ export const Conversation: FC<ConversationProps> = ({
       id="conversation"
       className={cx('conversation', {[incomingCssClass]: isConversationLoaded, loading: !isConversationLoaded})}
       ref={removeAnimationsClass}
+      key={activeConversation?.id}
     >
       {activeConversation && (
         <>
@@ -415,7 +416,6 @@ export const Conversation: FC<ConversationProps> = ({
           })}
 
           <MessagesList
-            key={activeConversation.id}
             conversation={activeConversation}
             selfUser={selfUser}
             initialMessage={initialMessage}


### PR DESCRIPTION
This will fix a problem where drag&dropping a file in a conversation would send the file to the wrong conversation (because it was keeping track of the old conversation)
