### PR TITLE
fix: Consider conversation domain for classified banner (FS-1980)

### DIFF
--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -776,7 +776,11 @@ const InputBar = ({
       {!!isTypingIndicatorEnabled && <TypingIndicator conversationId={conversationEntity.id} />}
 
       {classifiedDomains && !isConnectionRequest && (
-        <ClassifiedBar users={allUsers} classifiedDomains={classifiedDomains} />
+        <ClassifiedBar
+          conversationDomain={conversationEntity.domain}
+          users={allUsers}
+          classifiedDomains={classifiedDomains}
+        />
       )}
 
       {isReplying && !isEditing && <ReplyBar replyMessageEntity={replyMessageEntity} onCancel={handleCancelReply} />}

--- a/src/script/components/calling/CallingCell.tsx
+++ b/src/script/components/calling/CallingCell.tsx
@@ -447,7 +447,13 @@ const CallingCell: React.FC<CallingCellProps> = ({
             )
           )}
 
-          {classifiedDomains && <ClassifiedBar users={allUsers} classifiedDomains={classifiedDomains} />}
+          {classifiedDomains && (
+            <ClassifiedBar
+              conversationDomain={conversation.domain}
+              users={allUsers}
+              classifiedDomains={classifiedDomains}
+            />
+          )}
 
           {!isDeclined && (
             <>

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -257,6 +257,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
         />
         {classifiedDomains && (
           <ClassifiedBar
+            conversationDomain={conversation.domain}
             users={allUsers}
             classifiedDomains={classifiedDomains}
             style={{

--- a/src/script/components/input/ClassifiedBar.test.tsx
+++ b/src/script/components/input/ClassifiedBar.test.tsx
@@ -31,7 +31,7 @@ describe('ClassifiedBar', () => {
   const otherDomainUser = new User(createUuid(), 'other.domain');
 
   it.each([[[sameDomainUser]], [[sameDomainUser, otherDomainUser]]])('is empty if no domains are given', users => {
-    const {container} = render(<ClassifiedBar users={users} />);
+    const {container} = render(<ClassifiedBar users={users} conversationDomain="test" />);
 
     expect(container.querySelector('[data-uie-name=classified-label]')).toBe(null);
   });
@@ -39,7 +39,13 @@ describe('ClassifiedBar', () => {
   it.each([[[sameDomainUser]], [[classifiedDomainUser]], [[sameDomainUser, classifiedDomainUser]]])(
     'returns classified if all users in the classified domains',
     users => {
-      const {getByText, queryByText} = render(<ClassifiedBar users={users} classifiedDomains={classifiedDomains} />);
+      const {getByText, queryByText} = render(
+        <ClassifiedBar
+          conversationDomain={classifiedDomainUser.domain}
+          users={users}
+          classifiedDomains={classifiedDomains}
+        />,
+      );
 
       expect(getByText('conversationClassified')).not.toBe(null);
       expect(queryByText('conversationNotClassified')).toBe(null);
@@ -51,7 +57,9 @@ describe('ClassifiedBar', () => {
     [[classifiedDomainUser, otherDomainUser]],
     [[sameDomainUser, classifiedDomainUser, otherDomainUser]],
   ])('returns non-classified if a single user is from another domain', users => {
-    const {queryByText, getByText} = render(<ClassifiedBar users={users} classifiedDomains={classifiedDomains} />);
+    const {queryByText, getByText} = render(
+      <ClassifiedBar conversationDomain={classifiedDomains[0]} users={users} classifiedDomains={classifiedDomains} />,
+    );
 
     expect(queryByText('conversationClassified')).toBe(null);
     expect(getByText('conversationNotClassified')).not.toBe(null);

--- a/src/script/components/input/ClassifiedBar.tsx
+++ b/src/script/components/input/ClassifiedBar.tsx
@@ -27,6 +27,7 @@ import {User} from 'src/script/entity/User';
 import {t} from 'Util/LocalizerUtil';
 
 function isClassified(users: User[], classifiedDomains: string[], conversationDomain?: string): boolean {
+  // if a conversation is hosted on an unclassified domain it is not considered classified
   if (conversationDomain && !classifiedDomains.includes(conversationDomain)) {
     return false;
   }

--- a/src/script/components/input/ClassifiedBar.tsx
+++ b/src/script/components/input/ClassifiedBar.tsx
@@ -26,7 +26,10 @@ import {Icon} from 'Components/Icon';
 import {User} from 'src/script/entity/User';
 import {t} from 'Util/LocalizerUtil';
 
-function isClassified(users: User[], classifiedDomains: string[]): boolean {
+function isClassified(users: User[], classifiedDomains: string[], conversationDomain?: string): boolean {
+  if (conversationDomain && !classifiedDomains.includes(conversationDomain)) {
+    return false;
+  }
   // if a conversation has any temporary guests then it is not considered classified
   if (users.some(user => !classifiedDomains.includes(user.domain) || user.isTemporaryGuest())) {
     return false;
@@ -38,14 +41,15 @@ interface ClassifiedBarProps {
   classifiedDomains?: string[];
   style?: CSSObject;
   users: User[];
+  conversationDomain?: string;
 }
 
-const ClassifiedBar: React.FC<ClassifiedBarProps> = ({users, classifiedDomains, style}) => {
+const ClassifiedBar: React.FC<ClassifiedBarProps> = ({users, classifiedDomains, conversationDomain, style}) => {
   if (typeof classifiedDomains === 'undefined') {
     return null;
   }
 
-  const classified = isClassified(users, classifiedDomains);
+  const classified = isClassified(users, classifiedDomains, conversationDomain);
   const text = classified ? t('conversationClassified') : t('conversationNotClassified');
 
   return (

--- a/src/script/components/panel/UserDetails.tsx
+++ b/src/script/components/panel/UserDetails.tsx
@@ -37,6 +37,7 @@ import type {User} from '../../entity/User';
 export interface UserDetailsProps {
   badge?: string;
   classifiedDomains?: string[];
+  conversationDomain?: string;
   isGroupAdmin?: boolean;
   isSelfVerified: boolean;
   isVerified?: boolean;
@@ -51,6 +52,7 @@ export const UserDetailsComponent: React.FC<UserDetailsProps> = ({
   isGroupAdmin,
   avatarStyles,
   classifiedDomains,
+  conversationDomain,
 }) => {
   const user = useKoSubscribableChildren(participant, [
     'inTeam',
@@ -105,7 +107,13 @@ export const UserDetailsComponent: React.FC<UserDetailsProps> = ({
         </p>
       )}
 
-      {classifiedDomains && <ClassifiedBar users={[participant]} classifiedDomains={classifiedDomains} />}
+      {classifiedDomains && (
+        <ClassifiedBar
+          conversationDomain={conversationDomain}
+          users={[participant]}
+          classifiedDomains={classifiedDomains}
+        />
+      )}
 
       <Avatar
         className="panel-participant__avatar"

--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
@@ -294,6 +294,7 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
           {isSingleUserMode && !isServiceMode && firstParticipant && (
             <>
               <UserDetails
+                conversationDomain={activeConversation.domain}
                 participant={firstParticipant}
                 isVerified={isVerified}
                 isSelfVerified={isSelfVerified}

--- a/src/script/page/RightSidebar/GroupParticipantUser/GroupParticipantUser.tsx
+++ b/src/script/page/RightSidebar/GroupParticipantUser/GroupParticipantUser.tsx
@@ -148,6 +148,7 @@ const GroupParticipantUser: FC<GroupParticipantUserProps> = ({
 
       <FadingScrollbar className="panel__content">
         <UserDetails
+          conversationDomain={activeConversation.domain}
           participant={currentUser}
           badge={teamRepository.getRoleBadge(currentUser.id)}
           isGroupAdmin={isAdmin}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1980" title="FS-1980" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1980</a>  [Web] Wrong classification when conversation is on federated, unclassified backend
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

the conversation should be shown as UNCLASSIFIED, because it is hosted on a a unclassified domain.