### PR TITLE
refactor: Use delegate event handlers for message clicks

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -52,7 +52,6 @@ import {ContentMessage} from '../../entity/message/ContentMessage';
 import {DecryptErrorMessage} from '../../entity/message/DecryptErrorMessage';
 import {MemberMessage} from '../../entity/message/MemberMessage';
 import {Message} from '../../entity/message/Message';
-import {Text} from '../../entity/message/Text';
 import {User} from '../../entity/User';
 import {UserError} from '../../error/UserError';
 import {isMouseRightClickEvent, isAuxRightClickEvent} from '../../guards/Mouse';
@@ -330,7 +329,6 @@ export const Conversation: FC<ConversationProps> = ({
   };
 
   const handleClickOnMessage = (
-    messageEntity: ContentMessage | Text,
     event: MouseEvent | KeyboardEvent,
     elementType: ElementType,
     messageDetails: MessageDetails = {

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer.test.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer.test.tsx
@@ -103,10 +103,10 @@ describe('TextMessageRenderer', () => {
     expect(linkElem).not.toBe(null);
 
     fireEvent.click(linkElem);
-    expect(onClickElement).toHaveBeenCalled();
+    expect(onClickElement).toHaveBeenCalledTimes(1);
 
-    fireEvent.keyDown(linkElem);
-    expect(onClickElement).toHaveBeenCalled();
+    fireEvent.keyDown(linkElem, {key: 'Enter'});
+    expect(onClickElement).toHaveBeenCalledTimes(2);
   });
 
   it('should not trigger a key event if the message is not focused', () => {

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer.tsx
@@ -20,6 +20,8 @@
 import {useEffect, FC, useState} from 'react';
 
 import {Text} from 'src/script/entity/message/Text';
+import {isKeyDownEvent} from 'src/script/guards/Event';
+import {isMouseEvent} from 'src/script/guards/Mouse';
 import {getAllFocusableElements, setElementsTabIndex} from 'Util/focusUtil';
 import {handleKeyDown} from 'Util/KeyboardUtil';
 
@@ -68,12 +70,11 @@ export const TextMessageRenderer: FC<TextMessageRendererProps> = ({
   }, [isQuoteMsg, setCanShowMore, containerRef]);
 
   useEffect(() => {
-    const element = containerRef;
-    if (!element) {
+    if (!containerRef) {
       return;
     }
 
-    const interactiveMsgElements = getAllFocusableElements(element);
+    const interactiveMsgElements = getAllFocusableElements(containerRef);
     setElementsTabIndex(interactiveMsgElements, isCurrentConversationFocused);
   }, [isCurrentConversationFocused, containerRef]);
 
@@ -82,12 +83,12 @@ export const TextMessageRenderer: FC<TextMessageRendererProps> = ({
     elementType: ElementType,
     messageDetails: MessageDetails,
   ) => {
-    if (event.type === 'keydown' && isCurrentConversationFocused) {
-      handleKeyDown(event as KeyboardEvent, () => {
+    if (isKeyDownEvent(event) && isCurrentConversationFocused) {
+      handleKeyDown(event, () => {
         event.preventDefault();
         onMessageClick(event, elementType, messageDetails);
       });
-    } else if (event.type === 'click') {
+    } else if (isMouseEvent(event)) {
       event.preventDefault();
       onMessageClick(event, elementType, messageDetails);
     }

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer.tsx
@@ -93,7 +93,11 @@ export const TextMessageRenderer: FC<TextMessageRendererProps> = ({
     }
   };
 
-  const handleClick = (event: React.MouseEvent | React.KeyboardEvent) => {
+  /**
+   * Will handle interaction with the message.
+   * Depending on the child element clicked, it will forward the event to the parent component.
+   */
+  const handleInteraction = (event: React.MouseEvent | React.KeyboardEvent) => {
     const target = event.target as HTMLElement;
     if (!target) {
       return;
@@ -124,10 +128,10 @@ export const TextMessageRenderer: FC<TextMessageRendererProps> = ({
     <p
       ref={setContainerRef}
       key={`${editedTimestamp}:${text}`}
-      onClick={handleClick}
-      onAuxClick={handleClick}
-      onKeyDown={handleClick}
-      onKeyUp={handleClick}
+      onClick={handleInteraction}
+      onAuxClick={handleInteraction}
+      onKeyDown={handleInteraction}
+      onKeyUp={handleInteraction}
       className={msgClass}
       dangerouslySetInnerHTML={{__html: text}}
       dir="auto"

--- a/src/script/components/MessagesList/Message/index.tsx
+++ b/src/script/components/MessagesList/Message/index.tsx
@@ -38,7 +38,6 @@ import type {ContentMessage} from '../../../entity/message/ContentMessage';
 import type {DecryptErrorMessage} from '../../../entity/message/DecryptErrorMessage';
 import type {MemberMessage as MemberMessageEntity} from '../../../entity/message/MemberMessage';
 import {Message as BaseMessage} from '../../../entity/message/Message';
-import type {Text} from '../../../entity/message/Text';
 import type {User} from '../../../entity/User';
 import {useRelativeTimestamp} from '../../../hooks/useRelativeTimestamp';
 import {TeamState} from '../../../team/TeamState';
@@ -49,12 +48,7 @@ export interface MessageActions {
   onClickImage: (message: ContentMessage, event: React.UIEvent) => void;
   onClickInvitePeople: () => void;
   onClickLikes: (message: BaseMessage) => void;
-  onClickMessage: (
-    asset: Text,
-    event: MouseEvent | KeyboardEvent,
-    elementType: ElementType,
-    messageDetails: MessageDetails,
-  ) => void;
+  onClickMessage: (event: MouseEvent | KeyboardEvent, elementType: ElementType, messageDetails: MessageDetails) => void;
   onClickParticipants: (participants: User[]) => void;
   onClickReceipts: (message: BaseMessage) => void;
   onClickResetSession: (messageError: DecryptErrorMessage) => void;

--- a/src/script/guards/Event.ts
+++ b/src/script/guards/Event.ts
@@ -18,3 +18,4 @@
  */
 
 export const isDragEvent = (event: Event): event is DragEvent => 'dataTransfer' in event;
+export const isKeyDownEvent = (event: Event): event is KeyboardEvent => event.type === 'keydown';


### PR DESCRIPTION
Instead of adding (and removing) event handlers directly on the message elements that need handling, this PR will register a global event handler that will detect on which type of element we clicked. 

This way, we let React take care of all the `(add|remove)EventListener` calls and we can focus on the business logic