### PR TITLE
fix: Parse conversation roles directly from 'conversation.create' event [FS-1659]

### DIFF
--- a/src/script/conversation/ConversationMapper.test.ts
+++ b/src/script/conversation/ConversationMapper.test.ts
@@ -25,6 +25,7 @@ import {
   CONVERSATION_TYPE,
   Member as MemberBackendData,
   OtherMember as OtherMemberBackendData,
+  DefaultConversationRoleName,
   RemoteConversations,
 } from '@wireapp/api-client/lib/conversation/';
 import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data';
@@ -99,6 +100,35 @@ describe('ConversationMapper', () => {
       expect(conversationEntity['mutedTimestamp']()).toEqual(expectedMutedTimestamp);
       expect(conversationEntity.last_event_timestamp()).toBe(initialTimestamp);
       expect(conversationEntity.last_server_timestamp()).toBe(initialTimestamp);
+    });
+
+    it('maps a backend conversation roles', () => {
+      const conversation = {
+        ...entities.conversation,
+        roles: undefined,
+        members: {
+          self: {...entities.conversation.members.self, conversation_role: 'wire_admin'},
+          others: [
+            {
+              id: '1',
+              conversation_role: DefaultConversationRoleName.WIRE_ADMIN,
+            },
+            {
+              id: '2',
+              conversation_role: DefaultConversationRoleName.WIRE_MEMBER,
+            },
+          ],
+        },
+      };
+
+      const initialTimestamp = Date.now();
+      const [conversationEntity] = ConversationMapper.mapConversations([conversation], initialTimestamp);
+
+      expect(conversationEntity.roles()).toEqual({
+        [conversation.members.self.id]: DefaultConversationRoleName.WIRE_ADMIN,
+        [conversation.members.others[0].id]: DefaultConversationRoleName.WIRE_ADMIN,
+        [conversation.members.others[1].id]: DefaultConversationRoleName.WIRE_MEMBER,
+      });
     });
 
     it('maps multiple conversations', () => {

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -2394,14 +2394,6 @@ export class ConversationRepository {
 
     const creatorIsParticipant = createdByParticipant || createdBySelfUser;
 
-    const data = await this.conversationService.getConversationById(conversationEntity);
-    const allMembers = [...data.members.others, data.members.self];
-    const conversationRoles = allMembers.reduce<Record<string, string>>((roles, member) => {
-      roles[member.id] = member.conversation_role;
-      return roles;
-    }, {});
-    conversationEntity.roles(conversationRoles);
-
     if (!creatorIsParticipant) {
       (messageEntity as MemberMessage).memberMessageType = SystemMessageType.CONVERSATION_RESUME;
     }

--- a/src/script/conversation/ConversationRoleRepository.test.ts
+++ b/src/script/conversation/ConversationRoleRepository.test.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {ConversationRole, DefaultConversationRoleName as DefaultRole} from '@wireapp/api-client/lib/conversation/';
+import {DefaultConversationRoleName as DefaultRole} from '@wireapp/api-client/lib/conversation/';
 
 import {createRandomUuid} from 'Util/util';
 
@@ -68,24 +68,6 @@ describe('ConversationRoleRepository', () => {
       await roleRepository.loadTeamRoles();
 
       expect(roleRepository.teamRoles.length).toBe(1);
-    });
-  });
-
-  describe('setConversationRoles', () => {
-    it('sets conversation roles', async () => {
-      const newRoles: ConversationRole[] = [
-        {
-          actions: [Permissions.leaveConversation],
-          conversation_role: DefaultRole.WIRE_MEMBER,
-        },
-      ];
-
-      const conversationEntity = new Conversation();
-      roleRepository.setConversationRoles(conversationEntity, newRoles);
-
-      const realRoles = roleRepository.getConversationRoles(conversationEntity);
-
-      expect(realRoles.length).toBe(1);
     });
   });
 

--- a/src/script/conversation/ConversationRoleRepository.ts
+++ b/src/script/conversation/ConversationRoleRepository.ts
@@ -63,7 +63,6 @@ const defaultMemberRole: ConversationRole = {
 };
 
 export class ConversationRoleRepository {
-  readonly conversationRoles: Record<string, ConversationRole[]>;
   readonly logger: Logger;
   teamRoles: ConversationRole[];
 
@@ -74,7 +73,6 @@ export class ConversationRoleRepository {
     private readonly teamState = container.resolve(TeamState),
   ) {
     this.logger = getLogger('ConversationRoleRepository');
-    this.conversationRoles = {};
     this.teamRoles = [defaultAdminRole, defaultMemberRole];
   }
 
@@ -87,10 +85,6 @@ export class ConversationRoleRepository {
         this.logger.warn('Could not load team conversation roles', error);
       }
     }
-  };
-
-  readonly setConversationRoles = (conversation: Conversation, newRoles: ConversationRole[]): void => {
-    this.conversationRoles[conversation.id] = newRoles;
   };
 
   updateConversationRoles = async (conversation: Conversation): Promise<void> => {
@@ -122,7 +116,7 @@ export class ConversationRoleRepository {
     });
   };
 
-  readonly getUserRole = (conversation: Conversation, userEntity: User): string => {
+  private readonly getUserRole = (conversation: Conversation, userEntity: User): string => {
     return conversation.roles()[userEntity.id];
   };
 
@@ -130,18 +124,14 @@ export class ConversationRoleRepository {
     return this.getUserRole(conversation, userEntity) === DefaultRole.WIRE_ADMIN;
   };
 
-  readonly isSelfGroupAdmin = (conversation: Conversation): boolean => {
-    return this.isUserGroupAdmin(conversation, this.userState.self());
-  };
-
-  readonly getConversationRoles = (conversation: Conversation): ConversationRole[] => {
+  private readonly getConversationRoles = (conversation: Conversation): ConversationRole[] => {
     if (this.teamState.isTeam() && this.teamState.team()?.id === conversation.team_id) {
       return this.teamRoles;
     }
-    return this.conversationRoles[conversation.id] || this.teamRoles;
+    return this.teamRoles;
   };
 
-  readonly getUserPermissions = (conversation: Conversation, user: User): ConversationRole => {
+  private readonly getUserPermissions = (conversation: Conversation, user: User): ConversationRole => {
     const conversationRoles = this.getConversationRoles(conversation);
     const userRole: string = this.getUserRole(conversation, user);
     return conversationRoles?.find(({conversation_role}) => conversation_role === userRole) || defaultMemberRole;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1659" title="FS-1659" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1659</a>  [Web] Inconsistent display of conversation admin
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Currently the flow for creating a conversation locally when it was create by someone else if:
- we parse the content of the `conversation.create` event
- we map it to a conversation entity (without the roles)
- we re-fetch the entire conversation metadata
- we extract the roles for that fresh fetch

But, the `conversation.create` event actually contains everything we need to also compute the roles directly. 

This PR removes the extra fetch request and computes the roles directly from the payload the `conversation.create` event