### PR TITLE
feat: Do not show user status in input bar placeholder (ACC-443)

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -1176,6 +1176,7 @@
   "tooltipConversationDetailsAddPeople": "Add participants to conversation ({{shortcut}})",
   "tooltipConversationDetailsRename": "Change conversation name",
   "tooltipConversationEphemeral": "Self-deleting message",
+  "tooltipConversationEphemeralAriaLabel": "Type a self-deleting message, currently set to {{time}}",
   "tooltipConversationFile": "Add file",
   "tooltipConversationInfo": "Conversation info",
   "tooltipConversationInputMoreThanTwoUserTyping": "{{user1}} and {{count}} more people are typing",

--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -17,13 +17,12 @@
  *
  */
 
-import {ChangeEvent, FormEvent, KeyboardEvent as ReactKeyboardEvent, useEffect, useMemo, useRef, useState} from 'react';
+import {ChangeEvent, FormEvent, KeyboardEvent as ReactKeyboardEvent, useEffect, useRef, useState} from 'react';
 
 import {amplify} from 'amplify';
 import cx from 'classnames';
 import {container} from 'tsyringe';
 
-import {Availability} from '@wireapp/protocol-messaging';
 import {useMatchMedia} from '@wireapp/react-ui-kit';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
@@ -125,16 +124,13 @@ const InputBar = ({
     ['classifiedDomains', 'isSelfDeletingMessagesEnabled', 'isFileSharingSendingEnabled'],
   );
   const {self: selfUser} = useKoSubscribableChildren(userState, ['self']);
-  const {inTeam} = useKoSubscribableChildren(selfUser, ['inTeam']);
   const {
     connection,
-    firstUserEntity,
     participating_user_ets: participatingUserEts,
     localMessageTimer,
     messageTimer,
     hasGlobalMessageTimer,
     removed_from_conversation: removedFromConversation,
-    is1to1,
   } = useKoSubscribableChildren(conversationEntity, [
     'connection',
     'firstUserEntity',
@@ -145,7 +141,6 @@ const InputBar = ({
     'removed_from_conversation',
     'is1to1',
   ]);
-  const {availability} = useKoSubscribableChildren(firstUserEntity, ['availability']);
   const {isOutgoingRequest, isIncomingRequest} = useKoSubscribableChildren(connection, [
     'isOutgoingRequest',
     'isIncomingRequest',
@@ -173,21 +168,7 @@ const InputBar = ({
   const currentState = rightSidebar.history[lastItem];
   const isRightSidebarOpen = !!currentState;
 
-  const availabilityIsNone = availability === Availability.Type.NONE;
-  const showAvailabilityTooltip = firstUserEntity && inTeam && is1to1 && !availabilityIsNone;
-  const availabilityStrings: Record<string, string> = {
-    [Availability.Type.AVAILABLE]: t('userAvailabilityAvailable'),
-    [Availability.Type.AWAY]: t('userAvailabilityAway'),
-    [Availability.Type.BUSY]: t('userAvailabilityBusy'),
-  };
-
-  const inputPlaceholder = useMemo(() => {
-    if (showAvailabilityTooltip) {
-      return availabilityStrings[availability];
-    }
-
-    return messageTimer ? t('tooltipConversationEphemeral') : t('tooltipConversationInputPlaceholder');
-  }, [availability, messageTimer, showAvailabilityTooltip]); // eslint-disable-line react-hooks/exhaustive-deps
+  const inputPlaceholder = messageTimer ? t('tooltipConversationEphemeral') : t('tooltipConversationInputPlaceholder');
 
   const candidates = participatingUserEts.filter(userEntity => !userEntity.isService);
   const mentionSuggestions = editedMention ? searchRepository.searchUserInSet(editedMention.term, candidates) : [];

--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -45,7 +45,7 @@ import {
   getMentionCandidate,
   updateMentionRanges,
 } from 'Util/MentionUtil';
-import {formatLocale, TIME_IN_MILLIS} from 'Util/TimeUtil';
+import {formatDuration, formatLocale, TIME_IN_MILLIS} from 'Util/TimeUtil';
 import {getSelectionPosition} from 'Util/util';
 
 import {ControlButtons} from './components/InputBarControls/ControlButtons';
@@ -800,7 +800,11 @@ const InputBar = ({
                     onBlur={() => setIsTyping(false)}
                     value={inputValue}
                     placeholder={inputPlaceholder}
-                    aria-label={inputPlaceholder}
+                    aria-label={
+                      messageTimer
+                        ? t('tooltipConversationEphemeralAriaLabel', {time: formatDuration(messageTimer).text})
+                        : inputPlaceholder
+                    }
                     data-uie-name="input-message"
                     dir="auto"
                   />


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-443" title="ACC-443" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />ACC-443</a>  [Web] Message input bar should have a clear placeholder text instead of showing the user's status
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

**Removed**

<img width="921" alt="image" src="https://user-images.githubusercontent.com/63250054/215112377-6c979cd2-b02a-4168-963a-af4bafbd49ac.png">
<img width="916" alt="image" src="https://user-images.githubusercontent.com/63250054/215112464-a5d11f62-6c87-4d27-bd4e-7ba4b7abe053.png">

**We only have type a message now:**

<img width="902" alt="image" src="https://user-images.githubusercontent.com/63250054/215112589-e1a2c1a4-5230-4f42-8d2c-c495ab9c48bb.png">
