### PR TITLE
runfix: save connection conversation after creating it

### DIFF
--- a/src/script/components/panel/UserActions.tsx
+++ b/src/script/components/panel/UserActions.tsx
@@ -236,9 +236,10 @@ const UserActions: React.FC<UserActionsProps> = ({
                 ? createPlaceholder1to1Conversation(user, selfUser)
                 : await actionsViewModel.getConversationById(conversationId);
 
+            const savedConversation = await actionsViewModel.saveConversation(connectionConversation);
             if (!conversation) {
               // Only open the new conversation if we aren't currently in a conversation context
-              await actionsViewModel.open1to1Conversation(connectionConversation);
+              await actionsViewModel.open1to1Conversation(savedConversation);
             }
             onAction(Actions.SEND_REQUEST);
           },


### PR DESCRIPTION
## Description

I've mistakenly removed the saving part from the logic of creating a placeholder for the conversation after sending a connection request. See https://github.com/wireapp/wire-webapp/pull/15927/files#diff-f8053f2d1c4626a4daa1de18c4b8a9c3c9ba1fafa766a2de19d7cf26ad9e358eL229

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
