### PR TITLE
runfix: calls in mls 1:1 conversations

### DIFF
--- a/src/script/calling/CallingRepository.test.ts
+++ b/src/script/calling/CallingRepository.test.ts
@@ -96,6 +96,7 @@ describe('CallingRepository', () => {
   afterEach(() => {
     callingRepository['callState'].calls([]);
     callingRepository['conversationState'].conversations([]);
+    callingRepository.destroy();
     jest.clearAllMocks();
   });
 
@@ -105,7 +106,7 @@ describe('CallingRepository', () => {
 
   describe('startCall', () => {
     it.each([ConversationProtocol.PROTEUS, ConversationProtocol.MLS])(
-      'starts a normal call in a 1:1 conversation for proteus or MLS conversation',
+      'starts a ONEONONE call for proteus or MLS 1:1 conversation',
       async protocol => {
         const conversation = createConversation(CONVERSATION_TYPE.ONE_TO_ONE, protocol);
         const callType = CALL_TYPE.NORMAL;
@@ -153,6 +154,22 @@ describe('CallingRepository', () => {
         expect.any(Function),
       );
     });
+
+    it('does not subscribe to epoch updates after initiating a call in 1:1 mls conversation', async () => {
+      const conversationId = {domain: 'example.com', id: 'conversation1'};
+
+      const groupId = 'groupId';
+      const mlsConversation = createConversation(
+        CONVERSATION_TYPE.ONE_TO_ONE,
+        ConversationProtocol.MLS,
+        conversationId,
+        groupId,
+      );
+
+      await callingRepository.startCall(mlsConversation, CALL_TYPE.NORMAL);
+
+      expect(container.resolve(Core).service?.subconversation.subscribeToEpochUpdates).not.toHaveBeenCalled();
+    });
   });
 
   describe('answerCall', () => {
@@ -191,6 +208,38 @@ describe('CallingRepository', () => {
         expect.any(Function),
         expect.any(Function),
       );
+    });
+
+    it('does not subscribe to epoch updates after answering a call in mls 1:1 conversation', async () => {
+      const conversationId = {domain: 'example.com', id: 'conversation2'};
+      const selfParticipant = createSelfParticipant();
+      const userId = {domain: '', id: ''};
+
+      const groupId = 'groupId';
+      const mlsConversation = createConversation(
+        CONVERSATION_TYPE.ONE_TO_ONE,
+        ConversationProtocol.MLS,
+        conversationId,
+        groupId,
+      );
+
+      const incomingCall = new Call(
+        userId,
+        mlsConversation.qualifiedId,
+        CONV_TYPE.ONEONONE,
+        selfParticipant,
+        CALL_TYPE.NORMAL,
+        {
+          currentAvailableDeviceId: mediaDevices,
+        } as unknown as MediaDevicesHandler,
+      );
+
+      jest.spyOn(callingRepository, 'pushClients').mockResolvedValueOnce(true);
+      callingRepository['conversationState'].conversations.push(mlsConversation);
+
+      await callingRepository.answerCall(incomingCall);
+
+      expect(container.resolve(Core).service?.subconversation.subscribeToEpochUpdates).not.toHaveBeenCalled();
     });
   });
 

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -1211,12 +1211,12 @@ export class CallingRepository {
     const content = typeof payload === 'string' ? payload : JSON.stringify(payload);
 
     /**
-     * @note If myClientsOnly option is true, the message should be sent via the self-conversation.
+     * @note If myClientsOnly option is true, the message should be sent via the mls self-conversation.
      * This message is used to tell your other clients you have answered or
      * rejected a call and to stop ringing.
      */
     if (typeof payload === 'string' && isMLSConversation(conversation) && myClientsOnly) {
-      return void this.messageRepository.sendSelfCallingMessage(payload, conversation.qualifiedId);
+      return void this.messageRepository.sendCallingMessageToSelfMLSConversation(payload, conversation.qualifiedId);
     }
 
     const message = await this.messageRepository.sendCallingMessage(conversation, content, options);

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -68,7 +68,7 @@ import {ClientId, Participant, UserId} from './Participant';
 
 import {PrimaryModal} from '../components/Modals/PrimaryModal';
 import {Config} from '../Config';
-import {isMLSConversation, MLSConversation} from '../conversation/ConversationSelectors';
+import {isGroupMLSConversation, isMLSConversation, MLSConversation} from '../conversation/ConversationSelectors';
 import {ConversationState} from '../conversation/ConversationState';
 import {CallingEvent, EventBuilder} from '../conversation/EventBuilder';
 import {CONSENT_TYPE, MessageRepository, MessageSendingOptions} from '../conversation/MessageRepository';
@@ -343,7 +343,7 @@ export class CallingRepository {
     }
     const allClients = await this.core.service!.conversation.fetchAllParticipantsClients(call.conversationId);
 
-    if (!isMLSConversation(conversation)) {
+    if (!isGroupMLSConversation(conversation)) {
       const qualifiedClients = flattenUserMap(allClients);
 
       const clients: Clients = flatten(
@@ -663,7 +663,7 @@ export class CallingRepository {
       this.serializeQualifiedId(conversationId),
       this.serializeQualifiedId(userId),
       conversation && isMLSConversation(conversation) ? senderClientId : clientId,
-      conversation && isMLSConversation(conversation) ? CONV_TYPE.CONFERENCE_MLS : CONV_TYPE.CONFERENCE,
+      conversation && isGroupMLSConversation(conversation) ? CONV_TYPE.CONFERENCE_MLS : CONV_TYPE.CONFERENCE,
     );
 
     if (res !== 0) {
@@ -687,7 +687,7 @@ export class CallingRepository {
       return CONV_TYPE.ONEONONE;
     }
 
-    if (isMLSConversation(conversation)) {
+    if (isGroupMLSConversation(conversation)) {
       return CONV_TYPE.CONFERENCE_MLS;
     }
     return this.supportsConferenceCalling ? CONV_TYPE.CONFERENCE : CONV_TYPE.GROUP;
@@ -747,7 +747,7 @@ export class CallingRepository {
         this.removeCall(call);
       }
 
-      if (isMLSConversation(conversation)) {
+      if (isGroupMLSConversation(conversation)) {
         await this.joinMlsConferenceSubconversation(conversation);
       }
 
@@ -855,7 +855,7 @@ export class CallingRepository {
 
       const conversation = this.getConversationById(call.conversationId);
 
-      if (!conversation || !isMLSConversation(conversation)) {
+      if (!conversation || !isGroupMLSConversation(conversation)) {
         return;
       }
 
@@ -890,7 +890,7 @@ export class CallingRepository {
 
   private readonly updateConferenceSubconversationEpoch = async (conversationId: QualifiedId) => {
     const conversation = this.getConversationById(conversationId);
-    if (!conversation || !isMLSConversation(conversation)) {
+    if (!conversation || !isGroupMLSConversation(conversation)) {
       return;
     }
 
@@ -909,7 +909,7 @@ export class CallingRepository {
 
   private readonly handleCallParticipantChange = (conversationId: QualifiedId, members: QualifiedWcallMember[]) => {
     const conversation = this.getConversationById(conversationId);
-    if (!conversation || !isMLSConversation(conversation)) {
+    if (!conversation || !isGroupMLSConversation(conversation)) {
       return;
     }
 

--- a/src/script/conversation/ConversationSelectors.ts
+++ b/src/script/conversation/ConversationSelectors.ts
@@ -45,6 +45,10 @@ export function isMLSCapableConversation(conversation: Conversation): conversati
   return isMixedConversation(conversation) || isMLSConversation(conversation);
 }
 
+export function isGroupMLSConversation(conversation: Conversation): conversation is MLSConversation {
+  return isMLSConversation(conversation) && conversation.isGroup();
+}
+
 export function isSelfConversation(conversation: Conversation): boolean {
   return conversation.type() === CONVERSATION_TYPE.SELF;
 }

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -1356,11 +1356,11 @@ export class MessageRepository {
   }
 
   /**
-   * Sends a call message only to self conversation (eg. REJECT message that warn the user's other clients that the call has been picked up)
+   * Sends a call message only to self MLS conversation (eg. REJECT message that warn the user's other clients that the call has been picked up)
    * @param payload
    * @returns
    */
-  public sendSelfCallingMessage(payload: string, targetConversation: QualifiedId) {
+  public sendCallingMessageToSelfMLSConversation(payload: string, targetConversation: QualifiedId) {
     return this.sendCallingMessage(this.conversationState.getSelfMLSConversation(), {
       content: payload,
       qualifiedConversationId: targetConversation,


### PR DESCRIPTION
## Description

This PR ensures that client will not try to fetch/join MLS conference subconversations for 1:1 MLS conversation calls. Subconversations are only supported by regular group mls conversations. For 1:1 MLS conversations we should use the same type we do for proteus 1:1 conversations - ONEONONE (`0`). 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;