### PR TITLE
chore: update to node 18

### DIFF
--- a/.github/workflows/create_docker_image.yml
+++ b/.github/workflows/create_docker_image.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: 'yarn'
 
       - name: Install JS dependencies

--- a/.github/workflows/deploy-to-test-env.yml
+++ b/.github/workflows/deploy-to-test-env.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: 'yarn'
 
       - name: Install JS dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: 'yarn'
 
       - name: Install JS dependencies

--- a/.github/workflows/sync_translations.yml
+++ b/.github/workflows/sync_translations.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: 'yarn'
 
       - name: Authenticate git clone

--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: 'yarn'
 
       - name: Set environment variables

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
   },
   "engines": {
     "yarn": ">= 1.0.0",
-    "node": ">=16"
+    "node": ">=18"
   },
   "license": "GPL-3.0",
   "lint-staged": {

--- a/server/package.json
+++ b/server/package.json
@@ -34,6 +34,9 @@
     "rimraf": "4.4.1",
     "typescript": "5.2.2"
   },
+  "engines": {
+    "node": ">= 18"
+  },
   "scripts": {
     "build": "yarn clean && tsc && yarn generate-version-file && yarn copy-assets",
     "copy-assets": "node ./bin/copy_server_assets.js",


### PR DESCRIPTION
## Description
node 16 is EOL from September 11, 2023. We should update our engines to node 18
https://nodejs.org/en/blog/announcements/nodejs16-eol


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
