### PR TITLE
fix: Hidden Video Thumbnail on focus User Tile

### DIFF
--- a/src/style/components/group-video-grid.less
+++ b/src/style/components/group-video-grid.less
@@ -220,6 +220,7 @@
 
   &__thumbnail {
     position: absolute;
+    z-index: 2;
     top: 12px;
     right: 12px;
     display: flex;


### PR DESCRIPTION
Focusing on video title in maximized screen hiding the current user thumbnail. This PR Fixing it.