### PR TITLE
fix: change default font weight from 300 to 400 [ACC-436]

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@wireapp/avs": "8.2.30",
     "@wireapp/core": "38.5.4",
     "@wireapp/lru-cache": "3.8.1",
-    "@wireapp/react-ui-kit": "9.3.3",
+    "@wireapp/react-ui-kit": "9.3.4",
     "@wireapp/store-engine-dexie": "2.0.4",
     "@wireapp/store-engine-sqleet": "1.8.9",
     "@wireapp/webapp-events": "0.16.0",

--- a/src/style/common/tooltip.less
+++ b/src/style/common/tooltip.less
@@ -72,7 +72,7 @@
       padding: 4px;
       color: var(--background-fade-48);
       font-size: @font-size-xsmall;
-      font-weight: @font-weight-light;
+      font-weight: @font-weight-regular;
       transform: translate(0, 16px);
       white-space: nowrap;
     }
@@ -89,7 +89,7 @@
       background-color: #fff;
       color: #9fa1a2;
       font-size: @font-size-xsmall;
-      font-weight: @font-weight-light;
+      font-weight: @font-weight-regular;
       transform: translate(-50%, 4px);
       white-space: nowrap;
     }

--- a/src/style/common/typing.less
+++ b/src/style/common/typing.less
@@ -98,7 +98,7 @@
 
 .label-base {
   font-size: @font-size-base;
-  font-weight: @font-weight-light;
+  font-weight: @font-weight-regular;
   line-height: @line-height-lg;
 }
 
@@ -115,7 +115,7 @@
 
 .text-input {
   font-size: @font-size-base;
-  font-weight: @font-weight-light;
+  font-weight: @font-weight-regular;
   line-height: @line-height-lg;
 }
 

--- a/src/style/components/asset/message-button.less
+++ b/src/style/components/asset/message-button.less
@@ -71,6 +71,6 @@
     margin-top: 4px;
     color: @w-red;
     font-size: @font-size-xs;
-    font-weight: @font-weight-light;
+    font-weight: @font-weight-regular;
   }
 }

--- a/src/style/components/info-toggle.less
+++ b/src/style/components/info-toggle.less
@@ -30,7 +30,7 @@
     margin: 0;
     color: var(--black);
     cursor: pointer;
-    font-weight: @font-weight-light;
+    font-weight: @font-weight-regular;
     line-height: @line-height-lg;
   }
 

--- a/src/style/components/panel-participant-details.less
+++ b/src/style/components/panel-participant-details.less
@@ -137,7 +137,7 @@
 
   &__service-description {
     font-size: @font-size-medium;
-    font-weight: @font-weight-light;
+    font-weight: @font-weight-regular;
   }
 
   &__role-label {

--- a/src/style/content/conversation/input-bar.less
+++ b/src/style/content/conversation/input-bar.less
@@ -337,7 +337,7 @@
     max-width: @conversation-message-max-width;
     margin-top: 4px;
     font-size: @font-size-medium;
-    font-weight: @font-weight-light;
+    font-weight: @font-weight-regular;
     text-overflow: ellipsis;
     white-space: nowrap;
 

--- a/src/style/content/conversation/title-bar.less
+++ b/src/style/content/conversation/title-bar.less
@@ -66,7 +66,7 @@ body.theme-dark {
   background-color: var(--accent-color);
   box-shadow: 0 2px 16px 0 fade(#000, 8%);
   font-size: @font-size-small;
-  font-weight: @font-weight-light;
+  font-weight: @font-weight-regular;
 
   strong {
     font-weight: @font-weight-bold;

--- a/src/style/foundation/base.less
+++ b/src/style/foundation/base.less
@@ -48,14 +48,10 @@ body {
   color: var(--main-color);
   font-family: @font-family-base;
   font-size: @font-size-sm;
-  font-weight: @font-weight-light;
+  font-weight: @font-weight-regular;
   overflow-x: hidden;
   overflow-y: hidden !important;
   text-rendering: optimizeLegibility;
-
-  &.theme-dark {
-    font-weight: @font-weight-regular;
-  }
 }
 
 // Set default icon size

--- a/src/style/panel/add-participants.less
+++ b/src/style/panel/add-participants.less
@@ -59,7 +59,7 @@
   &__service-description {
     padding: 16px;
     font-size: @font-size-medium;
-    font-weight: @font-weight-light;
+    font-weight: @font-weight-regular;
   }
 
   &__footer {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4562,9 +4562,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/react-ui-kit@npm:9.3.3":
-  version: 9.3.3
-  resolution: "@wireapp/react-ui-kit@npm:9.3.3"
+"@wireapp/react-ui-kit@npm:9.3.4":
+  version: 9.3.4
+  resolution: "@wireapp/react-ui-kit@npm:9.3.4"
   dependencies:
     "@types/color": 3.0.3
     color: 4.2.3
@@ -4579,7 +4579,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 68c302cc9c256135c300f0009316e31ca38ac0fd98b8e3469b2f17421ed9ef6b648646732edd3aef17ec5822b38b3a2bfe2ea281e950c5f408f089ba10d33a5a
+  checksum: cda415f53ba3a437b8073f29647deb1d66ed34d4e3ce772cd2a3a7662ae2bbe4ed9cd7d64ba06ebd133c54b955653083369d4226fe70336538d2ec90005e1fcc
   languageName: node
   linkType: hard
 
@@ -16761,7 +16761,7 @@ __metadata:
     "@wireapp/eslint-config": 2.1.1
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.5.2
-    "@wireapp/react-ui-kit": 9.3.3
+    "@wireapp/react-ui-kit": 9.3.4
     "@wireapp/store-engine": ^5.0.3
     "@wireapp/store-engine-dexie": 2.0.4
     "@wireapp/store-engine-sqleet": 1.8.9


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-436" title="ACC-436" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />ACC-436</a>  [Web] Update Font Style for light mode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Issue
- There is feedback on font weight in light mode being too thing,  both general and accessibility related

### Solution
- set default font weight to @font-weight-regular(400) instead of @font-weight-light(300)
- bump ui-kit to the latest version (where font-weight has been changed in the same way)