### PR TITLE
runfix: adjust width of conversation elements in responsive view

### DIFF
--- a/src/script/components/MessagesList/Message/CallMessage.tsx
+++ b/src/script/components/MessagesList/Message/CallMessage.tsx
@@ -57,8 +57,10 @@ const CallMessage: React.FC<CallMessageProps> = ({message}) => {
         data-uie-name="element-message-call"
         data-uie-value={isCompleted ? 'completed' : 'not_completed'}
       >
-        <span className="message-header-sender-name">{unsafeSenderName}</span>
-        <span className="ellipsis">{caption}</span>
+        <p>
+          <span className="message-header-sender-name">{unsafeSenderName}</span>
+          <span>{caption}</span>
+        </p>
       </div>
       <div className="message-body-actions">
         <MessageTime timestamp={timestamp} data-uie-uid={message.id} data-uie-name="item-message-call-timestamp" />

--- a/src/script/components/MessagesList/Message/CallTimeoutMessage.tsx
+++ b/src/script/components/MessagesList/Message/CallTimeoutMessage.tsx
@@ -50,10 +50,10 @@ const CallTimeoutMessage: React.FC<CallTimeoutMessageProps> = ({message}) => {
         data-uie-name="element-message-call"
         data-uie-value={reason === REASON.NOONE_JOINED ? 'no-one-joined' : 'everyone-left'}
       >
-        <span className="ellipsis">
+        <p>
           {text}
           <b>{reason === REASON.NOONE_JOINED ? t('callNoOneJoined') : t('callEveryOneLeft')}</b>
-        </span>
+        </p>
       </div>
       <div className="message-body-actions">
         <MessageTime timestamp={timestamp} data-uie-uid={message.id} data-uie-name="item-message-call-timestamp" />

--- a/src/script/components/MessagesList/Message/DecryptErrorMessage.tsx
+++ b/src/script/components/MessagesList/Message/DecryptErrorMessage.tsx
@@ -57,7 +57,6 @@ const DecryptErrorMessage: React.FC<DecryptErrorMessageProps> = ({message, onCli
           >
             {t('conversationUnableToDecryptLink')}
           </a>
-          <hr className="message-header-line" />
         </div>
       </div>
       <div className="message-body message-body-decrypt-error">

--- a/src/script/components/MessagesList/Message/DeleteMessage.tsx
+++ b/src/script/components/MessagesList/Message/DeleteMessage.tsx
@@ -56,12 +56,12 @@ const DeleteMessage: React.FC<DeleteMessageProps> = ({message, onClickAvatar}) =
         />
       </div>
       <div className="message-header-label" data-uie-name="element-message-delete">
-        <span className="message-header-label-sender" data-uie-name="element-message-delete-sender-name">
+        <p className="message-header-label-sender" data-uie-name="element-message-delete-sender-name">
           {unsafeSenderName}
-        </span>
+        </p>
         <span className="message-header-label-icon icon-trash" title={formattedDeletionTime} />
       </div>
-      <div className="message-body-actions message-body-actions-large">
+      <div className="message-body-actions">
         <MessageTime
           timestamp={deletedTimeStamp}
           data-uie-uid={message.id}

--- a/src/script/components/MessagesList/Message/MemberMessage.tsx
+++ b/src/script/components/MessagesList/Message/MemberMessage.tsx
@@ -121,7 +121,6 @@ const MemberMessage: React.FC<MemberMessageProps> = ({
               </div>
               <div ref={initShowMore} className="message-header-label">
                 <span className="message-header-caption" dangerouslySetInnerHTML={{__html: htmlCaption}} />
-                <hr className="message-header-line" />
               </div>
               {isMemberChange && (
                 <div className="message-body-actions">
@@ -165,7 +164,6 @@ const MemberMessage: React.FC<MemberMessageProps> = ({
               </div>
               <div className="message-header-label">
                 <span className="ellipsis">{t('conversationCreateReceiptsEnabled')}</span>
-                <hr className="message-header-line" />
               </div>
             </div>
           )}

--- a/src/script/components/MessagesList/Message/SystemMessage.tsx
+++ b/src/script/components/MessagesList/Message/SystemMessage.tsx
@@ -54,7 +54,6 @@ const SystemMessage: React.FC<SystemMessageProps> = ({message}) => {
             <span className="message-header-sender-name">{unsafeSenderName}</span>
             <span className="ellipsis">{caption}</span>
           </span>
-          <hr className="message-header-line" />
         </div>
         <div className="message-body-actions">
           <MessageTime timestamp={timestamp} data-uie-uid={message.id} data-uie-name="item-message-call-timestamp" />

--- a/src/script/components/MessagesList/Message/VerificationMessage.tsx
+++ b/src/script/components/MessagesList/Message/VerificationMessage.tsx
@@ -114,7 +114,6 @@ const VerificationMessage: React.FC<VerificationMessageProps> = ({message}) => {
             </button>
           </>
         )}
-        <hr className="message-header-line" />
       </div>
     </div>
   );

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -280,7 +280,6 @@
 
   &:not(.message-timestamp-day) {
     border: 0;
-    margin-right: var(--conversation-message-timestamp-width);
 
     .message-header-label {
       border-bottom: 1px dotted @separator-color;

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -176,6 +176,7 @@
   min-width: 0; // fixes ellipsis not working with flexbox (FF)
   flex: 1;
   align-items: center;
+  padding-right: var(--conversation-message-timestamp-width);
   font-size: @font-size-small;
   font-weight: @font-weight-regular;
   white-space: normal;
@@ -617,10 +618,10 @@
   }
 }
 
-.message-body-actions-large {
-  position: relative;
-  width: 160px;
-}
+// .message-body-actions-large {
+//   position: relative;
+//   width: 160px;
+// }
 
 .message-services-warning {
   color: @w-red;

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -250,15 +250,6 @@
   height: 16px;
 }
 
-.message-header-line {
-  min-width: var(--conversation-message-timestamp-width);
-  height: 1px;
-  flex: 1;
-  border: none;
-  margin-left: 16px;
-  background: @separator-color;
-}
-
 // MESSAGE - TIMESTAMP
 .message-timestamp {
   height: 48px;

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -609,11 +609,6 @@
   }
 }
 
-// .message-body-actions-large {
-//   position: relative;
-//   width: 160px;
-// }
-
 .message-services-warning {
   color: @w-red;
   font-size: @font-size-small;


### PR DESCRIPTION
#### Issue

- some elements (system messages mostly) overlap with timestamps or do not fit the width of the message list correctly
![image](https://user-images.githubusercontent.com/78490891/204564755-4ebc81a8-4eb1-44e7-a09c-9ea072f045c6.png)


#### Corection
![image](https://user-images.githubusercontent.com/78490891/204565136-cc1d5079-d93f-4678-8b9c-ad363c950798.png)

