### PR TITLE
runfix: recurring tasks indexeddb store

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@datadog/browser-rum": "^4.50.0",
     "@emotion/react": "11.11.1",
     "@wireapp/avs": "9.3.7",
-    "@wireapp/core": "42.9.0",
+    "@wireapp/core": "42.9.3",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.9.9",
     "@wireapp/store-engine-dexie": "2.1.6",

--- a/src/__mocks__/@wireapp/core.ts
+++ b/src/__mocks__/@wireapp/core.ts
@@ -24,6 +24,11 @@ export class Account extends EventEmitter {
     federationEndpoints: true,
   };
 
+  recurringTaskScheduler = {
+    registerTask: jest.fn(),
+    cancelTask: jest.fn(),
+  };
+
   configureMLSCallbacks = jest.fn();
 
   service = {

--- a/src/script/self/SelfRepository.test.ts
+++ b/src/script/self/SelfRepository.test.ts
@@ -281,6 +281,7 @@ describe('SelfRepository', () => {
 
     it('registers periodic supported protocols refresh task to be called every 24h', async () => {
       const selfRepository = await testFactory.exposeSelfActors();
+      const core = container.resolve(Core);
 
       const selfUser = selfRepository['userState'].self()!;
 
@@ -290,13 +291,13 @@ describe('SelfRepository', () => {
       const evaluatedProtocols = [ConversationProtocol.PROTEUS];
 
       jest.spyOn(selfRepository, 'evaluateSelfSupportedProtocols').mockResolvedValueOnce(evaluatedProtocols);
-      jest.spyOn(selfRepository['selfService'], 'registerRecurringTask');
+      jest.spyOn(core.recurringTaskScheduler, 'registerTask');
 
       await act(async () => {
         await selfRepository.initialisePeriodicSelfSupportedProtocolsCheck();
       });
 
-      expect(selfRepository['selfService'].registerRecurringTask).toHaveBeenCalledWith({
+      expect(core.recurringTaskScheduler.registerTask).toHaveBeenCalledWith({
         every: TIME_IN_MILLIS.DAY,
         key: SelfRepository.SELF_SUPPORTED_PROTOCOLS_CHECK_KEY,
         task: expect.anything(),

--- a/src/script/self/SelfRepository.test.ts
+++ b/src/script/self/SelfRepository.test.ts
@@ -301,6 +301,8 @@ describe('SelfRepository', () => {
         key: SelfRepository.SELF_SUPPORTED_PROTOCOLS_CHECK_KEY,
         task: expect.anything(),
       });
+
+      expect(selfUser.supportedProtocols()).toEqual(evaluatedProtocols);
     });
   });
 

--- a/src/script/self/SelfRepository.test.ts
+++ b/src/script/self/SelfRepository.test.ts
@@ -279,7 +279,7 @@ describe('SelfRepository', () => {
       expect(selfRepository['selfService'].putSupportedProtocols).not.toHaveBeenCalled();
     });
 
-    it('registers periodic supported protocols refresh task every 24h', async () => {
+    it('registers periodic supported protocols refresh task to be called every 24h', async () => {
       const selfRepository = await testFactory.exposeSelfActors();
 
       const selfUser = selfRepository['userState'].self()!;

--- a/src/script/self/SelfRepository.ts
+++ b/src/script/self/SelfRepository.ts
@@ -36,10 +36,9 @@ import {TeamRepository} from '../team/TeamRepository';
 import {UserRepository} from '../user/UserRepository';
 import {UserState} from '../user/UserState';
 
-const SELF_SUPPORTED_PROTOCOLS_CHECK_KEY = 'self-supported-protocols-check';
-
 export class SelfRepository {
   private readonly logger: Logger;
+  static SELF_SUPPORTED_PROTOCOLS_CHECK_KEY = 'self-supported-protocols-check';
 
   constructor(
     private readonly selfService: SelfService,
@@ -232,7 +231,7 @@ export class SelfRepository {
     await this.selfService.registerRecurringTask({
       every: TIME_IN_MILLIS.DAY,
       task: refreshProtocolsTask,
-      key: SELF_SUPPORTED_PROTOCOLS_CHECK_KEY,
+      key: SelfRepository.SELF_SUPPORTED_PROTOCOLS_CHECK_KEY,
     });
   }
 

--- a/src/script/self/SelfRepository.ts
+++ b/src/script/self/SelfRepository.ts
@@ -19,7 +19,6 @@
 
 import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 import {FEATURE_KEY, FeatureMLS} from '@wireapp/api-client/lib/team/feature/';
-import {registerRecurringTask} from '@wireapp/core/lib/util/RecurringTaskScheduler';
 import {amplify} from 'amplify';
 import {container} from 'tsyringe';
 
@@ -230,7 +229,7 @@ export class SelfRepository {
     };
     await refreshProtocolsTask();
 
-    return registerRecurringTask({
+    await this.selfService.registerRecurringTask({
       every: TIME_IN_MILLIS.DAY,
       task: refreshProtocolsTask,
       key: SELF_SUPPORTED_PROTOCOLS_CHECK_KEY,

--- a/src/script/self/SelfRepository.ts
+++ b/src/script/self/SelfRepository.ts
@@ -32,6 +32,7 @@ import {SelfService} from './SelfService';
 import {ClientEntity, ClientRepository} from '../client';
 import {isMLSSupportedByEnvironment} from '../mls/isMLSSupportedByEnvironment';
 import {MLSMigrationStatus} from '../mls/MLSMigration/migrationStatus';
+import {Core} from '../service/CoreSingleton';
 import {TeamRepository} from '../team/TeamRepository';
 import {UserRepository} from '../user/UserRepository';
 import {UserState} from '../user/UserState';
@@ -46,6 +47,7 @@ export class SelfRepository {
     private readonly teamRepository: TeamRepository,
     private readonly clientRepository: ClientRepository,
     private readonly userState = container.resolve(UserState),
+    private readonly core = container.resolve(Core),
   ) {
     this.logger = getLogger('SelfRepository');
 
@@ -228,7 +230,7 @@ export class SelfRepository {
     };
     await refreshProtocolsTask();
 
-    await this.selfService.registerRecurringTask({
+    await this.core.recurringTaskScheduler.registerTask({
       every: TIME_IN_MILLIS.DAY,
       task: refreshProtocolsTask,
       key: SelfRepository.SELF_SUPPORTED_PROTOCOLS_CHECK_KEY,

--- a/src/script/self/SelfService.ts
+++ b/src/script/self/SelfService.ts
@@ -24,9 +24,13 @@ import type {UserUpdate} from '@wireapp/api-client/lib/user/';
 import {container} from 'tsyringe';
 
 import {APIClient} from '../service/APIClientSingleton';
+import {Core} from '../service/CoreSingleton';
 
 export class SelfService {
-  constructor(private readonly apiClient = container.resolve(APIClient)) {}
+  constructor(
+    private readonly apiClient = container.resolve(APIClient),
+    private readonly core = container.resolve(Core),
+  ) {}
 
   deleteSelf(password?: string): Promise<void> {
     return this.apiClient.api.self.deleteSelf({password});
@@ -71,5 +75,9 @@ export class SelfService {
 
   putSupportedProtocols(supportedProtocols: ConversationProtocol[]): Promise<void> {
     return this.apiClient.api.self.putSupportedProtocols(supportedProtocols);
+  }
+
+  registerRecurringTask(taskConfig: {every: number; task: () => Promise<void>; key: string}): Promise<void> {
+    return this.core.recurringTaskScheduler.registerTask(taskConfig);
   }
 }

--- a/src/script/self/SelfService.ts
+++ b/src/script/self/SelfService.ts
@@ -24,13 +24,9 @@ import type {UserUpdate} from '@wireapp/api-client/lib/user/';
 import {container} from 'tsyringe';
 
 import {APIClient} from '../service/APIClientSingleton';
-import {Core} from '../service/CoreSingleton';
 
 export class SelfService {
-  constructor(
-    private readonly apiClient = container.resolve(APIClient),
-    private readonly core = container.resolve(Core),
-  ) {}
+  constructor(private readonly apiClient = container.resolve(APIClient)) {}
 
   deleteSelf(password?: string): Promise<void> {
     return this.apiClient.api.self.deleteSelf({password});

--- a/src/script/self/SelfService.ts
+++ b/src/script/self/SelfService.ts
@@ -76,8 +76,4 @@ export class SelfService {
   putSupportedProtocols(supportedProtocols: ConversationProtocol[]): Promise<void> {
     return this.apiClient.api.self.putSupportedProtocols(supportedProtocols);
   }
-
-  registerRecurringTask(taskConfig: {every: number; task: () => Promise<void>; key: string}): Promise<void> {
-    return this.core.recurringTaskScheduler.registerTask(taskConfig);
-  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5489,9 +5489,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:42.9.0":
-  version: 42.9.0
-  resolution: "@wireapp/core@npm:42.9.0"
+"@wireapp/core@npm:42.9.3":
+  version: 42.9.3
+  resolution: "@wireapp/core@npm:42.9.3"
   dependencies:
     "@wireapp/api-client": ^26.2.4
     "@wireapp/commons": ^5.2.0
@@ -5510,7 +5510,7 @@ __metadata:
     logdown: 3.3.1
     long: ^5.2.0
     uuidjs: 4.2.13
-  checksum: 9988d8c1a084eb1112a5fc4969d54c2deea0eddd82a212cee6e19d7142d8f12b11854b407ebd820557cfb6dd40dd4679ed008838bf940b3bd043325c1b65c869
+  checksum: 9e277df83901c332d8772466c4be7417b69f0fa10447359bec1aecf55b580ae1b922a72d3c00683083ed17420385efc87f40e5af27235637a1362260b204350e
   languageName: node
   linkType: hard
 
@@ -18657,7 +18657,7 @@ __metadata:
     "@types/webpack-env": 1.18.2
     "@wireapp/avs": 9.3.7
     "@wireapp/copy-config": 2.1.8
-    "@wireapp/core": 42.9.0
+    "@wireapp/core": 42.9.3
     "@wireapp/eslint-config": 3.0.4
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.6.3


### PR DESCRIPTION
## Description

If we want to use the recurring task scheduler with core's indexedDB as a store, we need to call it through core.

For more details see https://github.com/wireapp/wire-web-packages/pull/5576.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
