### PR TITLE
fix: [Web] Improve aria-labels on search fields(ACC-439)

### DIFF
--- a/src/i18n/ar-SA.json
+++ b/src/i18n/ar-SA.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "تواصل",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "أشخاص",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "أضف خدمة",
   "searchServicePlaceholder": "البحث بحسب الاسم",
   "searchServices": "الخدمات",

--- a/src/i18n/bn-BD.json
+++ b/src/i18n/bn-BD.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Connect",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "People",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Search by name",
   "searchServices": "Services",

--- a/src/i18n/ca-ES.json
+++ b/src/i18n/ca-ES.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Connect",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "People",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Search by name",
   "searchServices": "Services",

--- a/src/i18n/cs-CZ.json
+++ b/src/i18n/cs-CZ.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Připojit",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "Kontakty",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Hledat podle jména",
   "searchServices": "Služby",

--- a/src/i18n/da-DK.json
+++ b/src/i18n/da-DK.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Forbind",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "Personer",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Tilføj tjeneste",
   "searchServicePlaceholder": "Søg ved navn",
   "searchServices": "Tjenester",

--- a/src/i18n/de-DE.json
+++ b/src/i18n/de-DE.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Suchergebnisse",
   "searchOthersFederation": "Mit {{domainName}} verbinden",
   "searchPeople": "Kontakte",
-  "searchPlaceholder": "Suche",
+  "searchPeoplePlaceholder": "Suche",
   "searchServiceConfirmButton": "Unterhaltung öffnen",
   "searchServicePlaceholder": "Nach Namen suchen",
   "searchServices": "Dienste",

--- a/src/i18n/el-GR.json
+++ b/src/i18n/el-GR.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Σύνδεση",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "Άτομα",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Αναζήτηση βάση ονόματος",
   "searchServices": "Υπηρεσίες",

--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Connect",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "People",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search people by name or username",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Search by name",
   "searchServices": "Services",

--- a/src/i18n/es-ES.json
+++ b/src/i18n/es-ES.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Conectar",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "Personas",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Abrir conversación",
   "searchServicePlaceholder": "Buscar por nombre",
   "searchServices": "Servicios",

--- a/src/i18n/et-EE.json
+++ b/src/i18n/et-EE.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Ühendu",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "Inimesed",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Lisa teenus",
   "searchServicePlaceholder": "Otsi nime järgi",
   "searchServices": "Teenused",

--- a/src/i18n/fa-IR.json
+++ b/src/i18n/fa-IR.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "درخواست دوستی",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "افراد",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "جستجو بر اساس نام",
   "searchServices": "سرویس‌ها",

--- a/src/i18n/fi-FI.json
+++ b/src/i18n/fi-FI.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Yhdistä",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "Ihmiset",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Hae nimellä",
   "searchServices": "Palvelut",

--- a/src/i18n/fr-FR.json
+++ b/src/i18n/fr-FR.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Se connecter",
   "searchOthersFederation": "Se connecter à {{domainName}}",
   "searchPeople": "Contacts",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Ajouter un service",
   "searchServicePlaceholder": "Rechercher par nom",
   "searchServices": "Services",

--- a/src/i18n/ga-IE.json
+++ b/src/i18n/ga-IE.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Connect",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "People",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Search by name",
   "searchServices": "Services",

--- a/src/i18n/he-IL.json
+++ b/src/i18n/he-IL.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Connect",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "People",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Search by name",
   "searchServices": "Services",

--- a/src/i18n/hi-IN.json
+++ b/src/i18n/hi-IN.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Connect",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "People",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Search by name",
   "searchServices": "Services",

--- a/src/i18n/hr-HR.json
+++ b/src/i18n/hr-HR.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Poveži se",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "Kontakti",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Otvori razgovor",
   "searchServicePlaceholder": "Traži po imenu",
   "searchServices": "Usluge",

--- a/src/i18n/hu-HU.json
+++ b/src/i18n/hu-HU.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Csatlakozás",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "Partner",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Új szolgáltatás",
   "searchServicePlaceholder": "Keresés név szerint",
   "searchServices": "Szolgáltatások",

--- a/src/i18n/id-ID.json
+++ b/src/i18n/id-ID.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Hubungkan",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "Orang",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Cari berdasarkan nama",
   "searchServices": "Layanan",

--- a/src/i18n/is-IS.json
+++ b/src/i18n/is-IS.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Connect",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "People",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Search by name",
   "searchServices": "Services",

--- a/src/i18n/it-IT.json
+++ b/src/i18n/it-IT.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Connetti",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "Persone",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Cerca per nome",
   "searchServices": "Servizi",

--- a/src/i18n/ja-JP.json
+++ b/src/i18n/ja-JP.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "つながる",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "メンバー",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "サービスを追加",
   "searchServicePlaceholder": "名前で検索する",
   "searchServices": "サービス",

--- a/src/i18n/lt-LT.json
+++ b/src/i18n/lt-LT.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Užmegzti kontaktą",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "Žmonės",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Pridėti paslaugą",
   "searchServicePlaceholder": "Ieškokite pagal vardą",
   "searchServices": "Paslaugos",

--- a/src/i18n/lv-LV.json
+++ b/src/i18n/lv-LV.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Pievienoties",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "Personas",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Search by name",
   "searchServices": "Pakalpojumi",

--- a/src/i18n/ms-MY.json
+++ b/src/i18n/ms-MY.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Connect",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "People",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Search by name",
   "searchServices": "Services",

--- a/src/i18n/nl-NL.json
+++ b/src/i18n/nl-NL.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Verbind",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "Deelnemers",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Service toevoegen",
   "searchServicePlaceholder": "Zoeken op naam",
   "searchServices": "Services",

--- a/src/i18n/no-NO.json
+++ b/src/i18n/no-NO.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Connect",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "Kontakter",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Search by name",
   "searchServices": "Tjenester",

--- a/src/i18n/pl-PL.json
+++ b/src/i18n/pl-PL.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Połącz",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "Osoby",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Szukaj według nazwy",
   "searchServices": "Usługi",

--- a/src/i18n/pt-BR.json
+++ b/src/i18n/pt-BR.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Conectar",
   "searchOthersFederation": "Conectar com o {{domainName}}",
   "searchPeople": "Pessoas",
-  "searchPlaceholder": "Pesquisar",
+  "searchPeoplePlaceholder": "Pesquisar",
   "searchServiceConfirmButton": "Abrir conversa",
   "searchServicePlaceholder": "Pesquisar por nome",
   "searchServices": "Serviços",

--- a/src/i18n/pt-PT.json
+++ b/src/i18n/pt-PT.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Ligar",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "Pessoas",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Pesquisar por nome",
   "searchServices": "Serviços",

--- a/src/i18n/ro-RO.json
+++ b/src/i18n/ro-RO.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Conectare",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "Persoane",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Adaugă serviciu",
   "searchServicePlaceholder": "Caută după nume",
   "searchServices": "Servicii",

--- a/src/i18n/ru-RU.json
+++ b/src/i18n/ru-RU.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Связаться",
   "searchOthersFederation": "Подключиться к {{domainName}}",
   "searchPeople": "Участники",
-  "searchPlaceholder": "Поиск",
+  "searchPeoplePlaceholder": "Поиск",
   "searchServiceConfirmButton": "Добавить сервис",
   "searchServicePlaceholder": "Поиск по имени",
   "searchServices": "Сервисы",

--- a/src/i18n/si-LK.json
+++ b/src/i18n/si-LK.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Connect",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "People",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Search by name",
   "searchServices": "Services",

--- a/src/i18n/sk-SK.json
+++ b/src/i18n/sk-SK.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Pripojiť",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "Ľudia",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Vyhľadať podľa mena",
   "searchServices": "Služby",

--- a/src/i18n/sl-SI.json
+++ b/src/i18n/sl-SI.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Poveži",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "Osebe",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Iskanje po imenu",
   "searchServices": "Storitve",

--- a/src/i18n/sr-SP.json
+++ b/src/i18n/sr-SP.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Повежи се",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "Особе",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Отворени разговор",
   "searchServicePlaceholder": "Претрага по имену",
   "searchServices": "Услуге",

--- a/src/i18n/sv-SE.json
+++ b/src/i18n/sv-SE.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Anslut",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "Personer",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Lägg till tjänst",
   "searchServicePlaceholder": "Sök efter namn",
   "searchServices": "Tjänster",

--- a/src/i18n/th-TH.json
+++ b/src/i18n/th-TH.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Connect",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "People",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Search by name",
   "searchServices": "Services",

--- a/src/i18n/tr-TR.json
+++ b/src/i18n/tr-TR.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Bağlan",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "İnsanlar",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Sohbet Başlat",
   "searchServicePlaceholder": "İsme göre ara",
   "searchServices": "Servisler",

--- a/src/i18n/uk-UA.json
+++ b/src/i18n/uk-UA.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Додати до контактів",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "Список контактів",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Додати сервіс",
   "searchServicePlaceholder": "Пошук за іменем",
   "searchServices": "Сервіси",

--- a/src/i18n/uz-UZ.json
+++ b/src/i18n/uz-UZ.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Connect",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "People",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Search by name",
   "searchServices": "Services",

--- a/src/i18n/vi-VN.json
+++ b/src/i18n/vi-VN.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Connect",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "People",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Search by name",
   "searchServices": "Services",

--- a/src/i18n/zh-CN.json
+++ b/src/i18n/zh-CN.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "好友请求",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "联系人",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "添加服务",
   "searchServicePlaceholder": "按名字搜索",
   "searchServices": "服务",

--- a/src/i18n/zh-HK.json
+++ b/src/i18n/zh-HK.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "Connect",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "People",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Search by name",
   "searchServices": "Services",

--- a/src/i18n/zh-TW.json
+++ b/src/i18n/zh-TW.json
@@ -1115,7 +1115,7 @@
   "searchOthers": "連接",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "聯絡人",
-  "searchPlaceholder": "Search",
+  "searchPeoplePlaceholder": "Search",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "按名稱搜尋",
   "searchServices": "服務",

--- a/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
@@ -146,7 +146,7 @@ const StartUI: React.FC<StartUIProps> = ({
       <div className="start-ui-header-user-input" data-uie-name="enter-search">
         <SearchInput
           input={searchQuery}
-          placeholder={t('searchPlaceholder')}
+          placeholder={t('searchPeoplePlaceholder')}
           selectedUsers={[]}
           setInput={setSearchQuery}
           enter={openFirstConversation}

--- a/src/script/page/MainContent/panels/Collection/FullSearch.tsx
+++ b/src/script/page/MainContent/panels/Collection/FullSearch.tsx
@@ -131,7 +131,7 @@ const FullSearch: React.FC<FullSearchProps> = ({searchProvider, click = noop, ch
             type="text"
             value={searchValue}
             ref={inputRef}
-            aria-label={t('tooltipConversationSearch')}
+            aria-label={t('fullsearchPlaceholder')}
             placeholder={t('fullsearchPlaceholder')}
             onChange={event => setSearchValue(event.currentTarget.value)}
             data-uie-name="full-search-header-input"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-439" title="ACC-439" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />ACC-439</a>  [Web] Improve aria-labels on search fields
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - Improve aria-labels on search fields

- The **PR Description**
  - We currently have search fields for searching within a conversation as well as searching for contacts under the contacts tab. During user testing, it was identified that these fields are hard to distinguish between for visually impaired/blind users.
----

# What's new in this PR?

### Issues

- update aria-label for Conversation search field 
- update aria-label for Contact search field under contacts tab

##### References
1. https://wearezeta.atlassian.net/browse/ACC-439
