### PR TITLE
runfix: revert 'message not found' fix

### DIFF
--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -1183,9 +1183,7 @@ export class MessageRepository {
     skipConversationMessages = false,
     ensureUser = false,
   ): Promise<StoredContentMessage> {
-    const messageEntity =
-      !skipConversationMessages &&
-      (conversation.getMessageByReplacementId(messageId) || conversation.getMessage(messageId));
+    const messageEntity = !skipConversationMessages && conversation.getMessage(messageId);
     const message =
       messageEntity ||
       (await this.eventService.loadEvent(conversation.id, messageId).then(event => {

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -968,15 +968,6 @@ export class Conversation {
   getMessage(messageId: string): Message | ContentMessage | MemberMessage | SystemMessage | undefined {
     return this.messages().find(messageEntity => messageEntity.id === messageId);
   }
-  /**
-   * Get a message by its replacing message id. Useful if the message in question is an edit and has replaced the original message.
-   * Only lookup in the loaded message list which is a limited view of all the messages in DB.
-   *
-   * @param messageId ID of message to be retrieved
-   */
-  getMessageByReplacementId(messageId: string): Message | ContentMessage | MemberMessage | SystemMessage | undefined {
-    return this.messages().find(messageEntity => (messageEntity as ContentMessage)?.replacing_message_id === messageId);
-  }
 
   updateGuests(): void {
     this.getTemporaryGuests().forEach(userEntity => userEntity.checkGuestExpiration());

--- a/src/script/event/EventService.ts
+++ b/src/script/event/EventService.ts
@@ -133,24 +133,12 @@ export class EventService {
           .equals(eventId)
           .filter(record => record.conversation === conversationId)
           .first();
-        if (entry) {
-          return entry;
-        }
-        return await this.storageService.db
-          .table(StorageSchemata.OBJECT_STORE.EVENTS)
-          .where('conversation')
-          .equals(conversationId)
-          .filter(item => item.data?.replacing_message_id === eventId)
-          .first();
+        return entry;
       }
 
       const records = (await this.storageService.getAll(StorageSchemata.OBJECT_STORE.EVENTS)) as EventRecord[];
       return records
-        .filter(
-          record =>
-            (record.id === eventId && record.conversation === conversationId) ||
-            (record.conversation === conversationId && record.data?.replacing_message_id === eventId),
-        )
+        .filter(record => record.id === eventId && record.conversation === conversationId)
         .sort(compareEventsById)
         .shift();
     } catch (error) {

--- a/src/script/message/QuoteEntity.ts
+++ b/src/script/message/QuoteEntity.ts
@@ -33,6 +33,7 @@ export class QuoteEntity {
   userId: string;
 
   static ERROR = {
+    INVALID_HASH: 'INVALID_HASH',
     MESSAGE_NOT_FOUND: 'MESSAGE_NOT_FOUND',
   };
 

--- a/src/script/notification/NotificationRepository.ts
+++ b/src/script/notification/NotificationRepository.ts
@@ -258,9 +258,7 @@ export class NotificationRepository {
             const messageInfo = messageId
               ? `message '${messageId}' of type '${messageType}'`
               : `'${messageType}' message`;
-            this.logger.info(
-              `Removed read notification for ${messageInfo} in '${conversationId?.id || conversationId}'.`,
-            );
+            this.logger.info(`Removed read notification for ${messageInfo} in '${conversationId}'.`);
           }
         });
       }
@@ -858,35 +856,30 @@ export class NotificationRepository {
       this.contentViewModelState.multitasking.isMinimized(true);
       notificationContent.trigger();
 
-      this.logger.info(`Notification for ${messageInfo} in '${conversationId?.id || conversationId}' closed by click.`);
+      this.logger.info(`Notification for ${messageInfo} in '${conversationId}' closed by click.`);
       notification.close();
     };
 
     notification.onclose = () => {
       window.clearTimeout(timeoutTriggerId);
       this.notifications.splice(this.notifications.indexOf(notification), 1);
-      this.logger.info(`Removed notification for ${messageInfo} in '${conversationId?.id || conversationId}' locally.`);
+      this.logger.info(`Removed notification for ${messageInfo} in '${conversationId}' locally.`);
     };
 
     notification.onerror = error => {
-      this.logger.error(
-        `Notification for ${messageInfo} in '${conversationId?.id || conversationId}' closed by error.`,
-        error,
-      );
+      this.logger.error(`Notification for ${messageInfo} in '${conversationId}' closed by error.`, error);
       notification.close();
     };
 
     notification.onshow = () => {
       timeoutTriggerId = window.setTimeout(() => {
-        this.logger.info(
-          `Notification for ${messageInfo} in '${conversationId?.id || conversationId}' closed by timeout.`,
-        );
+        this.logger.info(`Notification for ${messageInfo} in '${conversationId}' closed by timeout.`);
         notification.close();
       }, notificationContent.timeout);
     };
 
     this.notifications.push(notification);
-    this.logger.info(`Added notification for ${messageInfo} in '${conversationId?.id || conversationId}' to queue.`);
+    this.logger.info(`Added notification for ${messageInfo} in '${conversationId}' to queue.`);
   }
 
   /**

--- a/test/unit_tests/event/preprocessor/QuotedMessageMiddlewareSpec.js
+++ b/test/unit_tests/event/preprocessor/QuotedMessageMiddlewareSpec.js
@@ -81,6 +81,44 @@ describe('QuotedMessageMiddleware', () => {
       expect(parsedEvent.data.quote.error).toEqual(expectedError);
     });
 
+    it('adds an error if hashes do not match', async () => {
+      const expectedError = {
+        type: QuoteEntity.ERROR.INVALID_HASH,
+      };
+
+      const quotedMessage = {
+        data: {
+          content: 'pas salut',
+        },
+        time: 100,
+        type: ClientEvent.CONVERSATION.MESSAGE_ADD,
+      };
+
+      spyOn(quotedMessageMiddleware.eventService, 'loadEvent').and.returnValue(Promise.resolve(quotedMessage));
+
+      const quote = new Quote({
+        quotedMessageId: 'message-uuid',
+        quotedMessageSha256: '7fec6710751f67587b6f6109782257cd7c56b5d29570824132e8543e18242f1b',
+      });
+
+      const base64Quote = arrayToBase64(Quote.encode(quote).finish());
+
+      const event = {
+        conversation: 'conversation-uuid',
+        data: {
+          content: 'salut',
+          quote: base64Quote,
+        },
+        time: 100,
+        type: ClientEvent.CONVERSATION.MESSAGE_ADD,
+      };
+
+      const parsedEvent = await quotedMessageMiddleware.processEvent(event);
+
+      expect(parsedEvent.data.quote.message_id).toBeUndefined();
+      expect(parsedEvent.data.quote.error).toEqual(expectedError);
+    });
+
     it('decorates event with the quote metadata if validation is successful', async () => {
       const quotedMessage = {
         data: {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

revert the 'message not found' quote solution because of apparent issue relating to quotes not being received when users are offline on one device. 

The STR are:
- user1 and user2 have a conversation
- user1 has a created client but not loaded
- user2 sends a message in a conversation with user1
- user2 quotes the message they just sent
- user1 load the webapp with the existing client

-> user1 cannot see the quote
