### PR TITLE
runfix: make typing indicator responsive with font scaling [ACC-353]

### DIFF
--- a/src/script/components/Avatar.tsx
+++ b/src/script/components/Avatar.tsx
@@ -38,6 +38,7 @@ export enum AVATAR_SIZE {
   X_SMALL = 'avatar-xs',
   XX_SMALL = 'avatar-xxs',
   XXX_SMALL = 'avatar-xxxs',
+  RESPONSIVE = 'avatar-responsive',
 }
 
 export enum STATE {
@@ -58,6 +59,7 @@ export const DIAMETER = {
   [AVATAR_SIZE.X_SMALL]: 24,
   [AVATAR_SIZE.XX_SMALL]: 20,
   [AVATAR_SIZE.XXX_SMALL]: 16,
+  [AVATAR_SIZE.RESPONSIVE]: 'var(--icon-size-sm)',
 };
 
 export const INITIALS_SIZE = {
@@ -68,6 +70,7 @@ export const INITIALS_SIZE = {
   [AVATAR_SIZE.X_SMALL]: '11px',
   [AVATAR_SIZE.XX_SMALL]: '11px',
   [AVATAR_SIZE.XXX_SMALL]: '8px',
+  [AVATAR_SIZE.RESPONSIVE]: 'var(--icon-size-sm)',
 };
 
 export interface AvatarProps extends HTMLProps<HTMLDivElement> {

--- a/src/script/components/Avatar.tsx
+++ b/src/script/components/Avatar.tsx
@@ -76,7 +76,7 @@ export interface AvatarProps extends HTMLProps<HTMLDivElement> {
   avatarAlt?: string;
   noBadge?: boolean;
   noFilter?: boolean;
-  responsive?: boolean;
+  isResponsive?: boolean;
   onAvatarClick?: (participant: User | ServiceEntity, target: Node) => void;
 }
 
@@ -86,7 +86,7 @@ const Avatar: FC<AvatarProps> = ({
   noFilter = false,
   onAvatarClick,
   participant,
-  responsive = false,
+  isResponsive = false,
   ...props
 }) => {
   const handleAvatarInteraction = (
@@ -145,7 +145,7 @@ const Avatar: FC<AvatarProps> = ({
         noBadge={noBadge}
         onClick={handleAvatarInteraction}
         participant={participant}
-        responsive
+        isResponsive
         state={avatarState}
         {...props}
       />
@@ -159,7 +159,7 @@ const Avatar: FC<AvatarProps> = ({
       noFilter={noFilter}
       onAvatarInteraction={handleAvatarInteraction}
       participant={participant}
-      responsive
+      isResponsive
       state={avatarState}
       {...props}
     />

--- a/src/script/components/Avatar.tsx
+++ b/src/script/components/Avatar.tsx
@@ -61,13 +61,13 @@ export const DIAMETER = {
 };
 
 export const INITIALS_SIZE = {
-  [AVATAR_SIZE.LARGE]: '24px',
-  [AVATAR_SIZE.MEDIUM]: '16px',
-  [AVATAR_SIZE.SMALL]: '11px',
-  [AVATAR_SIZE.X_LARGE]: '32px',
-  [AVATAR_SIZE.X_SMALL]: '11px',
-  [AVATAR_SIZE.XX_SMALL]: '11px',
-  [AVATAR_SIZE.XXX_SMALL]: '8px',
+  [AVATAR_SIZE.LARGE]: 24,
+  [AVATAR_SIZE.MEDIUM]: 16,
+  [AVATAR_SIZE.SMALL]: 11,
+  [AVATAR_SIZE.X_LARGE]: 32,
+  [AVATAR_SIZE.X_SMALL]: 11,
+  [AVATAR_SIZE.XX_SMALL]: 11,
+  [AVATAR_SIZE.XXX_SMALL]: 8,
 };
 
 export interface AvatarProps extends HTMLProps<HTMLDivElement> {
@@ -145,6 +145,7 @@ const Avatar: FC<AvatarProps> = ({
         noBadge={noBadge}
         onClick={handleAvatarInteraction}
         participant={participant}
+        responsive
         state={avatarState}
         {...props}
       />
@@ -158,6 +159,7 @@ const Avatar: FC<AvatarProps> = ({
       noFilter={noFilter}
       onAvatarInteraction={handleAvatarInteraction}
       participant={participant}
+      responsive
       state={avatarState}
       {...props}
     />

--- a/src/script/components/Avatar.tsx
+++ b/src/script/components/Avatar.tsx
@@ -38,7 +38,6 @@ export enum AVATAR_SIZE {
   X_SMALL = 'avatar-xs',
   XX_SMALL = 'avatar-xxs',
   XXX_SMALL = 'avatar-xxxs',
-  RESPONSIVE = 'avatar-responsive',
 }
 
 export enum STATE {
@@ -59,7 +58,6 @@ export const DIAMETER = {
   [AVATAR_SIZE.X_SMALL]: 24,
   [AVATAR_SIZE.XX_SMALL]: 20,
   [AVATAR_SIZE.XXX_SMALL]: 16,
-  [AVATAR_SIZE.RESPONSIVE]: 'var(--icon-size-sm)',
 };
 
 export const INITIALS_SIZE = {
@@ -70,16 +68,16 @@ export const INITIALS_SIZE = {
   [AVATAR_SIZE.X_SMALL]: '11px',
   [AVATAR_SIZE.XX_SMALL]: '11px',
   [AVATAR_SIZE.XXX_SMALL]: '8px',
-  [AVATAR_SIZE.RESPONSIVE]: 'var(--icon-size-sm)',
 };
 
 export interface AvatarProps extends HTMLProps<HTMLDivElement> {
+  participant: User | ServiceEntity;
   avatarSize?: AVATAR_SIZE;
   avatarAlt?: string;
   noBadge?: boolean;
   noFilter?: boolean;
+  responsive?: boolean;
   onAvatarClick?: (participant: User | ServiceEntity, target: Node) => void;
-  participant: User | ServiceEntity;
 }
 
 const Avatar: FC<AvatarProps> = ({
@@ -88,6 +86,7 @@ const Avatar: FC<AvatarProps> = ({
   noFilter = false,
   onAvatarClick,
   participant,
+  responsive = false,
   ...props
 }) => {
   const handleAvatarInteraction = (

--- a/src/script/components/InputBar/components/TypingIndicator/TypingIndicator.styles.ts
+++ b/src/script/components/InputBar/components/TypingIndicator/TypingIndicator.styles.ts
@@ -24,13 +24,13 @@ export const wrapperStyles: CSSObject = {
   alignItems: 'center',
   marginLeft: 15,
   color: 'var(--text-input-placeholder)',
-  fontSize: 11,
+  fontSize: 'var(--font-size-xsmall)',
   fontWeight: 500,
-  paddingTop: 2,
+  paddingTop: '0.125rem',
   backgroundColor: 'var(--app-bg)',
-  padding: 5,
+  padding: '0.3125rem',
   position: 'absolute',
-  top: -26,
+  top: '-1.625rem',
   borderTopLeftRadius: 4,
   borderTopRightRadius: 4,
   'div:first-of-type': {
@@ -41,11 +41,11 @@ export const wrapperStyles: CSSObject = {
 };
 
 export const indicatorAnimationWrapperStyles: CSSObject = {
-  width: 38,
-  height: 16,
+  width: '2.375rem',
+  height: '1rem',
   marginLeft: 2,
   position: 'relative',
-  bottom: 3,
+  bottom: '0.1875rem',
 };
 
 const animationStyles: CSSObject = {
@@ -127,7 +127,7 @@ export const dotThreeStyles = css`
 `;
 
 export const indicatorTitleStyles = css`
-  height: 16px;
+  height: var(--icon-size-sm);
   position: relative;
   top: 1px;
 `;

--- a/src/script/components/InputBar/components/TypingIndicator/TypingIndicator.tsx
+++ b/src/script/components/InputBar/components/TypingIndicator/TypingIndicator.tsx
@@ -55,7 +55,7 @@ const TypingIndicator: FC<TypingIndicatorProps> = ({conversationId}) => {
             className="cursor-default"
             style={index > 0 ? {marginLeft: -8} : {}}
             participant={user}
-            avatarSize={AVATAR_SIZE.XXX_SMALL}
+            avatarSize={AVATAR_SIZE.RESPONSIVE}
           />
         ))}
       </div>

--- a/src/script/components/InputBar/components/TypingIndicator/TypingIndicator.tsx
+++ b/src/script/components/InputBar/components/TypingIndicator/TypingIndicator.tsx
@@ -55,7 +55,8 @@ const TypingIndicator: FC<TypingIndicatorProps> = ({conversationId}) => {
             className="cursor-default"
             style={index > 0 ? {marginLeft: -8} : {}}
             participant={user}
-            avatarSize={AVATAR_SIZE.RESPONSIVE}
+            avatarSize={AVATAR_SIZE.XXX_SMALL}
+            responsive
           />
         ))}
       </div>

--- a/src/script/components/InputBar/components/TypingIndicator/TypingIndicator.tsx
+++ b/src/script/components/InputBar/components/TypingIndicator/TypingIndicator.tsx
@@ -56,7 +56,7 @@ const TypingIndicator: FC<TypingIndicatorProps> = ({conversationId}) => {
             style={index > 0 ? {marginLeft: -8} : {}}
             participant={user}
             avatarSize={AVATAR_SIZE.XXX_SMALL}
-            responsive
+            isResponsive
           />
         ))}
       </div>

--- a/src/script/components/avatar/AvatarInitials.tsx
+++ b/src/script/components/avatar/AvatarInitials.tsx
@@ -28,16 +28,16 @@ export interface AvatarInitialsProps {
   avatarSize: AVATAR_SIZE;
   initials: string;
   color?: string;
-  responsive?: boolean;
+  isResponsive?: boolean;
 }
 
-const AvatarInitials: FC<AvatarInitialsProps> = ({avatarSize, initials, color = '#fff', responsive = false}) => (
+const AvatarInitials: FC<AvatarInitialsProps> = ({avatarSize, initials, color = '#fff', isResponsive = false}) => (
   <div
     css={{
       ...CSS_FILL_PARENT,
       color,
-      fontSize: responsive ? `${INITIALS_SIZE[avatarSize] / 16}rem` : `${INITIALS_SIZE[avatarSize]}px`,
-      lineHeight: responsive ? `${DIAMETER[avatarSize] / 16}rem` : `${DIAMETER[avatarSize]}px`,
+      fontSize: isResponsive ? `${INITIALS_SIZE[avatarSize] / 16}rem` : `${INITIALS_SIZE[avatarSize]}px`,
+      lineHeight: isResponsive ? `${DIAMETER[avatarSize] / 16}rem` : `${DIAMETER[avatarSize]}px`,
       textAlign: 'center',
       userSelect: 'none',
     }}

--- a/src/script/components/avatar/AvatarInitials.tsx
+++ b/src/script/components/avatar/AvatarInitials.tsx
@@ -28,15 +28,16 @@ export interface AvatarInitialsProps {
   avatarSize: AVATAR_SIZE;
   initials: string;
   color?: string;
+  responsive?: boolean;
 }
 
-const AvatarInitials: FC<AvatarInitialsProps> = ({avatarSize, initials, color = '#fff'}) => (
+const AvatarInitials: FC<AvatarInitialsProps> = ({avatarSize, initials, color = '#fff', responsive = false}) => (
   <div
     css={{
       ...CSS_FILL_PARENT,
       color,
       fontSize: INITIALS_SIZE[avatarSize],
-      lineHeight: `${DIAMETER[avatarSize]}px`,
+      lineHeight: responsive ? `${DIAMETER[avatarSize] / 16}rem` : `${DIAMETER[avatarSize]}px`,
       textAlign: 'center',
       userSelect: 'none',
     }}

--- a/src/script/components/avatar/AvatarInitials.tsx
+++ b/src/script/components/avatar/AvatarInitials.tsx
@@ -36,7 +36,7 @@ const AvatarInitials: FC<AvatarInitialsProps> = ({avatarSize, initials, color = 
     css={{
       ...CSS_FILL_PARENT,
       color,
-      fontSize: INITIALS_SIZE[avatarSize],
+      fontSize: responsive ? `${INITIALS_SIZE[avatarSize] / 16}rem` : `${INITIALS_SIZE[avatarSize]}px`,
       lineHeight: responsive ? `${DIAMETER[avatarSize] / 16}rem` : `${DIAMETER[avatarSize]}px`,
       textAlign: 'center',
       userSelect: 'none',

--- a/src/script/components/avatar/AvatarWrapper.tsx
+++ b/src/script/components/avatar/AvatarWrapper.tsx
@@ -26,22 +26,31 @@ import {DIAMETER, AVATAR_SIZE} from '../Avatar';
 export interface AvatarWrapperProps extends React.HTMLProps<HTMLDivElement> {
   avatarSize: AVATAR_SIZE;
   color: string;
+  responsive?: boolean;
 }
 
-const AvatarWrapper: React.FunctionComponent<AvatarWrapperProps> = ({color, avatarSize, ...props}) => (
-  <div
-    css={{
-      ...CSS_SQUARE(DIAMETER[avatarSize]),
-      color,
-      display: 'inline-block',
-      overflow: 'hidden',
-      position: 'relative',
-      transform: 'translateZ(0)',
-      userSelect: 'none',
-    }}
-    role="button"
-    {...props}
-  />
-);
+const AvatarWrapper: React.FunctionComponent<AvatarWrapperProps> = ({
+  color,
+  avatarSize,
+  responsive = false,
+  ...props
+}) => {
+  const avatarDiameter = responsive ? `${DIAMETER[avatarSize] / 16}rem` : DIAMETER[avatarSize];
+  return (
+    <div
+      css={{
+        ...CSS_SQUARE(avatarDiameter),
+        color,
+        display: 'inline-block',
+        overflow: 'hidden',
+        position: 'relative',
+        transform: 'translateZ(0)',
+        userSelect: 'none',
+      }}
+      role="button"
+      {...props}
+    />
+  );
+};
 
 export {AvatarWrapper};

--- a/src/script/components/avatar/AvatarWrapper.tsx
+++ b/src/script/components/avatar/AvatarWrapper.tsx
@@ -26,16 +26,16 @@ import {DIAMETER, AVATAR_SIZE} from '../Avatar';
 export interface AvatarWrapperProps extends React.HTMLProps<HTMLDivElement> {
   avatarSize: AVATAR_SIZE;
   color: string;
-  responsive?: boolean;
+  isResponsive?: boolean;
 }
 
 const AvatarWrapper: React.FunctionComponent<AvatarWrapperProps> = ({
   color,
   avatarSize,
-  responsive = false,
+  isResponsive = false,
   ...props
 }) => {
-  const avatarDiameter = responsive ? `${DIAMETER[avatarSize] / 16}rem` : DIAMETER[avatarSize];
+  const avatarDiameter = isResponsive ? `${DIAMETER[avatarSize] / 16}rem` : DIAMETER[avatarSize];
   return (
     <div
       css={{

--- a/src/script/components/avatar/TemporaryGuestAvatar.tsx
+++ b/src/script/components/avatar/TemporaryGuestAvatar.tsx
@@ -36,7 +36,7 @@ export interface TemporaryGuestAvatarProps extends React.HTMLProps<HTMLDivElemen
   noBadge?: boolean;
   onClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
   participant: User;
-  responsive?: boolean;
+  isResponsive?: boolean;
   state: STATE;
 }
 
@@ -45,7 +45,7 @@ const TemporaryGuestAvatar: React.FunctionComponent<TemporaryGuestAvatarProps> =
   noBadge,
   onClick,
   participant,
-  responsive = false,
+  isResponsive = false,
   state,
   ...props
 }) => {
@@ -68,11 +68,16 @@ const TemporaryGuestAvatar: React.FunctionComponent<TemporaryGuestAvatarProps> =
       data-uie-status={state}
       onClick={onClick}
       title={participant.name()}
-      responsive
+      isResponsive
       {...props}
     >
       <AvatarBackground />
-      <AvatarInitials color="var(--background)" avatarSize={avatarSize} initials={participant.initials()} responsive />
+      <AvatarInitials
+        color="var(--background)"
+        avatarSize={avatarSize}
+        initials={participant.initials()}
+        isResponsive
+      />
       {!noBadge && shouldShowBadge(avatarSize, state) && <AvatarBadge state={state} />}
       <AvatarBorder />
       <svg

--- a/src/script/components/avatar/TemporaryGuestAvatar.tsx
+++ b/src/script/components/avatar/TemporaryGuestAvatar.tsx
@@ -36,6 +36,7 @@ export interface TemporaryGuestAvatarProps extends React.HTMLProps<HTMLDivElemen
   noBadge?: boolean;
   onClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
   participant: User;
+  responsive?: boolean;
   state: STATE;
 }
 
@@ -44,6 +45,7 @@ const TemporaryGuestAvatar: React.FunctionComponent<TemporaryGuestAvatarProps> =
   noBadge,
   onClick,
   participant,
+  responsive = false,
   state,
   ...props
 }) => {
@@ -66,10 +68,11 @@ const TemporaryGuestAvatar: React.FunctionComponent<TemporaryGuestAvatarProps> =
       data-uie-status={state}
       onClick={onClick}
       title={participant.name()}
+      responsive
       {...props}
     >
       <AvatarBackground />
-      <AvatarInitials color="var(--background)" avatarSize={avatarSize} initials={participant.initials()} />
+      <AvatarInitials color="var(--background)" avatarSize={avatarSize} initials={participant.initials()} responsive />
       {!noBadge && shouldShowBadge(avatarSize, state) && <AvatarBadge state={state} />}
       <AvatarBorder />
       <svg

--- a/src/script/components/avatar/UserAvatar.tsx
+++ b/src/script/components/avatar/UserAvatar.tsx
@@ -39,7 +39,7 @@ export interface UserAvatarProps extends React.HTMLProps<HTMLDivElement> {
   avatarAlt?: string;
   noBadge?: boolean;
   noFilter?: boolean;
-  responsive?: boolean;
+  isResponsive?: boolean;
   onAvatarInteraction?: (
     event: ReactMouseEvent<HTMLDivElement, MouseEvent> | ReactKeyBoardEvent<HTMLDivElement>,
   ) => void;
@@ -59,7 +59,7 @@ const UserAvatar: React.FunctionComponent<UserAvatarProps> = ({
   avatarAlt = '',
   noBadge,
   noFilter,
-  responsive = false,
+  isResponsive = false,
   state,
   onAvatarInteraction,
   ...props
@@ -91,7 +91,7 @@ const UserAvatar: React.FunctionComponent<UserAvatarProps> = ({
       onClick={onAvatarInteraction}
       onKeyDown={onAvatarInteraction}
       title={name}
-      responsive
+      isResponsive
       {...props}
     >
       <AvatarBackground backgroundColor={backgroundColor} />

--- a/src/script/components/avatar/UserAvatar.tsx
+++ b/src/script/components/avatar/UserAvatar.tsx
@@ -39,6 +39,7 @@ export interface UserAvatarProps extends React.HTMLProps<HTMLDivElement> {
   avatarAlt?: string;
   noBadge?: boolean;
   noFilter?: boolean;
+  responsive?: boolean;
   onAvatarInteraction?: (
     event: ReactMouseEvent<HTMLDivElement, MouseEvent> | ReactKeyBoardEvent<HTMLDivElement>,
   ) => void;
@@ -58,6 +59,7 @@ const UserAvatar: React.FunctionComponent<UserAvatarProps> = ({
   avatarAlt = '',
   noBadge,
   noFilter,
+  responsive = false,
   state,
   onAvatarInteraction,
   ...props
@@ -89,6 +91,7 @@ const UserAvatar: React.FunctionComponent<UserAvatarProps> = ({
       onClick={onAvatarInteraction}
       onKeyDown={onAvatarInteraction}
       title={name}
+      responsive
       {...props}
     >
       <AvatarBackground backgroundColor={backgroundColor} />

--- a/src/style/common/variables.less
+++ b/src/style/common/variables.less
@@ -121,12 +121,27 @@
 @font-weight-regular: 400; // font-weight-xs should this this
 @font-weight-light: 300;
 
+body {
+  --font-size-xsmall: 0.6875rem;
+  --font-size-small: 0.75rem;
+  --font-size-medium: 0.875rem;
+  --font-size-base: 1rem;
+  --font-size-large: 1.25rem;
+  --font-size-xlarge: 1.5rem;
+}
+
 // ----------------------------------------------------------------------------
 // Icons
 // ----------------------------------------------------------------------------
 @icon-size-sm: 16px;
 @icon-size-md: 32px;
 @icon-size-lg: 56px;
+
+body {
+  --icon-size-sm: 1rem;
+  --icon-size-md: 2rem;
+  --icon-size-lg: 3.5rem;
+}
 
 // ----------------------------------------------------------------------------
 // Dot sizes


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-353" title="ACC-353" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-353</a>  [Web] Typing indicator is not affected by font scaling setting
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Changes
- use css variable for responsive font size
- set typing indicator to a rem font size instead of px
- change vertical px values to rem in typing indicator styles
- add a responsive size option to avatar sizes


![Peek 2023-01-03 11-46](https://user-images.githubusercontent.com/78490891/210342482-6e12321b-a6de-4141-bab7-eacb338688d7.gif)



[ACC-353]: https://wearezeta.atlassian.net/browse/ACC-353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACC-353]: https://wearezeta.atlassian.net/browse/ACC-353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACC-353]: https://wearezeta.atlassian.net/browse/ACC-353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ