### PR TITLE
runfix: show ping read receipt on hover

### DIFF
--- a/src/script/components/MessagesList/Message/MessageWrapper.tsx
+++ b/src/script/components/MessagesList/Message/MessageWrapper.tsx
@@ -251,7 +251,13 @@ export const MessageWrapper: React.FC<MessageParams & {hasMarker: boolean; isMes
     );
   }
   if (message.isPing()) {
-    return <PingMessage message={message} />;
+    return (
+      <PingMessage
+        message={message}
+        is1to1Conversation={conversation.is1to1()}
+        isLastDeliveredMessage={isLastDeliveredMessage}
+      />
+    );
   }
   if (message.isFileTypeRestricted()) {
     return <FileTypeRestrictedMessage message={message} />;

--- a/src/script/components/MessagesList/Message/PingMessage.tsx
+++ b/src/script/components/MessagesList/Message/PingMessage.tsx
@@ -45,7 +45,7 @@ const PingMessage: React.FC<PingMessageProps> = ({message, is1to1Conversation, i
         <div className={`icon-ping ${get_icon_classes}`} />
       </div>
       <div
-        className={cx('message-header-label', {
+        className={cx('message-body-content', 'message-header-label', {
           'ephemeral-message-obfuscated': isObfuscated,
         })}
         title={ephemeral_caption}

--- a/src/script/components/MessagesList/Message/PingMessage.tsx
+++ b/src/script/components/MessagesList/Message/PingMessage.tsx
@@ -23,24 +23,21 @@ import cx from 'classnames';
 
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 
-import {MessageTime} from './MessageTime';
+import {ReadReceiptStatus} from './ReadReceiptStatus';
 
 import {PingMessage as PingMessageEntity} from '../../../entity/message/PingMessage';
 
 export interface PingMessageProps {
   message: PingMessageEntity;
+  is1to1Conversation: boolean;
+  isLastDeliveredMessage: boolean;
 }
 
-const PingMessage: React.FC<PingMessageProps> = ({message}) => {
-  const {unsafeSenderName, caption, timestamp, ephemeral_caption, isObfuscated, get_icon_classes} =
-    useKoSubscribableChildren(message, [
-      'unsafeSenderName',
-      'caption',
-      'timestamp',
-      'ephemeral_caption',
-      'isObfuscated',
-      'get_icon_classes',
-    ]);
+const PingMessage: React.FC<PingMessageProps> = ({message, is1to1Conversation, isLastDeliveredMessage}) => {
+  const {unsafeSenderName, caption, ephemeral_caption, isObfuscated, get_icon_classes} = useKoSubscribableChildren(
+    message,
+    ['unsafeSenderName', 'caption', 'ephemeral_caption', 'isObfuscated', 'get_icon_classes'],
+  );
 
   return (
     <div className="message-header" data-uie-name="element-message-ping">
@@ -60,7 +57,12 @@ const PingMessage: React.FC<PingMessageProps> = ({message}) => {
         </p>
       </div>
       <div className="message-body-actions">
-        <MessageTime timestamp={timestamp} data-uie-uid={message.id} data-uie-name="item-message-call-timestamp" />
+        <ReadReceiptStatus
+          showOnHover
+          message={message}
+          is1to1Conversation={is1to1Conversation}
+          isLastDeliveredMessage={isLastDeliveredMessage}
+        />
       </div>
     </div>
   );

--- a/src/script/components/MessagesList/Message/ReadReceiptStatus.tsx
+++ b/src/script/components/MessagesList/Message/ReadReceiptStatus.tsx
@@ -30,8 +30,8 @@ import {formatTimeShort} from 'Util/TimeUtil';
 export interface ReadReceiptStatusProps {
   is1to1Conversation: boolean;
   isLastDeliveredMessage: boolean;
-  showOnHover?: boolean;
   message: Message;
+  showOnHover?: boolean;
 }
 
 const ReadReceiptStatus: React.FC<ReadReceiptStatusProps> = ({

--- a/src/script/components/MessagesList/Message/ReadReceiptStatus.tsx
+++ b/src/script/components/MessagesList/Message/ReadReceiptStatus.tsx
@@ -30,10 +30,16 @@ import {formatTimeShort} from 'Util/TimeUtil';
 export interface ReadReceiptStatusProps {
   is1to1Conversation: boolean;
   isLastDeliveredMessage: boolean;
+  showOnHover?: boolean;
   message: Message;
 }
 
-const ReadReceiptStatus: React.FC<ReadReceiptStatusProps> = ({message, is1to1Conversation, isLastDeliveredMessage}) => {
+const ReadReceiptStatus: React.FC<ReadReceiptStatusProps> = ({
+  message,
+  is1to1Conversation,
+  isLastDeliveredMessage,
+  showOnHover = false,
+}) => {
   const [readReceiptText, setReadReceiptText] = useState('');
   const {readReceipts} = useKoSubscribableChildren(message, ['readReceipts']);
 
@@ -56,7 +62,11 @@ const ReadReceiptStatus: React.FC<ReadReceiptStatusProps> = ({message, is1to1Con
       )}
       {showEyeIndicator && (
         <div
-          className={cx('message-status-read', is1to1Conversation && 'message-status-read__one-on-one')}
+          className={cx(
+            'message-status-read',
+            is1to1Conversation && 'message-status-read__one-on-one',
+            showOnHover && 'message-status-read__show-on-hover',
+          )}
           data-uie-name="status-message-read-receipts"
           aria-label={t('accessibility.messageDetailsReadReceipts', readReceiptText)}
         >

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -147,9 +147,10 @@
 
 .message-header-icon {
   .flex-center;
-
   width: @conversation-message-sender-width;
   max-height: @avatar-diameter-xs;
+
+  align-self: center;
   color: var(--background);
 
   &--svg {

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -54,9 +54,11 @@
     pointer-events: auto;
   }
 
-  &.hover .message-status-read,
   &:hover .message-status-read {
     opacity: 0;
+    &__show-on-hover {
+      opacity: 1;
+    }
   }
 
   &.hover .time,


### PR DESCRIPTION
## Description

> In the context of the reactions/action menu changes, it's been decided to show read receipts for pings and remove timestamp for system messages

#### In this PR:
- remove timestamp for ping read receipt
- don't hide ping read receipt on hover (the read receipt remains non-clickable)
- assign the same width to the ping message as other messages

## Screenshots/Screencast (for UI changes)
- before:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/a6434125-2cc7-4f0f-9704-4b6c4384d48b)

- after: 
![image](https://github.com/wireapp/wire-webapp/assets/78490891/ee01fc32-e9df-4139-9e7a-8d629a18d7f0)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;
