### PR TITLE
runfix: split handling quotes and replies

### DIFF
--- a/src/script/event/preprocessor/QuoteDecoderMiddleware.ts
+++ b/src/script/event/preprocessor/QuoteDecoderMiddleware.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2018 Wire Swiss GmbH
+ * Copyright (C) 2023 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/script/event/preprocessor/QuoteDecoderMiddleware.ts
+++ b/src/script/event/preprocessor/QuoteDecoderMiddleware.ts
@@ -1,0 +1,103 @@
+/*
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Quote} from '@wireapp/protocol-messaging';
+
+import {MessageAddEvent} from 'src/script/conversation/EventBuilder';
+import {getLogger, Logger} from 'Util/Logger';
+import {base64ToArray} from 'Util/util';
+
+import {QuoteEntity} from '../../message/QuoteEntity';
+import {StoredEvent} from '../../storage/record/EventRecord';
+import {ClientEvent} from '../Client';
+import {EventMiddleware, IncomingEvent} from '../EventProcessor';
+import type {EventService} from '../EventService';
+
+export class QuotedMessageMiddleware implements EventMiddleware {
+  private readonly logger: Logger;
+
+  constructor(private readonly eventService: EventService) {
+    this.logger = getLogger('QuotedMessageMiddleware');
+  }
+
+  /**
+   * Handles validation of the event if it contains a quote.
+   * If the event does contain a quote, will also decorate the event with some metadata regarding the quoted message
+   *
+   * @param event event in the DB format
+   * @returns the original event if no quote is found (or does not validate). The decorated event if the quote is valid
+   */
+  async processEvent(event: IncomingEvent): Promise<IncomingEvent> {
+    switch (event.type) {
+      case ClientEvent.CONVERSATION.MESSAGE_ADD: {
+        const originalMessageId = event.data.replacing_message_id;
+        return originalMessageId ? this.handleEditEvent(event, originalMessageId) : this.handleAddEvent(event);
+      }
+    }
+    return event;
+  }
+
+  private async handleEditEvent(event: MessageAddEvent, originalMessageId: string): Promise<MessageAddEvent> {
+    const originalEvent = (await this.eventService.loadEvent(event.conversation, originalMessageId)) as StoredEvent<
+      MessageAddEvent | undefined
+    >;
+    if (!originalEvent) {
+      return event;
+    }
+
+    const decoratedData = {...event.data, quote: originalEvent.data.quote};
+    return {...event, data: decoratedData};
+  }
+
+  private async handleAddEvent(event: MessageAddEvent): Promise<MessageAddEvent> {
+    const rawQuote = event.data.quote;
+
+    if (!rawQuote || typeof rawQuote !== 'string') {
+      return event;
+    }
+
+    const encodedQuote = base64ToArray(rawQuote);
+    const quote = Quote.decode(encodedQuote);
+    this.logger.info(`Found quoted message: ${quote.quotedMessageId}`);
+
+    const messageId = quote.quotedMessageId;
+
+    const quotedMessage = await this.eventService.loadEvent(event.conversation, messageId);
+    if (!quotedMessage) {
+      this.logger.warn(`Quoted message with ID "${messageId}" not found.`);
+      const quoteData = {
+        error: {
+          type: QuoteEntity.ERROR.MESSAGE_NOT_FOUND,
+        },
+      };
+
+      const decoratedData = {...event.data, quote: quoteData};
+      return {...event, data: decoratedData};
+    }
+
+    const quoteData = {
+      message_id: messageId,
+      user_id: quotedMessage.from,
+      hash: quote.quotedMessageSha256,
+    };
+
+    const decoratedData = {...event.data, quote: quoteData};
+    return {...event, data: decoratedData};
+  }
+}

--- a/src/script/event/preprocessor/RepliesUpdaterMiddleware.test.ts
+++ b/src/script/event/preprocessor/RepliesUpdaterMiddleware.test.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2018 Wire Swiss GmbH
+ * Copyright (C) 2023 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/script/event/preprocessor/RepliesUpdaterMiddleware.test.ts
+++ b/src/script/event/preprocessor/RepliesUpdaterMiddleware.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Conversation} from 'src/script/entity/Conversation';
+import {User} from 'src/script/entity/User';
+import {ClientEvent} from 'src/script/event/Client';
+import {QuoteEntity} from 'src/script/message/QuoteEntity';
+import {createMessageAddEvent, toSavedEvent} from 'test/helper/EventGenerator';
+import {createUuid} from 'Util/uuid';
+
+import {RepliesUpdaterMiddleware} from './RepliesUpdaterMiddleware';
+
+import {EventService} from '../EventService';
+
+function buildRepliesUpdaterMiddleware() {
+  const eventService = {
+    loadEvent: jest.fn(() => []),
+    loadEventsReplyingToMessage: jest.fn(),
+    loadReplacingEvent: jest.fn(),
+    replaceEvent: jest.fn(),
+  } as unknown as jest.Mocked<EventService>;
+
+  return [new RepliesUpdaterMiddleware(eventService), {eventService}] as const;
+}
+
+describe('QuotedMessageMiddleware', () => {
+  const conversation = new Conversation(createUuid());
+  conversation.selfUser(new User());
+
+  describe('processEvent', () => {
+    it('updates quotes in DB when a message is edited', async () => {
+      const [repliesUpdaterMiddleware, {eventService}] = buildRepliesUpdaterMiddleware();
+      const originalMessage = toSavedEvent(createMessageAddEvent());
+      const replies = [
+        createMessageAddEvent({dataOverrides: {quote: {message_id: originalMessage.id} as any}}),
+        createMessageAddEvent({dataOverrides: {quote: {message_id: originalMessage.id} as any}}),
+      ];
+      eventService.loadEvent.mockResolvedValue(originalMessage);
+      eventService.loadEventsReplyingToMessage.mockResolvedValue(replies);
+
+      const event = createMessageAddEvent({dataOverrides: {replacing_message_id: originalMessage.id}});
+
+      jest.useFakeTimers();
+
+      await repliesUpdaterMiddleware.processEvent(event);
+      jest.advanceTimersByTime(1);
+
+      expect(eventService.replaceEvent).toHaveBeenCalledWith(
+        jasmine.objectContaining({data: jasmine.objectContaining({quote: {message_id: event.id}})}),
+      );
+      jest.useRealTimers();
+    });
+
+    it('invalidates quotes in DB when a message is deleted', () => {
+      const [repliesUpdaterMiddleware, {eventService}] = buildRepliesUpdaterMiddleware();
+      const originalMessage = toSavedEvent(createMessageAddEvent());
+      const replies = [
+        createMessageAddEvent({dataOverrides: {quote: {message_id: originalMessage.id} as any}}),
+        createMessageAddEvent({dataOverrides: {quote: {message_id: originalMessage.id} as any}}),
+      ];
+      spyOn(eventService, 'loadEvent').and.returnValue(Promise.resolve(originalMessage));
+      spyOn(eventService, 'loadEventsReplyingToMessage').and.returnValue(Promise.resolve(replies));
+      spyOn(eventService, 'replaceEvent').and.returnValue(Promise.resolve());
+
+      const event = {
+        conversation: 'conversation-uuid',
+        data: {
+          replacing_message_id: 'original-id',
+        },
+        id: 'new-id',
+        type: ClientEvent.CONVERSATION.MESSAGE_DELETE,
+      } as any;
+
+      return repliesUpdaterMiddleware.processEvent(event).then(() => {
+        expect(eventService.replaceEvent).toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            data: jasmine.objectContaining({quote: {error: {type: QuoteEntity.ERROR.MESSAGE_NOT_FOUND}}}),
+          }),
+        );
+      });
+    });
+  });
+});

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -71,8 +71,9 @@ import {EventService} from '../event/EventService';
 import {EventServiceNoCompound} from '../event/EventServiceNoCompound';
 import {NotificationService} from '../event/NotificationService';
 import {EventStorageMiddleware} from '../event/preprocessor/EventStorageMiddleware';
-import {QuotedMessageMiddleware} from '../event/preprocessor/QuotedMessageMiddleware';
+import {QuotedMessageMiddleware} from '../event/preprocessor/QuoteDecoderMiddleware';
 import {ReceiptsMiddleware} from '../event/preprocessor/ReceiptsMiddleware';
+import {RepliesUpdaterMiddleware} from '../event/preprocessor/RepliesUpdaterMiddleware';
 import {ServiceMiddleware} from '../event/preprocessor/ServiceMiddleware';
 import {FederationEventProcessor} from '../event/processor/FederationEventProcessor';
 import {GiphyRepository} from '../extension/GiphyRepository';
@@ -384,12 +385,14 @@ export class App {
       const serviceMiddleware = new ServiceMiddleware(conversationRepository, userRepository, selfUser);
       const quotedMessageMiddleware = new QuotedMessageMiddleware(this.service.event);
       const readReceiptMiddleware = new ReceiptsMiddleware(this.service.event, conversationRepository, selfUser);
+      const repliesUpdaterMiddleware = new RepliesUpdaterMiddleware(this.service.event);
 
       eventRepository.setEventProcessMiddlewares([
         serviceMiddleware,
         readReceiptMiddleware,
-        eventStorageMiddleware,
         quotedMessageMiddleware,
+        eventStorageMiddleware,
+        repliesUpdaterMiddleware,
       ]);
       // Setup all the event processors
       const federationEventProcessor = new FederationEventProcessor(eventRepository, serverTimeHandler, selfUser);


### PR DESCRIPTION
## Description

The process of handling quotes need to be split into 2 different handlers:
- the one that process incoming quotes and decode them
- the one that updates all the messages that are quoting a message that has been updated/deleted

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

