### PR TITLE
refactor: change div to p tag in right sidebar [ACC-24]

### DIFF
--- a/src/script/components/panel/ConversationProtocolDetails/ConversationProtocolDetails.tsx
+++ b/src/script/components/panel/ConversationProtocolDetails/ConversationProtocolDetails.tsx
@@ -85,15 +85,15 @@ const ConversationProtocolDetails: React.FC<ConversationProtocolDetailsProps> = 
       <div className="conversation-details__list-head">{t('conversationDetailsProtocolDetails')}</div>
       <div css={wrapperStyles}>
         <div css={titleStyles}>Protocol</div>
-        <div css={subTitleStyles} data-uie-name="protocol-name">
+        <p css={subTitleStyles} data-uie-name="protocol-name">
           {protocol.toUpperCase()}
-        </div>
+        </p>
         {protocol === ConversationProtocol.MLS && cipherSuite && (
           <>
             <div css={titleStyles}>Cipher Suite</div>
-            <div css={subTitleStyles} data-uie-name="cipher-suite">
+            <p css={subTitleStyles} data-uie-name="cipher-suite">
               {Ciphersuite[cipherSuite]}
-            </div>
+            </p>
           </>
         )}
       </div>

--- a/src/script/components/panel/ServiceDetails.tsx
+++ b/src/script/components/panel/ServiceDetails.tsx
@@ -48,9 +48,12 @@ const ServiceDetails: React.FC<ServiceDetailsProps> = ({service}) => {
         data-uie-name="status-profile-picture"
       />
 
-      <div className="panel-participant__service-description" data-uie-name="status-service-description">
+      <p
+        className="panel-participant__service-description panel__info-text--margin"
+        data-uie-name="status-service-description"
+      >
         {service.description}
-      </div>
+      </p>
     </div>
   );
 };

--- a/src/script/components/panel/UserDetails.tsx
+++ b/src/script/components/panel/UserDetails.tsx
@@ -89,9 +89,9 @@ const UserDetails: React.FC<UserDetailsProps> = ({
       </div>
 
       {participant.handle && (
-        <div className="panel-participant__user-name" data-uie-name="status-username" title={participant.handle}>
+        <p className="panel-participant__user-name" data-uie-name="status-username" title={participant.handle}>
           {participant.handle}
-        </div>
+        </p>
       )}
 
       {classifiedDomains && (

--- a/src/script/components/userDevices/DeviceCard.tsx
+++ b/src/script/components/userDevices/DeviceCard.tsx
@@ -80,12 +80,12 @@ const DeviceCard: React.FC<DeviceCardProps> = ({
         <div className="label-xs">
           <span className="device-card__model">{name}</span>
         </div>
-        <div className="text-background label-xs">
+        <p className="text-background label-xs">
           <span>{t('preferencesDevicesId')}</span>
           <span data-uie-name="device-id">
             <DeviceId deviceId={id} />
           </span>
-        </div>
+        </p>
       </div>
       {showVerified && <VerifiedIcon isVerified={!!isVerified && isVerified()} />}
       {clickable && <Icon.ChevronRight className="disclose-icon" data-uie-name="disclose-icon" />}

--- a/src/script/components/userDevices/DeviceDetails.tsx
+++ b/src/script/components/userDevices/DeviceDetails.tsx
@@ -112,7 +112,7 @@ const DeviceDetails: React.FC<DeviceDetailsProps> = ({
       >
         {t('participantDevicesDetailShowMyDevice')}
       </button>
-      <div
+      <p
         className="panel__info-text"
         dangerouslySetInnerHTML={{
           __html: user ? t('participantDevicesDetailHeadline', {user: userName}) : '',

--- a/src/script/components/userDevices/DeviceList.tsx
+++ b/src/script/components/userDevices/DeviceList.tsx
@@ -44,9 +44,9 @@ const DeviceList: React.FC<DeviceListProps> = ({user, noPadding, clients, clickO
   return (
     <>
       <div className={cx('participant-devices__header', {'participant-devices__header--padding': !noPadding})}>
-        <div className="participant-devices__text-block panel__info-text" data-uie-name="status-devices-headline">
+        <p className="participant-devices__text-block panel__info-text" data-uie-name="status-devices-headline">
           {user ? t('participantDevicesHeadline', {brandName: Config.getConfig().BRAND_NAME, user: userName}) : ''}
-        </div>
+        </p>
         <a
           className="participant-devices__link accent-text"
           href={getPrivacyWhyUrl()}

--- a/src/script/components/userDevices/NoDevicesFound.tsx
+++ b/src/script/components/userDevices/NoDevicesFound.tsx
@@ -38,14 +38,14 @@ const NoDevicesFound: React.FC<NoDevicesFoundProps> = ({user, noPadding}) => {
 
   return (
     <div className={cx('participant-devices__header', {'participant-devices__header--padding': !noPadding})}>
-      <div className="participant-devices__text-block panel__info-text" data-uie-name="status-devices-headline">
+      <p className="participant-devices__text-block panel__info-text" data-uie-name="status-devices-headline">
         {user
           ? t('participantDevicesOutdatedClientMessage', {
               brandName: Config.getConfig().BRAND_NAME,
               user: userName,
             })
           : ''}
-      </div>
+      </p>
       <a
         className="participant-devices__link accent-text"
         href={getPrivacyPolicyUrl()}

--- a/src/script/page/RightSidebar/ConversationDetails/components/GroupDetails/GroupDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/components/GroupDetails/GroupDetails.tsx
@@ -73,12 +73,12 @@ const GroupDetails: FC<GroupDetailsProps> = ({
       </div>
 
       {isTeam && (
-        <div
+        <p
           className="panel__info-text conversation-details__group-size-info"
           data-uie-name="status-group-size-info-conversation-details"
         >
           {t('groupSizeInfo', ConversationRepository.CONFIG.GROUP.MAX_SIZE)}
-        </div>
+        </p>
       )}
     </>
   );

--- a/src/script/page/RightSidebar/GroupParticipantUser/GroupParticipantUser.tsx
+++ b/src/script/page/RightSidebar/GroupParticipantUser/GroupParticipantUser.tsx
@@ -201,9 +201,9 @@ const GroupParticipantUser: FC<GroupParticipantUserProps> = ({
               </div>
             </div>
 
-            <div className="panel__info-text panel__item-offset" css={{padding: '16px'}} tabIndex={0}>
+            <p className="panel__info-text panel__item-offset" css={{padding: '16px'}} tabIndex={0}>
               {t('conversationDetailsGroupAdminInfo')}
-            </div>
+            </p>
           </>
         )}
 

--- a/src/script/page/RightSidebar/Notifications/Notifications.tsx
+++ b/src/script/page/RightSidebar/Notifications/Notifications.tsx
@@ -70,9 +70,9 @@ const Notifications: FC<NotificationsProps> = ({activeConversation, onGoBack, on
           />
         </fieldset>
 
-        <div className="panel__info-text notification-settings__disclaimer" tabIndex={0}>
+        <p className="panel__info-text notification-settings__disclaimer" tabIndex={0}>
           {t('notificationSettingsDisclaimer')}
-        </div>
+        </p>
       </div>
     </div>
   );

--- a/src/script/page/RightSidebar/TimedMessages/TimedMessages.tsx
+++ b/src/script/page/RightSidebar/TimedMessages/TimedMessages.tsx
@@ -110,7 +110,7 @@ const TimedMessages: FC<TimedMessagesPanelProps> = ({activeConversation, onClose
           </label>
         ))}
 
-        <div className="panel__info-text timed-messages__disclaimer">{t('timedMessageDisclaimer')}</div>
+        <p className="panel__info-text timed-messages__disclaimer">{t('timedMessageDisclaimer')}</p>
       </div>
     </div>
   );


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-24" title="ACC-24" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />ACC-24</a>  Info and Relationships - HTML Structure (9.1.3.1)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
#### Issue
- paragraphs should be provided with a <p> tag

#### Changes
- Replace `<span>`or `<div>` by `<p>` in the non interactive elements of the right sidebar