### PR TITLE
runfix: Allow reseting user availabilities

### DIFF
--- a/src/script/user/UserMapper.test.ts
+++ b/src/script/user/UserMapper.test.ts
@@ -19,6 +19,8 @@
 
 import {UserAsset, UserAssetType} from '@wireapp/api-client/lib/user';
 
+import {Availability} from '@wireapp/protocol-messaging';
+
 import {ACCENT_ID, Config} from 'src/script/Config';
 import {User} from 'src/script/entity/User';
 import {serverTimeHandler} from 'src/script/time/serverTimeHandler';
@@ -199,6 +201,16 @@ describe('User Mapper', () => {
       const functionCall = () => mapper.updateUserFromObject(user_et, data);
 
       expect(functionCall).toThrow();
+    });
+
+    it.each([
+      [Availability.Type.AVAILABLE, Availability.Type.NONE],
+      [Availability.Type.NONE, Availability.Type.AVAILABLE],
+    ])('updates the availability (from %s to %s)', (from, to) => {
+      const user = new User();
+      user.availability(from);
+      mapper.updateUserFromObject(user, {availability: to});
+      expect(user.availability()).toBe(to);
     });
 
     it('can update user with v3 assets', () => {

--- a/src/script/user/UserMapper.ts
+++ b/src/script/user/UserMapper.ts
@@ -19,6 +19,8 @@
 
 import {container} from 'tsyringe';
 
+import {Availability} from '@wireapp/protocol-messaging';
+
 import {joaatHash} from 'Util/Crypto';
 import {getLogger, Logger} from 'Util/Logger';
 
@@ -109,7 +111,7 @@ export class UserMapper {
 
     const {
       accent_id: accentId,
-      availability,
+      availability = Availability.Type.NONE,
       assets,
       deleted,
       email,
@@ -125,9 +127,7 @@ export class UserMapper {
       userEntity.accent_id(accentId);
     }
 
-    if (availability) {
-      userEntity.availability(availability);
-    }
+    userEntity.availability(availability);
 
     let mappedAssets;
     if (assets?.length) {


### PR DESCRIPTION
Switching from a particular availability to a `0` value availability would prevent the user from being updated. 
We should consider falsy value as valid values for availabilities 