### PR TITLE
runfix: Open conversation list when group creation fails

### DIFF
--- a/src/script/view_model/ListViewModel.ts
+++ b/src/script/view_model/ListViewModel.ts
@@ -132,6 +132,9 @@ export class ListViewModel {
   }
 
   private readonly _initSubscriptions = () => {
+    amplify.subscribe(WebAppEvents.CONVERSATION.SHOW, (conversation?: Conversation) => {
+      this.openConversations(conversation?.archivedState());
+    });
     amplify.subscribe(WebAppEvents.PREFERENCES.MANAGE_ACCOUNT, this.openPreferencesAccount);
     amplify.subscribe(WebAppEvents.PREFERENCES.MANAGE_DEVICES, this.openPreferencesDevices);
     amplify.subscribe(WebAppEvents.PREFERENCES.SHOW_AV, this.openPreferencesAudioVideo);


### PR DESCRIPTION
## Description

Regression introduced here https://github.com/wireapp/wire-webapp/pull/15629/files#diff-64f21a6a4e966327cebd30656d98f168a75fb36f3d8732c1bc460b7ec83539f3L135

The listviewmodel doesn't automatically switch to the conversation list when we try to focus one particular conversation

### Before


https://github.com/wireapp/wire-webapp/assets/1090716/5d8457d8-0e7b-4a07-b10d-d3dafabc5a11

### After


https://github.com/wireapp/wire-webapp/assets/1090716/68a5e3c9-2da2-40b6-8131-2febe5b276e1


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;


