### PR TITLE
fix: Do not show current device proteus verification state

### DIFF
--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/DevicesPreference.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/DevicesPreference.tsx
@@ -62,7 +62,6 @@ export const DevicesPreferences: React.FC<DevicesPreferencesProps> = ({
 
   const {devices} = useKoSubscribableChildren(selfUser, ['devices']);
   const currentClient = clientState.currentClient;
-  const isSelfClientVerified = false;
 
   const isSSO = selfUser.isNoPasswordSSO;
   const getFingerprint = (device: ClientEntity) =>
@@ -111,7 +110,6 @@ export const DevicesPreferences: React.FC<DevicesPreferencesProps> = ({
             device={currentClient}
             fingerprint={localFingerprint}
             getDeviceIdentity={getDeviceIdentity}
-            isProteusVerified={isSelfClientVerified}
           />
         )}
       </fieldset>

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DetailedDevice.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DetailedDevice.tsx
@@ -29,7 +29,6 @@ import {ProteusDeviceDetails} from './ProteusDeviceDetails';
 export interface DeviceProps {
   device: ClientEntity;
   fingerprint: string;
-  showVerificationStatus?: boolean;
   isCurrentDevice?: boolean;
   getDeviceIdentity?: (deviceId: string) => Promise<TMP_DecoratedWireIdentity | undefined>;
   isProteusVerified?: boolean;
@@ -38,10 +37,9 @@ export interface DeviceProps {
 export const DetailedDevice: React.FC<DeviceProps> = ({
   device,
   fingerprint,
-  showVerificationStatus = true,
   isCurrentDevice,
   getDeviceIdentity,
-  isProteusVerified = false,
+  isProteusVerified,
 }) => {
   return (
     <>
@@ -54,12 +52,7 @@ export const DetailedDevice: React.FC<DeviceProps> = ({
         <MLSDeviceDetails isCurrentDevice={isCurrentDevice} getDeviceIdentity={() => getDeviceIdentity(device.id)} />
       )}
 
-      <ProteusDeviceDetails
-        device={device}
-        fingerprint={fingerprint}
-        isProteusVerified={isProteusVerified}
-        showVerificationStatus={showVerificationStatus}
-      />
+      <ProteusDeviceDetails device={device} fingerprint={fingerprint} isProteusVerified={isProteusVerified} />
     </>
   );
 };

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DeviceDetailsPreferences/DeviceDetailsPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DeviceDetailsPreferences/DeviceDetailsPreferences.tsx
@@ -91,12 +91,11 @@ export const DeviceDetailsPreferences: React.FC<DevicesPreferencesProps> = ({
             />
           </legend>
 
-          <DetailedDevice
-            getDeviceIdentity={getDeviceIdentity}
-            device={device}
-            fingerprint={fingerprint || ''}
-            showVerificationStatus={false}
-          />
+          <DetailedDevice getDeviceIdentity={getDeviceIdentity} device={device} fingerprint={fingerprint || ''} />
+
+          <h3 className="label preferences-label preferences-devices-fingerprint-label">
+            {t('preferencesDeviceDetailsVerificationStatus')}
+          </h3>
 
           <div className="participant-devices__verify slider">
             <input

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/ProteusDeviceDetails.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/ProteusDeviceDetails.tsx
@@ -30,12 +30,7 @@ interface ProteusDeviceDetailsProps extends Omit<DeviceProps, 'getDeviceIdentity
   showVerificationStatus?: boolean;
 }
 
-export const ProteusDeviceDetails = ({
-  device,
-  fingerprint,
-  isProteusVerified = false,
-  showVerificationStatus = true,
-}: ProteusDeviceDetailsProps) => {
+export const ProteusDeviceDetails = ({device, fingerprint, isProteusVerified}: ProteusDeviceDetailsProps) => {
   return (
     <div className="preferences-proteus-details">
       <h4>{t('proteusDeviceDetails')}</h4>
@@ -66,21 +61,23 @@ export const ProteusDeviceDetails = ({
         <FormattedId idSlices={splitFingerprint(fingerprint)} />
       </p>
 
-      <h3 className="label preferences-label preferences-devices-fingerprint-label">
-        {t('preferencesDeviceDetailsVerificationStatus')}
-      </h3>
+      {isProteusVerified !== undefined && (
+        <>
+          <h3 className="label preferences-label preferences-devices-fingerprint-label">
+            {t('preferencesDeviceDetailsVerificationStatus')}
+          </h3>
 
-      {showVerificationStatus && (
-        <p className="preferences-devices-verification-details">
-          {isProteusVerified ? (
-            <>
-              <span>{t('proteusVerified')}</span>
-              <VerificationBadges isProteusVerified />
-            </>
-          ) : (
-            <span>{t('proteusNotVerified')}</span>
-          )}
-        </p>
+          <p className="preferences-devices-verification-details">
+            {isProteusVerified ? (
+              <>
+                <span>{t('proteusVerified')}</span>
+                <VerificationBadges isProteusVerified />
+              </>
+            ) : (
+              <span>{t('proteusNotVerified')}</span>
+            )}
+          </p>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Description

## Screenshots/Screencast (for UI changes)

Removes this part of the current device details page

![image](https://github.com/wireapp/wire-webapp/assets/1090716/8258cedb-a23a-4d96-b11c-5ca685d5ab4d)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
