### PR TITLE
feat: re-fetch conversations on opening search-ui [FS-1689]

### DIFF
--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -23,6 +23,7 @@ import {
   CONVERSATION_ACCESS,
   CONVERSATION_LEGACY_ACCESS_ROLE,
   CONVERSATION_TYPE,
+  RemoteConversations,
 } from '@wireapp/api-client/lib/conversation/';
 import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data';
 import {ConversationProtocol} from '@wireapp/api-client/lib/conversation/NewConversation';
@@ -1306,8 +1307,12 @@ describe('ConversationRepository', () => {
       };
       const localConversations: any = [];
 
-      jest.spyOn(conversationService, 'getAllConversations').mockResolvedValue(remoteConversations as any);
-      jest.spyOn(conversationService, 'loadConversationStatesFromDb').mockResolvedValue(localConversations);
+      jest
+        .spyOn(conversationService, 'getAllConversations')
+        .mockResolvedValue(remoteConversations as unknown as RemoteConversations);
+      jest
+        .spyOn(conversationService, 'loadConversationStatesFromDb')
+        .mockResolvedValue(localConversations as unknown as ConversationDatabaseData[]);
       jest.spyOn(conversationService, 'saveConversationsInDb').mockImplementation(data => Promise.resolve(data));
 
       const conversations = await conversationRepository.loadConversations();
@@ -1367,8 +1372,8 @@ describe('ConversationRepository', () => {
             type: 2,
           },
         ],
-      };
-      const localConversations: any = [
+      } as unknown as RemoteConversations;
+      const localConversations = [
         {
           id: 'feabf90e-c785-577b-asdf-556d8018542c',
           // archived_state: true,
@@ -1404,8 +1409,11 @@ describe('ConversationRepository', () => {
         },
       ];
 
-      const mergedConversation = ConversationMapper.mergeConversation(localConversations, remoteConversations as any);
-      expect(mergedConversation).toHaveLength(remoteConversations.found.length);
+      const mergedConversation = ConversationMapper.mergeConversation(
+        localConversations as unknown as ConversationDatabaseData[],
+        remoteConversations as unknown as RemoteConversations,
+      );
+      expect(mergedConversation).toHaveLength(remoteConversations.found ? remoteConversations.found.length : 0);
     });
     it('keeps track of missing conversations', async () => {
       const conversationRepository = testFactory.conversation_repository!;
@@ -1463,7 +1471,9 @@ describe('ConversationRepository', () => {
         ],
       };
 
-      jest.spyOn(conversationService, 'getAllConversations').mockResolvedValue(remoteConversations as any);
+      jest
+        .spyOn(conversationService, 'getAllConversations')
+        .mockResolvedValue(remoteConversations as unknown as RemoteConversations);
 
       await conversationRepository.loadConversations();
 
@@ -1482,34 +1492,12 @@ describe('ConversationRepository', () => {
 
       const missingConversations = [
         {
-          members: {
-            others: [],
-            self: {},
-          },
-          name: 'conv1',
-          protocol: 'proteus',
-          qualified_id: {
-            domain: 'staging.zinfra.io',
-            id: '05d0f240-bfe9-40d7-b6cb-602dac89fa1b',
-          },
-          receipt_mode: 1,
-          team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
-          type: 0,
+          domain: 'staging.zinfra.io',
+          id: '05d0f240-bfe9-40d7-b6cb-602dac89fa1b',
         },
         {
-          members: {
-            others: [],
-            self: {},
-          },
-          name: 'conv2',
-          protocol: 'proteus',
-          qualified_id: {
-            domain: 'staging.zinfra.io',
-            id: '05d0f240-bfe9-40d7-1234-602dac89fa1b',
-          },
-          receipt_mode: 1,
-          team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
-          type: 0,
+          domain: 'staging.zinfra.io',
+          id: '05d0f240-bfe9-40d7-1234-602dac89fa1b',
         },
       ];
 
@@ -1551,7 +1539,9 @@ describe('ConversationRepository', () => {
       };
 
       jest.replaceProperty(conversationState, 'missingConversations', missingConversations as any);
-      jest.spyOn(conversationService, 'getConversationByIds').mockResolvedValue(remoteConversations as any);
+      jest
+        .spyOn(conversationService, 'getConversationByIds')
+        .mockResolvedValue(remoteConversations as unknown as RemoteConversations);
 
       expect(conversationState.missingConversations).toHaveLength(missingConversations.length);
 

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -28,6 +28,7 @@ import {
 import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data';
 import {ConversationProtocol} from '@wireapp/api-client/lib/conversation/NewConversation';
 import {ConversationCreateEvent, ConversationMemberJoinEvent, CONVERSATION_EVENT} from '@wireapp/api-client/lib/event/';
+import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {amplify} from 'amplify';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import ko from 'knockout';
@@ -1275,7 +1276,7 @@ describe('ConversationRepository', () => {
         found: [
           {
             members: {
-              others: [],
+              others: [] as QualifiedId[],
               self: {},
             },
             name: 'conv1',
@@ -1290,7 +1291,7 @@ describe('ConversationRepository', () => {
           },
           {
             members: {
-              others: [],
+              others: [] as QualifiedId[],
               self: {},
             },
             name: 'conv2',
@@ -1325,7 +1326,7 @@ describe('ConversationRepository', () => {
         found: [
           {
             members: {
-              others: [],
+              others: [] as QualifiedId[],
               self: {},
             },
             name: 'conv1',
@@ -1340,7 +1341,7 @@ describe('ConversationRepository', () => {
           },
           {
             members: {
-              others: [],
+              others: [] as QualifiedId[],
               self: {},
             },
             name: 'conv2',
@@ -1357,7 +1358,7 @@ describe('ConversationRepository', () => {
             id: 'feabf90e-c785-577b-800a-556d8018542c',
             // archived_state: true,
             members: {
-              others: [],
+              others: [] as QualifiedId[],
               self: {},
             },
             message_timer: null,
@@ -1378,7 +1379,7 @@ describe('ConversationRepository', () => {
           id: 'feabf90e-c785-577b-asdf-556d8018542c',
           // archived_state: true,
           members: {
-            others: [],
+            others: [] as QualifiedId[],
             self: {},
           },
           name: 'conv1',
@@ -1394,7 +1395,7 @@ describe('ConversationRepository', () => {
         {
           id: 'feabf90e-c785-577b-800a-556d8018542c',
           members: {
-            others: [],
+            others: [] as QualifiedId[],
             self: {},
           },
           name: 'conv2',
@@ -1423,7 +1424,7 @@ describe('ConversationRepository', () => {
         found: [
           {
             members: {
-              others: [],
+              others: [] as QualifiedId[],
               self: {},
             },
             name: 'conv1',
@@ -1440,7 +1441,7 @@ describe('ConversationRepository', () => {
         failed: [
           {
             members: {
-              others: [],
+              others: [] as QualifiedId[],
               self: {},
             },
             name: 'conv2',
@@ -1455,7 +1456,7 @@ describe('ConversationRepository', () => {
           },
           {
             members: {
-              others: [],
+              others: [] as QualifiedId[],
               self: {},
             },
             name: 'conv3',
@@ -1505,7 +1506,7 @@ describe('ConversationRepository', () => {
         found: [
           {
             members: {
-              others: [],
+              others: [] as QualifiedId[],
               self: {},
             },
             name: 'conv1',
@@ -1522,7 +1523,7 @@ describe('ConversationRepository', () => {
         failed: [
           {
             members: {
-              others: [],
+              others: [] as QualifiedId[],
               self: {},
             },
             name: 'conv2',

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -1382,11 +1382,18 @@ describe('ConversationRepository', () => {
           domain: 'staging.zinfra.io',
           id: '05d0f240-bfe9-40d7-1234-602dac89fa1b',
         },
+        {
+          domain: 'staging.zinfra.io',
+          id: '05d0f240-bfe9-40d7-5678-602dac89fa1b',
+        },
       ];
 
       const remoteConversations = {
         found: [generateConversation(missingConversations[0], 'conv1')],
-        failed: [generateConversation(missingConversations[1], 'conv2')],
+        failed: [
+          generateConversation(missingConversations[1], 'conv2').qualified_id,
+          generateConversation(missingConversations[2], 'conv3').qualified_id,
+        ],
       };
 
       jest.replaceProperty(conversationState, 'missingConversations', missingConversations as any);

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -1321,101 +1321,6 @@ describe('ConversationRepository', () => {
       expect(conversations).toHaveLength(remoteConversations.found.length);
     });
 
-    it('merges local conversation and remotes', async () => {
-      const remoteConversations = {
-        found: [
-          {
-            members: {
-              others: [] as QualifiedId[],
-              self: {},
-            },
-            name: 'conv1',
-            protocol: 'proteus',
-            qualified_id: {
-              domain: 'staging.zinfra.io',
-              id: '05d0f240-bfe9-40d7-b6cb-602dac89fa1b',
-            },
-            receipt_mode: 1,
-            team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
-            type: 0,
-          },
-          {
-            members: {
-              others: [] as QualifiedId[],
-              self: {},
-            },
-            name: 'conv2',
-            protocol: 'proteus',
-            qualified_id: {
-              domain: 'staging.zinfra.io',
-              id: '05d0f240-bfe9-40d7-1234-602dac89fa1b',
-            },
-            receipt_mode: 1,
-            team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
-            type: 0,
-          },
-          {
-            id: 'feabf90e-c785-577b-800a-556d8018542c',
-            // archived_state: true,
-            members: {
-              others: [] as QualifiedId[],
-              self: {},
-            },
-            message_timer: null,
-            name: null,
-            protocol: 'proteus',
-            qualified_id: {
-              domain: 'anta.wire.link',
-              id: 'feabf90e-c785-577b-800a-556d8018542c',
-            },
-            receipt_mode: null,
-            team: null,
-            type: 2,
-          },
-        ],
-      } as unknown as RemoteConversations;
-      const localConversations = [
-        {
-          id: 'feabf90e-c785-577b-asdf-556d8018542c',
-          // archived_state: true,
-          members: {
-            others: [] as QualifiedId[],
-            self: {},
-          },
-          name: 'conv1',
-          protocol: 'proteus',
-          qualified_id: {
-            domain: 'staging.zinfra.io',
-            id: 'feabf90e-c785-577b-asdf-556d8018542c',
-          },
-          receipt_mode: 1,
-          team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
-          type: 0,
-        },
-        {
-          id: 'feabf90e-c785-577b-800a-556d8018542c',
-          members: {
-            others: [] as QualifiedId[],
-            self: {},
-          },
-          name: 'conv2',
-          protocol: 'proteus',
-          qualified_id: {
-            domain: 'staging.zinfra.io',
-            id: '05d0f240-bfe9-40d7-1234-602dac89fa1b',
-          },
-          receipt_mode: 1,
-          team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
-          type: 0,
-        },
-      ];
-
-      const mergedConversation = ConversationMapper.mergeConversation(
-        localConversations as unknown as ConversationDatabaseData[],
-        remoteConversations as unknown as RemoteConversations,
-      );
-      expect(mergedConversation).toHaveLength(remoteConversations.found ? remoteConversations.found.length : 0);
-    });
     it('keeps track of missing conversations', async () => {
       const conversationRepository = testFactory.conversation_repository!;
       const conversationService = conversationRepository['conversationService'];
@@ -1549,6 +1454,103 @@ describe('ConversationRepository', () => {
       await conversationRepository.loadMissingConversations();
 
       expect(conversationState.missingConversations).toHaveLength(remoteConversations.failed.length);
+    });
+  });
+  describe('mergeConversation', () => {
+    it('merges local conversation and remotes', async () => {
+      const remoteConversations = {
+        found: [
+          {
+            members: {
+              others: [] as QualifiedId[],
+              self: {},
+            },
+            name: 'conv1',
+            protocol: 'proteus',
+            qualified_id: {
+              domain: 'staging.zinfra.io',
+              id: '05d0f240-bfe9-40d7-b6cb-602dac89fa1b',
+            },
+            receipt_mode: 1,
+            team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
+            type: 0,
+          },
+          {
+            members: {
+              others: [] as QualifiedId[],
+              self: {},
+            },
+            name: 'conv2',
+            protocol: 'proteus',
+            qualified_id: {
+              domain: 'staging.zinfra.io',
+              id: '05d0f240-bfe9-40d7-1234-602dac89fa1b',
+            },
+            receipt_mode: 1,
+            team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
+            type: 0,
+          },
+          {
+            id: 'feabf90e-c785-577b-800a-556d8018542c',
+            // archived_state: true,
+            members: {
+              others: [] as QualifiedId[],
+              self: {},
+            },
+            message_timer: null,
+            name: null,
+            protocol: 'proteus',
+            qualified_id: {
+              domain: 'anta.wire.link',
+              id: 'feabf90e-c785-577b-800a-556d8018542c',
+            },
+            receipt_mode: null,
+            team: null,
+            type: 2,
+          },
+        ],
+      } as unknown as RemoteConversations;
+      const localConversations = [
+        {
+          id: 'feabf90e-c785-577b-asdf-556d8018542c',
+          // archived_state: true,
+          members: {
+            others: [] as QualifiedId[],
+            self: {},
+          },
+          name: 'conv1',
+          protocol: 'proteus',
+          qualified_id: {
+            domain: 'staging.zinfra.io',
+            id: 'feabf90e-c785-577b-asdf-556d8018542c',
+          },
+          receipt_mode: 1,
+          team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
+          type: 0,
+        },
+        {
+          id: 'feabf90e-c785-577b-800a-556d8018542c',
+          members: {
+            others: [] as QualifiedId[],
+            self: {},
+          },
+          name: 'conv2',
+          protocol: 'proteus',
+          qualified_id: {
+            domain: 'staging.zinfra.io',
+            id: '05d0f240-bfe9-40d7-1234-602dac89fa1b',
+          },
+          receipt_mode: 1,
+          team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
+          type: 0,
+        },
+      ];
+
+      const mergedConversation = ConversationMapper.mergeConversation(
+        localConversations as unknown as ConversationDatabaseData[],
+        remoteConversations as unknown as RemoteConversations,
+      );
+      expect(mergedConversation).toHaveLength(remoteConversations.found ? remoteConversations.found.length : 0);
     });
   });
 });

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -51,7 +51,6 @@ import {ClientEvent} from 'src/script/event/Client';
 import {EventRepository} from 'src/script/event/EventRepository';
 import {NOTIFICATION_HANDLING_STATE} from 'src/script/event/NotificationHandlingState';
 import {StorageSchemata} from 'src/script/storage/StorageSchemata';
-import {matchQualifiedIds} from 'Util/QualifiedId';
 import {escapeRegex} from 'Util/SanitizationUtil';
 import {createRandomUuid} from 'Util/util';
 
@@ -1265,6 +1264,21 @@ describe('ConversationRepository', () => {
     });
   });
 
+  function generateConversation(id: QualifiedId, name: string) {
+    return {
+      members: {
+        others: [] as QualifiedId[],
+        self: {},
+      },
+      name,
+      protocol: 'proteus',
+      qualified_id: id,
+      receipt_mode: 1,
+      team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
+      type: 0,
+    };
+  }
+
   describe('loadConversations', () => {
     beforeEach(() => {
       testFactory.conversation_repository!['conversationState'].conversations.removeAll();
@@ -1275,36 +1289,21 @@ describe('ConversationRepository', () => {
       const conversationService = conversationRepository['conversationService'];
       const remoteConversations = {
         found: [
-          {
-            members: {
-              others: [] as QualifiedId[],
-              self: {},
-            },
-            name: 'conv1',
-            protocol: 'proteus',
-            qualified_id: {
+          generateConversation(
+            {
               domain: 'staging.zinfra.io',
               id: '05d0f240-bfe9-40d7-b6cb-602dac89fa1b',
             },
-            receipt_mode: 1,
-            team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
-            type: 0,
-          },
-          {
-            members: {
-              others: [] as QualifiedId[],
-              self: {},
-            },
-            name: 'conv2',
-            protocol: 'proteus',
-            qualified_id: {
+            'conv1',
+          ),
+
+          generateConversation(
+            {
               domain: 'staging.zinfra.io',
-              id: '05d0f240-bfe9-40d7-1234-602dac89fa1b',
+              id: '05d0f240-bfe9-1234-b6cb-602dac89fa1b',
             },
-            receipt_mode: 1,
-            team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
-            type: 0,
-          },
+            'conv2',
+          ),
         ],
       };
       const localConversations: any = [];
@@ -1328,53 +1327,30 @@ describe('ConversationRepository', () => {
       const conversationState = conversationRepository['conversationState'];
       const remoteConversations = {
         found: [
-          {
-            members: {
-              others: [] as QualifiedId[],
-              self: {},
-            },
-            name: 'conv1',
-            protocol: 'proteus',
-            qualified_id: {
+          generateConversation(
+            {
               domain: 'staging.zinfra.io',
               id: '05d0f240-bfe9-40d7-b6cb-602dac89fa1b',
             },
-            receipt_mode: 1,
-            team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
-            type: 0,
-          },
+            'conv1',
+          ),
         ],
         failed: [
-          {
-            members: {
-              others: [] as QualifiedId[],
-              self: {},
-            },
-            name: 'conv2',
-            protocol: 'proteus',
-            qualified_id: {
+          generateConversation(
+            {
               domain: 'staging.zinfra.io',
-              id: '05d0f240-bfe9-40d7-1234-602dac89fa1b',
+              id: '05d0f240-bfe9-1234-b6cb-602dac89fa1b',
             },
-            receipt_mode: 1,
-            team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
-            type: 0,
-          },
-          {
-            members: {
-              others: [] as QualifiedId[],
-              self: {},
-            },
-            name: 'conv3',
-            protocol: 'proteus',
-            qualified_id: {
+            'conv2',
+          ),
+
+          generateConversation(
+            {
               domain: 'staging.zinfra.io',
-              id: '05d0f240-bfe9-40d7-3212-602dac89fa1b',
+              id: '05d0f240-bfe9-5678-b6cb-602dac89fa1b',
             },
-            receipt_mode: 1,
-            team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
-            type: 0,
-          },
+            'conv3',
+          ),
         ],
       };
 
@@ -1409,40 +1385,8 @@ describe('ConversationRepository', () => {
       ];
 
       const remoteConversations = {
-        found: [
-          {
-            members: {
-              others: [] as QualifiedId[],
-              self: {},
-            },
-            name: 'conv1',
-            protocol: 'proteus',
-            qualified_id: {
-              domain: 'staging.zinfra.io',
-              id: '05d0f240-bfe9-40d7-b6cb-602dac89fa1b',
-            },
-            receipt_mode: 1,
-            team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
-            type: 0,
-          },
-        ],
-        failed: [
-          {
-            members: {
-              others: [] as QualifiedId[],
-              self: {},
-            },
-            name: 'conv2',
-            protocol: 'proteus',
-            qualified_id: {
-              domain: 'staging.zinfra.io',
-              id: '05d0f240-bfe9-40d7-1234-602dac89fa1b',
-            },
-            receipt_mode: 1,
-            team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
-            type: 0,
-          },
-        ],
+        found: [generateConversation(missingConversations[0], 'conv1')],
+        failed: [generateConversation(missingConversations[1], 'conv2')],
       };
 
       jest.replaceProperty(conversationState, 'missingConversations', missingConversations as any);
@@ -1455,150 +1399,6 @@ describe('ConversationRepository', () => {
       await conversationRepository.loadMissingConversations();
 
       expect(conversationState.missingConversations).toHaveLength(remoteConversations.failed.length);
-    });
-  });
-  describe('mergeConversation', () => {
-    it('merges local conversation and remotes', async () => {
-      const remoteConversations = {
-        found: [
-          {
-            members: {
-              others: [] as QualifiedId[],
-              self: {},
-            },
-            name: 'conv1',
-            protocol: 'proteus',
-            qualified_id: {
-              domain: 'staging.zinfra.io',
-              id: '05d0f240-bfe9-40d7-b6cb-602dac89fa1b',
-            },
-            receipt_mode: 1,
-            team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
-            type: 0,
-          },
-          {
-            members: {
-              others: [] as QualifiedId[],
-              self: {},
-            },
-            name: 'conv2',
-            protocol: 'proteus',
-            qualified_id: {
-              domain: 'staging.zinfra.io',
-              id: '05d0f240-bfe9-40d7-1234-602dac89fa1b',
-            },
-            receipt_mode: 1,
-            team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
-            type: 0,
-          },
-          {
-            members: {
-              others: [] as QualifiedId[],
-              self: {},
-            },
-            message_timer: null,
-            name: null,
-            protocol: 'proteus',
-            qualified_id: {
-              domain: 'anta.wire.link',
-              id: 'feabf90e-c785-577b-800a-556d8018542c',
-            },
-            receipt_mode: null,
-            team: null,
-            type: 2,
-          },
-        ],
-        failed: [
-          {
-            domain: 'staging.zinfra.io',
-            id: '05d0f240-bfe9-40d7-1234-602dac89fa1b',
-          },
-          {
-            domain: 'staging.zinfra.io',
-            id: '05d0f240-bfe9-40d7-5678-602dac89fa1b',
-          },
-        ],
-      } as unknown as RemoteConversations;
-      const localConversations = [
-        {
-          id: '05d0f240-bfe9-40d7-b6cb-602dac89fa1b',
-          members: {
-            others: [] as QualifiedId[],
-            self: {},
-          },
-          name: 'conv1',
-          protocol: 'proteus',
-          qualified_id: {
-            domain: 'staging.zinfra.io',
-            id: '05d0f240-bfe9-40d7-b6cb-602dac89fa1b',
-          },
-          receipt_mode: 1,
-          team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
-          type: 0,
-        },
-        {
-          id: '05d0f240-bfe9-40d7-1234-602dac89fa1b',
-          members: {
-            others: [] as QualifiedId[],
-            self: {},
-          },
-          name: 'conv2',
-          protocol: 'proteus',
-          qualified_id: {
-            domain: 'staging.zinfra.io',
-            id: '05d0f240-bfe9-40d7-1234-602dac89fa1b',
-          },
-          receipt_mode: 1,
-          team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
-          type: 0,
-        },
-        {
-          id: '05d0f240-bfe9-40d7-1234-602dac89fa1b',
-          members: {
-            others: [] as QualifiedId[],
-            self: {},
-          },
-          name: 'conv3',
-          protocol: 'proteus',
-          qualified_id: {
-            domain: 'staging.zinfra.io',
-            id: '05d0f240-bfe9-40d7-1234-602dac89fa1b',
-          },
-          receipt_mode: 1,
-          team: 'b0dcee1f-c64e-4d40-8b50-5baf932906b8',
-          type: 0,
-        },
-      ] as unknown as ConversationDatabaseData[];
-
-      const mergedConversation = ConversationMapper.mergeConversation(localConversations, remoteConversations);
-
-      /**
-       * The method mergeConversation should return all found conversations and the failed conversations that already exist locally
-       * @param remoteConversations new conversations fetched from backend
-       * @param localConversations conversations locally stored in database
-       * @returns the expected lenght of the merged conversations
-       */
-      const findExpectedLenght = (
-        remoteConversations: RemoteConversations,
-        localConversations: ConversationDatabaseData[],
-      ) => {
-        if (remoteConversations.found) {
-          if (remoteConversations.failed) {
-            const failedConversations = (remoteConversations.failed ?? []).reduce(
-              (prev: ConversationDatabaseData[], curr: QualifiedId) => {
-                const convo = localConversations.find(conversationId => matchQualifiedIds(conversationId, curr));
-                return convo ? [...prev, convo] : prev;
-              },
-              [],
-            );
-            return remoteConversations.found.length + failedConversations.length;
-          }
-          return remoteConversations.found.length;
-        }
-        return 0;
-      };
-
-      expect(mergedConversation).toHaveLength(findExpectedLenght(remoteConversations, localConversations));
     });
   });
 });

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -560,15 +560,18 @@ export class ConversationRepository {
   ): Promise<Conversation[]> {
     const {missingConversations} = this.conversationState;
     let conversationsData: any[];
+
     if (remoteConversations.failed?.length) {
       missingConversations.push(...remoteConversations.failed);
     }
+
     if (!remoteConversations.found?.length) {
       conversationsData = localConversations;
     } else {
       const data = ConversationMapper.mergeConversation(localConversations, remoteConversations);
       conversationsData = (await this.conversationService.saveConversationsInDb(data)) as any[];
     }
+
     const allConversationEntities = this.mapConversations(conversationsData);
     const newConversationEntities = allConversationEntities.filter(
       allConversations =>
@@ -577,10 +580,12 @@ export class ConversationRepository {
           .some(storedConversations => storedConversations.id === allConversations.id),
     );
     this.saveConversations(newConversationEntities);
+
     const remainingMissingConversations = missingConversations.filter(missingConversationsId =>
       newConversationEntities.some(conversation => conversation.id !== missingConversationsId.id),
     );
     this.conversationState.missingConversations = [...new Set(remainingMissingConversations)];
+
     return this.conversationState.conversations();
   }
 

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -558,7 +558,7 @@ export class ConversationRepository {
     remoteConversations: RemoteConversations,
     localConversations: ConversationDatabaseData[] = [],
   ): Promise<Conversation[]> {
-    const missingConversations = this.conversationState.missingConversations;
+    const {missingConversations} = this.conversationState;
     let conversationsData: any[];
     if (remoteConversations.failed?.length) {
       missingConversations.push(...remoteConversations.failed);

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -533,8 +533,12 @@ export class ConversationRepository {
       const data = ConversationMapper.mergeConversation(localConversations, remoteConversations);
       conversationsData = (await this.conversationService.saveConversationsInDb(data)) as any[];
     }
-    const conversationEntities = this.mapConversations(conversationsData);
-    this.saveConversations(conversationEntities);
+    const allConversationEntities = this.mapConversations(conversationsData);
+    const newConversationEntities = allConversationEntities.filter(
+      allConversations =>
+        !this.conversationState.conversations().some(oldConversations => oldConversations.id === allConversations.id),
+    );
+    this.saveConversations(newConversationEntities);
     return this.conversationState.conversations();
   }
 

--- a/src/script/conversation/ConversationService.ts
+++ b/src/script/conversation/ConversationService.ts
@@ -22,6 +22,7 @@ import type {
   Conversation as BackendConversation,
   ConversationCode,
   CONVERSATION_ACCESS,
+  RemoteConversations,
 } from '@wireapp/api-client/lib/conversation';
 import type {
   ConversationJoinData,
@@ -84,6 +85,14 @@ export class ConversationService {
    */
   getConversationById({id, domain}: QualifiedId): Promise<BackendConversation> {
     return this.apiClient.api.conversation.getConversation({domain, id});
+  }
+
+  /**
+   * Get conversations for a list of conversation IDs.
+   * @see https://staging-nginz-https.zinfra.io/v4/api/swagger-ui/#/default/post_conversations_list
+   */
+  getConversationByIds(conversations: QualifiedId[]): Promise<RemoteConversations> {
+    return this.apiClient.api.conversation.getConversationsByQualifiedIds(conversations);
   }
 
   /**

--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -48,6 +48,7 @@ export class ConversationState {
   public readonly visibleConversations: ko.PureComputed<Conversation[]>;
   public readonly filteredConversations: ko.PureComputed<Conversation[]>;
   public readonly archivedConversations: ko.PureComputed<Conversation[]>;
+  public readonly missingConversations: QualifiedId[] = [];
   private readonly selfProteusConversation: ko.PureComputed<Conversation | undefined>;
   private readonly selfMLSConversation: ko.PureComputed<Conversation | undefined>;
   public readonly unreadConversations: ko.PureComputed<Conversation[]>;

--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -48,13 +48,16 @@ export class ConversationState {
   public readonly visibleConversations: ko.PureComputed<Conversation[]>;
   public readonly filteredConversations: ko.PureComputed<Conversation[]>;
   public readonly archivedConversations: ko.PureComputed<Conversation[]>;
-  public readonly missingConversations: QualifiedId[] = [];
   private readonly selfProteusConversation: ko.PureComputed<Conversation | undefined>;
   private readonly selfMLSConversation: ko.PureComputed<Conversation | undefined>;
   public readonly unreadConversations: ko.PureComputed<Conversation[]>;
   public readonly connectedUsers: ko.PureComputed<User[]>;
 
   public readonly sortedConversations: ko.PureComputed<Conversation[]>;
+  /**
+   * conversations that could not be loaded because their back-end is currently offline
+   */
+  public missingConversations: QualifiedId[] = [];
 
   constructor(
     private readonly userState = container.resolve(UserState),

--- a/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
@@ -92,10 +92,7 @@ const StartUI: React.FC<StartUIProps> = ({
   } = generatePermissionHelpers(selfUser.teamRole());
 
   useEffect(() => {
-    const updateConversations = async () => {
-      await conversationRepository.loadMissingConversations();
-    };
-    void updateConversations();
+    void conversationRepository.loadMissingConversations();
   }, [conversationRepository]);
 
   const actions = mainViewModel.actions;

--- a/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
@@ -92,7 +92,10 @@ const StartUI: React.FC<StartUIProps> = ({
   } = generatePermissionHelpers(selfUser.teamRole());
 
   useEffect(() => {
-    void conversationRepository.loadConversations();
+    const updateConversations = async () => {
+      await conversationRepository.loadMissingConversations();
+    };
+    void updateConversations();
   }, [conversationRepository]);
 
   const actions = mainViewModel.actions;

--- a/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React, {useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
 import cx from 'classnames';
 import {container} from 'tsyringe';
@@ -90,6 +90,10 @@ const StartUI: React.FC<StartUIProps> = ({
     canCreateGuestRoom,
     canCreateGroupConversation,
   } = generatePermissionHelpers(selfUser.teamRole());
+
+  useEffect(() => {
+    void conversationRepository.loadConversations();
+  }, [conversationRepository]);
 
   const actions = mainViewModel.actions;
   const isTeam = teamState.isTeam();


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1689" title="FS-1689" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />FS-1689</a>  [web] Retry fetching missing conversation metadata when the Search UI is opened 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Feature
#### load missed conversations on opening the search ui
Step by step:
- User A creates a conversation with user B while user B's **client** is offline
- User A's **backend** becomes offline
- User B connects to Wire and `loadConversations()` returns the new conversation as *failed*
- The failed conversation is saved in user A's conversation state as a *missing conversation*
- User A's **backend** comes back online
- When user B clicks on the Contact tab, we refetch the missing conversations, and the new conversation appears in the conversation list
![Peek 2023-04-24 15-43](https://user-images.githubusercontent.com/78490891/234015318-f7259a39-8983-4005-89d7-098b57b69738.gif)

