### PR TITLE
runfix: team supported protocols

### DIFF
--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -495,7 +495,13 @@ export class TeamRepository extends TypedEventEmitter<Events> {
       return [ConversationProtocol.PROTEUS];
     }
 
-    return mlsFeature.config.supportedProtocols || [ConversationProtocol.PROTEUS];
+    const teamSupportedProtocols = mlsFeature.config.supportedProtocols;
+
+    // For old teams (created on some older backend versions) supportedProtocols field might not exist or be empty,
+    // we fallback to proteus in this case.
+    return teamSupportedProtocols && teamSupportedProtocols.length > 0
+      ? teamSupportedProtocols
+      : [ConversationProtocol.PROTEUS];
   }
 
   public getTeamMLSMigrationStatus(): MLSMigrationStatus {


### PR DESCRIPTION
## Description

This PR provides a backwards compatibility for some older teams that were created before `supportedProtocols` field was added to MLS feature on team features list. It can happen that the field is an empty list (`[]`) or does not exist at all (`undefined`). Added some unit tests.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
