### PR TITLE
runfix: tweak media queries in call ui

### DIFF
--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -275,7 +275,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
           <IconButton
             variant={IconButtonVariant.SECONDARY}
             className=" icon-back"
-            css={{height: '25px', left: '5px', position: 'absolute', top: verticalBreakpoint ? '3px' : '10px'}}
+            css={{height: '25px', left: '5px', position: 'absolute', top: '10px'}}
             onClick={minimize}
           />
         )}

--- a/src/style/foundation/video-calling.less
+++ b/src/style/foundation/video-calling.less
@@ -50,10 +50,6 @@
   // fade in animation
   animation: video-fade-in @animation-timing-slower @ease-out-quart forwards;
   opacity: 0;
-
-  @media (max-height: @screen-height-sm) {
-    height: calc(100% - 105px);
-  }
 }
 
 .video-element-remote-participant {
@@ -75,11 +71,6 @@
   align-items: baseline;
   justify-content: center;
   background-color: var(--sidebar-bg);
-
-  @media (max-height: @screen-height-sm) {
-    height: 30px;
-    line-height: 0.8rem;
-  }
 
   &__info-bar {
     .label-small-medium;
@@ -156,10 +147,6 @@
     @media (max-width: @call-ui-xs) {
       padding: 15px 10px;
     }
-
-    @media (max-height: @screen-height-sm) {
-      padding: 10px;
-    }
   }
 
   &__item__minimize {
@@ -180,7 +167,7 @@
     cursor: pointer;
     line-height: 0;
 
-    @media (max-height: @screen-height-sm) {
+    @media (max-width: @call-ui-xs) {
       margin: 0 5px;
     }
 

--- a/src/style/foundation/video-calling.less
+++ b/src/style/foundation/video-calling.less
@@ -143,10 +143,6 @@
     @media (max-width: @call-ui-sm) {
       justify-content: center;
     }
-
-    @media (max-width: @call-ui-xs) {
-      padding: 15px 10px;
-    }
   }
 
   &__item__minimize {


### PR DESCRIPTION
## Description

The vertical breakpoints were intended for dealing with issues with large font sizes and high level of zoom.
They're not necessary if we don't show labels anymore

## Screenshots/Screencast (for UI changes)

#### Before
![Peek 2023-11-16 16-39](https://github.com/wireapp/wire-webapp/assets/78490891/44ae8d0f-bccf-4117-932c-3982313e0e0f)



#### After
![Peek 2023-11-16 16-32](https://github.com/wireapp/wire-webapp/assets/78490891/283512c6-8bb3-416a-a915-3ac658c451a0)
