### PR TITLE
runfix: Fix number of displayed user for conversation create event

### DIFF
--- a/src/script/components/MessagesList/Message/MemberMessage.test.tsx
+++ b/src/script/components/MessagesList/Message/MemberMessage.test.tsx
@@ -110,7 +110,8 @@ describe('MemberMessage', () => {
 
       const {getByText, container} = render(<MemberMessage {...props} />);
 
-      expect(container.querySelectorAll('strong')).toHaveLength(CONFIG.REDUCED_USERS_COUNT);
+      // We expect to see the first 15 users + the user that created the conversation
+      expect(container.querySelectorAll('strong')).toHaveLength(CONFIG.REDUCED_USERS_COUNT + 1);
       const showMoreButton = getByText(`${nbUsers - CONFIG.REDUCED_USERS_COUNT} more`);
       showMoreButton.click();
 

--- a/src/script/components/MessagesList/Message/MemberMessage/MessageContent.tsx
+++ b/src/script/components/MessagesList/Message/MemberMessage/MessageContent.tsx
@@ -41,7 +41,7 @@ function generateNames(users: User[], declension = Declension.ACCUSATIVE, hasExt
 }
 
 function getVisibleUsers(users: User[]) {
-  return users.slice(0, CONFIG.REDUCED_USERS_COUNT - 1);
+  return users.slice(0, CONFIG.REDUCED_USERS_COUNT);
 }
 
 function ShowMoreButton({children, onClick}: {children: React.ReactNode; onClick: () => void}) {


### PR DESCRIPTION
## Description

I got mislead by the test expecting `REDUCED_USERS_COUNT` number of `<strong>` tags when displaying more than 17 Users added to a conversation. There is one extra `<strong>` for the creator of the conversation

## Screenshots/Screencast (for UI changes)

![Screenshot 2023-10-17 at 09 18 40](https://github.com/wireapp/wire-webapp/assets/1090716/cb8fee61-5df0-41c3-aaaf-37207a1f8ccc)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

