### PR TITLE
feat: maintain mls group list during migration [WPB-1115]

### DIFF
--- a/src/__mocks__/@wireapp/core.ts
+++ b/src/__mocks__/@wireapp/core.ts
@@ -52,6 +52,8 @@ export class Account extends EventEmitter {
       isMLSConversationEstablished: jest.fn(),
       joinByExternalCommit: jest.fn(),
       addUsersToMLSConversation: jest.fn(),
+      removeUserFromConversation: jest.fn(),
+      removeUsersFromMLSConversation: jest.fn(),
       addUsersToProteusConversation: jest.fn(),
       messageTimer: {
         setConversationLevelTimer: jest.fn(),

--- a/src/__mocks__/@wireapp/core.ts
+++ b/src/__mocks__/@wireapp/core.ts
@@ -52,6 +52,7 @@ export class Account extends EventEmitter {
       isMLSConversationEstablished: jest.fn(),
       joinByExternalCommit: jest.fn(),
       addUsersToMLSConversation: jest.fn(),
+      addUsersToProteusConversation: jest.fn(),
       messageTimer: {
         setConversationLevelTimer: jest.fn(),
       },

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -71,6 +71,8 @@ import {LegacyEventRecord, StorageService} from '../storage';
 
 jest.deepUnmock('axios');
 
+const mlsCapableProtocols = [ConversationProtocol.MLS, ConversationProtocol.MIXED];
+
 const _generateConversation = (
   conversation_type = CONVERSATION_TYPE.REGULAR,
   connection_status = ConnectionStatus.ACCEPTED,
@@ -86,7 +88,7 @@ const _generateConversation = (
   connectionEntity.status(connection_status);
   conversation.connection(connectionEntity);
 
-  if ([ConversationProtocol.MLS, ConversationProtocol.MIXED].includes(conversationProtocol)) {
+  if (mlsCapableProtocols.includes(conversationProtocol)) {
     conversation.groupId = groupId;
   }
 
@@ -1629,10 +1631,7 @@ describe('ConversationRepository', () => {
       const conversation = _generateConversation();
       const conversationRepository = await testFactory.exposeConversationActors();
 
-      const user1 = generateUser();
-      const user2 = generateUser();
-
-      const usersToAdd = [user1, user2];
+      const usersToAdd = [generateUser(), generateUser()];
 
       const coreConversationService = container.resolve(Core).service!.conversation;
       spyOn(coreConversationService, 'addUsersToProteusConversation');
@@ -1649,10 +1648,7 @@ describe('ConversationRepository', () => {
       const conversation = _generateConversation(undefined, undefined, ConversationProtocol.MIXED, '', mockedGroupId);
       const conversationRepository = await testFactory.exposeConversationActors();
 
-      const user1 = generateUser();
-      const user2 = generateUser();
-
-      const usersToAdd = [user1, user2];
+      const usersToAdd = [generateUser(), generateUser()];
 
       const coreConversationService = container.resolve(Core).service!.conversation;
       spyOn(coreConversationService, 'addUsersToMLSConversation');
@@ -1674,10 +1670,7 @@ describe('ConversationRepository', () => {
       const conversation = _generateConversation(undefined, undefined, ConversationProtocol.MLS, '', mockedGroupId);
       const conversationRepository = await testFactory.exposeConversationActors();
 
-      const user1 = generateUser();
-      const user2 = generateUser();
-
-      const usersToAdd = [user1, user2];
+      const usersToAdd = [generateUser(), generateUser()];
 
       const coreConversationService = container.resolve(Core).service!.conversation;
       spyOn(coreConversationService, 'addUsersToMLSConversation');
@@ -1759,10 +1752,7 @@ describe('ConversationRepository', () => {
 
           spyOn(testFactory.conversation_repository['userState'], 'self').and.returnValue(selfUser);
 
-          const user1 = generateUser();
-          const user2 = generateUser();
-
-          conversation.participating_user_ets([user1, user2]);
+          conversation.participating_user_ets([generateUser(), generateUser()]);
 
           const coreConversationService = container.resolve(Core).service!.conversation;
 

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -1644,29 +1644,51 @@ describe('ConversationRepository', () => {
       });
     });
 
-    it.each([ConversationProtocol.MIXED, ConversationProtocol.MLS])(
-      'should add users to mls group of %s conversation',
-      async protocol => {
-        const mockedGroupId = `mockedGroupId-${protocol}`;
-        const conversation = _generateConversation(undefined, undefined, protocol, '', mockedGroupId);
-        const conversationRepository = await testFactory.exposeConversationActors();
+    it('should add users to mls group of mixed conversation', async () => {
+      const mockedGroupId = `mockedGroupId`;
+      const conversation = _generateConversation(undefined, undefined, ConversationProtocol.MIXED, '', mockedGroupId);
+      const conversationRepository = await testFactory.exposeConversationActors();
 
-        const user1 = generateUser();
-        const user2 = generateUser();
+      const user1 = generateUser();
+      const user2 = generateUser();
 
-        const usersToAdd = [user1, user2];
+      const usersToAdd = [user1, user2];
 
-        const coreConversationService = container.resolve(Core).service!.conversation;
-        spyOn(coreConversationService, 'addUsersToMLSConversation');
+      const coreConversationService = container.resolve(Core).service!.conversation;
+      spyOn(coreConversationService, 'addUsersToMLSConversation');
 
-        await conversationRepository.addUsers(conversation, usersToAdd);
-        expect(coreConversationService.addUsersToMLSConversation).toHaveBeenCalledWith({
-          conversationId: conversation.qualifiedId,
-          qualifiedUsers: usersToAdd.map(user => user.qualifiedId),
-          groupId: mockedGroupId,
-        });
-      },
-    );
+      await conversationRepository.addUsers(conversation, usersToAdd);
+      expect(coreConversationService.addUsersToProteusConversation).toHaveBeenCalledWith({
+        conversationId: conversation.qualifiedId,
+        qualifiedUsers: usersToAdd.map(user => user.qualifiedId),
+      });
+      expect(coreConversationService.addUsersToMLSConversation).toHaveBeenCalledWith({
+        conversationId: conversation.qualifiedId,
+        qualifiedUsers: usersToAdd.map(user => user.qualifiedId),
+        groupId: mockedGroupId,
+      });
+    });
+
+    it('should add users to mls group of mls conversation', async () => {
+      const mockedGroupId = `mockedGroupId`;
+      const conversation = _generateConversation(undefined, undefined, ConversationProtocol.MLS, '', mockedGroupId);
+      const conversationRepository = await testFactory.exposeConversationActors();
+
+      const user1 = generateUser();
+      const user2 = generateUser();
+
+      const usersToAdd = [user1, user2];
+
+      const coreConversationService = container.resolve(Core).service!.conversation;
+      spyOn(coreConversationService, 'addUsersToMLSConversation');
+
+      await conversationRepository.addUsers(conversation, usersToAdd);
+      expect(coreConversationService.addUsersToMLSConversation).toHaveBeenCalledWith({
+        conversationId: conversation.qualifiedId,
+        qualifiedUsers: usersToAdd.map(user => user.qualifiedId),
+        groupId: mockedGroupId,
+      });
+    });
   });
 
   describe('removeMember', () => {

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -80,7 +80,7 @@ import {ConversationFilter} from './ConversationFilter';
 import {ConversationLabelRepository} from './ConversationLabelRepository';
 import {ConversationDatabaseData, ConversationMapper} from './ConversationMapper';
 import {ConversationRoleRepository} from './ConversationRoleRepository';
-import {isMLSCapableConversation} from './ConversationSelectors';
+import {isMLSCapableConversation, MixedConversation, MLSConversation} from './ConversationSelectors';
 import {ConversationService} from './ConversationService';
 import {ConversationState} from './ConversationState';
 import {ConversationStateHandler} from './ConversationStateHandler';
@@ -2627,7 +2627,7 @@ export class ConversationRepository {
     const qualifiedUserIds =
       eventData.users?.map(user => user.qualified_id) || eventData.user_ids.map(userId => ({domain: '', id: userId}));
 
-    if (conversationEntity.isUsingMLSProtocol) {
+    if (isMLSCapableConversation(conversationEntity)) {
       const isSelfJoin = isFromSelf && selfUserJoins;
       await this.handleMLSConversationMemberJoin(conversationEntity, isSelfJoin);
     }
@@ -2647,12 +2647,11 @@ export class ConversationRepository {
    * @param conversation Conversation member joined to
    * @param isSelfJoin whether user has joined by itself, if so we need to add other self clients to mls group
    */
-  private async handleMLSConversationMemberJoin(conversation: Conversation, isSelfJoin: boolean) {
+  private async handleMLSConversationMemberJoin(
+    conversation: MLSConversation | MixedConversation,
+    isSelfJoin: boolean,
+  ) {
     const {groupId} = conversation;
-
-    if (!groupId) {
-      throw new Error(`groupId not found for MLS conversation ${conversation.id}`);
-    }
 
     const isMLSConversationEstablished = await this.core.service!.conversation.isMLSConversationEstablished(groupId);
 

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1454,13 +1454,11 @@ export class ConversationRepository {
 
     const qualifiedUsers = userEntities.map(userEntity => userEntity.qualifiedId);
 
-    const {qualifiedId: conversationId, groupId} = conversation;
-
     try {
-      if (conversation.isUsingMLSProtocol && groupId) {
+      if (isMLSCapableConversation(conversation)) {
         const {events} = await this.core.service!.conversation.addUsersToMLSConversation({
-          conversationId,
-          groupId,
+          conversationId: conversation.qualifiedId,
+          groupId: conversation.groupId,
           qualifiedUsers,
         });
         if (!!events.length) {
@@ -1468,7 +1466,7 @@ export class ConversationRepository {
         }
       } else {
         const conversationMemberJoinEvent = await this.core.service!.conversation.addUsersToProteusConversation({
-          conversationId,
+          conversationId: conversation.qualifiedId,
           qualifiedUsers,
         });
         if (conversationMemberJoinEvent) {

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -85,8 +85,7 @@ import {
   isMLSCapableConversation,
   isMLSConversation,
   isProteusConversation,
-  MixedConversation,
-  MLSConversation,
+  MLSCapableConversation,
 } from './ConversationSelectors';
 import {ConversationService} from './ConversationService';
 import {ConversationState} from './ConversationState';
@@ -2656,10 +2655,7 @@ export class ConversationRepository {
    * @param conversation Conversation member joined to
    * @param isSelfJoin whether user has joined by itself, if so we need to add other self clients to mls group
    */
-  private async handleMLSConversationMemberJoin(
-    conversation: MLSConversation | MixedConversation,
-    isSelfJoin: boolean,
-  ) {
+  private async handleMLSConversationMemberJoin(conversation: MLSCapableConversation, isSelfJoin: boolean) {
     const {groupId} = conversation;
 
     const isMLSConversationEstablished = await this.core.service!.conversation.isMLSConversationEstablished(groupId);

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -80,6 +80,7 @@ import {ConversationFilter} from './ConversationFilter';
 import {ConversationLabelRepository} from './ConversationLabelRepository';
 import {ConversationDatabaseData, ConversationMapper} from './ConversationMapper';
 import {ConversationRoleRepository} from './ConversationRoleRepository';
+import {isMLSCapableConversation} from './ConversationSelectors';
 import {ConversationService} from './ConversationService';
 import {ConversationState} from './ConversationState';
 import {ConversationStateHandler} from './ConversationStateHandler';
@@ -951,11 +952,9 @@ export class ConversationRepository {
     }
     this.deleteConversationFromRepository(conversationId);
     await this.conversationService.deleteConversationFromDb(conversationId);
-    if (conversationEntity.protocol === ConversationProtocol.MLS) {
+    if (isMLSCapableConversation(conversationEntity)) {
       const {groupId} = conversationEntity;
-      if (groupId) {
-        await this.core.service!.conversation.wipeMLSConversation(groupId);
-      }
+      await this.core.service!.conversation.wipeMLSConversation(groupId);
     }
   };
 
@@ -2714,11 +2713,9 @@ export class ConversationRepository {
         eventJson.from = this.userState.self().id;
       }
 
-      if (conversationEntity.protocol === ConversationProtocol.MLS) {
+      if (isMLSCapableConversation(conversationEntity)) {
         const {groupId} = conversationEntity;
-        if (groupId) {
-          await this.core.service!.conversation.wipeMLSConversation(groupId);
-        }
+        await this.core.service!.conversation.wipeMLSConversation(groupId);
       }
     } else {
       // Update conversation roles (in case the removed user had some special role and it's not the self user)

--- a/src/script/conversation/ConversationSelectors.ts
+++ b/src/script/conversation/ConversationSelectors.ts
@@ -24,6 +24,7 @@ import {Conversation} from '../entity/Conversation';
 export type ProteusConversation = Conversation & {protocol: ConversationProtocol.PROTEUS};
 export type MixedConversation = Conversation & {groupId: string; protocol: ConversationProtocol.MIXED};
 export type MLSConversation = Conversation & {groupId: string; protocol: ConversationProtocol.MLS};
+export type MLSCapableConversation = MixedConversation | MLSConversation;
 
 export function isProteusConversation(conversation: Conversation): conversation is ProteusConversation {
   return !conversation.groupId && conversation.protocol === ConversationProtocol.PROTEUS;
@@ -37,9 +38,7 @@ export function isMLSConversation(conversation: Conversation): conversation is M
   return !!conversation.groupId && conversation.protocol === ConversationProtocol.MLS;
 }
 
-export function isMLSCapableConversation(
-  conversation: Conversation,
-): conversation is MixedConversation | MLSConversation {
+export function isMLSCapableConversation(conversation: Conversation): conversation is MLSCapableConversation {
   return isMixedConversation(conversation) || isMLSConversation(conversation);
 }
 

--- a/src/script/conversation/ConversationSelectors.ts
+++ b/src/script/conversation/ConversationSelectors.ts
@@ -37,6 +37,12 @@ export function isMLSConversation(conversation: Conversation): conversation is M
   return !!conversation.groupId && conversation.protocol === ConversationProtocol.MLS;
 }
 
+export function isMLSCapableConversation(
+  conversation: Conversation,
+): conversation is MixedConversation | MLSConversation {
+  return isMixedConversation(conversation) || isMLSConversation(conversation);
+}
+
 export function isSelfConversation(conversation: Conversation): boolean {
   return conversation.type() === CONVERSATION_TYPE.SELF;
 }

--- a/src/script/mls/MLSConversations.ts
+++ b/src/script/mls/MLSConversations.ts
@@ -30,7 +30,7 @@ import {
   isMLSConversation,
   isSelfConversation,
   isTeamConversation,
-  MixedConversation,
+  MLSCapableConversation,
   MLSConversation,
 } from '../conversation/ConversationSelectors';
 import {Conversation} from '../entity/Conversation';
@@ -87,10 +87,7 @@ export async function initMLSCallbacks(
  * @param conversations - all the conversations that the user is part of
  * @param core - the instance of the core
  */
-async function joinNewConversations(
-  conversations: (MLSConversation | MixedConversation)[],
-  core: Account,
-): Promise<void> {
+async function joinNewConversations(conversations: MLSCapableConversation[], core: Account): Promise<void> {
   // We send external proposal to all the MLS conversations that are in an unknown state (not established nor pendingWelcome)
   await useMLSConversationState.getState().sendExternalToPendingJoin(
     conversations,

--- a/src/script/mls/MLSConversations.ts
+++ b/src/script/mls/MLSConversations.ts
@@ -26,9 +26,11 @@ import {useMLSConversationState} from './mlsConversationState';
 
 import {ConversationRepository} from '../conversation/ConversationRepository';
 import {
+  isMLSCapableConversation,
   isMLSConversation,
   isSelfConversation,
   isTeamConversation,
+  MixedConversation,
   MLSConversation,
 } from '../conversation/ConversationSelectors';
 import {Conversation} from '../entity/Conversation';
@@ -51,10 +53,10 @@ export async function initMLSConversations(conversations: Conversation[], core: 
     throw new Error('MLS service not available');
   }
 
-  const mlsConversations = conversations.filter(isMLSConversation);
-  await joinNewConversations(mlsConversations, core);
+  const mlsCapableConversations = conversations.filter(isMLSCapableConversation);
+  await joinNewConversations(mlsCapableConversations, core);
 
-  return mlsService.schedulePeriodicKeyMaterialRenewals(mlsConversations.map(({groupId}) => groupId));
+  return mlsService.schedulePeriodicKeyMaterialRenewals(mlsCapableConversations.map(({groupId}) => groupId));
 }
 
 /**
@@ -85,7 +87,10 @@ export async function initMLSCallbacks(
  * @param conversations - all the conversations that the user is part of
  * @param core - the instance of the core
  */
-async function joinNewConversations(conversations: MLSConversation[], core: Account): Promise<void> {
+async function joinNewConversations(
+  conversations: (MLSConversation | MixedConversation)[],
+  core: Account,
+): Promise<void> {
   // We send external proposal to all the MLS conversations that are in an unknown state (not established nor pendingWelcome)
   await useMLSConversationState.getState().sendExternalToPendingJoin(
     conversations,

--- a/src/script/mls/mlsConversationState/mlsConversationState.ts
+++ b/src/script/mls/mlsConversationState/mlsConversationState.ts
@@ -20,7 +20,7 @@
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {create} from 'zustand';
 
-import {isMLSCapableConversation} from 'src/script/conversation/ConversationSelectors';
+import {isMLSCapableConversation, isMLSConversation} from 'src/script/conversation/ConversationSelectors';
 
 import {loadState, saveState} from './conversationStateStorage';
 
@@ -58,7 +58,7 @@ export const useMLSConversationState = create<StoreState>((set, get) => {
     established: initialState.established,
     filterEstablishedConversations: conversations =>
       conversations.filter(conversation => {
-        const isMLS = isMLSCapableConversation(conversation);
+        const isMLS = isMLSConversation(conversation);
         return !isMLS || get().isEstablished(conversation.groupId);
       }),
 

--- a/src/script/mls/mlsConversationState/mlsConversationState.ts
+++ b/src/script/mls/mlsConversationState/mlsConversationState.ts
@@ -58,8 +58,7 @@ export const useMLSConversationState = create<StoreState>((set, get) => {
     established: initialState.established,
     filterEstablishedConversations: conversations =>
       conversations.filter(conversation => {
-        const isMLS = isMLSConversation(conversation);
-        return !isMLS || get().isEstablished(conversation.groupId);
+        return !isMLSConversation(conversation) || get().isEstablished(conversation.groupId);
       }),
 
     isEstablished: groupId => get().established.has(groupId),

--- a/src/script/mls/mlsConversationState/mlsConversationState.ts
+++ b/src/script/mls/mlsConversationState/mlsConversationState.ts
@@ -20,7 +20,7 @@
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {create} from 'zustand';
 
-import {isMLSConversation} from 'src/script/conversation/ConversationSelectors';
+import {isMLSCapableConversation} from 'src/script/conversation/ConversationSelectors';
 
 import {loadState, saveState} from './conversationStateStorage';
 
@@ -58,7 +58,7 @@ export const useMLSConversationState = create<StoreState>((set, get) => {
     established: initialState.established,
     filterEstablishedConversations: conversations =>
       conversations.filter(conversation => {
-        const isMLS = isMLSConversation(conversation);
+        const isMLS = isMLSCapableConversation(conversation);
         return !isMLS || get().isEstablished(conversation.groupId);
       }),
 
@@ -87,10 +87,10 @@ export const useMLSConversationState = create<StoreState>((set, get) => {
       const alreadyEstablishedConversations: string[] = [];
 
       for (const conversation of conversations) {
-        const groupId = conversation.groupId;
-        if (!conversation.isUsingMLSProtocol || !groupId) {
+        if (!isMLSCapableConversation(conversation)) {
           continue;
         }
+        const {groupId} = conversation;
         if (!currentState.isEstablished(groupId) && !currentState.isPendingWelcome(groupId)) {
           if (await isAlreadyEstablished(groupId)) {
             // check is the conversation is not actually already established


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-1115" title="WPB-1115" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-1115</a>  [Web] Maintaining MLS group's clients list during migration
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Maintain MLS group in `"mixed"` conversation. It convers:
- adding users (and being added to a group)
- removing a user (being removed)
- leaving a group
- receiving commits
- periodic key material update

Note that leaving a group and removing user from a group might not work before being deployed to draft-20.

- [x] add unit tests