### PR TITLE
runfix: cleared conversation visible

### DIFF
--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -896,6 +896,14 @@ describe('ConversationRepository', () => {
   });
 
   describe('clearConversation', () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
     it('clears all the messages from database and local state and re-applies creation message', async () => {
       const conversationRepository = testFactory.conversation_repository!;
       const messageRepository = testFactory.message_repository!;
@@ -911,13 +919,15 @@ describe('ConversationRepository', () => {
       jest.spyOn(conversationEntity, 'removeMessages').mockImplementationOnce(jest.fn());
       jest.spyOn(conversationRepository['eventService'], 'deleteEvents').mockImplementationOnce(jest.fn());
 
+      const mockedCurrentDate = new Date(1000);
+      jest.setSystemTime(mockedCurrentDate);
       await conversationRepository.clearConversation(conversationEntity);
 
       expect(messageRepository.updateClearedTimestamp).toHaveBeenCalledWith(conversationEntity);
       expect(conversationEntity.removeMessages).toHaveBeenCalled();
       expect(conversationRepository['eventService'].deleteEvents).toHaveBeenCalledWith(
         conversationEntity.id,
-        undefined,
+        mockedCurrentDate.toISOString(),
       );
 
       expect(eventRepository.injectEvent).toHaveBeenCalledWith(

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -3277,7 +3277,7 @@ export class ConversationRepository {
       await this.clearConversationContent(conversationEntity, conversationEntity.cleared_timestamp());
     }
 
-    if (isActiveConversation && (conversationEntity.is_archived() || conversationEntity.is_cleared())) {
+    if (isActiveConversation && conversationEntity.is_archived()) {
       amplify.publish(WebAppEvents.CONVERSATION.SHOW, nextConversationEntity, {});
     }
   }

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -371,24 +371,6 @@ export class ConversationRepository {
     }
   };
 
-  /**
-   * Remove obsolete conversations locally.
-   */
-  cleanupConversations(): void {
-    this.conversationState.conversations().forEach(conversationEntity => {
-      if (
-        conversationEntity.isGroup() &&
-        conversationEntity.is_cleared() &&
-        conversationEntity.removed_from_conversation()
-      ) {
-        this.conversationService.deleteConversationFromDb(conversationEntity.id);
-        this.deleteConversationFromRepository(conversationEntity);
-      }
-    });
-
-    this.cleanupEphemeralMessages();
-  }
-
   //##############################################################################
   // Conversation service interactions
   //##############################################################################

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -2141,8 +2141,8 @@ export class ConversationRepository {
    * @param timestamp Timestamp of the event
    */
   public async clearConversation(conversation: Conversation) {
-    const timestamp = await this.messageRepository.updateClearedTimestamp(conversation);
-    return this.clearConversationContent(conversation, timestamp);
+    await this.messageRepository.updateClearedTimestamp(conversation);
+    return this.clearConversationContent(conversation, new Date().getTime());
   }
 
   /**

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -2140,8 +2140,8 @@ export class ConversationRepository {
    * @param conversation Conversation to clear content from
    * @param timestamp Timestamp of the event
    */
-  public async clearConversation(conversation: Conversation, timestamp?: number) {
-    await this.messageRepository.updateClearedTimestamp(conversation);
+  public async clearConversation(conversation: Conversation) {
+    const timestamp = await this.messageRepository.updateClearedTimestamp(conversation);
     return this.clearConversationContent(conversation, timestamp);
   }
 
@@ -2152,9 +2152,10 @@ export class ConversationRepository {
    * @param conversation Conversation to clear content from
    * @param timestamp Timestamp of the event
    */
-  private async clearConversationContent(conversation: Conversation, timestamp?: number) {
+  private async clearConversationContent(conversation: Conversation, timestamp: number) {
     await this.deleteMessages(conversation, timestamp);
-    return this.addCreationMessage(conversation, !!this.userState.self()?.isTemporaryGuest(), timestamp);
+    await this.addCreationMessage(conversation, !!this.userState.self()?.isTemporaryGuest(), timestamp);
+    conversation.setTimestamp(timestamp, Conversation.TIMESTAMP_TYPE.CLEARED);
   }
 
   async leaveGuestRoom(): Promise<void> {

--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -108,17 +108,9 @@ export class ConversationState {
           ConnectionStatus.PENDING,
         ];
 
-        const isCleared = conversationEntity.is_cleared();
-        const isRemoved = conversationEntity.removed_from_conversation();
-
-        if (
-          isSelfConversation(conversationEntity) ||
-          states_to_filter.includes(conversationEntity.connection().status())
-        ) {
-          return false;
-        }
-
-        return !(isCleared && isRemoved);
+        return !(
+          isSelfConversation(conversationEntity) || states_to_filter.includes(conversationEntity.connection().status())
+        );
       });
     });
 

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -1065,12 +1065,14 @@ export class MessageRepository {
   /**
    * Update cleared of conversation using timestamp.
    */
-  public async updateClearedTimestamp(conversation: Conversation): Promise<void> {
+  public async updateClearedTimestamp(conversation: Conversation): Promise<number> {
     const timestamp = conversation.getLastKnownTimestamp(this.serverTimeHandler.toServerTimestamp());
     if (timestamp && conversation.setTimestamp(timestamp, Conversation.TIMESTAMP_TYPE.CLEARED)) {
       const payload = MessageBuilder.buildClearedMessage(conversation.qualifiedId);
       await this.sendToSelfConversations(payload);
     }
+
+    return timestamp;
   }
 
   sendButtonAction(conversation: Conversation, message: CompositeMessage, buttonId: string): void {

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -1065,14 +1065,12 @@ export class MessageRepository {
   /**
    * Update cleared of conversation using timestamp.
    */
-  public async updateClearedTimestamp(conversation: Conversation): Promise<number> {
+  public async updateClearedTimestamp(conversation: Conversation): Promise<void> {
     const timestamp = conversation.getLastKnownTimestamp(this.serverTimeHandler.toServerTimestamp());
     if (timestamp && conversation.setTimestamp(timestamp, Conversation.TIMESTAMP_TYPE.CLEARED)) {
       const payload = MessageBuilder.buildClearedMessage(conversation.qualifiedId);
       await this.sendToSelfConversations(payload);
     }
-
-    return timestamp;
   }
 
   sendButtonAction(conversation: Conversation, message: CompositeMessage, buttonId: string): void {

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -489,7 +489,7 @@ export class App {
         startNewVersionPolling(Environment.version(false), this.update);
       }
       audioRepository.init(true);
-      conversationRepository.cleanupConversations();
+      await conversationRepository.cleanupEphemeralMessages();
       callingRepository.setReady();
       telemetry.timeStep(AppInitTimingsStep.APP_LOADED);
 

--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -271,9 +271,6 @@ export class ContentViewModel {
         this.conversationState.activeConversation(conversationEntity);
       }
 
-      if (conversationEntity.is_cleared()) {
-        conversationEntity.cleared_timestamp(0);
-      }
       const messageEntity = openFirstSelfMention ? conversationEntity.getFirstUnreadSelfMention() : exposeMessageEntity;
       this.changeConversation(conversationEntity, messageEntity);
       this.showAndNavigate(conversationEntity, openNotificationSettings);


### PR DESCRIPTION
## Description

We don't want cleared conversations to disappear or be deleted from the local store if the self user was removed from the group and/or the group was cleared.

Removing a conversation from the list (and from local database) should be an explicit action, clearing or leaving (or both) a conversation should not make it disappear.

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;