### PR TITLE
fix: Allow member join/leave events to also show unread count badge [WPB-5148]

### DIFF
--- a/src/script/conversation/ConversationCellState.ts
+++ b/src/script/conversation/ConversationCellState.ts
@@ -248,14 +248,9 @@ const _getStateGroupActivity = {
     return '';
   },
   icon: (conversationEntity: Conversation): ConversationStatusIcon | void => {
-    const lastMessageEntity = conversationEntity.getNewestMessage();
-    const isMemberRemoval = lastMessageEntity.isMember() && (lastMessageEntity as MemberMessage).isMemberRemoval();
-
-    if (isMemberRemoval) {
-      return conversationEntity.showNotificationsEverything()
-        ? ConversationStatusIcon.UNREAD_MESSAGES
-        : ConversationStatusIcon.MUTED;
-    }
+    return conversationEntity.showNotificationsEverything()
+      ? ConversationStatusIcon.UNREAD_MESSAGES
+      : ConversationStatusIcon.MUTED;
   },
   match: (conversationEntity: Conversation) => {
     const lastMessageEntity = conversationEntity.getNewestMessage();
@@ -307,7 +302,7 @@ const _getStateRemoved = {
 
     return '';
   },
-  icon: () => ConversationStatusIcon.NONE,
+  icon: () => ConversationStatusIcon.UNREAD_MESSAGES,
   match: (conversationEntity: Conversation) => conversationEntity.removed_from_conversation(),
 };
 

--- a/test/helper/UserGenerator.ts
+++ b/test/helper/UserGenerator.ts
@@ -48,7 +48,7 @@ export function generateAPIUser(
     handle: faker.internet.userName(),
     id: id.id,
     // replace special chars to avoid escaping problems with querying the DOM
-    name: faker.person.fullName().replace(/[^a-zA-Z ]/, ''),
+    name: faker.person.fullName().replace(/[^a-zA-Z ]/g, ''),
     qualified_id: id,
     ...overwites,
   };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5148" title="WPB-5148" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5148</a>  [web] unread count disapears when a member message arrives in a conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

## Screenshots/Screencast (for UI changes)

### Before

https://github.com/wireapp/wire-webapp/assets/1090716/cd7daad7-b297-4e34-931c-f5e825fe04c6

### After

https://github.com/wireapp/wire-webapp/assets/1090716/c410da38-77ed-44bb-ae13-b226251a6a71


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
