### PR TITLE
refactor: Streamline leaving and clearing conversation

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1752,13 +1752,13 @@ export class ConversationRepository {
   /**
    * Remove the current user from a conversation.
    *
-   * @param conversationEntity Conversation to remove user from
+   * @param conversation Conversation to remove user from
    * @param clearContent Should we clear the conversation content from the database?
    * @returns Resolves when user was removed from the conversation
    */
-  public async leaveConversation(conversationEntity: Conversation, {localOnly = false} = {}) {
+  public async leaveConversation(conversation: Conversation, {localOnly = false} = {}) {
     const userQualifiedId = this.userState.self().qualifiedId;
-    return this.removeMember(conversationEntity, userQualifiedId, {localOnly});
+    return this.removeMember(conversation, userQualifiedId, {localOnly});
   }
 
   /**

--- a/src/script/view_model/ActionsViewModel.ts
+++ b/src/script/view_model/ActionsViewModel.ts
@@ -130,17 +130,26 @@ export class ActionsViewModel {
     });
   };
 
+  private readonly leaveOrClearConversation = async (
+    conversation: Conversation,
+    {leave, clear}: {leave: boolean; clear: boolean},
+  ): Promise<void> => {
+    if (leave) {
+      await this.conversationRepository.leaveConversation(conversation);
+    }
+    if (clear) {
+      await this.conversationRepository.clearConversation(conversation);
+    }
+  };
+
   readonly clearConversation = (conversationEntity: Conversation): void => {
     if (conversationEntity) {
       const modalType = conversationEntity.isLeavable() ? PrimaryModal.type.OPTION : PrimaryModal.type.CONFIRM;
 
       PrimaryModal.show(modalType, {
         primaryAction: {
-          action: async (leaveConversation = false) => {
-            if (leaveConversation) {
-              await this.conversationRepository.leaveConversation(conversationEntity);
-            }
-            await this.conversationRepository.clearConversation(conversationEntity);
+          action: async (leave = false) => {
+            await this.leaveOrClearConversation(conversationEntity, {clear: true, leave: leave});
           },
           text: t('modalConversationClearAction'),
         },
@@ -264,8 +273,8 @@ export class ActionsViewModel {
     return this.connectionRepository.ignoreRequest(userEntity);
   };
 
-  readonly leaveConversation = (conversationEntity: Conversation): Promise<void> => {
-    if (!conversationEntity) {
+  readonly leaveConversation = (conversation: Conversation): Promise<void> => {
+    if (!conversation) {
       return Promise.reject();
     }
 
@@ -273,16 +282,16 @@ export class ActionsViewModel {
       PrimaryModal.show(PrimaryModal.type.OPTION, {
         primaryAction: {
           action: async (clearContent = false) => {
-            await this.conversationRepository.leaveConversation(conversationEntity, {clearContent});
+            await this.leaveOrClearConversation(conversation, {clear: clearContent, leave: true});
             resolve();
           },
           text: t('modalConversationLeaveAction'),
         },
         text: {
-          closeBtnLabel: t('modalConversationLeaveMessageCloseBtn', conversationEntity.display_name()),
+          closeBtnLabel: t('modalConversationLeaveMessageCloseBtn', conversation.display_name()),
           message: t('modalConversationLeaveMessage'),
           option: t('modalConversationLeaveOption'),
-          title: t('modalConversationLeaveHeadline', conversationEntity.display_name()),
+          title: t('modalConversationLeaveHeadline', conversation.display_name()),
         },
       });
     });

--- a/src/script/view_model/ActionsViewModel.ts
+++ b/src/script/view_model/ActionsViewModel.ts
@@ -136,8 +136,11 @@ export class ActionsViewModel {
 
       PrimaryModal.show(modalType, {
         primaryAction: {
-          action: (leaveConversation = false) => {
-            this.conversationRepository.clearConversation(conversationEntity, leaveConversation);
+          action: async (leaveConversation = false) => {
+            if (leaveConversation) {
+              await this.conversationRepository.leaveConversation(conversationEntity);
+            }
+            await this.conversationRepository.clearConversation(conversationEntity);
           },
           text: t('modalConversationClearAction'),
         },
@@ -270,10 +273,7 @@ export class ActionsViewModel {
       PrimaryModal.show(PrimaryModal.type.OPTION, {
         primaryAction: {
           action: async (clearContent = false) => {
-            await this.conversationRepository.removeMember(conversationEntity, this.userState.self().qualifiedId, {
-              clearContent,
-            });
-
+            await this.conversationRepository.leaveConversation(conversationEntity, {clearContent});
             resolve();
           },
           text: t('modalConversationLeaveAction'),


### PR DESCRIPTION
## Description

Avoid mixing clearing and leaving conversation. Make the code much leaner and avoid confusion between those 2 actions

**previously**: `leaveConversation` and `clearConversation` could both do leaving AND clearing the conversation. 
**now**: `leaveConversation` only does leaving and `clearConversation` only does clearing


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;


