### PR TITLE
runfix: use mvp specs for failure to add users message (WPB-4720)

### DIFF
--- a/src/script/components/MessagesList/Message/FailedToAddUsersMessage.test.tsx
+++ b/src/script/components/MessagesList/Message/FailedToAddUsersMessage.test.tsx
@@ -185,7 +185,9 @@ describe('FailedToAddUsersMessage', () => {
 
     const elementMessageFailedToAddDetails = getAllByTestId('multi-user-not-added-details');
     expect(elementMessageFailedToAddDetails[0].textContent).toContain(
-      'could not be added to the group as their backends do not federate with each other',
+      // 'We're currently using the MVP implementation of error messages, the full spec will be the following
+      // 'could not be added to the group as their backends do not federate with each other',
+      'could not be added to the group',
     );
   });
 });

--- a/src/script/components/MessagesList/Message/FailedToAddUsersMessage.tsx
+++ b/src/script/components/MessagesList/Message/FailedToAddUsersMessage.tsx
@@ -45,10 +45,12 @@ export interface FailedToAddUsersMessageProps {
   userState?: UserState;
 }
 
-const errorMessageType = {
-  [AddUsersFailureReasons.NON_FEDERATING_BACKENDS]: 'NonFederatingBackends',
-  [AddUsersFailureReasons.UNREACHABLE_BACKENDS]: 'OfflineBackend',
-} as const;
+// Mobile platforms are not using the full specs yet, we can uncomment this when they catch up
+// This is not used in the MVP specs
+// const errorMessageType = {
+//   [AddUsersFailureReasons.NON_FEDERATING_BACKENDS]: 'NonFederatingBackends',
+//   [AddUsersFailureReasons.UNREACHABLE_BACKENDS]: 'OfflineBackend',
+// } as const;
 
 const config = Config.getConfig();
 
@@ -69,9 +71,9 @@ const MessageDetails: FC<MessageDetailsProps> = ({users, children, message, doma
         css={warning}
         dangerouslySetInnerHTML={{
           __html:
-            // Mobile platforms are not using the full specs yet, we can uncomment this if product decides to go with MVP specs
-            // t(`failedToAddParticipantsPluralDetailsMvp`, {
-            t(`failedToAddParticipantsPluralDetails${errorMessageType[message.reason]}`, {
+            // Mobile platforms are not using the full specs yet, we can uncomment this when they catch up
+            // t(`failedToAddParticipantsPluralDetails${errorMessageType[message.reason]}`, {
+            t(`failedToAddParticipantsPluralDetailsMvp`, {
               name: users[0].name(),
               names: users
                 .slice(1)
@@ -147,9 +149,9 @@ const FailedToAddUsersMessage: React.FC<FailedToAddUsersMessageProps> = ({
                 css={warning}
                 dangerouslySetInnerHTML={{
                   __html:
-                    // Mobile platforms are not using the full specs yet, we can uncomment this if product decides to go with MVP specs
-                    // t(`failedToAddParticipantSingularMvp`, {
-                    t(`failedToAddParticipantSingular${errorMessageType[message.reason]}`, {
+                    // Mobile platforms are not using the full specs yet, we can uncomment this when they catch up
+                    // t(`failedToAddParticipantSingular${errorMessageType[message.reason]}`, {
+                    t(`failedToAddParticipantSingularMvp`, {
                       name: users[0].name(),
                       domain: users[0].domain,
                     }),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4720" title="WPB-4720" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-4720</a>  [Web] "backend could not be reached" does not always refer to the correct backend
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

We decided to align with other platform, and use MVP specs instead of the final one for error messages when failing to add users to an existing group conversation

We'll also need to correct the final error message, as it is possible to fail adding a user when some other backend is offline (currently, we only use the backend of the specific user as the cause of failure), see the linked ticket

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

