### PR TITLE
runfix: Adjust styles for paused video tile (ACC-274)

### DIFF
--- a/src/style/components/group-video-grid.less
+++ b/src/style/components/group-video-grid.less
@@ -194,6 +194,7 @@
       height: 100%;
       align-items: center;
       justify-content: center;
+      border-radius: 8px;
       background-color: var(--background-fade-16);
       transform: translateZ(0);
 
@@ -211,6 +212,7 @@
       }
 
       .background {
+        border-radius: 8px;
         transition: none;
       }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-274" title="ACC-274" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-274</a>  [Web] No name is displayed when video paused in a group call 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Border radius for paused video tile