### PR TITLE
feat: Open user details from message views flow in right sidebar and focus on panel header after opening right panel(ACC-254, ACC-426)

### DIFF
--- a/src/script/page/AppMain.tsx
+++ b/src/script/page/AppMain.tsx
@@ -97,7 +97,13 @@ const AppMain: FC<AppMainProps> = ({
 
   const {isActivatedAccount} = useKoSubscribableChildren(userState, ['isActivatedAccount']);
 
-  const {history, entity: currentEntity, close: closeRightSidebar, goTo} = useAppMainState(state => state.rightSidebar);
+  const {
+    history,
+    entity: currentEntity,
+    close: closeRightSidebar,
+    lastViewedMessageDetailsEntity,
+    goTo,
+  } = useAppMainState(state => state.rightSidebar);
   const currentState = history[history.length - 1];
 
   const toggleRightSidebar = (panelState: PanelState, params: RightSidebarParams, compareEntityId = false) => {
@@ -221,6 +227,7 @@ const AppMain: FC<AppMainProps> = ({
 
             {currentState && (
               <RightSidebar
+                lastViewedMessageDetailsEntity={lastViewedMessageDetailsEntity}
                 currentEntity={currentEntity}
                 repositories={repositories}
                 actionsViewModel={mainView.actions}

--- a/src/script/page/RightSidebar/MessageDetails/MessageDetails.test.tsx
+++ b/src/script/page/RightSidebar/MessageDetails/MessageDetails.test.tsx
@@ -89,6 +89,7 @@ describe('MessageDetails', () => {
     const {getByText} = render(
       <MessageDetails
         {...defaultProps}
+        togglePanel={() => undefined}
         activeConversation={conversation}
         messageEntity={message}
         userRepository={userRepository}

--- a/src/script/page/RightSidebar/MessageDetails/MessageDetails.tsx
+++ b/src/script/page/RightSidebar/MessageDetails/MessageDetails.tsx
@@ -44,6 +44,7 @@ import {UserReactionMap} from '../../../storage';
 import {TeamRepository} from '../../../team/TeamRepository';
 import {UserRepository} from '../../../user/UserRepository';
 import {PanelHeader} from '../PanelHeader';
+import {PanelEntity, PanelState} from '../RightSidebar';
 
 const MESSAGE_STATES = {
   LIKES: 'likes',
@@ -70,6 +71,7 @@ interface MessageDetailsProps {
   userRepository: UserRepository;
   showLikes?: boolean;
   updateEntity: (message: Message) => void;
+  togglePanel: (state: PanelState, entity: PanelEntity, addMode?: boolean) => void;
 }
 
 const MessageDetails: FC<MessageDetailsProps> = ({
@@ -82,6 +84,7 @@ const MessageDetails: FC<MessageDetailsProps> = ({
   userRepository,
   onClose,
   updateEntity,
+  togglePanel,
 }) => {
   const [receiptUsers, setReceiptUsers] = useState<User[]>([]);
   const [likeUsers, setLikeUsers] = useState<User[]>([]);
@@ -189,6 +192,8 @@ const MessageDetails: FC<MessageDetailsProps> = ({
     });
   }, [messageId, supportsLikes]);
 
+  const onParticipantClick = (userEntity: User) => togglePanel(PanelState.GROUP_PARTICIPANT_USER, userEntity);
+
   return (
     <div id="message-details" className="panel__page message-details">
       <PanelHeader
@@ -227,6 +232,7 @@ const MessageDetails: FC<MessageDetailsProps> = ({
             conversationRepository={conversationRepository}
             searchRepository={searchRepository}
             teamRepository={teamRepository}
+            onClick={onParticipantClick}
           />
         )}
 
@@ -238,6 +244,7 @@ const MessageDetails: FC<MessageDetailsProps> = ({
             conversationRepository={conversationRepository}
             searchRepository={searchRepository}
             teamRepository={teamRepository}
+            onClick={onParticipantClick}
           />
         )}
 

--- a/src/script/page/RightSidebar/PanelHeader/PanelHeader.tsx
+++ b/src/script/page/RightSidebar/PanelHeader/PanelHeader.tsx
@@ -67,7 +67,11 @@ const PanelHeader: FC<PanelHeaderProps> = ({
   useEffect(() => {
     if (!!panelHeaderRef.current) {
       const nextElementToFocus = panelHeaderRef.current.querySelector('button');
-      nextElementToFocus?.focus();
+      // TO-DO Remove setTimeout after replacing transition group animation libray
+      // triggering focus method without setTimeout is not working due to right side bar animation
+      setTimeout(() => {
+        nextElementToFocus?.focus();
+      }, 0);
     }
   }, []);
 

--- a/src/script/page/RightSidebar/RightSidebar.tsx
+++ b/src/script/page/RightSidebar/RightSidebar.tsx
@@ -86,6 +86,7 @@ interface RightSidebarProps {
   teamState: TeamState;
   userState: UserState;
   isFederated: boolean;
+  lastViewedMessageDetailsEntity: Message | null;
 }
 
 const RightSidebar: FC<RightSidebarProps> = ({
@@ -95,6 +96,7 @@ const RightSidebar: FC<RightSidebarProps> = ({
   teamState,
   userState,
   isFederated,
+  lastViewedMessageDetailsEntity,
 }) => {
   const {
     conversation: conversationRepository,
@@ -105,7 +107,6 @@ const RightSidebar: FC<RightSidebarProps> = ({
   } = repositories;
   const {conversationRoleRepository} = conversationRepository;
   const conversationState = container.resolve(ConversationState);
-
   const {activeConversation} = useKoSubscribableChildren(conversationState, ['activeConversation']);
 
   const [isAddMode, setIsAddMode] = useState<boolean>(false);
@@ -134,6 +135,12 @@ const RightSidebar: FC<RightSidebarProps> = ({
     const previousHistory = rightSidebar.history.slice(0, -1);
     const hasPreviousHistory = !!previousHistory.length;
     setAnimatePanelToLeft(false);
+
+    if (hasPreviousHistory && previousHistory.length === 1 && previousHistory[0] === PanelState.MESSAGE_DETAILS) {
+      rightSidebar.goBack(lastViewedMessageDetailsEntity);
+
+      return;
+    }
 
     if (hasPreviousHistory) {
       rightSidebar.goBack(entity);
@@ -301,6 +308,7 @@ const RightSidebar: FC<RightSidebarProps> = ({
               showLikes={rightSidebar.showLikes}
               userRepository={userRepository}
               onClose={closePanel}
+              togglePanel={togglePanel}
             />
           )}
 

--- a/src/script/page/state.ts
+++ b/src/script/page/state.ts
@@ -21,6 +21,7 @@ import {create} from 'zustand';
 
 import {PanelEntity, PanelState} from './RightSidebar';
 
+import {Message} from '../entity/message/Message';
 import {User} from '../entity/User';
 
 export enum ViewType {
@@ -48,6 +49,7 @@ type AppMainState = {
     highlightedUsers: RightSidebarParams['highlighted'];
     history: PanelState[];
     showLikes: RightSidebarParams['showLikes'];
+    lastViewedMessageDetailsEntity: Message | null;
     updateEntity: (entity: RightSidebarParams['entity']) => void;
   };
 };
@@ -72,6 +74,7 @@ const useAppMainState = create<AppMainState>((set, get) => ({
         },
       })),
     entity: null,
+    lastViewedMessageDetailsEntity: null,
     goBack: (entity: RightSidebarParams['entity']) =>
       set(state => ({
         ...state,
@@ -84,11 +87,15 @@ const useAppMainState = create<AppMainState>((set, get) => ({
         const previousState = rightSidebar.history[lastItem];
         const replacedNewState = previousState === panel ? rightSidebar.history.slice(0, -1) : rightSidebar.history;
 
+        const lastViewedMessageDetailsEntity =
+          params?.entity instanceof Message ? params.entity : state.rightSidebar.lastViewedMessageDetailsEntity;
+
         return {
           ...state,
           rightSidebar: {
             ...state.rightSidebar,
             entity: params?.entity || null,
+            lastViewedMessageDetailsEntity,
             highlightedUsers: params?.highlighted || [],
             history: [...replacedNewState, panel],
             showLikes: !!params?.showLikes,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-254" title="ACC-254" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-254</a>  Cannot open user profile from read recipient menu
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
The flow of opening a user profile from message views/like menu in sidebar was never implemented, this PR has implementation of the mentioned flow. 
When user opens any of the right panel items like participant profile details/notifications etc the right panel header back button/close button should get the focus after the panel opened.

### Description
`Flow 1`: From Message read receipts menu is opened -> a user is clicked -> user details view is opened.
`Flow 2 (Reversed 1)`: From user details view -> back button is clicked -> read receipts menu is opened.

### Challenge: **No way to know the message entity to go back to it in Flow 2**
### Solution: 
`onBackClick` which is passed to `GroupParticipantUser` for the reverse flow needs to know **last entity (Message)** to be able to go back to it.
This PR adds a new property called `lastViewedMessageDetailsEntity` to **rightSidebar state** then when `onBackClick` is fired it is checked if previous history is MESSAGE_DETAILS (read receipts menu) then we should go back to it (go back to -> MESSAGE_DETAILS/read receipts menu view). 
At this point the `lastViewedMessageDetailsEntity` is used to be able to go back.
