### PR TITLE
chore: bump core to include last_active field on client

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@emotion/react": "11.11.1",
     "@types/eslint": "8.37.0",
     "@wireapp/avs": "9.2.20",
-    "@wireapp/core": "40.6.3",
+    "@wireapp/core": "40.7.0",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.7.5",
     "@wireapp/store-engine-dexie": "2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6261,9 +6261,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^24.18.1":
-  version: 24.18.1
-  resolution: "@wireapp/api-client@npm:24.18.1"
+"@wireapp/api-client@npm:^24.19.0":
+  version: 24.19.0
+  resolution: "@wireapp/api-client@npm:24.19.0"
   dependencies:
     "@wireapp/commons": ^5.1.0
     "@wireapp/priority-queue": ^2.1.1
@@ -6276,7 +6276,7 @@ __metadata:
     spark-md5: 3.0.2
     tough-cookie: 4.1.3
     ws: 8.11.0
-  checksum: d43274ade071c5b9e02bd76bb9353e6e4ddd3d5aacdcd9f0b5f536836ce7375f76d62f4f5b651626c595d12bb9f741a96c0ef752c2f0de6ee043566cc089962e
+  checksum: 084d129cc3bf5f0ff6a756de40bf89cb2817f8edea6df1fa2d571541d0e3f75f85cdf4365c993fd6f6592698b82cb661804de56aa0c175a80754f456c927c03b
   languageName: node
   linkType: hard
 
@@ -6329,11 +6329,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:40.6.3":
-  version: 40.6.3
-  resolution: "@wireapp/core@npm:40.6.3"
+"@wireapp/core@npm:40.7.0":
+  version: 40.7.0
+  resolution: "@wireapp/core@npm:40.7.0"
   dependencies:
-    "@wireapp/api-client": ^24.18.1
+    "@wireapp/api-client": ^24.19.0
     "@wireapp/commons": ^5.1.0
     "@wireapp/core-crypto": 1.0.0-pre.5
     "@wireapp/cryptobox": 12.8.0
@@ -6350,7 +6350,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.13
-  checksum: 1d4ab45f514ce749036ad89bafd11c8ece2d84f4583d9e1de3cef83eb6cbda776981a232f684e9573330a28110959970d3693768199b951674d66b076d9ca991
+  checksum: 4da5b83fa6d984c58c75d4dd004909decb1b38c79e9d3a5a166e48f35fd716e15dfbc706be62caea71753be266d6ff4ca582e57f8a1de93d259049a54dc97503
   languageName: node
   linkType: hard
 
@@ -19353,7 +19353,7 @@ dexie@latest:
     "@typescript-eslint/parser": ^5.61.0
     "@wireapp/avs": 9.2.20
     "@wireapp/copy-config": 2.1.1
-    "@wireapp/core": 40.6.3
+    "@wireapp/core": 40.7.0
     "@wireapp/eslint-config": 2.2.2
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.6.0


### PR DESCRIPTION
Bumps version of `@wireapp/core` that adds `last_active` field on client entity and updates local client with remote data when the client is loaded. See https://github.com/wireapp/wire-web-packages/pull/5306