### PR TITLE
refactor: Optimize app re-rendering

### DIFF
--- a/src/script/components/UserList/UserList.test.tsx
+++ b/src/script/components/UserList/UserList.test.tsx
@@ -45,6 +45,7 @@ describe('UserList', () => {
     const user = new User('test-id');
     user.isMe = true;
 
+    userState.self(user);
     userState.users([user]);
 
     const users = ['1', '2', '3', '4'].map(id => new User(id));
@@ -67,6 +68,7 @@ describe('UserList', () => {
     const user = new User('test-id');
     user.isMe = true;
 
+    userState.self(user);
     userState.users([user]);
 
     const setStateMock = jest.fn();

--- a/src/script/conversation/MessageRepository.test.ts
+++ b/src/script/conversation/MessageRepository.test.ts
@@ -74,7 +74,7 @@ type MessageRepositoryDependencies = {
 
 async function buildMessageRepository(): Promise<[MessageRepository, MessageRepositoryDependencies]> {
   const userState = new UserState();
-  userState.users([selfUser]);
+  userState.self(selfUser);
   const clientState = new ClientState();
   clientState.currentClient(new ClientEntity(true, ''));
   const core = new Account();

--- a/src/script/media/MediaConstraintsHandler.test.ts
+++ b/src/script/media/MediaConstraintsHandler.test.ts
@@ -43,7 +43,7 @@ describe('MediaConstraintsHandler', () => {
     selfUserId?: string;
   } = {}) => {
     const userState: Partial<UserState> = {
-      self: ko.pureComputed(() => new User(selfUserId, '')),
+      self: ko.observable<User | undefined>(new User(selfUserId, '')),
     };
     return new MediaConstraintsHandler(availableDevices, userState as UserState);
   };

--- a/src/script/notification/NotificationRepository.test.ts
+++ b/src/script/notification/NotificationRepository.test.ts
@@ -108,7 +108,7 @@ describe('NotificationRepository', () => {
     selfUserEntity.isMe = true;
     selfUserEntity.inTeam(true);
     conversation.selfUser(selfUserEntity);
-    userState.users([selfUserEntity]);
+    userState.self(selfUserEntity);
 
     // Notification
     const title = conversation.display_name();

--- a/src/script/page/AppMain.tsx
+++ b/src/script/page/AppMain.tsx
@@ -42,7 +42,7 @@ import {PanelEntity, PanelState, RightSidebar} from './RightSidebar';
 import {RootProvider} from './RootProvider';
 import {useAppMainState, ViewType} from './state';
 import {useAppState, ContentState} from './useAppState';
-import {useWindowTitle} from './useWindowTitle';
+import {WindowTitleUpdater} from './useWindowTitle';
 
 import {ConversationState} from '../conversation/ConversationState';
 import {User} from '../entity/User';
@@ -94,8 +94,6 @@ const AppMain: FC<AppMainProps> = ({
 
   const teamState = container.resolve(TeamState);
   const userState = container.resolve(UserState);
-
-  useWindowTitle();
 
   const {isActivatedAccount} = useKoSubscribableChildren(userState, ['isActivatedAccount']);
 
@@ -214,6 +212,7 @@ const AppMain: FC<AppMainProps> = ({
       data-uie-name="status-webapp"
       data-uie-value="is-loaded"
     >
+      <WindowTitleUpdater />
       <RootProvider value={mainView}>
         <ErrorBoundary FallbackComponent={ErrorFallback}>
           <div id="app" className="app">

--- a/src/script/page/AppMain.tsx
+++ b/src/script/page/AppMain.tsx
@@ -42,7 +42,7 @@ import {PanelEntity, PanelState, RightSidebar} from './RightSidebar';
 import {RootProvider} from './RootProvider';
 import {useAppMainState, ViewType} from './state';
 import {useAppState, ContentState} from './useAppState';
-import {WindowTitleUpdater} from './useWindowTitle';
+import {WindowTitleUpdater} from './WindowTitleUpdater';
 
 import {ConversationState} from '../conversation/ConversationState';
 import {User} from '../entity/User';

--- a/src/script/page/WindowTitleUpdater.ts
+++ b/src/script/page/WindowTitleUpdater.ts
@@ -163,7 +163,7 @@ const useWindowTitle = () => {
   }, [initiateTitleUpdates, updateNotificationState]);
 };
 
-export function WindowTitleUpdater() {
+export function WindowTitleUpdater(): null {
   useWindowTitle();
 
   return null;

--- a/src/script/page/useWindowTitle.ts
+++ b/src/script/page/useWindowTitle.ts
@@ -40,7 +40,7 @@ const windowTitleLogger = getLogger('WindowTitlesViewModel');
 const MIN_UNREAD_COUNT = 0;
 const MIN_CONNECTION_REQUEST_COUNT = 1;
 
-export const useWindowTitle = () => {
+const useWindowTitle = () => {
   const userState = container.resolve(UserState);
   const conversationState = container.resolve(ConversationState);
 
@@ -162,3 +162,9 @@ export const useWindowTitle = () => {
     initiateTitleUpdates();
   }, [initiateTitleUpdates, updateNotificationState]);
 };
+
+export function WindowTitleUpdater() {
+  useWindowTitle();
+
+  return null;
+}

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -720,6 +720,7 @@ export class UserRepository {
     if (!user) {
       if (isMe) {
         userEntity.isMe = true;
+        this.userState.self(userEntity);
       }
       this.userState.users.push(userEntity);
     }

--- a/src/script/user/UserState.ts
+++ b/src/script/user/UserState.ts
@@ -39,10 +39,9 @@ export class UserState {
   public readonly isActivatedAccount: ko.PureComputed<boolean>;
   public readonly isTemporaryGuest: ko.PureComputed<boolean>;
   public readonly numberOfContacts: ko.PureComputed<number>;
-  public readonly self: ko.PureComputed<User>;
+  public readonly self = ko.observable<User | undefined>();
 
   constructor() {
-    this.self = ko.pureComputed<User>(() => this.users().find(user => user.isMe));
     this.users = ko.observableArray([]);
 
     this.connectRequests = ko

--- a/test/helper/TestFactory.js
+++ b/test/helper/TestFactory.js
@@ -177,6 +177,7 @@ export class TestFactory {
     const userState = new UserState();
     const selfUser = new User('self-id');
     selfUser.isMe = true;
+    userState.self(selfUser);
     userState.users([selfUser]);
 
     this.user_repository = new UserRepository(

--- a/test/unit_tests/team/TeamRepositorySpec.js
+++ b/test/unit_tests/team/TeamRepositorySpec.js
@@ -50,7 +50,7 @@ describe('TeamRepository', () => {
       const selfUser = new User('self-id');
       selfUser.teamId = 'e6d3adc5-9140-477a-abc1-8279d210ceab';
       selfUser.isMe = true;
-      userState.users([selfUser]);
+      userState.self(selfUser);
       const teamService = {
         getTeamById: jest.fn(team => Promise.resolve(team_metadata)),
       };
@@ -93,7 +93,7 @@ describe('TeamRepository', () => {
       const selfUser = new User();
       selfUser.isMe = true;
       selfUser.teamRole('z.team.TeamRole.ROLE.NONE');
-      userState.users([selfUser]);
+      userState.self(selfUser);
       const teamState = new TeamState(userState);
       teamState.team({
         id: 'team-id',


### PR DESCRIPTION
Because the `useWindowTitle` was a hook, everytime there was a change in there, the entire app would re-render. 
Extracting it into its own component makes title update only updating that headless component and leaves the app alone.

## Before

While searching for users, the entire app would re-render when users are fetched from backend
(squares appearing on screen represent component re-renders)

https://github.com/wireapp/wire-webapp/assets/1090716/e1b8c6ba-5221-4cf6-9c42-8ee78425ff9a

## After

No more full app re-render when backend search is done
(squares appearing on screen represent component re-renders)

https://github.com/wireapp/wire-webapp/assets/1090716/f5f8447f-161a-437c-bfe5-6473bc499075




