### PR TITLE
feat: mls 1:1 conversation listen to user update event

### DIFF
--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -675,7 +675,7 @@ describe('ConversationRepository', () => {
       expect(conversationEntity?.readOnlyState()).toEqual(null);
     });
 
-    it('re-evaluates 1:1 conversations with user after their supported protocols are updated', async () => {
+    it('re-evaluates 1:1 conversation with user after their supported protocols are updated', async () => {
       const conversationRepository = testFactory.conversation_repository!;
       const userRepository = testFactory.user_repository!;
       const mockedGroupId = 'groupId';
@@ -751,7 +751,7 @@ describe('ConversationRepository', () => {
       });
     });
 
-    it('does not re-evaluates 1:1 conversations with user after their supported protocols are updated if conversation did not exist before', async () => {
+    it('does not re-evaluates 1:1 conversation with user after their supported protocols are updated if conversation did not exist before', async () => {
       const conversationRepository = testFactory.conversation_repository!;
       const userRepository = testFactory.user_repository!;
 

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -228,7 +228,7 @@ describe('ConversationRepository', () => {
     });
   });
 
-  describe('get1To1Conversation', () => {
+  describe('getInitialised1To1Conversation', () => {
     beforeEach(() => {
       testFactory.conversation_repository['conversationState'].conversations([]);
       testFactory.conversation_repository['userState'].users([]);
@@ -295,7 +295,7 @@ describe('ConversationRepository', () => {
 
       jest.spyOn(conversationRepository['userState'], 'self').mockReturnValue(selfUser);
 
-      const conversationEntity = await conversationRepository.get1To1Conversation(userEntity);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(userEntity);
 
       expect(conversationEntity).toBe(newConversationEntity);
     });
@@ -330,7 +330,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'getConversationById')
         .mockResolvedValueOnce(proteus1to1ConversationResponse);
 
-      const conversationEntity = await conversationRepository.get1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
 
       expect(conversationEntity?.serialize()).toEqual(proteus1to1Conversation.serialize());
     });
@@ -363,7 +363,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'getConversationById')
         .mockResolvedValueOnce(proteus1to1ConversationResponse);
 
-      const conversationEntity = await conversationRepository.get1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
 
       expect(conversationEntity?.readOnlyState()).toEqual(
         CONVERSATION_READONLY_STATE.READONLY_ONE_TO_ONE_SELF_UNSUPPORTED_MLS,
@@ -401,7 +401,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
         .mockResolvedValueOnce(true);
 
-      const conversationEntity = await conversationRepository.get1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
 
       expect(conversationEntity?.serialize()).toEqual(mls1to1Conversation.serialize());
     });
@@ -463,7 +463,7 @@ describe('ConversationRepository', () => {
         .mockReturnValueOnce(proteus1to1Conversation);
       jest.spyOn(conversationRepository['conversationService'], 'deleteConversationFromDb');
 
-      const conversationEntity = await conversationRepository.get1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
 
       expect(conversationRepository['eventService'].moveEventsToConversation).toHaveBeenCalledWith(
         proteus1to1Conversation.id,
@@ -541,7 +541,7 @@ describe('ConversationRepository', () => {
 
       const [mls1to1Conversation] = conversationRepository.mapConversations([establishedMls1to1ConversationResponse]);
 
-      const conversationEntity = await conversationRepository.get1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
 
       expect(container.resolve(Core).service!.conversation.establishMLS1to1Conversation).toHaveBeenCalledWith(
         mockedGroupId,
@@ -586,7 +586,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
         .mockResolvedValueOnce(true);
 
-      const conversationEntity = await conversationRepository.get1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
 
       expect(conversationEntity?.serialize()).toEqual(mls1to1Conversation.serialize());
     });
@@ -626,7 +626,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
         .mockResolvedValueOnce(false);
 
-      const conversationEntity = await conversationRepository.get1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
 
       expect(conversationEntity?.serialize()).toEqual(mls1to1Conversation.serialize());
       expect(conversationEntity?.readOnlyState()).toEqual(
@@ -669,7 +669,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
         .mockResolvedValueOnce(true);
 
-      const conversationEntity = await conversationRepository.get1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
 
       expect(conversationEntity?.serialize()).toEqual(mls1to1Conversation.serialize());
       expect(conversationEntity?.readOnlyState()).toEqual(null);
@@ -739,7 +739,7 @@ describe('ConversationRepository', () => {
         configurable: true,
       });
 
-      jest.spyOn(conversationRepository, 'get1To1Conversation');
+      jest.spyOn(conversationRepository, 'getInitialised1To1Conversation');
 
       userRepository.emit('supportedProtocolsUpdated', {
         user: otherUser,
@@ -747,7 +747,7 @@ describe('ConversationRepository', () => {
       });
 
       await waitFor(() => {
-        expect(conversationRepository.get1To1Conversation).toHaveBeenCalledWith(otherUser);
+        expect(conversationRepository.getInitialised1To1Conversation).toHaveBeenCalledWith(otherUser);
       });
     });
 
@@ -758,7 +758,7 @@ describe('ConversationRepository', () => {
       const otherUserId = {id: 'f718410c-3833-479d-bd80-a5df03f38414', domain: 'test-domain'};
       const otherUser = new User(otherUserId.id, otherUserId.domain);
 
-      jest.spyOn(conversationRepository, 'get1To1Conversation');
+      jest.spyOn(conversationRepository, 'getInitialised1To1Conversation');
 
       conversationRepository['conversationState'].conversations([]);
 
@@ -768,7 +768,7 @@ describe('ConversationRepository', () => {
       });
 
       await waitFor(() => {
-        expect(conversationRepository.get1To1Conversation).not.toHaveBeenCalled();
+        expect(conversationRepository.getInitialised1To1Conversation).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1889,6 +1889,16 @@ export class ConversationRepository {
 
   private readonly onUserSupportedProtocolsUpdated = async ({user}: {user: User}) => {
     // After user's supported protocols are updated, we want to make sure that 1:1 conversation is initialised.
+    const localMLSConversation = this.conversationState.findMLS1to1Conversation(user.qualifiedId);
+    const localProteusConversation = this.conversationState.findProteus1to1Conversations(user.qualifiedId);
+
+    const does1to1ConversationExist = localMLSConversation || localProteusConversation;
+
+    // If conversation does not exist, we don't want to create it.
+    if (!does1to1ConversationExist) {
+      return;
+    }
+
     await this.get1To1Conversation(user);
   };
 

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -338,6 +338,7 @@ export class ConversationRepository {
     window.addEventListener<any>(WebAppEvents.CONVERSATION.JOIN, this.onConversationJoin);
 
     this.selfRepository.on('selfSupportedProtocolsUpdated', this.onSelfUserSupportedProtocolsUpdated);
+    this.userRepository.on('supportedProtocolsUpdated', this.onUserSupportedProtocolsUpdated);
   }
 
   public initMLSConversationRecoveredListener() {
@@ -1884,6 +1885,11 @@ export class ConversationRepository {
   private readonly onSelfUserSupportedProtocolsUpdated = async () => {
     const one2oneConversations = this.conversationState.conversations().filter(conversation => conversation.is1to1());
     await Promise.allSettled(one2oneConversations.map(conversation => this.init1to1Conversation(conversation)));
+  };
+
+  private readonly onUserSupportedProtocolsUpdated = async (user: User) => {
+    // After user's supported protocols are updated, we want to make sure that 1:1 conversation is initialised.
+    await this.get1To1Conversation(user);
   };
 
   /**

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1887,7 +1887,7 @@ export class ConversationRepository {
     await Promise.allSettled(one2oneConversations.map(conversation => this.init1to1Conversation(conversation)));
   };
 
-  private readonly onUserSupportedProtocolsUpdated = async (user: User) => {
+  private readonly onUserSupportedProtocolsUpdated = async ({user}: {user: User}) => {
     // After user's supported protocols are updated, we want to make sure that 1:1 conversation is initialised.
     await this.get1To1Conversation(user);
   };

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -104,7 +104,7 @@ interface UserAvailabilityEvent {
   type: USER.AVAILABILITY;
 }
 
-type Events = {supportedProtocolsUpdated: ConversationProtocol[]};
+type Events = {supportedProtocolsUpdated: {user: User; supportedProtocols: ConversationProtocol[]}};
 export class UserRepository extends TypedEventEmitter<Events> {
   private readonly logger: Logger;
   public readonly userMapper: UserMapper;
@@ -324,7 +324,9 @@ export class UserRepository extends TypedEventEmitter<Events> {
       );
 
     if (hasSupportedProtocolsChanged) {
-      this.emit('supportedProtocolsUpdated', newSupportedProtocols);
+      const user = await this.getUserById(userId);
+      await this.updateUserSupportedProtocols(userId, newSupportedProtocols);
+      this.emit('supportedProtocolsUpdated', {user, supportedProtocols: newSupportedProtocols});
     }
   }
 

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -301,13 +301,14 @@ export class UserRepository extends TypedEventEmitter<Events> {
   private async onUserUpdate(eventJson: UserUpdateEvent, source: EventSource): Promise<void> {
     const user = eventJson.user;
     const userId = generateQualifiedId(user);
-    await this.updateUser(userId, user, source === EventRepository.SOURCE.WEB_SOCKET);
 
     // Check if user's supported protocols were updated, if they were, we need to re-evaluate a 1:1 conversation to use with that user
     const newSupportedProtocols = user.supported_protocols;
     if (newSupportedProtocols) {
       await this.onUserSupportedProtocolsUpdate(userId, newSupportedProtocols);
     }
+
+    await this.updateUser(userId, user, source === EventRepository.SOURCE.WEB_SOCKET);
   }
 
   private async onUserSupportedProtocolsUpdate(
@@ -325,7 +326,6 @@ export class UserRepository extends TypedEventEmitter<Events> {
 
     if (hasSupportedProtocolsChanged) {
       const user = await this.getUserById(userId);
-      await this.updateUserSupportedProtocols(userId, newSupportedProtocols);
       this.emit('supportedProtocolsUpdated', {user, supportedProtocols: newSupportedProtocols});
     }
   }

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -24,6 +24,7 @@ import {
   UserLegalHoldDisableEvent,
   UserLegalHoldRequestEvent,
   USER_EVENT,
+  UserUpdateEvent,
 } from '@wireapp/api-client/lib/event';
 import type {BackendError, TraceState} from '@wireapp/api-client/lib/http';
 import {BackendErrorLabel} from '@wireapp/api-client/lib/http';
@@ -39,7 +40,7 @@ import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import {container} from 'tsyringe';
 import {flatten, uniq} from 'underscore';
 
-import type {AccentColor} from '@wireapp/commons';
+import {TypedEventEmitter, type AccentColor} from '@wireapp/commons';
 import {Availability} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
@@ -102,7 +103,9 @@ interface UserAvailabilityEvent {
   fromDomain: string | null;
   type: USER.AVAILABILITY;
 }
-export class UserRepository {
+
+type Events = {supportedProtocolsUpdated: ConversationProtocol[]};
+export class UserRepository extends TypedEventEmitter<Events> {
   private readonly logger: Logger;
   public readonly userMapper: UserMapper;
   public getTeamMembersFromUsers: (users: User[]) => Promise<void>;
@@ -127,6 +130,7 @@ export class UserRepository {
     private readonly propertyRepository: PropertiesRepository,
     private readonly userState = container.resolve(UserState),
   ) {
+    super();
     this.logger = getLogger('UserRepository');
 
     this.userMapper = new UserMapper(serverTimeHandler);
@@ -152,9 +156,7 @@ export class UserRepository {
         this.userDelete(eventJson);
         break;
       case USER_EVENT.UPDATE:
-        const user = eventJson.user;
-        const userId = generateQualifiedId(user);
-        await this.updateUser(userId, user, source === EventRepository.SOURCE.WEB_SOCKET);
+        await this.onUserUpdate(eventJson, source);
         break;
       case USER.AVAILABILITY:
         const {from, data, fromDomain} = eventJson;
@@ -293,6 +295,36 @@ export class UserRepository {
       window.setTimeout(() => {
         amplify.publish(WebAppEvents.LIFECYCLE.SIGN_OUT, SIGN_OUT_REASON.ACCOUNT_DELETED, true);
       }, 100);
+    }
+  }
+
+  private async onUserUpdate(eventJson: UserUpdateEvent, source: EventSource): Promise<void> {
+    const user = eventJson.user;
+    const userId = generateQualifiedId(user);
+    await this.updateUser(userId, user, source === EventRepository.SOURCE.WEB_SOCKET);
+
+    // Check if user's supported protocols were updated, if they were, we need to re-evaluate a 1:1 conversation to use with that user
+    const newSupportedProtocols = user.supported_protocols;
+    if (newSupportedProtocols) {
+      await this.onUserSupportedProtocolsUpdate(userId, newSupportedProtocols);
+    }
+  }
+
+  private async onUserSupportedProtocolsUpdate(
+    userId: QualifiedId,
+    newSupportedProtocols: ConversationProtocol[],
+  ): Promise<void> {
+    const localSupportedProtocols = this.findUserById(userId)?.supportedProtocols();
+
+    const hasSupportedProtocolsChanged =
+      !localSupportedProtocols ||
+      !(
+        localSupportedProtocols.length === newSupportedProtocols.length &&
+        [...localSupportedProtocols].every(protocol => newSupportedProtocols.includes(protocol))
+      );
+
+    if (hasSupportedProtocolsChanged) {
+      this.emit('supportedProtocolsUpdated', newSupportedProtocols);
     }
   }
 

--- a/src/script/view_model/ActionsViewModel.ts
+++ b/src/script/view_model/ActionsViewModel.ts
@@ -325,7 +325,7 @@ export class ActionsViewModel {
   };
 
   getOrCreate1to1Conversation = async (userEntity: User): Promise<Conversation> => {
-    const conversationEntity = await this.conversationRepository.get1To1Conversation(userEntity);
+    const conversationEntity = await this.conversationRepository.getInitialised1To1Conversation(userEntity);
     if (conversationEntity) {
       return conversationEntity;
     }
@@ -424,7 +424,7 @@ export class ActionsViewModel {
         primaryAction: {
           action: async () => {
             await this.connectionRepository.unblockUser(userEntity);
-            const conversationEntity = await this.conversationRepository.get1To1Conversation(userEntity);
+            const conversationEntity = await this.conversationRepository.getInitialised1To1Conversation(userEntity);
             resolve();
             if (conversationEntity) {
               await this.conversationRepository.updateParticipatingUserEntities(conversationEntity);


### PR DESCRIPTION
## Description

After user.update event is received and it includes `supported_protocols` field, we should re-evaluate what protocol should be used for 1:1 conversation with this user.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
