### PR TITLE
runfix: prevent overlapping added users

### DIFF
--- a/src/script/components/SearchInput.tsx
+++ b/src/script/components/SearchInput.tsx
@@ -67,7 +67,11 @@ const SearchInput: React.FC<SearchInputProps> = ({
   const placeHolderText = emptyInput && noSelectedUsers ? placeholder : '';
 
   return (
-    <form autoComplete="off" className={`search-outer ${forceDark ? '' : 'user-list-light'}`}>
+    <form
+      autoComplete="off"
+      className={`search-outer ${forceDark ? '' : 'user-list-light'}`}
+      css={noSelectedUsers && {minHeight: '48px'}}
+    >
       <div className="search-inner-wrap">
         <div className="search-inner" ref={innerElement}>
           <div className="search-icon icon-search" />

--- a/src/style/components/search-input.less
+++ b/src/style/components/search-input.less
@@ -19,7 +19,6 @@
 
 .search-outer {
   overflow: hidden;
-  min-height: 48px;
   padding: 0 12px;
 }
 


### PR DESCRIPTION
----

### Issue

- Name of added users are overlapping when adding participants in the sidebar

![image](https://user-images.githubusercontent.com/78490891/204259610-ca24c010-6f93-4e51-99c9-e7f6b181e194.png)

### Solution

- make the min-height for the search field a conditional