### PR TITLE
feat: add readonly proteus to blacklist

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@peculiar/x509": "1.9.5",
     "@wireapp/avs": "9.4.18",
     "@wireapp/commons": "5.2.1",
-    "@wireapp/core": "42.16.0",
+    "@wireapp/core": "42.17.0",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.9.10",
     "@wireapp/store-engine-dexie": "2.1.6",

--- a/src/__mocks__/@wireapp/core.ts
+++ b/src/__mocks__/@wireapp/core.ts
@@ -65,6 +65,8 @@ export class Account extends EventEmitter {
       },
       removeUsersFromMLSConversation: jest.fn(),
       removeUserFromConversation: jest.fn(),
+      blacklistConversation: jest.fn(),
+      removeConversationFromBlacklist: jest.fn(),
     },
     client: {
       deleteClient: jest.fn(),

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1468,8 +1468,12 @@ export class ConversationRepository {
     );
   };
 
-  public async blacklistConversation(conversationId: QualifiedId) {
+  private async blacklistConversation(conversationId: QualifiedId) {
     return this.conversationService.blacklistConversation(conversationId);
+  }
+
+  private async removeConversationFromBlacklist(conversationId: QualifiedId) {
+    return this.conversationService.removeConversationFromBlacklist(conversationId);
   }
 
   /**
@@ -1627,6 +1631,7 @@ export class ConversationRepository {
 
     // If proteus is not supported by the other user we have to mark conversation as readonly
     if (!doesOtherUserSupportProteus) {
+      await this.blacklistConversation(proteusConversationId);
       await this.updateConversationReadOnlyState(
         proteusConversation,
         CONVERSATION_READONLY_STATE.READONLY_ONE_TO_ONE_SELF_UNSUPPORTED_MLS,
@@ -1635,6 +1640,7 @@ export class ConversationRepository {
     }
 
     // If proteus is supported by the other user, we just return a proteus conversation and remove readonly state from it.
+    await this.removeConversationFromBlacklist(proteusConversationId);
     await this.updateConversationReadOnlyState(proteusConversation, null);
     return proteusConversation;
   };

--- a/src/script/conversation/ConversationService.ts
+++ b/src/script/conversation/ConversationService.ts
@@ -105,6 +105,10 @@ export class ConversationService {
     await this.coreConversationService.blacklistConversation(conversationId);
   }
 
+  public async removeConversationFromBlacklist(conversationId: QualifiedId): Promise<void> {
+    await this.coreConversationService.removeConversationFromBlacklist(conversationId);
+  }
+
   /**
    * Get conversations for a list of conversation IDs.
    * @see https://staging-nginz-https.zinfra.io/v4/api/swagger-ui/#/default/post_conversations_list

--- a/yarn.lock
+++ b/yarn.lock
@@ -5299,9 +5299,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:42.16.0":
-  version: 42.16.0
-  resolution: "@wireapp/core@npm:42.16.0"
+"@wireapp/core@npm:42.17.0":
+  version: 42.17.0
+  resolution: "@wireapp/core@npm:42.17.0"
   dependencies:
     "@wireapp/api-client": ^26.4.0
     "@wireapp/commons": ^5.2.1
@@ -5321,7 +5321,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: 68408bafe2d217b0280518adab539b1087c789193abfffa8020cc7e8bc6f5ba8699fd5201a7cc7215fffc34a8cb0c7426cb2bdefe16a65accd13abb41b88fbe5
+  checksum: 97176143fbab1c36abb7cb0ec6372347b108729cb49d43c8d332c11bba023b3ccbb49806d6edaea1a116f27e3e34ed7c53ade665e3e59fd0552129c2c10cb4eb
   languageName: node
   linkType: hard
 
@@ -18409,7 +18409,7 @@ __metadata:
     "@wireapp/avs": 9.4.18
     "@wireapp/commons": 5.2.1
     "@wireapp/copy-config": 2.1.9
-    "@wireapp/core": 42.16.0
+    "@wireapp/core": 42.17.0
     "@wireapp/eslint-config": 3.0.4
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.6.3


### PR DESCRIPTION
## Description

Adds proteus 1:1 conversation to blacklist when the other user does not support proteus anymore. We want to make sure we don't process any incoming messages in readonly conversation (e.g. when somebody logs in with some very old client without mls 1:1 conversations support and can still see proteus 1:1 conversation with this user). Of course when conversation is usable again we remove it from the black list as well.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
