### PR TITLE
runfix: correct icon color in light mode

### DIFF
--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -64,12 +64,6 @@
     margin-bottom: 4px;
   }
 
-  @media (prefers-color-scheme: dark) {
-    svg {
-      fill: var(--white);
-    }
-  }
-
   &--text {
     .label-small-medium;
     color: var(--main-color);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/78490891/212035725-ecb9a5cd-19ac-461e-9150-3471d3b7f6c6.png)
 ### Issue
- In an attempt to show the correct color for icon in windows high contrast mode, a media query for dark mode was used. It had the effect of setting the wrong color for icons if the system settings are set to dark mode but the app set to light mode

### Solution
- remove the media query for now