### PR TITLE
chore: Add debug util to fill lexical editor programmatically

### DIFF
--- a/src/script/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/script/components/RichTextEditor/RichTextEditor.tsx
@@ -173,7 +173,7 @@ export const RichTextEditor = ({
             openStateRef={mentionsOpen}
           />
 
-          <OnChangePlugin onChange={saveDraft} />
+          <OnChangePlugin onChange={saveDraft} ignoreSelectionChange />
           <TextChangePlugin onUpdate={parseUpdatedText} />
           <SendPlugin
             onSend={() => {

--- a/src/script/util/DebugUtil.ts
+++ b/src/script/util/DebugUtil.ts
@@ -268,6 +268,7 @@ export class DebugUtil {
    * @param text the text to add to the input
    */
   inputText(text: string) {
+    // This is a hacky way of accessing the lexical editor directly from the DOM element
     const lexicalEditor = (document.querySelector<HTMLElement>('[data-uie-name=input-message]') as any)
       .__lexicalEditor as LexicalEditor;
 

--- a/src/script/util/DebugUtil.ts
+++ b/src/script/util/DebugUtil.ts
@@ -33,6 +33,7 @@ import type {QualifiedId} from '@wireapp/api-client/lib/user';
 import {DatabaseKeys} from '@wireapp/core/lib/notification/NotificationDatabaseRepository';
 import Dexie from 'dexie';
 import keyboardjs from 'keyboardjs';
+import {$createTextNode, $getRoot, LexicalEditor} from 'lexical';
 import {container} from 'tsyringe';
 
 import {getLogger, Logger} from 'Util/Logger';
@@ -259,6 +260,22 @@ export class DebugUtil {
   /** Used by QA test automation. */
   triggerVersionCheck(baseVersion: string): Promise<string | void> {
     return checkVersion(baseVersion);
+  }
+
+  /**
+   * will allow to programatically add text in the message input.
+   * This is used by QA to fill the input
+   * @param text the text to add to the input
+   */
+  inputText(text: string) {
+    const lexicalEditor = (document.querySelector<HTMLElement>('[data-uie-name=input-message]') as any)
+      .__lexicalEditor as LexicalEditor;
+
+    lexicalEditor.update(() => {
+      const root = $getRoot().getLastChild()!;
+      const textNode = $createTextNode(text);
+      root.append(textNode);
+    });
   }
 
   /**


### PR DESCRIPTION
## Description

Add debug util so that QA can add text in the input from automation

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
