### PR TITLE
fix: set emoji image draggable attribute to false (WPB-4775)

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiImg.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiImg.tsx
@@ -34,11 +34,12 @@ const EmojiImg: FC<EmojiImgProps> = ({emojiUrl, styles, emojiName, emojiImgSize 
   return (
     <>
       <img
-        src={emojiUrl}
         alt={emojiName}
-        loading="eager"
-        css={{...emojiImgSize, ...messageReactionEmoji, ...styles}}
         aria-hidden={true}
+        css={{...emojiImgSize, ...messageReactionEmoji, ...styles}}
+        draggable="false"
+        loading="eager"
+        src={emojiUrl}
       />
     </>
   );


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4775" title="WPB-4775" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4775</a>  Drag and drop sends a message immediately without confirmation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Emoji pill's image could get dragged, dropped and sent as a new message by accident on certain OSs
Setting the html attribute `draggable` to `false` prevents that issue

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
