### PR TITLE
runfix: remove reqNewEpoch logic

### DIFF
--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -133,7 +133,6 @@ export class CallingRepository {
   private avsVersion: number = 0;
   private incomingCallCallback: (call: Call) => void;
   private requestClientsCallback: (conversationId: QualifiedId) => void;
-  private requestNewEpochCallback: (conversationId: QualifiedId) => void;
   private leaveCallCallback: (conversationId: QualifiedId) => void;
   private isReady: boolean = false;
   /** will cache the query to media stream (in order to avoid asking the system for streams multiple times when we have multiple peers) */
@@ -173,7 +172,6 @@ export class CallingRepository {
     this.logger = getLogger('CallingRepository');
     this.incomingCallCallback = () => {};
     this.requestClientsCallback = () => {};
-    this.requestNewEpochCallback = () => {};
     this.leaveCallCallback = () => {};
     this.callLog = [];
 
@@ -303,7 +301,6 @@ export class CallingRepository {
     wCall.setStateHandler(wUser, this.updateCallState);
     wCall.setParticipantChangedHandler(wUser, this.handleCallParticipantChanges);
     wCall.setReqClientsHandler(wUser, this.requestClients);
-    wCall.setReqNewEpochHandler(wUser, this.requestNewEpoch);
     wCall.setActiveSpeakerHandler(wUser, this.updateActiveSpeakers);
 
     return wUser;
@@ -424,10 +421,6 @@ export class CallingRepository {
 
   onRequestClientsCallback(callback: (conversationId: QualifiedId) => void): void {
     this.requestClientsCallback = callback;
-  }
-
-  onRequestNewEpochCallback(callback: (conversationId: QualifiedId) => void): void {
-    this.requestNewEpochCallback = callback;
   }
 
   findCall(conversationId: QualifiedId): Call | undefined {
@@ -1516,11 +1509,6 @@ export class CallingRepository {
     await this.pushClients(call);
     const qualifiedConversationId = this.parseQualifiedId(convId);
     this.requestClientsCallback(qualifiedConversationId);
-  };
-
-  private readonly requestNewEpoch = async (wUser: number, convId: SerializedConversationId) => {
-    const qualifiedConversationId = this.parseQualifiedId(convId);
-    this.requestNewEpochCallback(qualifiedConversationId);
   };
 
   private readonly getCallMediaStream = async (

--- a/src/script/view_model/CallingViewModel.test.ts
+++ b/src/script/view_model/CallingViewModel.test.ts
@@ -38,7 +38,6 @@ const mockCallingRepository = {
   leaveCall: jest.fn(),
   onIncomingCall: jest.fn(),
   onRequestClientsCallback: jest.fn(),
-  onRequestNewEpochCallback: jest.fn(),
   onLeaveCall: jest.fn(),
 } as unknown as CallingRepository;
 

--- a/src/script/view_model/CallingViewModel.ts
+++ b/src/script/view_model/CallingViewModel.ts
@@ -239,9 +239,6 @@ export class CallingViewModel {
     //update epoch info when AVS requests the list of clients
     this.callingRepository.onRequestClientsCallback(updateEpochInfo);
 
-    //update epoch info when AVS requests new epoch
-    this.callingRepository.onRequestNewEpochCallback(updateEpochInfo);
-
     //once we leave a call, we unsubscribe from all the events we've subscribed to during this call
     this.callingRepository.onLeaveCall(callingSubscriptions.removeCall);
 


### PR DESCRIPTION
`req_new_epoch` callback appeared to be redundant call on avs side.

Since epoch will update with every subconversation membership change (what is handled with subscribing to `"newEpoch"` event and reacting with `set_epoch_info` callback), there's no need to trigger epoch update manually with `corecrypto.updateKeyingMaterial()`.