### PR TITLE
fix: Improve message sending performances

### DIFF
--- a/src/script/event/EventService.ts
+++ b/src/script/event/EventService.ts
@@ -127,17 +127,13 @@ export class EventService {
 
     try {
       if (this.storageService.db) {
+        const eventStore = this.storageService.db.table(StorageSchemata.OBJECT_STORE.EVENTS);
         // First lookup the event by its direct id (using the index)
-        const event = this.storageService.db
-          .table(StorageSchemata.OBJECT_STORE.EVENTS)
-          .where('id')
-          .equals(eventId)
-          .first();
+        const event = eventStore.where('id').equals(eventId).first();
         return (
           event ||
           // If the event was not found, fallback to filtering all the events and check if a `replacing` message is found
-          this.storageService.db
-            .table(StorageSchemata.OBJECT_STORE.EVENTS)
+          eventStore
             .where('conversation')
             .equals(conversationId)
             .filter(item => item.data?.replacing_message_id === eventId || item.id === eventId)

--- a/src/script/event/EventService.ts
+++ b/src/script/event/EventService.ts
@@ -127,12 +127,22 @@ export class EventService {
 
     try {
       if (this.storageService.db) {
-        return await this.storageService.db
+        // First lookup the event by its direct id (using the index)
+        const event = this.storageService.db
           .table(StorageSchemata.OBJECT_STORE.EVENTS)
-          .where('conversation')
-          .equals(conversationId)
-          .filter(item => item.data?.replacing_message_id === eventId || item.id === eventId)
+          .where('id')
+          .equals(eventId)
           .first();
+        return (
+          event ||
+          // If the event was not found, fallback to filtering all the events and check if a `replacing` message is found
+          this.storageService.db
+            .table(StorageSchemata.OBJECT_STORE.EVENTS)
+            .where('conversation')
+            .equals(conversationId)
+            .filter(item => item.data?.replacing_message_id === eventId || item.id === eventId)
+            .first()
+        );
       }
 
       const records = await this.storageService.getAll<EventRecord>(StorageSchemata.OBJECT_STORE.EVENTS);


### PR DESCRIPTION
Since #14632 we never query individual events by their direct index (the `id`). 
Instead we load **all** the events and go through them one by one until we find the matching ID (or replacing ID). 

This is very suboptimal and gets slower and slower as more messages are added to the conversation. 

We will still need to optimize loading quotes. But this should fix many performances problems

https://user-images.githubusercontent.com/1090716/224311015-dd80ccf0-63bb-4eda-954d-0496fb25c62c.mov


https://user-images.githubusercontent.com/1090716/224311037-32669af1-2faa-4d77-9c7a-551c4ff71fe3.mov

Should fix https://github.com/wireapp/wire-desktop/issues/6486

