### PR TITLE
runfix: Handle mention deletion edge cases

### DIFF
--- a/src/script/components/RichTextEditor/nodes/Mention.tsx
+++ b/src/script/components/RichTextEditor/nodes/Mention.tsx
@@ -86,10 +86,12 @@ export const Mention = (props: MentionComponentProps) => {
       if (selectedNode) {
         const isCurrentNode = nodeKey === selectedNode?.getKey();
         if (event.key === 'Backspace') {
+          // When backspace is hit, we want to select the mention if the cursor is right after it
           const isNextNode =
             selectedNode?.getPreviousSibling()?.getKey() === nodeKey && rangeSelection?.focus.offset === 0;
           shouldSelectNode = isCurrentNode || isNextNode;
         } else if (event.key === 'Delete') {
+          // When backspace is hit, we want to select the mention if the cursor is right before it
           const isNextNode =
             selectedNode?.getNextSibling()?.getKey() === nodeKey &&
             rangeSelection?.focus.offset === selectedNode?.getTextContent().length;

--- a/src/script/components/RichTextEditor/nodes/Mention.tsx
+++ b/src/script/components/RichTextEditor/nodes/Mention.tsx
@@ -42,6 +42,7 @@ import {
   NodeSelection,
   RangeSelection,
   $isRangeSelection,
+  $createRangeSelection,
 } from 'lexical';
 
 import {KEY} from 'Util/KeyboardUtil';
@@ -81,12 +82,19 @@ export const Mention = (props: MentionComponentProps) => {
       const rangeSelection = $isRangeSelection(currentSelection) ? currentSelection : null;
 
       let shouldSelectNode = false;
-      if (event.key === 'Backspace') {
-        shouldSelectNode = nodeKey === rangeSelection?.getNodes()[0]?.getKey();
-      } else if (event.key === 'Delete') {
-        const currentNode = rangeSelection?.getNodes()[0];
-        const isOnTheEdgeOfNode = currentNode?.getTextContent().length === rangeSelection?.focus.offset;
-        shouldSelectNode = currentNode?.getNextSibling()?.getKey() === nodeKey && isOnTheEdgeOfNode;
+      const selectedNode = rangeSelection?.getNodes().length === 1 && rangeSelection?.getNodes()[0];
+      if (selectedNode) {
+        const isCurrentNode = nodeKey === selectedNode?.getKey();
+        if (event.key === 'Backspace') {
+          const isNextNode =
+            selectedNode?.getPreviousSibling()?.getKey() === nodeKey && rangeSelection?.focus.offset === 0;
+          shouldSelectNode = isCurrentNode || isNextNode;
+        } else if (event.key === 'Delete') {
+          const isNextNode =
+            selectedNode?.getNextSibling()?.getKey() === nodeKey &&
+            rangeSelection?.focus.offset === selectedNode?.getTextContent().length;
+          shouldSelectNode = isCurrentNode || isNextNode;
+        }
       }
       // If the cursor is right before the mention, we first select the mention before deleting it
       if (shouldSelectNode) {
@@ -101,9 +109,16 @@ export const Mention = (props: MentionComponentProps) => {
         const node = $getNodeByKey(nodeKey);
 
         if ($isMentionNode(node)) {
+          const previousNode = node.getPreviousSibling();
+          if ($isTextNode(previousNode)) {
+            const newSelection = $createRangeSelection();
+            const contentLength = previousNode.getTextContent().length;
+            newSelection.setTextNodeRange(previousNode, contentLength, previousNode, contentLength);
+            $setSelection(newSelection);
+          }
           node.remove();
+          return true;
         }
-
         setSelected(false);
       }
       return false;


### PR DESCRIPTION
## Description

fixes a bunch of edge case when dealing with deleting mentions, namely:
- deleting mention when the entire text is selected
- fixing the selection after a mention has been deleted

## Screenshots/Screencast (for UI changes)

https://github.com/wireapp/wire-webapp/assets/1090716/05350694-20ef-46f3-acb7-d7aa14b85019


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

