### PR TITLE
feat: rely on CoreCrypto to get device full identity

### DIFF
--- a/src/script/E2EIdentity/E2EIdentity.test.ts
+++ b/src/script/E2EIdentity/E2EIdentity.test.ts
@@ -103,25 +103,6 @@ describe('E2EIHandler', () => {
     expect(instance['gracePeriodInMS']).toEqual(newParams.gracePeriodInSeconds * TimeInMillis.SECOND);
   });
 
-  it('should return true when supportsMLS returns true and ENABLE_E2EI is true', () => {
-    const instance = E2EIHandler.getInstance(params);
-    expect(instance.isE2EIEnabled).toBe(true);
-  });
-
-  it('should return false when supportsMLS returns false', () => {
-    (util.supportsMLS as jest.Mock).mockReturnValue(false);
-
-    const instance = E2EIHandler.getInstance(params);
-    expect(instance.isE2EIEnabled).toBe(false);
-  });
-
-  it('should return false when ENABLE_E2EI is false', () => {
-    Config.getConfig = jest.fn().mockReturnValue({FEATURE: {ENABLE_E2EI: false}});
-
-    const instance = E2EIHandler.getInstance(params);
-    expect(instance.isE2EIEnabled).toBe(false);
-  });
-
   it('should set currentStep to INITIALIZE after initialize is called', () => {
     const instance = E2EIHandler.getInstance(params);
     instance.initialize();

--- a/src/script/E2EIdentity/E2EIdentity.ts
+++ b/src/script/E2EIdentity/E2EIdentity.ts
@@ -18,47 +18,48 @@
  */
 
 import {QualifiedId} from '@wireapp/api-client/lib/user';
+import {WireIdentity} from '@wireapp/core/lib/messagingProtocols/mls';
 import {container} from 'tsyringe';
 
 import {Core} from 'src/script/service/CoreSingleton';
-import {base64ToArray} from 'Util/util';
+import {base64ToArray, supportsMLS} from 'Util/util';
+import {createUuid} from 'Util/uuid';
+
+import {Config} from '../Config';
+
+export type TMP_DecoratedWireIdentity = WireIdentity & {
+  state: 'verified' | 'unverified';
+  thumbprint: string;
+};
 
 export function getE2EIdentityService() {
-  return container.resolve(Core).service?.e2eIdentity;
+  const e2eIdentityService = container.resolve(Core).service?.e2eIdentity;
+  if (!e2eIdentityService) {
+    throw new Error('trying to query E2EIdentity data in an non-e2eidentity environment');
+  }
+  return e2eIdentityService;
 }
 
-export async function getDeviceIdentity(groupId: string, userId: QualifiedId, deviceId: string) {
-  const identities = await getE2EIdentityService()?.getUserDeviceEntities(groupId, {[deviceId]: userId});
-  return identities?.[0];
+export function isE2EIEnabled(): boolean {
+  return supportsMLS() && Config.getConfig().FEATURE.ENABLE_E2EI;
 }
-/**
- * @param groupId id of the group
- * @param clientIdsWithUser client ids with user data
- * Returns devices E2EI certificates
- */
-export async function getDeviceVerificationState(groupId: string, userId: QualifiedId, deviceId: string) {
-  const identity = await getDeviceIdentity(groupId, userId, deviceId);
-  // @fixme: soon coreCrypto will return a `isValid` property. Use this one to check for validity
-  return identity ? 'verified' : 'unverified';
+
+export async function getDeviceIdentity(
+  groupId: string,
+  userId: QualifiedId,
+  deviceId: string,
+): Promise<TMP_DecoratedWireIdentity | undefined> {
+  const identities = await getE2EIdentityService().getUserDeviceEntities(groupId, {[deviceId]: userId});
+  return identities ? {...identities[0], state: 'verified', thumbprint: createUuid()} : undefined;
 }
 
 export async function getConversationState(groupId: string) {
-  return getE2EIdentityService()?.getConversationState(base64ToArray(groupId));
+  return getE2EIdentityService().getConversationState(base64ToArray(groupId));
 }
+
 /**
  * Checks if E2EI has active certificate.
  */
 export function hasActiveCertificate() {
-  return getE2EIdentityService()?.hasActiveCertificate();
-}
-
-/**
- * returns E2EI certificate data.
- */
-export function getCurrentDeviceCertificateData() {
-  if (!hasActiveCertificate()) {
-    return undefined;
-  }
-
-  return getE2EIdentityService()?.getCertificateData();
+  return getE2EIdentityService().hasActiveCertificate();
 }

--- a/src/script/E2EIdentity/E2EIdentity.ts
+++ b/src/script/E2EIdentity/E2EIdentity.ts
@@ -50,7 +50,7 @@ export async function getDeviceIdentity(
   deviceId: string,
 ): Promise<TMP_DecoratedWireIdentity | undefined> {
   const identities = await getE2EIdentityService().getUserDeviceEntities(groupId, {[deviceId]: userId});
-  return identities ? {...identities[0], state: 'verified', thumbprint: createUuid()} : undefined;
+  return identities?.length ? {...identities[0], state: 'verified', thumbprint: createUuid()} : undefined;
 }
 
 export async function getConversationState(groupId: string) {

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -20,15 +20,13 @@
 import {container} from 'tsyringe';
 
 import {PrimaryModal, removeCurrentModal} from 'Components/Modals/PrimaryModal';
-import {Config} from 'src/script/Config';
 import {Core} from 'src/script/service/CoreSingleton';
 import {UserState} from 'src/script/user/UserState';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
 import {removeUrlParameters} from 'Util/UrlUtil';
-import {supportsMLS} from 'Util/util';
 
 import {DelayTimerService} from './DelayTimer/DelayTimer';
-import {hasActiveCertificate} from './E2EIdentity';
+import {hasActiveCertificate, isE2EIEnabled} from './E2EIdentity';
 import {getModalOptions, ModalType} from './Modals';
 import {getOIDCServiceInstance} from './OIDCService';
 import {OIDCServiceStore} from './OIDCService/OIDCServiceStorage';
@@ -116,15 +114,11 @@ export class E2EIHandler {
   }
 
   public initialize(): void {
-    if (this.isE2EIEnabled) {
+    if (isE2EIEnabled()) {
       if (!hasActiveCertificate()) {
         this.showE2EINotificationMessage();
       }
     }
-  }
-
-  get isE2EIEnabled(): boolean {
-    return supportsMLS() && Config.getConfig().FEATURE.ENABLE_E2EI;
   }
 
   private async storeRedirectTargetAndRedirect(targetURL: string): Promise<void> {

--- a/src/script/components/VerificationBadge/VerificationBadges.tsx
+++ b/src/script/components/VerificationBadge/VerificationBadges.tsx
@@ -93,14 +93,9 @@ export const DeviceVerificationBadges = ({
   const [MLSStatus, setMLSStatus] = useState<MLSStatuses | undefined>(undefined);
   useEffect(() => {
     if (getDeviceIdentity) {
-      const statusesMap = {
-        verified: MLSStatuses.VALID,
-        unverified: MLSStatuses.EXPIRED,
-      };
       void (async () => {
         const identity = await getDeviceIdentity(device.id);
-        const state = identity?.state && statusesMap[identity?.state];
-        setMLSStatus(state ?? MLSStatuses.NOT_DOWNLOADED);
+        setMLSStatus(identity?.state ?? MLSStatuses.NOT_DOWNLOADED);
       })();
     }
   });

--- a/src/script/components/VerificationBadge/VerificationBadges.tsx
+++ b/src/script/components/VerificationBadge/VerificationBadges.tsx
@@ -100,7 +100,7 @@ export const DeviceVerificationBadges = ({
     }
   });
 
-  return <VerificationBadges isProteusVerified={device.meta?.isVerified?.() ?? false} MLSStatus={MLSStatus} />;
+  return <VerificationBadges isProteusVerified={!!device.meta?.isVerified?.()} MLSStatus={MLSStatus} />;
 };
 
 type ConversationVerificationBadgeProps = {

--- a/src/script/components/VerificationBadge/VerificationBadges.tsx
+++ b/src/script/components/VerificationBadge/VerificationBadges.tsx
@@ -90,7 +90,7 @@ export const DeviceVerificationBadges = ({
   device: ClientEntity;
   getDeviceIdentity?: (deviceId: string) => Promise<TMP_DecoratedWireIdentity | undefined>;
 }) => {
-  const [isMLSVerified, setIsMLSVerified] = useState<MLSStatuses | undefined>(undefined);
+  const [MLSStatus, setMLSStatus] = useState<MLSStatuses | undefined>(undefined);
   useEffect(() => {
     if (getDeviceIdentity) {
       const statusesMap = {
@@ -100,17 +100,12 @@ export const DeviceVerificationBadges = ({
       void (async () => {
         const identity = await getDeviceIdentity(device.id);
         const state = identity?.state && statusesMap[identity?.state];
-        setIsMLSVerified(state ?? MLSStatuses.NOT_DOWNLOADED);
+        setMLSStatus(state ?? MLSStatuses.NOT_DOWNLOADED);
       })();
     }
   });
 
-  return (
-    <VerificationBadges
-      isProteusVerified={device.meta?.isVerified?.() ?? false}
-      MLSStatus={isMLSVerified ? MLSStatuses.VALID : undefined}
-    />
-  );
+  return <VerificationBadges isProteusVerified={device.meta?.isVerified?.() ?? false} MLSStatus={MLSStatus} />;
 };
 
 type ConversationVerificationBadgeProps = {

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/DevicesPreference.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/DevicesPreference.tsx
@@ -73,32 +73,24 @@ export const DevicesPreferences: React.FC<DevicesPreferencesProps> = ({
     void cryptographyRepository.getLocalFingerprint().then(setLocalFingerprint);
   }, [cryptographyRepository]);
 
-  const renderDeviceBadges = (device: ClientEntity) => {
-    return (
-      <DeviceVerificationBadges
-        device={device}
-        userId={selfUser.qualifiedId}
-        groupId={conversationState.selfMLSConversation()?.groupId}
-      />
-    );
-  };
+  const getDeviceIdentity = e2eIdentity.isE2EIEnabled()
+    ? async (deviceId: string) => {
+        const selfConversation = conversationState.selfMLSConversation();
+        if (!selfConversation) {
+          return undefined;
+        }
+        return e2eIdentity.getDeviceIdentity(selfConversation.groupId, selfUser.qualifiedId, deviceId);
+      }
+    : undefined;
 
-  const getDeviceCertificate = async (deviceId: string) => {
-    if (deviceId === currentClient?.id) {
-      return e2eIdentity.getCurrentDeviceCertificateData();
-    }
-    const selfConversation = conversationState.selfMLSConversation();
-    if (!selfConversation) {
-      return undefined;
-    }
-    const identity = await e2eIdentity.getDeviceIdentity(selfConversation.groupId, selfUser.qualifiedId, deviceId);
-    return identity?.certificate;
+  const renderDeviceBadges = (device: ClientEntity) => {
+    return <DeviceVerificationBadges device={device} getDeviceIdentity={getDeviceIdentity} />;
   };
 
   if (selectedDevice) {
     return (
       <DeviceDetailsPreferences
-        getCertificate={getDeviceCertificate}
+        getDeviceIdentity={getDeviceIdentity}
         renderDeviceBadges={renderDeviceBadges}
         device={selectedDevice}
         getFingerprint={getFingerprint}
@@ -124,7 +116,7 @@ export const DevicesPreferences: React.FC<DevicesPreferencesProps> = ({
             isCurrentDevice
             device={currentClient}
             fingerprint={localFingerprint}
-            getCertificate={getDeviceCertificate}
+            getDeviceIdentity={getDeviceIdentity}
             isProteusVerified={isSelfClientVerified}
           />
         )}

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/DevicesPreference.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/DevicesPreference.tsx
@@ -22,7 +22,6 @@ import React, {useEffect, useState} from 'react';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {container} from 'tsyringe';
 
-import {DeviceVerificationBadges} from 'Components/VerificationBadge';
 import {ClientEntity} from 'src/script/client/ClientEntity';
 import {CryptographyRepository} from 'src/script/cryptography/CryptographyRepository';
 import {Conversation} from 'src/script/entity/Conversation';
@@ -83,15 +82,10 @@ export const DevicesPreferences: React.FC<DevicesPreferencesProps> = ({
       }
     : undefined;
 
-  const renderDeviceBadges = (device: ClientEntity) => {
-    return <DeviceVerificationBadges device={device} getDeviceIdentity={getDeviceIdentity} />;
-  };
-
   if (selectedDevice) {
     return (
       <DeviceDetailsPreferences
         getDeviceIdentity={getDeviceIdentity}
-        renderDeviceBadges={renderDeviceBadges}
         device={selectedDevice}
         getFingerprint={getFingerprint}
         onRemove={async device => {
@@ -135,7 +129,7 @@ export const DevicesPreferences: React.FC<DevicesPreferencesProps> = ({
               onSelect={setSelectedDevice}
               onRemove={removeDevice}
               deviceNumber={++index}
-              renderDeviceBadges={renderDeviceBadges}
+              getDeviceIdentity={getDeviceIdentity}
             />
           ))}
           <p className="preferences-detail">{t('preferencesDevicesActiveDetail')}</p>

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DetailedDevice.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DetailedDevice.tsx
@@ -19,7 +19,8 @@
 
 import React from 'react';
 
-import {ClientEntity, MLSPublicKeys} from 'src/script/client/ClientEntity';
+import {ClientEntity} from 'src/script/client/ClientEntity';
+import {TMP_DecoratedWireIdentity} from 'src/script/E2EIdentity';
 
 import {MLSDeviceDetails} from './MLSDeviceDetails';
 import {ProteusDeviceDetails} from './ProteusDeviceDetails';
@@ -30,7 +31,7 @@ export interface DeviceProps {
   fingerprint: string;
   showVerificationStatus?: boolean;
   isCurrentDevice?: boolean;
-  getCertificate: (deviceId: string) => Promise<string | undefined>;
+  getDeviceIdentity?: (deviceId: string) => Promise<TMP_DecoratedWireIdentity | undefined>;
   isProteusVerified?: boolean;
 }
 
@@ -40,11 +41,9 @@ export const DetailedDevice: React.FC<DeviceProps> = ({
   fingerprint,
   showVerificationStatus = true,
   isCurrentDevice,
-  getCertificate,
+  getDeviceIdentity,
   isProteusVerified = false,
 }) => {
-  const mlsFingerprint = device.mlsPublicKeys?.[MLSPublicKeys.ED25519];
-
   return (
     <>
       <h3 className="preferences-devices-model preferences-devices-model-name" data-uie-name="device-model">
@@ -52,15 +51,10 @@ export const DetailedDevice: React.FC<DeviceProps> = ({
         {renderDeviceBadges?.(device)}
       </h3>
 
-      {mlsFingerprint && (
-        <MLSDeviceDetails
-          fingerprint={mlsFingerprint}
-          isCurrentDevice={isCurrentDevice}
-          getCertificate={() => getCertificate(device.id)}
-        />
+      {getDeviceIdentity && (
+        <MLSDeviceDetails isCurrentDevice={isCurrentDevice} getDeviceIdentity={() => getDeviceIdentity(device.id)} />
       )}
 
-      {/* Proteus */}
       <ProteusDeviceDetails
         device={device}
         fingerprint={fingerprint}

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DetailedDevice.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DetailedDevice.tsx
@@ -19,6 +19,7 @@
 
 import React from 'react';
 
+import {DeviceVerificationBadges} from 'Components/VerificationBadge';
 import {ClientEntity} from 'src/script/client/ClientEntity';
 import {TMP_DecoratedWireIdentity} from 'src/script/E2EIdentity';
 
@@ -26,7 +27,6 @@ import {MLSDeviceDetails} from './MLSDeviceDetails';
 import {ProteusDeviceDetails} from './ProteusDeviceDetails';
 
 export interface DeviceProps {
-  renderDeviceBadges?: (device: ClientEntity) => React.ReactNode;
   device: ClientEntity;
   fingerprint: string;
   showVerificationStatus?: boolean;
@@ -36,7 +36,6 @@ export interface DeviceProps {
 }
 
 export const DetailedDevice: React.FC<DeviceProps> = ({
-  renderDeviceBadges,
   device,
   fingerprint,
   showVerificationStatus = true,
@@ -48,7 +47,7 @@ export const DetailedDevice: React.FC<DeviceProps> = ({
     <>
       <h3 className="preferences-devices-model preferences-devices-model-name" data-uie-name="device-model">
         <span>{device.model}</span>
-        {renderDeviceBadges?.(device)}
+        <DeviceVerificationBadges device={device} getDeviceIdentity={getDeviceIdentity} />
       </h3>
 
       {getDeviceIdentity && (

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/Device/Device.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/Device/Device.tsx
@@ -24,6 +24,8 @@ import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 import {WireIdentity} from '@wireapp/core-crypto';
 
 import {Icon} from 'Components/Icon';
+import {DeviceVerificationBadges} from 'Components/VerificationBadge';
+import {TMP_DecoratedWireIdentity} from 'src/script/E2EIdentity';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {handleKeyDown} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
@@ -35,13 +37,13 @@ import {FormattedId} from '../FormattedId';
 interface DeviceProps {
   device: ClientEntity;
   isSSO: boolean;
+  getDeviceIdentity?: (deviceId: string) => Promise<TMP_DecoratedWireIdentity | undefined>;
   onRemove: (device: ClientEntity) => void;
   onSelect: (device: ClientEntity, currentDeviceIdentity?: WireIdentity) => void;
   deviceNumber: number;
-  renderDeviceBadges: (device: ClientEntity) => React.ReactNode;
 }
 
-export const Device = ({device, isSSO, onSelect, onRemove, deviceNumber, renderDeviceBadges}: DeviceProps) => {
+export const Device = ({device, isSSO, onSelect, onRemove, getDeviceIdentity, deviceNumber}: DeviceProps) => {
   const {isVerified} = useKoSubscribableChildren(device.meta, ['isVerified']);
   const verifiedLabel = isVerified ? t('preferencesDevicesVerification') : t('preferencesDeviceNotVerified');
   const deviceAriaLabel = `${t('preferencesDevice')} ${deviceNumber}, ${device.getName()}, ${verifiedLabel}`;
@@ -74,7 +76,7 @@ export const Device = ({device, isSSO, onSelect, onRemove, deviceNumber, renderD
           aria-label={deviceAriaLabel}
         >
           {device.getName()}
-          {renderDeviceBadges(device)}
+          <DeviceVerificationBadges device={device} getDeviceIdentity={getDeviceIdentity} />
         </div>
 
         {mlsFingerprint && (

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DeviceDetailsPreferences/DeviceDetailsPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DeviceDetailsPreferences/DeviceDetailsPreferences.tsx
@@ -32,7 +32,6 @@ import {DetailedDevice} from '../DetailedDevice';
 
 interface DevicesPreferencesProps {
   device: ClientEntity;
-  renderDeviceBadges?: (device: ClientEntity) => React.ReactNode;
   getFingerprint: (device: ClientEntity) => Promise<string | undefined>;
   getDeviceIdentity?: (deviceId: string) => Promise<TMP_DecoratedWireIdentity | undefined>;
   onClose: () => void;
@@ -49,7 +48,6 @@ enum SessionResetState {
 
 export const DeviceDetailsPreferences: React.FC<DevicesPreferencesProps> = ({
   device,
-  renderDeviceBadges,
   getFingerprint,
   getDeviceIdentity,
   onVerify,
@@ -94,7 +92,6 @@ export const DeviceDetailsPreferences: React.FC<DevicesPreferencesProps> = ({
           </legend>
 
           <DetailedDevice
-            renderDeviceBadges={renderDeviceBadges}
             getDeviceIdentity={getDeviceIdentity}
             device={device}
             fingerprint={fingerprint || ''}

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DeviceDetailsPreferences/DeviceDetailsPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DeviceDetailsPreferences/DeviceDetailsPreferences.tsx
@@ -22,6 +22,7 @@ import React, {useEffect, useState} from 'react';
 import {Button, ButtonVariant} from '@wireapp/react-ui-kit';
 
 import {ClientEntity} from 'src/script/client/ClientEntity';
+import {TMP_DecoratedWireIdentity} from 'src/script/E2EIdentity';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 
@@ -33,7 +34,7 @@ interface DevicesPreferencesProps {
   device: ClientEntity;
   renderDeviceBadges?: (device: ClientEntity) => React.ReactNode;
   getFingerprint: (device: ClientEntity) => Promise<string | undefined>;
-  getCertificate: (deviceId: string) => Promise<string | undefined>;
+  getDeviceIdentity?: (deviceId: string) => Promise<TMP_DecoratedWireIdentity | undefined>;
   onClose: () => void;
   onRemove: (device: ClientEntity) => void;
   onResetSession: (device: ClientEntity) => Promise<void>;
@@ -50,7 +51,7 @@ export const DeviceDetailsPreferences: React.FC<DevicesPreferencesProps> = ({
   device,
   renderDeviceBadges,
   getFingerprint,
-  getCertificate,
+  getDeviceIdentity,
   onVerify,
   onRemove,
   onClose,
@@ -94,7 +95,7 @@ export const DeviceDetailsPreferences: React.FC<DevicesPreferencesProps> = ({
 
           <DetailedDevice
             renderDeviceBadges={renderDeviceBadges}
-            getCertificate={getCertificate}
+            getDeviceIdentity={getDeviceIdentity}
             device={device}
             fingerprint={fingerprint || ''}
             showVerificationStatus={false}

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.test.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.test.tsx
@@ -17,50 +17,25 @@
  *
  */
 
-import * as x509 from '@peculiar/x509';
 import {render} from '@testing-library/react';
 
 import {MLSStatuses} from 'Components/VerificationBadge';
 import {withTheme} from 'src/script/auth/util/test/TestUtil';
+import {TMP_DecoratedWireIdentity} from 'src/script/E2EIdentity';
 
 import {E2EICertificateDetails} from './E2EICertificateDetails';
 
-const certificateGenerator = async (notBefore: Date, notAfter: Date) => {
-  const alg = {
-    name: 'RSASSA-PKCS1-v1_5',
-    hash: 'SHA-256',
-    publicExponent: new Uint8Array([1, 0, 1]),
-    modulusLength: 2048,
-  };
-  const keys = await crypto.subtle.generateKey(alg, false, ['sign', 'verify']);
-  const cert = await x509.X509CertificateGenerator.createSelfSigned({
-    serialNumber: '01',
-    name: 'CN=Test',
-    notBefore,
-    notAfter,
-    signingAlgorithm: alg,
-    keys,
-    extensions: [
-      new x509.BasicConstraintsExtension(true, 2, true),
-      new x509.ExtendedKeyUsageExtension(['1.2.3.4.5.6.7', '2.3.4.5.6.7.8'], true),
-      new x509.KeyUsagesExtension(x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign, true),
-      await x509.SubjectKeyIdentifierExtension.create(keys.publicKey),
-    ],
-  });
-
-  return cert.toString('pem');
-};
-
 describe('E2EICertificateDetails', () => {
-  const currentDate = new Date();
+  const generateIdentity = (state: MLSStatuses) =>
+    ({
+      state,
+      certificate: 'certificate',
+    }) as TMP_DecoratedWireIdentity;
 
   it('is e2ei identity verified', async () => {
-    const yesterday = new Date(currentDate.getTime() - 86400000);
-    const followingDay = new Date(currentDate.getTime() + 86400000 * 2);
+    const identity = generateIdentity(MLSStatuses.VALID);
 
-    const generatedCertificate = await certificateGenerator(yesterday, followingDay);
-
-    const {getByTestId} = render(withTheme(<E2EICertificateDetails certificate={generatedCertificate} />));
+    const {getByTestId} = render(withTheme(<E2EICertificateDetails identity={identity} />));
 
     const E2EIdentityStatus = getByTestId('e2ei-identity-status');
     expect(E2EIdentityStatus.getAttribute('data-uie-value')).toEqual(MLSStatuses.VALID);
@@ -74,12 +49,9 @@ describe('E2EICertificateDetails', () => {
   });
 
   it('is e2ei identity expired', async () => {
-    const yesterday = new Date(currentDate.getTime() - 86400000);
-    const followingDay = new Date(currentDate.getTime() - 86400000 / 2);
+    const identity = generateIdentity(MLSStatuses.EXPIRED);
 
-    const generatedCertificate = await certificateGenerator(yesterday, followingDay);
-
-    const {getByTestId} = render(withTheme(<E2EICertificateDetails certificate={generatedCertificate} />));
+    const {getByTestId} = render(withTheme(<E2EICertificateDetails identity={identity} />));
 
     const E2EIdentityStatus = getByTestId('e2ei-identity-status');
     expect(E2EIdentityStatus.getAttribute('data-uie-value')).toEqual(MLSStatuses.EXPIRED);

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.tsx
@@ -22,9 +22,8 @@ import {useState} from 'react';
 import {Button, ButtonVariant} from '@wireapp/react-ui-kit';
 
 import {CertificateDetailsModal} from 'Components/Modals/CertificateDetailsModal';
-import {VerificationBadges} from 'Components/VerificationBadge';
-import {E2EIHandler} from 'src/script/E2EIdentity';
-import {getCertificateDetails, getCertificateState} from 'Util/certificateDetails';
+import {MLSStatuses, VerificationBadges} from 'Components/VerificationBadge';
+import {E2EIHandler, TMP_DecoratedWireIdentity} from 'src/script/E2EIdentity';
 import {t} from 'Util/LocalizerUtil';
 import {getLogger} from 'Util/Logger';
 
@@ -33,15 +32,16 @@ import {styles} from './E2EICertificateDetails.styles';
 const logger = getLogger('E2EICertificateDetails');
 
 interface E2EICertificateDetailsProps {
-  certificate?: string;
+  identity?: TMP_DecoratedWireIdentity;
   isCurrentDevice?: boolean;
 }
 
-export const E2EICertificateDetails = ({certificate, isCurrentDevice}: E2EICertificateDetailsProps) => {
+export const E2EICertificateDetails = ({identity, isCurrentDevice}: E2EICertificateDetailsProps) => {
   const [isCertificateDetailsModalOpen, setIsCertificateDetailsModalOpen] = useState(false);
 
-  const {isNotDownloaded, isValid, isExpireSoon} = getCertificateDetails(certificate);
-  const certificateState = getCertificateState({isNotDownloaded, isValid, isExpireSoon});
+  const certificateState = identity?.state ?? MLSStatuses.NOT_DOWNLOADED;
+  const isNotDownloaded = certificateState === MLSStatuses.NOT_DOWNLOADED;
+  const isValid = certificateState === MLSStatuses.VALID;
 
   const updateCertificate = (): null => {
     // TODO: Waiting for update certificate implementation
@@ -80,8 +80,11 @@ export const E2EICertificateDetails = ({certificate, isCurrentDevice}: E2EICerti
           </Button>
         )}
 
-        {isCertificateDetailsModalOpen && certificate && (
-          <CertificateDetailsModal certificate={certificate} onClose={() => setIsCertificateDetailsModalOpen(false)} />
+        {isCertificateDetailsModalOpen && identity?.certificate && (
+          <CertificateDetailsModal
+            certificate={identity.certificate}
+            onClose={() => setIsCertificateDetailsModalOpen(false)}
+          />
         )}
 
         {isCurrentDevice && (
@@ -92,7 +95,7 @@ export const E2EICertificateDetails = ({certificate, isCurrentDevice}: E2EICerti
               </Button>
             )}
 
-            {certificate && !isValid && (
+            {identity?.certificate && !isValid && (
               <Button variant={ButtonVariant.TERTIARY} onClick={updateCertificate} data-uie-name="update-certificate">
                 {t('E2EI.updateCertificate')}
               </Button>

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/MLSDeviceDetails/MLSDeviceDetails.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/MLSDeviceDetails/MLSDeviceDetails.tsx
@@ -40,21 +40,21 @@ export const MLSDeviceDetails = ({isCurrentDevice, getDeviceIdentity}: MLSDevice
     getDeviceIdentity?.().then(setIdentity);
   }, []);
 
-  if (!identity) {
-    return null;
-  }
-
   return (
     <div css={styles.wrapper}>
       <h4 className="paragraph-body-3">{t('mlsSignature', MLSPublicKeys.ED25519.toUpperCase())}</h4>
 
-      <p className="label-2 preferences-label preferences-devices-fingerprint-label">{t('mlsThumbprint')}</p>
+      {identity?.thumbprint && (
+        <>
+          <p className="label-2 preferences-label preferences-devices-fingerprint-label">{t('mlsThumbprint')}</p>
 
-      <p className="preferences-devices-fingerprint" css={{width: '230px'}}>
-        <FormattedId idSlices={splitFingerprint(identity.thumbprint)} />
-      </p>
+          <p className="preferences-devices-fingerprint" css={{width: '230px'}}>
+            <FormattedId idSlices={splitFingerprint(identity.thumbprint)} />
+          </p>
+        </>
+      )}
 
-      <E2EICertificateDetails certificate={identity.certificate} isCurrentDevice={isCurrentDevice} />
+      <E2EICertificateDetails identity={identity} isCurrentDevice={isCurrentDevice} />
     </div>
   );
 };

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/MLSDeviceDetails/MLSDeviceDetails.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/MLSDeviceDetails/MLSDeviceDetails.tsx
@@ -19,10 +19,9 @@
 
 import {useEffect, useState} from 'react';
 
-import {Config} from 'src/script/Config';
+import {TMP_DecoratedWireIdentity} from 'src/script/E2EIdentity';
 import {t} from 'Util/LocalizerUtil';
 import {splitFingerprint} from 'Util/StringUtil';
-import {supportsMLS} from 'Util/util';
 
 import {styles} from './MLSDeviceDetails.styles';
 
@@ -31,17 +30,19 @@ import {E2EICertificateDetails} from '../E2EICertificateDetails';
 import {FormattedId} from '../FormattedId';
 
 interface MLSDeviceDetailsProps {
-  fingerprint: string;
   isCurrentDevice?: boolean;
-  getCertificate: () => Promise<string | undefined>;
+  getDeviceIdentity: () => Promise<TMP_DecoratedWireIdentity | undefined>;
 }
 
-export const MLSDeviceDetails = ({fingerprint, isCurrentDevice, getCertificate}: MLSDeviceDetailsProps) => {
-  const [certificate, setCertificate] = useState<string | undefined>();
-  const isE2EIEnabled = supportsMLS() && Config.getConfig().FEATURE.ENABLE_E2EI;
+export const MLSDeviceDetails = ({isCurrentDevice, getDeviceIdentity}: MLSDeviceDetailsProps) => {
+  const [identity, setIdentity] = useState<TMP_DecoratedWireIdentity | undefined>();
   useEffect(() => {
-    getCertificate?.().then(setCertificate);
+    getDeviceIdentity?.().then(setIdentity);
   }, []);
+
+  if (!identity) {
+    return null;
+  }
 
   return (
     <div css={styles.wrapper}>
@@ -50,10 +51,10 @@ export const MLSDeviceDetails = ({fingerprint, isCurrentDevice, getCertificate}:
       <p className="label-2 preferences-label preferences-devices-fingerprint-label">{t('mlsThumbprint')}</p>
 
       <p className="preferences-devices-fingerprint" css={{width: '230px'}}>
-        <FormattedId idSlices={splitFingerprint(fingerprint)} />
+        <FormattedId idSlices={splitFingerprint(identity.thumbprint)} />
       </p>
 
-      {isE2EIEnabled && <E2EICertificateDetails certificate={certificate} isCurrentDevice={isCurrentDevice} />}
+      <E2EICertificateDetails certificate={identity.certificate} isCurrentDevice={isCurrentDevice} />
     </div>
   );
 };

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/ProteusDeviceDetails.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/ProteusDeviceDetails.tsx
@@ -25,7 +25,7 @@ import {formatTimestamp} from 'Util/TimeUtil';
 import {type DeviceProps} from './DetailedDevice';
 import {FormattedId} from './FormattedId';
 
-interface ProteusDeviceDetailsProps extends Omit<DeviceProps, 'getCertificate'> {
+interface ProteusDeviceDetailsProps extends Omit<DeviceProps, 'getDeviceIdentity'> {
   isProteusVerified?: boolean;
   showVerificationStatus?: boolean;
 }

--- a/src/script/page/RightSidebar/RightSidebar.tsx
+++ b/src/script/page/RightSidebar/RightSidebar.tsx
@@ -28,6 +28,7 @@ import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {DeviceVerificationBadges, UserVerificationBadges} from 'Components/VerificationBadge';
 import {ClientEntity} from 'src/script/client';
+import * as e2eIdentity from 'src/script/E2EIdentity';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 
 import {AddParticipants} from './AddParticipants';
@@ -186,7 +187,13 @@ const RightSidebar: FC<RightSidebarProps> = ({
   };
 
   const renderDeviceBadges = (device: ClientEntity, userId: QualifiedId) => {
-    return <DeviceVerificationBadges device={device} groupId={activeConversation?.groupId} userId={userId} />;
+    const selfConversation = conversationState.selfMLSConversation();
+    const getDeviceIdentity =
+      e2eIdentity.isE2EIEnabled() && selfConversation
+        ? () => e2eIdentity.getDeviceIdentity(selfConversation.groupId, userId, device.id)
+        : undefined;
+
+    return <DeviceVerificationBadges device={device} getDeviceIdentity={getDeviceIdentity} />;
   };
 
   if (!activeConversation) {

--- a/src/script/service/CoreSingleton.ts
+++ b/src/script/service/CoreSingleton.ts
@@ -28,6 +28,7 @@ import {APIClient} from './APIClientSingleton';
 import {createStorageEngine, DatabaseTypes} from './StoreEngineProvider';
 
 import {Config} from '../Config';
+import {isE2EIEnabled} from '../E2EIdentity';
 
 declare global {
   interface Window {
@@ -62,7 +63,7 @@ export class Core extends Account {
           ? {
               keyingMaterialUpdateThreshold: Config.getConfig().FEATURE.MLS_CONFIG_KEYING_MATERIAL_UPDATE_THRESHOLD,
               defaultCiphersuite: Config.getConfig().FEATURE.MLS_CONFIG_DEFAULT_CIPHERSUITE,
-              useE2EI: Config.getConfig().FEATURE.ENABLE_E2EI,
+              useE2EI: isE2EIEnabled(),
             }
           : undefined,
 

--- a/src/script/util/certificateDetails.ts
+++ b/src/script/util/certificateDetails.ts
@@ -33,34 +33,15 @@ const checkExpirationDate = (notAfter: Date) => {
   return currentDate > dateBeforeEnd;
 };
 
-export const getCertificateDetails = (certificate?: string) => {
+export const getCertificateState = (certificate?: string) => {
+  if (!certificate) {
+    return MLSStatuses.NOT_DOWNLOADED;
+  }
   const currentDate = new Date();
   const parsedCertificate = certificate ? new x509.X509Certificate(certificate) : null;
   const isValid =
     !!parsedCertificate && currentDate > parsedCertificate.notBefore && currentDate < parsedCertificate.notAfter;
   const isExpireSoon = isValid && !!parsedCertificate?.notAfter && checkExpirationDate(parsedCertificate.notAfter);
-
-  return {
-    isNotDownloaded: !certificate,
-    isValid,
-    isExpireSoon,
-  };
-};
-
-interface GetCertificateState {
-  isNotDownloaded?: boolean;
-  isValid?: boolean;
-  isExpireSoon?: boolean;
-}
-
-export const getCertificateState = ({
-  isNotDownloaded = false,
-  isValid = false,
-  isExpireSoon = false,
-}: GetCertificateState): MLSStatuses => {
-  if (isNotDownloaded) {
-    return MLSStatuses.NOT_DOWNLOADED;
-  }
 
   if (isValid && !isExpireSoon) {
     return MLSStatuses.VALID;

--- a/src/script/util/certificateDetails.ts
+++ b/src/script/util/certificateDetails.ts
@@ -38,9 +38,8 @@ export const getCertificateState = (certificate?: string) => {
     return MLSStatuses.NOT_DOWNLOADED;
   }
   const currentDate = new Date();
-  const parsedCertificate = certificate ? new x509.X509Certificate(certificate) : null;
-  const isValid =
-    !!parsedCertificate && currentDate > parsedCertificate.notBefore && currentDate < parsedCertificate.notAfter;
+  const parsedCertificate = new x509.X509Certificate(certificate);
+  const isValid = currentDate > parsedCertificate.notBefore && currentDate < parsedCertificate.notAfter;
   const isExpireSoon = isValid && !!parsedCertificate?.notAfter && checkExpirationDate(parsedCertificate.notAfter);
 
   if (isValid && !isExpireSoon) {


### PR DESCRIPTION
## Description

This completely relies on the future format of `CoreCrypto` for a device identity. It will contain certificate validation + thumbprint information. 
No need to compute this on our end. 

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

