### PR TITLE
fix: message not found on quotes of your own messages [SQSERVICES-1834]

### DIFF
--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -1183,7 +1183,9 @@ export class MessageRepository {
     skipConversationMessages = false,
     ensureUser = false,
   ): Promise<StoredContentMessage> {
-    const messageEntity = !skipConversationMessages && conversation.getMessage(messageId);
+    const messageEntity =
+      !skipConversationMessages &&
+      (conversation.getMessageByReplacementId(messageId) || conversation.getMessage(messageId));
     const message =
       messageEntity ||
       (await this.eventService.loadEvent(conversation.id, messageId).then(event => {

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -968,6 +968,15 @@ export class Conversation {
   getMessage(messageId: string): Message | ContentMessage | MemberMessage | SystemMessage | undefined {
     return this.messages().find(messageEntity => messageEntity.id === messageId);
   }
+  /**
+   * Get a message by its replacing message id. Useful if the message in question is an edit and has replaced the original message.
+   * Only lookup in the loaded message list which is a limited view of all the messages in DB.
+   *
+   * @param messageId ID of message to be retrieved
+   */
+  getMessageByReplacementId(messageId: string): Message | ContentMessage | MemberMessage | SystemMessage | undefined {
+    return this.messages().find(messageEntity => (messageEntity as ContentMessage)?.replacing_message_id === messageId);
+  }
 
   updateGuests(): void {
     this.getTemporaryGuests().forEach(userEntity => userEntity.checkGuestExpiration());

--- a/src/script/event/EventService.ts
+++ b/src/script/event/EventService.ts
@@ -149,7 +149,7 @@ export class EventService {
         .filter(
           record =>
             (record.id === eventId && record.conversation === conversationId) ||
-            (record.id === eventId && record.data.replacing_message_id === eventId),
+            (record.conversation === conversationId && record.data.replacing_message_id === eventId),
         )
         .sort(compareEventsById)
         .shift();

--- a/src/script/event/EventService.ts
+++ b/src/script/event/EventService.ts
@@ -127,21 +127,21 @@ export class EventService {
 
     try {
       if (this.storageService.db) {
-        let entry = await this.storageService.db
+        const entry = await this.storageService.db
           .table(StorageSchemata.OBJECT_STORE.EVENTS)
           .where('id')
           .equals(eventId)
           .filter(record => record.conversation === conversationId)
           .first();
-        if (!entry) {
-          entry = await this.storageService.db
-            .table(StorageSchemata.OBJECT_STORE.EVENTS)
-            .where('conversation')
-            .equals(conversationId)
-            .filter(item => item.data.replacing_message_id === eventId)
-            .first();
+        if (entry) {
+          return entry;
         }
-        return entry;
+        return await this.storageService.db
+          .table(StorageSchemata.OBJECT_STORE.EVENTS)
+          .where('conversation')
+          .equals(conversationId)
+          .filter(item => item.data.replacing_message_id === eventId)
+          .first();
       }
 
       const records = (await this.storageService.getAll(StorageSchemata.OBJECT_STORE.EVENTS)) as EventRecord[];

--- a/src/script/event/EventService.ts
+++ b/src/script/event/EventService.ts
@@ -127,18 +127,30 @@ export class EventService {
 
     try {
       if (this.storageService.db) {
-        const entry = await this.storageService.db
+        let entry = await this.storageService.db
           .table(StorageSchemata.OBJECT_STORE.EVENTS)
           .where('id')
           .equals(eventId)
           .filter(record => record.conversation === conversationId)
           .first();
+        if (!entry) {
+          entry = await this.storageService.db
+            .table(StorageSchemata.OBJECT_STORE.EVENTS)
+            .where('conversation')
+            .equals(conversationId)
+            .filter(item => item.data.replacing_message_id === eventId)
+            .first();
+        }
         return entry;
       }
 
       const records = (await this.storageService.getAll(StorageSchemata.OBJECT_STORE.EVENTS)) as EventRecord[];
       return records
-        .filter(record => record.id === eventId && record.conversation === conversationId)
+        .filter(
+          record =>
+            (record.id === eventId && record.conversation === conversationId) ||
+            (record.id === eventId && record.data.replacing_message_id === eventId),
+        )
         .sort(compareEventsById)
         .shift();
     } catch (error) {

--- a/src/script/event/preprocessor/QuotedMessageMiddleware.ts
+++ b/src/script/event/preprocessor/QuotedMessageMiddleware.ts
@@ -22,7 +22,6 @@ import {Quote} from '@wireapp/protocol-messaging';
 import {getLogger, Logger} from 'Util/Logger';
 import {base64ToArray} from 'Util/util';
 
-import {MessageHasher} from '../../message/MessageHasher';
 import {QuoteEntity} from '../../message/QuoteEntity';
 import {EventRecord} from '../../storage/record/EventRecord';
 import {ClientEvent} from '../Client';
@@ -117,24 +116,10 @@ export class QuotedMessageMiddleware {
       return {...event, data: decoratedData};
     }
 
-    const quotedMessageHash = new Uint8Array(quote.quotedMessageSha256).buffer;
-
-    const isValid = await MessageHasher.validateHash(quotedMessage, quotedMessageHash);
-    let quoteData;
-
-    if (!isValid) {
-      this.logger.warn(`Quoted message hash for message ID "${messageId}" does not match.`);
-      quoteData = {
-        error: {
-          type: QuoteEntity.ERROR.INVALID_HASH,
-        },
-      };
-    } else {
-      quoteData = {
-        message_id: messageId,
-        user_id: quotedMessage.from,
-      };
-    }
+    const quoteData = {
+      message_id: messageId,
+      user_id: quotedMessage.from,
+    };
 
     const decoratedData = {...event.data, quote: quoteData};
     return {...event, data: decoratedData};

--- a/src/script/message/QuoteEntity.ts
+++ b/src/script/message/QuoteEntity.ts
@@ -33,7 +33,6 @@ export class QuoteEntity {
   userId: string;
 
   static ERROR = {
-    INVALID_HASH: 'INVALID_HASH',
     MESSAGE_NOT_FOUND: 'MESSAGE_NOT_FOUND',
   };
 

--- a/src/script/notification/NotificationRepository.ts
+++ b/src/script/notification/NotificationRepository.ts
@@ -259,7 +259,9 @@ export class NotificationRepository {
             const messageInfo = messageId
               ? `message '${messageId}' of type '${messageType}'`
               : `'${messageType}' message`;
-            this.logger.info(`Removed read notification for ${messageInfo} in '${conversationId}'.`);
+            this.logger.info(
+              `Removed read notification for ${messageInfo} in '${conversationId?.id || conversationId}'.`,
+            );
           }
         });
       }
@@ -857,30 +859,35 @@ export class NotificationRepository {
       this.contentViewModelState.multitasking.isMinimized(true);
       notificationContent.trigger();
 
-      this.logger.info(`Notification for ${messageInfo} in '${conversationId}' closed by click.`);
+      this.logger.info(`Notification for ${messageInfo} in '${conversationId?.id || conversationId}' closed by click.`);
       notification.close();
     };
 
     notification.onclose = () => {
       window.clearTimeout(timeoutTriggerId);
       this.notifications.splice(this.notifications.indexOf(notification), 1);
-      this.logger.info(`Removed notification for ${messageInfo} in '${conversationId}' locally.`);
+      this.logger.info(`Removed notification for ${messageInfo} in '${conversationId?.id || conversationId}' locally.`);
     };
 
     notification.onerror = error => {
-      this.logger.error(`Notification for ${messageInfo} in '${conversationId}' closed by error.`, error);
+      this.logger.error(
+        `Notification for ${messageInfo} in '${conversationId?.id || conversationId}' closed by error.`,
+        error,
+      );
       notification.close();
     };
 
     notification.onshow = () => {
       timeoutTriggerId = window.setTimeout(() => {
-        this.logger.info(`Notification for ${messageInfo} in '${conversationId}' closed by timeout.`);
+        this.logger.info(
+          `Notification for ${messageInfo} in '${conversationId?.id || conversationId}' closed by timeout.`,
+        );
         notification.close();
       }, notificationContent.timeout);
     };
 
     this.notifications.push(notification);
-    this.logger.info(`Added notification for ${messageInfo} in '${conversationId}' to queue.`);
+    this.logger.info(`Added notification for ${messageInfo} in '${conversationId?.id || conversationId}' to queue.`);
   }
 
   /**

--- a/test/unit_tests/event/preprocessor/QuotedMessageMiddlewareSpec.js
+++ b/test/unit_tests/event/preprocessor/QuotedMessageMiddlewareSpec.js
@@ -81,44 +81,6 @@ describe('QuotedMessageMiddleware', () => {
       expect(parsedEvent.data.quote.error).toEqual(expectedError);
     });
 
-    it('adds an error if hashes do not match', async () => {
-      const expectedError = {
-        type: QuoteEntity.ERROR.INVALID_HASH,
-      };
-
-      const quotedMessage = {
-        data: {
-          content: 'pas salut',
-        },
-        time: 100,
-        type: ClientEvent.CONVERSATION.MESSAGE_ADD,
-      };
-
-      spyOn(quotedMessageMiddleware.eventService, 'loadEvent').and.returnValue(Promise.resolve(quotedMessage));
-
-      const quote = new Quote({
-        quotedMessageId: 'message-uuid',
-        quotedMessageSha256: '7fec6710751f67587b6f6109782257cd7c56b5d29570824132e8543e18242f1b',
-      });
-
-      const base64Quote = arrayToBase64(Quote.encode(quote).finish());
-
-      const event = {
-        conversation: 'conversation-uuid',
-        data: {
-          content: 'salut',
-          quote: base64Quote,
-        },
-        time: 100,
-        type: ClientEvent.CONVERSATION.MESSAGE_ADD,
-      };
-
-      const parsedEvent = await quotedMessageMiddleware.processEvent(event);
-
-      expect(parsedEvent.data.quote.message_id).toBeUndefined();
-      expect(parsedEvent.data.quote.error).toEqual(expectedError);
-    });
-
     it('decorates event with the quote metadata if validation is successful', async () => {
       const quotedMessage = {
         data: {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1834" title="SQSERVICES-1834" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1834</a>  "You cannot see this message." in reply to own message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

fix an issue with quotes of your own (edited) messages not appearing

### Causes (Optional)

reference to message id is changing, using replacing_message_id. also an issue with race condition for hashed quotes.
