### PR TITLE
refactor: Avoid temporal coupling when mapping user.inTeam property

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -99,7 +99,7 @@ export const Conversation = ({
     'isFileSharingSendingEnabled',
   ]);
   const {is1to1, isRequest} = useKoSubscribableChildren(activeConversation!, ['is1to1', 'isRequest']);
-  const {inTeam} = useKoSubscribableChildren(selfUser, ['inTeam']);
+  const inTeam = teamState.isInTeam(selfUser);
 
   const {activeCalls} = useKoSubscribableChildren(callState, ['activeCalls']);
   const [isMsgElementsFocusable, setMsgElementsFocusable] = useState(true);

--- a/src/script/components/TitleBar/TitleBar.tsx
+++ b/src/script/components/TitleBar/TitleBar.tsx
@@ -101,10 +101,6 @@ export const TitleBar: React.FC<TitleBarProps> = ({
     'verification_state',
   ]);
 
-  const inTeam = teamState.isTeam();
-
-  const hasGuest = inTeam && hasDirectGuest;
-
   const {isActivatedAccount} = useKoSubscribableChildren(selfUser, ['isActivatedAccount']);
   const {joinedCall, activeCalls} = useKoSubscribableChildren(callState, ['joinedCall', 'activeCalls']);
   const {isVideoCallingEnabled} = useKoSubscribableChildren(teamState, ['isVideoCallingEnabled']);
@@ -119,7 +115,7 @@ export const TitleBar: React.FC<TitleBarProps> = ({
     const translationKey = generateWarningBadgeKey({
       hasExternal,
       hasFederated: hasFederatedUsers,
-      hasGuest,
+      hasGuest: hasDirectGuest,
       hasService,
     });
 

--- a/src/script/components/TitleBar/TitleBar.tsx
+++ b/src/script/components/TitleBar/TitleBar.tsx
@@ -101,6 +101,10 @@ export const TitleBar: React.FC<TitleBarProps> = ({
     'verification_state',
   ]);
 
+  const inTeam = teamState.isTeam();
+
+  const hasGuest = inTeam && hasDirectGuest;
+
   const {isActivatedAccount} = useKoSubscribableChildren(selfUser, ['isActivatedAccount']);
   const {joinedCall, activeCalls} = useKoSubscribableChildren(callState, ['joinedCall', 'activeCalls']);
   const {isVideoCallingEnabled} = useKoSubscribableChildren(teamState, ['isVideoCallingEnabled']);
@@ -115,7 +119,7 @@ export const TitleBar: React.FC<TitleBarProps> = ({
     const translationKey = generateWarningBadgeKey({
       hasExternal,
       hasFederated: hasFederatedUsers,
-      hasGuest: hasDirectGuest,
+      hasGuest,
       hasService,
     });
 

--- a/src/script/components/UserList/UserList.tsx
+++ b/src/script/components/UserList/UserList.tsx
@@ -101,10 +101,8 @@ export const UserList = ({
   const hasMoreUsers = !truncate && users.length > maxShownUsers;
 
   const highlightedUserIds = highlightedUsers.map(user => user.id);
-  const {is_verified: isSelfVerified, inTeam: selfInTeam} = useKoSubscribableChildren(selfUser, [
-    'is_verified',
-    'inTeam',
-  ]);
+  const {is_verified: isSelfVerified} = useKoSubscribableChildren(selfUser, ['is_verified']);
+  const selfInTeam = teamState.isInTeam(selfUser);
 
   // subscribe to roles changes in order to react to them
   useKoSubscribableChildren(conversation, ['roles']);

--- a/src/script/components/UserSearchableList.tsx
+++ b/src/script/components/UserSearchableList.tsx
@@ -24,7 +24,6 @@ import {container} from 'tsyringe';
 import {debounce} from 'underscore';
 
 import {partition} from 'Util/ArrayUtil';
-import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 import {matchQualifiedIds} from 'Util/QualifiedId';
 import {sortByPriority} from 'Util/StringUtil';
@@ -66,6 +65,7 @@ const UserSearchableList: React.FC<UserListProps> = ({
   allowRemoteSearch,
   selfUser,
   users,
+  teamState = container.resolve(TeamState),
   ...props
 }) => {
   const {searchRepository, teamRepository, selfFirst, ...userListProps} = props;
@@ -74,7 +74,7 @@ const UserSearchableList: React.FC<UserListProps> = ({
   const [filteredUsers, setFilteredUsers] = useState<User[]>([]);
   const [remoteTeamMembers, setRemoteTeamMembers] = useState<User[]>([]);
 
-  const {inTeam: selfInTeam} = useKoSubscribableChildren(selfUser, ['inTeam']);
+  const selfInTeam = teamState.isInTeam(selfUser);
 
   /**
    * Try to load additional members from the backend.

--- a/src/script/components/calling/CallingCell.tsx
+++ b/src/script/components/calling/CallingCell.tsx
@@ -593,7 +593,7 @@ const CallingCell: React.FC<CallingCellProps> = ({
                             <CallParticipantsListItem
                               key={participant.clientId}
                               callParticipant={participant}
-                              selfInTeam={selfUser?.inTeam()}
+                              selfInTeam={selfUser && teamState.isInTeam(selfUser)}
                               isSelfVerified={isSelfVerified}
                               showContextMenu={!!isModerator}
                               onContextMenu={event => getParticipantContext(event, participant)}

--- a/src/script/components/list/ConversationListCell.tsx
+++ b/src/script/components/list/ConversationListCell.tsx
@@ -28,13 +28,11 @@ import React, {
 
 import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 import cx from 'classnames';
-import {container} from 'tsyringe';
 
 import {Availability} from '@wireapp/protocol-messaging';
 
 import {AvailabilityState} from 'Components/AvailabilityState';
 import {Avatar, AVATAR_SIZE, GroupAvatar} from 'Components/Avatar';
-import {TeamState} from 'src/script/team/TeamState';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {isKey, isOneOfKeys, KEY} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
@@ -58,7 +56,6 @@ export interface ConversationListCellProps {
   isFocused?: boolean;
   // This method resetting the current focused conversation to first conversation on click outside or click tab or shift + tab
   resetConversationFocus: () => void;
-  teamState?: TeamState;
 }
 
 const ConversationListCell = ({
@@ -72,7 +69,6 @@ const ConversationListCell = ({
   handleArrowKeyDown,
   isFocused = false,
   resetConversationFocus,
-  teamState = container.resolve(TeamState),
 }: ConversationListCellProps) => {
   const {
     isGroup,

--- a/src/script/components/list/ConversationListCell.tsx
+++ b/src/script/components/list/ConversationListCell.tsx
@@ -28,11 +28,13 @@ import React, {
 
 import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 import cx from 'classnames';
+import {container} from 'tsyringe';
 
 import {Availability} from '@wireapp/protocol-messaging';
 
 import {AvailabilityState} from 'Components/AvailabilityState';
 import {Avatar, AVATAR_SIZE, GroupAvatar} from 'Components/Avatar';
+import {TeamState} from 'src/script/team/TeamState';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {isKey, isOneOfKeys, KEY} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
@@ -56,6 +58,7 @@ export interface ConversationListCellProps {
   isFocused?: boolean;
   // This method resetting the current focused conversation to first conversation on click outside or click tab or shift + tab
   resetConversationFocus: () => void;
+  teamState?: TeamState;
 }
 
 const ConversationListCell = ({
@@ -69,6 +72,7 @@ const ConversationListCell = ({
   handleArrowKeyDown,
   isFocused = false,
   resetConversationFocus,
+  teamState = container.resolve(TeamState),
 }: ConversationListCellProps) => {
   const {
     isGroup,
@@ -208,7 +212,7 @@ const ConversationListCell = ({
           </div>
 
           <div className="conversation-list-cell-center">
-            {is1to1 && selfUser?.inTeam() ? (
+            {is1to1 && selfUser && teamState.isInTeam(selfUser) ? (
               <AvailabilityState
                 className="conversation-list-cell-availability"
                 availability={availabilityOfUser}

--- a/src/script/components/list/ConversationListCell.tsx
+++ b/src/script/components/list/ConversationListCell.tsx
@@ -212,7 +212,7 @@ const ConversationListCell = ({
           </div>
 
           <div className="conversation-list-cell-center">
-            {is1to1 && selfUser && teamState.isInTeam(selfUser) ? (
+            {is1to1 && selfUser?.teamId ? (
               <AvailabilityState
                 className="conversation-list-cell-availability"
                 availability={availabilityOfUser}

--- a/src/script/components/panel/UserActions.tsx
+++ b/src/script/components/panel/UserActions.tsx
@@ -22,9 +22,11 @@ import React from 'react';
 import {ConnectionStatus} from '@wireapp/api-client/lib/connection';
 import {CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation';
 import {amplify} from 'amplify';
+import {container} from 'tsyringe';
 
 import {WebAppEvents} from '@wireapp/webapp-events';
 
+import {TeamState} from 'src/script/team/TeamState';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 import {matchQualifiedIds} from 'Util/QualifiedId';
@@ -72,6 +74,7 @@ export interface UserActionsProps {
   onAction: (action: Actions) => void;
   selfUser: User;
   user: User;
+  teamState?: TeamState;
 }
 
 function createPlaceholder1to1Conversation(user: User, selfUser: User) {
@@ -96,13 +99,13 @@ const UserActions: React.FC<UserActionsProps> = ({
   onAction,
   conversationRoleRepository,
   selfUser,
+  teamState = container.resolve(TeamState),
 }) => {
   const {
     isAvailable,
     isBlocked,
     isCanceled,
     isRequest,
-    isTeamMember,
     isTemporaryGuest,
     isUnknown,
     isConnected,
@@ -111,7 +114,6 @@ const UserActions: React.FC<UserActionsProps> = ({
   } = useKoSubscribableChildren(user, [
     'isAvailable',
     'isTemporaryGuest',
-    'isTeamMember',
     'isBlocked',
     'isOutgoingRequest',
     'isIncomingRequest',
@@ -120,6 +122,7 @@ const UserActions: React.FC<UserActionsProps> = ({
     'isUnknown',
     'isConnected',
   ]);
+  const isTeamMember = teamState.isInTeam(user);
 
   const isNotMe = !user.isMe && isSelfActivated;
 

--- a/src/script/components/panel/UserDetails.tsx
+++ b/src/script/components/panel/UserDetails.tsx
@@ -21,6 +21,7 @@ import React, {useEffect} from 'react';
 
 import {amplify} from 'amplify';
 import {ErrorBoundary} from 'react-error-boundary';
+import {container} from 'tsyringe';
 
 import {WebAppEvents} from '@wireapp/webapp-events';
 
@@ -30,6 +31,7 @@ import {ErrorFallback} from 'Components/ErrorFallback';
 import {Icon} from 'Components/Icon';
 import {UserClassifiedBar} from 'Components/input/ClassifiedBar';
 import {UserName} from 'Components/UserName';
+import {TeamState} from 'src/script/team/TeamState';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 
@@ -43,6 +45,7 @@ interface UserDetailsProps {
   isVerified?: boolean;
   participant: User;
   avatarStyles?: React.CSSProperties;
+  teamState?: TeamState;
 }
 
 const UserDetailsComponent: React.FC<UserDetailsProps> = ({
@@ -52,9 +55,9 @@ const UserDetailsComponent: React.FC<UserDetailsProps> = ({
   isGroupAdmin,
   avatarStyles,
   classifiedDomains,
+  teamState = container.resolve(TeamState),
 }) => {
   const user = useKoSubscribableChildren(participant, [
-    'inTeam',
     'isGuest',
     'isTemporaryGuest',
     'expirationText',
@@ -75,7 +78,7 @@ const UserDetailsComponent: React.FC<UserDetailsProps> = ({
   return (
     <div className="panel-participant">
       <div className="panel-participant__head">
-        {user.inTeam ? (
+        {teamState.isInTeam(participant) ? (
           <AvailabilityState
             className="panel-participant__head__name"
             availability={user.availability}

--- a/src/script/components/panel/UserDetails.tsx
+++ b/src/script/components/panel/UserDetails.tsx
@@ -72,9 +72,6 @@ const UserDetailsComponent: React.FC<UserDetailsProps> = ({
     amplify.publish(WebAppEvents.USER.UPDATE, participant.qualifiedId);
   }, [participant]);
 
-  const isFederated = participant.isFederated;
-  const isGuest = !isFederated && user.isGuest;
-
   return (
     <div className="panel-participant">
       <div className="panel-participant__head">
@@ -126,14 +123,14 @@ const UserDetailsComponent: React.FC<UserDetailsProps> = ({
         </div>
       )}
 
-      {isFederated && (
+      {participant.isFederated && (
         <div className="panel-participant__label" data-uie-name="status-federated-user">
           <Icon.Federation />
           <span>{t('conversationFederationIndicator')}</span>
         </div>
       )}
 
-      {isGuest && user.isAvailable && !isFederated && (
+      {user.isGuest && user.isAvailable && (
         <div className="panel-participant__label" data-uie-name="status-guest">
           <Icon.Guest />
           <span>{t('conversationGuestIndicator')}</span>

--- a/src/script/conversation/ConversationFilter.ts
+++ b/src/script/conversation/ConversationFilter.ts
@@ -29,7 +29,7 @@ export class ConversationFilter {
   }
 
   static isInTeam(conversationEntity: Conversation, userEntity: User): boolean {
-    return userEntity.teamId === conversationEntity.team_id && conversationEntity.domain === userEntity.domain;
+    return userEntity.teamId === conversationEntity.teamId && conversationEntity.domain === userEntity.domain;
   }
 
   static showCallControls(conversationEntity: Conversation, hasCall: boolean): boolean {

--- a/src/script/conversation/ConversationMapper.test.ts
+++ b/src/script/conversation/ConversationMapper.test.ts
@@ -93,7 +93,7 @@ describe('ConversationMapper', () => {
       expect(conversationEntity.isGroup()).toBeTruthy();
       expect(conversationEntity.name()).toBe(conversation.name);
       expect(conversationEntity.mutedState()).toBe(0);
-      expect(conversationEntity.team_id).toEqual(conversation.team);
+      expect(conversationEntity.teamId).toEqual(conversation.team);
       expect(conversationEntity.type()).toBe(CONVERSATION_TYPE.REGULAR);
 
       const expectedMutedTimestamp = new Date(conversation.members.self.otr_muted_ref).getTime();
@@ -180,7 +180,7 @@ describe('ConversationMapper', () => {
       const [conversationEntity] = ConversationMapper.mapConversations([payload] as ConversationDatabaseData[]);
 
       expect(conversationEntity.name()).toBe(payload.name);
-      expect(conversationEntity.team_id).toBe(payload.team);
+      expect(conversationEntity.teamId).toBe(payload.team);
     });
   });
 
@@ -737,7 +737,7 @@ describe('ConversationMapper', () => {
       ];
 
       const conversationEntity = new Conversation('conversation-id', 'domain');
-      conversationEntity.team_id = 'team_id';
+      conversationEntity.teamId = 'team_id';
 
       ConversationMapper.mapAccessState(conversationEntity, accessModes, accessRole, accessRoleV2);
       expect(conversationEntity.accessState()).toEqual(ACCESS_STATE.TEAM.GUEST_ROOM);
@@ -756,7 +756,7 @@ describe('ConversationMapper', () => {
       const accessRoleV2: undefined = undefined;
 
       const conversationEntity = new Conversation();
-      conversationEntity.team_id = 'team_id';
+      conversationEntity.teamId = 'team_id';
 
       ConversationMapper.mapAccessState(conversationEntity, accessModes, accessRole, accessRoleV2);
       expect(conversationEntity.accessState()).toEqual(ACCESS_STATE.TEAM.GUESTS_SERVICES);
@@ -820,7 +820,7 @@ describe('ConversationMapper', () => {
 
       it.each(mockRightsLegacy)('sets correct accessState for %s', (state, {accessModes, accessRole}) => {
         const conversationEntity = new Conversation();
-        conversationEntity.team_id = 'team_id';
+        conversationEntity.teamId = 'team_id';
 
         ConversationMapper.mapAccessState(conversationEntity, accessModes, accessRole);
         expect(conversationEntity.accessState()).toEqual(state);
@@ -860,7 +860,7 @@ describe('ConversationMapper', () => {
 
       it.each(mockAccessRights)('sets correct accessState for %s', (state, {accessModes, accessRole}) => {
         const conversationEntity = new Conversation();
-        conversationEntity.team_id = 'team_id';
+        conversationEntity.teamId = 'team_id';
 
         ConversationMapper.mapAccessState(conversationEntity, accessModes, accessRole);
         expect(conversationEntity.accessState()).toEqual(state);

--- a/src/script/conversation/ConversationMapper.ts
+++ b/src/script/conversation/ConversationMapper.ts
@@ -271,7 +271,7 @@ export class ConversationMapper {
     // Team ID from database or backend payload
     const teamId = conversationData.team_id || conversationData.team;
     if (teamId) {
-      conversationEntity.team_id = teamId;
+      conversationEntity.teamId = teamId;
     }
 
     if (conversationData.is_guest) {
@@ -464,7 +464,7 @@ export class ConversationMapper {
   }
 
   static mapAccessCode(conversation: Conversation, accessCode: ConversationCode): void {
-    const isTeamConversation = conversation && conversation.team_id;
+    const isTeamConversation = conversation && conversation.teamId;
 
     if (accessCode.uri && isTeamConversation) {
       const baseUrl = `${window.wire.env.URL.ACCOUNT_BASE}/conversation-join/?key=${accessCode.key}&code=${accessCode.code}`;
@@ -479,7 +479,7 @@ export class ConversationMapper {
     accessRole: CONVERSATION_LEGACY_ACCESS_ROLE | CONVERSATION_ACCESS_ROLE[],
     accessRoleV2?: CONVERSATION_ACCESS_ROLE[],
   ): typeof ACCESS_STATE {
-    if (conversationEntity.team_id) {
+    if (conversationEntity.teamId) {
       if (conversationEntity.is1to1()) {
         return conversationEntity.accessState(ACCESS_STATE.TEAM.ONE2ONE);
       }

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -265,7 +265,7 @@ describe('ConversationRepository', () => {
       const selfUser = generateUser();
       selfUser.teamId = teamId;
       spyOn(testFactory.conversation_repository['userState'], 'self').and.returnValue(selfUser);
-      userEntity.inTeam(true);
+      userEntity.teamId = teamId;
       userEntity.isTeamMember(true);
       userEntity.teamId = teamId;
 

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -212,7 +212,7 @@ export class ConversationRepository {
           Promise.all(clients.map(client => this.userRepository.removeClientFromUser(userId, client))),
         ),
       );
-      const removedTeamUserIds = emptyUsers.filter(user => user.inTeam()).map(user => user.qualifiedId);
+      const removedTeamUserIds = emptyUsers.filter(user => teamState.isInTeam(user)).map(user => user.qualifiedId);
 
       if (removedTeamUserIds.length) {
         // If we have found some users that were removed from the conversation, we need to check if those users were also completely removed from the team
@@ -1086,7 +1086,7 @@ export class ConversationRepository {
    */
   async get1To1Conversation(userEntity: User): Promise<Conversation | null> {
     const selfUser = this.userState.self();
-    const inCurrentTeam = userEntity.inTeam() && !!selfUser && userEntity.teamId === selfUser.teamId;
+    const inCurrentTeam = selfUser && userEntity.teamId === selfUser.teamId;
 
     if (inCurrentTeam) {
       return this.getOrCreateProteusTeam1to1Conversation(userEntity);
@@ -1362,13 +1362,12 @@ export class ConversationRepository {
       .forEach(conversationEntity => this._mapGuestStatusSelf(conversationEntity));
 
     if (this.teamState.isTeam()) {
-      this.userState.self().inTeam(true);
-      this.userState.self().isTeamMember(true);
+      this.userState.self()?.isTeamMember(true);
     }
   }
 
   private _mapGuestStatusSelf(conversationEntity: Conversation) {
-    const conversationTeamId = conversationEntity.team_id;
+    const conversationTeamId = conversationEntity.teamId;
     const selfTeamId = this.teamState.team()?.id;
     const isConversationGuest = !!(conversationTeamId && (!selfTeamId || selfTeamId !== conversationTeamId));
     conversationEntity.isGuest(isConversationGuest);
@@ -1777,7 +1776,7 @@ export class ConversationRepository {
     const eventInjections = this.conversationState
       .conversations()
       .filter(conversationEntity => {
-        const conversationInTeam = conversationEntity.team_id === teamId;
+        const conversationInTeam = conversationEntity.teamId === teamId;
         const userIsParticipant = UserFilter.isParticipant(conversationEntity, userId);
         return conversationInTeam && userIsParticipant && !conversationEntity.removed_from_conversation();
       })
@@ -3165,7 +3164,7 @@ export class ConversationRepository {
       return !!this.propertyRepository.receiptMode();
     }
 
-    if (conversationEntity.team_id && conversationEntity.isGroup()) {
+    if (conversationEntity.teamId && conversationEntity.isGroup()) {
       return !!conversationEntity.receiptMode();
     }
 

--- a/src/script/conversation/ConversationRoleRepository.ts
+++ b/src/script/conversation/ConversationRoleRepository.ts
@@ -125,7 +125,7 @@ export class ConversationRoleRepository {
   };
 
   private readonly getConversationRoles = (conversation: Conversation): ConversationRole[] => {
-    if (this.teamState.isTeam() && this.teamState.team()?.id === conversation.team_id) {
+    if (this.teamState.isTeam() && this.teamState.team()?.id === conversation.teamId) {
       return this.teamRoles;
     }
     return this.teamRoles;

--- a/src/script/conversation/MessageRepository.test.ts
+++ b/src/script/conversation/MessageRepository.test.ts
@@ -47,6 +47,7 @@ import {EventRepository} from '../event/EventRepository';
 import {EventService} from '../event/EventService';
 import {PropertiesRepository} from '../properties/PropertiesRepository';
 import {ReactionMap} from '../storage';
+import {TeamState} from '../team/TeamState';
 import {ServerTimeHandler, serverTimeHandler} from '../time/serverTimeHandler';
 import {UserRepository} from '../user/UserRepository';
 import {UserState} from '../user/UserState';
@@ -80,6 +81,8 @@ async function buildMessageRepository(): Promise<[MessageRepository, MessageRepo
   clientState.currentClient = new ClientEntity(true, '');
   const core = new Account();
 
+  const teamState = new TeamState();
+
   const conversationState = new ConversationState(userState);
   const selfConversation = new Conversation(selfUser.id);
   selfConversation.selfUser(selfUser);
@@ -97,6 +100,7 @@ async function buildMessageRepository(): Promise<[MessageRepository, MessageRepo
     userState,
     clientState,
     conversationState,
+    teamState,
     core,
   };
 

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -95,6 +95,7 @@ import {PropertiesRepository} from '../properties/PropertiesRepository';
 import {PROPERTIES_TYPE} from '../properties/PropertiesType';
 import {Core} from '../service/CoreSingleton';
 import type {EventRecord, ReactionMap} from '../storage';
+import {TeamState} from '../team/TeamState';
 import {ServerTimeHandler} from '../time/serverTimeHandler';
 import {UserType} from '../tracking/attribute';
 import {EventName} from '../tracking/EventName';
@@ -166,6 +167,7 @@ export class MessageRepository {
     private readonly userState = container.resolve(UserState),
     private readonly clientState = container.resolve(ClientState),
     private readonly conversationState = container.resolve(ConversationState),
+    private readonly teamState = container.resolve(TeamState),
     private readonly core = container.resolve(Core),
   ) {
     this.logger = getLogger('MessageRepository');
@@ -1139,7 +1141,7 @@ export class MessageRepository {
       // we can remove the filter when we actually want this feature in federated env (and we will need to implement federation for the core broadcastService)
       .filter(user => !user.isFederated)
       .sort(({id: idA}, {id: idB}) => idA.localeCompare(idB, undefined, {sensitivity: 'base'}));
-    const [members, other] = partition(sortedUsers, user => user.isTeamMember());
+    const [members, other] = partition(sortedUsers, user => this.teamState.isInTeam(user));
     const users = [this.userState.self(), ...members, ...other].slice(
       0,
       UserRepository.CONFIG.MAXIMUM_TEAM_SIZE_BROADCAST,

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -965,7 +965,7 @@ export class MessageRepository {
       return !!this.propertyRepository.receiptMode();
     }
 
-    if (conversationEntity.team_id && conversationEntity.isGroup()) {
+    if (conversationEntity.teamId && conversationEntity.isGroup()) {
       return !!conversationEntity.receiptMode();
     }
 
@@ -1473,7 +1473,7 @@ export class MessageRepository {
         [Segmentation.CONVERSATION.SERVICES]: roundLogarithmic(services, 6),
         [Segmentation.MESSAGE.ACTION]: actionType,
       };
-      const isTeamConversation = !!conversationEntity.team_id;
+      const isTeamConversation = !!conversationEntity.teamId;
       if (isTeamConversation) {
         segmentations = {
           ...segmentations,

--- a/src/script/entity/Conversation.test.ts
+++ b/src/script/entity/Conversation.test.ts
@@ -88,7 +88,7 @@ describe('Conversation', () => {
     });
 
     it('should return the expected value for team conversations', () => {
-      conversation_et.team_id = createUuid();
+      conversation_et.teamId = createUuid();
 
       conversation_et.type(CONVERSATION_TYPE.CONNECT);
 
@@ -665,7 +665,7 @@ describe('Conversation', () => {
     it('is considered a team conversation when teamId and domain are equal', () => {
       const teamId = 'team1';
       const conversation = new Conversation(createUuid(), 'domain.test');
-      conversation.team_id = teamId;
+      conversation.teamId = teamId;
       const selfUser = new User(createUuid(), 'domain.test');
       selfUser.isMe = true;
       selfUser.teamId = teamId;
@@ -678,7 +678,7 @@ describe('Conversation', () => {
     it('is not considered a team conversation when teamId are equal but domains differ', () => {
       const teamId = 'team1';
       const conversation = new Conversation(createUuid(), 'otherdomain.test');
-      conversation.team_id = teamId;
+      conversation.teamId = teamId;
       const selfUser = new User(createUuid(), 'domain.test');
       selfUser.isMe = true;
       selfUser.teamId = teamId;

--- a/src/script/entity/Conversation.test.ts
+++ b/src/script/entity/Conversation.test.ts
@@ -621,7 +621,7 @@ describe('Conversation', () => {
       conversation_et = new Conversation(createUuid());
       const selfUserEntity = new User(createUuid(), null);
       selfUserEntity.isMe = true;
-      selfUserEntity.inTeam(true);
+      selfUserEntity.teamId = createUuid();
       conversation_et.selfUser(selfUserEntity);
 
       // Is false for conversations not containing a guest
@@ -650,7 +650,7 @@ describe('Conversation', () => {
       expect(conversation_et.hasGuest()).toBe(true);
 
       // Is false for conversations containing a guest if the self user is a personal account
-      selfUserEntity.inTeam(false);
+      selfUserEntity.teamId = createUuid();
       conversation_et.type(CONVERSATION_TYPE.ONE_TO_ONE);
 
       expect(conversation_et.hasGuest()).toBe(false);
@@ -1003,7 +1003,7 @@ describe('Conversation', () => {
       conversationEntity.mutedState(NOTIFICATION_STATES.EVERYTHING);
 
       expect(conversationEntity.notificationState()).toBe(NOTIFICATION_STATES.EVERYTHING);
-      selfUserEntity.inTeam(true);
+      selfUserEntity.teamId = createUuid();
       conversationEntity.mutedState(undefined);
 
       expect(conversationEntity.notificationState()).toBe(NOTIFICATION_STATES.EVERYTHING);

--- a/src/script/entity/Conversation.test.ts
+++ b/src/script/entity/Conversation.test.ts
@@ -657,7 +657,7 @@ describe('Conversation', () => {
 
       conversation_et.type(CONVERSATION_TYPE.REGULAR);
 
-      expect(conversation_et.hasGuest()).toBe(false);
+      expect(conversation_et.hasGuest()).toBe(true);
     });
   });
 

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -163,7 +163,7 @@ export class Conversation {
   public readonly showNotificationsMentionsAndReplies: ko.PureComputed<boolean>;
   public readonly showNotificationsNothing: ko.PureComputed<boolean>;
   public status: ko.Observable<ConversationStatus>;
-  public team_id: string;
+  public teamId: string;
   public readonly type: ko.Observable<CONVERSATION_TYPE>;
   public readonly unreadState: ko.PureComputed<UnreadState>;
   public readonly verification_state: ko.Observable<ConversationVerificationState>;
@@ -196,7 +196,7 @@ export class Conversation {
     this.accessCode = ko.observable();
     this.creator = undefined;
     this.name = ko.observable();
-    this.team_id = undefined;
+    this.teamId = undefined;
     this.type = ko.observable();
 
     this.is_loaded = ko.observable(false);
@@ -220,9 +220,9 @@ export class Conversation {
     this.isGuest = ko.observable(false);
 
     this.inTeam = ko.pureComputed(() => {
-      const isSameTeam = this.selfUser()?.teamId === this.team_id;
+      const isSameTeam = this.selfUser()?.teamId === this.teamId;
       const isSameDomain = this.domain === this.selfUser()?.domain;
-      return !!this.team_id && isSameTeam && !this.isGuest() && isSameDomain;
+      return !!this.teamId && isSameTeam && !this.isGuest() && isSameDomain;
     });
     this.isGuestRoom = ko.pureComputed(() => this.accessState() === ACCESS_STATE.TEAM.GUEST_ROOM);
     this.isGuestAndServicesRoom = ko.pureComputed(() => this.accessState() === ACCESS_STATE.TEAM.GUESTS_SERVICES);
@@ -233,7 +233,7 @@ export class Conversation {
     this.isTeam1to1 = ko.pureComputed(() => {
       const isGroupConversation = this.type() === CONVERSATION_TYPE.REGULAR;
       const hasOneParticipant = this.participating_user_ids().length === 1;
-      return isGroupConversation && hasOneParticipant && this.team_id && !this.name();
+      return isGroupConversation && hasOneParticipant && this.teamId && !this.name();
     });
     this.isGroup = ko.pureComputed(() => {
       const isGroupConversation = this.type() === CONVERSATION_TYPE.REGULAR;
@@ -251,11 +251,11 @@ export class Conversation {
 
     this.hasDirectGuest = ko.pureComputed(() => {
       const hasGuestUser = this.participating_user_ets().some(userEntity => userEntity.isDirectGuest());
-      return hasGuestUser && this.isGroup() && this.selfUser()?.inTeam();
+      return hasGuestUser && this.isGroup();
     });
     this.hasGuest = ko.pureComputed(() => {
       const hasGuestUser = this.participating_user_ets().some(userEntity => userEntity.isGuest());
-      return hasGuestUser && this.isGroup() && this.selfUser()?.inTeam();
+      return hasGuestUser && this.isGroup();
     });
     this.hasService = ko.pureComputed(() => this.participating_user_ets().some(userEntity => userEntity.isService));
     this.hasExternal = ko.pureComputed(() => this.participating_user_ets().some(userEntity => userEntity.isExternal()));
@@ -300,13 +300,13 @@ export class Conversation {
       const knownNotificationStates = Object.values(NOTIFICATION_STATE);
       if (knownNotificationStates.includes(mutedState)) {
         const isStateMentionsAndReplies = mutedState === NOTIFICATION_STATE.MENTIONS_AND_REPLIES;
-        const isInvalidState = isStateMentionsAndReplies && !this.selfUser().inTeam();
+        const isInvalidState = isStateMentionsAndReplies && !!this.selfUser()?.teamId;
 
         return isInvalidState ? NOTIFICATION_STATE.NOTHING : mutedState;
       }
 
       if (typeof mutedState === 'boolean') {
-        const migratedMutedState = this.selfUser().inTeam()
+        const migratedMutedState = !!this.selfUser()?.teamId
           ? NOTIFICATION_STATE.MENTIONS_AND_REPLIES
           : NOTIFICATION_STATE.NOTHING;
         return this.mutedState() ? migratedMutedState : NOTIFICATION_STATE.EVERYTHING;
@@ -1020,7 +1020,7 @@ export class Conversation {
       receipt_mode: this.receiptMode(),
       roles: this.roles(),
       status: this.status(),
-      team_id: this.team_id,
+      team_id: this.teamId,
       type: this.type(),
       verification_state: this.verification_state(),
       mlsVerificationState: this.mlsVerificationState(),

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -300,7 +300,7 @@ export class Conversation {
       const knownNotificationStates = Object.values(NOTIFICATION_STATE);
       if (knownNotificationStates.includes(mutedState)) {
         const isStateMentionsAndReplies = mutedState === NOTIFICATION_STATE.MENTIONS_AND_REPLIES;
-        const isInvalidState = isStateMentionsAndReplies && !!this.selfUser()?.teamId;
+        const isInvalidState = isStateMentionsAndReplies && !this.selfUser()?.teamId;
 
         return isInvalidState ? NOTIFICATION_STATE.NOTHING : mutedState;
       }

--- a/src/script/entity/User/User.ts
+++ b/src/script/entity/User/User.ts
@@ -62,7 +62,6 @@ export class User {
   public readonly expirationText: ko.Observable<string>;
   public readonly hasPendingLegalHold: ko.PureComputed<boolean>;
   public readonly initials: ko.PureComputed<string>;
-  public readonly inTeam: ko.Observable<boolean>;
   public readonly is_trusted: ko.PureComputed<boolean>;
   // Manual Proteus verification
   public readonly is_verified: ko.PureComputed<boolean>;
@@ -184,7 +183,6 @@ export class User {
     this.isUnknown = ko.pureComputed(() => this.connection().isUnknown());
     this.isExternal = ko.pureComputed(() => this.teamRole() === TEAM_ROLE.PARTNER);
 
-    this.inTeam = ko.observable(false);
     this.isGuest = ko.observable(false);
     this.isDirectGuest = ko.pureComputed(() => {
       return this.isGuest() && !this.isFederated;

--- a/src/script/entity/User/User.ts
+++ b/src/script/entity/User/User.ts
@@ -86,6 +86,7 @@ export class User {
   public readonly isOnLegalHold: ko.PureComputed<boolean>;
   public readonly isOutgoingRequest: ko.PureComputed<boolean>;
   public readonly isRequest: ko.PureComputed<boolean>;
+  /** @deprecated use teamState.isInTeam method instead */
   public readonly isTeamMember: ko.Observable<boolean> = ko.observable(false);
   public readonly isTemporaryGuest: ko.Observable<boolean>;
   public readonly isUnknown: ko.PureComputed<boolean>;

--- a/src/script/notification/NotificationRepository.test.ts
+++ b/src/script/notification/NotificationRepository.test.ts
@@ -108,7 +108,7 @@ describe('NotificationRepository', () => {
     [conversation] = ConversationMapper.mapConversations([entities.conversation]);
     const selfUserEntity = new User(createUuid());
     selfUserEntity.isMe = true;
-    selfUserEntity.inTeam(true);
+    selfUserEntity.teamId = createUuid();
     conversation.selfUser(selfUserEntity);
     userState.self(selfUserEntity);
 
@@ -796,7 +796,7 @@ describe('NotificationRepository', () => {
     beforeEach(() => {
       const selfUserEntity = new User(userId.id);
       selfUserEntity.isMe = true;
-      selfUserEntity.inTeam(true);
+      selfUserEntity.teamId = createUuid();
 
       conversationEntity = new Conversation(createUuid());
       conversationEntity.selfUser(selfUserEntity);

--- a/src/script/page/LeftSidebar/panels/StartUI/PeopleTab.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/PeopleTab.tsx
@@ -30,7 +30,6 @@ import {Icon} from 'Components/Icon';
 import {UserList, UserlistMode} from 'Components/UserList';
 import {Conversation} from 'src/script/entity/Conversation';
 import {UserRepository} from 'src/script/user/UserRepository';
-import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 import {getLogger} from 'Util/Logger';
 import {safeWindowOpen} from 'Util/SanitizationUtil';
@@ -101,7 +100,7 @@ export const PeopleTab = ({
   const [hasFederationError, setHasFederationError] = useState(false);
   const currentSearchQuery = useRef('');
 
-  const {inTeam} = useKoSubscribableChildren(selfUser, ['inTeam']);
+  const inTeam = teamState.isInTeam(selfUser);
 
   const getLocalUsers = (unfiltered?: boolean) => {
     const connectedUsers = conversationState.connectedUsers();

--- a/src/script/page/MainContent/MainContent.tsx
+++ b/src/script/page/MainContent/MainContent.tsx
@@ -150,7 +150,7 @@ const MainContent: FC<MainContentProps> = ({
                 className={cx('preferences-page preferences-about', incomingCssClass)}
                 ref={removeAnimationsClass}
               >
-                <AboutPreferences selfUser={selfUser} />
+                <AboutPreferences selfUser={selfUser} teamState={teamState} />
               </div>
             )}
 

--- a/src/script/page/MainContent/panels/preferences/AboutPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/AboutPreferences.tsx
@@ -19,9 +19,11 @@
 
 import React, {useMemo} from 'react';
 
+import {container} from 'tsyringe';
+
 import {Link, LinkVariant} from '@wireapp/react-ui-kit';
 
-import {useKoSubscribableChildren} from 'Util/ComponentUtil';
+import {TeamState} from 'src/script/team/TeamState';
 import {t} from 'Util/LocalizerUtil';
 
 import {PreferencesPage} from './components/PreferencesPage';
@@ -33,10 +35,11 @@ import {getPrivacyPolicyUrl, getTermsOfUsePersonalUrl, getTermsOfUseTeamUrl, URL
 
 interface AboutPreferencesProps {
   selfUser: User;
+  teamState: TeamState;
 }
 
-const AboutPreferences: React.FC<AboutPreferencesProps> = ({selfUser}) => {
-  const {inTeam} = useKoSubscribableChildren(selfUser, ['inTeam']);
+const AboutPreferences: React.FC<AboutPreferencesProps> = ({selfUser, teamState = container.resolve(TeamState)}) => {
+  const inTeam = teamState.isInTeam(selfUser);
   const config = Config.getConfig();
   const websiteUrl = URL.WEBSITE;
   const privacyPolicyUrl = getPrivacyPolicyUrl();

--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
@@ -136,7 +136,7 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
       'firstUserEntity',
     ]);
 
-    const teamId = activeConversation.team_id;
+    const teamId = activeConversation.teamId;
 
     const {
       isTeam,
@@ -438,7 +438,7 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
                   !!(
                     isSingleUserMode &&
                     firstParticipant &&
-                    (firstParticipant.isConnected() || firstParticipant.inTeam())
+                    (firstParticipant.isConnected() || teamState.isInTeam(firstParticipant))
                   )
                 }
                 showDevices={openParticipantDevices}

--- a/src/script/page/RightSidebar/GuestServicesOptions/components/GuestOptions/GuestOptions.tsx
+++ b/src/script/page/RightSidebar/GuestServicesOptions/components/GuestOptions/GuestOptions.tsx
@@ -20,6 +20,7 @@
 import {FC, useCallback, useEffect, useMemo, useState} from 'react';
 
 import cx from 'classnames';
+import {container} from 'tsyringe';
 
 import {Button, ButtonVariant} from '@wireapp/react-ui-kit';
 
@@ -27,6 +28,7 @@ import {CopyToClipboard} from 'Components/CopyToClipboard';
 import {Icon} from 'Components/Icon';
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
 import {BaseToggle} from 'Components/toggle/BaseToggle';
+import {TeamState} from 'src/script/team/TeamState';
 import {copyText} from 'Util/ClipboardUtil';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
@@ -49,6 +51,7 @@ interface GuestOptionsProps {
   isRequestOngoing?: boolean;
   isTeamStateGuestLinkEnabled?: boolean;
   isToggleDisabled?: boolean;
+  teamState?: TeamState;
 }
 
 const GuestOptions: FC<GuestOptionsProps> = ({
@@ -60,14 +63,16 @@ const GuestOptions: FC<GuestOptionsProps> = ({
   isRequestOngoing = false,
   isTeamStateGuestLinkEnabled = false,
   isToggleDisabled = false,
+  teamState = container.resolve(TeamState),
 }) => {
   const [isLinkCopied, setIsLinkCopied] = useState<boolean>(false);
   const [conversationHasGuestLinkEnabled, setConversationHasGuestLinkEnabled] = useState<boolean>(false);
 
-  const {accessCode, hasGuest, inTeam, isGuestAndServicesRoom, isGuestRoom, isServicesRoom} = useKoSubscribableChildren(
+  const {accessCode, hasGuest, isGuestAndServicesRoom, isGuestRoom, isServicesRoom} = useKoSubscribableChildren(
     activeConversation,
-    ['accessCode', 'hasGuest', 'inTeam', 'isGuestAndServicesRoom', 'isGuestRoom', 'isServicesRoom'],
+    ['accessCode', 'hasGuest', 'isGuestAndServicesRoom', 'isGuestRoom', 'isServicesRoom'],
   );
+  const inTeam = teamState.isInTeam(activeConversation);
 
   const isGuestEnabled = isGuestRoom || isGuestAndServicesRoom;
   const isGuestLinkEnabled = inTeam

--- a/src/script/page/RightSidebar/MessageDetails/MessageDetails.test.tsx
+++ b/src/script/page/RightSidebar/MessageDetails/MessageDetails.test.tsx
@@ -66,7 +66,7 @@ const getDefaultParams = (showReactions: boolean = false) => {
 describe('MessageDetails', () => {
   it('renders no reactions view', async () => {
     const conversation = new Conversation();
-    conversation.team_id = 'mock-team-id';
+    conversation.teamId = 'mock-team-id';
 
     const timestamp = new Date('2022-01-21T15:08:14.225Z').getTime();
     const userName = 'Jan Kowalski';

--- a/src/script/page/RightSidebar/MessageDetails/MessageDetails.tsx
+++ b/src/script/page/RightSidebar/MessageDetails/MessageDetails.tsx
@@ -92,7 +92,7 @@ const MessageDetails: FC<MessageDetailsProps> = ({
   } = useKoSubscribableChildren(messageEntity, ['timestamp', 'user', 'reactions', 'readReceipts', 'edited_timestamp']);
   const totalNbReactions = reactions.reduce((acc, [, users]) => acc + users.length, 0);
 
-  const teamId = activeConversation.team_id;
+  const teamId = activeConversation.teamId;
   const supportsReceipts = messageSender.isMe && teamId;
 
   const receiptUsers = userRepository

--- a/src/script/properties/PropertiesRepository.ts
+++ b/src/script/properties/PropertiesRepository.ts
@@ -115,7 +115,7 @@ export class PropertiesRepository {
     const isCheckConsentDisabled = !Config.getConfig().FEATURE.CHECK_CONSENT;
     const isPrivacyPreferenceSet = this.getPreference(PROPERTIES_TYPE.PRIVACY) !== undefined;
     const isTelemetryPreferenceSet = this.getPreference(PROPERTIES_TYPE.TELEMETRY_SHARING) !== undefined;
-    const isTeamAccount = this.selfUser().inTeam();
+    const isTeamAccount = !!this.selfUser().teamId;
     const enablePrivacy = () => {
       this.savePreference(PROPERTIES_TYPE.PRIVACY, true);
       this.publishProperties();

--- a/src/script/team/TeamState.ts
+++ b/src/script/team/TeamState.ts
@@ -136,7 +136,8 @@ export class TeamState {
   }
 
   isInTeam(entity: User | Conversation): boolean {
-    return !!this.team() && entity.teamId === this.team().id;
+    const team = this.team();
+    return !!team.id && entity.domain === this.teamDomain() && entity.teamId === team.id;
   }
 
   readonly isExternal = (userId: string): boolean => {

--- a/src/script/team/TeamState.ts
+++ b/src/script/team/TeamState.ts
@@ -25,6 +25,7 @@ import {sortUsersByPriority} from 'Util/StringUtil';
 
 import {TeamEntity} from './TeamEntity';
 
+import {Conversation} from '../entity/Conversation';
 import {User} from '../entity/User';
 import {ROLE} from '../user/UserPermission';
 import {UserState} from '../user/UserState';
@@ -132,6 +133,10 @@ export class TeamState {
     this.isGuestLinkEnabled = ko.pureComputed(
       () => this.teamFeatures()?.conversationGuestLinks?.status === FeatureStatus.ENABLED,
     );
+  }
+
+  isInTeam(entity: User | Conversation): boolean {
+    return !!this.team() && entity.teamId === this.team().id;
   }
 
   readonly isExternal = (userId: string): boolean => {

--- a/src/script/team/TeamState.ts
+++ b/src/script/team/TeamState.ts
@@ -66,7 +66,7 @@ export class TeamState {
     this.isTeamDeleted = ko.observable(false);
 
     /** Note: this does not include the self user */
-    this.teamMembers = ko.pureComputed(() => this.userState.users().filter(user => !user.isMe && user.isTeamMember()));
+    this.teamMembers = ko.pureComputed(() => this.userState.users().filter(user => !user.isMe && this.isInTeam(user)));
     this.memberRoles = ko.observable({});
     this.memberInviters = ko.observable({});
     this.teamFeatures = ko.observable();

--- a/src/script/team/TeamState.ts
+++ b/src/script/team/TeamState.ts
@@ -57,13 +57,11 @@ export class TeamState {
   /** all the members of the team + the users the selfUser is connected with */
   readonly teamUsers: ko.PureComputed<User[]>;
   readonly isTeam: ko.PureComputed<boolean>;
-  readonly team: ko.Observable<TeamEntity>;
+  readonly team = ko.observable(new TeamEntity());
   readonly teamDomain: ko.PureComputed<string>;
   readonly teamSize: ko.PureComputed<number>;
 
   constructor(private readonly userState = container.resolve(UserState)) {
-    this.team = ko.observable();
-
     this.isTeam = ko.pureComputed(() => !!this.team()?.id);
     this.isTeamDeleted = ko.observable(false);
 

--- a/src/script/tracking/Helpers.ts
+++ b/src/script/tracking/Helpers.ts
@@ -42,7 +42,7 @@ export function getConversationType(conversationEntity: any): ConversationType |
   }
 }
 export function getGuestAttributes(conversationEntity: Conversation): GuestAttributes {
-  const isTeamConversation = !!conversationEntity.team_id;
+  const isTeamConversation = !!conversationEntity.teamId;
   if (isTeamConversation) {
     const isAllowGuests = !conversationEntity.isTeamOnly();
     const _getUserType = (_conversationEntity: Conversation) => {

--- a/src/script/user/UserMapper.test.ts
+++ b/src/script/user/UserMapper.test.ts
@@ -81,7 +81,6 @@ describe('User Mapper', () => {
       );
 
       expect(user.isFederated).toBe(true);
-      expect(user.inTeam()).toBe(false);
     });
 
     it('can convert users with profile images marked as non public', () => {

--- a/src/script/user/UserMapper.ts
+++ b/src/script/user/UserMapper.ts
@@ -17,8 +17,6 @@
  *
  */
 
-import {container} from 'tsyringe';
-
 import {getLogger, Logger} from 'Util/Logger';
 
 import {isSelfAPIUser} from './UserGuards';
@@ -26,7 +24,6 @@ import {isSelfAPIUser} from './UserGuards';
 import {mapProfileAssets, mapProfileAssetsV1, updateUserEntityAssets} from '../assets/AssetMapper';
 import {User} from '../entity/User';
 import {UserRecord} from '../storage';
-import {TeamState} from '../team/TeamState';
 import type {ServerTimeHandler} from '../time/serverTimeHandler';
 import '../view_model/bindings/CommonBindings';
 
@@ -37,10 +34,7 @@ export class UserMapper {
    * Construct a new User Mapper.
    * @param serverTimeHandler Handles time shift between server and client
    */
-  constructor(
-    private readonly serverTimeHandler: ServerTimeHandler,
-    private teamState = container.resolve(TeamState),
-  ) {
+  constructor(private readonly serverTimeHandler: ServerTimeHandler) {
     this.logger = getLogger('UserMapper');
   }
 
@@ -187,12 +181,8 @@ export class UserMapper {
       }
     }
 
-    const currentTeam = this.teamState.team()?.id;
     if (teamId) {
       userEntity.teamId = teamId;
-      if (!userEntity.isFederated && currentTeam && currentTeam === teamId) {
-        userEntity.inTeam(true);
-      }
     }
 
     if (deleted) {

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -795,7 +795,7 @@ export class UserRepository {
     if (this.teamState.isTeam()) {
       this.mapGuestStatus([updatedUser]);
     }
-    if (updatedUser && updatedUser.inTeam() && updatedUser.isDeleted) {
+    if (updatedUser && this.teamState.isInTeam(updatedUser) && updatedUser.isDeleted) {
       amplify.publish(WebAppEvents.TEAM.MEMBER_LEAVE, updatedUser.teamId, userId);
     }
     return updatedUser;

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -911,8 +911,8 @@ export class UserRepository {
     const selfTeamId = this.userState.self().teamId;
     userEntities.forEach(userEntity => {
       if (!userEntity.isMe && selfTeamId) {
-        const isTeamMember = selfTeamId === userEntity.teamId;
-        const isGuest = !userEntity.isService && !isTeamMember && selfTeamId !== userEntity.teamId;
+        const isTeamMember = this.teamState.isInTeam(userEntity);
+        const isGuest = !userEntity.isService && !isTeamMember;
         userEntity.isGuest(isGuest);
         userEntity.isTeamMember(isTeamMember);
       }


### PR DESCRIPTION
## Description

In preparation for a change in how team members are dealt with, we need to clear how the `inTeam` property is computed. 
It should not be `set` but rather `computed` everytime we need it. 
This prevent temporal coupling (in case we are mapping users before the state is fully ready). 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
