### PR TITLE
runfix: Do not open typeahead menu when text is first entered in the input bar

### DIFF
--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -255,9 +255,10 @@ export const InputBar = ({
       cancelMessageEditing(true);
       setEditedMessage(messageEntity);
 
-      if (messageEntity.quote() && conversation) {
+      const quote = messageEntity.quote();
+      if (quote && conversation) {
         void messageRepository
-          .getMessageInConversationById(conversation, messageEntity.quote().messageId)
+          .getMessageInConversationById(conversation, quote.messageId)
           .then(quotedMessage => setReplyMessageEntity(quotedMessage));
       }
     }

--- a/src/script/components/RichTextEditor/plugins/TypeaheadMenuPlugin.tsx
+++ b/src/script/components/RichTextEditor/plugins/TypeaheadMenuPlugin.tsx
@@ -672,6 +672,7 @@ export function TypeaheadMenuPlugin<TOption extends TypeaheadOption>({
   containerId,
   isReversed = false,
 }: TypeaheadMenuPluginProps<TOption>): JSX.Element | null {
+  const previousText = useRef<string>('');
   const [editor] = useLexicalComposerContext();
   const [resolution, setResolution] = useState<Resolution | null>(null);
   const [menuVisible, setMenuVisible] = useState(false);
@@ -715,6 +716,12 @@ export function TypeaheadMenuPlugin<TOption extends TypeaheadOption>({
           return;
         }
 
+        const isInitialTextSet = previousText.current === '' && text.length > 1;
+        previousText.current = text;
+        if (isInitialTextSet) {
+          // Do not trigger the typeahead when the input first loads (goes from empty to a text larger than 1 char)
+          return;
+        }
         const match = triggerFn(text, editor);
         onQueryChange(match ? match.matchingString : null);
 


### PR DESCRIPTION
## Description

Will avoid showing the typeahead menu when we first load the input bar with some text

## Screenshots/Screencast (for UI changes)

### Before

https://github.com/wireapp/wire-webapp/assets/1090716/027220f0-96cc-4d58-8a49-08cebfa43775

### After

https://github.com/wireapp/wire-webapp/assets/1090716/b32b9604-71f8-4829-802b-d62c1951e9f6

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

