### PR TITLE
runfix: hack for android hearts [WPB-4488]

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.tsx
@@ -60,7 +60,7 @@ const MessageReactionsList: FC<MessageReactionsListProps> = ({reactions, ...prop
             index={index}
             emojiListCount={emojiListCount}
             {...emojiPillProps}
-            key={emojiUnicode}
+            key={emojiUnicode + index}
           />
         );
       })}

--- a/src/script/util/EmojiUtil.ts
+++ b/src/script/util/EmojiUtil.ts
@@ -72,5 +72,7 @@ export function getEmojiUnicode(emojis: string) {
   const hexCode = 16;
   const padding = 4;
   const unicode = [...emojis].map(emoji => emoji.codePointAt(0)?.toString(hexCode).padStart(padding, '0')).join('-');
-  return unicode;
+  // TODO: This is a hack to fix the heart emoji for old android devices. It should be reevaluated at some point in the future and removed.
+  // See https://wearezeta.atlassian.net/browse/WPB-4736
+  return unicode === '2764' ? '2764-fe0f' : unicode;
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4488" title="WPB-4488" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4488</a>  Cannot see reaction emoji
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
old android heart reactions are passing a unicode of 2764, an unknown character in our emoji library. this is mapping it to 2764-fe0f, 'red heart.' This is an interim fix until all the old android devices are phased out. I have created a follow-up ticket to check in another few months. 

## Screenshots/Screencast (for UI changes)
<img width="1029" alt="Screenshot 2023-09-18 at 13 19 51" src="https://github.com/wireapp/wire-webapp/assets/37285713/c1c550d8-b70b-4d56-b167-1be304a7a21c">


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

