### PR TITLE
fix: 2fa login handle error [SQSERVICES-1850]

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -9,6 +9,7 @@
   "BackendError.LABEL.CONVERSATION_NOT_FOUND": "CONVERSATION_NOT_FOUND",
   "BackendError.LABEL.CONVERSATION_TOO_MANY_MEMBERS": "This conversation has reached the limit of participants",
   "BackendError.LABEL.EMAIL_EXISTS": "This email address is already in use. {supportEmailExistsLink}",
+  "BackendError.LABEL.EMAIL_REQUIRED": "Log in with an email address is required when two-factor authentication is activated",
   "BackendError.LABEL.HANDLE_EXISTS": "This username is already taken",
   "BackendError.LABEL.HANDLE_TOO_SHORT": "Please enter a username with at least 2 characters",
   "BackendError.LABEL.INVALID_CODE": "Please retry, or request another code.",

--- a/src/script/auth/module/action/AuthAction.ts
+++ b/src/script/auth/module/action/AuthAction.ts
@@ -22,7 +22,7 @@ import type {LoginData, RegisterData, SendLoginCode} from '@wireapp/api-client/l
 import {VerificationActionType} from '@wireapp/api-client/lib/auth/VerificationActionType';
 import {ClientType} from '@wireapp/api-client/lib/client/';
 import {LowDiskSpaceError} from '@wireapp/store-engine/lib/engine/error';
-import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
+import {StatusCodes as HTTP_STATUS, StatusCodes} from 'http-status-codes';
 
 import type {CRUDEngine} from '@wireapp/store-engine';
 import {SQLeetEngine} from '@wireapp/store-engine-sqleet';
@@ -152,6 +152,13 @@ export class AuthAction {
         await apiClient.api.user.postVerificationCode(email, VerificationActionType.LOGIN);
         dispatch(AuthActionCreator.successfulSendTwoFactorCode());
       } catch (error) {
+        if (error.label === BackendError.LABEL.BAD_REQUEST) {
+          error = new BackendError({
+            code: StatusCodes.BAD_REQUEST,
+            label: BackendError.AUTH_ERRORS.EMAIL_REQUIRED,
+            message: error.message,
+          });
+        }
         dispatch(AuthActionCreator.failedSendTwoFactorCode(error));
         throw error;
       }

--- a/src/script/auth/module/action/BackendError.ts
+++ b/src/script/auth/module/action/BackendError.ts
@@ -31,11 +31,13 @@ export class BackendError extends Error {
   }
 
   static AUTH_ERRORS = {
+    BAD_REQUEST: 'bad-request',
     BLACKLISTED_EMAIL: 'blacklisted-email',
     BLACKLISTED_PHONE: 'blacklisted-phone',
     CODE_AUTHENTICATION_FAILED: 'code-authentication-failed',
     CODE_AUTHENTICATION_REQUIRED: 'code-authentication-required',
     DOMAIN_BLOCKED_FOR_REGISTRATION: 'domain-blocked-for-registration',
+    EMAIL_REQUIRED: 'email-required', // Synthetic error label
     INVALID_CODE: 'invalid-code',
     INVALID_CREDENTIALS: 'invalid-credentials',
     INVALID_EMAIL: 'invalid-email',

--- a/src/script/auth/module/reducer/authReducer.ts
+++ b/src/script/auth/module/reducer/authReducer.ts
@@ -111,10 +111,16 @@ export function authReducer(state: AuthState = initialAuthState, action: AppActi
         isSendingTwoFactorCode: true,
       };
     }
-    case AUTH_ACTION.SEND_TWO_FACTOR_CODE_SUCCESS:
+    case AUTH_ACTION.SEND_TWO_FACTOR_CODE_SUCCESS: {
+      return {
+        ...state,
+        isSendingTwoFactorCode: false,
+      };
+    }
     case AUTH_ACTION.SEND_TWO_FACTOR_CODE_FAILED: {
       return {
         ...state,
+        error: action.error,
         isSendingTwoFactorCode: false,
       };
     }

--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -136,7 +136,7 @@ const LoginComponent = ({
     if (defaultSSOCode) {
       navigate(`${ROUTE.SSO}/${defaultSSOCode}`);
     }
-  }, [defaultSSOCode]);
+  }, [defaultSSOCode, navigate]);
 
   useEffect(() => {
     const queryConversationCode = UrlUtil.getURLParameter(QUERY_KEY.CONVERSATION_CODE) || null;
@@ -196,31 +196,31 @@ const LoginComponent = ({
       if (isBackendError(error)) {
         switch (error.label) {
           case BackendError.LABEL.TOO_MANY_CLIENTS: {
-            resetAuthError();
+            await resetAuthError();
             if (formLoginData?.verificationCode) {
-              doSetLocalStorage(QUERY_KEY.CONVERSATION_CODE, formLoginData.verificationCode);
+              await doSetLocalStorage(QUERY_KEY.CONVERSATION_CODE, formLoginData.verificationCode);
             }
             if (entropy.current) {
-              pushEntropyData(entropy.current);
+              await pushEntropyData(entropy.current);
             }
             navigate(ROUTE.CLIENTS);
             break;
           }
+
           case BackendError.LABEL.CODE_AUTHENTICATION_REQUIRED: {
+            await resetAuthError();
             const login: LoginData = {...formLoginData, clientType: loginData.clientType};
             if (login.email || login.handle) {
+              await doSendTwoFactorCode(login.email || login.handle || '');
               setTwoFactorLoginData(login);
-              doSendTwoFactorCode(login.email || login.handle || '');
-              doSetLocalStorage(QUERY_KEY.JOIN_EXPIRES, Date.now() + 1000 * 60 * 10);
+              await doSetLocalStorage(QUERY_KEY.JOIN_EXPIRES, Date.now() + 1000 * 60 * 10);
             }
             break;
           }
+
           case BackendError.LABEL.CODE_AUTHENTICATION_FAILED: {
             setTwoFactorSubmitError(error);
             break;
-          }
-          case BackendError.LABEL.BAD_REQUEST: {
-            throw new BackendError({code: StatusCodes.BAD_REQUEST, label: BackendError.AUTH_ERRORS.EMAIL_REQUIRED});
           }
           case BackendError.LABEL.INVALID_CREDENTIALS:
           case BackendError.LABEL.SUSPENDED:

--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -208,9 +208,9 @@ const LoginComponent = ({
           }
           case BackendError.LABEL.CODE_AUTHENTICATION_REQUIRED: {
             const login: LoginData = {...formLoginData, clientType: loginData.clientType};
-            if (login.email) {
+            if (login.email || login.handle) {
               setTwoFactorLoginData(login);
-              doSendTwoFactorCode(login.email);
+              doSendTwoFactorCode(login.email || login.handle || '');
               doSetLocalStorage(QUERY_KEY.JOIN_EXPIRES, Date.now() + 1000 * 60 * 10);
             }
             break;
@@ -218,6 +218,9 @@ const LoginComponent = ({
           case BackendError.LABEL.CODE_AUTHENTICATION_FAILED: {
             setTwoFactorSubmitError(error);
             break;
+          }
+          case BackendError.LABEL.BAD_REQUEST: {
+            throw new BackendError({code: StatusCodes.BAD_REQUEST, label: BackendError.AUTH_ERRORS.EMAIL_REQUIRED});
           }
           case BackendError.LABEL.INVALID_CREDENTIALS:
           case BackendError.LABEL.SUSPENDED:

--- a/src/script/strings.ts
+++ b/src/script/strings.ts
@@ -558,6 +558,10 @@ export const errorHandlerStrings = defineMessages({
     defaultMessage: 'Invalid input',
     id: 'BackendError.LABEL.BAD_REQUEST',
   },
+  [BackendError.LABEL.EMAIL_REQUIRED]: {
+    defaultMessage: 'Log in with an email address is required when two-factor authentication is activated',
+    id: 'BackendError.LABEL.EMAIL_REQUIRED',
+  },
   [BackendError.LABEL.INVALID_OPERATION]: {
     defaultMessage: 'Invalid operation',
     id: 'BackendError.LABEL.INVALID_OPERATION',


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1850" title="SQSERVICES-1850" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1850</a>  [Web/TM] 2FA on Team Management does not work with username, only email address
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Appropriately handles the error when a user tries to login to a 2fa account with a handle

### Causes (Optional)

2fa with a handle is not allowed by the BE (technical constraint). however on web the error isn't handled correctly. 

### Solutions

show an informative error message when a user tries to use a handle to login with 2fa