### PR TITLE
runfix: prevent user warning from displaying after group creation [SQ…

### DIFF
--- a/src/script/components/MessagesList/Message/MemberMessage.tsx
+++ b/src/script/components/MessagesList/Message/MemberMessage.tsx
@@ -174,16 +174,20 @@ const MemberMessage: React.FC<MemberMessageProps> = ({
               <p className="message-member-footer-description">{t('temporaryGuestLeaveDescription')}</p>
             </div>
           )}
-          <div className="message-header">
-            <div className="message-header-icon" />
-            <p className="message-header-label">{t('conversationNewConversation')}</p>
-          </div>
-          <div className="message-header">
-            <div className="message-header-icon message-header-icon--svg text-foreground">
-              <Icon.Info />
-            </div>
-            <p className="message-header-label">{t('conversationUnverifiedUserWarning')}</p>
-          </div>
+          {isGroupCreation && (
+            <>
+              <div className="message-header">
+                <div className="message-header-icon" />
+                <p className="message-header-label">{t('conversationNewConversation')}</p>
+              </div>
+              <div className="message-header">
+                <div className="message-header-icon message-header-icon--svg text-foreground">
+                  <Icon.Info />
+                </div>
+                <p className="message-header-label">{t('conversationUnverifiedUserWarning')}</p>
+              </div>
+            </>
+          )}
         </>
       )}
     </>


### PR DESCRIPTION
### issue
- user warning is displayed when a new user is added to an existing conversation
![image](https://user-images.githubusercontent.com/78490891/220582508-89fbfc6c-41fb-4eaf-b196-564651b78b36.png)


### Solution
- only display the waring at group creation
![image](https://user-images.githubusercontent.com/78490891/220582262-fb3b5706-f4aa-48f7-a909-d57a5a8871ec.png)
