### PR TITLE
refactor: use plain string instead of observable for system message

### DIFF
--- a/src/script/components/MessagesList/Message/SystemMessage/SystemMessage.test.tsx
+++ b/src/script/components/MessagesList/Message/SystemMessage/SystemMessage.test.tsx
@@ -42,7 +42,7 @@ jest.mock('Components/Icon', () => ({
 
 describe('SystemMessage', () => {
   it('shows edit icon for RenameMessage', async () => {
-    const message = new RenameMessage();
+    const message = new RenameMessage('new name');
 
     render(<SystemMessage message={message} />);
 

--- a/src/script/components/MessagesList/Message/SystemMessage/SystemMessageBase.tsx
+++ b/src/script/components/MessagesList/Message/SystemMessage/SystemMessageBase.tsx
@@ -19,23 +19,19 @@
 
 import React, {ReactNode} from 'react';
 
-import {SystemMessage as SystemMessageEntity} from 'src/script/entity/message/SystemMessage';
+import {SystemMessage} from 'src/script/entity/message/SystemMessage';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 
 import {MessageTime} from '../MessageTime';
 
 export interface SystemMessageProps {
-  message: SystemMessageEntity;
+  message: SystemMessage;
   isSenderNameVisible?: boolean;
   icon?: ReactNode;
 }
 
 export const SystemMessageBase: React.FC<SystemMessageProps> = ({message, isSenderNameVisible = false, icon}) => {
-  const {unsafeSenderName, timestamp, caption} = useKoSubscribableChildren(message, [
-    'unsafeSenderName',
-    'timestamp',
-    'caption',
-  ]);
+  const {unsafeSenderName, timestamp} = useKoSubscribableChildren(message, ['unsafeSenderName', 'timestamp']);
 
   return (
     <div className="message-header" data-uie-name="element-message-system">
@@ -43,7 +39,7 @@ export const SystemMessageBase: React.FC<SystemMessageProps> = ({message, isSend
       <p className="message-header-label">
         <span className="message-header-label__multiline">
           {isSenderNameVisible && <span className="message-header-sender-name">{unsafeSenderName}</span>}
-          <span className="ellipsis">{caption}</span>
+          {message.caption && <span className="ellipsis">{message.caption}</span>}
         </span>
       </p>
       <div className="message-body-actions">

--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -122,7 +122,7 @@ const filterDuplicatedSystemMessages = (messages: MessageEntity[]) => {
             return [...uniqMessages, currentMessage];
           }
           // Dont show duplicated system messages that follow each other
-          if (prevMessage.caption() === currentMessage.caption()) {
+          if (prevMessage.caption === currentMessage.caption) {
             return uniqMessages;
           }
         }

--- a/src/script/conversation/EventMapper.ts
+++ b/src/script/conversation/EventMapper.ts
@@ -653,9 +653,7 @@ export class EventMapper {
    * @returns Rename message entity
    */
   private _mapEventRename({data: eventData}: LegacyEventRecord) {
-    const messageEntity = new RenameMessage();
-    messageEntity.name = eventData.name;
-    return messageEntity;
+    return new RenameMessage(eventData.name);
   }
 
   /**

--- a/src/script/entity/message/DeleteConversationMessage.ts
+++ b/src/script/entity/message/DeleteConversationMessage.ts
@@ -18,7 +18,6 @@
  */
 
 import {TEAM_EVENT} from '@wireapp/api-client/lib/event/TeamEvent';
-import ko from 'knockout';
 
 import {t} from 'Util/LocalizerUtil';
 
@@ -28,19 +27,14 @@ import {SystemMessageType} from '../../message/SystemMessageType';
 import type {Conversation} from '../Conversation';
 
 export class DeleteConversationMessage extends SystemMessage {
-  public readonly system_message_type: SystemMessageType;
-  public readonly caption: ko.PureComputed<string>;
-
   constructor(conversationEntity: Conversation) {
     super();
 
     this.type = TEAM_EVENT.DELETE;
     this.system_message_type = SystemMessageType.CONVERSATION_DELETE;
 
-    this.caption = ko.pureComputed(() =>
-      conversationEntity
-        ? t('notificationConversationDeletedNamed', conversationEntity.name())
-        : t('notificationConversationDeleted'),
-    );
+    this.caption = conversationEntity
+      ? t('notificationConversationDeletedNamed', conversationEntity.name())
+      : t('notificationConversationDeleted');
   }
 }

--- a/src/script/entity/message/MLSConversationRecoveredMessage.ts
+++ b/src/script/entity/message/MLSConversationRecoveredMessage.ts
@@ -17,8 +17,6 @@
  *
  */
 
-import ko from 'knockout';
-
 import {SystemMessageType} from 'src/script/message/SystemMessageType';
 import {t} from 'Util/LocalizerUtil';
 
@@ -28,6 +26,6 @@ export class MLSConversationRecoveredMessage extends SystemMessage {
   constructor() {
     super();
     this.system_message_type = SystemMessageType.MLS_CONVERSATION_RECOVERED;
-    this.caption = ko.pureComputed(() => t('mlsConversationRecovered'));
+    this.caption = t('mlsConversationRecovered');
   }
 }

--- a/src/script/entity/message/MessageTimerUpdateMessage.ts
+++ b/src/script/entity/message/MessageTimerUpdateMessage.ts
@@ -18,7 +18,6 @@
  */
 
 import {CONVERSATION_EVENT} from '@wireapp/api-client/lib/event/';
-import ko from 'knockout';
 
 import {t} from 'Util/LocalizerUtil';
 import {formatDuration} from 'Util/TimeUtil';
@@ -39,15 +38,15 @@ export class MessageTimerUpdateMessage extends SystemMessage {
 
     this.message_timer = ConversationEphemeralHandler.validateTimer(messageTimer);
 
-    this.caption = ko.pureComputed(() => {
-      if (this.message_timer) {
-        const timeString = formatDuration(this.message_timer).text;
-        return this.user().isMe
-          ? t('conversationUpdatedTimerYou', timeString)
-          : t('conversationUpdatedTimer', timeString);
-      }
-
-      return this.user().isMe ? t('conversationResetTimerYou') : t('conversationResetTimer');
-    });
+    this.caption = getCaption(this.message_timer, this.user().isMe);
   }
 }
+
+const getCaption = (messageTimer: number, isSelfUser: boolean) => {
+  if (messageTimer) {
+    const timeString = formatDuration(messageTimer).text;
+    return isSelfUser ? t('conversationUpdatedTimerYou', timeString) : t('conversationUpdatedTimer', timeString);
+  }
+
+  return isSelfUser ? t('conversationResetTimerYou') : t('conversationResetTimer');
+};

--- a/src/script/entity/message/ReceiptModeUpdateMessage.ts
+++ b/src/script/entity/message/ReceiptModeUpdateMessage.ts
@@ -18,7 +18,6 @@
  */
 
 import {CONVERSATION_EVENT} from '@wireapp/api-client/lib/event/';
-import ko from 'knockout';
 
 import {t} from 'Util/LocalizerUtil';
 
@@ -33,11 +32,13 @@ export class ReceiptModeUpdateMessage extends SystemMessage {
     this.type = CONVERSATION_EVENT.RECEIPT_MODE_UPDATE;
     this.system_message_type = SystemMessageType.CONVERSATION_RECEIPT_MODE_UPDATE;
 
-    this.caption = ko.pureComputed(() => {
-      if (isReceiptEnabled) {
-        return this.user().isMe ? t('conversationReceiptsOnYou') : t('conversationReceiptsOn');
-      }
-      return this.user().isMe ? t('conversationReceiptsOffYou') : t('conversationReceiptsOff');
-    });
+    this.caption = getCaption(isReceiptEnabled, this.user().isMe);
   }
 }
+
+const getCaption = (isReceiptEnabled: boolean, isSelfUser: boolean) => {
+  if (isReceiptEnabled) {
+    return isSelfUser ? t('conversationReceiptsOnYou') : t('conversationReceiptsOn');
+  }
+  return isSelfUser ? t('conversationReceiptsOffYou') : t('conversationReceiptsOff');
+};

--- a/src/script/entity/message/RenameMessage.ts
+++ b/src/script/entity/message/RenameMessage.ts
@@ -28,12 +28,12 @@ import {SystemMessageType} from '../../message/SystemMessageType';
 export class RenameMessage extends SystemMessage {
   public name: string;
 
-  constructor() {
+  constructor(name: string) {
     super();
 
     this.type = CONVERSATION_EVENT.RENAME;
     this.system_message_type = SystemMessageType.CONVERSATION_RENAME;
-    this.name = '';
+    this.name = name;
     this.caption = this.user().isMe ? t('conversationRenameYou') : t('conversationRename');
   }
 }

--- a/src/script/entity/message/RenameMessage.ts
+++ b/src/script/entity/message/RenameMessage.ts
@@ -18,7 +18,6 @@
  */
 
 import {CONVERSATION_EVENT} from '@wireapp/api-client/lib/event/';
-import ko from 'knockout';
 
 import {t} from 'Util/LocalizerUtil';
 
@@ -27,7 +26,6 @@ import {SystemMessage} from './SystemMessage';
 import {SystemMessageType} from '../../message/SystemMessageType';
 
 export class RenameMessage extends SystemMessage {
-  public readonly system_message_type: SystemMessageType;
   public name: string;
 
   constructor() {
@@ -36,6 +34,6 @@ export class RenameMessage extends SystemMessage {
     this.type = CONVERSATION_EVENT.RENAME;
     this.system_message_type = SystemMessageType.CONVERSATION_RENAME;
     this.name = '';
-    this.caption = ko.pureComputed(() => (this.user().isMe ? t('conversationRenameYou') : t('conversationRename')));
+    this.caption = this.user().isMe ? t('conversationRenameYou') : t('conversationRename');
   }
 }

--- a/src/script/entity/message/SystemMessage.ts
+++ b/src/script/entity/message/SystemMessage.ts
@@ -17,8 +17,6 @@
  *
  */
 
-import ko from 'knockout';
-
 import {Message} from './Message';
 import {RenameMessage} from './RenameMessage';
 
@@ -26,7 +24,7 @@ import {SuperType} from '../../message/SuperType';
 import {SystemMessageType} from '../../message/SystemMessageType';
 
 export class SystemMessage extends Message {
-  public caption: ko.PureComputed<string>;
+  public caption?: string;
   public system_message_type: SystemMessageType;
 
   constructor() {

--- a/src/script/notification/NotificationRepository.test.ts
+++ b/src/script/notification/NotificationRepository.test.ts
@@ -565,9 +565,8 @@ describe('NotificationRepository', () => {
     });
 
     it('if a group is renamed', () => {
-      const renameMessage = new RenameMessage();
+      const renameMessage = new RenameMessage('Lorem Ipsum Conversation');
       renameMessage.user(user);
-      (renameMessage as any).name = 'Lorem Ipsum Conversation';
 
       const expected_body = `${user.name()} renamed the conversation to ${renameMessage.name}`;
       expect(expected_body).toBeDefined();

--- a/src/script/notification/NotificationRepository.ts
+++ b/src/script/notification/NotificationRepository.ts
@@ -495,7 +495,7 @@ export class NotificationRepository {
         return createBodyMessageTimerUpdate();
       }
       case SystemMessageType.CONVERSATION_DELETE: {
-        return (messageEntity as DeleteConversationMessage).caption();
+        return (messageEntity as DeleteConversationMessage).caption;
       }
     }
   }


### PR DESCRIPTION
System message caption doesn't need to be a computed value - it does not change over time.