### PR TITLE
runfix: enable video on mls conference calls

### DIFF
--- a/src/script/calling/Call.ts
+++ b/src/script/calling/Call.ts
@@ -54,6 +54,7 @@ export class Call {
     Config.getConfig().FEATURE.ENFORCE_CONSTANT_BITRATE,
   );
   public readonly isConference: boolean;
+  public readonly isGroupOrConference: boolean;
   public readonly activeSpeakers: ko.ObservableArray<Participant> = ko.observableArray([]);
   public blockMessages: boolean = false;
   public currentPage: ko.Observable<number> = ko.observable(0);
@@ -95,6 +96,7 @@ export class Call {
     this.maximizedParticipant = ko.observable(null);
     this.muteState(isMuted ? MuteState.SELF_MUTED : MuteState.NOT_MUTED);
     this.isConference = [CONV_TYPE.CONFERENCE, CONV_TYPE.CONFERENCE_MLS].includes(this.conversationType);
+    this.isGroupOrConference = this.isConference || this.conversationType === CONV_TYPE.GROUP;
   }
 
   get hasWorkingAudioInput(): boolean {

--- a/src/script/calling/Call.ts
+++ b/src/script/calling/Call.ts
@@ -53,6 +53,7 @@ export class Call {
   public readonly isCbrEnabled: ko.Observable<boolean> = ko.observable(
     Config.getConfig().FEATURE.ENFORCE_CONSTANT_BITRATE,
   );
+  public readonly isConference: boolean;
   public readonly activeSpeakers: ko.ObservableArray<Participant> = ko.observableArray([]);
   public blockMessages: boolean = false;
   public currentPage: ko.Observable<number> = ko.observable(0);
@@ -93,6 +94,7 @@ export class Call {
     });
     this.maximizedParticipant = ko.observable(null);
     this.muteState(isMuted ? MuteState.SELF_MUTED : MuteState.NOT_MUTED);
+    this.isConference = [CONV_TYPE.CONFERENCE, CONV_TYPE.CONFERENCE_MLS].includes(this.conversationType);
   }
 
   get hasWorkingAudioInput(): boolean {

--- a/src/script/components/calling/CallingCell.tsx
+++ b/src/script/components/calling/CallingCell.tsx
@@ -24,7 +24,7 @@ import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 import cx from 'classnames';
 import {container} from 'tsyringe';
 
-import {CALL_TYPE, CONV_TYPE, REASON as CALL_REASON, STATE as CALL_STATE} from '@wireapp/avs';
+import {CALL_TYPE, REASON as CALL_REASON, STATE as CALL_STATE} from '@wireapp/avs';
 
 import {Avatar, AVATAR_SIZE, GroupAvatar} from 'Components/Avatar';
 import {Duration} from 'Components/calling/Duration';
@@ -169,8 +169,7 @@ const CallingCell: React.FC<CallingCellProps> = ({
   const {activeSpeakers} = useKoSubscribableChildren(call, ['activeSpeakers']);
 
   const isOutgoingVideoCall = isOutgoing && selfSharesCamera;
-  const isVideoUnsupported =
-    !selfSharesCamera && !conversation?.supportsVideoCall(call.conversationType === CONV_TYPE.CONFERENCE);
+  const isVideoUnsupported = !selfSharesCamera && !conversation?.supportsVideoCall(call.isConference);
   const disableVideoButton = isOutgoingVideoCall || isVideoUnsupported;
   const disableScreenButton = !callingRepository.supportsScreenSharing;
 

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -23,7 +23,7 @@ import {css} from '@emotion/react';
 import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 import {container} from 'tsyringe';
 
-import {CALL_TYPE, CONV_TYPE} from '@wireapp/avs';
+import {CALL_TYPE} from '@wireapp/avs';
 import {IconButton, IconButtonVariant, useMatchMedia} from '@wireapp/react-ui-kit';
 
 import {useCallAlertState} from 'Components/calling/useCallAlertState';
@@ -140,8 +140,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
 
   const showToggleVideo =
     isVideoCallingEnabled &&
-    (call.initialType === CALL_TYPE.VIDEO ||
-      conversation.supportsVideoCall(call.conversationType === CONV_TYPE.CONFERENCE));
+    (call.initialType === CALL_TYPE.VIDEO || conversation.supportsVideoCall(call.isConference));
   const availableCameras = useMemo(
     () =>
       videoinput.map(device => (device as MediaDeviceInfo).deviceId || (device as ElectronDesktopCapturerSource).id),

--- a/src/script/view_model/CallingViewModel.mocks.ts
+++ b/src/script/view_model/CallingViewModel.mocks.ts
@@ -39,7 +39,9 @@ export const mockCallingRepository = {
   onCallParticipantChangedCallback: jest.fn(),
   onCallClosed: jest.fn(),
   leaveCall: jest.fn(),
+  rejectCall: jest.fn(),
   setEpochInfo: jest.fn(),
+  supportsConferenceCalling: true,
 } as unknown as CallingRepository;
 
 export const callState = new CallState();

--- a/src/script/view_model/CallingViewModel.ts
+++ b/src/script/view_model/CallingViewModel.ts
@@ -325,7 +325,7 @@ export class CallingViewModel {
 
     this.callActions = {
       answer: async (call: Call) => {
-        if (call.conversationType === CONV_TYPE.CONFERENCE && !this.callingRepository.supportsConferenceCalling) {
+        if (call.isConference && !this.callingRepository.supportsConferenceCalling) {
           PrimaryModal.show(PrimaryModal.type.ACKNOWLEDGE, {
             primaryAction: {
               action: () => {

--- a/src/script/view_model/ListViewModel.ts
+++ b/src/script/view_model/ListViewModel.ts
@@ -21,7 +21,6 @@ import {amplify} from 'amplify';
 import ko from 'knockout';
 import {container} from 'tsyringe';
 
-import {CONV_TYPE} from '@wireapp/avs';
 import {Runtime} from '@wireapp/commons';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
@@ -154,7 +153,7 @@ export class ListViewModel {
       return;
     }
 
-    if (call.conversationType === CONV_TYPE.CONFERENCE && !this.callingRepository.supportsConferenceCalling) {
+    if (call.isConference && !this.callingRepository.supportsConferenceCalling) {
       PrimaryModal.show(PrimaryModal.type.ACKNOWLEDGE, {
         text: {
           message: `${t('modalConferenceCallNotSupportedMessage')} ${t('modalConferenceCallNotSupportedJoinMessage')}`,


### PR DESCRIPTION
## Description

MLS conference type of call was not considered being a conference call. This PR adds `CONFERENCE_MLS` to conference type of calls checks on call entity. We basically need the same behaviour for both `conference` and `mls_conference` calls.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
