### PR TITLE
runfix: mls 1to1 readonly conversation actions menu

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -143,6 +143,8 @@ const ContentMessageComponent: React.FC<ContentMessageProps> = ({
   const reactionGroupedByUser = groupByReactionUsers(reactions);
   const reactionsTotalCount = Array.from(reactionGroupedByUser).length;
 
+  const isConversationReadonly = conversation.readOnlyState() !== null;
+
   return (
     <div
       aria-label={messageAriaLabel}
@@ -228,7 +230,7 @@ const ContentMessageComponent: React.FC<ContentMessageProps> = ({
             />
           )}
         </div>
-        {isActionMenuVisible && (
+        {!isConversationReadonly && isActionMenuVisible && (
           <MessageActionsMenu
             isMsgWithHeader={shouldShowAvatar()}
             message={message}


### PR DESCRIPTION
## Description

Removes actions menu from conversation that is in readonly state.

We don't want to make user think that they can still react to messages / delete them or reply.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
