### PR TITLE
runfix: Avoid setting fixed height to images

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset.tsx
@@ -93,7 +93,6 @@ const ImageAsset: React.FC<ImageAssetProps> = ({asset, message, onClick, teamSta
     maxWidth: '100%',
     width: asset.width,
     maxHeight: '80vh',
-    height: asset.height,
   };
 
   return (


### PR DESCRIPTION
This was introduced with the changes here https://github.com/wireapp/wire-webapp/pull/14157/files

Only the `maxHeight` needs to be set (since the `height` is automatically computed from the width and aspect ratio)

![Wire 2022-11-28 at 4_25 PM](https://user-images.githubusercontent.com/1090716/204318230-105a36fb-35ae-421c-90d3-9fc7d152acd3.gif)

