### PR TITLE
fix: make user modal close button keyboard accessible [ACC-334]

### DIFF
--- a/src/script/components/Modals/UserModal/UserModal.tsx
+++ b/src/script/components/Modals/UserModal/UserModal.tsx
@@ -29,7 +29,7 @@ import {EnrichedFields} from 'Components/panel/EnrichedFields';
 import {UserActions} from 'Components/panel/UserActions';
 import {UserDetails} from 'Components/panel/UserDetails';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
-import {isEnterKey} from 'Util/KeyboardUtil';
+import {handleKeyDown} from 'Util/KeyboardUtil';
 import {replaceLink, t} from 'Util/LocalizerUtil';
 
 import {useUserModalState} from './UserModal.state';
@@ -162,11 +162,7 @@ const UserModal: React.FC<UserModalProps> = ({
           <Icon.Close
             className="modal__header__button"
             onClick={hide}
-            onKeyDown={(event: React.KeyboardEvent<SVGSVGElement>) => {
-              if (isEnterKey(event)) {
-                hide();
-              }
-            }}
+            onKeyDown={event => handleKeyDown(event, hide)}
             data-uie-name="do-close"
             tabIndex={TabIndex.FOCUSABLE}
           />

--- a/src/script/components/Modals/UserModal/UserModal.tsx
+++ b/src/script/components/Modals/UserModal/UserModal.tsx
@@ -29,7 +29,7 @@ import {EnrichedFields} from 'Components/panel/EnrichedFields';
 import {UserActions} from 'Components/panel/UserActions';
 import {UserDetails} from 'Components/panel/UserDetails';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
-import {KEY} from 'Util/KeyboardUtil';
+import {isEnterKey} from 'Util/KeyboardUtil';
 import {replaceLink, t} from 'Util/LocalizerUtil';
 
 import {useUserModalState} from './UserModal.state';
@@ -163,7 +163,7 @@ const UserModal: React.FC<UserModalProps> = ({
             className="modal__header__button"
             onClick={hide}
             onKeyDown={(event: React.KeyboardEvent<SVGSVGElement>) => {
-              if (event.key === KEY.ENTER) {
+              if (isEnterKey(event)) {
                 hide();
               }
             }}

--- a/src/script/components/Modals/UserModal/UserModal.tsx
+++ b/src/script/components/Modals/UserModal/UserModal.tsx
@@ -19,6 +19,7 @@
 
 import React, {useContext, useEffect, useState} from 'react';
 
+import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 import cx from 'classnames';
 import {container} from 'tsyringe';
 
@@ -28,6 +29,7 @@ import {EnrichedFields} from 'Components/panel/EnrichedFields';
 import {UserActions} from 'Components/panel/UserActions';
 import {UserDetails} from 'Components/panel/UserDetails';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
+import {KEY} from 'Util/KeyboardUtil';
 import {replaceLink, t} from 'Util/LocalizerUtil';
 
 import {useUserModalState} from './UserModal.state';
@@ -157,7 +159,17 @@ const UserModal: React.FC<UserModalProps> = ({
             </h2>
           )}
 
-          <Icon.Close className="modal__header__button" onClick={hide} data-uie-name="do-close" />
+          <Icon.Close
+            className="modal__header__button"
+            onClick={hide}
+            onKeyDown={(event: React.KeyboardEvent<SVGSVGElement>) => {
+              if (event.key === KEY.ENTER) {
+                hide();
+              }
+            }}
+            data-uie-name="do-close"
+            tabIndex={TabIndex.FOCUSABLE}
+          />
         </div>
 
         <div className={cx('modal__body user-modal__wrapper', {'user-modal__wrapper--max': !user && !userNotFound})}>

--- a/src/script/util/KeyboardUtil.ts
+++ b/src/script/util/KeyboardUtil.ts
@@ -140,8 +140,8 @@ export const offEscKey = (handler: KeyboardHandler) => {
 };
 
 export const handleKeyDown = (
-  event: React.KeyboardEvent<HTMLElement> | KeyboardEvent,
-  callback: (event?: React.KeyboardEvent<HTMLElement> | KeyboardEvent) => void,
+  event: React.KeyboardEvent<Element> | KeyboardEvent,
+  callback: (event?: React.KeyboardEvent<Element> | KeyboardEvent) => void,
 ) => {
   if (event.key === KEY.ENTER || event.key === KEY.SPACE) {
     callback(event);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-334" title="ACC-334" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-334</a>  [Web] Close button on user profile popup with keyboard is not reachable
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Issue
- User modal close button isn't keyboard accessible

### Change
- add a TabIndex and keyboard handler