### PR TITLE
feat: api v3 access_role change [FS-1192]

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@types/eslint": "^8.4.10",
     "@wireapp/antiscroll-2": "1.3.1",
     "@wireapp/avs": "8.2.17",
-    "@wireapp/core": "37.2.1",
+    "@wireapp/core": "37.2.2",
     "@wireapp/react-ui-kit": "9.2.0",
     "@wireapp/store-engine-dexie": "2.0.3",
     "@wireapp/store-engine-sqleet": "1.8.9",

--- a/src/script/conversation/ConversationAccessPermission.test.ts
+++ b/src/script/conversation/ConversationAccessPermission.test.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {CONVERSATION_ACCESS, ACCESS_ROLE_V2} from '@wireapp/api-client/lib/conversation/';
+import {CONVERSATION_ACCESS, CONVERSATION_ACCESS_ROLE} from '@wireapp/api-client/lib/conversation/';
 
 import {ACCESS_STATE, TEAM} from './AccessState';
 import {
@@ -134,25 +134,29 @@ describe('ConversationAccessPermissions', () => {
     const mockRights = {
       GUESTS_SERVICES: {
         accessRole: [
-          ACCESS_ROLE_V2.GUEST,
-          ACCESS_ROLE_V2.NON_TEAM_MEMBER,
-          ACCESS_ROLE_V2.TEAM_MEMBER,
-          ACCESS_ROLE_V2.SERVICE,
+          CONVERSATION_ACCESS_ROLE.GUEST,
+          CONVERSATION_ACCESS_ROLE.NON_TEAM_MEMBER,
+          CONVERSATION_ACCESS_ROLE.TEAM_MEMBER,
+          CONVERSATION_ACCESS_ROLE.SERVICE,
         ],
         accessModes: [CONVERSATION_ACCESS.INVITE, CONVERSATION_ACCESS.CODE],
       },
       GUEST_ROOM: {
-        accessRole: [ACCESS_ROLE_V2.GUEST, ACCESS_ROLE_V2.NON_TEAM_MEMBER, ACCESS_ROLE_V2.TEAM_MEMBER],
+        accessRole: [
+          CONVERSATION_ACCESS_ROLE.GUEST,
+          CONVERSATION_ACCESS_ROLE.NON_TEAM_MEMBER,
+          CONVERSATION_ACCESS_ROLE.TEAM_MEMBER,
+        ],
         accessModes: [CONVERSATION_ACCESS.INVITE, CONVERSATION_ACCESS.CODE],
       },
       SERVICES: {
         accessModes: [CONVERSATION_ACCESS.INVITE],
-        accessRole: [ACCESS_ROLE_V2.TEAM_MEMBER, ACCESS_ROLE_V2.SERVICE],
+        accessRole: [CONVERSATION_ACCESS_ROLE.TEAM_MEMBER, CONVERSATION_ACCESS_ROLE.SERVICE],
       },
-      TEAM_ONLY: {accessModes: [CONVERSATION_ACCESS.INVITE], accessRole: [ACCESS_ROLE_V2.TEAM_MEMBER]},
+      TEAM_ONLY: {accessModes: [CONVERSATION_ACCESS.INVITE], accessRole: [CONVERSATION_ACCESS_ROLE.TEAM_MEMBER]},
       LEGACY: {accessModes: [], accessRole: []} as UpdatedAccessRights,
       GUEST_FEATURES: {
-        accessRole: [ACCESS_ROLE_V2.GUEST, ACCESS_ROLE_V2.NON_TEAM_MEMBER],
+        accessRole: [CONVERSATION_ACCESS_ROLE.GUEST, CONVERSATION_ACCESS_ROLE.NON_TEAM_MEMBER],
         accessModes: [CONVERSATION_ACCESS.CODE],
       },
       ONE2ONE: {accessModes: [], accessRole: []} as UpdatedAccessRights,

--- a/src/script/conversation/ConversationAccessPermission.ts
+++ b/src/script/conversation/ConversationAccessPermission.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {ACCESS_ROLE_V2, CONVERSATION_ACCESS} from '@wireapp/api-client/lib/conversation/';
+import {CONVERSATION_ACCESS_ROLE, CONVERSATION_ACCESS} from '@wireapp/api-client/lib/conversation/';
 
 import {ACCESS_STATE, TEAM} from './AccessState';
 
@@ -79,7 +79,7 @@ export function featureFromStateChange(prevState: ACCESS_STATE, current: ACCESS_
   const [featureName, featureBitmask] = Object.entries(ACCESS).find(
     ([, bitmask]) => bitmask & (teamPermissionsForAccessState(prevState) ^ teamPermissionsForAccessState(current)),
   );
-  const featString = ACCESS_ROLE_V2[featureName as keyof typeof ACCESS_ROLE_V2];
+  const featString = CONVERSATION_ACCESS_ROLE[featureName as keyof typeof CONVERSATION_ACCESS_ROLE];
   return {
     feature: featString,
     featureName: (featString?.[0].toUpperCase() + featString?.slice(1)) as 'Guest' | 'Service',
@@ -118,7 +118,7 @@ export function toggleFeature(feature: number, state: ACCESS_STATE): TEAM {
 
 export interface UpdatedAccessRights {
   accessModes: CONVERSATION_ACCESS[];
-  accessRole: ACCESS_ROLE_V2[];
+  accessRole: CONVERSATION_ACCESS_ROLE[];
 }
 
 /**
@@ -138,7 +138,7 @@ export function updateAccessRights(accessState: ACCESS_STATE): UpdatedAccessRigh
     //find the name of the feature with the correct sigfigs
     .map((bit: '1' | '0', i) => Object.entries(ACCESS).find(([, bitmask]) => bitmask === +bit << i)?.[0])
     .forEach(feature => {
-      const accessRole = ACCESS_ROLE_V2[feature as keyof typeof ACCESS_ROLE_V2];
+      const accessRole = CONVERSATION_ACCESS_ROLE[feature as keyof typeof CONVERSATION_ACCESS_ROLE];
       const accessModes = CONVERSATION_ACCESS[feature as keyof typeof CONVERSATION_ACCESS];
       if (accessRole) {
         newAccessRights.accessRole.push(accessRole);

--- a/src/script/conversation/ConversationFilter.test.ts
+++ b/src/script/conversation/ConversationFilter.test.ts
@@ -17,7 +17,11 @@
  *
  */
 
-import {CONVERSATION_ACCESS, CONVERSATION_ACCESS_ROLE, CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation';
+import {
+  CONVERSATION_ACCESS,
+  CONVERSATION_LEGACY_ACCESS_ROLE,
+  CONVERSATION_TYPE,
+} from '@wireapp/api-client/lib/conversation';
 import {ConversationProtocol} from '@wireapp/api-client/lib/conversation/NewConversation';
 
 import {ConversationFilter} from './ConversationFilter';
@@ -87,7 +91,7 @@ describe('ConversationFilter', () => {
       const conversationData: ConversationDatabaseData = {
         access: [CONVERSATION_ACCESS.PRIVATE],
         accessRoleV2: undefined,
-        access_role: CONVERSATION_ACCESS_ROLE.PRIVATE,
+        access_role: CONVERSATION_LEGACY_ACCESS_ROLE.PRIVATE,
         archived_state: false,
         archived_timestamp: 0,
         cipher_suite: 1,

--- a/src/script/conversation/ConversationMapper.test.ts
+++ b/src/script/conversation/ConversationMapper.test.ts
@@ -18,10 +18,10 @@
  */
 
 import {
-  ACCESS_ROLE_V2,
+  CONVERSATION_ACCESS_ROLE,
   Conversation as ConversationBackendData,
   CONVERSATION_ACCESS,
-  CONVERSATION_ACCESS_ROLE,
+  CONVERSATION_LEGACY_ACCESS_ROLE,
   CONVERSATION_TYPE,
   Member as MemberBackendData,
   OtherMember as OtherMemberBackendData,
@@ -345,7 +345,7 @@ describe('ConversationMapper', () => {
 
       const remoteData: Partial<ConversationDatabaseData> = {
         access: [CONVERSATION_ACCESS.INVITE, CONVERSATION_ACCESS.CODE],
-        access_role: CONVERSATION_ACCESS_ROLE.NON_ACTIVATED,
+        access_role: CONVERSATION_LEGACY_ACCESS_ROLE.NON_ACTIVATED,
         creator: conversationCreatorId,
         id: conversationId,
         last_event_timestamp: new Date('1970-01-01T00:00:00.000Z').getTime(),
@@ -631,14 +631,18 @@ describe('ConversationMapper', () => {
       const accessModes = [CONVERSATION_ACCESS.INVITE, CONVERSATION_ACCESS.CODE];
       // ACCESS_STATE.TEAM.GUESTS_SERVICES
       const accessRole = [
-        ACCESS_ROLE_V2.GUEST,
-        ACCESS_ROLE_V2.NON_TEAM_MEMBER,
-        ACCESS_ROLE_V2.TEAM_MEMBER,
-        ACCESS_ROLE_V2.SERVICE,
+        CONVERSATION_ACCESS_ROLE.GUEST,
+        CONVERSATION_ACCESS_ROLE.NON_TEAM_MEMBER,
+        CONVERSATION_ACCESS_ROLE.TEAM_MEMBER,
+        CONVERSATION_ACCESS_ROLE.SERVICE,
       ];
 
       // ACCESS_STATE.TEAM.GUEST_ROOM
-      const accessRoleV2 = [ACCESS_ROLE_V2.GUEST, ACCESS_ROLE_V2.NON_TEAM_MEMBER, ACCESS_ROLE_V2.TEAM_MEMBER];
+      const accessRoleV2 = [
+        CONVERSATION_ACCESS_ROLE.GUEST,
+        CONVERSATION_ACCESS_ROLE.NON_TEAM_MEMBER,
+        CONVERSATION_ACCESS_ROLE.TEAM_MEMBER,
+      ];
 
       const conversationEntity = new Conversation('conversation-id', 'domain');
       conversationEntity.team_id = 'team_id';
@@ -651,13 +655,13 @@ describe('ConversationMapper', () => {
       const accessModes = [CONVERSATION_ACCESS.INVITE, CONVERSATION_ACCESS.CODE];
       // ACCESS_STATE.TEAM.GUESTS_SERVICES
       const accessRole = [
-        ACCESS_ROLE_V2.GUEST,
-        ACCESS_ROLE_V2.NON_TEAM_MEMBER,
-        ACCESS_ROLE_V2.TEAM_MEMBER,
-        ACCESS_ROLE_V2.SERVICE,
+        CONVERSATION_ACCESS_ROLE.GUEST,
+        CONVERSATION_ACCESS_ROLE.NON_TEAM_MEMBER,
+        CONVERSATION_ACCESS_ROLE.TEAM_MEMBER,
+        CONVERSATION_ACCESS_ROLE.SERVICE,
       ];
 
-      const accessRoleV2 = undefined;
+      const accessRoleV2: undefined = undefined;
 
       const conversationEntity = new Conversation();
       conversationEntity.team_id = 'team_id';
@@ -669,54 +673,54 @@ describe('ConversationMapper', () => {
     describe('maps roles properly for legacy api < v3', () => {
       const mockRightsLegacy: [
         ACCESS_STATE,
-        {accessRole: CONVERSATION_ACCESS_ROLE; accessModes: CONVERSATION_ACCESS[]},
+        {accessRole: CONVERSATION_LEGACY_ACCESS_ROLE; accessModes: CONVERSATION_ACCESS[]},
       ][] = [
         [
           ACCESS_STATE.TEAM.TEAM_ONLY,
           {
-            accessRole: CONVERSATION_ACCESS_ROLE.TEAM,
+            accessRole: CONVERSATION_LEGACY_ACCESS_ROLE.TEAM,
             accessModes: [CONVERSATION_ACCESS.INVITE],
           },
         ],
         [
           ACCESS_STATE.TEAM.GUEST_ROOM,
           {
-            accessRole: CONVERSATION_ACCESS_ROLE.ACTIVATED,
+            accessRole: CONVERSATION_LEGACY_ACCESS_ROLE.ACTIVATED,
             accessModes: [CONVERSATION_ACCESS.INVITE, CONVERSATION_ACCESS.CODE],
           },
         ],
         [
           ACCESS_STATE.TEAM.GUESTS_SERVICES,
           {
-            accessRole: CONVERSATION_ACCESS_ROLE.NON_ACTIVATED,
+            accessRole: CONVERSATION_LEGACY_ACCESS_ROLE.NON_ACTIVATED,
             accessModes: [CONVERSATION_ACCESS.INVITE, CONVERSATION_ACCESS.CODE],
           },
         ],
         [
           ACCESS_STATE.TEAM.LEGACY,
           {
-            accessRole: CONVERSATION_ACCESS_ROLE.NON_ACTIVATED,
+            accessRole: CONVERSATION_LEGACY_ACCESS_ROLE.NON_ACTIVATED,
             accessModes: [CONVERSATION_ACCESS.INVITE],
           },
         ],
         [
           ACCESS_STATE.TEAM.LEGACY,
           {
-            accessRole: CONVERSATION_ACCESS_ROLE.NON_ACTIVATED,
+            accessRole: CONVERSATION_LEGACY_ACCESS_ROLE.NON_ACTIVATED,
             accessModes: [CONVERSATION_ACCESS.CODE],
           },
         ],
         [
           ACCESS_STATE.TEAM.LEGACY,
           {
-            accessRole: CONVERSATION_ACCESS_ROLE.TEAM,
+            accessRole: CONVERSATION_LEGACY_ACCESS_ROLE.TEAM,
             accessModes: [CONVERSATION_ACCESS.CODE],
           },
         ],
         [
           ACCESS_STATE.TEAM.LEGACY,
           {
-            accessRole: CONVERSATION_ACCESS_ROLE.TEAM,
+            accessRole: CONVERSATION_LEGACY_ACCESS_ROLE.TEAM,
             accessModes: [CONVERSATION_ACCESS.CODE, CONVERSATION_ACCESS.INVITE],
           },
         ],
@@ -735,24 +739,28 @@ describe('ConversationMapper', () => {
       const mockRightsV3 = {
         [ACCESS_STATE.TEAM.GUESTS_SERVICES]: {
           accessRole: [
-            ACCESS_ROLE_V2.GUEST,
-            ACCESS_ROLE_V2.NON_TEAM_MEMBER,
-            ACCESS_ROLE_V2.TEAM_MEMBER,
-            ACCESS_ROLE_V2.SERVICE,
+            CONVERSATION_ACCESS_ROLE.GUEST,
+            CONVERSATION_ACCESS_ROLE.NON_TEAM_MEMBER,
+            CONVERSATION_ACCESS_ROLE.TEAM_MEMBER,
+            CONVERSATION_ACCESS_ROLE.SERVICE,
           ],
           accessModes: [CONVERSATION_ACCESS.INVITE, CONVERSATION_ACCESS.CODE],
         },
         [ACCESS_STATE.TEAM.GUEST_ROOM]: {
-          accessRole: [ACCESS_ROLE_V2.GUEST, ACCESS_ROLE_V2.NON_TEAM_MEMBER, ACCESS_ROLE_V2.TEAM_MEMBER],
+          accessRole: [
+            CONVERSATION_ACCESS_ROLE.GUEST,
+            CONVERSATION_ACCESS_ROLE.NON_TEAM_MEMBER,
+            CONVERSATION_ACCESS_ROLE.TEAM_MEMBER,
+          ],
           accessModes: [CONVERSATION_ACCESS.INVITE, CONVERSATION_ACCESS.CODE],
         },
         [ACCESS_STATE.TEAM.SERVICES]: {
           accessModes: [CONVERSATION_ACCESS.INVITE],
-          accessRole: [ACCESS_ROLE_V2.TEAM_MEMBER, ACCESS_ROLE_V2.SERVICE],
+          accessRole: [CONVERSATION_ACCESS_ROLE.TEAM_MEMBER, CONVERSATION_ACCESS_ROLE.SERVICE],
         },
         [ACCESS_STATE.TEAM.TEAM_ONLY]: {
           accessModes: [CONVERSATION_ACCESS.INVITE],
-          accessRole: [ACCESS_ROLE_V2.TEAM_MEMBER],
+          accessRole: [CONVERSATION_ACCESS_ROLE.TEAM_MEMBER],
         },
       };
 

--- a/src/script/conversation/ConversationMapper.ts
+++ b/src/script/conversation/ConversationMapper.ts
@@ -269,8 +269,7 @@ export class ConversationMapper {
       conversationEntity.accessModes = accessModes;
       conversationEntity.accessRole = accessRoleV2 || accessRole;
 
-      const actualAccessRole = this.accessRoleToAccessRoleV2(accessRoleV2 ?? accessRole);
-      ConversationMapper.mapAccessStateV3(conversationEntity, actualAccessRole);
+      ConversationMapper.mapAccessState(conversationEntity, accessModes, accessRole, accessRoleV2);
     }
 
     conversationEntity.receiptMode(conversationData.receipt_mode);

--- a/src/script/conversation/ConversationMapper.ts
+++ b/src/script/conversation/ConversationMapper.ts
@@ -474,6 +474,7 @@ export class ConversationMapper {
     const personalAccessState = conversationEntity.isGroup()
       ? ACCESS_STATE.PERSONAL.GROUP
       : ACCESS_STATE.PERSONAL.ONE2ONE;
+
     return conversationEntity.accessState(personalAccessState);
   }
 
@@ -517,6 +518,7 @@ export class ConversationMapper {
     const isExpectedModes = includesCodeMode && includesInviteMode && accessModes.length === 2;
 
     const isGuestRoomMode = isNonVerifiedRole && isExpectedModes;
+
     return isGuestRoomMode ? ACCESS_STATE.TEAM.GUESTS_SERVICES : ACCESS_STATE.TEAM.LEGACY;
   }
 }

--- a/src/script/conversation/ConversationMapper.ts
+++ b/src/script/conversation/ConversationMapper.ts
@@ -511,16 +511,16 @@ export class ConversationMapper {
       return ACCESS_STATE.TEAM.TEAM_ONLY;
     }
 
-    const isVerifiedRole = accessRole === CONVERSATION_LEGACY_ACCESS_ROLE.ACTIVATED;
-    if (isVerifiedRole) {
+    const isActivatedRole = accessRole === CONVERSATION_LEGACY_ACCESS_ROLE.ACTIVATED;
+    if (isActivatedRole) {
       return ACCESS_STATE.TEAM.GUEST_ROOM;
     }
-    const isNonVerifiedRole = accessRole === CONVERSATION_LEGACY_ACCESS_ROLE.NON_ACTIVATED;
+    const isNonActivatedRole = accessRole === CONVERSATION_LEGACY_ACCESS_ROLE.NON_ACTIVATED;
 
     const includesCodeMode = accessModes.includes(CONVERSATION_ACCESS.CODE);
     const isExpectedModes = includesCodeMode && includesInviteMode && accessModes.length === 2;
 
-    const isGuestRoomMode = isNonVerifiedRole && isExpectedModes;
+    const isGuestRoomMode = isNonActivatedRole && isExpectedModes;
 
     return isGuestRoomMode ? ACCESS_STATE.TEAM.GUESTS_SERVICES : ACCESS_STATE.TEAM.LEGACY;
   }

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -19,7 +19,11 @@
 
 import {ClientClassification} from '@wireapp/api-client/lib/client/';
 import {ConnectionStatus} from '@wireapp/api-client/lib/connection/';
-import {CONVERSATION_ACCESS, CONVERSATION_ACCESS_ROLE, CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation/';
+import {
+  CONVERSATION_ACCESS,
+  CONVERSATION_LEGACY_ACCESS_ROLE,
+  CONVERSATION_TYPE,
+} from '@wireapp/api-client/lib/conversation/';
 import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data';
 import {ConversationProtocol} from '@wireapp/api-client/lib/conversation/NewConversation';
 import {ConversationCreateEvent, ConversationMemberJoinEvent, CONVERSATION_EVENT} from '@wireapp/api-client/lib/event/';
@@ -532,7 +536,7 @@ describe('ConversationRepository', () => {
         (server as any).respondWith('GET', matchConversations, (xhr: any, conversationId: string) => {
           const conversation = {
             access: [CONVERSATION_ACCESS.PRIVATE],
-            accessRole: CONVERSATION_ACCESS_ROLE.ACTIVATED,
+            accessRole: CONVERSATION_LEGACY_ACCESS_ROLE.ACTIVATED,
             creator: '6761450e-1bd6-4027-a338-1191fe5e349f',
             id: conversationId,
             members: {
@@ -636,7 +640,7 @@ describe('ConversationRepository', () => {
           conversation: conversationId,
           data: {
             access: [CONVERSATION_ACCESS.INVITE],
-            access_role: CONVERSATION_ACCESS_ROLE.ACTIVATED,
+            access_role: CONVERSATION_LEGACY_ACCESS_ROLE.ACTIVATED,
             access_role_v2: [],
             creator: 'c472ba79-0bca-4a74-aaa3-a559a16705d3',
             id: 'c9405f98-e25a-4b1f-ade7-227ea765dff7',

--- a/src/script/conversation/ConversationService.ts
+++ b/src/script/conversation/ConversationService.ts
@@ -18,7 +18,7 @@
  */
 
 import type {
-  ACCESS_ROLE_V2,
+  CONVERSATION_ACCESS_ROLE,
   ClientMismatch,
   Conversation as BackendConversation,
   ConversationCode,
@@ -222,11 +222,11 @@ export class ConversationService {
   putConversationAccess(
     conversationId: string,
     accessModes: CONVERSATION_ACCESS[],
-    accessRole: ACCESS_ROLE_V2[],
+    accessRole: CONVERSATION_ACCESS_ROLE[],
   ): Promise<ConversationEvent> {
     return this.apiClient.api.conversation.putAccess(conversationId, {
       access: accessModes,
-      access_role_v2: accessRole,
+      access_role: accessRole,
     });
   }
 

--- a/src/script/conversation/ConversationStateHandler.ts
+++ b/src/script/conversation/ConversationStateHandler.ts
@@ -18,7 +18,7 @@
  */
 
 import {ConversationCode} from '@wireapp/api-client/lib/conversation/';
-import {ConversationAccessUpdateData, ConversationAccessV2UpdateData} from '@wireapp/api-client/lib/conversation/data/';
+import {ConversationAccessUpdateData} from '@wireapp/api-client/lib/conversation/data/';
 import {CONVERSATION_EVENT} from '@wireapp/api-client/lib/event/';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 
@@ -124,7 +124,7 @@ export class ConversationStateHandler extends AbstractConversationEventHandler {
 
   private _mapConversationAccessState(
     conversationEntity: Conversation,
-    eventJson: ConversationEvent<Partial<ConversationAccessV2UpdateData & ConversationAccessUpdateData>>,
+    eventJson: ConversationEvent<ConversationAccessUpdateData>,
   ): void {
     const {access: accessModes, ...roles} = eventJson.data;
     ConversationMapper.mapAccessState(conversationEntity, accessModes, roles?.access_role, roles?.access_role_v2);

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -18,9 +18,9 @@
  */
 
 import {
-  ACCESS_ROLE_V2,
-  CONVERSATION_ACCESS,
   CONVERSATION_ACCESS_ROLE,
+  CONVERSATION_ACCESS,
+  CONVERSATION_LEGACY_ACCESS_ROLE,
   CONVERSATION_TYPE,
 } from '@wireapp/api-client/lib/conversation/';
 import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data';
@@ -173,7 +173,7 @@ export class Conversation {
   public readonly hasExternal: ko.PureComputed<boolean>;
   public readonly hasFederatedUsers: ko.PureComputed<boolean>;
   public accessModes?: CONVERSATION_ACCESS[];
-  public accessRole?: CONVERSATION_ACCESS_ROLE | ACCESS_ROLE_V2[];
+  public accessRole?: CONVERSATION_LEGACY_ACCESS_ROLE | CONVERSATION_ACCESS_ROLE[];
   public domain: string;
 
   static get TIMESTAMP_TYPE(): typeof TIMESTAMP_TYPE {

--- a/src/script/storage/record/ConversationRecord.ts
+++ b/src/script/storage/record/ConversationRecord.ts
@@ -18,9 +18,9 @@
  */
 
 import {
-  ACCESS_ROLE_V2,
-  CONVERSATION_ACCESS,
   CONVERSATION_ACCESS_ROLE,
+  CONVERSATION_ACCESS,
+  CONVERSATION_LEGACY_ACCESS_ROLE,
   CONVERSATION_TYPE,
   DefaultConversationRoleName,
 } from '@wireapp/api-client/lib/conversation';
@@ -34,7 +34,7 @@ import {ConversationStatus} from '../../conversation/ConversationStatus';
 import {ConversationVerificationState} from '../../conversation/ConversationVerificationState';
 
 export interface ConversationRecord {
-  access_role: CONVERSATION_ACCESS_ROLE | ACCESS_ROLE_V2[];
+  access_role: CONVERSATION_LEGACY_ACCESS_ROLE | CONVERSATION_ACCESS_ROLE[];
   access: CONVERSATION_ACCESS[];
   archived_state: boolean;
   archived_timestamp: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4283,22 +4283,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^22.7.0":
-  version: 22.7.0
-  resolution: "@wireapp/api-client@npm:22.7.0"
+"@wireapp/api-client@npm:^22.8.0":
+  version: 22.8.0
+  resolution: "@wireapp/api-client@npm:22.8.0"
   dependencies:
-    "@wireapp/commons": ^5.0.3
+    "@wireapp/commons": ^5.0.4
     "@wireapp/priority-queue": ^2.0.3
     "@wireapp/protocol-messaging": 1.42.0
-    axios: 1.1.2
+    axios: 1.2.1
     axios-retry: 3.3.1
     http-status-codes: 2.2.0
     logdown: 3.3.1
     reconnecting-websocket: 4.4.0
     spark-md5: 3.0.2
     tough-cookie: 4.1.2
-    ws: 8.10.0
-  checksum: f8c17729cc2ff32c23af26ac2259785d8b593532175d5592a496673d9fdd42bc628bcbbac5db768b183669f8fb93f18b27cc12b9a22272b277fe849ebd40a8ca
+    ws: 8.11.0
+  checksum: 7ff2614b46987d0b36aecf2dac120189501e916a647910ff0f40d882ad1b1e9f9957607982d7b3e13d8937e301a3bf05eaee7f0f73432c58f8d2584cf61fc75b
   languageName: node
   linkType: hard
 
@@ -4316,15 +4316,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/commons@npm:^5.0.3":
-  version: 5.0.3
-  resolution: "@wireapp/commons@npm:5.0.3"
+"@wireapp/commons@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "@wireapp/commons@npm:5.0.4"
   dependencies:
     ansi-regex: 5.0.1
-    fs-extra: 10.1.0
+    fs-extra: 11.1.0
     logdown: 3.3.1
     platform: 1.3.6
-  checksum: cf69ac8d0c3c116b0ccde13cee46d3c6623f36c395f449a73ac4dbb602aff229abb86b0a811b3cc91e8773ee9c6892ffc455612aa876009ddba63f782b73e5b0
+  checksum: 714285b048d4c8b708d662b55e78c0fec1a6fa8c976c78fef420b4325c91087af8f32551850c78cea947710bad8b1ac288e21006f62cd982fe01a6f4983b1b24
   languageName: node
   linkType: hard
 
@@ -4351,18 +4351,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:37.2.1":
-  version: 37.2.1
-  resolution: "@wireapp/core@npm:37.2.1"
+"@wireapp/core@npm:37.2.2":
+  version: 37.2.2
+  resolution: "@wireapp/core@npm:37.2.2"
   dependencies:
-    "@wireapp/api-client": ^22.7.0
-    "@wireapp/commons": ^5.0.3
+    "@wireapp/api-client": ^22.8.0
+    "@wireapp/commons": ^5.0.4
     "@wireapp/core-crypto": 0.6.0-pre.4
     "@wireapp/cryptobox": 12.8.0
-    "@wireapp/promise-queue": ^2.1.0
+    "@wireapp/promise-queue": ^2.1.1
     "@wireapp/protocol-messaging": 1.42.0
     "@wireapp/store-engine-dexie": ^2.0.3
-    axios: 1.1.2
+    axios: 1.2.1
     bazinga64: 6.0.3
     hash.js: 1.1.7
     http-status-codes: 2.2.0
@@ -4370,7 +4370,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.12
-  checksum: 070d02030dde19bdd626d4451fe23d6dc6bcc5017660a466841cd8c101587fea71ab0a94a037bd4a0fce65940c8b488514e19060a15f41b3794a9a5aef31dfc6
+  checksum: 4061147740e6f6b5cf462d8c7c68b8904a5fd9b923f6d4c9966b2808985f1aa3eeb825d870d9ec2f7e26faa98624df4464ab8a8d89317df13bc9b8986cdf55a6
   languageName: node
   linkType: hard
 
@@ -4450,10 +4450,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/promise-queue@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@wireapp/promise-queue@npm:2.1.0"
-  checksum: 6785d8e21d4b57fc8b4848276678b83c9f0483897d9b4147ebc79b72a178e81187356fff2a07cfdd61e1cde36aeb1e0651d036ec372a26bde2a31ca63afde703
+"@wireapp/promise-queue@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@wireapp/promise-queue@npm:2.1.1"
+  checksum: 16da2f1d44bf3a7e488a9789956be8946115a7593407755324583e1743518c61340df46c115789f1ce0f0ba5e4159988525b16bbfd56cc82cf4f7a392bc118ca
   languageName: node
   linkType: hard
 
@@ -5205,6 +5205,17 @@ __metadata:
     form-data: ^4.0.0
     proxy-from-env: ^1.1.0
   checksum: 136c25a5031aa2845fdbda3006c36888bbe351b11d1195f1f898a23c5df1430febbdb1ad034a61f27967e83762d5b5a3e851fff8a363cb4badeb883f8ff21461
+  languageName: node
+  linkType: hard
+
+"axios@npm:1.2.1":
+  version: 1.2.1
+  resolution: "axios@npm:1.2.1"
+  dependencies:
+    follow-redirects: ^1.15.0
+    form-data: ^4.0.0
+    proxy-from-env: ^1.1.0
+  checksum: c4dc4e119064c9aed09a3de309bedb797a139a6fb372223aafe3e0c10a7d4a14e4d3e9c9d309467fadb9d2b490b891ee3df96ef5b55716bb971910466ff9f0c5
   languageName: node
   linkType: hard
 
@@ -8278,6 +8289,17 @@ __metadata:
     jsonfile: ^6.0.1
     universalify: ^2.0.0
   checksum: dc94ab37096f813cc3ca12f0f1b5ad6744dfed9ed21e953d72530d103cea193c2f81584a39e9dee1bea36de5ee66805678c0dddc048e8af1427ac19c00fffc50
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:11.1.0":
+  version: 11.1.0
+  resolution: "fs-extra@npm:11.1.0"
+  dependencies:
+    graceful-fs: ^4.2.0
+    jsonfile: ^6.0.1
+    universalify: ^2.0.0
+  checksum: 5ca476103fa1f5ff4a9b3c4f331548f8a3c1881edaae323a4415d3153b5dc11dc6a981c8d1dd93eec8367ceee27b53f8bd27eecbbf66ffcdd04927510c171e7f
   languageName: node
   linkType: hard
 
@@ -16670,7 +16692,7 @@ __metadata:
     "@wireapp/antiscroll-2": 1.3.1
     "@wireapp/avs": 8.2.17
     "@wireapp/copy-config": 2.0.3
-    "@wireapp/core": 37.2.1
+    "@wireapp/core": 37.2.2
     "@wireapp/eslint-config": 2.1.0
     "@wireapp/prettier-config": 0.5.2
     "@wireapp/react-ui-kit": 9.2.0
@@ -17071,7 +17093,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:8.10.0, ws@npm:^8.8.0":
+"ws@npm:8.11.0":
+  version: 8.11.0
+  resolution: "ws@npm:8.11.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ^5.0.2
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 316b33aba32f317cd217df66dbfc5b281a2f09ff36815de222bc859e3424d83766d9eb2bd4d667de658b6ab7be151f258318fb1da812416b30be13103e5b5c67
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.8.0":
   version: 8.10.0
   resolution: "ws@npm:8.10.0"
   peerDependencies:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1192" title="FS-1192" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-1192</a>  [Web] Parsing of conversation.access_update for API V3
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Apply api v3 changes of `access_role` field(s).

Before API v3 behaviour:
fields:
- `access_role` (string value) - deprecated field 
- `access_role_v2` (optional array of string values)

Check for `access_role_v2` field, if exists -> parse its values, if it's not defined, parse `access_role` value.

since v3 behaviour:
fields:
- `access_role` (array of string values) - contains the values stored previously in `access_role_v2`
- `access_role_v2` (optional value) - contains the same value as `access_role`

Check for `access_role_v2` field, if exists -> parse its values. If it's not defined, check if `access_role` is array type, if it is it mean we're dealing with new version of api and we can parse it the same way as `access_role_v2`. If it's a string type, parse it "the old way" (legacy).

Needs https://github.com/wireapp/wire-web-packages/pull/4682