### PR TITLE
refactor: make call participant list item content separate component

### DIFF
--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantItemContent/CallParticipantItemContent.styles.ts
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantItemContent/CallParticipantItemContent.styles.ts
@@ -1,0 +1,100 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {CSSObject} from '@emotion/react';
+
+export const listItem = (noInteraction = false): CSSObject => ({
+  display: 'flex',
+  overflow: 'hidden',
+  height: '56px',
+  alignItems: 'center',
+  paddingRight: '16px',
+  margin: '0',
+  cursor: noInteraction ? 'default' : 'pointer',
+});
+
+export const chevronIcon: CSSObject = {
+  border: 'none',
+  padding: 0,
+  alignItems: 'center',
+  display: 'flex',
+  height: '16px',
+  justifyContent: 'center',
+  opacity: '0',
+  transition: 'opacity 0.25s ease-in-out',
+  width: '16px',
+  svg: {
+    width: '8px',
+    path: {
+      fill: 'currentColor',
+    },
+  },
+};
+
+export const ellipsis: CSSObject = {
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'pre',
+};
+
+export const wrapper: CSSObject = {
+  display: 'flex',
+  minWidth: 0,
+  height: 'var(--avatar-diameter-m)',
+  flex: '1 1',
+  alignItems: 'center',
+  lineHeight: 'var(--line-height-sm)',
+};
+
+export const contentText: CSSObject = {
+  display: 'flex',
+  minWidth: 0, // this will ensure that ellipses is working
+  minHeight: 'var(--avatar-diameter-m)',
+  flexDirection: 'column',
+  flexGrow: 1,
+  alignItems: 'flex-start',
+  justifyContent: 'center',
+  fontSize: 'var(--font-size-medium)',
+  // @ts-ignore using variables
+  fontWeight: 'var(--font-weight-medium)',
+};
+
+export const nameWrapper: CSSObject = {
+  color: 'var(--main-color)',
+  display: 'flex',
+  overflow: 'hidden',
+  width: '100%',
+  paddingRight: '8px',
+};
+
+export const userAvailability: CSSObject = {
+  '.availability-state-label': ellipsis,
+  '.availability-state-icon': {
+    display: 'flex',
+  },
+};
+
+export const userName: CSSObject = {
+  maxWidth: '100%',
+  whiteSpace: 'nowrap',
+};
+
+export const selfIndicator: CSSObject = {
+  marginLeft: '4px',
+};

--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantItemContent/CallParticipantItemContent.tsx
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantItemContent/CallParticipantItemContent.tsx
@@ -19,14 +19,16 @@
 
 import React from 'react';
 
+import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
+
 import {Availability} from '@wireapp/protocol-messaging';
 
 import {AvailabilityState} from 'Components/AvailabilityState';
 import {Icon} from 'Components/Icon';
+import {t} from 'Util/LocalizerUtil';
+import {capitalizeFirstChar} from 'Util/StringUtil';
 
 import {
-  contentInfoWrapper,
-  contentInfoText,
   selfIndicator,
   userName,
   userAvailability,
@@ -35,28 +37,25 @@ import {
   chevronIcon,
   contentText,
   wrapper,
-} from './ParticipantItem.styles';
+} from './CallParticipantItemContent.styles';
 
-export interface ParticipantItemContentProps {
+export interface CallParticipantItemContentProps {
   name: string;
   selfInTeam?: boolean;
   availability?: Availability.Type;
-  shortDescription?: string;
-  selfString?: string;
-  hasUsernameInfo?: boolean;
-  showArrow?: boolean;
+  isSelf?: boolean;
   onDropdownClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
-export const ParticipantItemContent = ({
+export const CallParticipantItemContent = ({
   name,
   selfInTeam = false,
   availability = Availability.Type.NONE,
-  shortDescription = '',
-  selfString = '',
-  hasUsernameInfo = false,
-  showArrow = false,
-}: ParticipantItemContentProps) => {
+  isSelf = false,
+  onDropdownClick,
+}: CallParticipantItemContentProps) => {
+  const selfString = `(${capitalizeFirstChar(t('conversationYouNominative'))})`;
+
   return (
     <div css={wrapper}>
       <div css={contentText}>
@@ -76,21 +75,20 @@ export const ParticipantItemContent = ({
 
           {selfString && <div css={selfIndicator}>{selfString}</div>}
         </div>
-
-        {shortDescription && (
-          <div css={contentInfoWrapper}>
-            <span
-              css={[contentInfoText(hasUsernameInfo), ellipsis]}
-              className="subline"
-              data-uie-name="status-username"
-            >
-              {shortDescription}
-            </span>
-          </div>
-        )}
       </div>
 
-      {showArrow && <Icon.ChevronRight css={chevronIcon} data-hoverClass="chevron-icon" />}
+      {onDropdownClick && (
+        <button
+          data-hoverClass="chevron-icon"
+          tabIndex={TabIndex.UNFOCUSABLE}
+          css={chevronIcon}
+          onClick={onDropdownClick}
+          type="button"
+          data-uie-name="participant-menu-icon"
+        >
+          <Icon.Chevron />
+        </button>
+      )}
     </div>
   );
 };

--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantItemContent/index.ts
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantItemContent/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export * from './CallParticipantItemContent';

--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.tsx
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.tsx
@@ -23,16 +23,15 @@ import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 
 import {Avatar, AVATAR_SIZE} from 'Components/Avatar';
 import {callParticipantListWrapper} from 'Components/calling/CallParticipantsListItem/CallParticipantsListItem.styles';
-import {ParticipantItemContent} from 'Components/ParticipantItemContent';
 import {listItem} from 'Components/ParticipantItemContent/ParticipantItem.styles';
 import {UserStatusBadges} from 'Components/UserBadges';
 import {Participant} from 'src/script/calling/Participant';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {handleKeyDown} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
-import {capitalizeFirstChar} from 'Util/StringUtil';
 import {setContextMenuPosition} from 'Util/util';
 
+import {CallParticipantItemContent} from './CallParticipantItemContent/CallParticipantItemContent';
 import {CallParticipantStatusIcons} from './CallParticipantStatusIcons';
 
 export interface CallParticipantsListItemProps {
@@ -70,8 +69,6 @@ export const CallParticipantsListItem = ({
     });
   };
 
-  const selfString = `(${capitalizeFirstChar(t('conversationYouNominative'))})`;
-
   return (
     <div
       tabIndex={TabIndex.FOCUSABLE}
@@ -87,11 +84,11 @@ export const CallParticipantsListItem = ({
       <div css={listItem(true)}>
         <Avatar avatarSize={AVATAR_SIZE.SMALL} participant={user} aria-hidden="true" css={{margin: '0 10px'}} />
 
-        <ParticipantItemContent
+        <CallParticipantItemContent
           name={userName}
           selfInTeam={selfInTeam}
           availability={availability}
-          {...(isSelf && {selfString})}
+          isSelf={isSelf}
           {...(showDropdown && {
             onDropdownClick: event => onContextMenu?.(event as unknown as React.MouseEvent<HTMLDivElement>),
           })}

--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.tsx
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.tsx
@@ -31,7 +31,7 @@ import {handleKeyDown} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
 import {setContextMenuPosition} from 'Util/util';
 
-import {CallParticipantItemContent} from './CallParticipantItemContent/CallParticipantItemContent';
+import {CallParticipantItemContent} from './CallParticipantItemContent';
 import {CallParticipantStatusIcons} from './CallParticipantStatusIcons';
 
 export interface CallParticipantsListItemProps {


### PR DESCRIPTION
Follow up to https://github.com/wireapp/wire-webapp/pull/14874.

Removes `ParticipantItemContent` from `CallParticipantsListItem`. I've created separate component that will take care of displaying content for `CallParticipantsListItem` only. Feature I'm working on would require adding another prop to generic `ParticipantItemContent` that is calling specific (audio establish state) and adding some calling related conditional rendering. We don't want this generic component to grow too big and contain not-generic props.