### PR TITLE
runfix: Avoid trying to load deleted users when initially loading conversations

### DIFF
--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -468,6 +468,7 @@ describe('ConversationRepository', () => {
         type: 'conversation.message-add',
       };
 
+      jest.spyOn(testFactory.user_repository, 'getUserById').mockResolvedValue(new User());
       spyOn(testFactory.conversation_repository, 'addMissingMember').and.returnValue(
         Promise.resolve(conversationEntity),
       );

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -500,14 +500,6 @@ export class UserRepository {
     }
   }
 
-  /**
-   * Get a user from the backend.
-   */
-  private async fetchUser(userId: QualifiedId): Promise<User> {
-    const [userEntity] = await this.fetchUsers([userId]);
-    return userEntity;
-  }
-
   private async fetchRawUsers(userIds: QualifiedId[]): Promise<{found: APIClientUser[]; failed: QualifiedId[]}> {
     const chunksOfUserIds = chunk<QualifiedId>(
       userIds.filter(({id}) => !!id),
@@ -625,12 +617,6 @@ export class UserRepository {
 
   /**
    * Check for user locally and fetch it from the server otherwise.
-   */
-  /**
-   *
-   * @param userId
-   * @param param1
-   * @returns
    */
   async getUserById(userId: QualifiedId, {localOnly}: GetUserOptions = {}): Promise<User> {
     const user = this.findUserById(userId);

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -77,6 +77,14 @@ import type {SelfService} from '../self/SelfService';
 import {UserRecord} from '../storage';
 import type {ServerTimeHandler} from '../time/serverTimeHandler';
 
+type GetUserOptions = {
+  /**
+   * will only lookup for users that are in memory (will avoid a backend request in case the user is not found locally)
+   * Note that it will return a user considered `deleted` if the user is not found in memory
+   */
+  localOnly?: boolean;
+};
+
 function generateQualifiedId(userData: {id: string; qualified_id?: QualifiedId; domain?: string}): QualifiedId {
   if (userData.qualified_id) {
     return userData.qualified_id;
@@ -618,24 +626,34 @@ export class UserRepository {
   /**
    * Check for user locally and fetch it from the server otherwise.
    */
-  async getUserById(userId: QualifiedId): Promise<User> {
-    let user = this.findUserById(userId);
-    if (!user) {
-      try {
-        user = await this.fetchUser(userId);
-      } catch (error) {
-        const isNotFound = error.type === UserError.TYPE.USER_NOT_FOUND;
-        if (!isNotFound) {
-          this.logger.warn(
-            `Failed to find user with ID '${userId.id}' and domain '${userId.domain}': ${error.message}`,
-            error,
-          );
-        }
-        throw error;
-      }
+  /**
+   *
+   * @param userId
+   * @param param1
+   * @returns
+   */
+  async getUserById(userId: QualifiedId, {localOnly}: GetUserOptions = {}): Promise<User> {
+    const user = this.findUserById(userId);
+    if (user) {
+      return user;
     }
-
-    return user;
+    if (localOnly) {
+      const deletedUser = new User(userId.id, userId.domain);
+      deletedUser.isDeleted = true;
+      return deletedUser;
+    }
+    try {
+      return this.userMapper.mapUserFromJson(await this.userService.getUser(userId));
+    } catch (error) {
+      const isNotFound = error.type === UserError.TYPE.USER_NOT_FOUND;
+      if (!isNotFound) {
+        this.logger.warn(
+          `Failed to find user with ID '${userId.id}' and domain '${userId.domain}': ${error.message}`,
+          error,
+        );
+      }
+      throw error;
+    }
   }
 
   async getUserByHandle(fqn: QualifiedHandle): Promise<undefined | APIClientUser> {
@@ -656,7 +674,7 @@ export class UserRepository {
   /**
    * Check for users locally and fetch them from the server otherwise.
    */
-  async getUsersById(userIds: QualifiedId[] = [], offline: boolean = false): Promise<User[]> {
+  async getUsersById(userIds: QualifiedId[] = [], {localOnly}: GetUserOptions = {}): Promise<User[]> {
     if (!userIds.length) {
       return [];
     }
@@ -667,7 +685,7 @@ export class UserRepository {
       QualifiedId[],
     ];
 
-    if (offline || !unknownUserIds.length) {
+    if (localOnly || !unknownUserIds.length) {
       return knownUserEntities;
     }
 


### PR DESCRIPTION
At load time we update all the local conversation (adding `users` and `messages` entities to it). 
Thing is, some of those users will not be in the state (because they are `deleted` and won't be listed by backend). 

In order to avoid sending a storm of user requests (per each message that has a sender not in the app state), we can load the initial messages as `offline` and consider that a user that is not found locally as a `deleted` user

## Before 😬 
![image](https://user-images.githubusercontent.com/1090716/233115120-767a98ae-9879-4351-81f3-36746df70d3f.png)

## After ✨ 
![image](https://user-images.githubusercontent.com/1090716/233115288-da6eb370-4d4e-46a1-8f13-2e5c841d317d.png)

