### PR TITLE
fix: Improve user-facing decryption errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.10.5",
     "@types/eslint": "^8.4.10",
     "@wireapp/avs": "8.2.17",
-    "@wireapp/core": "38.0.0-beta.5",
+    "@wireapp/core": "38.0.0-beta.6",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.3.0",
     "@wireapp/store-engine-dexie": "2.0.3",

--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -372,18 +372,15 @@ export const Conversation: FC<ConversationProps> = ({
   const onSessionResetClick = async (messageEntity: DecryptErrorMessage): Promise<void> => {
     const resetProgress = () => {
       setTimeout(() => {
-        messageEntity.is_resetting_session(false);
         PrimaryModal.show(PrimaryModal.type.SESSION_RESET, {});
       }, MotionDuration.LONG);
     };
-
-    messageEntity.is_resetting_session(true);
 
     try {
       if (messageEntity.fromDomain && activeConversation) {
         await repositories.message.resetSession(
           {domain: messageEntity.fromDomain, id: messageEntity.from},
-          messageEntity.client_id,
+          messageEntity.clientId,
           activeConversation,
         );
         resetProgress();

--- a/src/script/components/MessagesList/Message/DecryptErrorMessage.test.tsx
+++ b/src/script/components/MessagesList/Message/DecryptErrorMessage.test.tsx
@@ -26,38 +26,24 @@ import {User} from 'src/script/entity/User';
 
 import {DecryptErrorMessage} from './DecryptErrorMessage';
 
-const createDecryptErrorMessage = (partialDecryptErrorMessage: Partial<DecryptErrorMessageEntity>) => {
-  const decryptErrorMessage: Partial<DecryptErrorMessageEntity> = {
-    user: ko.observable(new User()),
-    is_recoverable: ko.pureComputed(() => false),
-    is_resetting_session: ko.observable(false),
-    ...partialDecryptErrorMessage,
-  };
-  return decryptErrorMessage as DecryptErrorMessageEntity;
-};
+function createError(code: number) {
+  const error = new DecryptErrorMessageEntity('client', code);
+  error.user(new User());
+  return error;
+}
 
 describe('DecryptErrorMessage', () => {
   it('shows "reset session" action when error is recoverable', async () => {
-    const isRecoverable = ko.observable(false);
     const props = {
-      message: createDecryptErrorMessage({
-        is_recoverable: ko.pureComputed(() => isRecoverable()),
-      }),
+      message: createError(200),
       onClickResetSession: jest.fn(),
     };
 
-    const {queryByTestId, rerender} = render(<DecryptErrorMessage {...props} />);
+    const {queryByTestId} = render(<DecryptErrorMessage {...props} />);
 
     expect(queryByTestId('do-reset-encryption-session')).toBeNull();
 
     const decryptErrorMessage = queryByTestId('element-message-decrypt-error');
-    expect(decryptErrorMessage).not.toBeNull();
-
-    act(() => {
-      isRecoverable(true);
-    });
-    rerender(<DecryptErrorMessage {...props} />);
-
     expect(decryptErrorMessage).not.toBeNull();
   });
 
@@ -65,10 +51,7 @@ describe('DecryptErrorMessage', () => {
     const isResetting = ko.observable(false);
 
     const props = {
-      message: createDecryptErrorMessage({
-        is_recoverable: ko.pureComputed(() => true),
-        is_resetting_session: isResetting,
-      }),
+      message: createError(200),
       onClickResetSession: jest.fn(() => {
         isResetting(true);
       }),

--- a/src/script/conversation/EventMapper.ts
+++ b/src/script/conversation/EventMapper.ts
@@ -644,14 +644,9 @@ export class EventMapper {
    * @returns Decrypt error message entity
    */
   private _mapEventUnableToDecrypt({error_code: errorCode, error}: ErrorEvent) {
-    const messageEntity = new DecryptErrorMessage();
-
-    if (errorCode) {
-      messageEntity.error_code = typeof errorCode === 'string' ? parseInt(errorCode.split(' ')[0], 10) : errorCode;
-      messageEntity.client_id = error.replace(/\n/g, '').replace(/^.*\(([\w\d]+)\)$/g, '$1');
-    }
-
-    return messageEntity;
+    const code = typeof errorCode === 'string' ? parseInt(errorCode.split(' ')[0], 10) : errorCode;
+    const clientId = error.replace(/\n/g, '').replace(/^.*\(([\w\d]+)\)$/g, '$1');
+    return new DecryptErrorMessage(clientId, code);
   }
 
   /**

--- a/src/script/entity/message/DecryptErrorMessage.ts
+++ b/src/script/entity/message/DecryptErrorMessage.ts
@@ -24,7 +24,7 @@ import {Message} from './Message';
 import {SuperType} from '../../message/SuperType';
 
 export class DecryptErrorMessage extends Message {
-  constructor(public readonly clientId: String, public readonly code: number) {
+  constructor(public readonly clientId: string, public readonly code: number) {
     super();
     this.super_type = SuperType.UNABLE_TO_DECRYPT;
   }

--- a/src/script/entity/message/DecryptErrorMessage.ts
+++ b/src/script/entity/message/DecryptErrorMessage.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {ProteusErrors} from '@wireapp/core';
+import {ProteusErrors} from '@wireapp/core/lib/messagingProtocols/proteus';
 
 import {Message} from './Message';
 

--- a/src/script/entity/message/DecryptErrorMessage.ts
+++ b/src/script/entity/message/DecryptErrorMessage.ts
@@ -17,32 +17,23 @@
  *
  */
 
-import ko from 'knockout';
+import {ProteusErrors} from '@wireapp/core';
 
 import {Message} from './Message';
 
 import {SuperType} from '../../message/SuperType';
 
-const UNKNOWN_ERROR_CODE = 999;
 export class DecryptErrorMessage extends Message {
-  public client_id: string;
-  public error_code: number;
-  public domain?: string;
-  public readonly is_recoverable: ko.PureComputed<boolean>;
-  public readonly is_resetting_session: ko.Observable<boolean>;
-
-  constructor() {
+  constructor(public readonly clientId: String, public readonly code: number) {
     super();
     this.super_type = SuperType.UNABLE_TO_DECRYPT;
+  }
 
-    this.error_code = 0;
-    this.client_id = '';
+  get isRecoverable(): boolean {
+    return !this.isIdentityChanged && this.code >= 200 && this.code < 300;
+  }
 
-    this.is_recoverable = ko.pureComputed(() => {
-      // We consider a decryption error recoverable if the error code starts with 2 or if the error code is unknown
-      // in the case of the unknown error the session might actually not be recoverable but since we now use coreCrypto to decrypt, all errors are now unknown
-      return this.error_code.toString().startsWith('2') || this.error_code === UNKNOWN_ERROR_CODE;
-    });
-    this.is_resetting_session = ko.observable(false);
+  get isIdentityChanged(): boolean {
+    return this.code === ProteusErrors.RemoteIdentityChanged;
   }
 }

--- a/test/unit_tests/conversation/EventMapperSpec.js
+++ b/test/unit_tests/conversation/EventMapperSpec.js
@@ -360,8 +360,8 @@ describe('Event Mapper', () => {
 
       const message_et = event_mapper._mapEventUnableToDecrypt(event);
 
-      expect(message_et.error_code).toBe(205);
-      expect(message_et.client_id).toBe('c0a70d96aaeb87b6');
+      expect(message_et.code).toBe(205);
+      expect(message_et.clientId).toBe('c0a70d96aaeb87b6');
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4355,9 +4355,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:38.0.0-beta.5":
-  version: 38.0.0-beta.5
-  resolution: "@wireapp/core@npm:38.0.0-beta.5"
+"@wireapp/core@npm:38.0.0-beta.6":
+  version: 38.0.0-beta.6
+  resolution: "@wireapp/core@npm:38.0.0-beta.6"
   dependencies:
     "@wireapp/api-client": ^22.10.1
     "@wireapp/commons": ^5.0.4
@@ -4374,7 +4374,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.12
-  checksum: 3b7c8b685ea367430f9a9021f751e2869d5781f1408f8b224cc1061021345edde11593ef2067547ac0b3886c0f460237a813850929dd243f789601b278e224ac
+  checksum: 8d11f9aa9c7c6dec324846bb9e91cffa8025cd6d322eb79682760c5b348296e202f626b8db7352a334b6f5ed9e7186ba54dbcb7be1fc8920388020d4d305b469
   languageName: node
   linkType: hard
 
@@ -16415,7 +16415,7 @@ __metadata:
     "@typescript-eslint/parser": ^5.47.0
     "@wireapp/avs": 8.2.17
     "@wireapp/copy-config": 2.0.4
-    "@wireapp/core": 38.0.0-beta.5
+    "@wireapp/core": 38.0.0-beta.6
     "@wireapp/eslint-config": 2.1.1
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.5.2


### PR DESCRIPTION
This will handle 3 new types of decryption errors:

- Invalid Signatures errors
<img width="372" alt="image" src="https://user-images.githubusercontent.com/1090716/209973435-3c0d18c8-dd38-43f0-88e7-4597f8699faa.png">

- invalid message errors
<img width="368" alt="image" src="https://user-images.githubusercontent.com/1090716/209973887-4a084db0-3125-46c8-a031-077e41d8ccf5.png">


- remote identity changed error
<img width="448" alt="image" src="https://user-images.githubusercontent.com/1090716/209973682-04e6ca45-e492-40ce-9460-54c8bd0a2171.png">


Needs:
- [ ] https://github.com/wireapp/wire-web-packages/pull/4735
