### PR TITLE
fix: update call participant video state when changed [WPB-2494]

### DIFF
--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -1418,7 +1418,7 @@ export class CallingRepository {
   }
 
   private updateParticipantVideoState(call: Call, members: QualifiedWcallMember[]): void {
-    members.forEach(member => call.getParticipant(member.userId, member.clientid)?.isSendingVideo(!!member.vrecv));
+    members.forEach(member => call.getParticipant(member.userId, member.clientid)?.videoState(member.vrecv));
   }
 
   private updateParticipantAudioState(call: Call, members: QualifiedWcallMember[]): void {

--- a/src/script/calling/Participant.ts
+++ b/src/script/calling/Participant.ts
@@ -39,7 +39,7 @@ export class Participant {
   public sharesCamera: ko.PureComputed<boolean>;
   public startedScreenSharingAt: ko.Observable<number>;
   public isActivelySpeaking: ko.Observable<boolean>;
-  public isSendingVideo: ko.Observable<boolean>;
+  public isSendingVideo: ko.PureComputed<boolean>;
   public isAudioEstablished: ko.Observable<boolean>;
 
   // Audio
@@ -65,7 +65,9 @@ export class Participant {
     this.isActivelySpeaking = ko.observable(false);
     this.startedScreenSharingAt = ko.observable();
     this.isMuted = ko.observable(false);
-    this.isSendingVideo = ko.observable(false);
+    this.isSendingVideo = ko.pureComputed(() => {
+      return this.videoState() !== VIDEO_STATE.STOPPED;
+    });
     this.isAudioEstablished = ko.observable(false);
   }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2494" title="WPB-2494" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-2494</a>  [Web] Video stream not displayed anymore when leaving and rejoining a call while video is received
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Fixes the issue where video/screenshare of other call participants is not visible after rejoining the call.

We initialise call participants with video state `0` (`STOPPED`). Previously we were just listening to `videoStateChanged` (`vstateh`) event to update videoState of participants in webapp client. When rejoining the call this callback is not really fired since video state of the other users does not really change (we're the one who's joining the call), so webapp was never informed again that some participants are sharing video/screen. 

The solution is to update video state of each participant whenever participant list changes -     wCall.setParticipantChangedHandler(wUser, this.handleCallParticipantChanges). This callback gets fired if any state of call participant changes - whether it is audio establishment (`aestab`), **video state** (`vrecv`) or `muted`. When joining a call user is informed of what is the current state of call participants. For more details see https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/616857724/Use+case+observe+call+participants
