### PR TITLE
runfix: use correct accent color for amber-dark-800

### DIFF
--- a/src/style/common/accent-color.less
+++ b/src/style/common/accent-color.less
@@ -179,7 +179,7 @@
 @amber-dark-500: #ffd426;
 @amber-dark-600: #ccaa1e;
 @amber-dark-700: #997f17;
-@amber-dark-800: #201204;
+@amber-dark-800: #66550f;
 @amber-dark-900: #4d400b;
 
 .colors() {


### PR DESCRIPTION
## Description

It was reported that the self mention highlight was wrong for amber accent color in dark mode

## Screenshots/Screencast (for UI changes)

before:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/cc208c1b-9ce7-4604-9622-48284445e903)

After:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/6c2472e5-d3b9-4654-b80c-56b1195795e8)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
