### PR TITLE
refactor: rename last/first message to oldest/newest

### DIFF
--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -220,7 +220,7 @@ const MessagesList: FC<MessagesListParams> = ({
   };
 
   const loadFollowingMessages = () => {
-    const lastMessage = conversation.getLastMessage();
+    const lastMessage = conversation.getNewestMessage();
 
     if (lastMessage) {
       if (!isLastReceivedMessage(lastMessage, conversation)) {

--- a/src/script/conversation/ConversationCellState.ts
+++ b/src/script/conversation/ConversationCellState.ts
@@ -188,7 +188,7 @@ const _getStateDefault = {
 
 const _getStateGroupActivity = {
   description: (conversationEntity: Conversation): string => {
-    const lastMessageEntity = conversationEntity.getLastMessage();
+    const lastMessageEntity = conversationEntity.getNewestMessage();
 
     if (lastMessageEntity.isMember()) {
       const userCount = (lastMessageEntity as MemberMessage).userEntities().length;
@@ -248,7 +248,7 @@ const _getStateGroupActivity = {
     return '';
   },
   icon: (conversationEntity: Conversation): ConversationStatusIcon | void => {
-    const lastMessageEntity = conversationEntity.getLastMessage();
+    const lastMessageEntity = conversationEntity.getNewestMessage();
     const isMemberRemoval = lastMessageEntity.isMember() && (lastMessageEntity as MemberMessage).isMemberRemoval();
 
     if (isMemberRemoval) {
@@ -258,7 +258,7 @@ const _getStateGroupActivity = {
     }
   },
   match: (conversationEntity: Conversation) => {
-    const lastMessageEntity = conversationEntity.getLastMessage();
+    const lastMessageEntity = conversationEntity.getNewestMessage();
     const isExpectedType = lastMessageEntity ? lastMessageEntity.isMember() || lastMessageEntity.isSystem() : false;
     const unreadEvents = conversationEntity.unreadState().allEvents;
 
@@ -291,7 +291,7 @@ const _getStateMuted = {
 
 const _getStateRemoved = {
   description: (conversationEntity: Conversation) => {
-    const lastMessageEntity = conversationEntity.getLastMessage();
+    const lastMessageEntity = conversationEntity.getNewestMessage();
     const selfUserId = conversationEntity.selfUser().id;
 
     const isMemberRemoval = lastMessageEntity && lastMessageEntity.isMember() && lastMessageEntity.isMemberRemoval();
@@ -373,7 +373,7 @@ const _getStateUserName = {
     }
   },
   match: (conversationEntity: Conversation): boolean => {
-    const lastMessageEntity = conversationEntity.getLastMessage();
+    const lastMessageEntity = conversationEntity.getNewestMessage();
     const isMemberJoin =
       lastMessageEntity && lastMessageEntity.isMember() && (lastMessageEntity as MemberMessage).isMemberJoin();
     const isEmpty1to1Conversation = conversationEntity.is1to1() && isMemberJoin;

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -561,7 +561,7 @@ export class ConversationRepository {
   public async getPrecedingMessages(conversationEntity: Conversation): Promise<ContentMessage[]> {
     conversationEntity.is_pending(true);
 
-    const firstMessageEntity = conversationEntity.getFirstMessage();
+    const firstMessageEntity = conversationEntity.getOldestMessage();
     const upperBound =
       firstMessageEntity && firstMessageEntity.timestamp()
         ? new Date(firstMessageEntity.timestamp())
@@ -588,7 +588,7 @@ export class ConversationRepository {
     conversationEntity.hasAdditionalMessages(hasAdditionalMessages);
 
     if (!hasAdditionalMessages) {
-      const firstMessage = conversationEntity.getFirstMessage();
+      const firstMessage = conversationEntity.getOldestMessage();
       const checkCreationMessage = isMemberMessage(firstMessage) && firstMessage?.isCreation();
       if (checkCreationMessage) {
         const groupCreationMessageIn1to1 = conversationEntity.is1to1() && firstMessage?.isGroupCreation();
@@ -724,7 +724,7 @@ export class ConversationRepository {
    * @param conversationEntity Conversation to start from
    */
   private async getUnreadEvents(conversationEntity: Conversation): Promise<void> {
-    const first_message = conversationEntity.getFirstMessage();
+    const first_message = conversationEntity.getOldestMessage();
     const lower_bound = new Date(conversationEntity.last_read_timestamp());
     const upper_bound = first_message
       ? new Date(first_message.timestamp())
@@ -2639,7 +2639,7 @@ export class ConversationRepository {
        *
        * Our assumption is that the `_handleAssetUpdate` function (invoked by `notificationsQueue.subscribe`) is executed before this function.
        */
-      return conversationEntity.updateTimestamps(conversationEntity.getLastMessage(), true);
+      return conversationEntity.updateTimestamps(conversationEntity.getNewestMessage(), true);
     }
 
     if (!allowsAllFiles()) {

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -1044,14 +1044,14 @@ export class MessageRepository {
    */
   public async deleteMessageById(conversationEntity: Conversation, messageId: string): Promise<number> {
     const isLastDeleted =
-      conversationEntity.isShowingLastReceivedMessage() && conversationEntity.getLastMessage()?.id === messageId;
+      conversationEntity.isShowingLastReceivedMessage() && conversationEntity.getNewestMessage()?.id === messageId;
 
     const deleteCount = await this.eventService.deleteEvent(conversationEntity.id, messageId);
 
     amplify.publish(WebAppEvents.CONVERSATION.MESSAGE.REMOVED, messageId, conversationEntity.id);
 
-    if (isLastDeleted && conversationEntity.getLastMessage()?.timestamp()) {
-      conversationEntity.updateTimestamps(conversationEntity.getLastMessage(), true);
+    if (isLastDeleted && conversationEntity.getNewestMessage()?.timestamp()) {
+      conversationEntity.updateTimestamps(conversationEntity.getNewestMessage(), true);
     }
 
     return deleteCount;

--- a/src/script/entity/Conversation.test.ts
+++ b/src/script/entity/Conversation.test.ts
@@ -176,7 +176,7 @@ describe('Conversation', () => {
       conversation_et.addMessage(message_et);
 
       expect(conversation_et.messages().length).toBe(2);
-      const last_message_et = conversation_et.getLastMessage();
+      const last_message_et = conversation_et.getNewestMessage();
 
       expect(last_message_et.id).toBe(message_et.id);
       expect(last_message_et.timestamp()).toBe(second_timestamp);
@@ -190,7 +190,7 @@ describe('Conversation', () => {
       conversation_et.addMessage(message_et);
 
       expect(conversation_et.messages().length).toBe(2);
-      const last_message_et = conversation_et.getFirstMessage();
+      const last_message_et = conversation_et.getOldestMessage();
 
       expect(last_message_et.id).toBe(message_et.id);
       expect(last_message_et.timestamp()).toBe(older_timestamp);

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -908,14 +908,14 @@ export class Conversation {
   /**
    * Get the first message of the conversation.
    */
-  getFirstMessage(): Message | ContentMessage | MemberMessage | SystemMessage | undefined {
+  getOldestMessage(): Message | ContentMessage | MemberMessage | SystemMessage | undefined {
     return this.messages()[0];
   }
 
   /**
    * Get the last message of the conversation.
    */
-  getLastMessage(): Message | ContentMessage | MemberMessage | SystemMessage | undefined {
+  getNewestMessage(): Message | ContentMessage | MemberMessage | SystemMessage | undefined {
     return this.messages()[this.messages().length - 1];
   }
 
@@ -997,7 +997,9 @@ export class Conversation {
   }
 
   readonly isShowingLastReceivedMessage = (): boolean => {
-    return this.getLastMessage()?.timestamp() ? this.getLastMessage().timestamp() >= this.last_event_timestamp() : true;
+    return this.getNewestMessage()?.timestamp()
+      ? this.getNewestMessage().timestamp() >= this.last_event_timestamp()
+      : true;
   };
 
   serialize(): ConversationRecord {


### PR DESCRIPTION
Small improvement in readability: rename first/last to newest/oldest message to make it clear what message we're dealing with.