### PR TITLE
fix: close sidebar instead of closing window when opening conversation [SQSERVICES-1882]

### DIFF
--- a/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
@@ -104,24 +104,22 @@ const StartUI: React.FC<StartUIProps> = ({
     if (peopleSearchResults.current) {
       const {contacts, groups} = peopleSearchResults.current;
       if (contacts.length > 0) {
-        await openContact(contacts[0]);
-        return;
+        return openContact(contacts[0]);
       }
       if (groups.length > 0) {
-        await openConversation(groups[0]);
+        return openConversation(groups[0]);
       }
     }
   };
 
   const openContact = async (user: User) => {
     const conversationEntity = await actions.getOrCreate1to1Conversation(user);
-    await actions.open1to1Conversation(conversationEntity);
+    return actions.open1to1Conversation(conversationEntity);
   };
 
   const openOther = async (user: User) => {
     if (user.isOutgoingRequest()) {
-      await openContact(user);
-      return;
+      return openContact(user);
     }
 
     showUserModal({domain: user.domain, id: user.id});

--- a/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
@@ -117,12 +117,12 @@ const StartUI: React.FC<StartUIProps> = ({
     return actions.open1to1Conversation(conversationEntity);
   };
 
-  const openOther = async (user: User) => {
+  const openOther = (user: User) => {
     if (user.isOutgoingRequest()) {
       return openContact(user);
     }
 
-    showUserModal({domain: user.domain, id: user.id});
+    return showUserModal({domain: user.domain, id: user.id});
   };
 
   const openService = (service: ServiceEntity) => {
@@ -135,8 +135,9 @@ const StartUI: React.FC<StartUIProps> = ({
 
   const openInviteModal = () => showInviteModal({userState});
 
-  const openConversation = (conversation: Conversation): Promise<void> => {
-    return actions.openGroupConversation(conversation).then(onClose);
+  const openConversation = async (conversation: Conversation): Promise<void> => {
+    await actions.openGroupConversation(conversation);
+    close();
   };
 
   const before = (

--- a/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
@@ -100,27 +100,27 @@ const StartUI: React.FC<StartUIProps> = ({
 
   const peopleSearchResults = useRef<SearchResultsData | undefined>(undefined);
 
-  const openFirstConversation = (): void => {
+  const openFirstConversation = async (): Promise<void> => {
     if (peopleSearchResults.current) {
       const {contacts, groups} = peopleSearchResults.current;
       if (contacts.length > 0) {
-        openContact(contacts[0]);
+        await openContact(contacts[0]);
         return;
       }
       if (groups.length > 0) {
-        openConversation(groups[0]);
+        await openConversation(groups[0]);
       }
     }
   };
 
   const openContact = async (user: User) => {
     const conversationEntity = await actions.getOrCreate1to1Conversation(user);
-    actions.open1to1Conversation(conversationEntity);
+    await actions.open1to1Conversation(conversationEntity);
   };
 
-  const openOther = (user: User) => {
+  const openOther = async (user: User) => {
     if (user.isOutgoingRequest()) {
-      openContact(user);
+      await openContact(user);
       return;
     }
 

--- a/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
@@ -137,7 +137,7 @@ const StartUI: React.FC<StartUIProps> = ({
 
   const openConversation = async (conversation: Conversation): Promise<void> => {
     await actions.openGroupConversation(conversation);
-    close();
+    onClose();
   };
 
   const before = (

--- a/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
@@ -138,7 +138,7 @@ const StartUI: React.FC<StartUIProps> = ({
   const openInviteModal = () => showInviteModal({userState});
 
   const openConversation = (conversation: Conversation): Promise<void> => {
-    return actions.openGroupConversation(conversation).then(close);
+    return actions.openGroupConversation(conversation).then(onClose);
   };
 
   const before = (

--- a/src/script/page/LeftSidebar/panels/StartUI/components/GroupList.test.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/components/GroupList.test.tsx
@@ -21,16 +21,16 @@ import {fireEvent, render} from '@testing-library/react';
 import {CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation';
 import type {QualifiedId} from '@wireapp/api-client/lib/user/';
 
-import {createNavigate} from 'src/script/router/routerBindings';
 import {createRandomUuid, noop} from 'Util/util';
 
 import {GroupList} from './GroupList';
 
 import {Conversation} from '../../../../../entity/Conversation';
 import {User} from '../../../../../entity/User';
+import {navigate} from '../../../../../router/Router';
 
-jest.mock('../../../../../router/routerBindings', () => ({
-  createNavigate: jest.fn(),
+jest.mock('../../../../../router/Router', () => ({
+  navigate: jest.fn(),
 }));
 
 const getGroupItemById = (container: HTMLElement, id: string) =>
@@ -89,13 +89,13 @@ describe('GroupList', () => {
     const itemGroup1 = getGroupItemById(container, groups[0].id);
     fireEvent.click(itemGroup1!);
 
-    expect(createNavigate).toHaveBeenCalledWith(`/conversation/${groups[0].id}`);
+    expect(navigate).toHaveBeenCalledWith(`/conversation/${groups[0].id}`);
     expect(onClickSpy).toHaveBeenCalledWith(groups[0]);
 
     const itemGroup2 = getGroupItemById(container, groups[1].id);
     fireEvent.click(itemGroup2!);
 
-    expect(createNavigate).toHaveBeenCalledWith(`/conversation/${groups[1].id}`);
+    expect(navigate).toHaveBeenCalledWith(`/conversation/${groups[1].id}`);
     expect(onClickSpy).toHaveBeenCalledWith(groups[1]);
   });
 });

--- a/src/script/page/LeftSidebar/panels/StartUI/components/GroupList.test.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/components/GroupList.test.tsx
@@ -21,16 +21,16 @@ import {fireEvent, render} from '@testing-library/react';
 import {CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation';
 import type {QualifiedId} from '@wireapp/api-client/lib/user/';
 
+import {createNavigate} from 'src/script/router/routerBindings';
 import {createRandomUuid, noop} from 'Util/util';
 
 import {GroupList} from './GroupList';
 
 import {Conversation} from '../../../../../entity/Conversation';
 import {User} from '../../../../../entity/User';
-import {navigate} from '../../../../../router/Router';
 
-jest.mock('../../../../../router/Router', () => ({
-  navigate: jest.fn(),
+jest.mock('../../../../../router/routerBindings', () => ({
+  createNavigate: jest.fn(),
 }));
 
 const getGroupItemById = (container: HTMLElement, id: string) =>
@@ -89,13 +89,13 @@ describe('GroupList', () => {
     const itemGroup1 = getGroupItemById(container, groups[0].id);
     fireEvent.click(itemGroup1!);
 
-    expect(navigate).toHaveBeenCalledWith(`/conversation/${groups[0].id}`);
+    expect(createNavigate).toHaveBeenCalledWith(`/conversation/${groups[0].id}`);
     expect(onClickSpy).toHaveBeenCalledWith(groups[0]);
 
     const itemGroup2 = getGroupItemById(container, groups[1].id);
     fireEvent.click(itemGroup2!);
 
-    expect(navigate).toHaveBeenCalledWith(`/conversation/${groups[1].id}`);
+    expect(createNavigate).toHaveBeenCalledWith(`/conversation/${groups[1].id}`);
     expect(onClickSpy).toHaveBeenCalledWith(groups[1]);
   });
 });

--- a/src/script/page/LeftSidebar/panels/StartUI/components/groupList/GroupListItem.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/components/groupList/GroupListItem.tsx
@@ -23,12 +23,12 @@ import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 
 import {Avatar, AVATAR_SIZE} from 'Components/Avatar';
 import {GroupAvatar} from 'Components/avatar/GroupAvatar';
+import {createNavigate} from 'src/script/router/routerBindings';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {handleKeyDown} from 'Util/KeyboardUtil';
 
 import type {Conversation} from '../../../../../../entity/Conversation';
 import {generateConversationUrl} from '../../../../../../router/routeGenerator';
-import {navigate} from '../../../../../../router/Router';
 
 export interface GroupListItemProps {
   click: (group: Conversation) => void;
@@ -43,8 +43,9 @@ const GroupListItem: React.FC<GroupListItemProps> = ({click, group}) => {
   } = useKoSubscribableChildren(group, ['display_name', 'participating_user_ets', 'is1to1']);
 
   const onClick = () => {
+    const url = generateConversationUrl(group.qualifiedId);
     click(group);
-    navigate(generateConversationUrl(group.qualifiedId));
+    createNavigate(url);
   };
 
   return (
@@ -56,7 +57,7 @@ const GroupListItem: React.FC<GroupListItemProps> = ({click, group}) => {
       className="search-list-item"
       data-uie-uid={`${group.id}`}
       onClick={onClick}
-      onKeyDown={e => handleKeyDown(e, onClick)}
+      onKeyDown={event => handleKeyDown(event, onClick)}
       data-uie-value={displayName}
     >
       <div className="search-list-item-image">

--- a/src/script/page/LeftSidebar/panels/StartUI/components/groupList/GroupListItem.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/components/groupList/GroupListItem.tsx
@@ -23,12 +23,12 @@ import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 
 import {Avatar, AVATAR_SIZE} from 'Components/Avatar';
 import {GroupAvatar} from 'Components/avatar/GroupAvatar';
-import {createNavigate} from 'src/script/router/routerBindings';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {handleKeyDown} from 'Util/KeyboardUtil';
 
 import type {Conversation} from '../../../../../../entity/Conversation';
 import {generateConversationUrl} from '../../../../../../router/routeGenerator';
+import {navigate} from '../../../../../../router/Router';
 
 export interface GroupListItemProps {
   click: (group: Conversation) => void;
@@ -43,9 +43,8 @@ const GroupListItem: React.FC<GroupListItemProps> = ({click, group}) => {
   } = useKoSubscribableChildren(group, ['display_name', 'participating_user_ets', 'is1to1']);
 
   const onClick = () => {
-    const url = generateConversationUrl(group.qualifiedId);
     click(group);
-    createNavigate(url);
+    navigate(generateConversationUrl(group.qualifiedId));
   };
 
   return (

--- a/src/script/view_model/ActionsViewModel.ts
+++ b/src/script/view_model/ActionsViewModel.ts
@@ -111,7 +111,7 @@ export class ActionsViewModel {
       PrimaryModal.show(PrimaryModal.type.CONFIRM, {
         primaryAction: {
           action: async () => {
-            return this.connectionRepository.cancelRequest(userEntity, hideConversation, nextConversationEntity);
+            await this.connectionRepository.cancelRequest(userEntity, hideConversation, nextConversationEntity);
             resolve();
           },
           text: t('modalConnectCancelAction'),
@@ -204,7 +204,7 @@ export class ActionsViewModel {
         PrimaryModal.show(PrimaryModal.type.CONFIRM, {
           primaryAction: {
             action: async () => {
-              return this.messageRepository.deleteMessage(conversationEntity, messageEntity);
+              await this.messageRepository.deleteMessage(conversationEntity, messageEntity);
               resolve();
             },
             text: t('modalConversationDeleteMessageAction'),
@@ -227,7 +227,7 @@ export class ActionsViewModel {
         PrimaryModal.show(PrimaryModal.type.CONFIRM, {
           primaryAction: {
             action: async () => {
-              return this.messageRepository.deleteMessageForEveryone(conversationEntity, messageEntity);
+              await this.messageRepository.deleteMessageForEveryone(conversationEntity, messageEntity);
               resolve();
             },
             text: t('modalConversationDeleteMessageEveryoneAction'),
@@ -260,7 +260,7 @@ export class ActionsViewModel {
       PrimaryModal.show(PrimaryModal.type.OPTION, {
         primaryAction: {
           action: async (clearContent = false) => {
-            return this.conversationRepository.removeMember(
+            await this.conversationRepository.removeMember(
               conversationEntity,
               this.userState.self().qualifiedId,
               clearContent,

--- a/src/script/view_model/ActionsViewModel.ts
+++ b/src/script/view_model/ActionsViewModel.ts
@@ -110,8 +110,8 @@ export class ActionsViewModel {
     return new Promise(resolve => {
       PrimaryModal.show(PrimaryModal.type.CONFIRM, {
         primaryAction: {
-          action: () => {
-            this.connectionRepository.cancelRequest(userEntity, hideConversation, nextConversationEntity);
+          action: async () => {
+            await this.connectionRepository.cancelRequest(userEntity, hideConversation, nextConversationEntity);
             resolve();
           },
           text: t('modalConnectCancelAction'),
@@ -203,8 +203,8 @@ export class ActionsViewModel {
       return new Promise(resolve => {
         PrimaryModal.show(PrimaryModal.type.CONFIRM, {
           primaryAction: {
-            action: () => {
-              this.messageRepository.deleteMessage(conversationEntity, messageEntity);
+            action: async () => {
+              await this.messageRepository.deleteMessage(conversationEntity, messageEntity);
               resolve();
             },
             text: t('modalConversationDeleteMessageAction'),
@@ -226,8 +226,8 @@ export class ActionsViewModel {
       return new Promise(resolve => {
         PrimaryModal.show(PrimaryModal.type.CONFIRM, {
           primaryAction: {
-            action: () => {
-              this.messageRepository.deleteMessageForEveryone(conversationEntity, messageEntity);
+            action: async () => {
+              await this.messageRepository.deleteMessageForEveryone(conversationEntity, messageEntity);
               resolve();
             },
             text: t('modalConversationDeleteMessageEveryoneAction'),
@@ -259,8 +259,8 @@ export class ActionsViewModel {
     return new Promise(resolve => {
       PrimaryModal.show(PrimaryModal.type.OPTION, {
         primaryAction: {
-          action: (clearContent = false) => {
-            this.conversationRepository.removeMember(
+          action: async (clearContent = false) => {
+            await this.conversationRepository.removeMember(
               conversationEntity,
               this.userState.self().qualifiedId,
               clearContent,
@@ -311,7 +311,7 @@ export class ActionsViewModel {
     throw new Error(`Cannot find or create 1:1 conversation with user ID "${userEntity.id}".`);
   };
 
-  open1to1Conversation = (conversationEntity: Conversation): void => {
+  open1to1Conversation = (conversationEntity: Conversation): Promise<void> => {
     return this.openConversation(conversationEntity);
   };
 
@@ -330,9 +330,9 @@ export class ActionsViewModel {
     return this.openConversation(conversationEntity);
   };
 
-  private readonly openConversation = (conversationEntity: Conversation): void => {
+  private readonly openConversation = async (conversationEntity: Conversation): Promise<void> => {
     if (conversationEntity.is_archived()) {
-      this.conversationRepository.unarchiveConversation(conversationEntity, true);
+      await this.conversationRepository.unarchiveConversation(conversationEntity, true);
     }
 
     if (conversationEntity.is_cleared()) {
@@ -382,12 +382,12 @@ export class ActionsViewModel {
     return this.connectionRepository.createConnection(userEntity);
   };
 
-  readonly toggleMuteConversation = (conversationEntity: Conversation): void => {
+  readonly toggleMuteConversation = async (conversationEntity: Conversation): Promise<void> => {
     if (conversationEntity) {
       const notificationState = conversationEntity.showNotificationsEverything()
         ? NOTIFICATION_STATE.NOTHING
         : NOTIFICATION_STATE.EVERYTHING;
-      this.conversationRepository.setNotificationState(conversationEntity, notificationState);
+      await this.conversationRepository.setNotificationState(conversationEntity, notificationState);
     }
   };
 
@@ -404,7 +404,7 @@ export class ActionsViewModel {
             const conversationEntity = await this.conversationRepository.get1To1Conversation(userEntity);
             resolve();
             if (typeof conversationEntity !== 'boolean') {
-              this.conversationRepository.updateParticipatingUserEntities(conversationEntity);
+              await this.conversationRepository.updateParticipatingUserEntities(conversationEntity);
             }
           },
           text: t('modalUserUnblockAction'),

--- a/src/script/view_model/ActionsViewModel.ts
+++ b/src/script/view_model/ActionsViewModel.ts
@@ -332,7 +332,7 @@ export class ActionsViewModel {
 
   private readonly openConversation = async (conversationEntity: Conversation): Promise<void> => {
     if (conversationEntity.is_archived()) {
-      return this.conversationRepository.unarchiveConversation(conversationEntity, true);
+      await this.conversationRepository.unarchiveConversation(conversationEntity, true);
     }
 
     if (conversationEntity.is_cleared()) {

--- a/src/script/view_model/ActionsViewModel.ts
+++ b/src/script/view_model/ActionsViewModel.ts
@@ -111,7 +111,7 @@ export class ActionsViewModel {
       PrimaryModal.show(PrimaryModal.type.CONFIRM, {
         primaryAction: {
           action: async () => {
-            await this.connectionRepository.cancelRequest(userEntity, hideConversation, nextConversationEntity);
+            return this.connectionRepository.cancelRequest(userEntity, hideConversation, nextConversationEntity);
             resolve();
           },
           text: t('modalConnectCancelAction'),
@@ -204,7 +204,7 @@ export class ActionsViewModel {
         PrimaryModal.show(PrimaryModal.type.CONFIRM, {
           primaryAction: {
             action: async () => {
-              await this.messageRepository.deleteMessage(conversationEntity, messageEntity);
+              return this.messageRepository.deleteMessage(conversationEntity, messageEntity);
               resolve();
             },
             text: t('modalConversationDeleteMessageAction'),
@@ -227,7 +227,7 @@ export class ActionsViewModel {
         PrimaryModal.show(PrimaryModal.type.CONFIRM, {
           primaryAction: {
             action: async () => {
-              await this.messageRepository.deleteMessageForEveryone(conversationEntity, messageEntity);
+              return this.messageRepository.deleteMessageForEveryone(conversationEntity, messageEntity);
               resolve();
             },
             text: t('modalConversationDeleteMessageEveryoneAction'),
@@ -260,7 +260,7 @@ export class ActionsViewModel {
       PrimaryModal.show(PrimaryModal.type.OPTION, {
         primaryAction: {
           action: async (clearContent = false) => {
-            await this.conversationRepository.removeMember(
+            return this.conversationRepository.removeMember(
               conversationEntity,
               this.userState.self().qualifiedId,
               clearContent,
@@ -332,7 +332,7 @@ export class ActionsViewModel {
 
   private readonly openConversation = async (conversationEntity: Conversation): Promise<void> => {
     if (conversationEntity.is_archived()) {
-      await this.conversationRepository.unarchiveConversation(conversationEntity, true);
+      return this.conversationRepository.unarchiveConversation(conversationEntity, true);
     }
 
     if (conversationEntity.is_cleared()) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1882" title="SQSERVICES-1882" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1882</a>  When coming from team settings, webapp crashes when opening a new group. 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
[SQSERVICES-1882]

### Issue
- If a user comes from the team settings panel into the webapp (immediate-login), the webapp (the whole tab) will close when joining a group via search.
![Peek 2023-01-30 13-21](https://user-images.githubusercontent.com/78490891/215475617-9ba67bd7-7081-418a-b4c5-45d18289930c.gif)

### Solution
- replace `close` by `onClose` in the `openConversation` promise

#### What happened?
- Here's a quote from [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/close) about the `Window.close()` method: 
> `The Window.close()` method closes the current window, or the window on which it was called.
This method can only be called on windows that were opened by a script using the [Window.open()](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) method.

- Opening the app from Team Setting's sidebar uses the `Window.open()` method
- The `Window.close()` method in `openConversation` would only result in an error if the app was opened normally, and close the tab if the app was opened through Team Setting (or any external link using the `Window.open()` method)


[SQSERVICES-1882]: https://wearezeta.atlassian.net/browse/SQSERVICES-1882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ