### PR TITLE
runfix: Allow matching accentuated chars for mentions

### DIFF
--- a/src/script/components/RichTextEditor/plugins/MentionsPlugin/MentionsPlugin.tsx
+++ b/src/script/components/RichTextEditor/plugins/MentionsPlugin/MentionsPlugin.tsx
@@ -41,7 +41,7 @@ const TRIGGER = '@';
  * @param text the text in which to look for mentions triggers
  */
 function checkForMentions(text: string): MenuTextMatch | null {
-  const match = new RegExp(`(^| )(${TRIGGER}([\\w ]*))$`).exec(text);
+  const match = new RegExp(`(^| )(${TRIGGER}(\\S*))$`).exec(text);
 
   if (match === null) {
     return null;


### PR DESCRIPTION
## Description

Allow matching `Müller` for example when trying to mention someone. 

## Screenshots/Screencast (for UI changes)
![image](https://github.com/wireapp/wire-webapp/assets/1090716/e44a84eb-5f45-4252-b34d-8c747104323b)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
