### PR TITLE
runfix: Remove url info from datadog tracking

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -781,7 +781,6 @@ export class ConversationRepository {
    * Update all conversations on app init.
    */
   public async updateConversationsOnAppInit() {
-    this.logger.info('Updating group participants');
     await this.updateConversations(this.conversationState.filteredConversations());
   }
 
@@ -1941,10 +1940,10 @@ export class ConversationRepository {
       // Prevent logging typing events
       return;
     }
-    const {time, from, qualified_conversation} = event;
+    const {time, from, qualified_conversation, type} = event;
     const extra: Record<string, unknown> = {};
     extra.messageId = 'id' in event && event.id;
-    const logMessage = `Conversation Event: '${event.type}' (Source: ${source})`;
+    const logMessage = `Conversation Event: '${type}' (Source: ${source})`;
     switch (event.type) {
       case ClientEvent.CONVERSATION.ASSET_ADD:
         extra.contentType = event.data.content_type;
@@ -1958,7 +1957,7 @@ export class ConversationRepository {
       case ClientEvent.CONVERSATION.MESSAGE_DELETE:
         extra.deletedMessage = event.data.message_id;
     }
-    this.logger.info(logMessage, {time, from, qualified_conversation, ...extra});
+    this.logger.info(logMessage, {time, from, type, qualified_conversation, ...extra});
   }
 
   /**

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -334,6 +334,7 @@ export class App {
    */
   async initApp(clientType: ClientType, onProgress: (progress: number, message?: string) => void) {
     // add body information
+    const startTime = Date.now();
     const [apiVersionMin, apiVersionMax] = this.config.SUPPORTED_API_RANGE;
     await this.core.useAPIVersion(apiVersionMin, apiVersionMax, this.config.ENABLE_DEV_BACKEND_API);
 
@@ -461,8 +462,7 @@ export class App {
       callingRepository.setReady();
       telemetry.timeStep(AppInitTimingsStep.APP_LOADED);
 
-      const loadTime = telemetry.report();
-      this.logger.info(`App loaded within ${loadTime}s`);
+      this.logger.info(`App loaded in ${Date.now() - startTime}ms`);
 
       return selfUser;
     } catch (error) {


### PR DESCRIPTION
This will:
- remove the url data from the logs and RUM
- log application exact initial load time
- improve the conversation event logging