### PR TITLE
runfix: Make sure mention menu is positioned on init

### DIFF
--- a/src/script/components/RichTextEditor/plugins/TypeaheadMenuPlugin.tsx
+++ b/src/script/components/RichTextEditor/plugins/TypeaheadMenuPlugin.tsx
@@ -254,6 +254,11 @@ function useDynamicPositioning(
 ) {
   const [editor] = useLexicalComposerContext();
   useEffect(() => {
+    // Trigger initial positioning
+    onReposition();
+  }, []);
+
+  useEffect(() => {
     if (targetElement != null && resolution != null) {
       const rootElement = editor.getRootElement();
       const rootScrollParent = rootElement != null ? getScrollParent(rootElement, false) : document.body;
@@ -275,8 +280,6 @@ function useDynamicPositioning(
           }
         }
       };
-      // Trigger initial positioning
-      onReposition();
       const resizeObserver = new ResizeObserver(onReposition);
       window.addEventListener('resize', onReposition);
       document.addEventListener('scroll', handleScroll, {

--- a/src/script/components/RichTextEditor/plugins/TypeaheadMenuPlugin.tsx
+++ b/src/script/components/RichTextEditor/plugins/TypeaheadMenuPlugin.tsx
@@ -275,6 +275,8 @@ function useDynamicPositioning(
           }
         }
       };
+      // Trigger initial positioning
+      onReposition();
       const resizeObserver = new ResizeObserver(onReposition);
       window.addEventListener('resize', onReposition);
       document.addEventListener('scroll', handleScroll, {
@@ -536,7 +538,7 @@ function useMenuAnchorRef(opt: UseMenuAnchorRefOptions): MutableRefObject<HTMLEl
       anchorElementRef.current = containerDiv;
       rootElement.setAttribute('aria-controls', 'typeahead-menu');
     }
-  }, [editor, resolution, className, containerId]);
+  }, [editor, resolution, className, containerId, opt]);
 
   useEffect(() => {
     return () => {

--- a/src/script/components/RichTextEditor/plugins/TypeaheadMenuPlugin.tsx
+++ b/src/script/components/RichTextEditor/plugins/TypeaheadMenuPlugin.tsx
@@ -493,7 +493,7 @@ interface UseMenuAnchorRefOptions {
 }
 
 function useMenuAnchorRef(opt: UseMenuAnchorRefOptions): MutableRefObject<HTMLElement> {
-  const {resolution, setResolution, className, containerId} = opt;
+  const {resolution, setResolution, className, containerId, onAdded} = opt;
   const [editor] = useLexicalComposerContext();
   const anchorElementRef = useRef<HTMLElement>(document.createElement('div'));
   const positionMenu = useCallback(() => {
@@ -536,12 +536,12 @@ function useMenuAnchorRef(opt: UseMenuAnchorRefOptions): MutableRefObject<HTMLEl
         containerDiv.style.display = 'block';
         containerDiv.style.position = 'absolute';
         document.body.append(containerDiv);
-        opt.onAdded?.();
+        onAdded?.();
       }
       anchorElementRef.current = containerDiv;
       rootElement.setAttribute('aria-controls', 'typeahead-menu');
     }
-  }, [editor, resolution, className, containerId, opt]);
+  }, [editor, resolution, className, containerId, onAdded]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Description

We currently rely on `ResizeObserver` to trigger the initial call the `onReposition` callback. 
But, with some version of Chrome, the `ResizeObserver` doesn't trigger for an element that is not yet added to the DOM. 

Thus, on some Chrome version, the callback is never called and the menu doesn't appear at all. 

This PR makes sure that the callback is called when the menu is initialized. 


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
