### PR TITLE
runfix: update url after creating conversation

### DIFF
--- a/src/script/components/Avatar/Avatar.tsx
+++ b/src/script/components/Avatar/Avatar.tsx
@@ -20,7 +20,7 @@
 import {FC, HTMLProps, MouseEvent as ReactMouseEvent, KeyboardEvent as ReactKeyBoardEvent} from 'react';
 
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
-import {handleKeyDown} from 'Util/KeyboardUtil';
+import {handleKeyDown, isKeyboardEvent} from 'Util/KeyboardUtil';
 
 import {PlaceholderAvatar} from './PlaceholderAvatar';
 import {ServiceAvatar} from './ServiceAvatar';
@@ -95,7 +95,7 @@ const Avatar: FC<AvatarProps> = ({
   ) => {
     const parentNode = event.currentTarget.parentNode;
     if (parentNode) {
-      if ('key' in event) {
+      if (isKeyboardEvent(event)) {
         handleKeyDown(event, () => onAvatarClick?.(participant));
         return;
       }

--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -39,7 +39,7 @@ import {UserSearchableList} from 'Components/UserSearchableList';
 import {generateConversationUrl} from 'src/script/router/routeGenerator';
 import {createNavigate, createNavigateKeyboard} from 'src/script/router/routerBindings';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
-import {handleEnterDown, offEscKey, onEscKey} from 'Util/KeyboardUtil';
+import {handleEnterDown, isKeyboardEvent, offEscKey, onEscKey} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
 import {getLogger} from 'Util/Logger';
 import {sortUsersByPriority} from 'Util/StringUtil';
@@ -221,7 +221,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
         );
         setIsShown(false);
 
-        if ('key' in event) {
+        if (isKeyboardEvent(event)) {
           createNavigateKeyboard(generateConversationUrl(conversation.qualifiedId), true)(event);
         } else {
           createNavigate(generateConversationUrl(conversation.qualifiedId))(event);

--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -37,7 +37,7 @@ import {BaseToggle} from 'Components/toggle/BaseToggle';
 import {InfoToggle} from 'Components/toggle/InfoToggle';
 import {UserSearchableList} from 'Components/UserSearchableList';
 import {generateConversationUrl} from 'src/script/router/routeGenerator';
-import {createNavigate} from 'src/script/router/routerBindings';
+import {createNavigate, createNavigateKeyboard} from 'src/script/router/routerBindings';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {handleEnterDown, offEscKey, onEscKey} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
@@ -203,7 +203,9 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
     setAccessState(ACCESS_STATE.TEAM.GUESTS_SERVICES);
   };
 
-  const clickOnCreate = async (event: React.MouseEvent<HTMLButtonElement, MouseEvent>): Promise<void> => {
+  const clickOnCreate = async (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent> | React.KeyboardEvent<HTMLInputElement>,
+  ): Promise<void> => {
     if (!isCreatingConversation) {
       setIsCreatingConversation(true);
 
@@ -218,7 +220,12 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
           },
         );
         setIsShown(false);
-        createNavigate(generateConversationUrl(conversation.qualifiedId))(event);
+
+        if ('key' in event) {
+          createNavigateKeyboard(generateConversationUrl(conversation.qualifiedId), true)(event);
+        } else {
+          createNavigate(generateConversationUrl(conversation.qualifiedId))(event);
+        }
       } catch (error) {
         setIsCreatingConversation(false);
         logger.error(error);
@@ -351,7 +358,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
             selectedUsers={selectedContacts}
             setSelectedUsers={setSelectedContacts}
             placeholder={t('groupCreationParticipantsPlaceholder')}
-            enter={clickOnCreate}
+            onEnter={clickOnCreate}
           />
         )}
 

--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -36,6 +36,8 @@ import {TextInput} from 'Components/TextInput';
 import {BaseToggle} from 'Components/toggle/BaseToggle';
 import {InfoToggle} from 'Components/toggle/InfoToggle';
 import {UserSearchableList} from 'Components/UserSearchableList';
+import {generateConversationUrl} from 'src/script/router/routeGenerator';
+import {createNavigate} from 'src/script/router/routerBindings';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {handleEnterDown, offEscKey, onEscKey} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
@@ -201,12 +203,12 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
     setAccessState(ACCESS_STATE.TEAM.GUESTS_SERVICES);
   };
 
-  const clickOnCreate = async (): Promise<void> => {
+  const clickOnCreate = async (event: React.MouseEvent<HTMLButtonElement, MouseEvent>): Promise<void> => {
     if (!isCreatingConversation) {
       setIsCreatingConversation(true);
 
       try {
-        const conversationEntity = await conversationRepository.createGroupConversation(
+        const conversation = await conversationRepository.createGroupConversation(
           selectedContacts,
           groupName,
           isTeam ? accessState : undefined,
@@ -216,7 +218,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
           },
         );
         setIsShown(false);
-        amplify.publish(WebAppEvents.CONVERSATION.SHOW, conversationEntity, {});
+        createNavigate(generateConversationUrl(conversation.qualifiedId))(event);
       } catch (error) {
         setIsCreatingConversation(false);
         logger.error(error);

--- a/src/script/components/SearchInput.tsx
+++ b/src/script/components/SearchInput.tsx
@@ -30,7 +30,7 @@ import type {User} from '../entity/User';
 import {MAX_HANDLE_LENGTH} from '../user/UserHandleGenerator';
 
 export interface SearchInputProps {
-  enter?: () => void | Promise<void>;
+  onEnter?: (event: React.KeyboardEvent<HTMLInputElement>) => void | Promise<void>;
   /** Will force the component to have a dark theme and not follow user's theme */
   forceDark?: boolean;
   input: string;
@@ -41,7 +41,7 @@ export interface SearchInputProps {
 }
 
 const SearchInput: React.FC<SearchInputProps> = ({
-  enter: onEnter,
+  onEnter,
   input,
   selectedUsers = [],
   setSelectedUsers = () => {},
@@ -88,7 +88,7 @@ const SearchInput: React.FC<SearchInputProps> = ({
                 setSelectedUsers(selectedUsers.slice(0, -1));
               } else if (isEnterKey(event.nativeEvent)) {
                 event.preventDefault();
-                onEnter?.();
+                onEnter?.(event);
               }
               return true;
             }}

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
@@ -27,7 +27,7 @@ import {ConversationListCell} from 'Components/list/ConversationListCell';
 import {Call} from 'src/script/calling/Call';
 import {User} from 'src/script/entity/User';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
-import {handleKeyDown} from 'Util/KeyboardUtil';
+import {handleKeyDown, isKeyboardEvent} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
 import {matchQualifiedIds} from 'Util/QualifiedId';
 
@@ -110,7 +110,7 @@ export const ConversationsList = ({
               dataUieName="item-conversation"
               conversation={conversation}
               onClick={event => {
-                if ('key' in event) {
+                if (isKeyboardEvent(event)) {
                   createNavigateKeyboard(generateConversationUrl(conversation.qualifiedId), true)(event);
                 } else {
                   createNavigate(generateConversationUrl(conversation.qualifiedId))(event);

--- a/src/script/page/LeftSidebar/panels/Conversations/GroupedConversationsFolder.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/GroupedConversationsFolder.tsx
@@ -24,6 +24,7 @@ import type {ConversationLabel} from 'src/script/conversation/ConversationLabelR
 import {Conversation} from 'src/script/entity/Conversation';
 import {ListViewModel} from 'src/script/view_model/ListViewModel';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
+import {isKeyboardEvent} from 'Util/KeyboardUtil';
 
 import {GroupedConversationHeader} from './GroupedConversationHeader';
 
@@ -67,7 +68,7 @@ const GroupedConversationsFolder = ({
               handleArrowKeyDown={handleKeyDown(index)}
               resetConversationFocus={resetConversationFocus}
               onClick={event => {
-                if ('key' in event) {
+                if (isKeyboardEvent(event)) {
                   createNavigateKeyboard(generateConversationUrl(conversation.qualifiedId), true)(event);
                 } else {
                   createNavigate(generateConversationUrl(conversation.qualifiedId))(event);

--- a/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
@@ -152,7 +152,7 @@ const StartUI: React.FC<StartUIProps> = ({
           placeholder={t('searchPeoplePlaceholder')}
           selectedUsers={[]}
           setInput={setSearchQuery}
-          enter={openFirstConversation}
+          onEnter={openFirstConversation}
           forceDark
         />
       </div>

--- a/src/script/util/KeyboardUtil.ts
+++ b/src/script/util/KeyboardUtil.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import type {KeyboardEvent as ReactKeyboardEvent} from 'react';
+import type {KeyboardEvent as ReactKeyboardEvent, SyntheticEvent as ReactEvent} from 'react';
 
 import {Runtime} from '@wireapp/commons';
 
@@ -52,6 +52,10 @@ export const isPageUpDownKey = (keyboardEvent: KeyboardEvent): boolean =>
 export const isKey = (keyboardEvent?: KeyboardEvent | ReactKeyboardEvent, expectedKey = '') => {
   const eventKey = keyboardEvent?.key?.toLowerCase() || '';
   return eventKey === expectedKey.toLowerCase();
+};
+
+export const isKeyboardEvent = (event: Event | ReactEvent): event is KeyboardEvent | ReactKeyboardEvent => {
+  return 'key' in event;
 };
 
 export const isTabKey = (keyboardEvent: KeyboardEvent | ReactKeyboardEvent): boolean => isKey(keyboardEvent, KEY.TAB);


### PR DESCRIPTION
### Issue:
After creating a conversation, user was not navigated to the url of the new conversation. After creating a group, it did show up as `"active"` conversation, but after refreshing the page it would load a conversation that was `"active"` before creating a new one.

### Solution:
- Use our `createNavigate` util that will redirect the user to proper url.
- I've also improved `createGroupConversation` method's implementation to always return the conversation and fail otherwise (previously it would return undefined what doesn't make sense).