### PR TITLE
fix: address unavailable user display issues [FS-1684, FS-1570]

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/Warnings/PartialFailureToSend/PartialFailureToSend.test.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/Warnings/PartialFailureToSend/PartialFailureToSend.test.tsx
@@ -32,7 +32,7 @@ setStrings({en});
 function generateUsers(nbUsers: number, domain: string) {
   const users: User[] = [];
   for (let i = 0; i < nbUsers; i++) {
-    users.push({qualifiedId: {id: createUuid(), domain}, username: () => `User ${i}`});
+    users.push({qualifiedId: {id: createUuid(), domain}, name: () => `User ${i}`});
   }
   return users;
 }
@@ -124,7 +124,7 @@ describe('PartialFailureToSendWarning', () => {
     );
 
     expect(queryByText('Show details')).toBeNull();
-    expect(container.textContent).toContain(`${users[0].username()} will get your message later`);
+    expect(container.textContent).toContain(`${users[0].name()} will get your message later`);
   });
 
   it('does not show the extra info toggle if there is only a single unreachable user', () => {

--- a/src/script/components/MessagesList/Message/ContentMessage/Warnings/PartialFailureToSend/PartialFailureToSend.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/Warnings/PartialFailureToSend/PartialFailureToSend.tsx
@@ -30,7 +30,7 @@ import {matchQualifiedIds} from 'Util/QualifiedId';
 
 import {warning} from '../Warnings.styles';
 
-export type User = {qualifiedId: QualifiedId; username: () => string};
+export type User = {qualifiedId: QualifiedId; name: () => string};
 type Props = {
   failedToSend: {queued?: QualifiedUserClients; failed?: QualifiedId[]};
   knownUsers: User[];
@@ -44,7 +44,7 @@ function generateNamedUsers(users: User[], userClients: QualifiedUserClients): P
       const domainNamedUsers = Object.keys(domainUsers).reduce<ParsedUsers>(
         (domainNamedUsers, userId) => {
           const user = users.find(user => matchQualifiedIds(user.qualifiedId, {id: userId, domain}));
-          if (user && user.username()) {
+          if (user && user.name()) {
             domainNamedUsers.namedUsers.push(user);
           } else {
             domainNamedUsers.unknownUsers.push({id: userId, domain});
@@ -92,7 +92,7 @@ export const PartialFailureToSendWarning = ({failedToSend, knownUsers}: Props) =
     message.head = t('messageFailedToSendParticipants', {count: userCount.toString()});
     message.rest = t('messageFailedToSendPlural');
   } else if (namedUsers.length === 1) {
-    message.head = namedUsers[0].username();
+    message.head = namedUsers[0].name();
     message.rest = t('messageFailedToSendWillReceiveSingular');
   } else if (unreachableUsers.length === 1) {
     message.head = t('messageFailedToSendParticipantsFromDomainSingular', {domain: unreachableUsers[0].domain});
@@ -120,7 +120,7 @@ export const PartialFailureToSendWarning = ({failedToSend, knownUsers}: Props) =
                         data-uie-value={user.qualifiedId.id}
                         key={user.qualifiedId.id}
                       >
-                        {user.username()}
+                        {user.name()}
                       </Bold>
                     )),
                     ', ',

--- a/src/script/components/MessagesList/Message/ContentMessage/Warnings/PartialFailureToSend/PartialFailureToSend.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/Warnings/PartialFailureToSend/PartialFailureToSend.tsx
@@ -44,7 +44,7 @@ function generateNamedUsers(users: User[], userClients: QualifiedUserClients): P
       const domainNamedUsers = Object.keys(domainUsers).reduce<ParsedUsers>(
         (domainNamedUsers, userId) => {
           const user = users.find(user => matchQualifiedIds(user.qualifiedId, {id: userId, domain}));
-          if (user) {
+          if (user && user.username()) {
             domainNamedUsers.namedUsers.push(user);
           } else {
             domainNamedUsers.unknownUsers.push({id: userId, domain});
@@ -81,7 +81,9 @@ export const PartialFailureToSendWarning = ({failedToSend, knownUsers}: Props) =
 
   const showToggle = userCount > 1;
 
-  const {namedUsers} = generateNamedUsers(knownUsers, queued);
+  const {namedUsers, unknownUsers} = generateNamedUsers(knownUsers, queued);
+
+  failed.push(...unknownUsers);
 
   const unreachableUsers = generateUnreachableUsers(failed);
 

--- a/src/script/entity/Conversation.test.ts
+++ b/src/script/entity/Conversation.test.ts
@@ -484,11 +484,11 @@ describe('Conversation', () => {
     it('displays a fallback if no user name has been set', () => {
       conversation_et.type(CONVERSATION_TYPE.ONE_TO_ONE);
 
-      expect(conversation_et.display_name()).toBe('…');
+      expect(conversation_et.display_name()).toBe('Name not available');
 
       conversation_et.type(CONVERSATION_TYPE.CONNECT);
 
-      expect(conversation_et.display_name()).toBe('…');
+      expect(conversation_et.display_name()).toBe('Name not available');
     });
 
     it('displays a group conversation name with names from the participants', () => {

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -503,19 +503,19 @@ export class Conversation {
      *
      * - Name of the other participant
      * - Name of the other user of the associated connection
-     * - "..." if neither of those has been attached yet
+     * - "Name not available" if neither of those has been attached yet
      *
      * 'Group Conversation':
      * - Conversation name received from backend
      * - If unnamed, we will create a name from the participant names
      * - Join the user's first names to a comma separated list or uses the user's first name if only one user participating
-     * - "..." if the user entities have not yet been attached yet
+     * - "..." if the user entities have not yet been attached
      */
     this.display_name = ko.pureComputed(() => {
       if (this.isRequest() || this.is1to1()) {
         const [userEntity] = this.participating_user_ets();
         const userName = userEntity?.name();
-        return userName || '…';
+        return userName || t('unavailableUser');
       }
 
       if (this.isGroup()) {

--- a/src/script/notification/NotificationRepository.test.ts
+++ b/src/script/notification/NotificationRepository.test.ts
@@ -158,7 +158,7 @@ describe('NotificationRepository', () => {
 
           notification_content.title = truncate(titleText, titleLength, false);
         } else {
-          notification_content.title = '…';
+          notification_content.title = 'Name not available';
         }
 
         const [firstResultArgs] = showNotificationSpy.mock.calls[0];
@@ -685,7 +685,7 @@ describe('NotificationRepository', () => {
 
   describe('shows a well-formed request notification', () => {
     let connectionEntity: ConnectionEntity;
-    const expected_title = '…';
+    const expected_title = 'Name not available';
     let memberMessage: MemberMessage;
 
     beforeEach(() => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1684" title="FS-1684" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />FS-1684</a>  [web] Display fallback UI for user profile when user metadata is not available 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1570" title="FS-1570" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />FS-1570</a>  [web] Show system message indicating who will receive the message later
  </td></table>

### Issues found in playtest

- warning message for some unreachable users displays "\*empty string\*, \*empty string\* will receive your message later. It should be "2 users from \*offline b-e\* won't get your message"
- Conversation title for unreachable user is "...", should be "Name not available"
![image](https://github.com/wireapp/wire-webapp/assets/78490891/7ddd59d2-e312-423e-a3db-44650671e6dc)
- Handles were used in warning message instead of display names

### Solutions

- implement logic to add users with id stored in conversation but no session initiated to the list of unreachable users
- replace "..." by "Name not available" for 1 on 1 conversation titles (no change to group conversations)
![Screenshot from 2023-05-11 16-57-50](https://github.com/wireapp/wire-webapp/assets/78490891/198e0ec8-4f0c-4679-ab2c-3efec5a70ad3)
- replace handle by display name for known users
![image](https://github.com/wireapp/wire-webapp/assets/78490891/eb310d90-6f34-42d2-b7da-c352dd60e39b)
