### PR TITLE
fix: remove devices panel from group convos [WPB-3931]

### DIFF
--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
@@ -433,7 +433,7 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
             <>
               <ConversationDetailsBottomActions
                 isDeviceActionEnabled={
-                  firstParticipant && (firstParticipant.isConnected() || firstParticipant.inTeam())
+                  isSingleUserMode && firstParticipant && (firstParticipant.isConnected() || firstParticipant.inTeam())
                 }
                 showDevices={openParticipantDevices}
                 showNotifications={showNotifications}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3931" title="WPB-3931" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3931</a>  [Web] Device list of group participant is accessible from conversation details
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Device list doesnt make sense for group convo sidebar as it just shows the first users device. 

