### PR TITLE
fix: user "Set a status" dialog interaction accessible(ACC-440)

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -976,6 +976,8 @@
   "preferencesAccountAppLockCheckbox": "Lock with passcode",
   "preferencesAccountAppLockDetail": "Lock Wire after {{locktime}} in the background. Unlock with Touch ID or enter your passcode.",
   "preferencesAccountAvailabilityUnset": "Set a status",
+  "preferencesAccountSelectedLabel": "Selected",
+  "preferencesAccountUpdateLabel": "Change your status to",
   "preferencesAccountCopyLink": "Copy Profile Link",
   "preferencesAccountCreateTeam": "Create a team",
   "preferencesAccountData": "Data usage permissions",

--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -736,6 +736,7 @@
   "modalAvailabilityDontShowAgain": "Do not display this information again",
   "modalAvailabilityNoneMessage": "You will receive notifications for incoming calls and for messages according to the Notifications setting in each conversation.",
   "modalAvailabilityNoneTitle": "No status set",
+  "modalAvailabilityRemoveBtn": "Close window 'Set a status'",
   "modalCallEmptyConversationHeadline": "No one to call",
   "modalCallEmptyConversationMessage": "There is no one left here.",
   "modalCallEmptyLogCloseBtn": "Close window 'No calls'",

--- a/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {FC, FormEvent, MouseEvent, useState, useRef, ChangeEvent} from 'react';
+import {FC, FormEvent, MouseEvent, useState, useRef, ChangeEvent, useEffect} from 'react';
 
 import cx from 'classnames';
 
@@ -26,6 +26,7 @@ import {Checkbox, CheckboxLabel} from '@wireapp/react-ui-kit';
 import {FadingScrollbar} from 'Components/FadingScrollbar';
 import {Icon} from 'Components/Icon';
 import {ModalComponent} from 'Components/ModalComponent';
+import {isEscapeKey} from 'Util/KeyboardUtil';
 
 import {usePrimaryModalState, showNextModalInQueue, defaultContent, removeCurrentModal} from './PrimaryModalState';
 import {Action, PrimaryModalType} from './PrimaryModalTypes';
@@ -110,15 +111,34 @@ export const PrimaryModalComponent: FC = () => {
 
   const secondaryActions = Array.isArray(secondaryAction) ? secondaryAction : [secondaryAction];
 
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isModalVisible) {
+      modalRef.current?.focus();
+    }
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (isEscapeKey(event) && isModalVisible) {
+        removeCurrentModal();
+      }
+    };
+
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [isModalVisible]);
+
   return (
-    <div id="modals" data-uie-name="primary-modals-container">
-      <ModalComponent
-        isShown={isModalVisible}
-        onClosed={onModalHidden}
-        aria-describedby="modal-description"
-        onBgClick={onBgClick}
-        data-uie-name={modalUie}
-      >
+    <div
+      id="modals"
+      data-uie-name="primary-modals-container"
+      role="dialog"
+      aria-modal="true"
+      aria-label={titleText}
+      tabIndex={-1}
+      ref={modalRef}
+    >
+      <ModalComponent isShown={isModalVisible} onClosed={onModalHidden} onBgClick={onBgClick} data-uie-name={modalUie}>
         {isModalVisible && (
           <>
             <div className="modal__header" data-uie-name="status-modal-title">

--- a/src/script/page/MainContent/panels/preferences/accountPreferences/AvailabilityButtons.tsx
+++ b/src/script/page/MainContent/panels/preferences/accountPreferences/AvailabilityButtons.tsx
@@ -124,6 +124,11 @@ const AvailabilityButtons: React.FC<AvailabilityInputProps> = ({availability}) =
               key={item.availability}
               type="button"
               onClick={() => item.click?.()}
+              aria-label={
+                isActive
+                  ? `${t('preferencesAccountSelectedLabel')}, ${item.label}`
+                  : `${t('preferencesAccountUpdateLabel')} ${item.label}`
+              }
             >
               {item.availability !== undefined && icons[item.availability]}
               {item.label}

--- a/src/script/user/AvailabilityModal.ts
+++ b/src/script/user/AvailabilityModal.ts
@@ -46,6 +46,7 @@ function showModal(storageKey: string, title: string, message: string): void {
           message,
           option: t('modalAvailabilityDontShowAgain'),
           title,
+          closeBtnLabel: t('modalAvailabilityRemoveBtn'),
         },
       },
       'availability',

--- a/src/script/view_model/ListViewModel.ts
+++ b/src/script/view_model/ListViewModel.ts
@@ -25,7 +25,7 @@ import {CONV_TYPE} from '@wireapp/avs';
 import {Runtime} from '@wireapp/commons';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
-import {PrimaryModal} from 'Components/Modals/PrimaryModal';
+import {PrimaryModal, usePrimaryModalState} from 'Components/Modals/PrimaryModal';
 import {iterateItem} from 'Util/ArrayUtil';
 import {isEscapeKey} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
@@ -182,7 +182,10 @@ export class ListViewModel {
   };
 
   onKeyDownListView = (keyboardEvent: KeyboardEvent) => {
-    if (isEscapeKey(keyboardEvent)) {
+    const {currentModalId} = usePrimaryModalState.getState();
+    // don't switch view for primary modal(ex: preferences->set status->modal opened)
+    // when user press escape, only close the modal and stay within the preference screen
+    if (isEscapeKey(keyboardEvent) && currentModalId === null) {
       const newState = this.isActivatedAccount() ? ListState.CONVERSATIONS : ListState.TEMPORARY_GUEST;
       this.switchList(newState);
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-440" title="ACC-440" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />ACC-440</a>  [Web] "Status" dialog interaction
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - User "Set a status" dialog interaction

- The **PR Description**
  - As a Wire user with disabilities, I want the screen reader to inform me that the status buttons in preferences are to update my status in Wire
  - As a Wire user with disabilities, when I change my status from preferences, I want to be informed that I am in a dialog and that my status has been changed
  - As a Wire user, I would like to be able to dismiss the status change dialog with the “esc” key
----
##### References
1. https://wearezeta.atlassian.net/browse/ACC-440
