### PR TITLE
fix: Correct size for verified icon in call ui (SQSERVICES-1982)

### DIFF
--- a/src/script/components/list/ParticipantItem.tsx
+++ b/src/script/components/list/ParticipantItem.tsx
@@ -249,7 +249,7 @@ const ParticipantItem = <UserType extends User | ServiceEntity>(
                   <Icon.MicOff
                     className="mic-off-icon"
                     data-uie-name="status-audio-off"
-                    style={{height: 12, width: 12}}
+                    style={{height: 14, width: 14, marginLeft: 8}}
                   />
                 )}
               </>

--- a/src/style/components/list/conversation-list-calling-cell.less
+++ b/src/style/components/list/conversation-list-calling-cell.less
@@ -147,6 +147,10 @@
     }
 
     .participant-item {
+      svg {
+        margin: 0;
+      }
+
       &__image {
         width: 48px !important;
       }
@@ -155,7 +159,12 @@
         display: none !important;
       }
 
-      .verified-icon,
+      .verified-icon {
+        display: flex;
+        width: 14px !important;
+        height: 16px !important;
+      }
+
       .guest-icon svg {
         display: flex;
         width: 12px !important;
@@ -170,8 +179,8 @@
 
       .participant-mic-on-icon svg {
         display: flex;
-        width: 12px !important;
-        height: 12px !important;
+        width: 14px !important;
+        height: 14px !important;
       }
     }
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1982" title="SQSERVICES-1982" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1982</a>  [Web] Verified shield in call participant list is very small
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
![telegram-cloud-photo-size-4-5839268821192523324-x](https://user-images.githubusercontent.com/63250054/227938340-a5411486-c9ee-4b86-9874-01e185e018bf.jpg)
