### PR TITLE
runfix: Do not consider self user domain when displaying connection requests [WPB-4858]

### DIFF
--- a/src/script/components/ConnectRequests/ConnectionRequests.tsx
+++ b/src/script/components/ConnectRequests/ConnectionRequests.tsx
@@ -131,7 +131,7 @@ export const ConnectRequests: FC<ConnectRequestsProps> = ({
               <div className="connect-request-username label-username">{connectRequest.handle}</div>
 
               {classifiedDomains && (
-                <UserClassifiedBar users={[selfUser, connectRequest]} classifiedDomains={classifiedDomains} />
+                <UserClassifiedBar users={[connectRequest]} classifiedDomains={classifiedDomains} />
               )}
 
               <Avatar


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4858" title="WPB-4858" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4858</a>  Wrong classified information on incoming connection request from user on classified domain while being on unclassified one
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

In the same fashion as #15890 , we should also not consider the self user when displaying connection requests

## Screenshots/Screencast (for UI changes)
![image](https://github.com/wireapp/wire-webapp/assets/1090716/a9dc960f-1390-4a31-8bc7-c8bdb3ad1a50)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
