### PR TITLE
runfix: join mls conversations after processing messages

### DIFF
--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -404,7 +404,7 @@ export class App {
       await userRepository.loadUsers(selfUser, connections, conversations, teamMembers);
 
       if (supportsMLS()) {
-        //if mls is supported, we need to initialize the callbacks (the are used when decrypting messages)
+        //if mls is supported, we need to initialize the callbacks (they are used when decrypting messages)
         await initMLSCallbacks(this.core, this.repository.conversation);
       }
 

--- a/src/script/mls/MLSConversations.test.ts
+++ b/src/script/mls/MLSConversations.test.ts
@@ -23,7 +23,7 @@ import {randomUUID} from 'crypto';
 
 import {Account} from '@wireapp/core';
 
-import {initMLSConversations, registerUninitializedConversations} from './MLSConversations';
+import {initMLSConversations, registerUninitializedSelfAndTeamConversations} from './MLSConversations';
 import {useMLSConversationState} from './mlsConversationState';
 
 import {Conversation} from '../entity/Conversation';
@@ -85,7 +85,7 @@ describe('MLSConversations', () => {
       const mlsConversations = createConversations(nbMLSConversations);
       const conversations = [...proteusConversations, teamConversation, ...mlsConversations, selfConversation];
 
-      await registerUninitializedConversations(conversations, new User(), 'client-1', core);
+      await registerUninitializedSelfAndTeamConversations(conversations, new User(), 'client-1', core);
 
       expect(core.service!.mls.registerConversation).toHaveBeenCalledTimes(2);
     });

--- a/src/script/mls/MLSConversations.test.ts
+++ b/src/script/mls/MLSConversations.test.ts
@@ -63,7 +63,7 @@ describe('MLSConversations', () => {
       const mlsConversations = createConversations(nbMLSConversations);
       const conversations = [...proteusConversations, ...mlsConversations];
 
-      await initMLSConversations(conversations, new User(), new Account(), {} as any);
+      await initMLSConversations(conversations, new Account());
 
       expect(useMLSConversationState.getState().sendExternalToPendingJoin).toHaveBeenCalledWith(
         mlsConversations,
@@ -107,7 +107,7 @@ describe('MLSConversations', () => {
       const mlsConversations = createConversations(nbMLSConversations);
       const conversations = [...proteusConversations, teamConversation, ...mlsConversations, selfConversation];
 
-      await initMLSConversations(conversations, new User(), core, {} as any);
+      await initMLSConversations(conversations, core);
 
       expect(core.service!.mls.registerConversation).toHaveBeenCalledTimes(0);
     });

--- a/src/script/mls/MLSConversations.ts
+++ b/src/script/mls/MLSConversations.ts
@@ -39,13 +39,16 @@ type MLSConversationRepository = Pick<
   'findConversationByGroupId' | 'getConversationById' | 'conversationRoleRepository'
 >;
 
-export async function initMLSConversations(
-  conversations: Conversation[],
-  selfUser: User,
+export function initMLSConversations(conversations: Conversation[], core: Account): Promise<void> {
+  const mlsConversations = conversations.filter(isMLSConversation);
+  return joinNewConversations(mlsConversations, core);
+}
+
+export async function initMLSCallbacks(
   core: Account,
   conversationRepository: MLSConversationRepository,
 ): Promise<void> {
-  core.configureMLSCallbacks({
+  return core.configureMLSCallbacks({
     groupIdFromConversationId: async conversationId => {
       const conversation = await conversationRepository.getConversationById(conversationId);
       return conversation?.groupId;
@@ -54,9 +57,6 @@ export async function initMLSConversations(
     authorize: async () => true,
     userAuthorize: async () => true,
   });
-
-  const mlsConversations = conversations.filter(isMLSConversation);
-  await joinNewConversations(mlsConversations, core);
 }
 
 /**

--- a/src/script/mls/MLSConversations.ts
+++ b/src/script/mls/MLSConversations.ts
@@ -52,6 +52,7 @@ export function initMLSConversations(conversations: Conversation[], core: Accoun
 
 /**
  * Will initialise the MLS callbacks for the core.
+ * It should be called before processing messages queue as the callbacks are being used when decrypting mls messages.
  *
  * @param core - the instance of the core
  * @param conversationRepository - conversations repository

--- a/src/script/mls/MLSConversations.ts
+++ b/src/script/mls/MLSConversations.ts
@@ -39,11 +39,23 @@ type MLSConversationRepository = Pick<
   'findConversationByGroupId' | 'getConversationById' | 'conversationRoleRepository'
 >;
 
+/**
+ * Will initialize all the MLS conversations that the user is member of but that are not yet locally established.
+ *
+ * @param conversations - all the conversations that the user is part of
+ * @param core - the instance of the core
+ */
 export function initMLSConversations(conversations: Conversation[], core: Account): Promise<void> {
   const mlsConversations = conversations.filter(isMLSConversation);
   return joinNewConversations(mlsConversations, core);
 }
 
+/**
+ * Will initialise the MLS callbacks for the core.
+ *
+ * @param core - the instance of the core
+ * @param conversationRepository - conversations repository
+ */
 export async function initMLSCallbacks(
   core: Account,
   conversationRepository: MLSConversationRepository,
@@ -75,7 +87,7 @@ async function joinNewConversations(conversations: MLSConversation[], core: Acco
 }
 
 /**
- * Will register self and team mls conversations.
+ * Will register self and team MLS conversations.
  * The self conversation and the team conversation are special conversations created by noone and, thus, need to be manually created by the first device that detects them
  *
  * @param conversations all the conversations the user is part of

--- a/src/script/mls/MLSConversations.ts
+++ b/src/script/mls/MLSConversations.ts
@@ -75,13 +75,13 @@ async function joinNewConversations(conversations: MLSConversation[], core: Acco
 }
 
 /**
- * Will register special conversations agains the core.
- * The self conversation and the team conversation as special conversation that are created by noone and, thus, need to be manually created by the first device that detects them
+ * Will register self and team mls conversations.
+ * The self conversation and the team conversation are special conversations created by noone and, thus, need to be manually created by the first device that detects them
  *
  * @param conversations all the conversations the user is part of
  * @param core instance of the core
  */
-export async function registerUninitializedConversations(
+export async function registerUninitializedSelfAndTeamConversations(
   conversations: Conversation[],
   selfUser: User,
   selfClientId: string,


### PR DESCRIPTION
### Context
On app init there is a process of joining MLS groups with external commit user is a member of (from backend perspective). 

### Issue
The issue was it was joining the group before processing the message queue (slow/quick sync) that could include MLS welcome message, so user was joining the MLS group with external commit and then could receive welcome message what lead to some strange behaviour (the group was not established after decrypting the message that came after external join).

### Solution
The solution is to process message queue first and then join MLS groups user is a member of but haven't established yet. After user is added to a group, the welcome message is sent to all their clients, so the welcome message is the one that should initialise the conversation (no need to join with external commit sooner)