### PR TITLE
fix: address latest accessibility issues [ACC-394],  [ACC-395],  [ACC-326]

### DIFF
--- a/src/script/components/calling/GroupVideoGrid.tsx
+++ b/src/script/components/calling/GroupVideoGrid.tsx
@@ -131,14 +131,17 @@ const GroupVideoGrid: React.FunctionComponent<GroupVideoGripProps> = ({
             <Icon.Loading
               css={{
                 '> path': {
-                  fill: '#fff',
+                  fill: 'var(--main-color)',
                 },
                 height: 32,
                 marginBottom: 32,
                 width: 32,
               }}
             />
-            <div data-uie-name="no-active-speakers" css={{color: '#fff', fontSize: '0.6875rem', fontWeight: 500}}>
+            <div
+              data-uie-name="no-active-speakers"
+              css={{color: 'var(--main-color)', fontSize: 'var(--font-size-xsmall)', fontWeight: 500}}
+            >
               {t('noActiveSpeakers')}
             </div>
           </div>

--- a/src/style/common/context.less
+++ b/src/style/common/context.less
@@ -50,8 +50,9 @@
     }
 
     &:hover,
-    &.selected {
+    & > :focus-visible {
       background-color: var(--foreground-fade-16);
+      outline: none;
     }
 
     &--disabled {

--- a/src/style/components/list/conversation-list-calling-cell.less
+++ b/src/style/components/list/conversation-list-calling-cell.less
@@ -222,6 +222,7 @@ svg.small-icon {
     }
 
     span:last-child {
+      margin-left: 0.3rem;
       text-transform: uppercase;
     }
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-394" title="ACC-394" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-394</a>  [Web] Call moderation menu has always hover state for option
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Issues addressed
- [ACC-395] "no active speaker" text is invisible in light mode
> assign the correct css variable to the color
- [ACC-394] Call moderation menu  always has an hover state for option
> only apply context menu selection state on hover and focus:visible
- [ACC-326] Call timer and "CBR" have no margin at lager font size
> Add a left margin to "CBR" text


[ACC-395]: https://wearezeta.atlassian.net/browse/ACC-395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACC-394]: https://wearezeta.atlassian.net/browse/ACC-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACC-326]: https://wearezeta.atlassian.net/browse/ACC-326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ