### PR TITLE
fix: add port to link preview, if defined (SQSERVICES-2018)

### DIFF
--- a/src/script/util/UrlUtil.ts
+++ b/src/script/util/UrlUtil.ts
@@ -70,8 +70,8 @@ export const cleanURL = (url: string = ''): string => {
   // force a protocol if there is none
   url = url.replace(/^(?!https?:\/\/)/i, 'http://');
   try {
-    const {hostname, pathname, search, hash} = new URL(url);
-    return `${hostname.replace(/^www./, '')}${pathname.replace(/\/$/, '')}${search}${hash}`;
+    const {hostname, port, pathname, search, hash} = new URL(url);
+    return `${hostname.replace(/^www./, '')}${port ? `:${port}` : ''}${pathname.replace(/\/$/, '')}${search}${hash}`;
   } catch (error) {
     return '';
   }

--- a/test/unit_tests/util/UrlUtilSpec.js
+++ b/test/unit_tests/util/UrlUtilSpec.js
@@ -83,6 +83,7 @@ describe('UrlUtil', () => {
         {expected: baseUrl, url: 'www.wire.com'},
         {expected: baseUrl, url: 'wire.com/'},
         {expected: `${baseUrl}/join`, url: `${baseUrl}/join`},
+        {expected: `${baseUrl}:8080/join`, url: `${baseUrl}:8080/join`},
         {expected: `${baseUrl}/join`, url: `${baseUrl}/join/`},
         {expected: `${baseUrl}/join?key=ZE4543fdRETg`, url: `${baseUrl}/join?key=ZE4543fdRETg`},
         {expected: `${baseUrl}/join?key=ZE4543fdRETg#lOgIn`, url: `${baseUrl}/join?key=ZE4543fdRETg#lOgIn`},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-2018" title="SQSERVICES-2018" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-2018</a>  [webapp] Ports are removed from Link preview
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If a link preview is transmitted for an url with a defined port e.g. `https://wire.com:8080/path` the displayed url in the preview box will only show `wire.com/path` instead of `wire.com:8080/path`

### Solutions

Include port in `clearURL` functionality (this is then the same behavior as on iOS).

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Send a enriched message containing a link preview, containing an URL with a port.
The Port must show up in the link preview.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
