### PR TITLE
fix: issue with ping on current dev (SQSERVICES-1816)

### DIFF
--- a/src/script/components/InputBar/components/InputBarControls/ControlButtons.test.tsx
+++ b/src/script/components/InputBar/components/InputBarControls/ControlButtons.test.tsx
@@ -45,7 +45,7 @@ const allButtonTitles = [
 
 describe('ControlButtons', () => {
   it.each<[Partial<PropsType>, string[]]>([
-    [{disableFilesharing: true}, []],
+    [{disableFilesharing: true}, ['tooltipConversationPing']],
     [{isEditing: true}, []],
   ])('renders the right buttons depending on props (%s)', (overrides, buttonTitles) => {
     const params = {...defaultParams, ...overrides};

--- a/src/script/components/InputBar/components/InputBarControls/ControlButtons.tsx
+++ b/src/script/components/InputBar/components/InputBarControls/ControlButtons.tsx
@@ -82,22 +82,21 @@ const ControlButtons: React.FC<ControlButtonsProps> = ({
 
     return (
       <>
+        <li>
+          <button
+            className={`controls-right-button buttons-group-button-left ${scaledDownClass}`}
+            type="button"
+            onClick={onClickPing}
+            disabled={disablePing}
+            title={pingTooltip}
+            aria-label={pingTooltip}
+            data-uie-name="do-ping"
+          >
+            <Icon.Ping />
+          </button>
+        </li>
         {!disableFilesharing && (
           <>
-            <li>
-              <button
-                className={`controls-right-button buttons-group-button-left ${scaledDownClass}`}
-                type="button"
-                onClick={onClickPing}
-                disabled={disablePing}
-                title={pingTooltip}
-                aria-label={pingTooltip}
-                data-uie-name="do-ping"
-              >
-                <Icon.Ping />
-              </button>
-            </li>
-
             <li>
               <ImageUploadButton
                 onSelectImages={onSelectImages}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1816" title="SQSERVICES-1816" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1816</a>  [TM/Web] Disabling file sharing from TM makes the 'Ping' button from a conversation disappear
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

allow ping to show when file sharing is disabled.

