### PR TITLE
chore(deps): revert Bump maxmind from 4.3.9 to 4.3.10 in /server 

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,7 @@
     "helmet": "6.1.1",
     "http-status-codes": "2.2.0",
     "logdown": "3.3.1",
-    "maxmind": "4.3.10",
+    "maxmind": "4.3.9",
     "nocache": "3.0.4",
     "opn": "6.0.0",
     "pm2": "5.3.0"

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -3887,13 +3887,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"maxmind@npm:4.3.10":
-  version: 4.3.10
-  resolution: "maxmind@npm:4.3.10"
+"maxmind@npm:4.3.9":
+  version: 4.3.9
+  resolution: "maxmind@npm:4.3.9"
   dependencies:
     mmdb-lib: 2.0.2
-    tiny-lru: 10.4.1
-  checksum: 7733caa051f12633340b71e54f3c28f9257f5b076337e11e2e8ca4a2e1093bc8e65d5753329bd5dde57182405a0486c03ad3c5d9755ca56a0b054c10fdd0178b
+    tiny-lru: 10.3.0
+  checksum: 4a31b3695e2f0666221f288ad459ceabce3558d02b0afc5b7d7b76265e4578a3019d59ce264fe735dec8eb6c6d5460b4f0ab5bfb3bfb26be2e49b690f1927dd0
   languageName: node
   linkType: hard
 
@@ -5356,10 +5356,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-lru@npm:10.4.1":
-  version: 10.4.1
-  resolution: "tiny-lru@npm:10.4.1"
-  checksum: ec2ce11278ff5ecd094823d9d6fcc16fe0aa250bf25cb533d40b997452a113a9ecd9cccbf503ac459a17bb812d94c5ef05cbdfe94b5b8ad03d7cf4fadb78a905
+"tiny-lru@npm:10.3.0":
+  version: 10.3.0
+  resolution: "tiny-lru@npm:10.3.0"
+  checksum: cf5ae030c729293a319c989a03d97396197b74290a014c28ba2f6303b019078fd64174e9a96c5ca5c8b5ee796c1393a6a48240503cab444e654f14dc58b53599
   languageName: node
   linkType: hard
 
@@ -5675,7 +5675,7 @@ __metadata:
     http-status-codes: 2.2.0
     jest: 29.5.0
     logdown: 3.3.1
-    maxmind: 4.3.10
+    maxmind: 4.3.9
     nocache: 3.0.4
     opn: 6.0.0
     pm2: 5.3.0


### PR DESCRIPTION
This version of `maxmind` is not compatible with node v12 (still the version running on our hosting environment).