### PR TITLE
refactor: Improve re-rendering of classified bar

### DIFF
--- a/src/script/components/ConnectRequests/ConnectionRequests.tsx
+++ b/src/script/components/ConnectRequests/ConnectionRequests.tsx
@@ -24,7 +24,7 @@ import {container} from 'tsyringe';
 import {Button, ButtonVariant, IconButton, IconButtonVariant, useMatchMedia} from '@wireapp/react-ui-kit';
 
 import {Avatar, AVATAR_SIZE} from 'Components/Avatar';
-import {ClassifiedBar} from 'Components/input/ClassifiedBar';
+import {UserClassifiedBar} from 'Components/input/ClassifiedBar';
 import {UnverifiedUserWarning} from 'Components/Modals/UserModal';
 import {useAppMainState, ViewType} from 'src/script/page/state';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
@@ -126,7 +126,7 @@ export const ConnectRequests: FC<ConnectRequestsProps> = ({
               <div className="connect-request-username label-username">{connectRequest.handle}</div>
 
               {classifiedDomains && (
-                <ClassifiedBar users={[userState.self(), connectRequest]} classifiedDomains={classifiedDomains} />
+                <UserClassifiedBar users={[userState.self(), connectRequest]} classifiedDomains={classifiedDomains} />
               )}
 
               <Avatar

--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -30,7 +30,7 @@ import {Avatar, AVATAR_SIZE} from 'Components/Avatar';
 import {checkFileSharingPermission} from 'Components/Conversation/utils/checkFileSharingPermission';
 import {useEmoji} from 'Components/Emoji/useEmoji';
 import {Icon} from 'Components/Icon';
-import {ClassifiedBar} from 'Components/input/ClassifiedBar';
+import {ConversationClassifiedBar} from 'Components/input/ClassifiedBar';
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
 import {showWarningModal} from 'Components/Modals/utils/showWarningModal';
 import {ConversationRepository} from 'src/script/conversation/ConversationRepository';
@@ -126,7 +126,6 @@ const InputBar = ({
   const {
     connection,
     participating_user_ets: participatingUserEts,
-    allUserEntities: allUsers,
     localMessageTimer,
     messageTimer,
     hasGlobalMessageTimer,
@@ -135,7 +134,6 @@ const InputBar = ({
   } = useKoSubscribableChildren(conversationEntity, [
     'connection',
     'firstUserEntity',
-    'allUserEntities',
     'participating_user_ets',
     'localMessageTimer',
     'messageTimer',
@@ -799,11 +797,7 @@ const InputBar = ({
       {!!isTypingIndicatorEnabled && <TypingIndicator conversationId={conversationEntity.id} />}
 
       {classifiedDomains && !isConnectionRequest && (
-        <ClassifiedBar
-          conversationDomain={conversationEntity.domain}
-          users={allUsers}
-          classifiedDomains={classifiedDomains}
-        />
+        <ConversationClassifiedBar conversation={conversationEntity} classifiedDomains={classifiedDomains} />
       )}
 
       {isReplying && !isEditing && <ReplyBar replyMessageEntity={replyMessageEntity} onCancel={handleCancelReply} />}

--- a/src/script/components/MessagesList/Message/memberMessage/ConnectedMessage.tsx
+++ b/src/script/components/MessagesList/Message/memberMessage/ConnectedMessage.tsx
@@ -23,7 +23,7 @@ import {Button, ButtonVariant} from '@wireapp/react-ui-kit';
 
 import {Avatar, AVATAR_SIZE} from 'Components/Avatar';
 import {Icon} from 'Components/Icon';
-import {ClassifiedBar} from 'Components/input/ClassifiedBar';
+import {UserClassifiedBar} from 'Components/input/ClassifiedBar';
 import {UnverifiedUserWarning} from 'Components/Modals/UserModal';
 import {User} from 'src/script/entity/User';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
@@ -59,7 +59,9 @@ const ConnectedMessage: React.FC<ConnectedMessageProps> = ({
         <p className="message-connected-username label-username">{handle}</p>
       )}
 
-      {isOutgoingRequest && classifiedDomains && <ClassifiedBar users={[user]} classifiedDomains={classifiedDomains} />}
+      {isOutgoingRequest && classifiedDomains && (
+        <UserClassifiedBar users={[user]} classifiedDomains={classifiedDomains} />
+      )}
 
       <Avatar
         avatarSize={AVATAR_SIZE.X_LARGE}

--- a/src/script/components/calling/CallingCell.tsx
+++ b/src/script/components/calling/CallingCell.tsx
@@ -32,7 +32,7 @@ import {GroupVideoGrid} from 'Components/calling/GroupVideoGrid';
 import {useCallAlertState} from 'Components/calling/useCallAlertState';
 import {FadingScrollbar} from 'Components/FadingScrollbar';
 import {Icon} from 'Components/Icon';
-import {ClassifiedBar} from 'Components/input/ClassifiedBar';
+import {ConversationClassifiedBar} from 'Components/input/ClassifiedBar';
 import {useAppMainState, ViewType} from 'src/script/page/state';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {isEnterKey, KEY} from 'Util/KeyboardUtil';
@@ -106,14 +106,12 @@ const CallingCell: React.FC<CallingCellProps> = ({
   const {
     isGroup,
     participating_user_ets: userEts,
-    allUserEntities: allUsers,
     selfUser,
     display_name: conversationName,
     roles,
   } = useKoSubscribableChildren(conversation, [
     'isGroup',
     'participating_user_ets',
-    'allUserEntities',
     'selfUser',
     'display_name',
     'roles',
@@ -448,11 +446,7 @@ const CallingCell: React.FC<CallingCellProps> = ({
           )}
 
           {classifiedDomains && (
-            <ClassifiedBar
-              conversationDomain={conversation.domain}
-              users={allUsers}
-              classifiedDomains={classifiedDomains}
-            />
+            <ConversationClassifiedBar conversation={conversation} classifiedDomains={classifiedDomains} />
           )}
 
           {!isDeclined && (

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -28,7 +28,7 @@ import {IconButton, IconButtonVariant, useMatchMedia} from '@wireapp/react-ui-ki
 
 import {useCallAlertState} from 'Components/calling/useCallAlertState';
 import {Icon} from 'Components/Icon';
-import {ClassifiedBar} from 'Components/input/ClassifiedBar';
+import {ConversationClassifiedBar} from 'Components/input/ClassifiedBar';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {KEY} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
@@ -118,10 +118,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
     startedAt,
     participants,
   } = useKoSubscribableChildren(call, ['activeSpeakers', 'currentPage', 'pages', 'startedAt', 'participants']);
-  const {display_name: conversationName, allUserEntities: allUsers} = useKoSubscribableChildren(conversation, [
-    'display_name',
-    'allUserEntities',
-  ]);
+  const {display_name: conversationName} = useKoSubscribableChildren(conversation, ['display_name']);
   const {isVideoCallingEnabled, classifiedDomains} = useKoSubscribableChildren(teamState, [
     'isVideoCallingEnabled',
     'classifiedDomains',
@@ -256,9 +253,8 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
           setMaximizedParticipant={participant => setMaximizedParticipant(call, participant)}
         />
         {classifiedDomains && (
-          <ClassifiedBar
-            conversationDomain={conversation.domain}
-            users={allUsers}
+          <ConversationClassifiedBar
+            conversation={conversation}
             classifiedDomains={classifiedDomains}
             style={{
               ...classifiedBarStyles,

--- a/src/script/components/input/ClassifiedBar.test.tsx
+++ b/src/script/components/input/ClassifiedBar.test.tsx
@@ -19,19 +19,22 @@
 
 import {render} from '@testing-library/react';
 
+import {Conversation} from 'src/script/entity/Conversation';
 import {User} from 'src/script/entity/User';
 import {createUuid} from 'Util/uuid';
 
 import {ClassifiedBar} from './ClassifiedBar';
 
 describe('ClassifiedBar', () => {
+  const conversation = new Conversation();
   const classifiedDomains = ['same.domain', 'classified.domain', 'other-classified.domain'];
   const sameDomainUser = new User(createUuid(), 'same.domain');
   const classifiedDomainUser = new User(createUuid(), 'classified.domain');
   const otherDomainUser = new User(createUuid(), 'other.domain');
 
   it.each([[[sameDomainUser]], [[sameDomainUser, otherDomainUser]]])('is empty if no domains are given', users => {
-    const {container} = render(<ClassifiedBar users={users} conversationDomain="test" />);
+    conversation.participating_user_ets(users);
+    const {container} = render(<ClassifiedBar conversation={conversation} conversationDomain="test" />);
 
     expect(container.querySelector('[data-uie-name=classified-label]')).toBe(null);
   });
@@ -39,10 +42,11 @@ describe('ClassifiedBar', () => {
   it.each([[[sameDomainUser]], [[classifiedDomainUser]], [[sameDomainUser, classifiedDomainUser]]])(
     'returns classified if all users in the classified domains',
     users => {
+      conversation.participating_user_ets(users);
       const {getByText, queryByText} = render(
         <ClassifiedBar
           conversationDomain={classifiedDomainUser.domain}
-          users={users}
+          conversation={conversation}
           classifiedDomains={classifiedDomains}
         />,
       );
@@ -57,8 +61,13 @@ describe('ClassifiedBar', () => {
     [[classifiedDomainUser, otherDomainUser]],
     [[sameDomainUser, classifiedDomainUser, otherDomainUser]],
   ])('returns non-classified if a single user is from another domain', users => {
+    conversation.participating_user_ets(users);
     const {queryByText, getByText} = render(
-      <ClassifiedBar conversationDomain={classifiedDomains[0]} users={users} classifiedDomains={classifiedDomains} />,
+      <ClassifiedBar
+        conversationDomain={classifiedDomains[0]}
+        conversation={conversation}
+        classifiedDomains={classifiedDomains}
+      />,
     );
 
     expect(queryByText('conversationClassified')).toBe(null);

--- a/src/script/components/input/ClassifiedBar.test.tsx
+++ b/src/script/components/input/ClassifiedBar.test.tsx
@@ -23,7 +23,7 @@ import {Conversation} from 'src/script/entity/Conversation';
 import {User} from 'src/script/entity/User';
 import {createUuid} from 'Util/uuid';
 
-import {ClassifiedBar} from './ClassifiedBar';
+import {ConversationClassifiedBar} from './ClassifiedBar';
 
 describe('ClassifiedBar', () => {
   const conversation = new Conversation();
@@ -34,7 +34,7 @@ describe('ClassifiedBar', () => {
 
   it.each([[[sameDomainUser]], [[sameDomainUser, otherDomainUser]]])('is empty if no domains are given', users => {
     conversation.participating_user_ets(users);
-    const {container} = render(<ClassifiedBar conversation={conversation} conversationDomain="test" />);
+    const {container} = render(<ConversationClassifiedBar conversation={conversation} conversationDomain="test" />);
 
     expect(container.querySelector('[data-uie-name=classified-label]')).toBe(null);
   });
@@ -44,7 +44,7 @@ describe('ClassifiedBar', () => {
     users => {
       conversation.participating_user_ets(users);
       const {getByText, queryByText} = render(
-        <ClassifiedBar
+        <ConversationClassifiedBar
           conversationDomain={classifiedDomainUser.domain}
           conversation={conversation}
           classifiedDomains={classifiedDomains}
@@ -63,7 +63,7 @@ describe('ClassifiedBar', () => {
   ])('returns non-classified if a single user is from another domain', users => {
     conversation.participating_user_ets(users);
     const {queryByText, getByText} = render(
-      <ClassifiedBar
+      <ConversationClassifiedBar
         conversationDomain={classifiedDomains[0]}
         conversation={conversation}
         classifiedDomains={classifiedDomains}

--- a/src/script/components/input/ClassifiedBar.tsx
+++ b/src/script/components/input/ClassifiedBar.tsx
@@ -40,12 +40,16 @@ function isClassified(users: User[], classifiedDomains: string[], conversationDo
   return true;
 }
 
-interface UserClassifiedBarProps {
+interface ClassifiedBarProps {
   classifiedDomains?: string[];
   style?: CSSObject;
-  users: User[];
   conversationDomain?: string;
 }
+
+interface UserClassifiedBarProps extends ClassifiedBarProps {
+  users: User[];
+}
+
 export const UserClassifiedBar: React.FC<UserClassifiedBarProps> = ({
   users,
   conversationDomain,
@@ -71,11 +75,8 @@ export const UserClassifiedBar: React.FC<UserClassifiedBarProps> = ({
   );
 };
 
-interface ConversationClassifiedBarProps {
-  classifiedDomains?: string[];
-  style?: CSSObject;
+interface ConversationClassifiedBarProps extends ClassifiedBarProps {
   conversation: Conversation;
-  conversationDomain?: string;
 }
 
 export const ConversationClassifiedBar: React.FC<ConversationClassifiedBarProps> = ({

--- a/src/script/components/input/ClassifiedBar.tsx
+++ b/src/script/components/input/ClassifiedBar.tsx
@@ -40,15 +40,18 @@ function isClassified(users: User[], classifiedDomains: string[], conversationDo
   return true;
 }
 
-interface ClassifiedBarProps {
+interface UserClassifiedBarProps {
   classifiedDomains?: string[];
   style?: CSSObject;
-  conversation: Conversation;
+  users: User[];
   conversationDomain?: string;
 }
-
-const ClassifiedBar: React.FC<ClassifiedBarProps> = ({conversation, classifiedDomains, conversationDomain, style}) => {
-  const {allUserEntities: users} = useKoSubscribableChildren(conversation, ['allUserEntities']);
+export const UserClassifiedBar: React.FC<UserClassifiedBarProps> = ({
+  users,
+  conversationDomain,
+  classifiedDomains,
+  style,
+}) => {
   if (typeof classifiedDomains === 'undefined') {
     return null;
   }
@@ -68,4 +71,25 @@ const ClassifiedBar: React.FC<ClassifiedBarProps> = ({conversation, classifiedDo
   );
 };
 
-export {ClassifiedBar};
+interface ConversationClassifiedBarProps {
+  classifiedDomains?: string[];
+  style?: CSSObject;
+  conversation: Conversation;
+  conversationDomain?: string;
+}
+
+export const ConversationClassifiedBar: React.FC<ConversationClassifiedBarProps> = ({
+  conversation,
+  classifiedDomains,
+  style,
+}) => {
+  const {allUserEntities: users} = useKoSubscribableChildren(conversation, ['allUserEntities']);
+  return (
+    <UserClassifiedBar
+      users={users}
+      conversationDomain={conversation.domain}
+      classifiedDomains={classifiedDomains}
+      style={style}
+    />
+  );
+};

--- a/src/script/components/input/ClassifiedBar.tsx
+++ b/src/script/components/input/ClassifiedBar.tsx
@@ -81,16 +81,8 @@ interface ConversationClassifiedBarProps extends ClassifiedBarProps {
 
 export const ConversationClassifiedBar: React.FC<ConversationClassifiedBarProps> = ({
   conversation,
-  classifiedDomains,
-  style,
+  ...classifiedBarProps
 }) => {
   const {allUserEntities: users} = useKoSubscribableChildren(conversation, ['allUserEntities']);
-  return (
-    <UserClassifiedBar
-      users={users}
-      conversationDomain={conversation.domain}
-      classifiedDomains={classifiedDomains}
-      style={style}
-    />
-  );
+  return <UserClassifiedBar users={users} conversationDomain={conversation.domain} {...classifiedBarProps} />;
 };

--- a/src/script/components/input/ClassifiedBar.tsx
+++ b/src/script/components/input/ClassifiedBar.tsx
@@ -23,7 +23,9 @@ import {CSSObject} from '@emotion/react';
 import cx from 'classnames';
 
 import {Icon} from 'Components/Icon';
+import {Conversation} from 'src/script/entity/Conversation';
 import {User} from 'src/script/entity/User';
+import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 
 function isClassified(users: User[], classifiedDomains: string[], conversationDomain?: string): boolean {
@@ -41,11 +43,12 @@ function isClassified(users: User[], classifiedDomains: string[], conversationDo
 interface ClassifiedBarProps {
   classifiedDomains?: string[];
   style?: CSSObject;
-  users: User[];
+  conversation: Conversation;
   conversationDomain?: string;
 }
 
-const ClassifiedBar: React.FC<ClassifiedBarProps> = ({users, classifiedDomains, conversationDomain, style}) => {
+const ClassifiedBar: React.FC<ClassifiedBarProps> = ({conversation, classifiedDomains, conversationDomain, style}) => {
+  const {allUserEntities: users} = useKoSubscribableChildren(conversation, ['allUserEntities']);
   if (typeof classifiedDomains === 'undefined') {
     return null;
   }

--- a/src/script/components/panel/UserDetails.tsx
+++ b/src/script/components/panel/UserDetails.tsx
@@ -28,11 +28,11 @@ import {AvailabilityState} from 'Components/AvailabilityState';
 import {Avatar, AVATAR_SIZE} from 'Components/Avatar';
 import {ErrorFallback} from 'Components/ErrorFallback';
 import {Icon} from 'Components/Icon';
-import {ClassifiedBar} from 'Components/input/ClassifiedBar';
+import {UserClassifiedBar} from 'Components/input/ClassifiedBar';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 
-import type {User} from '../../entity/User';
+import {User} from '../../entity/User';
 
 export interface UserDetailsProps {
   badge?: string;
@@ -108,7 +108,7 @@ export const UserDetailsComponent: React.FC<UserDetailsProps> = ({
       )}
 
       {classifiedDomains && (
-        <ClassifiedBar
+        <UserClassifiedBar
           conversationDomain={conversationDomain}
           users={[participant]}
           classifiedDomains={classifiedDomains}


### PR DESCRIPTION
## Description

Since the classified bar was given the list of users from the parent component, it would force the parent component to re-render when the user list updates **even if the classified bar is not rendered**. 
This will make sure that updates that are only for the classified bar are only subscribed in the classified bar

We now have 2 components for classified bar:

- `UserClassifiedBar` which show a classified bar for a single user
- `ConversationClassifiedBar` that takes a full conversation and show the classified bar for that conversation

## Screenshots/Screencast (for UI changes)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;


