### PR TITLE
feat: Save failed to send data in database [FS-1472]

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -88,25 +88,16 @@ const ContentMessageComponent: React.FC<ContentMessageProps> = ({
   );
   const messageFocusedTabIndex = useMessageFocusedTabIndex(msgFocusState);
   const {entries: menuEntries} = useKoSubscribableChildren(contextMenu, ['entries']);
-  const {
-    headerSenderName,
-    timestamp,
-    ephemeral_caption,
-    ephemeral_status,
-    assets,
-    other_likes,
-    was_edited,
-    failedToSend,
-  } = useKoSubscribableChildren(message, [
-    'failedToSend',
-    'headerSenderName',
-    'timestamp',
-    'ephemeral_caption',
-    'ephemeral_status',
-    'assets',
-    'other_likes',
-    'was_edited',
-  ]);
+  const {headerSenderName, timestamp, ephemeral_caption, ephemeral_status, assets, other_likes, was_edited} =
+    useKoSubscribableChildren(message, [
+      'headerSenderName',
+      'timestamp',
+      'ephemeral_caption',
+      'ephemeral_status',
+      'assets',
+      'other_likes',
+      'was_edited',
+    ]);
 
   const shouldShowAvatar = (): boolean => {
     if (!previousMessage || hasMarker) {

--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -88,16 +88,25 @@ const ContentMessageComponent: React.FC<ContentMessageProps> = ({
   );
   const messageFocusedTabIndex = useMessageFocusedTabIndex(msgFocusState);
   const {entries: menuEntries} = useKoSubscribableChildren(contextMenu, ['entries']);
-  const {headerSenderName, timestamp, ephemeral_caption, ephemeral_status, assets, other_likes, was_edited} =
-    useKoSubscribableChildren(message, [
-      'headerSenderName',
-      'timestamp',
-      'ephemeral_caption',
-      'ephemeral_status',
-      'assets',
-      'other_likes',
-      'was_edited',
-    ]);
+  const {
+    headerSenderName,
+    timestamp,
+    ephemeral_caption,
+    ephemeral_status,
+    assets,
+    other_likes,
+    was_edited,
+    failedToSend,
+  } = useKoSubscribableChildren(message, [
+    'failedToSend',
+    'headerSenderName',
+    'timestamp',
+    'ephemeral_caption',
+    'ephemeral_status',
+    'assets',
+    'other_likes',
+    'was_edited',
+  ]);
 
   const shouldShowAvatar = (): boolean => {
     if (!previousMessage || hasMarker) {

--- a/src/script/conversation/EventMapper.ts
+++ b/src/script/conversation/EventMapper.ts
@@ -65,6 +65,7 @@ import type {Text as TextAsset} from '../entity/message/Text';
 import {VerificationMessage} from '../entity/message/VerificationMessage';
 import {ConversationError} from '../error/ConversationError';
 import {ClientEvent} from '../event/Client';
+import {isContentMessage} from '../guards/Message';
 import {CALL_MESSAGE_TYPE} from '../message/CallMessageType';
 import {MentionEntity} from '../message/MentionEntity';
 import {QuoteEntity} from '../message/QuoteEntity';
@@ -140,7 +141,7 @@ export class EventMapper {
    * @param event new json data to feed into the entity
    * @returns the updated message entity
    */
-  async updateMessageEvent(originalEntity: ContentMessage, event: LegacyEventRecord): Promise<ContentMessage> {
+  async updateMessageEvent(originalEntity: ContentMessage, event: EventRecord): Promise<ContentMessage> {
     const {id, data: eventData, edited_time: editedTime, conversation, qualified_conversation} = event;
 
     if (eventData.quote) {
@@ -184,6 +185,10 @@ export class EventMapper {
     if (event.reactions) {
       originalEntity.reactions(event.reactions);
       originalEntity.version = event.version;
+    }
+
+    if (event.failedToSend) {
+      originalEntity.failedToSend(event.failedToSend);
     }
 
     if (event.selected_button_id) {
@@ -394,7 +399,7 @@ export class EventMapper {
       messageEntity = undefined;
     }
 
-    return messageEntity;
+    return isContentMessage(messageEntity) ? this.updateMessageEvent(messageEntity, event) : messageEntity;
   }
 
   //##############################################################################
@@ -551,7 +556,7 @@ export class EventMapper {
    * @param event Message data
    * @returns Content message entity
    */
-  private async _mapEventMessageAdd(event: LegacyEventRecord) {
+  private async _mapEventMessageAdd(event: EventRecord) {
     const {data: eventData, edited_time: editedTime} = event;
     const messageEntity = new ContentMessage();
 

--- a/src/script/conversation/EventMapper.ts
+++ b/src/script/conversation/EventMapper.ts
@@ -141,7 +141,7 @@ export class EventMapper {
    * @param event new json data to feed into the entity
    * @returns the updated message entity
    */
-  async updateMessageEvent(originalEntity: ContentMessage, event: EventRecord): Promise<ContentMessage> {
+  async updateMessageEvent(originalEntity: ContentMessage, event: LegacyEventRecord): Promise<ContentMessage> {
     const {id, data: eventData, edited_time: editedTime, conversation, qualified_conversation} = event;
 
     if (eventData.quote) {
@@ -399,7 +399,9 @@ export class EventMapper {
       messageEntity = undefined;
     }
 
-    return isContentMessage(messageEntity) ? this.updateMessageEvent(messageEntity, event) : messageEntity;
+    return isContentMessage(messageEntity)
+      ? this.updateMessageEvent(messageEntity, event as EventRecord)
+      : messageEntity;
   }
 
   //##############################################################################
@@ -556,7 +558,7 @@ export class EventMapper {
    * @param event Message data
    * @returns Content message entity
    */
-  private async _mapEventMessageAdd(event: EventRecord) {
+  private async _mapEventMessageAdd(event: LegacyEventRecord) {
     const {data: eventData, edited_time: editedTime} = event;
     const messageEntity = new ContentMessage();
 

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -720,14 +720,19 @@ export class MessageRepository {
       return silentDegradationWarning ? true : this.requestUserSendingPermission(conversation, false, consentType);
     };
 
-    const handleSuccess = async ({sentAt}: SendResult) => {
+    const handleSuccess = async ({sentAt, failedToSend}: SendResult) => {
       const injectDelta = 10; // we want to make sure the message is injected slightly before it was received by the backend
       const sentTimestamp = new Date(sentAt).getTime() - injectDelta;
       const preMessageTimestamp = new Date(sentTimestamp).toISOString();
       // Trigger an empty mismatch to check for users that have no devices and that could have been removed from the team
       await this.onClientMismatch?.({time: preMessageTimestamp}, conversation, silentDegradationWarning);
       if (!skipInjection) {
-        await this.updateMessageAsSent(conversation, payload.messageId, syncTimestamp ? sentAt : undefined);
+        await this.updateMessageAsSent(
+          conversation,
+          payload.messageId,
+          syncTimestamp ? sentAt : undefined,
+          failedToSend,
+        );
       }
     };
 
@@ -1100,13 +1105,19 @@ export class MessageRepository {
    * @param isoDate If defined it will update event timestamp
    * @returns Resolves when sent status was updated
    */
-  private async updateMessageAsSent(conversationEntity: Conversation, eventId: string, isoDate?: string) {
+  private async updateMessageAsSent(
+    conversationEntity: Conversation,
+    eventId: string,
+    isoDate?: string,
+    failedToSend?: QualifiedUserClients,
+  ) {
     try {
       const messageEntity = await this.getMessageInConversationById(conversationEntity, eventId);
       const updatedStatus = messageEntity.readReceipts().length ? StatusType.SEEN : StatusType.SENT;
       messageEntity.status(updatedStatus);
-      const changes: Pick<Partial<EventRecord>, 'status' | 'time'> = {
+      const changes: Pick<Partial<EventRecord>, 'status' | 'time' | 'failedToSend'> = {
         status: updatedStatus,
+        failedToSend,
       };
       if (isoDate) {
         const timestamp = new Date(isoDate).getTime();

--- a/src/script/entity/message/ContentMessage.ts
+++ b/src/script/entity/message/ContentMessage.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import type {QualifiedUserClients} from '@wireapp/api-client/lib/conversation';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import type {ReactionType} from '@wireapp/core/lib/conversation/ReactionType';
 import ko from 'knockout';
@@ -44,6 +45,7 @@ export class ContentMessage extends Message {
   public readonly is_liked: ko.PureComputed<boolean>;
   public readonly like_caption: ko.PureComputed<string>;
   public readonly other_likes: ko.PureComputed<User[]>;
+  public readonly failedToSend: ko.Observable<QualifiedUserClients | undefined> = ko.observable();
   public readonly quote: ko.Observable<QuoteEntity>;
   // TODO: Rename to `reactionsUsers`
   public readonly reactions_user_ids: ko.PureComputed<string>;

--- a/src/script/storage/record/EventRecord.ts
+++ b/src/script/storage/record/EventRecord.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import type {QualifiedUserClients} from '@wireapp/api-client/lib/conversation';
 import type {ConversationEvent} from '@wireapp/api-client/lib/event';
 import type {QualifiedId} from '@wireapp/api-client/lib/user';
 import type {ReactionType} from '@wireapp/core/lib/conversation/';
@@ -47,6 +48,7 @@ export type UserReactionMap = {[userId: string]: ReactionType};
 type SentEvent = {
   /** sending status of the event*/
   status: StatusType;
+  failedToSend?: QualifiedUserClients;
 };
 
 /** represents an event that was saved to the DB */


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1472" title="FS-1472" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-1472</a>  [Web] Implement client protocol for sending messages with unreachable backends
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This will store the `failedToSend` return from backend to the DB (for later consumption) 

This indicates to which users the messages could not be sent (in case one backend is offline)