### PR TITLE
fix: 2fa entropy bug [SQSERVICES-1709]

### DIFF
--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -161,6 +161,8 @@ const Login = ({
   const immediateLogin = async () => {
     try {
       await doInit({isImmediateLogin: true, shouldValidateLocalClient: false});
+      // Try to initialize to check if the client needs 2fa before checking for entropyData
+      await doInitializeClient(ClientType.PERMANENT, undefined, undefined, undefined);
       const entropyData = await getEntropy?.();
       await doInitializeClient(ClientType.PERMANENT, undefined, undefined, entropyData);
       return history.push(ROUTE.HISTORY_INFO);

--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -164,7 +164,9 @@ const Login = ({
       // Try to initialize to check if the client needs 2fa before checking for entropyData
       await doInitializeClient(ClientType.PERMANENT, undefined, undefined, undefined);
       const entropyData = await getEntropy?.();
-      await doInitializeClient(ClientType.PERMANENT, undefined, undefined, entropyData);
+      if (entropyData) {
+        await doInitializeClient(ClientType.PERMANENT, undefined, undefined, entropyData);
+      }
       return history.push(ROUTE.HISTORY_INFO);
     } catch (error) {
       logger.error('Unable to login immediately', error);


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Fix an issue where immediate login causes the webapp to crash if user is required to enter 2fa and entropy.

### Causes (Optional)
as 2fa is only known upon login, attempting an immediate login (ie. without password/email) breaks the flow when also adding entropy as it thinks the user is already logged in and doesn't try to catch an error. 

### Solutions

try to initialize the client before adding entropy to know if it is able to be logged in or not. 


[SQPIT-764]: https://wearezeta.atlassian.net/browse/SQPIT-764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ