### PR TITLE
fix: Correct logic for sending broadcast messages when mismatch happens

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -249,7 +249,11 @@ export class ConversationRepository {
           shouldWarnLegalHold = hasChangedLegalHoldStatus && newDevices.some(device => device.isLegalHold());
         }
       }
-      return !conversation || silent
+      if (!conversation) {
+        // in case of a broadcast message, we want to keep sending the message even if there are some conversation degradation
+        return true;
+      }
+      return silent
         ? false
         : this.messageRepository.requestUserSendingPermission(conversation, shouldWarnLegalHold, consentType);
     });


### PR DESCRIPTION
When a message is broadcasted (without a conversation param), we need to create sessions for the clients we don't have a session with. 
The previous `return false` would stop sending the message if there is a mismatch. Which is not the intended behaviour. 

see https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/106660748/Use+case+setting+the+status#Step-2 for specs

> If the backend didn't accept the message but returned a 412 missing clients, the response will contain a list of missing clients that were not included as recipients of the original message.

> The client should create a session with those clients (which includes fetching prekeys) and then resend the message.