### PR TITLE
runfix: issue with when pasting undefined files

### DIFF
--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -567,6 +567,9 @@ const InputBar = ({
 
   const handlePasteFiles = (files: FileList): void => {
     const [pastedFile] = files;
+    if (!pastedFile) {
+      return;
+    }
     const {lastModified} = pastedFile;
 
     const date = formatLocale(lastModified || new Date(), 'PP, pp');


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Fixes a desktop automation issue seen below, when sometimes pastedFile is not defined so lastModified fails. 
<img width="890" alt="Screenshot 2023-02-02 at 15 10 36" src="https://user-images.githubusercontent.com/37285713/216357318-8b790a67-9a7e-4266-ac19-42c46638aa19.png">
![Screenshot 2023-02-02 at 14 34 50](https://user-images.githubusercontent.com/37285713/216357338-e9655d27-4f61-4c86-8e31-2df6418af2e3.png)


### Solutions

exit the function is pasted is not defined. 

