### PR TITLE
chore: make sure failing tests are reported

### DIFF
--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -76,7 +76,9 @@ jobs:
         run: yarn --immutable
 
       - name: Test
-        run: yarn test --coverage --coverage-reporters=lcov --detectOpenHandles=false | tee ./unit-tests.log
+        run: |
+          set -o pipefail
+          yarn test --coverage --coverage-reporters=lcov --detectOpenHandles=false | tee ./unit-tests.log
 
       - name: Monitor coverage
         uses: codecov/codecov-action@v3.1.1

--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -240,7 +240,6 @@ jobs:
           email: ${{secrets.WIRE_BOT_EMAIL}}
           password: ${{secrets.WIRE_BOT_PASSWORD}}
           conversation: '697c93e8-0b13-4204-a35e-59270462366a'
-          send_gif: 'in the oven'
           send_text: 'Staging bump for commit **${{github.sha}}** ("${{env.TITLE}}") done! 🏁'
 
       - name: Notify CI error


### PR DESCRIPTION
Since  #14691  the failing test would not report to github PR 