### PR TITLE
runfix: assign same max-width to replies (WPB-3583)

### DIFF
--- a/src/style/content/conversation/message-quote.less
+++ b/src/style/content/conversation/message-quote.less
@@ -1,5 +1,6 @@
 .message-quote {
   position: relative;
+  max-width: @conversation-max-width;
   padding-right: var(--conversation-message-timestamp-width);
   padding-left: @conversation-message-sender-width + 16;
   margin-bottom: 10px;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3583" title="WPB-3583" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-3583</a>  [WEB] Replies have a different max-width than messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Issue
- Messages have a max-width of 800px but replies do not
![Screenshot from 2023-08-01 12-10-40](https://github.com/wireapp/wire-webapp/assets/78490891/8923e0d0-39ae-4585-9832-6034abc2bd92)

### Solution
![image](https://github.com/wireapp/wire-webapp/assets/78490891/b43ecf4d-4290-404e-b11b-0ecdce50627e)
