### PR TITLE
chore: bump core to 40.6.0 - corecrypto draft 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@emotion/react": "11.11.1",
     "@types/eslint": "8.37.0",
     "@wireapp/avs": "9.2.15",
-    "@wireapp/core": "40.5.5",
+    "@wireapp/core": "40.6.0",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.7.5",
     "@wireapp/store-engine-dexie": "2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6102,9 +6102,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^24.15.7":
-  version: 24.15.7
-  resolution: "@wireapp/api-client@npm:24.15.7"
+"@wireapp/api-client@npm:^24.16.0":
+  version: 24.16.0
+  resolution: "@wireapp/api-client@npm:24.16.0"
   dependencies:
     "@wireapp/commons": ^5.1.0
     "@wireapp/priority-queue": ^2.1.1
@@ -6117,7 +6117,7 @@ __metadata:
     spark-md5: 3.0.2
     tough-cookie: 4.1.3
     ws: 8.11.0
-  checksum: 4e240b21a1862d9479e62500a8d8005e8dd89cffc3740e28d4733a7a246f17b044de216f2b8007a72a36358c43d082631a08b03df41c4efa5cec9ba90c22f376
+  checksum: 92af35a97144148d460a68c163f9b159fd9b4796376301e1434bf84698fad46980da0bd1409cada959ab82b0de282907e57a2a720955210077f1b96267c22c40
   languageName: node
   linkType: hard
 
@@ -6163,20 +6163,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core-crypto@npm:0.11.0":
-  version: 0.11.0
-  resolution: "@wireapp/core-crypto@npm:0.11.0"
-  checksum: 247272085a734b15a1fc82caaaad1c1f935609564a4fa8b5954727bcd16df23c4e85192772d853fcd15baabb6efd7e1777901aa4021e9e34fd46e89d98bab8ca
+"@wireapp/core-crypto@npm:1.0.0-pre.5":
+  version: 1.0.0-pre.5
+  resolution: "@wireapp/core-crypto@npm:1.0.0-pre.5"
+  checksum: 627e55ab7272f25047afda61d4e9f1f496a85a2326a2d01970fdf70f08abac996fabfa0c42d9bb8ee049abd03529b8f58ed72f0dcfb1c01f2a1c193ae6d14ad4
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:40.5.5":
-  version: 40.5.5
-  resolution: "@wireapp/core@npm:40.5.5"
+"@wireapp/core@npm:40.6.0":
+  version: 40.6.0
+  resolution: "@wireapp/core@npm:40.6.0"
   dependencies:
-    "@wireapp/api-client": ^24.15.7
+    "@wireapp/api-client": ^24.16.0
     "@wireapp/commons": ^5.1.0
-    "@wireapp/core-crypto": 0.11.0
+    "@wireapp/core-crypto": 1.0.0-pre.5
     "@wireapp/cryptobox": 12.8.0
     "@wireapp/promise-queue": ^2.2.0
     "@wireapp/protocol-messaging": 1.44.0
@@ -6191,7 +6191,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.13
-  checksum: 2be52a978e02389443164dfb3dfe7777a72b4d83500fd5da6b76f03c7b853f8c50c15e72ec730afc0cb1d63442385562ca2088e3a2e27972d2ed6c4a7d06fb9d
+  checksum: e27e71409de6224847a283d30a3c98ed748da40d4a881c940eb372964f3586263fc7691782eaa2ad2239cabaa6b27fa9dd3066c98ca8fc7e5a6511f63788ba99
   languageName: node
   linkType: hard
 
@@ -19060,7 +19060,7 @@ dexie@latest:
     "@typescript-eslint/parser": ^5.60.0
     "@wireapp/avs": 9.2.15
     "@wireapp/copy-config": 2.1.1
-    "@wireapp/core": 40.5.5
+    "@wireapp/core": 40.6.0
     "@wireapp/eslint-config": 2.2.2
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.6.0


### PR DESCRIPTION
https://github.com/wireapp/wire-web-packages/pull/5258

Bump core crypto to the version supporting draft-20 :rocket: 