### PR TITLE
fix: Avoid double file pasting trigger [FS-1306]

### DIFF
--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -934,7 +934,6 @@ const InputBar = ({
                     onClick={handleMentionFlow}
                     onInput={updateMentions}
                     onChange={onChange}
-                    onPaste={onPasteFiles}
                     onBlur={() => setIsTyping(false)}
                     value={inputValue}
                     placeholder={inputPlaceholder}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1306" title="FS-1306" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />FS-1306</a>  [Web] File Sharing restriction modal appears twice if you try to copy and paste file to conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Since there is already a file pasting handler on the full `document` there is not need to add it to the textarea (this triggered a double call to the file paster handler)