### PR TITLE
runfix: do not mark link preview as edited messages

### DIFF
--- a/src/script/event/preprocessor/EventStorageMiddleware/EventStorageMiddleware.test.ts
+++ b/src/script/event/preprocessor/EventStorageMiddleware/EventStorageMiddleware.test.ts
@@ -185,6 +185,7 @@ describe('EventStorageMiddleware', () => {
       linkPreviewEvent.data.previews = ['preview'];
 
       const updatedEvent = (await eventStorageMiddleware.processEvent(linkPreviewEvent)) as any;
+      expect(updatedEvent.edited_time).not.toBeUndefined();
       expect(eventService.replaceEvent).toHaveBeenCalled();
       expect(eventService.saveEvent).not.toHaveBeenCalled();
       expect(updatedEvent.data.previews[0]).toEqual('preview');
@@ -208,6 +209,7 @@ describe('EventStorageMiddleware', () => {
       const updatedEvent = (await eventStorageMiddleware.processEvent(event)) as any;
       expect(updatedEvent.time).toEqual(initial_time);
       expect(updatedEvent.time).not.toEqual(changed_time);
+      expect(updatedEvent.edited_time).toEqual(changed_time);
       expect(updatedEvent.data.content).toEqual('new content');
       expect(updatedEvent.primary_key).toEqual(originalEvent.primary_key);
       expect(Object.keys(updatedEvent.reactions).length).toEqual(0);

--- a/src/script/event/preprocessor/EventStorageMiddleware/eventHandlers/editedEventHandler.ts
+++ b/src/script/event/preprocessor/EventStorageMiddleware/eventHandlers/editedEventHandler.ts
@@ -56,7 +56,7 @@ function getUpdatesForEditMessage(
   // Remove reactions, so that likes (hearts) don't stay when a message's text gets edited
   const commonUpdates = getCommonMessageUpdates(originalEvent, newEvent);
 
-  return {...newEvent, ...commonUpdates, reactions: {}};
+  return {...newEvent, ...commonUpdates, edited_time: newEvent.time, reactions: {}};
 }
 
 function computeEventUpdates(originalEvent: StoredEvent<MessageAddEvent>, newEvent: MessageAddEvent) {

--- a/src/script/event/preprocessor/EventStorageMiddleware/eventHandlers/getCommonMessageUpdates.ts
+++ b/src/script/event/preprocessor/EventStorageMiddleware/eventHandlers/getCommonMessageUpdates.ts
@@ -24,7 +24,6 @@ export function getCommonMessageUpdates(originalEvent: StoredEvent<MessageAddEve
   return {
     ...newEvent,
     data: {...newEvent.data, expects_read_confirmation: originalEvent.data.expects_read_confirmation},
-    edited_time: newEvent.time,
     read_receipts: !newEvent.read_receipts ? originalEvent.read_receipts : newEvent.read_receipts,
     status: !newEvent.status || newEvent.status < originalEvent.status ? originalEvent.status : newEvent.status,
     time: originalEvent.time,


### PR DESCRIPTION
## Description

Currently link previews will, wrongly, mark a message as edited. 
This fixes it by not setting the `edited_time` when a link preview event is processed

## Screenshots/Screencast (for UI changes)

### After
![image](https://github.com/wireapp/wire-webapp/assets/1090716/5b3643d8-1cce-40ab-9e5f-5881903c09b5)

### Before
![image](https://github.com/wireapp/wire-webapp/assets/1090716/a00fc339-58ea-4c29-b0ee-094290e381eb)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

