### PR TITLE
fix: prevent long handles from causing misalignment in add users modal

### DIFF
--- a/src/script/components/ParticipantItemContent/ParticipantItem.styles.ts
+++ b/src/script/components/ParticipantItemContent/ParticipantItem.styles.ts
@@ -111,7 +111,7 @@ export const ellipsis: CSSObject = {
 
 export const wrapper: CSSObject = {
   display: 'flex',
-  minWidth: 0,
+  width: 0,
   height: 'var(--avatar-diameter-m)',
   flex: '1 1',
   alignItems: 'center',


### PR DESCRIPTION
## Description

Long user handles break the alignment of participants in the add users modal.
It appears flexbox is not computing the width of the truncated string correctly, even with the usual fix of assigning `min-width: 0` to the wrapper div.
Assigning a `width: 0` instead fixes the issue.

## Screenshots/Screencast (for UI changes)

- min-width: 0
![image](https://github.com/wireapp/wire-webapp/assets/78490891/d66a99a5-9f5b-4360-9cc4-b1fdbb5ff465)

- width: 0
![image](https://github.com/wireapp/wire-webapp/assets/78490891/9aeafa81-e4f9-4796-826a-c69ef3c1a8bc)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
