### PR TITLE
runfix: Fix checking self user team when call starts

### DIFF
--- a/src/script/view_model/CallingViewModel.ts
+++ b/src/script/view_model/CallingViewModel.ts
@@ -101,7 +101,7 @@ export class CallingViewModel {
     readonly permissionRepository: PermissionRepository,
     readonly teamRepository: TeamRepository,
     readonly propertiesRepository: PropertiesRepository,
-    private readonly selfUser: ko.Subscribable<User>,
+    private readonly selfUser: ko.Observable<User>,
     readonly multitasking: Multitasking,
     private readonly conversationState = container.resolve(ConversationState),
     readonly callState = container.resolve(CallState),
@@ -478,7 +478,7 @@ export class CallingViewModel {
   }
 
   private showRestrictedConferenceCallingModal() {
-    if (this.selfUser().inTeam()) {
+    if (this.teamState.isInTeam(this.selfUser())) {
       if (this.selfUser().teamRole() === ROLE.OWNER) {
         const replaceEnterprise = replaceLink(
           Config.getConfig().URL.PRICING,


### PR DESCRIPTION
## Description

For some reasons the `ko.Subscribable` type yeild an `any` type for the content of the subscribable. Which lead me to miss this call to `inTeam` when fixing this temporal coupling #16159 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
