### PR TITLE
runfix: remove creator client field [WPB-598]

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@emotion/react": "11.11.0",
     "@types/eslint": "8.37.0",
     "@wireapp/avs": "9.2.15",
-    "@wireapp/core": "40.5.0",
+    "@wireapp/core": "40.5.1",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.7.3",
     "@wireapp/store-engine-dexie": "2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5754,9 +5754,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^24.15.3":
-  version: 24.15.3
-  resolution: "@wireapp/api-client@npm:24.15.3"
+"@wireapp/api-client@npm:^24.15.4":
+  version: 24.15.4
+  resolution: "@wireapp/api-client@npm:24.15.4"
   dependencies:
     "@wireapp/commons": ^5.1.0
     "@wireapp/priority-queue": ^2.1.1
@@ -5769,7 +5769,7 @@ __metadata:
     spark-md5: 3.0.2
     tough-cookie: 4.1.2
     ws: 8.11.0
-  checksum: 9471314d2ca8ca9559bb2b1945cda8122f35f2ebf3be7bca34e05131383fd3d265d7535fa7c25930f6359b43245f3373e6f432635f0029a73024992278a2a955
+  checksum: 2689634c012cba0e68f2cc67226a32ac3f5e59e1d99ed8877642fc9fc60b01f9ecacae0e333f7ba4975c70fe2b3925eeedd2f1c2743b209234ad1ac6fc275f58
   languageName: node
   linkType: hard
 
@@ -5822,11 +5822,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:40.5.0":
-  version: 40.5.0
-  resolution: "@wireapp/core@npm:40.5.0"
+"@wireapp/core@npm:40.5.1":
+  version: 40.5.1
+  resolution: "@wireapp/core@npm:40.5.1"
   dependencies:
-    "@wireapp/api-client": ^24.15.3
+    "@wireapp/api-client": ^24.15.4
     "@wireapp/commons": ^5.1.0
     "@wireapp/core-crypto": 0.11.0
     "@wireapp/cryptobox": 12.8.0
@@ -5843,7 +5843,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.13
-  checksum: 3c99d8381e5f1f09ff5644f66ac4186fc52d7307246b236d729082b173fe388ceeba4d7b109913348b1c6a7fb7dd3ee594edfc1e3e7cbfd69ca10433a5219b49
+  checksum: b360d94a6312f4d1ed5d72959da8d699f772f2ec0c87300c246130e42c6234f1724cceee60541bd41f54b6968720774e4a291f0a0089fb5cb95d7cd61937cb1f
   languageName: node
   linkType: hard
 
@@ -18652,7 +18652,7 @@ dexie@latest:
     "@typescript-eslint/parser": ^5.59.9
     "@wireapp/avs": 9.2.15
     "@wireapp/copy-config": 2.1.0
-    "@wireapp/core": 40.5.0
+    "@wireapp/core": 40.5.1
     "@wireapp/eslint-config": 2.2.2
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.6.0


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-598" title="WPB-598" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-598</a>  [Clients] Implement breaking changes for API v4
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
- bump core version
- due to api v4 changes, we no longer pass neither `selfUserId` nor `creator_client` in conversation creation payload.

See https://github.com/wireapp/wire-web-packages/pull/5209