### PR TITLE
fix: uses history.state if it is not empty and stateObj is not provided

### DIFF
--- a/src/script/router/Router.test.ts
+++ b/src/script/router/Router.test.ts
@@ -89,22 +89,30 @@ describe('Router', () => {
       (global.history.replaceState as jest.Mock).mockRestore();
     });
 
-    it('throws an error if history.state is not empty and stateObj is not provided', () => {
-      Object.defineProperty(window.history, 'state', {value: {}, writable: true});
+    it('uses history.state if it is not empty and stateObj is not provided', () => {
+      const mockState = {eventKey: 'Enter'};
+      Object.defineProperty(window.history, 'state', {value: mockState, writable: true});
 
-      expect(() => setHistoryParam('/path')).toThrow('stateObj must be provided when history.state is not empty.');
+      setHistoryParam('/path');
+      expect(global.history.replaceState).toHaveBeenCalledWith(mockState, '', '#/path');
     });
 
-    it('does not throw an error if history.state is empty and stateObj is not provided', () => {
-      Object.defineProperty(window.history, 'state', {value: null, writable: true});
+    it('uses stateObj even if history.state is not empty', () => {
+      const mockState = {eventKey: 'Tab'};
+      Object.defineProperty(window.history, 'state', {value: mockState, writable: true});
 
-      expect(() => setHistoryParam('/path')).not.toThrow();
+      const newStateObj = {newState: 'state'};
+      setHistoryParam('/path', newStateObj);
+      expect(global.history.replaceState).toHaveBeenCalledWith(newStateObj, '', '#/path');
     });
 
-    it('does not throw an error if history.state is not empty and stateObj is provided', () => {
-      Object.defineProperty(window.history, 'state', {value: {}, writable: true}); // Temporarily override history.state for this test
+    it('explicitely resetting the state is allowed', () => {
+      const mockState = {eventKey: 'Tab'};
+      Object.defineProperty(window.history, 'state', {value: mockState, writable: true});
 
-      expect(() => setHistoryParam('/path', {})).not.toThrow();
+      const newStateObj = {};
+      setHistoryParam('/path', newStateObj);
+      expect(global.history.replaceState).toHaveBeenCalledWith(newStateObj, '', '#/path');
     });
   });
 });

--- a/src/script/router/Router.ts
+++ b/src/script/router/Router.ts
@@ -45,9 +45,6 @@ export const navigate = (path: string, stateObj?: {}) => {
   parseRoute();
 };
 
-export const setHistoryParam = (path: string, stateObj?: {}) => {
-  if (window.history.state && !stateObj) {
-    throw new Error('stateObj must be provided when history.state is not empty.');
-  }
+export const setHistoryParam = (path: string, stateObj: {} = window.history.state) => {
   window.history.replaceState(stateObj, '', `#${path}`);
 };


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - uses history.state if it is not empty and stateObj is not provided

- The **PR Description**
  - uses history.state if it is not empty and stateObj is not provided
----
