### PR TITLE
chore: bump avs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@datadog/browser-rum": "^4.42.2",
     "@emotion/react": "11.11.0",
     "@types/eslint": "8.37.0",
-    "@wireapp/avs": "9.2.13",
+    "@wireapp/avs": "9.2.15",
     "@wireapp/core": "40.3.0",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.7.2",

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -123,7 +123,7 @@ export interface SubconversationEpochInfoMember {
   in_subconv: boolean;
 }
 
-type SubconversationData = {epoch: number; secretKey: string; keyLength: number};
+type SubconversationData = {epoch: number; secretKey: string};
 
 export class CallingRepository {
   private readonly acceptVersionWarning: (conversationId: QualifiedId) => void;
@@ -882,20 +882,13 @@ export class CallingRepository {
     members: SubconversationEpochInfoMember[],
   ) {
     const serializedConversationId = this.serializeQualifiedId(conversationId);
-    const {epoch, secretKey, keyLength} = subconversationData;
+    const {epoch, secretKey} = subconversationData;
     const clients = {
       convid: serializedConversationId,
       clients: members,
     };
 
-    return this.wCall?.setEpochInfo(
-      this.wUser,
-      serializedConversationId,
-      epoch,
-      JSON.stringify(clients),
-      secretKey,
-      keyLength,
-    );
+    return this.wCall?.setEpochInfo(this.wUser, serializedConversationId, epoch, JSON.stringify(clients), secretKey);
   }
 
   rejectCall(conversationId: QualifiedId): void {

--- a/src/script/view_model/CallingViewModel.mocks.ts
+++ b/src/script/view_model/CallingViewModel.mocks.ts
@@ -119,7 +119,6 @@ export const prepareMLSConferenceMocks = (parentGroupId: string, subGroupId: str
 
   const mockSecretKey = 'secretKey';
   const mockEpochNumber = 1;
-  const mockKeyLength = 32;
 
   jest
     .spyOn(mockCore.service!.mls!, 'joinConferenceSubconversation')
@@ -148,5 +147,5 @@ export const prepareMLSConferenceMocks = (parentGroupId: string, subGroupId: str
     .spyOn(mockCallingRepository, 'leaveCall')
     .mockImplementation(conversationId => callClosedCallback(conversationId, CONV_TYPE.CONFERENCE_MLS));
 
-  return {expectedMemberListResult, mockSecretKey, mockEpochNumber, mockKeyLength};
+  return {expectedMemberListResult, mockSecretKey, mockEpochNumber};
 };

--- a/src/script/view_model/CallingViewModel.test.ts
+++ b/src/script/view_model/CallingViewModel.test.ts
@@ -108,7 +108,7 @@ describe('CallingViewModel', () => {
     it('updates epoch info after initiating a call', async () => {
       const mockParentGroupId = 'mockParentGroupId1';
       const mockSubGroupId = 'mockSubGroupId1';
-      const {expectedMemberListResult, mockEpochNumber, mockKeyLength, mockSecretKey} = prepareMLSConferenceMocks(
+      const {expectedMemberListResult, mockEpochNumber, mockSecretKey} = prepareMLSConferenceMocks(
         mockParentGroupId,
         mockSubGroupId,
       );
@@ -128,7 +128,6 @@ describe('CallingViewModel', () => {
         conversationId,
         {
           epoch: mockEpochNumber,
-          keyLength: mockKeyLength,
           secretKey: mockSecretKey,
         },
         expectedMemberListResult,
@@ -138,7 +137,7 @@ describe('CallingViewModel', () => {
     it('updates epoch info after answering a call', async () => {
       const mockParentGroupId = 'mockParentGroupId2';
       const mockSubGroupId = 'mockSubGroupId2';
-      const {expectedMemberListResult, mockEpochNumber, mockKeyLength, mockSecretKey} = prepareMLSConferenceMocks(
+      const {expectedMemberListResult, mockEpochNumber, mockSecretKey} = prepareMLSConferenceMocks(
         mockParentGroupId,
         mockSubGroupId,
       );
@@ -156,7 +155,6 @@ describe('CallingViewModel', () => {
         conversationId,
         {
           epoch: mockEpochNumber,
-          keyLength: mockKeyLength,
           secretKey: mockSecretKey,
         },
         expectedMemberListResult,
@@ -166,7 +164,7 @@ describe('CallingViewModel', () => {
     it('updates epoch info after mls service has emmited "newEpoch" event', async () => {
       const mockParentGroupId = 'mockParentGroupId3';
       const mockSubGroupId = 'mockSubGroupId3';
-      const {expectedMemberListResult, mockEpochNumber, mockKeyLength, mockSecretKey} = prepareMLSConferenceMocks(
+      const {expectedMemberListResult, mockEpochNumber, mockSecretKey} = prepareMLSConferenceMocks(
         mockParentGroupId,
         mockSubGroupId,
       );
@@ -183,7 +181,6 @@ describe('CallingViewModel', () => {
         conversationId,
         {
           epoch: mockEpochNumber,
-          keyLength: mockKeyLength,
           secretKey: mockSecretKey,
         },
         expectedMemberListResult,
@@ -201,7 +198,6 @@ describe('CallingViewModel', () => {
           conversationId,
           {
             epoch: newEpochNumber,
-            keyLength: mockKeyLength,
             secretKey: mockSecretKey,
           },
           expectedMemberListResult,
@@ -226,7 +222,6 @@ describe('CallingViewModel', () => {
         conversationId,
         {
           epoch: anotherEpochNumber,
-          keyLength: mockKeyLength,
           secretKey: mockSecretKey,
         },
         expectedMemberListResult,

--- a/src/script/view_model/CallingViewModel.ts
+++ b/src/script/view_model/CallingViewModel.ts
@@ -165,7 +165,7 @@ export class CallingViewModel {
           {mlsService: this.mlsService, conversationState: this.conversationState},
           conversation.qualifiedId,
           ({epoch, keyLength, secretKey, members}) => {
-            this.callingRepository.setEpochInfo(conversation.qualifiedId, {epoch, keyLength, secretKey}, members);
+            this.callingRepository.setEpochInfo(conversation.qualifiedId, {epoch, secretKey}, members);
           },
         );
 
@@ -179,7 +179,7 @@ export class CallingViewModel {
         {mlsService: this.mlsService, conversationState: this.conversationState},
         call.conversationId,
         ({epoch, keyLength, secretKey, members}) => {
-          this.callingRepository.setEpochInfo(call.conversationId, {epoch, keyLength, secretKey}, members);
+          this.callingRepository.setEpochInfo(call.conversationId, {epoch, secretKey}, members);
         },
       );
 
@@ -232,12 +232,12 @@ export class CallingViewModel {
         return;
       }
 
-      const {epoch, keyLength, secretKey, members} = await getSubconversationEpochInfo(
+      const {epoch, secretKey, members} = await getSubconversationEpochInfo(
         {mlsService: this.mlsService},
         conversationId,
         shouldAdvanceEpoch,
       );
-      this.callingRepository.setEpochInfo(conversationId, {epoch, keyLength, secretKey}, members);
+      this.callingRepository.setEpochInfo(conversationId, {epoch, secretKey}, members);
     };
 
     const closeCall = async (conversationId: QualifiedId, conversationType: CONV_TYPE) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5766,10 +5766,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/avs@npm:9.2.13":
-  version: 9.2.13
-  resolution: "@wireapp/avs@npm:9.2.13"
-  checksum: 1a5603c57de73ee2e101e7818c01ac6abb111d7cc6773492e6a37b94004777be744956fc214bdda9a500f8352485d5ab18ccb3440b3363ea3039f8f1a4eb0022
+"@wireapp/avs@npm:9.2.15":
+  version: 9.2.15
+  resolution: "@wireapp/avs@npm:9.2.15"
+  checksum: 2d4def0f02959cce907ddc0dfcae54338aa3ff6e66dbb6f1b543d0f22dbaff59c93be0dbeafb26e99c6ed8bad0c9b770c36db3d21b04ad61260716a9a15c3fe6
   languageName: node
   linkType: hard
 
@@ -18623,7 +18623,7 @@ dexie@latest:
     "@types/webpack-env": 1.18.1
     "@typescript-eslint/eslint-plugin": ^5.59.7
     "@typescript-eslint/parser": ^5.59.7
-    "@wireapp/avs": 9.2.13
+    "@wireapp/avs": 9.2.15
     "@wireapp/copy-config": 2.1.0
     "@wireapp/core": 40.3.0
     "@wireapp/eslint-config": 2.2.1


### PR DESCRIPTION
Bump avs lib version. It should fix cross-platform calls with MLS (web <-> android).
- there's no need to pass `keyLength` anymore.