### PR TITLE
fix: remove popup windows when status arent updated [SQSERVICES-2008]

### DIFF
--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -432,7 +432,7 @@ export class TeamRepository {
 
   private readonly handleFileSharingFeatureChange = (previousConfig: FeatureList, newConfig: FeatureList) => {
     const hasFileSharingChanged =
-      previousConfig?.fileSharing?.status && previousConfig?.fileSharing?.status !== newConfig?.fileSharing?.status;
+      previousConfig?.fileSharing?.status && previousConfig.fileSharing.status !== newConfig?.fileSharing?.status;
     const hasChangedToEnabled = newConfig?.fileSharing?.status === FeatureStatus.ENABLED;
 
     if (hasFileSharingChanged) {
@@ -450,7 +450,7 @@ export class TeamRepository {
   private readonly handleGuestLinkFeatureChange = (previousConfig: FeatureList, newConfig: FeatureList) => {
     const hasGuestLinkChanged =
       previousConfig?.conversationGuestLinks?.status &&
-      previousConfig?.conversationGuestLinks?.status !== newConfig?.conversationGuestLinks?.status;
+      previousConfig.conversationGuestLinks.status !== newConfig?.conversationGuestLinks?.status;
     const hasGuestLinkChangedToEnabled = newConfig?.conversationGuestLinks?.status === FeatureStatus.ENABLED;
 
     if (hasGuestLinkChanged) {
@@ -469,40 +469,41 @@ export class TeamRepository {
     {selfDeletingMessages: previousState}: FeatureList,
     {selfDeletingMessages: newState}: FeatureList,
   ) => {
-    if (previousState?.status) {
-      const previousTimeout = previousState?.config?.enforcedTimeoutSeconds * 1000;
-      const newTimeout = newState?.config?.enforcedTimeoutSeconds * 1000;
-      const previousStatus = previousState?.status;
-      const newStatus = newState?.status;
+    if (!previousState?.status) {
+      return;
+    }
+    const previousTimeout = previousState?.config?.enforcedTimeoutSeconds * 1000;
+    const newTimeout = (newState?.config?.enforcedTimeoutSeconds ?? 0) * 1000;
+    const previousStatus = previousState.status;
+    const newStatus = newState?.status;
 
-      const hasTimeoutChanged = previousTimeout !== newTimeout;
-      const isEnforced = newTimeout > SelfDeletingTimeout.OFF;
-      const hasStatusChanged = previousStatus !== newStatus;
-      const hasFeatureChanged = hasStatusChanged || hasTimeoutChanged;
-      const isFeatureEnabled = newStatus === FeatureStatus.ENABLED;
+    const hasTimeoutChanged = previousTimeout !== newTimeout;
+    const isEnforced = newTimeout > SelfDeletingTimeout.OFF;
+    const hasStatusChanged = previousStatus !== newStatus;
+    const hasFeatureChanged = hasStatusChanged || hasTimeoutChanged;
+    const isFeatureEnabled = newStatus === FeatureStatus.ENABLED;
 
-      if (hasFeatureChanged) {
-        PrimaryModal.show(PrimaryModal.type.ACKNOWLEDGE, {
-          text: {
-            htmlMessage: isFeatureEnabled
-              ? isEnforced
-                ? t('featureConfigChangeModalSelfDeletingMessagesDescriptionItemEnforced', {
-                    timeout: formatDuration(newTimeout).text,
-                  })
-                : t('featureConfigChangeModalSelfDeletingMessagesDescriptionItemEnabled')
-              : t('featureConfigChangeModalSelfDeletingMessagesDescriptionItemDisabled'),
-            title: t('featureConfigChangeModalSelfDeletingMessagesHeadline', {
-              brandName: Config.getConfig().BRAND_NAME,
-            }),
-          },
-        });
-      }
+    if (hasFeatureChanged) {
+      PrimaryModal.show(PrimaryModal.type.ACKNOWLEDGE, {
+        text: {
+          htmlMessage: isFeatureEnabled
+            ? isEnforced
+              ? t('featureConfigChangeModalSelfDeletingMessagesDescriptionItemEnforced', {
+                  timeout: formatDuration(newTimeout).text,
+                })
+              : t('featureConfigChangeModalSelfDeletingMessagesDescriptionItemEnabled')
+            : t('featureConfigChangeModalSelfDeletingMessagesDescriptionItemDisabled'),
+          title: t('featureConfigChangeModalSelfDeletingMessagesHeadline', {
+            brandName: Config.getConfig().BRAND_NAME,
+          }),
+        },
+      });
     }
   };
 
   private readonly handleAudioVideoFeatureChange = (previousConfig: FeatureList, newConfig: FeatureList) => {
     const hasVideoCallingChanged =
-      previousConfig?.videoCalling?.status && previousConfig?.videoCalling?.status !== newConfig?.videoCalling?.status;
+      previousConfig?.videoCalling?.status && previousConfig.videoCalling.status !== newConfig?.videoCalling?.status;
     const hasChangedToEnabled = newConfig?.videoCalling?.status === FeatureStatus.ENABLED;
 
     if (hasVideoCallingChanged) {
@@ -520,7 +521,7 @@ export class TeamRepository {
   private readonly handleConferenceCallingFeatureChange = (previousConfig: FeatureList, newConfig: FeatureList) => {
     if (
       previousConfig?.conferenceCalling?.status &&
-      previousConfig?.conferenceCalling?.status !== newConfig?.conferenceCalling?.status
+      previousConfig.conferenceCalling.status !== newConfig?.conferenceCalling?.status
     ) {
       const hasChangedToEnabled = newConfig?.conferenceCalling?.status === FeatureStatus.ENABLED;
       if (hasChangedToEnabled) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-2008" title="SQSERVICES-2008" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-2008</a>  [MacOS] Notification prompts received after logging in
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

prevent popups from showing if the config object is not created or missing property values

