### PR TITLE
fix: Consider self user when computing classified domains 

### DIFF
--- a/src/script/components/ConnectRequests/index.tsx
+++ b/src/script/components/ConnectRequests/index.tsx
@@ -121,7 +121,9 @@ const ConnectRequests: FC<ConnectRequestsProps> = ({
 
               <div className="connect-request-username label-username">{connectRequest.handle}</div>
 
-              {classifiedDomains && <ClassifiedBar users={[connectRequest]} classifiedDomains={classifiedDomains} />}
+              {classifiedDomains && (
+                <ClassifiedBar users={[userState.self(), connectRequest]} classifiedDomains={classifiedDomains} />
+              )}
 
               <Avatar
                 className="connect-request-avatar avatar-no-filter cursor-default"

--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -127,6 +127,7 @@ const InputBar = ({
   const {
     connection,
     participating_user_ets: participatingUserEts,
+    allUserEntities: allUsers,
     localMessageTimer,
     messageTimer,
     hasGlobalMessageTimer,
@@ -134,6 +135,7 @@ const InputBar = ({
   } = useKoSubscribableChildren(conversationEntity, [
     'connection',
     'firstUserEntity',
+    'allUserEntities',
     'participating_user_ets',
     'localMessageTimer',
     'messageTimer',
@@ -776,7 +778,7 @@ const InputBar = ({
       {!!isTypingIndicatorEnabled && <TypingIndicator conversationId={conversationEntity.id} />}
 
       {classifiedDomains && !isConnectionRequest && (
-        <ClassifiedBar users={participatingUserEts} classifiedDomains={classifiedDomains} />
+        <ClassifiedBar users={allUsers} classifiedDomains={classifiedDomains} />
       )}
 
       {isReplying && !isEditing && <ReplyBar replyMessageEntity={replyMessageEntity} onCancel={handleCancelReply} />}

--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -242,7 +242,7 @@ const ContentMessageComponent: React.FC<ContentMessageProps> = ({
         ))}
 
         {failedToSend && (
-          <PartialFailureToSendWarning failedToSend={failedToSend} knownUsers={conversation.allUserEntities} />
+          <PartialFailureToSendWarning failedToSend={failedToSend} knownUsers={conversation.allUserEntities()} />
         )}
 
         {status === StatusType.FAILED && (

--- a/src/script/components/calling/CallingCell.tsx
+++ b/src/script/components/calling/CallingCell.tsx
@@ -106,12 +106,14 @@ const CallingCell: React.FC<CallingCellProps> = ({
   const {
     isGroup,
     participating_user_ets: userEts,
+    allUserEntities: allUsers,
     selfUser,
     display_name: conversationName,
     roles,
   } = useKoSubscribableChildren(conversation, [
     'isGroup',
     'participating_user_ets',
+    'allUserEntities',
     'selfUser',
     'display_name',
     'roles',
@@ -445,7 +447,7 @@ const CallingCell: React.FC<CallingCellProps> = ({
             )
           )}
 
-          {classifiedDomains && <ClassifiedBar users={userEts} classifiedDomains={classifiedDomains} />}
+          {classifiedDomains && <ClassifiedBar users={allUsers} classifiedDomains={classifiedDomains} />}
 
           {!isDeclined && (
             <>

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -117,10 +117,10 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
     startedAt,
     participants,
   } = useKoSubscribableChildren(call, ['activeSpeakers', 'currentPage', 'pages', 'startedAt', 'participants']);
-  const {display_name: conversationName, participating_user_ets: conversationParticipants} = useKoSubscribableChildren(
-    conversation,
-    ['display_name', 'participating_user_ets'],
-  );
+  const {display_name: conversationName, allUserEntities: allUsers} = useKoSubscribableChildren(conversation, [
+    'display_name',
+    'allUserEntities',
+  ]);
   const {isVideoCallingEnabled, classifiedDomains} = useKoSubscribableChildren(teamState, [
     'isVideoCallingEnabled',
     'classifiedDomains',
@@ -210,7 +210,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
 
         {classifiedDomains && (
           <ClassifiedBar
-            users={conversationParticipants}
+            users={allUsers}
             classifiedDomains={classifiedDomains}
             style={{
               lineHeight: '1.5em',

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -196,7 +196,7 @@ export class ConversationRepository {
 
       const {missingClients, deletedClients, emptyUsers, missingUserIds} = extractClientDiff(
         filteredMismatch,
-        conversation?.allUserEntities,
+        conversation?.allUserEntities(),
         domain,
       );
 

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -934,7 +934,7 @@ export class MessageRepository {
       if (!message.user().isMe && !message.ephemeral_expires()) {
         throw new ConversationError(ConversationError.TYPE.WRONG_USER, ConversationError.MESSAGE.WRONG_USER);
       }
-      const userIds = options.targetedUsers || conversation.allUserEntities.map(user => user!.qualifiedId);
+      const userIds = options.targetedUsers || conversation.allUserEntities().map(user => user!.qualifiedId);
       const payload = MessageBuilder.buildDeleteMessage({
         messageId: message.id,
       });
@@ -1170,7 +1170,8 @@ export class MessageRepository {
       // If we get a userId>client pairs, we just return those, no need to create recipients
       return recipients;
     }
-    const filteredUsers = conversation.allUserEntities
+    const filteredUsers = conversation
+      .allUserEntities()
       // filter possible undefined values
       .flatMap(user => (user ? [user] : []))
       // if users are given by the caller, we filter to only keep those users

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -157,6 +157,7 @@ export class Conversation {
   public readonly notificationState: ko.PureComputed<number>;
   public readonly participating_user_ets: ko.ObservableArray<User>;
   public readonly participating_user_ids: ko.ObservableArray<QualifiedId>;
+  public readonly allUserEntities: ko.PureComputed<User[]>;
   public readonly receiptMode: ko.Observable<RECEIPT_MODE>;
   public readonly removed_from_conversation: ko.PureComputed<boolean>;
   public readonly roles: ko.Observable<Record<string, string>>;
@@ -213,6 +214,11 @@ export class Conversation {
 
     this.participating_user_ets = ko.observableArray([]); // Does not include self user
     this.participating_user_ids = ko.observableArray([]); // Does not include self user
+    this.allUserEntities = ko.pureComputed(() => {
+      const selfUser = this.selfUser();
+      const selfUserArray = selfUser ? [selfUser] : [];
+      return selfUserArray.concat(this.participating_user_ets());
+    });
     this.selfUser = ko.observable();
     this.roles = ko.observable({});
 
@@ -323,14 +329,14 @@ export class Conversation {
         return undefined;
       }
 
-      return this.allUserEntities.every(userEntity => userEntity.is_verified());
+      return this.allUserEntities().every(userEntity => userEntity.is_verified());
     });
 
     this.legalHoldStatus = ko.observable(LegalHoldStatus.DISABLED);
 
     this.hasLegalHold = ko.computed(() => {
       const isInitialized = this.hasInitializedUsers();
-      const hasLegalHold = isInitialized && this.allUserEntities.some(userEntity => userEntity.isOnLegalHold());
+      const hasLegalHold = isInitialized && this.allUserEntities().some(userEntity => userEntity.isOnLegalHold());
 
       if (isInitialized) {
         this.legalHoldStatus(hasLegalHold ? LegalHoldStatus.ENABLED : LegalHoldStatus.DISABLED);
@@ -574,12 +580,6 @@ export class Conversation {
       this.type,
       this.verification_state,
     ].forEach(property => (property as ko.Observable).subscribe(this.persistState));
-  }
-
-  get allUserEntities() {
-    const selfUser = this.selfUser();
-    const selfUserArray = selfUser ? [selfUser] : [];
-    return selfUserArray.concat(this.participating_user_ets());
   }
 
   readonly persistState = (): void => {


### PR DESCRIPTION
The `selfUser` was not considered when displaying the classified bar. 
Which means that if `A` is on a non-classified domain and `B` on a classified one, `A` will, wrongly, see the conversation as classified (but it should not) 