### PR TITLE
runfix: Do not add the appAlreadyOpen for embedded Login

### DIFF
--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -308,7 +308,7 @@ const LoginComponent = ({
       ) : (
         <Container centerText verticalCenter style={{width: '100%'}}>
           {!isValidLink && <Navigate to={ROUTE.CONVERSATION_JOIN_INVALID} replace />}
-          <AppAlreadyOpen />
+          {!embedded && <AppAlreadyOpen />}
           <Columns>
             {!embedded && (
               <IsMobile not>


### PR DESCRIPTION
This will fix having a double `app already opened` modal when joining a conversation from a guest link