### PR TITLE
runfix: Update openState of emoji/mention picker when menu is closed

### DIFF
--- a/src/script/components/RichTextEditor/plugins/EmojiPickerPlugin/EmojiPickerPlugin.tsx
+++ b/src/script/components/RichTextEditor/plugins/EmojiPickerPlugin/EmojiPickerPlugin.tsx
@@ -20,12 +20,7 @@
 import {MutableRefObject, useCallback, useMemo, useState} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {
-  MenuOption,
-  MenuRenderFn,
-  MenuTextMatch,
-  useBasicTypeaheadTriggerMatch,
-} from '@lexical/react/LexicalTypeaheadMenuPlugin';
+import {MenuOption, MenuRenderFn, MenuTextMatch} from '@lexical/react/LexicalTypeaheadMenuPlugin';
 // The emoji list comes from the emoji-picker-react package that we also use for reactions. It's a little hacky how we import it but since it's typechecked, we will be warned if this file doesn't exist in the repo with further updates
 import emojiList from 'emoji-picker-react/src/data/emojis.json';
 import {$createTextNode, $getSelection, $isRangeSelection, TextNode} from 'lexical';
@@ -117,31 +112,18 @@ export function EmojiPickerPlugin({openStateRef}: Props) {
     }
   };
 
-  const checkForTriggerMatch = useBasicTypeaheadTriggerMatch('/', {
-    minLength: 0,
-  });
+  const checkForEmojiPickerMatch = useCallback((text: string) => {
+    const info = getSelectionInfo([':']);
 
-  const checkForEmojiPickerMatch = useCallback(
-    (text: string) => {
+    if (info?.isTextNode && info.wordCharAfterCursor) {
       // Don't show the menu if the next character is a word character
-      const info = getSelectionInfo([':']);
+      return null;
+    }
 
-      if (info?.isTextNode && info.wordCharAfterCursor) {
-        return null;
-      }
+    const queryMatch = checkForEmojis(text);
 
-      const slashMatch = checkForTriggerMatch(text, lexicalEditor);
-
-      if (slashMatch !== null) {
-        return null;
-      }
-
-      const queryMatch = checkForEmojis(text);
-
-      return queryMatch?.replaceableString ? queryMatch : null;
-    },
-    [checkForTriggerMatch, lexicalEditor],
-  );
+    return queryMatch?.replaceableString ? queryMatch : null;
+  }, []);
 
   const options: Array<EmojiOption> = useMemo(() => {
     const filteredEmojis = emojiOptions.filter((emoji: EmojiOption) => {

--- a/src/script/components/RichTextEditor/plugins/EmojiPickerPlugin/EmojiPickerPlugin.tsx
+++ b/src/script/components/RichTextEditor/plugins/EmojiPickerPlugin/EmojiPickerPlugin.tsx
@@ -37,19 +37,19 @@ import {getDOMRangeRect} from '../../utils/getDomRangeRect';
 import {getSelectionInfo} from '../../utils/getSelectionInfo';
 
 const TRIGGER = ':';
+const triggerRegexp = new RegExp(`(\\W|^)(${TRIGGER}([\\w+\\-][\\w \\-]*))$`);
 
 /**
  * Will detect emoji triggers in a text
  * @param text the text in which to look for emoji triggers
  */
 function checkForEmojis(text: string): MenuTextMatch | null {
-  const match = new RegExp(`(^| )(${TRIGGER}([\\w +\\-][\\w \\-]*))$`).exec(text);
+  const match = triggerRegexp.exec(text);
 
   if (match === null) {
     return null;
   }
-  const search = match[2];
-  const term = match[3];
+  const [, , search, term] = match;
 
   if (term.length === 0) {
     return null;
@@ -115,12 +115,12 @@ export function EmojiPickerPlugin({openStateRef}: Props) {
   const checkForEmojiPickerMatch = useCallback((text: string) => {
     const info = getSelectionInfo([':']);
 
-    if (info?.isTextNode && info.wordCharAfterCursor) {
+    if (!info || (info.isTextNode && info.wordCharAfterCursor)) {
       // Don't show the menu if the next character is a word character
       return null;
     }
 
-    const queryMatch = checkForEmojis(text);
+    const queryMatch = checkForEmojis(info.textContent);
 
     return queryMatch?.replaceableString ? queryMatch : null;
   }, []);


### PR DESCRIPTION
## Description

Will prevent blocking sending when a mention valid mention is being typed but the user manually closes the selection menu.

## Screenshots/Screencast (for UI changes)

### Before

https://github.com/wireapp/wire-webapp/assets/1090716/c0e1941a-f599-42ac-852a-8c41c82f1e8c

### After


https://github.com/wireapp/wire-webapp/assets/1090716/327d069e-91e0-44e7-87c7-d3cbfee100ce



## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
