### PR TITLE
refactor: Streamline removing multiple users at once [WPB-4496]

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -395,22 +395,18 @@ export class ConversationRepository {
 
     for (const {conversation, usersToRemove} of result) {
       await this.insertFederationStopSystemMessage(conversation, domains);
-      await this.removeDeletedFederationUsers(conversation, usersToRemove);
+      await this.removeDeletedFederationUsers(
+        conversation,
+        usersToRemove.map(user => user.qualifiedId),
+      );
     }
   };
 
-  private readonly removeDeletedFederationUsers = async (conversation: Conversation, usersToRemove: User[]) => {
-    if (usersToRemove.length === 0) {
+  private readonly removeDeletedFederationUsers = async (conversation: Conversation, users: QualifiedId[]) => {
+    if (users.length === 0) {
       return;
     }
-
-    try {
-      for (const user of usersToRemove) {
-        await this.removeMembersLocally(conversation, [user.qualifiedId]);
-      }
-    } catch (error) {
-      console.warn('failed to remove users', error);
-    }
+    await this.removeMembersLocally(conversation, users);
   };
 
   private readonly insertFederationStopSystemMessage = async (conversation: Conversation, domains: string[]) => {

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1704,7 +1704,7 @@ export class ConversationRepository {
    * @param userId ID of member to be removed from the conversation
    * @returns Resolves when member was removed from the conversation
    */
-  private async removeMemberFromMLSConversation(conversationEntity: MLSConversation, userIds: QualifiedId[]) {
+  private async removeMembersFromMLSConversation(conversationEntity: MLSConversation, userIds: QualifiedId[]) {
     const {groupId, qualifiedId} = conversationEntity;
     const {events} = await this.core.service!.conversation.removeUsersFromMLSConversation({
       conversationId: qualifiedId,
@@ -1722,7 +1722,7 @@ export class ConversationRepository {
    * @param userId ID of member to be removed from the conversation
    * @returns Resolves when member was removed from the conversation
    */
-  private async removeMemberFromConversation(conversation: Conversation, userIds: QualifiedId[]) {
+  private async removeMembersFromConversation(conversation: Conversation, userIds: QualifiedId[]) {
     return await Promise.all(
       userIds.map(async userId => {
         const event = await this.core.service!.conversation.removeUserFromConversation(
@@ -1773,8 +1773,8 @@ export class ConversationRepository {
    */
   public async removeMembers(conversationEntity: Conversation, userIds: QualifiedId[]) {
     const events = isMLSConversation(conversationEntity)
-      ? await this.removeMemberFromMLSConversation(conversationEntity, userIds)
-      : await this.removeMemberFromConversation(conversationEntity, userIds);
+      ? await this.removeMembersFromMLSConversation(conversationEntity, userIds)
+      : await this.removeMembersFromConversation(conversationEntity, userIds);
 
     await this.eventRepository.injectEvents(events, EventRepository.SOURCE.BACKEND_RESPONSE);
   }

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1751,13 +1751,20 @@ export class ConversationRepository {
       : this.removeMembers(conversation, [userQualifiedId]);
   }
 
+  /**
+   * Will inject a `member-leave` that will then trigger the local removal of the user in the conversation
+   * @param conversation the conversation in which we want to remove users
+   * @param userIds the users to remove from the conversation
+   */
   private async removeMembersLocally(conversation: Conversation, userIds: QualifiedId[]) {
     const currentTimestamp = this.serverTimeHandler.toServerTimestamp();
     const events = userIds.map(userId => EventBuilder.buildMemberLeave(conversation, userId, true, currentTimestamp));
+    // Injecting the event will trigger all the handlers that will then actually remove the users from the conversation
     await this.eventRepository.injectEvents(events, EventRepository.SOURCE.INJECTED);
   }
+
   /**
-   * Umbrella function to remove a member from a conversation, no matter the protocol or type.
+   * Umbrella function to remove a member from a conversation (from backend and locally), no matter the protocol or type.
    *
    * @param conversationEntity Conversation to remove member from
    * @param userId ID of member to be removed from the conversation

--- a/src/script/event/EventRepository.ts
+++ b/src/script/event/EventRepository.ts
@@ -293,6 +293,12 @@ export class EventRepository {
   // Notification/Event handling
   //##############################################################################
 
+  async injectEvents(events: (ClientConversationEvent | IncomingEvent)[], source: EventSource = EventSource.INJECTED) {
+    for (const event of events) {
+      await this.injectEvent(event, source);
+    }
+  }
+
   /**
    * Inject event into a conversation.
    * @note Don't add unable to decrypt to self conversation

--- a/src/script/view_model/ActionsViewModel.ts
+++ b/src/script/view_model/ActionsViewModel.ts
@@ -375,7 +375,7 @@ export class ActionsViewModel {
           primaryAction: {
             action: async () => {
               try {
-                await this.conversationRepository.removeMember(conversationEntity, userEntity.qualifiedId);
+                await this.conversationRepository.removeMembers(conversationEntity, [userEntity.qualifiedId]);
                 resolve();
               } catch (error) {
                 reject(error);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4496" title="WPB-4496" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4496</a>  Stopping to federate causes messages about you removing someone
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

This is needed when a federation stop message arrives. We need then to remove multiple users at once. 


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
