### PR TITLE
chore: handle failed_to_confirm_clients b-e response (WPB-3393)(core bump)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@emotion/react": "11.11.1",
     "@types/eslint": "8.44.1",
     "@wireapp/avs": "9.3.7",
-    "@wireapp/core": "40.8.3",
+    "@wireapp/core": "40.8.4",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.7.7",
     "@wireapp/store-engine-dexie": "2.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4859,9 +4859,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^24.20.1":
-  version: 24.20.1
-  resolution: "@wireapp/api-client@npm:24.20.1"
+"@wireapp/api-client@npm:^24.20.2":
+  version: 24.20.2
+  resolution: "@wireapp/api-client@npm:24.20.2"
   dependencies:
     "@wireapp/commons": ^5.1.0
     "@wireapp/priority-queue": ^2.1.1
@@ -4874,7 +4874,7 @@ __metadata:
     spark-md5: 3.0.2
     tough-cookie: 4.1.3
     ws: 8.13.0
-  checksum: a8f58d9d31f920f28104d18aa3cc507470ec1788fd84e011557b47861b2ba41a6479322b665ef07cd11cfc18fbd853954bfe31a29cb764f766bfe3248e763839
+  checksum: 2c7dab29e72246d42d964b67cf04a0517855b2964b604b6ff978a805f613b520c5d43a4ddf81d555332f52bb8961e091696b3bab68637cdd64b61c05736ed6ae
   languageName: node
   linkType: hard
 
@@ -4927,11 +4927,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:40.8.3":
-  version: 40.8.3
-  resolution: "@wireapp/core@npm:40.8.3"
+"@wireapp/core@npm:40.8.4":
+  version: 40.8.4
+  resolution: "@wireapp/core@npm:40.8.4"
   dependencies:
-    "@wireapp/api-client": ^24.20.1
+    "@wireapp/api-client": ^24.20.2
     "@wireapp/commons": ^5.1.0
     "@wireapp/core-crypto": ^1.0.0-rc.1
     "@wireapp/cryptobox": 12.8.0
@@ -4948,7 +4948,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.13
-  checksum: 1f68c21c81e6b23378e7f01d61bc50e3a3f6d555a4e9da6cb4cdcc21ec2846cd4aa55f44c0e515ca41b6b72ff89677712ddd061273ae94aef550e11fe14bcadc
+  checksum: 8d8ed38dbb636d07dfd25e3a6b6c466023e77e946d9a167d4813cb62cb86573d013037524a7ea5e5b76d7920a75b5d05a763cb41dd0f3f992de5bedab2bef36e
   languageName: node
   linkType: hard
 
@@ -17748,7 +17748,7 @@ __metadata:
     "@typescript-eslint/parser": ^6.2.1
     "@wireapp/avs": 9.3.7
     "@wireapp/copy-config": 2.1.1
-    "@wireapp/core": 40.8.3
+    "@wireapp/core": 40.8.4
     "@wireapp/eslint-config": 2.2.3
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.6.0


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3393" title="WPB-3393" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-3393</a>  [Web] Sending Proteus messages when a remote backend is offline
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

bump core to 40.8.4 https://github.com/wireapp/wire-web-packages/pull/5357

I don't see a need to rename our state, I'd say the naming makes more sense now

#### Now:
```javascript
failedToSend : {
    queued: response.failed_to_confirm_clients,
    failed: [] // clients without prekeys
}
```

#### Previously:
```javascript
failedToSend : {
    queued: response.failed_to_send,
    failed: [] // clients without prekeys
}
```