### PR TITLE
fix: Do not show failed messages as delivered

### DIFF
--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -1215,12 +1215,12 @@ export class MessageRepository {
   private async updateMessageAsFailed(conversationEntity: Conversation, eventId: string, error: unknown) {
     try {
       const messageEntity = await this.getMessageInConversationById(conversationEntity, eventId);
-      if (isBackendError(error) && error.label === BackendErrorLabel.FEDERATION_REMOTE_ERROR) {
-        messageEntity.status(StatusType.FEDERATION_ERROR);
-        return this.eventService.updateEvent(messageEntity.primary_key, {status: StatusType.FEDERATION_ERROR});
-      }
-      messageEntity.status(StatusType.FAILED);
-      return this.eventService.updateEvent(messageEntity.primary_key, {status: StatusType.FAILED});
+      const errorStatus =
+        isBackendError(error) && error.label === BackendErrorLabel.FEDERATION_REMOTE_ERROR
+          ? StatusType.FEDERATION_ERROR
+          : StatusType.FAILED;
+      messageEntity.status(errorStatus);
+      return this.eventService.updateEvent(messageEntity.primary_key, {status: errorStatus});
     } catch (error) {
       if ((error as any).type !== ConversationError.TYPE.MESSAGE_NOT_FOUND) {
         throw error;

--- a/src/script/entity/Conversation.test.ts
+++ b/src/script/entity/Conversation.test.ts
@@ -298,7 +298,7 @@ describe('Conversation', () => {
 
   describe('getLastDeliveredMessage', () => {
     it('returns undefined if conversation has no messages', () => {
-      expect(conversation_et.getLastDeliveredMessage()).not.toBeDefined();
+      expect(conversation_et.lastDeliveredMessage()).not.toBeDefined();
     });
 
     it('returns last delivered message', () => {
@@ -311,35 +311,35 @@ describe('Conversation', () => {
       sentMessageEntity.status(StatusType.SENT);
       conversation_et.addMessage(sentMessageEntity);
 
-      expect(conversation_et.getLastDeliveredMessage()).not.toBeDefined();
+      expect(conversation_et.lastDeliveredMessage()).not.toBeDefined();
 
       const deliveredMessageEntity = new ContentMessage(createUuid());
       deliveredMessageEntity.user(selfUserEntity);
       deliveredMessageEntity.status(StatusType.DELIVERED);
       conversation_et.addMessage(deliveredMessageEntity);
 
-      expect(conversation_et.getLastDeliveredMessage()).toBe(deliveredMessageEntity);
+      expect(conversation_et.lastDeliveredMessage()).toBe(deliveredMessageEntity);
 
       const nextSentMessageEntity = new ContentMessage(createUuid());
       nextSentMessageEntity.user(selfUserEntity);
       nextSentMessageEntity.status(StatusType.SENT);
       conversation_et.addMessage(nextSentMessageEntity);
 
-      expect(conversation_et.getLastDeliveredMessage()).toBe(deliveredMessageEntity);
+      expect(conversation_et.lastDeliveredMessage()).toBe(deliveredMessageEntity);
 
       const nextDeliveredMessageEntity = new ContentMessage(createUuid());
       nextDeliveredMessageEntity.user(selfUserEntity);
       nextDeliveredMessageEntity.status(StatusType.DELIVERED);
       conversation_et.addMessage(nextDeliveredMessageEntity);
 
-      expect(conversation_et.getLastDeliveredMessage()).toBe(nextDeliveredMessageEntity);
+      expect(conversation_et.lastDeliveredMessage()).toBe(nextDeliveredMessageEntity);
 
       const remoteMessageEntity = new ContentMessage(createUuid());
       remoteMessageEntity.user(remoteUserEntity);
       remoteMessageEntity.status(StatusType.DELIVERED);
       conversation_et.addMessage(remoteMessageEntity);
 
-      expect(conversation_et.getLastDeliveredMessage()).toBe(nextDeliveredMessageEntity);
+      expect(conversation_et.lastDeliveredMessage()).toBe(nextDeliveredMessageEntity);
     });
   });
 

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -964,12 +964,12 @@ export class Conversation {
   /**
    * Get the last delivered message.
    */
-  getLastDeliveredMessage(): Message | undefined {
+  private getLastDeliveredMessage(): Message | undefined {
     return this.messages()
       .slice()
       .reverse()
       .find(messageEntity => {
-        const isDelivered = messageEntity.status() >= StatusType.DELIVERED;
+        const isDelivered = [StatusType.DELIVERED, StatusType.SEEN].includes(messageEntity.status());
         return isDelivered && messageEntity.user().isMe;
       });
   }

--- a/src/script/event/preprocessor/ReceiptsMiddleware.ts
+++ b/src/script/event/preprocessor/ReceiptsMiddleware.ts
@@ -77,7 +77,7 @@ export class ReceiptsMiddleware {
     }
   }
 
-  isMyMessage(originalEvent: EventRecord): boolean {
+  private isMyMessage(originalEvent: EventRecord): boolean {
     return this.userState.self() && this.userState.self().id === originalEvent.from;
   }
 


### PR DESCRIPTION
## Description

We used to have a check that was to permissive to know if a message is delivered. 
Now that we have errors in the `StatusType` enum that have a value higher than `StatusType.DELIVERED` we need to be explicit about the status that could be considered `delivered`. 

## Screenshots/Screencast (for UI changes)

### Before 
![image](https://github.com/wireapp/wire-webapp/assets/1090716/d8c4b6a3-786e-4de3-b731-a951e6764528)

### After
![image](https://github.com/wireapp/wire-webapp/assets/1090716/eaa12182-68c6-431f-bbcc-8f2b9336b833)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;


