### PR TITLE
fix: Secondary button right click needs to fall back to browser default right click[chat message markdown click](ACC-316)

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -48,7 +48,7 @@ import {Message} from '../../entity/message/Message';
 import {Text} from '../../entity/message/Text';
 import {User} from '../../entity/User';
 import {UserError} from '../../error/UserError';
-import {isMouseEvent} from '../../guards/Mouse';
+import {isMouseRightClickEvent, isAuxRightClickEvent} from '../../guards/Mouse';
 import {isServiceEntity} from '../../guards/Service';
 import {ServiceEntity} from '../../integration/ServiceEntity';
 import {MotionDuration} from '../../motion/MotionDuration';
@@ -188,7 +188,11 @@ export const Conversation: FC<ConversationProps> = ({
     return false;
   };
 
-  const handleMarkdownLinkClick = (event: Event, messageDetails: MessageDetails) => {
+  const handleMarkdownLinkClick = (event: MouseEvent | KeyboardEvent, messageDetails: MessageDetails) => {
+    if (isAuxRightClickEvent(event)) {
+      // Default browser behavior on right click
+      return true;
+    }
     const href = messageDetails.href!;
     PrimaryModal.show(PrimaryModal.type.CONFIRM, {
       primaryAction: {
@@ -222,7 +226,6 @@ export const Conversation: FC<ConversationProps> = ({
     }
   };
 
-  const btnRightClick = 2;
   const handleClickOnMessage = (
     messageEntity: ContentMessage | Text,
     event: MouseEvent | KeyboardEvent,
@@ -233,7 +236,7 @@ export const Conversation: FC<ConversationProps> = ({
       userDomain: '',
     },
   ) => {
-    if (isMouseEvent(event) && event.button === btnRightClick) {
+    if (isMouseRightClickEvent(event)) {
       // Default browser behavior on right click
       return true;
     }

--- a/src/script/guards/Mouse.ts
+++ b/src/script/guards/Mouse.ts
@@ -17,4 +17,12 @@
  *
  */
 
+const secondaryBtnRightClick = 2;
 export const isMouseEvent = (event: MouseEvent | KeyboardEvent): event is MouseEvent => event.type === 'click';
+export const isAuxClickEvent = (event: MouseEvent | KeyboardEvent): event is MouseEvent => event.type === 'auxclick';
+
+export const isMouseRightClickEvent = (event: MouseEvent | KeyboardEvent): event is MouseEvent =>
+  isMouseEvent(event) && event.button === secondaryBtnRightClick;
+
+export const isAuxRightClickEvent = (event: MouseEvent | KeyboardEvent): event is MouseEvent =>
+  isAuxClickEvent(event) && event.button === secondaryBtnRightClick;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-316" title="ACC-316" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-316</a>  Secondary button right click needs to fall back to browser default right click[chat message markdown click]
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

#### PR Submission Checklist for internal contributors

- The **PR Title**
  - Secondary button right click needs to fall back to browser default right click[chat message markdown click]

- The **PR Description**
  - Current: MAC two finger touch which is auxclick renders the markdown link modal and the browser menu both at the same time. 

Expected: two finger touch should only open the browser menu. Only left mouse click or single finger touch should open the confirmation modal.
----

# What's new in this PR?

### Issues

- secondary right click on button opens both modal and browser menu

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

- Secondary button right click needs to fall back to browser default right click

### Testing

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

----
##### References
1. https://wearezeta.atlassian.net/browse/ACC-316
