### PR TITLE
runfix: hash entropy to 32 bytes

### DIFF
--- a/src/script/auth/page/EntropyContainer.tsx
+++ b/src/script/auth/page/EntropyContainer.tsx
@@ -47,7 +47,7 @@ const EntropyContainer = ({onSetEntropy, containerSize = 400}: Props) => {
     setPercent(percentage);
   };
 
-  const fowardEntropy = async (entropy: Uint8Array) => {
+  const forwardEntropy = async (entropy: Uint8Array) => {
     // we want to hash the entire entropy array to get a 256 bit (32 bytes) array
     const hashedValue = await window.crypto.subtle.digest('SHA-256', entropy);
     onSetEntropy(new Uint8Array(hashedValue));
@@ -76,11 +76,11 @@ const EntropyContainer = ({onSetEntropy, containerSize = 400}: Props) => {
           </Muted>
           <Button
             css={{width: '70%'}}
-            onClick={() => fowardEntropy(entropy.entropyData)}
+            onClick={() => forwardEntropy(entropy.entropyData)}
             data-uie-name="do-entropy-confirm"
             onKeyDown={(event: React.KeyboardEvent) => {
               if (event.key === KEY.ENTER) {
-                fowardEntropy(entropy.entropyData);
+                forwardEntropy(entropy.entropyData);
               }
             }}
           >

--- a/src/script/auth/page/EntropyContainer.tsx
+++ b/src/script/auth/page/EntropyContainer.tsx
@@ -47,6 +47,12 @@ const EntropyContainer = ({onSetEntropy, containerSize = 400}: Props) => {
     setPercent(percentage);
   };
 
+  const fowardEntropy = async (entropy: Uint8Array) => {
+    // we want to hash the entire entropy array to get a 256 bit (32 bytes) array
+    const hashedValue = await window.crypto.subtle.digest('SHA-256', entropy);
+    onSetEntropy(new Uint8Array(hashedValue));
+  };
+
   return (
     <ContainerSM
       centerText
@@ -70,11 +76,11 @@ const EntropyContainer = ({onSetEntropy, containerSize = 400}: Props) => {
           </Muted>
           <Button
             css={{width: '70%'}}
-            onClick={() => onSetEntropy(entropy.entropyData)}
+            onClick={() => fowardEntropy(entropy.entropyData)}
             data-uie-name="do-entropy-confirm"
             onKeyDown={(event: React.KeyboardEvent) => {
               if (event.key === KEY.ENTER) {
-                onSetEntropy(entropy.entropyData);
+                fowardEntropy(entropy.entropyData);
               }
             }}
           >


### PR DESCRIPTION
Previously, Cryptobox was taking care of hashing the entropy data generated. 
But since the migration to coreCrypto, we need to give entropy that has the right amount of data