### PR TITLE
feat: Do not load all team members on app load [WPB-4553 WPB-4548 WPB-1912]

### DIFF
--- a/src/script/components/UserSearchableList.tsx
+++ b/src/script/components/UserSearchableList.tsx
@@ -82,7 +82,7 @@ const UserSearchableList: React.FC<UserListProps> = ({
    */
   const fetchMembersFromBackend = useCallback(
     debounce(async (query: string, ignoreMembers: User[]) => {
-      const resultUsers = await searchRepository.searchByName(query);
+      const resultUsers = await searchRepository.searchByName(query, selfUser.teamId);
       const selfTeamId = selfUser.teamId;
       const foundMembers = resultUsers.filter(user => user.teamId === selfTeamId);
       const ignoreIds = ignoreMembers.map(member => member.id);

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -415,15 +415,18 @@ export class App {
       onProgress(10);
       telemetry.timeStep(AppInitTimingsStep.INITIALIZED_CRYPTOGRAPHY);
 
-      const {members: teamMembers} = await teamRepository.initTeam(selfUser.teamId);
+      const connections = await connectionRepository.getConnections();
+
       telemetry.timeStep(AppInitTimingsStep.RECEIVED_USER_DATA);
 
-      const connections = await connectionRepository.getConnections();
       telemetry.addStatistic(AppInitStatisticsValue.CONNECTIONS, connections.length, 50);
 
       const conversations = await conversationRepository.loadConversations();
 
-      await userRepository.loadUsers(selfUser, connections, conversations, teamMembers);
+      const contacts = await userRepository.loadUsers(selfUser, connections, conversations);
+      if (selfUser.teamId) {
+        await teamRepository.initTeam(selfUser.teamId, contacts);
+      }
 
       if (supportsMLS()) {
         //if mls is supported, we need to initialize the callbacks (they are used when decrypting messages)

--- a/src/script/page/LeftSidebar/panels/StartUI/PeopleTab.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/PeopleTab.tsx
@@ -195,7 +195,7 @@ export const PeopleTab = ({
       onSearchResults(localSearchResults);
       if (canSearchUnconnectedUsers) {
         try {
-          const userEntities = await searchRepository.searchByName(searchQuery);
+          const userEntities = await searchRepository.searchByName(searchQuery, selfUser.teamId);
           const localUserIds = localSearchResults.contacts.map(({id}) => id);
           const onlyRemoteUsers = userEntities.filter(user => !localUserIds.includes(user.id));
           const results = inTeam

--- a/src/script/team/TeamRepository.test.ts
+++ b/src/script/team/TeamRepository.test.ts
@@ -17,8 +17,6 @@
  *
  */
 
-import {Permissions} from '@wireapp/api-client/lib/team/member';
-
 import {randomUUID} from 'crypto';
 
 import {User} from 'src/script/entity/User';
@@ -69,12 +67,6 @@ describe('TeamRepository', () => {
     has_more: false,
   };
   const team_metadata = teams_data.teams[0];
-  const team_members = {
-    members: [
-      {user: randomUUID(), permissions: {copy: Permissions.DEFAULT, self: Permissions.DEFAULT}},
-      {user: randomUUID(), permissions: {copy: Permissions.DEFAULT, self: Permissions.DEFAULT}},
-    ],
-  };
 
   describe('getTeam()', () => {
     it('returns the team entity', async () => {
@@ -88,17 +80,6 @@ describe('TeamRepository', () => {
 
       expect(team_et.creator).toEqual(team_data.creator);
       expect(team_et.id).toEqual(team_data.id);
-    });
-  });
-
-  describe('getAllTeamMembers()', () => {
-    it('returns team member entities', async () => {
-      const [teamRepo, {teamService}] = buildConnectionRepository();
-      jest.spyOn(teamService, 'getAllTeamMembers').mockResolvedValue({hasMore: false, members: team_members.members});
-      const entities = await teamRepo['getAllTeamMembers'](team_metadata.id);
-      expect(entities.length).toEqual(team_members.members.length);
-      expect(entities[0].userId).toEqual(team_members.members[0].user);
-      expect(entities[0].permissions).toEqual(team_members.members[0].permissions);
     });
   });
 

--- a/src/script/user/UserRepository.test.ts
+++ b/src/script/user/UserRepository.test.ts
@@ -220,10 +220,9 @@ describe('UserRepository', () => {
       it('loads all users from backend even when they are already known locally', async () => {
         const newUsers = [generateAPIUser(), generateAPIUser()];
         const users = [...localUsers, ...newUsers];
-        const userIds = users.map(user => user.qualified_id!);
         const fetchUserSpy = jest.spyOn(userRepository['userService'], 'getUsers').mockResolvedValue({found: users});
 
-        await userRepository.loadUsers(new User('self'), [], [], userIds);
+        await userRepository.loadUsers(new User('self'), [], []);
 
         expect(userState.users()).toHaveLength(users.length + 1);
         expect(fetchUserSpy).toHaveBeenCalledWith(users.map(user => user.qualified_id!));
@@ -232,7 +231,6 @@ describe('UserRepository', () => {
       it('assigns connections with users', async () => {
         const newUsers = [generateAPIUser(), generateAPIUser()];
         const users = [...localUsers, ...newUsers];
-        const userIds = users.map(user => user.qualified_id!);
         jest.spyOn(userRepository['userService'], 'getUsers').mockResolvedValue({found: users});
 
         const createConnectionWithUser = (userId: QualifiedId) => {
@@ -243,7 +241,7 @@ describe('UserRepository', () => {
 
         const connections = users.map(user => createConnectionWithUser(user.qualified_id));
 
-        await userRepository.loadUsers(new User('self'), connections, [], userIds);
+        await userRepository.loadUsers(new User('self'), connections, []);
 
         expect(userState.users()).toHaveLength(users.length + 1);
         users.forEach(user => {
@@ -264,7 +262,7 @@ describe('UserRepository', () => {
           .spyOn(userRepository['userService'], 'getUsers')
           .mockResolvedValue({found: localUsers});
 
-        await userRepository.loadUsers(new User('self'), [], [], userIds);
+        await userRepository.loadUsers(new User('self'), [], []);
 
         expect(userState.users()).toHaveLength(localUsers.length + 1);
         expect(fetchUserSpy).toHaveBeenCalledWith(userIds);
@@ -275,11 +273,10 @@ describe('UserRepository', () => {
 
       it('deletes users that are not needed', async () => {
         const newUsers = [generateAPIUser(), generateAPIUser()];
-        const userIds = newUsers.map(user => user.qualified_id!);
         const removeUserSpy = jest.spyOn(userRepository['userService'], 'removeUserFromDb').mockResolvedValue();
         jest.spyOn(userRepository['userService'], 'getUsers').mockResolvedValue({found: newUsers});
 
-        await userRepository.loadUsers(new User(), [], [], userIds);
+        await userRepository.loadUsers(new User(), [], []);
 
         expect(userState.users()).toHaveLength(newUsers.length + 1);
         expect(removeUserSpy).toHaveBeenCalledTimes(localUsers.length);

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -194,7 +194,6 @@ export class UserRepository {
    * @param selfUser the user currently logged in (will be excluded from fetch)
    * @param connections the connection to other users
    * @param conversations the conversation the user is part of (used to compute extra users that are part of those conversations but not directly connected to the user)
-   * @param extraUsers other users that would need to be loaded (team users usually that are not direct connections)
    */
   async loadUsers(selfUser: User, connections: ConnectionEntity[], conversations: Conversation[]): Promise<User[]> {
     const conversationMembers = flatten(conversations.map(conversation => conversation.participating_user_ids()));

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -196,17 +196,9 @@ export class UserRepository {
    * @param conversations the conversation the user is part of (used to compute extra users that are part of those conversations but not directly connected to the user)
    * @param extraUsers other users that would need to be loaded (team users usually that are not direct connections)
    */
-  async loadUsers(
-    selfUser: User,
-    connections: ConnectionEntity[],
-    conversations: Conversation[],
-    extraUsers: QualifiedId[],
-  ): Promise<User[]> {
+  async loadUsers(selfUser: User, connections: ConnectionEntity[], conversations: Conversation[]): Promise<User[]> {
     const conversationMembers = flatten(conversations.map(conversation => conversation.participating_user_ids()));
-    const allUserIds = connections
-      .map(connectionEntity => connectionEntity.userId)
-      .concat(conversationMembers)
-      .concat(extraUsers);
+    const allUserIds = connections.map(connectionEntity => connectionEntity.userId).concat(conversationMembers);
     const users = uniq(allUserIds, false, (userId: QualifiedId) => userId.id);
 
     // Remove all users that have non-qualified Ids in DB (there could be duplicated entries one qualified and one non-qualified)

--- a/test/helper/UserGenerator.ts
+++ b/test/helper/UserGenerator.ts
@@ -61,7 +61,7 @@ export function generateAPIUser(
   };
 }
 
-export function generateUser(id?: QualifiedId): User {
-  const apiUser = generateAPIUser(id);
+export function generateUser(id?: QualifiedId, overwites?: Partial<APIClientUser>): User {
+  const apiUser = generateAPIUser(id, overwites);
   return new UserMapper(serverTimeHandler).mapUserFromJson(apiUser, '');
 }

--- a/test/helper/UserGenerator.ts
+++ b/test/helper/UserGenerator.ts
@@ -19,7 +19,7 @@
 
 import {faker} from '@faker-js/faker';
 import {QualifiedId, UserAssetType} from '@wireapp/api-client/lib/user';
-import type {User as APIClientUser} from '@wireapp/api-client/lib/user/';
+import type {User as APIClientUser} from '@wireapp/api-client/lib/user';
 
 import {createUuid} from 'Util/uuid';
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4553" title="WPB-4553" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-4553</a>  [Web] Stop maintaining a local list of all team members
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

This will prevent all team members from being loaded at app load time. 
The idea is to only load all the users we have direct connection with. This includes:
- users that are connected to the selfUser (via a connection request)
- users the selfUser have interacted with through a conversation (but which are not necessarily connected to me)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
