### PR TITLE
runfix: Return reaction event instead of targeted message event

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -2905,7 +2905,7 @@ export class ConversationRepository {
       }
       const changes = messageEntity.getSelectionChange(buttonId);
       if (changes) {
-        this.eventService.updateEventSequentially(messageEntity.primary_key, changes);
+        await this.eventService.updateEventSequentially({primary_key: messageEntity.primary_key, ...changes});
       }
     } catch (error) {
       const isNotFound = error.type === ConversationError.TYPE.MESSAGE_NOT_FOUND;

--- a/src/script/event/EventService.ts
+++ b/src/script/event/EventService.ts
@@ -424,12 +424,13 @@ export class EventService {
    * @param primaryKey Event primary key
    * @param changes Changes to update message with
    */
-  async updateEventSequentially(primaryKey: string, changes: Partial<EventRecord> = {}): Promise<number> {
+  async updateEventSequentially(changes: IdentifiedUpdatePayload): Promise<number> {
     const hasVersionedChanges = !!changes.version;
     if (!hasVersionedChanges) {
       throw new ConversationError(ConversationError.TYPE.WRONG_CHANGE, ConversationError.MESSAGE.WRONG_CHANGE);
     }
 
+    const primaryKey = changes.primary_key;
     if (this.storageService.db) {
       // Create a DB transaction to avoid concurrent sequential update.
       return this.storageService.db.transaction('rw', StorageSchemata.OBJECT_STORE.EVENTS, async () => {

--- a/src/script/event/EventService.ts
+++ b/src/script/event/EventService.ts
@@ -430,7 +430,7 @@ export class EventService {
       throw new ConversationError(ConversationError.TYPE.WRONG_CHANGE, ConversationError.MESSAGE.WRONG_CHANGE);
     }
 
-    const primaryKey = changes.primary_key;
+    const {primary_key: primaryKey, ...updates} = changes;
     if (this.storageService.db) {
       // Create a DB transaction to avoid concurrent sequential update.
       return this.storageService.db.transaction('rw', StorageSchemata.OBJECT_STORE.EVENTS, async () => {
@@ -444,7 +444,7 @@ export class EventService {
         const databaseVersion = record.version || 1;
         const isSequentialUpdate = changes.version === databaseVersion + 1;
         if (isSequentialUpdate) {
-          return this.storageService.update(StorageSchemata.OBJECT_STORE.EVENTS, primaryKey, changes);
+          return this.storageService.update(StorageSchemata.OBJECT_STORE.EVENTS, primaryKey, updates);
         }
         const logMessage = 'Failed sequential database update';
         const logObject = {
@@ -455,7 +455,7 @@ export class EventService {
         throw new StorageError(StorageError.TYPE.NON_SEQUENTIAL_UPDATE, StorageError.MESSAGE.NON_SEQUENTIAL_UPDATE);
       });
     }
-    return this.storageService.update(StorageSchemata.OBJECT_STORE.EVENTS, primaryKey, changes);
+    return this.storageService.update(StorageSchemata.OBJECT_STORE.EVENTS, primaryKey, updates);
   }
 
   /**

--- a/src/script/event/preprocessor/EventStorageMiddleware/EventStorageMiddleware.ts
+++ b/src/script/event/preprocessor/EventStorageMiddleware/EventStorageMiddleware.ts
@@ -104,7 +104,7 @@ export class EventStorageMiddleware implements EventMiddleware {
         break;
 
       case 'sequential-update':
-        await this.eventService.updateEventSequentially(operation.event.primary_key, operation.updates);
+        await this.eventService.updateEventSequentially(operation.updates);
         break;
 
       case 'delete':

--- a/src/script/event/preprocessor/EventStorageMiddleware/eventHandlers/reactionEventHandler.ts
+++ b/src/script/event/preprocessor/EventStorageMiddleware/eventHandlers/reactionEventHandler.ts
@@ -35,6 +35,7 @@ function computeEventUpdates(target: StoredEvent<MessageAddEvent>, reactionEvent
   } = reactionEvent;
   const reactionMap = target.reactions ? userReactionMapToReactionMap(target.reactions) : [];
   return {
+    primary_key: target.primary_key,
     reactions: addReaction(reactionMap, reaction, qualified_from ?? {id: from, domain: ''}),
     version: version,
   };
@@ -50,7 +51,7 @@ export const handleReactionEvent: EventHandler = async (event, {findEvent}) => {
   }
   return {
     type: 'sequential-update',
-    event: targetEvent,
+    event,
     updates: computeEventUpdates(targetEvent, event),
   };
 };

--- a/src/script/event/preprocessor/EventStorageMiddleware/types.ts
+++ b/src/script/event/preprocessor/EventStorageMiddleware/types.ts
@@ -27,7 +27,7 @@ import {IdentifiedUpdatePayload} from '../../EventService';
 export type HandledEvents = ClientConversationEvent | ConversationEvent;
 export type DBOperation =
   | {type: 'update'; event: HandledEvents; updates: IdentifiedUpdatePayload}
-  | {type: 'sequential-update'; event: EventRecord; updates: Partial<EventRecord>}
+  | {type: 'sequential-update'; event: HandledEvents; updates: IdentifiedUpdatePayload}
   | {type: 'delete'; event: HandledEvents; id: string}
   | {type: 'insert'; event: HandledEvents};
 

--- a/test/unit_tests/event/EventServiceCommon.js
+++ b/test/unit_tests/event/EventServiceCommon.js
@@ -372,7 +372,7 @@ const testEventServiceClass = (testedServiceName, className) => {
       it('fails if changes do not contain version property', () => {
         const updates = {reactions: ['user-id']};
         return testFactory[testedServiceName]
-          .updateEventSequentially(12, updates)
+          .updateEventSequentially({primary_key: 12, ...updates})
           .then(fail)
           .catch(error => {
             expect(error.type).toBe(ConversationError.TYPE.WRONG_CHANGE);
@@ -385,7 +385,7 @@ const testEventServiceClass = (testedServiceName, className) => {
         spyOn(testFactory.storage_service, 'load').and.returnValue(Promise.resolve({version: 2}));
 
         return testFactory[testedServiceName]
-          .updateEventSequentially(12, updates)
+          .updateEventSequentially({primary_key: 12, ...updates})
           .then(fail)
           .catch(error => {
             expect(error.type).toBe(StorageError.TYPE.NON_SEQUENTIAL_UPDATE);
@@ -399,7 +399,7 @@ const testEventServiceClass = (testedServiceName, className) => {
         spyOn(testFactory.storage_service, 'update').and.returnValue(Promise.resolve('ok'));
 
         return testFactory[testedServiceName]
-          .updateEventSequentially(12, updates)
+          .updateEventSequentially({primary_key: 12, ...updates})
           .then(fail)
           .catch(error => {
             expect(error.type).toBe(StorageError.TYPE.NOT_FOUND);
@@ -413,7 +413,7 @@ const testEventServiceClass = (testedServiceName, className) => {
         spyOn(testFactory.storage_service, 'update').and.returnValue(Promise.resolve('ok'));
         spyOn(testFactory.storage_service.db, 'transaction').and.callThrough();
 
-        return testFactory[testedServiceName].updateEventSequentially(12, updates).then(() => {
+        return testFactory[testedServiceName].updateEventSequentially({primary_key: 12, ...updates}).then(() => {
           expect(testFactory.storage_service.update).toHaveBeenCalledWith(eventStoreName, 12, updates);
           expect(testFactory.storage_service.db.transaction).toHaveBeenCalled();
         });


### PR DESCRIPTION
## Description

When a reaction arrives we, mistakenly, returned the message targeted by the reaction instead of the reaction event itself. 
This was because we needed the message primary key to update the DB during the DBOperation execution. 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
