### PR TITLE
runfix: Avoid showing active conversation if it is not supposed to be visible

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.test.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.test.tsx
@@ -36,7 +36,11 @@ describe('Conversations', () => {
         removeEventListener: jest.fn(),
       },
     } as any,
-    listViewModel: {} as any,
+    listViewModel: {
+      contentViewModel: {
+        loadPreviousContent: jest.fn(),
+      },
+    } as any,
     preferenceNotificationRepository: {notifications: ko.observable([])} as any,
     propertiesRepository: {getPreference: jest.fn(), savePreference: jest.fn()} as any,
     selfUser: new User(),

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -128,6 +128,13 @@ const Conversations: React.FC<ConversationsProps> = ({
   };
 
   useEffect(() => {
+    if (!conversationState.isVisible(activeConversation)) {
+      // If the active conversation is not visible, switch to the recent view
+      listViewModel.contentViewModel.loadPreviousContent();
+    }
+  }, [activeConversation, conversationState, listViewModel.contentViewModel, conversations.length]);
+
+  useEffect(() => {
     if (!activeConversation) {
       return () => {};
     }

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -128,7 +128,7 @@ const Conversations: React.FC<ConversationsProps> = ({
   };
 
   useEffect(() => {
-    if (!conversationState.isVisible(activeConversation)) {
+    if (activeConversation && !conversationState.isVisible(activeConversation)) {
       // If the active conversation is not visible, switch to the recent view
       listViewModel.contentViewModel.loadPreviousContent();
     }


### PR DESCRIPTION
## Description

When the active conversation becomes inaccessible (eg. a legal hold request was sent to the user) we should not be able to still see the message list for that conversation

## Screenshots/Screencast (for UI changes)

### Before 

https://github.com/wireapp/wire-webapp/assets/1090716/b0e2aa85-843f-4900-9808-226d2799499e

### After

https://github.com/wireapp/wire-webapp/assets/1090716/d5d858a5-bd47-4df2-af3e-e3431d34a201


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
