### PR TITLE
runfix: assign margin instead of padding to assets

### DIFF
--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -384,7 +384,7 @@
 .image-asset {
   position: relative;
   display: flex;
-  padding: 8px 0 24px;
+  margin: 8px 0 24px;
   cursor: pointer;
 
   &--no-image {


### PR DESCRIPTION
- padding compounds with the margin left for typing indicator while margin doesn't :upside_down_face: 
- the issue had more to do with `display: flex` than margin/padding