### PR TITLE
feat: truncate notifications smartly [WPB-3754]

### DIFF
--- a/src/script/notification/NotificationRepository.test.ts
+++ b/src/script/notification/NotificationRepository.test.ts
@@ -123,7 +123,7 @@ describe('NotificationRepository', () => {
         tag: conversation.id,
       },
       timeout: NotificationRepository.CONFIG.TIMEOUT,
-      title: truncate(title, NotificationRepository.CONFIG.TITLE_LENGTH, false),
+      title: truncate(title, NotificationRepository.CONFIG.TITLE_MAX_LENGTH, false),
     };
 
     // Mocks
@@ -153,8 +153,13 @@ describe('NotificationRepository', () => {
         notification_content.trigger = trigger;
 
         if (_conversation.isGroup()) {
-          const titleLength = NotificationRepository.CONFIG.TITLE_LENGTH;
-          const titleText = `${_message.user().name()} in ${_conversation.display_name()}`;
+          const titleLength = NotificationRepository.CONFIG.TITLE_MAX_LENGTH;
+          const titleSectionLength = NotificationRepository.CONFIG.TITLE_LENGTH;
+          const titleText = `${_message.user().name()} in ${truncate(
+            _conversation.display_name(),
+            titleSectionLength,
+            false,
+          )}`;
 
           notification_content.title = truncate(titleText, titleLength, false);
         } else {
@@ -192,8 +197,14 @@ describe('NotificationRepository', () => {
 
         const obfuscateMessage = _setting === NotificationPreference.OBFUSCATE_MESSAGE;
         if (obfuscateMessage) {
-          const titleLength = NotificationRepository.CONFIG.TITLE_LENGTH;
-          const titleText = `${message.user().name()} in ${conversation.display_name()}`;
+          const titleLength = NotificationRepository.CONFIG.TITLE_MAX_LENGTH;
+          const titleSectionLength = NotificationRepository.CONFIG.TITLE_LENGTH;
+
+          const titleText = `${message.user().name()} in ${truncate(
+            conversation.display_name(),
+            titleSectionLength,
+            false,
+          )}`;
 
           notification_content.options.body = t('notificationObfuscated');
           notification_content.title = truncate(titleText, titleLength, false);
@@ -542,8 +553,14 @@ describe('NotificationRepository', () => {
 
   describe('shows a well-formed group notification', () => {
     beforeEach(() => {
-      const titleLength = NotificationRepository.CONFIG.TITLE_LENGTH;
-      const titleText = `${message.user().name()} in ${conversation.display_name()}`;
+      const titleLength = NotificationRepository.CONFIG.TITLE_MAX_LENGTH;
+      const titleSectionLength = NotificationRepository.CONFIG.TITLE_LENGTH;
+
+      const titleText = `${message.user().name()} in ${truncate(
+        conversation.display_name(),
+        titleSectionLength,
+        false,
+      )}`;
 
       notification_content.title = truncate(titleText, titleLength, false);
     });
@@ -604,8 +621,14 @@ describe('NotificationRepository', () => {
       beforeEach(() => {
         memberMessage.type = CONVERSATION_EVENT.MEMBER_JOIN;
 
-        const titleLength = NotificationRepository.CONFIG.TITLE_LENGTH;
-        const titleText = `${memberMessage.user().name()} in ${conversation.display_name()}`;
+        const titleLength = NotificationRepository.CONFIG.TITLE_MAX_LENGTH;
+        const titleSectionLength = NotificationRepository.CONFIG.TITLE_LENGTH;
+
+        const titleText = `${memberMessage.user().name()} in ${truncate(
+          conversation.display_name(),
+          titleSectionLength,
+          false,
+        )}`;
 
         notification_content.title = truncate(titleText, titleLength, false);
       });
@@ -641,8 +664,14 @@ describe('NotificationRepository', () => {
     describe('if people are removed', () => {
       beforeEach(() => {
         memberMessage.type = CONVERSATION_EVENT.MEMBER_LEAVE;
-        const titleLength = NotificationRepository.CONFIG.TITLE_LENGTH;
-        const titleText = `${memberMessage.user().name()} in ${conversation.display_name()}`;
+        const titleLength = NotificationRepository.CONFIG.TITLE_MAX_LENGTH;
+        const titleSectionLength = NotificationRepository.CONFIG.TITLE_LENGTH;
+
+        const titleText = `${memberMessage.user().name()} in ${truncate(
+          conversation.display_name(),
+          titleSectionLength,
+          false,
+        )}`;
 
         notification_content.title = truncate(titleText, titleLength, false);
       });

--- a/src/script/notification/NotificationRepository.test.ts
+++ b/src/script/notification/NotificationRepository.test.ts
@@ -93,6 +93,7 @@ describe('NotificationRepository', () => {
   let verifyNotificationEphemeral: (...args: any[]) => void;
   let verifyNotificationObfuscated: (...args: any[]) => void;
   let verifyNotificationSystem: (...args: any[]) => void;
+  let createTruncatedTitle: (name: string, conversationName: string) => string;
 
   let notification_content: any;
   const contentViewModelState: any = {};
@@ -143,6 +144,18 @@ describe('NotificationRepository', () => {
 
     const showNotificationSpy = jest.spyOn(notificationRepository as any, 'showNotification');
 
+    createTruncatedTitle = (name, conversationName) => {
+      const titleLength = NotificationRepository.CONFIG.TITLE_MAX_LENGTH;
+      const titleSectionLength = NotificationRepository.CONFIG.TITLE_LENGTH;
+
+      const titleText = `${truncate(name, titleSectionLength, false)} in ${truncate(
+        conversationName,
+        titleSectionLength,
+        false,
+      )}`;
+      return truncate(titleText, titleLength, false);
+    };
+
     verifyNotification = (_conversation, _message, _expected_body) => {
       return notificationRepository.notify(_message, undefined, _conversation).then(() => {
         expect(showNotificationSpy).toHaveBeenCalledTimes(1);
@@ -153,15 +166,7 @@ describe('NotificationRepository', () => {
         notification_content.trigger = trigger;
 
         if (_conversation.isGroup()) {
-          const titleLength = NotificationRepository.CONFIG.TITLE_MAX_LENGTH;
-          const titleSectionLength = NotificationRepository.CONFIG.TITLE_LENGTH;
-          const titleText = `${_message.user().name()} in ${truncate(
-            _conversation.display_name(),
-            titleSectionLength,
-            false,
-          )}`;
-
-          notification_content.title = truncate(titleText, titleLength, false);
+          notification_content.title = createTruncatedTitle(_message.user().name(), _conversation.display_name());
         } else {
           notification_content.title = 'Name not available';
         }
@@ -197,17 +202,8 @@ describe('NotificationRepository', () => {
 
         const obfuscateMessage = _setting === NotificationPreference.OBFUSCATE_MESSAGE;
         if (obfuscateMessage) {
-          const titleLength = NotificationRepository.CONFIG.TITLE_MAX_LENGTH;
-          const titleSectionLength = NotificationRepository.CONFIG.TITLE_LENGTH;
-
-          const titleText = `${message.user().name()} in ${truncate(
-            conversation.display_name(),
-            titleSectionLength,
-            false,
-          )}`;
-
           notification_content.options.body = t('notificationObfuscated');
-          notification_content.title = truncate(titleText, titleLength, false);
+          notification_content.title = createTruncatedTitle(_message.user().name(), _conversation.display_name());
         } else {
           notification_content.options.body = t('notificationObfuscated');
           notification_content.title = t('notificationObfuscatedTitle');
@@ -553,16 +549,7 @@ describe('NotificationRepository', () => {
 
   describe('shows a well-formed group notification', () => {
     beforeEach(() => {
-      const titleLength = NotificationRepository.CONFIG.TITLE_MAX_LENGTH;
-      const titleSectionLength = NotificationRepository.CONFIG.TITLE_LENGTH;
-
-      const titleText = `${message.user().name()} in ${truncate(
-        conversation.display_name(),
-        titleSectionLength,
-        false,
-      )}`;
-
-      notification_content.title = truncate(titleText, titleLength, false);
+      notification_content.title = createTruncatedTitle(user.name(), conversation.display_name());
     });
 
     it('if a group is created', () => {
@@ -620,17 +607,7 @@ describe('NotificationRepository', () => {
     describe('if people are added', () => {
       beforeEach(() => {
         memberMessage.type = CONVERSATION_EVENT.MEMBER_JOIN;
-
-        const titleLength = NotificationRepository.CONFIG.TITLE_MAX_LENGTH;
-        const titleSectionLength = NotificationRepository.CONFIG.TITLE_LENGTH;
-
-        const titleText = `${memberMessage.user().name()} in ${truncate(
-          conversation.display_name(),
-          titleSectionLength,
-          false,
-        )}`;
-
-        notification_content.title = truncate(titleText, titleLength, false);
+        notification_content.title = createTruncatedTitle(user.name(), conversation.display_name());
       });
 
       it('with one user being added to the conversation', () => {
@@ -664,16 +641,8 @@ describe('NotificationRepository', () => {
     describe('if people are removed', () => {
       beforeEach(() => {
         memberMessage.type = CONVERSATION_EVENT.MEMBER_LEAVE;
-        const titleLength = NotificationRepository.CONFIG.TITLE_MAX_LENGTH;
-        const titleSectionLength = NotificationRepository.CONFIG.TITLE_LENGTH;
 
-        const titleText = `${memberMessage.user().name()} in ${truncate(
-          conversation.display_name(),
-          titleSectionLength,
-          false,
-        )}`;
-
-        notification_content.title = truncate(titleText, titleLength, false);
+        notification_content.title = createTruncatedTitle(user.name(), conversation.display_name());
       });
 
       it('with one user being removed from the conversation', () => {

--- a/src/script/notification/NotificationRepository.ts
+++ b/src/script/notification/NotificationRepository.ts
@@ -108,7 +108,8 @@ export class NotificationRepository {
       BODY_LENGTH: 80,
       ICON_URL: '/image/logo/notification.png',
       TIMEOUT: TIME_IN_MILLIS.SECOND * 5,
-      TITLE_LENGTH: 38,
+      TITLE_LENGTH: 17,
+      TITLE_MAX_LENGTH: 38,
     };
   }
 
@@ -617,16 +618,22 @@ export class NotificationRepository {
    */
   private createTitle(messageEntity: Message, conversationEntity?: Conversation): string {
     const conversationName = conversationEntity && conversationEntity.display_name();
+    const truncatedConversationName = truncate(
+      conversationName ?? '',
+      NotificationRepository.CONFIG.TITLE_LENGTH,
+      false,
+    );
     const userEntity = messageEntity.user();
+    const truncatedName = truncate(userEntity.name(), NotificationRepository.CONFIG.TITLE_LENGTH, false);
 
     let title;
     if (conversationName) {
       title = conversationEntity.isGroup()
-        ? t('notificationTitleGroup', {conversation: conversationName, user: userEntity.name()}, {}, true)
+        ? t('notificationTitleGroup', {conversation: truncatedConversationName, user: truncatedName}, {}, true)
         : conversationName;
     }
 
-    return truncate(title || userEntity.name(), NotificationRepository.CONFIG.TITLE_LENGTH, false);
+    return truncate(title ?? truncatedName, NotificationRepository.CONFIG.TITLE_MAX_LENGTH, false);
   }
 
   /**
@@ -636,7 +643,7 @@ export class NotificationRepository {
    */
   private createTitleObfuscated(): string {
     const obfuscatedTitle = t('notificationObfuscatedTitle');
-    return truncate(obfuscatedTitle, NotificationRepository.CONFIG.TITLE_LENGTH, false);
+    return truncate(obfuscatedTitle, NotificationRepository.CONFIG.TITLE_MAX_LENGTH, false);
   }
 
   /**


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3754" title="WPB-3754" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3754</a>  "In what conversation??" Notification titles are truncated
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

truncates titles to fit correctly for long user names or conversation names to not cut off conversation name info. 

