### PR TITLE
runfix: show typing indicator on different input bar height

### DIFF
--- a/src/script/components/InputBar/TypingIndicator/TypingIndicator.styles.ts
+++ b/src/script/components/InputBar/TypingIndicator/TypingIndicator.styles.ts
@@ -30,7 +30,7 @@ export const wrapperStyles: CSSObject = {
   backgroundColor: 'var(--app-bg)',
   padding: 5,
   position: 'absolute',
-  bottom: 56,
+  top: -26,
   borderTopLeftRadius: 4,
   borderTopRightRadius: 4,
 };


### PR DESCRIPTION
----

#### Issue

- Typing indicator disappear if the input bar has a height over 56px (multiline input, responsive input bar)

#### Solution

- Set the absolute positioning from the top of the input bar instead of the bottom
- 26px is height + padding\*2 (16px + 5px\*2)