### PR TITLE
runfix: prevent storage of duplicate missing conversations [FS-1689]

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -593,6 +593,9 @@ export class ConversationRepository {
     let conversationsData: any[];
 
     if (remoteConversations.failed?.length) {
+      if (missingConversations) {
+        this.conversationState.missingConversations = [...new Set(remoteConversations.failed)];
+      }
       missingConversations.push(...remoteConversations.failed);
     }
 

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -549,16 +549,11 @@ export class ConversationRepository {
    * @returns all the conversations from backend merged with the locally stored conversations and loaded into memory
    */
   public async loadConversations(): Promise<Conversation[]> {
-    const remoteConversationsPromise = this.conversationService.getAllConversations().catch(error => {
+    const remoteConversations = await this.conversationService.getAllConversations().catch(error => {
       this.logger.error(`Failed to get all conversations from backend: ${error.message}`);
       return {found: []} as RemoteConversations;
     });
-
-    const [localConversations, remoteConversations] = await Promise.all([
-      this.conversationService.loadConversationStatesFromDb<ConversationDatabaseData>(),
-      remoteConversationsPromise,
-    ]);
-    return this.loadRemoteConversations(remoteConversations, localConversations);
+    return this.loadRemoteConversations(remoteConversations);
   }
 
   /**
@@ -582,22 +577,11 @@ export class ConversationRepository {
   /**
    * Will append the new conversations from backend to the locally stored conversations in memory
    * @param remoteConversations new conversations fetched from backend
-   * @param localConversations conversations locally stored in database, but not in memory. Omitted after first loading of the app
    * @returns the new conversations from backend merged with the locally stored conversations
    */
-  private async loadRemoteConversations(
-    remoteConversations: RemoteConversations,
-    localConversations: ConversationDatabaseData[] = [],
-  ): Promise<Conversation[]> {
-    const {missingConversations} = this.conversationState;
+  private async loadRemoteConversations(remoteConversations: RemoteConversations): Promise<Conversation[]> {
+    const localConversations = await this.conversationService.loadConversationStatesFromDb<ConversationDatabaseData>();
     let conversationsData: any[];
-
-    if (remoteConversations.failed?.length) {
-      if (missingConversations) {
-        this.conversationState.missingConversations = [...new Set(remoteConversations.failed)];
-      }
-      missingConversations.push(...remoteConversations.failed);
-    }
 
     if (!remoteConversations.found?.length) {
       conversationsData = localConversations;
@@ -613,12 +597,11 @@ export class ConversationRepository {
           .conversations()
           .some(storedConversations => storedConversations.id === allConversations.id),
     );
-    this.saveConversations(newConversationEntities);
+    if (newConversationEntities.length) {
+      this.saveConversations(newConversationEntities);
+    }
 
-    const remainingMissingConversations = missingConversations.filter(missingConversationsId =>
-      newConversationEntities.some(conversation => conversation.id !== missingConversationsId.id),
-    );
-    this.conversationState.missingConversations = [...new Set(remainingMissingConversations)];
+    this.conversationState.missingConversations = [...new Set(remoteConversations.failed)];
 
     return this.conversationState.conversations();
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1689" title="FS-1689" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />FS-1689</a>  [web] Retry fetching missing conversation metadata when the Search UI is opened 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


### Fix

- fix an issue where duplicate missing conversations would be added every time a user opens the search UI when a b-e is offline