### PR TITLE
feat: Refresh users when conversation details is opened [FS-1690]

### DIFF
--- a/src/script/components/Avatar/GroupAvatar.tsx
+++ b/src/script/components/Avatar/GroupAvatar.tsx
@@ -25,11 +25,10 @@ import type {User} from '../../entity/User';
 
 export interface GroupAvatarProps {
   className?: string;
-  isLight?: boolean;
   users: User[];
 }
 
-const GroupAvatar: React.FC<GroupAvatarProps> = ({users, isLight = false, className}) => {
+export const GroupAvatar: React.FC<GroupAvatarProps> = ({users, className}) => {
   const slicedUsers = users.slice(0, 4);
 
   return (
@@ -73,5 +72,3 @@ const GroupAvatar: React.FC<GroupAvatarProps> = ({users, isLight = false, classN
     </div>
   );
 };
-
-export {GroupAvatar};

--- a/src/script/components/calling/CallingCell.tsx
+++ b/src/script/components/calling/CallingCell.tsx
@@ -355,7 +355,7 @@ const CallingCell: React.FC<CallingCellProps> = ({
             >
               {!temporaryUserStyle && (
                 <div className="conversation-list-cell-left">
-                  {isGroup && <GroupAvatar users={conversationParticipants} isLight />}
+                  {isGroup && <GroupAvatar users={conversationParticipants} />}
                   {!isGroup && !!conversationParticipants.length && (
                     <Avatar participant={conversationParticipants[0]} avatarSize={AVATAR_SIZE.SMALL} />
                   )}

--- a/src/script/connection/ConnectionRepository.ts
+++ b/src/script/connection/ConnectionRepository.ts
@@ -120,7 +120,7 @@ export class ConnectionRepository {
     // Update info about user when connection gets accepted
     const shouldUpdateUser = previousStatus === ConnectionStatus.SENT && connectionEntity.isConnected();
     if (shouldUpdateUser) {
-      await this.userRepository.updateUserById(connectionEntity.userId);
+      await this.userRepository.updateUser(connectionEntity.userId);
       // Get conversation related to connection and set its type to 1:1
       // This case is important when the 'user.connection' event arrives after the 'conversation.member-join' event: https://wearezeta.atlassian.net/browse/SQCORE-348
       amplify.publish(WebAppEvents.CONVERSATION.MAP_CONNECTION, connectionEntity);

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -456,6 +456,14 @@ export class ConversationRepository {
     }
   }
 
+  public async refreshUnavailableParticipants(conversation: Conversation): Promise<void> {
+    const unavailableUsers = conversation.allUserEntities().filter(user => !user.isAvailable());
+    if (!unavailableUsers.length) {
+      return;
+    }
+    await this.userRepository.updateUsers(unavailableUsers.map(user => user.qualifiedId));
+  }
+
   /**
    * Create a guest room.
    */

--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
@@ -257,6 +257,10 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
     );
 
     useEffect(() => {
+      conversationRepository.refreshUnavailableParticipants(activeConversation);
+    }, [activeConversation, conversationRepository]);
+
+    useEffect(() => {
       if (isTeam && isSingleUserMode) {
         teamRepository.updateTeamMembersByIds(team, [firstParticipant.id], true);
       }

--- a/src/script/user/UserRepository.test.ts
+++ b/src/script/user/UserRepository.test.ts
@@ -283,4 +283,20 @@ describe('UserRepository', () => {
       });
     });
   });
+
+  describe('updateUsers', () => {
+    it('should update local users', async () => {
+      const userService = userRepository['userService'];
+      const user = new User(entities.user.jane_roe.id);
+      user.name('initial name');
+      userRepository['saveUser'](user);
+
+      jest.spyOn(userService, 'getUsers').mockResolvedValue({found: [entities.user.jane_roe]});
+
+      expect(userRepository.findUserById(user.qualifiedId)?.name()).toBe('initial name');
+      await userRepository.updateUsers([user.qualifiedId]);
+
+      expect(userRepository.findUserById(user.qualifiedId)?.name()).toBe(entities.user.jane_roe.name);
+    });
+  });
 });

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -647,16 +647,20 @@ export class UserRepository {
   /**
    * Update a local user from the backend by ID.
    */
-  updateUser = async (userId: QualifiedId): Promise<void> => {
-    const updatedUserData = await this.userService.getUser(userId);
-    this.updateSavedUser(updatedUserData);
+  updateUser = async (userId: QualifiedId): Promise<User> => {
+    const [user] = await this.updateUsers([userId]);
+    return user;
   };
 
   async updateUsers(userIds: QualifiedId[]) {
     const {found: users} = await this.userService.getUsers(userIds);
-    users.forEach(user => this.updateSavedUser(user));
+    return users.map(user => this.updateSavedUser(user));
   }
 
+  /**
+   * will update the local user with fresh data from backend
+   * @param user user data from backend
+   */
   private updateSavedUser(user: APIClientUser): User {
     const localUserEntity = this.findUserById(user.qualified_id ?? {id: user.id, domain: ''}) ?? new User();
     const updatedUser = this.userMapper.updateUserFromObject(localUserEntity, user);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1690" title="FS-1690" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />FS-1690</a>  [web] Retry fetching missing user metadata when conversation details are opened
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This will allow refreshing all the missing users of a conversation when the conversation details are opened 

https://user-images.githubusercontent.com/1090716/230091742-1b467266-8b78-4730-904f-3ae147bfdd9d.mov

