### PR TITLE
runfix: return the udpated asset event when dealing with asset uploaded events

### DIFF
--- a/src/script/event/preprocessor/EventStorageMiddleware/eventHandlers/assetEventHandler.ts
+++ b/src/script/event/preprocessor/EventStorageMiddleware/eventHandlers/assetEventHandler.ts
@@ -66,7 +66,8 @@ function computeEventUpdates(
     case ASSET_PREVIEW:
     case RETRY_EVENT:
     case AssetTransferState.UPLOADED: {
-      return {type: 'update', event: newEvent, updates: updateEventData(newEventData)};
+      const updatedEvent = updateEventData(newEventData);
+      return {type: 'update', event: updatedEvent, updates: updatedEvent};
     }
 
     case AssetTransferState.UPLOAD_FAILED: {


### PR DESCRIPTION
## Description

Broken behavior with the refactoring to the EventStorageMiddleware. 
The event returned by the middleware should be the updated event https://github.com/wireapp/wire-webapp/pull/16012/files#diff-8424911ba55dc95ddd7ee35e77e651a8894faa0c33cd485cbbf62f6537fe3d24L562

## Screenshots/Screencast (for UI changes)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;


