### PR TITLE
runfix: remove extra indentation from quotes

### DIFF
--- a/src/style/content/conversation/message-quote.less
+++ b/src/style/content/conversation/message-quote.less
@@ -4,7 +4,7 @@
     @conversation-max-width - var(--conversation-message-timestamp-width) - @conversation-message-sender-width - 16px
   );
   padding-right: var(--conversation-message-timestamp-width);
-  padding-left: @conversation-message-sender-width + 16;
+  padding-left: 16px;
   margin-bottom: 10px;
   font-size: @font-size-medium;
   line-height: 1.5em;
@@ -21,7 +21,7 @@
     position: absolute;
     top: 0;
     bottom: 0;
-    left: @conversation-message-sender-width;
+    left: 0;
     display: block;
     width: 4px;
     height: 100%;


### PR DESCRIPTION
## Description

Different structure of the DOM for reactions resulted in extra indentation for quotes/replies

We need to remove the extra `@conversation-message-sender-width` (width allotted to the avatar), not relevant to the new structure

## Screenshots/Screencast (for UI changes)

- Before:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/f912d01d-83cf-4671-b077-1609da3b03a2)

- After:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/75e433df-1875-4e82-bcca-b5731fa35066)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
