### PR TITLE
feat: bump core with mls send recovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@datadog/browser-rum": "^4.49.0",
     "@emotion/react": "11.11.1",
     "@wireapp/avs": "9.3.7",
-    "@wireapp/core": "42.7.0",
+    "@wireapp/core": "42.8.0",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.9.6",
     "@wireapp/store-engine-dexie": "2.1.6",

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -791,6 +791,7 @@ export class MessageRepository {
           groupId,
           payload,
           protocol: ConversationProtocol.MLS,
+          conversationId: conversation.qualifiedId,
         }
       : {
           conversationId: conversation.qualifiedId,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5373,9 +5373,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^26.2.2":
-  version: 26.2.2
-  resolution: "@wireapp/api-client@npm:26.2.2"
+"@wireapp/api-client@npm:^26.2.3":
+  version: 26.2.3
+  resolution: "@wireapp/api-client@npm:26.2.3"
   dependencies:
     "@wireapp/commons": ^5.2.0
     "@wireapp/priority-queue": ^2.1.4
@@ -5389,7 +5389,7 @@ __metadata:
     spark-md5: 3.0.2
     tough-cookie: 4.1.3
     ws: 8.14.2
-  checksum: bcf939e366a3cf2a4f8fd1184606d6d2c78d8304d0c1d40c2d2964dde1db5dcec80c91859f819da4e73b520dbfb5f0b5416a15c31ecadacdf428adb5a3411287
+  checksum: 2872223be89a6ae85092832270d23135bb22441d5d068522335416fcd783bac87d425030379128b741054ef3948593b485f67354e239800864b0b694887b6d8a
   languageName: node
   linkType: hard
 
@@ -5442,11 +5442,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:42.7.0":
-  version: 42.7.0
-  resolution: "@wireapp/core@npm:42.7.0"
+"@wireapp/core@npm:42.8.0":
+  version: 42.8.0
+  resolution: "@wireapp/core@npm:42.8.0"
   dependencies:
-    "@wireapp/api-client": ^26.2.2
+    "@wireapp/api-client": ^26.2.3
     "@wireapp/commons": ^5.2.0
     "@wireapp/core-crypto": 1.0.0-rc.12
     "@wireapp/cryptobox": 12.8.0
@@ -5463,7 +5463,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.13
-  checksum: 15f2dbe460decdf9f9387271f17b2898c93d18b896c149ad11556c0be43fd3bdf999ff9bc33a11ecc8844160f31b794889be8025e61b6a219c4e3a6faecd8c6b
+  checksum: f4ac96eab90916290a402e5060c06121b53d92a5b81a232cd878f0e77f2d5751d6637d558a6b40b29e9738d56bd3c15f8694e5f10aa5dd187b594cfba1d9e6b4
   languageName: node
   linkType: hard
 
@@ -18599,7 +18599,7 @@ __metadata:
     "@types/webpack-env": 1.18.1
     "@wireapp/avs": 9.3.7
     "@wireapp/copy-config": 2.1.8
-    "@wireapp/core": 42.7.0
+    "@wireapp/core": 42.8.0
     "@wireapp/eslint-config": 3.0.4
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.6.3


### PR DESCRIPTION
## Description

Bumps core with version that contains recovery from mls send message failure. For more details see https://github.com/wireapp/wire-web-packages/pull/5497.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
