### PR TITLE
runfix: archived or abandoned conversation not visible

### DIFF
--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -72,10 +72,8 @@ export class ConversationState {
       this.conversations().find(conversation => isMLSConversation(conversation) && isSelfConversation(conversation)),
     );
 
-    //anytime mls conversation state changes, we update the sorted conversations that will recalculate visible conversations
-    useMLSConversationState.subscribe(() => {
-      this.sortedConversations.notifySubscribers();
-    });
+    //anytime mls conversation state changes, we notify conversations observable, so filteredConversations is recomputed
+    useMLSConversationState.subscribe(() => this.conversations.notifySubscribers());
 
     this.visibleConversations = ko.pureComputed(() => {
       return this.sortedConversations().filter(

--- a/src/script/mls/mlsConversationState/mlsConversationState.ts
+++ b/src/script/mls/mlsConversationState/mlsConversationState.ts
@@ -33,7 +33,6 @@ const initialState = loadState();
 
 type StoreState = MLSConversationState & {
   isEstablished: (groupId: string) => boolean;
-  filterEstablishedConversations: (conversations: Conversation[]) => Conversation[];
   markAsEstablished: (groupId: string) => void;
   wipeConversationState: (groupId: string) => void;
   /**
@@ -52,8 +51,6 @@ type StoreState = MLSConversationState & {
 export const useMLSConversationState = create<StoreState>((set, get) => {
   return {
     established: initialState.established,
-    filterEstablishedConversations: conversations =>
-      conversations.filter(conversation => !conversation.groupId || get().isEstablished(conversation.groupId)),
 
     isEstablished: groupId => get().established.has(groupId),
 


### PR DESCRIPTION
Filter out only those MLS conversations that are not established and self user was not removed from the conversation. Conversation should still be visible after leaving a conversation without clearing the content - even if mls group is not established anymore.