### PR TITLE
chore: bump avs package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@emotion/react": "11.10.6",
     "@types/eslint": "8.4.10",
-    "@wireapp/avs": "9.0.23",
+    "@wireapp/avs": "9.1.11",
     "@wireapp/core": "39.1.6",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.3.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4642,10 +4642,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/avs@npm:9.0.23":
-  version: 9.0.23
-  resolution: "@wireapp/avs@npm:9.0.23"
-  checksum: a36cc6c63ce43e2b82a851220b22baa0443c805d8df2db80dff8f774953fdf74a72e3a3238d6a5a8ca6053c1feb6e9ad2a38b2eae41b02c71be7a414d97eb0bb
+"@wireapp/avs@npm:9.1.11":
+  version: 9.1.11
+  resolution: "@wireapp/avs@npm:9.1.11"
+  checksum: 9fe240ef1c051e85a1365a0cdf748740f376fe14bcb959e643db155a404cf0c73de17635bb1559d717fd6aabf160d665b58bd3a981ee55f4aaef97f9f8d634af
   languageName: node
   linkType: hard
 
@@ -17099,7 +17099,7 @@ __metadata:
     "@types/webpack-env": 1.18.0
     "@typescript-eslint/eslint-plugin": ^5.54.0
     "@typescript-eslint/parser": ^5.54.0
-    "@wireapp/avs": 9.0.23
+    "@wireapp/avs": 9.1.11
     "@wireapp/copy-config": 2.0.10
     "@wireapp/core": 39.1.6
     "@wireapp/eslint-config": 2.1.1


### PR DESCRIPTION
AVS team has fixes some severe security bugs. There doesn't seem to be any regressions with calling for both proteus and mls.