### PR TITLE
feat: Retry fetching missing user/conversation metadata every 3h (FS-1691)

### DIFF
--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -1422,11 +1422,14 @@ describe('ConversationRepository', () => {
     it('should not call loadMissingConversations & refreshAllConversationsUnavailableParticipants for non federated envs', async () => {
       const conversationRepo = await testFactory.exposeConversationActors();
 
-      spyOn(testFactory.conversation_repository!, 'loadMissingConversations').and.callThrough();
-      spyOn(testFactory.conversation_repository!, 'refreshAllConversationsUnavailableParticipants').and.callThrough();
+      spyOn(conversationRepo, 'loadMissingConversations').and.callThrough();
+      spyOn(
+        conversationRepo,
+        'refreshAllConversationsUnavailableParticipants' as keyof ConversationRepository,
+      ).and.callThrough();
 
       expect(conversationRepo.loadMissingConversations).not.toHaveBeenCalled();
-      expect(conversationRepo.refreshAllConversationsUnavailableParticipants).not.toHaveBeenCalled();
+      expect(conversationRepo['refreshAllConversationsUnavailableParticipants']).not.toHaveBeenCalled();
     });
 
     it('should call loadMissingConversations & refreshAllConversationsUnavailableParticipants every 3 hours for federated envs', async () => {
@@ -1435,15 +1438,18 @@ describe('ConversationRepository', () => {
       });
       const conversationRepo = await testFactory.exposeConversationActors();
 
-      spyOn(testFactory.conversation_repository!, 'loadMissingConversations').and.callThrough();
-      spyOn(testFactory.conversation_repository!, 'refreshAllConversationsUnavailableParticipants').and.callThrough();
+      spyOn(conversationRepo, 'loadMissingConversations').and.callThrough();
+      spyOn(
+        conversationRepo,
+        'refreshAllConversationsUnavailableParticipants' as keyof ConversationRepository,
+      ).and.callThrough();
 
       jest.advanceTimersByTime(3600000 * 4);
 
       await Promise.resolve();
 
       expect(conversationRepo.loadMissingConversations).toHaveBeenCalled();
-      expect(conversationRepo.refreshAllConversationsUnavailableParticipants).toHaveBeenCalled();
+      expect(conversationRepo['refreshAllConversationsUnavailableParticipants']).toHaveBeenCalled();
     });
   });
 });

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -100,8 +100,6 @@ describe('ConversationRepository', () => {
   };
 
   beforeAll(async () => {
-    jest.useFakeTimers();
-
     server = sinon.fakeServer.create();
     server.autoRespond = true;
 
@@ -145,7 +143,6 @@ describe('ConversationRepository', () => {
   afterAll(() => {
     server.restore();
     storage_service.clearStores();
-    jest.useRealTimers();
   });
 
   describe('filtered_conversations', () => {
@@ -1414,8 +1411,16 @@ describe('ConversationRepository', () => {
   });
 
   describe('scheduleMissingUsersAndConversationsMetadataRefresh', () => {
+    beforeAll(() => {
+      jest.useFakeTimers();
+    });
+
+    afterAll(() => {
+      jest.useRealTimers();
+    });
+
     it('should call loadMissingConversations & refreshAllConversationsUnavailableParticipants every 3 hours', async () => {
-      const conversationRepo = testFactory.conversation_repository!;
+      const conversationRepo = await testFactory.exposeConversationActors();
 
       spyOn(testFactory.conversation_repository!, 'loadMissingConversations').and.callThrough();
       spyOn(testFactory.conversation_repository!, 'refreshAllConversationsUnavailableParticipants').and.callThrough();

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -100,6 +100,8 @@ describe('ConversationRepository', () => {
   };
 
   beforeAll(async () => {
+    jest.useFakeTimers();
+
     server = sinon.fakeServer.create();
     server.autoRespond = true;
 
@@ -143,6 +145,7 @@ describe('ConversationRepository', () => {
   afterAll(() => {
     server.restore();
     storage_service.clearStores();
+    jest.useRealTimers();
   });
 
   describe('filtered_conversations', () => {
@@ -1407,6 +1410,22 @@ describe('ConversationRepository', () => {
       await conversationRepository.loadMissingConversations();
 
       expect(conversationState.missingConversations).toHaveLength(remoteConversations.failed.length);
+    });
+  });
+
+  describe('scheduleMissingUsersAndConversationsMetadataRefresh', () => {
+    it('should call loadMissingConversations & refreshAllConversationsUnavailableParticipants every 3 hours', async () => {
+      const conversationRepo = testFactory.conversation_repository!;
+
+      spyOn(testFactory.conversation_repository!, 'loadMissingConversations').and.callThrough();
+      spyOn(testFactory.conversation_repository!, 'refreshAllConversationsUnavailableParticipants').and.callThrough();
+
+      jest.advanceTimersByTime(3600000 * 4);
+
+      await Promise.resolve();
+
+      expect(conversationRepo.loadMissingConversations).toHaveBeenCalled();
+      expect(conversationRepo.refreshAllConversationsUnavailableParticipants).toHaveBeenCalled();
     });
   });
 });

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -1420,9 +1420,7 @@ describe('ConversationRepository', () => {
         return user;
       });
 
-      conversation.participating_user_ets.push(unavailableUsers[0]);
-      conversation.participating_user_ets.push(unavailableUsers[1]);
-      conversation.participating_user_ets.push(unavailableUsers[2]);
+      conversation.participating_user_ets.push(unavailableUsers[0], unavailableUsers[1], unavailableUsers[2]);
 
       const conversationRepo = await testFactory.exposeConversationActors();
       spyOn(testFactory.user_repository!, 'refreshUsers').and.callFake(() => {
@@ -1438,6 +1436,50 @@ describe('ConversationRepository', () => {
       expect(unavailableUsers[0].name).toBeTruthy();
       expect(unavailableUsers[1].name).toBeTruthy();
       expect(unavailableUsers[2].name).toBeTruthy();
+    });
+  });
+
+  describe('refreshAllConversationsUnavailableParticipants', () => {
+    it('should refresh all unavailable users & conversations', async () => {
+      const conversation1 = _generateConversation();
+      const conversation2 = _generateConversation();
+      const unavailableUsers1 = [generateUser(), generateUser(), generateUser()].map(user => {
+        user.id = '';
+        user.name('');
+        return user;
+      });
+      const unavailableUsers2 = [generateUser(), generateUser(), generateUser()].map(user => {
+        user.id = '';
+        user.name('');
+        return user;
+      });
+
+      conversation1.participating_user_ets.push(unavailableUsers1[0], unavailableUsers1[1], unavailableUsers1[2]);
+      conversation2.participating_user_ets.push(unavailableUsers2[0], unavailableUsers2[1], unavailableUsers2[2]);
+
+      const conversationRepo = await testFactory.exposeConversationActors();
+      testFactory.conversation_repository!['conversationState'].conversations([conversation1, conversation2]);
+
+      spyOn(testFactory.user_repository!, 'refreshUsers').and.callFake(() => {
+        unavailableUsers1.map(user => {
+          user.id = createUuid();
+          user.name(faker.name.fullName());
+        });
+        unavailableUsers2.map(user => {
+          user.id = createUuid();
+          user.name(faker.name.fullName());
+        });
+      });
+
+      await conversationRepo['refreshAllConversationsUnavailableParticipants']();
+
+      expect(testFactory.user_repository!.refreshUsers).toHaveBeenCalled();
+      expect(unavailableUsers1[0].name).toBeTruthy();
+      expect(unavailableUsers1[1].name).toBeTruthy();
+      expect(unavailableUsers1[2].name).toBeTruthy();
+      expect(unavailableUsers2[0].name).toBeTruthy();
+      expect(unavailableUsers2[1].name).toBeTruthy();
+      expect(unavailableUsers2[2].name).toBeTruthy();
     });
   });
 

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -1419,7 +1419,20 @@ describe('ConversationRepository', () => {
       jest.useRealTimers();
     });
 
-    it('should call loadMissingConversations & refreshAllConversationsUnavailableParticipants every 3 hours', async () => {
+    it('should not call loadMissingConversations & refreshAllConversationsUnavailableParticipants for non federated envs', async () => {
+      const conversationRepo = await testFactory.exposeConversationActors();
+
+      spyOn(testFactory.conversation_repository!, 'loadMissingConversations').and.callThrough();
+      spyOn(testFactory.conversation_repository!, 'refreshAllConversationsUnavailableParticipants').and.callThrough();
+
+      expect(conversationRepo.loadMissingConversations).not.toHaveBeenCalled();
+      expect(conversationRepo.refreshAllConversationsUnavailableParticipants).not.toHaveBeenCalled();
+    });
+
+    it('should call loadMissingConversations & refreshAllConversationsUnavailableParticipants every 3 hours for federated envs', async () => {
+      Object.defineProperty(container.resolve(Core).backendFeatures, 'isFederated', {
+        get: jest.fn(() => true),
+      });
       const conversationRepo = await testFactory.exposeConversationActors();
 
       spyOn(testFactory.conversation_repository!, 'loadMissingConversations').and.callThrough();

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -291,7 +291,10 @@ export class ConversationRepository {
 
     this.conversationRoleRepository = new ConversationRoleRepository(this.teamRepository, this.conversationService);
     this.leaveCall = noop;
-    this.scheduleMissingUsersAndConversationsMetadataRefresh();
+
+    if (this.core.backendFeatures.isFederated) {
+      this.scheduleMissingUsersAndConversationsMetadataRefresh();
+    }
   }
 
   checkMessageTimer(messageEntity: ContentMessage): void {
@@ -484,9 +487,6 @@ export class ConversationRepository {
    * @Note Federation only
    */
   private readonly scheduleMissingUsersAndConversationsMetadataRefresh = () => {
-    if (!this.core.backendFeatures.isFederated) {
-      return;
-    }
     window.setInterval(async () => {
       try {
         await this.loadMissingConversations();

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -469,9 +469,9 @@ export class ConversationRepository {
   }
 
   public async refreshAllConversationsUnavailableParticipants(): Promise<void> {
-    const allUnavailableUsers = this.conversationState.conversations().flatMap(conversation => {
-      return conversation.allUserEntities().filter(user => !user.isAvailable());
-    });
+    const allUnavailableUsers = this.conversationState
+      .conversations()
+      .flatMap(conversation => conversation.allUserEntities().filter(user => !user.isAvailable()));
 
     if (!allUnavailableUsers.length) {
       return;

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -484,6 +484,9 @@ export class ConversationRepository {
    * @Note Federation only
    */
   private readonly scheduleMissingUsersAndConversationsMetadataRefresh = () => {
+    if (!this.core.backendFeatures.isFederated) {
+      return;
+    }
     window.setInterval(async () => {
       try {
         await this.loadMissingConversations();

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -469,10 +469,10 @@ export class ConversationRepository {
   }
 
   public async refreshAllConversationsUnavailableParticipants(): Promise<void> {
-    const allUnavailableUsers: User[] = [];
-    this.conversationState.conversations().forEach(conversation => {
-      allUnavailableUsers.push(...conversation.allUserEntities().filter(user => !user.isAvailable()));
+    const allUnavailableUsers = this.conversationState.conversations().flatMap(conversation => {
+      return conversation.allUserEntities().filter(user => !user.isAvailable());
     });
+
     if (!allUnavailableUsers.length) {
       return;
     }

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -471,7 +471,7 @@ export class ConversationRepository {
     await this.userRepository.refreshUsers(unavailableUsers.map(user => user.qualifiedId));
   }
 
-  public async refreshAllConversationsUnavailableParticipants(): Promise<void> {
+  private async refreshAllConversationsUnavailableParticipants(): Promise<void> {
     const allUnavailableUsers = this.conversationState
       .conversations()
       .flatMap(conversation => conversation.allUserEntities().filter(user => !user.isAvailable()));


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1691" title="FS-1691" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />FS-1691</a>  [web] Retry fetching missing user/conversation metadata every 3h
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Scenario:

- Backend A & B are federated.
- User X from A & User Y from B are in a conversation.
- Connection between A & B goes offline.
- User X does a fresh login with no previous data on its local database.

## Issue:

At this point user X is unable to fetch the meta data of user Y because the data lives on the B backend and connection is offline.

## Solution 
@atomrc Has already implemented a try to refetch that missing meta data when opening the user details menu here:
https://github.com/wireapp/wire-webapp/pull/14975

This PR will add another solution to this issue to try to refetch all missing data every 3 hours.