### PR TITLE
fix: Make avatar lazy load and avoid flickering of userList

### DIFF
--- a/src/script/components/UserList/components/UserListItem/UserListItem.tsx
+++ b/src/script/components/UserList/components/UserListItem/UserListItem.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React, {ChangeEvent, useId, useState} from 'react';
+import React, {ChangeEvent, useId} from 'react';
 
 import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 
@@ -28,7 +28,6 @@ import {ParticipantItemContent} from 'Components/ParticipantItemContent';
 import {listItem, listWrapper} from 'Components/ParticipantItemContent/ParticipantItem.styles';
 import {UserStatusBadges} from 'Components/UserBadges';
 import {UserlistMode} from 'Components/UserList';
-import {InViewport} from 'Components/utils/InViewport';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 import {capitalizeFirstChar} from 'Util/StringUtil';
@@ -70,7 +69,6 @@ const UserListItem = ({
   onKeyDown,
 }: UserListItemProps) => {
   const checkboxId = useId();
-  const [isInViewport, setIsInViewport] = useState(false);
 
   const {
     is_verified: isVerified,
@@ -108,31 +106,27 @@ const UserListItem = ({
 
   const RenderParticipant = () => {
     return (
-      <InViewport css={listItem(noInteraction)} onVisible={() => setIsInViewport(true)}>
-        {isInViewport && (
-          <>
-            <Avatar avatarSize={AVATAR_SIZE.SMALL} participant={user} aria-hidden="true" css={{margin: '0 16px'}} />
+      <div css={listItem(noInteraction)}>
+        <Avatar avatarSize={AVATAR_SIZE.SMALL} participant={user} aria-hidden="true" css={{margin: '0 16px'}} />
 
-            <ParticipantItemContent
-              name={userName}
-              shortDescription={contentInfoText}
-              selfInTeam={selfInTeam}
-              availability={availability}
-              {...(isSelf && {selfString})}
-              hasUsernameInfo={hasUsernameInfo}
-            />
+        <ParticipantItemContent
+          name={userName}
+          shortDescription={contentInfoText}
+          selfInTeam={selfInTeam}
+          availability={availability}
+          {...(isSelf && {selfString})}
+          hasUsernameInfo={hasUsernameInfo}
+        />
 
-            <UserStatusBadges
-              config={{
-                guest: !isOthersMode && isDirectGuest,
-                federated: isFederated,
-                external,
-                verified: isSelfVerified && isVerified,
-              }}
-            />
-          </>
-        )}
-      </InViewport>
+        <UserStatusBadges
+          config={{
+            guest: !isOthersMode && isDirectGuest,
+            federated: isFederated,
+            external,
+            verified: isSelfVerified && isVerified,
+          }}
+        />
+      </div>
     );
   };
 

--- a/src/script/components/avatar/AvatarImage.tsx
+++ b/src/script/components/avatar/AvatarImage.tsx
@@ -23,6 +23,7 @@ import {CSSObject} from '@emotion/serialize';
 import {Transition} from 'react-transition-group';
 import {container} from 'tsyringe';
 
+import {InViewport} from 'Components/utils/InViewport';
 import {CSS_FILL_PARENT} from 'Util/CSSMixin';
 
 import {AssetRemoteData} from '../../assets/AssetRemoteData';
@@ -55,9 +56,10 @@ const AvatarImage: React.FunctionComponent<AvatarImageProps> = ({
   const [avatarImage, setAvatarImage] = useState('');
   const [showTransition, setShowTransition] = useState(false);
   const [avatarLoadingBlocked, setAvatarLoadingBlocked] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
-    if (!avatarLoadingBlocked) {
+    if (!avatarLoadingBlocked && isVisible) {
       setAvatarLoadingBlocked(true);
 
       const isSmall = ![AVATAR_SIZE.LARGE, AVATAR_SIZE.X_LARGE].includes(avatarSize);
@@ -82,7 +84,7 @@ const AvatarImage: React.FunctionComponent<AvatarImageProps> = ({
         }
       })();
     }
-  }, [previewPicture, mediumPicture, avatarSize]);
+  }, [previewPicture, mediumPicture, avatarSize, isVisible]);
 
   const transitionImageStyles: Record<string, CSSObject> = {
     entered: {opacity: 1, transform: 'scale(1)'},
@@ -90,30 +92,32 @@ const AvatarImage: React.FunctionComponent<AvatarImageProps> = ({
   };
 
   return (
-    <Transition in={!!avatarImage} timeout={showTransition ? 700 : 0}>
-      {(state: string) => {
-        return (
-          <img
-            css={{
-              ...CSS_FILL_PARENT,
-              backgroundColor,
-              borderRadius,
-              filter: isGrey ? 'grayscale(100%)' : 'none',
-              height: '100%',
-              objectFit: 'cover',
-              opacity: 0,
-              overflow: 'hidden',
-              transform: 'scale(0.88)',
-              transition: showTransition ? 'all 0.55s cubic-bezier(0.165, 0.84, 0.44, 1) 0.15s' : 'none',
-              width: '100%',
-              ...transitionImageStyles[state],
-            }}
-            src={avatarImage}
-            alt={avatarAlt}
-          />
-        );
-      }}
-    </Transition>
+    <InViewport onVisible={() => setIsVisible(true)}>
+      <Transition in={!!avatarImage} timeout={showTransition ? 700 : 0}>
+        {(state: string) => {
+          return (
+            <img
+              css={{
+                ...CSS_FILL_PARENT,
+                backgroundColor,
+                borderRadius,
+                filter: isGrey ? 'grayscale(100%)' : 'none',
+                height: '100%',
+                objectFit: 'cover',
+                opacity: 0,
+                overflow: 'hidden',
+                transform: 'scale(0.88)',
+                transition: showTransition ? 'all 0.55s cubic-bezier(0.165, 0.84, 0.44, 1) 0.15s' : 'none',
+                width: '100%',
+                ...transitionImageStyles[state],
+              }}
+              src={avatarImage}
+              alt={avatarAlt}
+            />
+          );
+        }}
+      </Transition>
+    </InViewport>
   );
 };
 


### PR DESCRIPTION
This fixes the UserList flickering when viewing it

https://user-images.githubusercontent.com/1090716/229551068-a9e72653-2699-4346-986a-cc493c469e9d.mov


And makes the avatar load lazily (only when they are on screen)

https://user-images.githubusercontent.com/1090716/229551127-cc593cf9-0c99-4730-9320-89d6023f0d13.mov

