### PR TITLE
fix: backend sends gracePeriod in seconds instead of ms

### DIFF
--- a/src/script/E2EIdentity/E2EIdentity.test.ts
+++ b/src/script/E2EIdentity/E2EIdentity.test.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {TimeInMillis} from '@wireapp/commons/lib/util/TimeUtil';
 import {container} from 'tsyringe';
 
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
@@ -76,8 +77,8 @@ jest.mock('src/script/user/UserState', () => ({
 }));
 
 describe('E2EIHandler', () => {
-  const params = {discoveryUrl: 'http://example.com', gracePeriodInMS: 30000};
-  const newParams = {discoveryUrl: 'http://new-example.com', gracePeriodInMS: 60000};
+  const params = {discoveryUrl: 'http://example.com', gracePeriodInSeconds: 30};
+  const newParams = {discoveryUrl: 'http://new-example.com', gracePeriodInSeconds: 60};
   const user = {name: () => 'John Doe', username: () => 'johndoe'};
   let coreMock: Core;
   let userStateMock: UserState;
@@ -135,11 +136,11 @@ describe('E2EIHandler', () => {
 
     // Assuming that the instance exposes getters for discoveryUrl and gracePeriodInMS for testing purposes
     expect(instance['discoveryUrl']).toEqual(params.discoveryUrl);
-    expect(instance['gracePeriodInMS']).toEqual(params.gracePeriodInMS);
+    expect(instance['gracePeriodInMS']).toEqual(params.gracePeriodInSeconds * TimeInMillis.SECOND);
 
     instance.updateParams(newParams);
     expect(instance['discoveryUrl']).toEqual(newParams.discoveryUrl);
-    expect(instance['gracePeriodInMS']).toEqual(newParams.gracePeriodInMS);
+    expect(instance['gracePeriodInMS']).toEqual(newParams.gracePeriodInSeconds * TimeInMillis.SECOND);
   });
 
   it('should return true when supportsMLS returns true and ENABLE_E2EI is true', () => {

--- a/src/script/E2EIdentity/E2EIdentity.ts
+++ b/src/script/E2EIdentity/E2EIdentity.ts
@@ -42,7 +42,7 @@ export enum E2EIHandlerStep {
 
 interface E2EIHandlerParams {
   discoveryUrl: string;
-  gracePeriodInMS: number;
+  gracePeriodInSeconds: number;
 }
 
 class E2EIHandler {
@@ -54,12 +54,12 @@ class E2EIHandler {
   private gracePeriodInMS: number;
   private currentStep: E2EIHandlerStep | null = E2EIHandlerStep.UNINITIALIZED;
 
-  private constructor({discoveryUrl, gracePeriodInMS}: E2EIHandlerParams) {
+  private constructor({discoveryUrl, gracePeriodInSeconds}: E2EIHandlerParams) {
     // ToDo: Do these values need to te able to be updated? Should we use a singleton with update fn?
     this.discoveryUrl = discoveryUrl;
-    this.gracePeriodInMS = gracePeriodInMS;
+    this.gracePeriodInMS = gracePeriodInSeconds * 1000;
     this.timer = DelayTimerService.getInstance({
-      gracePeriodInMS,
+      gracePeriodInMS: this.gracePeriodInMS,
       gracePeriodExpiredCallback: () => null,
       delayPeriodExpiredCallback: () => null,
     });
@@ -92,11 +92,11 @@ class E2EIHandler {
   /**
    * @param E2EIHandlerParams The params to create the grace period timer
    */
-  public updateParams({gracePeriodInMS, discoveryUrl}: E2EIHandlerParams) {
-    this.gracePeriodInMS = gracePeriodInMS;
+  public updateParams({gracePeriodInSeconds, discoveryUrl}: E2EIHandlerParams) {
+    this.gracePeriodInMS = gracePeriodInSeconds * 1000;
     this.discoveryUrl = discoveryUrl;
     this.timer.updateParams({
-      gracePeriodInMS,
+      gracePeriodInMS: this.gracePeriodInMS,
       gracePeriodExpiredCallback: () => null,
       delayPeriodExpiredCallback: () => null,
     });

--- a/src/script/E2EIdentity/E2EIdentity.ts
+++ b/src/script/E2EIdentity/E2EIdentity.ts
@@ -23,6 +23,7 @@ import {PrimaryModal, removeCurrentModal} from 'Components/Modals/PrimaryModal';
 import {Config} from 'src/script/Config';
 import {Core} from 'src/script/service/CoreSingleton';
 import {UserState} from 'src/script/user/UserState';
+import {TIME_IN_MILLIS} from 'Util/TimeUtil';
 import {removeUrlParameters} from 'Util/UrlUtil';
 import {supportsMLS} from 'Util/util';
 
@@ -57,7 +58,7 @@ class E2EIHandler {
   private constructor({discoveryUrl, gracePeriodInSeconds}: E2EIHandlerParams) {
     // ToDo: Do these values need to te able to be updated? Should we use a singleton with update fn?
     this.discoveryUrl = discoveryUrl;
-    this.gracePeriodInMS = gracePeriodInSeconds * 1000;
+    this.gracePeriodInMS = gracePeriodInSeconds * TIME_IN_MILLIS.SECOND;
     this.timer = DelayTimerService.getInstance({
       gracePeriodInMS: this.gracePeriodInMS,
       gracePeriodExpiredCallback: () => null,
@@ -93,7 +94,7 @@ class E2EIHandler {
    * @param E2EIHandlerParams The params to create the grace period timer
    */
   public updateParams({gracePeriodInSeconds, discoveryUrl}: E2EIHandlerParams) {
-    this.gracePeriodInMS = gracePeriodInSeconds * 1000;
+    this.gracePeriodInMS = gracePeriodInSeconds * TIME_IN_MILLIS.SECOND;
     this.discoveryUrl = discoveryUrl;
     this.timer.updateParams({
       gracePeriodInMS: this.gracePeriodInMS,

--- a/src/script/page/components/FeatureConfigChange/FeatureConfigChangeHandler/Features/E2EIdentity.ts
+++ b/src/script/page/components/FeatureConfigChange/FeatureConfigChangeHandler/Features/E2EIdentity.ts
@@ -47,7 +47,7 @@ export const handleE2EIdentityFeatureChange = (logger: Logger, config: FeatureLi
     // Either get the current E2EIdentity handler instance or create a new one
     const e2eHandler = E2EIHandler.getInstance({
       discoveryUrl: e2eiConfig.config.acmeDiscoveryUrl!,
-      gracePeriodInMS: e2eiConfig.config.verificationExpiration,
+      gracePeriodInSeconds: e2eiConfig.config.verificationExpiration,
     });
     e2eHandler.initialize();
   }


### PR DESCRIPTION
This PR fixes a bug with the E2EI GracePeriod. The backend sends the GracePeriod in Seconds, I did initially think it would be MS, they get converted now.