### PR TITLE
runfix: update epoch info only for mls conference call

### DIFF
--- a/src/script/view_model/CallingViewModel.ts
+++ b/src/script/view_model/CallingViewModel.ts
@@ -208,6 +208,11 @@ export class CallingViewModel {
     };
 
     const updateEpochInfo = async (conversationId: QualifiedId) => {
+      const conversation = this.getConversationById(conversationId);
+      if (!conversation?.isUsingMLSProtocol) {
+        return;
+      }
+
       const subconversation = await this.mlsService.getConferenceSubconversation(conversationId);
 
       //we don't want to react to avs callbacks when conversation was not yet established


### PR DESCRIPTION
This should fix the errors we saw in the nightly run.

`requestClientsCallback` is also called for proteus conversation, we forgot to put an if statement that checks if we're dealing with mls conversation before updating epoch info (and accessing mls service that is not initialised in this case)
