### PR TITLE
runfix: display placeholder user correctly in participant list [FS-1877]

### DIFF
--- a/src/script/components/Avatar/Avatar.tsx
+++ b/src/script/components/Avatar/Avatar.tsx
@@ -122,7 +122,7 @@ const Avatar: FC<AvatarProps> = ({
   }
 
   if (!participant.isAvailable()) {
-    return <PlaceholderAvatar avatarSize={avatarSize} onClick={() => onAvatarClick?.(participant)} />;
+    return <PlaceholderAvatar {...props} avatarSize={avatarSize} onClick={() => onAvatarClick?.(participant)} />;
   }
 
   const isMe = participant?.isMe;

--- a/src/script/components/UserList/components/UserListItem/UserListItem.tsx
+++ b/src/script/components/UserList/components/UserListItem/UserListItem.tsx
@@ -76,15 +76,7 @@ const UserListItem = ({
     availability,
     expirationText,
     name,
-    domain,
-  } = useKoSubscribableChildren(user, [
-    'isDirectGuest',
-    'is_verified',
-    'availability',
-    'expirationText',
-    'name',
-    'domain',
-  ]);
+  } = useKoSubscribableChildren(user, ['isDirectGuest', 'is_verified', 'availability', 'expirationText', 'name']);
 
   const {isMe: isSelf, isFederated} = user;
   const isTemporaryGuest = user.isTemporaryGuest();
@@ -111,7 +103,7 @@ const UserListItem = ({
       return expirationText;
     }
     if (!isAvailable) {
-      return domain;
+      return user.domain;
     }
 
     return user.handle;

--- a/src/script/components/UserList/components/UserListItem/UserListItem.tsx
+++ b/src/script/components/UserList/components/UserListItem/UserListItem.tsx
@@ -75,16 +75,28 @@ const UserListItem = ({
     isDirectGuest,
     availability,
     expirationText,
-    name: userName,
-  } = useKoSubscribableChildren(user, ['isDirectGuest', 'is_verified', 'availability', 'expirationText', 'name']);
+    name,
+    domain,
+  } = useKoSubscribableChildren(user, [
+    'isDirectGuest',
+    'is_verified',
+    'availability',
+    'expirationText',
+    'name',
+    'domain',
+  ]);
 
   const {isMe: isSelf, isFederated} = user;
   const isTemporaryGuest = user.isTemporaryGuest();
+
+  const isAvailable = user.isAvailable();
 
   const hasUsernameInfo = !hideInfo && !customInfo && !isTemporaryGuest;
   const isOthersMode = mode === UserlistMode.OTHERS;
 
   const selfString = `(${capitalizeFirstChar(t('conversationYouNominative'))})`;
+
+  const userName = isAvailable ? name : t('unavailableUser');
 
   const getContentInfoText = () => {
     if (customInfo) {
@@ -97,6 +109,9 @@ const UserListItem = ({
 
     if (isTemporaryGuest) {
       return expirationText;
+    }
+    if (!isAvailable) {
+      return domain;
     }
 
     return user.handle;

--- a/src/script/components/UserList/components/UserListItem/UserListItem.tsx
+++ b/src/script/components/UserList/components/UserListItem/UserListItem.tsx
@@ -80,7 +80,6 @@ const UserListItem = ({
 
   const {isMe: isSelf, isFederated} = user;
   const isTemporaryGuest = user.isTemporaryGuest();
-
   const isAvailable = user.isAvailable();
 
   const hasUsernameInfo = !hideInfo && !customInfo && !isTemporaryGuest;

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -544,7 +544,7 @@ export class UserRepository {
           (isAxiosError(error) && error.response?.status === HTTP_STATUS.BAD_REQUEST) ||
           Number((error as BackendError).code) === HTTP_STATUS.BAD_REQUEST;
         if (isNotFound || isBadRequest) {
-          return {found: [], failed: []};
+          return {found: [], failed: [...chunkOfQualifiedUserIds]};
         }
         throw error;
       }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1877" title="FS-1877" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />FS-1877</a>  [web] Display fallback UI on participant list when user metadata is not available
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Issue

- The participant list doesn't display "username" and domain of placeholder users
![image](https://user-images.githubusercontent.com/78490891/236444961-cd84be07-165e-4140-a198-18ef5d696472.png)


### Fix

![image](https://user-images.githubusercontent.com/78490891/236445117-ab622433-7550-4f53-a952-aba4df2f41af.png)
