### PR TITLE
runfix: align group header [ACC-372]

### DIFF
--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -668,7 +668,7 @@
 .message-group-creation-header,
 .message-member-footer {
   padding-top: 16px;
-  margin-left: 72px;
+  margin-left: 54px;
   font-size: @font-size-small;
   font-weight: @font-weight-regular;
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-372" title="ACC-372" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-372</a>  Information and content in (new) group is not aligned
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Issue
see ticket: 
![image](https://user-images.githubusercontent.com/78490891/208962436-97b41e79-3333-4e7f-8cb8-337d88fee313.png)
