### PR TITLE
runfix: do not send notifications on reactions (WPB-4275)

### DIFF
--- a/src/script/notification/NotificationRepository.ts
+++ b/src/script/notification/NotificationRepository.ts
@@ -114,7 +114,7 @@ export class NotificationRepository {
   }
 
   static get EVENTS_TO_NOTIFY(): SuperType[] {
-    return [SuperType.CALL, SuperType.CONTENT, SuperType.MEMBER, SuperType.PING, SuperType.REACTION, SuperType.SYSTEM];
+    return [SuperType.CALL, SuperType.CONTENT, SuperType.MEMBER, SuperType.PING, SuperType.SYSTEM];
   }
 
   /**


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4275" title="WPB-4275" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-4275</a>  [Web] Do not send notification for each reactions, send notification for new message only
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Change
As a single user can now react multiple time to a single message, product decided to not notify the user for reactions fo the time being see linked Jira ticket

#### Screengrab of the issue
![Peek 2023-08-29 12-35](https://github.com/wireapp/wire-webapp/assets/78490891/8e0dfbb4-1069-48cb-a008-87558e00250a)
