### PR TITLE
runfix: Do not show mention suggestion if there is a char before the @

### DIFF
--- a/src/script/components/RichTextEditor/plugins/EmojiPickerPlugin/EmojiPickerPlugin.tsx
+++ b/src/script/components/RichTextEditor/plugins/EmojiPickerPlugin/EmojiPickerPlugin.tsx
@@ -48,7 +48,7 @@ const TRIGGER = ':';
  * @param text the text in which to look for emoji triggers
  */
 function checkForEmojis(text: string): MenuTextMatch | null {
-  const match = new RegExp(`(^|[^\\w])(${TRIGGER}([\\w ]+))$`).exec(text);
+  const match = new RegExp(`(^| )(${TRIGGER}([\\w ]+))$`).exec(text);
 
   if (match === null) {
     return null;

--- a/src/script/components/RichTextEditor/plugins/MentionsPlugin/MentionsPlugin.tsx
+++ b/src/script/components/RichTextEditor/plugins/MentionsPlugin/MentionsPlugin.tsx
@@ -41,7 +41,7 @@ const TRIGGER = '@';
  * @param text the text in which to look for mentions triggers
  */
 function checkForMentions(text: string): MenuTextMatch | null {
-  const match = new RegExp(`(^|[^\\w])(${TRIGGER}([\\w ]*))$`).exec(text);
+  const match = new RegExp(`(^| )(${TRIGGER}([\\w ]*))$`).exec(text);
 
   if (match === null) {
     return null;


### PR DESCRIPTION
## Description

Only show the mention and the emoji picker when the trigger is after the beggining of the line or a space char

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
