### PR TITLE
fix: Search Field for Services changes during Search requests

### DIFF
--- a/src/script/page/RightSidebar/AddParticipants/AddParticipants.tsx
+++ b/src/script/page/RightSidebar/AddParticipants/AddParticipants.tsx
@@ -177,10 +177,11 @@ const AddParticipants: FC<AddParticipantsProps> = ({
   };
 
   const onSearchInput = async (value: string) => {
+    setSearchInput(value);
+
     if (isAddServiceState) {
       await searchServices(value);
     }
-    setSearchInput(value);
   };
 
   return (


### PR DESCRIPTION
When user writing smth in input fast, the input value giving wrong values. Updated functions order.