### PR TITLE
refactor: Cleanup conversation creation/ user addition types

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@datadog/browser-rum": "^4.47.0",
     "@emotion/react": "11.11.1",
     "@wireapp/avs": "9.3.7",
-    "@wireapp/core": "41.2.0",
+    "@wireapp/core": "41.2.2",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.8.1",
     "@wireapp/store-engine-dexie": "2.1.3",

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -643,7 +643,6 @@ describe('ConversationRepository', () => {
         createEvent = {
           conversation: conversationId,
           data: {
-            failed_to_add: [],
             access: [CONVERSATION_ACCESS.INVITE],
             access_role: CONVERSATION_LEGACY_ACCESS_ROLE.ACTIVATED,
             access_role_v2: [],

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -45,7 +45,7 @@ import {
 import {BackendErrorLabel} from '@wireapp/api-client/lib/http/';
 import type {BackendError} from '@wireapp/api-client/lib/http/';
 import type {QualifiedId} from '@wireapp/api-client/lib/user/';
-import {MLSReturnType} from '@wireapp/core/lib/conversation';
+import {MLSCreateConversationResponse} from '@wireapp/core/lib/conversation';
 import {amplify} from 'amplify';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import {container} from 'tsyringe';
@@ -550,7 +550,7 @@ export class ConversationRepository {
        * ToDo: Fetch all MLS Events from backend before doing anything else
        * Needs to be done to receive the latest epoch and avoid epoch mismatch errors
        */
-      let response: MLSReturnType;
+      let response: MLSCreateConversationResponse;
       const isMLSConversation = payload.protocol === ConversationProtocol.MLS;
       if (isMLSConversation) {
         response = await this.core.service!.conversation.createMLSConversation(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4815,9 +4815,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^25.2.0":
-  version: 25.2.0
-  resolution: "@wireapp/api-client@npm:25.2.0"
+"@wireapp/api-client@npm:^25.2.2":
+  version: 25.2.2
+  resolution: "@wireapp/api-client@npm:25.2.2"
   dependencies:
     "@wireapp/commons": ^5.1.0
     "@wireapp/priority-queue": ^2.1.1
@@ -4830,7 +4830,7 @@ __metadata:
     spark-md5: 3.0.2
     tough-cookie: 4.1.3
     ws: 8.13.0
-  checksum: 37ecdce86bfc36f56a8a4548b70d1fa2d5ae404a7e2e10abd49e3054f0fe9ec5c0b770d074647d54acd97544d97af840147c05fae08c1f5daaf0c2b97e443fa8
+  checksum: 0034aeb9a97d464f7a9ee0abab38db1be7ee180d75bd603963f565cf717e4a5044937fa6875e4a229e5a707da54492f153b88b5502632d835ff3c572e206447a
   languageName: node
   linkType: hard
 
@@ -4883,15 +4883,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:41.2.0":
-  version: 41.2.0
-  resolution: "@wireapp/core@npm:41.2.0"
+"@wireapp/core@npm:41.2.2":
+  version: 41.2.2
+  resolution: "@wireapp/core@npm:41.2.2"
   dependencies:
-    "@wireapp/api-client": ^25.2.0
+    "@wireapp/api-client": ^25.2.2
     "@wireapp/commons": ^5.1.0
     "@wireapp/core-crypto": 1.0.0-rc.6
     "@wireapp/cryptobox": 12.8.0
-    "@wireapp/promise-queue": ^2.2.0
+    "@wireapp/promise-queue": ^2.2.1
     "@wireapp/protocol-messaging": 1.44.0
     "@wireapp/store-engine": 5.1.1
     "@wireapp/store-engine-dexie": ^2.1.3
@@ -4904,7 +4904,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.13
-  checksum: b0a16e10cc31c198a87054a9bf8f9dbe6ef87a21947f087d5b1f086aea7c3af0edf953423ff49c31704169d2602c6fc98ce55f17acb2e8d2d19a68e72a617e4a
+  checksum: 62f88d3a0de74bc14a85f2a0f6c96a328f97c6fdaf0ff4972addcc7626b81cf121946c2c284a62e0a6835f46fad0f9db52cbdbcc36b9dc5e22937494a33dab5b
   languageName: node
   linkType: hard
 
@@ -4987,10 +4987,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/promise-queue@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@wireapp/promise-queue@npm:2.2.0"
-  checksum: c0c6c66be8316844cdeadb77d176846103f98087027dd8c88f99ab664b62982918a49cab6aeb16a35c7d07347f80a3f6bc200edc20877ed382b635cab6d61ff9
+"@wireapp/promise-queue@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "@wireapp/promise-queue@npm:2.2.1"
+  checksum: 32d253b20dae3eb0ab5068cba20d8e24a60a702b32cc99fa0594789c02779a8e39c10dd8ffe81ae353fab5bc7a841f63b691719f322e49661751a7fa421fd40d
   languageName: node
   linkType: hard
 
@@ -17851,7 +17851,7 @@ __metadata:
     "@types/webpack-env": 1.18.1
     "@wireapp/avs": 9.3.7
     "@wireapp/copy-config": 2.1.1
-    "@wireapp/core": 41.2.0
+    "@wireapp/core": 41.2.2
     "@wireapp/eslint-config": 3.0.1
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.6.0


### PR DESCRIPTION
Adapt to the latest changes of the core where adding users/creating conversation always returns the `failedToAdd` property as a extra metadata
see https://github.com/wireapp/wire-web-packages/pull/5398