### PR TITLE
chore: bump core version [FS-1562]

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.10.6",
     "@types/eslint": "8.4.10",
     "@wireapp/avs": "9.1.13",
-    "@wireapp/core": "39.2.7",
+    "@wireapp/core": "39.3.2",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.4.1",
     "@wireapp/store-engine-dexie": "2.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4331,9 +4331,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^23.2.1":
-  version: 23.2.1
-  resolution: "@wireapp/api-client@npm:23.2.1"
+"@wireapp/api-client@npm:^23.3.0":
+  version: 23.3.0
+  resolution: "@wireapp/api-client@npm:23.3.0"
   dependencies:
     "@wireapp/commons": ^5.0.4
     "@wireapp/priority-queue": ^2.0.3
@@ -4346,7 +4346,7 @@ __metadata:
     spark-md5: 3.0.2
     tough-cookie: 4.1.2
     ws: 8.11.0
-  checksum: aeddbbe94001c23415de215b08b8cd3e61ce2dbd9887b44e13ec82782b1625d078af91b65025393ac6b8d00c714e8a65251d8e45ced39f42bb61f8071372abfb
+  checksum: b96cd363d012fa6bb6f562f9aa82dc80004bf74ab68fc81560d108c8de1e2f95fae5655a260fc9e26b9039000bedeb65ba202af9ed8e37d5688acbf196528811
   languageName: node
   linkType: hard
 
@@ -4399,11 +4399,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:39.2.7":
-  version: 39.2.7
-  resolution: "@wireapp/core@npm:39.2.7"
+"@wireapp/core@npm:39.3.2":
+  version: 39.3.2
+  resolution: "@wireapp/core@npm:39.3.2"
   dependencies:
-    "@wireapp/api-client": ^23.2.1
+    "@wireapp/api-client": ^23.3.0
     "@wireapp/commons": ^5.0.4
     "@wireapp/core-crypto": 0.7.0-rc.3
     "@wireapp/cryptobox": 12.8.0
@@ -4420,7 +4420,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.13
-  checksum: 19098878b11465db1eca697b7ca8ead129fc76d1e4281e86ed0687ec83826c54bebbcb6d6e71c4426006f23863b2c1e5667ddb4c453f4fdafe120ed626db1152
+  checksum: 7fd91ed151e60d9971bd6fbbb8848c9c7fa18f8396c558ed478b9ea08f28227c3c3c544b94a17de68d51882d2967f116fa3e4e1194063a05fc78e0ebf6b074fb
   languageName: node
   linkType: hard
 
@@ -16714,7 +16714,7 @@ dexie@latest:
     "@typescript-eslint/parser": ^5.55.0
     "@wireapp/avs": 9.1.13
     "@wireapp/copy-config": 2.0.10
-    "@wireapp/core": 39.2.7
+    "@wireapp/core": 39.3.2
     "@wireapp/eslint-config": 2.1.1
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.5.2


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1562" title="FS-1562" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1562</a>  [Web][MLS] When the current device is deleted via another device, coreCrypto db wipe could fail
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Should fix issue where client is not logged out properly after its device was removed using some other client.
For more details see https://github.com/wireapp/wire-web-packages/pull/4972