### PR TITLE
fix: Avoid race condition when dealing with image and image placeholder [WPB-4890]

### DIFF
--- a/src/script/event/EventRepository.ts
+++ b/src/script/event/EventRepository.ts
@@ -167,6 +167,10 @@ export class EventRepository {
     }
   };
 
+  /**
+   * this function will process any incoming event. It is being queue in case 2 events arrive at the same time.
+   * Processing events should happen sequentially (thus the queue)
+   */
   private readonly handleIncomingEvent = queue(async (payload: HandledEventPayload, source: NotificationSource) => {
     try {
       await this.handleEvent(payload, source);

--- a/src/script/event/EventRepository.ts
+++ b/src/script/event/EventRepository.ts
@@ -168,7 +168,7 @@ export class EventRepository {
   };
 
   /**
-   * this function will process any incoming event. It is being queue in case 2 events arrive at the same time.
+   * this function will process any incoming event. It is being queued in case 2 events arrive at the same time.
    * Processing events should happen sequentially (thus the queue)
    */
   private readonly handleIncomingEvent = queue(async (payload: HandledEventPayload, source: NotificationSource) => {

--- a/src/script/event/EventRepository.ts
+++ b/src/script/event/EventRepository.ts
@@ -34,6 +34,7 @@ import {Asset as ProtobufAsset} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {getLogger, Logger} from 'Util/Logger';
+import {queue} from 'Util/PromiseQueue';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
 
 import {ClientEvent} from './Client';
@@ -166,7 +167,7 @@ export class EventRepository {
     }
   };
 
-  private readonly handleIncomingEvent = async (payload: HandledEventPayload, source: NotificationSource) => {
+  private readonly handleIncomingEvent = queue(async (payload: HandledEventPayload, source: NotificationSource) => {
     try {
       await this.handleEvent(payload, source);
     } catch (error) {
@@ -176,7 +177,7 @@ export class EventRepository {
         throw error;
       }
     }
-  };
+  });
 
   /**
    * connects to the websocket with the given account

--- a/src/script/util/PromiseQueue.ts
+++ b/src/script/util/PromiseQueue.ts
@@ -192,3 +192,14 @@ export class PromiseQueue {
     }
   }
 }
+
+/**
+ * Will make sure a function is executed in order. If the function is already running, then the next payload will be queued.
+ * @param callback the function to queue
+ */
+export function queue<ReturnType, Params extends any[]>(
+  callback: (...params: Params) => Promise<ReturnType>,
+): (...params: Params) => Promise<ReturnType> {
+  const promiseQueue = new PromiseQueue({name: 'queue'});
+  return (...params: Params) => promiseQueue.push(() => callback(...params));
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4890" title="WPB-4890" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4890</a>  [Web] After back online previously sent images shown as grey icons
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

When incoming messages arrive, they are treated one-by-one but, because of the async nature of their processing, there could be 2 events that are being processed at the same time. 

That's not a big issue in general, but in the particular case of images, we can fall into this scenario:
- the placeholder of an image is sent (containing all the metadata of the image)
- processing starts for the placeholder
- the actual image arrives
- processing starts for the image
- when the image is processed we look, in the DB, for the placeholder in order to replace it
- since the placeholder is not yet save to DB, it's not found
-> as a result: we do not replace the placeholder with the actual image and save both events 
-> on the UI level, the placeholder shows forever, along with the actual image

## Screenshots/Screencast (for UI changes)

### Before

the placeholder and the image are processed at the same. When receiving the event, we only display the placeholder (the other message is filtered). When switching conversation, we can see the actual image along with the placeholder

https://github.com/wireapp/wire-webapp/assets/1090716/4205390c-fcfa-44f0-8179-91c354d9af7b


### After

The placeholder is completely processed before the actual image and correctly replaced in DB

https://github.com/wireapp/wire-webapp/assets/1090716/40e9b703-1fc8-4603-8b51-ec2a74a7f069



## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

