### PR TITLE
refactor: Make UserRepository less stateful

### DIFF
--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -392,7 +392,7 @@ export class App {
       onProgress(10);
       telemetry.timeStep(AppInitTimingsStep.INITIALIZED_CRYPTOGRAPHY);
 
-      await teamRepository.initTeam();
+      const team = await teamRepository.initTeam();
 
       const conversationEntities = await conversationRepository.loadConversations();
 
@@ -412,7 +412,9 @@ export class App {
 
       await conversationRepository.conversationRoleRepository.loadTeamRoles();
 
-      await userRepository.loadTeamUserAvailabilities();
+      if (team) {
+        await userRepository.loadTeamUserAvailabilities([...team.members(), selfUser]);
+      }
 
       await eventRepository.connectWebSocket(this.core, ({done, total}) => {
         const baseMessage = t('initDecryption');
@@ -556,7 +558,7 @@ export class App {
       }
     }
 
-    await container.resolve(StorageService).init(this.core.storage);
+    container.resolve(StorageService).init(this.core.storage);
     this.repository.client.init(userEntity);
     await this.repository.properties.init(userEntity);
 

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -392,7 +392,7 @@ export class App {
       onProgress(10);
       telemetry.timeStep(AppInitTimingsStep.INITIALIZED_CRYPTOGRAPHY);
 
-      const team = await teamRepository.initTeam();
+      const team = await teamRepository.initTeam(selfUser.teamId);
 
       const conversationEntities = await conversationRepository.loadConversations();
 

--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -121,23 +121,22 @@ export class TeamRepository {
     );
   };
 
-  initTeam = async (): Promise<TeamEntity | undefined> => {
+  initTeam = async (teamId?: string): Promise<TeamEntity | undefined> => {
     const team = await this.getTeam();
-    const inTeam = this.userState.self().teamId;
-    if (inTeam) {
+    await this.updateFeatureConfig();
+    if (teamId) {
       await this.updateTeamMembers(team);
+      this.scheduleTeamRefresh();
     }
-    this.updateFeatureConfig();
-    this.scheduleTeamRefresh();
-    return inTeam ? team : undefined;
+    return teamId ? team : undefined;
   };
 
-  async updateFeatureConfig() {
+  private async updateFeatureConfig() {
     this.teamState.teamFeatures(await this.teamService.getAllTeamFeatures());
     return this.teamState.teamFeatures();
   }
 
-  readonly scheduleTeamRefresh = (): void => {
+  private readonly scheduleTeamRefresh = (): void => {
     window.setInterval(async () => {
       try {
         await this.getTeam();
@@ -149,13 +148,13 @@ export class TeamRepository {
   };
 
   async getTeam(): Promise<TeamEntity> {
-    const selfTeamId = this.userState.self().teamId;
-    const teamData = !!selfTeamId && (await this.getTeamById(selfTeamId));
+    const teamId = this.userState.self().teamId;
+    const teamData = !!teamId && (await this.getTeamById(teamId));
 
     const teamEntity = teamData ? this.teamMapper.mapTeamFromObject(teamData, this.teamState.team()) : new TeamEntity();
     this.teamState.team(teamEntity);
-    if (selfTeamId) {
-      await this.getSelfMember(selfTeamId);
+    if (teamId) {
+      await this.getSelfMember(teamId);
     }
     // doesn't need to be awaited because it publishes the account info over amplify.
     this.sendAccountInfo();

--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -121,13 +121,15 @@ export class TeamRepository {
     );
   };
 
-  initTeam = async (): Promise<void> => {
+  initTeam = async (): Promise<TeamEntity | undefined> => {
     const team = await this.getTeam();
-    if (this.userState.self().teamId) {
+    const inTeam = this.userState.self().teamId;
+    if (inTeam) {
       await this.updateTeamMembers(team);
     }
     this.updateFeatureConfig();
     this.scheduleTeamRefresh();
+    return inTeam ? team : undefined;
   };
 
   async updateFeatureConfig() {

--- a/src/script/user/UserService.ts
+++ b/src/script/user/UserService.ts
@@ -124,6 +124,9 @@ export class UserService {
    * @example ['0bb84213-8cc2-4bb1-9e0b-b8dd522396d5', '15ede065-72b3-433a-9917-252f076ed031']
    */
   async getUsers(userIds: QualifiedId[]) {
+    if (userIds.length === 0) {
+      return [];
+    }
     return (await this.apiClient.api.user.postListUsers({qualified_ids: userIds})).found;
   }
 

--- a/src/script/user/UserService.ts
+++ b/src/script/user/UserService.ts
@@ -124,11 +124,7 @@ export class UserService {
    * @example ['0bb84213-8cc2-4bb1-9e0b-b8dd522396d5', '15ede065-72b3-433a-9917-252f076ed031']
    */
   async getUsers(userIds: QualifiedId[]) {
-    if (userIds.length === 0) {
-      return Promise.resolve([]);
-    }
-    const {found} = await this.apiClient.api.user.postListUsers({qualified_ids: userIds});
-    return found;
+    return (await this.apiClient.api.user.postListUsers({qualified_ids: userIds})).found;
   }
 
   /**


### PR DESCRIPTION
The `UserRepository` is tighlty coupled to the `UserState`. This class should be stateless and instead the method calls should be done injecting the piece of state that it needs. 
