### PR TITLE
runfix: leave mls conversation

### DIFF
--- a/src/__mocks__/@wireapp/core.ts
+++ b/src/__mocks__/@wireapp/core.ts
@@ -59,6 +59,8 @@ export class Account extends EventEmitter {
       messageTimer: {
         setConversationLevelTimer: jest.fn(),
       },
+      removeUsersFromMLSConversation: jest.fn(),
+      removeUserFromConversation: jest.fn(),
     },
 
     client: {

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1742,9 +1742,13 @@ export class ConversationRepository {
    */
   public async leaveConversation(conversation: Conversation, {localOnly = false} = {}) {
     const userQualifiedId = this.userState.self().qualifiedId;
-    return localOnly
-      ? this.removeMembersLocally(conversation, [userQualifiedId])
-      : this.removeMembers(conversation, [userQualifiedId]);
+
+    if (localOnly) {
+      return this.removeMembersLocally(conversation, [userQualifiedId]);
+    }
+
+    const events = await this.removeMembersFromConversation(conversation, [userQualifiedId]);
+    await this.eventRepository.injectEvents(events, EventRepository.SOURCE.BACKEND_RESPONSE);
   }
 
   /**


### PR DESCRIPTION
## Description

https://github.com/wireapp/wire-webapp/pull/15965 introduced a regression in leaving MLS conversations. Leaving a MLS conversation is different than removing other users (we cannot send remove proposal for the self client, remove proposal has to be created by backend). When leaving MLS conversation we should remove self user "the proteus way", so just send a request to backend. For more details see https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/157287189/Use+case+leaving+a+conversation.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
