### PR TITLE
runfix: correct visual bugs at font size of 24px [ACC-302]

### DIFF
--- a/src/script/page/RightSidebar/GroupParticipantUser/GroupParticipantUser.tsx
+++ b/src/script/page/RightSidebar/GroupParticipantUser/GroupParticipantUser.tsx
@@ -201,7 +201,7 @@ const GroupParticipantUser: FC<GroupParticipantUserProps> = ({
               </div>
             </div>
 
-            <div className="panel__action-item panel__info-text panel__item-offset" tabIndex={0}>
+            <div className="panel__info-text panel__item-offset" css={{padding: '16px'}} tabIndex={0}>
               {t('conversationDetailsGroupAdminInfo')}
             </div>
           </>

--- a/src/style/content/preferences.less
+++ b/src/style/content/preferences.less
@@ -69,7 +69,6 @@ body.theme-dark {
 .preferences-detail {
   margin-top: 10px;
   font-size: @font-size-small;
-  line-height: @line-height-xs;
 
   &-intended {
     margin-left: 2rem;

--- a/src/style/modal/group-creation.less
+++ b/src/style/modal/group-creation.less
@@ -20,7 +20,7 @@
 .group-creation {
   &__modal {
     .modal-input-wrapper {
-      min-height: 67px;
+      min-height: 4rem;
     }
     .modal__content {
       height: 490px;

--- a/src/style/panel/panel.less
+++ b/src/style/panel/panel.less
@@ -137,7 +137,6 @@
 
   &__info-text {
     .subline;
-
     &:focus-visible {
       .focus-outline;
       .focus-offset;
@@ -401,7 +400,7 @@
     }
 
     &__title {
-      .heading-h3;
+      .ellipsis-nowrap .heading-h3;
 
       &:focus-visible {
         .focus-outline;

--- a/src/style/panel/participant-devices.less
+++ b/src/style/panel/participant-devices.less
@@ -19,7 +19,7 @@
 
 .participant-devices {
   &__fingerprint {
-    height: 72px;
+    min-height: 72px;
     margin-bottom: 32px;
     font-family: monospace;
     line-height: 1.375rem;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-302" title="ACC-302" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />ACC-302</a>  Font Scaling in Preferences (Part of BITV 11.7)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Fixes

Second round of fixes after feedback from QA : 

- Option descriptions in settings have a very low line spacing

![48c2c602-a4d5-46c1-a582-541765e59626](https://user-images.githubusercontent.com/78490891/203851581-f722a2c8-6c60-453c-bcec-271f772de0a4.png)

- Participant details: Overlapping description for group admin toggle description
![1bc78481-0e0c-42f6-8a98-9c1d0b914c82](https://user-images.githubusercontent.com/78490891/203851621-f9d1f659-3a1b-4ead-b6e9-bc783f8837f7.png)

- Participant device details: Fingerprint overlaps verify toggle
![75ffd8d4-b2c4-4078-af22-27f160c384d7](https://user-images.githubusercontent.com/78490891/203851714-c4f53884-89ea-4554-a191-0ca5ed4c6a66.png)

- The option page for this has a line break that causes line height issue
![04e77aaf-f304-4557-bdae-f025c3b56f2e](https://user-images.githubusercontent.com/78490891/203851870-8b4d5b7f-8e58-4266-9d43-1ce71178cafa.png)

- creat group input is overlaping text under it
![4fc5b67f-62ea-4b6b-8e17-ada959126cce](https://user-images.githubusercontent.com/78490891/203851935-5300ec28-3580-495f-852d-e02ade0ac2ee.png)
