### PR TITLE
refactor: filter duplicated messages

### DIFF
--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -19,7 +19,6 @@
 
 import React, {FC, useEffect, useLayoutEffect, useRef, useState} from 'react';
 
-import {CONVERSATION_EVENT} from '@wireapp/api-client/lib/event/';
 import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 import cx from 'classnames';
 
@@ -30,19 +29,18 @@ import {ContentMessage} from 'src/script/entity/message/ContentMessage';
 import {DecryptErrorMessage} from 'src/script/entity/message/DecryptErrorMessage';
 import {MemberMessage} from 'src/script/entity/message/MemberMessage';
 import {Message as MessageEntity} from 'src/script/entity/message/Message';
-import {SystemMessage} from 'src/script/entity/message/SystemMessage';
 import {User} from 'src/script/entity/User';
-import {ClientEvent} from 'src/script/event/Client';
 import {useRoveFocus} from 'src/script/hooks/useRoveFocus';
 import {ServiceEntity} from 'src/script/integration/ServiceEntity';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {onHitTopOrBottom} from 'Util/DOM/onHitTopOrBottom';
 import {useResizeObserver} from 'Util/DOM/resizeObserver';
+import {filterMessages} from 'Util/messagesFilterUtil';
 
 import {Message, MessageActions} from './Message';
 
 import {Conversation as ConversationEntity, Conversation} from '../../entity/Conversation';
-import {isMemberMessage, isContentMessage} from '../../guards/Message';
+import {isContentMessage} from '../../guards/Message';
 import {StatusType} from '../../message/StatusType';
 
 type FocusedElement = {center?: boolean; element: Element};
@@ -72,68 +70,6 @@ interface MessagesListParams {
   isMsgElementsFocusable: boolean;
   setMsgElementsFocusable: (isMsgElementsFocusable: boolean) => void;
 }
-
-const filterDuplicatedSystemMessages = (messages: MessageEntity[]) => {
-  return messages.reduce<MessageEntity[]>((uniqMessages, currentMessage) => {
-    if (isMemberMessage(currentMessage)) {
-      const typesToFilter = [
-        CONVERSATION_EVENT.MEMBER_JOIN,
-        CONVERSATION_EVENT.MEMBER_LEAVE,
-        ClientEvent.CONVERSATION.GROUP_CREATION,
-      ] as string[];
-
-      const uniqMemberMessages = uniqMessages.filter(isMemberMessage);
-
-      if (!!uniqMemberMessages.length && typesToFilter.includes(currentMessage.type)) {
-        switch (currentMessage.type) {
-          case ClientEvent.CONVERSATION.GROUP_CREATION:
-            // Dont show duplicated group creation messages
-            if (uniqMemberMessages.some(m => m.type === currentMessage.type)) {
-              return uniqMessages;
-            }
-          case CONVERSATION_EVENT.MEMBER_JOIN:
-          case CONVERSATION_EVENT.MEMBER_LEAVE:
-            // Dont show duplicated member join/leave messages that follow each other
-            if (uniqMemberMessages?.[uniqMemberMessages.length - 1]?.htmlCaption() === currentMessage.htmlCaption()) {
-              return uniqMessages;
-            }
-        }
-      }
-    }
-
-    if (currentMessage.isSystem()) {
-      const systemMessagesToFilter = [CONVERSATION_EVENT.RENAME] as string[];
-      if (systemMessagesToFilter.includes(currentMessage.type)) {
-        const uniqUpdateMessages = uniqMessages.filter(
-          (message): message is SystemMessage => message.isSystem() && systemMessagesToFilter.includes(message.type),
-        );
-
-        if (uniqUpdateMessages.length > 0) {
-          const prevMessage = uniqUpdateMessages?.[uniqUpdateMessages.length - 1];
-          if (!prevMessage) {
-            return [...uniqMessages, currentMessage];
-          }
-
-          if (prevMessage.isConversationRename() && currentMessage.isConversationRename()) {
-            // for rename messages, only name changes are relevant, caption stays the same
-            if (prevMessage.name === currentMessage.name) {
-              return uniqMessages;
-            }
-            return [...uniqMessages, currentMessage];
-          }
-          // Dont show duplicated system messages that follow each other
-          if (prevMessage.caption === currentMessage.caption) {
-            return uniqMessages;
-          }
-        }
-      }
-    }
-
-    return [...uniqMessages, currentMessage];
-  }, []);
-};
-
-const filterHiddenMessages = (messages: MessageEntity[]) => messages.filter(message => message.visible());
 
 const MessagesList: FC<MessagesListParams> = ({
   conversation,
@@ -181,7 +117,7 @@ const MessagesList: FC<MessagesListParams> = ({
   const [loaded, setLoaded] = useState(false);
   const [focusedMessage, setFocusedMessage] = useState<string | undefined>(initialMessage?.id);
 
-  const filteredMessages = filterDuplicatedSystemMessages(filterHiddenMessages(allMessages));
+  const filteredMessages = filterMessages(allMessages);
   const filteredMessagesLength = filteredMessages.length;
 
   const [messagesContainer, setMessageContainer] = useState<HTMLDivElement | null>(null);

--- a/src/script/util/messagesFilterUtil.ts
+++ b/src/script/util/messagesFilterUtil.ts
@@ -1,0 +1,98 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {CONVERSATION_EVENT} from '@wireapp/api-client/lib/event/';
+
+import {Message as MessageEntity} from 'src/script/entity/message/Message';
+
+import {SystemMessage} from '../entity/message/SystemMessage';
+import {ClientEvent} from '../event/Client';
+import {isMemberMessage} from '../guards/Message';
+
+/**
+ * Filters out duplicated system messages.
+ * It can happen that the backend sends us an event we've created (we've already received directly from an api call response, e.g. when renaming a conversation).
+ * @param messages - messages to filter
+ * @returns filtered messages
+ */
+const filterDuplicatedSystemMessages = (messages: MessageEntity[]) => {
+  return messages.reduce<MessageEntity[]>((uniqMessages, currentMessage) => {
+    if (isMemberMessage(currentMessage)) {
+      const typesToFilter = [
+        CONVERSATION_EVENT.MEMBER_JOIN,
+        CONVERSATION_EVENT.MEMBER_LEAVE,
+        ClientEvent.CONVERSATION.GROUP_CREATION,
+      ] as string[];
+
+      const uniqMemberMessages = uniqMessages.filter(isMemberMessage);
+
+      if (!!uniqMemberMessages.length && typesToFilter.includes(currentMessage.type)) {
+        switch (currentMessage.type) {
+          case ClientEvent.CONVERSATION.GROUP_CREATION:
+            // Dont show duplicated group creation messages
+            if (uniqMemberMessages.some(m => m.type === currentMessage.type)) {
+              return uniqMessages;
+            }
+          case CONVERSATION_EVENT.MEMBER_JOIN:
+          case CONVERSATION_EVENT.MEMBER_LEAVE:
+            // Dont show duplicated member join/leave messages that follow each other
+            if (uniqMemberMessages?.[uniqMemberMessages.length - 1]?.htmlCaption() === currentMessage.htmlCaption()) {
+              return uniqMessages;
+            }
+        }
+      }
+    }
+
+    if (currentMessage.isSystem()) {
+      const systemMessagesToFilter = [CONVERSATION_EVENT.RENAME] as string[];
+      if (systemMessagesToFilter.includes(currentMessage.type)) {
+        const uniqUpdateMessages = uniqMessages.filter(
+          (message): message is SystemMessage => message.isSystem() && systemMessagesToFilter.includes(message.type),
+        );
+
+        if (uniqUpdateMessages.length > 0) {
+          const prevMessage = uniqUpdateMessages?.[uniqUpdateMessages.length - 1];
+          if (!prevMessage) {
+            return [...uniqMessages, currentMessage];
+          }
+
+          if (prevMessage.isConversationRename() && currentMessage.isConversationRename()) {
+            // for rename messages, only name changes are relevant, caption stays the same
+            if (prevMessage.name === currentMessage.name) {
+              return uniqMessages;
+            }
+            return [...uniqMessages, currentMessage];
+          }
+          // Dont show duplicated system messages that follow each other
+          if (prevMessage.caption === currentMessage.caption) {
+            return uniqMessages;
+          }
+        }
+      }
+    }
+
+    return [...uniqMessages, currentMessage];
+  }, []);
+};
+
+const filterHiddenMessages = (messages: MessageEntity[]) => messages.filter(message => message.visible());
+
+export const filterMessages = (messages: MessageEntity[]) => {
+  return filterHiddenMessages(filterDuplicatedSystemMessages(messages));
+};


### PR DESCRIPTION
## Description

Moved logic of filtering duplicated system/member messages to an util file. Filter functions are pure functions that can live in a separate file instead of a UI component file.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
