### PR TITLE
fix: Verified icon in participant details is too close to the edge

### DIFF
--- a/src/style/components/panel-participant-details.less
+++ b/src/style/components/panel-participant-details.less
@@ -28,6 +28,7 @@
     width: 100%;
     align-items: center;
     justify-content: center;
+    padding: 0 16px;
 
     &__verified-icon {
       display: block;
@@ -54,7 +55,6 @@
         display: inline;
 
         .ellipsis;
-        padding: 0 16px;
       }
     }
   }


### PR DESCRIPTION
Now - verified icon is close to name instead of right edge.

<img width="331" alt="image" src="https://user-images.githubusercontent.com/13432884/210368504-acf88209-9532-48e8-8bbc-6f2ee3f7b176.png">

<img width="326" alt="image" src="https://user-images.githubusercontent.com/13432884/210368883-439fc9ee-50ca-4abe-a7c5-590dedcfd9b7.png">

