### PR TITLE
runfix: Only create a single system message for federation user removal

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1756,7 +1756,7 @@ export class ConversationRepository {
     const currentTimestamp = this.serverTimeHandler.toServerTimestamp();
     const event = EventBuilder.buildMemberLeave(conversation, userIds, '', currentTimestamp);
     // Injecting the event will trigger all the handlers that will then actually remove the users from the conversation
-    await this.eventRepository.injectEvent(event, EventRepository.SOURCE.INJECTED);
+    await this.eventRepository.injectEvent(event);
   }
 
   /**

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1754,9 +1754,9 @@ export class ConversationRepository {
    */
   private async removeMembersLocally(conversation: Conversation, userIds: QualifiedId[]) {
     const currentTimestamp = this.serverTimeHandler.toServerTimestamp();
-    const events = userIds.map(userId => EventBuilder.buildMemberLeave(conversation, userId, true, currentTimestamp));
+    const event = EventBuilder.buildMemberLeave(conversation, userIds, '', currentTimestamp);
     // Injecting the event will trigger all the handlers that will then actually remove the users from the conversation
-    await this.eventRepository.injectEvents(events, EventRepository.SOURCE.INJECTED);
+    await this.eventRepository.injectEvent(event, EventRepository.SOURCE.INJECTED);
   }
 
   /**
@@ -1789,7 +1789,7 @@ export class ConversationRepository {
       const currentTimestamp = this.serverTimeHandler.toServerTimestamp();
       const event = hasResponse
         ? response.event
-        : EventBuilder.buildMemberLeave(conversationEntity, user, true, currentTimestamp);
+        : EventBuilder.buildMemberLeave(conversationEntity, [user], this.userState.self().id, currentTimestamp);
 
       this.eventRepository.injectEvent(event, EventRepository.SOURCE.BACKEND_RESPONSE);
       return event;

--- a/src/script/conversation/EventBuilder.ts
+++ b/src/script/conversation/EventBuilder.ts
@@ -476,17 +476,17 @@ export const EventBuilder = {
 
   buildMemberLeave(
     conversationEntity: Conversation,
-    userId: QualifiedId,
-    removedBySelfUser: boolean,
+    userIds: QualifiedId[],
+    from: string,
     currentTimestamp: number,
   ): MemberLeaveEvent {
     return {
       ...buildQualifiedId(conversationEntity),
       data: {
-        qualified_user_ids: [userId],
-        user_ids: [userId.id],
+        qualified_user_ids: userIds,
+        user_ids: userIds.map(({id}) => id),
       },
-      from: removedBySelfUser ? conversationEntity.selfUser().id : userId.id,
+      from: from,
       time: conversationEntity.getNextIsoDate(currentTimestamp),
       type: CONVERSATION_EVENT.MEMBER_LEAVE,
     };

--- a/src/script/entity/message/MemberMessage.ts
+++ b/src/script/entity/message/MemberMessage.ts
@@ -226,7 +226,7 @@ export class MemberMessage extends SystemMessage {
           }
 
           const allUsers = this.generateNameString();
-          if (!this.user().isMe && !name) {
+          if (!this.user().id) {
             return t('conversationMemberWereRemoved', allUsers);
           }
           return this.user().isMe


### PR DESCRIPTION
## Description

This will inject a single system message when multiple users have been removed because of a de-federation event. 

## Screenshots/Screencast (for UI changes)

### After 

![image](https://github.com/wireapp/wire-webapp/assets/1090716/f8cc7a78-bf56-440f-8d17-d7ca94171047)

### Before

![image](https://github.com/wireapp/wire-webapp/assets/1090716/66c3e046-08aa-4458-a7e8-5cdf85f9e9d9)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
