### PR TITLE
fix: Do not allow non admin to remove services from conversations [WPB-4872]

### DIFF
--- a/src/script/page/RightSidebar/GroupParticipantService/GroupParticipantService.tsx
+++ b/src/script/page/RightSidebar/GroupParticipantService/GroupParticipantService.tsx
@@ -41,6 +41,7 @@ interface GroupParticipantServiceProps {
   activeConversation: Conversation;
   actionsViewModel: ActionsViewModel;
   integrationRepository: IntegrationRepository;
+  enableRemove: boolean;
   goToRoot: () => void;
   onBack: () => void;
   onClose: () => void;
@@ -54,6 +55,7 @@ const GroupParticipantService: FC<GroupParticipantServiceProps> = ({
   activeConversation,
   actionsViewModel,
   integrationRepository,
+  enableRemove,
   goToRoot,
   onBack,
   onClose,
@@ -69,7 +71,7 @@ const GroupParticipantService: FC<GroupParticipantServiceProps> = ({
   } = useKoSubscribableChildren(activeConversation, ['inTeam', 'isActiveParticipant', 'participating_user_ids']);
   const {teamRole} = useKoSubscribableChildren(selfUser, ['teamRole']);
 
-  const {canChatWithServices, canUpdateGroupParticipants} = generatePermissionHelpers(teamRole);
+  const {canChatWithServices} = generatePermissionHelpers(teamRole);
 
   const selectedInConversation = participatingUserIds.some(user => matchQualifiedIds(userEntity, user));
 
@@ -117,7 +119,7 @@ const GroupParticipantService: FC<GroupParticipantServiceProps> = ({
           </div>
         )}
 
-        {showActions && canUpdateGroupParticipants() && (
+        {showActions && enableRemove && (
           <div
             role="button"
             tabIndex={TabIndex.FOCUSABLE}

--- a/src/script/page/RightSidebar/RightSidebar.tsx
+++ b/src/script/page/RightSidebar/RightSidebar.tsx
@@ -274,6 +274,7 @@ const RightSidebar: FC<RightSidebarProps> = ({
               activeConversation={activeConversation}
               actionsViewModel={actionsViewModel}
               integrationRepository={integrationRepository}
+              enableRemove={conversationRoleRepository.canRemoveParticipants(activeConversation)}
               goToRoot={goToRoot}
               onBack={onBackClick}
               onClose={closePanel}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4872" title="WPB-4872" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4872</a>  [Webapp] Unauthorized 'remove service' button visibility
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Will not display the `remove from group` button on a service when the current user is not allowed to remove participants of a conversation 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
