### PR TITLE
runfix: avoid failure to send props mutation

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/Warnings/PartialFailureToSend/PartialFailureToSend.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/Warnings/PartialFailureToSend/PartialFailureToSend.tsx
@@ -83,9 +83,7 @@ export const PartialFailureToSendWarning = ({failedToSend, knownUsers}: Props) =
 
   const {namedUsers, unknownUsers} = generateNamedUsers(knownUsers, queued);
 
-  failed.push(...unknownUsers);
-
-  const unreachableUsers = generateUnreachableUsers(failed);
+  const unreachableUsers = generateUnreachableUsers([...failed, ...unknownUsers]);
 
   const message = {head: '', rest: ''};
   if (showToggle) {


### PR DESCRIPTION
### Issue

- avoid mutating the props `failedToSend.failed` by pushing `unknownUsers`