### PR TITLE
test: add missing mock to giphy test

### DIFF
--- a/src/script/components/Giphy/Giphy.test.tsx
+++ b/src/script/components/Giphy/Giphy.test.tsx
@@ -27,7 +27,7 @@ import {Giphy, GiphyState} from '.';
 
 const inputValue = 'Yammy yammy';
 const getDefaultProps = () => ({
-  giphyRepository: {getGifs: jest.fn().mockResolvedValue([])} as unknown as GiphyRepository,
+  giphyRepository: {getGifs: jest.fn().mockResolvedValue([]), resetOffset: jest.fn()} as unknown as GiphyRepository,
   inputValue,
   onClose: jest.fn(),
 });


### PR DESCRIPTION
## Description

`src/script/components/Giphy/Giphy.test.tsx` test was randomly failing (much more often on my local machine), see https://github.com/wireapp/wire-webapp/actions/runs/6573860480/job/17857725337. Adding this mock should stabilise it.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;