### PR TITLE
fix: Filter DeleteMessage when computing the oldest loaded message [WPB-3506]

### DIFF
--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -1120,7 +1120,7 @@ export class MessageRepository {
    */
   public async deleteMessageById(conversationEntity: Conversation, messageId: string): Promise<number> {
     const isLastDeleted =
-      conversationEntity.isShowingLastReceivedMessage() && conversationEntity.getNewestMessage()?.id === messageId;
+      conversationEntity.hasLastReceivedMessageLoaded() && conversationEntity.getNewestMessage()?.id === messageId;
 
     const deleteCount = await this.eventService.deleteEvent(conversationEntity.id, messageId);
     const previousMessage = conversationEntity.getNewestMessage();

--- a/src/script/guards/Message.ts
+++ b/src/script/guards/Message.ts
@@ -20,6 +20,7 @@
 import {Draft} from 'Util/DraftStateUtil';
 
 import {ContentMessage} from '../entity/message/ContentMessage';
+import {DeleteMessage} from '../entity/message/DeleteMessage';
 import {MemberMessage} from '../entity/message/MemberMessage';
 import {SuperType} from '../message/SuperType';
 
@@ -30,6 +31,9 @@ export const isReadableMessage = (message: any): message is ContentMessage =>
 
 export const isContentMessage = (message: any): message is ContentMessage =>
   message && 'super_type' in message && message.super_type === SuperType.CONTENT;
+
+export const isDeleteMessage = (message: any): message is DeleteMessage =>
+  message && 'super_type' in message && message.super_type === SuperType.DELETE;
 
 export const isMemberMessage = (message: any | undefined | null): message is MemberMessage =>
   message && 'super_type' in message && message.super_type === SuperType.MEMBER;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3506" title="WPB-3506" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3506</a>  [Web] Conversation list is not updated with new messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## The bug

loading a conversation that contains a `DeleteMessage` that hasn't been seen yet by the user will not show messages after this deleted message

## The problem

When messages arrives for a conversation that is not currently viewed by the user, we stack those messages in the `messages` property of the conversation. 

When the user clicks on a conversation to view, these are the steps that are triggered to load the messages we want to display to them:
- we check what is the **oldest** message that we have in the `messages` list;
- starting from this oldest message, we load 30 messages from DB in reverse chronology (so messages that were sent **before** this oldest message that we have loaded)
- those loaded messages are added to the `messages` list 
- the conversation can finally be showed to the user

This logic works pretty fine, except for `DeleteMessage` which can have a timestamp in the past. 
Since delete messages timestamp  are actually the timestamp of the message that was deleted. 

## An example

let's say we have a conversation between user1 and user2 with those messages:

- message1 by user2 (sent at timestamp 0)
- message2 by user2 (sent at timestamp 2)
- message3 by user2(sent at timestamp 3)

user1, is not currently looking at this conversation (so no messages are loaded into memory).

- user2, now deletes `message1`. 
- user1 receives the `delete` event and store it in the `messages` list
- the oldest message that user1 has loaded is the delete message for `message1` which has a timestamp of `0`. 
- user1 tries to load the conversation
- we try to load all messages in the conversation from timestamp `0`
- > we end-up not loading `message2` and `message3`.

## The fix

We computing the `oldest` message, we should not consider `delete` messages as we cannot trust their timestamp