### PR TITLE
chore: Avoid bumping version upon release tagging

### DIFF
--- a/bin/release_tag.ts
+++ b/bin/release_tag.ts
@@ -123,14 +123,7 @@ const ask = (questionToAsk: string): Promise<string> => {
   if (answer === 'yes') {
     logger.info(`Creating tag "${tagName}" ...`);
     if (!isDryRun) {
-      if (stage === DeploymentStage.PRODUCTION) {
-        exec('npm version minor --no-git-tag-version');
-        exec('git commit -am "chore: Bump application version"');
-      }
       exec(`git tag ${tagName} ${commitId}`);
-    }
-
-    if (!isDryRun) {
       logger.info(`Pushing "${tagName}" to "${origin}" ...`);
       exec(`git push origin && git push ${origin} ${tagName}`);
     }


### PR DESCRIPTION
Since https://github.com/wireapp/wire-webapp/pull/9973 we do bump the package.json version property everytime we release. 

This creates decrepencies between `dev` and `master` and require us to manually merge `master` back to `dev`. 

Since this `version` is never consumed inside the webapp and that we never publish on npm, there is no need in bumping this and we could remove that step. 