### PR TITLE
fix: remove reply message option from context menu

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageActions.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageActions.tsx
@@ -184,13 +184,15 @@ const MessageActionsMenu: FC<MessageActionsMenuProps> = ({
               message={message}
               handleReactionClick={handleReactionClick}
             />
-            <ReplyButton
-              actionId={MessageActionsId.REPLY}
-              currentMsgActionName={currentMsgActionName}
-              messageFocusedTabIndex={messageFocusedTabIndex}
-              onReplyClick={handleMessageReply}
-              onKeyPress={handleKeyDown}
-            />
+            {message.isReplyable() && (
+              <ReplyButton
+                actionId={MessageActionsId.REPLY}
+                currentMsgActionName={currentMsgActionName}
+                messageFocusedTabIndex={messageFocusedTabIndex}
+                onReplyClick={handleMessageReply}
+                onKeyPress={handleKeyDown}
+              />
+            )}
           </>
         )}
 

--- a/src/script/components/MessagesList/Message/MessageWrapper.tsx
+++ b/src/script/components/MessagesList/Message/MessageWrapper.tsx
@@ -142,13 +142,6 @@ export const MessageWrapper: React.FC<MessageParams & {hasMarker: boolean; isMes
       });
     }
 
-    if (message.isReplyable() && !conversation.removed_from_conversation()) {
-      entries.push({
-        click: () => amplify.publish(WebAppEvents.CONVERSATION.MESSAGE.REPLY, message),
-        label: t('conversationContextMenuReply'),
-      });
-    }
-
     if (message.isCopyable() && !isRestrictedFileShare) {
       entries.push({
         click: () => message.copy(),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - remove reply message option from context menu

- The **PR Description**
  - Send or receive a message
  - Open message options
  - Actual: In the message options is a options to reply to this message
  - Expected: Since the reply option is already in the floating action menu it should be removed from the message options in the context menu
----
##### References
1. https://wearezeta.atlassian.net/browse/WPB-2881
