### PR TITLE
fix: use correct scrollbar color [ACC-211]

### DIFF
--- a/src/style/foundation/base.less
+++ b/src/style/foundation/base.less
@@ -24,7 +24,7 @@
 }
 
 * {
-  --scrollbar-color: fade(#000, 50%);
+  --scrollbar-color: @gray-60;
   @scrollbar-size: 7px;
   scrollbar-color: var(--scrollbar-color) transparent;
   scrollbar-width: thin;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-211" title="ACC-211" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-211</a>  [web] Scroll bar in dark mode is hard to see (low contrast between bar and background)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Change

- The scrollbar should be a different color according to design spec, for better contrast in light and dark mode
![image](https://user-images.githubusercontent.com/78490891/213688824-0bbec8e8-700a-42a2-ad2a-b6967565cd2b.png)
