### PR TITLE
fix: Discard typing events after 1 minute

### DIFF
--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -67,7 +67,7 @@ import {formatBytes, getSelectionPosition} from 'Util/util';
 import {getRichTextInput} from './getRichTextInput';
 import {PastedFileControls} from './PastedFileControls';
 import {ReplyBar} from './ReplyBar';
-import {IS_TYPING_TIMEOUT} from './TypingIndicator';
+import {TYPING_TIMEOUT} from './TypingIndicator';
 import {TypingIndicator} from './TypingIndicator/TypingIndicator';
 
 import {AssetRepository} from '../../assets/AssetRepository';
@@ -409,7 +409,7 @@ const InputBar = ({
     let timerId: number;
     if (inputValue.length > 0) {
       setIsTyping(true);
-      timerId = window.setTimeout(() => setIsTyping(false), IS_TYPING_TIMEOUT);
+      timerId = window.setTimeout(() => setIsTyping(false), TYPING_TIMEOUT);
     } else {
       setIsTyping(false);
     }

--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -67,6 +67,7 @@ import {formatBytes, getSelectionPosition} from 'Util/util';
 import {getRichTextInput} from './getRichTextInput';
 import {PastedFileControls} from './PastedFileControls';
 import {ReplyBar} from './ReplyBar';
+import {IS_TYPING_TIMEOUT} from './TypingIndicator';
 import {TypingIndicator} from './TypingIndicator/TypingIndicator';
 
 import {AssetRepository} from '../../assets/AssetRepository';
@@ -91,7 +92,6 @@ import {UserState} from '../../user/UserState';
 const CONFIG = {
   ...Config.getConfig(),
   PING_TIMEOUT: TIME_IN_MILLIS.SECOND * 2,
-  IS_TYPING_TIMEOUT: TIME_IN_MILLIS.SECOND * 10,
 };
 
 const showWarningModal = (title: string, message: string): void => {
@@ -409,7 +409,7 @@ const InputBar = ({
     let timerId: number;
     if (inputValue.length > 0) {
       setIsTyping(true);
-      timerId = window.setTimeout(() => setIsTyping(false), CONFIG.IS_TYPING_TIMEOUT);
+      timerId = window.setTimeout(() => setIsTyping(false), IS_TYPING_TIMEOUT);
     } else {
       setIsTyping(false);
     }

--- a/src/script/components/InputBar/TypingIndicator/TypingIndicator.state.tsx
+++ b/src/script/components/InputBar/TypingIndicator/TypingIndicator.state.tsx
@@ -24,19 +24,21 @@ import {User} from '../../../entity/User';
 type TypingUser = {
   conversationId: string;
   user: User;
+  timerId: number;
 };
 
 type TypingIndicatorState = {
   typingUsers: TypingUser[];
   addTypingUser: (user: TypingUser) => void;
-  removeTypingUser: (user: TypingUser) => void;
+  removeTypingUser: (user: User, conversationId: string) => void;
   getTypingUsersInConversation: (conversationId: string) => User[];
   clearTypingUsers: () => void;
+  getTypingUser: (user: User, conversationId: string) => TypingUser | undefined;
 };
 
 const useTypingIndicatorState = create<TypingIndicatorState>((set, get) => ({
   typingUsers: [],
-  addTypingUser: ({conversationId, user}) =>
+  addTypingUser: ({conversationId, user, timerId}) =>
     set(state => {
       if (
         state.typingUsers.find(
@@ -45,12 +47,16 @@ const useTypingIndicatorState = create<TypingIndicatorState>((set, get) => ({
       ) {
         return state;
       }
-      return {typingUsers: [...state.typingUsers, {conversationId, user}]};
+      return {typingUsers: [...state.typingUsers, {conversationId, user, timerId}]};
     }),
-  removeTypingUser: ({conversationId, user: {id}}) =>
+  getTypingUser: (user, conversationId) =>
+    get().typingUsers.find(
+      typingUser => typingUser.conversationId === conversationId && typingUser.user.id === user.id,
+    ),
+  removeTypingUser: (user, conversationId) =>
     set(state => ({
       typingUsers: state.typingUsers.filter(
-        typingUser => !(typingUser.conversationId === conversationId && typingUser.user.id === id),
+        typingUser => !(typingUser.conversationId === conversationId && typingUser.user.id === user.id),
       ),
     })),
   getTypingUsersInConversation: conversationId =>

--- a/src/script/components/InputBar/TypingIndicator/TypingIndicator.test.tsx
+++ b/src/script/components/InputBar/TypingIndicator/TypingIndicator.test.tsx
@@ -50,9 +50,9 @@ describe('TypingIndicator', () => {
 
     const {addTypingUser} = useTypingIndicatorState.getState();
 
-    addTypingUser({conversationId: 'test-conversation-id', user: new User('test-id-1')});
-    addTypingUser({conversationId: 'test-conversation-id', user: new User('test-id-2')});
-    addTypingUser({conversationId: 'test-conversation-id', user: new User('test-id-3')});
+    addTypingUser({conversationId: 'test-conversation-id', user: new User('test-id-1'), timerId: 0});
+    addTypingUser({conversationId: 'test-conversation-id', user: new User('test-id-2'), timerId: 0});
+    addTypingUser({conversationId: 'test-conversation-id', user: new User('test-id-3'), timerId: 0});
 
     const {container} = render(<TypingIndicator {...props} />);
 
@@ -71,9 +71,9 @@ describe('TypingIndicator', () => {
     const {addTypingUser} = useTypingIndicatorState.getState();
 
     act(() => {
-      addTypingUser({conversationId: 'test-conversation-id', user: new User('test-id-1')});
-      addTypingUser({conversationId: 'test-conversation-id', user: new User('test-id-2')});
-      addTypingUser({conversationId: 'test-conversation-id', user: new User('test-id-3')});
+      addTypingUser({conversationId: 'test-conversation-id', user: new User('test-id-1'), timerId: 0});
+      addTypingUser({conversationId: 'test-conversation-id', user: new User('test-id-2'), timerId: 0});
+      addTypingUser({conversationId: 'test-conversation-id', user: new User('test-id-3'), timerId: 0});
     });
 
     expect(container.querySelectorAll('[data-uie-name="element-avatar-user"]').length).toBe(3);
@@ -91,15 +91,15 @@ describe('TypingIndicator', () => {
     const {addTypingUser, removeTypingUser} = useTypingIndicatorState.getState();
 
     act(() => {
-      addTypingUser({conversationId: 'test-conversation-id', user: new User('test-id-1')});
-      addTypingUser({conversationId: 'test-conversation-id', user: new User('test-id-2')});
-      addTypingUser({conversationId: 'test-conversation-id', user: new User('test-id-3')});
+      addTypingUser({conversationId: 'test-conversation-id', user: new User('test-id-1'), timerId: 0});
+      addTypingUser({conversationId: 'test-conversation-id', user: new User('test-id-2'), timerId: 0});
+      addTypingUser({conversationId: 'test-conversation-id', user: new User('test-id-3'), timerId: 0});
     });
 
     expect(container.querySelectorAll('[data-uie-name="element-avatar-user"]').length).toBe(3);
 
     act(() => {
-      removeTypingUser({conversationId: 'test-conversation-id', user: new User('test-id-3')});
+      removeTypingUser(new User('test-id-3'), 'test-conversation-id');
     });
 
     expect(container.querySelectorAll('[data-uie-name="element-avatar-user"]').length).toBe(2);

--- a/src/script/components/InputBar/TypingIndicator/index.ts
+++ b/src/script/components/InputBar/TypingIndicator/index.ts
@@ -23,4 +23,4 @@ export * from './TypingIndicator';
 
 export {useTypingIndicatorState} from './TypingIndicator.state';
 
-export const IS_TYPING_TIMEOUT = TIME_IN_MILLIS.SECOND * 10;
+export const TYPING_TIMEOUT = TIME_IN_MILLIS.SECOND * 10;

--- a/src/script/components/InputBar/TypingIndicator/index.ts
+++ b/src/script/components/InputBar/TypingIndicator/index.ts
@@ -17,6 +17,10 @@
  *
  */
 
+import {TIME_IN_MILLIS} from 'Util/TimeUtil';
+
 export * from './TypingIndicator';
 
 export {useTypingIndicatorState} from './TypingIndicator.state';
+
+export const IS_TYPING_TIMEOUT = TIME_IN_MILLIS.SECOND * 10;

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -49,7 +49,7 @@ import {flatten} from 'underscore';
 import {Asset as ProtobufAsset, Confirmation, LegalHoldStatus} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
-import {useTypingIndicatorState} from 'Components/InputBar/TypingIndicator';
+import {IS_TYPING_TIMEOUT, useTypingIndicatorState} from 'Components/InputBar/TypingIndicator';
 import {getNextItem} from 'Util/ArrayUtil';
 import {allowsAllFiles, getFileExtensionOrName, isAllowedFile} from 'Util/FileTypeUtil';
 import {replaceLink, t} from 'Util/LocalizerUtil';
@@ -2849,15 +2849,25 @@ export class ConversationRepository {
     }
 
     const conversationId = conversationEntity.id;
-    const {addTypingUser, removeTypingUser} = useTypingIndicatorState.getState();
-    const typingUser = {conversationId, user: qualifiedUser};
+    const {addTypingUser, getTypingUser, removeTypingUser} = useTypingIndicatorState.getState();
+
+    const oldUser = getTypingUser(qualifiedUser, conversationId);
+    if (oldUser) {
+      window.clearTimeout(oldUser.timerId);
+    }
 
     if (eventJson.data.status === CONVERSATION_TYPING.STARTED) {
+      const timerId = window.setTimeout(() => {
+        removeTypingUser(qualifiedUser, conversationId);
+      }, IS_TYPING_TIMEOUT * 6); // 10000 * 6 => 1 minute
+
+      const typingUser = {conversationId, user: qualifiedUser, timerId};
+
       addTypingUser(typingUser);
     }
 
     if (eventJson.data.status === CONVERSATION_TYPING.STOPPED) {
-      removeTypingUser(typingUser);
+      removeTypingUser(qualifiedUser, conversationId);
     }
 
     return {conversationEntity};

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -49,7 +49,7 @@ import {flatten} from 'underscore';
 import {Asset as ProtobufAsset, Confirmation, LegalHoldStatus} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
-import {IS_TYPING_TIMEOUT, useTypingIndicatorState} from 'Components/InputBar/TypingIndicator';
+import {TYPING_TIMEOUT, useTypingIndicatorState} from 'Components/InputBar/TypingIndicator';
 import {getNextItem} from 'Util/ArrayUtil';
 import {allowsAllFiles, getFileExtensionOrName, isAllowedFile} from 'Util/FileTypeUtil';
 import {replaceLink, t} from 'Util/LocalizerUtil';
@@ -2859,7 +2859,7 @@ export class ConversationRepository {
     if (eventJson.data.status === CONVERSATION_TYPING.STARTED) {
       const timerId = window.setTimeout(() => {
         removeTypingUser(qualifiedUser, conversationId);
-      }, IS_TYPING_TIMEOUT * 6); // 10000 * 6 => 1 minute
+      }, TYPING_TIMEOUT * 6); // 10000 * 6 => 1 minute
 
       const typingUser = {conversationId, user: qualifiedUser, timerId};
 


### PR DESCRIPTION
User A might start typing and after less than 10 seconds they might go offline for whatever reason hence they won't send any stop typing message anymore and other people in the conversation will end up seeing they are typing forever, this PR fixes this issue by discarding the event after one minute. 