### PR TITLE
feat: refresh self protocols on team refresh

### DIFF
--- a/src/script/self/SelfRepository.test.ts
+++ b/src/script/self/SelfRepository.test.ts
@@ -412,6 +412,25 @@ describe('SelfRepository', () => {
       expect(selfRepository.refreshSelfSupportedProtocols).toHaveBeenCalled();
     });
 
+    it('refreshes self supported protocols on team refresh', async () => {
+      const selfRepository = await testFactory.exposeSelfActors();
+
+      const selfUser = selfRepository['userState'].self()!;
+
+      const initialProtocols = [ConversationProtocol.PROTEUS];
+      selfUser.supportedProtocols(initialProtocols);
+
+      const evaluatedProtocols = [ConversationProtocol.PROTEUS, ConversationProtocol.MLS];
+
+      jest.spyOn(selfRepository, 'evaluateSelfSupportedProtocols').mockResolvedValueOnce(evaluatedProtocols);
+      jest.spyOn(selfRepository['selfService'], 'putSupportedProtocols');
+
+      await act(async () => selfRepository['teamRepository'].emit('teamRefreshed'));
+
+      expect(selfUser.supportedProtocols()).toEqual(evaluatedProtocols);
+      expect(selfRepository['selfService'].putSupportedProtocols).toHaveBeenCalledWith(evaluatedProtocols);
+    });
+
     it('refreshes self supported protocols after mls feature is enabled', async () => {
       const selfRepository = await testFactory.exposeSelfActors();
 

--- a/src/script/self/SelfRepository.ts
+++ b/src/script/self/SelfRepository.ts
@@ -55,6 +55,7 @@ export class SelfRepository {
     // It's possible that they have removed proteus client, and now all their clients are mls-capable.
     amplify.subscribe(WebAppEvents.CLIENT.REMOVE, this.refreshSelfSupportedProtocols);
 
+    teamRepository.on('teamRefreshed', this.refreshSelfSupportedProtocols);
     teamRepository.on('featureUpdated', ({event, prevFeatureList}) => {
       if (event.name === FEATURE_KEY.MLS) {
         void this.handleMLSFeatureUpdate(event.data, prevFeatureList?.[FEATURE_KEY.MLS]);

--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -78,6 +78,7 @@ type Events = {
     prevFeatureList?: FeatureList;
     event: TeamFeatureConfigurationUpdateEvent;
   };
+  teamRefreshed: void;
 };
 
 export class TeamRepository extends TypedEventEmitter<Events> {
@@ -156,6 +157,7 @@ export class TeamRepository extends TypedEventEmitter<Events> {
       try {
         await this.getTeam();
         await this.updateFeatureConfig();
+        this.emit('teamRefreshed');
       } catch (error) {
         this.logger.error(error);
       }


### PR DESCRIPTION
## Description

Makes user refresh self supported protocols after team (and its whole feature list) was refreshed. This happens every 24h.

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
