### PR TITLE
runfix: use different shade for self-mentions and selection [ACC-155]

### DIFF
--- a/src/style/common/accent-color.less
+++ b/src/style/common/accent-color.less
@@ -206,6 +206,7 @@ each(.colors(), .(@color-key, @color-name) {
   @accent-color-border: '@{name}-500';
   @accent-color-focus: '@{name}-400';
   @accent-color-selection: '@{name}-300';
+  @accent-color-self-mention: '@{name}-200';
   @button-primary-hover: '@{name}-600';
   @button-primary-focus-border: '@{name}-700';
   @button-primary-active: '@{name}-800';
@@ -238,6 +239,7 @@ each(.colors(), .(@color-key, @color-name) {
     --accent-color-border: @@accent-color-border;
     --accent-color-focus: @@accent-color-focus;
     --accent-color-selection: @@accent-color-selection;
+    --accent-color-self-mention: @@accent-color-self-mention;
     --accent-color-fade-16: fade(@@accent-color, 16%);
     --accent-color-fade-24: fade(@@accent-color, 24%);
     --accent-color-darken-16: darken(@@accent-color, 16%);
@@ -258,6 +260,7 @@ each(.colors(), .(@color-key, @color-name) {
     @accent-color-border-dark: '@{name}-dark-600';
     @accent-color-focus-dark: '@{name}-dark-600';
     @accent-color-selection-dark: '@{name}-dark-700';
+    @accent-color-self-mention-dark: '@{name}-dark-800';
     @button-primary-hover-dark: '@{name}-dark-400';
     @button-primary-focus-border-dark: '@{name}-dark-100';
     @button-primary-active-dark: '@{name}-dark-800';
@@ -289,6 +292,7 @@ each(.colors(), .(@color-key, @color-name) {
       --accent-color-border: @@accent-color-border-dark;
       --accent-color-focus: @@accent-color-focus-dark;
       --accent-color-selection: @@accent-color-selection-dark;
+      --accent-color-self-mention: @@accent-color-self-mention-dark;
       each(@color-index, {
         @accent-color: '@{name}-dark-@{value}';
         --accent-color-@{value}: @@accent-color;

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -104,7 +104,7 @@
 
     &.self-mention {
       padding: 3px 0 4px 0;
-      background-color: var(--accent-color-selection);
+      background-color: var(--accent-color-self-mention);
       color: var(--main-color);
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-155" title="ACC-155" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-155</a>  [Web][Dark Mode] Selected Text highlight in message Input UI doesn't have enough contrast with background
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Issue
- Self mentions and selection are supposed to be a different shade
![image](https://user-images.githubusercontent.com/78490891/210570186-77231161-6593-4977-9a99-61f8e8740aab.png)


### Change
- Add an accent-color variation for self-mentions
![Screenshot from 2023-01-04 14-49-00](https://user-images.githubusercontent.com/78490891/210569982-fa4464f5-3446-4ee1-b3bf-5c34fb8f5dfe.png)


[ACC-155]: https://wearezeta.atlassian.net/browse/ACC-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACC-155]: https://wearezeta.atlassian.net/browse/ACC-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACC-155]: https://wearezeta.atlassian.net/browse/ACC-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ