### PR TITLE
refactor: move send button out of lexical input

### DIFF
--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -563,7 +563,6 @@ const InputBar = ({
                 inputValue={inputValue}
                 setInputValue={setInputValue}
                 currentMentions={currentMentions}
-                sendMessage={onSend}
                 hasLocalEphemeralTimer={hasLocalEphemeralTimer}
                 saveDraftStateLexical={saveDraft}
                 loadDraftStateLexical={loadDraft}
@@ -573,7 +572,7 @@ const InputBar = ({
                     <ul className="controls-right buttons-group" css={{minWidth: '95px'}}>
                       {showGiphyButton && <GiphyButton onGifClick={onGifClick} />}
                     </ul>
-                    <SendMessageButton textValue={inputValue} onSend={sendMessage} mentions={mentionCandidates} />
+                    <SendMessageButton textValue={inputValue} onSend={onSend} mentions={mentionCandidates} />
                     <ul className="controls-right buttons-group" css={{justifyContent: 'center', width: '100%'}}>
                       <ControlButtons {...controlButtonsProps} isScaledDown={isScaledDown} />
                     </ul>
@@ -583,7 +582,7 @@ const InputBar = ({
                     <ul className="controls-right buttons-group">
                       <ControlButtons {...controlButtonsProps} showGiphyButton={showGiphyButton} />
                     </ul>
-                    <SendMessageButton textValue={inputValue} onSend={sendMessage} mentions={mentionCandidates} />
+                    <SendMessageButton textValue={inputValue} onSend={onSend} mentions={mentionCandidates} />
                   </>
                 )}
               </LexicalInput>

--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -571,8 +571,8 @@ const InputBar = ({
                   <>
                     <ul className="controls-right buttons-group" css={{minWidth: '95px'}}>
                       {showGiphyButton && <GiphyButton onGifClick={onGifClick} />}
+                      <SendMessageButton textValue={inputValue} onSend={onSend} mentions={mentionCandidates} />
                     </ul>
-                    <SendMessageButton textValue={inputValue} onSend={onSend} mentions={mentionCandidates} />
                     <ul className="controls-right buttons-group" css={{justifyContent: 'center', width: '100%'}}>
                       <ControlButtons {...controlButtonsProps} isScaledDown={isScaledDown} />
                     </ul>
@@ -581,8 +581,8 @@ const InputBar = ({
                   <>
                     <ul className="controls-right buttons-group">
                       <ControlButtons {...controlButtonsProps} showGiphyButton={showGiphyButton} />
+                      <SendMessageButton textValue={inputValue} onSend={onSend} mentions={mentionCandidates} />
                     </ul>
-                    <SendMessageButton textValue={inputValue} onSend={onSend} mentions={mentionCandidates} />
                   </>
                 )}
               </LexicalInput>

--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -30,6 +30,7 @@ import {WebAppEvents} from '@wireapp/webapp-events';
 import {Avatar, AVATAR_SIZE} from 'Components/Avatar';
 import {checkFileSharingPermission} from 'Components/Conversation/utils/checkFileSharingPermission';
 import {ClassifiedBar} from 'Components/input/ClassifiedBar';
+import {SendMessageButton} from 'Components/LexicalInput/components/SendMessageButton';
 import {LexicalInput} from 'Components/LexicalInput/LexicalInput';
 import {$createBeautifulMentionNode} from 'Components/LexicalInput/nodes/MentionNode';
 import {createNodes} from 'Components/LexicalInput/utils/generateNodes';
@@ -179,6 +180,12 @@ const InputBar = ({
   const isScaledDown = useMatchMedia('max-width: 768px');
 
   const showGiphyButton = inputValue.length > 0 && inputValue.length <= config.GIPHY_TEXT_LENGTH;
+
+  // Mentions
+  const {participating_user_ets: participatingUserEts} = useKoSubscribableChildren(conversationEntity, [
+    'participating_user_ets',
+  ]);
+  const mentionCandidates = participatingUserEts.filter(userEntity => !userEntity.isService);
 
   const resetDraftState = (resetInputValue = false) => {
     setCurrentMentions([]);
@@ -549,7 +556,7 @@ const InputBar = ({
               <LexicalInput
                 ref={lexicalRef}
                 editMessage={editMessage}
-                conversationEntity={conversationEntity}
+                mentionCandidates={mentionCandidates}
                 propertiesRepository={propertiesRepository}
                 searchRepository={searchRepository}
                 placeholder={inputPlaceholder}
@@ -566,14 +573,18 @@ const InputBar = ({
                     <ul className="controls-right buttons-group" css={{minWidth: '95px'}}>
                       {showGiphyButton && <GiphyButton onGifClick={onGifClick} />}
                     </ul>
+                    <SendMessageButton textValue={inputValue} onSend={sendMessage} mentions={mentionCandidates} />
                     <ul className="controls-right buttons-group" css={{justifyContent: 'center', width: '100%'}}>
                       <ControlButtons {...controlButtonsProps} isScaledDown={isScaledDown} />
                     </ul>
                   </>
                 ) : (
-                  <ul className="controls-right buttons-group">
-                    <ControlButtons {...controlButtonsProps} showGiphyButton={showGiphyButton} />
-                  </ul>
+                  <>
+                    <ul className="controls-right buttons-group">
+                      <ControlButtons {...controlButtonsProps} showGiphyButton={showGiphyButton} />
+                    </ul>
+                    <SendMessageButton textValue={inputValue} onSend={sendMessage} mentions={mentionCandidates} />
+                  </>
                 )}
               </LexicalInput>
             )}

--- a/src/script/components/LexicalInput/LexicalInput.tsx
+++ b/src/script/components/LexicalInput/LexicalInput.tsx
@@ -68,7 +68,6 @@ interface LexicalInputProps {
   setInputValue: (text: string) => void;
   editMessage: (messageEntity: ContentMessage, editor: LexicalEditor) => void;
   children: any;
-  sendMessage: any;
   hasLocalEphemeralTimer: boolean;
   saveDraftStateLexical: any;
   loadDraftStateLexical: any;


### PR DESCRIPTION
required to keep current responsive design logic:

![Peek 2023-07-26 14-36](https://github.com/wireapp/wire-webapp/assets/78490891/435dc3e4-30da-4c64-9f97-826181a5700f)
