### PR TITLE
runfix: Avoid sending legal hold update to self conversations

### DIFF
--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -89,7 +89,10 @@ export class ConversationState {
           ConnectionStatus.PENDING,
         ];
 
-        if (conversationEntity.isSelf() || states_to_filter.includes(conversationEntity.connection().status())) {
+        if (
+          isSelfConversation(conversationEntity) ||
+          states_to_filter.includes(conversationEntity.connection().status())
+        ) {
           return false;
         }
 

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -54,6 +54,7 @@ import {Config} from '../Config';
 import {ConnectionEntity} from '../connection/ConnectionEntity';
 import {ACCESS_STATE} from '../conversation/AccessState';
 import {ConversationRepository} from '../conversation/ConversationRepository';
+import {isSelfConversation} from '../conversation/ConversationSelectors';
 import {ConversationStatus} from '../conversation/ConversationStatus';
 import {ConversationVerificationState} from '../conversation/ConversationVerificationState';
 import {NOTIFICATION_STATE} from '../conversation/NotificationSetting';
@@ -345,7 +346,7 @@ export class Conversation {
     this.blockLegalHoldMessage = false;
 
     this.legalHoldStatus.subscribe(legalHoldStatus => {
-      if (!this.blockLegalHoldMessage && this.hasInitializedUsers()) {
+      if (!this.blockLegalHoldMessage && !isSelfConversation(this) && this.hasInitializedUsers()) {
         amplify.publish(WebAppEvents.CONVERSATION.INJECT_LEGAL_HOLD_MESSAGE, {
           conversationEntity: this,
           legalHoldStatus,


### PR DESCRIPTION
Since the `selfMlsConversation` is created by backend, it's considered as a regular conversation by the front-end. 
We need to filter some behavior that should not occur on special conversations such as `self`