### PR TITLE
refactor: use postListClients instead of hack

### DIFF
--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -334,9 +334,7 @@ export class CallingRepository {
       return false;
     }
     const {id, domain} = call.conversationId;
-    const allClients = conversation.isUsingMLSProtocol
-      ? await this.core.service!.conversation.fetchAllParticipantsClients(id, domain)
-      : await this.core.service!.conversation.getAllParticipantsClients(call.conversationId);
+    const allClients = await this.core.service!.conversation.fetchAllParticipantsClients(id, domain);
     const qualifiedClients = isQualifiedUserClients(allClients)
       ? flattenQualifiedUserClients(allClients)
       : flattenUserClients(allClients);
@@ -629,9 +627,7 @@ export class CallingRepository {
       case CALL_MESSAGE_TYPE.CONFKEY: {
         if (source !== EventRepository.SOURCE.STREAM) {
           const {id, domain} = conversationId;
-          const allClients = conversation.isUsingMLSProtocol
-            ? await this.core.service!.conversation.fetchAllParticipantsClients(id, domain)
-            : await this.core.service!.conversation.getAllParticipantsClients(conversationId);
+          const allClients = await this.core.service!.conversation.fetchAllParticipantsClients(id, domain);
           // We warn the message repository that a mismatch has happened outside of its lifecycle (eventually triggering a conversation degradation)
           const shouldContinue = await this.messageRepository.updateMissingClients(
             conversation,

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -1222,7 +1222,8 @@ export class MessageRepository {
     if (blockSystemMessage) {
       conversation.blockLegalHoldMessage = true;
     }
-    const missing = await this.conversationService.getAllParticipantsClients(conversation.qualifiedId);
+    const {id, domain} = conversation.qualifiedId;
+    const missing = await this.conversationService.fetchAllParticipantsClients(id, domain);
     const deleted = findDeletedClients(missing, await this.generateRecipients(conversation));
     await this.onClientMismatch?.({deleted, missing} as ClientMismatch, conversation, true);
     if (blockSystemMessage) {


### PR DESCRIPTION
User `POST: users/list-clients` (`POST: users/list-clients/v2` for api v1) method instead of a empty message hack.