### PR TITLE
fix: proper tab name for set username view

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -177,6 +177,7 @@
   "authErrorSignIn": "Please verify your details and try again.",
   "authErrorSuspended": "This account is no longer authorized to log in.",
   "authForgotPasswordTitle": "Change your password",
+  "authSetUsername": "Set username",
   "authHistoryButton": "OK",
   "authHistoryDescription": "For privacy reasons, your conversation history will not appear here.",
   "authHistoryHeadline": "It’s the first time you’re using {{brandName}} on this device.",

--- a/src/script/auth/page/Root.tsx
+++ b/src/script/auth/page/Root.tsx
@@ -165,7 +165,14 @@ const RootComponent: FC<RootProps & ConnectedProps & DispatchProps> = ({
                 }
               />
               <Route path={ROUTE.SET_EMAIL} element={<ProtectedSetEmail />} />
-              <Route path={ROUTE.SET_HANDLE} element={<ProtectedSetHandle />} />
+              <Route
+                path={ROUTE.SET_HANDLE}
+                element={
+                  <Title title={`${t('authSetUsername')} . ${brandName}`}>
+                    <ProtectedSetHandle />
+                  </Title>
+                }
+              />
               <Route
                 path={ROUTE.SET_PASSWORD}
                 element={


### PR DESCRIPTION
## Description

Changes the title of "set username" view when logging in for the first time and setting user handle.

## Screenshots/Screencast (for UI changes)
Before:
<img width="810" alt="Wire 2023-09-11 at 2_54 PM" src="https://github.com/wireapp/wire-webapp/assets/45733298/53dfa258-9270-47a3-9467-a87d49e9b9e7">

After:
<img width="721" alt="Screenshot 2023-09-11 at 15 27 38" src="https://github.com/wireapp/wire-webapp/assets/45733298/b961ce68-ef11-456b-bca2-add572ba7114">

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;