### PR TITLE
runfix: address visual issues related to font size [ACC-302]

### DIFF
--- a/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsOptions/ConversationDetailsOption.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsOptions/ConversationDetailsOption.tsx
@@ -46,11 +46,13 @@ const ConversationDetailsOption: FC<ConversationDetailsOptionProps> = ({
       <span className="panel__action-item__icon">{icon}</span>
 
       <span className="panel__action-item__summary">
-        <span className="panel__action-item__text">{title}</span>
-
-        <span className="panel__action-item__status" data-uie-name={statusUieName}>
-          {statusText}
+        <span className="panel__action-item__text">
+          <p>{title}</p>
         </span>
+
+        <p className="panel__action-item__status" data-uie-name={statusUieName}>
+          {statusText}
+        </p>
       </span>
 
       <Icon.ChevronRight className="chevron-right-icon" />

--- a/src/style/components/asset/link-preview-asset.less
+++ b/src/style/components/asset/link-preview-asset.less
@@ -37,8 +37,7 @@ link-preview-asset,
 }
 
 .link-preview-image-container {
-  .square(@link-preview-height);
-
+  width: @link-preview-height;
   flex: 0 0 auto;
   background-color: var(--foreground-fade-24);
 }
@@ -59,7 +58,7 @@ link-preview-asset,
 .link-preview-info {
   display: flex;
   width: 0;
-  height: @link-preview-height;
+  min-height: @link-preview-height;
   flex: 1 1 auto;
   flex-direction: column;
   justify-content: center;
@@ -83,8 +82,6 @@ link-preview-asset,
 
 .link-preview-info-title-multiline {
   .ellipsis-multiline(2);
-
-  max-height: 48px;
 }
 
 .link-preview-info-link {

--- a/src/style/components/search-input.less
+++ b/src/style/components/search-input.less
@@ -97,6 +97,11 @@
     color: var(--gray-70);
   }
 
+  &:placeholder-shown {
+    .ellipsis-nowrap;
+    font-size: 16px;
+  }
+
   // hack for chrome to fix line height issue
   &::-webkit-input-placeholder {
     transform: translateY(-1px);

--- a/src/style/content/conversation/input-bar.less
+++ b/src/style/content/conversation/input-bar.less
@@ -345,7 +345,7 @@
     white-space: nowrap;
 
     &__text {
-      height: 17px;
+      height: 1.2em;
       line-height: 1.0625rem;
 
       pre {

--- a/src/style/panel/panel.less
+++ b/src/style/panel/panel.less
@@ -347,13 +347,14 @@
     }
 
     &__text {
+      .ellipsis-nowrap;
       display: flex;
-      overflow: hidden;
       flex-grow: 1;
       align-items: center;
-      text-overflow: ellipsis;
-      white-space: nowrap;
       .text-medium;
+      & > p {
+        .ellipsis-nowrap;
+      }
     }
 
     &__status {
@@ -367,12 +368,12 @@
     }
 
     &__summary {
-      display: flex;
       overflow: hidden;
       flex-direction: column;
       flex-grow: 1;
       align-items: flex-start;
       justify-content: center;
+      text-align: left;
     }
 
     .service-icon {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-302" title="ACC-302" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />ACC-302</a>  Font Scaling in Preferences (Part of BITV 11.7)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----

#### Issues addressed

- Option for Self-deleting messages has cut-off title
![image](https://user-images.githubusercontent.com/78490891/204528227-b961fde7-a74a-4d8f-9de2-3301069b1b3f.png)

- Link previews have cut-off text
![image](https://user-images.githubusercontent.com/78490891/204528310-c0cc7ead-44c5-4e85-9778-5be3031046c7.png)

- User search placeholder is cut-off
![image](https://user-images.githubusercontent.com/78490891/204528445-b8ef5f91-a889-4fdb-a6c9-45b43b618d61.png)

- reply bar is cut-off
![image](https://user-images.githubusercontent.com/78490891/204528582-bf32d6c7-a353-42f6-bb4f-1d8473dbda59.png)
