### PR TITLE
chore: Fix eslint types

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@faker-js/faker": "7.6.0",
     "@formatjs/cli": "6.0.1",
     "@koush/wrtc": "0.5.3",
-    "@testing-library/react": "14.0.0",
+    "@testing-library/react": "13.4.0",
     "@types/adm-zip": "0.5.0",
     "@types/caniuse-lite": "^1.0.1",
     "@types/classnames": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@emotion/react": "11.10.6",
-    "@types/eslint": "^8.21.1",
+    "@types/eslint": "8.4.10",
     "@wireapp/avs": "9.0.21",
     "@wireapp/core": "38.13.2",
     "@wireapp/lru-cache": "3.8.1",
@@ -65,7 +65,6 @@
     "@types/caniuse-lite": "^1.0.1",
     "@types/classnames": "2.3.1",
     "@types/dexie-batch": "0.4.3",
-    "@types/eslint-scope": "^3.7.4",
     "@types/fs-extra": "11.0.1",
     "@types/generate-changelog": "1.8.1",
     "@types/highlight.js": "10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3206,9 +3206,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/dom@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@testing-library/dom@npm:9.0.0"
+"@testing-library/dom@npm:^8.5.0":
+  version: 8.20.0
+  resolution: "@testing-library/dom@npm:8.20.0"
   dependencies:
     "@babel/code-frame": ^7.10.4
     "@babel/runtime": ^7.12.5
@@ -3218,21 +3218,21 @@ __metadata:
     dom-accessibility-api: ^0.5.9
     lz-string: ^1.4.4
     pretty-format: ^27.0.2
-  checksum: 5381bf9438f0ee35f795e7f9b203564aa455e7cd838b6677084c82dd56396779c38cc49ddffed4e57a8bcc3c62b4bc96ea684bb4b24d13655152db745327b2cd
+  checksum: 1e599129a2fe91959ce80900a0a4897232b89e2a8e22c1f5950c36d39c97629ea86b4986b60b173b5525a05de33fde1e35836ea597b03de78cc51b122835c6f0
   languageName: node
   linkType: hard
 
-"@testing-library/react@npm:14.0.0":
-  version: 14.0.0
-  resolution: "@testing-library/react@npm:14.0.0"
+"@testing-library/react@npm:13.4.0":
+  version: 13.4.0
+  resolution: "@testing-library/react@npm:13.4.0"
   dependencies:
     "@babel/runtime": ^7.12.5
-    "@testing-library/dom": ^9.0.0
+    "@testing-library/dom": ^8.5.0
     "@types/react-dom": ^18.0.0
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 4a54c8f56cc4a39b50803205f84f06280bb76521d6d5d4b3b36651d760c7c7752ef142d857d52aaf4fad4848ed7a8be49afc793a5dda105955d2f8bef24901ac
+  checksum: 51ec548c1fdb1271089a5c63e0908f0166f2c7fcd9cacd3108ebbe0ce64cb4351812d885892020dc37608418cfb15698514856502b3cab0e5cc58d6cc1bd4a3e
   languageName: node
   linkType: hard
 
@@ -16868,7 +16868,7 @@ __metadata:
     "@faker-js/faker": 7.6.0
     "@formatjs/cli": 6.0.1
     "@koush/wrtc": 0.5.3
-    "@testing-library/react": 14.0.0
+    "@testing-library/react": 13.4.0
     "@types/adm-zip": 0.5.0
     "@types/caniuse-lite": ^1.0.1
     "@types/classnames": 2.3.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -3408,7 +3408,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eslint-scope@npm:^3.7.3, @types/eslint-scope@npm:^3.7.4":
+"@types/eslint-scope@npm:^3.7.3":
   version: 3.7.4
   resolution: "@types/eslint-scope@npm:3.7.4"
   dependencies:
@@ -3418,23 +3418,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eslint@npm:*":
+"@types/eslint@npm:*, @types/eslint@npm:8.4.10":
   version: 8.4.10
   resolution: "@types/eslint@npm:8.4.10"
   dependencies:
     "@types/estree": "*"
     "@types/json-schema": "*"
   checksum: 21e009ed9ed9bc8920fdafc6e11ff321c4538b4cc18a56fdd59dc5184ea7bbf363c71638c9bdb59fc1254dddcdd567485136ed68b0ee4750948d4e32cb79c689
-  languageName: node
-  linkType: hard
-
-"@types/eslint@npm:^8.21.1":
-  version: 8.21.1
-  resolution: "@types/eslint@npm:8.21.1"
-  dependencies:
-    "@types/estree": "*"
-    "@types/json-schema": "*"
-  checksum: 584068441e4000c7b41c8928274fdcc737bc62f564928c30eb64ec41bbdbac31612f9fedaf490bceab31ec8305e99615166428188ea345d58878394683086fae
   languageName: node
   linkType: hard
 
@@ -16883,8 +16873,7 @@ __metadata:
     "@types/caniuse-lite": ^1.0.1
     "@types/classnames": 2.3.1
     "@types/dexie-batch": 0.4.3
-    "@types/eslint": ^8.21.1
-    "@types/eslint-scope": ^3.7.4
+    "@types/eslint": 8.4.10
     "@types/fs-extra": 11.0.1
     "@types/generate-changelog": 1.8.1
     "@types/highlight.js": 10.1.0


### PR DESCRIPTION
Fixes a type issue introduced by https://github.com/wireapp/wire-webapp/pull/14700/files. 
There seems to be a conflicting types between `@types/eslint` and `@types/eslint-scope` for some reasons