### PR TITLE
runfix: allow message duplicate when retrying to send a message after a federation error [WBP-2010]

### DIFF
--- a/src/script/event/EventRepository.ts
+++ b/src/script/event/EventRepository.ts
@@ -572,7 +572,7 @@ export class EventRepository {
     }
 
     const containsLinkPreview = newEventData.previews && !!newEventData.previews.length;
-    const isRetryAttempt = originalEvent.status === StatusType.FAILED || StatusType.FEDERATION_ERROR;
+    const isRetryAttempt = originalEvent.status === (StatusType.FAILED || StatusType.FEDERATION_ERROR);
 
     if (!containsLinkPreview && !isRetryAttempt) {
       const errorMessage =

--- a/src/script/event/EventRepository.ts
+++ b/src/script/event/EventRepository.ts
@@ -572,7 +572,8 @@ export class EventRepository {
     }
 
     const containsLinkPreview = newEventData.previews && !!newEventData.previews.length;
-    const isRetryAttempt = originalEvent.status === (StatusType.FAILED || StatusType.FEDERATION_ERROR);
+    const isRetryAttempt =
+      originalEvent.status === StatusType.FAILED || originalEvent.status === StatusType.FEDERATION_ERROR;
 
     if (!containsLinkPreview && !isRetryAttempt) {
       const errorMessage =

--- a/src/script/event/EventRepository.ts
+++ b/src/script/event/EventRepository.ts
@@ -565,6 +565,14 @@ export class EventRepository {
   private handleMessageUpdate(originalEvent: EventRecord, newEvent: MessageAddEvent) {
     const newEventData = newEvent.data;
     const originalData = originalEvent.data;
+
+    const isFailed = (status: StatusType | undefined): status is StatusType.FAILED => {
+      return status === StatusType.FAILED;
+    };
+    const isFederationError = (status: StatusType | undefined): status is StatusType.FEDERATION_ERROR => {
+      return status === StatusType.FEDERATION_ERROR;
+    };
+
     if (originalEvent.from !== newEvent.from) {
       const logMessage = `ID previously used by user '${newEvent.from}'`;
       const errorMessage = 'ID reused by other user';
@@ -572,8 +580,7 @@ export class EventRepository {
     }
 
     const containsLinkPreview = newEventData.previews && !!newEventData.previews.length;
-    const isRetryAttempt =
-      originalEvent.status === StatusType.FAILED || originalEvent.status === StatusType.FEDERATION_ERROR;
+    const isRetryAttempt = isFailed(originalEvent.status) || isFederationError(originalEvent.status);
 
     if (!containsLinkPreview && !isRetryAttempt) {
       const errorMessage =

--- a/src/script/event/EventRepository.ts
+++ b/src/script/event/EventRepository.ts
@@ -572,7 +572,7 @@ export class EventRepository {
     }
 
     const containsLinkPreview = newEventData.previews && !!newEventData.previews.length;
-    const isRetryAttempt = originalEvent.status === StatusType.FAILED;
+    const isRetryAttempt = originalEvent.status === StatusType.FAILED || StatusType.FEDERATION_ERROR;
 
     if (!containsLinkPreview && !isRetryAttempt) {
       const errorMessage =

--- a/src/script/message/StatusType.ts
+++ b/src/script/message/StatusType.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import {EventRecord} from '../storage/record/EventRecord';
+
 /** Enum for different confirmation types */
 export enum StatusType {
   DELIVERED = 3,
@@ -27,3 +29,15 @@ export enum StatusType {
   SENT = 2,
   UNSPECIFIED = -1,
 }
+
+type FailedEventRecord = Omit<EventRecord, 'status'> & {
+  status: StatusType.FAILED;
+};
+type EventRecordWithFederationError = Omit<EventRecord, 'status'> & {
+  status: StatusType.FEDERATION_ERROR;
+};
+
+export const isEventRecordFailed = (event: any): event is FailedEventRecord =>
+  'status' in event && event.status === StatusType.FAILED;
+export const isEventRecordWithFederationError = (event: any): event is EventRecordWithFederationError =>
+  'status' in event && event.status === StatusType.FEDERATION_ERROR;


### PR DESCRIPTION
- A new event status for federation errors was not added to valid cases for retry attempts