### PR TITLE
runfix: Use MVP version of failed to add users [WPB-4757]

### DIFF
--- a/src/script/components/MessagesList/Message/FailedToAddUsersMessage.test.tsx
+++ b/src/script/components/MessagesList/Message/FailedToAddUsersMessage.test.tsx
@@ -25,9 +25,7 @@ import en from 'I18n/en-US.json';
 import {withTheme, generateQualifiedIds} from 'src/script/auth/util/test/TestUtil';
 import {FailedToAddUsersMessage as FailedToAddUsersMessageEntity} from 'src/script/entity/message/FailedToAddUsersMessage';
 import {User} from 'src/script/entity/User';
-import {UserRepository} from 'src/script/user/UserRepository';
 import {UserState} from 'src/script/user/UserState';
-import {TestFactory} from 'test/helper/TestFactory';
 import {setStrings} from 'Util/LocalizerUtil';
 
 import {FailedToAddUsersMessage} from './FailedToAddUsersMessage';
@@ -46,20 +44,8 @@ const createFailedToAddUsersMessage = (partialFailedToAddUsersMessage: Partial<F
 };
 
 describe('FailedToAddUsersMessage', () => {
-  const testFactory = new TestFactory();
-  let userState: UserState;
-  let userRepository: UserRepository;
-
-  beforeAll(async () => {
-    userRepository = await testFactory.exposeUserActors();
-    userState = userRepository['userState'];
-  });
-
-  afterEach(() => {
-    userRepository['userState'].users.removeAll();
-  });
-
   it('shows that 1 user could not be added', async () => {
+    const userState = new UserState();
     const [qualifiedId1] = generateQualifiedIds(1, 'test.domain');
 
     const user1 = new User(qualifiedId1.id, qualifiedId1.domain);
@@ -78,6 +64,7 @@ describe('FailedToAddUsersMessage', () => {
   });
 
   it('shows that multiple users could not be added', async () => {
+    const userState = new UserState();
     const [qualifiedId1, qualifiedId2] = generateQualifiedIds(2, 'test.domain');
 
     const user1 = new User(qualifiedId1.id, qualifiedId1.domain);
@@ -98,6 +85,7 @@ describe('FailedToAddUsersMessage', () => {
   });
 
   it('shows details of failed to add multi users', async () => {
+    const userState = new UserState();
     const [qualifiedId1, qualifiedId2] = generateQualifiedIds(2, 'test.domain');
 
     const user1 = new User(qualifiedId1.id, qualifiedId1.domain);
@@ -123,10 +111,12 @@ describe('FailedToAddUsersMessage', () => {
     });
 
     const elementMessageFailedToAddDetails = getByTestId('multi-user-not-added-details');
-    expect(elementMessageFailedToAddDetails.getAttribute('data-uie-value')).toEqual(qualifiedId1.domain);
+    // TODO: remove this condition when full specs are implemented
+    expect(elementMessageFailedToAddDetails.getAttribute('data-uie-value')).toEqual(false ? qualifiedId1.domain : '');
   });
 
   it('shows details of failed to add multi users from 2 different backends', async () => {
+    const userState = new UserState();
     const [qualifiedId1] = generateQualifiedIds(1, 'test.domain');
     const [qualifiedId2] = generateQualifiedIds(1, 'test-2.domain');
 
@@ -153,11 +143,15 @@ describe('FailedToAddUsersMessage', () => {
     });
 
     const elementMessageFailedToAddDetails = getAllByTestId('multi-user-not-added-details');
-    expect(elementMessageFailedToAddDetails[0].getAttribute('data-uie-value')).toEqual(qualifiedId1.domain);
-    expect(elementMessageFailedToAddDetails[1].getAttribute('data-uie-value')).toEqual(qualifiedId2.domain);
+    // TODO: remove this condition when full specs are implemented
+    expect(elementMessageFailedToAddDetails[0].getAttribute('data-uie-value')).toEqual(
+      false ? qualifiedId1.domain : '',
+    );
+    //expect(elementMessageFailedToAddDetails[1].getAttribute('data-uie-value')).toEqual(qualifiedId2.domain);
   });
 
   it('shows details of failed to add users from non federating backends', async () => {
+    const userState = new UserState();
     const [qualifiedId1] = generateQualifiedIds(1, 'test.domain');
     const [qualifiedId2] = generateQualifiedIds(1, 'test-2.domain');
 

--- a/src/script/components/MessagesList/Message/FailedToAddUsersMessage.tsx
+++ b/src/script/components/MessagesList/Message/FailedToAddUsersMessage.tsx
@@ -154,9 +154,10 @@ const FailedToAddUsersMessage: React.FC<FailedToAddUsersMessageProps> = ({
     </>
   );
 
-  const DetailsMessageComponent = FailureReasonToDetailsComponent[message.reason];
-  // FIXME: this is the MVP version, remove when the full specs are implemented
-  //const DetailsMessageComponent = FailureReasonToDetailsComponent[AddUsersFailureReasons.NON_FEDERATING_BACKENDS];
+  // FIXME: this is the MVP version, remove the condition when full specs are implemented
+  const DetailsMessageComponent = false
+    ? FailureReasonToDetailsComponent[message.reason]
+    : FailureReasonToDetailsComponent[AddUsersFailureReasons.NON_FEDERATING_BACKENDS];
 
   return (
     <>

--- a/src/script/components/MessagesList/Message/FailedToAddUsersMessage.tsx
+++ b/src/script/components/MessagesList/Message/FailedToAddUsersMessage.tsx
@@ -59,7 +59,7 @@ interface MessageDetailsProps {
   users: User[];
   domain?: string;
 }
-const MessageDetails: FC<MessageDetailsProps> = ({users, children, domain = ''}) => {
+const MessageDetails = ({users, children, domain = ''}: MessageDetailsProps) => {
   return (
     <p
       data-uie-name="multi-user-not-added-details"
@@ -87,7 +87,7 @@ const MessageDetails: FC<MessageDetailsProps> = ({users, children, domain = ''})
   );
 };
 
-const UnreachableBackendMessageDetails: FC<MessageDetailsProps> = props => {
+const UnreachableBackendMessageDetails = (props: MessageDetailsProps) => {
   const groupedUsers = useMemo(() => {
     return groupBy(props.users, user => user.domain);
   }, [props.users]);
@@ -101,7 +101,7 @@ const UnreachableBackendMessageDetails: FC<MessageDetailsProps> = props => {
   );
 };
 
-const NonFederatingBackendMessageDetails: FC<MessageDetailsProps> = props => {
+const NonFederatingBackendMessageDetails = (props: MessageDetailsProps) => {
   return <MessageDetails {...props} />;
 };
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4757" title="WPB-4757" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4757</a>  Wrong error message on adding users from mixed online/offline backends to group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Use the MVP version for the errors when failing to add users to a conversation (in order to align platforms) 

## Screenshots/Screencast (for UI changes)

### before
![image](https://github.com/wireapp/wire-webapp/assets/1090716/c7e7e67d-8c72-4f10-8cdb-f481a0c068a0)

### after
![image](https://github.com/wireapp/wire-webapp/assets/1090716/33b8e47e-bf42-42c4-a670-3f4d9fa5bd10)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
