### PR TITLE
runfix: Do not add duplicate events when restoring backup

### DIFF
--- a/src/script/backup/BackupRepository.test.ts
+++ b/src/script/backup/BackupRepository.test.ts
@@ -138,8 +138,10 @@ describe('BackupRepository', () => {
 
       await backupRepository.importHistory(new User('user1'), blob, noop, noop);
 
-      expect(importSpy).toHaveBeenCalledWith(eventStoreName, [omit(textEvent, 'primary_key')]);
-      expect(importSpy).not.toHaveBeenCalledWith(eventStoreName, [verificationEvent]);
+      expect(importSpy).toHaveBeenCalledWith(eventStoreName, [omit(textEvent, 'primary_key')], {
+        generateId: expect.any(Function),
+      });
+      expect(importSpy).not.toHaveBeenCalledWith(eventStoreName, [verificationEvent], expect.any(Object));
     });
 
     it('cancels export', async () => {
@@ -213,9 +215,12 @@ describe('BackupRepository', () => {
       expect(importSpy).toHaveBeenCalledWith(
         StorageSchemata.OBJECT_STORE.EVENTS,
         messages.map(message => omit(message, 'primary_key')),
+        {generateId: expect.any(Function)},
       );
 
-      expect(importSpy).toHaveBeenCalledWith(StorageSchemata.OBJECT_STORE.USERS, users, expect.any(Function));
+      expect(importSpy).toHaveBeenCalledWith(StorageSchemata.OBJECT_STORE.USERS, users, {
+        generatePrimaryKey: expect.any(Function),
+      });
     });
   });
 });

--- a/src/script/backup/BackupRepository.ts
+++ b/src/script/backup/BackupRepository.ts
@@ -284,7 +284,9 @@ export class BackupRepository {
     const entities = events.map(entity => this.prepareEvents(entity));
 
     const importEventChunk = async (eventChunk: Omit<EventRecord, 'primary_key'>[]) => {
-      const nbImported = await this.backupService.importEntities(StorageSchemata.OBJECT_STORE.EVENTS, eventChunk);
+      const nbImported = await this.backupService.importEntities(StorageSchemata.OBJECT_STORE.EVENTS, eventChunk, {
+        generateId: event => event.id,
+      });
       progressCallback(eventChunk.length);
       return nbImported;
     };
@@ -297,9 +299,9 @@ export class BackupRepository {
     const qualifiedUsers = users.filter(user => !!user.qualified_id);
 
     const importEventChunk = async (usersChunk: UserRecord[]) => {
-      const nbImported = await this.backupService.importEntities(StorageSchemata.OBJECT_STORE.USERS, usersChunk, user =>
-        constructUserPrimaryKey(user.qualified_id),
-      );
+      const nbImported = await this.backupService.importEntities(StorageSchemata.OBJECT_STORE.USERS, usersChunk, {
+        generatePrimaryKey: user => constructUserPrimaryKey(user.qualified_id),
+      });
       progressCallback(usersChunk.length);
       return nbImported;
     };

--- a/src/script/backup/BackupService.ts
+++ b/src/script/backup/BackupService.ts
@@ -77,21 +77,17 @@ export class BackupService {
   async importEntities<T>(
     tableName: string,
     entities: T[],
-    generatePrimaryKey?: (entry: T) => string,
+    {
+      generatePrimaryKey,
+      generateId,
+    }: {generatePrimaryKey?: (entry: T) => string; generateId?: (entry: T) => string} = {},
   ): Promise<number> {
-    const primaryKeys = generatePrimaryKey ? entities.map(generatePrimaryKey) : undefined;
     if (this.storageService.db) {
-      try {
-        await this.storageService.db.table(tableName).bulkAdd(entities, primaryKeys);
-        return entities.length;
-      } catch (error) {
-        if (error instanceof Dexie.BulkError) {
-          const {failures} = error;
-          const successCount = entities.length - failures.length;
-          return successCount;
-        }
-        throw error;
+      const table = await this.storageService.db.table(tableName);
+      if (generatePrimaryKey) {
+        return this.addByPrimaryKeys(table, entities, generatePrimaryKey);
       }
+      return this.addByIds(table, entities, generateId);
     }
 
     for (const entity of entities) {
@@ -99,5 +95,47 @@ export class BackupService {
       await this.storageService.save(tableName, key, entity);
     }
     return entities.length;
+  }
+
+  /**
+   * Will add all the entities that are not already in the database (identified by their id)
+   */
+  private async addByIds<T>(
+    table: Dexie.Table<T, unknown>,
+    entities: T[],
+    generateId?: (entry: T) => string,
+  ): Promise<number> {
+    const ids = generateId ? entities.map(generateId) : [];
+    const existingEntities = await table.where('id').anyOf(ids).toArray();
+    const newEntities = generateId
+      ? entities.filter(
+          entity => !existingEntities.some(existingEntity => generateId(existingEntity) === generateId(entity)),
+        )
+      : entities;
+
+    await table.bulkAdd(newEntities);
+    return newEntities.length;
+  }
+
+  /**
+   * Will bulk add the entities to the database ignoring the entries with primary keys that already exist
+   */
+  private async addByPrimaryKeys<T>(
+    table: Dexie.Table<T, unknown>,
+    entities: T[],
+    generatePrimaryKey: (entry: T) => string,
+  ): Promise<number> {
+    const primaryKeys = entities.map(generatePrimaryKey);
+    try {
+      await table.bulkAdd(entities, primaryKeys);
+      return entities.length;
+    } catch (error) {
+      if (error instanceof Dexie.BulkError) {
+        const {failures} = error;
+        const successCount = entities.length - failures.length;
+        return successCount;
+      }
+      throw error;
+    }
   }
 }


### PR DESCRIPTION
This will allow events, that are not exported with primary_key, to be deduped when restoring a backup. 

The problem is that the primary key for events is computed by Indexeddb, which means we don't have the control over it and one primary key doesn't identify a particular message across devices. 

We need to fallback to `id` that will allow matching the new entities to the ones already in the DB