### PR TITLE
fix: Wrong focus when first clicking on emoji search bar and prevent emoji selection while selecting text message

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageActions.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageActions.styles.ts
@@ -33,6 +33,7 @@ export const messageBodyActions: CSSObject = {
   position: 'absolute',
   right: '16px',
   top: '-20px',
+  userSelect: 'none',
   '@media (max-width: @screen-md-min)': {
     height: '45px',
     flexDirection: 'column',

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiPicker.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiPicker.tsx
@@ -117,11 +117,15 @@ const EmojiPickerContainer: FC<EmojiPickerContainerProps> = ({
             }
           }}
         >
+          {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */}
           <div
             ref={emojiRef}
             style={{maxHeight: window.innerHeight, ...style}}
             role="dialog"
             data-uie-name="emoji-picker-dialog"
+            onClick={event => {
+              event.stopPropagation();
+            }}
           >
             <EmojiPicker
               onEmojiClick={onEmojiClick}

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiPicker.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiPicker.tsx
@@ -123,6 +123,8 @@ const EmojiPickerContainer: FC<EmojiPickerContainerProps> = ({
             style={{maxHeight: window.innerHeight, ...style}}
             role="dialog"
             data-uie-name="emoji-picker-dialog"
+            // stop propagation to prevent emoji picker search input from losing focus
+            // due to message element's handleFocus
             onClick={event => {
               event.stopPropagation();
             }}

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactions.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactions.styles.ts
@@ -57,6 +57,7 @@ export const messageReactionButton: CSSObject = {
   margin: '0.5rem 0rem',
   padding: '3px',
   verticalAlign: 'top',
+  userSelect: 'none',
 };
 
 export const messageReactionButtonTooltip: CSSObject = {display: 'flex', maxWidth: 130, whiteSpace: 'break-spaces'};

--- a/src/script/components/MessagesList/Message/index.tsx
+++ b/src/script/components/MessagesList/Message/index.tsx
@@ -239,7 +239,7 @@ const Message: React.FC<
         ref={messageRef}
         role="listitem"
         onKeyDown={handleDivKeyDown}
-        onClick={({target}) => {
+        onClick={event => {
           handleFocus(index);
         }}
         className="message-wrapper"

--- a/src/script/components/MessagesList/Message/index.tsx
+++ b/src/script/components/MessagesList/Message/index.tsx
@@ -239,8 +239,10 @@ const Message: React.FC<
         ref={messageRef}
         role="listitem"
         onKeyDown={handleDivKeyDown}
-        onClick={event => {
-          handleFocus(index);
+        onClick={({target}) => {
+          if (target instanceof Element && messageRef.current?.contains(target)) {
+            handleFocus(index);
+          }
         }}
         className="message-wrapper"
       >

--- a/src/script/components/MessagesList/Message/index.tsx
+++ b/src/script/components/MessagesList/Message/index.tsx
@@ -240,9 +240,7 @@ const Message: React.FC<
         role="listitem"
         onKeyDown={handleDivKeyDown}
         onClick={({target}) => {
-          if (target instanceof Element && messageRef.current?.contains(target)) {
-            handleFocus(index);
-          }
+          handleFocus(index);
         }}
         className="message-wrapper"
       >


### PR DESCRIPTION
## Description

### ISSUE1:

**STR**

1. Go to a chat with a message in
3. Hover over message
5. Click on the “more emojis” reaction option
7. Click into the search field
9. start typing

**Expected result**

The typed text shows in the search bar and the results of that search are shown

**Actual result**

The typed text goes into the message composer field for the chat you are in

### ISSUE2:

While selecting text message all the emoji icons and emoji pills in the floating actions menu is also getting copied.

**Expected result**

Only text message can be selected/copied

## Screenshots/Screencast (for UI changes)
<img width="358" alt="Screenshot 2023-11-09 at 12 09 32" src="https://github.com/wireapp/wire-webapp/assets/28754444/c699eb5b-3129-4853-aae2-5167712d9bcc">

<img width="893" alt="Screenshot 2023-11-09 at 14 11 44" src="https://github.com/wireapp/wire-webapp/assets/28754444/b28f41ad-99b1-476e-9558-8540cac746a9">


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;