### PR TITLE
fix: limit interaction with unavailable users (WPB-2323)

### DIFF
--- a/src/script/components/panel/UserActions.tsx
+++ b/src/script/components/panel/UserActions.tsx
@@ -97,6 +97,7 @@ const UserActions: React.FC<UserActionsProps> = ({
   selfUser,
 }) => {
   const {
+    isAvailable,
     isBlocked,
     isCanceled,
     isRequest,
@@ -107,6 +108,7 @@ const UserActions: React.FC<UserActionsProps> = ({
     isOutgoingRequest,
     isIncomingRequest,
   } = useKoSubscribableChildren(user, [
+    'isAvailable',
     'isTemporaryGuest',
     'isTeamMember',
     'isBlocked',
@@ -157,7 +159,7 @@ const UserActions: React.FC<UserActionsProps> = ({
       : undefined;
 
   const open1To1Conversation: MenuItem | undefined =
-    isNotMe && (isConnected || isTeamMember)
+    isNotMe && isAvailable && (isConnected || isTeamMember)
       ? {
           click: async () => {
             await create1to1Conversation(user, true);
@@ -170,7 +172,7 @@ const UserActions: React.FC<UserActionsProps> = ({
       : undefined;
 
   const acceptConnectionRequest: MenuItem | undefined =
-    isNotMe && isIncomingRequest
+    isNotMe && isAvailable && isIncomingRequest
       ? {
           click: async () => {
             await actionsViewModel.acceptConnectionRequest(user);
@@ -214,7 +216,7 @@ const UserActions: React.FC<UserActionsProps> = ({
   const canConnect = !isTeamMember && !isTemporaryGuest;
 
   const sendConnectionRequest: MenuItem | undefined =
-    isNotMe && isNotConnectedUser && canConnect
+    isNotMe && isAvailable && isNotConnectedUser && canConnect
       ? {
           click: async () => {
             const connectionIsSent = await actionsViewModel.sendConnectionRequest(user);
@@ -238,7 +240,7 @@ const UserActions: React.FC<UserActionsProps> = ({
       : undefined;
 
   const blockUser: MenuItem | undefined =
-    isNotMe && (isConnected || isRequest)
+    isNotMe && isAvailable && (isConnected || isRequest)
       ? {
           click: async () => {
             await actionsViewModel.blockUser(user);
@@ -252,7 +254,7 @@ const UserActions: React.FC<UserActionsProps> = ({
       : undefined;
 
   const unblockUser: MenuItem | undefined =
-    isNotMe && isBlocked
+    isNotMe && isAvailable && isBlocked
       ? {
           click: async () => {
             await actionsViewModel.unblockUser(user);

--- a/src/script/page/RightSidebar/GroupParticipantUser/GroupParticipantUser.tsx
+++ b/src/script/page/RightSidebar/GroupParticipantUser/GroupParticipantUser.tsx
@@ -77,7 +77,7 @@ const GroupParticipantUser: FC<GroupParticipantUserProps> = ({
   isFederated = false,
 }) => {
   const {isGroup, roles} = useKoSubscribableChildren(activeConversation, ['isGroup', 'roles']);
-  const {isTemporaryGuest} = useKoSubscribableChildren(currentUser, ['isTemporaryGuest']);
+  const {isTemporaryGuest, isAvailable} = useKoSubscribableChildren(currentUser, ['isTemporaryGuest', 'isAvailable']);
   const {classifiedDomains, isTeam, team} = useKoSubscribableChildren(teamState, [
     'classifiedDomains',
     'isTeam',
@@ -156,7 +156,7 @@ const GroupParticipantUser: FC<GroupParticipantUserProps> = ({
           classifiedDomains={classifiedDomains}
         />
 
-        {!currentUser.isMe && (
+        {!currentUser.isMe && isAvailable && (
           <div className="conversation-details__devices">
             <button
               className="panel__action-item"
@@ -176,7 +176,7 @@ const GroupParticipantUser: FC<GroupParticipantUserProps> = ({
           </div>
         )}
 
-        {canChangeRole && (
+        {canChangeRole && isAvailable && (
           <>
             <div className="conversation-details__admin">
               <div


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2323" title="WPB-2323" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-2323</a>  [Web] limit interaction available in right sidebar with unavailable users
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

- The only available action with users that could  not be fetched because their b-e is offline is to remove them from a conversation
![Screenshot from 2023-06-27 13-41-50](https://github.com/wireapp/wire-webapp/assets/78490891/1d86e1c0-17d2-41ab-98bc-7a9244fe7d60)

