### PR TITLE
chore:  Revert back to node 16

### DIFF
--- a/.github/workflows/create_docker_image.yml
+++ b/.github/workflows/create_docker_image.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 16.x
           cache: 'yarn'
 
       - name: Install JS dependencies

--- a/.github/workflows/deploy-to-test-env.yml
+++ b/.github/workflows/deploy-to-test-env.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 16.x
           cache: 'yarn'
 
       - name: Install JS dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 16.x
           cache: 'yarn'
 
       - name: Install JS dependencies

--- a/.github/workflows/sync_translations.yml
+++ b/.github/workflows/sync_translations.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 16.x
           cache: 'yarn'
 
       - name: Authenticate git clone

--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 16.x
           cache: 'yarn'
 
       - name: Set environment variables

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
   },
   "engines": {
     "yarn": ">= 1.0.0",
-    "node": ">=18"
+    "node": ">=16"
   },
   "license": "GPL-3.0",
   "lint-staged": {

--- a/server/package.json
+++ b/server/package.json
@@ -34,9 +34,6 @@
     "rimraf": "4.4.1",
     "typescript": "5.2.2"
   },
-  "engines": {
-    "node": ">= 18"
-  },
   "scripts": {
     "build": "yarn clean && tsc && yarn generate-version-file && yarn copy-assets",
     "copy-assets": "node ./bin/copy_server_assets.js",


### PR DESCRIPTION
This reverts commit d0932283539fe282729d7c1abb51640c019e77dc.

## Description
Unfortunately node 18 is not compatible with our aws instances currently. would need to migrate to new instances.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
