### PR TITLE
runfix: subscribe to mls conversation state change in conversation state

### DIFF
--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -71,6 +71,12 @@ export class ConversationState {
     this.selfMLSConversation = ko.pureComputed(() =>
       this.conversations().find(conversation => isMLSConversation(conversation) && isSelfConversation(conversation)),
     );
+
+    //anytime mls conversation state changes, we update the sorted conversations that will recalculate visible conversations
+    useMLSConversationState.subscribe(() => {
+      this.sortedConversations.notifySubscribers();
+    });
+
     this.visibleConversations = ko.pureComputed(() => {
       const filteredMLSConversations = useMLSConversationState
         .getState()

--- a/src/script/mls/mlsConversationState/mlsConversationState.ts
+++ b/src/script/mls/mlsConversationState/mlsConversationState.ts
@@ -62,16 +62,24 @@ export const useMLSConversationState = create<StoreState>((set, get) => {
     isPendingWelcome: groupId => get().pendingWelcome.has(groupId),
 
     markAsEstablished: groupId =>
-      set(state => ({
-        ...state,
-        established: state.established.add(groupId),
-      })),
+      set(state => {
+        const newState = new Set(state.established);
+        newState.add(groupId);
+        return {
+          ...state,
+          established: newState,
+        };
+      }),
 
     markAsPendingWelcome: groupId =>
-      set(state => ({
-        ...state,
-        pendingWelcome: state.pendingWelcome.add(groupId),
-      })),
+      set(state => {
+        const newState = new Set(state.pendingWelcome);
+        newState.add(groupId);
+        return {
+          ...state,
+          pendingWelcome: newState,
+        };
+      }),
 
     pendingWelcome: initialState.pendingWelcome,
 


### PR DESCRIPTION
When updating `established` / `pendingWelcome` state we have to do it reactive way, so overwrite the reference. Otherwise even when subscribing to store updates, just adding new item to the set won't notify the subscribers.

In conversation state we subscribe to store changes and notify subscribers of `sortedConversations` (including `visibleConversations`).