### PR TITLE
runfix: Do not show connection requests on group conversations

### DIFF
--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -253,7 +253,8 @@ export class Conversation {
       return is1to1Conversation || this.isTeam1to1();
     });
     this.isRequest = ko.pureComputed(
-      () => this.type() === CONVERSATION_TYPE.CONNECT || this.participating_user_ets()[0]?.isRequest(),
+      () =>
+        this.type() === CONVERSATION_TYPE.CONNECT || (this.is1to1() && this.participating_user_ets()[0]?.isRequest()),
     );
     this.isSelf = ko.pureComputed(() => this.type() === CONVERSATION_TYPE.SELF);
 


### PR DESCRIPTION
## Description

Fix for #15894 . 
We want to show connection request state only for 1:1 conversations, not group conversations

## Screenshots/Screencast (for UI changes)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

