### PR TITLE
fix: Device name shows encoded chars instead of space (SQSERVICES-1893)

### DIFF
--- a/src/script/components/Modals/PrimaryModal/PrimaryModalState.ts
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModalState.ts
@@ -18,6 +18,7 @@
  */
 
 import {isValid} from 'date-fns';
+import {escape} from 'underscore';
 import {create} from 'zustand';
 
 import {replaceLink, t} from 'Util/LocalizerUtil';


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1893" title="SQSERVICES-1893" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1893</a>  [Webapp] Device name shows %20 instead of spaces
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - when a new device is added and the device name contains space, the popup message that appears when going into settings is URL encoded, so all the spaces show up as %20.

- The **PR Description**
  - Steps to reproduce:
  1. Login to wire in webapp
  2. Login to wire in Android App on a phone whose name that contains spaces (Google Pixel 3a) in my case.
  3. Go to the webapp, the settings icon on top left should show a dot
  4. Click on the settings icon and see the popup showing %20 instead of spaces.
----
##### References
1. https://wearezeta.atlassian.net/browse/SQSERVICES-1893
