### PR TITLE
refactor: Narrow down event types

### DIFF
--- a/src/script/conversation/ConversationEphemeralHandler.ts
+++ b/src/script/conversation/ConversationEphemeralHandler.ts
@@ -39,7 +39,7 @@ import {Text} from '../entity/message/Text';
 import type {EventService} from '../event/EventService';
 import {EphemeralStatusType} from '../message/EphemeralStatusType';
 import {StatusType} from '../message/StatusType';
-import type {LegacyEventRecord} from '../storage';
+import type {EventRecord} from '../storage';
 
 export class ConversationEphemeralHandler extends AbstractConversationEventHandler {
   eventListeners: Record<string, (...args: any[]) => void>;
@@ -124,7 +124,7 @@ export class ConversationEphemeralHandler extends AbstractConversationEventHandl
       case EphemeralStatusType.INACTIVE: {
         messageEntity.startMessageTimer(timeOffset);
 
-        const changes: Pick<Partial<LegacyEventRecord>, 'ephemeral_expires' | 'ephemeral_started'> = {
+        const changes: Pick<Partial<EventRecord>, 'ephemeral_expires' | 'ephemeral_started'> = {
           ephemeral_expires: messageEntity.ephemeral_expires(),
           ephemeral_started: Number(messageEntity.ephemeral_started()),
         };
@@ -170,7 +170,7 @@ export class ConversationEphemeralHandler extends AbstractConversationEventHandl
     messageEntity.ephemeral_expires(true);
 
     const assetEntity = messageEntity.getFirstAsset();
-    const changes: Pick<Partial<LegacyEventRecord>, 'data' | 'ephemeral_expires'> = {
+    const changes: Pick<Partial<EventRecord>, 'data' | 'ephemeral_expires'> = {
       data: {
         content_type: assetEntity.file_type,
         meta: {},
@@ -186,7 +186,7 @@ export class ConversationEphemeralHandler extends AbstractConversationEventHandl
     messageEntity.ephemeral_expires(true);
 
     const assetEntity = messageEntity.getFirstAsset() as MediumImage;
-    const changes: Pick<Partial<LegacyEventRecord>, 'data' | 'ephemeral_expires'> = {
+    const changes: Pick<Partial<EventRecord>, 'data' | 'ephemeral_expires'> = {
       data: {
         info: {
           height: assetEntity.size,
@@ -237,7 +237,7 @@ export class ConversationEphemeralHandler extends AbstractConversationEventHandl
     obfuscatedAsset.previews(assetEntity.previews());
 
     messageEntity.assets([obfuscatedAsset]);
-    const changes: Pick<Partial<LegacyEventRecord>, 'data' | 'ephemeral_expires'> = {
+    const changes: Pick<Partial<EventRecord>, 'data' | 'ephemeral_expires'> = {
       data: {
         content: obfuscatedAsset.text,
         previews: obfuscatedPreviews,

--- a/src/script/conversation/EventBuilder.ts
+++ b/src/script/conversation/EventBuilder.ts
@@ -35,7 +35,7 @@ import type {User} from '../entity/User';
 import {CALL, ClientEvent, CONVERSATION} from '../event/Client';
 import {StatusType} from '../message/StatusType';
 import {VerificationMessageType} from '../message/VerificationMessageType';
-import {AssetRecord, LegacyEventRecord} from '../storage';
+import {AssetRecord, EventRecord, ReadReceipt, UserReactionMap} from '../storage';
 
 export interface BaseEvent {
   conversation: string;
@@ -116,7 +116,18 @@ export type MemberLeaveEvent = BackendEventMessage<{
 }> & {
   type: CONVERSATION_EVENT.MEMBER_LEAVE;
 };
-export type MessageAddEvent = Omit<ConversationEvent<{}>, 'id'> & {
+export type MessageAddEvent = Omit<
+  ConversationEvent<{
+    sender: string;
+    replacing_message_id?: string;
+    previews?: string[];
+    /** who have received/read the event */
+    read_receipts?: ReadReceipt[];
+    /** who reacted to the event */
+    reactions?: UserReactionMap;
+  }>,
+  'id'
+> & {
   edited_time?: string;
   status: StatusType;
   type: CONVERSATION.MESSAGE_ADD;
@@ -133,6 +144,13 @@ export type ReactionEvent = ConversationEvent<{message_id: string; reaction: Rea
 };
 export type MessageHiddenEvent = ConversationEvent<{conversation_id: string; message_id: string}> & {
   type: CONVERSATION.MESSAGE_HIDDEN;
+};
+export type ConfirmationEvent = ConversationEvent<{
+  message_id: string;
+  more_message_ids: string[];
+  status: StatusType;
+}> & {
+  type: CONVERSATION.CONFIRMATION;
 };
 export type ButtonActionConfirmationEvent = ConversationEvent<{buttonId: string; messageId: string}> & {
   type: CONVERSATION.BUTTON_ACTION_CONFIRMATION;
@@ -173,13 +191,15 @@ export interface ErrorEvent extends BaseEvent {
   error: string;
   error_code: number | string;
   id: string;
-  type: CONVERSATION;
+  type: CONVERSATION.UNABLE_TO_DECRYPT | CONVERSATION.INCOMING_MESSAGE_TOO_BIG;
 }
 
 export type ClientConversationEvent =
   | AllVerifiedEvent
   | AssetAddEvent
+  | ErrorEvent
   | CompositeMessageAddEvent
+  | ConfirmationEvent
   | DeleteEvent
   | DeleteEverywhereEvent
   | DegradedMessageEvent
@@ -476,7 +496,7 @@ export const EventBuilder = {
     };
   },
 
-  buildUnableToDecrypt(event: LegacyEventRecord, decryptionError: DecryptionError): ErrorEvent {
+  buildUnableToDecrypt(event: EventRecord, decryptionError: DecryptionError): ErrorEvent {
     const {qualified_conversation: conversationId, qualified_from, conversation, data: eventData, from, time} = event;
 
     return {

--- a/src/script/conversation/EventBuilder.ts
+++ b/src/script/conversation/EventBuilder.ts
@@ -119,15 +119,17 @@ export type MemberLeaveEvent = BackendEventMessage<{
 export type MessageAddEvent = Omit<
   ConversationEvent<{
     sender: string;
+    content: string;
     replacing_message_id?: string;
     previews?: string[];
-    /** who have received/read the event */
-    read_receipts?: ReadReceipt[];
-    /** who reacted to the event */
-    reactions?: UserReactionMap;
+    expects_read_confirmation?: boolean;
   }>,
   'id'
 > & {
+  /** who have received/read the event */
+  read_receipts?: ReadReceipt[];
+  /** who reacted to the event */
+  reactions?: UserReactionMap;
   edited_time?: string;
   status: StatusType;
   type: CONVERSATION.MESSAGE_ADD;
@@ -459,6 +461,7 @@ export const EventBuilder = {
     return {
       ...buildQualifiedId(conversationEntity),
       data: {
+        content: '',
         sender: senderId,
       },
       from: conversationEntity.selfUser().id,
@@ -496,7 +499,7 @@ export const EventBuilder = {
     };
   },
 
-  buildUnableToDecrypt(event: EventRecord, decryptionError: DecryptionError): ErrorEvent {
+  buildUnableToDecrypt(event: Partial<EventRecord>, decryptionError: DecryptionError): ErrorEvent {
     const {qualified_conversation: conversationId, qualified_from, conversation, data: eventData, from, time} = event;
 
     return {

--- a/src/script/event/EventRepository.test.ts
+++ b/src/script/event/EventRepository.test.ts
@@ -444,7 +444,7 @@ describe('EventRepository', () => {
       event.data.replacing_message_id = originalMessage.id;
       event.time = changed_time;
 
-      return testFactory.event_repository!['handleEventSaving'](event).then((updatedEvent: EventRecord) => {
+      return testFactory.event_repository!['handleEventSaving'](event).then((updatedEvent: any) => {
         expect(updatedEvent.time).toEqual(initial_time);
         expect(updatedEvent.time).not.toEqual(changed_time);
         expect(updatedEvent.data.content).toEqual('new content');

--- a/src/script/event/EventRepository.ts
+++ b/src/script/event/EventRepository.ts
@@ -17,7 +17,8 @@
  *
  */
 
-import {CONVERSATION_EVENT, USER_EVENT, ConversationEvent} from '@wireapp/api-client/lib/event/';
+import {CONVERSATION_EVENT, USER_EVENT} from '@wireapp/api-client/lib/event';
+import type {BackendEvent} from '@wireapp/api-client/lib/event';
 import {NotificationSource, HandledEventPayload} from '@wireapp/core/lib/notification';
 import {amplify} from 'amplify';
 import ko from 'knockout';
@@ -42,16 +43,18 @@ import type {NotificationService} from './NotificationService';
 
 import {AssetTransferState} from '../assets/AssetTransferState';
 import type {ClientEntity} from '../client/ClientEntity';
-import {ClientConversationEvent, EventBuilder} from '../conversation/EventBuilder';
-import {AssetData, CryptographyMapper} from '../cryptography/CryptographyMapper';
+import {AssetAddEvent, ClientConversationEvent, EventBuilder, MessageAddEvent} from '../conversation/EventBuilder';
+import {CryptographyMapper} from '../cryptography/CryptographyMapper';
 import {CryptographyError} from '../error/CryptographyError';
 import {EventError} from '../error/EventError';
 import {categoryFromEvent} from '../message/MessageCategorization';
-import type {LegacyEventRecord} from '../storage';
+import type {EventRecord, StoredEvent} from '../storage';
 import type {ServerTimeHandler} from '../time/serverTimeHandler';
 import {EventName} from '../tracking/EventName';
 import {UserState} from '../user/UserState';
 import {Warnings} from '../view_model/WarningsContainer';
+
+type IncomingEvent = BackendEvent | ClientConversationEvent;
 
 export class EventRepository {
   logger: Logger;
@@ -159,7 +162,7 @@ export class EventRepository {
 
   private readonly handleIncomingEvent = async (payload: HandledEventPayload, source: NotificationSource) => {
     try {
-      await this.handleEvent({...payload, event: payload.event as LegacyEventRecord}, source);
+      await this.handleEvent(payload, source);
     } catch (error) {
       if (source === EventSource.NOTIFICATION_STREAM) {
         this.logger.warn(`Failed to handle event of type "${event.type}": ${error.message}`, error);
@@ -231,21 +234,17 @@ export class EventRepository {
     }
   }
 
-  private getIsoDateFromEvent(event: LegacyEventRecord, defaultValue = false): string | void {
-    const {client, connection, time: eventDate, type: eventType} = event;
-
-    if (eventDate) {
-      return eventDate;
+  private getIsoDateFromEvent(event: IncomingEvent, defaultValue = false): string | void {
+    if ('time' in event && event.time) {
+      return event.time;
     }
 
-    const isTypeUserClientAdd = eventType === USER_EVENT.CLIENT_ADD;
-    if (isTypeUserClientAdd) {
-      return client.time;
+    if (event.type === USER_EVENT.CLIENT_ADD) {
+      return event.client.time;
     }
 
-    const isTypeUserConnection = eventType === USER_EVENT.CONNECTION;
-    if (isTypeUserConnection) {
-      return connection.lastUpdate;
+    if (event.type === USER_EVENT.CONNECTION) {
+      return event.connection.last_update;
     }
 
     if (defaultValue) {
@@ -288,10 +287,7 @@ export class EventRepository {
    * @param source Source of injection
    * @returns Resolves when the event has been processed
    */
-  async injectEvent(
-    event: ClientConversationEvent | ConversationEvent,
-    source: EventSource = EventSource.INJECTED,
-  ): Promise<LegacyEventRecord | undefined> {
+  async injectEvent(event: ClientConversationEvent | IncomingEvent, source: EventSource = EventSource.INJECTED) {
     if (!event) {
       throw new EventError(EventError.TYPE.NO_EVENT, EventError.MESSAGE.NO_EVENT);
     }
@@ -302,13 +298,13 @@ export class EventRepository {
     }
 
     const id = 'id' in event ? event.id : 'ID not specified';
-    const {conversation: conversationId, type} = event;
+    const conversationId = 'conversation' in event && event.conversation;
     const inSelfConversation = conversationId === this.userState.self().id;
     if (!inSelfConversation) {
-      this.logger.info(`Injected event ID '${id}' of type '${type}' with source '${source}'`, event);
-      return this.handleEvent({event}, source);
+      this.logger.info(`Injected event ID '${id}' of type '${event.type}' with source '${source}'`, event);
+      return this.processEvent(event, source);
     }
-    return event;
+    return undefined;
   }
 
   /**
@@ -317,7 +313,7 @@ export class EventRepository {
    * @param event Mapped event to be distributed
    * @param source Source of notification
    */
-  private async distributeEvent(event: LegacyEventRecord, source: EventSource): Promise<LegacyEventRecord> {
+  private async distributeEvent(event: IncomingEvent, source: EventSource) {
     const {conversation: conversationId, from: userId, type} = event;
 
     const hasIds = conversationId && userId;
@@ -356,10 +352,7 @@ export class EventRepository {
    * @param source Source of event
    * @returns Resolves with the saved record or the plain event if the event was skipped
    */
-  private handleEvent(
-    {event, decryptedData, decryptionError}: Omit<ProcessedEventPayload, 'event'> & {event: LegacyEventRecord},
-    source: EventSource,
-  ): Promise<LegacyEventRecord | undefined> {
+  private handleEvent({event, decryptedData, decryptionError}: ProcessedEventPayload, source: EventSource) {
     const logObject = {eventJson: JSON.stringify(event), eventObject: event};
     const validationResult = validateEvent(
       event as {time: string; type: CONVERSATION_EVENT | USER_EVENT},
@@ -387,11 +380,11 @@ export class EventRepository {
    * @returns Resolves with the saved record or `true` if the event was skipped
    */
   private async processEvent(
-    event: LegacyEventRecord,
+    event: IncomingEvent | ClientConversationEvent,
     source: EventSource,
     decryptedData?: GenericMessage,
     decryptionError?: HandledEventPayload['decryptionError'],
-  ): Promise<LegacyEventRecord | undefined> {
+  ) {
     if (decryptionError) {
       this.logger.warn(`Decryption Error: (${decryptionError.code}) ${decryptionError.message}`, decryptionError);
       const ignoredCodes = [
@@ -406,7 +399,7 @@ export class EventRepository {
       });
       event = EventBuilder.buildUnableToDecrypt(event, decryptionError);
     }
-    if (decryptedData) {
+    if (decryptedData && event.type === CONVERSATION_EVENT.OTR_MESSAGE_ADD) {
       event = await new CryptographyMapper().mapGenericMessage(decryptedData, event);
       if (!event) {
         return undefined;
@@ -432,7 +425,7 @@ export class EventRepository {
    * @param source Source of event
    * @returns The distributed event
    */
-  private handleEventDistribution(event: LegacyEventRecord, source: EventSource): Promise<LegacyEventRecord> {
+  private handleEventDistribution(event: IncomingEvent, source: EventSource) {
     const eventDate = this.getIsoDateFromEvent(event);
     const isInjectedEvent = source === EventRepository.SOURCE.INJECTED;
     const canSetEventDate = !isInjectedEvent && eventDate;
@@ -456,52 +449,47 @@ export class EventRepository {
    * @param event Backend event extracted from notification stream
    * @returns Resolves with the saved event
    */
-  private handleEventSaving(event: LegacyEventRecord): Promise<LegacyEventRecord | undefined> {
-    const conversationId = event.conversation;
-    const mappedData = event.data || {};
+  private async handleEventSaving(event: IncomingEvent) {
+    const conversationId = 'conversation' in event && event.conversation;
+    const mappedData = ('data' in event && event.data) ?? {};
 
     // first check if a message that should be replaced exists in DB
-    const findEventToReplacePromise = mappedData.replacing_message_id
-      ? this.eventService.loadEvent(conversationId, mappedData.replacing_message_id)
-      : Promise.resolve();
+    const eventToReplace = mappedData.replacing_message_id
+      ? await this.eventService.loadEvent(conversationId, mappedData.replacing_message_id)
+      : undefined;
 
-    return (findEventToReplacePromise as Promise<LegacyEventRecord>).then((eventToReplace: LegacyEventRecord) => {
-      const hasLinkPreview = mappedData.previews && mappedData.previews.length;
-      const isReplacementWithoutOriginal = !eventToReplace && mappedData.replacing_message_id;
-      if (isReplacementWithoutOriginal && !hasLinkPreview) {
-        // the only valid case of a replacement with no original message is when an edited message gets a link preview
-        this.throwValidationError(event, 'Edit event without original event');
-      }
+    const hasLinkPreview = mappedData.previews && mappedData.previews.length;
+    const isReplacementWithoutOriginal = !eventToReplace && mappedData.replacing_message_id;
+    if (isReplacementWithoutOriginal && !hasLinkPreview) {
+      // the only valid case of a replacement with no original message is when an edited message gets a link preview
+      this.throwValidationError(event, 'Edit event without original event');
+    }
 
-      const handleEvent = (newEvent: LegacyEventRecord) => {
-        // check for duplicates (same id)
-        const loadEventPromise = newEvent.id
-          ? this.eventService.loadEvent(conversationId, newEvent.id)
-          : Promise.resolve(undefined);
+    const handleEvent = (newEvent: IncomingEvent) => {
+      // check for duplicates (same id)
+      const loadEventPromise =
+        'id' in newEvent ? this.eventService.loadEvent(conversationId, newEvent.id) : Promise.resolve(undefined);
 
-        return loadEventPromise.then((storedEvent?: LegacyEventRecord) => {
-          return storedEvent
-            ? this.handleDuplicatedEvent(storedEvent, newEvent)
-            : this.eventService.saveEvent(newEvent);
-        });
-      };
+      return loadEventPromise.then(storedEvent => {
+        return storedEvent ? this.handleDuplicatedEvent(storedEvent, newEvent) : this.eventService.saveEvent(newEvent);
+      });
+    };
 
-      return eventToReplace ? this.handleEventReplacement(eventToReplace, event) : handleEvent(event);
-    });
+    const canReplace =
+      eventToReplace.type === ClientEvent.CONVERSATION.MESSAGE_ADD &&
+      event.type === ClientEvent.CONVERSATION.MESSAGE_ADD;
+    return canReplace && eventToReplace ? this.handleEventReplacement(eventToReplace, event) : handleEvent(event);
   }
 
-  private handleEventReplacement(
-    originalEvent: LegacyEventRecord,
-    newEvent: LegacyEventRecord,
-  ): Promise<LegacyEventRecord> {
+  private handleEventReplacement(originalEvent: StoredEvent & MessageAddEvent, newEvent: MessageAddEvent) {
     if (originalEvent.from !== newEvent.from) {
       const logMessage = `ID previously used by user '${newEvent.from}'`;
       const errorMessage = 'ID reused by other user';
       this.throwValidationError(newEvent, errorMessage, logMessage);
     }
-    const newData = newEvent.data || {};
+    const newData = newEvent.data;
     const primaryKeyUpdate = {primary_key: originalEvent.primary_key};
-    const isLinkPreviewEdit = newData.previews && !!newData.previews.length;
+    const isLinkPreviewEdit = newData?.previews && !!newData?.previews.length;
 
     const commonUpdates = EventRepository.getCommonMessageUpdates(originalEvent, newEvent);
 
@@ -515,7 +503,7 @@ export class EventRepository {
     return this.eventService.replaceEvent(identifiedUpdates);
   }
 
-  private handleDuplicatedEvent(originalEvent: LegacyEventRecord, newEvent: LegacyEventRecord) {
+  private handleDuplicatedEvent(originalEvent: EventRecord, newEvent: IncomingEvent) {
     switch (newEvent.type) {
       case ClientEvent.CONVERSATION.ASSET_ADD:
         return this.handleAssetUpdate(originalEvent, newEvent);
@@ -528,10 +516,7 @@ export class EventRepository {
     }
   }
 
-  private async handleAssetUpdate(
-    originalEvent: LegacyEventRecord<AssetData>,
-    newEvent: LegacyEventRecord<AssetData>,
-  ): Promise<LegacyEventRecord> {
+  private async handleAssetUpdate(originalEvent: EventRecord, newEvent: AssetAddEvent) {
     const newEventData = newEvent.data;
     // the preview status is not sent by the client so we fake a 'preview' status in order to cleanly handle it in the switch statement
     const ASSET_PREVIEW = 'preview';
@@ -566,10 +551,7 @@ export class EventRepository {
     }
   }
 
-  private handleLinkPreviewUpdate(
-    originalEvent: LegacyEventRecord,
-    newEvent: LegacyEventRecord,
-  ): Promise<LegacyEventRecord> {
+  private handleLinkPreviewUpdate(originalEvent: EventRecord, newEvent: MessageAddEvent) {
     const newEventData = newEvent.data;
     const originalData = originalEvent.data;
     if (originalEvent.from !== newEvent.from) {
@@ -601,7 +583,7 @@ export class EventRepository {
     return this.eventService.replaceEvent(identifiedUpdates);
   }
 
-  private static getCommonMessageUpdates(originalEvent: LegacyEventRecord, newEvent: LegacyEventRecord) {
+  private static getCommonMessageUpdates(originalEvent: EventRecord, newEvent: MessageAddEvent) {
     return {
       ...newEvent,
       data: {...newEvent.data, expects_read_confirmation: originalEvent.data.expects_read_confirmation},
@@ -614,14 +596,14 @@ export class EventRepository {
   }
 
   private static getUpdatesForEditMessage(
-    originalEvent: LegacyEventRecord,
-    newEvent: LegacyEventRecord,
-  ): LegacyEventRecord & {reactions: {}} {
+    originalEvent: EventRecord,
+    newEvent: IncomingEvent,
+  ): EventRecord & {reactions: {}} {
     // Remove reactions, so that likes (hearts) don't stay when a message's text gets edited
     return {...newEvent, reactions: {}};
   }
 
-  private getUpdatesForLinkPreview(originalEvent: LegacyEventRecord, newEvent: LegacyEventRecord): LegacyEventRecord {
+  private getUpdatesForLinkPreview(originalEvent: EventRecord, newEvent: IncomingEvent): EventRecord {
     const newData = newEvent.data;
     const originalData = originalEvent.data;
     const updatingLinkPreview = !!originalData.previews.length;
@@ -648,7 +630,7 @@ export class EventRepository {
     };
   }
 
-  private throwValidationError(event: LegacyEventRecord, errorMessage: string, logMessage?: string): never {
+  private throwValidationError(event: IncomingEvent, errorMessage: string, logMessage?: string): never {
     const baseLogMessage = `Ignored '${event.type}' (${event.id || 'no ID'}) in '${event.conversation}' from '${
       event.from
     }':'`;

--- a/src/script/event/EventRepository.ts
+++ b/src/script/event/EventRepository.ts
@@ -480,7 +480,7 @@ export class EventRepository {
     };
 
     const canReplace =
-      eventToReplace.type === ClientEvent.CONVERSATION.MESSAGE_ADD &&
+      eventToReplace?.type === ClientEvent.CONVERSATION.MESSAGE_ADD &&
       event.type === ClientEvent.CONVERSATION.MESSAGE_ADD;
     return canReplace && eventToReplace ? this.handleEventReplacement(eventToReplace, event) : handleEvent(event);
   }

--- a/src/script/event/EventService.ts
+++ b/src/script/event/EventService.ts
@@ -25,7 +25,6 @@ import {Asset as ProtobufAsset} from '@wireapp/protocol-messaging';
 import {getLogger, Logger} from 'Util/Logger';
 
 import {AssetTransferState} from '../assets/AssetTransferState';
-import {AssetData} from '../cryptography/CryptographyMapper';
 import {BaseError, BASE_ERROR_TYPE} from '../error/BaseError';
 import {ConversationError} from '../error/ConversationError';
 import {StorageError} from '../error/StorageError';
@@ -36,16 +35,16 @@ import {StorageSchemata} from '../storage/StorageSchemata';
 
 export type Includes = {includeFrom: boolean; includeTo: boolean};
 type DexieCollection = Dexie.Collection<any, any>;
-export type DBEvents = DexieCollection | LegacyEventRecord[];
+export type DBEvents = DexieCollection | EventRecord[];
+type IdentifiedUpdatePayload = Partial<EventRecord> & Pick<EventRecord, 'primary_key'>;
 
 export const eventTimeToDate = (time: string) => new Date(time) || new Date(parseInt(time, 10));
 
-export const compareEventsByConversation = (eventA: LegacyEventRecord, eventB: LegacyEventRecord) =>
+export const compareEventsByConversation = (eventA: EventRecord, eventB: EventRecord) =>
   eventA.conversation.localeCompare(eventB.conversation);
 
-export const compareEventsById = (eventA: LegacyEventRecord, eventB: LegacyEventRecord) =>
-  eventA.id.localeCompare(eventB.id);
-export const compareEventsByTime = (eventA: LegacyEventRecord, eventB: LegacyEventRecord) =>
+export const compareEventsById = (eventA: EventRecord, eventB: EventRecord) => eventA.id.localeCompare(eventB.id);
+export const compareEventsByTime = (eventA: EventRecord, eventB: EventRecord) =>
   eventTimeToDate(eventA.time).getTime() - eventTimeToDate(eventB.time).getTime();
 
 /** Handles all databases interactions related to events */
@@ -56,7 +55,7 @@ export class EventService {
     this.logger = getLogger('EventService');
   }
 
-  async loadEvents(conversationId: string, eventIds: string[]): Promise<LegacyEventRecord[]> {
+  async loadEvents(conversationId: string, eventIds: string[]): Promise<EventRecord[]> {
     if (!conversationId || !eventIds) {
       this.logger.error(`Cannot get events '${eventIds}' in conversation '${conversationId}' without IDs`);
       throw new ConversationError(BASE_ERROR_TYPE.MISSING_PARAMETER, BaseError.MESSAGE.MISSING_PARAMETER);
@@ -73,7 +72,7 @@ export class EventService {
         return events;
       }
 
-      const records = (await this.storageService.getAll(StorageSchemata.OBJECT_STORE.EVENTS)) as LegacyEventRecord[];
+      const records = await this.storageService.getAll<EventRecord>(StorageSchemata.OBJECT_STORE.EVENTS);
       return records
         .filter(record => record.conversation === conversationId && eventIds.includes(record.id))
         .sort(compareEventsById);
@@ -86,7 +85,7 @@ export class EventService {
     }
   }
 
-  async loadEphemeralEvents(conversationId: string): Promise<LegacyEventRecord[]> {
+  async loadEphemeralEvents(conversationId: string): Promise<EventRecord[]> {
     if (!conversationId) {
       this.logger.error(`Cannot get ephemeral events in conversation '${conversationId}' without ID`);
       throw new ConversationError(BASE_ERROR_TYPE.MISSING_PARAMETER, BaseError.MESSAGE.MISSING_PARAMETER);
@@ -103,7 +102,7 @@ export class EventService {
         return events;
       }
 
-      const records = (await this.storageService.getAll(StorageSchemata.OBJECT_STORE.EVENTS)) as LegacyEventRecord[];
+      const records = await this.storageService.getAll<EventRecord>(StorageSchemata.OBJECT_STORE.EVENTS);
       return records
         .filter(record => record.conversation === conversationId && !!record.ephemeral_expires)
         .sort(compareEventsById);
@@ -161,7 +160,7 @@ export class EventService {
     categoryMin: MessageCategory,
     categoryMax = MessageCategory.LIKED,
   ): Promise<DBEvents> {
-    const filterExpired = (record: LegacyEventRecord) => {
+    const filterExpired = (record: EventRecord) => {
       if (typeof record.ephemeral_expires !== 'undefined') {
         return +record.ephemeral_expires - Date.now() > 0;
       }
@@ -179,7 +178,7 @@ export class EventService {
       return events;
     }
 
-    const records = (await this.storageService.getAll(StorageSchemata.OBJECT_STORE.EVENTS)) as LegacyEventRecord[];
+    const records = await this.storageService.getAll<EventRecord>(StorageSchemata.OBJECT_STORE.EVENTS);
     return records
       .filter(
         record =>
@@ -200,7 +199,7 @@ export class EventService {
       return events;
     }
 
-    const records = (await this.storageService.getAll(StorageSchemata.OBJECT_STORE.EVENTS)) as LegacyEventRecord[];
+    const records = await this.storageService.getAll<EventRecord>(StorageSchemata.OBJECT_STORE.EVENTS);
     return records
       .filter(record => {
         return (
@@ -236,7 +235,7 @@ export class EventService {
       const events = await this._loadEventsInDateRange(conversationId, fromDate, toDate, limit, includeParams);
       return this.storageService.db
         ? await (events as Dexie.Collection<any, any>).reverse().sortBy('time')
-        : (events as LegacyEventRecord[]).reverse().sort(compareEventsByTime);
+        : (events as EventRecord[]).reverse().sort(compareEventsByTime);
     } catch (error) {
       const message = `Failed to load events for conversation '${conversationId}' from database: '${error.message}'`;
       this.logger.error(message);
@@ -271,7 +270,7 @@ export class EventService {
     const events = await this._loadEventsInDateRange(conversationId, fromDate, toDate, limit, includeParams);
     return this.storageService.db
       ? (events as DexieCollection).sortBy('time')
-      : (events as LegacyEventRecord[]).sort(compareEventsByTime);
+      : (events as EventRecord[]).sort(compareEventsByTime);
   }
 
   /**
@@ -314,7 +313,7 @@ export class EventService {
       return events;
     }
 
-    const records = (await this.storageService.getAll(StorageSchemata.OBJECT_STORE.EVENTS)) as LegacyEventRecord[];
+    const records = await this.storageService.getAll<EventRecord>(StorageSchemata.OBJECT_STORE.EVENTS);
     return records
       .filter(record => {
         const recordDate = eventTimeToDate(record.time).getTime();
@@ -334,22 +333,25 @@ export class EventService {
    *
    * @param event JSON event to be stored
    */
-  async saveEvent(event: LegacyEventRecord): Promise<LegacyEventRecord> {
-    event.category = categoryFromEvent(event);
-    event.primary_key = await this.storageService.save(StorageSchemata.OBJECT_STORE.EVENTS, undefined, event);
+  async saveEvent(event: Omit<EventRecord, 'primary_key' | 'category'>): Promise<EventRecord> {
+    const savedEvent: EventRecord = {
+      ...event,
+      category: categoryFromEvent(event),
+      primary_key: await this.storageService.save(StorageSchemata.OBJECT_STORE.EVENTS, undefined, event),
+    } as EventRecord;
     if (this.storageService.isTemporaryAndNonPersistent) {
       /**
        * Dexie supports auto-incrementing primary keys and saves those keys to a predefined column.
        * The SQLeetEngine also supports auto-incrementing primary keys but it does not save them to a predefined column, so we have to do that manually:
        */
-      await this.storageService.update(StorageSchemata.OBJECT_STORE.EVENTS, event.primary_key, {
-        primary_key: event.primary_key,
+      await this.storageService.update(StorageSchemata.OBJECT_STORE.EVENTS, savedEvent.primary_key, {
+        primary_key: savedEvent.primary_key,
       });
     }
-    return event;
+    return savedEvent;
   }
 
-  async replaceEvent<T extends Partial<LegacyEventRecord>>(event: T): Promise<T> {
+  async replaceEvent<T extends IdentifiedUpdatePayload>(event: T): Promise<T> {
     await this.storageService.update(StorageSchemata.OBJECT_STORE.EVENTS, event.primary_key, event);
     return event;
   }
@@ -371,11 +373,8 @@ export class EventService {
   async updateEventAsUploadFailed(
     primaryKey: string,
     reason: ProtobufAsset.NotUploaded | AssetTransferState,
-  ): Promise<LegacyEventRecord | undefined> {
-    const record = await this.storageService.load<LegacyEventRecord<AssetData>>(
-      StorageSchemata.OBJECT_STORE.EVENTS,
-      primaryKey,
-    );
+  ): Promise<EventRecord | undefined> {
+    const record = await this.storageService.load<EventRecord>(StorageSchemata.OBJECT_STORE.EVENTS, primaryKey);
     if (!record) {
       this.logger.warn('Did not find message to update asset (failed)', primaryKey);
       return undefined;
@@ -394,10 +393,7 @@ export class EventService {
    * @param primaryKey event's primary key
    * @param updates Updates to perform on the message.
    */
-  async updateEvent<T extends Partial<LegacyEventRecord>>(
-    primaryKey: string,
-    updates: T,
-  ): Promise<T & {primary_key: string}> {
+  async updateEvent<T extends Partial<EventRecord>>(primaryKey: string, updates: T): Promise<IdentifiedUpdatePayload> {
     const hasNoChanges = !updates || !Object.keys(updates).length;
     if (hasNoChanges) {
       throw new ConversationError(ConversationError.TYPE.NO_CHANGES, ConversationError.MESSAGE.NO_CHANGES);
@@ -418,7 +414,7 @@ export class EventService {
    * @param primaryKey Event primary key
    * @param changes Changes to update message with
    */
-  async updateEventSequentially(primaryKey: string, changes: Partial<LegacyEventRecord> = {}): Promise<number> {
+  async updateEventSequentially(primaryKey: string, changes: Partial<EventRecord> = {}): Promise<number> {
     const hasVersionedChanges = !!changes.version;
     if (!hasVersionedChanges) {
       throw new ConversationError(ConversationError.TYPE.WRONG_CHANGE, ConversationError.MESSAGE.WRONG_CHANGE);

--- a/src/script/event/EventService.ts
+++ b/src/script/event/EventService.ts
@@ -336,7 +336,7 @@ export class EventService {
   async saveEvent(event: Omit<EventRecord, 'primary_key' | 'category'>): Promise<EventRecord> {
     const savedEvent: EventRecord = {
       ...event,
-      category: categoryFromEvent(event),
+      category: categoryFromEvent(event as EventRecord),
       primary_key: await this.storageService.save(StorageSchemata.OBJECT_STORE.EVENTS, undefined, event),
     } as EventRecord;
     if (this.storageService.isTemporaryAndNonPersistent) {

--- a/src/script/event/EventServiceNoCompound.ts
+++ b/src/script/event/EventServiceNoCompound.ts
@@ -29,7 +29,7 @@ import {
 } from './EventService';
 
 import {MessageCategory} from '../message/MessageCategory';
-import {LegacyEventRecord, StorageService} from '../storage';
+import {EventRecord, LegacyEventRecord, StorageService} from '../storage';
 import {StorageSchemata} from '../storage/StorageSchemata';
 
 // TODO: These types should be moved to a more appropriate place (e.g. EventService) once it has been migrated to TS
@@ -59,11 +59,11 @@ export class EventServiceNoCompound extends EventService {
         .equals(conversationId)
         .sortBy('time');
     } else {
-      const records = (await this.storageService.getAll(StorageSchemata.OBJECT_STORE.EVENTS)) as LegacyEventRecord[];
+      const records = await this.storageService.getAll<EventRecord>(StorageSchemata.OBJECT_STORE.EVENTS);
       events = records.filter(record => record.conversation === conversationId).sort(compareEventsByTime);
     }
 
-    return (events as LegacyEventRecord[]).filter(record => record.category >= category);
+    return events.filter(record => record.category >= category);
   }
 
   async _loadEventsInDateRange(
@@ -102,7 +102,7 @@ export class EventServiceNoCompound extends EventService {
         .limit(limit);
     }
 
-    const records = (await this.storageService.getAll(StorageSchemata.OBJECT_STORE.EVENTS)) as LegacyEventRecord[];
+    const records = await this.storageService.getAll<EventRecord>(StorageSchemata.OBJECT_STORE.EVENTS);
     return records
       .filter(record => {
         const timestamp = eventTimeToDate(record.time);

--- a/src/script/event/preprocessor/QuotedMessageMiddleware.ts
+++ b/src/script/event/preprocessor/QuotedMessageMiddleware.ts
@@ -24,7 +24,7 @@ import {base64ToArray} from 'Util/util';
 
 import {MessageHasher} from '../../message/MessageHasher';
 import {QuoteEntity} from '../../message/QuoteEntity';
-import {LegacyEventRecord} from '../../storage/record/EventRecord';
+import {EventRecord} from '../../storage/record/EventRecord';
 import {ClientEvent} from '../Client';
 import type {EventService} from '../EventService';
 
@@ -44,7 +44,7 @@ export class QuotedMessageMiddleware {
    * @param event event in the DB format
    * @returns the original event if no quote is found (or does not validate). The decorated event if the quote is valid
    */
-  async processEvent(event: LegacyEventRecord): Promise<LegacyEventRecord> {
+  async processEvent(event: EventRecord): Promise<EventRecord> {
     switch (event.type) {
       case ClientEvent.CONVERSATION.MESSAGE_ADD: {
         if (event.data.replacing_message_id) {
@@ -63,7 +63,7 @@ export class QuotedMessageMiddleware {
     }
   }
 
-  private async _handleDeleteEvent(event: LegacyEventRecord): Promise<LegacyEventRecord> {
+  private async _handleDeleteEvent(event: EventRecord): Promise<EventRecord> {
     const originalMessageId = event.data.message_id;
     const {replies} = await this._findRepliesToMessage(event.conversation, originalMessageId);
     this.logger.info(`Invalidating '${replies.length}' replies to deleted message '${originalMessageId}'`);
@@ -74,7 +74,7 @@ export class QuotedMessageMiddleware {
     return event;
   }
 
-  private async _handleEditEvent(event: LegacyEventRecord): Promise<LegacyEventRecord> {
+  private async _handleEditEvent(event: EventRecord): Promise<EventRecord> {
     const originalMessageId = event.data.replacing_message_id;
     const {originalEvent, replies} = await this._findRepliesToMessage(event.conversation, originalMessageId);
     if (!originalEvent) {
@@ -91,7 +91,7 @@ export class QuotedMessageMiddleware {
     return {...event, data: decoratedData};
   }
 
-  private async _handleAddEvent(event: LegacyEventRecord): Promise<LegacyEventRecord> {
+  private async _handleAddEvent(event: EventRecord): Promise<EventRecord> {
     const rawQuote = event.data && event.data.quote;
 
     if (!rawQuote) {
@@ -143,7 +143,7 @@ export class QuotedMessageMiddleware {
   private async _findRepliesToMessage(
     conversationId: string,
     messageId: string,
-  ): Promise<{originalEvent?: LegacyEventRecord; replies: LegacyEventRecord[]}> {
+  ): Promise<{originalEvent?: EventRecord; replies: EventRecord[]}> {
     const originalEvent = await this.eventService.loadEvent(conversationId, messageId);
 
     if (!originalEvent) {

--- a/src/script/event/preprocessor/ReceiptsMiddleware.ts
+++ b/src/script/event/preprocessor/ReceiptsMiddleware.ts
@@ -24,7 +24,7 @@ import {getLogger, Logger} from 'Util/Logger';
 
 import type {ConversationRepository} from '../../conversation/ConversationRepository';
 import {StatusType} from '../../message/StatusType';
-import type {LegacyEventRecord} from '../../storage/record/EventRecord';
+import type {EventRecord} from '../../storage/record/EventRecord';
 import {UserState} from '../../user/UserState';
 import {ClientEvent} from '../Client';
 import type {EventService} from '../EventService';
@@ -47,7 +47,7 @@ export class ReceiptsMiddleware {
   /**
    * Handles incoming (and injected outgoing) events.
    */
-  async processEvent(event: LegacyEventRecord): Promise<LegacyEventRecord> {
+  async processEvent(event: EventRecord): Promise<EventRecord> {
     switch (event.type) {
       case ClientEvent.CONVERSATION.ASSET_ADD:
       case ClientEvent.CONVERSATION.KNOCK:
@@ -64,7 +64,7 @@ export class ReceiptsMiddleware {
       }
       case ClientEvent.CONVERSATION.CONFIRMATION: {
         const messageIds = event.data.more_message_ids.concat(event.data.message_id);
-        const originalEvents: LegacyEventRecord[] = await this.eventService.loadEvents(event.conversation, messageIds);
+        const originalEvents = await this.eventService.loadEvents(event.conversation, messageIds);
         originalEvents.forEach(originalEvent => this.updateConfirmationStatus(originalEvent, event));
         this.logger.info(
           `Confirmed '${originalEvents.length}' messages with status '${event.data.status}' from '${event.from}'`,
@@ -78,16 +78,16 @@ export class ReceiptsMiddleware {
     }
   }
 
-  isMyMessage(originalEvent: LegacyEventRecord): boolean {
+  isMyMessage(originalEvent: EventRecord): boolean {
     return this.userState.self() && this.userState.self().id === originalEvent.from;
   }
 
   private updateConfirmationStatus(
-    originalEvent: LegacyEventRecord,
-    confirmationEvent: LegacyEventRecord,
-  ): Promise<LegacyEventRecord | void> {
+    originalEvent: EventRecord,
+    confirmationEvent: EventRecord,
+  ): Promise<EventRecord | void> {
     const status = confirmationEvent.data.status;
-    const currentReceipts = originalEvent.read_receipts || [];
+    const currentReceipts = ('read_receipts' in originalEvent && originalEvent.read_receipts) || [];
 
     // I shouldn't receive this read receipt
     if (!this.isMyMessage(originalEvent)) {

--- a/src/script/message/MessageCategorization.ts
+++ b/src/script/message/MessageCategorization.ts
@@ -22,7 +22,7 @@ import {isObject} from 'underscore';
 import {MessageCategory} from './MessageCategory';
 
 import {ClientEvent} from '../event/Client';
-import {LegacyEventRecord} from '../storage/record/EventRecord';
+import {EventRecord} from '../storage/record/EventRecord';
 
 const _checkAsset = (event: any): MessageCategory | void => {
   const {data: eventData, type: eventType} = event;
@@ -80,9 +80,9 @@ const _checkText = (event: any): MessageCategory | void => {
   }
 };
 
-export const categoryFromEvent = (event: LegacyEventRecord): MessageCategory => {
+export const categoryFromEvent = (event: Partial<EventRecord>): MessageCategory => {
   try {
-    const eventReactions = event.reactions;
+    const eventReactions = 'reactions' in event && event.reactions;
     let category = MessageCategory.NONE;
 
     const categoryChecks = [_checkText, _checkAsset, _checkPing, _checkLocation, _checkComposite];

--- a/src/script/storage/record/EventRecord.ts
+++ b/src/script/storage/record/EventRecord.ts
@@ -42,7 +42,7 @@ export interface AssetRecord {
 export type UserReactionMap = {[userId: string]: ReactionType};
 
 /** represents an event that was saved to the DB */
-export type StoredEvent = {
+export type StoredEvent<T> = {
   primary_key: string;
   category: number;
   id: string;
@@ -53,9 +53,11 @@ export type StoredEvent = {
   /** some events are updated sequentially and we keep track of a version */
   version?: number;
   status?: StatusType;
+} & {
+  [K in keyof T]: T[K];
 };
 
-export type EventRecord = StoredEvent & (ConversationEvent | ClientConversationEvent);
+export type EventRecord = StoredEvent<ConversationEvent | ClientConversationEvent>;
 
 /** @deprecated This is the old swallow-all type. Use the EventRecord Discriminated Union Type instead */
 export interface LegacyEventRecord<T = any> {

--- a/src/script/storage/record/EventRecord.ts
+++ b/src/script/storage/record/EventRecord.ts
@@ -46,7 +46,12 @@ export type StoredEvent<T> = {
   primary_key: string;
   category: number;
   id: string;
-  /** if the message is ephemeral, that's the amount of time it should be displayed to the user */
+  /** if the message is ephemeral, that's the amount of time it should be displayed to the user
+   * the different types are
+   *  - string: a datestring
+   *  - number: a timestamp
+   *  - boolean: indicate it has been consumed
+   */
   ephemeral_expires?: number | boolean | string;
   ephemeral_started?: number;
   ephemeral_time?: string;

--- a/src/script/storage/record/EventRecord.ts
+++ b/src/script/storage/record/EventRecord.ts
@@ -21,6 +21,8 @@ import type {ConversationEvent} from '@wireapp/api-client/lib/event';
 import type {QualifiedId} from '@wireapp/api-client/lib/user';
 import type {ReactionType} from '@wireapp/core/lib/conversation/';
 
+import {ClientConversationEvent} from 'src/script/conversation/EventBuilder';
+
 import {StatusType} from '../../message/StatusType';
 
 export interface ReadReceipt {
@@ -40,13 +42,20 @@ export interface AssetRecord {
 export type UserReactionMap = {[userId: string]: ReactionType};
 
 /** represents an event that was saved to the DB */
-type StoredEvent = {
+export type StoredEvent = {
   primary_key: string;
   category: number;
   id: string;
+  /** if the message is ephemeral, that's the amount of time it should be displayed to the user */
+  ephemeral_expires?: number | boolean | string;
+  ephemeral_started?: number;
+  ephemeral_time?: string;
+  /** some events are updated sequentially and we keep track of a version */
+  version?: number;
+  status?: StatusType;
 };
 
-export type EventRecord = StoredEvent & ConversationEvent;
+export type EventRecord = StoredEvent & (ConversationEvent | ClientConversationEvent);
 
 /** @deprecated This is the old swallow-all type. Use the EventRecord Discriminated Union Type instead */
 export interface LegacyEventRecord<T = any> {


### PR DESCRIPTION
This will differentiate between:
- Incoming events (coming from backend or manually injected)
- Stored events (events that are in the DB that have been mapped previously)