### PR TITLE
feat: Send self device sync message through MLS and proteus conversations [FS-1208]

### DIFF
--- a/src/script/components/userDevices/DeviceDetails.tsx
+++ b/src/script/components/userDevices/DeviceDetails.tsx
@@ -89,7 +89,9 @@ const DeviceDetails: React.FC<DeviceDetailsProps> = ({
 
   const clickToResetSession = () => {
     const _resetProgress = () => window.setTimeout(() => setIsResettingSession(false), MotionDuration.LONG);
-    const conversation = user.isMe ? conversationState.getSelfConversation() : conversationState.activeConversation();
+    const conversation = user.isMe
+      ? conversationState.getSelfProteusConversation()
+      : conversationState.activeConversation();
     setIsResettingSession(true);
     if (conversation) {
       messageRepository

--- a/src/script/conversation/ConversationState.test.ts
+++ b/src/script/conversation/ConversationState.test.ts
@@ -64,26 +64,32 @@ describe('ConversationState', () => {
   describe('getSelfConversations', () => {
     it('returns empty array if there are no self conversations', () => {
       const conversationState = createConversationState();
-      expect(conversationState.getSelfConversations()).toEqual([]);
+      expect(conversationState.getSelfConversations(true)).toEqual([]);
       conversationState.conversations([selfProteusConversation, selfMLSConversation, regularConversation]);
     });
 
     it('returns only proteus self conversation', () => {
       const conversationState = createConversationState();
       conversationState.conversations([selfProteusConversation, regularConversation]);
-      expect(conversationState.getSelfConversations()).toEqual([selfProteusConversation]);
+      expect(conversationState.getSelfConversations(true)).toEqual([selfProteusConversation]);
     });
 
     it('returns only mls self conversation', () => {
       const conversationState = createConversationState();
       conversationState.conversations([selfMLSConversation, regularConversation]);
-      expect(conversationState.getSelfConversations()).toEqual([selfMLSConversation]);
+      expect(conversationState.getSelfConversations(true)).toEqual([selfMLSConversation]);
     });
 
     it('returns both the self MLS and proteus conversations', () => {
       const conversationState = createConversationState();
       conversationState.conversations([selfProteusConversation, selfMLSConversation, regularConversation]);
-      expect(conversationState.getSelfConversations()).toEqual([selfMLSConversation, selfProteusConversation]);
+      expect(conversationState.getSelfConversations(true)).toEqual([selfProteusConversation, selfMLSConversation]);
+    });
+
+    it('filters out mls conversation if not supported', () => {
+      const conversationState = createConversationState();
+      conversationState.conversations([selfProteusConversation, selfMLSConversation, regularConversation]);
+      expect(conversationState.getSelfConversations(false)).toEqual([selfProteusConversation]);
     });
   });
 

--- a/src/script/conversation/ConversationState.test.ts
+++ b/src/script/conversation/ConversationState.test.ts
@@ -48,18 +48,42 @@ describe('ConversationState', () => {
   const selfMLSConversation = createConversation(ConversationProtocol.MLS, CONVERSATION_TYPE.SELF);
   const regularConversation = createConversation();
 
-  describe('getSelfConversation', () => {
+  describe('getSelfProteusConversation', () => {
     it('throws if no self conversation are set', () => {
       const conversationState = createConversationState();
-      expect(() => conversationState.getSelfConversation()).toThrow('proteus');
-      expect(() => conversationState.getSelfConversation(true)).toThrow('MLS');
+      expect(() => conversationState.getSelfProteusConversation()).toThrow('proteus');
     });
 
     it('finds the MLS and proteus self conversations', () => {
       const conversationState = createConversationState();
       conversationState.conversations([selfProteusConversation, selfMLSConversation, regularConversation]);
-      expect(conversationState.getSelfConversation()).toBe(selfProteusConversation);
-      expect(conversationState.getSelfConversation(true)).toBe(selfMLSConversation);
+      expect(conversationState.getSelfProteusConversation()).toBe(selfProteusConversation);
+    });
+  });
+
+  describe('getSelfConversations', () => {
+    it('returns empty array if there are no self conversations', () => {
+      const conversationState = createConversationState();
+      expect(conversationState.getSelfConversations()).toEqual([]);
+      conversationState.conversations([selfProteusConversation, selfMLSConversation, regularConversation]);
+    });
+
+    it('returns only proteus self conversation', () => {
+      const conversationState = createConversationState();
+      conversationState.conversations([selfProteusConversation, regularConversation]);
+      expect(conversationState.getSelfConversations()).toEqual([selfProteusConversation]);
+    });
+
+    it('returns only mls self conversation', () => {
+      const conversationState = createConversationState();
+      conversationState.conversations([selfMLSConversation, regularConversation]);
+      expect(conversationState.getSelfConversations()).toEqual([selfMLSConversation]);
+    });
+
+    it('returns both the self MLS and proteus conversations', () => {
+      const conversationState = createConversationState();
+      conversationState.conversations([selfProteusConversation, selfMLSConversation, regularConversation]);
+      expect(conversationState.getSelfConversations()).toEqual([selfMLSConversation, selfProteusConversation]);
     });
   });
 

--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -118,20 +118,18 @@ export class ConversationState {
     });
   }
 
-  getSelfConversation(useMLS: boolean = false): Conversation {
-    if (!useMLS) {
-      const proteusConversation = this.selfProteusConversation();
-      if (!proteusConversation) {
-        throw new Error('No proteus self conversation');
-      }
-      return proteusConversation;
-    }
+  getSelfConversations(): Conversation[] {
+    return [this.selfMLSConversation(), this.selfProteusConversation()].filter(
+      (conversation): conversation is Conversation => !!conversation,
+    );
+  }
 
-    const mlsConversation = this.selfMLSConversation();
-    if (!mlsConversation) {
-      throw new Error('No MLS self conversation');
+  getSelfProteusConversation(): Conversation {
+    const proteusConversation = this.selfProteusConversation();
+    if (!proteusConversation) {
+      throw new Error('No proteus self conversation');
     }
-    return mlsConversation;
+    return proteusConversation;
   }
 
   /**

--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -118,10 +118,15 @@ export class ConversationState {
     });
   }
 
-  getSelfConversations(): Conversation[] {
-    return [this.selfMLSConversation(), this.selfProteusConversation()].filter(
-      (conversation): conversation is Conversation => !!conversation,
-    );
+  /**
+   * Returns all the selfConversations available (proteus and MLS)
+   * The MLS conversation can be manually filtered (in case MLS is not supported)
+   * @param includeMLS will filter out the MLS self conversation if false
+   */
+  getSelfConversations(includeMLS: boolean): Conversation[] {
+    const baseConversations = [this.selfProteusConversation()];
+    const selfConversations = includeMLS ? baseConversations.concat(this.selfMLSConversation()) : baseConversations;
+    return selfConversations.filter((conversation): conversation is Conversation => !!conversation);
   }
 
   getSelfProteusConversation(): Conversation {

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -55,7 +55,7 @@ import {roundLogarithmic} from 'Util/NumberUtil';
 import {matchQualifiedIds} from 'Util/QualifiedId';
 import {capitalizeFirstChar} from 'Util/StringUtil';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
-import {createRandomUuid, loadUrlBlob} from 'Util/util';
+import {createRandomUuid, loadUrlBlob, supportsMLS} from 'Util/util';
 
 import {findDeletedClients} from './ClientMismatchUtil';
 import {ConversationRepository} from './ConversationRepository';
@@ -987,7 +987,7 @@ export class MessageRepository {
   }
 
   private async sendToSelfConversations(payload: GenericMessage) {
-    const selfConversations = this.conversationState.getSelfConversations();
+    const selfConversations = this.conversationState.getSelfConversations(supportsMLS());
     await Promise.all(
       selfConversations.map(selfConversation =>
         this.sendAndInjectMessage(payload, selfConversation, {

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -969,16 +969,13 @@ export class MessageRepository {
    */
   public async deleteMessage(conversation: Conversation, message: Message): Promise<void> {
     try {
-      const selfConversation = this.conversationState.getSelfConversation();
       const payload = MessageBuilder.buildHideMessage({
         conversationId: conversation.id,
         messageId: message.id,
         qualifiedConversationId: conversation.qualifiedId,
       });
-      await this.sendAndInjectMessage(payload, selfConversation, {
-        skipInjection: true,
-      });
 
+      await this.sendToSelfConversations(payload);
       await this.deleteMessageById(conversation, message.id);
     } catch (error) {
       this.logger.info(
@@ -989,15 +986,25 @@ export class MessageRepository {
     }
   }
 
+  private async sendToSelfConversations(payload: GenericMessage) {
+    const selfConversations = this.conversationState.getSelfConversations();
+    await Promise.all(
+      selfConversations.map(selfConversation =>
+        this.sendAndInjectMessage(payload, selfConversation, {
+          skipInjection: true,
+        }),
+      ),
+    );
+  }
+
   /**
    * Update cleared of conversation using timestamp.
    */
   public async updateClearedTimestamp(conversation: Conversation): Promise<void> {
     const timestamp = conversation.getLastKnownTimestamp(this.serverTimeHandler.toServerTimestamp());
-    const selfConversation = this.conversationState.getSelfConversation();
     if (timestamp && conversation.setTimestamp(timestamp, Conversation.TIMESTAMP_TYPE.CLEARED)) {
       const payload = MessageBuilder.buildClearedMessage(conversation.qualifiedId);
-      await this.sendAndInjectMessage(payload, selfConversation, {skipInjection: true});
+      await this.sendToSelfConversations(payload);
     }
   }
 
@@ -1235,10 +1242,9 @@ export class MessageRepository {
    * @param conversation Conversation to be marked as read
    */
   public async markAsRead(conversation: Conversation) {
-    const selfConversation = this.conversationState.getSelfConversation();
     const timestamp = conversation.last_read_timestamp();
     const payload = MessageBuilder.buildLastReadMessage(conversation.qualifiedId, timestamp);
-    await this.sendAndInjectMessage(payload, selfConversation, {skipInjection: true});
+    await this.sendToSelfConversations(payload);
     /*
      * FIXME notification removal can be improved.
      * We can add the conversation ID in the payload of the event and only check unread messages for this particular conversation
@@ -1253,9 +1259,8 @@ export class MessageRepository {
    * @param countlyId Countly new ID
    */
   public async sendCountlySync(countlyId: string) {
-    const selfConversation = this.conversationState.getSelfConversation();
     const payload = MessageBuilder.buildDataTransferMessage(countlyId);
-    await this.sendAndInjectMessage(payload, selfConversation, {skipInjection: true});
+    await this.sendToSelfConversations(payload);
     this.logger.info(`Sent countly sync message with ID ${countlyId}`);
   }
 

--- a/src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx
@@ -153,7 +153,9 @@ const DevicesPreferences: React.FC<DevicesPreferencesProps> = ({
         }}
         onClose={() => setSelectedDevice(undefined)}
         onVerify={(device, verified) => verifyDevice(self.qualifiedId, device, verified)}
-        onResetSession={device => resetSession(self.qualifiedId, device, conversationState.getSelfConversation())}
+        onResetSession={device =>
+          resetSession(self.qualifiedId, device, conversationState.getSelfProteusConversation())
+        }
       />
     );
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1208" title="FS-1208" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-1208</a>  [Web] Send sync messages through the self MLS conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This adds a method to retrieve both proteus and mls self conversation and allow sending payload through both at a time. 
This will send:
- `cleared` conversation payload
- `delete-for-me` messages
- `last-read-timestamp` messages
- `countly` sync messages