### PR TITLE
feat: trigger corecrypto migration script [FS-1095]

### DIFF
--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -622,7 +622,7 @@ export class App {
 
     const storeName = this.service.storage.dbName;
     if (!storeName) {
-      this.logger.error('Client was not able to perform DB migration storage was not initialised');
+      this.logger.error('Client was not able to perform DB migration: storage was not initialised yet.');
       return;
     }
 

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -32,6 +32,7 @@ import {container} from 'tsyringe';
 import {Runtime} from '@wireapp/commons';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
+import {dbMigrationStateStore} from 'Util/dbMigrationStateStore/dbMigrationStateStore';
 import {DebugUtil} from 'Util/DebugUtil';
 import {Environment} from 'Util/Environment';
 import {t} from 'Util/LocalizerUtil';
@@ -395,11 +396,14 @@ export class App {
             const newClient = {class: ClientClassification.UNKNOWN, id: clientId};
             userRepository.addClientToUser(qualifiedId, newClient, true);
           },
+          dbMigrationHooks: {
+            getState: dbMigrationStateStore.getDBMigrationState,
+            onSuccess: dbMigrationStateStore.deleteDBMigrationState,
+          },
         });
       } catch (error) {
         throw new ClientError(CLIENT_ERROR_TYPE.NO_VALID_CLIENT, 'Client has been deleted on backend');
       }
-
       const selfUser = await this.initiateSelfUser();
 
       if (this.apiClient.backendFeatures.isFederated && this.repository.storage.storageService.db && context.domain) {

--- a/src/script/storage/StorageSchemata.ts
+++ b/src/script/storage/StorageSchemata.ts
@@ -420,6 +420,11 @@ export class StorageSchemata {
         upgrade: dbMigrationStateStore.setNeedsCoreDBMigration,
         version: 20,
       },
+
+      //TODO:
+      // When defining new upgrade (v21) we should delete those 3 tables:
+      // - StorageSchemata.OBJECT_STORE.KEYS, StorageSchemata.OBJECT_STORE.PRE_KEYS, StorageSchemata.OBJECT_STORE.SESSIONS
+      // (only when they're empty - that would mean the data was successfully migrated to corecrypto)
     ];
   }
 }

--- a/src/script/storage/StorageSchemata.ts
+++ b/src/script/storage/StorageSchemata.ts
@@ -19,6 +19,7 @@
 
 import type {Dexie, Transaction} from 'dexie';
 
+import {dbMigrationStateStore} from 'Util/dbMigrationStateStore/dbMigrationStateStore';
 import {base64ToArray} from 'Util/util';
 
 import {categoryFromEvent} from '../message/MessageCategorization';
@@ -413,6 +414,13 @@ export class StorageSchemata {
       {
         schema: {},
         version: 19,
+      },
+      {
+        schema: {},
+        upgrade: transaction => {
+          dbMigrationStateStore.setDBMigrationState({storeName: transaction.db.name});
+        },
+        version: 20,
       },
     ];
   }

--- a/src/script/storage/StorageSchemata.ts
+++ b/src/script/storage/StorageSchemata.ts
@@ -417,9 +417,7 @@ export class StorageSchemata {
       },
       {
         schema: {},
-        upgrade: transaction => {
-          dbMigrationStateStore.setDBMigrationState({storeName: transaction.db.name});
-        },
+        upgrade: dbMigrationStateStore.setNeedsCoreDBMigration,
         version: 20,
       },
     ];

--- a/src/script/util/dbMigrationStateStore/dbMigrationStateStore.test.ts
+++ b/src/script/util/dbMigrationStateStore/dbMigrationStateStore.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {dbMigrationStateStore} from './dbMigrationStateStore';
+
+const mockStoreName = 'mockStoreName';
+const mockStoreName2 = 'mockStoreName2';
+
+describe('dbMigrationStateStore', () => {
+  it('adds and retrieves state from the store', () => {
+    expect(dbMigrationStateStore.getDBMigrationState()).toEqual(undefined);
+    dbMigrationStateStore.setDBMigrationState({storeName: mockStoreName});
+    expect(dbMigrationStateStore.getDBMigrationState()).toEqual({storeName: mockStoreName});
+  });
+
+  it('updates state entry', () => {
+    dbMigrationStateStore.setDBMigrationState({storeName: mockStoreName});
+    expect(dbMigrationStateStore.getDBMigrationState()).toEqual({storeName: mockStoreName});
+
+    dbMigrationStateStore.setDBMigrationState({storeName: mockStoreName2});
+    expect(dbMigrationStateStore.getDBMigrationState()).toEqual({storeName: mockStoreName2});
+  });
+
+  it('deletes state from the store', () => {
+    dbMigrationStateStore.setDBMigrationState({storeName: mockStoreName});
+    expect(dbMigrationStateStore.getDBMigrationState()).toEqual({storeName: mockStoreName});
+
+    dbMigrationStateStore.deleteDBMigrationState();
+    expect(dbMigrationStateStore.getDBMigrationState()).toEqual(undefined);
+  });
+});

--- a/src/script/util/dbMigrationStateStore/dbMigrationStateStore.test.ts
+++ b/src/script/util/dbMigrationStateStore/dbMigrationStateStore.test.ts
@@ -19,29 +19,18 @@
 
 import {dbMigrationStateStore} from './dbMigrationStateStore';
 
-const mockStoreName = 'mockStoreName';
-const mockStoreName2 = 'mockStoreName2';
-
 describe('dbMigrationStateStore', () => {
-  it('adds and retrieves state from the store', () => {
-    expect(dbMigrationStateStore.getDBMigrationState()).toEqual(undefined);
-    dbMigrationStateStore.setDBMigrationState({storeName: mockStoreName});
-    expect(dbMigrationStateStore.getDBMigrationState()).toEqual({storeName: mockStoreName});
-  });
-
-  it('updates state entry', () => {
-    dbMigrationStateStore.setDBMigrationState({storeName: mockStoreName});
-    expect(dbMigrationStateStore.getDBMigrationState()).toEqual({storeName: mockStoreName});
-
-    dbMigrationStateStore.setDBMigrationState({storeName: mockStoreName2});
-    expect(dbMigrationStateStore.getDBMigrationState()).toEqual({storeName: mockStoreName2});
+  it('adds and retrieves value from the store', () => {
+    expect(dbMigrationStateStore.isCoreDBMigrationNeeded()).toEqual(false);
+    dbMigrationStateStore.setNeedsCoreDBMigration();
+    expect(dbMigrationStateStore.isCoreDBMigrationNeeded()).toEqual(true);
   });
 
   it('deletes state from the store', () => {
-    dbMigrationStateStore.setDBMigrationState({storeName: mockStoreName});
-    expect(dbMigrationStateStore.getDBMigrationState()).toEqual({storeName: mockStoreName});
+    dbMigrationStateStore.setNeedsCoreDBMigration();
+    expect(dbMigrationStateStore.isCoreDBMigrationNeeded()).toEqual(true);
 
-    dbMigrationStateStore.deleteDBMigrationState();
-    expect(dbMigrationStateStore.getDBMigrationState()).toEqual(undefined);
+    dbMigrationStateStore.markCoreDBMigrationDone();
+    expect(dbMigrationStateStore.isCoreDBMigrationNeeded()).toEqual(false);
   });
 });

--- a/src/script/util/dbMigrationStateStore/dbMigrationStateStore.ts
+++ b/src/script/util/dbMigrationStateStore/dbMigrationStateStore.ts
@@ -19,28 +19,24 @@
 
 export const storageKey = 'dbMigrationState';
 
-export interface DBMigrationState {
-  storeName: string;
-}
-
-const getDBMigrationState = (): DBMigrationState | undefined => {
+const isCoreDBMigrationNeeded = (): boolean => {
   const storedState = localStorage.getItem(storageKey);
   if (!storedState) {
-    return undefined;
+    return false;
   }
   return JSON.parse(storedState);
 };
 
-const setDBMigrationState = (state: DBMigrationState) => {
-  localStorage.setItem(storageKey, JSON.stringify(state));
+const setNeedsCoreDBMigration = () => {
+  localStorage.setItem(storageKey, JSON.stringify(true));
 };
 
-const deleteDBMigrationState = () => {
+const markCoreDBMigrationDone = () => {
   localStorage.removeItem(storageKey);
 };
 
 export const dbMigrationStateStore = {
-  deleteDBMigrationState,
-  getDBMigrationState,
-  setDBMigrationState,
+  isCoreDBMigrationNeeded,
+  setNeedsCoreDBMigration,
+  markCoreDBMigrationDone,
 };

--- a/src/script/util/dbMigrationStateStore/dbMigrationStateStore.ts
+++ b/src/script/util/dbMigrationStateStore/dbMigrationStateStore.ts
@@ -1,0 +1,46 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export const storageKey = 'dbMigrationState';
+
+export interface DBMigrationState {
+  storeName: string;
+}
+
+const getDBMigrationState = (): DBMigrationState | undefined => {
+  const storedState = localStorage.getItem(storageKey);
+  if (!storedState) {
+    return undefined;
+  }
+  return JSON.parse(storedState);
+};
+
+const setDBMigrationState = (state: DBMigrationState) => {
+  localStorage.setItem(storageKey, JSON.stringify(state));
+};
+
+const deleteDBMigrationState = () => {
+  localStorage.removeItem(storageKey);
+};
+
+export const dbMigrationStateStore = {
+  deleteDBMigrationState,
+  getDBMigrationState,
+  setDBMigrationState,
+};

--- a/src/script/util/dbMigrationStateStore/index.ts
+++ b/src/script/util/dbMigrationStateStore/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export * from './dbMigrationStateStore';


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1095" title="FS-1095" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-1095</a>  [Web] Trigger CoreCrypto DB migration code when webapp is loaded with CoreCrypto as the proteus handler
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Trigger `cryptobox` -> `corecrypto` migration script.
- when storage version upgrade is detected (`v19` -> `v20`) store, `"migrationState"` in localstorage.
- after app (core and storage) is initialised, check `"migrationState"` entry.
- if `"migrationState"` was defined, trigger migration script with stored db name
- after migration was successful, delete `"migrationState"` entry from the local storage.