### PR TITLE
fix: Use correct color in dark mode for update banner button

### DIFF
--- a/src/style/foundation/warnings.less
+++ b/src/style/foundation/warnings.less
@@ -45,7 +45,8 @@
   background-color: var(--accent-color);
   color: var(--app-bg-secondary);
 
-  a {
+  a,
+  button {
     color: var(--app-bg-secondary);
     &:hover,
     &:focus {


### PR DESCRIPTION
Old: 
![image](https://user-images.githubusercontent.com/63250054/204812149-4566819f-e465-4282-85e1-3712032e4d50.png)

New:
<img width="467" alt="image" src="https://user-images.githubusercontent.com/63250054/204812102-7c50a8b0-9ab6-4350-b07a-622268f1aa2e.png">