### PR TITLE
runfix: Address displaying conversation details when there a no participants

### DIFF
--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
@@ -401,7 +401,7 @@ const ConversationDetails: FC<ConversationDetailsProps> = ({
         {isActivatedAccount && (
           <>
             <ConversationDetailsBottomActions
-              isDeviceActionEnabled={!!(firstParticipant.isConnected || firstParticipant.inTeam)}
+              isDeviceActionEnabled={firstParticipant && (firstParticipant.isConnected() || firstParticipant.inTeam())}
               showDevices={openParticipantDevices}
               showNotifications={showNotifications}
               notificationStatusText={notificationStatusText}


### PR DESCRIPTION
Regression introduced by https://github.com/wireapp/wire-webapp/pull/14304/files