### PR TITLE
runfix: correct visual issues at max font size of 24px [ACC-302]

### DIFF
--- a/src/style/components/list/participant-item.less
+++ b/src/style/components/list/participant-item.less
@@ -120,7 +120,7 @@
         display: flex;
         min-width: 0; // this will ensure that ellipses is working
         max-width: @participant-max-width;
-        height: @avatar-diameter-m;
+        min-height: @avatar-diameter-m;
         flex-direction: column;
         flex-grow: 1;
         align-items: flex-start;

--- a/src/style/foundation/video-calling.less
+++ b/src/style/foundation/video-calling.less
@@ -175,7 +175,7 @@
       left: 50%;
       margin: 0;
       color: var(--main-color);
-      font-size: @font-size-xsmall;
+      font-size: 11px;
       font-weight: @font-weight-regular;
       transform: translateX(-50%);
       white-space: nowrap;

--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -60,6 +60,7 @@
   padding: 8px;
   border-radius: 6px;
   color: var(--main-color);
+  font-size: 11px;
   text-transform: capitalize;
 
   svg {

--- a/src/style/panel/panel.less
+++ b/src/style/panel/panel.less
@@ -333,7 +333,7 @@
     &__icon,
     &__context {
       display: flex;
-      width: 40px;
+      min-width: 40px;
       margin-left: 1px;
 
       path {
@@ -369,6 +369,7 @@
 
     &__summary {
       display: flex;
+      overflow: hidden;
       flex-direction: column;
       flex-grow: 1;
       align-items: flex-start;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-302" title="ACC-302" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />ACC-302</a>  Font Scaling in Preferences (Part of BITV 11.7)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Issues

- left sidebar buttons overflow from the panel at max font size
- not enough height for the participants in right sidebar
- text of call ui buttons overlap

![image](https://user-images.githubusercontent.com/78490891/203790450-830c1fa4-044a-4909-8ab4-fbc9ca7f3e7e.png)

![image](https://user-images.githubusercontent.com/78490891/203790288-db625a34-6797-43b5-af16-3858c249bee1.png)

### Solutions

Decision has been made on design's side to fix the font size for some ui elements. The workaround would be to introduce a responsive font size for tooltips.

- Fix the font size to default 11px for buttons
- replace height by min-height for the relevent elements
-  Fix the font size to default 11px for call ui buttons
![Screenshot from 2022-11-24 13-47-58](https://user-images.githubusercontent.com/78490891/203789401-f0286b90-449a-4354-8237-6cfd2fb511c2.png)
![image](https://user-images.githubusercontent.com/78490891/203790022-de9e9a0b-667e-46bf-ad30-ccf5306d38ca.png)
