### PR TITLE
fix: Show correct description when all users are added to the conversation [FS-1728]

### DIFF
--- a/src/script/components/UserSearchableList.tsx
+++ b/src/script/components/UserSearchableList.tsx
@@ -158,9 +158,9 @@ const UserSearchableList: React.FC<UserListProps> = ({
     user => !props.excludeUsers?.some(excludeId => matchQualifiedIds(user.qualifiedId, excludeId)),
   );
   const isEmptyUserList = userList.length === 0;
-  const hasUsers = users.length === 0;
-  const noResultsDataUieName = hasUsers ? 'status-all-added' : 'status-no-matches';
-  const noResultsTranslationText = hasUsers ? 'searchListEveryoneParticipates' : 'searchListNoMatches';
+  const isSearching = filter.length > 0;
+  const noResultsDataUieName = !isSearching ? 'status-all-added' : 'status-no-matches';
+  const noResultsTranslationText = !isSearching ? 'searchListEveryoneParticipates' : 'searchListNoMatches';
 
   return (
     <div className="user-list-wrapper" data-uie-name={dataUieName} role="list">


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1728" title="FS-1728" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1728</a>  [Web] Wrong description when trying to add participants and all contacts are already added
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Regression introduced by #14835 
![image](https://user-images.githubusercontent.com/1090716/227217336-7f671dd5-2d7e-4bcd-939b-b369e6479122.png)
