### PR TITLE
chore: remove edge from test env action

### DIFF
--- a/.github/workflows/deploy-to-test-env.yml
+++ b/.github/workflows/deploy-to-test-env.yml
@@ -9,7 +9,6 @@ on:
         type: choice
         options:
           - wire-webapp-qa-al2-migration
-          - wire-webapp-edge-al2
           - wire-webapp-mls-al2
 
 concurrency:


### PR DESCRIPTION
## Description
Edge has moved to a prod env. As such it should be removed from the github action deploy. 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
