### PR TITLE
runfix: Make sure event is stored in DB before processing quotes

### DIFF
--- a/src/script/event/preprocessor/QuotedMessageMiddleware.ts
+++ b/src/script/event/preprocessor/QuotedMessageMiddleware.ts
@@ -83,7 +83,6 @@ export class QuotedMessageMiddleware implements EventMiddleware {
       if (quote && typeof quote !== 'string' && 'message_id' in quote && 'id' in event) {
         quote.message_id = event.id as string;
       }
-      // we want to update the messages quoting the original message later, thus the timeout
       await this.eventService.replaceEvent(reply);
     });
     const decoratedData = {...event.data, quote: originalEvent.data.quote};

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -387,9 +387,9 @@ export class App {
 
       eventRepository.setEventProcessMiddlewares([
         serviceMiddleware,
-        quotedMessageMiddleware,
         readReceiptMiddleware,
         eventStorageMiddleware,
+        quotedMessageMiddleware,
       ]);
       // Setup all the event processors
       const federationEventProcessor = new FederationEventProcessor(eventRepository, serverTimeHandler, selfUser);


### PR DESCRIPTION
## Description

When processing incoming event, the QuotedMessageMiddleware rely on the fact that the received event was already stored in DB. 
Previously we used a hack to do the DB update only *after* the event has been stored (with `setTimeout`), but now we can do that cleanly and run the `Storage` middleware *before* the Quoted middleware

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
