### PR TITLE
fix: load missing devices of users from local db in memory before sending a message [FS-1455] 

### DIFF
--- a/src/script/conversation/MessageRepository.test.ts
+++ b/src/script/conversation/MessageRepository.test.ts
@@ -89,7 +89,9 @@ async function buildMessageRepository(): Promise<[MessageRepository, MessageRepo
     eventRepository: new EventRepository(new EventService({} as any), {} as any, {} as any, {} as any),
     propertiesRepository: new PropertiesRepository({} as any, {} as any),
     serverTimeHandler: serverTimeHandler,
-    userRepository: {} as UserRepository,
+    userRepository: {
+      assignAllClients: jest.fn().mockResolvedValue(true),
+    } as unknown as UserRepository,
     assetRepository: {} as AssetRepository,
     userState,
     teamState: new TeamState(),

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -749,7 +749,7 @@ export class MessageRepository {
           payload,
           protocol: ConversationProtocol.PROTEUS,
           targetMode,
-          userIds: this.generateRecipients(conversation, recipients, skipSelf),
+          userIds: await this.generateRecipients(conversation, recipients, skipSelf),
         };
 
     const shouldProceedSending = await injectOptimisticEvent();
@@ -1148,24 +1148,31 @@ export class MessageRepository {
     }, {} as UserClients);
   }
 
-  private generateRecipients(
+  private async generateRecipients(
     conversation: Conversation,
     recipients?: QualifiedId[] | QualifiedUserClients | UserClients,
     skipSelf?: boolean,
-  ): QualifiedUserClients | UserClients {
+  ): Promise<QualifiedUserClients | UserClients> {
     if (isQualifiedUserClients(recipients) || isUserClients(recipients)) {
       // If we get a userId>client pairs, we just return those, no need to create recipients
       return recipients;
     }
-    const users = conversation.allUserEntities
+    const filteredUsers = conversation.allUserEntities
+      // filter possible undefined values
+      .flatMap(user => (user ? [user] : []))
       // if users are given by the caller, we filter to only keep those users
       .filter(user => !recipients || recipients.some(userId => matchQualifiedIds(user, userId)))
       // we filter the self user if skipSelf is true
       .filter(user => !skipSelf || !user.isMe);
 
+    // Check if we have users without assigned clients and assign them from local database if possible
+    if (filteredUsers.some(user => user?.devices().length === 0)) {
+      await this.userRepository.assignAllClients();
+    }
+
     return this.core.backendFeatures.federationEndpoints
-      ? this.createQualifiedRecipients(users)
-      : this.createRecipients(users);
+      ? this.createQualifiedRecipients(filteredUsers)
+      : this.createRecipients(filteredUsers);
   }
 
   /**

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -259,7 +259,7 @@ export class UserRepository {
    * Assign all locally stored clients to the users.
    * @returns Resolves with all user entities where client entities have been assigned to.
    */
-  private async assignAllClients(): Promise<User[]> {
+  public async assignAllClients(): Promise<User[]> {
     const recipients = await this.clientRepository.getAllClientsFromDb();
     const userIds: QualifiedId[] = Object.entries(recipients).map(([userId, clientEntities]) => {
       return {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1455" title="FS-1455" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1455</a>  [web] First message sent in a conversation will always fetch new prekeys
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

in case of missing devices for users (when sending a message) load all devices from DB and assign to users

This improves our calls to Backend before sending a message (list-users, list-prekeys). We reduce the payload of these calls to only users where we don't have any devices in our database.