### PR TITLE
chore: Group eslint updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,11 @@ updates:
     open-pull-requests-limit: 99
     labels:
       - 'type: chore 🧹'
+    groups:
+      eslint:
+        patterns:
+          - '*eslint*'
+
     ignore:
       - dependency-name: core-js
         versions:


### PR DESCRIPTION
This will make sure eslint dependencies are updates together
cf https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/