### PR TITLE
refactor: Remove duplicated state entry for self user devices

### DIFF
--- a/src/script/client/ClientRepository.ts
+++ b/src/script/client/ClientRepository.ts
@@ -77,8 +77,6 @@ export class ClientRepository {
     this.selfUser = ko.observable(undefined);
     this.logger = getLogger('ClientRepository');
 
-    this.clientState.clients = ko.pureComputed(() => (this.selfUser() ? this.selfUser().devices() : []));
-
     amplify.subscribe(WebAppEvents.LIFECYCLE.ASK_TO_CLEAR_DATA, this.logoutClient);
     amplify.subscribe(WebAppEvents.USER.EVENT_FROM_BACKEND, this.onUserEvent);
   }
@@ -298,7 +296,7 @@ export class ClientRepository {
     await this.core.service!.client.deleteClient(clientId, password);
     selfUser.removeClient(clientId);
     amplify.publish(WebAppEvents.USER.CLIENT_REMOVED, selfUser.qualifiedId, clientId);
-    return this.clientState.clients();
+    return selfUser.devices();
   }
 
   logoutClient = async (): Promise<void> => {

--- a/src/script/client/ClientState.ts
+++ b/src/script/client/ClientState.ts
@@ -17,15 +17,11 @@
  *
  */
 
-import ko from 'knockout';
 import {singleton} from 'tsyringe';
 
 import {ClientEntity} from './ClientEntity';
 
 @singleton()
 export class ClientState {
-  clients: ko.PureComputed<ClientEntity[]>;
   currentClient: ClientEntity | undefined;
-
-  constructor() {}
 }

--- a/src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.test.tsx
+++ b/src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.test.tsx
@@ -18,7 +18,6 @@
  */
 
 import {render, waitFor} from '@testing-library/react';
-import ko from 'knockout';
 
 import {ClientEntity} from 'src/script/client/ClientEntity';
 import {ClientState} from 'src/script/client/ClientState';
@@ -38,11 +37,12 @@ function createDevice(): ClientEntity {
 }
 
 describe('DevicesPreferences', () => {
+  const selfUser = new User(createUuid());
+  selfUser.devices([createDevice(), createDevice()]);
   const clientState = new ClientState();
-  clientState.clients = ko.pureComputed(() => [createDevice(), createDevice()]);
   clientState.currentClient = createDevice();
   const defaultParams = {
-    clientState: clientState,
+    clientState,
     conversationState: new ConversationState(),
     cryptographyRepository: {
       getLocalFingerprint: jest.fn().mockResolvedValue('0000000000000'),
@@ -50,8 +50,8 @@ describe('DevicesPreferences', () => {
     } as unknown as CryptographyRepository,
     removeDevice: jest.fn(),
     resetSession: jest.fn(),
-    selfUser: new User(createUuid()),
     verifyDevice: jest.fn(),
+    selfUser,
   };
 
   it('displays all devices', async () => {
@@ -59,6 +59,6 @@ describe('DevicesPreferences', () => {
 
     await waitFor(() => getByText('preferencesDevicesCurrent'));
     expect(getByText('preferencesDevicesCurrent')).toBeDefined();
-    expect(getAllByText('preferencesDevicesId')).toHaveLength(clientState.clients().length + 1);
+    expect(getAllByText('preferencesDevicesId')).toHaveLength(selfUser.devices().length);
   });
 });

--- a/src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.test.tsx
+++ b/src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.test.tsx
@@ -59,6 +59,6 @@ describe('DevicesPreferences', () => {
 
     await waitFor(() => getByText('preferencesDevicesCurrent'));
     expect(getByText('preferencesDevicesCurrent')).toBeDefined();
-    expect(getAllByText('preferencesDevicesId')).toHaveLength(selfUser.devices().length);
+    expect(getAllByText('preferencesDevicesId')).toHaveLength(selfUser.devices().length + 1);
   });
 });

--- a/src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/devices/DevicesPreferences.tsx
@@ -141,7 +141,8 @@ const DevicesPreferences = ({
   selfUser,
 }: DevicesPreferencesProps) => {
   const [selectedDevice, setSelectedDevice] = useState<ClientEntity | undefined>();
-  const {clients} = useKoSubscribableChildren(clientState, ['clients']);
+
+  const {devices} = useKoSubscribableChildren(selfUser, ['devices']);
   const currentClient = clientState.currentClient;
   const isSSO = selfUser.isNoPasswordSSO;
   const getFingerprint = (device: ClientEntity) =>
@@ -179,10 +180,10 @@ const DevicesPreferences = ({
 
       <hr className="preferences-devices-separator preferences-separator" />
 
-      {clients.length > 0 && (
+      {devices.length > 0 && (
         <fieldset className="preferences-section">
           <legend className="preferences-header">{t('preferencesDevicesActive')}</legend>
-          {clients.map((device, index) => (
+          {devices.map((device, index) => (
             <Device
               device={device}
               key={device.id}


### PR DESCRIPTION
## Description

This `clientState.clients` was a duplicated value for what on the `selfUser` entity. 
To clarify things up, let's only keep the `selfUser.devices` 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

