### PR TITLE
feat: update protocols on migration config update

### DIFF
--- a/src/script/self/SelfRepository.test.ts
+++ b/src/script/self/SelfRepository.test.ts
@@ -319,5 +319,30 @@ describe('SelfRepository', () => {
 
       expect(selfRepository.refreshSelfSupportedProtocols).not.toHaveBeenCalled();
     });
+
+    it('refreshes self supported protocols on mls migration feature config update', async () => {
+      const selfRepository = await testFactory.exposeSelfActors();
+
+      const mockedMLSMigrationFeatureUpdateEvent: TeamFeatureConfigurationUpdateEvent = {
+        name: FEATURE_KEY.MLS_MIGRATION,
+        team: '',
+        time: '',
+        data: {
+          status: FeatureStatus.ENABLED,
+          config: {finaliseRegardlessAfter: '', startTime: ''},
+        },
+
+        type: TEAM_EVENT.FEATURE_CONFIG_UPDATE,
+      };
+
+      jest.spyOn(selfRepository, 'refreshSelfSupportedProtocols').mockImplementationOnce(jest.fn());
+
+      selfRepository['teamRepository'].emit('featureUpdated', {
+        event: mockedMLSMigrationFeatureUpdateEvent,
+        prevFeatureList: {},
+      });
+
+      expect(selfRepository.refreshSelfSupportedProtocols).toHaveBeenCalled();
+    });
   });
 });

--- a/src/script/self/SelfRepository.ts
+++ b/src/script/self/SelfRepository.ts
@@ -63,6 +63,9 @@ export class SelfRepository extends TypedEventEmitter<Events> {
       if (event.name === FEATURE_KEY.MLS) {
         void this.handleMLSFeatureUpdate(event.data, prevFeatureList?.[FEATURE_KEY.MLS]);
       }
+      if (event.name === FEATURE_KEY.MLS_MIGRATION) {
+        void this.refreshSelfSupportedProtocols();
+      }
     });
   }
 

--- a/src/script/self/SelfRepository.ts
+++ b/src/script/self/SelfRepository.ts
@@ -63,6 +63,10 @@ export class SelfRepository extends TypedEventEmitter<Events> {
       if (event.name === FEATURE_KEY.MLS) {
         void this.handleMLSFeatureUpdate(event.data, prevFeatureList?.[FEATURE_KEY.MLS]);
       }
+
+      // MLS Migration feature config is also considered when evaluating self supported protocols
+      // We still allow proteus to be used if migration is enabled (but startTime has not been reached yet),
+      // or when migration is enabled, started and not finalised yet (finaliseRegardlessAfter has not arrived yet)
       if (event.name === FEATURE_KEY.MLS_MIGRATION) {
         void this.refreshSelfSupportedProtocols();
       }


### PR DESCRIPTION
## Description

Since MLS Migration feature config is also considered when calculating a list of self user's supported protocols, we need to re-evaluate this list every time MLS migration feature config gets updated.

We still allow `"proteus"` protocol to be used even when team's supported protocols is only `["mls"]` if migration feature is enabled. There are two cases: migration feature is enabled but `startTime` has not arrived, or migration feature is enabled and migration has started but not finalised (we're between `startTime` and `finaliseRegardlessAfter` dates). For more details see https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/815693828/Use+case+updating+your+supported+protocols#Choosing-supported-protocol-based-on-migration-config-and-supported-protocols-list-of-user%E2%80%99s-team.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
