### PR TITLE
fix: Reset input value when canceling message edit

### DIFF
--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -765,7 +765,7 @@ const InputBar = ({
     input: inputValue,
     isEditing: isEditing,
     isScaledDown: isScaledDown,
-    onCancelEditing: cancelMessageEditing,
+    onCancelEditing: () => cancelMessageEditing(true, true),
     onClickPing: onPingClick,
     onGifClick: onGifClick,
     onSelectFiles: uploadFiles,


### PR DESCRIPTION
When clicking the `x` button when editing we should also clear the input bar content. 
This regression was introduced with the migration to React 
