### PR TITLE
runfix: Do not send typing stop event when no typing has occurred

### DIFF
--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -170,6 +170,7 @@ export const InputBar = ({
   const isReplying = !!replyMessageEntity;
   const isConnectionRequest = isOutgoingRequest || isIncomingRequest;
   const hasLocalEphemeralTimer = isSelfDeletingMessagesEnabled && !!localMessageTimer && !hasGlobalMessageTimer;
+  const isTypingRef = useRef(false);
 
   // To be changed when design chooses a breakpoint, the conditional can be integrated to the ui-kit directly
   const isScaledDown = useMatchMedia('max-width: 768px');
@@ -192,6 +193,7 @@ export const InputBar = ({
     text: textValue,
     onTypingChange: useCallback(
       isTyping => {
+        isTypingRef.current = isTyping;
         if (isTyping) {
           void conversationRepository.sendTypingStart(conversation);
         } else {
@@ -567,7 +569,7 @@ export const InputBar = ({
                 loadDraftState={loadDraft}
                 onShiftTab={onShiftTab}
                 onSend={sendMessage}
-                onBlur={() => isTypingIndicatorEnabled && conversationRepository.sendTypingStop(conversation)}
+                onBlur={() => isTypingRef.current && conversationRepository.sendTypingStop(conversation)}
               >
                 {isScaledDown ? (
                   <>


### PR DESCRIPTION
## Description

We have some automation errors that the webapp sends typing stop event for deleted conversations. This is due to a typing stop event being sent on `blur`. 
We need to check that some typing has occurred before sending the typing stop event

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
