### PR TITLE
fix: Shortcut for incoming call not work properly

### DIFF
--- a/src/script/components/calling/CallingCell.tsx
+++ b/src/script/components/calling/CallingCell.tsx
@@ -259,6 +259,9 @@ const CallingCell: React.FC<CallingCellProps> = ({
 
   useEffect(() => {
     if (isIncoming) {
+      // Capture will be dispatched to registered element before being dispatched to any EventTarget beneath it in the DOM Tree.
+      // It's needed because when someone is calling we need to change order of shortcuts to the top of keyboard usage.
+      // If we didn't pass this prop other Event Listeners will be dispatched in same time.
       document.addEventListener('keydown', answerOrRejectCall, {capture: true});
 
       return () => {

--- a/src/script/components/calling/CallingCell.tsx
+++ b/src/script/components/calling/CallingCell.tsx
@@ -234,14 +234,22 @@ const CallingCell: React.FC<CallingCellProps> = ({
 
   const answerOrRejectCall = useCallback(
     (event: KeyboardEvent) => {
+      const answerCallShortcut = !event.shiftKey && event.ctrlKey && isEnterKey(event);
+      const hangUpCallShortcut = event.ctrlKey && event.shiftKey && isEnterKey(event);
+
       const removeEventListener = () => window.removeEventListener('keydown', answerOrRejectCall);
 
-      if (!event.shiftKey && event.ctrlKey && isEnterKey(event)) {
+      if (answerCallShortcut || hangUpCallShortcut) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+
+      if (answerCallShortcut) {
         answerCall();
         removeEventListener();
       }
 
-      if (event.ctrlKey && event.shiftKey && isEnterKey(event)) {
+      if (hangUpCallShortcut) {
         callActions.reject(call);
         removeEventListener();
       }
@@ -251,10 +259,10 @@ const CallingCell: React.FC<CallingCellProps> = ({
 
   useEffect(() => {
     if (isIncoming) {
-      window.addEventListener('keydown', answerOrRejectCall);
+      document.addEventListener('keydown', answerOrRejectCall, {capture: true});
 
       return () => {
-        window.removeEventListener('keydown', answerOrRejectCall);
+        document.removeEventListener('keydown', answerOrRejectCall, {capture: true});
       };
     }
 


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/ACC-437?focusedCommentId=111099

Fix for answer or deciline call by shortcut.
Prev: Shortcut capturing another input actions.
Now: Shortcut capturing only answer / deciline call. Normal usage of keyboard works properly.