### PR TITLE
fix: display cannot find user warning instead of placeholder profile (WPB-2877)

### DIFF
--- a/src/script/components/Modals/UserModal/UserModal.tsx
+++ b/src/script/components/Modals/UserModal/UserModal.tsx
@@ -156,7 +156,7 @@ const UserModal: React.FC<UserModalProps> = ({
       userRepository
         .getUserById(userId)
         .then(user => {
-          if (user.isDeleted) {
+          if (user.isDeleted || !user.isAvailable()) {
             setUserNotFound(true);
             return;
           }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2877" title="WPB-2877" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-2877</a>  [Web] Link to user profile with invalid userID shows default template
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Issue
- when trying to access a user profile that doesn't exist via url, a placeholder profile would appear
![image](https://github.com/wireapp/wire-webapp/assets/78490891/8a7befe4-3c62-4235-aa69-951915ca1c23)

### Solution
- Expected behavior is to show a warning that a user could not be found
![image](https://github.com/wireapp/wire-webapp/assets/78490891/7b6984de-0c33-491b-8623-a9b86e823914)
