### PR TITLE
fix: Add padding to start-ui search when typing (SQSERVICES-1678)

### DIFF
--- a/src/script/components/SearchInput.tsx
+++ b/src/script/components/SearchInput.tsx
@@ -19,6 +19,8 @@
 
 import React, {useEffect, useLayoutEffect, useRef} from 'react';
 
+import cx from 'classnames';
+
 import {isRemovalAction, isEnterKey} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
 
@@ -77,7 +79,7 @@ const SearchInput: React.FC<SearchInputProps> = ({
           <div className="search-icon icon-search" />
 
           <input
-            className="search-input"
+            className={cx('search-input', {'search-input-padding': !!input})}
             data-uie-name="enter-users"
             maxLength={MAX_HANDLE_LENGTH}
             onChange={event => setInput(event.target.value)}

--- a/src/style/components/search-input.less
+++ b/src/style/components/search-input.less
@@ -166,5 +166,5 @@ body.theme-dark {
 }
 
 .search-input-padding {
-  padding: 0 40px 0 40px !important;
+  padding: 0 40px !important;
 }

--- a/src/style/components/search-input.less
+++ b/src/style/components/search-input.less
@@ -164,3 +164,7 @@ body.theme-dark {
     margin-bottom: 6px;
   }
 }
+
+.search-input-padding {
+  padding: 0 40px 0 40px !important;
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1678" title="SQSERVICES-1678" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1678</a>  Connection search box text passes underneath "clear all" button.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Changed from

<img width="314" alt="image" src="https://user-images.githubusercontent.com/63250054/218714574-27ca5031-47ff-498e-8f33-f8ca88a83023.png">

to

<img width="304" alt="image" src="https://user-images.githubusercontent.com/63250054/218714481-fdc587ac-8e1d-4652-b7ee-328c8d2a8d0a.png">