### PR TITLE
fix: Very long name causes misaligned system message

### DIFF
--- a/src/script/components/MessagesList/Message/DecryptErrorMessage.tsx
+++ b/src/script/components/MessagesList/Message/DecryptErrorMessage.tsx
@@ -52,20 +52,24 @@ const DecryptErrorMessage: React.FC<DecryptErrorMessageProps> = ({message, onCli
         <div className="message-header-icon">
           <span className="icon-sysmsg-error text-red" />
         </div>
-        <div className="message-header-label ellipsis">
-          <span dangerouslySetInnerHTML={{__html: caption}} />
-          <span>&nbsp;</span>
-          <a
-            className="accent-text"
-            href={link}
-            rel="nofollow noopener noreferrer"
-            target="_blank"
-            data-uie-name="go-decrypt-error-link"
-          >
-            {t('conversationUnableToDecryptLink')}
-          </a>
+
+        <div className="message-header-label">
+          <p>
+            <span dangerouslySetInnerHTML={{__html: caption}} />
+            <span>&nbsp;</span>
+            <a
+              className="accent-text"
+              href={link}
+              rel="nofollow noopener noreferrer"
+              target="_blank"
+              data-uie-name="go-decrypt-error-link"
+            >
+              {t('conversationUnableToDecryptLink')}
+            </a>
+          </p>
         </div>
       </div>
+
       <div className="message-body message-body-decrypt-error">
         <p className="message-header-decrypt-error-label" data-uie-name="status-decrypt-error">
           {message.code && (
@@ -81,6 +85,7 @@ const DecryptErrorMessage: React.FC<DecryptErrorMessageProps> = ({message, onCli
             </>
           )}
         </p>
+
         {message.isRecoverable && (
           <div className="message-header-decrypt-reset-session">
             {isResettingSession ? (

--- a/src/script/components/MessagesList/Message/VerificationMessage.tsx
+++ b/src/script/components/MessagesList/Message/VerificationMessage.tsx
@@ -63,7 +63,7 @@ const VerificationMessage: React.FC<VerificationMessageProps> = ({message}) => {
         <VerifiedIcon isVerified={isTypeVerified} />
       </div>
       <div
-        className="message-header-label"
+        className="message-header-label message-header-label--verification"
         data-uie-name="element-message-verification"
         data-uie-value={verificationMessageType}
       >
@@ -71,7 +71,7 @@ const VerificationMessage: React.FC<VerificationMessageProps> = ({message}) => {
         {isTypeUnverified && (
           <>
             <span className="message-header-sender-name">{unsafeSenderName}</span>
-            <span className="ellipsis">{t('conversationDeviceUnverified')}</span>
+            <span>{t('conversationDeviceUnverified')}</span>
             <button
               type="button"
               className="button-reset-default message-verification-action accent-text"
@@ -87,7 +87,7 @@ const VerificationMessage: React.FC<VerificationMessageProps> = ({message}) => {
         {isTypeNewDevice && (
           <>
             <span className="message-header-plain-sender-name">{nameList}</span>
-            <span className="ellipsis">
+            <span>
               {hasMultipleUsers ? t('conversationDeviceStartedUsingMany') : t('conversationDeviceStartedUsingOne')}
             </span>
             <button
@@ -102,7 +102,7 @@ const VerificationMessage: React.FC<VerificationMessageProps> = ({message}) => {
         )}
         {isTypeNewMember && (
           <>
-            <span className="ellipsis">{t('conversationDeviceNewPeopleJoined')}</span>
+            <span>{t('conversationDeviceNewPeopleJoined')}</span>
             &nbsp;
             <button
               type="button"

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -181,6 +181,10 @@
   font-weight: @font-weight-regular;
   white-space: normal;
 
+  &--verification {
+    display: inline;
+  }
+
   a {
     cursor: pointer;
   }


### PR DESCRIPTION
Before:
<img width="545" alt="image" src="https://user-images.githubusercontent.com/13432884/212844508-f622b68f-640f-43a4-a248-9d457ccd82c2.png">
* Also another system messages get cut.

Now:
<img width="470" alt="image" src="https://user-images.githubusercontent.com/13432884/212844739-bceb765b-3553-4ae3-b89b-bae7bf80f7d8.png">
In another views also fixed. :)
