### PR TITLE
runfix: assign padding instead of margin to assets

### DIFF
--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -384,8 +384,7 @@
 .image-asset {
   position: relative;
   display: flex;
-  padding-top: 8px;
-  padding-bottom: 24px;
+  padding: 8px 0 24px;
   cursor: pointer;
 
   &--no-image {

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -307,13 +307,10 @@
   padding-left: @conversation-message-sender-width;
 
   &-content {
-    display: flex;
     width: calc(100% - var(--conversation-message-timestamp-width));
     max-width: calc(
       @conversation-max-width - @conversation-message-sender-width - var(--conversation-message-timestamp-width)
     );
-    flex: 1;
-    flex-direction: column;
   }
 
   .text {
@@ -387,8 +384,8 @@
 .image-asset {
   position: relative;
   display: flex;
-  margin-top: 8px;
-  margin-bottom: 24px;
+  padding-top: 8px;
+  padding-bottom: 24px;
   cursor: pointer;
 
   &--no-image {


### PR DESCRIPTION
### Issue
- margin to assets introduce some discrepancy between image and the wrapper div that we suspect is breaking automation
![image](https://github.com/wireapp/wire-webapp/assets/78490891/3847d184-4997-44d5-bc09-f1bf26eeb7d4)

### Solution
- use padding instead of margin to correct the issue
- a wrapper div using `display: flex` prevented the padding to display properly, it's been reverted to display block