### PR TITLE
fix: Avoid double escaping of special characters in typing indicator

### DIFF
--- a/src/script/components/InputBar/components/TypingIndicator/TypingIndicator.tsx
+++ b/src/script/components/InputBar/components/TypingIndicator/TypingIndicator.tsx
@@ -21,7 +21,7 @@ import {FC} from 'react';
 
 import {Avatar, AVATAR_SIZE} from 'Components/Avatar';
 import {Icon} from 'Components/Icon';
-import {StringIdentifer, t} from 'Util/LocalizerUtil';
+import {t} from 'Util/LocalizerUtil';
 
 import {useTypingIndicatorState} from './TypingIndicator.state';
 import {
@@ -60,17 +60,27 @@ const TypingIndicator: FC<TypingIndicatorProps> = ({conversationId}) => {
         ))}
       </div>
       <p css={indicatorTitleStyles} data-uie-name="typing-indicator-title">
-        {usersCount === 1 && t('tooltipConversationInputOneUserTyping' as StringIdentifer, {user1: users[0].name()})}
+        {usersCount === 1 && t('tooltipConversationInputOneUserTyping', {user1: users[0].name()}, undefined, true)}
         {usersCount === 2 &&
-          t('tooltipConversationInputTwoUserTyping' as StringIdentifer, {
-            user1: users[0].name(),
-            user2: users[1].name(),
-          })}
+          t(
+            'tooltipConversationInputTwoUserTyping',
+            {
+              user1: users[0].name(),
+              user2: users[1].name(),
+            },
+            undefined,
+            true,
+          )}
         {usersCount > 2 &&
-          t('tooltipConversationInputMoreThanTwoUserTyping' as StringIdentifer, {
-            user1: users[0].name(),
-            count: (usersCount - 1).toString(),
-          })}
+          t(
+            'tooltipConversationInputMoreThanTwoUserTyping',
+            {
+              user1: users[0].name(),
+              count: (usersCount - 1).toString(),
+            },
+            undefined,
+            true,
+          )}
       </p>
       <div css={indicatorAnimationWrapperStyles}>
         <div css={dotOneStyles} />


### PR DESCRIPTION
Before:
<img width="280" alt="image" src="https://user-images.githubusercontent.com/63250054/207868043-981f9d93-c65a-4f0b-a900-68a4d7a46b38.png">

After:
<img width="275" alt="image" src="https://user-images.githubusercontent.com/63250054/207868126-b9a3bd91-7bf4-4ba2-b271-04063aa346ea.png">
