### PR TITLE
feat: req_new_epoch advance epoch number

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.10.5",
     "@types/eslint": "^8.4.10",
     "@wireapp/avs": "9.0.20",
-    "@wireapp/core": "38.9.1",
+    "@wireapp/core": "38.10.1",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.3.5",
     "@wireapp/store-engine-dexie": "2.0.4",

--- a/src/script/calling/mlsConference.ts
+++ b/src/script/calling/mlsConference.ts
@@ -52,6 +52,7 @@ export const getSubconversationEpochInfo = async (
   {mlsService}: {mlsService: MLSService},
   subconversationGroupId: string,
   parentGroupId: string,
+  shouldAdvanceEpoch = false,
 ): Promise<{
   members: SubconversationEpochInfoMember[];
   epoch: number;
@@ -59,6 +60,10 @@ export const getSubconversationEpochInfo = async (
   keyLength: number;
 }> => {
   const members = await generateSubconversationMembers({mlsService}, subconversationGroupId, parentGroupId);
+
+  if (shouldAdvanceEpoch) {
+    await mlsService.renewKeyMaterial(subconversationGroupId);
+  }
 
   const epoch = Number(await mlsService.getEpoch(subconversationGroupId));
 

--- a/src/script/view_model/CallingViewModel.ts
+++ b/src/script/view_model/CallingViewModel.ts
@@ -207,7 +207,7 @@ export class CallingViewModel {
       return !!this.callState.joinedCall();
     };
 
-    const updateEpochInfo = async (conversationId: QualifiedId) => {
+    const updateEpochInfo = async (conversationId: QualifiedId, shouldAdvanceEpoch = false) => {
       const conversation = this.getConversationById(conversationId);
       if (!conversation?.isUsingMLSProtocol) {
         return;
@@ -228,6 +228,7 @@ export class CallingViewModel {
         {mlsService: this.mlsService},
         subconversationGroupId,
         parentGroupId,
+        shouldAdvanceEpoch,
       );
       this.callingRepository.setEpochInfo(conversationId, {epoch, keyLength, secretKey}, members);
     };
@@ -243,7 +244,7 @@ export class CallingViewModel {
     this.callingRepository.onRequestClientsCallback(updateEpochInfo);
 
     //update epoch info when AVS requests new epoch
-    this.callingRepository.onRequestNewEpochCallback(updateEpochInfo);
+    this.callingRepository.onRequestNewEpochCallback(conversationId => updateEpochInfo(conversationId, true));
 
     //once we leave a call, we unsubscribe from all the events we've subscribed to during this call
     this.callingRepository.onLeaveCall(callingSubscriptions.removeCall);

--- a/src/script/view_model/CallingViewModel.ts
+++ b/src/script/view_model/CallingViewModel.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {SUBCONVERSATION_ID} from '@wireapp/api-client/lib/conversation/Subconversation';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import ko from 'knockout';
 import {container} from 'tsyringe';
@@ -213,21 +214,20 @@ export class CallingViewModel {
         return;
       }
 
-      const subconversation = await this.mlsService.getConferenceSubconversation(conversationId);
+      const subconversationGroupId = await this.mlsService.getGroupIdFromConversationId(
+        conversationId,
+        SUBCONVERSATION_ID.CONFERENCE,
+      );
 
       //we don't want to react to avs callbacks when conversation was not yet established
-      const isMLSConversationEstablished = await this.mlsService.conversationExists(subconversation.group_id);
+      const isMLSConversationEstablished = await this.mlsService.conversationExists(subconversationGroupId);
       if (!isMLSConversationEstablished) {
         return;
       }
 
-      const parentGroupId = await this.mlsService.getGroupIdFromConversationId(conversationId);
-      const subconversationGroupId = subconversation.group_id;
-
       const {epoch, keyLength, secretKey, members} = await getSubconversationEpochInfo(
         {mlsService: this.mlsService},
-        subconversationGroupId,
-        parentGroupId,
+        conversationId,
         shouldAdvanceEpoch,
       );
       this.callingRepository.setEpochInfo(conversationId, {epoch, keyLength, secretKey}, members);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4383,9 +4383,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:38.9.1":
-  version: 38.9.1
-  resolution: "@wireapp/core@npm:38.9.1"
+"@wireapp/core@npm:38.10.1":
+  version: 38.10.1
+  resolution: "@wireapp/core@npm:38.10.1"
   dependencies:
     "@wireapp/api-client": ^22.15.2
     "@wireapp/commons": ^5.0.4
@@ -4403,7 +4403,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.13
-  checksum: 70b8acbc8f885b630d98f7963c4951bc5fc2be5db193d192545710136a25f1f42dfb8076e366a3c23aae9fc90dcad47b43d7603a04c1a10db5280a303b8f7e43
+  checksum: 5ba0480421d26be42bedbd7d90e2c9aa70dc76e9fe40013899919c2c14dbfa9ac304f7e02c456b3783d3854c4012d9ced956a94f7a3e9ac114877756dbcf3350
   languageName: node
   linkType: hard
 
@@ -16712,7 +16712,7 @@ __metadata:
     "@typescript-eslint/parser": ^5.50.0
     "@wireapp/avs": 9.0.20
     "@wireapp/copy-config": 2.0.7
-    "@wireapp/core": 38.9.1
+    "@wireapp/core": 38.10.1
     "@wireapp/eslint-config": 2.1.1
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.5.2


### PR DESCRIPTION
When AVS library requests new epoch with `req_new_epoch` callback, we should advance epoch number by calling `corecrypto.updateKeyingMaterial(groupId)` and update epoch info with `set_epoch_info`.

It also reduces some redundant calls to BE subconversation endpoint (we're getting the info from local corecrypto store instead). 