### PR TITLE
runfix: Allow matching emojis against the keywords list

### DIFF
--- a/src/script/components/RichTextEditor/plugins/EmojiPickerPlugin/EmojiPickerPlugin.tsx
+++ b/src/script/components/RichTextEditor/plugins/EmojiPickerPlugin/EmojiPickerPlugin.tsx
@@ -150,7 +150,7 @@ export function EmojiPickerPlugin({openStateRef}: Props) {
       }
 
       const expectedWords = (queryString.match(/\s/g) || []).length + 1;
-      const emojiNameWords = emoji.title.split(' ');
+      const emojiNameWords = emoji.keywords.flatMap(keyword => keyword.split(' '));
 
       if (emojiNameWords.length < expectedWords) {
         return false;

--- a/src/script/components/RichTextEditor/plugins/EmojiPickerPlugin/EmojiPickerPlugin.tsx
+++ b/src/script/components/RichTextEditor/plugins/EmojiPickerPlugin/EmojiPickerPlugin.tsx
@@ -48,7 +48,7 @@ const TRIGGER = ':';
  * @param text the text in which to look for emoji triggers
  */
 function checkForEmojis(text: string): MenuTextMatch | null {
-  const match = new RegExp(`(^| )(${TRIGGER}(\\w[\\w +\-]*))$`).exec(text);
+  const match = new RegExp(`(^| )(${TRIGGER}([\\w +\\-][\\w \\-]*))$`).exec(text);
 
   if (match === null) {
     return null;
@@ -149,11 +149,7 @@ export function EmojiPickerPlugin({openStateRef}: Props) {
         return false;
       }
 
-      const queryWords = queryString.split('_');
-
-      return queryWords.every(queryWord => {
-        return emoji.keywords.some(emojiNameWord => emojiNameWord.startsWith(queryWord));
-      });
+      return emoji.keywords.some(emojiNameWord => emojiNameWord.includes(queryString));
     });
 
     return filteredEmojis

--- a/src/script/components/RichTextEditor/plugins/EmojiPickerPlugin/EmojiPickerPlugin.tsx
+++ b/src/script/components/RichTextEditor/plugins/EmojiPickerPlugin/EmojiPickerPlugin.tsx
@@ -48,7 +48,7 @@ const TRIGGER = ':';
  * @param text the text in which to look for emoji triggers
  */
 function checkForEmojis(text: string): MenuTextMatch | null {
-  const match = new RegExp(`(^| )(${TRIGGER}([\\w ]+))$`).exec(text);
+  const match = new RegExp(`(^| )(${TRIGGER}([\\w +\-]+))$`).exec(text);
 
   if (match === null) {
     return null;
@@ -145,21 +145,14 @@ export function EmojiPickerPlugin({openStateRef}: Props) {
 
   const options: Array<EmojiOption> = useMemo(() => {
     const filteredEmojis = emojiOptions.filter((emoji: EmojiOption) => {
-      if (queryString == null) {
-        return false;
-      }
-
-      const expectedWords = (queryString.match(/\s/g) || []).length + 1;
-      const emojiNameWords = emoji.keywords.flatMap(keyword => keyword.split(' '));
-
-      if (emojiNameWords.length < expectedWords) {
+      if (queryString === null) {
         return false;
       }
 
       const queryWords = queryString.split('_');
 
       return queryWords.every(queryWord => {
-        return emojiNameWords.some(emojiNameWord => emojiNameWord.startsWith(queryWord));
+        return emoji.keywords.some(emojiNameWord => emojiNameWord.startsWith(queryWord));
       });
     });
 

--- a/src/script/components/RichTextEditor/plugins/EmojiPickerPlugin/EmojiPickerPlugin.tsx
+++ b/src/script/components/RichTextEditor/plugins/EmojiPickerPlugin/EmojiPickerPlugin.tsx
@@ -48,7 +48,7 @@ const TRIGGER = ':';
  * @param text the text in which to look for emoji triggers
  */
 function checkForEmojis(text: string): MenuTextMatch | null {
-  const match = new RegExp(`(^| )(${TRIGGER}([\\w +\-]+))$`).exec(text);
+  const match = new RegExp(`(^| )(${TRIGGER}(\\w[\\w +\-]*))$`).exec(text);
 
   if (match === null) {
     return null;
@@ -62,7 +62,7 @@ function checkForEmojis(text: string): MenuTextMatch | null {
 
   return {
     leadOffset: match.index,
-    matchingString: term.replaceAll(' ', '_'),
+    matchingString: term,
     replaceableString: search,
   };
 }


### PR DESCRIPTION
## Description

We were, previously, only trying to match emojis based on the title of the emoji. This PR will also try to match emojis based on the entire list of keywords.

## Screenshots/Screencast (for UI changes)

![image](https://github.com/wireapp/wire-webapp/assets/1090716/9eaaed22-851b-47be-9ccf-427678c72605)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

