### PR TITLE
fix: Conversation ui message restriction box width

### DIFF
--- a/src/style/common/variables.less
+++ b/src/style/common/variables.less
@@ -233,7 +233,7 @@ body {
 @conversation-message-sender-width: 56px;
 
 body {
-  --conversation-message-timestamp-width: 140px;
+  --conversation-message-timestamp-width: 200px;
   @media (max-width: @screen-md-min) {
     --conversation-message-timestamp-width: 60px;
   }

--- a/src/style/content/conversation/input-bar.less
+++ b/src/style/content/conversation/input-bar.less
@@ -46,7 +46,7 @@
 
   width: 100%;
   max-width: calc(
-    @conversation-max-width - @conversation-message-sender-width - var(--conversation-message-timestamp-width)
+    @conversation-max-width - @conversation-message-sender-width + var(--conversation-message-timestamp-width)
   );
   height: @conversation-input-line-height;
   min-height: @conversation-input-line-height;


### PR DESCRIPTION
## Description
Fixed: The issue of conversation message box text restriction.

## Screenshots/Screencast (for UI changes)
<img width="1399" alt="Screenshot 2023-09-23 at 7 48 14 PM" src="https://github.com/wireapp/wire-webapp/assets/79074968/4d3f6924-3860-40fc-b2b6-45bf71163ab2">

Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;
