### PR TITLE
runfix: update legal privacy link

### DIFF
--- a/app-config/package.json
+++ b/app-config/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "wire-web-config-default-master": "https://github.com/wireapp/wire-web-config-wire#v0.31.9-0",
-    "wire-web-config-default-staging": "https://github.com/wireapp/wire-web-config-default#v0.31.9"
+    "wire-web-config-default-staging": "https://github.com/wireapp/wire-web-config-default#v0.31.10"
   }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

as our Netlify account was closed (on accident?) we no longer have access to the staging version of the wire website. all of the references to it must be updated to the default wire website. This should catch the last one. please check the wire-webapp-config-default repo v31.10 to see the associated change. 

