### PR TITLE
runfix: Do not consider conversation domain for classified state of a user [WPB-4843]

### DIFF
--- a/src/script/components/panel/UserDetails.tsx
+++ b/src/script/components/panel/UserDetails.tsx
@@ -38,7 +38,6 @@ import {User} from '../../entity/User';
 export interface UserDetailsProps {
   badge?: string;
   classifiedDomains?: string[];
-  conversationDomain?: string;
   isGroupAdmin?: boolean;
   isSelfVerified: boolean;
   isVerified?: boolean;
@@ -53,7 +52,6 @@ export const UserDetailsComponent: React.FC<UserDetailsProps> = ({
   isGroupAdmin,
   avatarStyles,
   classifiedDomains,
-  conversationDomain,
 }) => {
   const user = useKoSubscribableChildren(participant, [
     'inTeam',
@@ -108,13 +106,7 @@ export const UserDetailsComponent: React.FC<UserDetailsProps> = ({
         </p>
       )}
 
-      {classifiedDomains && (
-        <UserClassifiedBar
-          conversationDomain={conversationDomain}
-          users={[participant]}
-          classifiedDomains={classifiedDomains}
-        />
-      )}
+      {classifiedDomains && <UserClassifiedBar users={[participant]} classifiedDomains={classifiedDomains} />}
 
       <Avatar
         className="panel-participant__avatar"

--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
@@ -312,7 +312,6 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
           {isSingleUserMode && !isServiceMode && firstParticipant && (
             <>
               <UserDetails
-                conversationDomain={activeConversation.domain}
                 participant={firstParticipant}
                 isVerified={isVerified}
                 isSelfVerified={isSelfVerified}

--- a/src/script/page/RightSidebar/GroupParticipantUser/GroupParticipantUser.tsx
+++ b/src/script/page/RightSidebar/GroupParticipantUser/GroupParticipantUser.tsx
@@ -149,7 +149,6 @@ const GroupParticipantUser: FC<GroupParticipantUserProps> = ({
 
       <FadingScrollbar className="panel__content">
         <UserDetails
-          conversationDomain={activeConversation.domain}
           participant={currentUser}
           badge={teamRepository.getRoleBadge(currentUser.id)}
           isGroupAdmin={isAdmin}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4843" title="WPB-4843" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4843</a>  Conversation view and sidebar show different security level if a 1:1 conversation is hosted on other backend
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Will make sure, when displaying a user's profile, even in the context of a conversation, to not consider the conversation's domain in the computation of whether a user is classified or not. 

## Screenshots/Screencast (for UI changes)
![Screenshot 2023-09-25 at 17 42 36](https://github.com/wireapp/wire-webapp/assets/1090716/4bd61b63-52d0-46e5-9966-f44720c1a06e)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
