### PR TITLE
fix: set default floating action menu visibility to false

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -134,7 +134,7 @@ const ContentMessageComponent: React.FC<ContentMessageProps> = ({
     senderName,
   });
 
-  const [isActionMenuVisible, setActionMenuVisibility] = useState(true);
+  const [isActionMenuVisible, setActionMenuVisibility] = useState(false);
   const isMenuOpen = useMessageActionsState(state => state.isMenuOpen);
   useEffect(() => {
     setActionMenuVisibility(isMessageFocused || msgFocusState);


### PR DESCRIPTION
## Description

set default floating action menu visibility to false to avoid rendering all the menu while loading mesages

## Screenshots/Screencast (for UI changes)

## Checklist

- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

