### PR TITLE
runfix: duplicate system messages

### DIFF
--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -19,6 +19,7 @@
 
 import React, {FC, useEffect, useLayoutEffect, useRef, useState} from 'react';
 
+import {CONVERSATION_EVENT} from '@wireapp/api-client/lib/event/';
 import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 import cx from 'classnames';
 
@@ -29,7 +30,9 @@ import {ContentMessage} from 'src/script/entity/message/ContentMessage';
 import {DecryptErrorMessage} from 'src/script/entity/message/DecryptErrorMessage';
 import {MemberMessage} from 'src/script/entity/message/MemberMessage';
 import {Message as MessageEntity} from 'src/script/entity/message/Message';
+import {SystemMessage} from 'src/script/entity/message/SystemMessage';
 import {User} from 'src/script/entity/User';
+import {ClientEvent} from 'src/script/event/Client';
 import {useRoveFocus} from 'src/script/hooks/useRoveFocus';
 import {ServiceEntity} from 'src/script/integration/ServiceEntity';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
@@ -69,25 +72,46 @@ interface MessagesListParams {
   setMsgElementsFocusable: (isMsgElementsFocusable: boolean) => void;
 }
 
-const filterDuplicatedMemberMessages = (messages: MessageEntity[]) => {
-  const typesToFilter = ['conversation.member-join', 'conversation.group-creation', 'conversation.member-leave'];
+const filterDuplicatedSystemMessages = (messages: MessageEntity[]) => {
   return messages.reduce<MessageEntity[]>((uniqMessages, currentMessage) => {
     if (isMemberMessage(currentMessage)) {
+      const typesToFilter = [
+        CONVERSATION_EVENT.MEMBER_JOIN,
+        CONVERSATION_EVENT.MEMBER_LEAVE,
+        ClientEvent.CONVERSATION.GROUP_CREATION,
+      ] as string[];
+
       const uniqMemberMessages = uniqMessages.filter(isMemberMessage);
 
       if (!!uniqMemberMessages.length && typesToFilter.includes(currentMessage.type)) {
         switch (currentMessage.type) {
-          case 'conversation.group-creation':
+          case ClientEvent.CONVERSATION.GROUP_CREATION:
             // Dont show duplicated group creation messages
             if (uniqMemberMessages.some(m => m.type === currentMessage.type)) {
               return uniqMessages;
             }
-          case 'conversation.member-join':
-          case 'conversation.member-leave':
+          case CONVERSATION_EVENT.MEMBER_JOIN:
+          case CONVERSATION_EVENT.MEMBER_LEAVE:
             // Dont show duplicated member join/leave messages that follow each other
             if (uniqMemberMessages?.[uniqMemberMessages.length - 1]?.htmlCaption() === currentMessage.htmlCaption()) {
               return uniqMessages;
             }
+        }
+      }
+    }
+
+    if (currentMessage.isSystem()) {
+      const systemMessagesToFilter = [CONVERSATION_EVENT.RENAME] as string[];
+      if (systemMessagesToFilter.includes(currentMessage.type)) {
+        const uniqUpdateMessages = uniqMessages.filter(
+          (message): message is SystemMessage => message.isSystem() && systemMessagesToFilter.includes(message.type),
+        );
+
+        if (uniqUpdateMessages.length > 0) {
+          // Dont show duplicated system messages that follow each other
+          if (uniqUpdateMessages?.[uniqUpdateMessages.length - 1]?.caption() === currentMessage.caption()) {
+            return uniqMessages;
+          }
         }
       }
     }
@@ -143,7 +167,7 @@ const MessagesList: FC<MessagesListParams> = ({
   const [loaded, setLoaded] = useState(false);
   const [focusedMessage, setFocusedMessage] = useState<string | undefined>(initialMessage?.id);
 
-  const filteredMessages = filterDuplicatedMemberMessages(filterHiddenMessages(allMessages));
+  const filteredMessages = filterDuplicatedSystemMessages(filterHiddenMessages(allMessages));
   const filteredMessagesLength = filteredMessages.length;
 
   const [messagesContainer, setMessageContainer] = useState<HTMLDivElement | null>(null);


### PR DESCRIPTION
Adds logic to filter duplicated system messages of given type.

Currently backend, when requesting notification stream, returns also the events you're the creator of, what results in some duplicated system messages in the chat. So far I've identified only `conversation.rename` being duplicated, but if we find different types of system messages that are duplicated it will be easy to cover them by just including them in `systemMessagesToFilter` array. 