### PR TITLE
fix: handle failure to send mls messages (WPB-2300)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@emotion/react": "11.11.1",
     "@types/eslint": "8.37.0",
     "@wireapp/avs": "9.2.15",
-    "@wireapp/core": "40.5.2",
+    "@wireapp/core": "40.5.4",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.7.5",
     "@wireapp/store-engine-dexie": "2.1.1",

--- a/src/script/components/MessagesList/Message/ContentMessage/Warnings/CompleteFailureToSend/CompleteFailureToSend.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/Warnings/CompleteFailureToSend/CompleteFailureToSend.tsx
@@ -57,7 +57,7 @@ export const CompleteFailureToSendWarning = ({isMessageFocused, onRetry, unreach
           </Link>
         </p>
       ) : (
-        <p>{t('messageCouldNotBeSentConnectivityIssues')}</p>
+        <p css={warning}>{t('messageCouldNotBeSentConnectivityIssues')}</p>
       )}
       <div css={{display: 'flex'}}>
         <Button tabIndex={messageFocusedTabIndex} type="button" variant={ButtonVariant.TERTIARY} onClick={onRetry}>

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
@@ -72,7 +72,9 @@ const ContentAsset = ({
               onMessageClick={onClickMessage}
               text={(asset as Text).render(selfId, message.accent_color())}
               className={cx('text', {
-                'text-foreground': status === StatusType.SENDING || status === StatusType.FAILED,
+                'text-foreground': [StatusType.FAILED, StatusType.FEDERATION_ERROR, StatusType.SENDING].includes(
+                  status,
+                ),
                 'text-large': includesOnlyEmojis(asset.text),
                 'ephemeral-message-obfuscated': isObfuscated,
               })}

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -50,7 +50,6 @@ import {roundLogarithmic} from 'Util/NumberUtil';
 import {matchQualifiedIds} from 'Util/QualifiedId';
 import {capitalizeFirstChar} from 'Util/StringUtil';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
-import {isBackendError} from 'Util/TypePredicateUtil';
 import {loadUrlBlob, supportsMLS} from 'Util/util';
 import {createUuid} from 'Util/uuid';
 
@@ -809,9 +808,7 @@ export class MessageRepository {
       }
       return result;
     } catch (error) {
-      if (isBackendError(error)) {
-        await this.updateMessageAsFailed(conversation, payload.messageId, error);
-      }
+      await this.updateMessageAsFailed(conversation, payload.messageId, error);
       return {id: payload.messageId, sentAt: new Date().toISOString(), state: SendAndInjectSendingState.FAILED};
     }
   }
@@ -1187,7 +1184,7 @@ export class MessageRepository {
     return undefined;
   }
 
-  private async updateMessageAsFailed(conversationEntity: Conversation, eventId: string, error: BackendError) {
+  private async updateMessageAsFailed(conversationEntity: Conversation, eventId: string, error: BackendError | any) {
     try {
       const messageEntity = await this.getMessageInConversationById(conversationEntity, eventId);
       if (error.label === BackendErrorLabel.FEDERATION_REMOTE_ERROR) {

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -18,7 +18,7 @@
  */
 
 import {ConversationProtocol, MessageSendingStatus, QualifiedUserClients} from '@wireapp/api-client/lib/conversation';
-import {BackendError, BackendErrorLabel} from '@wireapp/api-client/lib/http/';
+import {BackendErrorLabel} from '@wireapp/api-client/lib/http/';
 import {QualifiedId, RequestCancellationError, User as APIClientUser} from '@wireapp/api-client/lib/user';
 import {MessageSendingState, MessageTargetMode, GenericMessageType, SendResult} from '@wireapp/core/lib/conversation';
 import {
@@ -50,6 +50,7 @@ import {roundLogarithmic} from 'Util/NumberUtil';
 import {matchQualifiedIds} from 'Util/QualifiedId';
 import {capitalizeFirstChar} from 'Util/StringUtil';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
+import {isBackendError} from 'Util/TypePredicateUtil';
 import {loadUrlBlob, supportsMLS} from 'Util/util';
 import {createUuid} from 'Util/uuid';
 
@@ -1184,10 +1185,10 @@ export class MessageRepository {
     return undefined;
   }
 
-  private async updateMessageAsFailed(conversationEntity: Conversation, eventId: string, error: BackendError | any) {
+  private async updateMessageAsFailed(conversationEntity: Conversation, eventId: string, error: unknown) {
     try {
       const messageEntity = await this.getMessageInConversationById(conversationEntity, eventId);
-      if (error.label === BackendErrorLabel.FEDERATION_REMOTE_ERROR) {
+      if (isBackendError(error) && error.label === BackendErrorLabel.FEDERATION_REMOTE_ERROR) {
         messageEntity.status(StatusType.FEDERATION_ERROR);
         return this.eventService.updateEvent(messageEntity.primary_key, {status: StatusType.FEDERATION_ERROR});
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6138,9 +6138,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^24.15.5":
-  version: 24.15.5
-  resolution: "@wireapp/api-client@npm:24.15.5"
+"@wireapp/api-client@npm:^24.15.6":
+  version: 24.15.6
+  resolution: "@wireapp/api-client@npm:24.15.6"
   dependencies:
     "@wireapp/commons": ^5.1.0
     "@wireapp/priority-queue": ^2.1.1
@@ -6153,7 +6153,7 @@ __metadata:
     spark-md5: 3.0.2
     tough-cookie: 4.1.3
     ws: 8.11.0
-  checksum: 525aced6e2f8f4d7ebf4fb3baed3be29ff4ee928e513248362b46d4a093a79b08a3b7661cd485248fa80305acb2299742daf79b99195ef09cf8eae1fa7e2d2fd
+  checksum: 9f14648dc839aff733c19b236f78f7563552639293ce9bd131d0a34ede2025b8ed51f22123c0efadf98454b6e4f23211dc605536105709fb741c47bbc7590a81
   languageName: node
   linkType: hard
 
@@ -6206,11 +6206,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:40.5.2":
-  version: 40.5.2
-  resolution: "@wireapp/core@npm:40.5.2"
+"@wireapp/core@npm:40.5.4":
+  version: 40.5.4
+  resolution: "@wireapp/core@npm:40.5.4"
   dependencies:
-    "@wireapp/api-client": ^24.15.5
+    "@wireapp/api-client": ^24.15.6
     "@wireapp/commons": ^5.1.0
     "@wireapp/core-crypto": 0.11.0
     "@wireapp/cryptobox": 12.8.0
@@ -6227,7 +6227,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.13
-  checksum: f7e0cb030d2d1faf1f08848059252b252681ad80f2fbcd1404c02e70cad2c49617c60b3bd96f80dfc3540dd1c1758a470b38224d864a7aad2c97f516ef15d3c7
+  checksum: d8ed22d3696c5b979586664ff647d9dd98730fd99827504cf6cb2fbd27b900c4163de352cf9921417c3c76d286b7a2ab8a53ddc4f4829ed87aad9b781a1092df
   languageName: node
   linkType: hard
 
@@ -19049,7 +19049,7 @@ dexie@latest:
     "@typescript-eslint/parser": ^5.59.11
     "@wireapp/avs": 9.2.15
     "@wireapp/copy-config": 2.1.1
-    "@wireapp/core": 40.5.2
+    "@wireapp/core": 40.5.4
     "@wireapp/eslint-config": 2.2.2
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.6.0


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2300" title="WPB-2300" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-2300</a>  [Web] On sending a messages to a conversation owned by an offline b-e with MLS the option to retry does dot appear
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Issues

1. when sending a message to an mls conversation, the option to retry do not appear when the owning b-e is offline

2. same thing when sending a message while internet is offline using api v4

3. wrong styling in some cases

### Solutions

1. bump core to 40.5.4, see https://github.com/wireapp/wire-web-packages/pull/5254

2. handle `AxiosError` as failure to send

3. make sure error messages appear in red, and unsent messages gray
