### PR TITLE
runfix: Update message category before saving to DB

### DIFF
--- a/src/script/event/EventService.ts
+++ b/src/script/event/EventService.ts
@@ -334,10 +334,13 @@ export class EventService {
    * @param event JSON event to be stored
    */
   async saveEvent(event: Omit<EventRecord, 'primary_key' | 'category'>): Promise<EventRecord> {
-    const savedEvent: EventRecord = {
+    const categorizedEvent = {
       ...event,
       category: categoryFromEvent(event as EventRecord),
-      primary_key: await this.storageService.save(StorageSchemata.OBJECT_STORE.EVENTS, undefined, event),
+    };
+    const savedEvent: EventRecord = {
+      ...event,
+      primary_key: await this.storageService.save(StorageSchemata.OBJECT_STORE.EVENTS, undefined, categorizedEvent),
     } as EventRecord;
     if (this.storageService.isTemporaryAndNonPersistent) {
       /**

--- a/src/script/event/EventService.ts
+++ b/src/script/event/EventService.ts
@@ -339,7 +339,7 @@ export class EventService {
       category: categoryFromEvent(event as EventRecord),
     };
     const savedEvent: EventRecord = {
-      ...event,
+      ...categorizedEvent,
       primary_key: await this.storageService.save(StorageSchemata.OBJECT_STORE.EVENTS, undefined, categorizedEvent),
     } as EventRecord;
     if (this.storageService.isTemporaryAndNonPersistent) {

--- a/test/unit_tests/event/EventServiceCommon.js
+++ b/test/unit_tests/event/EventServiceCommon.js
@@ -300,17 +300,19 @@ const testEventServiceClass = (testedServiceName, className) => {
       const newEvent = {
         conversation: conversationId,
         id: '4af67f76-09f9-4831-b3a4-9df877b8c29a',
+        data: {},
         from: senderId,
         time: '2016-08-04T13:27:58.993Z',
         type: 'conversation.message-add',
       };
+      const categorizedEvent = {...newEvent, category: MessageCategory.TEXT};
 
       it('save event in the database', () => {
         spyOn(testFactory.storage_service, 'save').and.callFake(event => Promise.resolve(event));
 
         return testFactory[testedServiceName].saveEvent(newEvent).then(event => {
           expect(event.category).toBeDefined();
-          expect(testFactory.storage_service.save).toHaveBeenCalledWith(eventStoreName, undefined, newEvent);
+          expect(testFactory.storage_service.save).toHaveBeenCalledWith(eventStoreName, undefined, categorizedEvent);
         });
       });
     });


### PR DESCRIPTION
This is a regression introduced by #14640 . 
The category was added to the event we return, but not the payload we save in the DB