### PR TITLE
runfix: make sure we find original event when dealing with updated quotes

### DIFF
--- a/src/script/event/preprocessor/RepliesUpdaterMiddleware.ts
+++ b/src/script/event/preprocessor/RepliesUpdaterMiddleware.ts
@@ -70,7 +70,7 @@ export class RepliesUpdaterMiddleware implements EventMiddleware {
    * will update the message ID of all the replies to an edited message
    */
   private async handleEditEvent(event: MessageAddEvent, originalMessageId: string) {
-    const {originalEvent, replies} = await this.findRepliesToMessage(event.conversation, originalMessageId);
+    const {originalEvent, replies} = await this.findRepliesToMessage(event.conversation, originalMessageId, event.id);
     if (!originalEvent) {
       return event;
     }
@@ -89,8 +89,10 @@ export class RepliesUpdaterMiddleware implements EventMiddleware {
   private async findRepliesToMessage(
     conversationId: string,
     messageId: string,
+    /** in case the message was edited, we need to query the DB using the old event ID */
+    previousMessageId?: string,
   ): Promise<{originalEvent?: MessageAddEvent; replies: StoredEvent<MessageAddEvent>[]}> {
-    const originalEvent = await this.eventService.loadEvent(conversationId, messageId);
+    const originalEvent = await this.eventService.loadEvent(conversationId, previousMessageId ?? messageId);
 
     if (!originalEvent || originalEvent.type !== ClientEvent.CONVERSATION.MESSAGE_ADD) {
       return {


### PR DESCRIPTION
## Description

When the `RepliesUpdaterMiddleware` runs, any `edit` event would already have been updated in the DB (and they ID would have changed already). 
We need to query the DB using the new event ID to fetch the original event when updating the replies to that event


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
