### PR TITLE
fix: Remove local data when account or client get deleted

### DIFF
--- a/src/script/client/ClientRepository.ts
+++ b/src/script/client/ClientRepository.ts
@@ -556,9 +556,8 @@ export class ClientRepository {
 
     const isCurrentClient = clientId === this.clientState.currentClient().id;
     if (isCurrentClient) {
-      const shouldClearData = this.clientState.currentClient().isTemporary();
       // If the current client has been removed, we need to sign out
-      amplify.publish(WebAppEvents.LIFECYCLE.SIGN_OUT, SIGN_OUT_REASON.CLIENT_REMOVED, shouldClearData);
+      amplify.publish(WebAppEvents.LIFECYCLE.SIGN_OUT, SIGN_OUT_REASON.CLIENT_REMOVED, true);
       return;
     }
     const localClients = await this.getClientsForSelf();


### PR DESCRIPTION
Previously: Local data is not deleted when account or client get deleted, only works for temporary client.
Now: Remove local data when account or client get deleted.