### PR TITLE
fix: use correct type for InternalErrorRoute

### DIFF
--- a/server/routes/error/ErrorRoutes.ts
+++ b/server/routes/error/ErrorRoutes.ts
@@ -30,7 +30,7 @@ const logger = logdown('@wireapp/wire-webapp/routes/error/errorRoutes', {
   markdown: false,
 });
 
-const InternalErrorRoute = (): express.ErrorRequestHandler => (err, req, res) => {
+const InternalErrorRoute = (): express.ErrorRequestHandler => (err, req, res, next) => {
   logger.error(`[${formatDate()}] ${err.stack}`);
   const error = {
     code: HTTP_STATUS.INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
[express.ErrorRequestHandler](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a2315c4f11c4c7cf75f37d74f3dac8c91abd848e/types/express-serve-static-core/index.d.ts#L83) expects 4 arguments in its type. This PR prevents the function from throwing an exception when trying to use `res.status()` when handling an error.