### PR TITLE
refactor: avoid state in text renderer component

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer/TextMessageRenderer.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer/TextMessageRenderer.tsx
@@ -28,7 +28,7 @@ import {ShowMoreButton} from './ShowMoreButton';
 
 export type ElementType = 'markdownLink' | 'email' | 'mention';
 
-interface TextMessageRendererProps {
+interface TextMessageRendererProps extends HTMLProps<HTMLParagraphElement> {
   onMessageClick: (event: MouseEvent | KeyboardEvent, elementType: ElementType, messageDetails: MessageDetails) => void;
   text: string;
   isFocusable: boolean;
@@ -42,7 +42,7 @@ export interface MessageDetails {
   userDomain?: string;
 }
 
-const TextMessage: FC<TextMessageRendererProps & HTMLProps<HTMLParagraphElement>> = ({
+const TextMessage: FC<TextMessageRendererProps> = ({
   text,
   onMessageClick,
   isFocusable,


### PR DESCRIPTION
Put `key` on the whole component instead of on the `<p>` element. This way after the `key` (text content) has changed, the whole component rerenders (state resets) and `useEffect`s are called.

With this improvement we can get rid of one extra rerender for each message. Because it previously had to render twice:
- initial render with `containerRef` `null` value
- rerender after saving element's reference in `containerRef` state

What may lead to some performance issues when opening a conversation full of messages.

React's docs: https://beta.reactjs.org/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key