### PR TITLE
refactor: Inject self user into component

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -467,7 +467,7 @@ export const Conversation: FC<ConversationProps> = ({
           <TitleBar
             repositories={repositories}
             conversation={activeConversation}
-            userState={userState}
+            selfUser={selfUser}
             teamState={teamState}
             callActions={mainViewModel.calling.callActions}
             openRightSidebar={openRightSidebar}

--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -78,6 +78,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
     isMLSEnabled: isMLSEnabledForTeam,
     isProtocolToggleEnabledForUser,
   } = useKoSubscribableChildren(teamState, ['isTeam', 'isMLSEnabled', 'isProtocolToggleEnabledForUser']);
+  const {self: selfUser} = useKoSubscribableChildren(userState, ['self']);
 
   const isMLSFeatureEnabled = Config.getConfig().FEATURE.ENABLE_MLS;
 
@@ -406,6 +407,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
           <FadingScrollbar className="group-creation__list">
             {filteredContacts.length > 0 && (
               <UserSearchableList
+                selfUser={selfUser}
                 users={filteredContacts}
                 filter={participantsInput}
                 selected={selectedContacts}

--- a/src/script/components/Modals/LegalHoldModal/LegalHoldModal.tsx
+++ b/src/script/components/Modals/LegalHoldModal/LegalHoldModal.tsx
@@ -415,6 +415,7 @@ const LegalHoldModal: FC<LegalHoldModalProps> = ({
                   searchRepository={searchRepository}
                   teamRepository={teamRepository}
                   onClick={setUserDevices}
+                  selfUser={selfUser}
                   noUnderline
                 />
               </>

--- a/src/script/components/Modals/UserModal/UserModal.test.tsx
+++ b/src/script/components/Modals/UserModal/UserModal.test.tsx
@@ -24,7 +24,6 @@ import {User} from 'src/script/entity/User';
 import {Core} from 'src/script/service/CoreSingleton';
 import {TeamState} from 'src/script/team/TeamState';
 import {UserRepository} from 'src/script/user/UserRepository';
-import {UserState} from 'src/script/user/UserState';
 
 import {UserModal, UserModalProps} from './UserModal';
 import {showUserModal} from './UserModal.state';
@@ -42,7 +41,7 @@ describe('UserModal', () => {
       userRepository: {
         getUserById,
       } as unknown as UserRepository,
-      userState: {} as UserState,
+      selfUser: new User(),
     };
     showUserModal({domain: 'test-domain.mock', id: 'mock-id'});
     const {getByTestId} = render(<UserModal {...props} />);
@@ -65,7 +64,7 @@ describe('UserModal', () => {
       userRepository: {
         getUserById,
       } as unknown as UserRepository,
-      userState: {} as UserState,
+      selfUser: new User(),
     };
 
     showUserModal({domain: 'test-domain.mock', id: 'mock-id'});

--- a/src/script/components/Modals/UserModal/UserModal.tsx
+++ b/src/script/components/Modals/UserModal/UserModal.tsx
@@ -44,11 +44,10 @@ import {RootContext} from '../../../page/RootProvider';
 import {Core} from '../../../service/CoreSingleton';
 import {TeamState} from '../../../team/TeamState';
 import {UserRepository} from '../../../user/UserRepository';
-import {UserState} from '../../../user/UserState';
 
 export interface UserModalProps {
   userRepository: UserRepository;
-  userState?: UserState;
+  selfUser: User;
   teamState?: TeamState;
   core?: Core;
 }
@@ -127,8 +126,8 @@ export const UnverifiedUserWarning: React.FC<UnverifiedUserWarningProps> = ({use
 
 const UserModal: React.FC<UserModalProps> = ({
   userRepository,
+  selfUser,
   core = container.resolve(Core),
-  userState = container.resolve(UserState),
   teamState = container.resolve(TeamState),
 }) => {
   const onClose = useUserModalState(state => state.onClose);
@@ -146,9 +145,11 @@ const UserModal: React.FC<UserModalProps> = ({
     resetState();
   };
   const {classifiedDomains} = useKoSubscribableChildren(teamState, ['classifiedDomains']);
-  const {self, isActivatedAccount} = useKoSubscribableChildren(userState, ['self', 'isActivatedAccount']);
-  const {is_trusted: isTrusted} = useKoSubscribableChildren(self, ['is_trusted']);
-  const {is_verified: isSelfVerified} = useKoSubscribableChildren(self, ['is_verified']);
+  const {
+    is_trusted: isTrusted,
+    is_verified: isSelfVerified,
+    isActivatedAccount,
+  } = useKoSubscribableChildren(selfUser, ['is_trusted', 'is_verified', 'isActivatedAccount']);
   const isFederated = core.backendFeatures?.isFederated;
 
   useEffect(() => {
@@ -219,7 +220,7 @@ const UserModal: React.FC<UserModalProps> = ({
                 user={user}
                 onAction={hide}
                 isSelfActivated={isActivatedAccount}
-                selfUser={self}
+                selfUser={selfUser}
               />
             </>
           )}

--- a/src/script/components/TitleBar/TitleBar.test.tsx
+++ b/src/script/components/TitleBar/TitleBar.test.tsx
@@ -38,7 +38,6 @@ import {Conversation} from '../../entity/Conversation';
 import {User} from '../../entity/User';
 import {PanelState} from '../../page/RightSidebar/RightSidebar';
 import {TeamState} from '../../team/TeamState';
-import {UserState} from '../../user/UserState';
 import {ViewModelRepositories} from '../../view_model/MainViewModel';
 
 jest.mock('@wireapp/react-ui-kit', () => ({
@@ -85,7 +84,7 @@ const getDefaultProps = (callingRepository: CallingRepository, conversation: Con
     } as CallingRepository,
   } as ViewModelRepositories,
   teamState: new TeamState(),
-  userState: new UserState(),
+  selfUser: new User(),
 });
 
 describe('TitleBar', () => {
@@ -101,22 +100,22 @@ describe('TitleBar', () => {
   });
 
   it("doesn't show conversation search button for user with activated account", async () => {
-    const userState = createUserState({isActivatedAccount: ko.pureComputed(() => false)});
+    const selfUser = createUser(false);
     const conversation = new Conversation();
 
     const {queryByText} = render(
-      withTheme(<TitleBar {...getDefaultProps(callingRepository, conversation)} userState={userState} />),
+      withTheme(<TitleBar {...getDefaultProps(callingRepository, conversation)} selfUser={selfUser} />),
     );
 
     expect(queryByText('tooltipConversationSearch')).toBeNull();
   });
 
   it('opens search area after search button click', async () => {
-    const userState = createUserState({isActivatedAccount: ko.pureComputed(() => true)});
+    const selfUser = createUser(true);
     const conversation = new Conversation();
 
     const {getByText} = render(
-      withTheme(<TitleBar {...getDefaultProps(callingRepository, conversation)} userState={userState} />),
+      withTheme(<TitleBar {...getDefaultProps(callingRepository, conversation)} selfUser={selfUser} />),
     );
 
     const searchButton = getByText('tooltipConversationSearch');
@@ -128,13 +127,13 @@ describe('TitleBar', () => {
   });
 
   it('opens conversation details on conversation name click', async () => {
-    const userState = createUserState({isActivatedAccount: ko.pureComputed(() => true)});
+    const selfUser = createUser(true);
     const displayName = 'test name';
     const conversation = createConversationEntity({
       display_name: ko.pureComputed(() => displayName),
     });
     const props = getDefaultProps(callingRepository, conversation);
-    const {getByText} = render(withTheme(<TitleBar {...props} userState={userState} />));
+    const {getByText} = render(withTheme(<TitleBar {...props} selfUser={selfUser} />));
 
     const conversationName = getByText(displayName);
     expect(conversationName).toBeDefined();
@@ -144,13 +143,13 @@ describe('TitleBar', () => {
   });
 
   it('opens conversation details on info button click', async () => {
-    const userState = createUserState({isActivatedAccount: ko.pureComputed(() => true)});
+    const selfUser = createUser(true);
     const conversation = createConversationEntity();
     const props = getDefaultProps(callingRepository, conversation);
 
     mockedUiKit.useMatchMedia.mockReturnValue(false);
 
-    const {getByLabelText} = render(withTheme(<TitleBar {...props} userState={userState} />));
+    const {getByLabelText} = render(withTheme(<TitleBar {...props} selfUser={selfUser} />));
 
     const infoButton = getByLabelText('tooltipConversationInfo');
     expect(infoButton).toBeDefined();
@@ -172,11 +171,11 @@ describe('TitleBar', () => {
   });
 
   it("doesn't show legal-hold icon for non legal-hold user", async () => {
-    const userState = createUserState({isActivatedAccount: ko.pureComputed(() => true)});
+    const selfUser = createUser(true);
     const conversation = createConversationEntity({hasLegalHold: ko.pureComputed(() => false)});
 
     const {container} = render(
-      withTheme(<TitleBar {...getDefaultProps(callingRepository, conversation)} userState={userState} />),
+      withTheme(<TitleBar {...getDefaultProps(callingRepository, conversation)} selfUser={selfUser} />),
     );
 
     const legalHoldDotButton = container.querySelector('button[data-uie-name="status-legal-hold-conversation"]');
@@ -184,11 +183,11 @@ describe('TitleBar', () => {
   });
 
   it('shows legal-hold icon for legal-hold user', async () => {
-    const userState = createUserState({isActivatedAccount: ko.pureComputed(() => true)});
+    const selfUser = createUser(true);
     const conversation = createConversationEntity({hasLegalHold: ko.pureComputed(() => true)});
 
     const {container} = render(
-      withTheme(<TitleBar {...getDefaultProps(callingRepository, conversation)} userState={userState} />),
+      withTheme(<TitleBar {...getDefaultProps(callingRepository, conversation)} selfUser={selfUser} />),
     );
 
     const legalHoldDotButton = container.querySelector('button[data-uie-name="status-legal-hold-conversation"]');
@@ -198,13 +197,13 @@ describe('TitleBar', () => {
   it.each([ConversationVerificationState.UNVERIFIED, ConversationVerificationState.DEGRADED])(
     "doesn't show verified icon in not-verified conversation",
     async state => {
-      const userState = createUserState({isActivatedAccount: ko.pureComputed(() => true)});
+      const selfUser = createUser(true);
       const conversation = createConversationEntity({
         verification_state: ko.observable<ConversationVerificationState>(state),
       });
 
       const {container} = render(
-        withTheme(<TitleBar {...getDefaultProps(callingRepository, conversation)} userState={userState} />),
+        withTheme(<TitleBar {...getDefaultProps(callingRepository, conversation)} selfUser={selfUser} />),
       );
 
       const verifiedIcon = container.querySelector('[data-uie-name="conversation-title-bar-verified-icon"]');
@@ -213,13 +212,13 @@ describe('TitleBar', () => {
   );
 
   it('shows verified icon in verified conversation', async () => {
-    const userState = createUserState({isActivatedAccount: ko.pureComputed(() => true)});
+    const selfUser = createUser(true);
     const conversation = createConversationEntity({
       verification_state: ko.observable<ConversationVerificationState>(ConversationVerificationState.VERIFIED),
     });
 
     const {container} = render(
-      withTheme(<TitleBar {...getDefaultProps(callingRepository, conversation)} userState={userState} />),
+      withTheme(<TitleBar {...getDefaultProps(callingRepository, conversation)} selfUser={selfUser} />),
     );
 
     const verifiedIcon = container.querySelector('[data-uie-name="conversation-title-bar-verified-icon"]');
@@ -302,9 +301,10 @@ describe('TitleBar', () => {
   });
 });
 
-function createUserState(user?: Partial<UserState>) {
-  const userState = new UserState();
-  return Object.assign(userState, user) as UserState;
+function createUser(activated: boolean = true) {
+  const user = new User();
+  user.isTemporaryGuest(!activated);
+  return user;
 }
 
 function createTeamState(team?: Partial<TeamState>) {

--- a/src/script/components/TitleBar/TitleBar.tsx
+++ b/src/script/components/TitleBar/TitleBar.tsx
@@ -30,6 +30,7 @@ import {WebAppEvents} from '@wireapp/webapp-events';
 import {useCallAlertState} from 'Components/calling/useCallAlertState';
 import {Icon} from 'Components/Icon';
 import {LegalHoldDot} from 'Components/LegalHoldDot';
+import {User} from 'src/script/entity/User';
 import {useAppMainState, ViewType} from 'src/script/page/state';
 import {ContentState} from 'src/script/page/useAppState';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
@@ -47,7 +48,6 @@ import {PanelState} from '../../page/RightSidebar/RightSidebar';
 import {TeamState} from '../../team/TeamState';
 import {Shortcut} from '../../ui/Shortcut';
 import {ShortcutType} from '../../ui/ShortcutType';
-import {UserState} from '../../user/UserState';
 import {CallActions} from '../../view_model/CallingViewModel';
 import {ViewModelRepositories} from '../../view_model/MainViewModel';
 
@@ -56,7 +56,7 @@ export interface TitleBarProps {
   conversation: Conversation;
   openRightSidebar: (panelState: PanelState, params: RightSidebarParams, compareEntityId?: boolean) => void;
   repositories: ViewModelRepositories;
-  userState: UserState;
+  selfUser: User;
   teamState: TeamState;
   isRightSidebarOpen?: boolean;
   callState?: CallState;
@@ -66,9 +66,9 @@ export const TitleBar: React.FC<TitleBarProps> = ({
   repositories,
   conversation,
   callActions,
+  selfUser,
   openRightSidebar,
   isRightSidebarOpen = false,
-  userState = container.resolve(UserState),
   callState = container.resolve(CallState),
   teamState = container.resolve(TeamState),
 }) => {
@@ -101,7 +101,7 @@ export const TitleBar: React.FC<TitleBarProps> = ({
     'verification_state',
   ]);
 
-  const {isActivatedAccount} = useKoSubscribableChildren(userState, ['isActivatedAccount']);
+  const {isActivatedAccount} = useKoSubscribableChildren(selfUser, ['isActivatedAccount']);
   const {joinedCall, activeCalls} = useKoSubscribableChildren(callState, ['joinedCall', 'activeCalls']);
   const {isVideoCallingEnabled} = useKoSubscribableChildren(teamState, ['isVideoCallingEnabled']);
 

--- a/src/script/components/UserSearchableList.tsx
+++ b/src/script/components/UserSearchableList.tsx
@@ -37,7 +37,6 @@ import {SearchRepository} from '../search/SearchRepository';
 import type {TeamRepository} from '../team/TeamRepository';
 import {TeamState} from '../team/TeamState';
 import {validateHandle} from '../user/UserHandleGenerator';
-import {UserState} from '../user/UserState';
 
 export type UserListProps = React.ComponentProps<typeof UserList> & {
   conversationState?: ConversationState;
@@ -51,7 +50,7 @@ export type UserListProps = React.ComponentProps<typeof UserList> & {
   teamRepository: TeamRepository;
   teamState?: TeamState;
   truncate?: boolean;
-  userState?: UserState;
+  selfUser: User;
   dataUieName?: string;
   /** will prevent showing those users in the list */
   excludeUsers?: QualifiedId[];
@@ -66,16 +65,16 @@ const UserSearchableList: React.FC<UserListProps> = ({
   highlightedUsers,
   selected: selectedUsers,
   allowRemoteSearch,
+  selfUser,
   users,
   ...props
 }) => {
   const {searchRepository, teamRepository, selfFirst, ...userListProps} = props;
-  const {userState = container.resolve(UserState), conversationState = container.resolve(ConversationState)} = props;
+  const {conversationState = container.resolve(ConversationState)} = props;
 
   const [filteredUsers, setFilteredUsers] = useState<User[]>([]);
   const [remoteTeamMembers, setRemoteTeamMembers] = useState<User[]>([]);
 
-  const {self: selfUser} = useKoSubscribableChildren(userState, ['self']);
   const {inTeam: selfInTeam} = useKoSubscribableChildren(selfUser, ['inTeam']);
 
   /**

--- a/src/script/entity/User/User.ts
+++ b/src/script/entity/User/User.ts
@@ -70,6 +70,7 @@ export class User {
   public readonly isExpired: ko.Observable<boolean>;
   public readonly isExternal: ko.PureComputed<boolean>;
   public readonly isGuest: ko.Observable<boolean>;
+  public readonly isActivatedAccount: ko.PureComputed<boolean>;
   /** indicates whether that user entity is available (if we have metadata for the user, it's considered available) */
   public readonly isAvailable: ko.PureComputed<boolean>;
 
@@ -185,6 +186,7 @@ export class User {
       return this.isGuest() && !this.isFederated;
     });
     this.isTemporaryGuest = ko.observable(false);
+    this.isActivatedAccount = ko.pureComputed(() => !this.isTemporaryGuest());
     this.teamRole = ko.observable(TEAM_ROLE.NONE);
     this.teamId = undefined;
 

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -60,6 +60,7 @@ import {ConversationRepository} from '../conversation/ConversationRepository';
 import {ConversationService} from '../conversation/ConversationService';
 import {MessageRepository} from '../conversation/MessageRepository';
 import {CryptographyRepository} from '../cryptography/CryptographyRepository';
+import {User} from '../entity/User';
 import {AccessTokenError} from '../error/AccessTokenError';
 import {AuthError} from '../error/AuthError';
 import {BaseError} from '../error/BaseError';
@@ -418,7 +419,7 @@ export class App {
 
       onProgress(25, t('initReceivedUserData'));
       telemetry.addStatistic(AppInitStatisticsValue.CONVERSATIONS, conversations.length, 50);
-      this._subscribeToUnloadEvents();
+      this._subscribeToUnloadEvents(selfUser);
 
       await conversationRepository.conversationRoleRepository.loadTeamRoles();
 
@@ -467,7 +468,7 @@ export class App {
       amplify.publish(WebAppEvents.LIFECYCLE.LOADED);
 
       telemetry.timeStep(AppInitTimingsStep.UPDATED_CONVERSATIONS);
-      if (userRepository['userState'].isActivatedAccount()) {
+      if (selfUser.isActivatedAccount()) {
         // start regularly polling the server to check if there is a new version of Wire
         startNewVersionPolling(Environment.version(false), this.update);
       }
@@ -611,13 +612,13 @@ export class App {
   /**
    * Subscribe to 'beforeunload' to stop calls and disconnect the WebSocket.
    */
-  private _subscribeToUnloadEvents(): void {
+  private _subscribeToUnloadEvents(selfUser: User): void {
     window.addEventListener('unload', () => {
       this.logger.info("'window.onunload' was triggered, so we will disconnect from the backend.");
       this.repository.event.disconnectWebSocket();
       this.repository.calling.destroy();
 
-      if (this.repository.user['userState'].isActivatedAccount()) {
+      if (selfUser.isActivatedAccount()) {
         if (this.service.storage.isTemporaryAndNonPersistent) {
           this.logout(SIGN_OUT_REASON.CLIENT_REMOVED, true);
         } else {
@@ -772,7 +773,7 @@ export class App {
   redirectToLogin(signOutReason: SIGN_OUT_REASON): void {
     this.logger.info(`Redirecting to login after connectivity verification. Reason: ${signOutReason}`);
     const isTemporaryGuestReason = App.CONFIG.SIGN_OUT_REASONS.TEMPORARY_GUEST.includes(signOutReason);
-    const isLeavingGuestRoom = isTemporaryGuestReason && this.repository.user['userState'].isTemporaryGuest();
+    const isLeavingGuestRoom = isTemporaryGuestReason && this.repository.user['userState'].self()?.isTemporaryGuest();
 
     if (isLeavingGuestRoom) {
       const websiteUrl = getWebsiteUrl();

--- a/src/script/page/AppMain.tsx
+++ b/src/script/page/AppMain.tsx
@@ -88,15 +88,14 @@ const AppMain: FC<AppMainProps> = ({
 
   const {repository: repositories} = app;
 
-  const {accent_id, availability: userAvailability} = useKoSubscribableChildren(selfUser, [
-    'accent_id',
-    'availability',
-  ]);
+  const {
+    accent_id,
+    availability: userAvailability,
+    isActivatedAccount,
+  } = useKoSubscribableChildren(selfUser, ['accent_id', 'availability', 'isActivatedAccount']);
 
   const teamState = container.resolve(TeamState);
   const userState = container.resolve(UserState);
-
-  const {isActivatedAccount} = useKoSubscribableChildren(userState, ['isActivatedAccount']);
 
   const {
     history,
@@ -263,7 +262,7 @@ const AppMain: FC<AppMainProps> = ({
           />
 
           {/*The order of these elements matter to show proper modals stack upon each other*/}
-          <UserModal userRepository={repositories.user} />
+          <UserModal selfUser={selfUser} userRepository={repositories.user} />
           <PrimaryModalComponent />
           <GroupCreationModal userState={userState} teamState={teamState} />
         </ErrorBoundary>

--- a/src/script/page/MainContent/MainContent.tsx
+++ b/src/script/page/MainContent/MainContent.tsx
@@ -78,7 +78,7 @@ const MainContent: FC<MainContentProps> = ({
   const teamState = container.resolve(TeamState);
   const {showRequestModal} = useLegalHoldModalState();
 
-  const {isActivatedAccount} = useKoSubscribableChildren(userState, ['self', 'isActivatedAccount']);
+  const {isActivatedAccount} = useKoSubscribableChildren(selfUser, ['isActivatedAccount']);
 
   const contentState = useAppState(state => state.contentState);
   const isShowingConversation = useAppState(state => state.isShowingConversation);
@@ -216,7 +216,7 @@ const MainContent: FC<MainContentProps> = ({
                 className={cx('preferences-page preferences-options', incomingCssClass)}
                 ref={removeAnimationsClass}
               >
-                <OptionPreferences propertiesRepository={repositories.properties} />
+                <OptionPreferences selfUser={selfUser} propertiesRepository={repositories.properties} />
               </div>
             )}
 

--- a/src/script/page/MainContent/panels/preferences/OptionPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/OptionPreferences.tsx
@@ -22,12 +22,12 @@ import React, {useEffect, useState} from 'react';
 import {AudioPreference, NotificationPreference, WebappProperties} from '@wireapp/api-client/lib/user/data/';
 import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 import {amplify} from 'amplify';
-import {container} from 'tsyringe';
 
 import {Checkbox, CheckboxLabel, IndicatorRangeInput} from '@wireapp/react-ui-kit';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {RadioGroup} from 'Components/Radio';
+import {User} from 'src/script/entity/User';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 
@@ -38,19 +38,15 @@ import {Theme} from '../../../../components/AppContainer/hooks/useTheme';
 import {RootFontSize, useRootFontSize} from '../../../../hooks/useRootFontSize';
 import {PropertiesRepository} from '../../../../properties/PropertiesRepository';
 import {PROPERTIES_TYPE} from '../../../../properties/PropertiesType';
-import {UserState} from '../../../../user/UserState';
 interface OptionPreferencesProps {
   propertiesRepository: PropertiesRepository;
-  userState?: UserState;
+  selfUser: User;
 }
 
 const fontSizes = Object.values(RootFontSize);
 
-const OptionPreferences: React.FC<OptionPreferencesProps> = ({
-  propertiesRepository,
-  userState = container.resolve(UserState),
-}) => {
-  const {isActivatedAccount} = useKoSubscribableChildren(userState, ['self', 'isActivatedAccount']);
+const OptionPreferences: React.FC<OptionPreferencesProps> = ({propertiesRepository, selfUser}) => {
+  const {isActivatedAccount} = useKoSubscribableChildren(selfUser, ['isActivatedAccount']);
   const {
     properties: {settings},
   } = propertiesRepository;

--- a/src/script/page/RightSidebar/AddParticipants/AddParticipants.tsx
+++ b/src/script/page/RightSidebar/AddParticipants/AddParticipants.tsx
@@ -235,6 +235,7 @@ const AddParticipants: FC<AddParticipantsProps> = ({
               teamRepository={teamRepository}
               conversationRepository={conversationRepository}
               excludeUsers={participatingUserIds}
+              selfUser={selfUser}
               isSelectable
               allowRemoteSearch
             />

--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
@@ -155,8 +155,12 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
       'team',
     ]);
 
-    const {self: selfUser, isActivatedAccount} = useKoSubscribableChildren(userState, ['self', 'isActivatedAccount']);
-    const {is_verified: isSelfVerified, teamRole} = useKoSubscribableChildren(selfUser, ['is_verified', 'teamRole']);
+    const {self: selfUser} = useKoSubscribableChildren(userState, ['self']);
+    const {
+      is_verified: isSelfVerified,
+      teamRole,
+      isActivatedAccount,
+    } = useKoSubscribableChildren(selfUser, ['is_verified', 'teamRole', 'isActivatedAccount']);
 
     const isActiveGroupParticipant = isGroup && !removedFromConversation;
 

--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
@@ -377,6 +377,7 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
                       truncate
                       showEmptyAdmin
                       selfFirst={false}
+                      selfUser={selfUser}
                       noSelfInteraction
                     />
 

--- a/src/script/page/RightSidebar/ConversationParticipants/ConversationParticipants.tsx
+++ b/src/script/page/RightSidebar/ConversationParticipants/ConversationParticipants.tsx
@@ -113,6 +113,7 @@ const ConversationParticipants: FC<ConversationParticipantsProps> = ({
             conversationRepository={conversationRepository}
             conversation={activeConversation}
             selfFirst={false}
+            selfUser={selfUser}
             noSelfInteraction
           />
         </FadingScrollbar>

--- a/src/script/page/RightSidebar/GroupParticipantService/GroupParticipantService.tsx
+++ b/src/script/page/RightSidebar/GroupParticipantService/GroupParticipantService.tsx
@@ -34,7 +34,6 @@ import {User} from '../../../entity/User';
 import {IntegrationRepository} from '../../../integration/IntegrationRepository';
 import {ServiceEntity} from '../../../integration/ServiceEntity';
 import {generatePermissionHelpers} from '../../../user/UserPermission';
-import {UserState} from '../../../user/UserState';
 import {ActionsViewModel} from '../../../view_model/ActionsViewModel';
 import {PanelHeader} from '../PanelHeader';
 
@@ -47,7 +46,7 @@ interface GroupParticipantServiceProps {
   onClose: () => void;
   serviceEntity: ServiceEntity;
   userEntity: User;
-  userState: UserState;
+  selfUser: User;
   isAddMode?: boolean;
 }
 
@@ -60,7 +59,7 @@ const GroupParticipantService: FC<GroupParticipantServiceProps> = ({
   onClose,
   serviceEntity,
   userEntity,
-  userState,
+  selfUser,
   isAddMode = false,
 }) => {
   const {
@@ -68,7 +67,6 @@ const GroupParticipantService: FC<GroupParticipantServiceProps> = ({
     isActiveParticipant,
     participating_user_ids: participatingUserIds,
   } = useKoSubscribableChildren(activeConversation, ['inTeam', 'isActiveParticipant', 'participating_user_ids']);
-  const {self: selfUser} = useKoSubscribableChildren(userState, ['self']);
   const {teamRole} = useKoSubscribableChildren(selfUser, ['teamRole']);
 
   const {canChatWithServices, canUpdateGroupParticipants} = generatePermissionHelpers(teamRole);

--- a/src/script/page/RightSidebar/GroupParticipantUser/GroupParticipantUser.tsx
+++ b/src/script/page/RightSidebar/GroupParticipantUser/GroupParticipantUser.tsx
@@ -83,8 +83,11 @@ const GroupParticipantUser: FC<GroupParticipantUserProps> = ({
     'isTeam',
     'team',
   ]);
-  const {isActivatedAccount, self: selfUser} = useKoSubscribableChildren(userState, ['isActivatedAccount', 'self']);
-  const {is_verified: isSelfVerified} = useKoSubscribableChildren(selfUser, ['is_verified']);
+  const {self: selfUser} = useKoSubscribableChildren(userState, ['self']);
+  const {is_verified: isSelfVerified, isActivatedAccount} = useKoSubscribableChildren(selfUser, [
+    'is_verified',
+    'isActivatedAccount',
+  ]);
 
   const canChangeRole =
     conversationRoleRepository.canChangeParticipantRoles(activeConversation) && !currentUser.isMe && !isTemporaryGuest;

--- a/src/script/page/RightSidebar/GroupParticipantUser/GroupParticipantUser.tsx
+++ b/src/script/page/RightSidebar/GroupParticipantUser/GroupParticipantUser.tsx
@@ -42,7 +42,6 @@ import {User} from '../../../entity/User';
 import {ClientEvent} from '../../../event/Client';
 import {TeamRepository} from '../../../team/TeamRepository';
 import {TeamState} from '../../../team/TeamState';
-import {UserState} from '../../../user/UserState';
 import {ActionsViewModel} from '../../../view_model/ActionsViewModel';
 import {PanelHeader} from '../PanelHeader';
 import {PanelEntity} from '../RightSidebar';
@@ -58,7 +57,7 @@ interface GroupParticipantUserProps {
   conversationRoleRepository: ConversationRoleRepository;
   teamRepository: TeamRepository;
   teamState: TeamState;
-  userState: UserState;
+  selfUser: User;
   isFederated?: boolean;
 }
 
@@ -73,7 +72,7 @@ const GroupParticipantUser: FC<GroupParticipantUserProps> = ({
   conversationRoleRepository,
   teamRepository,
   teamState,
-  userState,
+  selfUser,
   isFederated = false,
 }) => {
   const {isGroup, roles} = useKoSubscribableChildren(activeConversation, ['isGroup', 'roles']);
@@ -83,7 +82,6 @@ const GroupParticipantUser: FC<GroupParticipantUserProps> = ({
     'isTeam',
     'team',
   ]);
-  const {self: selfUser} = useKoSubscribableChildren(userState, ['self']);
   const {is_verified: isSelfVerified, isActivatedAccount} = useKoSubscribableChildren(selfUser, [
     'is_verified',
     'isActivatedAccount',

--- a/src/script/page/RightSidebar/MessageDetails/MessageDetails.test.tsx
+++ b/src/script/page/RightSidebar/MessageDetails/MessageDetails.test.tsx
@@ -90,6 +90,7 @@ describe('MessageDetails', () => {
     const {getByText} = render(
       <MessageDetails
         {...defaultProps}
+        selfUser={new User()}
         togglePanel={() => undefined}
         activeConversation={conversation}
         messageEntity={message}

--- a/src/script/page/RightSidebar/MessageDetails/MessageDetails.tsx
+++ b/src/script/page/RightSidebar/MessageDetails/MessageDetails.tsx
@@ -93,6 +93,7 @@ interface MessageDetailsProps {
   searchRepository: SearchRepository;
   userRepository: UserRepository;
   showReactions?: boolean;
+  selfUser: User;
   updateEntity: (message: Message) => void;
   togglePanel: (state: PanelState, entity: PanelEntity, addMode?: boolean) => void;
 }
@@ -105,6 +106,7 @@ const MessageDetails: FC<MessageDetailsProps> = ({
   searchRepository,
   showReactions = false,
   userRepository,
+  selfUser,
   onClose,
   updateEntity,
   togglePanel,
@@ -262,6 +264,7 @@ const MessageDetails: FC<MessageDetailsProps> = ({
         {messageState === MESSAGE_STATES.RECEIPTS && (
           <UserSearchableList
             dataUieName="read-list"
+            selfUser={selfUser}
             users={receiptUsers}
             infos={receiptTimes}
             noUnderline
@@ -288,6 +291,7 @@ const MessageDetails: FC<MessageDetailsProps> = ({
                   <span css={reactionsCountAlignment}>({emojiCount})</span>
                 </div>
                 <UserSearchableList
+                  selfUser={selfUser}
                   key={reactionKey}
                   dataUieName="reaction-list"
                   users={users}

--- a/src/script/page/RightSidebar/RightSidebar.tsx
+++ b/src/script/page/RightSidebar/RightSidebar.tsx
@@ -108,6 +108,7 @@ const RightSidebar: FC<RightSidebarProps> = ({
   const {conversationRoleRepository} = conversationRepository;
   const conversationState = container.resolve(ConversationState);
   const {activeConversation} = useKoSubscribableChildren(conversationState, ['activeConversation']);
+  const {self: selfUser} = useKoSubscribableChildren(userState, ['self']);
 
   const [isAddMode, setIsAddMode] = useState<boolean>(false);
   const [animatePanelToLeft, setAnimatePanelToLeft] = useState<boolean>(true);
@@ -223,7 +224,7 @@ const RightSidebar: FC<RightSidebarProps> = ({
               conversationRoleRepository={conversationRoleRepository}
               teamRepository={teamRepository}
               teamState={teamState}
-              userState={userState}
+              selfUser={selfUser}
               isFederated={isFederated}
             />
           )}
@@ -278,7 +279,7 @@ const RightSidebar: FC<RightSidebarProps> = ({
               onClose={closePanel}
               serviceEntity={serviceEntity}
               userEntity={userServiceEntity}
-              userState={userState}
+              selfUser={selfUser}
               isAddMode={isAddMode}
             />
           )}
@@ -301,6 +302,7 @@ const RightSidebar: FC<RightSidebarProps> = ({
           {currentState === PanelState.MESSAGE_DETAILS && messageEntity && (
             <MessageDetails
               activeConversation={activeConversation}
+              selfUser={selfUser}
               conversationRepository={conversationRepository}
               messageEntity={messageEntity}
               updateEntity={rightSidebar.updateEntity}

--- a/src/script/user/UserState.ts
+++ b/src/script/user/UserState.ts
@@ -36,8 +36,6 @@ export class UserState {
   /** Note: this does not include the self user */
   public teamUsers: ko.PureComputed<User[]>;
   public readonly connectRequests: ko.PureComputed<User[]>;
-  public readonly isActivatedAccount: ko.PureComputed<boolean>;
-  public readonly isTemporaryGuest: ko.PureComputed<boolean>;
   public readonly numberOfContacts: ko.PureComputed<number>;
   public readonly self = ko.observable<User | undefined>();
 
@@ -55,9 +53,6 @@ export class UserState {
           .sort(sortUsersByPriority);
       })
       .extend({rateLimit: TIME_IN_MILLIS.SECOND});
-
-    this.isActivatedAccount = ko.pureComputed(() => !this.self()?.isTemporaryGuest());
-    this.isTemporaryGuest = ko.pureComputed(() => this.self()?.isTemporaryGuest());
 
     this.isTeam = ko.observable();
     this.teamMembers = ko.pureComputed((): User[] => []);

--- a/src/script/view_model/ListViewModel.ts
+++ b/src/script/view_model/ListViewModel.ts
@@ -96,9 +96,9 @@ export class ListViewModel {
     this.contentViewModel = mainViewModel.content;
     this.callingViewModel = mainViewModel.calling;
 
-    this.isActivatedAccount = this.userState.isActivatedAccount;
     this.isProAccount = this.teamState.isTeam;
     this.selfUser = this.userState.self;
+    this.isActivatedAccount = this.selfUser().isActivatedAccount;
 
     // State
     this.lastUpdate = ko.observable();

--- a/src/script/view_model/ListViewModel.ts
+++ b/src/script/view_model/ListViewModel.ts
@@ -98,7 +98,7 @@ export class ListViewModel {
 
     this.isProAccount = this.teamState.isTeam;
     this.selfUser = this.userState.self;
-    this.isActivatedAccount = this.selfUser().isActivatedAccount;
+    this.isActivatedAccount = ko.pureComputed(() => this.selfUser()?.isActivatedAccount());
 
     // State
     this.lastUpdate = ko.observable();


### PR DESCRIPTION
## Description
This will remove the tight coupling that we have between the components and the `UserState`. The `selfUser` needs to be explicitely injected into the components that need it

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

