### PR TITLE
fix: Filter people in the conversation from the Add Participant list [FS-1660]

### DIFF
--- a/src/script/components/UserSearchableList.tsx
+++ b/src/script/components/UserSearchableList.tsx
@@ -19,12 +19,14 @@
 
 import React, {useCallback, useEffect, useState} from 'react';
 
+import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {container} from 'tsyringe';
 import {debounce} from 'underscore';
 
 import {partition} from 'Util/ArrayUtil';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
+import {matchQualifiedIds} from 'Util/QualifiedId';
 import {sortByPriority} from 'Util/StringUtil';
 
 import {UserList} from './UserList';
@@ -51,6 +53,8 @@ export type UserListProps = React.ComponentProps<typeof UserList> & {
   truncate?: boolean;
   userState?: UserState;
   dataUieName?: string;
+  /* will prevent showing those users in the list */
+  excludeUsers?: QualifiedId[];
 };
 
 const UserSearchableList: React.FC<UserListProps> = ({
@@ -150,7 +154,9 @@ const UserSearchableList: React.FC<UserListProps> = ({
       }
     : undefined;
 
-  const userList = foundUserEntities();
+  const userList = foundUserEntities().filter(
+    user => !props.excludeUsers?.some(excludeId => matchQualifiedIds(user.qualifiedId, excludeId)),
+  );
   const isEmptyUserList = userList.length === 0;
   const hasUsers = users.length === 0;
   const noResultsDataUieName = hasUsers ? 'status-all-added' : 'status-no-matches';

--- a/src/script/page/RightSidebar/AddParticipants/AddParticipants.tsx
+++ b/src/script/page/RightSidebar/AddParticipants/AddParticipants.tsx
@@ -32,7 +32,6 @@ import {UserSearchableList} from 'Components/UserSearchableList';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {handleKeyDown} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
-import {matchQualifiedIds} from 'Util/QualifiedId';
 import {safeWindowOpen} from 'Util/SanitizationUtil';
 import {sortUsersByPriority} from 'Util/StringUtil';
 
@@ -115,17 +114,12 @@ const AddParticipants: FC<AddParticipantsProps> = ({
 
   const [isInitialServiceSearch, setIsInitialServiceSearch] = useState<boolean>(true);
   const contacts = useMemo(() => {
-    let users: User[] = [];
-
     if (isTeam) {
       const isTeamOrServices = isTeamOnly || isServicesRoom;
-      users = isTeamOrServices ? teamMembers.sort(sortUsersByPriority) : teamUsers;
-    } else {
-      users = connectedUsers;
+      return isTeamOrServices ? teamMembers.sort(sortUsersByPriority) : teamUsers;
     }
-
-    return users.filter(userEntity => !participatingUserIds.find(userId => matchQualifiedIds(userEntity, userId)));
-  }, [connectedUsers, isServicesRoom, isTeam, isTeamOnly, participatingUserIds, teamMembers, teamUsers]);
+    return connectedUsers;
+  }, [connectedUsers, isServicesRoom, isTeam, isTeamOnly, teamMembers, teamUsers]);
 
   const enabledAddAction = selectedContacts.length > ENABLE_ADD_ACTIONS_LENGTH;
 
@@ -240,6 +234,7 @@ const AddParticipants: FC<AddParticipantsProps> = ({
               searchRepository={searchRepository}
               teamRepository={teamRepository}
               conversationRepository={conversationRepository}
+              excludeUsers={participatingUserIds}
               isSelectable
             />
           )}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1660" title="FS-1660" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1660</a>  [Web] People that are already in the conversation can be "added" again
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Will ensure that the users already in a conversation never show up in the SearchableUserList