### PR TITLE
runfix: Retrict image asset height

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset.tsx
@@ -88,7 +88,7 @@ const ImageAsset: React.FC<ImageAssetProps> = ({asset, message, onClick, teamSta
     username: `${message.user().name()}`,
   });
 
-  const style: CSSObject = {
+  const imageContainerStyle: CSSObject = {
     aspectRatio: `${asset.ratio}`,
     maxWidth: '100%',
     width: asset.width,
@@ -97,7 +97,7 @@ const ImageAsset: React.FC<ImageAssetProps> = ({asset, message, onClick, teamSta
   };
 
   return (
-    <div data-uie-name="image-asset" css={style}>
+    <div data-uie-name="image-asset" css={imageContainerStyle}>
       {isFileSharingReceivingEnabled ? (
         <InViewport
           className={cx('image-asset', {

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset.tsx
@@ -19,6 +19,7 @@
 
 import React, {useEffect, useState} from 'react';
 
+import {CSSObject} from '@emotion/react';
 import cx from 'classnames';
 import {container} from 'tsyringe';
 
@@ -87,8 +88,16 @@ const ImageAsset: React.FC<ImageAssetProps> = ({asset, message, onClick, teamSta
     username: `${message.user().name()}`,
   });
 
+  const style: CSSObject = {
+    aspectRatio: `${asset.ratio}`,
+    maxWidth: '100%',
+    width: asset.width,
+    maxHeight: '80vh',
+    height: asset.height,
+  };
+
   return (
-    <div data-uie-name="image-asset" style={{aspectRatio: `${asset.ratio}`, maxWidth: '100%', width: asset.width}}>
+    <div data-uie-name="image-asset" css={style}>
       {isFileSharingReceivingEnabled ? (
         <InViewport
           className={cx('image-asset', {


### PR DESCRIPTION
Avoids pushing the lower bound of the conversation when sending a very long portrait image. 

We need to apply the same restrictions to the container than we apply to the image itself

This image:
![image](https://user-images.githubusercontent.com/1090716/203257629-0d0958f0-eac5-46a8-81c4-7e465bfb3105.png)

Has a container that has a overflowing height:
![image](https://user-images.githubusercontent.com/1090716/203257059-de4bb4bd-ae88-4525-9849-74aceb15ba5a.png)
