### PR TITLE
fix: emoji name is not getting rendered correctly for emojis with skin tone modifers

### DIFF
--- a/src/script/util/EmojiUtil.ts
+++ b/src/script/util/EmojiUtil.ts
@@ -68,10 +68,9 @@ Object.keys(emojiesList).forEach(key => {
   emojiDictionary.set(key, formattedEmojiName);
 });
 
-const skinToneModifiers = new Set(['1f3fd', '1f3fe', '1f3ff', '1f3fc', '1f3fb']);
-
 // Function to get the emoji without skintone modifiers
 const removeSkinToneModifiers = (emojiUnicode: string): string => {
+  const skinToneModifiers = new Set(['1f3fd', '1f3fe', '1f3ff', '1f3fc', '1f3fb']);
   if (!emojiUnicode) {
     return '';
   }
@@ -81,18 +80,13 @@ const removeSkinToneModifiers = (emojiUnicode: string): string => {
   return unicodeWithoutSkinModifier.join('-');
 };
 export const getEmojiTitleFromEmojiUnicode = (emojiUnicode: string): string => {
-  const emojiUnicodeSplitted = emojiUnicode.split('-');
-
-  const hasSkinToneModifier = emojiUnicodeSplitted.some(part => {
-    return skinToneModifiers.has(part);
-  });
-
-  if (hasSkinToneModifier) {
-    const unicodeWithoutSkinModifier = removeSkinToneModifiers(emojiUnicode);
-
-    return emojiDictionary.get(unicodeWithoutSkinModifier) || '';
+  if (emojiDictionary.has(emojiUnicode)) {
+    return emojiDictionary.get(emojiUnicode)!;
   }
-  return emojiDictionary.get(emojiUnicode) || '';
+
+  const unicodeWithoutSkinModifier = removeSkinToneModifiers(emojiUnicode);
+
+  return emojiDictionary.get(unicodeWithoutSkinModifier) || '';
 };
 
 export function getEmojiUnicode(emojis: string) {

--- a/src/script/util/EmojiUtil.ts
+++ b/src/script/util/EmojiUtil.ts
@@ -61,11 +61,38 @@ Object.keys(emojiesList).forEach(key => {
   const emojiObject = emojiValue[0];
   const emojiNames = emojiObject.n;
 
-  emojiDictionary.set(key, emojiNames[0].replaceAll('-', ' '));
+  // Replace hyphens with spaces, but only if not followed by a number
+  // example- thumbs down emoji name is -1
+  const formattedEmojiName = emojiNames[0].replace(/-(?![0-9])/g, ' ');
+
+  emojiDictionary.set(key, formattedEmojiName);
 });
 
+const skinToneModifiers = new Set(['1f3fd', '1f3fe', '1f3ff', '1f3fc', '1f3fb']);
+
+// Function to get the emoji without skintone modifiers
+const removeSkinToneModifiers = (emojiUnicode: string): string => {
+  if (!emojiUnicode) {
+    return '';
+  }
+  const emojiUnicodeSplitted = emojiUnicode.split('-');
+  const unicodeWithoutSkinModifier = emojiUnicodeSplitted.filter(part => !skinToneModifiers.has(part));
+
+  return unicodeWithoutSkinModifier.join('-');
+};
 export const getEmojiTitleFromEmojiUnicode = (emojiUnicode: string): string => {
-  return emojiDictionary.has(emojiUnicode) ? emojiDictionary.get(emojiUnicode)! : '';
+  const emojiUnicodeSplitted = emojiUnicode.split('-');
+
+  const hasSkinToneModifier = emojiUnicodeSplitted.some(part => {
+    return skinToneModifiers.has(part);
+  });
+
+  if (hasSkinToneModifier) {
+    const unicodeWithoutSkinModifier = removeSkinToneModifiers(emojiUnicode);
+
+    return emojiDictionary.get(unicodeWithoutSkinModifier) || '';
+  }
+  return emojiDictionary.get(emojiUnicode) || '';
 };
 
 export function getEmojiUnicode(emojis: string) {


### PR DESCRIPTION
## Description
In the latest version of emoji-picker library a new version of emoji.json file got added. In this json file the unicode object called "u" has the emoji unicode without the skintone modifiers. if the emoji has skin tone modifiers then its part of another object property called "v".

Example:

This is the emoji object of a boy emoji-
`{
    "n": [
        "boy"
    ],
    "u": "1f466",
    "v": [
        "1f466-1f3fb",
        "1f466-1f3fc",
        "1f466-1f3fd",
        "1f466-1f3fe",
        "1f466-1f3ff"
    ],
    "a": "0.6"
}`

As you can see the unicode object property "u" has the emoji unicode, the "v" property holds the unicode with skin modifier. But not all emoji has skin modifiers so we need to use the actual emoji unicode value as our unicode key. When a skin tone modifier emoji comes like hand emojis then we need to discard the skin modifier part of the unicode and take the rest of it and compare the unicode value with our emoji dictionary to fetch the emoji title/name. So suppose receive 1f466-1f3fb then we need to discard the 1f3fb part of it and compare only 1f466 with the emoji dictionary. The skin modifier can be any part of the unicode not just at the end, but they are fixed value set one of 1f3fb/1f3fc/1f3fd/1f3fe/1f3ff

Another fix I have done is, don't replace a hyphen from the emoji title with space if its followed by a numeric character. This is fixed the issue of thumbs down emoji title which is -1 and was displayed as 1 now its -1.

## Screenshots/Screencast (for UI changes)

### BEFORE
<img width="307" alt="Screenshot 2023-10-27 at 11 42 08" src="https://github.com/wireapp/wire-webapp/assets/28754444/120f641d-7eed-4697-a0fa-6c7d64014d5a">

### AFTER
<img width="176" alt="Screenshot 2023-10-27 at 11 42 31" src="https://github.com/wireapp/wire-webapp/assets/28754444/ea78b64a-05d3-4b93-bdb1-7f05cb0bc896">

<img width="181" alt="Screenshot 2023-10-27 at 11 42 35" src="https://github.com/wireapp/wire-webapp/assets/28754444/477178ec-43a2-44f2-b515-79a604c1f217">


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;