### PR TITLE
runfix: correct user warning width in conversation [SQSERVICES-1855]

### DIFF
--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -138,6 +138,7 @@
 .message-header {
   position: relative;
   display: flex;
+  width: 100%;
   padding-top: 6px;
   margin-bottom: 4px;
   line-height: @avatar-diameter-xs;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1855" title="SQSERVICES-1855" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />SQSERVICES-1855</a>  [Web] Unverified user warning before sending first message in chat
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Issue
![image](https://user-images.githubusercontent.com/78490891/220328731-5f350553-4341-4e75-89e1-f800e631b9f5.png)

### Solution
- assign a 100& width to message-header
![image](https://user-images.githubusercontent.com/78490891/220328940-4c162ee1-5dab-4eed-93d6-65e23dd63946.png)
