### PR TITLE
fix: StartUI search field placeholder

### DIFF
--- a/src/i18n/de-DE.json
+++ b/src/i18n/de-DE.json
@@ -1148,7 +1148,7 @@
   "searchOthers": "Suchergebnisse",
   "searchOthersFederation": "Mit {{domainName}} verbinden",
   "searchPeople": "Kontakte",
-  "searchPeoplePlaceholder": "Personen nach Namen oder Benutzernamen suchen",
+  "searchPeoplePlaceholder": "Personen und Gruppen suchen",
   "searchServiceConfirmButton": "Unterhaltung öffnen",
   "searchServicePlaceholder": "Nach Namen suchen",
   "searchServices": "Dienste",

--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -1148,7 +1148,7 @@
   "searchOthers": "Connect",
   "searchOthersFederation": "Connect with {{domainName}}",
   "searchPeople": "People",
-  "searchPeoplePlaceholder": "Search people by name or username",
+  "searchPeoplePlaceholder": "Search for people and groups",
   "searchServiceConfirmButton": "Open Conversation",
   "searchServicePlaceholder": "Search by name",
   "searchServices": "Services",


### PR DESCRIPTION
Fix cutted text for search input field in StartUI (Contacts tab).