### PR TITLE
fix: Do not show conversation domain on conversation join on Wire public instances

### DIFF
--- a/src/script/auth/page/ConversationJoin.tsx
+++ b/src/script/auth/page/ConversationJoin.tsx
@@ -78,6 +78,7 @@ const ConversationJoinComponent = ({
   const [showCookiePolicyBanner, setShowCookiePolicyBanner] = useState(true);
   const [showEntropyForm, setShowEntropyForm] = useState(false);
   const isEntropyRequired = Config.getConfig().FEATURE.ENABLE_EXTRA_CLIENT_ENTROPY;
+  const isWirePublicInstance = Config.getConfig().BRAND_NAME === 'Wire';
 
   useEffect(() => {
     const localConversationCode = UrlUtil.getURLParameter(QUERY_KEY.CONVERSATION_CODE);
@@ -218,9 +219,11 @@ const ConversationJoinComponent = ({
           <H1 style={{fontWeight: 500, marginTop: '0', marginBottom: '1rem'}} data-uie-name="status-join-headline">
             {_(conversationJoinStrings.mainHeadline)}
           </H1>
-          <Muted data-uie-name="status-join-subhead">
-            {_(conversationJoinStrings.headline, {domain: window.location.hostname})}
-          </Muted>
+          {!isWirePublicInstance && (
+            <Muted data-uie-name="status-join-subhead">
+              {_(conversationJoinStrings.headline, {domain: window.location.hostname})}
+            </Muted>
+          )}
         </div>
         <Columns style={{display: 'flex', gap: '2rem', alignSelf: 'center', maxWidth: '100%'}}>
           <Column>


### PR DESCRIPTION

## Description

This will make sure that this string is not diplayed on wire public instance. (only self hosted instances will display it). 

## Screenshots/Screencast (for UI changes)

![image](https://github.com/wireapp/wire-webapp/assets/1090716/7f6e1f7a-b344-47fd-980a-d2c1d64afba8)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

### Important details for the reviewers

Note that we currently have no way of detecting a public instance from other instance. The quickfix of checking if `BRAND_NAME === 'Wire'` does the job for now. We can think of a better solution later on if need be. 
