### PR TITLE
runfix: Avoid downloading users twice

### DIFF
--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -198,6 +198,7 @@ export class UserRepository {
       .concat(conversationMembers)
       .concat(extraUsers);
     const users = uniq(allUserIds, false, (userId: QualifiedId) => userId.id);
+
     const dbUsers = await this.userService.loadUserFromDb();
     /* prior to April 2023, we were only storing the availability in the DB, we need to refetch those users */
     const [localUsers, incompleteUsers] = partition(dbUsers, user => !!user.qualified_id);
@@ -213,10 +214,9 @@ export class UserRepository {
       await this.userService.removeUserFromDb(user.qualified_id);
     });
 
-    const missingUsers = users
-      .filter(user => !liveUsers.find(localUser => matchQualifiedIds(user, localUser.qualified_id)))
-      // we add the users that are locally incomplete
-      .concat(incompleteUsers.map((user: any) => ({id: user.id, domain: user.domain})));
+    const missingUsers = users.filter(
+      user => !liveUsers.find(localUser => matchQualifiedIds(user, localUser.qualified_id)),
+    );
 
     const {found, failed} = await this.fetchRawUsers(missingUsers);
 


### PR DESCRIPTION
Since this change https://github.com/wireapp/wire-webapp/pull/15005/files#diff-2e118a63f0efd413c707bdcb15bbca567cfd723812a312a4850249dd2cbab331R201-R204 we try to load users that are not complete in the DB. 
But, those users are also considered 'missing', so they are counted in 2 sets:
- the set of users missing
- the set of users that have partial data in the database

So they ended-up being downloaded twice

## The fix

The fix was simply not to fetch the users that are incomplete in the DB. They are already included in the set of users that are not found in DB