### PR TITLE
fix: Typing indicator toggle syncs inverting to other devices

### DIFF
--- a/src/script/page/MainContent/panels/preferences/accountPreferences/PrivacySection.tsx
+++ b/src/script/page/MainContent/panels/preferences/accountPreferences/PrivacySection.tsx
@@ -53,11 +53,23 @@ const PrivacySection: React.FC<PrivacySectionProps> = ({
       'appLockInactivityTimeoutSecs',
     ]);
 
-  const {receiptMode} = useKoSubscribableChildren(propertiesRepository, ['receiptMode']);
-  const {typingIndicatorMode} = useKoSubscribableChildren(propertiesRepository, ['typingIndicatorMode']);
+  const {receiptMode, typingIndicatorMode} = useKoSubscribableChildren(propertiesRepository, [
+    'receiptMode',
+    'typingIndicatorMode',
+  ]);
+
+  const changeReceiptMode = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const isChecked = event.target.checked;
+
+    propertiesRepository.updateProperty(
+      PropertiesRepository.CONFIG.WIRE_RECEIPT_MODE.key,
+      isChecked ? RECEIPT_MODE.ON : RECEIPT_MODE.OFF,
+    );
+  };
 
   const handleTypingModeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const isChecked = event.target.checked;
+
     propertiesRepository.updateProperty(
       PropertiesRepository.CONFIG.WIRE_TYPING_INDICATOR_MODE.key,
       isChecked ? CONVERSATION_TYPING_INDICATOR_MODE.ON : CONVERSATION_TYPING_INDICATOR_MODE.OFF,
@@ -67,13 +79,7 @@ const PrivacySection: React.FC<PrivacySectionProps> = ({
     <PreferencesSection hasSeparator className="preferences-section-privacy" title={t('preferencesAccountPrivacy')}>
       <>
         <Checkbox
-          onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-            const isChecked = event.target.checked;
-            propertiesRepository.updateProperty(
-              PropertiesRepository.CONFIG.WIRE_RECEIPT_MODE.key,
-              isChecked ? RECEIPT_MODE.ON : RECEIPT_MODE.OFF,
-            );
-          }}
+          onChange={changeReceiptMode}
           checked={receiptMode === RECEIPT_MODE.ON}
           data-uie-name="status-preference-read-receipts"
         >
@@ -83,6 +89,7 @@ const PrivacySection: React.FC<PrivacySectionProps> = ({
         </Checkbox>
         <p className="preferences-detail preferences-detail-intended">{t('preferencesAccountReadReceiptsDetail')}</p>
       </>
+
       <div className="checkbox-margin">
         <Checkbox
           onChange={handleTypingModeChange}
@@ -97,6 +104,7 @@ const PrivacySection: React.FC<PrivacySectionProps> = ({
           {t('preferencesAccountTypingIndicatorsDetail')}
         </p>
       </div>
+
       {isAppLockAvailable && (
         <div className="checkbox-margin">
           <Checkbox

--- a/src/script/properties/PropertiesRepository.ts
+++ b/src/script/properties/PropertiesRepository.ts
@@ -305,7 +305,7 @@ export class PropertiesRepository {
         }
         return this.propertiesService.putPropertiesByKey(key, value);
       case PropertiesRepository.CONFIG.WIRE_TYPING_INDICATOR_MODE.key:
-        if (value === CONVERSATION_TYPING_INDICATOR_MODE.ON) {
+        if (value === CONVERSATION_TYPING_INDICATOR_MODE.OFF) {
           return this.propertiesService.deletePropertiesByKey(key);
         }
         return this.propertiesService.putPropertiesByKey(key, value);


### PR DESCRIPTION
Before:
Toggling Typing Indicator in Account Privacy Section doesn't sync value with other device. Value is not updated.

Now:
Toggling Typing Indicator in Account Privacy Section syncing value with other device. Value is updated.