### PR TITLE
refactor: Remove dependency between UserMapper and UserState

### DIFF
--- a/src/script/notification/NotificationRepository.test.ts
+++ b/src/script/notification/NotificationRepository.test.ts
@@ -102,7 +102,7 @@ describe('NotificationRepository', () => {
     amplify.publish(WebAppEvents.EVENT.NOTIFICATION_HANDLING_STATE, NOTIFICATION_HANDLING_STATE.WEB_SOCKET);
 
     // Create entities
-    user = userMapper.mapUserFromJson(payload.users.get.one[0]);
+    user = userMapper.mapUserFromJson(payload.users.get.one[0], '');
     [conversation] = ConversationMapper.mapConversations([entities.conversation]);
     const selfUserEntity = new User(createRandomUuid());
     selfUserEntity.isMe = true;
@@ -597,7 +597,7 @@ describe('NotificationRepository', () => {
       memberMessage = new MemberMessage();
       memberMessage.user(user);
       (memberMessage as any).memberMessageType = SystemMessageType.NORMAL;
-      otherUser = userMapper.mapUserFromJson(payload.users.get.many[1]);
+      otherUser = userMapper.mapUserFromJson(payload.users.get.many[1], '');
     });
 
     describe('if people are added', () => {
@@ -665,7 +665,7 @@ describe('NotificationRepository', () => {
       });
 
       it('with multiple users being removed from the conversation', () => {
-        const user_ets = userMapper.mapUsersFromJson(payload.users.get.many);
+        const user_ets = userMapper.mapUsersFromJson(payload.users.get.many, '');
         memberMessage.userEntities(user_ets);
 
         return notificationRepository.notify(memberMessage, undefined, conversation).then(() => {
@@ -726,7 +726,7 @@ describe('NotificationRepository', () => {
     const expected_body = t('notificationPing');
 
     beforeAll(() => {
-      user = userMapper.mapUserFromJson(payload.users.get.one[0]);
+      user = userMapper.mapUserFromJson(payload.users.get.one[0], '');
     });
 
     beforeEach(() => {

--- a/src/script/user/UserMapper.test.ts
+++ b/src/script/user/UserMapper.test.ts
@@ -40,7 +40,7 @@ describe('User Mapper', () => {
 
   describe('mapUserFromJson', () => {
     it('can convert JSON into a single user entity', () => {
-      const user_et = mapper.mapUserFromJson(self_user_payload);
+      const user_et = mapper.mapUserFromJson(self_user_payload, '');
 
       expect(user_et.email()).toBe('jd@wire.com');
       expect(user_et.name()).toBe('John Doe');
@@ -53,8 +53,7 @@ describe('User Mapper', () => {
       ['local.test', false],
       ['federated.test', true],
     ])('can detect if a user is a federated user (%s)', (domain, expected) => {
-      const user = mapper.updateUserFromObject(
-        new User('', ''),
+      const user = mapper.mapUserFromJson(
         {
           id: 'id',
           locale: '',
@@ -71,8 +70,7 @@ describe('User Mapper', () => {
     it('Detects that user is not in the team if teamId is the same but domain is different', () => {
       const teamId = 'team1';
 
-      const user = mapper.updateUserFromObject(
-        new User('', ''),
+      const user = mapper.mapUserFromJson(
         {
           id: 'id',
           locale: '',
@@ -90,14 +88,14 @@ describe('User Mapper', () => {
     it('can convert users with profile images marked as non public', () => {
       self_user_payload.picture[0].info.public = false;
       self_user_payload.picture[1].info.public = false;
-      const user_et = mapper.mapUserFromJson(self_user_payload);
+      const user_et = mapper.mapUserFromJson(self_user_payload, '');
 
       expect(user_et.name()).toBe('John Doe');
     });
 
     it('will return default accent color if null/undefined', () => {
       self_user_payload.accent_id = null;
-      const user_et = mapper.mapUserFromJson(self_user_payload);
+      const user_et = mapper.mapUserFromJson(self_user_payload, '');
 
       expect(user_et.name()).toBe('John Doe');
       expect(user_et.accent_id()).toBe(ACCENT_ID.BLUE);
@@ -105,7 +103,7 @@ describe('User Mapper', () => {
 
     it('will return default accent color if backend returns 0', () => {
       self_user_payload.accent_id = 0;
-      const user_et = mapper.mapUserFromJson(self_user_payload);
+      const user_et = mapper.mapUserFromJson(self_user_payload, '');
 
       expect(user_et.name()).toBe('John Doe');
       expect(user_et.joaatHash).toBe(526273169);
@@ -128,7 +126,7 @@ describe('User Mapper', () => {
 
   describe('mapUsersFromJson', () => {
     it('can convert JSON into multiple user entities', () => {
-      const user_ets = mapper.mapUsersFromJson(payload.users.get.many);
+      const user_ets = mapper.mapUsersFromJson(payload.users.get.many, '');
 
       expect(user_ets.length).toBe(2);
       expect(user_ets[0].email()).toBe('jd@wire.com');
@@ -136,14 +134,14 @@ describe('User Mapper', () => {
     });
 
     it('returns an empty array if input was undefined', () => {
-      const user_ets = mapper.mapUsersFromJson(undefined);
+      const user_ets = mapper.mapUsersFromJson(undefined, '');
 
       expect(user_ets).toBeDefined();
       expect(user_ets.length).toBe(0);
     });
 
     it('returns an empty array if input was an empty array', () => {
-      const user_ets = mapper.mapUsersFromJson([]);
+      const user_ets = mapper.mapUsersFromJson([], '');
 
       expect(user_ets).toBeDefined();
       expect(user_ets.length).toBe(0);

--- a/src/script/user/UserMapper.ts
+++ b/src/script/user/UserMapper.ts
@@ -41,12 +41,12 @@ export class UserMapper {
     this.logger = getLogger('UserMapper');
   }
 
-  mapUserFromJson(userData: UserRecord): User {
-    return this.updateUserFromObject(new User('', ''), userData, '');
+  mapUserFromJson(userData: UserRecord, localDomain: string): User {
+    return this.updateUserFromObject(new User('', ''), userData, localDomain);
   }
 
   mapSelfUserFromJson(userData: UserRecord): User {
-    const userEntity = this.updateUserFromObject(new User('', ''), userData, userData.qualified_id.domain);
+    const userEntity = this.updateUserFromObject(new User('', ''), userData, '');
     userEntity.isMe = true;
 
     if (isSelfAPIUser(userData)) {
@@ -61,9 +61,9 @@ export class UserMapper {
    * @note Return an empty array in any case to prevent crashes.
    * @returns Mapped user entities
    */
-  mapUsersFromJson(usersData: UserRecord[]): User[] {
+  mapUsersFromJson(usersData: UserRecord[], localDomain: string): User[] {
     if (usersData?.length) {
-      return usersData.filter(userData => userData).map(userData => this.mapUserFromJson(userData));
+      return usersData.filter(userData => userData).map(userData => this.mapUserFromJson(userData, localDomain));
     }
     this.logger.warn('We got no user data from the backend');
     return [];
@@ -74,6 +74,7 @@ export class UserMapper {
    * @note Mapping of single properties to an existing user happens when the user changes his name or accent color.
    * @param userEntity User entity that the info shall be mapped to
    * @param userData Updated user data from backend
+   * @param localDomain Domain of the current backend (used to determine if the user is federated)
    * @todo Pass in "serverTimeHandler", so that it can be removed from the "UserMapper" constructor
    */
   updateUserFromObject(userEntity: User, userData: Partial<UserRecord>, localDomain: string): User {

--- a/src/script/user/UserRepository.test.ts
+++ b/src/script/user/UserRepository.test.ts
@@ -184,8 +184,6 @@ describe('UserRepository', () => {
     });
 
     describe('saveUser', () => {
-      afterEach(() => userState.users.removeAll());
-
       it('saves a user', () => {
         const user = new User(entities.user.jane_roe.id);
 
@@ -210,8 +208,10 @@ describe('UserRepository', () => {
       const localUsers = [generateAPIUser(), generateAPIUser(), generateAPIUser()];
       beforeEach(async () => {
         jest.resetAllMocks();
-        userState.users.removeAll();
         jest.spyOn(userRepository['userService'], 'loadUserFromDb').mockResolvedValue(localUsers);
+        const selfUser = new User('self');
+        selfUser.isMe = true;
+        userState.users([selfUser]);
       });
 
       it('loads all users from backend if no users are stored locally', async () => {
@@ -278,7 +278,6 @@ describe('UserRepository', () => {
       let userJohnDoe: User;
 
       beforeEach(() => {
-        userState.users.removeAll();
         userJaneRoe = new User(entities.user.jane_roe.id);
         userJohnDoe = new User(entities.user.john_doe.id);
 
@@ -293,8 +292,6 @@ describe('UserRepository', () => {
 
         spyOn(testFactory.client_repository!, 'getAllClientsFromDb').and.returnValue(Promise.resolve(recipients));
       });
-
-      afterEach(() => userState.users.removeAll());
 
       it('assigns all available clients to the users', () => {
         return userRepository.assignAllClients().then(() => {

--- a/src/script/user/UserRepository.test.ts
+++ b/src/script/user/UserRepository.test.ts
@@ -358,6 +358,7 @@ describe('UserRepository', () => {
       const userService = userRepository['userService'];
       const user = new User(entities.user.jane_roe.id);
       user.name('initial name');
+      user.isMe = true;
       userRepository['saveUser'](user);
 
       jest.spyOn(userService, 'getUsers').mockResolvedValue({found: [entities.user.jane_roe]});

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -556,7 +556,7 @@ export class UserRepository {
       /* When a federated backend is unreachable, we generate placeholder users locally with some default values */
       userId => new User(userId.id, userId.domain),
     );
-    const mappedUsers = this.userMapper.mapUsersFromJson(found).concat(failedToLoad);
+    const mappedUsers = this.userMapper.mapUsersFromJson(found, this.userState.self().domain).concat(failedToLoad);
     if (this.userState.isTeam()) {
       this.mapGuestStatus(mappedUsers);
     }

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -304,7 +304,7 @@ export class UserRepository {
       user.name = fixWebsocketString(user.name);
     }
 
-    this.userMapper.updateUserFromObject(userEntity, user);
+    this.userMapper.updateUserFromObject(userEntity, user, selfUser.domain);
     // Update the database record
     await this.userService.updateUser(userEntity.qualifiedId, user);
     if (isSelfUser) {
@@ -736,7 +736,7 @@ export class UserRepository {
   };
 
   async refreshUsers(userIds: QualifiedId[]) {
-    const {found: users} = await this.userService.getUsers(userIds);
+    const {found: users} = await this.fetchRawUsers(userIds, this.userState.self().domain);
     return users.map(user => this.updateSavedUser(user));
   }
 
@@ -746,7 +746,7 @@ export class UserRepository {
    */
   private updateSavedUser(user: APIClientUser): User {
     const localUserEntity = this.findUserById(generateQualifiedId(user)) ?? new User();
-    const updatedUser = this.userMapper.updateUserFromObject(localUserEntity, user);
+    const updatedUser = this.userMapper.updateUserFromObject(localUserEntity, user, this.userState.self().domain);
     // TODO update the user in db
     if (this.userState.isTeam()) {
       this.mapGuestStatus([updatedUser]);

--- a/test/helper/UserGenerator.ts
+++ b/test/helper/UserGenerator.ts
@@ -55,5 +55,5 @@ export function generateAPIUser(
 
 export function generateUser(id?: QualifiedId): User {
   const apiUser = generateAPIUser(id);
-  return new UserMapper(serverTimeHandler).mapUserFromJson(apiUser);
+  return new UserMapper(serverTimeHandler).mapUserFromJson(apiUser, '');
 }


### PR DESCRIPTION
This is an effort to reduce the impact of the `UserState` across the app. 
The ultimate goal is to have the UserState only consumed by the UI (not the repository or any deep layers of the app)