### PR TITLE
fix: resetting mentions when replying to a message

### DIFF
--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -384,7 +384,7 @@ const InputBar = ({
 
   const replyMessage = (messageEntity: ContentMessage): void => {
     if (messageEntity?.isReplyable() && messageEntity !== replyMessageEntity) {
-      cancelMessageReply();
+      cancelMessageReply(false);
       cancelMessageEditing(!!editMessageEntity);
       setReplyMessageEntity(messageEntity);
 
@@ -553,6 +553,7 @@ const InputBar = ({
 
       return;
     }
+
     const updatedMentions = updateMentionRanges(currentMentions, 0, 0, trimmedStartLength - beforeLength);
 
     if (isEditing) {


### PR DESCRIPTION
Fixing the faulty behaviour of disappearing mentions when replying to a message. 


![test](https://user-images.githubusercontent.com/77456193/208125966-cee4e031-eb6d-4517-a971-a73b19493b94.gif)
