### PR TITLE
runfix: Show message actions menu when component renders under the mouse

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -137,11 +137,7 @@ const ContentMessageComponent: React.FC<ContentMessageProps> = ({
   const [isActionMenuVisible, setActionMenuVisibility] = useState(true);
   const isMenuOpen = useMessageActionsState(state => state.isMenuOpen);
   useEffect(() => {
-    if (isMessageFocused || msgFocusState) {
-      setActionMenuVisibility(true);
-    } else {
-      setActionMenuVisibility(false);
-    }
+    setActionMenuVisibility(isMessageFocused || msgFocusState);
   }, [msgFocusState, isMessageFocused]);
 
   const reactionGroupedByUser = groupByReactionUsers(reactions);
@@ -151,13 +147,21 @@ const ContentMessageComponent: React.FC<ContentMessageProps> = ({
     <div
       aria-label={messageAriaLabel}
       className="content-message-wrapper"
-      onMouseEnter={event => {
+      ref={element => {
+        setTimeout(() => {
+          if (element?.parentElement?.querySelector(':hover') === element) {
+            // Trigger the action menu in case the component is rendered with the mouse already hovering over it
+            setActionMenuVisibility(true);
+          }
+        });
+      }}
+      onMouseEnter={() => {
         // open another floating action menu if none already open
         if (!isMenuOpen) {
           setActionMenuVisibility(true);
         }
       }}
-      onMouseLeave={event => {
+      onMouseLeave={() => {
         // close floating message actions when no active menu is open like context menu/emoji picker
         if (!isMenuOpen) {
           setActionMenuVisibility(false);


### PR DESCRIPTION
When a message is rendered right under the mouse, the context menu doesn't appear (you need to leave and re-enter the component). 

This PR, manually triggers a mouseEnter event at render time if the component is being hovered by the mouse. 

## Before 


https://github.com/wireapp/wire-webapp/assets/1090716/ddc4d208-7e04-4caa-a789-1ad905da46be

## After


https://github.com/wireapp/wire-webapp/assets/1090716/1b26c1c1-794a-4685-84e8-3d9886ab23fa

