### PR TITLE
runfix: log only unhandled errors in group creation flow

### DIFF
--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -41,7 +41,6 @@ import {createNavigate, createNavigateKeyboard} from 'src/script/router/routerBi
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {handleEnterDown, isKeyboardEvent, offEscKey, onEscKey} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
-import {getLogger} from 'Util/Logger';
 import {sortUsersByPriority} from 'Util/StringUtil';
 
 import {Config} from '../../../Config';
@@ -68,8 +67,6 @@ enum GroupCreationModalState {
   PARTICIPANTS = 'GroupCreationModal.STATE.PARTICIPANTS',
   PREFERENCES = 'GroupCreationModal.STATE.PREFERENCES',
 }
-
-const logger = getLogger('GroupCreationModal');
 
 const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
   userState = container.resolve(UserState),
@@ -232,7 +229,6 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
       } catch (error) {
         amplify.publish(WebAppEvents.CONVERSATION.SHOW, undefined, {});
         setIsCreatingConversation(false);
-        logger.error(error);
       }
 
       setIsShown(false);

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -455,18 +455,23 @@ export class ConversationRepository {
       }
       return conversationEntity;
     } catch (error) {
-      if (isBackendError(error)) {
-        switch (error.label) {
-          case BackendErrorLabel.CLIENT_ERROR:
-            this.handleTooManyMembersError();
-            break;
-          case BackendErrorLabel.NOT_CONNECTED:
-            await this.handleUsersNotConnected(userEntities.map(user => user.qualifiedId));
-            break;
-          case BackendErrorLabel.LEGAL_HOLD_MISSING_CONSENT:
-            this.showLegalHoldConsentError();
-            break;
-        }
+      if (!isBackendError(error)) {
+        this.logger.error(error);
+        throw error;
+      }
+
+      switch (error.label) {
+        case BackendErrorLabel.CLIENT_ERROR:
+          this.handleTooManyMembersError();
+          break;
+        case BackendErrorLabel.NOT_CONNECTED:
+          await this.handleUsersNotConnected(userEntities.map(user => user.qualifiedId));
+          break;
+        case BackendErrorLabel.LEGAL_HOLD_MISSING_CONSENT:
+          this.showLegalHoldConsentError();
+          break;
+        default:
+          this.logger.error(error);
       }
       throw error;
     }


### PR DESCRIPTION
Log group-creation errors only when they're not handled.