### PR TITLE
chore: Upgrade avs to 9.0.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@emotion/react": "11.10.5",
     "@types/eslint": "^8.4.10",
-    "@wireapp/avs": "8.2.30",
+    "@wireapp/avs": "9.0.20",
     "@wireapp/core": "38.7.1",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.3.4",

--- a/src/script/calling/CallingRepository.test.ts
+++ b/src/script/calling/CallingRepository.test.ts
@@ -410,9 +410,7 @@ describe.skip('E2E audio call', () => {
           convId,
           userId,
           clientid,
-          /* FIXME uncomment when avs 9 has fixed bug with starting video conversation
           CONV_TYPE.CONFERENCE,
-          */
         );
       },
     );

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -643,9 +643,7 @@ export class CallingRepository {
       this.serializeQualifiedId(conversationId),
       this.serializeQualifiedId(userId),
       conversation?.isUsingMLSProtocol ? senderClientId : clientId,
-      /* FIXME uncomment when avs 9 has fixed bug with starting video conversation
       conversation?.isUsingMLSProtocol ? CONV_TYPE.CONFERENCE_MLS : CONV_TYPE.CONFERENCE,
-      */
     );
 
     if (res !== 0) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4245,10 +4245,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/avs@npm:8.2.30":
-  version: 8.2.30
-  resolution: "@wireapp/avs@npm:8.2.30"
-  checksum: 50ca7ebc98664d82b1583897003bfdccca4eca61d6e00ea4415d1335746c47a7e938ad0628b4be0b26869bf69c1bb0c66d834e3f2a459559e5e5036df7d2e2b3
+"@wireapp/avs@npm:9.0.20":
+  version: 9.0.20
+  resolution: "@wireapp/avs@npm:9.0.20"
+  checksum: 10330d1ab771efe03f0fb9717a8813a428020c039159cd624c8c095b49fbfb4e5750912b30f9236e031885ff3995171ccb0a0071972f675494398b1f404c8a02
   languageName: node
   linkType: hard
 
@@ -16559,7 +16559,7 @@ __metadata:
     "@types/webpack-env": 1.18.0
     "@typescript-eslint/eslint-plugin": ^5.49.0
     "@typescript-eslint/parser": ^5.49.0
-    "@wireapp/avs": 8.2.30
+    "@wireapp/avs": 9.0.20
     "@wireapp/copy-config": 2.0.5
     "@wireapp/core": 38.7.1
     "@wireapp/eslint-config": 2.1.1


### PR DESCRIPTION
There was a regression in avs 9+ that prevented us from upgrading (video toggling would remove other participants video). 
9.0.20 is supposed to fix this issue. Plan is to run a calling regression on this version and see if there are broken scenarios