### PR TITLE
fix: Do not try to load deleted users on app load [FS-1607]

### DIFF
--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -409,7 +409,7 @@ export class App {
 
       await conversationRepository.conversationRoleRepository.loadTeamRoles();
 
-      await userRepository.loadUsers();
+      await userRepository.loadTeamUserAvailabilities();
 
       await eventRepository.connectWebSocket(this.core, ({done, total}) => {
         const baseMessage = t('initDecryption');

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -161,22 +161,25 @@ export class UserRepository {
     }
   };
 
-  async loadUsers(): Promise<void> {
-    if (this.userState.isTeam()) {
-      const users = await this.userService.loadUserFromDb();
+  /**
+   * Will load the availability status to the team users and subscribe to changes.
+   */
+  async loadTeamUserAvailabilities(): Promise<void> {
+    const users = this.userState.users();
+    if (this.userState.isTeam() && users.length) {
+      const availabilities = await this.userService.loadUserFromDb();
 
-      if (users.length) {
-        this.logger.log(`Loaded state of '${users.length}' users from database`, users);
+      this.logger.log(`Loaded state of '${users.length}' users from database`, users);
 
-        await Promise.all(
-          users.map(async user => {
-            const userEntity = await this.getUserById({domain: user.domain, id: user.id});
-            userEntity.availability(user.availability);
-          }),
+      users.forEach(user => {
+        const userAvailability = availabilities.find(availability =>
+          matchQualifiedIds({id: availability.id, domain: availability.domain ?? ''}, user.qualifiedId),
         );
-      }
-
-      this.userState.users().forEach(userEntity => userEntity.subscribeToChanges());
+        if (userAvailability) {
+          user.availability(userAvailability.availability);
+        }
+        user.subscribeToChanges();
+      });
     }
   }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1607" title="FS-1607" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1607</a>  [web] Webapp is not removing deleted users for the `users` database
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


This changes the strategy we use to load the user availabilities and put them on the user enties. 

What we did before was:
- load all the user availabilities in DB
- map those to locally loaded users and load missing users from the BE
-> this would lead to querying deleted users from the server

The new strategy is:
- load all the users from backend 
- for all those loaded users, find the availabilities in DB
-> this way some availabilities might not be mapped, but that means they belonged to deleted users
