### PR TITLE
feat: add button for 2fa submit [SQSERVICES-1991/ SQSERVICES-1940]

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -661,6 +661,7 @@
   "login.subhead": "Enter your email address or username.",
   "login.twoFactorLoginSubHead": "Please check your email {email} for the verification code and enter it below.",
   "login.twoFactorLoginTitle": "Verify your account",
+  "login.submitTwoFactorButton": "Submit",
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "messageCouldNotBeSent": "Message could not be sent due to connectivity issues.",

--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -31,6 +31,7 @@ import {AnyAction, Dispatch} from 'redux';
 import {Runtime, UrlUtil} from '@wireapp/commons';
 import {
   ArrowIcon,
+  Button,
   Checkbox,
   CheckboxLabel,
   CodeInput,
@@ -39,6 +40,7 @@ import {
   Columns,
   Container,
   ContainerXS,
+  FlexBox,
   Form,
   H1,
   H2,
@@ -103,6 +105,8 @@ const LoginComponent = ({
 
   const [twoFactorSubmitError, setTwoFactorSubmitError] = useState<string | Error>('');
   const [twoFactorLoginData, setTwoFactorLoginData] = useState<LoginData>();
+  const [verificationCode, setVerificationCode] = useState('');
+  const [twoFactorSubmitFailedOnce, setTwoFactorSubmitFailedOnce] = useState(false);
 
   const isOauth = UrlUtil.hasURLParameter(QUERY_KEY.SCOPE);
 
@@ -244,6 +248,7 @@ const LoginComponent = ({
 
           case BackendError.LABEL.CODE_AUTHENTICATION_FAILED: {
             setTwoFactorSubmitError(error);
+            setTwoFactorSubmitFailedOnce(true);
             break;
           }
           case BackendError.LABEL.INVALID_CREDENTIALS:
@@ -281,8 +286,12 @@ const LoginComponent = ({
   };
 
   const submitTwoFactorLogin = (code?: string) => {
+    setVerificationCode(code ?? '');
     setTwoFactorSubmitError('');
-    handleSubmit({...twoFactorLoginData, verificationCode: code}, []);
+    // Do not auto submit if already failed once
+    if (!twoFactorSubmitFailedOnce) {
+      handleSubmit({...twoFactorLoginData, verificationCode: code}, []);
+    }
   };
 
   const storeEntropy = async (entropyData: Uint8Array) => {
@@ -333,10 +342,10 @@ const LoginComponent = ({
                     </Text>
                     <Label markInvalid={!!twoFactorSubmitError}>
                       <CodeInput
+                        disabled={isFetching}
                         style={{marginTop: 60}}
                         onCodeComplete={submitTwoFactorLogin}
                         data-uie-name="enter-code"
-                        markInvalid={!!twoFactorSubmitError}
                       />
                     </Label>
                     <div style={{display: 'flex', justifyContent: 'center', marginTop: 10}}>
@@ -351,6 +360,16 @@ const LoginComponent = ({
                         </TextLink>
                       )}
                     </div>
+                    <FlexBox justify="center">
+                      <Button
+                        disabled={!!twoFactorSubmitError || isFetching}
+                        type="submit"
+                        css={{marginTop: 65}}
+                        onClick={() => handleSubmit({...twoFactorLoginData, verificationCode}, [])}
+                      >
+                        {_({id: 'login.submitTwoFactorButton'})}
+                      </Button>
+                    </FlexBox>
                   </div>
                 ) : (
                   <>

--- a/src/script/strings.ts
+++ b/src/script/strings.ts
@@ -770,6 +770,10 @@ export const loginStrings = defineMessages({
     defaultMessage: 'Verify your account',
     id: 'login.twoFactorLoginTitle',
   },
+  submitTwoFactorButton: {
+    defaultMessage: 'Submit',
+    id: 'login.submitTwoFactorButton',
+  },
 });
 
 export const ssoLoginStrings = defineMessages({


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1991" title="SQSERVICES-1991" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1991</a>  [Web] Missing feedback after entering 2FA code
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

UI does not have appropriate user feedback to understand what happens when 2fa code is entered. 

https://user-images.githubusercontent.com/37285713/229517795-3bf4620a-ceba-4d6f-a545-cc9c74585915.mov


### Solutions

Adds a button to 2fa login flow to allow blocking the UI. (first usage is submitted automatically)

https://user-images.githubusercontent.com/37285713/229516730-c337767b-68f4-475e-bff4-18d1d0305427.mov

### Needs releases with:

FRIDA
