### PR TITLE
fix: prevent content shift on conversation start (WPB-1953)

### DIFF
--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -24,11 +24,11 @@
 }
 
 .messages {
-  max-width: @conversation-max-width;
   transform: translateZ(0);
   &.flex-center {
     margin: auto;
     & .message {
+      width: 100%;
       min-width: 75%;
     }
   }
@@ -314,6 +314,7 @@
 // MESSAGE - BODY
 .message-body {
   position: relative;
+  max-width: @conversation-max-width;
   padding-right: var(--conversation-message-timestamp-width);
   padding-left: @conversation-message-sender-width;
 

--- a/src/style/content/conversation/title-bar.less
+++ b/src/style/content/conversation/title-bar.less
@@ -16,6 +16,9 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  *
  */
+
+@button-group-width: 128px;
+
 #show-participants {
   min-width: 0; //needed for the truncation of long titles to work properly in flex-boxes
 }
@@ -38,7 +41,6 @@
   display: flex;
   height: 100%;
   flex-grow: 1;
-  margin-left: 10px;
   user-select: none;
 
   &--verified {
@@ -76,8 +78,12 @@ body.theme-dark {
 .conversation-title-bar-icons,
 .conversation-title-bar-library {
   display: flex;
+  min-width: @button-group-width;
   height: 100%;
   align-items: center;
+  @media (min-width: calc(@screen-sm-min * 2)) and (max-width: @screen-md-min) {
+    min-width: 0;
+  }
 }
 
 .conversation-title-bar-icons {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-1953" title="WPB-1953" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-1953</a>  [Web] Content shifts from being centered after 1:1 message is being sent
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Issue

- content shifts from centered to align-left when starting a conversation
- centered elements are not properly centered with the conversation title

![Peek 2023-07-24 18-07](https://github.com/wireapp/wire-webapp/assets/78490891/2d83bbe4-0ae5-414d-b015-1698228f9167)


### Solution

- apply the max width to the body of the message instead of the wrapper, so that the message header is always aligned left and the avatar is centered properly

![Peek 2023-07-24 17-53](https://github.com/wireapp/wire-webapp/assets/78490891/3fb8b688-bec6-42eb-a610-851e4b5257a6)

- assign the same width to left and right title bar element so the title is properly centered
