### PR TITLE
fix: Change constant bit rate title to avoid breaking calling ui in large font sizes (ACC-326)

### DIFF
--- a/src/script/components/calling/CallingCell.tsx
+++ b/src/script/components/calling/CallingCell.tsx
@@ -288,8 +288,12 @@ const CallingCell: React.FC<CallingCellProps> = ({
                     </span>
 
                     {isCbrEnabled && (
-                      <span className="conversation-list-cell-description" data-uie-name="call-cbr">
-                        {t('callStateCbr')}
+                      <span
+                        aria-label={t('callStateCbr')}
+                        className="conversation-list-cell-description"
+                        data-uie-name="call-cbr"
+                      >
+                        CBR
                       </span>
                     )}
                   </div>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-326" title="ACC-326" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-326</a>  [Web] Big font size cuts off information in call ui
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<img width="269" alt="image" src="https://user-images.githubusercontent.com/63250054/208945103-6517e0e4-aefd-47f6-bfda-00ee00c1fe5b.png">
