### PR TITLE
feat: Handle member removal not triggered by a particular user [WPB-4496]

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -412,6 +412,7 @@
   "conversationMemberLeftYou": "[bold]You[/bold] left",
   "conversationMemberRemoved": "[bold]{{name}}[/bold] removed {{users}}",
   "conversationMemberRemovedMissingLegalHoldConsent": "{{user}} was removed from this conversation because legal hold has been activated. [link]Learn more[/link]",
+  "conversationMemberWereRemoved": "{{users}} were removed from the conversation",
   "conversationMemberRemovedYou": "[bold]You[/bold] removed {{users}}",
   "conversationMessageDelivered": "Delivered",
   "conversationMissedMessages": "You haven’t used this device for a while. Some messages may not appear here.",

--- a/src/script/conversation/ConversationFederationUtils.ts
+++ b/src/script/conversation/ConversationFederationUtils.ts
@@ -47,7 +47,7 @@ export function getFederationDeleteEventUpdates(
 
     if (conversation.domain === deletedDomain && !is1to1) {
       result.conversationsToLeave.push(conversation);
-    } else if (is1to1 && firstUserEntity.qualifiedId.domain === deletedDomain) {
+    } else if (is1to1 && firstUserEntity?.qualifiedId.domain === deletedDomain) {
       result.conversationsToDisable.push(conversation);
     } else {
       const usersToDelete = allUserEntities.filter(user => user.domain === deletedDomain);

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -334,12 +334,11 @@ export class ConversationRepository {
       case FEDERATION_EVENT.FEDERATION_DELETE:
         const {domain: deletedDomain} = event;
         await this.onFederationDelete(deletedDomain);
-
         break;
+
       case FEDERATION_EVENT.FEDERATION_CONNECTION_REMOVED:
         const {domains: deletedDomains} = event;
         await this.onFederationConnectionRemove(deletedDomains);
-
         break;
     }
   };
@@ -365,7 +364,7 @@ export class ConversationRepository {
 
     conversationsToDisable.forEach(async conversation => {
       conversation.status(ConversationStatus.PAST_MEMBER);
-      conversation.firstUserEntity().markConnectionAsUnknown();
+      conversation.firstUserEntity()?.markConnectionAsUnknown();
       await this.insertFederationStopSystemMessage(conversation, [deletedDomain]);
     });
 
@@ -395,8 +394,8 @@ export class ConversationRepository {
     const result = getUsersToDeleteFromFederatedConversations(domains, allConversations);
 
     for (const {conversation, usersToRemove} of result) {
-      await this.removeDeletedFederationUsers(conversation, usersToRemove);
       await this.insertFederationStopSystemMessage(conversation, domains);
+      await this.removeDeletedFederationUsers(conversation, usersToRemove);
     }
   };
 

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -110,7 +110,7 @@ export class Conversation {
   public cipherSuite: number = 1;
   public readonly isUsingMLSProtocol: boolean;
   public readonly display_name: ko.PureComputed<string>;
-  public readonly firstUserEntity: ko.PureComputed<User>;
+  public readonly firstUserEntity: ko.PureComputed<User | undefined>;
   public readonly enforcedTeamMessageTimer: ko.PureComputed<number>;
   public readonly globalMessageTimer: ko.Observable<number | null>;
   public readonly hasContentMessages: ko.Observable<boolean>;

--- a/src/script/entity/message/MemberMessage.ts
+++ b/src/script/entity/message/MemberMessage.ts
@@ -226,6 +226,9 @@ export class MemberMessage extends SystemMessage {
           }
 
           const allUsers = this.generateNameString();
+          if (!this.user().isMe && !name) {
+            return t('conversationMemberWereRemoved', allUsers);
+          }
           return this.user().isMe
             ? t('conversationMemberRemovedYou', allUsers)
             : t('conversationMemberRemoved', {name, users: allUsers});


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4496" title="WPB-4496" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4496</a>  Stopping to federate causes messages about you removing someone
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

This will allow displaying users that were removed not by someone in particular. This could happen when 2 backends stop federating. Users are only removed locally and it's not caused by anyone in particular

## Screenshots/Screencast (for UI changes)

![image](https://github.com/wireapp/wire-webapp/assets/1090716/308fee4a-0ed9-4ad6-9110-bf846aece823)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
