### PR TITLE
chore: Replace deprecated gha-yarn-cache with native setup-node cache

### DIFF
--- a/.github/workflows/create_docker_image.yml
+++ b/.github/workflows/create_docker_image.yml
@@ -22,13 +22,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use latest Node.js v16
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
-
-      - name: Yarn cache
-        uses: c-hive/gha-yarn-cache@v2.1.0
+          cache: 'yarn'
 
       - name: Install JS dependencies
         run: yarn --immutable

--- a/.github/workflows/deploy-to-test-env.yml
+++ b/.github/workflows/deploy-to-test-env.yml
@@ -35,13 +35,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use latest Node.js v16
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
-
-      - name: Yarn cache
-        uses: c-hive/gha-yarn-cache@v2.1.0
+          cache: 'yarn'
 
       - name: Install JS dependencies
         run: yarn --immutable

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,8 +18,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Yarn cache
-        uses: c-hive/gha-yarn-cache@v2.1.0
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: 'yarn'
 
       - name: Install JS dependencies
         run: yarn --immutable

--- a/.github/workflows/sync_translations.yml
+++ b/.github/workflows/sync_translations.yml
@@ -19,8 +19,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Yarn cache
-        uses: c-hive/gha-yarn-cache@v2.1.0
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: 'yarn'
 
       - name: Authenticate git clone
         env:

--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -32,10 +32,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use latest Node.js v16
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
+          cache: 'yarn'
 
       - name: Set environment variables
         run: |
@@ -65,9 +66,6 @@ jobs:
           contains(env.TITLE || env.PR_LAST_COMMIT_MESSAGE, '[skip ci]') ||
           contains(env.TITLE || env.PR_LAST_COMMIT_MESSAGE, '[ci skip]')
         uses: andymckay/cancel-action@0.3
-
-      - name: Yarn cache
-        uses: c-hive/gha-yarn-cache@v2.1.0
 
       - name: Authenticate git clone
         env:


### PR DESCRIPTION
see https://github.com/marketplace/actions/yarn-install-cache#deprecated for deprecation warning 