### PR TITLE
fix: Change font size of seach placeholder (ACC-327)

### DIFF
--- a/src/style/components/search-input.less
+++ b/src/style/components/search-input.less
@@ -98,7 +98,7 @@
 
   &:placeholder-shown {
     .ellipsis-nowrap;
-    font-size: 16px;
+    font-size: 14px;
   }
 
   // hack for chrome to fix line height issue


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-327" title="ACC-327" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-327</a>  [Web] User search reminder text is cut-off on federated env
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Before:
![telegram-cloud-photo-size-4-5843923659503286854-x](https://user-images.githubusercontent.com/63250054/208892768-14494297-46f6-47c0-810a-36db0711cd24.jpg)

After:
<img width="320" alt="image" src="https://user-images.githubusercontent.com/63250054/208893055-aae03f66-3233-459b-98b2-a4b2666b957d.png">
