### PR TITLE
chore: bump core to enable lastprekey improvement [FS-1542]

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.10.5",
     "@types/eslint": "^8.4.10",
     "@wireapp/avs": "9.0.21",
-    "@wireapp/core": "38.12.0",
+    "@wireapp/core": "38.13.0",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.3.5",
     "@wireapp/store-engine-dexie": "2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4415,9 +4415,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:38.12.0":
-  version: 38.12.0
-  resolution: "@wireapp/core@npm:38.12.0"
+"@wireapp/core@npm:38.13.0":
+  version: 38.13.0
+  resolution: "@wireapp/core@npm:38.13.0"
   dependencies:
     "@wireapp/api-client": ^22.15.4
     "@wireapp/commons": ^5.0.4
@@ -4435,7 +4435,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.13
-  checksum: fbdc8fb59208f55e24f6ed846491c99ed46f7cac25850e14b732cfb218c707f05a4e741631ecf4c54792251140b56976de52d691b1b5ba529d24a2747bf6d78d
+  checksum: befcf63aa698349e248d616558f5cea9f59c698aa7218b6d46c54302612098f0e2231cbe07b182fbe14591c84a25d4ebb83113189b5d84c54fb9cdb7bae9d025
   languageName: node
   linkType: hard
 
@@ -16826,7 +16826,7 @@ __metadata:
     "@typescript-eslint/parser": ^5.51.0
     "@wireapp/avs": 9.0.21
     "@wireapp/copy-config": 2.0.8
-    "@wireapp/core": 38.12.0
+    "@wireapp/core": 38.13.0
     "@wireapp/eslint-config": 2.1.1
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.5.2


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1542" title="FS-1542" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-1542</a>  [Web] Adopt Proteus last resort PreKeys API
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Bump `core` version to:
- enable `lastPrekey` improvements with corecrypto.