### PR TITLE
fix: do not hide conversation when its content is cleared

### DIFF
--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -56,7 +56,7 @@ import {Conversation} from 'src/script/entity/Conversation';
 import {Message} from 'src/script/entity/message/Message';
 import {User} from 'src/script/entity/User';
 import {ConversationError} from 'src/script/error/ConversationError';
-import {ClientEvent} from 'src/script/event/Client';
+import {ClientEvent, CONVERSATION} from 'src/script/event/Client';
 import {EventRepository} from 'src/script/event/EventRepository';
 import {NOTIFICATION_HANDLING_STATE} from 'src/script/event/NotificationHandlingState';
 import {StorageSchemata} from 'src/script/storage/StorageSchemata';
@@ -892,6 +892,38 @@ describe('ConversationRepository', () => {
 
       expect(loadedEvents.length).toBe(1);
       expect(loadedEvents[0].id).toBe(messageWithTime.id);
+    });
+  });
+
+  describe('clearConversationContent', () => {
+    it('clears all the messages from database and local state and re-applies creation message', async () => {
+      const conversationRepository = testFactory.conversation_repository!;
+      const messageRepository = testFactory.message_repository!;
+      const eventRepository = testFactory.event_repository!;
+
+      const conversationEntity = _generateConversation({type: CONVERSATION_TYPE.REGULAR});
+      const selfUser = generateUser();
+
+      conversationEntity.selfUser(selfUser);
+
+      jest.spyOn(eventRepository, 'injectEvent').mockImplementationOnce(jest.fn());
+      jest.spyOn(messageRepository, 'updateClearedTimestamp').mockImplementationOnce(jest.fn());
+      jest.spyOn(conversationEntity, 'removeMessages').mockImplementationOnce(jest.fn());
+      jest.spyOn(conversationRepository['eventService'], 'deleteEvents').mockImplementationOnce(jest.fn());
+
+      await conversationRepository.clearConversationContent(conversationEntity);
+
+      expect(messageRepository.updateClearedTimestamp).toHaveBeenCalledWith(conversationEntity);
+      expect(conversationEntity.removeMessages).toHaveBeenCalled();
+      expect(conversationRepository['eventService'].deleteEvents).toHaveBeenCalledWith(
+        conversationEntity.id,
+        undefined,
+      );
+
+      expect(eventRepository.injectEvent).toHaveBeenCalledWith(
+        expect.objectContaining({type: CONVERSATION.GROUP_CREATION, conversation: conversationEntity.id}),
+        undefined,
+      );
     });
   });
 

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -895,7 +895,7 @@ describe('ConversationRepository', () => {
     });
   });
 
-  describe('clearConversationContent', () => {
+  describe('clearConversation', () => {
     it('clears all the messages from database and local state and re-applies creation message', async () => {
       const conversationRepository = testFactory.conversation_repository!;
       const messageRepository = testFactory.message_repository!;
@@ -911,7 +911,7 @@ describe('ConversationRepository', () => {
       jest.spyOn(conversationEntity, 'removeMessages').mockImplementationOnce(jest.fn());
       jest.spyOn(conversationRepository['eventService'], 'deleteEvents').mockImplementationOnce(jest.fn());
 
-      await conversationRepository.clearConversationContent(conversationEntity);
+      await conversationRepository.clearConversation(conversationEntity);
 
       expect(messageRepository.updateClearedTimestamp).toHaveBeenCalledWith(conversationEntity);
       expect(conversationEntity.removeMessages).toHaveBeenCalled();

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -2137,7 +2137,7 @@ export class ConversationRepository {
    * Clear conversation content.
    * It will clear all messages and events from the conversation and re-apply the conversation creation event.
    *
-   * @param conversation Conversation to clear
+   * @param conversation Conversation to clear content from
    */
   public async clearConversationContent(conversation: Conversation) {
     await this.messageRepository.updateClearedTimestamp(conversation);
@@ -2197,8 +2197,8 @@ export class ConversationRepository {
   /**
    * Remove the current user from a conversation.
    *
-   * @param conversation Conversation to remove user from
-   * @returns Resolves when user was removed from the conversation
+   * @param conversation Conversation to remove the self user from
+   * @returns Resolves when the self user was removed from the conversation
    */
   public async leaveConversation(conversation: Conversation) {
     const userQualifiedId = this.userState.self().qualifiedId;
@@ -2453,7 +2453,7 @@ export class ConversationRepository {
   /**
    * Clears conversation content from view and the database.
    *
-   * @param conversationEntity Conversation entity to delete
+   * @param conversationEntity Conversation entity to clear
    * @param timestamp Optional timestamps for which messages to remove
    */
   private async _clearConversation(conversationEntity: Conversation, timestamp?: number) {

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -2134,25 +2134,25 @@ export class ConversationRepository {
   }
 
   /**
-   * Clear conversation content.
-   * It will clear all messages and events from the conversation and re-apply the conversation creation event.
+   * Clear conversation.
+   * It will update conversation's cleared timestamp on BE and clear all conversation content.
    *
    * @param conversation Conversation to clear content from
    * @param timestamp Timestamp of the event
    */
-  public async clearConversationContent(conversation: Conversation, timestamp?: number) {
+  public async clearConversation(conversation: Conversation, timestamp?: number) {
     await this.messageRepository.updateClearedTimestamp(conversation);
-    return this.onConversationContentCleared(conversation, timestamp);
+    return this.clearConversationContent(conversation, timestamp);
   }
 
   /**
-   * React to member update event that was triggered by conversation content being cleared.
+   * Clears conversation content.
    * It will clear all messages and events from the conversation and re-apply the conversation creation event.
    *
    * @param conversation Conversation to clear content from
    * @param timestamp Timestamp of the event
    */
-  private async onConversationContentCleared(conversation: Conversation, timestamp?: number) {
+  private async clearConversationContent(conversation: Conversation, timestamp?: number) {
     await this.deleteMessages(conversation, timestamp);
     return this.addCreationMessage(conversation, !!this.userState.self()?.isTemporaryGuest(), timestamp);
   }
@@ -3286,7 +3286,7 @@ export class ConversationRepository {
     }
 
     if (conversationEntity.is_cleared()) {
-      await this.onConversationContentCleared(conversationEntity, conversationEntity.cleared_timestamp());
+      await this.clearConversationContent(conversationEntity, conversationEntity.cleared_timestamp());
     }
 
     if (isActiveConversation && (conversationEntity.is_archived() || conversationEntity.is_cleared())) {

--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -84,7 +84,6 @@ export class ConversationState {
     this.visibleConversations = ko.pureComputed(() => {
       return this.sortedConversations().filter(
         conversation =>
-          !conversation.is_cleared() &&
           !conversation.is_archived() &&
           // We filter out 1 on 1 conversation with unavailable users that don't have messages
           (!conversation.is1to1() ||

--- a/src/script/view_model/ActionsViewModel.ts
+++ b/src/script/view_model/ActionsViewModel.ts
@@ -149,7 +149,7 @@ export class ActionsViewModel {
       await this.conversationRepository.leaveConversation(conversation);
     }
     if (clear) {
-      await this.conversationRepository.clearConversationContent(conversation);
+      await this.conversationRepository.clearConversation(conversation);
     }
   };
 

--- a/src/script/view_model/ActionsViewModel.ts
+++ b/src/script/view_model/ActionsViewModel.ts
@@ -149,7 +149,7 @@ export class ActionsViewModel {
       await this.conversationRepository.leaveConversation(conversation);
     }
     if (clear) {
-      await this.conversationRepository.clearConversation(conversation);
+      await this.conversationRepository.clearConversationContent(conversation);
     }
   };
 


### PR DESCRIPTION
## Description

According to spec, conversation should not be gone from the conversations list after its content gets cleared. "Clear content" button should only clear the contents and do nothing more.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
