### PR TITLE
fix: Reset roles when a member leaves a conversation [FS-1494]

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -2532,6 +2532,8 @@ export class ConversationRepository {
           }
         });
 
+      // Update conversation roles (in case the removed user had some special role)
+      await this.conversationRoleRepository.updateConversationRoles(conversationEntity);
       await this.updateParticipatingUserEntities(conversationEntity);
 
       this.verificationStateHandler.onMemberLeft(conversationEntity);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1494" title="FS-1494" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1494</a>  [Web] When removing an admin from a federated group and re-adding this user, the user still shows as admin to remote users
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This will make sure that a member that was considered admin, will not be anymore if they are removed and re-added to the same conversation
