### PR TITLE
feat: Use new buttons in giphy modal (ACC-71)

### DIFF
--- a/src/script/components/Giphy/Giphy.test.tsx
+++ b/src/script/components/Giphy/Giphy.test.tsx
@@ -19,6 +19,8 @@
 
 import {fireEvent, render} from '@testing-library/react';
 
+import {withTheme} from 'src/script/auth/util/test/TestUtil';
+
 import {GiphyRepository} from '../../extension/GiphyRepository';
 import {GiphyService} from '../../extension/GiphyService';
 
@@ -33,12 +35,12 @@ const getDefaultProps = () => ({
 
 describe('Giphy', () => {
   it('rendered modal', () => {
-    const {getByText} = render(<Giphy {...getDefaultProps()} defaultGiphyState={GiphyState.RESULT} />);
+    const {getByText} = render(withTheme(<Giphy {...getDefaultProps()} defaultGiphyState={GiphyState.RESULT} />));
     expect(getByText(inputValue)).not.toBeNull();
   });
 
   it('closes giphy modal', async () => {
-    const {getByTestId} = render(<Giphy {...getDefaultProps()} />);
+    const {getByTestId} = render(withTheme(<Giphy {...getDefaultProps()} />));
     const closeButton = getByTestId('do-close-giphy-modal');
 
     expect(closeButton).not.toBeNull();
@@ -46,7 +48,7 @@ describe('Giphy', () => {
   });
 
   it('no giphys found', async () => {
-    const {getByText} = render(<Giphy {...getDefaultProps()} defaultGiphyState={GiphyState.ERROR} />);
+    const {getByText} = render(withTheme(<Giphy {...getDefaultProps()} defaultGiphyState={GiphyState.ERROR} />));
 
     expect(getByText('extensionsGiphyNoGifs')).not.toBeNull();
   });

--- a/src/script/components/Giphy/Giphy.tsx
+++ b/src/script/components/Giphy/Giphy.tsx
@@ -22,6 +22,7 @@ import {FC, useEffect, useState} from 'react';
 import {amplify} from 'amplify';
 import cx from 'classnames';
 
+import {Button} from '@wireapp/react-ui-kit';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {GifImage} from 'Components/Giphy/GifImage';
@@ -258,27 +259,27 @@ const Giphy: FC<GiphyProps> = ({giphyRepository, defaultGiphyState = GiphyState.
           </div>
 
           <footer className="giphy-modal-footer modal-footer">
-            <button
+            <Button
               type="button"
-              className={cx('button button-inverted', {'button-disabled': !hasGifs})}
               aria-disabled={!hasGifs}
+              disabled={!hasGifs}
               onClick={getRandomGif}
               data-uie-name="do-try-another"
               aria-label={t('accessibility.giphyModal.tryAnother')}
             >
               {t('extensionsGiphyButtonMore')}
-            </button>
+            </Button>
 
-            <button
+            <Button
               type="button"
-              className={cx('button', {'button-disabled': !selectedGif})}
               aria-disabled={!selectedGif}
+              disabled={!selectedGif}
               onClick={onSend}
               data-uie-name="do-send-gif"
               aria-label={t('accessibility.giphyModal.sendGif')}
             >
               {t('extensionsGiphyButtonOk')}
-            </button>
+            </Button>
           </footer>
         </div>
       </div>

--- a/src/style/common/modal.less
+++ b/src/style/common/modal.less
@@ -191,7 +191,7 @@
     margin: 16px auto 0;
     text-align: center;
 
-    .button {
+    button {
       width: 210px;
     }
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-71" title="ACC-71" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-71</a>  Create element or focus one with a information about the caller
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<img width="524" alt="image" src="https://user-images.githubusercontent.com/63250054/208441396-a5281fe8-b774-4804-a911-2fdea0651a23.png">