### PR TITLE
runfix: correct mention font-size and edit icon in replies

### DIFF
--- a/src/script/components/InputBar/ReplyBar.tsx
+++ b/src/script/components/InputBar/ReplyBar.tsx
@@ -66,7 +66,12 @@ const ReplyBar: FC<ReplyBarProps> = ({replyMessageEntity, onCancel}) => {
             </span>
 
             {wasEdited && (
-              <Icon.Edit data-uie-name="message-edited-reply-box" aria-label={t('replyBarEditMessage')} tabIndex={0} />
+              <Icon.Edit
+                className="edit-icon"
+                data-uie-name="message-edited-reply-box"
+                aria-label={t('replyBarEditMessage')}
+                tabIndex={0}
+              />
             )}
           </div>
 

--- a/src/style/content/conversation/input-bar.less
+++ b/src/style/content/conversation/input-bar.less
@@ -325,13 +325,10 @@
     font-weight: @font-weight-bold;
 
     .edit-icon {
+      width: 8px;
+      height: 8px;
       margin-left: 4px;
-
-      svg {
-        width: 8px;
-        height: 8px;
-        fill: var(--background-fade-40);
-      }
+      fill: var(--background-fade-40);
     }
   }
 

--- a/src/style/content/conversation/message-quote.less
+++ b/src/style/content/conversation/message-quote.less
@@ -117,4 +117,8 @@
   .video-asset {
     background-color: transparent;
   }
+
+  .message-mention {
+    font-size: @font-size-medium;
+  }
 }


### PR DESCRIPTION
### Issues

- font size of mentions is larger than the rest of the reply
- edit icon is larger than it should be in reply box
![image](https://user-images.githubusercontent.com/78490891/206203342-387f2db1-0430-41bc-b4fb-b3f89e593000.png)


### Changes

- make sure mentions adopt the font size of the parent `message-quote` element
- assign the proper class to the edit icon in replies
![image](https://user-images.githubusercontent.com/78490891/206203193-41905824-343a-4a29-9c52-796e30eda6aa.png)
