### PR TITLE
runfix: assign correct margin to no search result text [ACC-381]

### DIFF
--- a/src/style/list/start-ui.less
+++ b/src/style/list/start-ui.less
@@ -200,8 +200,7 @@ body.theme-dark {
 .start-ui-no-contacts,
 .start-ui-no-search-results {
   .text-light;
-  margin-top: 72px;
-  margin-bottom: 16px;
+  margin: 72px 20px 16px;
   line-height: @line-height-lg;
   text-align: center;
   white-space: pre-wrap;
@@ -343,7 +342,7 @@ body.theme-dark .start-ui-list-header {
   }
 
   &__text {
-    margin: 24px 16px 0;
+    margin: 24px 20px 0;
     font-size: @font-size-small;
     font-weight: @font-weight-bold;
     text-align: center;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-381" title="ACC-381" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-381</a>  "No search results" text overflowing in federated environements
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Changes
- design review decided on a 20px margin to fit the search field
- add the same margin to non-federated env results
![image](https://user-images.githubusercontent.com/78490891/209349048-c04ae12c-9bca-4749-a5b9-cd105abd8b9c.png)
