### PR TITLE
runfix: Only replace emojies for currently edited editor node

### DIFF
--- a/src/script/components/RichTextEditor/plugins/InlineEmojiReplacementPlugin/InlineEmojiReplacementPlugin.tsx
+++ b/src/script/components/RichTextEditor/plugins/InlineEmojiReplacementPlugin/InlineEmojiReplacementPlugin.tsx
@@ -64,8 +64,9 @@ export function ReplaceEmojiPlugin(): null {
             const currentSelection = $isRangeSelection(selection) ? selection : undefined;
             const isUpdatedNode =
               currentSelection?.anchor.key === newNode.getKey() && currentSelection?.focus.key === newNode.getKey();
-            const updatedText = findAndTransformEmoji(text);
-            if (isUpdatedNode && updatedText !== text) {
+            // We only want to trigger emoji replacement for the node being updated (the update listener will trigger for all the node in the editor)
+            if (isUpdatedNode) {
+              const updatedText = findAndTransformEmoji(text);
               const sizeDiff = updatedText.length - text.length;
               newNode.setTextContent(updatedText);
               // After emoji replacement, the size of the text could vary. We need to reposition the selection so that it stays in place for the user

--- a/src/script/components/RichTextEditor/plugins/InlineEmojiReplacementPlugin/InlineEmojiReplacementPlugin.tsx
+++ b/src/script/components/RichTextEditor/plugins/InlineEmojiReplacementPlugin/InlineEmojiReplacementPlugin.tsx
@@ -62,16 +62,20 @@ export function ReplaceEmojiPlugin(): null {
             const text = newNode.getTextContent();
             const selection = $getSelection();
             const currentSelection = $isRangeSelection(selection) ? selection : undefined;
+            const isUpdatedNode =
+              currentSelection?.anchor.key === newNode.getKey() && currentSelection?.focus.key === newNode.getKey();
             const updatedText = findAndTransformEmoji(text);
-            const sizeDiff = updatedText.length - text.length;
-            newNode.setTextContent(updatedText);
-            // After emoji replacement, the size of the text could vary. We need to reposition the selection so that it stays in place for the user
-            currentSelection?.setTextNodeRange(
-              newNode,
-              currentSelection.anchor.offset + sizeDiff,
-              newNode,
-              currentSelection.focus.offset + sizeDiff,
-            );
+            if (isUpdatedNode && updatedText !== text) {
+              const sizeDiff = updatedText.length - text.length;
+              newNode.setTextContent(updatedText);
+              // After emoji replacement, the size of the text could vary. We need to reposition the selection so that it stays in place for the user
+              currentSelection?.setTextNodeRange(
+                newNode,
+                currentSelection.anchor.offset + sizeDiff,
+                newNode,
+                currentSelection.focus.offset + sizeDiff,
+              );
+            }
             // We register a text transform listener for a single round when the space key is pressed (then the listener is released)
             unregister();
           });


### PR DESCRIPTION
## Description

the `registerNodeTransform` lexical editor hook will trigger the listener for every node in the current nodes. Which means that it triggers for the node being edited **and** for all the other nodes present. 

The bug then changed the selection to the last node in the editor (and thus changes the position of the cursor unexpectedly). 


https://github.com/wireapp/wire-webapp/assets/1090716/bf3e5ecd-5beb-4c42-bc4a-10ce31642f3e



## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;


