### PR TITLE
fix: prevent no search result text from overflowing

### DIFF
--- a/src/style/list/start-ui.less
+++ b/src/style/list/start-ui.less
@@ -204,7 +204,7 @@ body.theme-dark {
   margin-bottom: 16px;
   line-height: @line-height-lg;
   text-align: center;
-  white-space: pre;
+  white-space: pre-wrap;
 
   &__content {
     display: flex;
@@ -343,11 +343,11 @@ body.theme-dark .start-ui-list-header {
   }
 
   &__text {
-    margin-top: 24px;
+    margin: 24px 16px 0;
     font-size: @font-size-small;
     font-weight: @font-weight-bold;
     text-align: center;
-    white-space: pre;
+    white-space: pre-wrap;
   }
 
   &__button {


### PR DESCRIPTION
<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-381" title="ACC-381" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-381</a>  "No search results" text overflowing in federated environements
  </td></table>
  <br />


### Issue
![image](https://user-images.githubusercontent.com/78490891/209343841-9bf84410-cbe8-403d-9b32-fcaad95eb5bb.png)

### Solution
- use `pre-wrap` instead of `pre` as whitespace to prevent text from overflowing in German
![Screenshot from 2022-12-23 14-23-21](https://user-images.githubusercontent.com/78490891/209344047-9e339eee-0245-436a-a210-4f2ca9534f9e.png)
