### PR TITLE
feat: indicate unestablished call participant [FS-1644]

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -1303,6 +1303,7 @@
   "videoCallScreenShareNotSupported": "Screen sharing is not supported in this browser",
   "videoSpeakersTabAll": "All ({{count}})",
   "videoSpeakersTabSpeakers": "Speakers",
+  "videoCallParticipantConnecting": "Connecting...",
   "warningCallIssues": "This version of {{brandName}} can not participate in the call. Please use",
   "warningCallQualityPoor": "Poor connection",
   "warningCallUnsupportedIncoming": "{{user}} is calling. Your browser doesn’t support calls.",

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -30,6 +30,7 @@ import {container} from 'tsyringe';
 import 'webrtc-adapter';
 
 import {
+  AUDIO_STATE,
   CALL_TYPE,
   CONV_TYPE,
   ENV as AVS_ENV,
@@ -1429,6 +1430,14 @@ export class CallingRepository {
     members.forEach(member => call.getParticipant(member.userId, member.clientid)?.isSendingVideo(!!member.vrecv));
   }
 
+  private updateParticipantAudioState(call: Call, members: QualifiedWcallMember[]): void {
+    members.forEach(member =>
+      call
+        .getParticipant(member.userId, member.clientid)
+        ?.isAudioEstablished(member.aestab === AUDIO_STATE.ESTABLISHED),
+    );
+  }
+
   private updateParticipantList(call: Call, members: QualifiedWcallMember[]): void {
     const newMembers = members
       .filter(({userId, clientid}) => !call.getParticipant(userId, clientid))
@@ -1473,6 +1482,7 @@ export class CallingRepository {
     this.updateParticipantList(call, members);
     this.updateParticipantMutedState(call, members);
     this.updateParticipantVideoState(call, members);
+    this.updateParticipantAudioState(call, members);
     this.callParticipantChangedCallback(conversationId, members);
   };
 

--- a/src/script/calling/Participant.ts
+++ b/src/script/calling/Participant.ts
@@ -40,6 +40,7 @@ export class Participant {
   public startedScreenSharingAt: ko.Observable<number>;
   public isActivelySpeaking: ko.Observable<boolean>;
   public isSendingVideo: ko.Observable<boolean>;
+  public isAudioEstablished: ko.Observable<boolean>;
 
   // Audio
   public audioStream: ko.Observable<MediaStream | undefined>;
@@ -65,6 +66,7 @@ export class Participant {
     this.startedScreenSharingAt = ko.observable();
     this.isMuted = ko.observable(false);
     this.isSendingVideo = ko.observable(false);
+    this.isAudioEstablished = ko.observable(false);
   }
 
   readonly doesMatchIds = (userId: QualifiedId, clientId: ClientId): boolean =>

--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantItemContent/CallParticipantItemContent.styles.ts
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantItemContent/CallParticipantItemContent.styles.ts
@@ -76,7 +76,7 @@ export const contentText: CSSObject = {
 };
 
 export const nameWrapper = (isAudioEstablished: boolean): CSSObject => ({
-  color: isAudioEstablished ? 'var(--main-color)' : 'var(--gray-70)',
+  color: isAudioEstablished ? 'var(--main-color)' : 'var(--text-input-placeholder)',
   display: 'flex',
   overflow: 'hidden',
   width: '100%',

--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantItemContent/CallParticipantItemContent.styles.ts
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantItemContent/CallParticipantItemContent.styles.ts
@@ -75,15 +75,18 @@ export const contentText: CSSObject = {
   fontWeight: 'var(--font-weight-medium)',
 };
 
-export const nameWrapper: CSSObject = {
-  color: 'var(--main-color)',
+export const nameWrapper = (isAudioEstablished: boolean): CSSObject => ({
+  color: isAudioEstablished ? 'var(--main-color)' : 'var(--gray-70)',
   display: 'flex',
   overflow: 'hidden',
   width: '100%',
   paddingRight: '8px',
-};
+});
 
 export const userAvailability: CSSObject = {
+  maxWidth: '100%',
+  whiteSpace: 'nowrap',
+
   '.availability-state-label': ellipsis,
   '.availability-state-icon': {
     display: 'flex',

--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantItemContent/CallParticipantItemContent.tsx
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantItemContent/CallParticipantItemContent.tsx
@@ -42,6 +42,7 @@ import {
 export interface CallParticipantItemContentProps {
   name: string;
   selfInTeam?: boolean;
+  isAudioEstablished: boolean;
   availability?: Availability.Type;
   isSelf?: boolean;
   onDropdownClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
@@ -50,6 +51,7 @@ export interface CallParticipantItemContentProps {
 export const CallParticipantItemContent = ({
   name,
   selfInTeam = false,
+  isAudioEstablished,
   availability = Availability.Type.NONE,
   isSelf = false,
   onDropdownClick,

--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantItemContent/CallParticipantItemContent.tsx
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantItemContent/CallParticipantItemContent.tsx
@@ -61,11 +61,11 @@ export const CallParticipantItemContent = ({
   return (
     <div css={wrapper}>
       <div css={contentText}>
-        <div css={nameWrapper}>
-          {selfInTeam ? (
+        <div css={nameWrapper(isAudioEstablished)}>
+          {selfInTeam && availability ? (
             <AvailabilityState
               availability={availability}
-              css={[userName, userAvailability, ellipsis]}
+              css={[userAvailability, ellipsis]}
               dataUieName="status-name"
               label={name}
             />

--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantItemContent/CallParticipantItemContent.tsx
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantItemContent/CallParticipantItemContent.tsx
@@ -64,7 +64,7 @@ export const CallParticipantItemContent = ({
     <div css={wrapper}>
       <div css={contentText}>
         <div css={nameWrapper(isAudioEstablished)}>
-          {selfInTeam && availability ? (
+          {selfInTeam ? (
             <AvailabilityState
               availability={availability}
               css={[userAvailability, ellipsis]}

--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantItemContent/CallParticipantItemContent.tsx
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantItemContent/CallParticipantItemContent.tsx
@@ -45,7 +45,8 @@ export interface CallParticipantItemContentProps {
   isAudioEstablished: boolean;
   availability?: Availability.Type;
   isSelf?: boolean;
-  onDropdownClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  showContextMenu: boolean;
+  onDropdownClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 export const CallParticipantItemContent = ({
@@ -54,6 +55,7 @@ export const CallParticipantItemContent = ({
   isAudioEstablished,
   availability = Availability.Type.NONE,
   isSelf = false,
+  showContextMenu,
   onDropdownClick,
 }: CallParticipantItemContentProps) => {
   const selfString = `(${capitalizeFirstChar(t('conversationYouNominative'))})`;
@@ -79,7 +81,7 @@ export const CallParticipantItemContent = ({
         </div>
       </div>
 
-      {onDropdownClick && (
+      {isAudioEstablished && showContextMenu && (
         <button
           data-hoverClass="chevron-icon"
           tabIndex={TabIndex.UNFOCUSABLE}

--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.styles.ts
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.styles.ts
@@ -21,7 +21,7 @@ import {CSSObject} from '@emotion/react';
 
 import {listWrapper} from '../../ParticipantItemContent/ParticipantItem.styles';
 
-export const callParticipantListWrapper = (isLast = false): CSSObject => ({
+export const callParticipantListItemWrapper = (isLast = false): CSSObject => ({
   ...listWrapper({noUnderline: true, noInteraction: true}),
   '&:hover, &:focus, &:focus-visible': {
     backgroundColor: 'var(--disabled-call-button-bg)',
@@ -38,6 +38,27 @@ const commonIconStyles = {
   height: '12px',
   width: '12px',
 };
+
+export const callParticipantAvatar = (isAudioEstablished = false): CSSObject => ({
+  margin: '0 10px',
+  opacity: isAudioEstablished ? '1' : '0.5',
+});
+
+export const callParticipantConnecting: CSSObject = {
+  color: 'var(--danger-color)',
+  fontSize: 'var(--font-size-small)',
+  flexShrink: 0,
+};
+
+export const callParticipantListItem = (noInteraction = false): CSSObject => ({
+  display: 'flex',
+  overflow: 'hidden',
+  height: '56px',
+  alignItems: 'center',
+  paddingRight: '16px',
+  margin: '0',
+  cursor: noInteraction ? 'default' : 'pointer',
+});
 
 export const callStatusIcons = (activeIconsCount: number): CSSObject => ({
   display: 'grid',

--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.test.tsx
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.test.tsx
@@ -69,7 +69,9 @@ const createMockParticipant = ({
 describe('CallParticipantsListItem', () => {
   it('should render participant user avatar', () => {
     const participant = createMockParticipant({});
-    const {getByTestId} = render(<CallParticipantsListItem callParticipant={participant} />);
+    const {getByTestId} = render(
+      <CallParticipantsListItem showContextMenu={true} onContextMenu={jest.fn()} callParticipant={participant} />,
+    );
 
     expect(getByTestId('element-avatar-user')).toBeDefined();
   });
@@ -83,7 +85,12 @@ describe('CallParticipantsListItem', () => {
     });
 
     const {getByTestId, getByText} = render(
-      <CallParticipantsListItem callParticipant={participant} selfInTeam={true} />,
+      <CallParticipantsListItem
+        showContextMenu={true}
+        onContextMenu={jest.fn()}
+        callParticipant={participant}
+        selfInTeam={true}
+      />,
     );
 
     expect(getByText(participantName)).toBeDefined();
@@ -95,7 +102,9 @@ describe('CallParticipantsListItem', () => {
   it('should mark user as self if relevant', () => {
     const selfParticipant = createMockParticipant({isSelfUser: true});
 
-    const {getByText} = render(<CallParticipantsListItem callParticipant={selfParticipant} />);
+    const {getByText} = render(
+      <CallParticipantsListItem showContextMenu={true} onContextMenu={jest.fn()} callParticipant={selfParticipant} />,
+    );
 
     expect(getByText('(ConversationYouNominative)')).toBeDefined();
   });
@@ -107,7 +116,9 @@ describe('CallParticipantsListItem', () => {
       isExternal: true,
     });
 
-    const {getByTestId} = render(<CallParticipantsListItem callParticipant={selfParticipant} />);
+    const {getByTestId} = render(
+      <CallParticipantsListItem showContextMenu={true} onContextMenu={jest.fn()} callParticipant={selfParticipant} />,
+    );
 
     expect(getByTestId('status-guest')).toBeDefined();
     expect(getByTestId('status-external')).toBeDefined();

--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.test.tsx
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.test.tsx
@@ -74,7 +74,7 @@ describe('CallParticipantsListItem', () => {
   it('should render participant user avatar', () => {
     const participant = createMockParticipant({});
     const {getByTestId} = render(
-      <CallParticipantsListItem showContextMenu={true} onContextMenu={jest.fn()} callParticipant={participant} />,
+      <CallParticipantsListItem showContextMenu onContextMenu={jest.fn()} callParticipant={participant} />,
     );
 
     expect(getByTestId('element-avatar-user')).toBeDefined();
@@ -89,12 +89,7 @@ describe('CallParticipantsListItem', () => {
     });
 
     const {getByTestId, getByText} = render(
-      <CallParticipantsListItem
-        showContextMenu={true}
-        onContextMenu={jest.fn()}
-        callParticipant={participant}
-        selfInTeam={true}
-      />,
+      <CallParticipantsListItem showContextMenu onContextMenu={jest.fn()} callParticipant={participant} selfInTeam />,
     );
 
     expect(getByText(participantName)).toBeDefined();
@@ -107,7 +102,7 @@ describe('CallParticipantsListItem', () => {
     const selfParticipant = createMockParticipant({isSelfUser: true});
 
     const {getByText} = render(
-      <CallParticipantsListItem showContextMenu={true} onContextMenu={jest.fn()} callParticipant={selfParticipant} />,
+      <CallParticipantsListItem showContextMenu onContextMenu={jest.fn()} callParticipant={selfParticipant} />,
     );
 
     expect(getByText('(ConversationYouNominative)')).toBeDefined();
@@ -121,7 +116,7 @@ describe('CallParticipantsListItem', () => {
     });
 
     const {getByTestId} = render(
-      <CallParticipantsListItem showContextMenu={true} onContextMenu={jest.fn()} callParticipant={selfParticipant} />,
+      <CallParticipantsListItem showContextMenu onContextMenu={jest.fn()} callParticipant={selfParticipant} />,
     );
 
     expect(getByTestId('status-guest')).toBeDefined();
@@ -132,7 +127,7 @@ describe('CallParticipantsListItem', () => {
     const participant = createMockParticipant({});
     const onContextMenu = jest.fn();
     const {getByTestId} = render(
-      <CallParticipantsListItem showContextMenu={true} onContextMenu={onContextMenu} callParticipant={participant} />,
+      <CallParticipantsListItem showContextMenu onContextMenu={onContextMenu} callParticipant={participant} />,
     );
 
     const userItem = getByTestId('item-user');
@@ -145,7 +140,7 @@ describe('CallParticipantsListItem', () => {
     const participant = createMockParticipant({isAudioEstablished: false});
     const onContextMenu = jest.fn();
     const {getByTestId} = render(
-      <CallParticipantsListItem showContextMenu={true} onContextMenu={onContextMenu} callParticipant={participant} />,
+      <CallParticipantsListItem showContextMenu onContextMenu={onContextMenu} callParticipant={participant} />,
     );
 
     const userItem = getByTestId('item-user');
@@ -158,7 +153,7 @@ describe('CallParticipantsListItem', () => {
     const participant = createMockParticipant({isAudioEstablished: false});
     const onContextMenu = jest.fn();
     const {getByText} = render(
-      <CallParticipantsListItem showContextMenu={true} onContextMenu={onContextMenu} callParticipant={participant} />,
+      <CallParticipantsListItem showContextMenu onContextMenu={onContextMenu} callParticipant={participant} />,
     );
 
     expect(getByText('videoCallParticipantConnecting')).toBeDefined();

--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.test.tsx
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.test.tsx
@@ -35,6 +35,7 @@ const createMockParticipant = ({
   isGuest = false,
   isFederated = false,
   isExternal = false,
+  isAudioEstablished = true,
 }: {
   name?: string;
   availability?: Availability.Type;
@@ -42,6 +43,7 @@ const createMockParticipant = ({
   isGuest?: boolean;
   isFederated?: boolean;
   isExternal?: boolean;
+  isAudioEstablished?: boolean;
 }) => {
   const user = new User(createRandomUuid());
   user.name('user');
@@ -62,6 +64,8 @@ const createMockParticipant = ({
 
   const clientId = createRandomUuid();
   const participant = new Participant(user, clientId);
+
+  participant.isAudioEstablished(isAudioEstablished);
 
   return participant;
 };
@@ -122,5 +126,41 @@ describe('CallParticipantsListItem', () => {
 
     expect(getByTestId('status-guest')).toBeDefined();
     expect(getByTestId('status-external')).toBeDefined();
+  });
+
+  it('should open context menu on user item click', () => {
+    const participant = createMockParticipant({});
+    const onContextMenu = jest.fn();
+    const {getByTestId} = render(
+      <CallParticipantsListItem showContextMenu={true} onContextMenu={onContextMenu} callParticipant={participant} />,
+    );
+
+    const userItem = getByTestId('item-user');
+    userItem.click();
+
+    expect(onContextMenu).toHaveBeenCalled();
+  });
+
+  it('should not open context menu when user is in unestablished audio state', () => {
+    const participant = createMockParticipant({isAudioEstablished: false});
+    const onContextMenu = jest.fn();
+    const {getByTestId} = render(
+      <CallParticipantsListItem showContextMenu={true} onContextMenu={onContextMenu} callParticipant={participant} />,
+    );
+
+    const userItem = getByTestId('item-user');
+    userItem.click();
+
+    expect(onContextMenu).not.toHaveBeenCalled();
+  });
+
+  it('should show "connecting..." text if user is in unestablishd audio state', () => {
+    const participant = createMockParticipant({isAudioEstablished: false});
+    const onContextMenu = jest.fn();
+    const {getByText} = render(
+      <CallParticipantsListItem showContextMenu={true} onContextMenu={onContextMenu} callParticipant={participant} />,
+    );
+
+    expect(getByText('videoCallParticipantConnecting')).toBeDefined();
   });
 });

--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.tsx
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.tsx
@@ -54,6 +54,8 @@ export const CallParticipantsListItem = ({
   const {user} = callParticipant;
   const {isMe: isSelf, isFederated} = user;
 
+  const {isAudioEstablished} = useKoSubscribableChildren(callParticipant, ['isAudioEstablished']);
+
   const {
     isDirectGuest,
     is_verified: isVerified,
@@ -85,6 +87,7 @@ export const CallParticipantsListItem = ({
         <Avatar avatarSize={AVATAR_SIZE.SMALL} participant={user} aria-hidden="true" css={{margin: '0 10px'}} />
 
         <CallParticipantItemContent
+          isAudioEstablished={isAudioEstablished}
           name={userName}
           selfInTeam={selfInTeam}
           availability={availability}

--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.tsx
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.tsx
@@ -36,10 +36,10 @@ import {CallParticipantStatusIcons} from './CallParticipantStatusIcons';
 
 export interface CallParticipantsListItemProps {
   callParticipant: Participant;
+  showContextMenu: boolean;
+  onContextMenu: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
   selfInTeam?: boolean;
   isSelfVerified?: boolean;
-  showDropdown?: boolean;
-  onContextMenu?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
   isLast?: boolean;
 }
 
@@ -47,7 +47,7 @@ export const CallParticipantsListItem = ({
   callParticipant,
   isSelfVerified = false,
   selfInTeam,
-  showDropdown = false,
+  showContextMenu,
   onContextMenu,
   isLast = false,
 }: CallParticipantsListItemProps) => {
@@ -71,16 +71,22 @@ export const CallParticipantsListItem = ({
     });
   };
 
+  const reactiveProps =
+    isAudioEstablished && showContextMenu
+      ? {
+          role: 'button',
+          tabIndex: TabIndex.FOCUSABLE,
+          onContextMenu,
+          onClick: onContextMenu,
+          onKeyDown: handleContextKeyDown,
+        }
+      : undefined;
+
   return (
     <div
-      tabIndex={TabIndex.FOCUSABLE}
-      role="button"
-      onContextMenu={onContextMenu}
-      onClick={onContextMenu}
-      onKeyDown={handleContextKeyDown}
+      {...reactiveProps}
       data-uie-name="item-user"
       data-uie-value={userName}
-      aria-label={t('accessibility.openConversation', userName)}
       css={callParticipantListWrapper(isLast)}
     >
       <div css={listItem(true)}>
@@ -97,9 +103,8 @@ export const CallParticipantsListItem = ({
           selfInTeam={selfInTeam}
           availability={availability}
           isSelf={isSelf}
-          {...(showDropdown && {
-            onDropdownClick: event => onContextMenu?.(event as unknown as React.MouseEvent<HTMLDivElement>),
-          })}
+          showContextMenu={showContextMenu}
+          onDropdownClick={event => onContextMenu?.(event as unknown as React.MouseEvent<HTMLDivElement>)}
         />
 
         {isAudioEstablished ? (

--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.tsx
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.tsx
@@ -84,7 +84,12 @@ export const CallParticipantsListItem = ({
       css={callParticipantListWrapper(isLast)}
     >
       <div css={listItem(true)}>
-        <Avatar avatarSize={AVATAR_SIZE.SMALL} participant={user} aria-hidden="true" css={{margin: '0 10px'}} />
+        <Avatar
+          avatarSize={AVATAR_SIZE.SMALL}
+          participant={user}
+          aria-hidden="true"
+          css={{margin: '0 10px', opacity: isAudioEstablished ? '1' : '0.5'}}
+        />
 
         <CallParticipantItemContent
           isAudioEstablished={isAudioEstablished}
@@ -97,16 +102,29 @@ export const CallParticipantsListItem = ({
           })}
         />
 
-        <UserStatusBadges
-          config={{
-            guest: isDirectGuest,
-            federated: isFederated,
-            external: isExternal,
-            verified: isSelfVerified && isVerified,
-          }}
-        />
-
-        <CallParticipantStatusIcons callParticipant={callParticipant} />
+        {isAudioEstablished ? (
+          <>
+            <UserStatusBadges
+              config={{
+                guest: isDirectGuest,
+                federated: isFederated,
+                external: isExternal,
+                verified: isSelfVerified && isVerified,
+              }}
+            />
+            <CallParticipantStatusIcons callParticipant={callParticipant} />
+          </>
+        ) : (
+          <span
+            css={{
+              color: 'var(--red-500)',
+              fontSize: 'var(--font-size-small)',
+              flexShrink: 0,
+            }}
+          >
+            {t('videoCallParticipantConnecting')}
+          </span>
+        )}
       </div>
     </div>
   );

--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.tsx
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.tsx
@@ -122,7 +122,7 @@ export const CallParticipantsListItem = ({
         ) : (
           <span
             css={{
-              color: 'var(--red-500)',
+              color: 'var(--danger-color)',
               fontSize: 'var(--font-size-small)',
               flexShrink: 0,
             }}

--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.tsx
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.tsx
@@ -22,8 +22,6 @@ import React from 'react';
 import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 
 import {Avatar, AVATAR_SIZE} from 'Components/Avatar';
-import {callParticipantListWrapper} from 'Components/calling/CallParticipantsListItem/CallParticipantsListItem.styles';
-import {listItem} from 'Components/ParticipantItemContent/ParticipantItem.styles';
 import {UserStatusBadges} from 'Components/UserBadges';
 import {Participant} from 'src/script/calling/Participant';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
@@ -32,6 +30,12 @@ import {t} from 'Util/LocalizerUtil';
 import {setContextMenuPosition} from 'Util/util';
 
 import {CallParticipantItemContent} from './CallParticipantItemContent';
+import {
+  callParticipantListItemWrapper,
+  callParticipantListItem,
+  callParticipantAvatar,
+  callParticipantConnecting,
+} from './CallParticipantsListItem.styles';
 import {CallParticipantStatusIcons} from './CallParticipantStatusIcons';
 
 export interface CallParticipantsListItemProps {
@@ -87,14 +91,14 @@ export const CallParticipantsListItem = ({
       {...reactiveProps}
       data-uie-name="item-user"
       data-uie-value={userName}
-      css={callParticipantListWrapper(isLast)}
+      css={callParticipantListItemWrapper(isLast)}
     >
-      <div css={listItem(true)}>
+      <div css={callParticipantListItem(true)}>
         <Avatar
           avatarSize={AVATAR_SIZE.SMALL}
           participant={user}
           aria-hidden="true"
-          css={{margin: '0 10px', opacity: isAudioEstablished ? '1' : '0.5'}}
+          css={callParticipantAvatar(isAudioEstablished)}
         />
 
         <CallParticipantItemContent
@@ -120,15 +124,7 @@ export const CallParticipantsListItem = ({
             <CallParticipantStatusIcons callParticipant={callParticipant} />
           </>
         ) : (
-          <span
-            css={{
-              color: 'var(--danger-color)',
-              fontSize: 'var(--font-size-small)',
-              flexShrink: 0,
-            }}
-          >
-            {t('videoCallParticipantConnecting')}
-          </span>
+          <span css={callParticipantConnecting}>{t('videoCallParticipantConnecting')}</span>
         )}
       </div>
     </div>

--- a/src/script/components/calling/CallingCell.tsx
+++ b/src/script/components/calling/CallingCell.tsx
@@ -595,10 +595,8 @@ const CallingCell: React.FC<CallingCellProps> = ({
                               callParticipant={participant}
                               selfInTeam={selfUser?.inTeam()}
                               isSelfVerified={isSelfVerified}
-                              showDropdown={isModerator}
-                              onContextMenu={
-                                isModerator ? event => getParticipantContext(event, participant) : undefined
-                              }
+                              showContextMenu={!!isModerator}
+                              onContextMenu={event => getParticipantContext(event, participant)}
                               isLast={participantsArray.length === index}
                             />
                           </li>

--- a/src/script/components/calling/GroupVideoGridTile.tsx
+++ b/src/script/components/calling/GroupVideoGridTile.tsx
@@ -127,7 +127,7 @@ const GroupVideoGridTile: React.FC<GroupVideoGridTileProps> = ({
               },
             }}
           >
-            {'Connecting...'}
+            {t('videoCallParticipantConnecting')}
           </span>
         )}
       </span>

--- a/src/script/components/calling/GroupVideoGridTile.tsx
+++ b/src/script/components/calling/GroupVideoGridTile.tsx
@@ -43,6 +43,24 @@ export interface GroupVideoGridTileProps {
   selfParticipant: Participant;
 }
 
+const getParticipantNameColor = ({
+  isActivelySpeaking,
+  isAudioEstablished,
+}: {
+  isActivelySpeaking: boolean;
+  isAudioEstablished: boolean;
+}) => {
+  if (!isAudioEstablished) {
+    return 'var(--gray-60)';
+  }
+
+  if (isActivelySpeaking) {
+    return 'var(--app-bg-secondary)';
+  }
+
+  return 'var(--white)';
+};
+
 const GroupVideoGridTile: React.FC<GroupVideoGridTileProps> = ({
   minimized,
   participant,
@@ -51,12 +69,10 @@ const GroupVideoGridTile: React.FC<GroupVideoGridTileProps> = ({
   isMaximized,
   onTileDoubleClick,
 }) => {
-  const {isMuted, videoState, videoStream, isActivelySpeaking} = useKoSubscribableChildren(participant, [
-    'isMuted',
-    'videoStream',
-    'isActivelySpeaking',
-    'videoState',
-  ]);
+  const {isMuted, videoState, videoStream, isActivelySpeaking, isAudioEstablished} = useKoSubscribableChildren(
+    participant,
+    ['isMuted', 'videoStream', 'isActivelySpeaking', 'videoState', 'isAudioEstablished'],
+  );
   const {name} = useKoSubscribableChildren(participant?.user, ['name']);
 
   const sharesScreen = videoState === VIDEO_STATE.SCREENSHARE;
@@ -74,6 +90,8 @@ const GroupVideoGridTile: React.FC<GroupVideoGridTileProps> = ({
     }
   };
 
+  const participantNameColor = getParticipantNameColor({isActivelySpeaking, isAudioEstablished});
+
   const nameContainer = !minimized && (
     <div
       className="group-video-grid__element__label"
@@ -83,12 +101,35 @@ const GroupVideoGridTile: React.FC<GroupVideoGridTileProps> = ({
     >
       <span
         data-uie-name={isActivelySpeaking ? 'status-active-speaking' : isMuted ? 'status-audio-off' : 'status-audio-on'}
-        className="group-video-grid__element__label__name"
         css={{
-          color: isActivelySpeaking ? 'var(--app-bg-secondary)' : 'var(--white)',
+          overflow: 'hidden',
+          display: 'flex',
+          color: participantNameColor,
         }}
       >
-        {name}
+        <span
+          css={{
+            textOverflow: 'ellipsis',
+            overflow: 'hidden',
+          }}
+        >
+          {name}
+        </span>
+        {!isAudioEstablished && (
+          <span
+            css={{
+              color: 'var(--participant-audio-connecting-color)',
+              flexShrink: 0,
+              '&::before': {
+                content: "' • '",
+                whiteSpace: 'pre',
+                color: participantNameColor,
+              },
+            }}
+          >
+            {'Connecting...'}
+          </span>
+        )}
       </span>
     </div>
   );

--- a/src/style/common/mixins.less
+++ b/src/style/common/mixins.less
@@ -42,7 +42,7 @@
   .setColorFade(foreground, @foreground);
   .setColorFade(background, @background);
   .setVariables(app-bg sidebar-bg input-bar-bg sidebar-border-color main-color border-color app-bg-secondary conversation-list-bg-opacity);
-  .setVariables(group-video-bg group-video-tile-bg inactive-call-button-bg inactive-call-button-border inactive-call-button-hover-bg inactive-call-button-hover-border disabled-call-button-bg disabled-call-button-border disabled-call-button-svg button-group-left-hover button-group-right-hover toggle-button-unselected-hover-border toggle-button-unselected-hover-bg);
+  .setVariables(group-video-bg group-video-tile-bg participant-audio-connecting-color inactive-call-button-bg inactive-call-button-border inactive-call-button-hover-bg inactive-call-button-hover-border disabled-call-button-bg disabled-call-button-border disabled-call-button-svg button-group-left-hover button-group-right-hover toggle-button-unselected-hover-border toggle-button-unselected-hover-bg);
   .setVariables(modal-bg modal-border-color);
   .setVariables(preference-account-input-bg);
   .setVariables(text-input-editing text-input-background text-input-border text-input-border-hover text-input-placeholder text-input-color text-input-alert text-input-disabled text-input-label text-input-success);

--- a/src/style/foundation/themes.less
+++ b/src/style/foundation/themes.less
@@ -44,6 +44,7 @@ body.theme-default {
   // ----------------------------------------------------------------------------
   @group-video-bg: var(--gray-10);
   @group-video-tile-bg: var(--gray-90);
+  @participant-audio-connecting-color: @red-dark-500;
   @inactive-call-button-bg: var(--white);
   @inactive-call-button-border: var(--gray-40);
   @inactive-call-button-hover-bg: var(--gray-20);
@@ -138,6 +139,7 @@ body.theme-dark {
   // ----------------------------------------------------------------------------
   @group-video-bg: var(--gray-100);
   @group-video-tile-bg: var(--gray-95);
+  @participant-audio-connecting-color: @red-dark-500;
   @inactive-call-button-bg: var(--gray-90);
   @inactive-call-button-border: var(--gray-100);
   @inactive-call-button-hover-bg: var(--gray-80);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1644" title="FS-1644" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-1644</a>  [Web]  “Indicate users with bad / lost connection during the call“
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Show `Connecting...` text next to call participant name when audio is in unestablished state. 

This is needed mostly for calls on MLS protocol based conversations:

When call participant's client crashes, avs library detects that it has lost signal and is no longer in established audio state. With current MLS calls implementation (call "rooms" based on MLS subconversations), client that does not establish audio state back in 3 minute timeout, will get kicked from a call (and underlying MLS subconversation) by some other call participant. This feature is implemented to let other users know that this user is not actively participating in the call and might get dropped out soon (or hopefully connect back). 

It may also appear for proteus calls for a very short time, when user is joining the call (establishing audio state).

Designs: https://www.figma.com/file/OrP9jAJdfttfvsm3nxnihP/Accessibility-Quick-Wins-(Web%2FDesktop)?node-id=9150%3A34677&t=Q0qMbGvAx4OHx3mk-1

Todo:

- [x] Display `Connecting...` state in call participants grid view (maximised call view)
- [x] Display `Connecting...` state in call participant list (left sidebar)
- [x] Add test cases

Calling grid UI:
![connecting-grid](https://user-images.githubusercontent.com/45733298/230364306-2a84ee73-d8f7-40b7-9557-a12e01fdb480.gif)

Call Participants list:
![connecting-list](https://user-images.githubusercontent.com/45733298/230364360-cfc4f240-bf37-4d75-8e7d-552716e23d1a.gif)
