### PR TITLE
fix: message details click closes right panel if clicked on new details button

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -255,7 +255,7 @@ export const Conversation: FC<ConversationProps> = ({
 
   const showMessageDetails = (message: Message, showLikes = false) => {
     if (!is1to1) {
-      openRightSidebar(PanelState.MESSAGE_DETAILS, {entity: message, showLikes});
+      openRightSidebar(PanelState.MESSAGE_DETAILS, {entity: message, showLikes}, true);
     }
   };
 

--- a/src/script/page/AppMain.tsx
+++ b/src/script/page/AppMain.tsx
@@ -114,11 +114,9 @@ const AppMain: FC<AppMainProps> = ({
 
     if (isDifferentId || isDifferentState) {
       goTo(panelState, params);
-
-      return;
+    } else {
+      closeRightSidebar();
     }
-
-    closeRightSidebar();
   };
 
   // To be changed when design chooses a breakpoint, the conditional can be integrated to the ui-kit directly


### PR DESCRIPTION
… details button

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  -[web] message details click closes right panel if clicked on new details button

- The **PR Description**
  - Current Behavior:

    If you click on the details button in the context menu for reactions it opens up the side panel with details about reacters/viewers.
    
    if you click on a details button for a second message it closes the right panel

    Expected Behavior: 
    The click on a new details button will open the details panel for that message. 

Solution:

toggleRightSidebar function has a compareEntityId flag, it should set to be true then comparing of current panel id with the incoming panel id works and returns isDifferentId boolean. based on this we should call the closeSidebar function.

` const isDifferentId = compareEntityId && currentEntity?.id !== params?.entity?.id;`
----

##### References
1. https://wearezeta.atlassian.net/browse/WPB-3532
