### PR TITLE
refactor: create drop file area component

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -26,7 +26,7 @@ import {groupBy} from 'underscore';
 import {useMatchMedia} from '@wireapp/react-ui-kit';
 
 import {CallingCell} from 'Components/calling/CallingCell';
-import {DropFileArea} from 'Components/DropFileArea/DropFileArea';
+import {DropFileArea} from 'Components/DropFileArea';
 import {Giphy} from 'Components/Giphy';
 import {InputBar} from 'Components/InputBar';
 import {MessagesList} from 'Components/MessagesList';

--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -26,9 +26,9 @@ import {groupBy} from 'underscore';
 import {useMatchMedia} from '@wireapp/react-ui-kit';
 
 import {CallingCell} from 'Components/calling/CallingCell';
+import {DropFileArea} from 'Components/DropFileArea/DropFileArea';
 import {Giphy} from 'Components/Giphy';
 import {InputBar} from 'Components/InputBar';
-import {useDropFiles} from 'Components/InputBar/hooks/useDropFiles';
 import {MessagesList} from 'Components/MessagesList';
 import {showDetailViewModal} from 'Components/Modals/DetailViewModal';
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
@@ -225,8 +225,6 @@ export const Conversation: FC<ConversationProps> = ({
     },
     [repositories.asset, uploadFiles, uploadImages],
   );
-
-  const {ref: handleFileDrop} = useDropFiles(checkFileSharingPermission(uploadDroppedFiles));
 
   const openGiphy = (text: string) => {
     setInputValue(text);
@@ -482,19 +480,12 @@ export const Conversation: FC<ConversationProps> = ({
     };
   };
 
-  const wrapperRefHandler = useCallback(
-    (element: HTMLElement | null) => {
-      removeAnimationsClass(element);
-      handleFileDrop(element);
-    },
-    [handleFileDrop],
-  );
-
   return (
-    <div
+    <DropFileArea
+      onFileDropped={checkFileSharingPermission(uploadDroppedFiles)}
       id="conversation"
       className={cx('conversation', {[incomingCssClass]: isConversationLoaded, loading: !isConversationLoaded})}
-      ref={wrapperRefHandler}
+      ref={removeAnimationsClass}
       key={activeConversation?.id}
     >
       {activeConversation && (
@@ -580,6 +571,6 @@ export const Conversation: FC<ConversationProps> = ({
       {isGiphyModalOpen && inputValue && (
         <Giphy giphyRepository={repositories.giphy} inputValue={inputValue} onClose={closeGiphy} />
       )}
-    </div>
+    </DropFileArea>
   );
 };

--- a/src/script/components/DropFileArea/DropFileArea.test.tsx
+++ b/src/script/components/DropFileArea/DropFileArea.test.tsx
@@ -1,0 +1,79 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {fireEvent, render} from '@testing-library/react';
+
+import {DropFileArea} from './DropFileArea';
+
+const getDefaultProps = () => ({
+  onFileDropped: jest.fn(),
+});
+
+const pngFileName = 'chucknorris.png';
+const pngFile = new File(['(⌐□_□)'], pngFileName, {type: 'image/png'});
+
+const jpegFileName = 'eminem.jpg';
+const jpegFile = new File(['(⌐□_□)'], jpegFileName, {type: 'image/jpeg'});
+
+describe('DropFileArea', () => {
+  it('triggers passed upload function after dropping a file', async () => {
+    const props = getDefaultProps();
+
+    const {getByTestId} = render(
+      <DropFileArea data-uie-name="dropzone" {...props}>
+        <p>drop file here</p>
+      </DropFileArea>,
+    );
+
+    const dropZone = getByTestId('dropzone');
+
+    fireEvent.drop(dropZone, {
+      dataTransfer: {
+        files: [pngFile],
+      },
+    });
+
+    //this is shallow comaprison (we could pass any 2 files), that's why we are checking file names also
+    expect(props.onFileDropped).toHaveBeenCalledWith([pngFile]);
+    expect(props.onFileDropped.mock.calls[0][0][0].name).toEqual(pngFileName);
+  });
+
+  it('triggers passed upload function after dropping multiple files', async () => {
+    const props = getDefaultProps();
+
+    const {getByTestId} = render(
+      <DropFileArea data-uie-name="dropzone" {...props}>
+        <p>drop file here</p>
+      </DropFileArea>,
+    );
+
+    const dropZone = getByTestId('dropzone');
+
+    fireEvent.drop(dropZone, {
+      dataTransfer: {
+        files: [pngFile, jpegFile],
+      },
+    });
+
+    expect(props.onFileDropped).toHaveBeenCalledWith([pngFile, jpegFile]);
+
+    expect(props.onFileDropped.mock.calls[0][0][0].name).toEqual(pngFileName);
+    expect(props.onFileDropped.mock.calls[0][0][1].name).toEqual(jpegFileName);
+  });
+});

--- a/src/script/components/DropFileArea/DropFileArea.test.tsx
+++ b/src/script/components/DropFileArea/DropFileArea.test.tsx
@@ -49,7 +49,7 @@ describe('DropFileArea', () => {
       },
     });
 
-    //this is shallow comaprison (we could pass any 2 files), that's why we are checking file names also
+    //this is shallow comparison (we could pass any 2 files), that's why we are checking file names also
     expect(props.onFileDropped).toHaveBeenCalledWith([pngFile]);
     expect(props.onFileDropped.mock.calls[0][0][0].name).toEqual(pngFileName);
   });

--- a/src/script/components/DropFileArea/index.ts
+++ b/src/script/components/DropFileArea/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export * from './DropFileArea';


### PR DESCRIPTION
Removes `useDropFile` hook and replaces it with `DropFileArea` component - no need of any state (or ref) management. We're using native react's event handlers that are being (un)subscribed automatically.
- much simpler reusable api
- no extra rerendering (no state)