### PR TITLE
refactor: remove pending welcome mls state

### DIFF
--- a/src/__mocks__/@wireapp/core.ts
+++ b/src/__mocks__/@wireapp/core.ts
@@ -35,6 +35,7 @@ export class Account extends EventEmitter {
       renewKeyMaterial: jest.fn(),
       getClientIds: jest.fn(),
       getEpoch: jest.fn(),
+      conversationExists: jest.fn(),
       exportSecretKey: jest.fn(),
       leaveConferenceSubconversation: jest.fn(),
       on: this.on,

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -793,6 +793,7 @@ describe('ConversationRepository', () => {
           get: jest.fn(() => mockSelfClientId),
         });
 
+        jest.spyOn(container.resolve(Core).service!.mls!, 'conversationExists').mockResolvedValueOnce(true);
         return testFactory.conversation_repository['handleConversationEvent'](memberJoinEvent).then(() => {
           expect(testFactory.conversation_repository['onMemberJoin']).toHaveBeenCalled();
           expect(testFactory.conversation_repository.updateParticipatingUserEntities).toHaveBeenCalled();

--- a/src/script/mls/MLSConversations.test.ts
+++ b/src/script/mls/MLSConversations.test.ts
@@ -51,7 +51,7 @@ function createConversations(
 
 describe('MLSConversations', () => {
   beforeEach(() => {
-    jest.spyOn(useMLSConversationState.getState(), 'sendExternalToPendingJoin').mockReturnValue(undefined);
+    jest.spyOn(useMLSConversationState.getState(), 'joinWithExternalCommit').mockReturnValue(undefined);
   });
 
   describe('initMLSConversations', () => {
@@ -65,7 +65,7 @@ describe('MLSConversations', () => {
 
       await initMLSConversations(conversations, new Account());
 
-      expect(useMLSConversationState.getState().sendExternalToPendingJoin).toHaveBeenCalledWith(
+      expect(useMLSConversationState.getState().joinWithExternalCommit).toHaveBeenCalledWith(
         mlsConversations,
         expect.any(Function),
         expect.any(Function),

--- a/src/script/mls/mlsConversationState/conversationStateStorage.ts
+++ b/src/script/mls/mlsConversationState/conversationStateStorage.ts
@@ -29,16 +29,14 @@ export const loadState = (): MLSConversationState => {
   if (!storedState) {
     return {
       established: new Set(),
-      pendingWelcome: new Set(),
     };
   }
   const parsedState = JSON.parse(storedState);
   return {
     established: new Set(parsedState.established),
-    pendingWelcome: new Set(parsedState.pendingWelcome),
   };
 };
 
-export const saveState = ({established, pendingWelcome}: MLSConversationState) => {
-  storage?.setItem(storageKey, JSON.stringify({established: [...established], pendingWelcome: [...pendingWelcome]}));
+export const saveState = ({established}: MLSConversationState) => {
+  storage?.setItem(storageKey, JSON.stringify({established: [...established]}));
 };

--- a/src/script/mls/mlsConversationState/mlsConversationState.test.ts
+++ b/src/script/mls/mlsConversationState/mlsConversationState.test.ts
@@ -25,7 +25,7 @@ import {useMLSConversationState} from './mlsConversationState';
 
 import {Conversation} from '../../entity/Conversation';
 
-describe('mlsPendingStateUtil', () => {
+describe('mlsConversationState', () => {
   const createConversation = (protocol: ConversationProtocol) => {
     const conversation = new Conversation(createUuid(), '', protocol);
     if (protocol === ConversationProtocol.MLS) {
@@ -73,14 +73,14 @@ describe('mlsPendingStateUtil', () => {
     const sendExternalProposal = jest.fn();
     await useMLSConversationState
       .getState()
-      .sendExternalToPendingJoin(conversations, () => Promise.resolve(false), sendExternalProposal);
+      .joinWithExternalCommit(conversations, () => Promise.resolve(false), sendExternalProposal);
 
     expect(sendExternalProposal).toHaveBeenCalledTimes(nbMlsConversations);
 
     const sendExternalProposal2 = jest.fn();
     await useMLSConversationState
       .getState()
-      .sendExternalToPendingJoin(conversations, () => Promise.resolve(false), sendExternalProposal2);
+      .joinWithExternalCommit(conversations, () => Promise.resolve(false), sendExternalProposal2);
     expect(sendExternalProposal2).not.toHaveBeenCalled();
   });
 
@@ -94,13 +94,13 @@ describe('mlsPendingStateUtil', () => {
     const currentSize = useMLSConversationState.getState().established.size;
     await useMLSConversationState
       .getState()
-      .sendExternalToPendingJoin(conversations, () => Promise.resolve(true), sendExternalProposal);
+      .joinWithExternalCommit(conversations, () => Promise.resolve(true), sendExternalProposal);
 
     expect(sendExternalProposal).not.toHaveBeenCalled();
     expect(useMLSConversationState.getState().established.size).toBe(currentSize + conversations.length);
   });
 
-  it('sends external proposal only to conversations that are not pending and not established', async () => {
+  it('sends external proposal only to conversations that are not established', async () => {
     const conversations = [
       createConversation(ConversationProtocol.MLS),
       createConversation(ConversationProtocol.MLS),
@@ -109,13 +109,12 @@ describe('mlsPendingStateUtil', () => {
     ];
 
     useMLSConversationState.getState().markAsEstablished(conversations[1].groupId!);
-    useMLSConversationState.getState().markAsPendingWelcome(conversations[2].groupId!);
 
     const sendExternalProposal = jest.fn();
     await useMLSConversationState
       .getState()
-      .sendExternalToPendingJoin(conversations, () => Promise.resolve(false), sendExternalProposal);
+      .joinWithExternalCommit(conversations, () => Promise.resolve(false), sendExternalProposal);
 
-    expect(sendExternalProposal).toHaveBeenCalledTimes(1);
+    expect(sendExternalProposal).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/script/mls/mlsConversationState/mlsConversationState.ts
+++ b/src/script/mls/mlsConversationState/mlsConversationState.ts
@@ -25,30 +25,27 @@ import {loadState, saveState} from './conversationStateStorage';
 import {Conversation} from '../../entity/Conversation';
 
 export interface MLSConversationState {
-  /** list of conversations that are fully joined */
+  /** list of conversations that are already established */
   established: Set<string>;
-  /** list of conversations that are waiting for a welcome */
-  pendingWelcome: Set<string>;
 }
 
 const initialState = loadState();
 
 type StoreState = MLSConversationState & {
   isEstablished: (groupId: string) => boolean;
-  isPendingWelcome: (groupId: string) => boolean;
   filterEstablishedConversations: (conversations: Conversation[]) => Conversation[];
   markAsEstablished: (groupId: string) => void;
-  markAsPendingWelcome: (groupId: string) => void;
   wipeConversationState: (groupId: string) => void;
   /**
-   * Will send external proposal for all the conversations that are not pendingWelcome or established
-   * @param conversations The conversations that we want to process (only the mls conversations will be considered)
-   * @param sendExternalProposal Callback that will be called with every conversation that needs an external proposal
+   * Will join all the conversations that are not already established  with external commits.
+   * @param conversations conversations that we want to process (only the mls conversations will be considered)
+   * @param isAlreadyEstablished callback to check if a conversation is already established
+   * @param joinWithExternalCommit callback to join a conversation with an external commit
    */
-  sendExternalToPendingJoin(
+  joinWithExternalCommit(
     conversations: Conversation[],
-    isEstablishedConversation: (groupId: string) => Promise<boolean>,
-    sendExternalProposal: (conversationId: QualifiedId) => Promise<unknown>,
+    isAlreadyEstablished: (groupId: string) => Promise<boolean>,
+    joinWithExternalCommit: (conversationId: QualifiedId) => Promise<unknown>,
   ): Promise<void>;
 };
 
@@ -60,35 +57,17 @@ export const useMLSConversationState = create<StoreState>((set, get) => {
 
     isEstablished: groupId => get().established.has(groupId),
 
-    isPendingWelcome: groupId => get().pendingWelcome.has(groupId),
-
     markAsEstablished: groupId =>
       set(state => {
         const established = new Set(state.established);
         established.add(groupId);
 
-        const pendingWelcome = new Set(state.pendingWelcome);
-        pendingWelcome.delete(groupId);
-
         return {
           established,
-          pendingWelcome,
         };
       }),
 
-    markAsPendingWelcome: groupId =>
-      set(state => {
-        const pendingWelcome = new Set(state.pendingWelcome);
-        pendingWelcome.add(groupId);
-        return {
-          ...state,
-          pendingWelcome,
-        };
-      }),
-
-    pendingWelcome: initialState.pendingWelcome,
-
-    async sendExternalToPendingJoin(conversations, isAlreadyEstablished, sendExternalCommit): Promise<void> {
+    async joinWithExternalCommit(conversations, isAlreadyEstablished, sendExternalCommit): Promise<void> {
       const currentState = get();
       const conversationsToJoin: {groupId: string; conversationId: QualifiedId}[] = [];
       const pendingConversations: string[] = [];
@@ -99,7 +78,7 @@ export const useMLSConversationState = create<StoreState>((set, get) => {
         if (!conversation.isUsingMLSProtocol || !groupId) {
           continue;
         }
-        if (!currentState.isEstablished(groupId) && !currentState.isPendingWelcome(groupId)) {
+        if (!currentState.isEstablished(groupId)) {
           if (await isAlreadyEstablished(groupId)) {
             // check is the conversation is not actually already established
             alreadyEstablishedConversations.push(groupId);
@@ -123,7 +102,6 @@ export const useMLSConversationState = create<StoreState>((set, get) => {
       set({
         ...currentState,
         established: new Set([...currentState.established, ...alreadyEstablishedConversations]),
-        pendingWelcome: new Set([...currentState.pendingWelcome, ...pendingConversations]),
       });
     },
 
@@ -131,12 +109,10 @@ export const useMLSConversationState = create<StoreState>((set, get) => {
       set(state => {
         const established = new Set(state.established);
         established.delete(groupId);
-        const pendingWelcome = new Set(state.pendingWelcome);
-        pendingWelcome.delete(groupId);
+
         return {
           ...state,
           established,
-          pendingWelcome,
         };
       }),
   };


### PR DESCRIPTION
Removes pending welcome state from mls conversations state since it's not needed anymore, see: https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/563053166/Use+case+being+added+to+a+conversation+MLS