### PR TITLE
runfix: Make sure we save new users loaded via the user modal

### DIFF
--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -780,7 +780,10 @@ export class UserRepository {
    * @param user user data from backend
    */
   private async updateSavedUser(user: APIClientUser): Promise<User> {
-    const localUserEntity = this.findUserById(generateQualifiedId(user)) ?? new User();
+    const localUserEntity = this.findUserById(generateQualifiedId(user));
+    if (!localUserEntity) {
+      return this.getUserById(user.qualified_id);
+    }
     const updatedUser = this.userMapper.updateUserFromObject(localUserEntity, user, this.userState.self().domain);
     const {qualifiedId: userId} = updatedUser;
 

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -782,6 +782,7 @@ export class UserRepository {
   private async updateSavedUser(user: APIClientUser): Promise<User> {
     const localUserEntity = this.findUserById(generateQualifiedId(user));
     if (!localUserEntity) {
+      // If the user could not be found locally, we will get it and save it locally
       return this.getUserById(user.qualified_id);
     }
     const updatedUser = this.userMapper.updateUserFromObject(localUserEntity, user, this.userState.self().domain);


### PR DESCRIPTION
## Description

Since #15813 we `refresh` rather than `get` the user when loading the userModal. Which means that if the user is not present locally, we will not save the user entity locally. 
This makes sure that when calling `refresh` we save any new user coming in

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

