### PR TITLE
fix: new conversation opening using keyboard is not focusing on the last message

### DIFF
--- a/src/script/router/Router.test.ts
+++ b/src/script/router/Router.test.ts
@@ -19,7 +19,7 @@
 
 import {waitFor} from '@testing-library/react';
 
-import {configureRoutes, navigate} from './Router';
+import {configureRoutes, navigate, setHistoryParam} from './Router';
 
 describe('Router', () => {
   afterEach(() => {
@@ -75,6 +75,36 @@ describe('Router', () => {
       waitFor(() => {
         expect(handlers.conversation).toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('setHistoryParam', () => {
+    // Mock window.history.replaceState before each test
+    beforeEach(() => {
+      global.history.replaceState = jest.fn();
+    });
+
+    // Restore the original method after each test
+    afterEach(() => {
+      (global.history.replaceState as jest.Mock).mockRestore();
+    });
+
+    it('throws an error if history.state is not empty and stateObj is not provided', () => {
+      Object.defineProperty(window.history, 'state', {value: {}, writable: true});
+
+      expect(() => setHistoryParam('/path')).toThrow('stateObj must be provided when history.state is not empty.');
+    });
+
+    it('does not throw an error if history.state is empty and stateObj is not provided', () => {
+      Object.defineProperty(window.history, 'state', {value: null, writable: true});
+
+      expect(() => setHistoryParam('/path')).not.toThrow();
+    });
+
+    it('does not throw an error if history.state is not empty and stateObj is provided', () => {
+      Object.defineProperty(window.history, 'state', {value: {}, writable: true}); // Temporarily override history.state for this test
+
+      expect(() => setHistoryParam('/path', {})).not.toThrow();
     });
   });
 });

--- a/src/script/router/Router.ts
+++ b/src/script/router/Router.ts
@@ -46,5 +46,8 @@ export const navigate = (path: string, stateObj?: {}) => {
 };
 
 export const setHistoryParam = (path: string, stateObj?: {}) => {
+  if (window.history.state && !stateObj) {
+    throw new Error('stateObj must be provided when history.state is not empty.');
+  }
   window.history.replaceState(stateObj, '', `#${path}`);
 };

--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -218,6 +218,7 @@ export class ContentViewModel {
       this.previousConversation = this.conversationState.activeConversation();
       setHistoryParam(
         generateConversationUrl({id: conversationEntity?.id ?? '', domain: conversationEntity?.domain ?? ''}),
+        history.state,
       );
 
       if (openNotificationSettings) {


### PR DESCRIPTION
…ing a conversation

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - New conversation opening using keyboard is not focusing on the last message

- The **PR Description**
  - New conversation opening using keyboard should focusing on the last message.
----

# What's new in this PR?

### Issues

- New conversation opening using keyboard is not focusing on the last message. The issue was introduced in [this PR](https://github.com/wireapp/wire-webapp/pull/15397/files)

### Solutions

- pass current history state when calling setHistoryParam from showConversation method

### Testing

#### How to Test

- unit tests added
- open a new conversation by clicking enter from the left panel->the last message of that conversation should get focused.

#### PR Post Submission Checklist for internal contributors (Optional)
