### PR TITLE
fix: Link preview focus and right panel focus on open

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/asset/LinkPreviewAssetComponent.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/LinkPreviewAssetComponent.tsx
@@ -19,7 +19,6 @@
 
 import React from 'react';
 
-import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 import cx from 'classnames';
 
 import {Image} from 'Components/Image';
@@ -34,14 +33,16 @@ import {AssetHeader} from './AssetHeader';
 
 import type {ContentMessage} from '../../../../../entity/message/ContentMessage';
 import type {Text} from '../../../../../entity/message/Text';
+import {useMessageFocusedTabIndex} from '../../util';
 
 export interface LinkPreviewAssetProps {
   /** Does the asset have a visible header? */
   header?: boolean;
   message: ContentMessage;
+  isFocusable?: boolean;
 }
 
-const LinkPreviewAsset: React.FC<LinkPreviewAssetProps> = ({header = false, message}) => {
+const LinkPreviewAsset: React.FC<LinkPreviewAssetProps> = ({header = false, message, isFocusable = true}) => {
   const {
     previews: [preview],
   } = useKoSubscribableChildren(message.getFirstAsset() as Text, ['previews']);
@@ -51,6 +52,7 @@ const LinkPreviewAsset: React.FC<LinkPreviewAssetProps> = ({header = false, mess
   const author = isTweet ? preview.tweet?.author?.substring(0, 20) : '';
   const previewImage = preview?.image;
   const {isObfuscated} = useKoSubscribableChildren(message, ['isObfuscated']);
+  const messageFocusedTabIndex = useMessageFocusedTabIndex(isFocusable);
 
   const onClick = () => {
     if (!message.isExpired()) {
@@ -79,7 +81,7 @@ const LinkPreviewAsset: React.FC<LinkPreviewAssetProps> = ({header = false, mess
   ) : (
     <div
       role="button"
-      tabIndex={TabIndex.FOCUSABLE}
+      tabIndex={messageFocusedTabIndex}
       className="link-preview-asset"
       onClick={onClick}
       onKeyDown={e => handleKeyDown(e, onClick)}

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
@@ -80,8 +80,8 @@ const ContentAsset = ({
             />
           )}
           {(asset as Text).previews().map(preview => (
-            <div key={preview.url} className="message-asset">
-              <LinkPreviewAsset message={message} />
+            <div key={asset.id} className="message-asset">
+              <LinkPreviewAsset message={message} isFocusable={isMessageFocused} />
             </div>
           ))}
         </>

--- a/src/script/page/RightSidebar/PanelHeader/PanelHeader.tsx
+++ b/src/script/page/RightSidebar/PanelHeader/PanelHeader.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {FC} from 'react';
+import {FC, useEffect, useRef} from 'react';
 
 import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 import cx from 'classnames';
@@ -62,8 +62,17 @@ const PanelHeader: FC<PanelHeaderProps> = ({
   onGoBack = noop,
   onToggleMute = noop,
 }: PanelHeaderProps) => {
+  const panelHeaderRef = useRef<HTMLHeadingElement>(null);
+
+  useEffect(() => {
+    if (!!panelHeaderRef.current) {
+      const nextElementToFocus = panelHeaderRef.current.querySelector('button');
+      nextElementToFocus?.focus();
+    }
+  }, []);
+
   return (
-    <header className={cx('panel__header', {'panel__header--reverse': isReverse}, className)}>
+    <header className={cx('panel__header', {'panel__header--reverse': isReverse}, className)} ref={panelHeaderRef}>
       {showBackArrow && (
         <DragableClickWrapper onClick={() => onGoBack()}>
           <button className="icon-button" data-uie-name={goBackUie} title={goBackTitle} onBlur={handleBlur}>

--- a/src/script/page/RightSidebar/TimedMessages/TimedMessages.tsx
+++ b/src/script/page/RightSidebar/TimedMessages/TimedMessages.tsx
@@ -19,6 +19,8 @@
 
 import {FC, useEffect, useState} from 'react';
 
+import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
+
 import {FadingScrollbar} from 'Components/FadingScrollbar';
 import {RadioGroup} from 'Components/Radio';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
@@ -107,7 +109,9 @@ const TimedMessages: FC<TimedMessagesPanelProps> = ({activeConversation, onClose
             }))}
           />
         </div>
-        <p className="panel__info-text timed-messages__disclaimer">{t('timedMessageDisclaimer')}</p>
+        <p className="panel__info-text timed-messages__disclaimer" tabIndex={TabIndex.FOCUSABLE}>
+          {t('timedMessageDisclaimer')}
+        </p>
       </FadingScrollbar>
     </div>
   );

--- a/src/style/common/button.less
+++ b/src/style/common/button.less
@@ -521,7 +521,9 @@
   }
 
   &:focus-visible {
-    outline: 1px solid var(--accent-color-300);
+    .focus-outline;
+    .focus-offset;
+    outline-offset: -0.2rem;
   }
 
   body.theme-dark & {
@@ -531,10 +533,6 @@
     &:focus-visible,
     &.active {
       color: var(--accent-color-500);
-    }
-
-    &:focus-visible {
-      outline: 1px solid var(--accent-color-600);
     }
   }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - All link previews get focused when you press shift+tab from message input bar.
- After opening right panel options like notification, self deleting message, the focus doesn't shift to the first interactive element of the panel example back button/close button

- The **PR Description**
  - Only the last focused message link preview can be focused, shift+tab from message input bar should focus on the last message → info button in the title bar.
  - After opening right panel options like notification, self deleting message, the focus doesn't shift to the first interactive element of the panel example back button/close button. 

Expected: After the panel is opened, back button/close button should get the focus.
----
##### References
1. https://wearezeta.atlassian.net/browse/ACC-427
1. https://wearezeta.atlassian.net/browse/ACC-426
