### PR TITLE
fix: accidentally removed translation [WPB-1341]

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -975,7 +975,7 @@
   "oauth.scope.read_self": "Access user information",
   "oauth.scope.write_conversations": "Create conversations",
   "oauth.scope.write_conversations_code": "Create conversation guest links",
-  "oauth.subhead": "{app} requires your permission to:",
+  "oauth.subhead": "Microsoft Outlook requires your permission to:",
   "offlineBackendLearnMore": "Learn more",
   "ongoingAudioCall": "Ongoing audio call with {{conversationName}}.",
   "ongoingGroupAudioCall": "Ongoing conference call with {{conversationName}}.",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-1341" title="WPB-1341" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-1341</a>  [Web] [OAuth] OAuth Authorization Prompt requests non-displayed scopes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

fix issue with accidentally overwritten translation.


