### PR TITLE
runfix: mls recovery message copy [WPB-523]

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -730,7 +730,7 @@
   "messageReactionDetails": "{{emojiCount}} reaction, react with {{emojiName}} emoji",
   "mlsToggleInfo": "When this is on, conversation will use the new messaging layer security (MLS) protocol.",
   "mlsToggleName": "MLS",
-  "mlsConversationRecovered": "The MLS group key was updated without our knowledge. This could happen due to lost messages between backends, or a bug. We have automatically rejoined the conversation, but you may have lost messages. Please contact your administrator.",
+  "mlsConversationRecovered": "You haven’t used this device for a while, or an issue has occurred. Some older messages may not appear here.",
   "modalAccountCreateAction": "OK",
   "modalAccountCreateHeadline": "Create an account?",
   "modalAccountCreateMessage": "By creating an account you will lose the conversation history in this guest room.",

--- a/src/script/components/MessagesList/Message/SystemMessage/SystemMessage.tsx
+++ b/src/script/components/MessagesList/Message/SystemMessage/SystemMessage.tsx
@@ -51,7 +51,7 @@ export const SystemMessage: React.FC<SystemMessageProps> = ({message}) => {
   }
 
   if (message instanceof MLSConversationRecoveredMessage) {
-    return <SystemMessageBase message={message} icon={<span className="icon-sysmsg-error text-red" />} />;
+    return <SystemMessageBase message={message} icon={<Icon.Info />} />;
   }
 
   return <SystemMessageBase message={message} />;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-523" title="WPB-523" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-523</a>  [Web] MLS Client recover from "not able to decrypt a message"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Changes copy and icon of system message after MLS conversation has recovered from being out of sync. 