### PR TITLE
runfix: Do not show temporary users as logged in when joining conversation [WPB-4754]

### DIFF
--- a/src/script/auth/page/ConversationJoin.tsx
+++ b/src/script/auth/page/ConversationJoin.tsx
@@ -265,7 +265,7 @@ const mapStateToProps = (state: RootState) => ({
   isAuthenticated: AuthSelector.isAuthenticated(state),
   isFetching: ConversationSelector.isFetching(state),
   isTemporaryGuest: SelfSelector.isTemporaryGuest(state),
-  selfName: SelfSelector.getSelfName(state),
+  selfName: !SelfSelector.isTemporaryGuest(state) && SelfSelector.getSelfName(state),
 });
 
 type DispatchProps = ReturnType<typeof mapDispatchToProps>;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4754" title="WPB-4754" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4754</a>  [web] seeing the conversation join page as a temporary user shows that I'm logged in as this user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Make sure we don't show temporary users as logged in on the `conversation join` page. 

## Screenshots/Screencast (for UI changes)

### Before 
![image](https://github.com/wireapp/wire-webapp/assets/1090716/b706f078-d301-4edd-8a18-2233c3bc515a)

### after
![image](https://github.com/wireapp/wire-webapp/assets/1090716/87f1c8d7-2f3f-48b9-a28c-b6a54e552549)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
