### PR TITLE
refactor: Use corecrypto to get devices verification state

### DIFF
--- a/src/script/E2EIdentity/E2EIdentity.ts
+++ b/src/script/E2EIdentity/E2EIdentity.ts
@@ -27,15 +27,19 @@ export function getE2EIdentityService() {
   return container.resolve(Core).service?.e2eIdentity;
 }
 
+export async function getDeviceIdentity(groupId: string, userId: QualifiedId, deviceId: string) {
+  const identities = await getE2EIdentityService()?.getUserDeviceEntities(groupId, {[deviceId]: userId});
+  return identities?.[0];
+}
 /**
  * @param groupId id of the group
  * @param clientIdsWithUser client ids with user data
  * Returns devices E2EI certificates
  */
 export async function getDeviceVerificationState(groupId: string, userId: QualifiedId, deviceId: string) {
-  const identities = await getE2EIdentityService()?.getUserDeviceEntities(groupId, {[deviceId]: userId});
+  const identity = await getDeviceIdentity(groupId, userId, deviceId);
   // @fixme: soon coreCrypto will return a `isValid` property. Use this one to check for validity
-  return identities?.length ? 'verified' : 'unverified';
+  return identity ? 'verified' : 'unverified';
 }
 
 export async function getConversationState(groupId: string) {
@@ -51,7 +55,7 @@ export function hasActiveCertificate() {
 /**
  * returns E2EI certificate data.
  */
-export function getCertificateData() {
+export function getCurrentDeviceCertificateData() {
   if (!hasActiveCertificate()) {
     return undefined;
   }

--- a/src/script/E2EIdentity/E2EIdentity.ts
+++ b/src/script/E2EIdentity/E2EIdentity.ts
@@ -32,11 +32,10 @@ export function getE2EIdentityService() {
  * @param clientIdsWithUser client ids with user data
  * Returns devices E2EI certificates
  */
-export async function getUserDeviceEntities(
-  groupId: string | Uint8Array,
-  clientIdsWithUser: Record<string, QualifiedId>,
-) {
-  return getE2EIdentityService()?.getUserDeviceEntities(groupId, clientIdsWithUser);
+export async function getDeviceVerificationState(groupId: string, userId: QualifiedId, deviceId: string) {
+  const identities = await getE2EIdentityService()?.getUserDeviceEntities(groupId, {[deviceId]: userId});
+  // @fixme: soon coreCrypto will return a `isValid` property. Use this one to check for validity
+  return identities?.length ? 'verified' : 'unverified';
 }
 
 export async function getConversationState(groupId: string) {

--- a/src/script/components/UserDevices.tsx
+++ b/src/script/components/UserDevices.tsx
@@ -148,7 +148,7 @@ const UserDevices: React.FC<UserDevicesProps> = ({
 
       {showDeviceList && deviceMode === FIND_MODE.NOT_FOUND && <NoDevicesFound {...{noPadding, user}} />}
 
-      {current.state === UserDevicesState.DEVICE_DETAILS && (
+      {current.state === UserDevicesState.DEVICE_DETAILS && selectedClient && (
         <DeviceDetails
           {...{
             renderDeviceBadges: renderBadges,
@@ -158,7 +158,7 @@ const UserDevices: React.FC<UserDevicesProps> = ({
             logger,
             messageRepository,
             noPadding,
-            selectedClient,
+            device: selectedClient,
             user,
           }}
         />

--- a/src/script/components/VerificationBadge/VerificationBadges.tsx
+++ b/src/script/components/VerificationBadge/VerificationBadges.tsx
@@ -32,7 +32,7 @@ import {
 
 import {ClientEntity} from 'src/script/client';
 import {ConversationVerificationState} from 'src/script/conversation/ConversationVerificationState';
-import {getUserDeviceEntities} from 'src/script/E2EIdentity';
+import {getDeviceVerificationState} from 'src/script/E2EIdentity';
 import {Conversation} from 'src/script/entity/Conversation';
 import {User} from 'src/script/entity/User';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
@@ -97,9 +97,8 @@ export const DeviceVerificationBadges = ({
   useEffect(() => {
     if (groupId) {
       void (async () => {
-        const identities = await getUserDeviceEntities(groupId, {[device.id]: userId});
-        // TODO, soon coreCrypto will return a `isValid` property. Use this one to check for validity
-        setIsMLSVerified(!!identities?.length);
+        const verificationState = await getDeviceVerificationState(groupId, userId, device.id);
+        setIsMLSVerified(verificationState === 'verified');
       })();
     }
   });

--- a/src/script/components/userDevices/DeviceDetails.tsx
+++ b/src/script/components/userDevices/DeviceDetails.tsx
@@ -109,7 +109,7 @@ export const DeviceDetails = ({
 
   return (
     <div className={cx('participant-devices__header', {'participant-devices__header--padding': !noPadding})}>
-      {mlsFingerprint && <MLSDeviceDetails fingerprint={mlsFingerprint} isOtherDevice />}
+      {mlsFingerprint && <MLSDeviceDetails fingerprint={mlsFingerprint} />}
 
       <div className="device-proteus-details">
         <h3 className="device-details-title paragraph-body-3">{t('participantDevicesProteusDeviceVerification')}</h3>

--- a/src/script/components/userDevices/DeviceDetails.tsx
+++ b/src/script/components/userDevices/DeviceDetails.tsx
@@ -32,7 +32,6 @@ import type {Logger} from 'Util/Logger';
 import {splitFingerprint} from 'Util/StringUtil';
 
 import type {ClientRepository, ClientEntity} from '../../client';
-import {MLSPublicKeys} from '../../client';
 import {Config} from '../../Config';
 import {ConversationState} from '../../conversation/ConversationState';
 import type {MessageRepository} from '../../conversation/MessageRepository';
@@ -40,7 +39,6 @@ import type {CryptographyRepository} from '../../cryptography/CryptographyReposi
 import type {User} from '../../entity/User';
 import {MotionDuration} from '../../motion/MotionDuration';
 import {FormattedId} from '../../page/MainContent/panels/preferences/DevicesPreferences/components/FormattedId';
-import {MLSDeviceDetails} from '../../page/MainContent/panels/preferences/DevicesPreferences/components/MLSDeviceDetails';
 
 interface DeviceDetailsProps {
   clickToShowSelfFingerprint: () => void;
@@ -50,12 +48,12 @@ interface DeviceDetailsProps {
   logger: Logger;
   messageRepository: MessageRepository;
   noPadding: boolean;
-  selectedClient?: ClientEntity;
+  device: ClientEntity;
   user: User;
 }
 
 export const DeviceDetails = ({
-  selectedClient,
+  device,
   cryptographyRepository,
   user,
   clickToShowSelfFingerprint,
@@ -68,24 +66,24 @@ export const DeviceDetails = ({
   const [fingerprintRemote, setFingerprintRemote] = useState<string>();
   const [isResettingSession, setIsResettingSession] = useState(false);
 
-  const clientMeta = useMemo(() => selectedClient?.meta, [selectedClient]);
+  const clientMeta = useMemo(() => device?.meta, [device]);
 
   const {isVerified} = useKoSubscribableChildren(clientMeta, ['isVerified']);
   const {name: userName} = useKoSubscribableChildren(user, ['name']);
 
   useEffect(() => {
     setFingerprintRemote(undefined);
-    if (selectedClient) {
+    if (device) {
       void cryptographyRepository
-        .getRemoteFingerprint(user.qualifiedId, selectedClient.id)
+        .getRemoteFingerprint(user.qualifiedId, device.id)
         .then(remoteFingerprint => setFingerprintRemote(remoteFingerprint));
     }
-  }, [selectedClient]);
+  }, [device]);
 
   const clickToToggleDeviceVerification = () => {
     const toggleVerified = !isVerified;
     clientRepository
-      .verifyClient(user.qualifiedId, selectedClient, toggleVerified)
+      .verifyClient(user.qualifiedId, device, toggleVerified)
       .catch((error: DexieError) => logger.warn(`Failed to toggle client verification: ${error.message}`));
   };
 
@@ -97,7 +95,7 @@ export const DeviceDetails = ({
     setIsResettingSession(true);
     if (conversation) {
       messageRepository
-        .resetSession(user.qualifiedId, selectedClient.id, conversation)
+        .resetSession(user.qualifiedId, device.id, conversation)
         .then(_resetProgress)
         .catch(_resetProgress);
     }
@@ -105,11 +103,12 @@ export const DeviceDetails = ({
 
   const activeConversation = conversationState.activeConversation();
   const isConversationMLS = activeConversation && isMLSConversation(activeConversation);
-  const mlsFingerprint = selectedClient.mlsPublicKeys?.[MLSPublicKeys.ED25519];
 
   return (
     <div className={cx('participant-devices__header', {'participant-devices__header--padding': !noPadding})}>
-      {mlsFingerprint && <MLSDeviceDetails fingerprint={mlsFingerprint} />}
+      {/*
+      TODO get the fingerprint from CoreCrypto (?)
+      mlsFingerprint && <MLSDeviceDetails fingerprint={mlsFingerprint} />*/}
 
       <div className="device-proteus-details">
         <h3 className="device-details-title paragraph-body-3">{t('participantDevicesProteusDeviceVerification')}</h3>

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/DevicesPreference.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/DevicesPreference.tsx
@@ -20,7 +20,6 @@
 import React, {useEffect, useState} from 'react';
 
 import {QualifiedId} from '@wireapp/api-client/lib/user';
-import {WireIdentity} from '@wireapp/core-crypto/platforms/web/corecrypto';
 import {container} from 'tsyringe';
 
 import {DeviceVerificationBadges} from 'Components/VerificationBadge';
@@ -60,7 +59,6 @@ export const DevicesPreferences: React.FC<DevicesPreferencesProps> = ({
   resetSession,
 }) => {
   const [selectedDevice, setSelectedDevice] = useState<ClientEntity | undefined>();
-  const [selectedDeviceIdentity, setSelectedDeviceIdentity] = useState<WireIdentity>();
   const [localFingerprint, setLocalFingerprint] = useState('');
 
   const {devices} = useKoSubscribableChildren(selfUser, ['devices']);
@@ -90,7 +88,6 @@ export const DevicesPreferences: React.FC<DevicesPreferencesProps> = ({
       <DeviceDetailsPreferences
         renderDeviceBadges={renderDeviceBadges}
         device={selectedDevice}
-        deviceIdentity={selectedDeviceIdentity}
         getFingerprint={getFingerprint}
         onRemove={async device => {
           await removeDevice(device);
@@ -106,25 +103,6 @@ export const DevicesPreferences: React.FC<DevicesPreferencesProps> = ({
   }
 
   const certificate = e2eIdentity.getCertificateData();
-
-  const selectDevice = async (device: ClientEntity, deviceIdentity?: WireIdentity) => {
-    setSelectedDevice(device);
-
-    if (deviceIdentity) {
-      setSelectedDeviceIdentity(deviceIdentity);
-    }
-  };
-
-  const getDeviceIdentity = async (deviceId: string) => {
-    const selfConversation = conversationState?.getSelfMLSConversation();
-
-    if (!selfConversation) {
-      return null;
-    }
-
-    const groupId = selfConversation.groupId;
-    return e2eIdentity.getUserDeviceEntities(groupId, {[deviceId]: selfUser});
-  };
 
   return (
     <PreferencesPage title={t('preferencesDevices')}>
@@ -150,10 +128,10 @@ export const DevicesPreferences: React.FC<DevicesPreferencesProps> = ({
               device={device}
               key={device.id}
               isSSO={isSSO}
-              onSelect={selectDevice}
+              onSelect={setSelectedDevice}
               onRemove={removeDevice}
               deviceNumber={++index}
-              getDeviceIdentity={getDeviceIdentity}
+              renderDeviceBadges={renderDeviceBadges}
             />
           ))}
           <p className="preferences-detail">{t('preferencesDevicesActiveDetail')}</p>

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/DevicesPreference.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/DevicesPreference.tsx
@@ -110,6 +110,7 @@ export const DevicesPreferences: React.FC<DevicesPreferencesProps> = ({
         <legend className="preferences-header">{t('preferencesDevicesCurrent')}</legend>
         {currentClient && (
           <DetailedDevice
+            isCurrentDevice
             device={currentClient}
             fingerprint={localFingerprint}
             certificate={certificate}

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/DevicesPreference.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/DevicesPreference.tsx
@@ -83,9 +83,22 @@ export const DevicesPreferences: React.FC<DevicesPreferencesProps> = ({
     );
   };
 
+  const getDeviceCertificate = async (deviceId: string) => {
+    if (deviceId === currentClient?.id) {
+      return e2eIdentity.getCurrentDeviceCertificateData();
+    }
+    const selfConversation = conversationState.selfMLSConversation();
+    if (!selfConversation) {
+      return undefined;
+    }
+    const identity = await e2eIdentity.getDeviceIdentity(selfConversation.groupId, selfUser.qualifiedId, deviceId);
+    return identity?.certificate;
+  };
+
   if (selectedDevice) {
     return (
       <DeviceDetailsPreferences
+        getCertificate={getDeviceCertificate}
         renderDeviceBadges={renderDeviceBadges}
         device={selectedDevice}
         getFingerprint={getFingerprint}
@@ -102,8 +115,6 @@ export const DevicesPreferences: React.FC<DevicesPreferencesProps> = ({
     );
   }
 
-  const certificate = e2eIdentity.getCertificateData();
-
   return (
     <PreferencesPage title={t('preferencesDevices')}>
       <fieldset className="preferences-section" data-uie-name="preferences-device-current">
@@ -113,7 +124,7 @@ export const DevicesPreferences: React.FC<DevicesPreferencesProps> = ({
             isCurrentDevice
             device={currentClient}
             fingerprint={localFingerprint}
-            certificate={certificate}
+            getCertificate={getDeviceCertificate}
             isProteusVerified={isSelfClientVerified}
           />
         )}

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DetailedDevice.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DetailedDevice.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {ClientEntity, MLSPublicKeys} from 'src/script/client/ClientEntity';
 
@@ -30,7 +30,7 @@ export interface DeviceProps {
   fingerprint: string;
   showVerificationStatus?: boolean;
   isCurrentDevice?: boolean;
-  certificate?: string;
+  getCertificate: (deviceId: string) => Promise<string | undefined>;
   isProteusVerified?: boolean;
 }
 
@@ -40,10 +40,14 @@ export const DetailedDevice: React.FC<DeviceProps> = ({
   fingerprint,
   showVerificationStatus = true,
   isCurrentDevice,
-  certificate,
+  getCertificate,
   isProteusVerified = false,
 }) => {
+  const [certificate, setCertificate] = useState<string | undefined>();
   const mlsFingerprint = device.mlsPublicKeys?.[MLSPublicKeys.ED25519];
+  useEffect(() => {
+    getCertificate?.(device.id).then(setCertificate);
+  }, []);
 
   return (
     <>

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DetailedDevice.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DetailedDevice.tsx
@@ -29,7 +29,7 @@ export interface DeviceProps {
   device: ClientEntity;
   fingerprint: string;
   showVerificationStatus?: boolean;
-  isOtherDevice?: boolean;
+  isCurrentDevice?: boolean;
   certificate?: string;
   isProteusVerified?: boolean;
 }
@@ -39,7 +39,7 @@ export const DetailedDevice: React.FC<DeviceProps> = ({
   device,
   fingerprint,
   showVerificationStatus = true,
-  isOtherDevice = false,
+  isCurrentDevice,
   certificate,
   isProteusVerified = false,
 }) => {
@@ -53,7 +53,7 @@ export const DetailedDevice: React.FC<DeviceProps> = ({
       </h3>
 
       {mlsFingerprint && (
-        <MLSDeviceDetails fingerprint={mlsFingerprint} isOtherDevice={isOtherDevice} certificate={certificate} />
+        <MLSDeviceDetails fingerprint={mlsFingerprint} isCurrentDevice={isCurrentDevice} certificate={certificate} />
       )}
 
       {/* Proteus */}

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DetailedDevice.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DetailedDevice.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 
 import {ClientEntity, MLSPublicKeys} from 'src/script/client/ClientEntity';
 
@@ -43,11 +43,7 @@ export const DetailedDevice: React.FC<DeviceProps> = ({
   getCertificate,
   isProteusVerified = false,
 }) => {
-  const [certificate, setCertificate] = useState<string | undefined>();
   const mlsFingerprint = device.mlsPublicKeys?.[MLSPublicKeys.ED25519];
-  useEffect(() => {
-    getCertificate?.(device.id).then(setCertificate);
-  }, []);
 
   return (
     <>
@@ -57,7 +53,11 @@ export const DetailedDevice: React.FC<DeviceProps> = ({
       </h3>
 
       {mlsFingerprint && (
-        <MLSDeviceDetails fingerprint={mlsFingerprint} isCurrentDevice={isCurrentDevice} certificate={certificate} />
+        <MLSDeviceDetails
+          fingerprint={mlsFingerprint}
+          isCurrentDevice={isCurrentDevice}
+          getCertificate={() => getCertificate(device.id)}
+        />
       )}
 
       {/* Proteus */}

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/Device/Device.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/Device/Device.tsx
@@ -74,7 +74,6 @@ export const Device = ({device, isSSO, onSelect, onRemove, deviceNumber, renderD
           aria-label={deviceAriaLabel}
         >
           {device.getName()}
-
           {renderDeviceBadges(device)}
         </div>
 

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DeviceDetailsPreferences/DeviceDetailsPreferences.test.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DeviceDetailsPreferences/DeviceDetailsPreferences.test.tsx
@@ -32,6 +32,7 @@ describe('DeviceDetailsPreferences', () => {
   const defaultParams = {
     device,
     getFingerprint: jest.fn().mockResolvedValue('00000000'),
+    getCertificate: jest.fn().mockResolvedValue('00000000'),
     onClose: jest.fn(),
     onRemove: jest.fn(),
     onResetSession: jest.fn().mockResolvedValue(undefined),

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DeviceDetailsPreferences/DeviceDetailsPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DeviceDetailsPreferences/DeviceDetailsPreferences.tsx
@@ -19,8 +19,6 @@
 
 import React, {useEffect, useState} from 'react';
 
-import {WireIdentity} from '@wireapp/core-crypto/platforms/web/corecrypto';
-
 import {Button, ButtonVariant} from '@wireapp/react-ui-kit';
 
 import {ClientEntity} from 'src/script/client/ClientEntity';
@@ -39,7 +37,6 @@ interface DevicesPreferencesProps {
   onRemove: (device: ClientEntity) => void;
   onResetSession: (device: ClientEntity) => Promise<void>;
   onVerify: (device: ClientEntity, verified: boolean) => void;
-  deviceIdentity?: WireIdentity;
 }
 
 enum SessionResetState {
@@ -56,7 +53,6 @@ export const DeviceDetailsPreferences: React.FC<DevicesPreferencesProps> = ({
   onRemove,
   onClose,
   onResetSession,
-  deviceIdentity,
 }) => {
   const {isVerified} = useKoSubscribableChildren(device.meta, ['isVerified']);
   const [resetState, setResetState] = useState<SessionResetState>(SessionResetState.RESET);
@@ -99,7 +95,6 @@ export const DeviceDetailsPreferences: React.FC<DevicesPreferencesProps> = ({
             device={device}
             fingerprint={fingerprint || ''}
             showVerificationStatus={false}
-            certificate={deviceIdentity?.certificate}
             isOtherDevice
           />
 

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DeviceDetailsPreferences/DeviceDetailsPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DeviceDetailsPreferences/DeviceDetailsPreferences.tsx
@@ -33,6 +33,7 @@ interface DevicesPreferencesProps {
   device: ClientEntity;
   renderDeviceBadges?: (device: ClientEntity) => React.ReactNode;
   getFingerprint: (device: ClientEntity) => Promise<string | undefined>;
+  getCertificate: (deviceId: string) => Promise<string | undefined>;
   onClose: () => void;
   onRemove: (device: ClientEntity) => void;
   onResetSession: (device: ClientEntity) => Promise<void>;
@@ -49,6 +50,7 @@ export const DeviceDetailsPreferences: React.FC<DevicesPreferencesProps> = ({
   device,
   renderDeviceBadges,
   getFingerprint,
+  getCertificate,
   onVerify,
   onRemove,
   onClose,
@@ -92,10 +94,10 @@ export const DeviceDetailsPreferences: React.FC<DevicesPreferencesProps> = ({
 
           <DetailedDevice
             renderDeviceBadges={renderDeviceBadges}
+            getCertificate={getCertificate}
             device={device}
             fingerprint={fingerprint || ''}
             showVerificationStatus={false}
-            isOtherDevice
           />
 
           <div className="participant-devices__verify slider">

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.tsx
@@ -34,10 +34,10 @@ const logger = getLogger('E2EICertificateDetails');
 
 interface E2EICertificateDetailsProps {
   certificate?: string;
-  isOtherDevice?: boolean;
+  isCurrentDevice?: boolean;
 }
 
-export const E2EICertificateDetails = ({certificate, isOtherDevice = false}: E2EICertificateDetailsProps) => {
+export const E2EICertificateDetails = ({certificate, isCurrentDevice}: E2EICertificateDetailsProps) => {
   const [isCertificateDetailsModalOpen, setIsCertificateDetailsModalOpen] = useState(false);
 
   const {isNotDownloaded, isValid, isExpireSoon} = getCertificateDetails(certificate);
@@ -50,9 +50,7 @@ export const E2EICertificateDetails = ({certificate, isOtherDevice = false}: E2E
 
   const getCertificate = async () => {
     try {
-      const e2eHandler = E2EIHandler.getInstance();
-
-      await e2eHandler.enroll();
+      await E2EIHandler.getInstance().enroll();
     } catch (error) {
       logger.error('Cannot get E2EI instance: ', error);
     }
@@ -86,16 +84,20 @@ export const E2EICertificateDetails = ({certificate, isOtherDevice = false}: E2E
           <CertificateDetailsModal certificate={certificate} onClose={() => setIsCertificateDetailsModalOpen(false)} />
         )}
 
-        {!isOtherDevice && isNotDownloaded && (
-          <Button variant={ButtonVariant.TERTIARY} onClick={getCertificate} data-uie-name="get-certificate">
-            {t('E2EI.getCertificate')}
-          </Button>
-        )}
+        {isCurrentDevice && (
+          <>
+            {isNotDownloaded && (
+              <Button variant={ButtonVariant.TERTIARY} onClick={getCertificate} data-uie-name="get-certificate">
+                {t('E2EI.getCertificate')}
+              </Button>
+            )}
 
-        {!isOtherDevice && certificate && !isValid && (
-          <Button variant={ButtonVariant.TERTIARY} onClick={updateCertificate} data-uie-name="update-certificate">
-            {t('E2EI.updateCertificate')}
-          </Button>
+            {certificate && !isValid && (
+              <Button variant={ButtonVariant.TERTIARY} onClick={updateCertificate} data-uie-name="update-certificate">
+                {t('E2EI.updateCertificate')}
+              </Button>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/MLSDeviceDetails/MLSDeviceDetails.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/MLSDeviceDetails/MLSDeviceDetails.tsx
@@ -30,11 +30,11 @@ import {FormattedId} from '../FormattedId';
 
 interface MLSDeviceDetailsProps {
   fingerprint: string;
-  isOtherDevice?: boolean;
+  isCurrentDevice?: boolean;
   certificate?: string;
 }
 
-export const MLSDeviceDetails = ({fingerprint, isOtherDevice = false, certificate}: MLSDeviceDetailsProps) => {
+export const MLSDeviceDetails = ({fingerprint, isCurrentDevice, certificate}: MLSDeviceDetailsProps) => {
   const isE2EIEnabled = supportsMLS() && Config.getConfig().FEATURE.ENABLE_E2EI;
 
   return (
@@ -47,7 +47,7 @@ export const MLSDeviceDetails = ({fingerprint, isOtherDevice = false, certificat
         <FormattedId idSlices={splitFingerprint(fingerprint)} />
       </p>
 
-      {isE2EIEnabled && <E2EICertificateDetails certificate={certificate} isOtherDevice={isOtherDevice} />}
+      {isE2EIEnabled && <E2EICertificateDetails certificate={certificate} isCurrentDevice={isCurrentDevice} />}
     </div>
   );
 };

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/MLSDeviceDetails/MLSDeviceDetails.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/MLSDeviceDetails/MLSDeviceDetails.tsx
@@ -17,6 +17,8 @@
  *
  */
 
+import {useEffect, useState} from 'react';
+
 import {Config} from 'src/script/Config';
 import {t} from 'Util/LocalizerUtil';
 import {splitFingerprint} from 'Util/StringUtil';
@@ -31,11 +33,15 @@ import {FormattedId} from '../FormattedId';
 interface MLSDeviceDetailsProps {
   fingerprint: string;
   isCurrentDevice?: boolean;
-  certificate?: string;
+  getCertificate: () => Promise<string | undefined>;
 }
 
-export const MLSDeviceDetails = ({fingerprint, isCurrentDevice, certificate}: MLSDeviceDetailsProps) => {
+export const MLSDeviceDetails = ({fingerprint, isCurrentDevice, getCertificate}: MLSDeviceDetailsProps) => {
+  const [certificate, setCertificate] = useState<string | undefined>();
   const isE2EIEnabled = supportsMLS() && Config.getConfig().FEATURE.ENABLE_E2EI;
+  useEffect(() => {
+    getCertificate?.().then(setCertificate);
+  }, []);
 
   return (
     <div css={styles.wrapper}>

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/ProteusDeviceDetails.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/ProteusDeviceDetails.tsx
@@ -25,7 +25,7 @@ import {formatTimestamp} from 'Util/TimeUtil';
 import {type DeviceProps} from './DetailedDevice';
 import {FormattedId} from './FormattedId';
 
-interface ProteusDeviceDetailsProps extends DeviceProps {
+interface ProteusDeviceDetailsProps extends Omit<DeviceProps, 'getCertificate'> {
   isProteusVerified?: boolean;
   showVerificationStatus?: boolean;
 }


### PR DESCRIPTION
## Description

This harmonizes the way we get devices certificates. CoreCrypto is our sole source of truth for that

## Screenshots/Screencast (for UI changes)

![image](https://github.com/wireapp/wire-webapp/assets/1090716/9f5562ee-a5c2-45ee-8ac8-ec34a1a0da70)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
