### PR TITLE
feat: add api v3 support [FS-1268]

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@types/eslint": "^8.4.10",
     "@wireapp/antiscroll-2": "1.3.1",
     "@wireapp/avs": "8.2.17",
-    "@wireapp/core": "37.2.2",
+    "@wireapp/core": "37.2.3",
     "@wireapp/react-ui-kit": "9.2.0",
     "@wireapp/store-engine-dexie": "2.0.3",
     "@wireapp/store-engine-sqleet": "1.8.9",

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -396,9 +396,15 @@ export class ConversationRepository {
       };
 
       if (accessState) {
-        const {accessModes: access, accessRole: access_role_v2} = updateAccessRights(accessState);
+        const {accessModes: access, accessRole} = updateAccessRights(accessState);
 
-        payload = {...payload, access, access_role_v2};
+        const accessRoleField = this.core.backendFeatures.version >= 3 ? 'access_role' : 'access_role_v2';
+
+        payload = {
+          ...payload,
+          access,
+          [accessRoleField]: accessRole,
+        };
       }
     }
 

--- a/src/script/conversation/ConversationService.ts
+++ b/src/script/conversation/ConversationService.ts
@@ -220,7 +220,7 @@ export class ConversationService {
    * @returns Resolves with the server response
    */
   putConversationAccess(
-    conversationId: QualifiedId | string,
+    conversationId: QualifiedId,
     accessModes: CONVERSATION_ACCESS[],
     accessRole: CONVERSATION_ACCESS_ROLE[],
   ): Promise<ConversationEvent> {

--- a/src/script/conversation/ConversationService.ts
+++ b/src/script/conversation/ConversationService.ts
@@ -220,7 +220,7 @@ export class ConversationService {
    * @returns Resolves with the server response
    */
   putConversationAccess(
-    conversationId: string,
+    conversationId: QualifiedId | string,
     accessModes: CONVERSATION_ACCESS[],
     accessRole: CONVERSATION_ACCESS_ROLE[],
   ): Promise<ConversationEvent> {

--- a/src/script/conversation/ConversationService.ts
+++ b/src/script/conversation/ConversationService.ts
@@ -224,9 +224,11 @@ export class ConversationService {
     accessModes: CONVERSATION_ACCESS[],
     accessRole: CONVERSATION_ACCESS_ROLE[],
   ): Promise<ConversationEvent> {
+    const accessRoleField = this.apiClient.backendFeatures.version >= 3 ? 'access_role' : 'access_role_v2';
+
     return this.apiClient.api.conversation.putAccess(conversationId, {
       access: accessModes,
-      access_role: accessRole,
+      [accessRoleField]: accessRole,
     });
   }
 

--- a/src/script/conversation/ConversationStateHandler.ts
+++ b/src/script/conversation/ConversationStateHandler.ts
@@ -67,7 +67,11 @@ export class ConversationStateHandler extends AbstractConversationEventHandler {
               conversationEntity.accessCode(undefined);
               await this.revokeAccessCode(conversationEntity);
             }
-            await this.conversationService.putConversationAccess(conversationEntity.id, accessModes, accessRole);
+
+            const {domain, id} = conversationEntity;
+            const conversationId = domain ? {id, domain} : id;
+
+            await this.conversationService.putConversationAccess(conversationId, accessModes, accessRole);
 
             conversationEntity.accessState(accessState);
           } catch (e) {

--- a/src/script/conversation/ConversationStateHandler.ts
+++ b/src/script/conversation/ConversationStateHandler.ts
@@ -69,7 +69,7 @@ export class ConversationStateHandler extends AbstractConversationEventHandler {
             }
 
             const {domain, id} = conversationEntity;
-            const conversationId = domain ? {id, domain} : id;
+            const conversationId = {id, domain};
 
             await this.conversationService.putConversationAccess(conversationId, accessModes, accessRole);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4041,9 +4041,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^22.8.0":
-  version: 22.8.0
-  resolution: "@wireapp/api-client@npm:22.8.0"
+"@wireapp/api-client@npm:^22.9.0":
+  version: 22.9.0
+  resolution: "@wireapp/api-client@npm:22.9.0"
   dependencies:
     "@wireapp/commons": ^5.0.4
     "@wireapp/priority-queue": ^2.0.3
@@ -4056,7 +4056,7 @@ __metadata:
     spark-md5: 3.0.2
     tough-cookie: 4.1.2
     ws: 8.11.0
-  checksum: 7ff2614b46987d0b36aecf2dac120189501e916a647910ff0f40d882ad1b1e9f9957607982d7b3e13d8937e301a3bf05eaee7f0f73432c58f8d2584cf61fc75b
+  checksum: 36b0f95baed6c7b1ec0e8cb9ded30ea4fe85eaace4709185c47f60ab02d8391a0dd350b9d2811cee1361a223dea9c082c40c194ec0b1dc3dc5edcb2faaec790b
   languageName: node
   linkType: hard
 
@@ -4109,11 +4109,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:37.2.2":
-  version: 37.2.2
-  resolution: "@wireapp/core@npm:37.2.2"
+"@wireapp/core@npm:37.2.3":
+  version: 37.2.3
+  resolution: "@wireapp/core@npm:37.2.3"
   dependencies:
-    "@wireapp/api-client": ^22.8.0
+    "@wireapp/api-client": ^22.9.0
     "@wireapp/commons": ^5.0.4
     "@wireapp/core-crypto": 0.6.0-pre.4
     "@wireapp/cryptobox": 12.8.0
@@ -4128,7 +4128,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.12
-  checksum: 4061147740e6f6b5cf462d8c7c68b8904a5fd9b923f6d4c9966b2808985f1aa3eeb825d870d9ec2f7e26faa98624df4464ab8a8d89317df13bc9b8986cdf55a6
+  checksum: 7cfda05e9d1b1021a694109ed161504537c476079ceffdb2b5d7a045f3fa656e387e024507e47c89bf89d2c231adb42579bbc1faa86b9230b3d0e0e927963469
   languageName: node
   linkType: hard
 
@@ -16246,7 +16246,7 @@ __metadata:
     "@wireapp/antiscroll-2": 1.3.1
     "@wireapp/avs": 8.2.17
     "@wireapp/copy-config": 2.0.3
-    "@wireapp/core": 37.2.2
+    "@wireapp/core": 37.2.3
     "@wireapp/eslint-config": 2.1.0
     "@wireapp/prettier-config": 0.5.2
     "@wireapp/react-ui-kit": 9.2.0


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1268" title="FS-1268" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />FS-1268</a>  [Web] Remove deprecated API V3 endpoints/fields for conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Remove deprecated endpoints/fields due to api v3 updates (backwards compatibility):
- [x] The deprecated GET /conversations/ids endpoint was removed.
- [x] The deprecated endpoints GET /conversations/ids and GET /conversations have been removed. Use POST /conversations/list-ids followed by POST /conversations/list instead.
- [x] The endpoint PUT /conversations/:id/access has been removed. Use its qualified counterpart instead.
- [x] The field access_role_v2 in the Conversation type, in the request body of POST /conversations, and in the request body of PUT /conversations/:domain/:id/access has been removed. Its content is now contained in the access_role field instead. It replaces the legacy access role, previously contained in the access_role field.

Needs: https://github.com/wireapp/wire-web-packages/pull/4693