### PR TITLE
runfix: conversation component infinite rerender

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -482,10 +482,13 @@ export const Conversation: FC<ConversationProps> = ({
     };
   };
 
-  const wrapperRefHandler = (element: HTMLElement | null) => {
-    removeAnimationsClass(element);
-    handleFileDrop(element);
-  };
+  const wrapperRefHandler = useCallback(
+    (element: HTMLElement | null) => {
+      removeAnimationsClass(element);
+      handleFileDrop(element);
+    },
+    [handleFileDrop],
+  );
 
   return (
     <div


### PR DESCRIPTION
Fix for infinite rerender bug in conversation component.

The reason behind the issue is the fact that react is calling ref callback function every time we change it's reference. 
Docs: https://reactjs.org/docs/refs-and-the-dom.html#caveats-with-callback-refs