### PR TITLE
chore: Add debug function for sending status

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@types/eslint": "^8.4.10",
     "@wireapp/antiscroll-2": "1.3.1",
     "@wireapp/avs": "8.2.17",
-    "@wireapp/core": "37.1.1",
+    "@wireapp/core": "37.2.0",
     "@wireapp/react-ui-kit": "9.0.2",
     "@wireapp/store-engine-dexie": "2.0.3",
     "@wireapp/store-engine-sqleet": "1.8.9",

--- a/src/script/util/DebugUtil.ts
+++ b/src/script/util/DebugUtil.ts
@@ -172,6 +172,10 @@ export class DebugUtil {
     };
   }
 
+  isSendingMessage(): boolean {
+    return this.core.service!.conversation.isSendingMessage();
+  }
+
   async getLastMessagesFromDatabase(
     amount = 10,
     conversationId = this.conversationState.activeConversation().id,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4167,9 +4167,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^22.6.1":
-  version: 22.6.1
-  resolution: "@wireapp/api-client@npm:22.6.1"
+"@wireapp/api-client@npm:^22.7.0":
+  version: 22.7.0
+  resolution: "@wireapp/api-client@npm:22.7.0"
   dependencies:
     "@wireapp/commons": ^5.0.3
     "@wireapp/priority-queue": ^2.0.3
@@ -4182,7 +4182,7 @@ __metadata:
     spark-md5: 3.0.2
     tough-cookie: 4.1.2
     ws: 8.10.0
-  checksum: a1cbc2cc80f44dfc88886a89425acda0f91834ec2182dafa6ef9dab030b3963e5db9847553661213e305a3b355090cb2cda3dcafc622bc693f1c85c93bd9817c
+  checksum: f8c17729cc2ff32c23af26ac2259785d8b593532175d5592a496673d9fdd42bc628bcbbac5db768b183669f8fb93f18b27cc12b9a22272b277fe849ebd40a8ca
   languageName: node
   linkType: hard
 
@@ -4235,15 +4235,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:37.1.1":
-  version: 37.1.1
-  resolution: "@wireapp/core@npm:37.1.1"
+"@wireapp/core@npm:37.2.0":
+  version: 37.2.0
+  resolution: "@wireapp/core@npm:37.2.0"
   dependencies:
-    "@wireapp/api-client": ^22.6.1
+    "@wireapp/api-client": ^22.7.0
     "@wireapp/commons": ^5.0.3
     "@wireapp/core-crypto": 0.6.0-pre.4
     "@wireapp/cryptobox": 12.8.0
-    "@wireapp/promise-queue": ^2.0.3
+    "@wireapp/promise-queue": ^2.1.0
     "@wireapp/protocol-messaging": 1.42.0
     "@wireapp/store-engine-dexie": ^2.0.3
     axios: 1.1.2
@@ -4254,7 +4254,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.12
-  checksum: 19994abdec60930ad75bf46888f1bcf8e2e3db1f80457d43f48e30fae3709d4fe600453213d87f44ac9403251f25565b9683731f2bd1b1053c561da8d371138c
+  checksum: 5c8c01424e2bbca84e7951e9de0209e6c2fc88603edf92f3e420a4daa750d0e6ee988ffc841f691e739aa74620c4fcd25b5a11e5a9de638effd5a9b02ae5b583
   languageName: node
   linkType: hard
 
@@ -4334,10 +4334,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/promise-queue@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@wireapp/promise-queue@npm:2.0.3"
-  checksum: 7945ef95828ee4262fddf6ed4b907c443538de76795a4130b2ee49878e155fcdaec9f44bcab7c45a2bb4e5ccfef204d6d92c89b9b9be3f1e7a5efd5aea1d4d92
+"@wireapp/promise-queue@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@wireapp/promise-queue@npm:2.1.0"
+  checksum: 6785d8e21d4b57fc8b4848276678b83c9f0483897d9b4147ebc79b72a178e81187356fff2a07cfdd61e1cde36aeb1e0651d036ec372a26bde2a31ca63afde703
   languageName: node
   linkType: hard
 
@@ -16526,7 +16526,7 @@ __metadata:
     "@wireapp/antiscroll-2": 1.3.1
     "@wireapp/avs": 8.2.17
     "@wireapp/copy-config": 2.0.3
-    "@wireapp/core": 37.1.1
+    "@wireapp/core": 37.2.0
     "@wireapp/eslint-config": 2.1.0
     "@wireapp/prettier-config": 0.5.2
     "@wireapp/react-ui-kit": 9.0.2


### PR DESCRIPTION
Adds a debug function that will allow QA to know when a message is being sent. 

This is particularly useful for `status` message which doesn't have any visual indication whether the status is being sent or successfully sent. 