### PR TITLE
fix:  Conversation details of archived conversation still show 'Archive' option

### DIFF
--- a/src/script/page/RightSidebar/ConversationDetails/utils/getConversationActions.ts
+++ b/src/script/page/RightSidebar/ConversationDetails/utils/getConversationActions.ts
@@ -72,7 +72,7 @@ const getConversationActions = (
     {
       condition: conversationEntity.is_archived(),
       item: {
-        click: async () => actionsViewModel.unArchiveConversation(conversationEntity),
+        click: async () => actionsViewModel.unarchiveConversation(conversationEntity),
         icon: 'archive-icon',
         identifier: 'do-unarchive',
         label: t('conversationsPopoverUnarchive'),

--- a/src/script/page/RightSidebar/ConversationDetails/utils/getConversationActions.ts
+++ b/src/script/page/RightSidebar/ConversationDetails/utils/getConversationActions.ts
@@ -61,12 +61,21 @@ const getConversationActions = (
       },
     },
     {
-      condition: true,
+      condition: !conversationEntity.is_archived(),
       item: {
         click: async () => actionsViewModel.archiveConversation(conversationEntity),
         icon: 'archive-icon',
         identifier: 'do-archive',
         label: t('conversationDetailsActionArchive'),
+      },
+    },
+    {
+      condition: conversationEntity.is_archived(),
+      item: {
+        click: async () => actionsViewModel.unArchiveConversation(conversationEntity),
+        icon: 'archive-icon',
+        identifier: 'do-unarchive',
+        label: t('conversationsPopoverUnarchive'),
       },
     },
     {

--- a/src/script/view_model/ActionsViewModel.ts
+++ b/src/script/view_model/ActionsViewModel.ts
@@ -34,7 +34,6 @@ import type {MainViewModel} from './MainViewModel';
 import type {ClientEntity} from '../client';
 import type {ConnectionRepository} from '../connection/ConnectionRepository';
 import type {ConversationRepository} from '../conversation/ConversationRepository';
-import {ConversationState} from '../conversation/ConversationState';
 import type {MessageRepository} from '../conversation/MessageRepository';
 import {NOTIFICATION_STATE} from '../conversation/NotificationSetting';
 import type {Conversation} from '../entity/Conversation';
@@ -42,13 +41,10 @@ import type {Message} from '../entity/message/Message';
 import type {User} from '../entity/User';
 import type {IntegrationRepository} from '../integration/IntegrationRepository';
 import type {ServiceEntity} from '../integration/ServiceEntity';
-import {ListState} from '../page/useAppState';
 import {SelfRepository} from '../self/SelfRepository';
 import {UserState} from '../user/UserState';
 
 export class ActionsViewModel {
-  public readonly mainViewModel: MainViewModel;
-  private readonly conversationState: ConversationState;
   constructor(
     private readonly selfRepository: SelfRepository,
     private readonly connectionRepository: ConnectionRepository,
@@ -56,11 +52,8 @@ export class ActionsViewModel {
     private readonly integrationRepository: IntegrationRepository,
     private readonly messageRepository: MessageRepository,
     private readonly userState = container.resolve(UserState),
-    mainViewModel: MainViewModel,
-  ) {
-    this.mainViewModel = mainViewModel;
-    this.conversationState = container.resolve(ConversationState);
-  }
+    private readonly mainViewModel: MainViewModel,
+  ) {}
 
   readonly acceptConnectionRequest = (userEntity: User): Promise<void> => {
     return this.connectionRepository.acceptRequest(userEntity);
@@ -74,16 +67,12 @@ export class ActionsViewModel {
     return this.conversationRepository.archiveConversation(conversationEntity);
   };
 
-  readonly unArchiveConversation = (conversationEntity: Conversation): Promise<void> => {
+  readonly unArchiveConversation = (conversationEntity: Conversation): void => {
     if (!conversationEntity) {
-      return Promise.reject();
+      return;
     }
 
-    return this.conversationRepository.unarchiveConversation(conversationEntity, true, 'manual un-archive').then(() => {
-      if (!this.conversationState.archivedConversations().length) {
-        this.mainViewModel.list.switchList(ListState.CONVERSATIONS);
-      }
-    });
+    return this.mainViewModel.list.clickToUnarchive(conversationEntity);
   };
 
   /**

--- a/src/script/view_model/ActionsViewModel.ts
+++ b/src/script/view_model/ActionsViewModel.ts
@@ -67,7 +67,7 @@ export class ActionsViewModel {
     return this.conversationRepository.archiveConversation(conversationEntity);
   };
 
-  readonly unArchiveConversation = (conversationEntity: Conversation): void => {
+  readonly unarchiveConversation = (conversationEntity: Conversation): void => {
     if (!conversationEntity) {
       return;
     }

--- a/src/script/view_model/MainViewModel.ts
+++ b/src/script/view_model/MainViewModel.ts
@@ -113,6 +113,8 @@ export class MainViewModel {
       repositories.conversation,
       repositories.integration,
       repositories.message,
+      userState,
+      this,
     );
 
     this.calling = new CallingViewModel(


### PR DESCRIPTION
## Description

Conversation details of an archived conversation still show 'Archive' option. When a conversation is archived, the conversation details should show unarchive option. If user tries to unarchive a conversation then first we should unarchive the conversation then check if that was the last archived conversation if yes we need to switch the view to conversation list otherwise stay in the archived view.

## Screenshots/Screencast (for UI changes)

<img width="1512" alt="Screenshot 2023-10-30 at 13 41 46" src="https://github.com/wireapp/wire-webapp/assets/28754444/7c1dd44c-9eb5-45ad-863e-be60b0f2ae5d">


<img width="1503" alt="Screenshot 2023-10-30 at 13 41 03" src="https://github.com/wireapp/wire-webapp/assets/28754444/a7d32a8d-d370-4115-a10d-6676d13be164">


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- Need to update the unarchived icon.
