### PR TITLE
fix: self leave conversation shouldn't be archived automatically

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -2828,10 +2828,6 @@ export class ConversationRepository {
 
       this.verificationStateHandler.onMemberLeft(conversationEntity);
 
-      if (isFromSelf && conversationEntity.removed_from_conversation()) {
-        this.archiveConversation(conversationEntity);
-      }
-
       return {conversationEntity, messageEntity};
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - Leave conversation should not archive automatically

- The **PR Description**
  - conversation should not be automatically archived after user is removed from the conversation or after they have left by themselves. Archiving conversations should always be an overt activity performed by the user.
----
##### References
1. https://wearezeta.atlassian.net/browse/WPB-3769
