### PR TITLE
fix: prevent guest icon to show for federated users WPB-1987

### DIFF
--- a/src/script/components/InputBar/components/MentionSuggestions/MentionSuggestionsItem.tsx
+++ b/src/script/components/InputBar/components/MentionSuggestions/MentionSuggestionsItem.tsx
@@ -86,7 +86,7 @@ const MentionSuggestionsItemComponent: React.ForwardRefRenderFunction<HTMLDivEle
       {suggestion.isFederated && (
         <Icon.Federation className="mention-suggestion-list__item__guest-badge" data-uie-name="status-federated" />
       )}
-      {isDirectGuest && (
+      {isDirectGuest && !suggestion.isFederated && (
         <Icon.Guest className="mention-suggestion-list__item__guest-badge" data-uie-name="status-guest" />
       )}
     </div>

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageHeader.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageHeader.tsx
@@ -67,7 +67,7 @@ function BadgeSection({sender}: {sender: User}) {
         </span>
       )}
 
-      {sender.isDirectGuest() && (
+      {sender.isDirectGuest() && !sender.isFederated && (
         <span
           className="message-header-icon-guest with-tooltip with-tooltip--external"
           data-tooltip={t('conversationGuestIndicator')}

--- a/src/script/components/UserList/components/UserListItem/UserListItem.tsx
+++ b/src/script/components/UserList/components/UserListItem/UserListItem.tsx
@@ -127,7 +127,7 @@ const UserListItem = ({
 
         <UserStatusBadges
           config={{
-            guest: !isOthersMode && isDirectGuest,
+            guest: !isOthersMode && isDirectGuest && !isFederated,
             federated: isFederated,
             external,
             verified: isSelfVerified && isVerified,

--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.tsx
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.tsx
@@ -115,7 +115,7 @@ export const CallParticipantsListItem = ({
           <>
             <UserStatusBadges
               config={{
-                guest: isDirectGuest,
+                guest: isDirectGuest && !isFederated,
                 federated: isFederated,
                 external: isExternal,
                 verified: isSelfVerified && isVerified,

--- a/src/script/components/panel/UserDetails.tsx
+++ b/src/script/components/panel/UserDetails.tsx
@@ -137,7 +137,7 @@ export const UserDetailsComponent: React.FC<UserDetailsProps> = ({
         </div>
       )}
 
-      {isGuest && user.isAvailable && (
+      {isGuest && user.isAvailable && !isFederated && (
         <div className="panel-participant__label" data-uie-name="status-guest">
           <Icon.Guest />
           <span>{t('conversationGuestIndicator')}</span>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-1987" title="WPB-1987" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-1987</a>  There should be no guest label shown for federated users
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Issue

- users that are able to message you but were not fetched by your client (people on your contact list whose b-e was unavailable when starting a session on a new device) show up as guest
- once user metadata has been fetched, they show up at both federated and guest and should only show up as federated
 
![image](https://github.com/wireapp/wire-webapp/assets/78490891/d3773a33-b6c0-4dbc-abed-c1aacd5103be)

### Solution

- add a `!isFederated` check for relevant instances of the guest icon
