### PR TITLE
fix: prevent typing in conversation while in fullscreen call-ui (WPB-5044)

### DIFF
--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -31,7 +31,7 @@ import {ConversationClassifiedBar} from 'Components/input/ClassifiedBar';
 import {isMediaDevice} from 'src/script/guards/MediaDevice';
 import {MediaDeviceType} from 'src/script/media/MediaDeviceType';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
-import {KEY} from 'Util/KeyboardUtil';
+import {isEnterKey, KEY} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
 import {preventFocusOutside} from 'Util/util';
 
@@ -265,7 +265,9 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent): void => {
-      event.preventDefault();
+      if (!isEnterKey(event)) {
+        event.preventDefault();
+      }
       preventFocusOutside(event, 'video-calling');
     };
     document.addEventListener('keydown', onKeyDown);

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -265,6 +265,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent): void => {
+      event.preventDefault();
       preventFocusOutside(event, 'video-calling');
     };
     document.addEventListener('keydown', onKeyDown);

--- a/src/script/util/util.ts
+++ b/src/script/util/util.ts
@@ -267,7 +267,6 @@ const focusableElementsSelector =
 
 export const preventFocusOutside = (event: KeyboardEvent, parentId: string): void => {
   if (!isTabKey(event)) {
-    event.preventDefault();
     return;
   }
   event.preventDefault();

--- a/src/script/util/util.ts
+++ b/src/script/util/util.ts
@@ -267,6 +267,7 @@ const focusableElementsSelector =
 
 export const preventFocusOutside = (event: KeyboardEvent, parentId: string): void => {
   if (!isTabKey(event)) {
+    event.preventDefault();
     return;
   }
   event.preventDefault();


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5044" title="WPB-5044" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5044</a>  Typing while in fullscreen call remembers the last conversation you had opened
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

It was possible to type in the current conversation when in a fullscreen call.

The util that prevents focus outside off fullscreen does not call `preventDefault` when pressing a key other than tab.

Calling `preventDefault` before calling the `preventFocusOutside` util, excluding the enter key, prevents typing in fullscreen while allowing keyboard navigation (the `Tab` key is handled directly by `preventFocusOutside`)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

### Important details for the reviewers
