### PR TITLE
feat: handle connection request with no longer federating users (WPB-2221)

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -940,6 +940,8 @@
   "modalUserCannotBeAddedHeadline": "Guests cannot be added",
   "modalUserCannotConnectLegalHoldHeadline": "Cannot connect to this user",
   "modalUserCannotConnectLegalHoldMessage": "You cannot connect to this user due to legal hold. [link]Learn more[/link]",
+  "modalUserCannotConnectNotFederatingHeadline": "Connection not possible",
+  "modalUserCannotConnectNotFederatingMessage": "You can’t send a connection request as your backend doesn’t federate with the one of {{username}}.",
   "modalUserLearnMore": "Learn more",
   "modalUserUnblockAction": "Unblock",
   "modalUserUnblockHeadline": "Unblock?",

--- a/src/script/connection/ConnectionRepository.ts
+++ b/src/script/connection/ConnectionRepository.ts
@@ -31,6 +31,7 @@ import {WebAppEvents} from '@wireapp/webapp-events';
 import {replaceLink, t} from 'Util/LocalizerUtil';
 import {getLogger, Logger} from 'Util/Logger';
 import {matchQualifiedIds} from 'Util/QualifiedId';
+import {isBackendError} from 'Util/TypePredicateUtil';
 
 import type {ConnectionEntity} from './ConnectionEntity';
 import {ConnectionMapper} from './ConnectionMapper';
@@ -189,21 +190,32 @@ export class ConnectionRepository {
       await this.onUserConnection(connectionEvent, EventRepository.SOURCE.INJECTED);
       return true;
     } catch (error) {
-      if (error.label === BackendErrorLabel.LEGAL_HOLD_MISSING_CONSENT) {
-        const replaceLinkLegalHold = replaceLink(
-          Config.getConfig().URL.SUPPORT.LEGAL_HOLD_BLOCK,
-          '',
-          'read-more-legal-hold',
-        );
-        PrimaryModal.show(PrimaryModal.type.ACKNOWLEDGE, {
-          text: {
-            htmlMessage: t('modalUserCannotConnectLegalHoldMessage', {}, replaceLinkLegalHold),
-            title: t('modalUserCannotConnectLegalHoldHeadline'),
-          },
-        });
+      if (isBackendError(error)) {
+        if (error.label === BackendErrorLabel.LEGAL_HOLD_MISSING_CONSENT) {
+          const replaceLinkLegalHold = replaceLink(
+            Config.getConfig().URL.SUPPORT.LEGAL_HOLD_BLOCK,
+            '',
+            'read-more-legal-hold',
+          );
+          PrimaryModal.show(PrimaryModal.type.ACKNOWLEDGE, {
+            text: {
+              htmlMessage: t('modalUserCannotConnectLegalHoldMessage', {}, replaceLinkLegalHold),
+              title: t('modalUserCannotConnectLegalHoldHeadline'),
+            },
+          });
+        }
+        if (error.label === BackendErrorLabel.FEDERATION_NOT_ALLOWED) {
+          PrimaryModal.show(PrimaryModal.type.ACKNOWLEDGE, {
+            text: {
+              htmlMessage: t('modalUserCannotConnectNotFederatingMessage', userEntity.name()),
+              title: t('modalUserCannotConnectNotFederatingHeadline'),
+            },
+          });
+        }
+        this.logger.error(`Failed to send connection request to user '${userEntity.id}': ${error.message}`, error);
+        return false;
       }
-      this.logger.error(`Failed to send connection request to user '${userEntity.id}': ${error.message}`, error);
-      return false;
+      throw error;
     }
   }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2221" title="WPB-2221" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-2221</a>  [Web] Handle connection requests to users on backends with which we don’t federate
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Feature

- display a modal when trying to connect to a user whom back-end we're no longer federated with
![Screenshot from 2023-08-03 18-02-02](https://github.com/wireapp/wire-webapp/assets/78490891/74a27dde-3a8f-42c1-85ad-ef41eba31e75)


*note: I used the latest suggestion from the localization team that is not reflected on the design yet*