### PR TITLE
runfix: don't include conv domain when deleting conv form the store

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -351,7 +351,7 @@ export class ConversationRepository {
         conversationEntity.is_cleared() &&
         conversationEntity.removed_from_conversation()
       ) {
-        this.conversationService.deleteConversationFromDb(conversationEntity);
+        this.conversationService.deleteConversationFromDb(conversationEntity.id);
         this.deleteConversationFromRepository(conversationEntity);
       }
     });
@@ -949,7 +949,7 @@ export class ConversationRepository {
       this.conversationLabelRepository.saveLabels();
     }
     this.deleteConversationFromRepository(conversationId);
-    await this.conversationService.deleteConversationFromDb(conversationId);
+    await this.conversationService.deleteConversationFromDb(conversationId.id);
     if (conversationEntity.protocol === ConversationProtocol.MLS) {
       const {groupId} = conversationEntity;
       if (groupId) {
@@ -1896,7 +1896,7 @@ export class ConversationRepository {
     this.deleteMessages(conversationEntity, timestamp);
 
     if (conversationEntity.removed_from_conversation()) {
-      this.conversationService.deleteConversationFromDb(conversationEntity);
+      this.conversationService.deleteConversationFromDb(conversationEntity.id);
       this.deleteConversationFromRepository(conversationEntity);
     }
   }

--- a/src/script/conversation/ConversationService.ts
+++ b/src/script/conversation/ConversationService.ts
@@ -295,9 +295,8 @@ export class ConversationService {
    * Deletes a conversation entity from the local database.
    * @returns Resolves when the entity was deleted
    */
-  async deleteConversationFromDb({id, domain}: QualifiedId): Promise<string> {
-    const key = domain ? `${id}@${domain}` : id;
-    const primaryKey = await this.storageService.delete(StorageSchemata.OBJECT_STORE.CONVERSATIONS, key);
+  async deleteConversationFromDb(conversationId: string): Promise<string> {
+    const primaryKey = await this.storageService.delete(StorageSchemata.OBJECT_STORE.CONVERSATIONS, conversationId);
     return primaryKey;
   }
 

--- a/src/script/conversation/ConversationService.ts
+++ b/src/script/conversation/ConversationService.ts
@@ -296,8 +296,7 @@ export class ConversationService {
    * @returns Resolves when the entity was deleted
    */
   async deleteConversationFromDb(conversationId: string): Promise<string> {
-    const primaryKey = await this.storageService.delete(StorageSchemata.OBJECT_STORE.CONVERSATIONS, conversationId);
-    return primaryKey;
+    return this.storageService.delete(StorageSchemata.OBJECT_STORE.CONVERSATIONS, conversationId);
   }
 
   loadConversation<T>(conversationId: string): Promise<T | undefined> {


### PR DESCRIPTION
This seems to be in the code forever, when deleting the conversation locally, we lookup for the domain field on a conversation an try to construct the key like `${id}@${domain}`, but when saving the conversation in the store, we never include the domain. We use plain `conversationEntity.id` as a `primaryKey` in the `indexedDB` store. 

So now, when deleting conversation locally, it is never being removed from the store. Since conversations are never deleted, clients load them on app init and might try to perform some actions (like periodic key material updates for mls-capable conversations) what results in some errors in the console (conversations were deleted on backend).

I've identified all the places where we add db conversation entry (`storageService.save(StorageSchemata.OBJECT_STORE.CONVERSATIONS, ...)`) and we always pass plain conversation id, see:

https://github.com/wireapp/wire-webapp/blob/d5ef1bbfe2b8d7a2d61c5952c7c908662381d3ae/src/script/conversation/ConversationService.ts#L355

https://github.com/wireapp/wire-webapp/blob/d5ef1bbfe2b8d7a2d61c5952c7c908662381d3ae/src/script/conversation/ConversationService.ts#L373

https://github.com/wireapp/wire-webapp/blob/d5ef1bbfe2b8d7a2d61c5952c7c908662381d3ae/src/script/conversation/ConversationService.ts#L304

I think we can simply start using plain conversation id when deleting conversations.