### PR TITLE
runfix: Clear root before loading an edited message in the text editor

### DIFF
--- a/src/script/components/RichTextEditor/plugins/EditedMessagePlugin.tsx
+++ b/src/script/components/RichTextEditor/plugins/EditedMessagePlugin.tsx
@@ -38,6 +38,7 @@ export function EditedMessagePlugin({message}: Props): null {
       setTimeout(() => {
         editor.update(() => {
           const root = $getRoot();
+          root.clear();
           // This behaviour is needed to clear selection, if we not clear selection will be on beginning.
           $setSelection(null);
           // Replace the current root with the content of the message being edited


### PR DESCRIPTION
## Screenshots/Screencast (for UI changes)

### After

https://github.com/wireapp/wire-webapp/assets/1090716/64281ed3-112e-439b-923c-9ec376b22f8e



### Before

https://github.com/wireapp/wire-webapp/assets/1090716/f0afa107-a318-4560-a52b-fb2a407081df


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
