### PR TITLE
refactor: Extract federation event handling to an event processor

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -39,8 +39,6 @@ import {
   ConversationRenameEvent,
   ConversationTypingEvent,
   CONVERSATION_EVENT,
-  FederationEvent,
-  FEDERATION_EVENT,
 } from '@wireapp/api-client/lib/event';
 import {BackendErrorLabel} from '@wireapp/api-client/lib/http/';
 import type {BackendError} from '@wireapp/api-client/lib/http/';
@@ -49,7 +47,7 @@ import {MLSCreateConversationResponse} from '@wireapp/core/lib/conversation';
 import {amplify} from 'amplify';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import {container} from 'tsyringe';
-import {debounce, flatten} from 'underscore';
+import {flatten} from 'underscore';
 
 import {Asset as ProtobufAsset, Confirmation, LegalHoldStatus} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
@@ -76,10 +74,6 @@ import {ACCESS_STATE} from './AccessState';
 import {extractClientDiff} from './ClientMismatchUtil';
 import {updateAccessRights} from './ConversationAccessPermission';
 import {ConversationEphemeralHandler} from './ConversationEphemeralHandler';
-import {
-  getUsersToDeleteFromFederatedConversations,
-  getFederationDeleteEventUpdates,
-} from './ConversationFederationUtils';
 import {ConversationFilter} from './ConversationFilter';
 import {ConversationLabelRepository} from './ConversationLabelRepository';
 import {ConversationDatabaseData, ConversationMapper} from './ConversationMapper';
@@ -315,7 +309,6 @@ export class ConversationRepository {
     amplify.subscribe(WebAppEvents.TEAM.MEMBER_LEAVE, this.teamMemberLeave);
     amplify.subscribe(WebAppEvents.USER.UNBLOCKED, this.onUnblockUser);
     amplify.subscribe(WebAppEvents.CONVERSATION.INJECT_LEGAL_HOLD_MESSAGE, this.injectLegalHoldMessage);
-    amplify.subscribe(WebAppEvents.FEDERATION.EVENT_FROM_BACKEND, debounce(this.onFederationEvent, 1000));
 
     this.eventService.addEventUpdatedListener(this.updateLocalMessageEntity);
     this.eventService.addEventDeletedListener(this.deleteLocalMessageEntity);
@@ -326,95 +319,6 @@ export class ConversationRepository {
   public initMLSConversationRecoveredListener() {
     return this.conversationService.addMLSConversationRecoveredListener(this.onMLSConversationRecovered);
   }
-
-  private readonly onFederationEvent = async (event: FederationEvent) => {
-    const {type} = event;
-
-    switch (type) {
-      case FEDERATION_EVENT.FEDERATION_DELETE:
-        const {domain: deletedDomain} = event;
-        await this.onFederationDelete(deletedDomain);
-        break;
-
-      case FEDERATION_EVENT.FEDERATION_CONNECTION_REMOVED:
-        const {domains: deletedDomains} = event;
-        await this.onFederationConnectionRemove(deletedDomains);
-        break;
-    }
-  };
-
-  /**
-   * For the `federation.delete` event: (Backend A has stopped federating with us)
-      - receive the event from backend
-      - leave the conversations locally that are owned by the backend A which was deleted.
-      - remove the deleted backend A users locally from our own conversations.
-      - insert system message to the affected conversations about federation termination.
-   * @param deletedDomain the domain that stopped federating
-   */
-  private onFederationDelete = async (deletedDomain: string) => {
-    const {conversationsToDeleteUsers, conversationsToLeave, conversationsToDisable} = getFederationDeleteEventUpdates(
-      deletedDomain,
-      this.conversationState.conversations(),
-    );
-
-    conversationsToLeave.forEach(async conversation => {
-      await this.leaveConversation(conversation, {localOnly: true});
-      await this.insertFederationStopSystemMessage(conversation, [deletedDomain]);
-    });
-
-    conversationsToDisable.forEach(async conversation => {
-      conversation.status(ConversationStatus.PAST_MEMBER);
-      conversation.firstUserEntity()?.markConnectionAsUnknown();
-      await this.insertFederationStopSystemMessage(conversation, [deletedDomain]);
-    });
-
-    conversationsToDeleteUsers.forEach(async ({conversation, users}) => {
-      await this.insertFederationStopSystemMessage(conversation, [deletedDomain]);
-      await this.removeDeletedFederationUsers(conversation, users);
-    });
-  };
-
-  /**
-   * For the `federation.connectionRemoved` event: (Backend A & B stopped federating, user is on C)
-    - receive the event from backend
-    - Identify all conversations that are not owned from A or B domain and that contain users from A and B
-      - remove users from A and B from those conversations
-      - insert system message in those conversations about backend A and B stopping to federate
-    - identify all conversations owned by domain A that contains users from B
-      - remove users from B from those conversations
-      - insert system message in those conversations about backend A and B stopping to federate
-    - Identify all conversations owned by domain B that contains users from A
-      - remove users from A from those conversations
-      - insert system message in those conversations about backend A and B stopping to federate
-   * @param domains The domains that stopped federating with each other
-   */
-  private readonly onFederationConnectionRemove = async (domains: string[]) => {
-    const allConversations = this.conversationState.conversations();
-
-    const result = getUsersToDeleteFromFederatedConversations(domains, allConversations);
-
-    for (const {conversation, usersToRemove} of result) {
-      await this.insertFederationStopSystemMessage(conversation, domains);
-      await this.removeDeletedFederationUsers(
-        conversation,
-        usersToRemove.map(user => user.qualifiedId),
-      );
-    }
-  };
-
-  private readonly removeDeletedFederationUsers = async (conversation: Conversation, users: QualifiedId[]) => {
-    if (users.length === 0) {
-      return;
-    }
-    await this.removeMembersLocally(conversation, users);
-  };
-
-  private readonly insertFederationStopSystemMessage = async (conversation: Conversation, domains: string[]) => {
-    const currentTimestamp = this.serverTimeHandler.toServerTimestamp();
-    const selfUser = this.userState.self();
-    const event = EventBuilder.buildFederationStop(conversation, selfUser, domains, currentTimestamp);
-    await this.eventRepository.injectEvent(event, EventRepository.SOURCE.INJECTED);
-  };
 
   private readonly updateLocalMessageEntity = async ({
     obj: updatedEvent,
@@ -1740,27 +1644,11 @@ export class ConversationRepository {
    * @param clearContent Should we clear the conversation content from the database?
    * @returns Resolves when user was removed from the conversation
    */
-  public async leaveConversation(conversation: Conversation, {localOnly = false} = {}) {
+  public async leaveConversation(conversation: Conversation) {
     const userQualifiedId = this.userState.self().qualifiedId;
-
-    if (localOnly) {
-      return this.removeMembersLocally(conversation, [userQualifiedId]);
-    }
 
     const events = await this.removeMembersFromConversation(conversation, [userQualifiedId]);
     await this.eventRepository.injectEvents(events, EventRepository.SOURCE.BACKEND_RESPONSE);
-  }
-
-  /**
-   * Will inject a `member-leave` that will then trigger the local removal of the user in the conversation
-   * @param conversation the conversation in which we want to remove users
-   * @param userIds the users to remove from the conversation
-   */
-  private async removeMembersLocally(conversation: Conversation, userIds: QualifiedId[]) {
-    const currentTimestamp = this.serverTimeHandler.toServerTimestamp();
-    const event = EventBuilder.buildMemberLeave(conversation, userIds, '', currentTimestamp);
-    // Injecting the event will trigger all the handlers that will then actually remove the users from the conversation
-    await this.eventRepository.injectEvent(event);
   }
 
   /**

--- a/src/script/event/EventProcessor.ts
+++ b/src/script/event/EventProcessor.ts
@@ -1,0 +1,30 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {BackendEvent} from '@wireapp/api-client/lib/event';
+
+import {EventSource} from './EventSource';
+
+import {ClientConversationEvent} from '../conversation/EventBuilder';
+
+export type IncomingEvent = BackendEvent | ClientConversationEvent;
+
+export interface EventProcessor {
+  processEvent(event: IncomingEvent, source: EventSource): Promise<void>;
+}

--- a/src/script/event/processor/FederationEventProcessor/ConversationFederationUtils.test.ts
+++ b/src/script/event/processor/FederationEventProcessor/ConversationFederationUtils.test.ts
@@ -29,7 +29,7 @@ import {
   FederationConnectionRemovedResult,
 } from './ConversationFederationUtils';
 
-import {Conversation} from '../entity/Conversation';
+import {Conversation} from '../../../entity/Conversation';
 
 describe('ConversationFederationUtils', () => {
   describe('getFederationDeleteEventUpdates', () => {

--- a/src/script/event/processor/FederationEventProcessor/ConversationFederationUtils.ts
+++ b/src/script/event/processor/FederationEventProcessor/ConversationFederationUtils.ts
@@ -17,8 +17,8 @@
  *
  */
 
-import {Conversation} from '../entity/Conversation';
-import {User} from '../entity/User';
+import {Conversation} from '../../../entity/Conversation';
+import {User} from '../../../entity/User';
 
 export interface FederationDeleteResult {
   conversationsToLeave: Conversation[];

--- a/src/script/event/processor/FederationEventProcessor/FederationEventProcessor.ts
+++ b/src/script/event/processor/FederationEventProcessor/FederationEventProcessor.ts
@@ -1,0 +1,146 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {FEDERATION_EVENT} from '@wireapp/api-client/lib/event';
+import type {QualifiedId} from '@wireapp/api-client/lib/user';
+import {container} from 'tsyringe';
+
+import {ConversationState} from 'src/script/conversation/ConversationState';
+import {ConversationStatus} from 'src/script/conversation/ConversationStatus';
+import {EventBuilder} from 'src/script/conversation/EventBuilder';
+import {Conversation} from 'src/script/entity/Conversation';
+import {User} from 'src/script/entity/User';
+import {ServerTimeHandler} from 'src/script/time/serverTimeHandler';
+
+import {
+  getUsersToDeleteFromFederatedConversations,
+  getFederationDeleteEventUpdates,
+} from './ConversationFederationUtils';
+
+import {EventProcessor, IncomingEvent} from '../../EventProcessor';
+import {EventRepository} from '../../EventRepository';
+
+export class FederationEventProcessor implements EventProcessor {
+  constructor(
+    private eventRepository: EventRepository,
+    private serverTimeHandler: ServerTimeHandler,
+    private selfUser: User,
+    private conversationState: ConversationState = container.resolve(ConversationState),
+  ) {}
+
+  async processEvent(event: IncomingEvent) {
+    const {type} = event;
+
+    switch (type) {
+      case FEDERATION_EVENT.FEDERATION_DELETE:
+        const {domain: deletedDomain} = event;
+        await this.onFederationDelete(deletedDomain);
+        break;
+
+      case FEDERATION_EVENT.FEDERATION_CONNECTION_REMOVED:
+        const {domains: deletedDomains} = event;
+        await this.onFederationConnectionRemove(deletedDomains);
+        break;
+    }
+  }
+
+  /**
+   * For the `federation.delete` event: (Backend A has stopped federating with us)
+      - receive the event from backend
+      - leave the conversations locally that are owned by the backend A which was deleted.
+      - remove the deleted backend A users locally from our own conversations.
+      - insert system message to the affected conversations about federation termination.
+   * @param deletedDomain the domain that stopped federating
+   */
+  private onFederationDelete = async (deletedDomain: string) => {
+    const {conversationsToDeleteUsers, conversationsToLeave, conversationsToDisable} = getFederationDeleteEventUpdates(
+      deletedDomain,
+      this.conversationState.conversations(),
+    );
+
+    conversationsToLeave.forEach(async conversation => {
+      await this.removeMembersLocally(conversation, [this.selfUser]);
+      await this.insertFederationStopSystemMessage(conversation, [deletedDomain]);
+    });
+
+    conversationsToDisable.forEach(async conversation => {
+      conversation.status(ConversationStatus.PAST_MEMBER);
+      conversation.firstUserEntity()?.markConnectionAsUnknown();
+      await this.insertFederationStopSystemMessage(conversation, [deletedDomain]);
+    });
+
+    conversationsToDeleteUsers.forEach(async ({conversation, users}) => {
+      await this.insertFederationStopSystemMessage(conversation, [deletedDomain]);
+      await this.removeDeletedFederationUsers(conversation, users);
+    });
+  };
+
+  /**
+   * For the `federation.connectionRemoved` event: (Backend A & B stopped federating, user is on C)
+    - receive the event from backend
+    - Identify all conversations that are not owned from A or B domain and that contain users from A and B
+      - remove users from A and B from those conversations
+      - insert system message in those conversations about backend A and B stopping to federate
+    - identify all conversations owned by domain A that contains users from B
+      - remove users from B from those conversations
+      - insert system message in those conversations about backend A and B stopping to federate
+    - Identify all conversations owned by domain B that contains users from A
+      - remove users from A from those conversations
+      - insert system message in those conversations about backend A and B stopping to federate
+   * @param domains The domains that stopped federating with each other
+   */
+  private readonly onFederationConnectionRemove = async (domains: string[]) => {
+    const allConversations = this.conversationState.conversations();
+
+    const result = getUsersToDeleteFromFederatedConversations(domains, allConversations);
+
+    for (const {conversation, usersToRemove} of result) {
+      await this.insertFederationStopSystemMessage(conversation, domains);
+      await this.removeDeletedFederationUsers(
+        conversation,
+        usersToRemove.map(user => user.qualifiedId),
+      );
+    }
+  };
+
+  private readonly removeDeletedFederationUsers = async (conversation: Conversation, users: QualifiedId[]) => {
+    if (users.length === 0) {
+      return;
+    }
+    await this.removeMembersLocally(conversation, users);
+  };
+
+  private readonly insertFederationStopSystemMessage = async (conversation: Conversation, domains: string[]) => {
+    const currentTimestamp = this.serverTimeHandler.toServerTimestamp();
+    const event = EventBuilder.buildFederationStop(conversation, this.selfUser, domains, currentTimestamp);
+    await this.eventRepository.injectEvent(event, EventRepository.SOURCE.INJECTED);
+  };
+
+  /**
+   * Will inject a `member-leave` that will then trigger the local removal of the user in the conversation
+   * @param conversation the conversation in which we want to remove users
+   * @param userIds the users to remove from the conversation
+   */
+  private async removeMembersLocally(conversation: Conversation, userIds: QualifiedId[]) {
+    const currentTimestamp = this.serverTimeHandler.toServerTimestamp();
+    const event = EventBuilder.buildMemberLeave(conversation, userIds, '', currentTimestamp);
+    // Injecting the event will trigger all the handlers that will then actually remove the users from the conversation
+    await this.eventRepository.injectEvent(event);
+  }
+}

--- a/src/script/event/processor/FederationEventProcessor/index.ts
+++ b/src/script/event/processor/FederationEventProcessor/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export * from './FederationEventProcessor';

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -73,7 +73,7 @@ import {NotificationService} from '../event/NotificationService';
 import {QuotedMessageMiddleware} from '../event/preprocessor/QuotedMessageMiddleware';
 import {ReceiptsMiddleware} from '../event/preprocessor/ReceiptsMiddleware';
 import {ServiceMiddleware} from '../event/preprocessor/ServiceMiddleware';
-import {FederationEventProcessor} from '../event/processor/FederationEventProcessor/FederationEventProcessor';
+import {FederationEventProcessor} from '../event/processor/FederationEventProcessor';
 import {GiphyRepository} from '../extension/GiphyRepository';
 import {GiphyService} from '../extension/GiphyService';
 import {getWebsiteUrl} from '../externalRoute';

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -73,6 +73,7 @@ import {NotificationService} from '../event/NotificationService';
 import {QuotedMessageMiddleware} from '../event/preprocessor/QuotedMessageMiddleware';
 import {ReceiptsMiddleware} from '../event/preprocessor/ReceiptsMiddleware';
 import {ServiceMiddleware} from '../event/preprocessor/ServiceMiddleware';
+import {FederationEventProcessor} from '../event/processor/FederationEventProcessor/FederationEventProcessor';
 import {GiphyRepository} from '../extension/GiphyRepository';
 import {GiphyService} from '../extension/GiphyService';
 import {getWebsiteUrl} from '../externalRoute';
@@ -276,6 +277,7 @@ export class App {
       quotedMessageMiddleware.processEvent.bind(quotedMessageMiddleware),
       readReceiptMiddleware.processEvent.bind(readReceiptMiddleware),
     ]);
+
     repositories.backup = new BackupRepository(new BackupService(), repositories.conversation);
 
     repositories.integration = new IntegrationRepository(
@@ -385,6 +387,10 @@ export class App {
 
       const selfUser = await this.initiateSelfUser();
       await initializeDataDog(this.config, selfUser.qualifiedId);
+
+      // Setup all the event processors
+      const federationEventProcessor = new FederationEventProcessor(eventRepository, serverTimeHandler, selfUser);
+      eventRepository.setEventProcessors([federationEventProcessor]);
 
       onProgress(5, t('initReceivedSelfUser', selfUser.name()));
       telemetry.timeStep(AppInitTimingsStep.RECEIVED_SELF_USER);


### PR DESCRIPTION
## Description

In an effort to remove amplify from the codebase, this will add a mechanism to register event processors to the `EventRepository`. 
This way the repository can make direct calls of those processors and `await` them before continuing while still being unaware what the job of a processor is. 

In the future, we could convert all those `amplify.publish` by a focused specialized eventProcessor

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
