### PR TITLE
chore: Remove cyclic dependencies check on commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx --no-install lint-staged && yarn check:circular-dependencies 
+npx --no-install lint-staged


### PR DESCRIPTION
Checking for cyclic dependencies upon each commit is very costy and adds very little value. 
Let's not slow down the dev process and keep only valuable indicators for now. 