### PR TITLE
fix: leave call on conversation delete [FS-1608]

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.10.6",
     "@types/eslint": "8.4.10",
     "@wireapp/avs": "9.0.23",
-    "@wireapp/core": "39.1.5",
+    "@wireapp/core": "39.1.6",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.3.9",
     "@wireapp/store-engine-dexie": "2.0.4",

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -131,7 +131,7 @@ export class CallingRepository {
   private avsVersion: number = 0;
   private incomingCallCallback: (call: Call) => void;
   private requestNewEpochCallback: (conversationId: QualifiedId) => void;
-  private callClosedCallback: (conversationId: QualifiedId) => void;
+  private callClosedCallback: (conversationId: QualifiedId, conversationType: CONV_TYPE) => void;
   private callParticipantChangedCallback: (conversationId: QualifiedId, members: QualifiedWcallMember[]) => void;
   private isReady: boolean = false;
   /** will cache the query to media stream (in order to avoid asking the system for streams multiple times when we have multiple peers) */
@@ -415,7 +415,7 @@ export class CallingRepository {
     this.incomingCallCallback = callback;
   }
 
-  onCallClosed(callback: (conversationId: QualifiedId) => void): void {
+  onCallClosed(callback: (conversationId: QualifiedId, conversationType: CONV_TYPE) => void): void {
     this.callClosedCallback = callback;
   }
 
@@ -1233,7 +1233,7 @@ export class CallingRepository {
       return;
     }
 
-    this.callClosedCallback(conversationId);
+    this.callClosedCallback(conversationId, call.conversationType);
 
     if (reason === REASON.NORMAL) {
       this.callState.selectableScreens([]);

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -843,6 +843,9 @@ export class ConversationRepository {
     if (!conversationEntity) {
       return;
     }
+
+    this.leaveCall(conversationEntity.qualifiedId, LEAVE_CALL_REASON.USER_MANUALY_LEFT_CONVERSATION);
+
     if (this.conversationState.isActiveConversation(conversationEntity)) {
       const nextConversation = this.getNextConversation(conversationEntity);
       amplify.publish(WebAppEvents.CONVERSATION.SHOW, nextConversation, {});

--- a/src/script/view_model/CallingViewModel.mocks.ts
+++ b/src/script/view_model/CallingViewModel.mocks.ts
@@ -28,10 +28,7 @@ import {CallingViewModel} from './CallingViewModel';
 import {Call} from '../calling/Call';
 import {CallingRepository} from '../calling/CallingRepository';
 import {CallState} from '../calling/CallState';
-import {Conversation} from '../entity/Conversation';
 import {Core} from '../service/CoreSingleton';
-
-let callClosedCallback: (conversationId: QualifiedId) => void = (conversationId: QualifiedId) => {};
 
 export const mockCallingRepository = {
   startCall: jest.fn(),
@@ -40,8 +37,8 @@ export const mockCallingRepository = {
   onRequestClientsCallback: jest.fn(),
   onRequestNewEpochCallback: jest.fn(),
   onCallParticipantChangedCallback: jest.fn(),
-  onCallClosed: jest.fn().mockImplementation(callback => (callClosedCallback = callback)),
-  leaveCall: jest.fn().mockImplementation(conversationId => callClosedCallback(conversationId)),
+  onCallClosed: jest.fn(),
+  leaveCall: jest.fn(),
   setEpochInfo: jest.fn(),
 } as unknown as CallingRepository;
 
@@ -72,10 +69,6 @@ export function buildCallingViewModel() {
     undefined,
     mockCore,
   );
-
-  jest
-    .spyOn(callingViewModel, 'getConversationById')
-    .mockImplementation(() => ({isUsingMLSProtocol: true} as Conversation));
 
   return callingViewModel;
 }
@@ -147,6 +140,13 @@ export const prepareMLSConferenceMocks = (parentGroupId: string, subGroupId: str
   jest.spyOn(mockCore.service!.mls!, 'getEpoch').mockImplementation(() => Promise.resolve(mockEpochNumber));
 
   jest.spyOn(mockCore.service!.mls!, 'exportSecretKey').mockResolvedValue(mockSecretKey);
+
+  let callClosedCallback: (conversationId: QualifiedId, callType: CONV_TYPE) => void;
+
+  jest.spyOn(mockCallingRepository, 'onCallClosed').mockImplementation(callback => (callClosedCallback = callback));
+  jest
+    .spyOn(mockCallingRepository, 'leaveCall')
+    .mockImplementation(conversationId => callClosedCallback(conversationId, CONV_TYPE.CONFERENCE_MLS));
 
   return {expectedMemberListResult, mockSecretKey, mockEpochNumber, mockKeyLength};
 };

--- a/src/script/view_model/CallingViewModel.ts
+++ b/src/script/view_model/CallingViewModel.ts
@@ -240,10 +240,9 @@ export class CallingViewModel {
       this.callingRepository.setEpochInfo(conversationId, {epoch, keyLength, secretKey}, members);
     };
 
-    const leaveCall = async (conversationId: QualifiedId) => {
-      const conversation = this.getConversationById(conversationId);
-
-      if (!conversation?.isUsingMLSProtocol) {
+    const closeCall = async (conversationId: QualifiedId, conversationType: CONV_TYPE) => {
+      // There's nothing we need to do for non-mls calls
+      if (conversationType !== CONV_TYPE.CONFERENCE_MLS) {
         return;
       }
 
@@ -336,7 +335,7 @@ export class CallingViewModel {
     this.callingRepository.onRequestNewEpochCallback(conversationId => updateEpochInfo(conversationId, true));
 
     //once the call gets closed (eg. we leave a call or get dropped), we remove ourselfes from subconversation and unsubscribe from all the call events
-    this.callingRepository.onCallClosed(leaveCall);
+    this.callingRepository.onCallClosed(closeCall);
 
     //handle participant change avs callback to detect stale clients in subconversations
     this.callingRepository.onCallParticipantChangedCallback(handleCallParticipantChange);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4691,9 +4691,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:39.1.5":
-  version: 39.1.5
-  resolution: "@wireapp/core@npm:39.1.5"
+"@wireapp/core@npm:39.1.6":
+  version: 39.1.6
+  resolution: "@wireapp/core@npm:39.1.6"
   dependencies:
     "@wireapp/api-client": ^23.1.3
     "@wireapp/commons": ^5.0.4
@@ -4711,7 +4711,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.13
-  checksum: ad5271625e31e312b2c172e26bbe590c6cff223090267d8389fe4da018a820dcf8bb589cb0d9d956b79535d037ddc2f6c99456038cd71af70f9c7b45e2001a1a
+  checksum: 7de3e325da60e49fd204986aedc7731b763f998de30a6c9ceef0e03b57a74d6b988b32e2977b8d9e0e56c6102bf2931f07a48913e4123021ea21504b314b43de
   languageName: node
   linkType: hard
 
@@ -17101,7 +17101,7 @@ __metadata:
     "@typescript-eslint/parser": ^5.54.0
     "@wireapp/avs": 9.0.23
     "@wireapp/copy-config": 2.0.10
-    "@wireapp/core": 39.1.5
+    "@wireapp/core": 39.1.6
     "@wireapp/eslint-config": 2.1.1
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.5.2


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1608" title="FS-1608" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1608</a>  [Web] client does not leave call when conversation gets deleted
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Call was never ended after conversation was deleted, so end users were still able to here each other even though there was no conversation nor call visible on the UI.

This PR should fix this bug for both Proteus and MLS calls + `@wireapp/core` package version bump.