### PR TITLE
feat: clean unaccepted oauth scopes [SQSERVICES-2075/SQSERVICES-2076 ]

### DIFF
--- a/src/script/auth/page/OAuthPermissions.tsx
+++ b/src/script/auth/page/OAuthPermissions.tsx
@@ -122,9 +122,13 @@ const OAuthPermissionsComponent = ({
     };
     getUserData().catch(error => {
       console.error(error);
-      doLogout().catch(error => {
-        console.error(error);
-      });
+      if (error.message === 'OAuth client not found') {
+        window.location.replace('/');
+      } else {
+        doLogout().catch(error => {
+          console.error(error);
+        });
+      }
     });
   }, [
     assetRepository,

--- a/src/script/auth/page/OAuthPermissions.tsx
+++ b/src/script/auth/page/OAuthPermissions.tsx
@@ -61,7 +61,7 @@ import {oauthStrings} from '../../strings';
 import {actionRoot} from '../module/action';
 import {bindActionCreators, RootState} from '../module/reducer';
 import * as SelfSelector from '../module/selector/SelfSelector';
-import {oAuthParams, oAuthScope} from '../util/oauthUtil';
+import {oAuthParams, oAuthScope, oAuthScopesToString} from '../util/oauthUtil';
 
 interface Props extends React.HTMLProps<HTMLDivElement> {
   assetRepository?: AssetRepository;
@@ -90,10 +90,11 @@ const OAuthPermissionsComponent = ({
   const [oAuthApp, setOAuthApp] = useState<OAuthClient | null>(null);
   const oauthParams = oAuthParams(window.location);
   const oauthScope = oAuthScope(oauthParams);
+  const cleanedScopes = oAuthScopesToString(oauthScope);
 
   const onContinue = async () => {
     try {
-      const url = await postOauthCode(oauthParams);
+      const url = await postOauthCode({...oauthParams, scope: cleanedScopes});
       window.location.replace(url);
     } catch (error) {
       console.error(error);

--- a/src/script/auth/util/oauthUtil.ts
+++ b/src/script/auth/util/oauthUtil.ts
@@ -38,3 +38,10 @@ export const oAuthParams = (location: Location) => {
  */
 export const oAuthScope = (oauthBody: OAuthBody) =>
   oauthBody.scope.split(/\+|%20|\s/).filter(scope => Object.values(Scope).includes(scope as Scope)) as Scope[];
+
+/**
+ * Takes the oauth Scopes and returns the scopes as a string accepted by the API.
+ * @param Scopes Scopes accepted by the app
+ * @returns string
+ */
+export const oAuthScopesToString = (scopes: Scope[]) => scopes.join(' ');


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-2075" title="SQSERVICES-2075" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-2075</a>  [Web] [OAuth] OAuth Authorization Prompt requests non-displayed scopes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Filters out unaccepted Scopes before forwarding them to the BE

