### PR TITLE
fix: Correctly display username not available on connection requests [WPB-4499]

### DIFF
--- a/src/script/components/Avatar/UserAvatar.tsx
+++ b/src/script/components/Avatar/UserAvatar.tsx
@@ -21,6 +21,7 @@ import React, {MouseEvent as ReactMouseEvent, KeyboardEvent as ReactKeyBoardEven
 
 import {COLOR} from '@wireapp/react-ui-kit';
 
+import {useUserName} from 'Components/UserName';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 
@@ -67,17 +68,16 @@ const UserAvatar: React.FunctionComponent<UserAvatarProps> = ({
 }) => {
   const isImageGrey = !noFilter && [STATE.BLOCKED, STATE.IGNORED, STATE.PENDING, STATE.UNKNOWN].includes(state);
   const backgroundColor = state === STATE.UNKNOWN ? COLOR.GRAY : undefined;
+  const name = useUserName(participant);
   const {
     mediumPictureResource,
     previewPictureResource,
     accent_color: accentColor,
-    name,
     initials,
   } = useKoSubscribableChildren(participant, [
     'mediumPictureResource',
     'previewPictureResource',
     'accent_color',
-    'name',
     'initials',
   ]);
   const avatarImgAlt = avatarAlt ? avatarAlt : `${t('userProfileImageAlt')} ${name}`;

--- a/src/script/components/ConnectRequests/ConnectionRequests.tsx
+++ b/src/script/components/ConnectRequests/ConnectionRequests.tsx
@@ -26,6 +26,7 @@ import {Button, ButtonVariant, IconButton, IconButtonVariant, useMatchMedia} fro
 import {Avatar, AVATAR_SIZE} from 'Components/Avatar';
 import {UserClassifiedBar} from 'Components/input/ClassifiedBar';
 import {UnverifiedUserWarning} from 'Components/Modals/UserModal';
+import {UserName} from 'Components/UserName';
 import {useAppMainState, ViewType} from 'src/script/page/state';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
@@ -38,11 +39,13 @@ import {UserState} from '../../user/UserState';
 interface ConnectRequestsProps {
   readonly userState: UserState;
   readonly teamState: TeamState;
+  readonly selfUser: User;
 }
 
 export const ConnectRequests: FC<ConnectRequestsProps> = ({
   userState = container.resolve(UserState),
   teamState = container.resolve(TeamState),
+  selfUser,
 }) => {
   const connectRequestsRefEnd = useRef<HTMLDivElement | null>(null);
   const temporaryConnectRequestsCount = useRef<number>(0);
@@ -121,12 +124,14 @@ export const ConnectRequests: FC<ConnectRequestsProps> = ({
               data-uie-uid={connectRequest.id}
               data-uie-name="connect-request"
             >
-              <div className="connect-request-name ellipsis">{connectRequest.name()}</div>
+              <div className="connect-request-name ellipsis">
+                <UserName user={connectRequest} />
+              </div>
 
               <div className="connect-request-username label-username">{connectRequest.handle}</div>
 
               {classifiedDomains && (
-                <UserClassifiedBar users={[userState.self(), connectRequest]} classifiedDomains={classifiedDomains} />
+                <UserClassifiedBar users={[selfUser, connectRequest]} classifiedDomains={classifiedDomains} />
               )}
 
               <Avatar

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageHeader.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageHeader.tsx
@@ -19,6 +19,7 @@
 
 import {AVATAR_SIZE, Avatar} from 'Components/Avatar';
 import {Icon} from 'Components/Icon';
+import {UserName} from 'Components/UserName';
 import {ContentMessage} from 'src/script/entity/message/ContentMessage';
 import {DeleteMessage} from 'src/script/entity/message/DeleteMessage';
 import {User} from 'src/script/entity/User';
@@ -90,7 +91,7 @@ export function MessageHeader({
   children,
 }: MessageHeaderParams) {
   const {user: sender} = useKoSubscribableChildren(message, ['user']);
-  const {name: senderName, isAvailable} = useKoSubscribableChildren(sender, ['name', 'isAvailable']);
+  const {isAvailable} = useKoSubscribableChildren(sender, ['isAvailable']);
 
   return (
     <div className="message-header">
@@ -110,7 +111,7 @@ export function MessageHeader({
           data-uie-name={uieName ? `${uieName}-sender-name` : 'sender-name'}
           data-uie-uid={sender.id}
         >
-          {!isAvailable ? t('unavailableUser') : senderName}
+          <UserName user={sender} />
         </h4>
 
         {!noBadges && <BadgeSection sender={sender} />}

--- a/src/script/components/UserList/components/UserListItem/UserListItem.tsx
+++ b/src/script/components/UserList/components/UserListItem/UserListItem.tsx
@@ -28,6 +28,7 @@ import {ParticipantItemContent} from 'Components/ParticipantItemContent';
 import {listItem, listWrapper} from 'Components/ParticipantItemContent/ParticipantItem.styles';
 import {UserStatusBadges} from 'Components/UserBadges';
 import {UserlistMode} from 'Components/UserList';
+import {useUserName} from 'Components/UserName';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 import {capitalizeFirstChar} from 'Util/StringUtil';
@@ -75,7 +76,6 @@ const UserListItem = ({
     isDirectGuest,
     availability,
     expirationText,
-    name,
   } = useKoSubscribableChildren(user, ['isDirectGuest', 'is_verified', 'availability', 'expirationText', 'name']);
 
   const {isMe: isSelf, isFederated} = user;
@@ -87,7 +87,7 @@ const UserListItem = ({
 
   const selfString = `(${capitalizeFirstChar(t('conversationYouNominative'))})`;
 
-  const userName = isAvailable ? name : t('unavailableUser');
+  const userName = useUserName(user);
 
   const getContentInfoText = () => {
     if (customInfo) {

--- a/src/script/components/UserName.tsx
+++ b/src/script/components/UserName.tsx
@@ -1,0 +1,43 @@
+/*
+ * Wire
+ * Copyright (C) 2021 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {useKoSubscribableChildren} from 'Util/ComponentUtil';
+import {t} from 'Util/LocalizerUtil';
+
+import {User} from '../entity/User';
+
+interface UserNameProps {
+  user: User;
+}
+
+/**
+ * will return the name of the user, if available, otherwise a string indicating that the user is unavailable
+ * @param user the user to get the name for
+ */
+export function useUserName(user: User) {
+  const {isAvailable, name} = useKoSubscribableChildren(user, ['isAvailable', 'name']);
+  return isAvailable ? name : t('unavailableUser');
+}
+
+/**
+ * component that will display the username, if available, otherwise a string indicating that the user is unavailable
+ */
+export function UserName({user}: UserNameProps) {
+  return useUserName(user);
+}

--- a/src/script/components/panel/UserDetails.tsx
+++ b/src/script/components/panel/UserDetails.tsx
@@ -90,7 +90,7 @@ export const UserDetailsComponent: React.FC<UserDetailsProps> = ({
             data-uie-name="status-name"
             css={user.isAvailable ? undefined : {color: 'var(--gray-70)'}}
           >
-            <UserName user={user} />
+            <UserName user={participant} />
           </h2>
         )}
 

--- a/src/script/components/panel/UserDetails.tsx
+++ b/src/script/components/panel/UserDetails.tsx
@@ -29,6 +29,7 @@ import {Avatar, AVATAR_SIZE} from 'Components/Avatar';
 import {ErrorFallback} from 'Components/ErrorFallback';
 import {Icon} from 'Components/Icon';
 import {UserClassifiedBar} from 'Components/input/ClassifiedBar';
+import {UserName} from 'Components/UserName';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 
@@ -89,7 +90,7 @@ export const UserDetailsComponent: React.FC<UserDetailsProps> = ({
             data-uie-name="status-name"
             css={user.isAvailable ? undefined : {color: 'var(--gray-70)'}}
           >
-            {user.isAvailable ? user.name : t('unavailableUser')}
+            <UserName user={user} />
           </h2>
         )}
 

--- a/src/script/page/MainContent/MainContent.tsx
+++ b/src/script/page/MainContent/MainContent.tsx
@@ -229,7 +229,7 @@ const MainContent: FC<MainContentProps> = ({
             )}
 
             {contentState === ContentState.CONNECTION_REQUESTS && (
-              <ConnectRequests teamState={teamState} userState={userState} />
+              <ConnectRequests teamState={teamState} selfUser={selfUser} userState={userState} />
             )}
 
             {contentState === ContentState.CONVERSATION && (


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4499" title="WPB-4499" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4499</a>  Connection request to user with no name
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

Will make sure we display `Name not available` everywhere we try to display a username.

## Screenshots/Screencast (for UI changes)

### After
![image](https://github.com/wireapp/wire-webapp/assets/1090716/25a97c1c-e8b7-497a-8dd2-7b5476bbfbfd)

### Before
![image](https://github.com/wireapp/wire-webapp/assets/1090716/86dd6224-0cc4-4fea-8f28-f754daf5e004)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
