### PR TITLE
runfix: join only established self mls group, otherwise establish

### DIFF
--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -431,11 +431,11 @@ export class App {
       if (supportsMLS()) {
         // Once all the messages have been processed and the message sending queue freed we can now:
 
-        //join all the mls groups we're member of and have not yet joined (eg. we were not send welcome message)
-        await initMLSConversations(conversations, this.core);
-
         //add the potential `self` and `team` conversations
         await registerUninitializedSelfAndTeamConversations(conversations, selfUser, clientEntity().id, this.core);
+
+        //join all the mls groups we're member of and have not yet joined (eg. we were not send welcome message)
+        await initMLSConversations(conversations, this.core);
       }
 
       telemetry.timeStep(AppInitTimingsStep.UPDATED_FROM_NOTIFICATIONS);


### PR DESCRIPTION
When logging in with the user for the first time, their self-mls group is unestablished (epoch 0). When we load webapp we should first try to establish MLS group, and as a 2nd step (if epoch was higher than 0, so the group was already established), try joining via external commit.

We were doing these steps in the opposite order, so we were trying to join with external commit first. First step of joining via ext commit is to fetch group info that does not exist when group is not established yet, therefore we were ending up with 500 error when hitting `GET: /conversations/{domian}/{id}/groupinfo`