### PR TITLE
fix: Enable api version 4

### DIFF
--- a/src/script/Config.ts
+++ b/src/script/Config.ts
@@ -76,7 +76,7 @@ const config = {
   ALLOWED_IMAGE_TYPES: ['image/bmp', 'image/gif', 'image/jpeg', 'image/jpg', 'image/png'],
 
   /** Which min and max version of the backend api do we support */
-  SUPPORTED_API_RANGE: [1, env.ENABLE_DEV_BACKEND_API ? Infinity : 3],
+  SUPPORTED_API_RANGE: [1, env.ENABLE_DEV_BACKEND_API ? Infinity : 4],
 
   /** DataDog client api keys acces */
   dataDog: {


### PR DESCRIPTION
## Description

Now that api v4 is officially supported, we should use this one when not using dev api version
