### PR TITLE
refactor: Improve quote long text detection

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/MessageQuote.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageQuote.tsx
@@ -35,7 +35,6 @@ import {formatDateNumeral, formatTimeShort, isBeforeToday} from 'Util/TimeUtil';
 import {AudioAsset} from './asset/AudioAsset';
 import {FileAsset} from './asset/FileAssetComponent';
 import {LocationAsset} from './asset/LocationAsset';
-import {RenderShowMsgBtn} from './asset/RenderShowMsgBtn';
 import {TextMessageRenderer} from './asset/TextMessageRenderer';
 import {VideoAsset} from './asset/VideoAsset';
 
@@ -161,12 +160,6 @@ const QuotedMessage: FC<QuotedMessageProps> = ({
     was_edited,
     timestamp,
   } = useKoSubscribableChildren(quotedMessage, ['user', 'assets', 'headerSenderName', 'was_edited', 'timestamp']);
-  const [showFullText, setShowFullText] = useState(false);
-  const [canShowMore, setCanShowMore] = useState(false);
-
-  useEffect(() => {
-    setShowFullText(false);
-  }, [quotedMessage]);
 
   return (
     <>
@@ -200,27 +193,16 @@ const QuotedMessage: FC<QuotedMessageProps> = ({
           )}
 
           {asset.isText() && (
-            <>
-              <TextMessageRenderer
-                onMessageClick={handleClickOnMessage}
-                text={asset.render(selfId)}
-                msgClass={cx('message-quote__text', {
-                  'message-quote__text--full': showFullText,
-                  'message-quote__text--large': includesOnlyEmojis(asset.text),
-                })}
-                isCurrentConversationFocused={focusConversation}
-                data-uie-name="media-text-quote"
-                isQuoteMsg
-                setCanShowMore={setCanShowMore}
-              />
-              {canShowMore && (
-                <RenderShowMsgBtn
-                  showFullText={showFullText}
-                  setShowFullText={setShowFullText}
-                  isCurrentConversationFocused={focusConversation}
-                />
-              )}
-            </>
+            <TextMessageRenderer
+              onMessageClick={handleClickOnMessage}
+              text={asset.render(selfId)}
+              className={cx('message-quote__text', {
+                'message-quote__text--large': includesOnlyEmojis(asset.text),
+              })}
+              isCurrentConversationFocused={focusConversation}
+              data-uie-name="media-text-quote"
+              collapse
+            />
           )}
 
           {asset.isVideo() && (

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageQuote.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageQuote.tsx
@@ -160,15 +160,7 @@ const QuotedMessage: FC<QuotedMessageProps> = ({
     headerSenderName,
     was_edited,
     timestamp,
-    edited_timestamp: editedTimestamp,
-  } = useKoSubscribableChildren(quotedMessage, [
-    'user',
-    'assets',
-    'headerSenderName',
-    'was_edited',
-    'timestamp',
-    'edited_timestamp',
-  ]);
+  } = useKoSubscribableChildren(quotedMessage, ['user', 'assets', 'headerSenderName', 'was_edited', 'timestamp']);
   const [showFullText, setShowFullText] = useState(false);
   const [canShowMore, setCanShowMore] = useState(false);
 
@@ -217,11 +209,9 @@ const QuotedMessage: FC<QuotedMessageProps> = ({
                   'message-quote__text--large': includesOnlyEmojis(asset.text),
                 })}
                 isCurrentConversationFocused={focusConversation}
-                asset={asset}
                 data-uie-name="media-text-quote"
                 isQuoteMsg
                 setCanShowMore={setCanShowMore}
-                editedTimestamp={editedTimestamp}
               />
               {canShowMore && (
                 <RenderShowMsgBtn

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer.tsx
@@ -19,7 +19,8 @@
 
 import {useEffect, FC, useState} from 'react';
 
-import {Text} from 'src/script/entity/message/Text';
+import murmurhash from 'murmurhash';
+
 import {isKeyDownEvent} from 'src/script/guards/Event';
 import {isMouseEvent} from 'src/script/guards/Mouse';
 import {getAllFocusableElements, setElementsTabIndex} from 'Util/focusUtil';
@@ -32,9 +33,7 @@ interface TextMessageRendererProps {
   text: string;
   isCurrentConversationFocused: boolean;
   msgClass: string;
-  asset: Text;
   isQuoteMsg?: boolean;
-  editedTimestamp?: number;
   setCanShowMore?: (showMore: boolean) => void;
 }
 export interface MessageDetails {
@@ -48,9 +47,7 @@ export const TextMessageRenderer: FC<TextMessageRendererProps> = ({
   onMessageClick,
   msgClass,
   isCurrentConversationFocused,
-  asset,
   isQuoteMsg = false,
-  editedTimestamp,
   setCanShowMore,
   ...props
 }) => {
@@ -128,7 +125,7 @@ export const TextMessageRenderer: FC<TextMessageRendererProps> = ({
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
     <p
       ref={setContainerRef}
-      key={`${editedTimestamp}:${text}`}
+      key={murmurhash.v3(text)}
       onClick={handleInteraction}
       onAuxClick={handleInteraction}
       onKeyDown={handleInteraction}

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer/ShowMoreButton.test.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer/ShowMoreButton.test.tsx
@@ -21,14 +21,14 @@ import {fireEvent, render} from '@testing-library/react';
 
 import {t} from 'Util/LocalizerUtil';
 
-import {RenderShowMsgBtn} from './RenderShowMsgBtn';
+import {ShowMoreButton} from './ShowMoreButton';
 
-describe('ToggleMsgFullTxt', () => {
+describe('ShowMoreButton', () => {
   it('toggles button show more/show less for a quoted message', () => {
     let show = true;
     const setShowFullText = jest.fn(show => !show);
     const {getByTestId, getByText, rerender} = render(
-      <RenderShowMsgBtn showFullText={show} setShowFullText={setShowFullText} isCurrentConversationFocused />,
+      <ShowMoreButton active={show} onClick={setShowFullText} isCurrentConversationFocused />,
     );
 
     expect(getByText(t('replyQuoteShowLess'))).not.toBeNull();
@@ -40,7 +40,7 @@ describe('ToggleMsgFullTxt', () => {
     show = false;
 
     // re-render the same component with different props
-    rerender(<RenderShowMsgBtn showFullText={show} setShowFullText={setShowFullText} isCurrentConversationFocused />);
+    rerender(<ShowMoreButton active={show} onClick={setShowFullText} isCurrentConversationFocused />);
     fireEvent.click(toggleShowBtn);
 
     expect(setShowFullText).toHaveBeenCalled();

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer/ShowMoreButton.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer/ShowMoreButton.tsx
@@ -17,40 +17,37 @@
  *
  */
 
-import {FC} from 'react';
+import {FC, HTMLProps} from 'react';
 
 import cx from 'classnames';
 
 import {Icon} from 'Components/Icon';
 import {t} from 'Util/LocalizerUtil';
 
-interface ShowMsgBtnProps {
-  showFullText: boolean;
+interface ShowMoreButtonProps {
+  active: boolean;
   isCurrentConversationFocused: boolean;
-  setShowFullText: (showMore: boolean) => void;
 }
 
-export const RenderShowMsgBtn: FC<ShowMsgBtnProps> = ({
-  showFullText,
+export const ShowMoreButton: FC<ShowMoreButtonProps & HTMLProps<HTMLButtonElement>> = ({
+  active,
   isCurrentConversationFocused,
-  setShowFullText,
+  ...props
 }) => {
   return (
-    <>
-      <button
-        type="button"
-        className="button-reset-default message-quote__text__show-more"
-        onClick={() => setShowFullText(!showFullText)}
-        data-uie-name="do-show-more-quote"
-        tabIndex={isCurrentConversationFocused ? 0 : -1}
-      >
-        <span>{showFullText ? t('replyQuoteShowLess') : t('replyQuoteShowMore')}</span>
-        <Icon.Disclose
-          className={cx('disclose-icon', {
-            'upside-down': showFullText,
-          })}
-        />
-      </button>
-    </>
+    <button
+      className="button-reset-default message-quote__text__show-more"
+      data-uie-name="do-show-more-quote"
+      tabIndex={isCurrentConversationFocused ? 0 : -1}
+      {...props}
+      type="button"
+    >
+      <span>{active ? t('replyQuoteShowLess') : t('replyQuoteShowMore')}</span>
+      <Icon.Disclose
+        className={cx('disclose-icon', {
+          'upside-down': active,
+        })}
+      />
+    </button>
   );
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer/TextMessageRenderer.test.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer/TextMessageRenderer.test.tsx
@@ -19,39 +19,14 @@
 
 import {fireEvent, render} from '@testing-library/react';
 
-import {PROTO_MESSAGE_TYPE} from 'src/script/cryptography/ProtoMessageType';
-import {LinkPreview} from 'src/script/entity/message/LinkPreview';
-import {Text} from 'src/script/entity/message/Text';
-import {createRandomUuid} from 'Util/util';
-
 import {TextMessageRenderer} from './TextMessageRenderer';
-
-import {MentionEntity} from '../../../../../../message/MentionEntity';
-
-const mention = {
-  domain: '',
-  length: 0,
-  startIndex: 1,
-  type: PROTO_MESSAGE_TYPE.MENTION_TYPE_USER_ID,
-  userId: '1',
-};
-
-const textAsset = new Text(createRandomUuid());
-textAsset.mentions([new MentionEntity(mention.startIndex, mention.length, mention.userId, mention.domain)]);
-textAsset.previews([new LinkPreview()]);
 
 describe('TextMessageRenderer', () => {
   it('renders a text message', () => {
     const onClickElement = jest.fn();
     const txtMsg = 'simple message';
     const {getByText} = render(
-      <TextMessageRenderer
-        text={txtMsg}
-        onMessageClick={onClickElement}
-        isCurrentConversationFocused
-        msgClass=""
-        asset={textAsset}
-      />,
+      <TextMessageRenderer text={txtMsg} onMessageClick={onClickElement} isCurrentConversationFocused />,
     );
     const txtMsgElement = getByText(txtMsg);
     expect(txtMsgElement).not.toBe(null);
@@ -67,13 +42,7 @@ describe('TextMessageRenderer', () => {
     const onClickElement = jest.fn();
     const text = `<div class="message-mention" role="buttton" data-uie-name="label-other-mention" data-user-id="1fc1e32d-084b-49be-a392-85377f7208f3" data-user-domain="staging.zinfra.io"><span class="mention-at-sign">@</span>jj</div> yes it is`;
     const {getByTestId} = render(
-      <TextMessageRenderer
-        text={text}
-        onMessageClick={onClickElement}
-        isCurrentConversationFocused
-        msgClass=""
-        asset={textAsset}
-      />,
+      <TextMessageRenderer text={text} onMessageClick={onClickElement} isCurrentConversationFocused />,
     );
     const mention = getByTestId('label-other-mention');
     fireEvent.click(mention);
@@ -88,16 +57,9 @@ describe('TextMessageRenderer', () => {
 
     const linkTxt = 'this is a link';
     const text = `<a href="https://link.com" target="_blank" rel="nofollow noopener noreferrer" data-md-link="true" data-uie-name="markdown-link">${linkTxt}</a>`;
-    textAsset.text = linkTxt;
 
     const {getByText} = render(
-      <TextMessageRenderer
-        text={text}
-        onMessageClick={onClickElement}
-        isCurrentConversationFocused
-        msgClass=""
-        asset={textAsset}
-      />,
+      <TextMessageRenderer text={text} onMessageClick={onClickElement} isCurrentConversationFocused />,
     );
     const linkElem = getByText(linkTxt);
     expect(linkElem).not.toBe(null);
@@ -114,16 +76,9 @@ describe('TextMessageRenderer', () => {
 
     const linkTxt = 'this is a link';
     const text = `<a href="https://link.com" target="_blank" rel="nofollow noopener noreferrer" data-md-link="true" data-uie-name="markdown-link">${linkTxt}</a>`;
-    textAsset.text = linkTxt;
 
     const {getByText} = render(
-      <TextMessageRenderer
-        text={text}
-        onMessageClick={onClickElement}
-        isCurrentConversationFocused={false}
-        msgClass=""
-        asset={textAsset}
-      />,
+      <TextMessageRenderer text={text} onMessageClick={onClickElement} isCurrentConversationFocused={false} />,
     );
     const linkElem = getByText(linkTxt);
     expect(linkElem).not.toBe(null);

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer/TextMessageRenderer.test.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer/TextMessageRenderer.test.tsx
@@ -86,4 +86,23 @@ describe('TextMessageRenderer', () => {
     fireEvent.keyDown(linkElem);
     expect(onClickElement).not.toHaveBeenCalled();
   });
+
+  it('collapses long text when asked to', () => {
+    const onClickElement = jest.fn();
+
+    const text = 'this is a link<br>multiline text';
+
+    Object.defineProperty(HTMLParagraphElement.prototype, 'clientHeight', {get: () => 100});
+    Object.defineProperty(HTMLParagraphElement.prototype, 'scrollHeight', {get: () => 200});
+
+    const {getByText} = render(
+      <TextMessageRenderer text={text} onMessageClick={onClickElement} isCurrentConversationFocused={false} collapse />,
+    );
+    const showMoreButton = getByText('replyQuoteShowMore');
+    expect(showMoreButton).not.toBe(null);
+
+    fireEvent.click(showMoreButton);
+    const showLessButton = getByText('replyQuoteShowLess');
+    expect(showLessButton).not.toBe(null);
+  });
 });

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer/TextMessageRenderer.test.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer/TextMessageRenderer.test.tsx
@@ -26,7 +26,7 @@ import {createRandomUuid} from 'Util/util';
 
 import {TextMessageRenderer} from './TextMessageRenderer';
 
-import {MentionEntity} from '../../../../../message/MentionEntity';
+import {MentionEntity} from '../../../../../../message/MentionEntity';
 
 const mention = {
   domain: '',

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer/TextMessageRenderer.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer/TextMessageRenderer.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {useEffect, FC, useState, HTMLProps} from 'react';
+import {useEffect, FC, useState, HTMLProps, useRef} from 'react';
 
 import {isKeyDownEvent} from 'src/script/guards/Event';
 import {isMouseEvent} from 'src/script/guards/Mouse';
@@ -54,15 +54,19 @@ export const TextMessageRenderer: FC<TextMessageRendererProps & HTMLProps<HTMLPa
   const [canShowMore, setCanShowMore] = useState<boolean>(false);
   const [showFullText, setShowFullText] = useState<boolean>(!collapse);
 
+  const collapsedHeightRef = useRef<number>(0);
+
   useEffect(() => {
     const element = containerRef;
 
     if (element && collapse) {
       const preNode = element.querySelector('pre');
+      const collapsedHeight = collapsedHeightRef.current || element.clientHeight;
       const width = Math.max(element.scrollWidth, preNode ? preNode.scrollWidth : 0);
       const height = Math.max(element.scrollHeight, preNode ? preNode.scrollHeight : 0);
       const isWider = width > element.clientWidth;
-      const isHigher = height > element.clientHeight;
+      const isHigher = height > collapsedHeight;
+      collapsedHeightRef.current = collapsedHeight;
       setCanShowMore?.(isWider || isHigher);
     }
   }, [collapse, setCanShowMore, containerRef]);
@@ -121,6 +125,8 @@ export const TextMessageRenderer: FC<TextMessageRendererProps & HTMLProps<HTMLPa
   };
   const extraClasses = showFullText ? 'message-quote__text--full' : '';
 
+  const toggleShowMore = () => setShowFullText(prev => !prev);
+
   return (
     <>
       {
@@ -144,7 +150,7 @@ export const TextMessageRenderer: FC<TextMessageRendererProps & HTMLProps<HTMLPa
       />
       {canShowMore && (
         <ShowMoreButton
-          onClick={() => setShowFullText(!showFullText)}
+          onClick={toggleShowMore}
           isCurrentConversationFocused={isCurrentConversationFocused}
           active={showFullText}
         ></ShowMoreButton>

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer/TextMessageRenderer.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer/TextMessageRenderer.tsx
@@ -19,8 +19,6 @@
 
 import {useEffect, FC, useState, HTMLProps} from 'react';
 
-import murmurhash from 'murmurhash';
-
 import {isKeyDownEvent} from 'src/script/guards/Event';
 import {isMouseEvent} from 'src/script/guards/Mouse';
 import {getAllFocusableElements, setElementsTabIndex} from 'Util/focusUtil';
@@ -134,7 +132,7 @@ export const TextMessageRenderer: FC<TextMessageRendererProps & HTMLProps<HTMLPa
       <p
         ref={setContainerRef}
         // We want to make sure that this element is re-rendered when the text changes (this will trigger the containerRef to be updated).
-        key={murmurhash.v3(text)}
+        key={text}
         onClick={handleInteraction}
         onAuxClick={handleInteraction}
         onKeyDown={handleInteraction}

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer/index.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export * from './TextMessageRenderer';

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
@@ -71,7 +71,7 @@ const ContentAsset = ({
             <TextMessageRenderer
               onMessageClick={onClickMessage}
               text={(asset as Text).render(selfId, message.accent_color())}
-              msgClass={cx('text', {
+              className={cx('text', {
                 'text-foreground': status === StatusType.SENDING,
                 'text-large': includesOnlyEmojis(asset.text),
                 'ephemeral-message-obfuscated': isObfuscated,

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
@@ -77,7 +77,6 @@ const ContentAsset = ({
                 'ephemeral-message-obfuscated': isObfuscated,
               })}
               isCurrentConversationFocused={focusConversation}
-              asset={asset as Text}
             />
           )}
           {(asset as Text).previews().map(preview => (


### PR DESCRIPTION
A few improvements in this PR:
- long text detection is now completely isolated inside the TextRenderer components (based on a new `collapse` props)
- the `ShowMoreButton` is also isolated in the `TextRender` component and not visible to the `Quote` component (it just passes a `collapse` props to it)
- limits re-renders of the `Quote` component (as the children is now responsible for collapsing)