### PR TITLE
fix: display classified bar correctly [FS-1758]

### DIFF
--- a/src/script/components/calling/FullscreenVideoCall.styles.ts
+++ b/src/script/components/calling/FullscreenVideoCall.styles.ts
@@ -19,6 +19,11 @@
 
 import {css, CSSObject} from '@emotion/react';
 
+export const classifiedBarStyles: CSSObject = {
+  lineHeight: '1.5em',
+  display: 'flex',
+};
+
 export const videoControlActiveStyles = css`
   background-color: var(--main-color);
   border: 1px solid var(--main-color);

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -42,7 +42,8 @@ import {
   videoControlInActiveStyles,
   videoControlDisabledStyles,
   paginationButtonStyles,
-} from './FullscreenVideoCallStyles';
+  classifiedBarStyles,
+} from './FullscreenVideoCall.styles';
 import {GroupVideoGrid} from './GroupVideoGrid';
 import {Pagination} from './Pagination';
 
@@ -259,8 +260,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
             users={allUsers}
             classifiedDomains={classifiedDomains}
             style={{
-              lineHeight: '1.5em',
-              display: 'flex',
+              ...classifiedBarStyles,
             }}
           />
         )}

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -208,22 +208,6 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
           />
         )}
 
-        {classifiedDomains && (
-          <ClassifiedBar
-            users={allUsers}
-            classifiedDomains={classifiedDomains}
-            style={{
-              lineHeight: '1.5em',
-              margin: '1em 0',
-              position: 'absolute',
-              display: 'flex',
-              right: 0,
-              left: 0,
-              bottom: 100,
-            }}
-          />
-        )}
-
         {/* Calling conversation name and duration */}
         <div
           className="video-remote-name"
@@ -270,6 +254,16 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
           }
           setMaximizedParticipant={participant => setMaximizedParticipant(call, participant)}
         />
+        {classifiedDomains && (
+          <ClassifiedBar
+            users={allUsers}
+            classifiedDomains={classifiedDomains}
+            style={{
+              lineHeight: '1.5em',
+              display: 'flex',
+            }}
+          />
+        )}
       </div>
       {!maximizedParticipant && activeCallViewTab === CallViewTab.ALL && totalPages > 1 && (
         <>

--- a/src/style/components/classified-bar.less
+++ b/src/style/components/classified-bar.less
@@ -20,10 +20,9 @@
 .classified-bar {
   display: flex;
   width: 100%;
-  height: 16px;
+  min-height: 16px;
   align-items: center;
   justify-content: center;
-  padding: 12px 0;
   border-width: 1px 0;
   font-size: 0.6875rem;
   font-weight: 600;

--- a/src/style/components/classified-bar.less
+++ b/src/style/components/classified-bar.less
@@ -20,7 +20,7 @@
 .classified-bar {
   display: flex;
   width: 100%;
-  min-height: 16px;
+  min-height: 1rem;
   align-items: center;
   justify-content: center;
   border-width: 1px 0;

--- a/src/style/foundation/video-calling.less
+++ b/src/style/foundation/video-calling.less
@@ -44,7 +44,9 @@
 }
 
 .video-element-remote {
+  display: flex;
   height: calc(100% - 179px);
+  flex-direction: column;
   // fade in animation
   animation: video-fade-in @animation-timing-slower @ease-out-quart forwards;
   opacity: 0;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1758" title="FS-1758" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1758</a>  [web] Enlarge font slider to 24px make classified banner not readable in call window 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


#### Issues

- Classified banners disappears from the call ui at certain responsive breakpoints
- Pagination would overlay the banner leading to a broken UI
- Classified banner in the side bar call ui would not fit the text at larger font sizes

![Peek 2023-03-30 11-24](https://user-images.githubusercontent.com/78490891/228832752-bc675400-879f-45f5-bc23-55a1e749fc41.gif)

#### Solutions

- Do not rely on absolute positioning for full screen call ui
![Peek 2023-03-30 13-52](https://user-images.githubusercontent.com/78490891/228833134-ae1a327b-e3c0-4509-ad49-636aaf1094ca.gif)

- Remove static height from classified banner for sidebar (Doesn't look good at the max font size, there's always limit on what you can fit inside  a box ;) )
![Peek 2023-03-30 14-07](https://user-images.githubusercontent.com/78490891/228833554-3b87737c-3ab3-4877-8bbe-dc7389bebe2b.gif)

