### PR TITLE
fix: unarchived conversation is missing after reload [WPB-3753]

### DIFF
--- a/src/script/conversation/ConversationMapper.test.ts
+++ b/src/script/conversation/ConversationMapper.test.ts
@@ -339,7 +339,7 @@ describe('ConversationMapper', () => {
     });
   });
 
-  describe('mergeConversation', () => {
+  describe('mergeConversations', () => {
     function getDataWithReadReceiptMode(
       localReceiptMode: RECEIPT_MODE,
       remoteReceiptMode: RECEIPT_MODE,
@@ -539,6 +539,63 @@ describe('ConversationMapper', () => {
 
         expect(merged_conversation.message_timer).toEqual(expected.message_timer);
       });
+    });
+
+    it('returns the local data if the remote data is not present', () => {
+      const localData: Partial<ConversationDatabaseData> = {
+        archived_state: false,
+        archived_timestamp: 1487239601118,
+        cleared_timestamp: 0,
+        ephemeral_timer: 0,
+        global_message_timer: 0,
+        id: 'de7466b0-985c-4dc3-ad57-17877db45b4c',
+        is_guest: false,
+        is_managed: false,
+        last_event_timestamp: 1488387380633,
+        last_read_timestamp: 1488387380633,
+        last_server_timestamp: 1488387380633,
+        muted_state: NOTIFICATION_STATE.EVERYTHING,
+        muted_timestamp: 0,
+        name: 'Family Gathering',
+        others: ['532af01e-1e24-4366-aacf-33b67d4ee376'],
+        receipt_mode: RECEIPT_MODE.ON,
+        status: 0,
+        team_id: '5316fe03-24ee-4b19-b789-6d026bd3ce5f',
+        type: 2,
+        verification_state: 0,
+      };
+
+      const [merged_conversation] = ConversationMapper.mergeConversations(
+        [localData] as ConversationDatabaseData[],
+        {found: []} as RemoteConversations,
+      );
+
+      expect(merged_conversation).toEqual(localData);
+    });
+
+    it('returns the remote data if the local data is not present', () => {
+      const [merged_conversation] = ConversationMapper.mergeConversations([], {
+        found: [remoteData],
+      } as RemoteConversations);
+
+      const mergedConversation = {
+        accessModes: remoteData.access,
+        archived_state: false,
+        archived_timestamp: 1487239601118,
+        creator: '532af01e-1e24-4366-aacf-33b67d4ee376',
+        id: 'de7466b0-985c-4dc3-ad57-17877db45b4c',
+        last_event_timestamp: 1,
+        last_server_timestamp: 1,
+        muted_state: 0,
+        muted_timestamp: 0,
+        name: 'Family Gathering',
+        others: ['532af01e-1e24-4366-aacf-33b67d4ee376'],
+        roles: {},
+        team_id: '5316fe03-24ee-4b19-b789-6d026bd3ce5f',
+        type: 2,
+      };
+
+      expect(merged_conversation).toEqual(mergedConversation);
     });
 
     it('updates local archive and muted timestamps if time of remote data is newer', () => {

--- a/src/script/conversation/ConversationMapper.ts
+++ b/src/script/conversation/ConversationMapper.ts
@@ -311,27 +311,27 @@ export class ConversationMapper {
 
     const conversationsMap = new Map<string, ConversationDatabaseData>();
 
-    for (const conversation of localConversations) {
-      const conversationId = conversation.qualified_id?.id || conversation.id;
-      conversationsMap.set(conversationId, conversation);
+    for (const localConversation of localConversations) {
+      const conversationId = localConversation.qualified_id?.id || localConversation.id;
+      conversationsMap.set(conversationId, localConversation);
     }
 
     for (let i = 0; i < foundRemoteConversations.length; i++) {
-      const conversation = foundRemoteConversations[i];
-      const conversationId = conversation.qualified_id?.id || conversation.id;
+      const remoteConversation = foundRemoteConversations[i];
+      const conversationId = remoteConversation.qualified_id?.id || remoteConversation.id;
       const localConversation = conversationsMap.get(conversationId);
 
       if (localConversation) {
-        conversationsMap.set(conversationId, this.mergeSingleConversation(localConversation, conversation, i));
+        conversationsMap.set(conversationId, this.mergeSingleConversation(localConversation, remoteConversation, i));
         continue;
       }
 
-      const localConversationData = (conversation.qualified_id || {
+      const localConversationData = (remoteConversation.qualified_id || {
         id: conversationId,
         domain: '',
       }) as ConversationDatabaseData;
 
-      conversationsMap.set(conversationId, this.mergeSingleConversation(localConversationData, conversation, i));
+      conversationsMap.set(conversationId, this.mergeSingleConversation(localConversationData, remoteConversation, i));
     }
 
     return Array.from(conversationsMap.values());

--- a/src/script/conversation/ConversationMapper.ts
+++ b/src/script/conversation/ConversationMapper.ts
@@ -293,15 +293,19 @@ export class ConversationMapper {
     return conversationEntity;
   }
 
+  /**
+   * Will merge the locally stored conversations with the new conversations fetched from the backend.
+   * @param localConversations locally stored conversations
+   * @param remoteConversations new conversations fetched from backend
+   * @returns the new conversations from backend merged with the locally stored conversations
+   */
   static mergeConversations(
     localConversations: ConversationDatabaseData[],
     remoteConversations: RemoteConversations,
   ): ConversationDatabaseData[] {
-    localConversations = localConversations.filter(conversationData => conversationData);
+    const foundRemoteConversations = remoteConversations.found;
 
-    const foundConversations = remoteConversations.found;
-
-    if (!foundConversations) {
+    if (!foundRemoteConversations) {
       return localConversations;
     }
 
@@ -312,8 +316,8 @@ export class ConversationMapper {
       conversationsMap.set(conversationId, conversation);
     }
 
-    for (let i = 0; i < foundConversations.length; i++) {
-      const conversation = foundConversations[i];
+    for (let i = 0; i < foundRemoteConversations.length; i++) {
+      const conversation = foundRemoteConversations[i];
       const conversationId = conversation.qualified_id?.id || conversation.id;
       const localConversation = conversationsMap.get(conversationId);
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3753" title="WPB-3753" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3753</a>  [Web] Conversation content is gone after leaving a conversation and unarchiving
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Conversation was missing in conversations list when user has left it without clearing the content, unarchived automatically archived conversation and reloaded the webapp. We should not hide conversations we've left (or were removed from) that are still known by the local db. This PR should fix it.