### PR TITLE
fix: Add pending icon to outgoing connection request (WPB-4849)

### DIFF
--- a/src/script/components/list/ConversationListCell.tsx
+++ b/src/script/components/list/ConversationListCell.tsx
@@ -33,14 +33,14 @@ import {Availability} from '@wireapp/protocol-messaging';
 
 import {AvailabilityState} from 'Components/AvailabilityState';
 import {Avatar, AVATAR_SIZE, GroupAvatar} from 'Components/Avatar';
-import {Icon} from 'Components/Icon';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {isKey, isOneOfKeys, KEY} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
 import {noop, setContextMenuPosition} from 'Util/util';
 
+import {ConversationListCellStatusIcon} from './ConversationListCellStatusIcon';
+
 import {generateCellState} from '../../conversation/ConversationCellState';
-import {ConversationStatusIcon} from '../../conversation/ConversationStatusIcon';
 import type {Conversation} from '../../entity/Conversation';
 import {MediaType} from '../../media/MediaType';
 
@@ -252,80 +252,7 @@ const ConversationListCell = ({
             onKeyDown={handleContextKeyDown}
           />
 
-          {!showJoinButton && (
-            <>
-              {cellState.icon === ConversationStatusIcon.PENDING_CONNECTION && (
-                <span
-                  className="conversation-list-cell-badge cell-badge-light"
-                  data-uie-name="status-pending"
-                  title={t('accessibility.conversationStatusPending')}
-                >
-                  <Icon.Pending className="svg-icon" />
-                </span>
-              )}
-
-              {cellState.icon === ConversationStatusIcon.UNREAD_MENTION && (
-                <span
-                  className="conversation-list-cell-badge cell-badge-dark"
-                  data-uie-name="status-mention"
-                  title={t('accessibility.conversationStatusUnreadMention')}
-                >
-                  <Icon.Mention className="svg-icon" />
-                </span>
-              )}
-
-              {cellState.icon === ConversationStatusIcon.UNREAD_REPLY && (
-                <span
-                  className="conversation-list-cell-badge cell-badge-dark"
-                  data-uie-name="status-reply"
-                  title={t('accessibility.conversationStatusUnreadReply')}
-                  aria-label={t('accessibility.conversationStatusUnreadReply')}
-                >
-                  <Icon.Reply className="svg-icon" />
-                </span>
-              )}
-
-              {cellState.icon === ConversationStatusIcon.UNREAD_PING && (
-                <span
-                  className="conversation-list-cell-badge cell-badge-dark"
-                  data-uie-name="status-ping"
-                  title={t('accessibility.conversationStatusUnreadPing')}
-                >
-                  <Icon.Ping className="svg-icon" />
-                </span>
-              )}
-
-              {cellState.icon === ConversationStatusIcon.MISSED_CALL && (
-                <span
-                  className="conversation-list-cell-badge cell-badge-dark"
-                  data-uie-name="status-missed-call"
-                  title={t('accessibility.callStatusMissed')}
-                >
-                  <Icon.Hangup className="svg-icon" />
-                </span>
-              )}
-
-              {cellState.icon === ConversationStatusIcon.MUTED && (
-                <span
-                  className="conversation-list-cell-badge cell-badge-light conversation-muted"
-                  data-uie-name="status-silence"
-                  title={t('accessibility.conversationStatusMuted')}
-                >
-                  <Icon.Mute className="svg-icon" />
-                </span>
-              )}
-
-              {cellState.icon === ConversationStatusIcon.UNREAD_MESSAGES && unreadState.allMessages.length > 0 && (
-                <span
-                  className="conversation-list-cell-badge cell-badge-dark"
-                  data-uie-name="status-unread"
-                  title={t('accessibility.conversationStatusUnread')}
-                >
-                  {unreadState.allMessages.length}
-                </span>
-              )}
-            </>
-          )}
+          {!showJoinButton && <ConversationListCellStatusIcon conversation={conversation} />}
 
           {showJoinButton && (
             <button

--- a/src/script/components/list/ConversationListCellStatusIcon.tsx
+++ b/src/script/components/list/ConversationListCellStatusIcon.tsx
@@ -37,18 +37,7 @@ const ConversationListCellStatusIcon = ({conversation}: ConversationListCellStat
     unreadState,
     mutedState,
     isRequest,
-  } = useKoSubscribableChildren(conversation, [
-    'isGroup',
-    'is1to1',
-    'selfUser',
-    'participating_user_ets',
-    'display_name',
-    'removed_from_conversation',
-    'availabilityOfUser',
-    'unreadState',
-    'mutedState',
-    'isRequest',
-  ]);
+  } = useKoSubscribableChildren(conversation, ['participating_user_ets', 'unreadState', 'mutedState', 'isRequest']);
 
   const cellState = useMemo(() => generateCellState(conversation), [unreadState, mutedState, isRequest]);
 

--- a/src/script/components/list/ConversationListCellStatusIcon.tsx
+++ b/src/script/components/list/ConversationListCellStatusIcon.tsx
@@ -32,20 +32,17 @@ export interface ConversationListCellStatusIconProps {
 }
 
 const ConversationListCellStatusIcon = ({conversation}: ConversationListCellStatusIconProps) => {
-  const {
-    participating_user_ets: users,
-    unreadState,
-    mutedState,
-    isRequest,
-  } = useKoSubscribableChildren(conversation, ['participating_user_ets', 'unreadState', 'mutedState', 'isRequest']);
+  const {unreadState, mutedState, isRequest} = useKoSubscribableChildren(conversation, [
+    'unreadState',
+    'mutedState',
+    'isRequest',
+  ]);
 
   const cellState = useMemo(() => generateCellState(conversation), [unreadState, mutedState, isRequest]);
 
-  const {isRequest: isUserRequest} = useKoSubscribableChildren(users[0], ['isRequest']);
-
   return (
     <>
-      {(isUserRequest || cellState.icon === ConversationStatusIcon.PENDING_CONNECTION) && (
+      {cellState.icon === ConversationStatusIcon.PENDING_CONNECTION && (
         <span
           className="conversation-list-cell-badge cell-badge-light"
           data-uie-name="status-pending"

--- a/src/script/components/list/ConversationListCellStatusIcon.tsx
+++ b/src/script/components/list/ConversationListCellStatusIcon.tsx
@@ -1,0 +1,133 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {useMemo} from 'react';
+
+import {Icon} from 'Components/Icon';
+import {useKoSubscribableChildren} from 'Util/ComponentUtil';
+import {t} from 'Util/LocalizerUtil';
+
+import {generateCellState} from '../../conversation/ConversationCellState';
+import {ConversationStatusIcon} from '../../conversation/ConversationStatusIcon';
+import type {Conversation} from '../../entity/Conversation';
+
+export interface ConversationListCellStatusIconProps {
+  conversation: Conversation;
+}
+
+const ConversationListCellStatusIcon = ({conversation}: ConversationListCellStatusIconProps) => {
+  const {
+    participating_user_ets: users,
+    unreadState,
+    mutedState,
+    isRequest,
+  } = useKoSubscribableChildren(conversation, [
+    'isGroup',
+    'is1to1',
+    'selfUser',
+    'participating_user_ets',
+    'display_name',
+    'removed_from_conversation',
+    'availabilityOfUser',
+    'unreadState',
+    'mutedState',
+    'isRequest',
+  ]);
+
+  const cellState = useMemo(() => generateCellState(conversation), [unreadState, mutedState, isRequest]);
+
+  const {isRequest: isUserRequest} = useKoSubscribableChildren(users[0], ['isRequest']);
+
+  return (
+    <>
+      {(isUserRequest || cellState.icon === ConversationStatusIcon.PENDING_CONNECTION) && (
+        <span
+          className="conversation-list-cell-badge cell-badge-light"
+          data-uie-name="status-pending"
+          title={t('accessibility.conversationStatusPending')}
+        >
+          <Icon.Pending className="svg-icon" />
+        </span>
+      )}
+
+      {cellState.icon === ConversationStatusIcon.UNREAD_MENTION && (
+        <span
+          className="conversation-list-cell-badge cell-badge-dark"
+          data-uie-name="status-mention"
+          title={t('accessibility.conversationStatusUnreadMention')}
+        >
+          <Icon.Mention className="svg-icon" />
+        </span>
+      )}
+
+      {cellState.icon === ConversationStatusIcon.UNREAD_REPLY && (
+        <span
+          className="conversation-list-cell-badge cell-badge-dark"
+          data-uie-name="status-reply"
+          title={t('accessibility.conversationStatusUnreadReply')}
+          aria-label={t('accessibility.conversationStatusUnreadReply')}
+        >
+          <Icon.Reply className="svg-icon" />
+        </span>
+      )}
+
+      {cellState.icon === ConversationStatusIcon.UNREAD_PING && (
+        <span
+          className="conversation-list-cell-badge cell-badge-dark"
+          data-uie-name="status-ping"
+          title={t('accessibility.conversationStatusUnreadPing')}
+        >
+          <Icon.Ping className="svg-icon" />
+        </span>
+      )}
+
+      {cellState.icon === ConversationStatusIcon.MISSED_CALL && (
+        <span
+          className="conversation-list-cell-badge cell-badge-dark"
+          data-uie-name="status-missed-call"
+          title={t('accessibility.callStatusMissed')}
+        >
+          <Icon.Hangup className="svg-icon" />
+        </span>
+      )}
+
+      {cellState.icon === ConversationStatusIcon.MUTED && (
+        <span
+          className="conversation-list-cell-badge cell-badge-light conversation-muted"
+          data-uie-name="status-silence"
+          title={t('accessibility.conversationStatusMuted')}
+        >
+          <Icon.Mute className="svg-icon" />
+        </span>
+      )}
+
+      {cellState.icon === ConversationStatusIcon.UNREAD_MESSAGES && unreadState.allMessages.length > 0 && (
+        <span
+          className="conversation-list-cell-badge cell-badge-dark"
+          data-uie-name="status-unread"
+          title={t('accessibility.conversationStatusUnread')}
+        >
+          {unreadState.allMessages.length}
+        </span>
+      )}
+    </>
+  );
+};
+
+export {ConversationListCellStatusIcon};

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -252,7 +252,9 @@ export class Conversation {
       const is1to1Conversation = this.type() === CONVERSATION_TYPE.ONE_TO_ONE;
       return is1to1Conversation || this.isTeam1to1();
     });
-    this.isRequest = ko.pureComputed(() => this.type() === CONVERSATION_TYPE.CONNECT);
+    this.isRequest = ko.pureComputed(
+      () => this.type() === CONVERSATION_TYPE.CONNECT || this.participating_user_ets()[0]?.isRequest(),
+    );
     this.isSelf = ko.pureComputed(() => this.type() === CONVERSATION_TYPE.SELF);
 
     this.hasDirectGuest = ko.pureComputed(() => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4849" title="WPB-4849" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4849</a>  Missing pending icon on outgoing connection request
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description
This commit addresses a backend issue where outgoing connection requests are incorrectly categorized as type 3 (1:1 conversations) instead of type 2 (connect). To work around this issue, we now utilize the "isRequest" property from the users[0] of the conversation users. This approach ensures that the conversation type is accurately represented as type 2 in the incoming list of conversations, aligning with the expected behavior.

## Screenshots/Screencast (for UI changes)

Before:
![image](https://github.com/wireapp/wire-webapp/assets/63250054/a40b4838-7694-4b8a-a7fe-c400d7abc26d)

After:
<img width="311" alt="image" src="https://github.com/wireapp/wire-webapp/assets/63250054/14decf90-8c52-4564-b6c1-e1988ca135bf">



## Checklist

- [X] PR has been self reviewed by the author;
- [X] Hard-to-understand areas of the code have been commented;
- [X] If it is a core feature, unit tests have been added;
