### PR TITLE
fix: factor in the selfClient when it comes to the calculation of isMLSVerified

### DIFF
--- a/src/script/client/ClientRepository.test.ts
+++ b/src/script/client/ClientRepository.test.ts
@@ -56,7 +56,7 @@ describe('ClientRepository', () => {
       const client = new ClientEntity(false, null);
       client.id = clientId;
 
-      testFactory.client_repository['clientState'].currentClient(client);
+      testFactory.client_repository['clientState'].currentClient = client;
 
       const clients = [
         {class: ClientClassification.DESKTOP, id: '706f64373b1bcf79'},
@@ -112,9 +112,9 @@ describe('ClientRepository', () => {
       spyOn(clientService, 'getClientById').and.returnValue(Promise.resolve(clientPayloadServer));
       spyOn(clientService, 'putClientCapabilities').and.returnValue(Promise.resolve());
 
-      return testFactory.client_repository.getValidLocalClient().then(clientObservable => {
-        expect(clientObservable).toBeDefined();
-        expect(clientObservable().id).toBe(clientId);
+      return testFactory.client_repository.getValidLocalClient().then(client => {
+        expect(client).toBeDefined();
+        expect(client.id).toBe(clientId);
       });
     });
 
@@ -168,7 +168,7 @@ describe('ClientRepository', () => {
     beforeEach(() => {
       (jasmine as any).getEnv().allowRespy(true);
       spyOn(Runtime, 'isDesktopApp').and.returnValue(false);
-      testFactory.client_repository['clientState'].currentClient(undefined);
+      testFactory.client_repository['clientState'].currentClient = undefined;
     });
 
     it('returns true on Electron', () => {
@@ -179,7 +179,7 @@ describe('ClientRepository', () => {
         type: ClientType.PERMANENT,
       };
       const clientEntity = ClientMapper.mapClient(clientPayload, true, null);
-      testFactory.client_repository['clientState'].currentClient(clientEntity);
+      testFactory.client_repository['clientState'].currentClient = clientEntity;
       spyOn(Runtime, 'isDesktopApp').and.returnValue(true);
       const isPermanent = testFactory.client_repository.isCurrentClientPermanent();
 
@@ -194,7 +194,7 @@ describe('ClientRepository', () => {
         type: ClientType.TEMPORARY,
       };
       const clientEntity = ClientMapper.mapClient(clientPayload, true, null);
-      testFactory.client_repository['clientState'].currentClient(clientEntity);
+      testFactory.client_repository['clientState'].currentClient = clientEntity;
       spyOn(Runtime, 'isDesktopApp').and.returnValue(true);
       const isPermanent = testFactory.client_repository.isCurrentClientPermanent();
 
@@ -216,7 +216,7 @@ describe('ClientRepository', () => {
         type: ClientType.PERMANENT,
       };
       const clientEntity = ClientMapper.mapClient(clientPayload, true, null);
-      testFactory.client_repository['clientState'].currentClient(clientEntity);
+      testFactory.client_repository['clientState'].currentClient = clientEntity;
       const isPermanent = testFactory.client_repository.isCurrentClientPermanent();
 
       expect(isPermanent).toBeTruthy();
@@ -230,7 +230,7 @@ describe('ClientRepository', () => {
         type: ClientType.TEMPORARY,
       };
       const clientEntity = ClientMapper.mapClient(clientPayload, true, null);
-      testFactory.client_repository['clientState'].currentClient(clientEntity);
+      testFactory.client_repository['clientState'].currentClient = clientEntity;
       const isPermanent = testFactory.client_repository.isCurrentClientPermanent();
 
       expect(isPermanent).toBeFalsy();
@@ -244,12 +244,12 @@ describe('ClientRepository', () => {
   });
 
   describe('isCurrentClient', () => {
-    beforeEach(() => testFactory.client_repository['clientState'].currentClient(undefined));
+    beforeEach(() => (testFactory.client_repository['clientState'].currentClient = undefined));
 
     it('returns true if user ID and client ID match', () => {
       const clientEntity = new ClientEntity(false, null);
       clientEntity.id = clientId;
-      testFactory.client_repository['clientState'].currentClient(clientEntity);
+      testFactory.client_repository['clientState'].currentClient = clientEntity;
       testFactory.client_repository.selfUser(new User(userId, null));
       const result = testFactory.client_repository['isCurrentClient']({domain: '', id: userId}, clientId);
 
@@ -259,7 +259,7 @@ describe('ClientRepository', () => {
     it('returns false if only the user ID matches', () => {
       const clientEntity = new ClientEntity(false, null);
       clientEntity.id = clientId;
-      testFactory.client_repository['clientState'].currentClient(clientEntity);
+      testFactory.client_repository['clientState'].currentClient = clientEntity;
       const result = testFactory.client_repository['isCurrentClient']({domain: '', id: userId}, 'ABCDE');
 
       expect(result).toBeFalsy();
@@ -268,7 +268,7 @@ describe('ClientRepository', () => {
     it('returns false if only the client ID matches', () => {
       const clientEntity = new ClientEntity(false, null);
       clientEntity.id = clientId;
-      testFactory.client_repository['clientState'].currentClient(clientEntity);
+      testFactory.client_repository['clientState'].currentClient = clientEntity;
       const result = testFactory.client_repository['isCurrentClient']({domain: '', id: 'ABCDE'}, clientId);
 
       expect(result).toBeFalsy();
@@ -281,14 +281,14 @@ describe('ClientRepository', () => {
     });
 
     it('throws an error if client ID is not specified', () => {
-      testFactory.client_repository['clientState'].currentClient(new ClientEntity(false, null));
+      testFactory.client_repository['clientState'].currentClient = new ClientEntity(false, null);
       const functionCall = () => testFactory.client_repository['isCurrentClient']({domain: '', id: userId}, undefined);
 
       expect(functionCall).toThrow(ClientError);
     });
 
     it('throws an error if user ID is not specified', () => {
-      testFactory.client_repository['clientState'].currentClient(new ClientEntity(false, null));
+      testFactory.client_repository['clientState'].currentClient = new ClientEntity(false, null);
       const functionCall = () => testFactory.client_repository['isCurrentClient'](undefined, clientId);
 
       expect(functionCall).toThrow(ClientError);

--- a/src/script/client/ClientRepository.test.ts
+++ b/src/script/client/ClientRepository.test.ts
@@ -244,6 +244,7 @@ describe('ClientRepository', () => {
   });
 
   describe('isCurrentClient', () => {
+    //@ts-ignore
     beforeEach(() => (testFactory.client_repository['clientState'].currentClient = undefined));
 
     it('returns true if user ID and client ID match', () => {

--- a/src/script/client/ClientRepository.ts
+++ b/src/script/client/ClientRepository.ts
@@ -159,8 +159,8 @@ export class ClientRepository {
         }
 
         const currentClient = ClientMapper.mapClient(clientRecord, true, clientRecord.domain);
-        this.clientState.currentClient(currentClient);
-        return this.clientState.currentClient();
+        this.clientState.currentClient = currentClient;
+        return this.clientState.currentClient;
       });
   }
 
@@ -245,13 +245,16 @@ export class ClientRepository {
    * Get and validate the local client.
    * @returns Resolves with an observable containing the client if valid
    */
-  async getValidLocalClient(): Promise<ko.Observable<ClientEntity>> {
+  async getValidLocalClient(): Promise<ClientEntity> {
     try {
       const clientEntity = await this.getCurrentClientFromDb();
       await this.getClientByIdFromBackend(clientEntity.id);
       const currentClient = this.clientState.currentClient;
 
-      await this.clientService.putClientCapabilities(currentClient().id, {
+      if (!currentClient) {
+        throw new ClientError(ClientError.TYPE.CLIENT_NOT_SET, ClientError.MESSAGE.CLIENT_NOT_SET);
+      }
+      await this.clientService.putClientCapabilities(currentClient.id, {
         capabilities: [ClientCapability.LEGAL_HOLD_IMPLICIT_CONSENT],
       });
 
@@ -270,9 +273,9 @@ export class ClientRepository {
    * Load current client type from amplify store.
    * @returns Type of current client
    */
-  private loadCurrentClientType(): ClientType.PERMANENT | ClientType.TEMPORARY {
-    if (this.clientState.currentClient()) {
-      return this.clientState.currentClient().type;
+  private loadCurrentClientType(): ClientType.PERMANENT | ClientType.TEMPORARY | undefined {
+    if (this.clientState.currentClient) {
+      return this.clientState.currentClient.type;
     }
     const isPermanent = loadValue(StorageKey.AUTH.PERSIST);
     const type = isPermanent ? ClientType.PERMANENT : ClientType.TEMPORARY;
@@ -299,8 +302,8 @@ export class ClientRepository {
   }
 
   logoutClient = async (): Promise<void> => {
-    if (this.clientState.currentClient()) {
-      if (this.clientState.isTemporaryClient()) {
+    if (this.clientState.currentClient) {
+      if (this.clientState.currentClient.isTemporary()) {
         await this.deleteLocalTemporaryClient();
         amplify.publish(WebAppEvents.LIFECYCLE.SIGN_OUT, SIGN_OUT_REASON.USER_REQUESTED, true);
       } else {
@@ -387,10 +390,10 @@ export class ClientRepository {
    * @returns Type of current client is permanent
    */
   isCurrentClientPermanent(): boolean {
-    if (!this.clientState.currentClient()) {
+    if (!this.clientState.currentClient) {
       throw new ClientError(ClientError.TYPE.CLIENT_NOT_SET, ClientError.MESSAGE.CLIENT_NOT_SET);
     }
-    return Runtime.isDesktopApp() || this.clientState.currentClient().isPermanent();
+    return Runtime.isDesktopApp() || this.clientState.currentClient.isPermanent();
   }
 
   /**
@@ -450,7 +453,7 @@ export class ClientRepository {
 
             delete clientsFromBackend[clientId];
 
-            if (this.clientState.currentClient() && this.isCurrentClient(userId, clientId)) {
+            if (this.clientState.currentClient && this.isCurrentClient(userId, clientId)) {
               this.logger.warn(`Removing duplicate local self client`);
               await this.removeClient(userId, clientId);
             }
@@ -477,7 +480,7 @@ export class ClientRepository {
         for (const clientId in clientsFromBackend) {
           const clientPayload = clientsFromBackend[clientId];
 
-          if (this.clientState.currentClient() && this.isCurrentClient(userId, clientId)) {
+          if (this.clientState.currentClient && this.isCurrentClient(userId, clientId)) {
             continue;
           }
 
@@ -512,7 +515,7 @@ export class ClientRepository {
    * @returns Is the client the current local client
    */
   private isCurrentClient(userId: QualifiedId, clientId: string): boolean {
-    if (!this.clientState.currentClient()) {
+    if (!this.clientState.currentClient) {
       throw new ClientError(ClientError.TYPE.CLIENT_NOT_SET, ClientError.MESSAGE.CLIENT_NOT_SET);
     }
     if (!userId) {
@@ -521,7 +524,7 @@ export class ClientRepository {
     if (!clientId) {
       throw new ClientError(ClientError.TYPE.NO_CLIENT_ID, ClientError.MESSAGE.NO_CLIENT_ID);
     }
-    return matchQualifiedIds(userId, this.selfUser()) && clientId === this.clientState.currentClient().id;
+    return matchQualifiedIds(userId, this.selfUser()) && clientId === this.clientState.currentClient.id;
   }
 
   //##############################################################################
@@ -563,7 +566,7 @@ export class ClientRepository {
       return;
     }
 
-    const isCurrentClient = clientId === this.clientState.currentClient().id;
+    const isCurrentClient = clientId === this.clientState.currentClient.id;
     if (isCurrentClient) {
       // If the current client has been removed, we need to sign out
       amplify.publish(WebAppEvents.LIFECYCLE.SIGN_OUT, SIGN_OUT_REASON.CLIENT_REMOVED, true);

--- a/src/script/client/ClientState.ts
+++ b/src/script/client/ClientState.ts
@@ -27,7 +27,5 @@ export class ClientState {
   clients: ko.PureComputed<ClientEntity[]>;
   currentClient: ClientEntity | undefined;
 
-  constructor() {
-    this.isTemporaryClient = this.currentClient?.isTemporary();
-  }
+  constructor() {}
 }

--- a/src/script/client/ClientState.ts
+++ b/src/script/client/ClientState.ts
@@ -25,11 +25,9 @@ import {ClientEntity} from './ClientEntity';
 @singleton()
 export class ClientState {
   clients: ko.PureComputed<ClientEntity[]>;
-  currentClient: ko.Observable<ClientEntity>;
-  isTemporaryClient: ko.PureComputed<boolean>;
+  currentClient: ClientEntity | undefined;
 
   constructor() {
-    this.currentClient = ko.observable();
-    this.isTemporaryClient = ko.pureComputed(() => this.currentClient()?.isTemporary());
+    this.isTemporaryClient = this.currentClient?.isTemporary();
   }
 }

--- a/src/script/components/HistoryExport/HistoryExport.tsx
+++ b/src/script/components/HistoryExport/HistoryExport.tsx
@@ -179,15 +179,19 @@ const HistoryExport = ({switchContent, user, clientState = container.resolve(Cli
       setNumberOfRecords(numberOfRecords);
       setNumberOfProcessedRecords(0);
 
-      const archiveBlob = await backupRepository.generateHistory(
-        user,
-        clientState.currentClient().id,
-        onProgress,
-        password,
-      );
+      if (clientState.currentClient) {
+        const archiveBlob = await backupRepository.generateHistory(
+          user,
+          clientState.currentClient.id,
+          onProgress,
+          password,
+        );
 
-      onSuccess(archiveBlob);
-      logger.log(`Completed export of '${numberOfRecords}' records from history`);
+        onSuccess(archiveBlob);
+        logger.log(`Completed export of '${numberOfRecords}' records from history`);
+      } else {
+        throw new Error('No local client found');
+      }
     } catch (error) {
       onError(error as Error);
     }

--- a/src/script/components/userDevices/SelfFingerprint.tsx
+++ b/src/script/components/userDevices/SelfFingerprint.tsx
@@ -25,7 +25,6 @@ import {container} from 'tsyringe';
 
 import {WebAppEvents} from '@wireapp/webapp-events';
 
-import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 
 import {DeviceCard} from './DeviceCard';
@@ -50,11 +49,11 @@ const SelfFingerprint: React.FC<SelfFingerprintProps> = ({
     cryptographyRepository.getLocalFingerprint().then(setLocalFingerprint);
   }, [cryptographyRepository]);
 
-  const {currentClient} = useKoSubscribableChildren(clientState, ['currentClient']);
+  const currentClient = clientState.currentClient;
 
   return (
     <div className={cx('participant-devices__header', {'participant-devices__header--padding': !noPadding})}>
-      <DeviceCard device={currentClient} />
+      {currentClient && <DeviceCard device={currentClient} />}
       <div className="participant-devices__fingerprint">
         <DeviceId deviceId={localFingerprint} />
       </div>

--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.test.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.test.ts
@@ -20,7 +20,6 @@
 import {ConversationProtocol} from '@wireapp/api-client/lib/conversation/NewConversation';
 
 import {ClientEntity} from 'src/script/client';
-import {ClientState} from 'src/script/client/ClientState';
 import {Conversation} from 'src/script/entity/Conversation';
 import {User} from 'src/script/entity/User';
 import {Core} from 'src/script/service/CoreSingleton';
@@ -77,16 +76,11 @@ describe('MLSConversationVerificationStateHandler', () => {
         },
       },
     } as unknown as jest.Mocked<Core>;
-    // Mock the client state
-    const mockClientState = {
-      currentClient: () => selfClientEntity,
-    } as unknown as jest.Mocked<ClientState>;
 
     handler = new MLSConversationVerificationStateHandler(
       mockOnConversationVerificationStateChange,
       mockConversationState,
       mockCore,
-      mockClientState,
     );
 
     jest.clearAllMocks();
@@ -198,6 +192,7 @@ describe('MLSConversationVerificationStateHandler', () => {
 
       const user = new User();
       user.isMe = true;
+      user.localClient = selfClientEntity;
       conversation.getAllUserEntities = jest.fn().mockReturnValue([user]);
 
       jest.spyOn(handler as any, 'isCertificateActiveAndValid').mockReturnValue(true);

--- a/src/script/conversation/MessageRepository.test.ts
+++ b/src/script/conversation/MessageRepository.test.ts
@@ -76,7 +76,7 @@ async function buildMessageRepository(): Promise<[MessageRepository, MessageRepo
   const userState = new UserState();
   userState.self(selfUser);
   const clientState = new ClientState();
-  clientState.currentClient(new ClientEntity(true, ''));
+  clientState.currentClient = new ClientEntity(true, '');
   const core = new Account();
 
   const conversationState = new ConversationState(userState);

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -753,7 +753,7 @@ export class MessageRepository {
 
     const injectOptimisticEvent = async () => {
       if (!skipInjection) {
-        const senderId = this.clientState.currentClient().id;
+        const senderId = this.clientState.currentClient?.id;
         const currentTimestamp = this.serverTimeHandler.toServerTimestamp();
         const optimisticEvent = EventBuilder.buildMessageAdd(conversation, currentTimestamp, senderId);
         this.trackContributed(conversation, payload);

--- a/src/script/entity/User/User.ts
+++ b/src/script/entity/User/User.ts
@@ -54,7 +54,7 @@ export class User {
   public readonly connection: ko.Observable<ConnectionEntity>;
   /** does not include current client/device */
   public readonly devices: ko.ObservableArray<ClientEntity>;
-  public localClient: ko.Observable<ClientEntity> | undefined;
+  public localClient: ClientEntity | undefined;
   public readonly email: ko.Observable<string>;
   public locale?: string;
   public readonly expirationRemaining: ko.Observable<number>;
@@ -216,7 +216,7 @@ export class User {
           return false;
         }
 
-        return this.localClient ? this.localClient().meta.isMLSVerified?.() ?? false : false;
+        return this.localClient?.meta.isMLSVerified?.() ?? false;
       }
       return this.devices().every(client_et => client_et.meta.isMLSVerified?.() ?? false);
     });

--- a/src/script/entity/User/User.ts
+++ b/src/script/entity/User/User.ts
@@ -22,10 +22,12 @@ import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {amplify} from 'amplify';
 import ko from 'knockout';
+import {container} from 'tsyringe';
 
 import {Availability} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
+import {ClientState} from 'src/script/client/ClientState';
 import {t} from 'Util/LocalizerUtil';
 import {clamp} from 'Util/NumberUtil';
 import {getFirstChar} from 'Util/StringUtil';
@@ -210,10 +212,14 @@ export class User {
       return this.devices().every(client_et => client_et.meta.isVerified?.());
     });
     this.isMLSVerified = ko.pureComputed(() => {
-      if (this.devices().length === 0 && !this.isMe) {
-        return false;
+      if (this.devices().length === 0) {
+        if (!this.isMe) {
+          return false;
+        }
+        const clientState = container.resolve(ClientState);
+        return clientState.currentClient().meta.isMLSVerified?.() ?? false;
       }
-      return this.devices().every(client_et => client_et.meta.isMLSVerified?.());
+      return this.devices().every(client_et => client_et.meta.isMLSVerified?.() ?? false);
     });
     this.isOnLegalHold = ko.pureComputed(() => {
       return this.devices().some(client_et => client_et.isLegalHold());

--- a/src/script/entity/User/User.ts
+++ b/src/script/entity/User/User.ts
@@ -22,12 +22,10 @@ import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {amplify} from 'amplify';
 import ko from 'knockout';
-import {container} from 'tsyringe';
 
 import {Availability} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
-import {ClientState} from 'src/script/client/ClientState';
 import {t} from 'Util/LocalizerUtil';
 import {clamp} from 'Util/NumberUtil';
 import {getFirstChar} from 'Util/StringUtil';
@@ -56,6 +54,7 @@ export class User {
   public readonly connection: ko.Observable<ConnectionEntity>;
   /** does not include current client/device */
   public readonly devices: ko.ObservableArray<ClientEntity>;
+  public localClient: ko.Observable<ClientEntity> | undefined;
   public readonly email: ko.Observable<string>;
   public locale?: string;
   public readonly expirationRemaining: ko.Observable<number>;
@@ -216,8 +215,8 @@ export class User {
         if (!this.isMe) {
           return false;
         }
-        const clientState = container.resolve(ClientState);
-        return clientState.currentClient().meta.isMLSVerified?.() ?? false;
+
+        return this.localClient ? this.localClient().meta.isMLSVerified?.() ?? false : false;
       }
       return this.devices().every(client_et => client_et.meta.isMLSVerified?.() ?? false);
     });

--- a/src/script/event/EventRepository.ts
+++ b/src/script/event/EventRepository.ts
@@ -48,7 +48,6 @@ import {NOTIFICATION_HANDLING_STATE} from './NotificationHandlingState';
 import type {NotificationService} from './NotificationService';
 
 import {AssetTransferState} from '../assets/AssetTransferState';
-import type {ClientEntity} from '../client/ClientEntity';
 import {AssetAddEvent, ClientConversationEvent, EventBuilder, MessageAddEvent} from '../conversation/EventBuilder';
 import {CryptographyMapper} from '../cryptography/CryptographyMapper';
 import {CryptographyError} from '../error/CryptographyError';
@@ -63,7 +62,6 @@ import {Warnings} from '../view_model/WarningsContainer';
 
 export class EventRepository {
   logger: Logger;
-  currentClient: ko.Observable<ClientEntity> | undefined;
   notificationHandlingState: ko.Observable<NOTIFICATION_HANDLING_STATE>;
   previousHandlingState: NOTIFICATION_HANDLING_STATE | undefined;
   notificationsHandled: number;
@@ -109,8 +107,6 @@ export class EventRepository {
     private readonly userState = container.resolve(UserState),
   ) {
     this.logger = getLogger('EventRepository');
-
-    this.currentClient = undefined;
 
     this.notificationHandlingState = ko.observable(NOTIFICATION_HANDLING_STATE.STREAM);
     this.notificationHandlingState.subscribe(handling_state => {

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -375,6 +375,7 @@ export class App {
       });
 
       const selfUser = await this.initiateSelfUser();
+
       await initializeDataDog(this.config, selfUser.qualifiedId);
 
       // Setup all event middleware
@@ -458,6 +459,7 @@ export class App {
       telemetry.timeStep(AppInitTimingsStep.APP_PRE_LOADED);
 
       selfUser.devices(clientEntities);
+
       this._handleUrlParams();
       await conversationRepository.updateConversationsOnAppInit();
       await conversationRepository.conversationLabelRepository.loadLabels();
@@ -475,6 +477,9 @@ export class App {
       conversationRepository.cleanupConversations();
       callingRepository.setReady();
       telemetry.timeStep(AppInitTimingsStep.APP_LOADED);
+
+      // Add the local client to the user
+      selfUser.localClient = await clientRepository.getValidLocalClient();
 
       this.logger.info(`App loaded in ${Date.now() - startTime}ms`);
 

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -439,7 +439,7 @@ export class App {
         // Once all the messages have been processed and the message sending queue freed we can now:
 
         //add the potential `self` and `team` conversations
-        await registerUninitializedSelfAndTeamConversations(conversations, selfUser, clientEntity().id, this.core);
+        await registerUninitializedSelfAndTeamConversations(conversations, selfUser, clientEntity.id, this.core);
 
         //join all the mls groups we're member of and have not yet joined (eg. we were not send welcome message)
         await initMLSConversations(conversations, this.core);

--- a/src/script/page/AppLock/AppLock.tsx
+++ b/src/script/page/AppLock/AppLock.tsx
@@ -211,7 +211,7 @@ const AppLock: React.FC<AppLockProps> = ({
     const target = event.target as HTMLFormElement & {password: HTMLInputElement};
     try {
       setIsLoading(true);
-      const currentClientId = clientState.currentClient().id;
+      const currentClientId = clientState.currentClient.id;
       await clientRepository.clientService.deleteClient(currentClientId, target.password.value);
       appLockRepository.removeCode();
       amplify.publish(WebAppEvents.LIFECYCLE.SIGN_OUT, SIGN_OUT_REASON.USER_REQUESTED, true);

--- a/src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.test.tsx
+++ b/src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.test.tsx
@@ -40,7 +40,7 @@ function createDevice(): ClientEntity {
 describe('DevicesPreferences', () => {
   const clientState = new ClientState();
   clientState.clients = ko.pureComputed(() => [createDevice(), createDevice()]);
-  clientState.currentClient(createDevice());
+  clientState.currentClient = createDevice();
   const defaultParams = {
     clientState: clientState,
     conversationState: new ConversationState(),

--- a/src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx
@@ -141,7 +141,8 @@ const DevicesPreferences = ({
   selfUser,
 }: DevicesPreferencesProps) => {
   const [selectedDevice, setSelectedDevice] = useState<ClientEntity | undefined>();
-  const {clients, currentClient} = useKoSubscribableChildren(clientState, ['clients', 'currentClient']);
+  const {clients} = useKoSubscribableChildren(clientState, ['clients']);
+  const currentClient = clientState.currentClient;
   const isSSO = selfUser.isNoPasswordSSO;
   const getFingerprint = (device: ClientEntity) =>
     cryptographyRepository.getRemoteFingerprint(selfUser.qualifiedId, device.id);
@@ -173,7 +174,7 @@ const DevicesPreferences = ({
     <PreferencesPage title={t('preferencesDevices')}>
       <fieldset className="preferences-section" data-uie-name="preferences-device-current">
         <legend className="preferences-header">{t('preferencesDevicesCurrent')}</legend>
-        <DetailedDevice device={currentClient} fingerprint={localFingerprint} />
+        {currentClient && <DetailedDevice device={currentClient} fingerprint={localFingerprint} />}
       </fieldset>
 
       <hr className="preferences-devices-separator preferences-separator" />

--- a/src/script/util/DebugUtil.ts
+++ b/src/script/util/DebugUtil.ts
@@ -334,7 +334,7 @@ export class DebugUtil {
     messageId: string,
     conversationId: string = this.conversationState.activeConversation().id,
   ): Promise<void> {
-    const clientId = this.clientState.currentClient().id;
+    const clientId = this.clientState.currentClient?.id;
     const userId = this.userState.self().id;
 
     const isOTRMessage = (notification: BackendEvent) => notification.type === CONVERSATION_EVENT.OTR_MESSAGE_ADD;

--- a/test/helper/TestFactory.js
+++ b/test/helper/TestFactory.js
@@ -123,7 +123,7 @@ export class TestFactory {
     currentClient.time = '2016-10-07T16:01:42.133Z';
     currentClient.type = ClientType.TEMPORARY;
 
-    this.client_repository['clientState'].currentClient(currentClient);
+    this.client_repository['clientState'].currentClient = currentClient;
 
     return this.client_repository;
   }
@@ -262,7 +262,7 @@ export class TestFactory {
     clientEntity.class = ClientClassification.DESKTOP;
     clientEntity.id = '60aee26b7f55a99f';
     const clientState = new ClientState();
-    clientState.currentClient(clientEntity);
+    clientState.currentClient = clientEntity;
 
     this.message_repository = new MessageRepository(
       () => this.conversation_repository,

--- a/test/helper/TestFactory.js
+++ b/test/helper/TestFactory.js
@@ -145,7 +145,6 @@ export class TestFactory {
       serverTimeHandler,
       this.user_repository['userState'],
     );
-    this.event_repository.currentClient = this.client_repository['clientState'].currentClient;
 
     return this.event_repository;
   }


### PR DESCRIPTION
Previously, I didn't consider the self-client when updating/reading the user's client's certificate info.
This caused the self-user to be falsely marked as validated for MLS conversations, even if the user didn't go through the E2EE enrollment process.

This is the fix for that problem.

Refactoring Part:
I took this task to do a minor refactoring of the self-client. The Observable was unnecessary since the local client doesn't change during the app's runtime. 
This fact should be more clear now.