### PR TITLE
fix: Fully clear input bar after sending a japanese text (SQSERVICES-1900)

### DIFF
--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -222,7 +222,9 @@ const InputBar = ({
     setCurrentMentions([]);
 
     if (resetInputValue) {
-      setInputValue('');
+      setTimeout(() => {
+        setInputValue('');
+      }, 0);
     }
   };
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1900" title="SQSERVICES-1900" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1900</a>  Japanese input results in an unintended message being sent
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

https://user-images.githubusercontent.com/63250054/222124768-cd703d4b-9537-44cd-8859-9969a651cf69.MP4

