### PR TITLE
refactor: code legibility improvements for failure to send handling [FS-1571]

### DIFF
--- a/src/script/components/MessagesList/Message/MessageWrapper.tsx
+++ b/src/script/components/MessagesList/Message/MessageWrapper.tsx
@@ -28,7 +28,6 @@ import {WebAppEvents} from '@wireapp/webapp-events';
 import {OutgoingQuote} from 'src/script/conversation/MessageRepository';
 import {ContentMessage} from 'src/script/entity/message/ContentMessage';
 import {Text} from 'src/script/entity/message/Text';
-import {MentionEntity} from 'src/script/message/MentionEntity';
 import {QuoteEntity} from 'src/script/message/QuoteEntity';
 import {t} from 'Util/LocalizerUtil';
 
@@ -105,7 +104,7 @@ export const MessageWrapper: React.FC<MessageParams & {hasMarker: boolean; isMes
     if (firstAsset instanceof Text) {
       const messageId = message.id;
       const messageText = firstAsset.text;
-      const mentions: MentionEntity[] = firstAsset.mentions();
+      const mentions = firstAsset.mentions();
       const incomingQuote = message.quote();
       const quote: OutgoingQuote | undefined =
         incomingQuote && isOutgoingQuote(incomingQuote) ? (incomingQuote as OutgoingQuote) : undefined;

--- a/src/script/components/MessagesList/Message/MessageWrapper.tsx
+++ b/src/script/components/MessagesList/Message/MessageWrapper.tsx
@@ -95,18 +95,18 @@ export const MessageWrapper: React.FC<MessageParams & {hasMarker: boolean; isMes
     }
   };
 
+  const isOutgoingQuote = (quoteEntity: QuoteEntity): quoteEntity is OutgoingQuote => {
+    return quoteEntity.hash !== undefined;
+  };
+
   const onRetry = async (message: ContentMessage) => {
     const firstAsset = message.getFirstAsset();
 
     if (firstAsset instanceof Text) {
       const messageId = message.id;
       const messageText = firstAsset.text;
-      const mentions: MentionEntity[] = firstAsset.mentions() && firstAsset.mentions();
+      const mentions: MentionEntity[] = firstAsset?.mentions?.() || [];
       const incomingQuote = message.quote();
-
-      const isOutgoingQuote = (quoteEntity: QuoteEntity): quoteEntity is OutgoingQuote => {
-        return quoteEntity.hash !== undefined;
-      };
       const quote: OutgoingQuote | undefined =
         incomingQuote && isOutgoingQuote(incomingQuote) ? (incomingQuote as OutgoingQuote) : undefined;
 

--- a/src/script/components/MessagesList/Message/MessageWrapper.tsx
+++ b/src/script/components/MessagesList/Message/MessageWrapper.tsx
@@ -53,6 +53,10 @@ import {ContextMenuEntry} from '../../../ui/ContextMenu';
 
 import {MessageParams} from './index';
 
+const isOutgoingQuote = (quoteEntity: QuoteEntity): quoteEntity is OutgoingQuote => {
+  return quoteEntity.hash !== undefined;
+};
+
 export const MessageWrapper: React.FC<MessageParams & {hasMarker: boolean; isMessageFocused: boolean}> = ({
   message,
   conversation,
@@ -95,17 +99,13 @@ export const MessageWrapper: React.FC<MessageParams & {hasMarker: boolean; isMes
     }
   };
 
-  const isOutgoingQuote = (quoteEntity: QuoteEntity): quoteEntity is OutgoingQuote => {
-    return quoteEntity.hash !== undefined;
-  };
-
   const onRetry = async (message: ContentMessage) => {
     const firstAsset = message.getFirstAsset();
 
     if (firstAsset instanceof Text) {
       const messageId = message.id;
       const messageText = firstAsset.text;
-      const mentions: MentionEntity[] = firstAsset?.mentions?.() || [];
+      const mentions: MentionEntity[] = firstAsset.mentions();
       const incomingQuote = message.quote();
       const quote: OutgoingQuote | undefined =
         incomingQuote && isOutgoingQuote(incomingQuote) ? (incomingQuote as OutgoingQuote) : undefined;

--- a/src/script/conversation/EventMapper.ts
+++ b/src/script/conversation/EventMapper.ts
@@ -145,7 +145,7 @@ export class EventMapper {
     const {id, data: eventData, edited_time: editedTime, conversation, qualified_conversation} = event;
 
     if (eventData.quote) {
-      const {hash: hash, message_id: messageId, user_id: userId, error} = eventData.quote;
+      const {hash, message_id: messageId, user_id: userId, error} = eventData.quote;
       originalEntity.quote(new QuoteEntity({error, hash, messageId, userId}));
     }
 

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -1141,11 +1141,10 @@ export class MessageRepository {
   }
 
   private async updateMessageAsFailed(conversationEntity: Conversation, eventId: string) {
-    const updatedStatus = StatusType.FAILED;
     try {
       const messageEntity = await this.getMessageInConversationById(conversationEntity, eventId);
-      messageEntity.status(updatedStatus);
-      return await this.eventService.updateEvent(messageEntity.primary_key, {status: updatedStatus});
+      messageEntity.status(StatusType.FAILED);
+      return await this.eventService.updateEvent(messageEntity.primary_key, {status: StatusType.FAILED});
     } catch (error) {
       if ((error as any).type !== ConversationError.TYPE.MESSAGE_NOT_FOUND) {
         throw error;

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -1141,9 +1141,9 @@ export class MessageRepository {
   }
 
   private async updateMessageAsFailed(conversationEntity: Conversation, eventId: string) {
+    const updatedStatus = StatusType.FAILED;
     try {
       const messageEntity = await this.getMessageInConversationById(conversationEntity, eventId);
-      const updatedStatus = StatusType.FAILED;
       messageEntity.status(updatedStatus);
       return await this.eventService.updateEvent(messageEntity.primary_key, {status: updatedStatus});
     } catch (error) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1571" title="FS-1571" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />FS-1571</a>  [web] implement retry mechanism for messages that have completely failed to send
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

see https://github.com/wireapp/wire-webapp/pull/14757

previous feature was merged at the same time code legibility refinements were suggested in code review (thanks @przemvs ), those are addressed here 