### PR TITLE
fix: Detect deleted clients when sending a message [FS-1090]

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.10.6",
     "@types/eslint": "8.4.10",
     "@wireapp/avs": "9.0.23",
-    "@wireapp/core": "38.15.0",
+    "@wireapp/core": "38.15.1",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.3.8",
     "@wireapp/store-engine-dexie": "2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4623,14 +4623,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^22.17.0":
-  version: 22.17.0
-  resolution: "@wireapp/api-client@npm:22.17.0"
+"@wireapp/api-client@npm:^22.17.1":
+  version: 22.17.1
+  resolution: "@wireapp/api-client@npm:22.17.1"
   dependencies:
     "@wireapp/commons": ^5.0.4
     "@wireapp/priority-queue": ^2.0.3
     "@wireapp/protocol-messaging": 1.44.0
-    axios: 1.3.3
+    axios: 1.3.4
     axios-retry: 3.4.0
     http-status-codes: 2.2.0
     logdown: 3.3.1
@@ -4638,7 +4638,7 @@ __metadata:
     spark-md5: 3.0.2
     tough-cookie: 4.1.2
     ws: 8.11.0
-  checksum: 5db09aa7576e7dc51e1fe384bab08a10d8bd908da37dc39e55c4667d4a691f8077551b41180498931a50d638b2204360666e9b6a171852491103ad9aed4ded74
+  checksum: 4d17c62d8582fd08d71b369c79840d02d5cf6ff71eb801e01fe73cfbc9eb1fb9671b630e645d3644332d98badf944bd46f79565404a55562c18d0d2ef70305c7
   languageName: node
   linkType: hard
 
@@ -4691,11 +4691,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:38.15.0":
-  version: 38.15.0
-  resolution: "@wireapp/core@npm:38.15.0"
+"@wireapp/core@npm:38.15.1":
+  version: 38.15.1
+  resolution: "@wireapp/core@npm:38.15.1"
   dependencies:
-    "@wireapp/api-client": ^22.17.0
+    "@wireapp/api-client": ^22.17.1
     "@wireapp/commons": ^5.0.4
     "@wireapp/core-crypto": 0.6.2
     "@wireapp/cryptobox": 12.8.0
@@ -4703,7 +4703,7 @@ __metadata:
     "@wireapp/protocol-messaging": 1.44.0
     "@wireapp/store-engine": 5.0.3
     "@wireapp/store-engine-dexie": ^2.0.5
-    axios: 1.3.3
+    axios: 1.3.4
     bazinga64: 6.0.4
     hash.js: 1.1.7
     http-status-codes: 2.2.0
@@ -4711,7 +4711,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.13
-  checksum: 91fe509aef85fd35720c1be03f740d0b342e2083da8ad149c413ed8ba0bc5889103751c00102b50d44667de8257f2f91c1f8329e98ed4aa1d47893c5c30e8343
+  checksum: a819772957a4f7772dddd798dcaa30934e234edcb893ef38d9155efde6d2682b4da30bb7a1849fe81eea388cd1406d7e17e0c19f3b4e01573c96172cbaf9ae13
   languageName: node
   linkType: hard
 
@@ -5544,6 +5544,17 @@ __metadata:
     form-data: ^4.0.0
     proxy-from-env: ^1.1.0
   checksum: b734a4bc348e2fa27150a7d4289d783fa405feb3f79f8daf28fd05813a12c8525ae9d3854aafe7ba041b005a4a751a0ba3b923331ceed41296ae14c7e54e2f26
+  languageName: node
+  linkType: hard
+
+"axios@npm:1.3.4":
+  version: 1.3.4
+  resolution: "axios@npm:1.3.4"
+  dependencies:
+    follow-redirects: ^1.15.0
+    form-data: ^4.0.0
+    proxy-from-env: ^1.1.0
+  checksum: 7440edefcf8498bc3cdf39de00443e8101f249972c83b739c6e880d9d669fea9486372dbe8739e88b3bf8bb1ad15f6106693f206f078f4516fe8fd47b1c3093c
   languageName: node
   linkType: hard
 
@@ -17101,7 +17112,7 @@ __metadata:
     "@typescript-eslint/parser": ^5.53.0
     "@wireapp/avs": 9.0.23
     "@wireapp/copy-config": 2.0.9
-    "@wireapp/core": 38.15.0
+    "@wireapp/core": 38.15.1
     "@wireapp/eslint-config": 2.1.1
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.5.2


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1090" title="FS-1090" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-1090</a>  [Web] Webapp doesn't learn about deleted clients.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
There could be situations where we know of clients, but do not have a session with them. Which means that, when we try to encrypt for those clients, we will try to get the prekeys from them to which the backend will say that there are no prekeys. Previously we would just filter them out and ignore them. Now the core warns the webapp that those clients have been deleted and that the webapp should wipe them out from the DB

see https://github.com/wireapp/wire-web-packages/pull/4914