### PR TITLE
fix: Incoming call - add custom shortcuts to accept or reject call

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -229,7 +229,7 @@
   "callAccept": "Accept",
   "callChooseSharedScreen": "Choose a screen to share",
   "callChooseSharedWindow": "Choose a window to share",
-  "callConversationAcceptOrDecline": "{{conversationName}} is calling. Press enter to accept the call or press escape to decline the call.",
+  "callConversationAcceptOrDecline": "{{conversationName}} is calling. Press control + enter to accept the call or press control + shift + enter to decline the call.",
   "callDecline": "Decline",
   "callDegradationAction": "OK",
   "callDegradationDescription": "The call was disconnected because {{username}} is no longer a verified contact.",

--- a/src/script/components/calling/CallingCell.tsx
+++ b/src/script/components/calling/CallingCell.tsx
@@ -36,7 +36,7 @@ import {ClassifiedBar} from 'Components/input/ClassifiedBar';
 import {ParticipantItem} from 'Components/list/ParticipantItem';
 import {useAppMainState, ViewType} from 'src/script/page/state';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
-import {isEnterKey, isEscapeKey, KEY} from 'Util/KeyboardUtil';
+import {isEnterKey, KEY} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
 import {sortUsersByPriority} from 'Util/StringUtil';
 
@@ -229,17 +229,14 @@ const CallingCell: React.FC<CallingCellProps> = ({
 
   const answerOrRejectCall = useCallback(
     (event: KeyboardEvent) => {
-      event.preventDefault();
-      event.stopPropagation();
-
       const removeEventListener = () => window.removeEventListener('keydown', answerOrRejectCall);
 
-      if (isEnterKey(event)) {
+      if (!event.shiftKey && event.ctrlKey && isEnterKey(event)) {
         answerCall();
         removeEventListener();
       }
 
-      if (isEscapeKey(event)) {
+      if (event.ctrlKey && event.shiftKey && isEnterKey(event)) {
         callActions.reject(call);
         removeEventListener();
       }


### PR DESCRIPTION
Fix for accept or reject incoming call.
Jira: https://wearezeta.atlassian.net/browse/ACC-437?focusedCommentId=110856

Prev:
When someone is calling to you can't write text and send message.
Now:
When someone is calling to you, You can write text and send message. You can accept call by click Ctrl + Enter, and reject by Ctrl + Shift + Enter.