### PR TITLE
fix: web and MLS group convo wasn't renamed on header when backend wa…

### DIFF
--- a/src/script/components/MessagesList/Message/MemberMessage.test.tsx
+++ b/src/script/components/MessagesList/Message/MemberMessage.test.tsx
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2021 Wire Swiss GmbH
+ * Copyright (C) 2023 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -34,7 +34,7 @@ const createMemberMessage = (partialMemberMessage: Partial<MemberMessageEntity>)
     isMemberLeave: () => false,
     isMemberRemoval: () => false,
     showLargeAvatar: () => false,
-    showNamedCreation: ko.pureComputed(() => false),
+    showNamedCreation: ko.pureComputed(() => true),
     timestamp: ko.observable(Date.now()),
     ...partialMemberMessage,
   };
@@ -54,10 +54,27 @@ describe('MemberMessage', () => {
       onClickInvitePeople: () => {},
       onClickParticipants: () => {},
       shouldShowInvitePeople: false,
+      conversationName: 'group 1',
     };
 
     const {queryByTestId} = render(<MemberMessage {...props} />);
-
     expect(queryByTestId('element-connected-message')).not.toBeNull();
+  });
+  it('shows conversation title', async () => {
+    const props = {
+      hasReadReceiptsTurnedOn: false,
+      isSelfTemporaryGuest: false,
+      message: createMemberMessage({
+        otherUser: ko.pureComputed(() => new User('id')),
+      }),
+      onClickCancelRequest: () => {},
+      onClickInvitePeople: () => {},
+      onClickParticipants: () => {},
+      shouldShowInvitePeople: false,
+      conversationName: 'group 1',
+    };
+
+    const {getByTestId} = render(<MemberMessage {...props} />);
+    expect(getByTestId('conversation-name').textContent).toBe(props.conversationName);
   });
 });

--- a/src/script/components/MessagesList/Message/MemberMessage.test.tsx
+++ b/src/script/components/MessagesList/Message/MemberMessage.test.tsx
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2023 Wire Swiss GmbH
+ * Copyright (C) 2021 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/script/components/MessagesList/Message/MemberMessage.tsx
+++ b/src/script/components/MessagesList/Message/MemberMessage.tsx
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2021 Wire Swiss GmbH
+ * Copyright (C) 2023 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -40,6 +40,7 @@ export interface MemberMessageProps {
   onClickInvitePeople: () => void;
   onClickParticipants: (participants: User[]) => void;
   shouldShowInvitePeople: boolean;
+  conversationName: string;
 }
 
 const MemberMessage: React.FC<MemberMessageProps> = ({
@@ -51,12 +52,12 @@ const MemberMessage: React.FC<MemberMessageProps> = ({
   onClickParticipants,
   onClickCancelRequest,
   classifiedDomains,
+  conversationName,
 }) => {
   const {
     otherUser,
     timestamp,
     user,
-    name,
     htmlGroupCreationHeader,
     htmlCaption,
     highlightedUsers,
@@ -105,7 +106,9 @@ const MemberMessage: React.FC<MemberMessageProps> = ({
                 className="message-group-creation-header-text"
                 dangerouslySetInnerHTML={{__html: htmlGroupCreationHeader}}
               />
-              <h2 className="message-group-creation-header-name">{name}</h2>
+              <h2 className="message-group-creation-header-name" data-uie-name="conversation-name">
+                {conversationName}
+              </h2>
             </div>
           )}
           {hasUsers && (

--- a/src/script/components/MessagesList/Message/MemberMessage.tsx
+++ b/src/script/components/MessagesList/Message/MemberMessage.tsx
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2023 Wire Swiss GmbH
+ * Copyright (C) 2021 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/script/components/MessagesList/Message/MessageWrapper.tsx
+++ b/src/script/components/MessagesList/Message/MessageWrapper.tsx
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2022 Wire Swiss GmbH
+ * Copyright (C) 2023 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,6 +29,7 @@ import {OutgoingQuote} from 'src/script/conversation/MessageRepository';
 import {ContentMessage} from 'src/script/entity/message/ContentMessage';
 import {Text} from 'src/script/entity/message/Text';
 import {QuoteEntity} from 'src/script/message/QuoteEntity';
+import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 
 import {CallMessage} from './CallMessage';
@@ -116,6 +117,7 @@ export const MessageWrapper: React.FC<MessageParams & {hasMarker: boolean; isMes
       await messageRepository.retryUploadFile(conversation, file, firstAsset.isImage(), message.id);
     }
   };
+  const {display_name: displayName} = useKoSubscribableChildren(conversation, ['display_name']);
 
   const contextMenuEntries = ko.pureComputed(() => {
     const entries: ContextMenuEntry[] = [];
@@ -245,6 +247,7 @@ export const MessageWrapper: React.FC<MessageParams & {hasMarker: boolean; isMes
     return (
       <MemberMessage
         message={message}
+        conversationName={displayName}
         onClickInvitePeople={onClickInvitePeople}
         onClickParticipants={onClickParticipants}
         onClickCancelRequest={onClickCancelRequest}

--- a/src/script/components/MessagesList/Message/MessageWrapper.tsx
+++ b/src/script/components/MessagesList/Message/MessageWrapper.tsx
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2023 Wire Swiss GmbH
+ * Copyright (C) 2022 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsHeader/ConversationDetailsHeader.test.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsHeader/ConversationDetailsHeader.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render, fireEvent} from '@testing-library/react';
+
+import {ConversationDetailsHeader} from './ConversationDetailsHeader';
+
+const getDefaultProps = () => ({
+  isActiveGroupParticipant: true,
+  canRenameGroup: true,
+  displayName: 'Group Chat',
+  updateConversationName: jest.fn(),
+  isGroup: true,
+  userParticipants: [],
+  serviceParticipants: [],
+  allUsersCount: 0,
+  isTeam: false,
+});
+
+describe('ConversationDetailsHeader', () => {
+  it('renders the display name when not editing', () => {
+    const props = getDefaultProps();
+    const {getByText} = render(<ConversationDetailsHeader {...props} />);
+
+    const nameElement = getByText(props.displayName);
+    expect(nameElement).not.toBe(null);
+  });
+
+  it('allows editing the group name', () => {
+    const props = getDefaultProps();
+    const {getByText, getByTestId} = render(<ConversationDetailsHeader {...props} />);
+
+    const nameElement = getByText(props.displayName);
+    fireEvent.click(nameElement);
+
+    const textareaElement = getByTestId('enter-name') as HTMLInputElement;
+    expect(textareaElement).not.toBe(null);
+  });
+
+  it('calls updateConversationName when pressing Enter to save the renamed conversation', () => {
+    const props = getDefaultProps();
+    const {getByText, getByTestId} = render(<ConversationDetailsHeader {...props} />);
+
+    const nameElement = getByText(props.displayName);
+    fireEvent.click(nameElement);
+
+    const newGroupName = 'Group Name Update';
+    const textareaElement = getByTestId('enter-name') as HTMLInputElement;
+    fireEvent.change(textareaElement, {target: {value: newGroupName}});
+    fireEvent.keyDown(textareaElement, {key: 'Enter', code: 'Enter'});
+
+    expect(props.updateConversationName).toHaveBeenCalledTimes(1);
+    expect(props.updateConversationName).toHaveBeenCalledWith(newGroupName);
+  });
+});

--- a/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsHeader/ConversationDetailsHeader.test.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsHeader/ConversationDetailsHeader.test.tsx
@@ -19,16 +19,21 @@
 
 import {render, fireEvent} from '@testing-library/react';
 
+import {User} from 'src/script/entity/User';
+import {ServiceEntity} from 'src/script/integration/ServiceEntity';
+
 import {ConversationDetailsHeader} from './ConversationDetailsHeader';
 
+const participant = new User('id');
+const service = new ServiceEntity({id: 'id'});
 const getDefaultProps = () => ({
   isActiveGroupParticipant: true,
   canRenameGroup: true,
   displayName: 'Group Chat',
   updateConversationName: jest.fn(),
   isGroup: true,
-  userParticipants: [],
-  serviceParticipants: [],
+  userParticipants: new Array(participant),
+  serviceParticipants: new Array(service),
   allUsersCount: 0,
   isTeam: false,
 });

--- a/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsHeader/ConversationDetailsHeader.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsHeader/ConversationDetailsHeader.tsx
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2023 Wire Swiss GmbH
+ * Copyright (C) 2022 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsHeader/ConversationDetailsHeader.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsHeader/ConversationDetailsHeader.tsx
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2022 Wire Swiss GmbH
+ * Copyright (C) 2023 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - Web and MLS group convo wasn't renamed on header when backend was off

- The **PR Description**
  - Environment: Web, Foma

    STR:
    
    There is MLS group conversation on Forma with users
    
    When backend is off - Admin renames group convo

    Actual result: conversation was renamed on participant details and group list menu, but not in internal conversation header
    
    Expected result: conversation was renamed on all webapp layouts
----
### Testing

#### Test Coverage (Optional)

- [ ] I have added unit test to this contribution
----
##### References
1. https://wearezeta.atlassian.net/browse/WPB-1915
