### PR TITLE
runfix: old images missing domain (FS-1001)

### DIFF
--- a/src/script/conversation/EventMapper.ts
+++ b/src/script/conversation/EventMapper.ts
@@ -77,6 +77,10 @@ export class EventMapper {
     this.logger = getLogger('EventMapper');
   }
 
+  private get fallbackDomain() {
+    return this.apiClient.context?.domain;
+  }
+
   /**
    * Convert multiple JSON events into message entities.
    *
@@ -158,7 +162,7 @@ export class EventMapper {
       const {
         preview_id,
         preview_key,
-        preview_domain = qualified_conversation?.domain || this.apiClient.context?.domain,
+        preview_domain = qualified_conversation?.domain || this.fallbackDomain,
         preview_otr_key,
         preview_sha256,
         preview_token,
@@ -743,7 +747,7 @@ export class EventMapper {
     const {
       preview_id,
       preview_key,
-      preview_domain = qualified_conversation?.domain || this.apiClient.context?.domain,
+      preview_domain = qualified_conversation?.domain || this.fallbackDomain,
       preview_otr_key,
       preview_sha256,
       preview_token,
@@ -779,13 +783,7 @@ export class EventMapper {
       assetEntity.height = `${info.height}px`;
     }
 
-    const {
-      key,
-      otr_key,
-      sha256,
-      token,
-      domain = qualified_conversation?.domain || this.apiClient.context?.domain,
-    } = eventData;
+    const {key, otr_key, sha256, token, domain = qualified_conversation?.domain || this.fallbackDomain} = eventData;
 
     if (!otr_key || !sha256) {
       return assetEntity;
@@ -826,7 +824,7 @@ export class EventMapper {
 
           const remoteData = AssetRemoteData.v3(
             assetKey,
-            assetDomain || this.apiClient.context?.domain,
+            assetDomain || this.fallbackDomain,
             otrKey,
             sha256,
             assetToken,

--- a/src/script/conversation/EventMapper.ts
+++ b/src/script/conversation/EventMapper.ts
@@ -73,7 +73,7 @@ export class EventMapper {
   /**
    * Construct a new Event Mapper.
    */
-  constructor(private readonly fallbackDomain = container.resolve(APIClient).context?.domain) {
+  constructor(private readonly apiClient = container.resolve(APIClient)) {
     this.logger = getLogger('EventMapper');
   }
 
@@ -158,7 +158,7 @@ export class EventMapper {
       const {
         preview_id,
         preview_key,
-        preview_domain = qualified_conversation?.domain || this.fallbackDomain,
+        preview_domain = qualified_conversation?.domain || this.apiClient.context?.domain,
         preview_otr_key,
         preview_sha256,
         preview_token,
@@ -743,7 +743,7 @@ export class EventMapper {
     const {
       preview_id,
       preview_key,
-      preview_domain = qualified_conversation?.domain,
+      preview_domain = qualified_conversation?.domain || this.apiClient.context?.domain,
       preview_otr_key,
       preview_sha256,
       preview_token,
@@ -771,7 +771,6 @@ export class EventMapper {
     const {data: eventData, conversation: conversationId, qualified_conversation} = event;
     const {content_length, content_type, id: assetId, info} = eventData;
     const assetEntity = new MediumImage(assetId);
-
     assetEntity.file_size = content_length;
     assetEntity.file_type = content_type;
 
@@ -780,12 +779,17 @@ export class EventMapper {
       assetEntity.height = `${info.height}px`;
     }
 
-    const {key, otr_key, sha256, token, domain = qualified_conversation?.domain} = eventData;
+    const {
+      key,
+      otr_key,
+      sha256,
+      token,
+      domain = qualified_conversation?.domain || this.apiClient.context?.domain,
+    } = eventData;
 
     if (!otr_key || !sha256) {
       return assetEntity;
     }
-
     const remoteData = key
       ? AssetRemoteData.v3(key, domain, otr_key, sha256, token, true)
       : AssetRemoteData.v2(conversationId, assetId, otr_key, sha256, true);
@@ -820,7 +824,14 @@ export class EventMapper {
           otrKey = new Uint8Array(otrKey);
           sha256 = new Uint8Array(sha256);
 
-          const remoteData = AssetRemoteData.v3(assetKey, assetDomain, otrKey, sha256, assetToken, true);
+          const remoteData = AssetRemoteData.v3(
+            assetKey,
+            assetDomain || this.apiClient.context?.domain,
+            otrKey,
+            sha256,
+            assetToken,
+            true,
+          );
           linkPreviewData.image = remoteData;
         }
       }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1001" title="FS-1001" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1001</a>  [Web] Old images do not display when using API V2
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

fix issue with missing domain value

