### PR TITLE
fix: prevent deletion of draft messages [ACC-351]

### DIFF
--- a/src/script/router/routerBindings.ts
+++ b/src/script/router/routerBindings.ts
@@ -28,6 +28,7 @@ import {useAppMainState, ViewType} from '../page/state';
 export const createNavigate =
   (link: string): React.MouseEventHandler =>
   (event: React.MouseEvent<Element, MouseEvent>) => {
+    // The order here matters, setting the view before calling navigate() would not save the history
     navigate(link);
     setResponsiveView();
     event.preventDefault();

--- a/src/script/router/routerBindings.ts
+++ b/src/script/router/routerBindings.ts
@@ -28,8 +28,8 @@ import {useAppMainState, ViewType} from '../page/state';
 export const createNavigate =
   (link: string): React.MouseEventHandler =>
   (event: React.MouseEvent<Element, MouseEvent>) => {
-    setResponsiveView();
     navigate(link);
+    setResponsiveView();
     event.preventDefault();
   };
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-351" title="ACC-351" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-351</a>  [Web] Switching conversation in responsive design deletes drafted message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Issue
- message drafts are deleted when switching groups in responsive view
![Peek 2022-12-20 15-40](https://user-images.githubusercontent.com/78490891/208693037-7d269c22-0541-400d-800e-a706c5e1f554.gif)


### Solution
- Change the order the functions are called in `createNavigate`
![Peek 2022-12-20 15-42](https://user-images.githubusercontent.com/78490891/208693284-893a9088-24f7-4133-80b1-9d7933f76d6f.gif)
