### PR TITLE
runfix: lock websocket when uploading a commit bundle to BE

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@datadog/browser-rum": "^4.49.0",
     "@emotion/react": "11.11.1",
     "@wireapp/avs": "9.3.7",
-    "@wireapp/core": "42.5.1",
+    "@wireapp/core": "42.6.0",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.9.6",
     "@wireapp/store-engine-dexie": "2.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5373,23 +5373,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^26.1.2":
-  version: 26.1.2
-  resolution: "@wireapp/api-client@npm:26.1.2"
+"@wireapp/api-client@npm:^26.2.0":
+  version: 26.2.0
+  resolution: "@wireapp/api-client@npm:26.2.0"
   dependencies:
     "@wireapp/commons": ^5.1.3
     "@wireapp/priority-queue": ^2.1.4
     "@wireapp/protocol-messaging": 1.44.0
     axios: 1.5.0
-    axios-retry: 3.7.0
-    http-status-codes: 2.2.0
+    axios-retry: 3.8.0
+    http-status-codes: 2.3.0
     logdown: 3.3.1
     pako: 2.1.0
     reconnecting-websocket: 4.4.0
     spark-md5: 3.0.2
     tough-cookie: 4.1.3
-    ws: 8.14.1
-  checksum: 2eb424fe1390f97636d3089cdb0010c9b52f663c0ed02f0fe0b9893b6bb2b5a04ca85857a5ffffb588b5efddc4096cef38e54126f8ab6817a70198f149c5a90d
+    ws: 8.14.2
+  checksum: c78a59f64164eb1f718e7a3390e6d25d8f097904b2db35958ec7cb3f1e2954a0f8670ea23c2d999c8f160b822a009e1bfc44fc1df1ddb19fcd1858d2fb9dfe34
   languageName: node
   linkType: hard
 
@@ -5442,11 +5442,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:42.5.1":
-  version: 42.5.1
-  resolution: "@wireapp/core@npm:42.5.1"
+"@wireapp/core@npm:42.6.0":
+  version: 42.6.0
+  resolution: "@wireapp/core@npm:42.6.0"
   dependencies:
-    "@wireapp/api-client": ^26.1.2
+    "@wireapp/api-client": ^26.2.0
     "@wireapp/commons": ^5.1.3
     "@wireapp/core-crypto": 1.0.0-rc.12
     "@wireapp/cryptobox": 12.8.0
@@ -5458,12 +5458,12 @@ __metadata:
     bazinga64: ^6.3.1
     deepmerge-ts: 5.1.0
     hash.js: 1.1.7
-    http-status-codes: 2.2.0
+    http-status-codes: 2.3.0
     idb: 7.1.1
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.13
-  checksum: ada8a88efa72cab542d782565ea994c74e93c88f32fa2ee6146fa409a101280af108d8401a00e03b23910b18c56e0f00dd72c91852ff1ce535234e90e125a539
+  checksum: 66c57a07d0e03d45896730107a8a33ccdfc38c246325efc83684734bb54989b830117b897f703282074264ceb979b415b4073c3c2d941aa0e7fa8cbe55a71d7e
   languageName: node
   linkType: hard
 
@@ -6326,13 +6326,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios-retry@npm:3.7.0":
-  version: 3.7.0
-  resolution: "axios-retry@npm:3.7.0"
+"axios-retry@npm:3.8.0":
+  version: 3.8.0
+  resolution: "axios-retry@npm:3.8.0"
   dependencies:
     "@babel/runtime": ^7.15.4
     is-retry-allowed: ^2.2.0
-  checksum: ef34b50a86b5cd65ce2bf933aaed422ffb1a17b8fe11a53e444437fb42be400b48271d1ff9fd23a051627b7f3b33bebdeb1d66556aae04d5d6bfbe57fecdfb64
+  checksum: 448d951b971ccd35eaedc0f10ff1129a6bf2b3dfe13ce57749809bd37975332ae0e906ea4e67a41c9c98215bb1bf8a554e6880f1272419c758f91e4d68ca6b55
   languageName: node
   linkType: hard
 
@@ -10496,6 +10496,13 @@ __metadata:
   version: 2.2.0
   resolution: "http-status-codes@npm:2.2.0"
   checksum: 31e1d730856210445da0907d9b484629e69e4fe92ac032478a7aa4d89e5b215e2b4e75d7ebce40d0537b6850bd281b2f65c7cc36cc2677e5de056d6cea1045ce
+  languageName: node
+  linkType: hard
+
+"http-status-codes@npm:2.3.0":
+  version: 2.3.0
+  resolution: "http-status-codes@npm:2.3.0"
+  checksum: dae3b99e0155441b6df28e8265ff27c56a45f82c6092f736414233e9ccf063d5ea93c1e1279e8b499c4642e2538b37995c76b1640ed3f615d0e2883d3a1dcfd5
   languageName: node
   linkType: hard
 
@@ -18599,7 +18606,7 @@ __metadata:
     "@types/webpack-env": 1.18.1
     "@wireapp/avs": 9.3.7
     "@wireapp/copy-config": 2.1.8
-    "@wireapp/core": 42.5.1
+    "@wireapp/core": 42.6.0
     "@wireapp/eslint-config": 3.0.4
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.6.3
@@ -18995,9 +19002,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:8.14.1":
-  version: 8.14.1
-  resolution: "ws@npm:8.14.1"
+"ws@npm:8.14.2":
+  version: 8.14.2
+  resolution: "ws@npm:8.14.2"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -19006,7 +19013,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 9e310be2b0ff69e1f87d8c6d093ecd17a1ed4c37f281d17c35e8c30e2bd116401775b3d503249651374e6e0e1e9905db62fff096b694371c77561aee06bc3466
+  checksum: 3ca0dad26e8cc6515ff392b622a1467430814c463b3368b0258e33696b1d4bed7510bc7030f7b72838b9fdeb8dbd8839cbf808367d6aae2e1d668ce741d4308b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Bumps core with version that locks websocket when commit bundle is being uploaded backend. For more details see: https://github.com/wireapp/wire-web-packages/pull/5520.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
