### PR TITLE
runfix: change ConversationVerificationState back to a numeric value

### DIFF
--- a/src/script/conversation/ConversationVerificationState.ts
+++ b/src/script/conversation/ConversationVerificationState.ts
@@ -18,7 +18,7 @@
  */
 
 export enum ConversationVerificationState {
-  DEGRADED = 'degraded',
-  UNVERIFIED = 'unverified',
-  VERIFIED = 'verified',
+  DEGRADED = 2,
+  UNVERIFIED = 0,
+  VERIFIED = 1,
 }

--- a/src/script/conversation/ConversationVerificationStateHandler/Proteus/ProteusStateHandler.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/Proteus/ProteusStateHandler.ts
@@ -188,7 +188,7 @@ export class ProteusConversationVerificationStateHandler {
         logger: this.logger,
       });
 
-      if (conversationVerificationState) {
+      if (conversationVerificationState !== undefined) {
         /**
          * TEMPORARY DEBUGGING FIX:
          * We have seen conversations in a degraded state without an unverified device in there.


### PR DESCRIPTION
Fixes the database problematic introduced with a previous PR