### PR TITLE
chore: Upload test results as releases assets

### DIFF
--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -76,7 +76,7 @@ jobs:
         run: yarn --immutable
 
       - name: Test
-        run: yarn test --coverage --coverage-reporters=lcov --detectOpenHandles=false
+        run: yarn test --coverage --coverage-reporters=lcov --detectOpenHandles=false | tee ./unit-tests.log
 
       - name: Monitor coverage
         uses: codecov/codecov-action@v3.1.1
@@ -200,6 +200,7 @@ jobs:
           tag_name: ${{env.TAG}}
           name: ${{env.TAG}}
           body_path: ./CHANGELOG.md
+          files: ./unit-tests.log
           draft: false
           prerelease: false
 
@@ -226,6 +227,7 @@ jobs:
           tag_name: ${{env.TAG}}
           name: ${{env.TAG}}
           body_path: ./CHANGELOG.md
+          files: ./unit-tests.log
           draft: false
           prerelease: true
 

--- a/package.json
+++ b/package.json
@@ -229,7 +229,7 @@
     "start:server:dev": "cross-env NODE_ENV=development node ./server/dist/index.js",
     "stylelint": "prettier --ignore-path .prettierignore --write \"**/*.less\" && stylelint --ignore-path .gitignore \"**/*.less\"",
     "test": "yarn test:types && yarn test:server && yarn test:app",
-    "test:app": "jest --forceExit",
+    "test:app": "jest --forceExit --verbose",
     "test:server": "cd server && yarn test",
     "test:types": "tsc --project tsconfig.build.json --noEmit && cd server && tsc --noEmit",
     "translate:extract": "i18next-scanner 'src/{page,script}/**/*.{js,html,htm}'",


### PR DESCRIPTION
This will be needed in order to proof that security related tests are run on releases