### PR TITLE
fix: [Web] Heart icon is very close to user image(ACC-354)

### DIFF
--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -380,6 +380,7 @@
   .flex-center;
 
   position: absolute;
+  top: 4px;
   bottom: 0;
   left: 0;
   width: @conversation-message-sender-width;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-354" title="ACC-354" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-354</a>  [Web] Heart icon is very close to user image
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [Web] Heart icon is very close to user image

- The **PR Description**
  - [Web] Heart icon is very close to user image
----

# What's new in this PR?

### Issues

- [Web] Heart icon is very close to user image

### Solutions

- add top: 4px for the like icon as mentioned in the figma

[ACC-354]: https://wearezeta.atlassian.net/browse/ACC-354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACC-354]: https://wearezeta.atlassian.net/browse/ACC-354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACC-354]: https://wearezeta.atlassian.net/browse/ACC-354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ