### PR TITLE
fix: use localization strings properly for font slider

### DIFF
--- a/src/script/page/MainContent/panels/preferences/OptionPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/OptionPreferences.tsx
@@ -44,16 +44,6 @@ interface OptionPreferencesProps {
   userState?: UserState;
 }
 
-const fontSliderOptions = [
-  {value: 0, label: RootFontSize.XXS, heading: t('preferencesOptionsFontSizeSmall')},
-  {value: 1, label: RootFontSize.XS},
-  {value: 2, label: RootFontSize.S},
-  {value: 3, label: RootFontSize.M, heading: t('preferencesOptionsFontSizeDefault')},
-  {value: 4, label: RootFontSize.L},
-  {value: 5, label: RootFontSize.XL},
-  {value: 6, label: RootFontSize.XXL, heading: t('preferencesOptionsFontSizeLarge')},
-];
-
 const fontSizes = Object.values(RootFontSize);
 
 const OptionPreferences: React.FC<OptionPreferencesProps> = ({
@@ -130,6 +120,16 @@ const OptionPreferences: React.FC<OptionPreferencesProps> = ({
     setSliderValue(value);
     setCurrentRootFontSize(fontSize);
   };
+
+  const fontSliderOptions = [
+    {value: 0, label: RootFontSize.XXS, heading: t('preferencesOptionsFontSizeSmall')},
+    {value: 1, label: RootFontSize.XS},
+    {value: 2, label: RootFontSize.S},
+    {value: 3, label: RootFontSize.M, heading: t('preferencesOptionsFontSizeDefault')},
+    {value: 4, label: RootFontSize.L},
+    {value: 5, label: RootFontSize.XL},
+    {value: 6, label: RootFontSize.XXL, heading: t('preferencesOptionsFontSizeLarge')},
+  ];
 
   return (
     <PreferencesPage title={t('preferencesOptions')}>


### PR DESCRIPTION
### Issue
- font slider label does not use the localization strings correctly

### Solution
- move the font option object to the inside of the React component
![image](https://user-images.githubusercontent.com/78490891/220307238-97233019-4a4a-4e33-a5dd-01e94a09517e.png)
