### PR TITLE
runfix: apply correct design to unreachable user warnings

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -685,7 +685,6 @@
   "messageFailedToSendWillReceivePlural": "will get your message later.",
   "messageFailedToSendWillReceiveSingular": "will get your message later.",
   "messageWillNotBeSent": "File could not be sent due to connectivity issues.",
-  "messageWillNotBeSentDiscard": "Discard",
   "mlsToggleInfo": "When this is on, conversation will use the new messaging layer security (MLS) protocol.",
   "mlsToggleName": "MLS",
   "modalAccountCreateAction": "OK",

--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.test.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.test.tsx
@@ -60,7 +60,6 @@ describe('message', () => {
       onClickReceipts: jest.fn(),
       onClickTimestamp: jest.fn(),
       onLike: jest.fn(),
-      onDiscard: jest.fn(),
       onRetry: jest.fn(),
       previousMessage: undefined,
       selfId: {domain: '', id: createRandomUuid()},

--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -57,7 +57,6 @@ export interface ContentMessageProps extends Omit<MessageActions, 'onClickResetS
   isLastDeliveredMessage: boolean;
   message: ContentMessage;
   onClickButton: (message: CompositeMessage, buttonId: string) => void;
-  onDiscard: () => void;
   onRetry: (message: ContentMessage) => void;
   previousMessage?: Message;
   quotedMessage?: ContentMessage;
@@ -83,7 +82,6 @@ const ContentMessageComponent: React.FC<ContentMessageProps> = ({
   onClickLikes,
   onClickButton,
   onLike,
-  onDiscard,
   onRetry,
   isMsgElementsFocusable,
 }) => {
@@ -191,7 +189,6 @@ const ContentMessageComponent: React.FC<ContentMessageProps> = ({
         {status === StatusType.FAILED && (
           <CompleteFailureToSendWarning
             isTextAsset={message.getFirstAsset().isText()}
-            onDiscard={() => onDiscard()}
             onRetry={() => onRetry(message)}
           />
         )}

--- a/src/script/components/MessagesList/Message/ContentMessage/Warnings/CompleteFailureToSend/CompleteFailureToSend.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/Warnings/CompleteFailureToSend/CompleteFailureToSend.tsx
@@ -26,10 +26,9 @@ import {warning} from '../Warnings.styles';
 type Props = {
   isTextAsset: boolean;
   onRetry: () => void;
-  onDiscard?: () => void;
 };
 
-export const CompleteFailureToSendWarning = ({isTextAsset, onRetry, onDiscard}: Props) => {
+export const CompleteFailureToSendWarning = ({isTextAsset, onRetry}: Props) => {
   return (
     <>
       <div>

--- a/src/script/components/MessagesList/Message/ContentMessage/Warnings/CompleteFailureToSend/CompleteFailureToSend.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/Warnings/CompleteFailureToSend/CompleteFailureToSend.tsx
@@ -38,9 +38,6 @@ export const CompleteFailureToSendWarning = ({isTextAsset, onRetry, onDiscard}: 
           <Button type="button" variant={ButtonVariant.TERTIARY} onClick={onRetry}>
             {t('messageCouldNotBeSentRetry')}
           </Button>
-          <Button type="button" variant={ButtonVariant.TERTIARY} onClick={onDiscard}>
-            {t('messageWillNotBeSentDiscard')}
-          </Button>
         </div>
       </div>
     </>

--- a/src/script/components/MessagesList/Message/ContentMessage/Warnings/PartialFailureToSend/PartialFailureToSend.test.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/Warnings/PartialFailureToSend/PartialFailureToSend.test.tsx
@@ -219,4 +219,35 @@ describe('PartialFailureToSendWarning', () => {
 
     expect(getByText('Show details')).not.toBeNull();
   });
+
+  it('does not display an unreachable user warning if there are no unreachable users', () => {
+    const namedUsers = generateUsers(2, 'domain1');
+    const queued = generateUserClients(namedUsers);
+
+    const failed = [] as QualifiedId[];
+
+    const {getByText, container} = render(
+      withTheme(<PartialFailureToSendWarning knownUsers={namedUsers} failedToSend={{queued, failed}} />),
+    );
+    act(() => {
+      getByText('Show details').click();
+    });
+
+    expect(container.textContent).not.toContain(`won't get your message`);
+  });
+
+  it('does not display a named user warning if there are no named users', () => {
+    const failed = [...generateQualifiedIds(2, 'domain2')];
+
+    const queued = {} as QualifiedUserClients;
+
+    const {getByText, container} = render(
+      withTheme(<PartialFailureToSendWarning knownUsers={[]} failedToSend={{queued, failed}} />),
+    );
+    act(() => {
+      getByText('Show details').click();
+    });
+
+    expect(container.textContent).not.toContain(`will get your message later`);
+  });
 });

--- a/src/script/components/MessagesList/Message/ContentMessage/Warnings/PartialFailureToSend/PartialFailureToSend.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/Warnings/PartialFailureToSend/PartialFailureToSend.tsx
@@ -129,7 +129,7 @@ export const PartialFailureToSendWarning = ({failedToSend, knownUsers}: Props) =
 
               {/* maps through the unreachable users that will never receive the message:
               "3 participants from alpha.domain, 1 participant from beta.domain won't get your message" */}
-              {failed && (
+              {unreachableUsers.length !== 0 && (
                 <p css={warning}>
                   {joinWith(
                     unreachableUsers.map(user => (

--- a/src/script/components/MessagesList/Message/MessageWrapper.tsx
+++ b/src/script/components/MessagesList/Message/MessageWrapper.tsx
@@ -116,10 +116,6 @@ export const MessageWrapper: React.FC<MessageParams & {hasMarker: boolean; isMes
     }
   };
 
-  const onDiscard = async () => {
-    await messageRepository.deleteMessageById(conversation, message.id);
-  };
-
   const contextMenuEntries = ko.pureComputed(() => {
     const entries: ContextMenuEntry[] = [];
 
@@ -214,7 +210,6 @@ export const MessageWrapper: React.FC<MessageParams & {hasMarker: boolean; isMes
         onClickInvitePeople={onClickInvitePeople}
         onClickParticipants={onClickParticipants}
         onClickReceipts={onClickReceipts}
-        onDiscard={onDiscard}
         onRetry={onRetry}
         isMessageFocused={isMessageFocused}
         isMsgElementsFocusable={isMsgElementsFocusable}


### PR DESCRIPTION
### Issues

- A discard button was added to the failure to send warning without product approval (my bad)
- The warning for unreachable users would display even if there were none

![image](https://user-images.githubusercontent.com/78490891/234584072-352231e5-84b5-4009-866a-62cca36a4c6c.png)

![image](https://user-images.githubusercontent.com/78490891/234583931-daebd9ad-ff6e-49d1-bb80-d3996d269152.png)


### Solutions

- remove the discard button, it is still possible to delete the message in the context menu
- make sure the unreachable user warning is only sent if there are unreachable users

![Screenshot from 2023-04-26 15-00-01](https://user-images.githubusercontent.com/78490891/234584679-87ec220f-76fe-409a-ba1e-4ec219e9f41d.png)
![image](https://user-images.githubusercontent.com/78490891/234584910-d8a3b98f-f15a-44f8-8cde-fd39b0c68623.png)
