### PR TITLE
fix: send message with cursor at the beginning

### DIFF
--- a/src/script/components/Emoji/useEmoji.tsx
+++ b/src/script/components/Emoji/useEmoji.tsx
@@ -202,7 +202,7 @@ const useEmoji = (
   const replaceAllInlineEmoji = (input: HTMLInputElement | HTMLTextAreaElement, shiftKeyPressed = false) => {
     const {selectionStart: selection, value: text} = input;
 
-    if (selection) {
+    if (selection !== null) {
       let textBeforeCursor = text.slice(0, selection);
       let textAfterCursor = text.slice(selection);
 


### PR DESCRIPTION
selection is a number | null, which of course can be 0 :P
A quite typical problem with truthy checks and numbers.