### PR TITLE
fix: Fix group name change, focus edit icon

### DIFF
--- a/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsHeader/ConversationDetailsHeader.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsHeader/ConversationDetailsHeader.tsx
@@ -117,7 +117,6 @@ const ConversationDetailsHeader: FC<ConversationDetailsHeaderProps> = ({
           {!isEditingName ? (
             <div
               className="conversation-details__name"
-              title={t('tooltipConversationDetailsRename')}
               data-uie-name="status-name"
               {...(canRenameGroup && {
                 onClick: clickToEditGroupName,
@@ -130,7 +129,7 @@ const ConversationDetailsHeader: FC<ConversationDetailsHeaderProps> = ({
                   className="conversation-details__name__edit-icon"
                   aria-label={t('tooltipConversationDetailsRename')}
                 >
-                  <Icon.Edit aria-hidden="true" />
+                  <Icon.Edit />
                 </button>
               )}
             </div>

--- a/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsHeader/ConversationDetailsHeader.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsHeader/ConversationDetailsHeader.tsx
@@ -126,8 +126,11 @@ const ConversationDetailsHeader: FC<ConversationDetailsHeaderProps> = ({
               {displayName && <span className="conversation-details__name">{displayName}</span>}
 
               {canRenameGroup && (
-                <button className="conversation-details__name__edit-icon">
-                  <Icon.Edit />
+                <button
+                  className="conversation-details__name__edit-icon"
+                  aria-label={t('tooltipConversationDetailsRename')}
+                >
+                  <Icon.Edit aria-hidden="true" />
                 </button>
               )}
             </div>

--- a/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsHeader/ConversationDetailsHeader.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsHeader/ConversationDetailsHeader.tsx
@@ -53,6 +53,7 @@ const ConversationDetailsHeader: FC<ConversationDetailsHeaderProps> = ({
   isTeam = false,
 }) => {
   const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
+  const isEditGroupNameTouched = useRef(false);
 
   const [isEditingName, setIsEditingName] = useState<boolean>(false);
   const [groupName, setGroupName] = useState(displayName);
@@ -73,16 +74,16 @@ const ConversationDetailsHeader: FC<ConversationDetailsHeaderProps> = ({
     if (isEnterKey(event)) {
       event.preventDefault();
       const {value: currentValue} = event.currentTarget;
-
       const currentConversationName = displayName.trim();
       const newConversationName = removeLineBreaks(currentValue.trim());
-
       const isNameChanged = newConversationName !== currentConversationName;
 
       if (isNameChanged) {
         updateConversationName(newConversationName);
         setGroupName(newConversationName);
         setIsEditingName(false);
+
+        isEditGroupNameTouched.current = false;
       }
     }
   };
@@ -95,13 +96,17 @@ const ConversationDetailsHeader: FC<ConversationDetailsHeaderProps> = ({
         textAreaRef.current.style.height = `${scrollHeight}px`;
       }
 
-      setTimeout(() => {
-        const currentValue = textAreaRef.current?.value;
-        const caretPosition = currentValue?.length || 0;
+      if (!isEditGroupNameTouched.current) {
+        setTimeout(() => {
+          const currentValue = textAreaRef.current?.value;
+          const caretPosition = currentValue?.length || 0;
 
-        textAreaRef.current?.setSelectionRange(caretPosition, caretPosition);
-        textAreaRef.current?.focus();
-      }, 0);
+          textAreaRef.current?.setSelectionRange(caretPosition, caretPosition);
+          textAreaRef.current?.focus();
+
+          isEditGroupNameTouched.current = true;
+        }, 0);
+      }
     }
   }, [isEditingName, groupName]);
 
@@ -120,7 +125,11 @@ const ConversationDetailsHeader: FC<ConversationDetailsHeaderProps> = ({
             >
               {displayName && <span className="conversation-details__name">{displayName}</span>}
 
-              {canRenameGroup && <Icon.Edit className="conversation-details__name__edit-icon" />}
+              {canRenameGroup && (
+                <button className="conversation-details__name__edit-icon">
+                  <Icon.Edit />
+                </button>
+              )}
             </div>
           ) : (
             <textarea

--- a/src/style/panel/conversation-details.less
+++ b/src/style/panel/conversation-details.less
@@ -70,10 +70,18 @@
     }
 
     &__edit-icon {
-      flex-grow: 1;
-      margin-left: 11px;
+      display: flex;
+      align-items: center;
+      padding: 4px;
+      border: none;
+      margin-left: 7px;
+      background: transparent;
       opacity: 0;
       transition: opacity @animation-timing-faster @ease-in-quart;
+
+      &:focus {
+        opacity: 1;
+      }
 
       svg {
         width: 12px;


### PR DESCRIPTION
Fix for changing group name in Right Sidebar.

Previous: 
When user change cursor position and write smth, the cursor going to the end of the text.
We can't focus edit group name by keyboard.

Now: 
Changing group name work proper.
We can focus edit group name by keyboard.