### PR TITLE
chore: Add commit sha to manually created release artifacts

### DIFF
--- a/.github/workflows/create_docker_image.yml
+++ b/.github/workflows/create_docker_image.yml
@@ -45,11 +45,15 @@ jobs:
       - name: Build
         run: yarn build:prod
 
+      - name: Set short sha
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
       - name: Push Docker image
         env:
           DOCKER_PASSWORD: ${{secrets.WEBTEAM_QUAY_PASSWORD}}
           DOCKER_USERNAME: ${{secrets.WEBTEAM_QUAY_USERNAME}}
-        run: yarn docker '' "${{inputs.tag}}"
+        run: yarn docker "${{inputs.tag}}-${{ steps.vars.outputs.sha_short }}"
 
       - name: Create GitHub release
         if: ${{inputs.create_release}}

--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -172,21 +172,21 @@ jobs:
         env:
           DOCKER_PASSWORD: ${{secrets.WEBTEAM_QUAY_PASSWORD}}
           DOCKER_USERNAME: ${{secrets.WEBTEAM_QUAY_USERNAME}}
-        run: yarn docker '' "${{env.BRANCH_NAME}}"
+        run: yarn docker "${{env.BRANCH_NAME}}"
 
       - name: Push staging Docker image
         if: contains(env.TAG, 'staging')
         env:
           DOCKER_PASSWORD: ${{secrets.WEBTEAM_QUAY_PASSWORD}}
           DOCKER_USERNAME: ${{secrets.WEBTEAM_QUAY_USERNAME}}
-        run: yarn docker '' staging "$TAG"
+        run: yarn docker staging "$TAG"
 
       - name: Push production Docker image
         if: contains(env.TAG, 'production')
         env:
           DOCKER_PASSWORD: ${{secrets.WEBTEAM_QUAY_PASSWORD}}
           DOCKER_USERNAME: ${{secrets.WEBTEAM_QUAY_USERNAME}}
-        run: yarn docker '' production "$TAG"
+        run: yarn docker production "$TAG"
 
       - name: Generate changelog for production release
         if: contains(env.TAG, 'production')

--- a/bin/push_docker.js
+++ b/bin/push_docker.js
@@ -33,23 +33,16 @@ require('dotenv').config();
  * Note: You must run "yarn build:prod" before creating the Docker image, otherwise the compiled JavaScript code (and other assets) won't be part of the bundle.
  *
  * Demo execution:
- * yarn docker '' staging '2021-08-25' '1240cfda9e609470cf1154e18f5bc582ca8907ff'
+ * yarn docker staging '2021-08-25' '1240cfda9e609470cf1154e18f5bc582ca8907ff'
  */
 
-/** Either empty (for our own cloud releases) or a suffix (i.e. "ey") for custom deployments */
-const distributionParam = process.argv[2] || '';
 /** Either "staging" (for internal releases / staging bumps) or "production" (for cloud releases) */
-const stageParam = process.argv[3] || '';
+const stageParam = process.argv[2] || '';
 /** Version tag of webapp (i.e. "2021-08-25") */
-const versionParam = process.argv[4] || '';
+const versionParam = process.argv[3] || '';
 /** Commit ID of https://github.com/wireapp/wire-webapp (i.e. "1240cfda9e609470cf1154e18f5bc582ca8907ff") */
-const commitSha = process.env.GITHUB_SHA || process.argv[5];
+const commitSha = process.env.GITHUB_SHA || process.argv[4];
 const commitShortSha = commitSha.substring(0, 7);
-/** Defines which config version (listed in "app-config/package.json") is going to be used */
-const configurationEntry = `wire-web-config-default-${
-  distributionParam || stageParam === 'production' ? 'master' : 'staging'
-}`;
-const configVersion = appConfigPkg.dependencies[configurationEntry].split('#')[1];
 const dockerRegistryDomain = 'quay.io';
 const repository = `${dockerRegistryDomain}/wire/webapp${distributionParam ? `-${distributionParam}` : ''}`;
 
@@ -61,6 +54,11 @@ if (stageParam) {
 }
 
 if (['production', 'staging'].includes(stageParam)) {
+  /** Defines which config version (listed in "app-config/package.json") is going to be used */
+  const configurationEntry = `wire-web-config-default-${
+    distributionParam || stageParam === 'production' ? 'master' : 'staging'
+  }`;
+  const configVersion = appConfigPkg.dependencies[configurationEntry].split('#')[1];
   tags.push(`${repository}:${versionParam}-${configVersion}-${commitShortSha}`);
 }
 


### PR DESCRIPTION
## Description

Will generate a docker image tagged `<tag>-<shortCommitSha>` when generating a release artefact with github actions. 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
