### PR TITLE
runfix: include file extension when pasting file to input bar [SQSERVICES-2064]

### DIFF
--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -46,7 +46,7 @@ import {
   updateMentionRanges,
 } from 'Util/MentionUtil';
 import {formatDuration, formatLocale, TIME_IN_MILLIS} from 'Util/TimeUtil';
-import {getSelectionPosition} from 'Util/util';
+import {getFileExtension, getSelectionPosition} from 'Util/util';
 
 import {ControlButtons} from './components/InputBarControls/ControlButtons';
 import {GiphyButton} from './components/InputBarControls/GiphyButton';
@@ -583,7 +583,7 @@ const InputBar = ({
     const {lastModified} = pastedFile;
 
     const date = formatLocale(lastModified || new Date(), 'PP, pp');
-    const fileName = t('conversationSendPastedFile', date);
+    const fileName = `${t('conversationSendPastedFile', date)}.${getFileExtension(pastedFile.name)}`;
 
     const newFile = new File([pastedFile], fileName, {
       type: pastedFile.type,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-2064" title="SQSERVICES-2064" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-2064</a>  [Web] Add extension to file name when file was pasted to input bar
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Currently when file is pasted directly to input bar (cmd + v) we set a fixed name `"Pasted image at {{date}}"` without file extension. New Android is not able to display preview of such a image. Also when such a file is downloaded on new Android and sent back to web. Webapp is not able to display preview either. 

Solution is to include file extension in file name.