### PR TITLE
fix: Remove title from conversation list cell, announce the message for screen reader only(ACC-314)

### DIFF
--- a/src/script/components/list/ConversationListCell.tsx
+++ b/src/script/components/list/ConversationListCell.tsx
@@ -202,7 +202,7 @@ const ConversationListCell: React.FC<ConversationListCellProps> = ({
           <span
             id={contextMenuKeyboardShortcut}
             aria-label={t('accessibility.conversationOptionsMenuAccessKey')}
-          ></span>
+          />
           <div
             className={cx('conversation-list-cell-left', {
               'conversation-list-cell-left-opaque': removedFromConversation || users.length === 0,

--- a/src/script/components/list/ConversationListCell.tsx
+++ b/src/script/components/list/ConversationListCell.tsx
@@ -108,6 +108,7 @@ const ConversationListCell: React.FC<ConversationListCellProps> = ({
   const contextMenuRef = useRef<HTMLButtonElement>(null);
   const [focusContextMenu, setContextMenuFocus] = useState(false);
   const [isContextMenuOpen, setContextMenuOpen] = useState(false);
+  const contextMenuKeyboardShortcut = `keyboard-shortcut-${conversation.id}`;
 
   const openContextMenu = (event: MouseEvent | React.MouseEvent<Element, MouseEvent>) => {
     event.stopPropagation();
@@ -196,8 +197,12 @@ const ConversationListCell: React.FC<ConversationListCellProps> = ({
           data-uie-name="go-open-conversation"
           tabIndex={focusConversation ? 0 : -1}
           aria-label={t('accessibility.openConversation', displayName)}
-          title={t('accessibility.conversationOptionsMenuAccessKey')}
+          aria-describedby={contextMenuKeyboardShortcut}
         >
+          <span
+            id={contextMenuKeyboardShortcut}
+            aria-label={t('accessibility.conversationOptionsMenuAccessKey')}
+          ></span>
           <div
             className={cx('conversation-list-cell-left', {
               'conversation-list-cell-left-opaque': removedFromConversation || users.length === 0,

--- a/src/script/components/list/ConversationListCell.tsx
+++ b/src/script/components/list/ConversationListCell.tsx
@@ -199,10 +199,7 @@ const ConversationListCell: React.FC<ConversationListCellProps> = ({
           aria-label={t('accessibility.openConversation', displayName)}
           aria-describedby={contextMenuKeyboardShortcut}
         >
-          <span
-            id={contextMenuKeyboardShortcut}
-            aria-label={t('accessibility.conversationOptionsMenuAccessKey')}
-          />
+          <span id={contextMenuKeyboardShortcut} aria-label={t('accessibility.conversationOptionsMenuAccessKey')} />
           <div
             className={cx('conversation-list-cell-left', {
               'conversation-list-cell-left-opaque': removedFromConversation || users.length === 0,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-314" title="ACC-314" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />ACC-314</a>  Remove title from conversation list cell, announce the message for screen reader only
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

…shortcut for screen reader only(ACC-314)

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - Remove title from conversation list cell, announce the message for screen reader only

- The **PR Description**
  - Conversation list cell has a title attribute which describes the keyboard shortcut to focus on the context menu for keyboard users. Since its relevant to other users, we will be announcing it for screen readers only.
----

# What's new in this PR?

### Issues
- keyboard shortcut message shouldn't appear for all users

### Solutions

- remove title, use aria-describedBy

### Testing

#### How to Test

- play screen reader and focus on conversation item, keyboard shortcut to focus on the context menu should be announced

----
##### References
1. https://wearezeta.atlassian.net/browse/ACC-314
