### PR TITLE
feat: init 1to1 after restoring a backup

### DIFF
--- a/src/script/backup/BackupRepository.ts
+++ b/src/script/backup/BackupRepository.ts
@@ -384,7 +384,10 @@ export class BackupRepository {
     }
 
     await this.conversationRepository.updateConversations(importedConversations);
-    await Promise.all(this.conversationRepository.mapConnections(this.connectionState.connections()));
+    await this.conversationRepository.init1To1Conversations(
+      this.connectionState.connections(),
+      this.conversationRepository.getAllLocalConversations(),
+    );
     // doesn't need to be awaited
     void this.conversationRepository.checkForDeletedConversations();
   }

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1934,6 +1934,14 @@ export class ConversationRepository {
   }
 
   /**
+   * Get all conversations from the local state.
+   * @returns All conversations from the local state
+   */
+  public getAllLocalConversations() {
+    return this.conversationState.conversations();
+  }
+
+  /**
    * Set the notification handling state.
    *
    * @note Temporarily do not unarchive conversations when handling the notification stream


### PR DESCRIPTION
## Description

We need to re-init all the 1to1 conversations after restoring a backup from file. The backup could contain some old proteus 1:1 conversations and their events. We have to make sure that those that have a MLS 1:1 conversation already are hidden and initialised properly. 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
