### PR TITLE
fix: Adjust layout for restricted sent image spacing (WPB-4789) (#15861)

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset.tsx
@@ -98,7 +98,7 @@ const ImageAsset: React.FC<ImageAssetProps> = ({
   });
 
   const imageContainerStyle: CSSObject = {
-    aspectRatio: `${asset.ratio}`,
+    aspectRatio: isFileSharingReceivingEnabled ? `${asset.ratio}` : undefined,
     maxWidth: '100%',
     width: asset.width,
     maxHeight: '80vh',


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4789" title="WPB-4789" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4789</a>  [Web] Restricted sent file icon has more space on layout than expected
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
cherry pick of https://github.com/wireapp/wire-webapp/pull/15861