### PR TITLE
fix: rendering of autodetcted links (SQSERVICES-1892)

### DIFF
--- a/src/script/util/messageRenderer.ts
+++ b/src/script/util/messageRenderer.ts
@@ -187,7 +187,11 @@ export const renderMessage = (message: string, selfId: QualifiedId | null, menti
       link.attrPush(['data-uie-name', 'wire-deep-link']);
     }
     if (link.markup === 'linkify') {
-      nextToken.content = encodeURI(nextToken.content);
+      const displayedLink = removeMentionsHashes(nextToken.content);
+      if (!href.endsWith(`://${displayedLink}`) && href != displayedLink && href != `mailto:${displayedLink}`) {
+        link.attrPush(['data-md-link', 'true']);
+        link.attrPush(['data-uie-name', 'markdown-link']);
+      }
     }
     return self.renderToken(tokens, idx, options);
   };

--- a/test/unit_tests/util/messageRendererSpec.js
+++ b/test/unit_tests/util/messageRendererSpec.js
@@ -70,6 +70,14 @@ describe('renderMessage', () => {
 
     expect(renderMessage(`e.g. ${link}.`)).toBe(expected);
   });
+
+  it('renders URLs with braces in the path component', () => {
+    const link = 'https://www.underscore.com/api/{version}/endpoint';
+    const expected = `e.g. <a href="https://www.underscore.com/api/%7Bversion%7D/endpoint" target="_blank" rel="nofollow noopener noreferrer" data-md-link="true" data-uie-name="markdown-link">https://www.underscore.com/api/{version}/endpoint</a>.`;
+
+    expect(renderMessage(`e.g. ${link}.`)).toBe(expected);
+  });
+
   it('renders URLs with escaped parameters', () => {
     const link = 'http://www.underscore.com/?parameter=%2f';
     const expected = `e.g. <a href="${link}" target="_blank" rel="nofollow noopener noreferrer">${link}</a>.`;

--- a/test/unit_tests/util/messageRendererSpec.js
+++ b/test/unit_tests/util/messageRendererSpec.js
@@ -257,15 +257,24 @@ describe('renderMessage', () => {
   });
 
   it('conversts unicode links to punycode', () => {
+    const expected = `<a href="https://xn--mller-kva.de" target="_blank" rel="nofollow noopener noreferrer" data-md-link=\"true\" data-uie-name=\"markdown-link\">https://müller.de</a>`;
     expect(renderMessage('https://müller.de')).toBe(
-      // if this test fails because the rendering of the url was changed to no longer display unicode characters urlescaped,
-      // then the output should be the same as the second test, to make the user aware of the fact that it is a punycode url aka "url open info popup"
-      `<a href="https://xn--mller-kva.de" target="_blank" rel="nofollow noopener noreferrer" data-md-link=\"true\" data-uie-name=\"markdown-link\">https://müller.de</a>`,
+      // if this test fails because the rendering of the url was changed to no longer generate the same output as the markdown code below,
+      // then this output needs to be verified against potential unicode confusable output
+      expected,
     );
 
-    expect(renderMessage('[https://müller.de](https://müller.de)')).toBe(
-      `<a href="https://xn--mller-kva.de" target="_blank" rel="nofollow noopener noreferrer" data-md-link=\"true\" data-uie-name=\"markdown-link\">https://müller.de</a>`,
+    expect(renderMessage('[https://müller.de](https://müller.de)')).toBe(expected);
+  });
+  it('unicode confusables generate a code', () => {
+    const expected = `<a href="https://xn--vlid-53d.domain" target="_blank" rel="nofollow noopener noreferrer" data-md-link=\"true\" data-uie-name=\"markdown-link\">https://v\u0430lid.domain</a>`;
+    expect(renderMessage('https://v\u0430lid.domain')).toBe(
+      // if this test fails because the rendering of the url was changed to no longer generate the same output as the markdown code below,
+      // then this output needs to be verified against potential unicode confusable output
+      expected,
     );
+
+    expect(renderMessage('[https://v\u0430lid.domain](https://v\u0430lid.domain)')).toBe(expected);
   });
 
   describe('Mentions', () => {

--- a/test/unit_tests/util/messageRendererSpec.js
+++ b/test/unit_tests/util/messageRendererSpec.js
@@ -70,6 +70,12 @@ describe('renderMessage', () => {
 
     expect(renderMessage(`e.g. ${link}.`)).toBe(expected);
   });
+  it('renders URLs with escaped parameters', () => {
+    const link = 'http://www.underscore.com/?parameter=%2f';
+    const expected = `e.g. <a href="${link}" target="_blank" rel="nofollow noopener noreferrer">${link}</a>.`;
+
+    expect(renderMessage(`e.g. ${link}.`)).toBe(expected);
+  });
 
   it('renders localhost links', () => {
     const link = 'http://localhost:8888/';
@@ -246,7 +252,7 @@ describe('renderMessage', () => {
     expect(renderMessage('https://müller.de')).toBe(
       // if this test fails because the rendering of the url was changed to no longer display unicode characters urlescaped,
       // then the output should be the same as the second test, to make the user aware of the fact that it is a punycode url aka "url open info popup"
-      `<a href="https://xn--mller-kva.de" target="_blank" rel="nofollow noopener noreferrer">https://m%C3%BCller.de</a>`,
+      `<a href="https://xn--mller-kva.de" target="_blank" rel="nofollow noopener noreferrer" data-md-link=\"true\" data-uie-name=\"markdown-link\">https://müller.de</a>`,
     );
 
     expect(renderMessage('[https://müller.de](https://müller.de)')).toBe(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1892" title="SQSERVICES-1892" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1892</a>  [Web] Broken encoding in links with curly braces
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Auto-detected links are not shown correctly from time to time, due to URL-escaping the whole string.


### Solutions

Don't apply URL-escaping to the user presented string, instead show a popup when the URL differs from the URL, that is shown to the user in text.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

This can be verified by generating URLs similar to the ones used in the newly added tests:
* https://müller.de
* https://www.underscore.com/api/{version}/endpoint
* http://www.underscore.com/?parameter=%2f

### Notes

This does not solve SQSERVICES-1892 completely, but it resolves the rendering issue related to it.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
