### PR TITLE
runfix: Listen for email validation when using phone registration

### DIFF
--- a/src/script/auth/module/action/SelfAction.test.ts
+++ b/src/script/auth/module/action/SelfAction.test.ts
@@ -21,6 +21,7 @@ import type {Self} from '@wireapp/api-client/lib/self/';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 
 import {SelfActionCreator} from './creator/';
+import {WebSocketAction} from './WebSocketAction';
 
 import {mockStoreFactory} from '../../util/test/mockStoreFactory';
 
@@ -151,6 +152,7 @@ describe('SelfAction', () => {
     const mockedApiClient = {
       api: {auth: {putEmail: () => Promise.resolve()}},
     };
+    jest.spyOn(WebSocketAction, 'listen').mockReturnValue({type: 'websocket-listen'} as any);
 
     const store = mockStoreFactory({
       apiClient: mockedApiClient,
@@ -160,6 +162,7 @@ describe('SelfAction', () => {
     expect(store.getActions()).toEqual([
       SelfActionCreator.startSetSelfEmail(),
       SelfActionCreator.successfulSetSelfEmail(email),
+      WebSocketAction.listen(),
     ]);
   });
 

--- a/src/script/auth/module/action/SelfAction.ts
+++ b/src/script/auth/module/action/SelfAction.ts
@@ -24,6 +24,7 @@ import {Environment} from 'Util/Environment';
 import {getLogger} from 'Util/Logger';
 
 import {SelfActionCreator} from './creator/';
+import {WebSocketAction} from './WebSocketAction';
 
 import type {ThunkAction} from '../reducer';
 
@@ -117,6 +118,8 @@ export class SelfAction {
       try {
         await apiClient.api.auth.putEmail({email});
         dispatch(SelfActionCreator.successfulSetSelfEmail(email));
+        // we listen to the websocket after setting the email address. This way we will be warned when the user validates his email
+        dispatch(WebSocketAction.listen());
       } catch (error) {
         dispatch(SelfActionCreator.failedSetSelfEmail(error));
         throw error;

--- a/src/script/auth/module/action/WebSocketAction.ts
+++ b/src/script/auth/module/action/WebSocketAction.ts
@@ -1,0 +1,52 @@
+/*
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {USER_EVENT} from '@wireapp/api-client/lib/event/';
+
+import {getLogger} from 'Util/Logger';
+
+import type {ThunkAction} from '../../module/reducer';
+import * as SelfSelector from '../../module/selector/SelfSelector';
+
+const logger = getLogger('WebSocketAction');
+export const WebSocketAction = {
+  listen(): ThunkAction {
+    return async (dispatch, getState, {core, actions: {selfAction}}) => {
+      await core.listen({
+        // We just want to get unencrypted backend events, so we use a dry run in order not to store the last notificationId and avoid decrypting events
+        dryRun: true,
+        onEvent: async ({event}) => {
+          try {
+            switch (event.type) {
+              case USER_EVENT.UPDATE: {
+                const isSelfId = event.user.id === SelfSelector.getSelf(getState()).id;
+                if (isSelfId) {
+                  await dispatch(selfAction.fetchSelf());
+                }
+              }
+            }
+          } catch (error) {
+            const message = error instanceof Error ? error.message : error;
+            logger.error(`There was an error with event ID "${event.type}": ${message}`, error);
+          }
+        },
+      });
+    };
+  },
+};


### PR DESCRIPTION
We need to listen for the user's changes when setting an email for an account that was created using a phone identifier. 

By listening to the websocket we can listen for the `user.update` events and fetch the new self user when one of those happen

This was broken since https://github.com/wireapp/wire-webapp/pull/14397

