### PR TITLE
runfix: Reset complete draft state when sending message

### DIFF
--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -202,12 +202,11 @@ export const InputBar = ({
     ),
   });
 
-  const resetDraftState = (resetInputValue = false) => {
-    if (resetInputValue) {
-      editorRef.current?.update(() => {
-        $getRoot().clear();
-      });
-    }
+  const resetDraftState = () => {
+    setReplyMessageEntity(null);
+    editorRef.current?.update(() => {
+      $getRoot().clear();
+    });
   };
 
   const clearPastedFile = () => setPastedFile(null);
@@ -237,12 +236,12 @@ export const InputBar = ({
     };
   });
 
-  const cancelMessageEditing = (resetDraft = true, resetInputValue = false) => {
+  const cancelMessageEditing = (resetDraft = true) => {
     setEditedMessage(undefined);
     setReplyMessageEntity(null);
 
     if (resetDraft) {
-      resetDraftState(resetInputValue);
+      resetDraftState();
     }
   };
 
@@ -253,7 +252,7 @@ export const InputBar = ({
   const editMessage = (messageEntity?: ContentMessage) => {
     if (messageEntity?.isEditable() && messageEntity !== editedMessage) {
       cancelMessageReply();
-      cancelMessageEditing(true, true);
+      cancelMessageEditing(true);
       setEditedMessage(messageEntity);
 
       if (messageEntity.quote() && conversation) {
@@ -291,7 +290,7 @@ export const InputBar = ({
 
   const sendMessageEdit = (messageText: string, mentions: MentionEntity[]): void | Promise<any> => {
     const mentionEntities = mentions.slice(0);
-    cancelMessageEditing(true, true);
+    cancelMessageEditing(true);
 
     if (!messageText.length && editedMessage) {
       return messageRepository.deleteMessageForEveryone(conversation, editedMessage);
@@ -345,7 +344,7 @@ export const InputBar = ({
     }
 
     editorRef.current?.focus();
-    editorRef.current?.update(() => $getRoot().clear());
+    resetDraftState();
   };
 
   const onGifClick = () => openGiphy(textValue);
@@ -403,13 +402,13 @@ export const InputBar = ({
   const sendGiphy = (gifUrl: string, tag: string): void => {
     void generateQuote().then(quoteEntity => {
       void messageRepository.sendGif(conversation, gifUrl, tag, quoteEntity);
-      cancelMessageEditing(true, true);
+      cancelMessageEditing(true);
     });
   };
 
   const onWindowClick = (event: Event): void =>
     handleClickOutsideOfInputBar(event, () => {
-      cancelMessageEditing(true, true);
+      cancelMessageEditing(true);
       cancelMessageReply();
     });
 
@@ -506,7 +505,7 @@ export const InputBar = ({
     input: textValue,
     isEditing: isEditing,
     isScaledDown: isScaledDown,
-    onCancelEditing: () => cancelMessageEditing(true, true),
+    onCancelEditing: () => cancelMessageEditing(true),
     onClickPing: onPingClick,
     onGifClick: onGifClick,
     onSelectFiles: uploadFiles,
@@ -551,7 +550,7 @@ export const InputBar = ({
                 editedMessage={editedMessage}
                 onEscape={() => {
                   if (editedMessage) {
-                    cancelMessageEditing(true, true);
+                    cancelMessageEditing(true);
                   } else if (replyMessageEntity) {
                     cancelMessageReply();
                   }

--- a/src/script/components/InputBar/util/DraftStateUtil.ts
+++ b/src/script/components/InputBar/util/DraftStateUtil.ts
@@ -37,12 +37,11 @@ export const saveDraftState = async (
   replyMessageId?: string,
 ): Promise<void> => {
   // we only save state for newly written messages
-  const storeReply = replyMessageId;
   const storageKey = generateConversationInputStorageKey(conversationEntity);
 
   await storageRepository.storageService.saveToSimpleStorage<any>(storageKey, {
     editorState,
-    replyId: storeReply,
+    replyId: replyMessageId,
   });
 };
 

--- a/src/script/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/script/components/RichTextEditor/RichTextEditor.tsx
@@ -190,7 +190,10 @@ export const RichTextEditor = ({
 
 function Placeholder({text, hasLocalEphemeralTimer}: {text: string; hasLocalEphemeralTimer: boolean}) {
   return (
-    <div className={cx('editor-placeholder', {'conversation-input-bar-text--accent': hasLocalEphemeralTimer})}>
+    <div
+      className={cx('editor-placeholder', {'conversation-input-bar-text--accent': hasLocalEphemeralTimer})}
+      data-uie-name="input-placeholder"
+    >
       {text}
     </div>
   );

--- a/src/script/components/RichTextEditor/nodes/Mention.tsx
+++ b/src/script/components/RichTextEditor/nodes/Mention.tsx
@@ -203,7 +203,7 @@ export const Mention = (props: MentionComponentProps) => {
   }, [editor, moveCursor, selectMention, unselectMention, deleteMention]);
 
   return (
-    <span ref={ref} className={classNameFinal} data-mention={mention}>
+    <span ref={ref} className={classNameFinal} data-mention={mention} data-uie-name="item-input-mention">
       {mention}
     </span>
   );


### PR DESCRIPTION
## Description

Fixes a bug where, when you send a reply to a message then switch conversation and go back to the original conversation, then the editor is still in reply mode. 

### After 

https://github.com/wireapp/wire-webapp/assets/1090716/006e4ea6-dbba-4873-8e3b-a4f63b45084c

### Before

https://github.com/wireapp/wire-webapp/assets/1090716/8a95b6eb-3863-448d-845b-0377f41e91b5

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
