### PR TITLE
runfix: Always map user team ID even when from different team

### DIFF
--- a/src/script/user/UserMapper.ts
+++ b/src/script/user/UserMapper.ts
@@ -182,10 +182,11 @@ export class UserMapper {
     }
 
     const currentTeam = this.teamState.team()?.id;
-    if (isSelf || (currentTeam && teamId && teamId === currentTeam && !userEntity.isFederated)) {
-      // To be in the same team, the user needs to have the same teamId and to be on the same domain (not federated)
-      userEntity.inTeam(!!teamId);
+    if (teamId) {
       userEntity.teamId = teamId;
+      if (!userEntity.isFederated && currentTeam && currentTeam === teamId) {
+        userEntity.inTeam(true);
+      }
     }
 
     if (deleted) {


### PR DESCRIPTION
TeamId was not mapped in case the self user was not a team user. 
This was a bug introduced with https://github.com/wireapp/wire-webapp/pull/15086/files#diff-e1f7e79fd74f74a44a5b6dc1d33a3ded9e2dc4ee5c610d6c9edb55f03731835e