### PR TITLE
feat: Send REJECT message through the self MLS conversation [FS-1327]

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@emotion/react": "11.10.5",
     "@types/eslint": "^8.4.10",
-    "@wireapp/avs": "8.2.17",
+    "@wireapp/avs": "9.0.1",
     "@wireapp/core": "38.0.0-beta.6",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.3.0",

--- a/src/script/calling/CallingRepository.test.ts
+++ b/src/script/calling/CallingRepository.test.ts
@@ -427,7 +427,17 @@ describe.skip('E2E audio call', () => {
     spyOn<any>(client, 'checkConcurrentJoinedCall').and.returnValue(Promise.resolve(true));
     spyOn<any>(client, 'sendMessage').and.callFake(
       (context, convId, userId, clientid, destUserId, destDeviceId, payload) => {
-        wCall.recvMsg(remoteWuser, payload, payload.length, Date.now(), Date.now(), convId, userId, clientid);
+        wCall.recvMsg(
+          remoteWuser,
+          payload,
+          payload.length,
+          Date.now(),
+          Date.now(),
+          convId,
+          userId,
+          clientid,
+          CONV_TYPE.CONFERENCE,
+        );
       },
     );
     return client.initAvs(user, 'device').then(({wCall: wCallInstance, wUser}) => {

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -559,9 +559,8 @@ export class CallingRepository {
   }
 
   private extractTargetedConversationId(event: CallingEvent): QualifiedId {
-    const {content, conversation, qualified_conversation} = event;
-    const targetedConversationId =
-      'qualified_conversation' in content ? content.qualified_conversation : qualified_conversation;
+    const {targetConversation, conversation, qualified_conversation} = event;
+    const targetedConversationId = targetConversation || qualified_conversation;
     const conversationId = targetedConversationId ?? {domain: '', id: conversation};
 
     return conversationId;
@@ -1120,7 +1119,7 @@ export class CallingRepository {
       const parsedPayload = JSON.parse(payload);
       const messageType = parsedPayload.type as CALL_MESSAGE_TYPE;
       if (messageType === CALL_MESSAGE_TYPE.REJECT) {
-        return void this.messageRepository.sendSelfCallingMessage(payload);
+        return void this.messageRepository.sendSelfCallingMessage(payload, conversation.qualifiedId);
       }
     }
 

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -558,6 +558,11 @@ export class CallingRepository {
     );
   }
 
+  /**
+   * Will extract the conversation that is referred to by the calling event.
+   * It could happen that messages relative to a particular conversation was sent in a different conversation (most likely the self conversation).
+   * We need to find the correct conversation in order for AVS to know which call is concerned
+   */
   private extractTargetedConversationId(event: CallingEvent): QualifiedId {
     const {targetConversation, conversation, qualified_conversation} = event;
     const targetedConversationId = targetConversation || qualified_conversation;

--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -137,6 +137,14 @@ export class ConversationState {
     return proteusConversation;
   }
 
+  getSelfMLSConversation(): Conversation {
+    const proteusConversation = this.selfMLSConversation();
+    if (!proteusConversation) {
+      throw new Error('No MLS self conversation');
+    }
+    return proteusConversation;
+  }
+
   /**
    * returns true if the conversation should be visible to the user
    * @param conversation the conversation to check visibility

--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -138,11 +138,11 @@ export class ConversationState {
   }
 
   getSelfMLSConversation(): Conversation {
-    const proteusConversation = this.selfMLSConversation();
-    if (!proteusConversation) {
+    const mlsConversation = this.selfMLSConversation();
+    if (!mlsConversation) {
       throw new Error('No MLS self conversation');
     }
-    return proteusConversation;
+    return mlsConversation;
   }
 
   /**

--- a/src/script/conversation/EventBuilder.ts
+++ b/src/script/conversation/EventBuilder.ts
@@ -59,14 +59,7 @@ export interface CallingEvent {
    * content is an object that comes from avs
    */
   content: {
-    keys: {
-      idx: number;
-      data: string;
-    }[];
-    resp: boolean;
-    sessid: string;
-    src_clientid: string;
-    src_userid: string;
+    qualified_conversation?: QualifiedId;
     type: CALL_MESSAGE_TYPE;
     version: string;
   };

--- a/src/script/conversation/EventBuilder.ts
+++ b/src/script/conversation/EventBuilder.ts
@@ -59,10 +59,10 @@ export interface CallingEvent {
    * content is an object that comes from avs
    */
   content: {
-    qualified_conversation?: QualifiedId;
     type: CALL_MESSAGE_TYPE;
     version: string;
   };
+  targetConversation?: QualifiedId;
   conversation: string;
   from: string;
   qualified_conversation?: QualifiedId;

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -1260,6 +1260,14 @@ export class MessageRepository {
   }
 
   /**
+   * Sends a call message only to self conversation (eg. REJECT message that warn the user's other clients that the call has been picked up)
+   * @param payload
+   * @returns
+   */
+  public sendSelfCallingMessage(payload: string) {
+    return this.sendCallingMessage(this.conversationState.getSelfMLSConversation(), payload);
+  }
+  /**
    * Send call message in specified conversation.
    *
    * @param eventInfoEntity Event info to be send

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -1264,8 +1264,11 @@ export class MessageRepository {
    * @param payload
    * @returns
    */
-  public sendSelfCallingMessage(payload: string) {
-    return this.sendCallingMessage(this.conversationState.getSelfMLSConversation(), payload);
+  public sendSelfCallingMessage(payload: string, targetConversation: QualifiedId) {
+    return this.sendCallingMessage(this.conversationState.getSelfMLSConversation(), {
+      content: payload,
+      qualifiedConversationId: targetConversation,
+    });
   }
   /**
    * Send call message in specified conversation.
@@ -1274,8 +1277,13 @@ export class MessageRepository {
    * @param conversationId id of the conversation to send call message to
    * @returns Resolves when the confirmation was sent
    */
-  public sendCallingMessage(conversation: Conversation, payload: string, options: MessageSendingOptions = {}) {
-    const message = MessageBuilder.buildCallMessage({content: payload});
+  public sendCallingMessage(
+    conversation: Conversation,
+    payload: string | {content: string; qualifiedConversationId: QualifiedId},
+    options: MessageSendingOptions = {},
+  ) {
+    const objectPayload = typeof payload === 'string' ? {content: payload} : payload;
+    const message = MessageBuilder.buildCallMessage(objectPayload);
 
     return this.sendAndInjectMessage(message, conversation, {
       ...options,

--- a/src/script/cryptography/CryptographyMapper.ts
+++ b/src/script/cryptography/CryptographyMapper.ts
@@ -398,6 +398,7 @@ export class CryptographyMapper {
   _mapCalling(calling: Calling, eventData: ConversationEvent & {sender: string}) {
     return {
       content: JSON.parse(calling.content),
+      targetConversation: calling.qualifiedConversationId,
       sender: eventData.sender,
       type: ClientEvent.CALL.E_CALL,
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4320,10 +4320,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/avs@npm:8.2.17":
-  version: 8.2.17
-  resolution: "@wireapp/avs@npm:8.2.17"
-  checksum: defbcfe3b4a121533d430e77f7420f59c7362e6d91f78cd42eb8afdacdf447b70abb072f049a627a5c4a3ee5a1880632a25849a306bcd7e53c238b8aca14e081
+"@wireapp/avs@npm:9.0.1":
+  version: 9.0.1
+  resolution: "@wireapp/avs@npm:9.0.1"
+  checksum: 0488decc8b59cd165af07a611e33fe0ef108a1d0fa67aaeaec53346186b2b2dc4043d709db4556f3d77c81dae88545e5f0a98159bb494722d8d6a67bcced8d04
   languageName: node
   linkType: hard
 
@@ -16420,7 +16420,7 @@ __metadata:
     "@types/webpack-env": 1.18.0
     "@typescript-eslint/eslint-plugin": ^5.47.1
     "@typescript-eslint/parser": ^5.47.1
-    "@wireapp/avs": 8.2.17
+    "@wireapp/avs": 9.0.1
     "@wireapp/copy-config": 2.0.4
     "@wireapp/core": 38.0.0-beta.6
     "@wireapp/eslint-config": 2.1.1


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1327" title="FS-1327" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-1327</a>  [web] Send REJECT in the selfConversation when call if picked up from once device
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This will allow warning the other of the user's devices that a call has been rejected or picked up from another device (and thus allow the current device to stop ringing). 

Since this message is sent through the self MLS conversation, we need to add a new payload that indicates which conversation is actually ringing (it is not the self conversation that is ringing)