### PR TITLE
fix: Always query conversation by qualifiedIds [FS-1452]

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.10.5",
     "@types/eslint": "^8.4.10",
     "@wireapp/avs": "8.2.30",
-    "@wireapp/core": "38.5.3",
+    "@wireapp/core": "38.5.4",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.3.3",
     "@wireapp/store-engine-dexie": "2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4372,22 +4372,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^22.14.3":
-  version: 22.14.3
-  resolution: "@wireapp/api-client@npm:22.14.3"
+"@wireapp/api-client@npm:^22.14.4":
+  version: 22.14.4
+  resolution: "@wireapp/api-client@npm:22.14.4"
   dependencies:
     "@wireapp/commons": ^5.0.4
     "@wireapp/priority-queue": ^2.0.3
     "@wireapp/protocol-messaging": 1.44.0
     axios: 1.2.2
-    axios-retry: 3.3.1
+    axios-retry: 3.4.0
     http-status-codes: 2.2.0
     logdown: 3.3.1
     reconnecting-websocket: 4.4.0
     spark-md5: 3.0.2
     tough-cookie: 4.1.2
     ws: 8.11.0
-  checksum: 9530414998240a09721aba489c031f6058def4a19b2318c12838569b8a8d9dfd84db0a4a3e956f5670f706c526777e44c06b4832151435a7df44e712c3b16be7
+  checksum: 12ecfa3cae3d39b2b1757861421654311c2de2260589e5d0bbc6be7f9fe07aef7412721b671af860f3922cea7c9e301b3e677383b296f28a318279537eb99a1c
   languageName: node
   linkType: hard
 
@@ -4440,11 +4440,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:38.5.3":
-  version: 38.5.3
-  resolution: "@wireapp/core@npm:38.5.3"
+"@wireapp/core@npm:38.5.4":
+  version: 38.5.4
+  resolution: "@wireapp/core@npm:38.5.4"
   dependencies:
-    "@wireapp/api-client": ^22.14.3
+    "@wireapp/api-client": ^22.14.4
     "@wireapp/commons": ^5.0.4
     "@wireapp/core-crypto": 0.6.0-rc.3
     "@wireapp/cryptobox": 12.8.0
@@ -4460,7 +4460,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.13
-  checksum: 03167f87fcd046f632f97c9a21ee57a67a6ac840629a318ce51f2badf5fd5c3a9ad02e34b657b75dc5270cb3853ed809f8000bd106e3dbe97ea236e21d64ca48
+  checksum: e3c6c03c4be587b72b33fde2d3861342e2f0bfa095b7b200f9fd4ecd331303faf3f07c1d477de0bb738e0e097aeb45b9896ba0daa816347a2d68b0ebc16a5439
   languageName: node
   linkType: hard
 
@@ -5271,13 +5271,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios-retry@npm:3.3.1":
-  version: 3.3.1
-  resolution: "axios-retry@npm:3.3.1"
+"axios-retry@npm:3.4.0":
+  version: 3.4.0
+  resolution: "axios-retry@npm:3.4.0"
   dependencies:
     "@babel/runtime": ^7.15.4
     is-retry-allowed: ^2.2.0
-  checksum: 125c75e08048a28de5d0dfa9de9a1924185d863a4323a71472646a1d5a326f727ff59e75e1b557220da1aad7cba01222c47c26194c5940f295378668dd3b9163
+  checksum: fae18aeef220cfde22f93ed663d644e1a913a5cfc9760904ffd7a7e5ec8c7fbd53a58e1be461b6b30de19dce178823630655bcb77a487e17000f5e977ef94a2e
   languageName: node
   linkType: hard
 
@@ -16766,7 +16766,7 @@ __metadata:
     "@typescript-eslint/parser": ^5.48.2
     "@wireapp/avs": 8.2.30
     "@wireapp/copy-config": 2.0.5
-    "@wireapp/core": 38.5.3
+    "@wireapp/core": 38.5.4
     "@wireapp/eslint-config": 2.1.1
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.5.2


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1452" title="FS-1452" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />FS-1452</a>  [Web] Remove deprecated GET /conversation/:cnv
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This will make all the calls to get a single conversation using qualified ids 

see https://github.com/wireapp/wire-web-packages/pull/4807