### PR TITLE
runfix: Add error log on core.init

### DIFF
--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -361,6 +361,8 @@ export class App {
       try {
         await this.core.init(clientType);
       } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : error;
+        this.logger.error(`Error when initializing core: "${errorMessage}"`, error);
         throw new AccessTokenError(AccessTokenError.TYPE.REQUEST_FORBIDDEN, 'Session has expired');
       }
       const localClient = await this.core.initClient();


### PR DESCRIPTION
Add error logs when `core.init` call fails. 
It would previously swallow the error and throw a new type of error, so it's not possible to go back to the original error. 