### PR TITLE
fix: enable soundless calls when CBR is enforced (WPB-4401)

### DIFF
--- a/src/script/page/MainContent/panels/preferences/avPreferences/CallOptions.tsx
+++ b/src/script/page/MainContent/panels/preferences/avPreferences/CallOptions.tsx
@@ -102,7 +102,6 @@ const CallOptions: React.FC<CallOptionsProps> = ({constraintsHandler, properties
           }}
           checked={soundlessCallsEnabled}
           data-uie-name="status-preference-soundless-incoming-calls"
-          disabled={isCbrEncodingEnforced}
         >
           <CheckboxLabel htmlFor="status-preference-soundless-incoming-calls">
             {t('preferencesOptionsEnableSoundlessIncomingCalls')}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4401" title="WPB-4401" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4401</a>  Greyed out "Silence other calls" option when CBR is enforced
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

A check that disables the soundless call checkbox when Constant BitRate is enforced was added by mistake during a refactor a year ago.
See screenshot of the diff from a year ago and the original PR here https://github.com/wireapp/wire-webapp/pull/13241/files#diff-2d92bf1a7c3061dcada1f4ca071ce5f4008d13b1090ba6de30843d9f21ad0a28R101

## Screenshots/Screencast (for UI changes)
![image](https://github.com/wireapp/wire-webapp/assets/78490891/c7abdef9-7c9b-4fd2-9753-ef77953b4f0b)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
