### PR TITLE
runfix: Use range for supported api version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.10.6",
     "@types/eslint": "8.4.10",
     "@wireapp/avs": "9.0.23",
-    "@wireapp/core": "39.1.4",
+    "@wireapp/core": "39.1.5",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.3.9",
     "@wireapp/store-engine-dexie": "2.0.4",

--- a/src/script/Config.ts
+++ b/src/script/Config.ts
@@ -117,8 +117,8 @@ export class Configuration {
   /** Image MIME types */
   readonly ALLOWED_IMAGE_TYPES = ['image/bmp', 'image/gif', 'image/jpeg', 'image/jpg', 'image/png'];
 
-  /** Which versions of the backend api do we support */
-  readonly SUPPORTED_API_VERSIONS = [3, 2, 1];
+  /** Which min and max version of the backend api do we support */
+  readonly SUPPORTED_API_RANGE = [1, env.ENABLE_DEV_BACKEND_API ? Infinity : 3];
 }
 
 let instance: Configuration;

--- a/src/script/auth/main.tsx
+++ b/src/script/auth/main.tsx
@@ -74,7 +74,8 @@ const render = (Component: FC): void => {
 
 async function runApp() {
   const config = Config.getConfig();
-  await core.useAPIVersion(config.SUPPORTED_API_VERSIONS, config.ENABLE_DEV_BACKEND_API);
+  const [min, max] = config.SUPPORTED_API_RANGE;
+  await core.useAPIVersion(min, max, config.ENABLE_DEV_BACKEND_API);
   render(Root);
   if (module.hot) {
     module.hot.accept('./page/Root', () => {

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -333,7 +333,8 @@ export class App {
    */
   async initApp(clientType: ClientType, onProgress: (progress: number, message?: string) => void) {
     // add body information
-    await this.core.useAPIVersion(this.config.SUPPORTED_API_VERSIONS, this.config.ENABLE_DEV_BACKEND_API);
+    const [apiVersionMin, apiVersionMax] = this.config.SUPPORTED_API_RANGE;
+    await this.core.useAPIVersion(apiVersionMin, apiVersionMax, this.config.ENABLE_DEV_BACKEND_API);
     const osCssClass = Runtime.isMacOS() ? 'os-mac' : 'os-pc';
     const platformCssClass = Runtime.isDesktopApp() ? 'platform-electron' : 'platform-web';
     document.body.classList.add(osCssClass, platformCssClass);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4623,9 +4623,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^23.1.2":
-  version: 23.1.2
-  resolution: "@wireapp/api-client@npm:23.1.2"
+"@wireapp/api-client@npm:^23.1.3":
+  version: 23.1.3
+  resolution: "@wireapp/api-client@npm:23.1.3"
   dependencies:
     "@wireapp/commons": ^5.0.4
     "@wireapp/priority-queue": ^2.0.3
@@ -4638,7 +4638,7 @@ __metadata:
     spark-md5: 3.0.2
     tough-cookie: 4.1.2
     ws: 8.11.0
-  checksum: d99ddff2b4771d0a4ff38592d03da7ca95f5755c754fb40b6c286d8883f4514e92ee94d432f0594a703c267ad77baa207779e520948b8a7663c3552062f3ca3a
+  checksum: 40acaffdddb20e81613cb70555f434855cb5a59936df1209e4c182453f4e59c80fb1b2b38400262e046a35b470e60d11aad332605820d236d060a4301b6b30a7
   languageName: node
   linkType: hard
 
@@ -4691,11 +4691,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:39.1.4":
-  version: 39.1.4
-  resolution: "@wireapp/core@npm:39.1.4"
+"@wireapp/core@npm:39.1.5":
+  version: 39.1.5
+  resolution: "@wireapp/core@npm:39.1.5"
   dependencies:
-    "@wireapp/api-client": ^23.1.2
+    "@wireapp/api-client": ^23.1.3
     "@wireapp/commons": ^5.0.4
     "@wireapp/core-crypto": 0.6.2
     "@wireapp/cryptobox": 12.8.0
@@ -4711,7 +4711,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.13
-  checksum: 4ceb70937eebdd1d39bf4372bf928bbb7942318247627224c5d996951baf297c0f47616e155dfc7f506023e9a36aa6daba7dff0fbc9678c9fe0e6bd1ddbc63fc
+  checksum: ad5271625e31e312b2c172e26bbe590c6cff223090267d8389fe4da018a820dcf8bb589cb0d9d956b79535d037ddc2f6c99456038cd71af70f9c7b45e2001a1a
   languageName: node
   linkType: hard
 
@@ -17101,7 +17101,7 @@ __metadata:
     "@typescript-eslint/parser": ^5.54.0
     "@wireapp/avs": 9.0.23
     "@wireapp/copy-config": 2.0.10
-    "@wireapp/core": 39.1.4
+    "@wireapp/core": 39.1.5
     "@wireapp/eslint-config": 2.1.1
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.5.2


### PR DESCRIPTION
This will allow a more flexible way of using dev versions of the API 