### PR TITLE
runfix: conversation not deleted locally ondelete event

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -2261,7 +2261,16 @@ export class ConversationRepository {
             this.unarchiveConversation(conversationEntity, false, ConversationRepository.eventFromStreamMessage);
           }
           const isBackendTimestamp = eventSource !== EventSource.INJECTED;
-          if (type !== CONVERSATION_EVENT.MEMBER_JOIN && type !== CONVERSATION_EVENT.MEMBER_LEAVE) {
+
+          const eventsToSkip: (CLIENT_CONVERSATION_EVENT | CONVERSATION_EVENT)[] = [
+            CONVERSATION_EVENT.MEMBER_LEAVE,
+            CONVERSATION_EVENT.MEMBER_JOIN,
+            CONVERSATION_EVENT.DELETE,
+          ];
+
+          const shouldUpdateTimestampServer = !eventsToSkip.includes(type);
+
+          if (shouldUpdateTimestampServer) {
             conversationEntity.updateTimestampServer(eventJson.server_time || eventJson.time, isBackendTimestamp);
           }
         }


### PR DESCRIPTION
When receiving `conversation.delete` event we are deleting conversation locally, but updating server timestamp, was saving the conversation entity back into the local database, causing the conversation to reappear after app reload. Once conversation was deleted locally we don't want to see it anymore, it should be completely wiped out from the local indexedDB.

The fix is to simply add this event type to the list of events that should skip updating server timestamp.