### PR TITLE
fix: reset the eventKey to stop focusing on every new message user send/receive after opening a conversation using enter key

### DIFF
--- a/src/script/components/MessagesList/Message/index.tsx
+++ b/src/script/components/MessagesList/Message/index.tsx
@@ -152,6 +152,11 @@ const Message: React.FC<
     }
     if (history.state?.eventKey === 'Enter') {
       handleFocus(totalMessage - 1);
+
+      // reset the eventKey to stop focusing on every new message user send/receive afterwards
+      // last message should be focused only when user enters a new conversation using keyboard(press enter)
+      history.state.eventKey = '';
+      window.history.replaceState(history.state, '', window.location.hash);
     }
   }, [totalMessage]);
 
@@ -160,7 +165,7 @@ const Message: React.FC<
     if (isMessageFocused) {
       messageRef.current?.focus();
     }
-  }, [isMessageFocused, message]);
+  }, [isMessageFocused]);
 
   // set message elements focus for non content type mesages
   // some non content type message has interactive element like invite people for member message


### PR DESCRIPTION
## Description
Reset the eventKey to stop focusing on every new message user send/receive after opening a conversation using enter key

## Screenshots/Screencast (for UI changes)

### **BEFORE**

**New conversation opened using keyboard so last message got focused**

<img width="1194" alt="Screenshot 2023-09-14 at 09 52 00" src="https://github.com/wireapp/wire-webapp/assets/28754444/6dfd6ec7-f88c-4063-bf69-57036e3ba741">

**User send/receive new message and the focus shifts to that message**

<img width="1189" alt="Screenshot 2023-09-14 at 09 58 44" src="https://github.com/wireapp/wire-webapp/assets/28754444/f2e96790-1847-4c99-907b-07f7b20de18a">

### **AFTER**

**User send/receive new message and the focus doesn't shifts to that message**

<img width="1192" alt="Screenshot 2023-09-14 at 10 00 45" src="https://github.com/wireapp/wire-webapp/assets/28754444/48d161e0-bb1c-4a63-88ed-8a5f1a595d1b">




## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;