### PR TITLE
runfix: use device primary key to update device as verified [FS-1407]

### DIFF
--- a/src/script/client/ClientRepository.ts
+++ b/src/script/client/ClientRepository.ts
@@ -187,8 +187,7 @@ export class ClientRepository {
    * @param changes New values which should be updated on the client
    * @returns Number of updated records
    */
-  private updateClientInDb(userId: QualifiedId, clientId: string, changes: Partial<ClientRecord>): Promise<number> {
-    const primaryKey = constructClientId(userId, clientId);
+  private updateClientInDb(primaryKey: string, changes: Partial<ClientRecord>): Promise<number> {
     // Preserve primary key on update
     changes.meta.primary_key = primaryKey;
     return this.clientService.updateClientInDb(primaryKey, changes);
@@ -203,7 +202,8 @@ export class ClientRepository {
    * @returns Resolves when the verification state has been updated
    */
   async verifyClient(userId: QualifiedId, clientEntity: ClientEntity, isVerified: boolean): Promise<void> {
-    await this.updateClientInDb(userId, clientEntity.id, {meta: {is_verified: isVerified}});
+    const primaryKey = clientEntity.meta.primaryKey ?? constructClientId(userId, clientEntity.id);
+    await this.updateClientInDb(primaryKey, {meta: {is_verified: isVerified}});
     clientEntity.meta.isVerified(isVerified);
     amplify.publish(WebAppEvents.CLIENT.VERIFICATION_STATE_CHANGED, userId, clientEntity, isVerified);
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1407" title="FS-1407" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1407</a>  [web] own device verification is sometimes not persisted across reloads
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Since the migration to CoreCrypto, we now generate fully qualified ids for devices. But some devices might have a non-qualified id in DB still (we don't migrate those). 
So in order to access the DB entry we need to use the primary key (and not a live generated ID). 

We can fallback to constructing the ID in case the entry doesn't have a primary key (which should never happen, but according to the types it's possible)

[FS-1407]: https://wearezeta.atlassian.net/browse/FS-1407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FS-1407]: https://wearezeta.atlassian.net/browse/FS-1407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FS-1407]: https://wearezeta.atlassian.net/browse/FS-1407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ