### PR TITLE
fix: Avoid requesting the same image more than once [SQSERVICES-1985]

### DIFF
--- a/src/script/assets/AssetRepository.ts
+++ b/src/script/assets/AssetRepository.ts
@@ -78,12 +78,15 @@ export class AssetRepository {
       return objectUrl;
     }
 
-    const blob = await this.load(asset);
-    if (!blob) {
-      return undefined;
-    }
-    const url = window.URL.createObjectURL(blob);
-    return setAssetUrl(asset.identifier, url);
+    const urlPromise = new Promise<string>(async (resolve, reject) => {
+      const blob = await this.load(asset);
+      if (!blob) {
+        return reject(undefined);
+      }
+      const url = window.URL.createObjectURL(blob);
+      resolve(url);
+    });
+    return setAssetUrl(asset.identifier, urlPromise);
   }
 
   public async load(asset: AssetRemoteData): Promise<undefined | Blob> {

--- a/src/script/assets/AssetURLCache.ts
+++ b/src/script/assets/AssetURLCache.ts
@@ -17,11 +17,11 @@
  *
  */
 
-const cache = new Map<string, string>();
+const cache = new Map<string, Promise<string>>();
 
-export const getAssetUrl = (identifier: string): string | undefined => cache.get(identifier);
+export const getAssetUrl = (identifier: string): Promise<string> | undefined => cache.get(identifier);
 
-export const setAssetUrl = (identifier: string, url: string) => {
+export const setAssetUrl = (identifier: string, url: Promise<string>) => {
   const isExistingUrl = getAssetUrl(identifier);
 
   if (!isExistingUrl) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1985" title="SQSERVICES-1985" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1985</a>  [web] At load time the avatar are downloaded as many times as they are in view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## The problem

When the app first loads, when a conversation is displayed there are `n` avatar requests that are sent at the same time. 
Those trigger `n` actual network request and some of them are targeting the same image. 
This ends up in duplicate requests that are hitting backend and eventually putting the webapp in a rate limit state. 

## The solution

instead of caching the image only when the request is successful, we cache the **promise** of the request **as soon as the request is fired**. This way any subsequent request will then get the cached promise and will avoid sending the request on the network

## Before

![Screenshot 2023-03-28 at 17 40 05](https://user-images.githubusercontent.com/1090716/228304443-93feb313-1e90-460a-b8fb-b1995b708420.png)

## After

![Screenshot 2023-03-28 at 17 41 50](https://user-images.githubusercontent.com/1090716/228304504-6c567bd5-381e-469a-b07b-43ac59f3db56.png)
