### PR TITLE
runfix: Remove relevant connection requests upon federation-delete event [WPB-4510]

### DIFF
--- a/src/script/event/processor/FederationEventProcessor/ConversationFederationUtils.test.ts
+++ b/src/script/event/processor/FederationEventProcessor/ConversationFederationUtils.test.ts
@@ -88,6 +88,41 @@ describe('ConversationFederationUtils', () => {
       expect(result.conversationsToDeleteUsers[0].users).toContainEqual(userFromDeletedDomain);
     });
 
+    it('finds connection requests to delete', () => {
+      const deletedDomain = 'deleted.wire.link';
+
+      const user1 = generateUser();
+      const userFromDeletedDomain = generateUser({domain: deletedDomain, id: 'test-id'});
+
+      const conversations: Conversation[] = [
+        generateConversation({
+          type: CONVERSATION_TYPE.CONNECT,
+          id: {
+            id: 'test-2',
+            domain: 'wire.link',
+          },
+          users: [user1],
+        }),
+        generateConversation({
+          type: CONVERSATION_TYPE.CONNECT,
+          id: {
+            id: 'test-3',
+            domain: deletedDomain,
+          },
+          users: [userFromDeletedDomain],
+        }),
+      ];
+
+      const result: FederationDeleteResult = getFederationDeleteEventUpdates(deletedDomain, conversations);
+
+      expect(result.conversationsToLeave).toHaveLength(0);
+      expect(result.conversationsToDisable).toHaveLength(0);
+      expect(result.conversationsToDeleteUsers).toHaveLength(0);
+      expect(result.connectionRequestsToDelete).toHaveLength(1);
+
+      expect(result.connectionRequestsToDelete[0]).toBe(conversations[1]);
+    });
+
     it('correctly finds one to one conversations to disable', () => {
       const deletedDomain = 'deleted.wire.link';
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4510" title="WPB-4510" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4510</a>  Connection request not removed after defederating
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Will make sure connection requests with user from a deleted backend are removed from the UI when a defederation event happens

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
