### PR TITLE
feat: shift+tab from message input bar should set the entire message focusable(ACC-268)

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -93,6 +93,7 @@ export const Conversation: FC<ConversationProps> = ({
   const {is1to1, isRequest} = useKoSubscribableChildren(activeConversation!, ['is1to1', 'isRequest']);
   const {self: selfUser} = useKoSubscribableChildren(userState, ['self']);
   const {activeCalls} = useKoSubscribableChildren(callState, ['activeCalls']);
+  const [isMsgElementsFocusable, setMsgElementsFocusable] = useState(true);
 
   // To be changed when design chooses a breakpoint, the conditional can be integrated to the ui-kit directly
   const smBreakpoint = useMatchMedia('max-width: 640px');
@@ -226,10 +227,10 @@ export const Conversation: FC<ConversationProps> = ({
     messageEntity: ContentMessage | Text,
     event: MouseEvent | KeyboardEvent,
     elementType: ElementType,
-    messageDetails: {
-      href: '';
-      userId: '';
-      userDomain: '';
+    messageDetails: MessageDetails = {
+      href: '',
+      userId: '',
+      userDomain: '',
     },
   ) => {
     if (isMouseEvent(event) && event.button === btnRightClick) {
@@ -437,6 +438,8 @@ export const Conversation: FC<ConversationProps> = ({
             onLoading={loading => setIsConversationLoaded(!loading)}
             getVisibleCallback={getInViewportCallback}
             isLastReceivedMessage={isLastReceivedMessage}
+            isMsgElementsFocusable={isMsgElementsFocusable}
+            setMsgElementsFocusable={setMsgElementsFocusable}
           />
 
           <InputBar
@@ -451,6 +454,9 @@ export const Conversation: FC<ConversationProps> = ({
             storageRepository={repositories.storage}
             teamState={teamState}
             userState={userState}
+            onShiftTab={() => {
+              setMsgElementsFocusable(false);
+            }}
           />
 
           <div className="conversation-loading">

--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -454,9 +454,7 @@ export const Conversation: FC<ConversationProps> = ({
             storageRepository={repositories.storage}
             teamState={teamState}
             userState={userState}
-            onShiftTab={() => {
-              setMsgElementsFocusable(false);
-            }}
+            onShiftTab={() => setMsgElementsFocusable(false)}
           />
 
           <div className="conversation-loading">

--- a/src/script/components/InputBar/InputBar.test.tsx
+++ b/src/script/components/InputBar/InputBar.test.tsx
@@ -85,6 +85,7 @@ const getDefaultProps = () => ({
   userState: {
     self: () => new User('id'),
   } as UserState,
+  onShiftTab: jest.fn(),
 });
 
 describe('InputBar', () => {

--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -53,7 +53,7 @@ import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {loadDraftState, saveDraftState} from 'Util/DraftStateUtil';
 import {allowsAllFiles, getFileExtensionOrName, hasAllowedExtension} from 'Util/FileTypeUtil';
 import {isHittingUploadLimit} from 'Util/isHittingUploadLimit';
-import {insertAtCaret, isFunctionKey, KEY} from 'Util/KeyboardUtil';
+import {insertAtCaret, isFunctionKey, isTabKey, KEY} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
 import {
   createMentionEntity,
@@ -115,6 +115,7 @@ interface InputBarProps {
   readonly storageRepository: StorageRepository;
   readonly teamState: TeamState;
   readonly userState: UserState;
+  onShiftTab: () => void;
 }
 
 const InputBar = ({
@@ -129,6 +130,7 @@ const InputBar = ({
   storageRepository,
   userState = container.resolve(UserState),
   teamState = container.resolve(TeamState),
+  onShiftTab,
 }: InputBarProps) => {
   const {classifiedDomains, isSelfDeletingMessagesEnabled, isFileSharingSendingEnabled} = useKoSubscribableChildren(
     teamState,
@@ -451,7 +453,10 @@ const InputBar = ({
 
   const onTextAreaKeyDown = (keyboardEvent: ReactKeyboardEvent<HTMLTextAreaElement>): void | boolean => {
     const inputHandledByEmoji = !editedMention && emojiKeyDown(keyboardEvent);
-
+    // shift+tab from message input bar set last focused message's elements non focusable
+    if (keyboardEvent.shiftKey && isTabKey(keyboardEvent)) {
+      onShiftTab();
+    }
     if (!inputHandledByEmoji) {
       switch (keyboardEvent.key) {
         case KEY.ARROW_UP: {

--- a/src/script/components/MessagesList/Message/ContentMessage/index.test.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/index.test.tsx
@@ -64,6 +64,7 @@ describe('message', () => {
       previousMessage: undefined,
       selfId: {domain: '', id: createRandomUuid()},
       totalMessage: 1,
+      isMsgElementsFocusable: true,
     };
   });
 

--- a/src/script/components/MessagesList/Message/ContentMessage/index.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/index.tsx
@@ -60,6 +60,7 @@ export interface ContentMessageProps extends Omit<MessageActions, 'onClickResetS
   selfId: QualifiedId;
   handleFocus: (index: number) => void;
   totalMessage: number;
+  isMsgElementsFocusable: boolean;
 }
 
 const ContentMessageComponent: React.FC<ContentMessageProps> = ({
@@ -82,6 +83,7 @@ const ContentMessageComponent: React.FC<ContentMessageProps> = ({
   onLike,
   handleFocus,
   totalMessage,
+  isMsgElementsFocusable,
 }) => {
   const {entries: menuEntries} = useKoSubscribableChildren(contextMenu, ['entries']);
   const {headerSenderName, timestamp, ephemeral_caption, ephemeral_status, assets, other_likes, was_edited} =
@@ -106,17 +108,19 @@ const ContentMessageComponent: React.FC<ContentMessageProps> = ({
     return !previousMessage.isContent() || previousMessage.user().id !== message.user().id;
   };
 
+  // check if current message is focused and its elements focusable
+  const msgFocusState = isMsgElementsFocusable && focusConversation;
   const avatarSection = shouldShowAvatar() ? (
     <div className="message-header">
       <div className="message-header-icon">
         <Avatar
-          tabIndex={focusConversation ? 0 : -1}
+          tabIndex={msgFocusState ? 0 : -1}
           participant={message.user()}
           onAvatarClick={onClickAvatar}
           avatarSize={AVATAR_SIZE.X_SMALL}
         />
       </div>
-      <div className="message-header-label" role="button">
+      <div className="message-header-label">
         <span className={`message-header-label-sender ${message.accent_color()}`} data-uie-name="sender-name">
           {headerSenderName}
         </span>
@@ -185,7 +189,7 @@ const ContentMessageComponent: React.FC<ContentMessageProps> = ({
           focusMessage={onClickTimestamp}
           handleClickOnMessage={onClickMessage}
           showUserDetails={onClickAvatar}
-          focusConversation={focusConversation}
+          focusConversation={msgFocusState}
         />
       )}
       <div className="message-body" title={ephemeral_caption}>
@@ -204,7 +208,7 @@ const ContentMessageComponent: React.FC<ContentMessageProps> = ({
             onClickButton={onClickButton}
             onClickImage={onClickImage}
             onClickMessage={onClickMessage}
-            focusConversation={focusConversation}
+            focusConversation={msgFocusState}
           />
         ))}
 
@@ -214,7 +218,7 @@ const ContentMessageComponent: React.FC<ContentMessageProps> = ({
               className="message-body-like-icon like-button message-show-on-hover"
               message={message}
               onLike={onLike}
-              focusConversation={focusConversation}
+              focusConversation={msgFocusState}
             />
           </div>
         )}
@@ -222,7 +226,7 @@ const ContentMessageComponent: React.FC<ContentMessageProps> = ({
         <div className="message-body-actions">
           {menuEntries.length > 0 && (
             <button
-              tabIndex={focusConversation ? 0 : -1}
+              tabIndex={msgFocusState ? 0 : -1}
               className="context-menu icon-more font-size-xs"
               aria-label={t('accessibility.conversationContextMenuOpenLabel')}
               onKeyDown={handleContextKeyDown}
@@ -250,7 +254,7 @@ const ContentMessageComponent: React.FC<ContentMessageProps> = ({
             is1to1Conversation={conversation.is1to1()}
             isLastDeliveredMessage={isLastDeliveredMessage}
             onClickReceipts={onClickReceipts}
-            focusConversation={focusConversation}
+            focusConversation={msgFocusState}
           />
         </div>
       </div>
@@ -261,7 +265,7 @@ const ContentMessageComponent: React.FC<ContentMessageProps> = ({
             is1to1Conversation={conversation.is1to1()}
             onLike={onLike}
             onClickLikes={onClickLikes}
-            focusConversation={focusConversation}
+            focusConversation={msgFocusState}
           />
         </div>
       )}

--- a/src/script/components/MessagesList/Message/MessageWrapper.tsx
+++ b/src/script/components/MessagesList/Message/MessageWrapper.tsx
@@ -75,6 +75,7 @@ export const MessageWrapper: React.FC<MessageParams & {hasMarker: boolean; focus
   teamState = container.resolve(TeamState),
   handleFocus,
   totalMessage,
+  isMsgElementsFocusable,
 }) => {
   const findMessage = (conversation: Conversation, messageId: string) => {
     return messageRepository.getMessageInConversationById(conversation, messageId, true, true);
@@ -183,6 +184,7 @@ export const MessageWrapper: React.FC<MessageParams & {hasMarker: boolean; focus
         focusConversation={focusConversation}
         handleFocus={handleFocus}
         totalMessage={totalMessage}
+        isMsgElementsFocusable={isMsgElementsFocusable}
       />
     );
   }

--- a/src/script/components/MessagesList/Message/index.tsx
+++ b/src/script/components/MessagesList/Message/index.tsx
@@ -86,6 +86,8 @@ export interface MessageParams extends MessageActions {
   focusConversation: boolean;
   handleFocus: (index: number) => void;
   handleArrowKeyDown: (e: React.KeyboardEvent) => void;
+  isMsgElementsFocusable: boolean;
+  setMsgElementsFocusable: (isMsgElementsFocusable: boolean) => void;
 }
 
 const Message: React.FC<
@@ -103,6 +105,8 @@ const Message: React.FC<
     handleFocus,
     handleArrowKeyDown,
     index,
+    isMsgElementsFocusable,
+    setMsgElementsFocusable,
   } = props;
   const messageElementRef = useRef<HTMLDivElement>(null);
   const messageRef = useRef<HTMLDivElement>(null);
@@ -130,6 +134,13 @@ const Message: React.FC<
   }, [isMarked, messageElementRef]);
 
   const handleDivKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    // when a message is focused set its elements focusable
+    if (!event.shiftKey && isTabKey(event)) {
+      if (!messageRef.current) {
+        return;
+      }
+      setMsgElementsFocusable(true);
+    }
     if (isTabKey(event)) {
       // don't call arrow key down for tab key
       return;
@@ -169,6 +180,7 @@ const Message: React.FC<
       {...props}
       hasMarker={markerType !== MessageMarkerType.NONE}
       focusConversation={focusConversation}
+      isMsgElementsFocusable={isMsgElementsFocusable}
     />
   );
   const wrappedContent = onVisible ? (

--- a/src/script/components/MessagesList/MessageList.test.tsx
+++ b/src/script/components/MessagesList/MessageList.test.tsx
@@ -64,6 +64,8 @@ const getDefaultParams = (): React.ComponentProps<typeof MessagesList> => {
     showMessageDetails: jest.fn(),
     showParticipants: jest.fn(),
     showUserDetails: jest.fn(),
+    isMsgElementsFocusable: true,
+    setMsgElementsFocusable: jest.fn(),
   };
 };
 

--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -64,6 +64,8 @@ interface MessagesListParams {
   showParticipants: (users: User[]) => void;
   showUserDetails: (user: User | ServiceEntity) => void;
   isLastReceivedMessage: (messageEntity: MessageEntity, conversationEntity: ConversationEntity) => boolean;
+  isMsgElementsFocusable: boolean;
+  setMsgElementsFocusable: (isMsgElementsFocusable: boolean) => void;
 }
 
 const filterDuplicatedMemberMessages = (messages: MessageEntity[]) => {
@@ -113,6 +115,8 @@ const MessagesList: FC<MessagesListParams> = ({
   messageActions,
   onLoading,
   isLastReceivedMessage,
+  isMsgElementsFocusable,
+  setMsgElementsFocusable,
 }) => {
   const {
     messages: allMessages,
@@ -328,6 +332,8 @@ const MessagesList: FC<MessagesListParams> = ({
               focusConversation={currentFocus === index}
               handleFocus={setCurrentFocus}
               handleArrowKeyDown={handleKeyDown}
+              isMsgElementsFocusable={isMsgElementsFocusable}
+              setMsgElementsFocusable={setMsgElementsFocusable}
             />
           );
         })}

--- a/src/script/components/avatar/AvatarWrapper.tsx
+++ b/src/script/components/avatar/AvatarWrapper.tsx
@@ -39,6 +39,7 @@ const AvatarWrapper: React.FunctionComponent<AvatarWrapperProps> = ({color, avat
       transform: 'translateZ(0)',
       userSelect: 'none',
     }}
+    role="button"
     {...props}
   />
 );

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -564,6 +564,11 @@
     &__count {
       margin-left: 4px;
     }
+
+    &:focus,
+    &:focus-visible {
+      opacity: 1;
+    }
   }
 
   .time,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-268" title="ACC-268" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-268</a>  9.2.4.3 Focus order for chat content area
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  -  shift+tab from message input bar should set the entire message focusable(ACC-268)

- The **PR Description**
  - when a user press shift+tab from input bar, set the last focused message elements non focusable(tabindex -1)
- the wrapper div of the last focused message is still focused as we didn't reset its tabindex
- to focus a message element check its self(element level) focus state and message level focus state
- on focus visible set read receipt outline visible
----

# What's new in this PR?

### Issues

- shift+tab from message input bar was focusing the last message element

### Solutions

- shift+tab from message input bar should set the entire message focusable

### Testing

#### How to Test

- unit test and screen reader testing
----
##### References
1. https://wearezeta.atlassian.net/browse/ACC-268
