### PR TITLE
fix: close right sidebar when changing view [ACC-352]

### DIFF
--- a/src/script/components/TitleBar/TitleBar.tsx
+++ b/src/script/components/TitleBar/TitleBar.tsx
@@ -143,10 +143,7 @@ export const TitleBar: React.FC<TitleBarProps> = ({
 
   const {setCurrentView: setView} = useAppMainState(state => state.responsiveView);
 
-  const setLeftSidebar = () => {
-    setView(ViewType.LEFT_SIDEBAR);
-  };
-
+  const setLeftSidebar = () => setView(ViewType.LEFT_SIDEBAR);
   const {close: closeRightSidebar} = useAppMainState(state => state.rightSidebar);
 
   const onClickBack = () => {

--- a/src/script/components/TitleBar/TitleBar.tsx
+++ b/src/script/components/TitleBar/TitleBar.tsx
@@ -143,7 +143,16 @@ export const TitleBar: React.FC<TitleBarProps> = ({
 
   const {setCurrentView: setView} = useAppMainState(state => state.responsiveView);
 
-  const setLeftSidebar = () => setView(ViewType.LEFT_SIDEBAR);
+  const setLeftSidebar = () => {
+    setView(ViewType.LEFT_SIDEBAR);
+  };
+
+  const {close: closeRightSidebar} = useAppMainState(state => state.rightSidebar);
+
+  const onClickBack = () => {
+    setLeftSidebar();
+    closeRightSidebar();
+  };
 
   const showDetails = useCallback(
     (addParticipants: boolean): void => {
@@ -205,7 +214,7 @@ export const TitleBar: React.FC<TitleBarProps> = ({
             variant={IconButtonVariant.SECONDARY}
             className="conversation-title-bar-icon icon-back"
             css={{marginBottom: 0}}
-            onClick={setLeftSidebar}
+            onClick={onClickBack}
           />
         )}
 

--- a/src/script/components/TitleBar/TitleBar.tsx
+++ b/src/script/components/TitleBar/TitleBar.tsx
@@ -141,13 +141,12 @@ export const TitleBar: React.FC<TitleBarProps> = ({
   const mdBreakpoint = useMatchMedia('max-width: 768px');
   const smBreakpoint = useMatchMedia('max-width: 640px');
 
-  const {setCurrentView: setView} = useAppMainState(state => state.responsiveView);
-
-  const setLeftSidebar = () => setView(ViewType.LEFT_SIDEBAR);
   const {close: closeRightSidebar} = useAppMainState(state => state.rightSidebar);
 
-  const onClickBack = () => {
-    setLeftSidebar();
+  const {setCurrentView: setView} = useAppMainState(state => state.responsiveView);
+
+  const setLeftSidebar = () => {
+    setView(ViewType.LEFT_SIDEBAR);
     closeRightSidebar();
   };
 
@@ -197,7 +196,9 @@ export const TitleBar: React.FC<TitleBarProps> = ({
 
   const onClickStartAudio = () => {
     callActions.startAudio(conversation);
-    setLeftSidebar();
+    if (smBreakpoint) {
+      setLeftSidebar();
+    }
   };
 
   return (
@@ -211,7 +212,7 @@ export const TitleBar: React.FC<TitleBarProps> = ({
             variant={IconButtonVariant.SECONDARY}
             className="conversation-title-bar-icon icon-back"
             css={{marginBottom: 0}}
-            onClick={onClickBack}
+            onClick={setLeftSidebar}
           />
         )}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-352" title="ACC-352" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-352</a>  [Web] Conversation details stay open when going back to conversation list in collapsed view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Issue
- Right sidebar stays open when changing views in responsive view
![Peek 2022-12-20 13-02](https://user-images.githubusercontent.com/78490891/208671157-7b9b1c64-3151-4776-8685-592dba009d00.gif)

### Solution
- Close the right sidebar when clicking the back button
![Peek 2022-12-20 13-49](https://user-images.githubusercontent.com/78490891/208671450-ffcaa75e-be5e-46a1-9bb3-d0b38e0a6bd8.gif)
