### PR TITLE
chore(qa): Add a debug tool to reset the device identity

### DIFF
--- a/src/script/util/DebugUtil.ts
+++ b/src/script/util/DebugUtil.ts
@@ -109,6 +109,10 @@ export class DebugUtil {
     return Promise.all(blockUsers);
   }
 
+  async resetIdentity(): Promise<void> {
+    this.core['coreCryptoClient'].wipe();
+  }
+
   /** Used by QA test automation. */
   async breakSession(userId: string | QualifiedId, clientId: string): Promise<void> {
     const proteusService = this.core.service!.proteus;


### PR DESCRIPTION
This adds a way for QA (or dev) to manually break the local identity of the device (and get decryption errors)