### PR TITLE
fix: Do not show conversation with temporary users as classified (FS-1983)

### DIFF
--- a/src/script/components/input/ClassifiedBar.tsx
+++ b/src/script/components/input/ClassifiedBar.tsx
@@ -27,7 +27,8 @@ import {User} from 'src/script/entity/User';
 import {t} from 'Util/LocalizerUtil';
 
 function isClassified(users: User[], classifiedDomains: string[]): boolean {
-  if (users.some(user => !classifiedDomains.includes(user.domain))) {
+  // if a conversation has any temporary guests then it is not considered classified
+  if (users.some(user => !classifiedDomains.includes(user.domain) || user.isTemporaryGuest())) {
     return false;
   }
   return true;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1983" title="FS-1983" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1983</a>  [Web] Wrong classification when conversation includes a temporary user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
According to spec we should filter temporary users which we are not.
if a conversation has any temp users then it is not classified.