### PR TITLE
runfix: dont create removal task for self-client

### DIFF
--- a/src/script/view_model/CallingViewModel.ts
+++ b/src/script/view_model/CallingViewModel.ts
@@ -247,13 +247,6 @@ export class CallingViewModel {
       conversationId: QualifiedId,
       memberToRemove: QualifiedWcallMember,
     ): Promise<void> => {
-      const isSelfClient =
-        memberToRemove.userId.id === this.core.userId && memberToRemove.clientid === this.core.clientId;
-      //this is not very likely to happen (selfClient will leave or get dropped from the call)
-      if (isSelfClient) {
-        return;
-      }
-
       const subconversationGroupId = await this.mlsService.getGroupIdFromConversationId(
         conversationId,
         SUBCONVERSATION_ID.CONFERENCE,
@@ -291,6 +284,12 @@ export class CallingViewModel {
       }
 
       for (const member of members) {
+        const isSelfClient = member.userId.id === this.core.userId && member.clientid === this.core.clientId;
+        //no need to set a timer for selfClient (it will most likely leave or get dropped from the call before the timer could expire)
+        if (isSelfClient) {
+          continue;
+        }
+
         const {id: userId, domain} = member.userId;
         const clientQualifiedId = constructFullyQualifiedClientId(userId, member.clientid, domain);
 


### PR DESCRIPTION
A little improvement to https://github.com/wireapp/wire-webapp/pull/14599/
There's no need to set up a timer for selfclient at all.