### PR TITLE
runfix: 2fa too many requests blocking error [FS-1755]

### DIFF
--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -217,8 +217,14 @@ const LoginComponent = ({
               try {
                 await doSendTwoFactorCode(login.email || login.handle || '');
               } catch (error) {
-                if (error.code !== StatusCodes.TOO_MANY_REQUESTS) {
-                  throw error;
+                if (isBackendError(error)) {
+                  /**  The BE can respond quite restrictively to the send code request.
+                   * We don't want to block the user from logging in if they have already received a code in the last few minutes.
+                   * Any other error should still be thrown.
+                   */
+                  if (error.code !== StatusCodes.TOO_MANY_REQUESTS) {
+                    throw error;
+                  }
                 }
               } finally {
                 setTwoFactorLoginData(login);

--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -214,9 +214,16 @@ const LoginComponent = ({
             await resetAuthError();
             const login: LoginData = {...formLoginData, clientType: loginData.clientType};
             if (login.email || login.handle) {
-              await doSendTwoFactorCode(login.email || login.handle || '');
-              setTwoFactorLoginData(login);
-              await doSetLocalStorage(QUERY_KEY.JOIN_EXPIRES, Date.now() + 1000 * 60 * 10);
+              try {
+                await doSendTwoFactorCode(login.email || login.handle || '');
+              } catch (error) {
+                if (error.code !== StatusCodes.TOO_MANY_REQUESTS) {
+                  throw error;
+                }
+              } finally {
+                setTwoFactorLoginData(login);
+                await doSetLocalStorage(QUERY_KEY.JOIN_EXPIRES, Date.now() + 1000 * 60 * 10);
+              }
             }
             break;
           }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1755" title="FS-1755" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1755</a>  [Backend] Rate limiting on /v3/verification-code/send endpoint hits already after second try
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Theres an issue with webapp where requesting a second 2fa code will block webapp from running even if you have a valid 2fa code in your email. 

### Causes (Optional)

there's a rate limit on BE for 2fa codes and we are not properly handling the error on FE. 

### Solutions

Properly handle the 429 error from the 2fa code request endpoint. 

