### PR TITLE
fix: reaction tooltip user count click closes right panel if clicked on another message tooltip user count

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -260,7 +260,7 @@ export const Conversation: FC<ConversationProps> = ({
   };
 
   const showMessageReactions = (message: Message, showReactions = true) => {
-    openRightSidebar(PanelState.MESSAGE_DETAILS, {entity: message, showReactions});
+    openRightSidebar(PanelState.MESSAGE_DETAILS, {entity: message, showReactions}, true);
   };
 
   const handleEmailClick = (event: Event, messageDetails: MessageDetails) => {


### PR DESCRIPTION
## Desc
<img width="301" alt="Screenshot 2023-09-13 at 09 46 49" src="https://github.com/wireapp/wire-webapp/assets/28754444/dfb4f539-e2ec-48e0-84d1-180400fa7e72">
<img width="307" alt="Screenshot 2023-09-13 at 09 46 58" src="https://github.com/wireapp/wire-webapp/assets/28754444/7e385027-60be-43e0-800c-85dab169248a">



## Checklist

- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers
Related to [PR](https://github.com/wireapp/wire-webapp/pull/15539/files)