### PR TITLE
fix: Center user video call

### DIFF
--- a/src/script/components/calling/GroupVideoGridTile.tsx
+++ b/src/script/components/calling/GroupVideoGridTile.tsx
@@ -69,16 +69,15 @@ const GroupVideoGridTile: React.FC<GroupVideoGridTileProps> = ({
   const handleTileClick = () => onTileDoubleClick(participant?.user.qualifiedId, participant?.clientId);
 
   const handleEnterTileClick = (keyboardEvent: React.KeyboardEvent) => {
-    if (!isEnterKey(keyboardEvent)) {
-      return;
+    if (isEnterKey(keyboardEvent)) {
+      handleTileClick();
     }
-
-    handleTileClick();
   };
 
   return (
     <button
       data-uie-name="item-grid"
+      css={{position: 'relative'}}
       data-user-id={participant?.user.id}
       className="group-video-grid__element"
       onDoubleClick={handleTileClick}

--- a/src/script/components/calling/GroupVideoGridTile.tsx
+++ b/src/script/components/calling/GroupVideoGridTile.tsx
@@ -77,7 +77,6 @@ const GroupVideoGridTile: React.FC<GroupVideoGridTileProps> = ({
   return (
     <button
       data-uie-name="item-grid"
-      css={{position: 'relative'}}
       data-user-id={participant?.user.id}
       className="group-video-grid__element"
       onDoubleClick={handleTileClick}

--- a/src/style/components/group-video-grid.less
+++ b/src/style/components/group-video-grid.less
@@ -98,6 +98,10 @@
       padding: 0;
       border: none;
 
+      &:focus {
+        z-index: 1;
+      }
+
       &__overlay {
         position: absolute;
         top: 0;
@@ -133,7 +137,6 @@
       }
 
       &-video {
-        position: absolute;
         width: 100%;
         height: 100%;
         border-radius: 8px;

--- a/src/style/components/group-video-grid.less
+++ b/src/style/components/group-video-grid.less
@@ -92,8 +92,8 @@
     &__element {
       position: relative;
       overflow: hidden;
-      width: calc(100% / var(--columns) - 2px);
-      height: calc(100% / var(--rows) - 2px);
+      width: calc(100% / var(--columns));
+      height: calc(100% / var(--rows));
       box-sizing: border-box;
       padding: 0;
       border: none;


### PR DESCRIPTION
Fix for displaying user video call, changed HTML Tag broke position of user video call.

Broken PR: https://github.com/wireapp/wire-webapp/pull/14425 