### PR TITLE
fix: Avoid duplicated current client in Database

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@emotion/react": "11.10.6",
     "@types/eslint": "8.4.10",
     "@wireapp/avs": "9.1.13",
-    "@wireapp/core": "39.2.7",
+    "@wireapp/core": "39.3.3",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.4.1",
     "@wireapp/store-engine-dexie": "2.0.5",

--- a/src/script/client/ClientRepository.ts
+++ b/src/script/client/ClientRepository.ts
@@ -351,7 +351,7 @@ export class ClientRepository {
             const isSelfClient = matchQualifiedIds({domain, id: userId}, this.selfUser().qualifiedId);
             clientEntityMap[domain] ||= {};
             clientEntityMap[domain][userId] = updateClients
-              ? await this.updateClientsOfUserById({domain, id: userId}, clients, true)
+              ? await this.updateUserClients({domain, id: userId}, clients, true)
               : ClientMapper.mapClients(clients, isSelfClient, domain);
           }),
         ),
@@ -400,7 +400,7 @@ export class ClientRepository {
   async updateClientsForSelf(): Promise<ClientEntity[]> {
     const clientsData = await this.clientService.getClients();
     const {domain, id} = this.selfUser();
-    return this.updateClientsOfUserById({domain, id}, clientsData, false);
+    return this.updateUserClients({domain, id}, clientsData, false);
   }
 
   /**
@@ -413,7 +413,7 @@ export class ClientRepository {
    * @param publish Change clients using amplify
    * @returns Resolves with the entities once clients have been updated
    */
-  private async updateClientsOfUserById(
+  private async updateUserClients(
     userId: QualifiedId,
     clientsData: RegisteredClient[] | PublicClient[],
     publish: boolean = true,

--- a/src/script/conversation/EventBuilder.ts
+++ b/src/script/conversation/EventBuilder.ts
@@ -20,7 +20,6 @@
 import {MemberLeaveReason} from '@wireapp/api-client/lib/conversation/data/';
 import {ConversationOtrMessageAddEvent, CONVERSATION_EVENT} from '@wireapp/api-client/lib/event/';
 import type {QualifiedId} from '@wireapp/api-client/lib/user/';
-import {ReactionType} from '@wireapp/core/lib/conversation';
 import {DecryptionError} from '@wireapp/core/lib/errors/DecryptionError';
 
 import type {REASON as AVS_REASON} from '@wireapp/avs';
@@ -30,6 +29,7 @@ import {createRandomUuid} from 'Util/util';
 
 import {CALL_MESSAGE_TYPE} from '../calling/enum/CallMessageType';
 import type {Conversation} from '../entity/Conversation';
+import {ReactionType} from '../entity/message/ContentMessage';
 import type {Message} from '../entity/message/Message';
 import type {User} from '../entity/User';
 import {CALL, ClientEvent, CONVERSATION} from '../event/Client';

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -19,13 +19,7 @@
 
 import {ConversationProtocol, MessageSendingStatus, QualifiedUserClients} from '@wireapp/api-client/lib/conversation';
 import {QualifiedId, RequestCancellationError, User as APIClientUser} from '@wireapp/api-client/lib/user';
-import {
-  MessageSendingState,
-  MessageTargetMode,
-  ReactionType,
-  GenericMessageType,
-  SendResult,
-} from '@wireapp/core/lib/conversation';
+import {MessageSendingState, MessageTargetMode, GenericMessageType, SendResult} from '@wireapp/core/lib/conversation';
 import {
   AudioMetaData,
   EditedTextContent,
@@ -75,7 +69,7 @@ import {CryptographyRepository} from '../cryptography/CryptographyRepository';
 import {PROTO_MESSAGE_TYPE} from '../cryptography/ProtoMessageType';
 import {Conversation} from '../entity/Conversation';
 import {CompositeMessage} from '../entity/message/CompositeMessage';
-import {ContentMessage} from '../entity/message/ContentMessage';
+import {ContentMessage, ReactionType} from '../entity/message/ContentMessage';
 import {FileAsset} from '../entity/message/FileAsset';
 import {Message} from '../entity/message/Message';
 import {User} from '../entity/User';

--- a/src/script/cryptography/CryptographyMapper.test.ts
+++ b/src/script/cryptography/CryptographyMapper.test.ts
@@ -18,7 +18,7 @@
  */
 
 import {CONVERSATION_EVENT} from '@wireapp/api-client/lib/event/';
-import {GenericMessageType, ReactionType} from '@wireapp/core/lib/conversation';
+import {GenericMessageType} from '@wireapp/core/lib/conversation';
 import {isObject} from 'underscore';
 
 import {
@@ -45,6 +45,8 @@ import {ClientEvent} from 'src/script/event/Client';
 import {arrayToBase64, createRandomUuid} from 'Util/util';
 
 import {CryptographyMapper} from './CryptographyMapper';
+
+import {ReactionType} from '../entity/message/ContentMessage';
 
 describe('CryptographyMapper', () => {
   const mapper = new CryptographyMapper();

--- a/src/script/entity/message/ContentMessage.ts
+++ b/src/script/entity/message/ContentMessage.ts
@@ -19,7 +19,6 @@
 
 import type {QualifiedUserClients} from '@wireapp/api-client/lib/conversation';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
-import type {ReactionType} from '@wireapp/core/lib/conversation/ReactionType';
 import ko from 'knockout';
 
 import {copyText} from 'Util/ClipboardUtil';
@@ -37,6 +36,11 @@ import type {QuoteEntity} from '../../message/QuoteEntity';
 import {SuperType} from '../../message/SuperType';
 import {UserReactionMap} from '../../storage';
 import {User} from '../User';
+
+export enum ReactionType {
+  LIKE = '❤️',
+  NONE = '',
+}
 
 export class ContentMessage extends Message {
   private readonly isLikedProvisional: ko.Observable<boolean>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4331,9 +4331,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^23.2.1":
-  version: 23.2.1
-  resolution: "@wireapp/api-client@npm:23.2.1"
+"@wireapp/api-client@npm:^23.3.0":
+  version: 23.3.0
+  resolution: "@wireapp/api-client@npm:23.3.0"
   dependencies:
     "@wireapp/commons": ^5.0.4
     "@wireapp/priority-queue": ^2.0.3
@@ -4346,7 +4346,7 @@ __metadata:
     spark-md5: 3.0.2
     tough-cookie: 4.1.2
     ws: 8.11.0
-  checksum: aeddbbe94001c23415de215b08b8cd3e61ce2dbd9887b44e13ec82782b1625d078af91b65025393ac6b8d00c714e8a65251d8e45ced39f42bb61f8071372abfb
+  checksum: b96cd363d012fa6bb6f562f9aa82dc80004bf74ab68fc81560d108c8de1e2f95fae5655a260fc9e26b9039000bedeb65ba202af9ed8e37d5688acbf196528811
   languageName: node
   linkType: hard
 
@@ -4399,11 +4399,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:39.2.7":
-  version: 39.2.7
-  resolution: "@wireapp/core@npm:39.2.7"
+"@wireapp/core@npm:39.3.3":
+  version: 39.3.3
+  resolution: "@wireapp/core@npm:39.3.3"
   dependencies:
-    "@wireapp/api-client": ^23.2.1
+    "@wireapp/api-client": ^23.3.0
     "@wireapp/commons": ^5.0.4
     "@wireapp/core-crypto": 0.7.0-rc.3
     "@wireapp/cryptobox": 12.8.0
@@ -4420,7 +4420,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.13
-  checksum: 19098878b11465db1eca697b7ca8ead129fc76d1e4281e86ed0687ec83826c54bebbcb6d6e71c4426006f23863b2c1e5667ddb4c453f4fdafe120ed626db1152
+  checksum: 2bbd4e86e91876a4bf17a535818a01e66ddecd3a2b8dedb5f6f8f18386d1ed5dbd2c94d40ba3b505845c6a2951dacfd42ce66727566c831531ee11947035b0e0
   languageName: node
   linkType: hard
 
@@ -16714,7 +16714,7 @@ dexie@latest:
     "@typescript-eslint/parser": ^5.55.0
     "@wireapp/avs": 9.1.13
     "@wireapp/copy-config": 2.0.10
-    "@wireapp/core": 39.2.7
+    "@wireapp/core": 39.3.3
     "@wireapp/eslint-config": 2.1.1
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.5.2


### PR DESCRIPTION
See https://github.com/wireapp/wire-web-packages/pull/4992

This will avoid having an entry for the current client in the database when we load the application. 
This could cause the webapp to try to send an encrypted message to this particular device (which could cause a session not to be found)