### PR TITLE
fix: Adjust layout for restricted sent image spacing (WPB-4789)

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset.tsx
@@ -98,7 +98,7 @@ const ImageAsset: React.FC<ImageAssetProps> = ({
   });
 
   const imageContainerStyle: CSSObject = {
-    aspectRatio: `${asset.ratio}`,
+    aspectRatio: isFileSharingReceivingEnabled ? `${asset.ratio}` : undefined,
     maxWidth: '100%',
     width: asset.width,
     maxHeight: '80vh',


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4789" title="WPB-4789" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4789</a>  [Web] Restricted sent file icon has more space on layout than expected
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description
Actual result: file shows as restricted icon - expected, but after it there mush space of an empty layout until next sent message

Expected result: restricted file icon should be lined up with expected empty row till next message

## Screenshots/Screencast (for UI changes)

Before:
<img width="834" alt="image" src="https://github.com/wireapp/wire-webapp/assets/63250054/706dc1ce-b486-43ab-bd17-0f19782188e7">

After:
<img width="873" alt="image" src="https://github.com/wireapp/wire-webapp/assets/63250054/2131fa3b-2480-4e5b-a5b7-a35ded775728">


## Checklist

- [X] PR has been self reviewed by the author;
- [X] Hard-to-understand areas of the code have been commented;
- [X] If it is a core feature, unit tests have been added;
