### PR TITLE
fix: map conneciton to conversation when request is sent

### DIFF
--- a/src/script/connection/ConnectionRepository.ts
+++ b/src/script/connection/ConnectionRepository.ts
@@ -124,9 +124,9 @@ export class ConnectionRepository {
       await this.userRepository.refreshUser(connectionEntity.userId);
       // Get conversation related to connection and set its type to 1:1
       // This case is important when the 'user.connection' event arrives after the 'conversation.member-join' event: https://wearezeta.atlassian.net/browse/SQCORE-348
-
-      amplify.publish(WebAppEvents.CONVERSATION.MAP_CONNECTION, connectionEntity, source);
     }
+
+    amplify.publish(WebAppEvents.CONVERSATION.MAP_CONNECTION, connectionEntity, source);
 
     await this.sendNotification(connectionEntity, source, previousStatus);
   }


### PR DESCRIPTION
## Description
### Problem
There was a bug with sending a connection request that could even lead to app crash.

STR:
- there's user `A` with two clients `A1` and `A2` and user B with one client `B1`
- `A1`, `A2`, and `B1` are active (they're online and are connected to the websocket)
- `A1` sends a connection request to `B1`
- `A1` can see an outgoing connection request with `B` user's name
- `A2` cannot see it (there's "Name is not available" text displayed instead)
- `A2` clicks on a conversation, tries to access 1:1 conversation details and app crashes

The reason behind it is the fact that we were not mapping a connection to conversation when connection's status was different than "accepted".

### Solution
The solution is to always map a connection to a conversation, regardless the connection's state.

## Screenshots/Screencast (for UI changes)

Before:
![Kapture 2023-10-06 at 14 24 58](https://github.com/wireapp/wire-webapp/assets/45733298/12a3027e-fe49-45e1-9dfe-e0025bb97497)

After:
![Kapture 2023-10-06 at 14 37 57](https://github.com/wireapp/wire-webapp/assets/45733298/7432e022-550e-4e1d-97be-71041a7a8a70)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
