### PR TITLE
runfix: Do not throw handled connection request errors

### DIFF
--- a/src/script/connection/ConnectionRepository.ts
+++ b/src/script/connection/ConnectionRepository.ts
@@ -219,9 +219,9 @@ export class ConnectionRepository {
 
           default: {
             this.logger.error(`Failed to send connection request to user '${userEntity.id}': ${error.message}`, error);
-            return false;
           }
         }
+        return false;
       }
       throw error;
     }


### PR DESCRIPTION
This change was mis-translated (https://github.com/wireapp/wire-webapp/pull/15555/files#diff-1628b416827c3090ce492ad7381584fc9410d3a202dc3ee5a034286e07bc4bb9L192-L206) . Handled backend errors should not be re-thrown