### PR TITLE
runfix: Migrate previously stored availability to new stored users

### DIFF
--- a/src/script/user/UserMapper.ts
+++ b/src/script/user/UserMapper.ts
@@ -82,7 +82,7 @@ export class UserMapper {
    */
   updateUserFromObject(userEntity: User, userData: Partial<StoredUser>): User {
     // We are trying to update non-matching users
-    const isUnexpectedId = userEntity.id !== '' && userData.id !== userEntity.id;
+    const isUnexpectedId = userEntity.id && userData.id && userData.id !== userEntity.id;
     if (isUnexpectedId) {
       throw new Error(`Updating wrong user entity. User '${userEntity.id}' does not match data '${userData.id}'.`);
     }
@@ -180,9 +180,9 @@ export class UserMapper {
 
     if (ssoId && Object.keys(ssoId).length) {
       userEntity.isSingleSignOn = true;
-    }
-    if (ssoId?.subject) {
-      userEntity.isNoPasswordSSO = true;
+      if (ssoId.subject) {
+        userEntity.isNoPasswordSSO = true;
+      }
     }
 
     if (teamId && !userEntity.isFederated) {

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -184,7 +184,7 @@ export class UserRepository {
     const users = connections.map(connectionEntity => connectionEntity.userId).concat(extraUsers);
     // TODO migrate old user entries that only have availability
     const dbUsers = await this.userService.loadUserFromDb();
-    /* prio to April 2023, we were only storing the availability in the DB, we need to refetch those users */
+    /* prior to April 2023, we were only storing the availability in the DB, we need to refetch those users */
     const [localUsers, incompleteUsers] = partition(dbUsers, user => !!user.qualified_id);
 
     /** users we have in the DB that are not matching any loaded users */

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -200,7 +200,8 @@ export class UserRepository {
 
     const missingUsers = users
       .filter(user => !liveUsers.find(localUser => matchQualifiedIds(user, localUser.qualified_id)))
-      .concat(incompleteUsers.map(user => ({id: user.id, domain: user.domain})));
+      // we add the users that are locally incomplete
+      .concat(incompleteUsers.map((user: any) => ({id: user.id, domain: user.domain})));
 
     const {found, failed} = await this.fetchRawUsers(missingUsers);
 

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -183,7 +183,9 @@ export class UserRepository {
   async loadUsers(connections: ConnectionEntity[], extraUsers: QualifiedId[]): Promise<User[]> {
     const users = connections.map(connectionEntity => connectionEntity.userId).concat(extraUsers);
     // TODO migrate old user entries that only have availability
-    const localUsers = await this.userService.loadUserFromDb();
+    const dbUsers = await this.userService.loadUserFromDb();
+    /* prio to April 2023, we were only storing the availability in the DB, we need to refetch those users */
+    const [localUsers, incompleteUsers] = partition(dbUsers, user => !!user.qualified_id);
 
     /** users we have in the DB that are not matching any loaded users */
     const [orphanUsers, liveUsers] = partition(
@@ -196,16 +198,24 @@ export class UserRepository {
       await this.userService.removeUserFromDb(user.qualified_id);
     });
 
-    const missingUsers = users.filter(
-      user => !liveUsers.find(localUser => matchQualifiedIds(user, localUser.qualified_id)),
-    );
+    const missingUsers = users
+      .filter(user => !liveUsers.find(localUser => matchQualifiedIds(user, localUser.qualified_id)))
+      .concat(incompleteUsers.map(user => ({id: user.id, domain: user.domain})));
 
     const {found, failed} = await this.fetchRawUsers(missingUsers);
 
-    // Save all new users to the database
-    await Promise.all(found.map(user => this.saveUserInDb(user)));
+    const userWithAvailability = found.map(user => {
+      const availability = incompleteUsers.find(incompleteUser => incompleteUser.id === user.id);
+      if (availability) {
+        return {availability: availability.availability, ...user};
+      }
+      return user;
+    });
 
-    const mappedUsers = this.mapUserResponse(found.concat(liveUsers), failed);
+    // Save all new users to the database
+    await Promise.all(userWithAvailability.map(user => this.saveUserInDb(user)));
+
+    const mappedUsers = this.mapUserResponse(userWithAvailability.concat(liveUsers), failed);
 
     // Assign connections to users
     mappedUsers.forEach(user => {


### PR DESCRIPTION
migrates, at load time, from DB entries from this (previous format that only has the `availability`)

![image](https://user-images.githubusercontent.com/1090716/231523186-1a56c8d8-0dd9-49cd-b00a-92e680c9c147.png)


to this (new format that has the entire user's metadata)

![image](https://user-images.githubusercontent.com/1090716/231524016-25ad62d4-77dc-49a0-bac3-83f4fb6c44bf.png)
