### PR TITLE
chore: indicate if connection map was triggered by socket event

### DIFF
--- a/src/script/connection/ConnectionRepository.ts
+++ b/src/script/connection/ConnectionRepository.ts
@@ -125,8 +125,7 @@ export class ConnectionRepository {
       // Get conversation related to connection and set its type to 1:1
       // This case is important when the 'user.connection' event arrives after the 'conversation.member-join' event: https://wearezeta.atlassian.net/browse/SQCORE-348
 
-      const isWebSocketEvent = source === EventRepository.SOURCE.WEB_SOCKET;
-      amplify.publish(WebAppEvents.CONVERSATION.MAP_CONNECTION, connectionEntity, isWebSocketEvent);
+      amplify.publish(WebAppEvents.CONVERSATION.MAP_CONNECTION, connectionEntity, source);
     }
 
     await this.sendNotification(connectionEntity, source, previousStatus);

--- a/src/script/connection/ConnectionRepository.ts
+++ b/src/script/connection/ConnectionRepository.ts
@@ -124,7 +124,9 @@ export class ConnectionRepository {
       await this.userRepository.refreshUser(connectionEntity.userId);
       // Get conversation related to connection and set its type to 1:1
       // This case is important when the 'user.connection' event arrives after the 'conversation.member-join' event: https://wearezeta.atlassian.net/browse/SQCORE-348
-      amplify.publish(WebAppEvents.CONVERSATION.MAP_CONNECTION, connectionEntity);
+
+      const isWebSocketEvent = source === EventRepository.SOURCE.WEB_SOCKET;
+      amplify.publish(WebAppEvents.CONVERSATION.MAP_CONNECTION, connectionEntity, isWebSocketEvent);
     }
 
     await this.sendNotification(connectionEntity, source, previousStatus);

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1373,12 +1373,12 @@ export class ConversationRepository {
    * @note If there is no conversation it will request it from the backend
    *
    * @param connectionEntity Connection entity
-   * @param wasTrigerredByWebsocketEvent Whether the connection was mapped due to a websocket event
+   * @param source Event source that has triggered the mapping
    * @returns Resolves when connection was mapped return value
    */
   private readonly mapConnection = async (
     connectionEntity: ConnectionEntity,
-    source = EventSource,
+    source?: EventSource,
   ): Promise<Conversation | undefined> => {
     try {
       const conversation = await this.getConnectionConversation(connectionEntity);

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1378,7 +1378,7 @@ export class ConversationRepository {
    */
   private readonly mapConnection = async (
     connectionEntity: ConnectionEntity,
-    wasTrigerredByWebsocketEvent = false,
+    source = EventSource,
   ): Promise<Conversation | undefined> => {
     try {
       const conversation = await this.getConnectionConversation(connectionEntity);

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1373,7 +1373,10 @@ export class ConversationRepository {
    * @note If there is no conversation it will request it from the backend
    * @returns Resolves when connection was mapped return value
    */
-  private readonly mapConnection = async (connectionEntity: ConnectionEntity): Promise<Conversation | undefined> => {
+  private readonly mapConnection = async (
+    connectionEntity: ConnectionEntity,
+    wasTrigerredByWebsocketEvent = false,
+  ): Promise<Conversation | undefined> => {
     try {
       const conversation = await this.getConnectionConversation(connectionEntity);
 

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1371,6 +1371,9 @@ export class ConversationRepository {
    * Maps user connection to the corresponding conversation.
    *
    * @note If there is no conversation it will request it from the backend
+   *
+   * @param connectionEntity Connection entity
+   * @param wasTrigerredByWebsocketEvent Whether the connection was mapped due to a websocket event
    * @returns Resolves when connection was mapped return value
    */
   private readonly mapConnection = async (


### PR DESCRIPTION
## Description

Adds an optional param to mapConnection method indicating if it was triggered after parsing an event that came through websocket. This will be useful for 1:1 conversations with MLS - we need to add a delay in this case to reduce the possibility of a race condition where two users try to establish a 1:1 MLS conversation at the same time.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
