### PR TITLE
runfix: Make sure link previews are handled before edit events

### DIFF
--- a/src/script/event/preprocessor/EventStorageMiddleware/EventStorageMiddleware.test.ts
+++ b/src/script/event/preprocessor/EventStorageMiddleware/EventStorageMiddleware.test.ts
@@ -177,6 +177,7 @@ describe('EventStorageMiddleware', () => {
         JSON.stringify({
           ...linkPreviewEvent,
           data: {...linkPreviewEvent.data, replacing_message_id: replacingId},
+          edited_time: new Date().toISOString(),
         }),
       );
       eventService.loadEvent.mockResolvedValue(storedEvent);

--- a/src/script/event/preprocessor/EventStorageMiddleware/EventStorageMiddleware.ts
+++ b/src/script/event/preprocessor/EventStorageMiddleware/EventStorageMiddleware.ts
@@ -58,7 +58,7 @@ export class EventStorageMiddleware implements EventMiddleware {
   }
 
   private async getDbOperation(event: HandledEvents, duplicateEvent?: HandledEvents): Promise<DBOperation> {
-    const handlers = [handleEditEvent, handleLinkPreviewEvent, handleAssetEvent, handleReactionEvent];
+    const handlers = [handleLinkPreviewEvent, handleEditEvent, handleAssetEvent, handleReactionEvent];
     for (const handler of handlers) {
       const operation = await handler(event, {
         duplicateEvent,

--- a/src/script/event/preprocessor/EventStorageMiddleware/eventHandlers/getCommonMessageUpdates.ts
+++ b/src/script/event/preprocessor/EventStorageMiddleware/eventHandlers/getCommonMessageUpdates.ts
@@ -24,6 +24,7 @@ export function getCommonMessageUpdates(originalEvent: StoredEvent<MessageAddEve
   return {
     ...newEvent,
     data: {...newEvent.data, expects_read_confirmation: originalEvent.data.expects_read_confirmation},
+    edited_time: originalEvent.edited_time,
     read_receipts: !newEvent.read_receipts ? originalEvent.read_receipts : newEvent.read_receipts,
     status: !newEvent.status || newEvent.status < originalEvent.status ? originalEvent.status : newEvent.status,
     time: originalEvent.time,


### PR DESCRIPTION
## Description

In case a `LinkPreview` events arrive with an `replacing_message_id` ref, it should only be considered a link preview, not a message edit. 
Thus we need to put the `linkPreviewEventHandler` before the `EditEventHandler`

## Screenshots/Screencast (for UI changes)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
