### PR TITLE
runfix: Avoid having double user entries in DB

### DIFF
--- a/src/script/user/UserService.ts
+++ b/src/script/user/UserService.ts
@@ -49,6 +49,17 @@ export class UserService {
     return this.storageService.getAll<UserRecord>(this.USER_STORE_NAME);
   }
 
+  /**
+   * Will remove all the non-qualified entries in the DB
+   */
+  async clearNonQualifiedUsers(): Promise<void> {
+    const keys = await this.storageService.readAllPrimaryKeys(this.USER_STORE_NAME);
+    const nonQualifiedKeys = keys.filter(key => !key.includes('@'));
+    for (const key of nonQualifiedKeys) {
+      await this.storageService.delete(this.USER_STORE_NAME, key);
+    }
+  }
+
   async removeUserFromDb(user: {id: string; domain: string}): Promise<void> {
     const primaryKey = constructUserPrimaryKey(user);
     await this.storageService.delete(this.USER_STORE_NAME, primaryKey);

--- a/src/script/user/UserService.ts
+++ b/src/script/user/UserService.ts
@@ -52,12 +52,18 @@ export class UserService {
   /**
    * Will remove all the non-qualified entries in the DB
    */
-  async clearNonQualifiedUsers(): Promise<void> {
+  async clearNonQualifiedUsers(): Promise<UserRecord[]> {
     const keys = await this.storageService.readAllPrimaryKeys(this.USER_STORE_NAME);
     const nonQualifiedKeys = keys.filter(key => !key.includes('@'));
+    const deletedEntries = [];
     for (const key of nonQualifiedKeys) {
-      await this.storageService.delete(this.USER_STORE_NAME, key);
+      const entry = await this.storageService.load<UserRecord>(this.USER_STORE_NAME, key);
+      if (entry) {
+        deletedEntries.push(entry);
+        await this.storageService.delete(this.USER_STORE_NAME, key);
+      }
     }
+    return deletedEntries;
   }
 
   async removeUserFromDb(user: {id: string; domain: string}): Promise<void> {


### PR DESCRIPTION
## The bug
When loading the app, you could be shown your previous availability status and get stuck to this

## The explanation
In the database there could be one entry for your user that is not fully qualified. This is the entry that was used to load your availability status from. 
**BUT** if you changed your status, then we would update the fully qualified entry. 

Next time you load the application, then only the non-qualified entry would be considered and you would end up with the previous status at each load.

## The solution

At load time, we deleted the non qualified users we have in DB and keep them in memory for later mapping (in case we don't find a qualified user in DB that correspond users in memory)