### PR TITLE
fix: Avoid failed request to get all clients of a conversation

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.10.6",
     "@types/eslint": "8.4.10",
     "@wireapp/avs": "9.1.11",
-    "@wireapp/core": "39.2.1",
+    "@wireapp/core": "39.2.3",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.4.0",
     "@wireapp/store-engine-dexie": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.10.6",
     "@types/eslint": "8.4.10",
     "@wireapp/avs": "9.1.11",
-    "@wireapp/core": "39.2.0",
+    "@wireapp/core": "39.2.1",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.4.0",
     "@wireapp/store-engine-dexie": "2.0.5",

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1357,7 +1357,7 @@ export class ConversationRepository {
      * Needs to be done to receive the latest epoch and avoid epoch mismatch errors
      */
 
-    const qualifiedUserIds = userEntities.map(userEntity => userEntity.qualifiedId);
+    const qualifiedUsers = userEntities.map(userEntity => userEntity.qualifiedId);
 
     const {qualifiedId: conversationId, groupId} = conversation;
 
@@ -1366,7 +1366,7 @@ export class ConversationRepository {
         const {events} = await this.core.service!.conversation.addUsersToMLSConversation({
           conversationId,
           groupId,
-          qualifiedUserIds,
+          qualifiedUsers,
         });
         if (!!events.length) {
           events.forEach(event => this.eventRepository.injectEvent(event));
@@ -1374,7 +1374,7 @@ export class ConversationRepository {
       } else {
         const conversationMemberJoinEvent = await this.core.service!.conversation.addUsersToProteusConversation({
           conversationId,
-          qualifiedUserIds,
+          qualifiedUsers,
         });
         if (conversationMemberJoinEvent) {
           this.eventRepository.injectEvent(conversationMemberJoinEvent, EventRepository.SOURCE.BACKEND_RESPONSE);
@@ -1382,7 +1382,7 @@ export class ConversationRepository {
       }
     } catch (error) {
       if (error) {
-        this.handleAddToConversationError(error as BackendClientError, conversation, qualifiedUserIds);
+        this.handleAddToConversationError(error as BackendClientError, conversation, qualifiedUsers);
       }
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4247,9 +4247,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:39.2.1":
-  version: 39.2.1
-  resolution: "@wireapp/core@npm:39.2.1"
+"@wireapp/core@npm:39.2.3":
+  version: 39.2.3
+  resolution: "@wireapp/core@npm:39.2.3"
   dependencies:
     "@wireapp/api-client": ^23.1.3
     "@wireapp/commons": ^5.0.4
@@ -4268,7 +4268,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.13
-  checksum: b46eb800df92a7b517a66fe9cd34a37c55895cc410566f4aa3e79617a91b9b056ca34cd0fa6f769804c3bd20cbe39f7724d933a792cad697ec62b37a2263b802
+  checksum: 8cd6f57a11b6069f5d95fa9895050cee58e0a1dc27da3c9b50bc7def898520e62656e324dd25e5001b5bcaf4c19cad0c36a61b3aa3f485c1b941837f0a30f2c8
   languageName: node
   linkType: hard
 
@@ -16524,7 +16524,7 @@ dexie@latest:
     "@typescript-eslint/parser": ^5.54.1
     "@wireapp/avs": 9.1.11
     "@wireapp/copy-config": 2.0.10
-    "@wireapp/core": 39.2.1
+    "@wireapp/core": 39.2.3
     "@wireapp/eslint-config": 2.1.1
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.5.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -4247,9 +4247,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:39.2.0":
-  version: 39.2.0
-  resolution: "@wireapp/core@npm:39.2.0"
+"@wireapp/core@npm:39.2.1":
+  version: 39.2.1
+  resolution: "@wireapp/core@npm:39.2.1"
   dependencies:
     "@wireapp/api-client": ^23.1.3
     "@wireapp/commons": ^5.0.4
@@ -4268,7 +4268,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.13
-  checksum: 676f98d206e643a67dc24bd3be8ae39f1949e1c944695c902f67c46f0b970fd8bd468d15373cbaa4846ea6343213c409d7eb5f6343904415c61ad85fecf3f8ba
+  checksum: b46eb800df92a7b517a66fe9cd34a37c55895cc410566f4aa3e79617a91b9b056ca34cd0fa6f769804c3bd20cbe39f7724d933a792cad697ec62b37a2263b802
   languageName: node
   linkType: hard
 
@@ -16524,7 +16524,7 @@ dexie@latest:
     "@typescript-eslint/parser": ^5.54.1
     "@wireapp/avs": 9.1.11
     "@wireapp/copy-config": 2.0.10
-    "@wireapp/core": 39.2.0
+    "@wireapp/core": 39.2.1
     "@wireapp/eslint-config": 2.1.1
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.5.2


### PR DESCRIPTION
This will avoid this error from popping up  when requesting clients in a conversation where we know no users

```text
 Uncaught r: Error in $['qualified_users']: parsing [] failed, expected Array, but encountered Object
 ```