### PR TITLE
chore: Improve lint job to use more CPUs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Now that the entire build is faster than just the linting part, let's speed up the linting job a little bit 

This bring down the job from 3min to 1min