### PR TITLE
feat: Use anchor tag for link preview

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/asset/LinkPreviewAssetComponent.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/LinkPreviewAssetComponent.tsx
@@ -26,7 +26,7 @@ import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {handleKeyDown} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
 import {safeWindowOpen} from 'Util/SanitizationUtil';
-import {cleanURL} from 'Util/UrlUtil';
+import {cleanURL, prependProtocol} from 'Util/UrlUtil';
 import {isTweetUrl} from 'Util/ValidationUtil';
 
 import {AssetHeader} from './AssetHeader';
@@ -116,13 +116,16 @@ const LinkPreviewAsset: React.FC<LinkPreviewAssetProps> = ({header = false, mess
                 <p>{t('conversationTweetAuthor')}</p>
               </div>
             ) : (
-              <p
+              <a
                 className="link-preview-info-link text-foreground ellipsis"
+                href={prependProtocol(preview.url)}
+                target="_blank"
+                rel="noopener noreferrer"
                 title={preview.url}
                 data-uie-name="link-preview-url"
               >
                 {cleanURL(preview.url)}
-              </p>
+              </a>
             )}
           </>
         )}


### PR DESCRIPTION
This allows one to use the browser's context
menu for instance to copy the link or open
it in a new window.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We currently can't use the browser's context menu when a link is previewed. We can't copy/open in new (private) windows etc.

### Causes (Optional)

The link previews use a paragraph tag.

### Solutions

The link previews use an anchor tag.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
