### PR TITLE
fix: Let calling message update the event timestamp when before a deleted message

### DIFF
--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -1053,11 +1053,12 @@ export class MessageRepository {
       conversationEntity.isShowingLastReceivedMessage() && conversationEntity.getNewestMessage()?.id === messageId;
 
     const deleteCount = await this.eventService.deleteEvent(conversationEntity.id, messageId);
+    const previousMessage = conversationEntity.getNewestMessage();
 
     amplify.publish(WebAppEvents.CONVERSATION.MESSAGE.REMOVED, messageId, conversationEntity.id);
 
-    if (isLastDeleted && conversationEntity.getNewestMessage()?.timestamp()) {
-      conversationEntity.updateTimestamps(conversationEntity.getNewestMessage(), true);
+    if (isLastDeleted && previousMessage?.timestamp()) {
+      conversationEntity.updateTimestamps(previousMessage, true);
     }
 
     return deleteCount;

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -892,7 +892,10 @@ export class Conversation {
     if (message_et) {
       const timestamp = message_et.timestamp();
       if (timestamp <= this.last_server_timestamp()) {
-        if (message_et.timestamp_affects_order()) {
+        // Some message do not bubble the conversation up in the conversation list (call messages for example or some system messages).
+        // Those should not update the conversation timestamp.
+        // This is ignored if the `forceUpdate` flag is set.
+        if (message_et.timestamp_affects_order() || forceUpdate) {
           this.setTimestamp(timestamp, TIMESTAMP_TYPE.LAST_EVENT, forceUpdate);
 
           const from_self = message_et.user()?.isMe;


### PR DESCRIPTION
STR: 

- start a call in a group (pick up or not, is doesn't affect the result)
- send a text message
- delete that text message
- send another text message
-> the last text message doesn't show up

## The problem 

The problem is that the conversation timestamp gets updated backward when deleting the last event of the conversation. 
**But** because call events are not supposed to affect the timestamp, in this case we try to update the timestamp to the timestamp of a message that is not supposed to update it. 

That means that the conversation last event timestamp will be in the future compared to the last loaded event (which typically means that the conversation is scrolled up and we are not looking at the last message of the conversation). 
In this case the webapp doesn't append new messages at the end of the message list. 

## Notes for the future

This timestamp computation is pretty messy and would need a clean rethink at some point 