### PR TITLE
fix: set default font weight to 400 in dark mode [ACC-290]

### DIFF
--- a/src/style/foundation/base.less
+++ b/src/style/foundation/base.less
@@ -48,10 +48,14 @@ body {
   color: var(--main-color);
   font-family: @font-family-base;
   font-size: @font-size-sm;
-  font-weight: 300;
+  font-weight: @font-weight-light;
   overflow-x: hidden;
   overflow-y: hidden !important;
   text-rendering: optimizeLegibility;
+
+  &.theme-dark {
+    font-weight: @font-weight-regular;
+  }
 }
 
 // Set default icon size


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-290" title="ACC-290" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-290</a>  [Web] Font used in Dark Mode is incorrect (light weight)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Change
- when no font weight is specified, the default should be 300 in light mode and 400 in dark mode