### PR TITLE
runfix: Select mention before deleting it

### DIFF
--- a/src/script/components/RichTextEditor/nodes/Mention.tsx
+++ b/src/script/components/RichTextEditor/nodes/Mention.tsx
@@ -81,14 +81,15 @@ export const Mention = (props: MentionComponentProps) => {
       const rangeSelection = $isRangeSelection(currentSelection) ? currentSelection : null;
 
       const shouldSelect = nodeKey === rangeSelection?.getNodes()[0]?.getKey();
+      // If the cursor is right before the mention, we first select the mention before deleting it
       if (shouldSelect) {
         event.preventDefault();
         setSelected(true);
         return true;
       }
+      // When the mention is selected, we actually delete it
       if (isSelected && $isNodeSelection($getSelection())) {
         event.preventDefault();
-
         const node = $getNodeByKey(nodeKey);
 
         if ($isMentionNode(node)) {

--- a/src/script/components/RichTextEditor/nodes/Mention.tsx
+++ b/src/script/components/RichTextEditor/nodes/Mention.tsx
@@ -41,6 +41,7 @@ import {
   NodeKey,
   NodeSelection,
   RangeSelection,
+  $isRangeSelection,
 } from 'lexical';
 
 import {KEY} from 'Util/KeyboardUtil';
@@ -75,9 +76,18 @@ export const Mention = (props: MentionComponentProps) => {
   }, [className, classNameFocused, isFocused]);
 
   const deleteMention = useCallback(
-    (payload: KeyboardEvent) => {
+    (event: KeyboardEvent) => {
+      const currentSelection = $getSelection();
+      const rangeSelection = $isRangeSelection(currentSelection) ? currentSelection : null;
+
+      const shouldSelect = nodeKey === rangeSelection?.getNodes()[0]?.getKey();
+      if (shouldSelect) {
+        event.preventDefault();
+        setSelected(true);
+        return true;
+      }
       if (isSelected && $isNodeSelection($getSelection())) {
-        payload.preventDefault();
+        event.preventDefault();
 
         const node = $getNodeByKey(nodeKey);
 


### PR DESCRIPTION
## Description

When hitting the backspace key, deleting a mention should take 2 steps:
- first step: visually selecting the mention
- second step: actually deleting it.


https://github.com/wireapp/wire-webapp/assets/1090716/368f3348-ff5e-4ef2-a17d-135c52240607


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
