### PR TITLE
chore: Create release page when creating release artifact

### DIFF
--- a/.github/workflows/create_docker_image.yml
+++ b/.github/workflows/create_docker_image.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Build
         run: yarn build:prod
 
+      - name: Push Docker image
+        env:
+          DOCKER_PASSWORD: ${{secrets.WEBTEAM_QUAY_PASSWORD}}
+          DOCKER_USERNAME: ${{secrets.WEBTEAM_QUAY_USERNAME}}
+        run: yarn docker '' "${{inputs.tag}}"
+
       - name: Create GitHub release
         id: create_release_production
         uses: softprops/action-gh-release@v1
@@ -50,9 +56,3 @@ jobs:
           files: ./unit-tests.log
           draft: false
           prerelease: true
-
-      - name: Push Docker image
-        env:
-          DOCKER_PASSWORD: ${{secrets.WEBTEAM_QUAY_PASSWORD}}
-          DOCKER_USERNAME: ${{secrets.WEBTEAM_QUAY_USERNAME}}
-        run: yarn docker '' "${{inputs.tag}}"

--- a/.github/workflows/create_docker_image.yml
+++ b/.github/workflows/create_docker_image.yml
@@ -1,10 +1,10 @@
-name: Create Docker image
+name: Create Release Artifact
 
 on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'tagname for the Docker image'
+        description: 'tagname for the Artifact'
         required: true
         type: string
 
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test_build_deploy:
+  create_image:
     runs-on: ubuntu-latest
 
     steps:
@@ -32,10 +32,24 @@ jobs:
         run: yarn --immutable
 
       - name: Test
-        run: yarn test --coverage --coverage-reporters=lcov --detectOpenHandles=false
+        run: |
+          set -o pipefail
+          yarn test --coverage --coverage-reporters=lcov --detectOpenHandles=false 2>&1 | tee ./unit-tests.log
 
       - name: Build
         run: yarn build:prod
+
+      - name: Create GitHub release
+        id: create_release_production
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{github.token}}
+        with:
+          tag_name: ${{inputs.tag}}
+          name: ${{inputs.tag}}
+          files: ./unit-tests.log
+          draft: false
+          prerelease: true
 
       - name: Push Docker image
         env:

--- a/.github/workflows/create_docker_image.yml
+++ b/.github/workflows/create_docker_image.yml
@@ -8,6 +8,12 @@ on:
         required: true
         type: string
 
+      create_release:
+        description: 'Wether or not a release entry should be created on github'
+        required: false
+        default: true
+        type: boolean
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
@@ -46,6 +52,7 @@ jobs:
         run: yarn docker '' "${{inputs.tag}}"
 
       - name: Create GitHub release
+        if: ${{inputs.create_release}}
         id: create_release_production
         uses: softprops/action-gh-release@v1
         env:


### PR DESCRIPTION
## Description

Will create a release page along with a docker image uploaded to quay. 
This will enable matching a docker image tag with a release page 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
