### PR TITLE
runfix: reset default button background on dropdown button

### DIFF
--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantItemContent/CallParticipantItemContent.styles.ts
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantItemContent/CallParticipantItemContent.styles.ts
@@ -31,6 +31,7 @@ export const listItem = (noInteraction = false): CSSObject => ({
 
 export const chevronIcon: CSSObject = {
   border: 'none',
+  background: 'none',
   padding: 0,
   alignItems: 'center',
   display: 'flex',


### PR DESCRIPTION
After migrating styles to css-in-js we forgot about resetting default background color for button, so when item was hovered in dark mode, both button's background and icon were white, so only white square was visible:

Before:
![Screenshot 2023-04-13 at 15 25 28](https://user-images.githubusercontent.com/45733298/231773616-789eba1b-2a3b-48ed-b22d-57236f6be8ef.png)

After:
![Screenshot 2023-04-13 at 15 25 36](https://user-images.githubusercontent.com/45733298/231773636-d5e86ebe-9062-4f14-a9e5-12a416e11ded.png)
