### PR TITLE
runfix: Fix translation replacements for upgrade to enterprise modal

### DIFF
--- a/src/script/page/FeatureConfigChangeNotifier.test.tsx
+++ b/src/script/page/FeatureConfigChangeNotifier.test.tsx
@@ -21,10 +21,14 @@ import {act, render, waitFor} from '@testing-library/react';
 import {FeatureStatus, FEATURE_KEY} from '@wireapp/api-client/lib/team/feature';
 
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
+import en from 'I18n/en-US.json';
+import {setStrings} from 'Util/LocalizerUtil';
 
 import {FeatureConfigChangeNotifier} from './FeatureConfigChangeNotifier';
 
 import {TeamState} from '../team/TeamState';
+
+setStrings({en});
 
 describe('FeatureConfigChangeNotifier', () => {
   const showModalSpy = jest.spyOn(PrimaryModal, 'show');
@@ -55,19 +59,19 @@ describe('FeatureConfigChangeNotifier', () => {
   it.each([
     [
       FEATURE_KEY.FILE_SHARING,
-      'featureConfigChangeModalFileSharingDescriptionItemFileSharingEnabled',
-      'featureConfigChangeModalFileSharingDescriptionItemFileSharingDisabled',
+      'Sharing and receiving files of any type is now enabled',
+      'Sharing and receiving files of any type is now disabled',
     ],
+    [FEATURE_KEY.VIDEO_CALLING, 'Camera in calls is enabled', 'Camera in calls is disabled'],
     [
-      FEATURE_KEY.VIDEO_CALLING,
-      'featureConfigChangeModalAudioVideoDescriptionItemCameraEnabled',
-      'featureConfigChangeModalAudioVideoDescriptionItemCameraDisabled',
+      FEATURE_KEY.CONFERENCE_CALLING,
+      'Your team was upgraded to  Enterprise, which gives you access to features such as conference calls and more. <a href="undefined" data-uie-name="read-more-pricing" class="modal__text__read-more" rel="nofollow noopener noreferrer" target="_blank">Learn more about  Enterprise</a>',
+      undefined,
     ],
-    [FEATURE_KEY.CONFERENCE_CALLING, 'featureConfigChangeModalConferenceCallingEnabled', undefined],
     [
       FEATURE_KEY.CONVERSATION_GUEST_LINKS,
-      'featureConfigChangeModalConversationGuestLinksDescriptionItemConversationGuestLinksEnabled',
-      'featureConfigChangeModalConversationGuestLinksDescriptionItemConversationGuestLinksDisabled',
+      'Generating guest links is now enabled for all group admins.',
+      'Generating guest links is now disabled for all group admins.',
     ],
   ] as const)('shows a modal when feature %s is turned on and off', async (feature, enabledString, disabledString) => {
     const teamState = new TeamState();
@@ -121,22 +125,22 @@ describe('FeatureConfigChangeNotifier', () => {
     [
       {status: FeatureStatus.DISABLED, config: {enforcedTimeoutSeconds: 0}},
       {status: FeatureStatus.ENABLED, config: {enforcedTimeoutSeconds: 10}},
-      'featureConfigChangeModalSelfDeletingMessagesDescriptionItemEnforced',
+      'Self-deleting messages are now mandatory. New messages will self-delete after 10 seconds.',
     ],
     [
       {status: FeatureStatus.DISABLED, config: {enforcedTimeoutSeconds: 0}},
       {status: FeatureStatus.ENABLED, config: {enforcedTimeoutSeconds: 0}},
-      'featureConfigChangeModalSelfDeletingMessagesDescriptionItemEnabled',
+      'Self-deleting messages are enabled. You can set a timer before writing a message.',
     ],
     [
       {status: FeatureStatus.ENABLED, config: {enforcedTimeoutSeconds: 0}},
       {status: FeatureStatus.ENABLED, config: {enforcedTimeoutSeconds: 10}},
-      'featureConfigChangeModalSelfDeletingMessagesDescriptionItemEnforced',
+      'Self-deleting messages are now mandatory. New messages will self-delete after 10 seconds.',
     ],
     [
       {status: FeatureStatus.ENABLED, config: {enforcedTimeoutSeconds: 10}},
       {status: FeatureStatus.DISABLED, config: {enforcedTimeoutSeconds: 0}},
-      'featureConfigChangeModalSelfDeletingMessagesDescriptionItemDisabled',
+      'Self-deleting messages are disabled',
     ],
   ])(
     'indicates the config change when self deleting messages have changed (%s) to (%s)',

--- a/src/script/page/FeatureConfigChangeNotifier.ts
+++ b/src/script/page/FeatureConfigChangeNotifier.ts
@@ -30,7 +30,7 @@ import {
 
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
-import {StringIdentifer, t} from 'Util/LocalizerUtil';
+import {StringIdentifer, replaceLink, t} from 'Util/LocalizerUtil';
 import {getLogger} from 'Util/Logger';
 import {formatDuration} from 'Util/TimeUtil';
 
@@ -106,8 +106,18 @@ const featureNotifications: Partial<
     if (!status || status === FeatureStatus.DISABLED) {
       return undefined;
     }
+    const replaceEnterprise = replaceLink(
+      Config.getConfig().URL.PRICING,
+      'modal__text__read-more',
+      'read-more-pricing',
+    );
+
     return {
-      htmlMessage: t('featureConfigChangeModalConferenceCallingEnabled'),
+      htmlMessage: t(
+        'featureConfigChangeModalConferenceCallingEnabled',
+        {brandName: Config.getConfig().BRAND_NAME},
+        replaceEnterprise,
+      ),
       title: 'featureConfigChangeModalConferenceCallingTitle',
     };
   },


### PR DESCRIPTION
This modal is missing some string replacements
![image](https://github.com/wireapp/wire-webapp/assets/1090716/1e55a0df-b152-4a93-a6d9-0556ba26cf02)
