### PR TITLE
fix: remove immediate login for 2fa+entropy case [SQSERVICES-1709]

### DIFF
--- a/src/script/auth/page/ConversationJoin.tsx
+++ b/src/script/auth/page/ConversationJoin.tsx
@@ -160,7 +160,7 @@ const ConversationJoinComponent = ({
        */
       await setLastEventDate(new Date(conversationEvent.time));
 
-      routeToApp(conversationEvent.conversation, conversationEvent.qualified_conversation.domain);
+      routeToApp(conversationEvent.conversation, conversationEvent.qualified_conversation?.domain ?? '');
     } catch (error) {
       if (error.label) {
         switch (error.label) {
@@ -314,7 +314,7 @@ const ConversationJoinComponent = ({
               onClick={async () => {
                 try {
                   const conversationEvent = await doJoinConversationByCode(conversationKey, conversationCode);
-                  routeToApp(conversationEvent.conversation, conversationEvent.qualified_conversation.domain);
+                  routeToApp(conversationEvent.conversation, conversationEvent.qualified_conversation?.domain ?? '');
                 } catch (error) {
                   console.warn('Unable to join conversation with existing account', error);
                 }

--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -157,7 +157,9 @@ const LoginComponent = ({
   useEffect(() => {
     resetAuthError();
     const isImmediateLogin = UrlUtil.hasURLParameter(QUERY_KEY.IMMEDIATE_LOGIN);
-    if (isImmediateLogin) {
+    const is2FAEntropy = UrlUtil.hasURLParameter(QUERY_KEY.TWO_FACTOR) && isEntropyRequired;
+
+    if (isImmediateLogin && !is2FAEntropy) {
       immediateLogin();
     }
     return () => {
@@ -173,6 +175,7 @@ const LoginComponent = ({
       return navigate(ROUTE.HISTORY_INFO);
     } catch (error) {
       logger.error('Unable to login immediately', error);
+      setShowEntropyForm(false);
     }
   };
 

--- a/src/script/auth/route.ts
+++ b/src/script/auth/route.ts
@@ -34,6 +34,7 @@ export const QUERY_KEY = {
   PWA_AWARE: 'pwa_aware',
   SSO_AUTO_LOGIN: 'sso_auto_login',
   TRACKING: 'tracking',
+  TWO_FACTOR: '2fa',
 };
 
 export const FORWARDED_QUERY_KEYS = [


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1709" title="SQSERVICES-1709" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1709</a>  [Web] Mouse entropy shows up twice, once before and once after 2FA
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Listens for 2fa query key in order to disable immediate login for cases in which 2fa and entropy are both enabled, as this can lead to an error. 

### Solutions

recovers from immediate login errors in the case they are still uncaught
stops immediate login if 2fa query is present and entropy flag is present

