### PR TITLE
fix: import events without id field

### DIFF
--- a/src/script/backup/BackupService.ts
+++ b/src/script/backup/BackupService.ts
@@ -119,7 +119,7 @@ export class BackupService {
       return entities.length;
     }
 
-    const ids = entities.map(generateId).filter((id): id is string => id !== undefined);
+    const ids = entities.map(generateId).filter((id): id is string => typeof id === 'string');
     const existingEntities = await table.where('id').anyOf(ids).toArray();
     const newEntities = entities.filter(
       entity => !existingEntities.some(existingEntity => generateId(existingEntity) === generateId(entity)),

--- a/src/script/backup/BackupService.ts
+++ b/src/script/backup/BackupService.ts
@@ -81,7 +81,7 @@ export class BackupService {
     {
       generatePrimaryKey,
       generateId,
-    }: {generatePrimaryKey?: (entry: T) => string; generateId?: (entry: T) => string} = {},
+    }: {generatePrimaryKey?: (entry: T) => string; generateId?: (entry: T) => string | undefined} = {},
   ): Promise<number> {
     if (this.storageService.db) {
       const table = await this.storageService.db.table(tableName);
@@ -112,14 +112,14 @@ export class BackupService {
   private async addByIds<T>(
     table: Dexie.Table<T, unknown>,
     entities: T[],
-    generateId?: (entry: T) => string,
+    generateId?: (entry: T) => string | undefined,
   ): Promise<number> {
     if (!generateId) {
       await table.bulkAdd(entities);
       return entities.length;
     }
 
-    const ids = entities.map(generateId);
+    const ids = entities.map(generateId).filter((id): id is string => id !== undefined);
     const existingEntities = await table.where('id').anyOf(ids).toArray();
     const newEntities = entities.filter(
       entity => !existingEntities.some(existingEntity => generateId(existingEntity) === generateId(entity)),

--- a/src/script/storage/record/EventRecord.ts
+++ b/src/script/storage/record/EventRecord.ts
@@ -61,7 +61,7 @@ export type StoredEvent<T> = {
   /** Only used with IndexedDB table 'event' */
   primary_key: string;
   category: number;
-  id: string;
+  id?: string;
   /** if the message is ephemeral, that's the amount of time it should be displayed to the user
    * the different types are
    *  - string: a datestring


### PR DESCRIPTION
Regression introduced in https://github.com/wireapp/wire-webapp/pull/15085

There are some types of events like `conversation.member-join` or `conversation.member-leave` that do not contain `"id"`. `"id"` field was typed as mandatory, while it was not true for mentioned types of events. 

`table.where('id').anyOf(ids).toArray()` was throwing error when the list of `ids` contained at least one `undefined` value. 

The fix is to type id as optional and filter out the events that do not contain id.