### PR TITLE
test: do not mock user globally in testfactory

### DIFF
--- a/src/script/client/ClientRepository.test.ts
+++ b/src/script/client/ClientRepository.test.ts
@@ -37,6 +37,15 @@ describe('ClientRepository', () => {
 
   beforeAll(async () => {
     await testFactory.exposeClientActors();
+
+    const user = new User(entities.user.john_doe.id, null);
+    user.email(entities.user.john_doe.email);
+    user.isMe = true;
+    user.locale = entities.user.john_doe.locale;
+    user.name(entities.user.john_doe.name);
+    user.phone(entities.user.john_doe.phone);
+
+    testFactory.client_repository?.init(user);
     userId = testFactory.client_repository.selfUser().id;
   });
 

--- a/test/helper/TestFactory.js
+++ b/test/helper/TestFactory.js
@@ -108,16 +108,8 @@ export class TestFactory {
   async exposeClientActors() {
     await this.exposeCryptographyActors();
 
-    const user = new User(entities.user.john_doe.id, null);
-    user.email(entities.user.john_doe.email);
-    user.isMe = true;
-    user.locale = entities.user.john_doe.locale;
-    user.name(entities.user.john_doe.name);
-    user.phone(entities.user.john_doe.phone);
-
     this.client_service = new ClientService(this.storage_service);
     this.client_repository = new ClientRepository(this.client_service, this.cryptography_repository, new ClientState());
-    this.client_repository.init(user);
 
     const currentClient = new ClientEntity(false, null);
     currentClient.address = '62.96.148.44';

--- a/test/helper/TestFactory.js
+++ b/test/helper/TestFactory.js
@@ -107,13 +107,8 @@ export class TestFactory {
    */
   async exposeClientActors() {
     await this.exposeCryptographyActors();
-    const clientEntity = new ClientEntity(false, null);
-    clientEntity.address = '192.168.0.1';
-    clientEntity.class = ClientClassification.DESKTOP;
-    clientEntity.id = '60aee26b7f55a99f';
 
     const user = new User(entities.user.john_doe.id, null);
-    user.devices.push(clientEntity);
     user.email(entities.user.john_doe.email);
     user.isMe = true;
     user.locale = entities.user.john_doe.locale;


### PR DESCRIPTION
## Description

Improves some test by removing global mocks for the self user in testfactory (it was misleading when trying to mock self user in other tests, but the global mock was overwriting it).

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
