### PR TITLE
chore: bump core with new core-crypto version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@peculiar/x509": "1.9.5",
     "@wireapp/avs": "9.5.2",
     "@wireapp/commons": "5.2.2",
-    "@wireapp/core": "42.18.0",
+    "@wireapp/core": "42.19.0",
     "@wireapp/lru-cache": "3.8.1",
     "@wireapp/react-ui-kit": "9.9.12",
     "@wireapp/store-engine-dexie": "2.1.6",

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -146,7 +146,7 @@ module.exports = {
     new CopyPlugin({
       patterns: [
         {
-          context: 'node_modules/@wireapp/core-crypto/platforms/web/assets',
+          context: 'node_modules/@wireapp/core-crypto/platforms/web',
           from: '*.wasm',
           to: `${dist}/min/core-crypto.wasm`,
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5358,20 +5358,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core-crypto@npm:1.0.0-rc.13":
-  version: 1.0.0-rc.13
-  resolution: "@wireapp/core-crypto@npm:1.0.0-rc.13"
-  checksum: 8edbf8ffbda8db2b0a2a9dd93fe5c823fb337bb6f4eef0333d3c96ea8d594739b50511eb8d463e11863205537e505fe78fe8a25fcf6e61c675ad30a335cf1b5d
+"@wireapp/core-crypto@npm:1.0.0-rc.16":
+  version: 1.0.0-rc.16
+  resolution: "@wireapp/core-crypto@npm:1.0.0-rc.16"
+  checksum: 95061f0a0ee69205492ffb254a60c81be604b6a7d76e5f3e512129c2a5669adc39114e343f50002ff77db7302e1cfd39ac8dd684a87d28555b95c1e4fda7a4f3
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:42.18.0":
-  version: 42.18.0
-  resolution: "@wireapp/core@npm:42.18.0"
+"@wireapp/core@npm:42.19.0":
+  version: 42.19.0
+  resolution: "@wireapp/core@npm:42.19.0"
   dependencies:
     "@wireapp/api-client": ^26.5.0
     "@wireapp/commons": ^5.2.2
-    "@wireapp/core-crypto": 1.0.0-rc.13
+    "@wireapp/core-crypto": 1.0.0-rc.16
     "@wireapp/cryptobox": 12.8.0
     "@wireapp/promise-queue": ^2.2.7
     "@wireapp/protocol-messaging": 1.44.0
@@ -5387,7 +5387,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: 348ea24ff583893ec1a229d0eca09b7963d37727bb31fd358ad7d19e8c8f532c7330a4cf27e4952744bad9431026c53bc090adf8eb357e83973af616b33fc347
+  checksum: a5b26d66d215b697f5da53e85afbdf869a870ee7f56224cd74517e9d1134bad24450b45ce3822608d9b2de37a0fbf720a660bed4f5427edca87b8344b90260b3
   languageName: node
   linkType: hard
 
@@ -18514,7 +18514,7 @@ __metadata:
     "@wireapp/avs": 9.5.2
     "@wireapp/commons": 5.2.2
     "@wireapp/copy-config": 2.1.10
-    "@wireapp/core": 42.18.0
+    "@wireapp/core": 42.19.0
     "@wireapp/eslint-config": 3.0.4
     "@wireapp/lru-cache": 3.8.1
     "@wireapp/prettier-config": 0.6.3


### PR DESCRIPTION
## Description

Bumps core with new version of core-crypto https://github.com/wireapp/wire-web-packages/pull/5665.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
