### PR TITLE
feat: refetch user on navigating to conversation

### DIFF
--- a/src/script/self/SelfRepository.ts
+++ b/src/script/self/SelfRepository.ts
@@ -152,9 +152,15 @@ export class SelfRepository extends TypedEventEmitter<Events> {
     });
   }
 
-  getSelfSupportedProtocols(): ConversationProtocol[] | null {
-    return this.userState.self()?.supportedProtocols() || null;
-  }
+  public getSelfSupportedProtocols = async (): Promise<ConversationProtocol[]> => {
+    const localSupportedProtocols = this.selfUser.supportedProtocols();
+
+    if (localSupportedProtocols) {
+      return localSupportedProtocols;
+    }
+
+    return this.refreshSelfSupportedProtocols();
+  };
 
   public async deleteSelfUserClient(clientId: string, password?: string): Promise<ClientEntity[]> {
     const clients = this.clientRepository.deleteClient(clientId, password);

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -668,13 +668,16 @@ export class UserRepository {
   /**
    * Check for supported protocols on user entity locally, otherwise fetch them from the backend.
    * @param userId - the user to fetch the supported protocols for
+   * @param forceRefetch - if true, the supported protocols will be fetched from the backend even if they are already stored locally
    */
 
-  public async getUserSupportedProtocols(userId: QualifiedId): Promise<ConversationProtocol[]> {
-    const localSupportedProtocols = this.findUserById(userId)?.supportedProtocols();
+  public async getUserSupportedProtocols(userId: QualifiedId, forceRefetch = false): Promise<ConversationProtocol[]> {
+    if (!forceRefetch) {
+      const localSupportedProtocols = this.findUserById(userId)?.supportedProtocols();
 
-    if (localSupportedProtocols) {
-      return localSupportedProtocols;
+      if (localSupportedProtocols) {
+        return localSupportedProtocols;
+      }
     }
 
     const supportedProtocols = await this.userService.getUserSupportedProtocols(userId);

--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -150,7 +150,7 @@ export class ContentViewModel {
       return conversationEntity;
     }
 
-    return this.conversationRepository.init1to1Conversation(conversationEntity);
+    return this.conversationRepository.init1to1Conversation(conversationEntity, true);
   };
 
   /**


### PR DESCRIPTION
## Description

When navigating to a 1:1 conversation, we should refetch user's supported protocols to make sure we're up-to-date with their list of supported protocols and that the correct protocol will be chosen for 1:1 conversation.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;