### PR TITLE
fix: Stop handling team events when team is deleted [FS-1406]

### DIFF
--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -216,10 +216,15 @@ export class TeamRepository {
   }
 
   readonly onTeamEvent = (eventJson: any, source: EventSource): void => {
-    const type = eventJson.type;
+    if (this.teamState.isTeamDeleted()) {
+      // We don't want to handle any events after the team has been deleted
+      return;
+    }
 
+    const type = eventJson.type;
     const logObject = {eventJson: JSON.stringify(eventJson), eventObject: eventJson};
-    this.logger.info(`»» Team Event: '${type}' (Source: ${source})`, logObject);
+
+    this.logger.info(`Team Event: '${type}' (Source: ${source})`, logObject);
 
     switch (type) {
       case TEAM_EVENT.CONVERSATION_DELETE: {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1406" title="FS-1406" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1406</a>  [Web] Database is accessed after is has been closed when team is deleted
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
It is possible for backend to send team events even after the team has been deleted.
On the front end it might end-up in calls that will try to access the DB after it has been closed or deleted. 

The solution is to stop handling team events once the team has been locally marked as deleted