### PR TITLE
runfix: prevent call button to stay on screen in responsive view [ACC-324]

### DIFF
--- a/src/script/components/TitleBar/TitleBar.tsx
+++ b/src/script/components/TitleBar/TitleBar.tsx
@@ -289,7 +289,7 @@ export const TitleBar: React.FC<TitleBarProps> = ({
           </div>
         )}
 
-        {mdBreakpoint ? (
+        {showCallControls && mdBreakpoint ? (
           <>
             <IconButton
               className="icon-search"

--- a/src/script/components/TitleBar/TitleBar.tsx
+++ b/src/script/components/TitleBar/TitleBar.tsx
@@ -289,7 +289,7 @@ export const TitleBar: React.FC<TitleBarProps> = ({
           </div>
         )}
 
-        {showCallControls && mdBreakpoint ? (
+        {mdBreakpoint ? (
           <>
             <IconButton
               className="icon-search"
@@ -301,16 +301,17 @@ export const TitleBar: React.FC<TitleBarProps> = ({
             >
               <span className="visually-hidden">{t('tooltipConversationSearch')}</span>
             </IconButton>
-
-            <IconButton
-              title={t('tooltipConversationCall')}
-              aria-label={t('tooltipConversationCall')}
-              css={{marginBottom: 0}}
-              onClick={onClickStartAudio}
-              data-uie-name="do-call"
-            >
-              <Icon.Pickup />
-            </IconButton>
+            {showCallControls && (
+              <IconButton
+                title={t('tooltipConversationCall')}
+                aria-label={t('tooltipConversationCall')}
+                css={{marginBottom: 0}}
+                onClick={onClickStartAudio}
+                data-uie-name="do-call"
+              >
+                <Icon.Pickup />
+              </IconButton>
+            )}
           </>
         ) : (
           <button


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-324" title="ACC-324" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-324</a>  [Web] Call button re-appears when re-sizing window to small size
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Issue

- the call button stay on screen after initiating a call in responsive view
![Peek 2022-12-08 16-37](https://user-images.githubusercontent.com/78490891/206497863-ad40f833-06a1-49e3-9ad6-9aa8c3c4102f.gif)

### Solution

- assign the correct conditional to the call button component
![Peek 2022-12-08 17-13](https://user-images.githubusercontent.com/78490891/206501370-cfb3c12e-5771-4554-8f11-b78f552e2424.gif)

