### PR TITLE
refactor: mls migration

### DIFF
--- a/src/script/client/ClientRepository.ts
+++ b/src/script/client/ClientRepository.ts
@@ -396,9 +396,13 @@ export class ClientRepository {
    * @returns Resolves when the clients have been updated
    */
   async updateClientsForSelf(): Promise<ClientEntity[]> {
-    const clientsData = await this.clientService.getClients();
+    const clientsData = await this.getAllSelfClients();
     const {domain, id} = this.selfUser();
     return this.updateUserClients({domain, id}, clientsData, false);
+  }
+
+  public async getAllSelfClients(): Promise<RegisteredClient[]> {
+    return this.clientService.getClients();
   }
 
   /**

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -102,7 +102,6 @@ import {Core} from '../service/CoreSingleton';
 import {StorageKey, StorageRepository, StorageService} from '../storage';
 import {TeamRepository} from '../team/TeamRepository';
 import {TeamService} from '../team/TeamService';
-import {TeamState} from '../team/TeamState';
 import {AppInitStatisticsValue} from '../telemetry/app_init/AppInitStatisticsValue';
 import {AppInitTelemetry} from '../telemetry/app_init/AppInitTelemetry';
 import {AppInitTimingsStep} from '../telemetry/app_init/AppInitTimingsStep';
@@ -498,9 +497,9 @@ export class App {
       telemetry.timeStep(AppInitTimingsStep.APP_LOADED);
 
       if (supportsSelfSupportedProtocolsUpdates()) {
-        const teamState = container.resolve(TeamState);
-        await initialisePeriodicSelfSupportedProtocolsCheck(selfUser, teamState.teamFeatures(), {
+        await initialisePeriodicSelfSupportedProtocolsCheck(selfUser, {
           userRepository: this.repository.user,
+          teamRepository: this.repository.team,
         });
       }
 

--- a/src/script/mls/MLSMigration/MLSMigration.ts
+++ b/src/script/mls/MLSMigration/MLSMigration.ts
@@ -21,11 +21,9 @@ import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {registerRecurringTask} from '@wireapp/core/lib/util/RecurringTaskScheduler';
 import {container} from 'tsyringe';
 
-import {APIClient} from '@wireapp/api-client';
 import {Account} from '@wireapp/core';
 
 import {ConversationRepository} from 'src/script/conversation/ConversationRepository';
-import {APIClient as APIClientSingleton} from 'src/script/service/APIClientSingleton';
 import {Core as CoreSingleton} from 'src/script/service/CoreSingleton';
 import {TeamState} from 'src/script/team/TeamState';
 import {UserRepository} from 'src/script/user/UserRepository';
@@ -61,7 +59,6 @@ export const initialiseMLSMigrationFlow = async ({
   selfUserId,
 }: InitialiseMLSMigrationFlowParams) => {
   const core = container.resolve(CoreSingleton);
-  const apiClient = container.resolve(APIClientSingleton);
 
   return periodicallyCheckMigrationConfig(
     () =>
@@ -72,20 +69,19 @@ export const initialiseMLSMigrationFlow = async ({
         userRepository,
         selfUserId,
       }),
-    {apiClient, teamState},
+    {teamState},
   );
 };
 
 interface CheckMigrationConfigParams {
-  apiClient: APIClient;
   teamState: TeamState;
 }
 
 const periodicallyCheckMigrationConfig = async (
   onMigrationStartTimeArrived: () => Promise<void>,
-  {apiClient, teamState}: CheckMigrationConfigParams,
+  {teamState}: CheckMigrationConfigParams,
 ) => {
-  const checkMigrationConfigTask = () => checkMigrationConfig(onMigrationStartTimeArrived, {apiClient, teamState});
+  const checkMigrationConfigTask = () => checkMigrationConfig(onMigrationStartTimeArrived, {teamState});
 
   // We check the migration config immediately (on app load) and every 24 hours
   await checkMigrationConfigTask();
@@ -99,9 +95,9 @@ const periodicallyCheckMigrationConfig = async (
 
 const checkMigrationConfig = async (
   onMigrationStartTimeArrived: () => Promise<void>,
-  {apiClient, teamState}: CheckMigrationConfigParams,
+  {teamState}: CheckMigrationConfigParams,
 ) => {
-  const isMLSSupportedByEnv = await isMLSSupportedByEnvironment({apiClient});
+  const isMLSSupportedByEnv = await isMLSSupportedByEnvironment();
 
   if (!isMLSSupportedByEnv) {
     return;

--- a/src/script/mls/MLSMigration/MLSMigration.ts
+++ b/src/script/mls/MLSMigration/MLSMigration.ts
@@ -72,22 +72,20 @@ export const initialiseMLSMigrationFlow = async ({
         userRepository,
         selfUserId,
       }),
-    {core, apiClient, teamState},
+    {apiClient, teamState},
   );
 };
 
 interface CheckMigrationConfigParams {
-  core: Account;
   apiClient: APIClient;
   teamState: TeamState;
 }
 
 const periodicallyCheckMigrationConfig = async (
   onMigrationStartTimeArrived: () => Promise<void>,
-  {core, apiClient, teamState}: CheckMigrationConfigParams,
+  {apiClient, teamState}: CheckMigrationConfigParams,
 ) => {
-  const checkMigrationConfigTask = () =>
-    checkMigrationConfig(onMigrationStartTimeArrived, {core, apiClient, teamState});
+  const checkMigrationConfigTask = () => checkMigrationConfig(onMigrationStartTimeArrived, {apiClient, teamState});
 
   // We check the migration config immediately (on app load) and every 24 hours
   await checkMigrationConfigTask();
@@ -101,9 +99,9 @@ const periodicallyCheckMigrationConfig = async (
 
 const checkMigrationConfig = async (
   onMigrationStartTimeArrived: () => Promise<void>,
-  {core, apiClient, teamState}: CheckMigrationConfigParams,
+  {apiClient, teamState}: CheckMigrationConfigParams,
 ) => {
-  const isMLSSupportedByEnv = await isMLSSupportedByEnvironment({core, apiClient});
+  const isMLSSupportedByEnv = await isMLSSupportedByEnvironment({apiClient});
 
   if (!isMLSSupportedByEnv) {
     return;

--- a/src/script/mls/MLSMigration/finaliseMigration/finaliseMigration.test.ts
+++ b/src/script/mls/MLSMigration/finaliseMigration/finaliseMigration.test.ts
@@ -22,7 +22,6 @@ import {FeatureStatus} from '@wireapp/api-client/lib/team';
 
 import {MixedConversation, MLSConversation} from 'src/script/conversation/ConversationSelectors';
 import {Conversation} from 'src/script/entity/Conversation';
-import {TeamState} from 'src/script/team/TeamState';
 import {TestFactory} from 'test/helper/TestFactory';
 import {generateUser} from 'test/helper/UserGenerator';
 import {createUuid} from 'Util/uuid';
@@ -70,12 +69,12 @@ const testFactory = new TestFactory();
 describe('finaliseMigrationOfMixedConversations', () => {
   it('should finalise when finaliseRegardlessAfter date arrived', async () => {
     const conversationRepository = await testFactory.exposeConversationActors();
-    const teamState = new TeamState();
+    const teamRepository = await testFactory.exposeTeamActors();
 
     const mixedConversation = createMixedConversation();
     const mlsConversation = changeConversationProtocolToMLS(mixedConversation);
 
-    jest.spyOn(teamState, 'teamFeatures').mockReturnValueOnce({
+    jest.spyOn(teamRepository['teamState'], 'teamFeatures').mockReturnValueOnce({
       mlsMigration: {
         status: FeatureStatus.ENABLED,
         config: {
@@ -87,7 +86,7 @@ describe('finaliseMigrationOfMixedConversations', () => {
 
     jest.spyOn(conversationRepository, 'updateConversationProtocol').mockResolvedValueOnce(mlsConversation);
 
-    await finaliseMigrationOfMixedConversations([mixedConversation], {teamState, conversationRepository});
+    await finaliseMigrationOfMixedConversations([mixedConversation], {teamRepository, conversationRepository});
 
     expect(conversationRepository.updateConversationProtocol).toHaveBeenCalledWith(
       mixedConversation,
@@ -97,14 +96,14 @@ describe('finaliseMigrationOfMixedConversations', () => {
 
   it('should finalise when all conversation participants support MLS', async () => {
     const conversationRepository = await testFactory.exposeConversationActors();
-    const teamState = new TeamState();
+    const teamRepository = await testFactory.exposeTeamActors();
 
     const mixedConversation = createMixedConversation();
     injectParticipantsIntoConversation(mixedConversation, {doAllSupportMLS: true});
 
     const mlsConversation = changeConversationProtocolToMLS(mixedConversation);
 
-    jest.spyOn(teamState, 'teamFeatures').mockReturnValueOnce({
+    jest.spyOn(teamRepository['teamState'], 'teamFeatures').mockReturnValueOnce({
       mlsMigration: {
         status: FeatureStatus.ENABLED,
         config: {
@@ -116,7 +115,7 @@ describe('finaliseMigrationOfMixedConversations', () => {
 
     jest.spyOn(conversationRepository, 'updateConversationProtocol').mockResolvedValueOnce(mlsConversation);
 
-    await finaliseMigrationOfMixedConversations([mixedConversation], {teamState, conversationRepository});
+    await finaliseMigrationOfMixedConversations([mixedConversation], {teamRepository, conversationRepository});
 
     expect(conversationRepository.updateConversationProtocol).toHaveBeenCalledWith(
       mixedConversation,
@@ -126,12 +125,12 @@ describe('finaliseMigrationOfMixedConversations', () => {
 
   it('should not be finalized if none of the requirements are met', async () => {
     const conversationRepository = await testFactory.exposeConversationActors();
-    const teamState = new TeamState();
+    const teamRepository = await testFactory.exposeTeamActors();
 
     const mixedConversation = createMixedConversation();
     injectParticipantsIntoConversation(mixedConversation, {doAllSupportMLS: false});
 
-    jest.spyOn(teamState, 'teamFeatures').mockReturnValueOnce({
+    jest.spyOn(teamRepository['teamState'], 'teamFeatures').mockReturnValueOnce({
       mlsMigration: {
         status: FeatureStatus.ENABLED,
         config: {
@@ -143,7 +142,7 @@ describe('finaliseMigrationOfMixedConversations', () => {
 
     jest.spyOn(conversationRepository, 'updateConversationProtocol');
 
-    await finaliseMigrationOfMixedConversations([mixedConversation], {teamState, conversationRepository});
+    await finaliseMigrationOfMixedConversations([mixedConversation], {teamRepository, conversationRepository});
 
     expect(conversationRepository.updateConversationProtocol).not.toHaveBeenCalled();
   });

--- a/src/script/mls/MLSMigration/finaliseMigration/finaliseMigration.ts
+++ b/src/script/mls/MLSMigration/finaliseMigration/finaliseMigration.ts
@@ -43,7 +43,7 @@ export const finaliseMigrationOfMixedConversations = async (
     await checkFinalisationCriteria(
       mixedConversation,
       () => finaliseMigrationOfMixedConversation(mixedConversation, {conversationRepository}),
-      {teamRepository},
+      teamRepository,
     );
   }
 };
@@ -51,7 +51,7 @@ export const finaliseMigrationOfMixedConversations = async (
 const checkFinalisationCriteria = async (
   mixedConversation: MixedConversation,
   onReadyToFinalise: (mixedConversation: MixedConversation) => Promise<void>,
-  {teamRepository}: {teamRepository: TeamRepository},
+  teamRepository: TeamRepository,
 ) => {
   const migrationStatus = teamRepository.getTeamMLSMigrationStatus();
   const isMigrationFinalised = migrationStatus === MLSMigrationStatus.FINALISED;

--- a/src/script/mls/MLSMigration/finaliseMigration/finaliseMigration.ts
+++ b/src/script/mls/MLSMigration/finaliseMigration/finaliseMigration.ts
@@ -22,14 +22,17 @@ import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 import {ConversationRepository} from 'src/script/conversation/ConversationRepository';
 import {MixedConversation, isMLSConversation, isMixedConversation} from 'src/script/conversation/ConversationSelectors';
 import {Conversation} from 'src/script/entity/Conversation';
-import {TeamState} from 'src/script/team/TeamState';
+import {TeamRepository} from 'src/script/team/TeamRepository';
 
-import {MLSMigrationStatus, getMLSMigrationStatus} from '../migrationStatus';
+import {MLSMigrationStatus} from '../migrationStatus';
 import {mlsMigrationLogger} from '../MLSMigrationLogger';
 
 export const finaliseMigrationOfMixedConversations = async (
   conversations: Conversation[],
-  {teamState, conversationRepository}: {teamState: TeamState; conversationRepository: ConversationRepository},
+  {
+    teamRepository,
+    conversationRepository,
+  }: {teamRepository: TeamRepository; conversationRepository: ConversationRepository},
 ) => {
   const mixedConversatons = conversations.filter(isMixedConversation);
   mlsMigrationLogger.info(
@@ -40,7 +43,7 @@ export const finaliseMigrationOfMixedConversations = async (
     await checkFinalisationCriteria(
       mixedConversation,
       () => finaliseMigrationOfMixedConversation(mixedConversation, {conversationRepository}),
-      {teamState},
+      {teamRepository},
     );
   }
 };
@@ -48,10 +51,9 @@ export const finaliseMigrationOfMixedConversations = async (
 const checkFinalisationCriteria = async (
   mixedConversation: MixedConversation,
   onReadyToFinalise: (mixedConversation: MixedConversation) => Promise<void>,
-  {teamState}: {teamState: TeamState},
+  {teamRepository}: {teamRepository: TeamRepository},
 ) => {
-  const mlsMigrationFeature = teamState.teamFeatures().mlsMigration;
-  const migrationStatus = getMLSMigrationStatus(mlsMigrationFeature);
+  const migrationStatus = teamRepository.getTeamMLSMigrationStatus();
   const isMigrationFinalised = migrationStatus === MLSMigrationStatus.FINALISED;
 
   if (isMigrationFinalised || doAllConversationParticipantsSupportMLS(mixedConversation)) {

--- a/src/script/mls/isMLSSupportedByEnvironment.ts
+++ b/src/script/mls/isMLSSupportedByEnvironment.ts
@@ -17,17 +17,18 @@
  *
  */
 
-import {APIClient} from '@wireapp/api-client';
+import {container} from 'tsyringe';
 
 import {supportsMLS} from 'Util/util';
 
+import {APIClient} from '../service/APIClientSingleton';
+
 /**
  * Will check if MLS is supported by client (whether MLS feature is enabled and secret store is supported) and backend (whether used api version supports MLS and backend removal key is present).
- *
- * @param apiClient -the instance of the apiClient
- * @param core - the instance of the core
  */
-export const isMLSSupportedByEnvironment = async ({apiClient}: {apiClient: APIClient}) => {
+export const isMLSSupportedByEnvironment = async () => {
+  const apiClient = container.resolve(APIClient);
+
   const isMLSSupportedByClient = supportsMLS();
 
   if (!isMLSSupportedByClient) {

--- a/src/script/mls/isMLSSupportedByEnvironment.ts
+++ b/src/script/mls/isMLSSupportedByEnvironment.ts
@@ -27,14 +27,13 @@ import {APIClient} from '../service/APIClientSingleton';
  * Will check if MLS is supported by client (whether MLS feature is enabled and secret store is supported) and backend (whether used api version supports MLS and backend removal key is present).
  */
 export const isMLSSupportedByEnvironment = async () => {
-  const apiClient = container.resolve(APIClient);
-
   const isMLSSupportedByClient = supportsMLS();
 
   if (!isMLSSupportedByClient) {
     return false;
   }
 
+  const apiClient = container.resolve(APIClient);
   const isMLSEnabledOnBackend = apiClient.backendFeatures.supportsMLS;
 
   if (!isMLSEnabledOnBackend) {

--- a/src/script/mls/isMLSSupportedByEnvironment.ts
+++ b/src/script/mls/isMLSSupportedByEnvironment.ts
@@ -18,7 +18,6 @@
  */
 
 import {APIClient} from '@wireapp/api-client';
-import {Account} from '@wireapp/core';
 
 import {supportsMLS} from 'Util/util';
 
@@ -28,14 +27,14 @@ import {supportsMLS} from 'Util/util';
  * @param apiClient -the instance of the apiClient
  * @param core - the instance of the core
  */
-export const isMLSSupportedByEnvironment = async ({core, apiClient}: {core: Account; apiClient: APIClient}) => {
+export const isMLSSupportedByEnvironment = async ({apiClient}: {apiClient: APIClient}) => {
   const isMLSSupportedByClient = supportsMLS();
 
   if (!isMLSSupportedByClient) {
     return false;
   }
 
-  const isMLSEnabledOnBackend = core.backendFeatures.supportsMLS;
+  const isMLSEnabledOnBackend = apiClient.backendFeatures.supportsMLS;
 
   if (!isMLSEnabledOnBackend) {
     return false;

--- a/src/script/mls/supportedProtocols/evaluateSelfSupportedProtocols/evaluateSelfSupportedProtocols.test.ts
+++ b/src/script/mls/supportedProtocols/evaluateSelfSupportedProtocols/evaluateSelfSupportedProtocols.test.ts
@@ -20,11 +20,9 @@
 import {RegisteredClient} from '@wireapp/api-client/lib/client';
 import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 import {FeatureList, FeatureStatus} from '@wireapp/api-client/lib/team';
-import {container} from 'tsyringe';
 
 import {APIClient} from '@wireapp/api-client';
 
-import {Core} from 'src/script/service/CoreSingleton';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
 
 import {evaluateSelfSupportedProtocols} from './evaluateSelfSupportedProtocols';
@@ -188,7 +186,6 @@ describe('evaluateSelfSupportedProtocols', () => {
 
       it.each(testScenarios)('evaluates self supported protocols', async ({mls, mlsMigration}, expected) => {
         const mockedApiClient = {api: {client: {getClients: jest.fn()}}} as unknown as APIClient;
-        const mockCore = container.resolve(Core);
 
         jest.spyOn(mockedApiClient.api.client, 'getClients').mockResolvedValueOnce(selfClients);
 
@@ -199,7 +196,6 @@ describe('evaluateSelfSupportedProtocols', () => {
 
         const supportedProtocols = await evaluateSelfSupportedProtocols({
           apiClient: mockedApiClient,
-          core: mockCore,
           teamFeatureList,
         });
 

--- a/src/script/mls/supportedProtocols/evaluateSelfSupportedProtocols/evaluateSelfSupportedProtocols.test.ts
+++ b/src/script/mls/supportedProtocols/evaluateSelfSupportedProtocols/evaluateSelfSupportedProtocols.test.ts
@@ -21,8 +21,6 @@ import {RegisteredClient} from '@wireapp/api-client/lib/client';
 import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 import {FeatureList, FeatureStatus} from '@wireapp/api-client/lib/team';
 
-import {APIClient} from '@wireapp/api-client';
-
 import {TestFactory} from 'test/helper/TestFactory';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
 
@@ -188,10 +186,10 @@ describe('evaluateSelfSupportedProtocols', () => {
       const selfClients = generateListOfSelfClients({allActiveClientsMLSCapable});
 
       it.each(testScenarios)('evaluates self supported protocols', async ({mls, mlsMigration}, expected) => {
-        const mockedApiClient = {api: {client: {getClients: jest.fn()}}} as unknown as APIClient;
         const teamRepository = await testFactory.exposeTeamActors();
+        const userRepository = await testFactory.exposeUserActors();
 
-        jest.spyOn(mockedApiClient.api.client, 'getClients').mockResolvedValueOnce(selfClients);
+        jest.spyOn(userRepository, 'getAllSelfClients').mockResolvedValueOnce(selfClients);
 
         const teamFeatureList = {
           mlsMigration,
@@ -201,8 +199,8 @@ describe('evaluateSelfSupportedProtocols', () => {
         jest.spyOn(teamRepository['teamState'], 'teamFeatures').mockReturnValue(teamFeatureList);
 
         const supportedProtocols = await evaluateSelfSupportedProtocols({
-          apiClient: mockedApiClient,
           teamRepository,
+          userRepository,
         });
 
         expect(supportedProtocols).toEqual(

--- a/src/script/mls/supportedProtocols/evaluateSelfSupportedProtocols/evaluateSelfSupportedProtocols.test.ts
+++ b/src/script/mls/supportedProtocols/evaluateSelfSupportedProtocols/evaluateSelfSupportedProtocols.test.ts
@@ -23,12 +23,15 @@ import {FeatureList, FeatureStatus} from '@wireapp/api-client/lib/team';
 
 import {APIClient} from '@wireapp/api-client';
 
+import {TestFactory} from 'test/helper/TestFactory';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
 
 import {evaluateSelfSupportedProtocols} from './evaluateSelfSupportedProtocols';
 
 import * as mlsSupport from '../../isMLSSupportedByEnvironment';
 import {MLSMigrationStatus} from '../../MLSMigration/migrationStatus';
+
+const testFactory = new TestFactory();
 
 jest.spyOn(mlsSupport, 'isMLSSupportedByEnvironment').mockResolvedValue(true);
 
@@ -186,6 +189,7 @@ describe('evaluateSelfSupportedProtocols', () => {
 
       it.each(testScenarios)('evaluates self supported protocols', async ({mls, mlsMigration}, expected) => {
         const mockedApiClient = {api: {client: {getClients: jest.fn()}}} as unknown as APIClient;
+        const teamRepository = await testFactory.exposeTeamActors();
 
         jest.spyOn(mockedApiClient.api.client, 'getClients').mockResolvedValueOnce(selfClients);
 
@@ -194,9 +198,11 @@ describe('evaluateSelfSupportedProtocols', () => {
           mls,
         } as unknown as FeatureList;
 
+        jest.spyOn(teamRepository['teamState'], 'teamFeatures').mockReturnValue(teamFeatureList);
+
         const supportedProtocols = await evaluateSelfSupportedProtocols({
           apiClient: mockedApiClient,
-          teamFeatureList,
+          teamRepository,
         });
 
         expect(supportedProtocols).toEqual(

--- a/src/script/mls/supportedProtocols/evaluateSelfSupportedProtocols/evaluateSelfSupportedProtocols.ts
+++ b/src/script/mls/supportedProtocols/evaluateSelfSupportedProtocols/evaluateSelfSupportedProtocols.ts
@@ -20,27 +20,26 @@
 import {RegisteredClient} from '@wireapp/api-client/lib/client';
 import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 
-import {APIClient} from '@wireapp/api-client';
-
 import {TeamRepository} from 'src/script/team/TeamRepository';
+import {UserRepository} from 'src/script/user/UserRepository';
 
 import {isMLSSupportedByEnvironment} from '../../isMLSSupportedByEnvironment';
 import {MLSMigrationStatus} from '../../MLSMigration/migrationStatus';
 import {wasClientActiveWithinLast4Weeks} from '../wasClientActiveWithinLast4Weeks';
 
 export const evaluateSelfSupportedProtocols = async ({
-  apiClient,
   teamRepository,
+  userRepository,
 }: {
-  apiClient: APIClient;
   teamRepository: TeamRepository;
+  userRepository: UserRepository;
 }): Promise<Set<ConversationProtocol>> => {
   const supportedProtocols = new Set<ConversationProtocol>();
 
   const teamSupportedProtocols = teamRepository.getTeamSupportedProtocols();
   const mlsMigrationStatus = teamRepository.getTeamMLSMigrationStatus();
 
-  const selfClients = await apiClient.api.client.getClients();
+  const selfClients = await userRepository.getAllSelfClients();
 
   const isProteusProtocolSupported = await isProteusSupported({teamSupportedProtocols, mlsMigrationStatus});
   if (isProteusProtocolSupported) {
@@ -51,7 +50,6 @@ export const evaluateSelfSupportedProtocols = async ({
     teamSupportedProtocols,
     selfClients,
     mlsMigrationStatus,
-    apiClient,
   };
 
   const isMLSProtocolSupported = await isMLSSupported(mlsCheckDependencies);
@@ -74,14 +72,12 @@ const isMLSSupported = async ({
   teamSupportedProtocols,
   selfClients,
   mlsMigrationStatus,
-  apiClient,
 }: {
   teamSupportedProtocols: Set<ConversationProtocol>;
   selfClients: RegisteredClient[];
   mlsMigrationStatus: MLSMigrationStatus;
-  apiClient: APIClient;
 }): Promise<boolean> => {
-  const isMLSSupportedByEnv = await isMLSSupportedByEnvironment({apiClient});
+  const isMLSSupportedByEnv = await isMLSSupportedByEnvironment();
 
   if (!isMLSSupportedByEnv) {
     return false;
@@ -104,14 +100,12 @@ const isMLSForcedWithoutMigration = async ({
   teamSupportedProtocols,
   selfClients,
   mlsMigrationStatus,
-  apiClient,
 }: {
   teamSupportedProtocols: Set<ConversationProtocol>;
   selfClients: RegisteredClient[];
   mlsMigrationStatus: MLSMigrationStatus;
-  apiClient: APIClient;
 }): Promise<boolean> => {
-  const isMLSSupportedByEnv = await isMLSSupportedByEnvironment({apiClient});
+  const isMLSSupportedByEnv = await isMLSSupportedByEnvironment();
 
   if (!isMLSSupportedByEnv) {
     return false;

--- a/src/script/mls/supportedProtocols/evaluateSelfSupportedProtocols/evaluateSelfSupportedProtocols.ts
+++ b/src/script/mls/supportedProtocols/evaluateSelfSupportedProtocols/evaluateSelfSupportedProtocols.ts
@@ -22,18 +22,15 @@ import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 import {FeatureList, FeatureMLS, FeatureStatus} from '@wireapp/api-client/lib/team';
 
 import {APIClient} from '@wireapp/api-client';
-import {Account} from '@wireapp/core';
 
 import {isMLSSupportedByEnvironment} from '../../isMLSSupportedByEnvironment';
 import {getMLSMigrationStatus, MLSMigrationStatus} from '../../MLSMigration/migrationStatus';
 import {wasClientActiveWithinLast4Weeks} from '../wasClientActiveWithinLast4Weeks';
 
 export const evaluateSelfSupportedProtocols = async ({
-  core,
   apiClient,
   teamFeatureList,
 }: {
-  core: Account;
   apiClient: APIClient;
   teamFeatureList: FeatureList;
 }): Promise<Set<ConversationProtocol>> => {
@@ -56,7 +53,6 @@ export const evaluateSelfSupportedProtocols = async ({
     teamSupportedProtocols,
     selfClients,
     mlsMigrationStatus,
-    core,
     apiClient,
   };
 
@@ -80,16 +76,14 @@ const isMLSSupported = async ({
   teamSupportedProtocols,
   selfClients,
   mlsMigrationStatus,
-  core,
   apiClient,
 }: {
   teamSupportedProtocols: Set<ConversationProtocol>;
   selfClients: RegisteredClient[];
   mlsMigrationStatus: MLSMigrationStatus;
-  core: Account;
   apiClient: APIClient;
 }): Promise<boolean> => {
-  const isMLSSupportedByEnv = await isMLSSupportedByEnvironment({core, apiClient});
+  const isMLSSupportedByEnv = await isMLSSupportedByEnvironment({apiClient});
 
   if (!isMLSSupportedByEnv) {
     return false;
@@ -112,16 +106,14 @@ const isMLSForcedWithoutMigration = async ({
   teamSupportedProtocols,
   selfClients,
   mlsMigrationStatus,
-  core,
   apiClient,
 }: {
   teamSupportedProtocols: Set<ConversationProtocol>;
   selfClients: RegisteredClient[];
   mlsMigrationStatus: MLSMigrationStatus;
-  core: Account;
   apiClient: APIClient;
 }): Promise<boolean> => {
-  const isMLSSupportedByEnv = await isMLSSupportedByEnvironment({core, apiClient});
+  const isMLSSupportedByEnv = await isMLSSupportedByEnvironment({apiClient});
 
   if (!isMLSSupportedByEnv) {
     return false;

--- a/src/script/mls/supportedProtocols/supportedProtocols.test.ts
+++ b/src/script/mls/supportedProtocols/supportedProtocols.test.ts
@@ -18,7 +18,6 @@
  */
 
 import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
-import {FeatureList} from '@wireapp/api-client/lib/team';
 import {act} from 'react-dom/test-utils';
 
 import {TestFactory} from 'test/helper/TestFactory';
@@ -43,17 +42,17 @@ describe('supportedProtocols', () => {
     [[ConversationProtocol.PROTEUS], [ConversationProtocol.MLS]],
   ])('Updates the list of supported protocols', async (initialProtocols, evaluatedProtocols) => {
     const userRepository = await testFactory.exposeUserActors();
+    const teamRepository = await testFactory.exposeTeamActors();
+
     const selfUser = userRepository['userState'].self();
 
     selfUser.supportedProtocols(initialProtocols);
-
-    const mockFeatureList = {} as FeatureList;
 
     //this funciton is tested standalone in evaluateSelfSupportedProtocols.test.ts
     jest.spyOn(supportedProtocols, 'evaluateSelfSupportedProtocols').mockResolvedValueOnce(new Set(evaluatedProtocols));
     jest.spyOn(userRepository, 'changeSupportedProtocols');
 
-    await initialisePeriodicSelfSupportedProtocolsCheck(selfUser, mockFeatureList, {userRepository});
+    await initialisePeriodicSelfSupportedProtocolsCheck(selfUser, {userRepository, teamRepository});
 
     expect(userRepository.changeSupportedProtocols).toHaveBeenCalledWith(evaluatedProtocols);
     expect(selfUser.supportedProtocols()).toEqual(evaluatedProtocols);
@@ -61,6 +60,8 @@ describe('supportedProtocols', () => {
 
   it("Does not update supported protocols if they didn't change", async () => {
     const userRepository = await testFactory.exposeUserActors();
+    const teamRepository = await testFactory.exposeTeamActors();
+
     const selfUser = userRepository['userState'].self();
 
     const initialProtocols = [ConversationProtocol.PROTEUS];
@@ -68,19 +69,18 @@ describe('supportedProtocols', () => {
 
     const evaluatedProtocols = [ConversationProtocol.PROTEUS];
 
-    const mockFeatureList = {} as FeatureList;
-
     //this funciton is tested standalone in evaluateSelfSupportedProtocols.test.ts
     jest.spyOn(supportedProtocols, 'evaluateSelfSupportedProtocols').mockResolvedValueOnce(new Set(evaluatedProtocols));
     jest.spyOn(userRepository, 'changeSupportedProtocols');
 
-    await initialisePeriodicSelfSupportedProtocolsCheck(selfUser, mockFeatureList, {userRepository});
+    await initialisePeriodicSelfSupportedProtocolsCheck(selfUser, {userRepository, teamRepository});
     expect(selfUser.supportedProtocols()).toEqual(evaluatedProtocols);
     expect(userRepository.changeSupportedProtocols).not.toHaveBeenCalled();
   });
 
   it('Re-evaluates supported protocols every 24h', async () => {
     const userRepository = await testFactory.exposeUserActors();
+    const teamRepository = await testFactory.exposeTeamActors();
     const selfUser = userRepository['userState'].self();
 
     const initialProtocols = [ConversationProtocol.PROTEUS];
@@ -88,13 +88,11 @@ describe('supportedProtocols', () => {
 
     const evaluatedProtocols = [ConversationProtocol.PROTEUS];
 
-    const mockFeatureList = {} as FeatureList;
-
     //this funciton is tested standalone in evaluateSelfSupportedProtocols.test.ts
     jest.spyOn(supportedProtocols, 'evaluateSelfSupportedProtocols').mockResolvedValueOnce(new Set(evaluatedProtocols));
     jest.spyOn(userRepository, 'changeSupportedProtocols');
 
-    await initialisePeriodicSelfSupportedProtocolsCheck(selfUser, mockFeatureList, {userRepository});
+    await initialisePeriodicSelfSupportedProtocolsCheck(selfUser, {userRepository, teamRepository});
     expect(selfUser.supportedProtocols()).toEqual(evaluatedProtocols);
     expect(userRepository.changeSupportedProtocols).not.toHaveBeenCalled();
 

--- a/src/script/mls/supportedProtocols/supportedProtocols.ts
+++ b/src/script/mls/supportedProtocols/supportedProtocols.ts
@@ -20,8 +20,6 @@
 import {registerRecurringTask} from '@wireapp/core/lib/util/RecurringTaskScheduler';
 import {container} from 'tsyringe';
 
-import {APIClient} from '@wireapp/api-client';
-
 import {User} from 'src/script/entity/User';
 import {APIClient as APIClientSingleton} from 'src/script/service/APIClientSingleton';
 import {TeamRepository} from 'src/script/team/TeamRepository';
@@ -65,11 +63,9 @@ export const initialisePeriodicSelfSupportedProtocolsCheck = async (
 const updateSelfSupportedProtocols = async (
   selfUser: User,
   {
-    apiClient,
     userRepository,
     teamRepository,
   }: {
-    apiClient: APIClient;
     userRepository: UserRepository;
     teamRepository: TeamRepository;
   },
@@ -78,7 +74,7 @@ const updateSelfSupportedProtocols = async (
   logger.info('Evaluating self supported protocols, currently supported protocols:', localSupportedProtocols);
 
   try {
-    const refreshedSupportedProtocols = await evaluateSelfSupportedProtocols({apiClient, teamRepository});
+    const refreshedSupportedProtocols = await evaluateSelfSupportedProtocols({teamRepository, userRepository});
 
     const hasSupportedProtocolsChanged = !(
       localSupportedProtocols.size === refreshedSupportedProtocols.size &&

--- a/src/script/mls/supportedProtocols/supportedProtocols.ts
+++ b/src/script/mls/supportedProtocols/supportedProtocols.ts
@@ -18,10 +18,8 @@
  */
 
 import {registerRecurringTask} from '@wireapp/core/lib/util/RecurringTaskScheduler';
-import {container} from 'tsyringe';
 
 import {User} from 'src/script/entity/User';
-import {APIClient as APIClientSingleton} from 'src/script/service/APIClientSingleton';
 import {TeamRepository} from 'src/script/team/TeamRepository';
 import {UserRepository} from 'src/script/user/UserRepository';
 import {getLogger} from 'Util/Logger';
@@ -45,10 +43,7 @@ export const initialisePeriodicSelfSupportedProtocolsCheck = async (
   selfUser: User,
   {userRepository, teamRepository}: {userRepository: UserRepository; teamRepository: TeamRepository},
 ) => {
-  const apiClient = container.resolve(APIClientSingleton);
-
-  const checkSupportedProtocolsTask = () =>
-    updateSelfSupportedProtocols(selfUser, {apiClient, teamRepository, userRepository});
+  const checkSupportedProtocolsTask = () => updateSelfSupportedProtocols(selfUser, {teamRepository, userRepository});
 
   // We update supported protocols of self user on initial app load and then in 24 hours intervals
   await checkSupportedProtocolsTask();

--- a/src/script/mls/supportedProtocols/supportedProtocols.ts
+++ b/src/script/mls/supportedProtocols/supportedProtocols.ts
@@ -22,11 +22,9 @@ import {registerRecurringTask} from '@wireapp/core/lib/util/RecurringTaskSchedul
 import {container} from 'tsyringe';
 
 import {APIClient} from '@wireapp/api-client';
-import {Account} from '@wireapp/core';
 
 import {User} from 'src/script/entity/User';
 import {APIClient as APIClientSingleton} from 'src/script/service/APIClientSingleton';
-import {Core as CoreSingleton} from 'src/script/service/CoreSingleton';
 import {UserRepository} from 'src/script/user/UserRepository';
 import {getLogger} from 'Util/Logger';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
@@ -51,10 +49,9 @@ export const initialisePeriodicSelfSupportedProtocolsCheck = async (
   {userRepository}: {userRepository: UserRepository},
 ) => {
   const apiClient = container.resolve(APIClientSingleton);
-  const core = container.resolve(CoreSingleton);
 
   const checkSupportedProtocolsTask = () =>
-    updateSelfSupportedProtocols(selfUser, teamFeatureList, {apiClient, core, userRepository});
+    updateSelfSupportedProtocols(selfUser, teamFeatureList, {apiClient, userRepository});
 
   // We update supported protocols of self user on initial app load and then in 24 hours intervals
   await checkSupportedProtocolsTask();
@@ -70,11 +67,9 @@ const updateSelfSupportedProtocols = async (
   selfUser: User,
   teamFeatureList: FeatureList,
   {
-    core,
     apiClient,
     userRepository,
   }: {
-    core: Account;
     apiClient: APIClient;
     userRepository: UserRepository;
   },
@@ -83,7 +78,7 @@ const updateSelfSupportedProtocols = async (
   logger.info('Evaluating self supported protocols, currently supported protocols:', localSupportedProtocols);
 
   try {
-    const refreshedSupportedProtocols = await evaluateSelfSupportedProtocols({apiClient, core, teamFeatureList});
+    const refreshedSupportedProtocols = await evaluateSelfSupportedProtocols({apiClient, teamFeatureList});
 
     const hasSupportedProtocolsChanged = !(
       localSupportedProtocols.size === refreshedSupportedProtocols.size &&

--- a/src/script/page/AppMain.tsx
+++ b/src/script/page/AppMain.tsx
@@ -200,7 +200,7 @@ const AppMain: FC<AppMainProps> = ({
     if (supportsMLSMigration()) {
       //after app is loaded, check mls migration configuration and start migration if needed
       await initialiseMLSMigrationFlow({
-        teamState,
+        teamRepository: repositories.team,
         conversationRepository: repositories.conversation,
         userRepository: repositories.user,
         selfUserId: selfUser.qualifiedId,

--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import type {ConversationRolesList} from '@wireapp/api-client/lib/conversation/ConversationRole';
+import {ConversationProtocol, ConversationRolesList} from '@wireapp/api-client/lib/conversation';
 import type {
   TeamConversationDeleteEvent,
   TeamDeleteEvent,
@@ -60,6 +60,7 @@ import {EventSource} from '../event/EventSource';
 import {NOTIFICATION_HANDLING_STATE} from '../event/NotificationHandlingState';
 import {IntegrationMapper} from '../integration/IntegrationMapper';
 import {ServiceEntity} from '../integration/ServiceEntity';
+import {MLSMigrationStatus, getMLSMigrationStatus} from '../mls/MLSMigration/migrationStatus';
 import {ROLE, ROLE as TEAM_ROLE, roleFromTeamPermissions} from '../user/UserPermission';
 import {UserRepository} from '../user/UserRepository';
 import {UserState} from '../user/UserState';
@@ -633,5 +634,21 @@ export class TeamRepository {
       this.teamMapper.updateTeamFromObject(teamData, this.teamState.team());
       this.sendAccountInfo();
     }
+  }
+
+  public getTeamSupportedProtocols(): Set<ConversationProtocol> {
+    const mlsFeature = this.teamState.teamFeatures().mls;
+
+    if (!mlsFeature || mlsFeature.status === FeatureStatus.DISABLED) {
+      return new Set([ConversationProtocol.PROTEUS]);
+    }
+
+    return new Set<ConversationProtocol>(mlsFeature.config.supportedProtocols);
+  }
+
+  public getTeamMLSMigrationStatus(): MLSMigrationStatus {
+    const mlsMigrationFeature = this.teamState.teamFeatures().mlsMigration;
+
+    return getMLSMigrationStatus(mlsMigrationFeature);
   }
 }

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -929,4 +929,8 @@ export class UserRepository {
       this.logger.warn(`Failed to retrieve marketing consent: ${error.message || error.code}`, error);
     }
   }
+
+  public async getAllSelfClients() {
+    return this.clientRepository.getAllSelfClients();
+  }
 }

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -827,6 +827,11 @@ export class UserRepository {
     return await this.updateUser(this.userState.self().qualifiedId, {supported_protocols: supportedProtocols});
   }
 
+  getSelfSupportedProtocols(): Set<ConversationProtocol> {
+    const supportedProtocols = this.userState.self().supportedProtocols();
+    return new Set(supportedProtocols);
+  }
+
   async changeEmail(email: string): Promise<void> {
     return this.selfService.putSelfEmail(email);
   }


### PR DESCRIPTION
Some refactoring in mls migration flow:
Use team repository instead of team state directly - to be consistent with other repositories the migration modules are consuming. 

Don't use api client directly - to stick to current webapp flow:
- api is consumed by service on webapp
- service in consumed by repository
- we interact with repository

