### PR TITLE
refactor: Optimize app state slice selection

### DIFF
--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -155,7 +155,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
   );
   const showSwitchMicrophone = availableMicrophones.length > 1;
 
-  const {unreadMessagesCount} = useAppState();
+  const unreadMessagesCount = useAppState(state => state.unreadMessagesCount);
   const hasUnreadMessages = unreadMessagesCount > 0;
 
   const {showAlert, isGroupCall, clearShowAlert} = useCallAlertState();

--- a/src/script/page/AppMain.tsx
+++ b/src/script/page/AppMain.tsx
@@ -84,7 +84,7 @@ const AppMain: FC<AppMainProps> = ({
     throw new Error('API Context has not been set');
   }
 
-  const {contentState} = useAppState();
+  const contentState = useAppState(state => state.contentState);
 
   const {repository: repositories} = app;
 

--- a/src/script/page/LeftSidebar/LeftSidebar.tsx
+++ b/src/script/page/LeftSidebar/LeftSidebar.tsx
@@ -51,7 +51,7 @@ const Animated: React.FC<{children: React.ReactNode}> = ({children, ...rest}) =>
 const LeftSidebar: React.FC<LeftSidebarProps> = ({listViewModel, selfUser, isActivatedAccount}) => {
   const {conversationRepository, propertiesRepository} = listViewModel;
   const repositories = listViewModel.contentViewModel.repositories;
-  const {listState} = useAppState();
+  const listState = useAppState(state => state.listState);
 
   const switchList = (list: ListState) => listViewModel.switchList(list);
 

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
@@ -69,7 +69,7 @@ export const ConversationsList = ({
   resetConversationFocus,
   handleArrowKeyDown,
 }: ConversationsListProps) => {
-  const {contentState} = useAppState();
+  const contentState = useAppState(state => state.contentState);
 
   const {joinableCalls} = useKoSubscribableChildren(callState, ['joinableCalls']);
 

--- a/src/script/page/LeftSidebar/panels/Preferences.tsx
+++ b/src/script/page/LeftSidebar/panels/Preferences.tsx
@@ -120,7 +120,7 @@ const Preferences: React.FC<PreferencesProps> = ({
   preferenceNotificationRepository,
   onClose,
 }) => {
-  const {contentState} = useAppState();
+  const contentState = useAppState(state => state.contentState);
 
   useEffect(() => {
     // Update local team

--- a/src/script/page/MainContent/MainContent.tsx
+++ b/src/script/page/MainContent/MainContent.tsx
@@ -78,7 +78,8 @@ const MainContent: FC<MainContentProps> = ({
   const teamState = container.resolve(TeamState);
   const {showRequestModal} = useLegalHoldModalState();
 
-  const {contentState, isShowingConversation} = useAppState();
+  const contentState = useAppState(state => state.contentState);
+  const isShowingConversation = useAppState(state => state.isShowingConversation);
 
   useEffect(() => {
     if (!isShowingConversation() && conversationState.activeConversation()) {

--- a/src/script/page/components/WindowTitleUpdater.ts
+++ b/src/script/page/components/WindowTitleUpdater.ts
@@ -43,7 +43,8 @@ const useWindowTitle = () => {
   const userState = container.resolve(UserState);
   const conversationState = container.resolve(ConversationState);
 
-  const {contentState, setUnreadMessagesCount} = useAppState();
+  const contentState = useAppState(state => state.contentState);
+  const setUnreadMessagesCount = useAppState(state => state.setUnreadMessagesCount);
 
   const [updateWindowTitle, setUpdateWindowTitle] = useState(false);
 


### PR DESCRIPTION
## Description

As per [zustand documentation](https://docs.pmnd.rs/zustand/recipes/recipes#selecting-multiple-state-slices), it's more optimal to select just a slice of a state rather than the entire state. 

This will make the component re-renders **only** if the slice of the state has changed (it's performing a strict equal between the previous selected state and the new one). 

This PR will optimize a few re-rendering when messages are received 