### PR TITLE
runfix: differentiate converstion rename event by name

### DIFF
--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -108,8 +108,20 @@ const filterDuplicatedSystemMessages = (messages: MessageEntity[]) => {
         );
 
         if (uniqUpdateMessages.length > 0) {
+          const prevMessage = uniqUpdateMessages?.[uniqUpdateMessages.length - 1];
+          if (!prevMessage) {
+            return [...uniqMessages, currentMessage];
+          }
+
+          if (prevMessage.isConversationRename() && currentMessage.isConversationRename()) {
+            // for rename messages, only name changes are relevant, caption stays the same
+            if (prevMessage.name === currentMessage.name) {
+              return uniqMessages;
+            }
+            return [...uniqMessages, currentMessage];
+          }
           // Dont show duplicated system messages that follow each other
-          if (uniqUpdateMessages?.[uniqUpdateMessages.length - 1]?.caption() === currentMessage.caption()) {
+          if (prevMessage.caption() === currentMessage.caption()) {
             return uniqMessages;
           }
         }

--- a/src/script/entity/message/SystemMessage.ts
+++ b/src/script/entity/message/SystemMessage.ts
@@ -20,6 +20,7 @@
 import ko from 'knockout';
 
 import {Message} from './Message';
+import {RenameMessage} from './RenameMessage';
 
 import {SuperType} from '../../message/SuperType';
 import {SystemMessageType} from '../../message/SystemMessageType';
@@ -34,7 +35,7 @@ export class SystemMessage extends Message {
     this.system_message_type = SystemMessageType.NORMAL;
   }
 
-  isConversationRename(): boolean {
+  isConversationRename(): this is RenameMessage {
     return this.system_message_type === SystemMessageType.CONVERSATION_RENAME;
   }
 }


### PR DESCRIPTION
Small regression introduced in: https://github.com/wireapp/wire-webapp/pull/15265

`.caption()` of conversation rename system message is always `{{}} renamed the conversation`, we have to consider message as duplicated when `.name` is different, not the caption.