### PR TITLE
runfix: provide css selector to radio options

### DIFF
--- a/src/script/components/Radio/RadioGroup.tsx
+++ b/src/script/components/Radio/RadioGroup.tsx
@@ -32,6 +32,7 @@ interface RadioGroupProps<T> {
     value: T;
     detailLabel?: string;
     isDisabled?: boolean;
+    optionUeiName?: string;
   }[];
   selectedValue: T;
   uieName?: string;
@@ -49,7 +50,7 @@ const RadioGroup = <T extends string | number>({
 
   return (
     <div aria-labelledby={ariaLabelledBy} data-uie-name={uieName} role="radiogroup">
-      {options.map(({value, label, detailLabel, isDisabled = false}) => {
+      {options.map(({value, label, detailLabel, isDisabled = false, optionUeiName = `${uieName}-${value}`}) => {
         const currentId = radioId + value;
         const isChecked = selectedValue === value;
 
@@ -65,7 +66,7 @@ const RadioGroup = <T extends string | number>({
               value={value}
               onChange={() => onChange(value)}
               checked={isChecked}
-              data-uie-name={`${uieName}-${value}`}
+              data-uie-name={optionUeiName}
             />
 
             <label css={radioLabelStyles(isDisabled)} htmlFor={currentId}>

--- a/src/script/page/RightSidebar/TimedMessages/TimedMessages.tsx
+++ b/src/script/page/RightSidebar/TimedMessages/TimedMessages.tsx
@@ -103,6 +103,7 @@ const TimedMessages: FC<TimedMessagesPanelProps> = ({activeConversation, onClose
               label: text,
               value: value,
               isDisabled: isCustom,
+              optionUeiName: 'item-timed-messages-option',
             }))}
           />
         </div>


### PR DESCRIPTION
### Issue
- The refactored radio options for self deleting messages don't provide the correct css selectors for automation

### Change
- Include an option to provide a ueiname for radio options