### PR TITLE
runfix: wipe conversation from mls state after it was deleted

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@emotion/react": "11.11.1",
     "@types/eslint": "8.37.0",
     "@wireapp/avs": "9.2.15",
-    "@wireapp/core": "40.5.2",
+    "@wireapp/core": "40.5.3",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.7.5",
     "@wireapp/store-engine-dexie": "2.1.1",

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -79,6 +79,7 @@ import {ConversationFilter} from './ConversationFilter';
 import {ConversationLabelRepository} from './ConversationLabelRepository';
 import {ConversationDatabaseData, ConversationMapper} from './ConversationMapper';
 import {ConversationRoleRepository} from './ConversationRoleRepository';
+import {isMLSConversation} from './ConversationSelectors';
 import {ConversationService} from './ConversationService';
 import {ConversationState} from './ConversationState';
 import {ConversationStateHandler} from './ConversationStateHandler';
@@ -950,11 +951,8 @@ export class ConversationRepository {
     }
     this.deleteConversationFromRepository(conversationId);
     await this.conversationService.deleteConversationFromDb(conversationId.id);
-    if (conversationEntity.protocol === ConversationProtocol.MLS) {
-      const {groupId} = conversationEntity;
-      if (groupId) {
-        await this.core.service!.conversation.wipeMLSConversation(groupId);
-      }
+    if (isMLSConversation(conversationEntity)) {
+      await this.conversationService.wipeMLSConversation(conversationEntity);
     }
   };
 
@@ -2652,11 +2650,8 @@ export class ConversationRepository {
         eventJson.from = this.userState.self().id;
       }
 
-      if (conversationEntity.protocol === ConversationProtocol.MLS) {
-        const {groupId} = conversationEntity;
-        if (groupId) {
-          await this.core.service!.conversation.wipeMLSConversation(groupId);
-        }
+      if (isMLSConversation(conversationEntity)) {
+        await this.conversationService.wipeMLSConversation(conversationEntity);
       }
     } else {
       // Update conversation roles (in case the removed user had some special role and it's not the self user)

--- a/src/script/conversation/ConversationService.ts
+++ b/src/script/conversation/ConversationService.ts
@@ -45,11 +45,15 @@ import {container} from 'tsyringe';
 
 import {getLogger, Logger} from 'Util/Logger';
 
+import {MLSConversation} from './ConversationSelectors';
+
 import type {Conversation as ConversationEntity} from '../entity/Conversation';
 import type {EventService} from '../event/EventService';
 import {MessageCategory} from '../message/MessageCategory';
+import {useMLSConversationState} from '../mls';
 import {search as fullTextSearch} from '../search/FullTextSearch';
 import {APIClient} from '../service/APIClientSingleton';
+import {Core} from '../service/CoreSingleton';
 import {StorageService} from '../storage';
 import {ConversationRecord} from '../storage/record/ConversationRecord';
 import {StorageSchemata} from '../storage/StorageSchemata';
@@ -62,6 +66,7 @@ export class ConversationService {
     eventService: EventService,
     private readonly storageService = container.resolve(StorageService),
     private readonly apiClient = container.resolve(APIClient),
+    private readonly core = container.resolve(Core),
   ) {
     this.eventService = eventService;
     this.logger = getLogger('ConversationService');
@@ -394,5 +399,15 @@ export class ConversationService {
     return events
       .filter(record => record.ephemeral_expires !== true)
       .filter(({data: event_data}: any) => fullTextSearch(event_data.content, query));
+  }
+
+  /**
+   * Wipes MLS conversation in corecrypto and deletes the conversation state.
+   * @param mlsConversation mls conversation
+   */
+  async wipeMLSConversation(mlsConversation: MLSConversation) {
+    const {groupId} = mlsConversation;
+    await this.core.service!.conversation.wipeMLSConversation(groupId);
+    return useMLSConversationState.getState().wipeConversationState(groupId);
   }
 }

--- a/src/script/mls/mlsConversationState/mlsConversationState.ts
+++ b/src/script/mls/mlsConversationState/mlsConversationState.ts
@@ -39,6 +39,7 @@ type StoreState = MLSConversationState & {
   filterEstablishedConversations: (conversations: Conversation[]) => Conversation[];
   markAsEstablished: (groupId: string) => void;
   markAsPendingWelcome: (groupId: string) => void;
+  wipeConversationState: (groupId: string) => void;
   /**
    * Will send external proposal for all the conversations that are not pendingWelcome or established
    * @param conversations The conversations that we want to process (only the mls conversations will be considered)
@@ -63,21 +64,25 @@ export const useMLSConversationState = create<StoreState>((set, get) => {
 
     markAsEstablished: groupId =>
       set(state => {
-        const newState = new Set(state.established);
-        newState.add(groupId);
+        const established = new Set(state.established);
+        established.add(groupId);
+
+        const pendingWelcome = new Set(state.pendingWelcome);
+        pendingWelcome.delete(groupId);
+
         return {
-          ...state,
-          established: newState,
+          established,
+          pendingWelcome,
         };
       }),
 
     markAsPendingWelcome: groupId =>
       set(state => {
-        const newState = new Set(state.pendingWelcome);
-        newState.add(groupId);
+        const pendingWelcome = new Set(state.pendingWelcome);
+        pendingWelcome.add(groupId);
         return {
           ...state,
-          pendingWelcome: newState,
+          pendingWelcome,
         };
       }),
 
@@ -121,6 +126,19 @@ export const useMLSConversationState = create<StoreState>((set, get) => {
         pendingWelcome: new Set([...currentState.pendingWelcome, ...pendingConversations]),
       });
     },
+
+    wipeConversationState: groupId =>
+      set(state => {
+        const established = new Set(state.established);
+        established.delete(groupId);
+        const pendingWelcome = new Set(state.pendingWelcome);
+        pendingWelcome.delete(groupId);
+        return {
+          ...state,
+          established,
+          pendingWelcome,
+        };
+      }),
   };
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6138,9 +6138,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^24.15.5":
-  version: 24.15.5
-  resolution: "@wireapp/api-client@npm:24.15.5"
+"@wireapp/api-client@npm:^24.15.6":
+  version: 24.15.6
+  resolution: "@wireapp/api-client@npm:24.15.6"
   dependencies:
     "@wireapp/commons": ^5.1.0
     "@wireapp/priority-queue": ^2.1.1
@@ -6153,7 +6153,7 @@ __metadata:
     spark-md5: 3.0.2
     tough-cookie: 4.1.3
     ws: 8.11.0
-  checksum: 525aced6e2f8f4d7ebf4fb3baed3be29ff4ee928e513248362b46d4a093a79b08a3b7661cd485248fa80305acb2299742daf79b99195ef09cf8eae1fa7e2d2fd
+  checksum: 9f14648dc839aff733c19b236f78f7563552639293ce9bd131d0a34ede2025b8ed51f22123c0efadf98454b6e4f23211dc605536105709fb741c47bbc7590a81
   languageName: node
   linkType: hard
 
@@ -6206,11 +6206,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:40.5.2":
-  version: 40.5.2
-  resolution: "@wireapp/core@npm:40.5.2"
+"@wireapp/core@npm:40.5.3":
+  version: 40.5.3
+  resolution: "@wireapp/core@npm:40.5.3"
   dependencies:
-    "@wireapp/api-client": ^24.15.5
+    "@wireapp/api-client": ^24.15.6
     "@wireapp/commons": ^5.1.0
     "@wireapp/core-crypto": 0.11.0
     "@wireapp/cryptobox": 12.8.0
@@ -6227,7 +6227,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.13
-  checksum: f7e0cb030d2d1faf1f08848059252b252681ad80f2fbcd1404c02e70cad2c49617c60b3bd96f80dfc3540dd1c1758a470b38224d864a7aad2c97f516ef15d3c7
+  checksum: f40f7c7f369fbb922121f31d064e38850a18d7dd9be8953daa438313616055a6806095d207c564124023d4a8c800e757deec1f219be948cbb538379f72966125
   languageName: node
   linkType: hard
 
@@ -19049,7 +19049,7 @@ dexie@latest:
     "@typescript-eslint/parser": ^5.59.11
     "@wireapp/avs": 9.2.15
     "@wireapp/copy-config": 2.1.1
-    "@wireapp/core": 40.5.2
+    "@wireapp/core": 40.5.3
     "@wireapp/eslint-config": 2.2.2
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.6.0


### PR DESCRIPTION
We were never clearing an entry from mlsConversationStore after conversation was deleted (we've left or we were removed / conversation was deleted). This PR moves the logic of wiping the conversation from both corecrypto and mls conversation state to conversation service, this method makes sure mls group related data is cleared.

It also bumps core to the latest version. 