### PR TITLE
fix: do not create a placeholder 1:1 conversation for accepted conversations

### DIFF
--- a/src/script/components/panel/UserActions.tsx
+++ b/src/script/components/panel/UserActions.tsx
@@ -19,6 +19,7 @@
 
 import React from 'react';
 
+import {ConnectionStatus} from '@wireapp/api-client/lib/connection';
 import {CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation';
 import {amplify} from 'amplify';
 
@@ -219,19 +220,24 @@ const UserActions: React.FC<UserActionsProps> = ({
     isNotMe && isAvailable && isNotConnectedUser && canConnect
       ? {
           click: async () => {
-            const connectionIsSent = await actionsViewModel.sendConnectionRequest(user);
-            if (!connectionIsSent) {
+            try {
+              const {connectionStatus, conversationId} = await actionsViewModel.sendConnectionRequest(user);
+
+              // If connection's state is SENT, we create a local 1:1 conversation that will act as a placeholder
+              // before the other user has accepted the request.
+              const connectionConversation =
+                connectionStatus === ConnectionStatus.SENT
+                  ? createPlaceholder1to1Conversation(user, selfUser)
+                  : await actionsViewModel.getConversationById(conversationId);
+
+              if (!conversation) {
+                // Only open the new conversation if we aren't currently in a conversation context
+                await actionsViewModel.open1to1Conversation(connectionConversation);
+              }
+              onAction(Actions.SEND_REQUEST);
+            } catch {
               // Sending the connection failed, there is nothing more to do
-              return;
             }
-            // We create a local 1:1 conversation that will act as a placeholder before the other user has accepted the request
-            const newConversation = createPlaceholder1to1Conversation(user, selfUser);
-            const savedConversation = await actionsViewModel.saveConversation(newConversation);
-            if (!conversation) {
-              // Only open the new conversation if we aren't currently in a conversation context
-              actionsViewModel.open1to1Conversation(savedConversation);
-            }
-            onAction(Actions.SEND_REQUEST);
           },
           icon: 'plus-icon',
           identifier: ActionIdentifier[Actions.SEND_REQUEST],

--- a/src/script/components/panel/UserActions.tsx
+++ b/src/script/components/panel/UserActions.tsx
@@ -220,24 +220,27 @@ const UserActions: React.FC<UserActionsProps> = ({
     isNotMe && isAvailable && isNotConnectedUser && canConnect
       ? {
           click: async () => {
-            try {
-              const {connectionStatus, conversationId} = await actionsViewModel.sendConnectionRequest(user);
+            const connectionData = await actionsViewModel.sendConnectionRequest(user);
 
-              // If connection's state is SENT, we create a local 1:1 conversation that will act as a placeholder
-              // before the other user has accepted the request.
-              const connectionConversation =
-                connectionStatus === ConnectionStatus.SENT
-                  ? createPlaceholder1to1Conversation(user, selfUser)
-                  : await actionsViewModel.getConversationById(conversationId);
-
-              if (!conversation) {
-                // Only open the new conversation if we aren't currently in a conversation context
-                await actionsViewModel.open1to1Conversation(connectionConversation);
-              }
-              onAction(Actions.SEND_REQUEST);
-            } catch {
+            if (!connectionData) {
               // Sending the connection failed, there is nothing more to do
+              return;
             }
+
+            const {connectionStatus, conversationId} = connectionData;
+
+            // If connection's state is SENT, we create a local 1:1 conversation that will act as a placeholder
+            // before the other user has accepted the request.
+            const connectionConversation =
+              connectionStatus === ConnectionStatus.SENT
+                ? createPlaceholder1to1Conversation(user, selfUser)
+                : await actionsViewModel.getConversationById(conversationId);
+
+            if (!conversation) {
+              // Only open the new conversation if we aren't currently in a conversation context
+              await actionsViewModel.open1to1Conversation(connectionConversation);
+            }
+            onAction(Actions.SEND_REQUEST);
           },
           icon: 'plus-icon',
           identifier: ActionIdentifier[Actions.SEND_REQUEST],

--- a/src/script/connection/ConnectionRepository.ts
+++ b/src/script/connection/ConnectionRepository.ts
@@ -184,12 +184,17 @@ export class ConnectionRepository {
    * @param userEntity User to connect to
    * @returns Promise that resolves to true if the request was successfully sent, false if not
    */
-  public async createConnection(userEntity: User): Promise<boolean> {
+  public async createConnection(
+    userEntity: User,
+  ): Promise<{connectionStatus: ConnectionStatus; conversationId: QualifiedId}> {
     try {
       const response = await this.connectionService.postConnections(userEntity.qualifiedId);
       const connectionEvent = {connection: response, user: {name: userEntity.name()}};
       await this.onUserConnection(connectionEvent, EventRepository.SOURCE.INJECTED);
-      return true;
+      return {
+        connectionStatus: response.status,
+        conversationId: response.qualified_conversation || {id: response.conversation, domain: ''},
+      };
     } catch (error) {
       if (isBackendError(error)) {
         switch (error.label) {
@@ -229,7 +234,6 @@ export class ConnectionRepository {
             break;
           }
         }
-        return false;
       }
       throw error;
     }

--- a/src/script/connection/ConnectionRepository.ts
+++ b/src/script/connection/ConnectionRepository.ts
@@ -186,7 +186,7 @@ export class ConnectionRepository {
    */
   public async createConnection(
     userEntity: User,
-  ): Promise<{connectionStatus: ConnectionStatus; conversationId: QualifiedId}> {
+  ): Promise<{connectionStatus: ConnectionStatus; conversationId: QualifiedId} | null> {
     try {
       const response = await this.connectionService.postConnections(userEntity.qualifiedId);
       const connectionEvent = {connection: response, user: {name: userEntity.name()}};
@@ -234,6 +234,7 @@ export class ConnectionRepository {
             break;
           }
         }
+        return null;
       }
       throw error;
     }

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -641,7 +641,7 @@ export class ConversationRepository {
       const response = await this.conversationService.getConversationById(qualifiedId);
       const [conversationEntity] = this.mapConversations([response]);
 
-      this.saveConversation(conversationEntity);
+      await this.saveConversation(conversationEntity);
 
       fetching_conversations[conversationId].forEach(({resolveFn}) => resolveFn(conversationEntity));
       delete fetching_conversations[conversationId];

--- a/src/script/view_model/ActionsViewModel.ts
+++ b/src/script/view_model/ActionsViewModel.ts
@@ -392,7 +392,7 @@ export class ActionsViewModel {
    */
   readonly sendConnectionRequest = (
     userEntity: User,
-  ): Promise<{connectionStatus: ConnectionStatus; conversationId: QualifiedId}> => {
+  ): Promise<{connectionStatus: ConnectionStatus; conversationId: QualifiedId} | null> => {
     return this.connectionRepository.createConnection(userEntity);
   };
 

--- a/src/script/view_model/ActionsViewModel.ts
+++ b/src/script/view_model/ActionsViewModel.ts
@@ -17,7 +17,9 @@
  *
  */
 
+import {ConnectionStatus} from '@wireapp/api-client/lib/connection/';
 import {BackendErrorLabel} from '@wireapp/api-client/lib/http';
+import {QualifiedId} from '@wireapp/api-client/lib/user/';
 import {amplify} from 'amplify';
 import {container} from 'tsyringe';
 
@@ -305,6 +307,10 @@ export class ActionsViewModel {
     return Promise.reject();
   };
 
+  getConversationById = async (conversation: QualifiedId): Promise<Conversation> => {
+    return this.conversationRepository.getConversationById(conversation);
+  };
+
   saveConversation = async (conversation: Conversation): Promise<Conversation> => {
     return this.conversationRepository.saveConversation(conversation);
   };
@@ -384,7 +390,9 @@ export class ActionsViewModel {
    * @param userEntity User to connect to
    * @returns Promise that resolves to true if the request was successfully sent, false if not
    */
-  readonly sendConnectionRequest = (userEntity: User): Promise<boolean> => {
+  readonly sendConnectionRequest = (
+    userEntity: User,
+  ): Promise<{connectionStatus: ConnectionStatus; conversationId: QualifiedId}> => {
     return this.connectionRepository.createConnection(userEntity);
   };
 


### PR DESCRIPTION
## Description

Do not create a placeholder conversation after sending a POST request to /connections/{domain}/{uid} responds with a connection which status is other than `"sent"`.

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;
