### PR TITLE
runfix: Correct focus order in preferences (ACC-303)

### DIFF
--- a/src/script/page/LeftSidebar/panels/Preferences.tsx
+++ b/src/script/page/LeftSidebar/panels/Preferences.tsx
@@ -132,9 +132,7 @@ const Preferences: React.FC<PreferencesProps> = ({
     setTimeout(() => {
       const centerColumn = document.getElementById('center-column');
       const nextElementToFocus = centerColumn?.querySelector("[tabindex='0']") as HTMLElement | null;
-      if (nextElementToFocus) {
-        nextElementToFocus.focus();
-      }
+      nextElementToFocus?.focus();
     }, ANIMATED_PAGE_TRANSITION_DURATION + 1);
   };
 

--- a/src/script/page/LeftSidebar/panels/Preferences.tsx
+++ b/src/script/page/LeftSidebar/panels/Preferences.tsx
@@ -37,6 +37,7 @@ import {
 } from '../../../notification/PreferenceNotificationRepository';
 import {TeamRepository} from '../../../team/TeamRepository';
 import {ContentViewModel} from '../../../view_model/ContentViewModel';
+import {ANIMATED_PAGE_TRANSITION_DURATION} from '../../MainContent';
 import {useAppMainState, ViewType} from '../../state';
 import {ContentState, useAppState} from '../../useAppState';
 
@@ -127,6 +128,15 @@ const Preferences: React.FC<PreferencesProps> = ({
   const onClickSelect = (item: typeof items[number]) => {
     setCurrentView(ViewType.CENTRAL_COLUMN);
     contentViewModel.switchContent(item.id);
+
+    setTimeout(() => {
+      const nextElementToFocus = document
+        ?.getElementById('center-column')
+        ?.querySelector("[tabindex='0']") as HTMLElement | null;
+      if (nextElementToFocus) {
+        nextElementToFocus.focus();
+      }
+    }, ANIMATED_PAGE_TRANSITION_DURATION + 1);
   };
 
   useEffect(() => {

--- a/src/script/page/LeftSidebar/panels/Preferences.tsx
+++ b/src/script/page/LeftSidebar/panels/Preferences.tsx
@@ -130,9 +130,8 @@ const Preferences: React.FC<PreferencesProps> = ({
     contentViewModel.switchContent(item.id);
 
     setTimeout(() => {
-      const nextElementToFocus = document
-        ?.getElementById('center-column')
-        ?.querySelector("[tabindex='0']") as HTMLElement | null;
+      const centerColumn = document.getElementById('center-column');
+      const nextElementToFocus = centerColumn?.querySelector("[tabindex='0']") as HTMLElement | null;
       if (nextElementToFocus) {
         nextElementToFocus.focus();
       }

--- a/src/script/page/MainContent/MainContent.tsx
+++ b/src/script/page/MainContent/MainContent.tsx
@@ -49,8 +49,10 @@ import {PanelState} from '../RightSidebar';
 import {RootContext} from '../RootProvider';
 import {ContentState, useAppState} from '../useAppState';
 
+export const ANIMATED_PAGE_TRANSITION_DURATION = 500;
+
 const Animated: FC<{children: ReactNode}> = ({children, ...rest}) => (
-  <CSSTransition classNames="slide-in-left" timeout={{enter: 500}} {...rest}>
+  <CSSTransition classNames="slide-in-left" timeout={{enter: ANIMATED_PAGE_TRANSITION_DURATION}} {...rest}>
     {children}
   </CSSTransition>
 );

--- a/src/script/page/MainContent/panels/preferences/components/PreferencesPage.tsx
+++ b/src/script/page/MainContent/panels/preferences/components/PreferencesPage.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {useContext, FC, useCallback} from 'react';
+import {useContext, FC} from 'react';
 
 import {IconButton, IconButtonVariant, useMatchMedia} from '@wireapp/react-ui-kit';
 
@@ -41,20 +41,8 @@ const PreferencesPage: FC<PreferencesPageProps> = ({title, children}) => {
 
   const goHome = () => root?.content.loadPreviousContent();
 
-  const containerRef = useCallback((element: HTMLDivElement | null) => {
-    const nextElementToFocus = element?.querySelector("[tabindex='0']") as HTMLElement | null;
-    if (nextElementToFocus) {
-      nextElementToFocus.focus();
-    }
-  }, []);
-
   return (
-    <div
-      role="tabpanel"
-      ref={containerRef}
-      aria-labelledby={title}
-      style={{display: 'flex', flexDirection: 'column', height: '100vh'}}
-    >
+    <div role="tabpanel" aria-labelledby={title} style={{display: 'flex', flexDirection: 'column', height: '100vh'}}>
       <div className="preferences-titlebar">
         {smBreakpoint && isCentralColumn && (
           <IconButton


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-303" title="ACC-303" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-303</a>  Wrong focus order in Preferences
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Focus order in preferences should be: opening the preferences → focus on close button → first menu item → 2nd menu item →  3rd, 4th… →  first element in the content area.

Currently whenever a preference page is mounted we focus on it's first element which is wrong, on the initial load of preferences this should be avoided to have the focus on tab items, but when we click on to switch between preferences pages we should focus on their first element. 