### PR TITLE
fix: align username to the left in replies (WPB-5282)

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/MessageQuote.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageQuote.tsx
@@ -168,7 +168,7 @@ const QuotedMessage: FC<QuotedMessageProps> = ({
       <div className="message-quote__sender">
         <button
           type="button"
-          className="button-reset-default"
+          className="button-reset-default text-left"
           onClick={() => showUserDetails(quotedUser)}
           data-uie-name="label-name-quote"
           tabIndex={messageFocusedTabIndex}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5282" title="WPB-5282" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5282</a>  Long usernames are centered in replies
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Text of the username sender in replies is centered as the component has default button styling.
It would be more appropriate to align the text to the left 

## Screenshots/Screencast (for UI changes)
#### Before:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/659a48a3-7b51-4c4f-9abf-b5db282cd455)

#### After:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/3d0905ac-df83-48d5-9e05-72ed57e93dfa)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
