### PR TITLE
fix: Filter URL schemes (SQSERVICES-1945)

### DIFF
--- a/src/script/util/messageRenderer.ts
+++ b/src/script/util/messageRenderer.ts
@@ -173,18 +173,17 @@ export const renderMessage = (message: string, selfId: QualifiedId | null, menti
     const link = tokens[idx];
     const href = removeMentionsHashes(link.attrGet('href') ?? '');
     const isEmail = href?.startsWith('mailto:');
-    const isWireDeepLink = href?.toLowerCase().startsWith('wire://');
+    const isWireDeepLink = href.toLowerCase().startsWith('wire://');
     const nextToken = tokens[idx + 1];
     const text = nextToken?.type === 'text' ? nextToken.content : '';
+    const closeToken = tokens.slice(idx).find(token => token.type === 'link_close');
 
-    if (!href || !text.trim()) {
-      nextToken.content = '';
-      const closeToken = tokens.slice(idx).find(token => token.type === 'link_close');
+    if (href == '' || closeToken == nextToken || (!text.trim() && closeToken == tokens[idx + 2])) {
       if (closeToken) {
         closeToken.type = 'text';
-        closeToken.content = '';
+        closeToken.content = `](${cleanString(href)})`;
       }
-      return `[${cleanString(text)}](${cleanString(href)})`;
+      return '['; //'${cleanString(text)}`;
     }
     if (isEmail) {
       link.attrPush(['data-email-link', 'true']);

--- a/src/script/util/messageRenderer.ts
+++ b/src/script/util/messageRenderer.ts
@@ -62,8 +62,8 @@ markdownit.normalizeLink = (url: string): string => {
   if (isValidUrl(url)) {
     return url;
   }
-  // prepend "https://" if url does not contain a protocol
-  if (!url.match(/^[a-z]+:/i)) {
+  // prepend "https://" if url does not begin with a protocol or vbscript:, javascript:, file:, data:
+  if (!url.match(/^(.*:\/\/|(vbscript|javascript|file|data):)/i)) {
     return `https://${url}`;
   }
   return url;

--- a/src/script/util/messageRenderer.ts
+++ b/src/script/util/messageRenderer.ts
@@ -50,6 +50,24 @@ const originalFenceRule = markdownit.renderer.rules.fence!;
 
 markdownit.renderer.rules.heading_open = () => '<div class="md-heading">';
 markdownit.renderer.rules.heading_close = () => '</div>';
+const originalNormalizeLink = markdownit.normalizeLink!;
+
+const isValidUrl = (url: string): boolean => {
+  // only allow urls to https://, http:// and mailto:
+  return !!url.match(/^(https?:\/\/|mailto:)/i);
+};
+markdownit.validateLink = isValidUrl;
+markdownit.normalizeLink = (url: string): string => {
+  url = originalNormalizeLink(url);
+  if (isValidUrl(url)) {
+    return url;
+  }
+  // prepend "https://" if url does not contain a protocol
+  if (!url.match(/^[a-z]+:/i)) {
+    return `https://${url}`;
+  }
+  return url;
+};
 
 markdownit.renderer.rules.softbreak = () => '<br>';
 markdownit.renderer.rules.hardbreak = () => '<br>';

--- a/test/unit_tests/util/messageRendererSpec.js
+++ b/test/unit_tests/util/messageRendererSpec.js
@@ -191,7 +191,9 @@ describe('renderMessage', () => {
   });
 
   it('renders a link from markdown notation with formatting', () => {
-    expect(renderMessage('[**doop**](http://www.example.com)')).toBe('[](http://www.example.com)<strong>doop</strong>');
+    expect(renderMessage('[**doop**](http://www.example.com)')).toBe(
+      '<a href="http://www.example.com" target="_blank" rel="nofollow noopener noreferrer" data-md-link="true" data-uie-name="markdown-link"><strong>doop</strong></a>',
+    );
   });
 
   it('renders a without protocol link from markdown notation', () => {

--- a/test/unit_tests/util/messageRendererSpec.js
+++ b/test/unit_tests/util/messageRendererSpec.js
@@ -190,8 +190,32 @@ describe('renderMessage', () => {
     );
   });
 
+  it('renders a link from markdown notation with formatting', () => {
+    expect(renderMessage('[**doop**](http://www.example.com)')).toBe('[](http://www.example.com)<strong>doop</strong>');
+  });
+
+  it('renders a without protocol link from markdown notation', () => {
+    expect(renderMessage('[doop](www.example.com)')).toBe(
+      '<a href="https://www.example.com" target="_blank" rel="nofollow noopener noreferrer" data-md-link="true" data-uie-name="markdown-link">doop</a>',
+    );
+  });
+
   it('does not render a js link from markdown notation', () => {
     expect(renderMessage("[doop](javascript:alert('nope'))")).toBe("[doop](javascript:alert('nope'))");
+    expect(renderMessage("[doop](javaScript:alert('nope'))")).toBe("[doop](javaScript:alert('nope'))");
+  });
+
+  it('does not render a link to a custom protocol from markdown notation', () => {
+    expect(renderMessage('[doop](something://123-444-666)')).toBe('[doop](something://123-444-666)');
+  });
+
+  it('does not render a data URL from markdown notation', () => {
+    expect(
+      renderMessage('[doop](data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7)'),
+    ).toBe('[doop](data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7)');
+    expect(
+      renderMessage('[**doop**](data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7)'),
+    ).toBe('[<strong>doop</strong>](data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7)');
   });
 
   it('does not render markdown links with empty or only whitespace values', () => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1945" title="SQSERVICES-1945" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />SQSERVICES-1945</a>  [wire-webapp] App allows arbitrary URL schemes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently the list of supported protocols in links is directly defined by markdown-it.
As there is no need to support external protocols, this PR limits the list of supported protocols down to http, https and mailto

### Solutions

Apply a custom filter to markdown-it to limit the supported urls.

In the same step this PR fixes link rendering of formatted links, and links to domains without a given protocol.


### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Render similar Markdown, as added in this PR to verify the behavior, only links to http, https and mailto should work.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
