### PR TITLE
feat: reevaluate supported protocols on client delete

### DIFF
--- a/src/__mocks__/@wireapp/core.ts
+++ b/src/__mocks__/@wireapp/core.ts
@@ -55,5 +55,9 @@ export class Account extends EventEmitter {
         setConversationLevelTimer: jest.fn(),
       },
     },
+
+    client: {
+      deleteClient: jest.fn(),
+    },
   };
 }

--- a/src/script/self/SelfRepository.ts
+++ b/src/script/self/SelfRepository.ts
@@ -55,6 +55,14 @@ export class SelfRepository {
     amplify.subscribe(WebAppEvents.CLIENT.REMOVE, this.refreshSelfSupportedProtocols);
   }
 
+  private get selfUser() {
+    const selfUser = this.userState.self();
+    if (!selfUser) {
+      throw new Error('Self user is not available');
+    }
+    return selfUser;
+  }
+
   /**
    * Proteus is supported if:
    * - Proteus is in the list of supported protocols
@@ -148,7 +156,7 @@ export class SelfRepository {
   ): Promise<ConversationProtocol[]> {
     this.logger.info('Supported protocols will get updated to:', supportedProtocols);
     await this.selfService.putSupportedProtocols(supportedProtocols);
-    await this.userRepository.updateUserSupportedProtocols(this.userState.self().qualifiedId, supportedProtocols);
+    await this.userRepository.updateUserSupportedProtocols(this.selfUser.qualifiedId, supportedProtocols);
     return supportedProtocols;
   }
 
@@ -158,8 +166,7 @@ export class SelfRepository {
    * @param supportedProtocols - an array of new supported protocols
    */
   public readonly refreshSelfSupportedProtocols = async (): Promise<ConversationProtocol[]> => {
-    const selfUser = this.userState.self();
-    const localSupportedProtocols = selfUser.supportedProtocols();
+    const localSupportedProtocols = this.selfUser.supportedProtocols();
 
     this.logger.info('Evaluating self supported protocols, currently supported protocols:', localSupportedProtocols);
     const refreshedSupportedProtocols = await this.evaluateSelfSupportedProtocols();

--- a/src/script/self/SelfRepository.ts
+++ b/src/script/self/SelfRepository.ts
@@ -19,14 +19,17 @@
 
 import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 import {registerRecurringTask} from '@wireapp/core/lib/util/RecurringTaskScheduler';
+import {amplify} from 'amplify';
 import {container} from 'tsyringe';
+
+import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {Logger, getLogger} from 'Util/Logger';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
 
 import {SelfService} from './SelfService';
 
-import {ClientRepository} from '../client';
+import {ClientEntity, ClientRepository} from '../client';
 import {isMLSSupportedByEnvironment} from '../mls/isMLSSupportedByEnvironment';
 import {MLSMigrationStatus} from '../mls/MLSMigration/migrationStatus';
 import {TeamRepository} from '../team/TeamRepository';
@@ -46,6 +49,10 @@ export class SelfRepository {
     private readonly userState = container.resolve(UserState),
   ) {
     this.logger = getLogger('SelfRepository');
+
+    // Every time user's client is deleted, we need to re-evaluate self supported protocols.
+    // It's possible that they have removed proteus client, and now all their clients are mls-capable.
+    amplify.subscribe(WebAppEvents.CLIENT.REMOVE, this.refreshSelfSupportedProtocols);
   }
 
   /**
@@ -150,7 +157,7 @@ export class SelfRepository {
    * It will send a request to the backend to change the supported protocols and then update the user in the local state.
    * @param supportedProtocols - an array of new supported protocols
    */
-  public async refreshSelfSupportedProtocols(): Promise<ConversationProtocol[]> {
+  public readonly refreshSelfSupportedProtocols = async (): Promise<ConversationProtocol[]> => {
     const selfUser = this.userState.self();
     const localSupportedProtocols = selfUser.supportedProtocols();
 
@@ -171,7 +178,7 @@ export class SelfRepository {
     }
 
     return this.updateSelfSupportedProtocols(refreshedSupportedProtocols);
-  }
+  };
 
   /**
    * Will initialise the intervals for checking (and updating if necessary) self supported protocols.
@@ -197,5 +204,12 @@ export class SelfRepository {
       task: refreshProtocolsTask,
       key: SELF_SUPPORTED_PROTOCOLS_CHECK_KEY,
     });
+  }
+
+  public async deleteSelfUserClient(clientId: string, password?: string): Promise<ClientEntity[]> {
+    const clients = this.clientRepository.deleteClient(clientId, password);
+
+    await this.refreshSelfSupportedProtocols();
+    return clients;
   }
 }

--- a/src/script/view_model/ActionsViewModel.ts
+++ b/src/script/view_model/ActionsViewModel.ts
@@ -27,7 +27,7 @@ import {PrimaryModal, removeCurrentModal, usePrimaryModalState} from 'Components
 import {t} from 'Util/LocalizerUtil';
 import {isBackendError} from 'Util/TypePredicateUtil';
 
-import type {ClientRepository, ClientEntity} from '../client';
+import type {ClientEntity} from '../client';
 import type {ConnectionRepository} from '../connection/ConnectionRepository';
 import type {ConversationRepository} from '../conversation/ConversationRepository';
 import type {MessageRepository} from '../conversation/MessageRepository';
@@ -37,11 +37,12 @@ import type {Message} from '../entity/message/Message';
 import type {User} from '../entity/User';
 import type {IntegrationRepository} from '../integration/IntegrationRepository';
 import type {ServiceEntity} from '../integration/ServiceEntity';
+import {SelfRepository} from '../self/SelfRepository';
 import {UserState} from '../user/UserState';
 
 export class ActionsViewModel {
   constructor(
-    private readonly clientRepository: ClientRepository,
+    private readonly selfRepository: SelfRepository,
     private readonly connectionRepository: ConnectionRepository,
     private readonly conversationRepository: ConversationRepository,
     private readonly integrationRepository: IntegrationRepository,
@@ -152,7 +153,7 @@ export class ActionsViewModel {
     const isTemporary = clientEntity.isTemporary();
     if (isSSO || isTemporary) {
       // Temporary clients and clients of SSO users don't require a password to be removed
-      return this.clientRepository.deleteClient(clientEntity.id, undefined);
+      return this.selfRepository.deleteSelfUserClient(clientEntity.id, undefined);
     }
 
     return new Promise<void>(resolve => {
@@ -171,7 +172,7 @@ export class ActionsViewModel {
               if (!isSending) {
                 isSending = true;
                 try {
-                  await this.clientRepository.deleteClient(clientEntity.id, password);
+                  await this.selfRepository.deleteSelfUserClient(clientEntity.id, password);
                   removeCurrentModal();
                   resolve();
                 } catch (error) {

--- a/src/script/view_model/MainViewModel.ts
+++ b/src/script/view_model/MainViewModel.ts
@@ -108,7 +108,7 @@ export class MainViewModel {
     };
 
     this.actions = new ActionsViewModel(
-      repositories.client,
+      repositories.self,
       repositories.connection,
       repositories.conversation,
       repositories.integration,


### PR DESCRIPTION
## Description

Re-evaluate the list of supported protocols every time one of self user's client is deleted.

For user to add `"mls"` to the list of their supported protocols, all of their active (`last_active` <= 4 weeks) clients must be mls-capable devices. User might want to delete their old proteus devices, not to wait for those 4 weeks to pass. We need to reevaluate the list of supported protocols every time their client gets deleted, so:
- every time user deletes some other client themselves using current client
- every time user receives an event from backend about their client being deleted.

## Checklist

- [ ] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;