### PR TITLE
refactor: Make CallingRepository a little more stateless

### DIFF
--- a/src/script/calling/CallingRepository.test.ts
+++ b/src/script/calling/CallingRepository.test.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import {amplify} from 'amplify';
 import 'jsdom-worker';
 import ko, {Subscription} from 'knockout';
 
@@ -38,7 +37,6 @@ import {createRandomUuid} from 'Util/util';
 import {CALL_MESSAGE_TYPE} from './enum/CallMessageType';
 import {LEAVE_CALL_REASON} from './enum/LeaveCallReason';
 
-import {usePrimaryModalState} from '../components/Modals/PrimaryModal';
 import {CALL} from '../event/Client';
 import {MediaDevicesHandler} from '../media/MediaDevicesHandler';
 import {UserRepository} from '../user/UserRepository';
@@ -87,30 +85,6 @@ describe('CallingRepository', () => {
   });
 
   describe('startCall', () => {
-    it('warns the user that there is an ongoing call before starting a new one', done => {
-      const activeCall = new Call(
-        selfUser.qualifiedId,
-        createConversationId(),
-        CONV_TYPE.ONEONONE,
-        new Participant(new User(), ''),
-        0,
-        {currentAvailableDeviceId: mediaDevices} as MediaDevicesHandler,
-      );
-      activeCall.state(CALL_STATE.MEDIA_ESTAB);
-      spyOn(callingRepository['callState'], 'calls').and.returnValue([activeCall]);
-      spyOn(amplify, 'publish').and.returnValue(undefined);
-      const conversationId = createConversationId();
-      const conversationType = CONV_TYPE.ONEONONE;
-      const callType = CALL_TYPE.NORMAL;
-      spyOn(wCall, 'start');
-      callingRepository.startCall(conversationId, conversationType, callType).catch(done);
-      setTimeout(() => {
-        expect(usePrimaryModalState.getState().currentModalId).not.toBeNull();
-        expect(wCall.start).not.toHaveBeenCalled();
-        done();
-      }, 10);
-    });
-
     it('starts a normal call in a 1:1 conversation', () => {
       const conversationId = createConversationId();
       const conversationType = CONV_TYPE.ONEONONE;

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -849,18 +849,14 @@ export class CallingRepository {
     this.wCall?.reject(this.wUser, this.serializeQualifiedId(conversationId));
   }
 
-  changeCallPage(newPage: number, call: Call): void {
+  changeCallPage(call: Call, newPage: number): void {
     call.currentPage(newPage);
     if (!this.callState.isSpeakersViewActive()) {
-      this.requestCurrentPageVideoStreams();
+      this.requestCurrentPageVideoStreams(call);
     }
   }
 
-  requestCurrentPageVideoStreams(): void {
-    const call = this.callState.joinedCall();
-    if (!call) {
-      return;
-    }
+  requestCurrentPageVideoStreams(call: Call): void {
     const currentPageParticipants = call.pages()[call.currentPage()];
     this.requestVideoStreams(call.conversationId, currentPageParticipants);
   }
@@ -1436,7 +1432,7 @@ export class CallingRepository {
     }
 
     call.updatePages();
-    this.changeCallPage(call.currentPage(), call);
+    this.changeCallPage(call, call.currentPage());
   }
 
   private readonly handleCallParticipantChanges = (convId: SerializedConversationId, membersJson: string) => {

--- a/src/script/components/calling/CallingOverlayContainer.tsx
+++ b/src/script/components/calling/CallingOverlayContainer.tsx
@@ -91,7 +91,7 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
   };
 
   const changePage = (newPage: number, call: Call) => {
-    callingRepository.changeCallPage(newPage, call);
+    callingRepository.changeCallPage(call, newPage);
   };
 
   const leave = (call: Call) => {

--- a/src/script/components/calling/CallingOverlayContainer.tsx
+++ b/src/script/components/calling/CallingOverlayContainer.tsx
@@ -106,8 +106,8 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
 
   const setActiveCallViewTab = (tab: string) => {
     callState.activeCallViewTab(tab);
-    if (tab === CallViewTab.ALL) {
-      callingRepository.requestCurrentPageVideoStreams();
+    if (tab === CallViewTab.ALL && joinedCall) {
+      callingRepository.requestCurrentPageVideoStreams(joinedCall);
     }
   };
 

--- a/src/script/view_model/CallingViewModel.test.ts
+++ b/src/script/view_model/CallingViewModel.test.ts
@@ -1,0 +1,141 @@
+/*
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import ko from 'knockout';
+
+import {CALL_TYPE, CONV_TYPE, STATE} from '@wireapp/avs';
+
+import {PrimaryModal} from 'Components/Modals/PrimaryModal';
+import {createRandomUuid} from 'Util/util';
+
+import {CallingViewModel} from './CallingViewModel';
+
+import {Call} from '../calling/Call';
+import {CallingRepository} from '../calling/CallingRepository';
+import {CallState} from '../calling/CallState';
+import {LEAVE_CALL_REASON} from '../calling/enum/LeaveCallReason';
+import {Conversation} from '../entity/Conversation';
+
+const mockCallingRepository = {
+  startCall: jest.fn(),
+  answerCall: jest.fn(),
+  leaveCall: jest.fn(),
+  onIncomingCall: jest.fn(),
+} as unknown as CallingRepository;
+
+const callState = new CallState();
+
+function buildCall(conversationId: string) {
+  return new Call(
+    {id: 'user1', domain: ''},
+    {id: conversationId, domain: ''},
+    CONV_TYPE.ONEONONE,
+    {} as any,
+    CALL_TYPE.NORMAL,
+    {currentAvailableDeviceId: {audioOutput: ko.observable()}} as any,
+  );
+}
+
+function buildCallingViewModel() {
+  return new CallingViewModel(
+    mockCallingRepository,
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    undefined,
+    callState,
+  );
+}
+
+describe('CallingViewModel', () => {
+  afterEach(() => {
+    callState.calls.removeAll();
+  });
+
+  describe('answerCall', () => {
+    it('answers a call directly if no call is ongoing', async () => {
+      const callingViewModel = buildCallingViewModel();
+      const call = buildCall('conversation1');
+      await callingViewModel.callActions.answer(call);
+      expect(mockCallingRepository.answerCall).toHaveBeenCalledWith(call);
+    });
+
+    it('lets the user leave previous call before answering a new one', async () => {
+      jest.useFakeTimers();
+      const callingViewModel = buildCallingViewModel();
+      const joinedCall = buildCall('conversation1');
+      joinedCall.state(STATE.MEDIA_ESTAB);
+      callState.calls.push(joinedCall);
+
+      jest.spyOn(PrimaryModal, 'show').mockImplementation((_, payload) => payload.primaryAction?.action?.());
+      const newCall = buildCall('conversation2');
+      Promise.resolve().then(() => {
+        jest.runAllTimers();
+      });
+      await callingViewModel.callActions.answer(newCall);
+      expect(mockCallingRepository.leaveCall).toHaveBeenCalledWith(
+        joinedCall.conversationId,
+        LEAVE_CALL_REASON.MANUAL_LEAVE_TO_JOIN_ANOTHER_CALL,
+      );
+      expect(mockCallingRepository.answerCall).toHaveBeenCalledWith(newCall);
+    });
+  });
+
+  describe('startCall', () => {
+    it('starts a call directly if no call is ongoing', async () => {
+      const callingViewModel = buildCallingViewModel();
+      const conversation = new Conversation(createRandomUuid());
+      await callingViewModel.callActions.startAudio(conversation);
+      expect(mockCallingRepository.startCall).toHaveBeenCalledWith(
+        conversation.qualifiedId,
+        CONV_TYPE.ONEONONE,
+        CALL_TYPE.NORMAL,
+      );
+    });
+
+    it('lets the user leave previous call before starting a new one', async () => {
+      jest.useFakeTimers();
+      const callingViewModel = buildCallingViewModel();
+      const joinedCall = buildCall('conversation1');
+      joinedCall.state(STATE.MEDIA_ESTAB);
+      callState.calls.push(joinedCall);
+
+      jest.spyOn(PrimaryModal, 'show').mockImplementation((_, payload) => payload.primaryAction?.action?.());
+      const conversation = new Conversation('conversation2');
+      Promise.resolve().then(() => {
+        jest.runAllTimers();
+      });
+      await callingViewModel.callActions.startAudio(conversation);
+      expect(mockCallingRepository.leaveCall).toHaveBeenCalledWith(
+        joinedCall.conversationId,
+        LEAVE_CALL_REASON.MANUAL_LEAVE_TO_JOIN_ANOTHER_CALL,
+      );
+      expect(mockCallingRepository.startCall).toHaveBeenCalledWith(
+        conversation.qualifiedId,
+        CONV_TYPE.ONEONONE,
+        CALL_TYPE.NORMAL,
+      );
+    });
+  });
+});

--- a/src/script/view_model/CallingViewModel.ts
+++ b/src/script/view_model/CallingViewModel.ts
@@ -53,12 +53,12 @@ import {TeamState} from '../team/TeamState';
 import {ROLE} from '../user/UserPermission';
 
 export interface CallActions {
-  answer: (call: Call) => void;
+  answer: (call: Call) => Promise<void>;
   changePage: (newPage: number, call: Call) => void;
   leave: (call: Call) => void;
   reject: (call: Call) => void;
-  startAudio: (conversationEntity: Conversation) => void;
-  startVideo: (conversationEntity: Conversation) => void;
+  startAudio: (conversationEntity: Conversation) => Promise<void>;
+  startVideo: (conversationEntity: Conversation) => Promise<void>;
   switchCameraInput: (call: Call, deviceId: string) => void;
   switchScreenInput: (call: Call, deviceId: string) => void;
   toggleCamera: (call: Call) => void;
@@ -209,18 +209,18 @@ export class CallingViewModel {
       reject: (call: Call) => {
         this.callingRepository.rejectCall(call.conversationId);
       },
-      startAudio: (conversationEntity: Conversation): void => {
+      startAudio: async (conversationEntity: Conversation) => {
         if (conversationEntity.isGroup() && !this.teamState.isConferenceCallingEnabled()) {
           this.showRestrictedConferenceCallingModal();
         } else {
-          startCall(conversationEntity, CALL_TYPE.NORMAL);
+          await startCall(conversationEntity, CALL_TYPE.NORMAL);
         }
       },
-      startVideo: (conversationEntity: Conversation): void => {
+      startVideo: async (conversationEntity: Conversation) => {
         if (conversationEntity.isGroup() && !this.teamState.isConferenceCallingEnabled()) {
           this.showRestrictedConferenceCallingModal();
         } else {
-          startCall(conversationEntity, CALL_TYPE.VIDEO);
+          await startCall(conversationEntity, CALL_TYPE.VIDEO);
         }
       },
       switchCameraInput: (call: Call, deviceId: string) => {

--- a/src/script/view_model/CallingViewModel.ts
+++ b/src/script/view_model/CallingViewModel.ts
@@ -172,15 +172,6 @@ export class CallingViewModel {
 
     this.callActions = {
       answer: async (call: Call) => {
-        const canAnwer = await this.canInitiateCall(call.conversationId, {
-          action: t('modalCallSecondIncomingAction'),
-          message: t('modalCallSecondIncomingMessage'),
-          title: t('modalCallSecondIncomingHeadline'),
-        });
-        if (!canAnwer) {
-          return;
-        }
-
         if (call.conversationType === CONV_TYPE.CONFERENCE && !this.callingRepository.supportsConferenceCalling) {
           PrimaryModal.show(PrimaryModal.type.ACKNOWLEDGE, {
             primaryAction: {
@@ -196,6 +187,15 @@ export class CallingViewModel {
             },
           });
         } else {
+          const canAnwer = await this.canInitiateCall(call.conversationId, {
+            action: t('modalCallSecondIncomingAction'),
+            message: t('modalCallSecondIncomingMessage'),
+            title: t('modalCallSecondIncomingHeadline'),
+          });
+          if (!canAnwer) {
+            return;
+          }
+
           this.callingRepository.answerCall(call);
         }
       },

--- a/src/script/view_model/CallingViewModel.ts
+++ b/src/script/view_model/CallingViewModel.ts
@@ -182,7 +182,7 @@ export class CallingViewModel {
         }
       },
       changePage: (newPage, call) => {
-        this.callingRepository.changeCallPage(newPage, call);
+        this.callingRepository.changeCallPage(call, newPage);
       },
       leave: (call: Call) => {
         this.callingRepository.leaveCall(call.conversationId, LEAVE_CALL_REASON.MANUAL_LEAVE_BY_UI_CLICK);


### PR DESCRIPTION
This will move the view-related logic from the calling repository to the view model (where it should have belonged in the first place). 

This touches those 2 scenarios:

Answering a call that is ringing when a call is already ongoing in another conversation:

https://user-images.githubusercontent.com/1090716/214856074-47028a4d-f4ef-4ed6-b04c-091bfb513c10.mov



Starting a call while another one is already ongoing:

https://user-images.githubusercontent.com/1090716/214856102-41a222fa-176b-46d8-8440-346b893867a2.mov


