### PR TITLE
fix: Use fully qualified conversation for lastRead message [WPB-4662]

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@datadog/browser-rum": "^4.48.2",
     "@emotion/react": "11.11.1",
     "@wireapp/avs": "9.3.7",
-    "@wireapp/core": "42.3.0",
+    "@wireapp/core": "42.3.1",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.9.5",
     "@wireapp/store-engine-dexie": "2.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5412,9 +5412,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:42.3.0":
-  version: 42.3.0
-  resolution: "@wireapp/core@npm:42.3.0"
+"@wireapp/core@npm:42.3.1":
+  version: 42.3.1
+  resolution: "@wireapp/core@npm:42.3.1"
   dependencies:
     "@wireapp/api-client": ^26.0.4
     "@wireapp/commons": ^5.1.3
@@ -5433,7 +5433,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.13
-  checksum: 32b878779aead05fe5743a2bc1a8e8f48ff8f3066b7be99b6c34d0440cac0ee441c4f4e429bc5d64f606068e96eeea78cb3bc87373cbc3bff80b75344613f3b0
+  checksum: b17cf5b2f203491c41c248f6dd2385fb83283cd8a64cd3e4cf1e4894ea9f021ad970f359cb15cfa51f33fbf317794cdbe9c131698052a893c4b6beb5ffbb0754
   languageName: node
   linkType: hard
 
@@ -18512,7 +18512,7 @@ __metadata:
     "@types/webpack-env": 1.18.1
     "@wireapp/avs": 9.3.7
     "@wireapp/copy-config": 2.1.7
-    "@wireapp/core": 42.3.0
+    "@wireapp/core": 42.3.1
     "@wireapp/eslint-config": 3.0.4
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.6.3


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4662" title="WPB-4662" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4662</a>  LastRead event has different conversationId domain than conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

This will make sure the conversationID sent along with the `lastRead` message is fully qualified
see https://github.com/wireapp/wire-web-packages/pull/5494

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

