### PR TITLE
fix: reloading an active conversation is jumping onto wrong conversation(ACC-268)

### DIFF
--- a/src/script/components/list/ConversationListCell.tsx
+++ b/src/script/components/list/ConversationListCell.tsx
@@ -32,8 +32,6 @@ import {AvailabilityState} from 'Components/AvailabilityState';
 import {Avatar, AVATAR_SIZE} from 'Components/Avatar';
 import {GroupAvatar} from 'Components/avatar/GroupAvatar';
 import {Icon} from 'Components/Icon';
-import {generateConversationUrl} from 'src/script/router/routeGenerator';
-import {setHistoryParam} from 'src/script/router/Router';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {isKey, isOneOfKeys, KEY} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
@@ -172,12 +170,6 @@ const ConversationListCell: React.FC<ConversationListCellProps> = ({
       handleFocus(index);
     }
   }, [index, isActive, isFolder, isConversationListFocus, handleFocus]);
-
-  // on conversation/app load reset last message focus to ensure last message is focused
-  // only when user enters a new conversation using keyboard(press enter)
-  useEffect(() => {
-    setHistoryParam(generateConversationUrl(conversation.qualifiedId));
-  }, [conversation]);
 
   return (
     <li onContextMenu={openContextMenu}>

--- a/src/script/page/AppMain.tsx
+++ b/src/script/page/AppMain.tsx
@@ -145,7 +145,7 @@ const AppMain: FC<AppMainProps> = ({
       }
     };
 
-    // on conversation/app load reset last message focus to ensure last message is focused
+    // on app load reset last message focus to ensure last message is focused
     // only when user enters a new conversation using keyboard(press enter)
     const historyState = window.history.state;
     if (historyState && !!historyState.eventKey) {

--- a/src/script/page/AppMain.tsx
+++ b/src/script/page/AppMain.tsx
@@ -145,6 +145,14 @@ const AppMain: FC<AppMainProps> = ({
       }
     };
 
+    // on conversation/app load reset last message focus to ensure last message is focused
+    // only when user enters a new conversation using keyboard(press enter)
+    const historyState = window.history.state;
+    if (historyState && !!historyState.eventKey) {
+      historyState.eventKey = '';
+      window.history.replaceState(historyState, '', window.location.hash);
+    }
+
     configureRoutes({
       '/': showMostRecentConversation,
       '/conversation/:conversationId(/:domain)': (conversationId: string, domain: string = apiContext.domain ?? '') =>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-268" title="ACC-268" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-268</a>  9.2.4.3 Focus order for chat content area
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - reloading an active conversation is jumping onto wrong conversation and the conversation id in the url is wrong
  
- The **PR Description**
  -  reloading an active conversation is jumping onto wrong conversation and the conversation id in the url is wrong
  - this is caused by a resetting history param logic which is suppose to reset the last message focus on app load
----

# What's new in this PR?

### Issues

- reloading an active conversation is jumping onto wrong conversation and the conversation id in the url is wrong

### Solutions

- instead of running the history state reset for every conversation, run it on app initialisation only once

### Testing

#### How to Test

- open a conversation, now reload the app. The conversation id in the URL should't change.
