### PR TITLE
refactor: get 1to1 conversation

### DIFF
--- a/src/script/view_model/ActionsViewModel.ts
+++ b/src/script/view_model/ActionsViewModel.ts
@@ -408,7 +408,7 @@ export class ActionsViewModel {
             await this.connectionRepository.unblockUser(userEntity);
             const conversationEntity = await this.conversationRepository.get1To1Conversation(userEntity);
             resolve();
-            if (typeof conversationEntity !== 'boolean') {
+            if (conversationEntity) {
               await this.conversationRepository.updateParticipatingUserEntities(conversationEntity);
             }
           },


### PR DESCRIPTION
Simplifies the logic in get1to1Conversation method in ConversationRepository. Logic for handled team-owned 1:1 is excluded to a separate method. Behaviour does not change except the fact that the method returns `Conversation` or `null` (if it's not found) instead of `false` as it was before.