### PR TITLE
chore: Run Github Actions on a more powerful machine

### DIFF
--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test_build_deploy:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-2vcpu-ubuntu-2204
 
     env:
       TEST_COVERAGE_FAIL_THRESHOLD: 45


### PR DESCRIPTION
In order to improve our feedback loop, we are going to give a try to BuildJet machines for running the CI. 
(see https://buildjet.com/for-github-actions/docs/runners) 