### PR TITLE
fix: dont run the MLSStateHandler without MLS enabled

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -68,6 +68,7 @@ import {
 } from 'Util/StringUtil';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
 import {isBackendError} from 'Util/TypePredicateUtil';
+import {supportsMLS} from 'Util/util';
 import {createUuid} from 'Util/uuid';
 
 import {ACCESS_STATE} from './AccessState';
@@ -273,7 +274,7 @@ export class ConversationRepository {
       this.conversationState,
     );
 
-    if (Config.getConfig().FEATURE.ENABLE_MLS === true) {
+    if (supportsMLS()) {
       // we register a handler that will handle MLS conversations on its own
       registerMLSConversationVerificationStateHandler(
         this.onConversationVerificationStateChange,

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -272,12 +272,15 @@ export class ConversationRepository {
       this.userState,
       this.conversationState,
     );
-    // we register a handler that will handle MLS conversations on its own
-    registerMLSConversationVerificationStateHandler(
-      this.onConversationVerificationStateChange,
-      this.conversationState,
-      this.core,
-    );
+
+    if (Config.getConfig().FEATURE.ENABLE_MLS === true) {
+      // we register a handler that will handle MLS conversations on its own
+      registerMLSConversationVerificationStateHandler(
+        this.onConversationVerificationStateChange,
+        this.conversationState,
+        this.core,
+      );
+    }
 
     this.isBlockingNotificationHandling = true;
     this.conversationsWithNewEvents = new Map();

--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
@@ -45,12 +45,10 @@ export class MLSConversationVerificationStateHandler {
     this.logger = getLogger('MLSConversationVerificationStateHandler');
     // We need to check if the core service is available
     if (!this.core.service?.mls) {
-      this.logger.info('MLS service is not available');
       return;
     }
     // We need to check if the e2eIdentity service is available
     if (!this.core.service?.e2eIdentity) {
-      this.logger.info('E2EIdentity service is not available');
       return;
     }
     // We hook into the newEpoch event of the MLS service to check if the conversation needs to be verified or degraded

--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
@@ -43,14 +43,11 @@ export class MLSConversationVerificationStateHandler {
     private readonly core = container.resolve(Core),
   ) {
     this.logger = getLogger('MLSConversationVerificationStateHandler');
-    // We need to check if the core service is available
-    if (!this.core.service?.mls) {
+    // We need to check if the core service is available and if the e2eIdentity is available
+    if (!this.core.service?.mls || !this.core.service?.e2eIdentity) {
       return;
     }
-    // We need to check if the e2eIdentity service is available
-    if (!this.core.service?.e2eIdentity) {
-      return;
-    }
+
     // We hook into the newEpoch event of the MLS service to check if the conversation needs to be verified or degraded
     this.core.service.mls.on('newEpoch', this.checkEpoch);
   }

--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
@@ -45,12 +45,12 @@ export class MLSConversationVerificationStateHandler {
     this.logger = getLogger('MLSConversationVerificationStateHandler');
     // We need to check if the core service is available
     if (!this.core.service?.mls) {
-      this.logger.error('MLS service not available');
+      this.logger.info('MLS service is not available');
       return;
     }
     // We need to check if the e2eIdentity service is available
     if (!this.core.service?.e2eIdentity) {
-      this.logger.error('E2E identity service not available');
+      this.logger.info('E2EIdentity service is not available');
       return;
     }
     // We hook into the newEpoch event of the MLS service to check if the conversation needs to be verified or degraded


### PR DESCRIPTION
This PR fixes the problem that the MLSConversationVerificationStateHandler Class gets instantiated with disabled MLS.