### PR TITLE
runfix: Gracefully clear editor when message is sent [WPB-5008]

### DIFF
--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -21,7 +21,7 @@ import {useCallback, useEffect, useRef, useState} from 'react';
 
 import {amplify} from 'amplify';
 import cx from 'classnames';
-import {$getRoot, LexicalEditor} from 'lexical';
+import {CLEAR_EDITOR_COMMAND, LexicalEditor} from 'lexical';
 import {container} from 'tsyringe';
 
 import {useMatchMedia} from '@wireapp/react-ui-kit';
@@ -204,9 +204,7 @@ export const InputBar = ({
 
   const resetDraftState = () => {
     setReplyMessageEntity(null);
-    editorRef.current?.update(() => {
-      $getRoot().clear();
-    });
+    editorRef.current?.dispatchCommand(CLEAR_EDITOR_COMMAND, undefined);
   };
 
   const clearPastedFile = () => setPastedFile(null);

--- a/src/script/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/script/components/RichTextEditor/RichTextEditor.tsx
@@ -19,6 +19,7 @@
 
 import {ReactElement, useRef} from 'react';
 
+import {ClearEditorPlugin} from '@lexical/react/LexicalClearEditorPlugin';
 import {InitialConfigType, LexicalComposer} from '@lexical/react/LexicalComposer';
 import {ContentEditable} from '@lexical/react/LexicalContentEditable';
 import {EditorRefPlugin} from '@lexical/react/LexicalEditorRefPlugin';
@@ -166,6 +167,7 @@ export const RichTextEditor = ({
             ErrorBoundary={LexicalErrorBoundary}
           />
 
+          <ClearEditorPlugin />
           <MentionsPlugin
             onSearch={search => (typeof search === 'string' ? getMentionCandidates(search) : [])}
             openStateRef={mentionsOpen}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5008" title="WPB-5008" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5008</a>  [Web] Pasting text message into input bar with command+v throws error in concole 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

When using the `root.clear()` method, we completely empty the editor (and it becomes impossible to paste something in it since we only have the `root` node in there and we cannot just add text to the root). 
The `ClearEditorPlugin` takes care of cleanly clearing the content of the editor and leave it in a ready state. 

## Screenshots/Screencast (for UI changes)
![image](https://github.com/wireapp/wire-webapp/assets/1090716/de3fb512-3ac3-460e-8b41-7d27bd59a20a)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
