### PR TITLE
feat: add QA util to reconnect to websocket with/without dryRun flag

### DIFF
--- a/src/script/event/EventRepository.ts
+++ b/src/script/event/EventRepository.ts
@@ -183,11 +183,13 @@ export class EventRepository {
    *
    * @param account the account to connect to
    * @param onNotificationStreamProgress callback when a notification for the notification stream has been processed
+   * @param dryRun when set will not decrypt and not store the last notification ID. This is useful if you only want to subscribe to unencrypted backend events
    * @returns Resolves when the notification stream has fully been processed
    */
   async connectWebSocket(
     account: Account,
     onNotificationStreamProgress: (progress: {done: number; total: number}) => void,
+    dryRun = false,
   ): Promise<void> {
     await this.handleTimeDrift();
     const connect = () => {
@@ -204,6 +206,7 @@ export class EventRepository {
           onEvent: this.handleIncomingEvent,
           onMissedNotifications: this.triggerMissedSystemEventMessageRendering,
           onNotificationStreamProgress: onNotificationStreamProgress,
+          dryRun,
         });
       });
     };

--- a/src/script/util/DebugUtil.ts
+++ b/src/script/util/DebugUtil.ts
@@ -186,7 +186,7 @@ export class DebugUtil {
 
   async reconnectWebSocketWithLastNotificationIdFromBackend({dryRun} = {dryRun: false}) {
     await this.core.service?.notification.initializeNotificationStream();
-    return this.eventRepository.connectWebSocket(this.core, () => {}, dryRun);
+    return this.reconnectWebSocket({dryRun});
   }
 
   /** Used by QA test automation. */

--- a/src/script/util/DebugUtil.ts
+++ b/src/script/util/DebugUtil.ts
@@ -180,6 +180,15 @@ export class DebugUtil {
     );
   }
 
+  reconnectWebSocket({dryRun} = {dryRun: false}) {
+    return this.eventRepository.connectWebSocket(this.core, () => {}, dryRun);
+  }
+
+  async reconnectWebSocketWithLastNotificationIdFromBackend({dryRun} = {dryRun: false}) {
+    await this.core.service?.notification.initializeNotificationStream();
+    return this.eventRepository.connectWebSocket(this.core, () => {}, dryRun);
+  }
+
   /** Used by QA test automation. */
   blockAllConnections(): Promise<void[]> {
     const blockUsers = this.userState.users().map(userEntity => this.connectionRepository.blockUser(userEntity));

--- a/src/script/util/DebugUtil.ts
+++ b/src/script/util/DebugUtil.ts
@@ -189,6 +189,13 @@ export class DebugUtil {
     return this.reconnectWebSocket({dryRun});
   }
 
+  async updateActiveConversationKeyPackages() {
+    const groupId = this.conversationState.activeConversation()?.groupId;
+    if (groupId) {
+      return this.core.service?.mls?.renewKeyMaterial(groupId);
+    }
+  }
+
   /** Used by QA test automation. */
   blockAllConnections(): Promise<void[]> {
     const blockUsers = this.userState.users().map(userEntity => this.connectionRepository.blockUser(userEntity));


### PR DESCRIPTION
Adds 3 methods to webapp's debug util:

- `reconnectWebSocket({dryRun})` - reconnects to the websocket with or without `dryRun` flag (`false` by default)
- `reconnectWebSocketWithLastNotificationIdFromBackend({dryRun})` - does the same thing but before reconnecting to the websocket it updates the local store with `lastNotificationIId` fetched from backend - we're basically saying we don't care about any messages that we've missed, we just want to be in sync with backend from this point on.
- `updateActiveConversationKeyPackages()` - for mls conversations only - will update the keying material of currently selected conversation.

`dryRun` param specifies whether we want to decrypt messages that are encrypted or simply ignore decrypting them. Encrypted messages include: `conversation.otr-message-add`, `conversation.mls-message-add` and `conversation.mls-welcome`.