### PR TITLE
feat: enforce self deleting message group settings in conversations [SQSERVICES-2024]

### DIFF
--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
@@ -139,9 +139,19 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
 
     const teamId = activeConversation.team_id;
 
-    const {isTeam, classifiedDomains, team} = useKoSubscribableChildren(teamState, [
+    const {
+      isTeam,
+      classifiedDomains,
+      team,
+      isSelfDeletingMessagesEnabled,
+      isSelfDeletingMessagesEnforced,
+      getEnforcedSelfDeletingMessagesTimeout,
+    } = useKoSubscribableChildren(teamState, [
       'isTeam',
       'classifiedDomains',
+      'isSelfDeletingMessagesEnabled',
+      'isSelfDeletingMessagesEnforced',
+      'getEnforcedSelfDeletingMessagesTimeout',
       'team',
     ]);
 
@@ -153,7 +163,8 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
     const showOptionGuests = isActiveGroupParticipant && !!teamId && roleRepository.canToggleGuests(activeConversation);
     const hasAdvancedNotifications = isMutable && isTeam;
     const showOptionNotificationsGroup = hasAdvancedNotifications && isGroup;
-    const showOptionTimedMessages = isActiveGroupParticipant && roleRepository.canToggleTimeout(activeConversation);
+    const showOptionTimedMessages =
+      isActiveGroupParticipant && roleRepository.canToggleTimeout(activeConversation) && isSelfDeletingMessagesEnabled;
     const showOptionServices =
       isActiveGroupParticipant && !!teamId && roleRepository.canToggleGuests(activeConversation);
     const showOptionReadReceipts = !!teamId && roleRepository.canToggleReadReceipts(activeConversation);
@@ -175,8 +186,11 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
     const servicesOptionsText = isServicesRoom ? t('conversationDetailsOn') : t('conversationDetailsOff');
 
     const notificationStatusText = getNotificationText(notificationState);
-    const timedMessagesText =
-      hasTimer && globalMessageTimer ? formatDuration(globalMessageTimer).text : t('ephemeralUnitsNone');
+    const timedMessagesText = isSelfDeletingMessagesEnforced
+      ? formatDuration(getEnforcedSelfDeletingMessagesTimeout).text
+      : hasTimer && globalMessageTimer
+      ? formatDuration(globalMessageTimer).text
+      : t('ephemeralUnitsNone');
 
     const showActionMute = isMutable && !isTeam;
     const isVerified = verificationState === ConversationVerificationState.VERIFIED;

--- a/src/script/page/RightSidebar/RightSidebar.tsx
+++ b/src/script/page/RightSidebar/RightSidebar.tsx
@@ -248,6 +248,7 @@ const RightSidebar: FC<RightSidebarProps> = ({
 
           {currentState === PanelState.TIMED_MESSAGES && (
             <TimedMessages
+              teamState={teamState}
               activeConversation={activeConversation}
               repositories={repositories}
               onClose={closePanel}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-2024" title="SQSERVICES-2024" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />SQSERVICES-2024</a>  [Web] Group settings for Self-Deleting Messages should respect Team Settings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

forces conversations to respect team self-deleting message settings. 

### Solutions

check team settings for self-deleting messages 

