### PR TITLE
fix: Only allow remote user search on group creation and add participants [SQSERVICES-2001]

### DIFF
--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -366,6 +366,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
                 teamRepository={teamRepository}
                 conversationRepository={conversationRepository}
                 noUnderline
+                allowRemoteSearch
               />
             )}
           </FadingScrollbar>

--- a/src/script/components/UserSearchableList.tsx
+++ b/src/script/components/UserSearchableList.tsx
@@ -53,8 +53,10 @@ export type UserListProps = React.ComponentProps<typeof UserList> & {
   truncate?: boolean;
   userState?: UserState;
   dataUieName?: string;
-  /* will prevent showing those users in the list */
+  /** will prevent showing those users in the list */
   excludeUsers?: QualifiedId[];
+  /** will do an extra request to the server when user types in (otherwise will only lookup given local users) */
+  allowRemoteSearch?: boolean;
 };
 
 const UserSearchableList: React.FC<UserListProps> = ({
@@ -63,6 +65,7 @@ const UserSearchableList: React.FC<UserListProps> = ({
   filter = '',
   highlightedUsers,
   selected: selectedUsers,
+  allowRemoteSearch,
   users,
   ...props
 }) => {
@@ -103,11 +106,9 @@ const UserSearchableList: React.FC<UserListProps> = ({
     if (normalizedQuery) {
       const trimmedQuery = filter.trim();
       const isHandle = trimmedQuery.startsWith('@') && validateHandle(normalizedQuery);
-      if (searchRepository) {
-        const SEARCHABLE_FIELDS = SearchRepository.CONFIG.SEARCHABLE_FIELDS;
-        const properties = isHandle ? [SEARCHABLE_FIELDS.USERNAME] : undefined;
-        resultUsers = searchRepository.searchUserInSet(normalizedQuery, users, properties);
-      }
+      const SEARCHABLE_FIELDS = SearchRepository.CONFIG.SEARCHABLE_FIELDS;
+      const properties = isHandle ? [SEARCHABLE_FIELDS.USERNAME] : undefined;
+      resultUsers = searchRepository.searchUserInSet(normalizedQuery, users, properties);
       resultUsers = resultUsers.filter(
         user =>
           user.isMe ||
@@ -115,7 +116,7 @@ const UserSearchableList: React.FC<UserListProps> = ({
           teamRepository.isSelfConnectedTo(user.id) ||
           user.username() === normalizedQuery,
       );
-      if (searchRepository && selfInTeam) {
+      if (selfInTeam && allowRemoteSearch) {
         fetchMembersFromBackend(trimmedQuery, isHandle, resultUsers);
       }
     } else {

--- a/src/script/page/RightSidebar/AddParticipants/AddParticipants.tsx
+++ b/src/script/page/RightSidebar/AddParticipants/AddParticipants.tsx
@@ -236,6 +236,7 @@ const AddParticipants: FC<AddParticipantsProps> = ({
               conversationRepository={conversationRepository}
               excludeUsers={participatingUserIds}
               isSelectable
+              allowRemoteSearch
             />
           )}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-2001" title="SQSERVICES-2001" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-2001</a>  [Web] Incorrect user display in Group search results
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Currently the webapp is performing a remote search even on fixed user lists (like participant of a conversation). 

This should only happen if we want to add new people to a conversation. 

## Before 

(Here `Florian Cherie` doesn't belong in this conversation and should not appear in the search result)

https://user-images.githubusercontent.com/1090716/230125267-db10a481-1354-4933-ba75-e380ebcac1fd.mov

## After

`Florian Cherie` is not showing anymore in the search results

https://user-images.githubusercontent.com/1090716/230125396-3643103c-2bb6-46dd-b86b-80e80a918b45.mov

