### PR TITLE
runfix: correct video tiles background color in dark mode

### DIFF
--- a/src/style/components/group-video-grid.less
+++ b/src/style/components/group-video-grid.less
@@ -97,6 +97,7 @@
       box-sizing: border-box;
       padding: 0;
       border: none;
+      background-color: inherit;
 
       &:focus {
         z-index: 1;


### PR DESCRIPTION
### Issue
- Video tiles background is white in dark mode
![Screenshot from 2023-01-05 10-58-21](https://user-images.githubusercontent.com/78490891/210753590-e47101fc-fd10-4780-a36d-8900e6bac274.png)

### Solution
- Set the background color to `inherit`
![Screenshot from 2023-01-05 10-58-26](https://user-images.githubusercontent.com/78490891/210753755-8168c1ed-9a0e-4d90-bef5-a741d25e93ff.png)

