### PR TITLE
refactor: remove lru-cache lib in favour of Map

### DIFF
--- a/src/script/assets/AssetURLCache.ts
+++ b/src/script/assets/AssetURLCache.ts
@@ -30,7 +30,5 @@ export const setAssetUrl = (identifier: string, url: string) => {
   }
 
   cache.set(identifier, url);
-  window.URL.revokeObjectURL(url);
-
   return url;
 };

--- a/src/script/assets/AssetURLCache.ts
+++ b/src/script/assets/AssetURLCache.ts
@@ -24,11 +24,9 @@ export const getAssetUrl = (identifier: string): string | undefined => cache.get
 export const setAssetUrl = (identifier: string, url: string) => {
   const isExistingUrl = getAssetUrl(identifier);
 
-  if (isExistingUrl) {
-    window.URL.revokeObjectURL(url);
-    return isExistingUrl;
+  if (!isExistingUrl) {
+    cache.set(identifier, url);
   }
 
-  cache.set(identifier, url);
   return url;
 };

--- a/src/script/assets/AssetURLCache.ts
+++ b/src/script/assets/AssetURLCache.ts
@@ -17,9 +17,7 @@
  *
  */
 
-import {LRUCache} from '@wireapp/lru-cache';
-
-const cache: LRUCache<string> = new LRUCache(100);
+const cache = new Map<string, string>();
 
 export const getAssetUrl = (identifier: string): string | undefined => cache.get(identifier);
 
@@ -31,11 +29,8 @@ export const setAssetUrl = (identifier: string, url: string) => {
     return isExistingUrl;
   }
 
-  const outdatedUrl = cache.set(identifier, url);
-
-  if (outdatedUrl != null) {
-    window.URL.revokeObjectURL(outdatedUrl);
-  }
+  cache.set(identifier, url);
+  window.URL.revokeObjectURL(url);
 
   return url;
 };


### PR DESCRIPTION
Use native `Map` object instead of `lru-cache` lib.