### PR TITLE
fix: Force user refresh when display user modal [WPB-3069]

### DIFF
--- a/src/script/components/Modals/UserModal/UserModal.test.tsx
+++ b/src/script/components/Modals/UserModal/UserModal.test.tsx
@@ -31,7 +31,7 @@ import {showUserModal} from './UserModal.state';
 describe('UserModal', () => {
   it('correctly fetches user from user repository', async () => {
     jest.useFakeTimers();
-    const getUserById = jest.fn(async (id: QualifiedId) => {
+    const refreshUser = jest.fn(async (id: QualifiedId) => {
       return new User('mock-id', 'test-domain.mock');
     });
 
@@ -39,7 +39,7 @@ describe('UserModal', () => {
       core: {} as Core,
       teamState: {} as TeamState,
       userRepository: {
-        getUserById,
+        refreshUser,
       } as unknown as UserRepository,
       selfUser: new User(),
     };
@@ -47,12 +47,12 @@ describe('UserModal', () => {
     const {getByTestId} = render(<UserModal {...props} />);
     await waitFor(() => getByTestId('do-close'));
 
-    expect(getUserById).toHaveBeenCalledTimes(1);
+    expect(refreshUser).toHaveBeenCalledTimes(1);
   });
 
   it('shows user not found when user is deleted', async () => {
     jest.useFakeTimers();
-    const getUserById = jest.fn(async (id: QualifiedId) => {
+    const refreshUser = jest.fn(async (id: QualifiedId) => {
       const user = new User('mock-id', 'test-domain.mock');
       user.isDeleted = true;
       return user;
@@ -62,7 +62,7 @@ describe('UserModal', () => {
       core: {} as Core,
       teamState: {} as TeamState,
       userRepository: {
-        getUserById,
+        refreshUser,
       } as unknown as UserRepository,
       selfUser: new User(),
     };
@@ -71,7 +71,7 @@ describe('UserModal', () => {
 
     const {getByTestId} = render(<UserModal {...props} />);
 
-    expect(getUserById).toHaveBeenCalledTimes(1);
+    expect(refreshUser).toHaveBeenCalledTimes(1);
 
     await waitFor(() => {
       expect(getByTestId('status-modal-text')).toBeInstanceOf(HTMLDivElement);

--- a/src/script/components/Modals/UserModal/UserModal.tsx
+++ b/src/script/components/Modals/UserModal/UserModal.tsx
@@ -155,7 +155,7 @@ const UserModal: React.FC<UserModalProps> = ({
   useEffect(() => {
     if (userId) {
       userRepository
-        .getUserById(userId)
+        .refreshUser(userId)
         .then(user => {
           if (user.isDeleted || !user.isAvailable()) {
             setUserNotFound(true);

--- a/src/script/components/Modals/UserModal/UserModal.tsx
+++ b/src/script/components/Modals/UserModal/UserModal.tsx
@@ -155,6 +155,7 @@ const UserModal: React.FC<UserModalProps> = ({
   useEffect(() => {
     if (userId) {
       userRepository
+        // We want to get the fresh version of the user from backend (in case the user was deleted)
         .refreshUser(userId)
         .then(user => {
           if (user.isDeleted || !user.isAvailable()) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3069" title="WPB-3069" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3069</a>  [Web] 'default' user profile link pops up if you open profile of a deleted user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

Make sure we have a fresh server version of the user when displaying the user modal. 
This will ensure that if the user is deleted we will get the info when displaying the modal

## Screenshots/Screencast (for UI changes)

### Before
![image](https://github.com/wireapp/wire-webapp/assets/1090716/62e0ee4d-d9cf-470c-a7a0-2cba37f93794)

### After
![image](https://github.com/wireapp/wire-webapp/assets/1090716/2db6df66-d49c-4aae-b6a9-71655550e825)


## Checklist

- [X] PR has been self reviewed by the author;
- [X] Hard-to-understand areas of the code have been commented;
- [X] If it is a core feature, unit tests have been added;

