### PR TITLE
fix: Enable session reset even for unknown error codes

### DIFF
--- a/src/script/entity/message/DecryptErrorMessage.ts
+++ b/src/script/entity/message/DecryptErrorMessage.ts
@@ -23,6 +23,7 @@ import {Message} from './Message';
 
 import {SuperType} from '../../message/SuperType';
 
+const UNKNOWN_ERROR_CODE = 999;
 export class DecryptErrorMessage extends Message {
   public client_id: string;
   public error_code: number;
@@ -38,7 +39,9 @@ export class DecryptErrorMessage extends Message {
     this.client_id = '';
 
     this.is_recoverable = ko.pureComputed(() => {
-      return this.error_code.toString().startsWith('2');
+      // We consider a decryption error recoverable if the error code starts with 2 or if the error code is unknown
+      // in the case of the unkonwn error the session might actually not be recoverable but since we now use coreCrypto to decrypt, all errors are now unknown
+      return this.error_code.toString().startsWith('2') || this.error_code === UNKNOWN_ERROR_CODE;
     });
     this.is_resetting_session = ko.observable(false);
   }

--- a/src/script/entity/message/DecryptErrorMessage.ts
+++ b/src/script/entity/message/DecryptErrorMessage.ts
@@ -40,7 +40,7 @@ export class DecryptErrorMessage extends Message {
 
     this.is_recoverable = ko.pureComputed(() => {
       // We consider a decryption error recoverable if the error code starts with 2 or if the error code is unknown
-      // in the case of the unkonwn error the session might actually not be recoverable but since we now use coreCrypto to decrypt, all errors are now unknown
+      // in the case of the unknown error the session might actually not be recoverable but since we now use coreCrypto to decrypt, all errors are now unknown
       return this.error_code.toString().startsWith('2') || this.error_code === UNKNOWN_ERROR_CODE;
     });
     this.is_resetting_session = ko.observable(false);


### PR DESCRIPTION
Since the migration to coreCrypto, decryption error always end up being `UNKNOWN` error (so we will never get a 2xx error. 
This might be fixed in a future version of coreCrypto. 

But, since, most common error are actually recoverable, it's better to still show the button to reset the session rather than not showing it and offer no possibility for the end user

![image](https://user-images.githubusercontent.com/1090716/209943903-a421a780-a632-4475-9f5f-7e44bb50e8df.png)
