### PR TITLE
fix: Await for message processing when loading the app

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.10.5",
     "@types/eslint": "^8.4.10",
     "@wireapp/avs": "9.0.20",
-    "@wireapp/core": "38.11.0",
+    "@wireapp/core": "38.11.1",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.3.5",
     "@wireapp/store-engine-dexie": "2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4383,9 +4383,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:38.11.0":
-  version: 38.11.0
-  resolution: "@wireapp/core@npm:38.11.0"
+"@wireapp/core@npm:38.11.1":
+  version: 38.11.1
+  resolution: "@wireapp/core@npm:38.11.1"
   dependencies:
     "@wireapp/api-client": ^22.15.4
     "@wireapp/commons": ^5.0.4
@@ -4403,7 +4403,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.13
-  checksum: 41e0f8da4bb54a24b2c91a6a2f16b0d91a174e5febbdc3087045cb0ac9eb79c602e8716ee514e0d3f3aeeff4cb2605f3ce218372a11d53a47cd723e7142ca8af
+  checksum: 002a2263e82a06af6e665d57bd2cc17791bf6385e89236c1484e1b27e6b2d352a2012dbde0f7d604571d37b6846c0f34325dea52ec65016b2180d9619d10a03f
   languageName: node
   linkType: hard
 
@@ -16712,7 +16712,7 @@ __metadata:
     "@typescript-eslint/parser": ^5.50.0
     "@wireapp/avs": 9.0.20
     "@wireapp/copy-config": 2.0.7
-    "@wireapp/core": 38.11.0
+    "@wireapp/core": 38.11.1
     "@wireapp/eslint-config": 2.1.1
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.5.2


### PR DESCRIPTION
When loading the webapp, we are processing incoming events and saving them to the DB. 
The thing is, the previous version of the `core` would not await for the event handler to be done before moving on to the next event. 
Which means we could have an event that is supposed to be saved to the DB but we start processing the next event before this one has actually been saved. This created some race condition where we would query the DB for an event (because of a quote) but it has not yet been saved in the DB

see https://github.com/wireapp/wire-web-packages/pull/4866