### PR TITLE
fix: Typeahead menu renders multiple times

### DIFF
--- a/src/script/components/RichTextEditor/plugins/EmojiPickerPlugin/EmojiPickerPlugin.tsx
+++ b/src/script/components/RichTextEditor/plugins/EmojiPickerPlugin/EmojiPickerPlugin.tsx
@@ -21,7 +21,6 @@ import {MutableRefObject, useCallback, useMemo, useState} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
-  LexicalTypeaheadMenuPlugin,
   MenuOption,
   MenuRenderFn,
   MenuTextMatch,
@@ -32,6 +31,7 @@ import emojiList from 'emoji-picker-react/src/data/emojis.json';
 import {$createTextNode, $getSelection, $isRangeSelection, TextNode} from 'lexical';
 import * as ReactDOM from 'react-dom';
 
+import {TypeaheadMenuPlugin} from 'Components/RichTextEditor/plugins/TypeaheadMenuPlugin';
 import {loadValue, storeValue} from 'Util/StorageUtil';
 import {sortByPriority} from 'Util/StringUtil';
 
@@ -247,12 +247,13 @@ export function EmojiPickerPlugin({openStateRef}: Props) {
   openStateRef.current = options.length > 0;
 
   return (
-    <LexicalTypeaheadMenuPlugin
+    <TypeaheadMenuPlugin
       onQueryChange={setQueryString}
       onSelectOption={onSelectOption}
       triggerFn={checkForEmojiPickerMatch}
       options={options}
       menuRenderFn={menuRender}
+      containerId="emoji-typeahead-menu"
     />
   );
 }

--- a/src/script/components/RichTextEditor/plugins/MentionsPlugin/MentionsPlugin.tsx
+++ b/src/script/components/RichTextEditor/plugins/MentionsPlugin/MentionsPlugin.tsx
@@ -32,7 +32,7 @@ import {MentionSuggestionsItem} from './MentionSuggestionsItem';
 import {User} from '../../../../entity/User';
 import {$createMentionNode} from '../../nodes/MentionNode';
 import {getSelectionInfo} from '../../utils/getSelectionInfo';
-import {ReverseTypeaheadMenuPlugin} from '../ReverseTypeaheadMenuPlugin';
+import {TypeaheadMenuPlugin} from '../TypeaheadMenuPlugin';
 
 const TRIGGER = '@';
 
@@ -160,12 +160,14 @@ export function MentionsPlugin({onSearch, openStateRef}: MentionsPluginProps) {
   openStateRef.current = options.length > 0;
 
   return (
-    <ReverseTypeaheadMenuPlugin
+    <TypeaheadMenuPlugin
       onQueryChange={setQueryString}
       onSelectOption={handleSelectOption}
       triggerFn={checkForMentionMatch}
       options={options}
       menuRenderFn={menuRenderFn}
+      containerId="mentions-typeahead-menu"
+      isReversed
     />
   );
 }

--- a/src/style/components/lexical-input.less
+++ b/src/style/components/lexical-input.less
@@ -1,4 +1,4 @@
-#typeahead-menu {
+.typeahead-menu {
   position: unset !important;
   z-index: 99999;
   display: unset !important;


### PR DESCRIPTION
## Description

Input bar Emojis Picker and Mentions renders multiple times new DOM Element for typeahead menu. Now we render only one time typeahead menu with different id for EmojisPicker and Mentions popover.

## Screenshots/Screencast (for UI changes)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
