### PR TITLE
test: Avoid having special chars in user names

### DIFF
--- a/test/helper/UserGenerator.ts
+++ b/test/helper/UserGenerator.ts
@@ -47,7 +47,8 @@ export function generateAPIUser(
     ],
     handle: faker.internet.userName(),
     id: id.id,
-    name: faker.person.fullName(),
+    // replace special chars to avoid escaping problems with querying the DOM
+    name: faker.person.fullName().replace(/[^a-zA-Z ]/, ''),
     qualified_id: id,
     ...overwites,
   };


### PR DESCRIPTION
## Description

When a special char (like `'`) is used in user names it gets escaped in the DOM for unit test and we are not able to query it via `@testing-library`. 

As a simple fix, this will replace special chars with empty string and avoid unit test querying errors


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
