### PR TITLE
runfix: Handle deleting mentions using the delete key

### DIFF
--- a/src/script/components/RichTextEditor/nodes/Mention.tsx
+++ b/src/script/components/RichTextEditor/nodes/Mention.tsx
@@ -80,13 +80,21 @@ export const Mention = (props: MentionComponentProps) => {
       const currentSelection = $getSelection();
       const rangeSelection = $isRangeSelection(currentSelection) ? currentSelection : null;
 
-      const shouldSelect = nodeKey === rangeSelection?.getNodes()[0]?.getKey();
+      let shouldSelectNode = false;
+      if (event.key === 'Backspace') {
+        shouldSelectNode = nodeKey === rangeSelection?.getNodes()[0]?.getKey();
+      } else if (event.key === 'Delete') {
+        const currentNode = rangeSelection?.getNodes()[0];
+        const isOnTheEdgeOfNode = currentNode?.getTextContent().length === rangeSelection?.focus.offset;
+        shouldSelectNode = currentNode?.getNextSibling()?.getKey() === nodeKey && isOnTheEdgeOfNode;
+      }
       // If the cursor is right before the mention, we first select the mention before deleting it
-      if (shouldSelect) {
+      if (shouldSelectNode) {
         event.preventDefault();
         setSelected(true);
         return true;
       }
+
       // When the mention is selected, we actually delete it
       if (isSelected && $isNodeSelection($getSelection())) {
         event.preventDefault();
@@ -98,7 +106,6 @@ export const Mention = (props: MentionComponentProps) => {
 
         setSelected(false);
       }
-
       return false;
     },
     [isSelected, nodeKey, setSelected],


### PR DESCRIPTION
## Description

This will select the mention before deleting it when using the `Delete` key (`Backspace` key was already implemented)


https://github.com/wireapp/wire-webapp/assets/1090716/e8e6dc48-0eb9-43c8-b988-a38a9848a396

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
