### PR TITLE
runfix: address design review of the font size slider [ACC-302]

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@wireapp/antiscroll-2": "1.3.1",
     "@wireapp/avs": "8.2.17",
     "@wireapp/core": "37.2.3",
-    "@wireapp/react-ui-kit": "9.2.0",
+    "@wireapp/react-ui-kit": "9.2.2",
     "@wireapp/store-engine-dexie": "2.0.3",
     "@wireapp/store-engine-sqleet": "1.8.9",
     "@wireapp/webapp-events": "0.16.0",

--- a/src/style/common/accent-color.less
+++ b/src/style/common/accent-color.less
@@ -206,8 +206,6 @@ each(.colors(), .(@color-key, @color-name) {
   @accent-color-border: '@{name}-500';
   @accent-color-focus: '@{name}-400';
   @accent-color-selection: '@{name}-300';
-  @icon-primary-active-fill: '@{name}-500';
-  @icon-secondary-active-border: 'accent_colors-0';
   @button-primary-hover: '@{name}-600';
   @button-primary-focus-border: '@{name}-700';
   @button-primary-active: '@{name}-800';
@@ -216,11 +214,12 @@ each(.colors(), .(@color-key, @color-name) {
   @button-secondary-active-bg: '@{name}-50';
   @button-secondary-active-border: '@{name}-500';
   @toggle-button-hover-bg: '@{name}-700';
+  @icon-primary-active-fill: '@{name}-500';
+  @icon-secondary-active-border: 'accent_colors-0';
+  @indicator-range-input-thumb: '@{name}-700';
   @toggle-button-unselected-bg: '@{name}-100';
 
   .main-accent-color-@{color-key} {
-    --icon-primary-active-fill: @@icon-primary-active-fill;
-    --icon-secondary-active-border: @@icon-secondary-active-border;
     --button-primary-hover: @@button-primary-hover;
     --button-primary-focus-border: @@button-primary-focus-border;
     --button-primary-active: @@button-primary-active;
@@ -229,6 +228,9 @@ each(.colors(), .(@color-key, @color-name) {
     --button-secondary-active-bg: @@button-secondary-active-bg;
     --button-secondary-active-border: @@button-secondary-active-border;
     --toggle-button-hover-bg: @@toggle-button-hover-bg;
+    --icon-primary-active-fill: @@icon-primary-active-fill;
+    --icon-secondary-active-border: @@icon-secondary-active-border;
+    --indicator-range-input-thumb: @@indicator-range-input-thumb;
     --toggle-button-unselected-bg: @@toggle-button-unselected-bg;
     --accent-color: @@accent-color;
     --accent-color-highlight: @@accent-color-highlight;
@@ -256,8 +258,6 @@ each(.colors(), .(@color-key, @color-name) {
     @accent-color-border-dark: '@{name}-dark-600';
     @accent-color-focus-dark: '@{name}-dark-600';
     @accent-color-selection-dark: '@{name}-dark-700';
-    @icon-primary-active-fill-dark: 'w-white';
-    @icon-secondary-active-border-dark: '@{name}-dark-800' ;
     @button-primary-hover-dark: '@{name}-dark-400';
     @button-primary-focus-border-dark: '@{name}-dark-100';
     @button-primary-active-dark: '@{name}-dark-800';
@@ -266,10 +266,11 @@ each(.colors(), .(@color-key, @color-name) {
     @button-secondary-active-bg-dark: 'w-gray-95';
     @button-secondary-active-border-dark: '@{name}-dark-800';
     @toggle-button-hover-bg-dark: '@{name}-dark-300';
+    @icon-primary-active-fill-dark: 'w-white';
+    @icon-secondary-active-border-dark: '@{name}-dark-800' ;
+    @indicator-range-input-thumb-dark: '@{name}-dark-300';
     @toggle-button-unselected-bg-dark: '@{name}-dark-800';
     .main-accent-color-@{color-key} {
-      --icon-primary-active-fill: @@icon-primary-active-fill-dark;
-      --icon-secondary-active-border: @@icon-secondary-active-border-dark;
       --button-primary-hover: @@button-primary-hover-dark;
       --button-primary-focus-border: @@button-primary-focus-border-dark;
       --button-primary-active: @@button-primary-active-dark;
@@ -277,6 +278,9 @@ each(.colors(), .(@color-key, @color-name) {
       --button-secondary-hover-border: @@button-secondary-hover-border-dark;
       --button-secondary-active-bg: @@button-secondary-active-bg-dark;
       --button-secondary-active-border: @@button-secondary-active-border-dark;
+      --icon-primary-active-fill: @@icon-primary-active-fill-dark;
+      --icon-secondary-active-border: @@icon-secondary-active-border-dark;
+      --indicator-range-input-thumb: @@indicator-range-input-thumb-dark;
       --toggle-button-hover-bg: @@toggle-button-hover-bg-dark;
       --toggle-button-unselected-bg: @@toggle-button-unselected-bg-dark;
       --accent-color: @@accent-color-dark;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4239,14 +4239,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/react-ui-kit@npm:9.2.0":
-  version: 9.2.0
-  resolution: "@wireapp/react-ui-kit@npm:9.2.0"
+"@wireapp/react-ui-kit@npm:9.2.2":
+  version: 9.2.2
+  resolution: "@wireapp/react-ui-kit@npm:9.2.2"
   dependencies:
     "@types/color": 3.0.3
     color: 4.2.3
     emotion-normalize: 11.0.1
-    react-select: 5.6.0
+    react-select: 5.7.0
     react-transition-group: 4.4.5
   peerDependencies:
     "@emotion/react": 11.10.4
@@ -4256,7 +4256,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 706df6c53ccf7a71a71904bfd1e07d3ee1c348fe81f8efa92de9628ee745e7b7d5f8b41af1d82be8d16580faa8457235710e92762892e9639f655e9d1512c58c
+  checksum: 04ecd580987ab65f26b7ac0e01cd9536bc71ab4d2cfa362931a260f8e5e2ddec5c03299cb6da0bd601548899d23582fc1fd260502c0381c790795e3a5fcafb71
   languageName: node
   linkType: hard
 
@@ -13387,9 +13387,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-select@npm:5.6.0":
-  version: 5.6.0
-  resolution: "react-select@npm:5.6.0"
+"react-select@npm:5.7.0":
+  version: 5.7.0
+  resolution: "react-select@npm:5.7.0"
   dependencies:
     "@babel/runtime": ^7.12.0
     "@emotion/cache": ^11.4.0
@@ -13403,7 +13403,7 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: d0a51e618168f3f275fbf96e23eb88ac6066006bcca136e293327f6eddd0b419ef02aaa847bf1670c5f07c8e9d9fc4b975fcae833085e11fc41e29e2b802a75b
+  checksum: 3d29f7bb6dd66ad55396d820f05da6112f1d21b67526422a8ff5aa6cd47c783804c1b73042ac2949ba0871056a3dc68c06a73a8281abb61571e475d72bbd80dc
   languageName: node
   linkType: hard
 
@@ -16249,7 +16249,7 @@ __metadata:
     "@wireapp/core": 37.2.3
     "@wireapp/eslint-config": 2.1.0
     "@wireapp/prettier-config": 0.5.2
-    "@wireapp/react-ui-kit": 9.2.0
+    "@wireapp/react-ui-kit": 9.2.2
     "@wireapp/store-engine": ^5.0.3
     "@wireapp/store-engine-dexie": 2.0.3
     "@wireapp/store-engine-sqleet": 1.8.9


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-302" title="ACC-302" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />ACC-302</a>  Font Scaling in Preferences (Part of BITV 11.7)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Changes 
- Bump ui-kit to 9.2.2 to integrate new changes to the font size slider
- add thumb color to accent-color less file