### PR TITLE
chore: add default protocol param to supported protocols debug util

### DIFF
--- a/src/script/util/DebugUtil.ts
+++ b/src/script/util/DebugUtil.ts
@@ -215,7 +215,7 @@ export class DebugUtil {
     await proteusService['cryptoClient'].debugBreakSession(sessionId);
   }
 
-  async setTeamSupportedProtocols(supportedProtocols: ConversationProtocol[]) {
+  async setTeamSupportedProtocols(supportedProtocols: ConversationProtocol[], defaultProtocol?: ConversationProtocol) {
     const {teamId} = await this.userRepository.getSelf();
     if (!teamId) {
       throw new Error('teamId of self user is undefined');
@@ -228,7 +228,7 @@ export class DebugUtil {
     }
 
     const response = await this.apiClient.api.teams.feature.putMLSFeature(teamId, {
-      config: {...mlsFeature.config, supportedProtocols},
+      config: {...mlsFeature.config, supportedProtocols, defaultProtocol: defaultProtocol || supportedProtocols[0]},
       status: FeatureStatus.ENABLED,
     });
 


### PR DESCRIPTION
## Description

Adds a `defaultProtocol` field to setTeamSupportedProtocols` debug util. Default protocol has to be one of `supportedProtocols` list.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
