### PR TITLE
refactor: is mls conversation checks

### DIFF
--- a/src/script/calling/CallingRepository.test.ts
+++ b/src/script/calling/CallingRepository.test.ts
@@ -56,6 +56,9 @@ const createConversation = (
   const conversation = new Conversation(createUuid(), '', protocol);
   conversation.participating_user_ets.push(new User(createUuid()));
   conversation.type(type);
+  if (protocol === ConversationProtocol.MLS) {
+    conversation.groupId = 'group-id';
+  }
   return conversation;
 };
 

--- a/src/script/components/userDevices/DeviceDetails.tsx
+++ b/src/script/components/userDevices/DeviceDetails.tsx
@@ -24,6 +24,7 @@ import type {DexieError} from 'dexie';
 import {container} from 'tsyringe';
 
 import {Icon} from 'Components/Icon';
+import {isMLSConversation} from 'src/script/conversation/ConversationSelectors';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 import type {Logger} from 'Util/Logger';
@@ -100,7 +101,8 @@ const DeviceDetails: React.FC<DeviceDetailsProps> = ({
     }
   };
 
-  const isMLSConversation = !!conversationState.activeConversation()?.isUsingMLSProtocol;
+  const activeConversation = conversationState.activeConversation();
+  const isConversationMLS = activeConversation && isMLSConversation(activeConversation);
 
   return (
     <div className={cx('participant-devices__header', {'participant-devices__header--padding': !noPadding})}>
@@ -157,7 +159,7 @@ const DeviceDetails: React.FC<DeviceDetailsProps> = ({
             style={{display: isResettingSession ? 'initial' : 'none'}}
             data-uie-name="status-loading"
           />
-          {!isMLSConversation && (
+          {!isConversationMLS && (
             <button
               type="button"
               className="button-reset-default button-label participant-devices__reset-session accent-text ellipsis"

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1499,13 +1499,13 @@ export class ConversationRepository {
 
     const qualifiedUsers = userEntities.map(userEntity => userEntity.qualifiedId);
 
-    const {qualifiedId: conversationId, groupId} = conversation;
+    const {qualifiedId: conversationId} = conversation;
 
     try {
-      if (conversation.isUsingMLSProtocol && groupId) {
+      if (isMLSConversation(conversation)) {
         const {events} = await this.core.service!.conversation.addUsersToMLSConversation({
           conversationId,
-          groupId,
+          groupId: conversation.groupId,
           qualifiedUsers,
         });
         if (!!events.length) {
@@ -2592,7 +2592,7 @@ export class ConversationRepository {
     const qualifiedUserIds =
       eventData.users?.map(user => user.qualified_id) || eventData.user_ids.map(userId => ({domain: '', id: userId}));
 
-    if (conversationEntity.isUsingMLSProtocol) {
+    if (isMLSConversation(conversationEntity)) {
       const isSelfJoin = isFromSelf && selfUserJoins;
       await this.handleMLSConversationMemberJoin(conversationEntity, isSelfJoin);
     }

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -107,7 +107,6 @@ export class Conversation {
   public groupId?: string;
   public epoch: number = -1;
   public cipherSuite: number = 1;
-  public readonly isUsingMLSProtocol: boolean;
   public readonly display_name: ko.PureComputed<string>;
   public readonly firstUserEntity: ko.PureComputed<User | undefined>;
   public readonly enforcedTeamMessageTimer: ko.PureComputed<number>;
@@ -201,13 +200,6 @@ export class Conversation {
     this.name = ko.observable();
     this.team_id = undefined;
     this.type = ko.observable();
-
-    /**
-     * If a conversation has the groupId property it means that it
-     * is MLS protocol based as this property is for MLS conversations only.
-     * @returns boolean
-     */
-    this.isUsingMLSProtocol = protocol === ConversationProtocol.MLS;
 
     this.is_loaded = ko.observable(false);
     this.is_pending = ko.observable(false);

--- a/src/script/view_model/CallingViewModel.ts
+++ b/src/script/view_model/CallingViewModel.ts
@@ -252,7 +252,7 @@ export class CallingViewModel {
 
     const handleCallParticipantChange = (conversationId: QualifiedId, members: QualifiedWcallMember[]) => {
       const conversation = this.getConversationById(conversationId);
-      if (!conversation?.isUsingMLSProtocol) {
+      if (conversation && isMLSConversation(conversation)) {
         return;
       }
 


### PR DESCRIPTION
## Description

Removes `isUsingMLSConversation` flag from conversation entity. With mls migration feature, the `protocol` field will get updated from `proteus` to `mls`, `isUsingMLSConversation` was a readonly value initialised once after conversation entity was created, in case of migrated conversation it could provide misleading information. 

This PR replaces this check with `isMLSConversation` that takes a conversation entity as an argument. It not only checks the  `protocol` field but also assures that the conversation with MLS protocol contains a `groupId`.

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;