### PR TITLE
feat: prepare devices, users and conversations to contain a E2EI verification indicator

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@peculiar/x509": "1.9.5",
     "@wireapp/avs": "9.4.18",
     "@wireapp/commons": "5.2.1",
-    "@wireapp/core": "42.12.1",
+    "@wireapp/core": "42.13.0",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.9.10",
     "@wireapp/store-engine-dexie": "2.1.6",

--- a/src/script/client/ClientEntity.ts
+++ b/src/script/client/ClientEntity.ts
@@ -44,6 +44,7 @@ export class ClientEntity {
   };
   meta: {
     isVerified?: ko.Observable<boolean>;
+    isMLSVerified?: ko.Observable<boolean>;
     primaryKey?: string;
     userId?: string;
   };
@@ -71,6 +72,7 @@ export class ClientEntity {
     // Metadata maintained by us
     this.meta = {
       isVerified: ko.observable(false),
+      isMLSVerified: ko.observable(false),
       primaryKey: undefined,
     };
   }
@@ -115,6 +117,9 @@ export class ClientEntity {
 
     jsonObject.meta.is_verified = jsonObject.meta.isVerified;
     delete jsonObject.meta.isVerified;
+
+    jsonObject.meta.is_mls_verified = jsonObject.meta.isMLSVerified;
+    delete jsonObject.meta.isMLSVerified;
 
     if (jsonObject.meta.primaryKey) {
       jsonObject.meta.primary_key = jsonObject.meta.primaryKey;

--- a/src/script/client/ClientMapper.test.ts
+++ b/src/script/client/ClientMapper.test.ts
@@ -60,6 +60,7 @@ describe('ClientMapper', () => {
       expect(clientEntity.location?.lat).toBe(clientPayload.location.lat);
       expect(clientEntity.location?.lon).toBe(clientPayload.location.lon);
       expect(clientEntity.meta.isVerified?.()).toBe(false);
+      expect(clientEntity.meta.isMLSVerified?.()).toBe(false);
       expect(clientEntity.model).toBe(clientPayload.model);
       expect(clientEntity.time).toBe(clientPayload.time);
       expect(clientEntity.type).toBe(ClientType.TEMPORARY);
@@ -75,6 +76,7 @@ describe('ClientMapper', () => {
       expect(clientEntity.id).toBe(clientPayload.id);
       expect(clientEntity.class).toBe(clientPayload.class);
       expect(clientEntity.meta.isVerified?.()).toBe(false);
+      expect(clientEntity.meta.isMLSVerified?.()).toBe(false);
       expect(clientEntity.isPermanent()).toBe(false);
       expect(clientEntity.isTemporary()).toBe(false);
     });
@@ -85,6 +87,7 @@ describe('ClientMapper', () => {
         id: '66d0515a23a0ef25',
         meta: {
           is_verified: true,
+          is_mls_verified: true,
         },
       };
 
@@ -104,6 +107,7 @@ describe('ClientMapper', () => {
         domain: '',
         meta: {
           is_verified: true,
+          is_mls_verified: true,
         },
       };
 
@@ -143,6 +147,7 @@ describe('ClientMapper', () => {
       expect(clientEntity.location?.lat).toBe(clientPayload.location.lat);
       expect(clientEntity.location?.lon).toBe(clientPayload.location.lon);
       expect(clientEntity.meta.isVerified?.()).toBe(false);
+      expect(clientEntity.meta.isMLSVerified?.()).toBe(false);
       expect(clientEntity.model).toBe(clientPayload.model);
       expect(clientEntity.time).toBe(clientPayload.time);
       expect(clientEntity.type).toBe(ClientType.PERMANENT);
@@ -165,6 +170,7 @@ describe('ClientMapper', () => {
       expect(clientEntity.location?.lat).toBe(clientPayload.location.lat);
       expect(clientEntity.location?.lon).toBe(clientPayload.location.lon);
       expect(clientEntity.meta.isVerified?.()).toBe(false);
+      expect(clientEntity.meta.isMLSVerified?.()).toBe(false);
       expect(clientEntity.model).toBe(clientPayload.model);
       expect(clientEntity.time).toBe(clientPayload.time);
       expect(clientEntity.type).toBe(ClientType.PERMANENT);

--- a/src/script/client/ClientMapper.ts
+++ b/src/script/client/ClientMapper.ts
@@ -57,7 +57,8 @@ export class ClientMapper {
     if (isClientRecord(clientPayload)) {
       const {userId} = parseClientId(clientPayload.meta.primary_key);
 
-      clientEntity.meta.isVerified(clientPayload.meta.is_verified);
+      clientEntity.meta.isVerified?.(!!clientPayload.meta.is_verified);
+      clientEntity.meta.isMLSVerified?.(!!clientPayload.meta.is_mls_verified);
       clientEntity.meta.primaryKey = clientPayload.meta.primary_key;
       clientEntity.meta.userId = userId;
     }

--- a/src/script/client/ClientRepository.test.ts
+++ b/src/script/client/ClientRepository.test.ts
@@ -100,6 +100,7 @@ describe('ClientRepository', () => {
       ...clientPayloadServer,
       meta: {
         is_verified: true,
+        is_mls_verified: true,
         primary_key: 'local_identity',
       },
     };

--- a/src/script/client/ClientRepository.ts
+++ b/src/script/client/ClientRepository.ts
@@ -219,6 +219,7 @@ export class ClientRepository {
       domain: userId.domain,
       meta: {
         is_verified: false,
+        is_mls_verified: false,
         primary_key: constructClientId(userId, clientPayload.id),
       },
     };

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -129,6 +129,7 @@ export class Conversation {
   public readonly is_loaded: ko.Observable<boolean>;
   public readonly is_pending: ko.Observable<boolean>;
   public readonly is_verified: ko.PureComputed<boolean | undefined>;
+  public readonly isMLSVerified: ko.PureComputed<boolean | undefined>;
   public readonly is1to1: ko.PureComputed<boolean>;
   public readonly isActiveParticipant: ko.PureComputed<boolean>;
   public readonly isClearable: ko.PureComputed<boolean>;
@@ -333,6 +334,13 @@ export class Conversation {
       }
 
       return this.allUserEntities().every(userEntity => userEntity.is_verified());
+    });
+    this.isMLSVerified = ko.pureComputed(() => {
+      if (!this.hasInitializedUsers()) {
+        return undefined;
+      }
+
+      return this.allUserEntities().every(userEntity => userEntity.isMLSVerified());
     });
 
     this.legalHoldStatus = ko.observable(LegalHoldStatus.DISABLED);
@@ -1016,6 +1024,13 @@ export class Conversation {
       ? this.participating_user_ets().concat(this.selfUser())
       : this.participating_user_ets();
     return userEntities.filter(userEntity => !userEntity.is_verified());
+  }
+
+  getUsersWithUnverifiedMLSClients(): User[] {
+    const userEntities = this.selfUser()
+      ? this.participating_user_ets().concat(this.selfUser())
+      : this.participating_user_ets();
+    return userEntities.filter(userEntity => !userEntity.isMLSVerified());
   }
 
   getAllUserEntities(): User[] {

--- a/src/script/entity/User/User.ts
+++ b/src/script/entity/User/User.ts
@@ -63,7 +63,9 @@ export class User {
   public readonly initials: ko.PureComputed<string>;
   public readonly inTeam: ko.Observable<boolean>;
   public readonly is_trusted: ko.PureComputed<boolean>;
+  // Manual Proteus verification
   public readonly is_verified: ko.PureComputed<boolean>;
+  // MLS certificate verification
   public readonly isMLSVerified: ko.PureComputed<boolean>;
   public readonly isBlocked: ko.PureComputed<boolean>;
   public readonly isCanceled: ko.PureComputed<boolean>;
@@ -200,6 +202,7 @@ export class User {
     });
 
     this.devices = ko.observableArray();
+    // Proteus verification
     this.is_verified = ko.pureComputed(() => {
       if (this.devices().length === 0 && !this.isMe) {
         return false;

--- a/src/script/entity/User/User.ts
+++ b/src/script/entity/User/User.ts
@@ -64,6 +64,7 @@ export class User {
   public readonly inTeam: ko.Observable<boolean>;
   public readonly is_trusted: ko.PureComputed<boolean>;
   public readonly is_verified: ko.PureComputed<boolean>;
+  public readonly isMLSVerified: ko.PureComputed<boolean>;
   public readonly isBlocked: ko.PureComputed<boolean>;
   public readonly isCanceled: ko.PureComputed<boolean>;
   public readonly isConnected: ko.PureComputed<boolean>;
@@ -203,7 +204,13 @@ export class User {
       if (this.devices().length === 0 && !this.isMe) {
         return false;
       }
-      return this.devices().every(client_et => client_et.meta.isVerified());
+      return this.devices().every(client_et => client_et.meta.isVerified?.());
+    });
+    this.isMLSVerified = ko.pureComputed(() => {
+      if (this.devices().length === 0 && !this.isMe) {
+        return false;
+      }
+      return this.devices().every(client_et => client_et.meta.isMLSVerified?.());
     });
     this.isOnLegalHold = ko.pureComputed(() => {
       return this.devices().some(client_et => client_et.isLegalHold());

--- a/src/script/storage/record/ClientRecord.ts
+++ b/src/script/storage/record/ClientRecord.ts
@@ -32,6 +32,7 @@ export interface ClientRecord {
   };
   meta: {
     is_verified?: boolean;
+    is_mls_verified?: boolean;
     primary_key?: string;
   };
   model?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5299,9 +5299,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:42.12.1":
-  version: 42.12.1
-  resolution: "@wireapp/core@npm:42.12.1"
+"@wireapp/core@npm:42.13.0":
+  version: 42.13.0
+  resolution: "@wireapp/core@npm:42.13.0"
   dependencies:
     "@wireapp/api-client": ^26.3.1
     "@wireapp/commons": ^5.2.1
@@ -5321,7 +5321,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: 2c5933f28c72752cb0eaa1554d14c23a4f0204d5bd207bdf770c4dcdc245800316835e236480d0704ae334a5c9f01706446b95e9c70a6d9cfe5e739220bea0ee
+  checksum: 8874e5f14b022adf6896598b7d470a81e5699448e4c9bf2f36666e4b1701062a2cb67b1f99edf6dca336d1bb99dd639a80091bb9784703d7928dfdc18ed68407
   languageName: node
   linkType: hard
 
@@ -18373,7 +18373,7 @@ __metadata:
     "@wireapp/avs": 9.4.18
     "@wireapp/commons": 5.2.1
     "@wireapp/copy-config": 2.1.9
-    "@wireapp/core": 42.12.1
+    "@wireapp/core": 42.13.0
     "@wireapp/eslint-config": 3.0.4
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.6.3


### PR DESCRIPTION
It makes it a lot simpler for us in the future if the entities contain the information about the MLS verification status themselves. 
We can easily access these values in the frontend code and mirror the current proteus behaviour. 

This is the preparation for some refactoring when it comes to the MLSVerificationState