### PR TITLE
refactor: Cleanup user state

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -291,8 +291,6 @@ export class ConversationRepository {
       onMessageTimeout: this.handleMessageExpiration,
     });
 
-    this.userState.directlyConnectedUsers = this.conversationState.connectedUsers;
-
     this.conversationLabelRepository = new ConversationLabelRepository(
       this.conversationState.conversations,
       this.conversationState.visibleConversations,

--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -51,6 +51,9 @@ export class ConversationState {
   private readonly selfProteusConversation: ko.PureComputed<Conversation | undefined>;
   private readonly selfMLSConversation: ko.PureComputed<Conversation | undefined>;
   public readonly unreadConversations: ko.PureComputed<Conversation[]>;
+  /**
+   * All the users that are connected to the selfUser through a conversation. Those users are not necessarily **directly** connected to the selfUser (through a connection request)
+   */
   public readonly connectedUsers: ko.PureComputed<User[]>;
 
   public readonly sortedConversations: ko.PureComputed<Conversation[]>;

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -1135,8 +1135,8 @@ export class MessageRepository {
       messageId: createUuid(),
     });
 
-    const sortedUsers = this.userState
-      .directlyConnectedUsers()
+    const sortedUsers = this.conversationState
+      .connectedUsers()
       // For the moment, we do not want to send status in federated env
       // we can remove the filter when we actually want this feature in federated env (and we will need to implement federation for the core broadcastService)
       .filter(user => !user.isFederated)

--- a/src/script/team/TeamState.ts
+++ b/src/script/team/TeamState.ts
@@ -51,7 +51,9 @@ export class TeamState {
   public readonly isAppLockEnabled: ko.PureComputed<boolean>;
   public readonly isAppLockEnforced: ko.PureComputed<boolean>;
   public readonly appLockInactivityTimeoutSecs: ko.PureComputed<number>;
+  /** all the members of the team */
   readonly teamMembers: ko.PureComputed<User[]>;
+  /** all the members of the team + the users the selfUser is connected with */
   readonly teamUsers: ko.PureComputed<User[]>;
   readonly isTeam: ko.PureComputed<boolean>;
   readonly team: ko.Observable<TeamEntity>;
@@ -81,10 +83,6 @@ export class TeamState {
     });
 
     this.supportsLegalHold = ko.observable(false);
-
-    this.userState.isTeam = this.isTeam;
-    this.userState.teamMembers = this.teamMembers;
-    this.userState.teamUsers = this.teamUsers;
 
     this.isFileSharingSendingEnabled = ko.pureComputed(() => {
       const status = this.teamFeatures()?.fileSharing?.status;

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -76,6 +76,7 @@ import type {EventSource} from '../event/EventSource';
 import type {PropertiesRepository} from '../properties/PropertiesRepository';
 import type {SelfService} from '../self/SelfService';
 import {UserRecord} from '../storage';
+import {TeamState} from '../team/TeamState';
 import type {ServerTimeHandler} from '../time/serverTimeHandler';
 
 type GetUserOptions = {
@@ -126,6 +127,7 @@ export class UserRepository {
     serverTimeHandler: ServerTimeHandler,
     private readonly propertyRepository: PropertiesRepository,
     private readonly userState = container.resolve(UserState),
+    private readonly teamState = container.resolve(TeamState),
   ) {
     this.logger = getLogger('UserRepository');
 
@@ -561,7 +563,7 @@ export class UserRepository {
       userId => new User(userId.id, userId.domain),
     );
     const mappedUsers = this.userMapper.mapUsersFromJson(found, this.userState.self().domain).concat(failedToLoad);
-    if (this.userState.isTeam()) {
+    if (this.teamState.isTeam()) {
       this.mapGuestStatus(mappedUsers);
     }
     return mappedUsers;
@@ -790,7 +792,7 @@ export class UserRepository {
     // update the user in db
     await this.updateUser(userId, user);
 
-    if (this.userState.isTeam()) {
+    if (this.teamState.isTeam()) {
       this.mapGuestStatus([updatedUser]);
     }
     if (updatedUser && updatedUser.inTeam() && updatedUser.isDeleted) {

--- a/src/script/user/UserState.ts
+++ b/src/script/user/UserState.ts
@@ -27,21 +27,14 @@ import {User} from '../entity/User';
 
 @singleton()
 export class UserState {
-  public directlyConnectedUsers: ko.PureComputed<User[]>;
-  public isTeam: ko.Observable<boolean> | ko.PureComputed<boolean>;
+  public readonly self = ko.observable<User | undefined>();
+  /** All the users we know of (connected users, conversation users, team members, users we have searched for...) */
+  public readonly users = ko.observableArray<User>([]);
   /** All the users that are directly connect to the self user (do not include users that are connected through conversations) */
   public readonly connectedUsers: ko.PureComputed<User[]>;
-  public readonly users: ko.ObservableArray<User>;
-  public teamMembers: ko.PureComputed<User[]>;
-  /** Note: this does not include the self user */
-  public teamUsers: ko.PureComputed<User[]>;
   public readonly connectRequests: ko.PureComputed<User[]>;
-  public readonly numberOfContacts: ko.PureComputed<number>;
-  public readonly self = ko.observable<User | undefined>();
 
   constructor() {
-    this.users = ko.observableArray([]);
-
     this.connectRequests = ko
       .pureComputed(() => this.users().filter(userEntity => userEntity.isIncomingRequest()))
       .extend({rateLimit: 50});
@@ -53,16 +46,5 @@ export class UserState {
           .sort(sortUsersByPriority);
       })
       .extend({rateLimit: TIME_IN_MILLIS.SECOND});
-
-    this.isTeam = ko.observable();
-    this.teamMembers = ko.pureComputed((): User[] => []);
-    this.teamUsers = ko.pureComputed((): User[] => []);
-
-    this.directlyConnectedUsers = ko.pureComputed((): User[] => []);
-
-    this.numberOfContacts = ko.pureComputed(() => {
-      const contacts = this.isTeam() ? this.teamUsers() : this.connectedUsers();
-      return contacts.filter(userEntity => !userEntity.isService).length;
-    });
   }
 }


### PR DESCRIPTION
## Description

We currently have a weird relationship between the `UserState`, the `TeamState` and the `ConversationState`. 
The `UserState` get some of its state from those other two. Which make things hard to follow and understand. 

This PR brings back the single source of truth to find information about users and adds documentation to explain what each observable represents

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
