### PR TITLE
runfix: uncentered device page [WPB-3460]

### DIFF
--- a/src/script/auth/page/ClientManager.tsx
+++ b/src/script/auth/page/ClientManager.tsx
@@ -80,7 +80,7 @@ const ClientManagerComponent = ({doGetAllClients, doLogout}: Props & ConnectedPr
           flexDirection: 'column',
           justifyContent: 'space-around',
           minHeight: 428,
-          marginInline: isMobile ? '20px' : 'inherit',
+          marginInline: isMobile ? '20px' : 'auto',
         }}
       >
         <H1 center style={{marginTop: '140px'}}>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3460" title="WPB-3460" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3460</a>  [Web] The page to delete a device after login is not centered anymore
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

improper css rule is breaking margin

