### PR TITLE
runfix: truncate titles less if there is extra space remaining [WPB-3754]

### DIFF
--- a/src/script/notification/NotificationRepository.test.ts
+++ b/src/script/notification/NotificationRepository.test.ts
@@ -94,6 +94,7 @@ describe('NotificationRepository', () => {
   let verifyNotificationObfuscated: (...args: any[]) => void;
   let verifyNotificationSystem: (...args: any[]) => void;
   let createTruncatedTitle: (name: string, conversationName: string) => string;
+  let calculateTitleLength: (sectionString: string) => number;
 
   let notification_content: any;
   const contentViewModelState: any = {};
@@ -144,13 +145,18 @@ describe('NotificationRepository', () => {
 
     const showNotificationSpy = jest.spyOn(notificationRepository as any, 'showNotification');
 
+    calculateTitleLength = sectionString => {
+      const length =
+        NotificationRepository.CONFIG.TITLE_LENGTH - sectionString.length + NotificationRepository.CONFIG.TITLE_LENGTH;
+      return length > NotificationRepository.CONFIG.TITLE_LENGTH ? length : NotificationRepository.CONFIG.TITLE_LENGTH;
+    };
+
     createTruncatedTitle = (name, conversationName) => {
       const titleLength = NotificationRepository.CONFIG.TITLE_MAX_LENGTH;
-      const titleSectionLength = NotificationRepository.CONFIG.TITLE_LENGTH;
 
-      const titleText = `${truncate(name, titleSectionLength, false)} in ${truncate(
+      const titleText = `${truncate(name, calculateTitleLength(conversationName), false)} in ${truncate(
         conversationName,
-        titleSectionLength,
+        calculateTitleLength(name),
         false,
       )}`;
       return truncate(titleText, titleLength, false);

--- a/src/script/notification/NotificationRepository.test.ts
+++ b/src/script/notification/NotificationRepository.test.ts
@@ -146,9 +146,10 @@ describe('NotificationRepository', () => {
     const showNotificationSpy = jest.spyOn(notificationRepository as any, 'showNotification');
 
     calculateTitleLength = sectionString => {
-      const length =
-        NotificationRepository.CONFIG.TITLE_LENGTH - sectionString.length + NotificationRepository.CONFIG.TITLE_LENGTH;
-      return length > NotificationRepository.CONFIG.TITLE_LENGTH ? length : NotificationRepository.CONFIG.TITLE_LENGTH;
+      const defaultSectionLength = NotificationRepository.CONFIG.TITLE_LENGTH;
+      const length = defaultSectionLength - sectionString.length + defaultSectionLength;
+
+      return length > defaultSectionLength ? length : defaultSectionLength;
     };
 
     createTruncatedTitle = (name, conversationName) => {

--- a/src/script/notification/NotificationRepository.ts
+++ b/src/script/notification/NotificationRepository.ts
@@ -615,9 +615,10 @@ export class NotificationRepository {
    Calculate the length of the opposite title section string and return the extra length
   */
   private calculatedTitleLength = (sectionString: string) => {
-    const length =
-      NotificationRepository.CONFIG.TITLE_LENGTH - sectionString.length + NotificationRepository.CONFIG.TITLE_LENGTH;
-    return length > NotificationRepository.CONFIG.TITLE_LENGTH ? length : NotificationRepository.CONFIG.TITLE_LENGTH;
+    const maxSectionLength = NotificationRepository.CONFIG.TITLE_LENGTH;
+    const length = maxSectionLength - sectionString.length + maxSectionLength;
+
+    return length > maxSectionLength ? length : maxSectionLength;
   };
 
   /**

--- a/src/script/notification/NotificationRepository.ts
+++ b/src/script/notification/NotificationRepository.ts
@@ -612,19 +612,30 @@ export class NotificationRepository {
   }
 
   /**
+   Calculate the length of the opposite title section string and return the extra length
+  */
+  private calculatedTitleLength = (sectionString: string) => {
+    const length =
+      NotificationRepository.CONFIG.TITLE_LENGTH - sectionString.length + NotificationRepository.CONFIG.TITLE_LENGTH;
+    return length > NotificationRepository.CONFIG.TITLE_LENGTH ? length : NotificationRepository.CONFIG.TITLE_LENGTH;
+  };
+
+  /**
    * Creates the notification title.
    *
    * @param Notification message title
    */
   private createTitle(messageEntity: Message, conversationEntity?: Conversation): string {
     const conversationName = conversationEntity && conversationEntity.display_name();
+    const userEntity = messageEntity.user();
+
     const truncatedConversationName = truncate(
       conversationName ?? '',
-      NotificationRepository.CONFIG.TITLE_LENGTH,
+      this.calculatedTitleLength(userEntity.name()),
       false,
     );
-    const userEntity = messageEntity.user();
-    const truncatedName = truncate(userEntity.name(), NotificationRepository.CONFIG.TITLE_LENGTH, false);
+
+    const truncatedName = truncate(userEntity.name(), this.calculatedTitleLength(conversationName ?? ''), false);
 
     let title;
     if (conversationName) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3754" title="WPB-3754" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3754</a>  "In what conversation??" Notification titles are truncated
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

truncate notifications titles were cutting extra short even if there was extra real estate still remaining
