### PR TITLE
runfix: Move input reset to onSend in inputBar (SQSERVICES-1900)

### DIFF
--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -222,18 +222,7 @@ const InputBar = ({
     setCurrentMentions([]);
 
     if (resetInputValue) {
-      /*
-        When trying to update a textarea with japanese value to
-        empty in onKeyDown handler the text is not fully cleared
-        and some parts of text is pasted by the OS/Browser after
-        we do setInputValue('');
-        To fix this we have to add a setTimeout in order to postpone
-        the operation of clearing the text to after of the proccess
-        of the onKeyDown and onKeyUp DOM events.
-       */
-      setTimeout(() => {
-        setInputValue('');
-      }, 0);
+      setInputValue('');
     }
   };
 
@@ -553,8 +542,18 @@ const InputBar = ({
     } else {
       sendMessage(messageText, updatedMentions);
     }
-
-    resetDraftState(true);
+    /*
+      When trying to update a textarea with japanese value to
+      empty in onKeyDown handler the text is not fully cleared
+      and some parts of text is pasted by the OS/Browser after
+      we do setInputValue('');
+      To fix this we have to add a setTimeout in order to postpone
+      the operation of clearing the text to after of the proccess
+      of the onKeyDown and onKeyUp DOM events.
+    */
+    setTimeout(() => {
+      resetDraftState(true);
+    }, 0);
     textareaRef.current?.focus();
   };
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1900" title="SQSERVICES-1900" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1900</a>  Japanese input results in an unintended message being sent
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
