### PR TITLE
fix: Use qualified Ids when matching users for search filtering [WPB-4823]

### DIFF
--- a/src/script/components/UserSearchableList.tsx
+++ b/src/script/components/UserSearchableList.tsx
@@ -98,14 +98,13 @@ const UserSearchableList: React.FC<UserListProps> = ({
   // Filter all list items if a filter is provided
 
   useEffect(() => {
-    const connectedUsers = conversationState.connectedUsers();
     const {query: normalizedQuery} = searchRepository.normalizeQuery(filter);
     const results = searchRepository
       .searchUserInSet(filter, users)
       .filter(
         user =>
           user.isMe ||
-          connectedUsers.includes(user) ||
+          conversationState.hasConversationWith(user) ||
           teamRepository.isSelfConnectedTo(user.id) ||
           user.username() === normalizedQuery,
       );

--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -196,7 +196,7 @@ export class ConversationState {
   }
 
   /**
-   * indicate whether the selfUser has a conversation with this other user
+   * indicate whether the selfUser has a conversation (1:1 or group conversation) with this other user
    * @param user the user to check
    */
   hasConversationWith(user: User) {

--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -195,6 +195,14 @@ export class ConversationState {
         });
   }
 
+  /**
+   * indicate whether the selfUser has a conversation with this other user
+   * @param user the user to check
+   */
+  hasConversationWith(user: User) {
+    return this.connectedUsers().some(connectedUser => matchQualifiedIds(connectedUser.qualifiedId, user.qualifiedId));
+  }
+
   isSelfConversation(conversationId: QualifiedId): boolean {
     const selfConversationIds: QualifiedId[] = [this.selfProteusConversation(), this.selfMLSConversation()]
       .filter((conversation): conversation is Conversation => !!conversation)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4823" title="WPB-4823" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4823</a>  [Web] [Bundestag] Team members not showing up in group search
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

This attempts to fix an issue where some local users could not be found in the search. 
The theory being: since we try to match users by comparing actual user entities (the entire object), if 2 different entities represent the same user, then the check will be false. 

```js
const userId = 'user1';
const userA = new User(userId);
const userB = new User(userId);

userA === userB; // false ❌
```

To fix that, we now match users only by their IDs (which means that 2 entities representing the same user would return `true`)


```js
const userId = 'user1';
const userA = new User(userId);
const userB = new User(userId);

userA.id === userB.id; // true ✅
```

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
