### PR TITLE
chore: add eslint warning for floating promises

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,7 +39,7 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-var-requires": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
-    "@typescript-eslint/no-floating-promises": "off",
+    "@typescript-eslint/no-floating-promises": "warn",
     "@typescript-eslint/typedef": "off",
     "no-dupe-class-members": "off",
     "no-undef": "off",


### PR DESCRIPTION
Enables `"@typescript-eslint/no-floating-promises": "warn"` eslint rule.