### PR TITLE
feat(server): Enable dynamic replacement of hostname in client config

### DIFF
--- a/server/Server.ts
+++ b/server/Server.ts
@@ -69,7 +69,7 @@ class Server {
     this.initSiteMap(this.config);
     this.app.use(Root());
     this.app.use(HealthCheckRoute());
-    this.app.use(ConfigRoute(this.clientConfig));
+    this.app.use(ConfigRoute(this.config, this.clientConfig));
     this.app.use(GoogleWebmasterRoute(this.config));
     this.app.use(AppleAssociationRoute());
     this.app.use(NotFoundRoute());

--- a/server/Server.ts
+++ b/server/Server.ts
@@ -38,6 +38,7 @@ import {GoogleWebmasterRoute} from './routes/googlewebmaster/GoogleWebmasterRout
 import {RedirectRoutes} from './routes/RedirectRoutes';
 import {Root} from './routes/Root';
 import * as BrowserUtil from './util/BrowserUtil';
+import {replaceHostnameInObject} from './util/hostnameReplacer';
 
 class Server {
   private readonly app: express.Express;
@@ -136,12 +137,14 @@ class Server {
         preload: true,
       }),
     );
-    this.app.use(
+    this.app.use((req, res, next) => {
       helmet.contentSecurityPolicy({
-        directives: this.config.CSP,
+        directives: this.config.ENABLE_DYNAMIC_HOSTNAME
+          ? replaceHostnameInObject(this.config.CSP, req)
+          : this.config.CSP,
         reportOnly: false,
-      }),
-    );
+      })(req, res, next);
+    });
     this.app.use(
       helmet.referrerPolicy({
         policy: 'same-origin',

--- a/server/config/env.ts
+++ b/server/config/env.ts
@@ -61,8 +61,8 @@ export type Env = {
   /** Specifies the name of the brand, e.g. Wire */
   BRAND_NAME: string;
 
-  /** enables replacing all occurences of {{hostname}} in the urls given to the frontend by the hostname that was queries by the frontend */
-  URL_HOSTNAME_SWAP?: string;
+  /** enables replacing all occurences of {{hostname}} in the urls given to the frontend by the hostname of the client*/
+  ENABLE_DYNAMIC_HOSTNAME?: string;
 
   /** Allows a client to use a development version of the api (if present) */
   ENABLE_DEV_BACKEND_API?: string;

--- a/server/config/env.ts
+++ b/server/config/env.ts
@@ -61,6 +61,9 @@ export type Env = {
   /** Specifies the name of the brand, e.g. Wire */
   BRAND_NAME: string;
 
+  /** enables replacing all occurences of {{hostname}} in the urls given to the frontend by the hostname that was queries by the frontend */
+  URL_HOSTNAME_SWAP?: string;
+
   /** Allows a client to use a development version of the api (if present) */
   ENABLE_DEV_BACKEND_API?: string;
 

--- a/server/config/server.config.ts
+++ b/server/config/server.config.ts
@@ -107,6 +107,7 @@ export function generateConfig(params: ConfigGeneratorParams, env: Env) {
       IMAGE_URL: env.OPEN_GRAPH_IMAGE_URL,
       TITLE: env.OPEN_GRAPH_TITLE,
     },
+    URL_HOSTNAME_SWAP: env.URL_HOSTNAME_SWAP === 'true',
     PORT_HTTP: Number(env.PORT) || 21080,
     ROBOTS: {
       ALLOW: readFile(ROBOTS_ALLOW_FILE, 'User-agent: *\r\nDisallow: /'),

--- a/server/config/server.config.ts
+++ b/server/config/server.config.ts
@@ -107,7 +107,7 @@ export function generateConfig(params: ConfigGeneratorParams, env: Env) {
       IMAGE_URL: env.OPEN_GRAPH_IMAGE_URL,
       TITLE: env.OPEN_GRAPH_TITLE,
     },
-    URL_HOSTNAME_SWAP: env.URL_HOSTNAME_SWAP === 'true',
+    ENABLE_DYNAMIC_HOSTNAME: env.ENABLE_DYNAMIC_HOSTNAME === 'true',
     PORT_HTTP: Number(env.PORT) || 21080,
     ROBOTS: {
       ALLOW: readFile(ROBOTS_ALLOW_FILE, 'User-agent: *\r\nDisallow: /'),

--- a/server/routes/config/ConfigRoute.ts
+++ b/server/routes/config/ConfigRoute.ts
@@ -20,13 +20,14 @@
 import {Router} from 'express';
 
 import {ClientConfig, ServerConfig} from '../../config';
+import {replaceHostname} from '../../util/hostnameReplacer';
 
 export const ConfigRoute = (serverConfig: ServerConfig, clientConfig: ClientConfig) =>
   Router().get('/config.js', (request, res) => {
     const serializedConfig = `window.wire = window.wire || {}; window.wire.env = ${JSON.stringify(clientConfig)};`;
     const payload = serverConfig.ENABLE_DYNAMIC_HOSTNAME
       ? // In case we want URLs that depends on the the hostname, we need to replace the placeholder with the actual hostname.
-        serializedConfig.replaceAll('[[hostname]]', request.hostname.replace('webapp.', ''))
+        replaceHostname(serializedConfig, request)
       : serializedConfig;
     res.type('application/javascript').send(payload);
   });

--- a/server/routes/config/ConfigRoute.ts
+++ b/server/routes/config/ConfigRoute.ts
@@ -26,7 +26,7 @@ export const ConfigRoute = (serverConfig: ServerConfig, clientConfig: ClientConf
     const serializedConfig = `window.wire = window.wire || {}; window.wire.env = ${JSON.stringify(clientConfig)};`;
     const payload = serverConfig.ENABLE_DYNAMIC_HOSTNAME
       ? // In case we want URLs that depends on the the hostname, we need to replace the placeholder with the actual hostname.
-        serializedConfig.replaceAll('[[hostname]]', request.hostname)
+        serializedConfig.replaceAll('[[hostname]]', request.hostname.replace('webapp.', ''))
       : serializedConfig;
     res.type('application/javascript').send(payload);
   });

--- a/server/routes/config/ConfigRoute.ts
+++ b/server/routes/config/ConfigRoute.ts
@@ -19,10 +19,13 @@
 
 import {Router} from 'express';
 
-import {ClientConfig} from '../../config';
+import {ClientConfig, ServerConfig} from '../../config';
 
-export const ConfigRoute = (config: ClientConfig) =>
-  Router().get('/config.js', (_, res) => {
-    const payload = `window.wire = window.wire || {}; window.wire.env = ${JSON.stringify(config)};`;
+export const ConfigRoute = (serverConfig: ServerConfig, clientConfig: ClientConfig) =>
+  Router().get('/config.js', (request, res) => {
+    const serializedConfig = `window.wire = window.wire || {}; window.wire.env = ${JSON.stringify(clientConfig)};`;
+    const payload = serverConfig.URL_HOSTNAME_SWAP
+      ? serializedConfig.replaceAll('{{hostname}}', request.hostname)
+      : serializedConfig;
     res.type('application/javascript').send(payload);
   });

--- a/server/routes/config/ConfigRoute.ts
+++ b/server/routes/config/ConfigRoute.ts
@@ -24,8 +24,9 @@ import {ClientConfig, ServerConfig} from '../../config';
 export const ConfigRoute = (serverConfig: ServerConfig, clientConfig: ClientConfig) =>
   Router().get('/config.js', (request, res) => {
     const serializedConfig = `window.wire = window.wire || {}; window.wire.env = ${JSON.stringify(clientConfig)};`;
-    const payload = serverConfig.URL_HOSTNAME_SWAP
-      ? serializedConfig.replaceAll('{{hostname}}', request.hostname)
+    const payload = serverConfig.ENABLE_DYNAMIC_HOSTNAME
+      ? // In case we want URLs that depends on the the hostname, we need to replace the placeholder with the actual hostname.
+        serializedConfig.replaceAll('{{hostname}}', request.hostname)
       : serializedConfig;
     res.type('application/javascript').send(payload);
   });

--- a/server/routes/config/ConfigRoute.ts
+++ b/server/routes/config/ConfigRoute.ts
@@ -26,7 +26,7 @@ export const ConfigRoute = (serverConfig: ServerConfig, clientConfig: ClientConf
     const serializedConfig = `window.wire = window.wire || {}; window.wire.env = ${JSON.stringify(clientConfig)};`;
     const payload = serverConfig.ENABLE_DYNAMIC_HOSTNAME
       ? // In case we want URLs that depends on the the hostname, we need to replace the placeholder with the actual hostname.
-        serializedConfig.replaceAll('{{hostname}}', request.hostname)
+        serializedConfig.replaceAll('[[hostname]]', request.hostname)
       : serializedConfig;
     res.type('application/javascript').send(payload);
   });

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "commonjs",
     "outDir": "dist",
     "removeComments": true,
-    "lib": ["esnext", "dom"],
+    "lib": ["esnext"],
     "downlevelIteration": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",

--- a/server/util/hostnameReplacer.ts
+++ b/server/util/hostnameReplacer.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2018 Wire Swiss GmbH
+ * Copyright (C) 2023 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/server/util/hostnameReplacer.ts
+++ b/server/util/hostnameReplacer.ts
@@ -23,6 +23,6 @@ export function replaceHostname(template: string, request: Request): string {
   return template.replaceAll('[[hostname]]', request.hostname.replace('webapp.', ''));
 }
 
-export function replaceHostnameInObject<T>(template: T, request: Request): T {
-  return JSON.parse(replaceHostname(JSON.stringify(template), request));
+export function replaceHostnameInObject<T>(object: T, request: Request): T {
+  return JSON.parse(replaceHostname(JSON.stringify(object), request));
 }

--- a/server/util/hostnameReplacer.ts
+++ b/server/util/hostnameReplacer.ts
@@ -1,0 +1,28 @@
+/*
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Request} from 'express';
+
+export function replaceHostname(template: string, request: Request): string {
+  return template.replaceAll('[[hostname]]', request.hostname.replace('webapp.', ''));
+}
+
+export function replaceHostnameInObject<T>(template: T, request: Request): T {
+  return JSON.parse(replaceHostname(JSON.stringify(template), request));
+}


### PR DESCRIPTION
## Description

This will enable an instance of Wire web server to have multiple hostnames serving it and still serve a config that depends on the hostname it was queried from.

Currently our configuration is static and if you have the same wire webserver instance running on `a.com` and `b.com` then the config you will receive will have static urls:

```js
{ 
  BACKEND_REST: 'https://backend.base-domain.com'
}
```

What this PR brings is the ability to serve a config that depends on the hostname

```js
{
  BACKEND_REST: 'https://backend.[[hostname]]`
}
```

on `a.com` it's going to serve

```js
{
  BACKEND_REST: 'https://backend.a.com`
}
```

on `b.com` it's going to serve

```js
{
  BACKEND_REST: 'https://backend.b.com`
}
```

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

