### PR TITLE
runfix: join mls groups one by one

### DIFF
--- a/src/script/backup/BackupRepository.test.ts
+++ b/src/script/backup/BackupRepository.test.ts
@@ -82,7 +82,7 @@ async function buildBackupRepository() {
 
   const backupService = new BackupService(storageService);
   const conversationRepository = {
-    init1To1Conversations: jest.fn(),
+    initAllLocal1To1Conversations: jest.fn(),
     getAllLocalConversations: jest.fn(),
     checkForDeletedConversations: jest.fn(),
     mapConnections: jest.fn().mockImplementation(() => []),

--- a/src/script/backup/BackupRepository.ts
+++ b/src/script/backup/BackupRepository.ts
@@ -18,7 +18,6 @@
  */
 
 import type Dexie from 'dexie';
-import {container} from 'tsyringe';
 import {omit} from 'underscore';
 
 import {chunk} from 'Util/ArrayUtil';
@@ -41,7 +40,6 @@ import {
 } from './Error';
 import {preprocessConversations, preprocessEvents, preprocessUsers} from './recordPreprocessors';
 
-import {ConnectionState} from '../connection/ConnectionState';
 import type {ConversationRepository} from '../conversation/ConversationRepository';
 import type {Conversation} from '../entity/Conversation';
 import {User} from '../entity/User';
@@ -91,11 +89,7 @@ export class BackupRepository {
   private canceled: boolean = false;
   private worker: WebWorker;
 
-  constructor(
-    backupService: BackupService,
-    conversationRepository: ConversationRepository,
-    private readonly connectionState = container.resolve(ConnectionState),
-  ) {
+  constructor(backupService: BackupService, conversationRepository: ConversationRepository) {
     this.logger = getLogger('BackupRepository');
 
     this.backupService = backupService;

--- a/src/script/backup/BackupRepository.ts
+++ b/src/script/backup/BackupRepository.ts
@@ -384,10 +384,7 @@ export class BackupRepository {
     }
 
     await this.conversationRepository.updateConversations(importedConversations);
-    await this.conversationRepository.init1To1Conversations(
-      this.connectionState.connections(),
-      this.conversationRepository.getAllLocalConversations(),
-    );
+    await this.conversationRepository.initAllLocal1To1Conversations();
     // doesn't need to be awaited
     void this.conversationRepository.checkForDeletedConversations();
   }

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -108,6 +108,7 @@ import {PrimaryModal} from '../components/Modals/PrimaryModal';
 import {Config} from '../Config';
 import {ConnectionEntity} from '../connection/ConnectionEntity';
 import {ConnectionRepository} from '../connection/ConnectionRepository';
+import {ConnectionState} from '../connection/ConnectionState';
 import {
   AssetAddEvent,
   ButtonActionConfirmationEvent,
@@ -198,6 +199,7 @@ export class ConversationRepository {
     private readonly userState = container.resolve(UserState),
     private readonly teamState = container.resolve(TeamState),
     private readonly conversationState = container.resolve(ConversationState),
+    private readonly connectionState = container.resolve(ConnectionState),
     private readonly core = container.resolve(Core),
   ) {
     this.eventService = eventRepository.eventService;
@@ -331,7 +333,7 @@ export class ConversationRepository {
 
     window.addEventListener<any>(WebAppEvents.CONVERSATION.JOIN, this.onConversationJoin);
 
-    this.selfRepository.on('selfSupportedProtocolsUpdated', this.onSelfUserSupportedProtocolsUpdated);
+    this.selfRepository.on('selfSupportedProtocolsUpdated', this.initAllLocal1To1Conversations);
     this.userRepository.on('supportedProtocolsUpdated', this.onUserSupportedProtocolsUpdated);
   }
 
@@ -1829,11 +1831,6 @@ export class ConversationRepository {
     );
   }
 
-  private readonly onSelfUserSupportedProtocolsUpdated = async () => {
-    const one2oneConversations = this.conversationState.conversations().filter(conversation => conversation.is1to1());
-    await Promise.allSettled(one2oneConversations.map(conversation => this.init1to1Conversation(conversation)));
-  };
-
   private readonly onUserSupportedProtocolsUpdated = async ({user}: {user: User}) => {
     // After user's supported protocols are updated, we want to make sure that 1:1 conversation is initialised.
     const localMLSConversation = this.conversationState.findMLS1to1Conversation(user.qualifiedId);
@@ -1856,7 +1853,14 @@ export class ConversationRepository {
   private async mapConnections(connections: ConnectionEntity[]): Promise<void> {
     this.logger.log(`Mapping '${connections.length}' user connection(s) to conversations`, connections);
     for (const connection of connections) {
-      await this.mapConnection(connection);
+      try {
+        await this.mapConnection(connection);
+      } catch (error) {
+        this.logger.error(
+          `Failed when mapping a connection with user ${connection.userId} to a conversation, error: `,
+          error,
+        );
+      }
     }
   }
 
@@ -1867,11 +1871,19 @@ export class ConversationRepository {
     await this.initTeam1To1Conversations(conversations);
   };
 
+  public readonly initAllLocal1To1Conversations = async () => {
+    return this.init1To1Conversations(this.connectionState.connections(), this.getAllLocalConversations());
+  };
+
   private readonly initTeam1To1Conversations = async (conversations: Conversation[]) => {
     const team1To1Conversations = conversations.filter(conversation => conversation.isTeam1to1());
 
     for (const conversation of team1To1Conversations) {
-      await this.init1to1Conversation(conversation);
+      try {
+        await this.init1to1Conversation(conversation);
+      } catch (error) {
+        this.logger.error(`Failed when initialising 1:1 conversation with id ${conversation.id}, error: `, error);
+      }
     }
   };
 

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1851,23 +1851,28 @@ export class ConversationRepository {
 
   /**
    * Maps user connections to the corresponding conversations.
-   * @param connectionEntities Connections entities
+   * @param connections Connections entities
    */
-  mapConnections(connectionEntities: ConnectionEntity[]): Promise<Conversation | undefined>[] {
-    this.logger.log(`Mapping '${connectionEntities.length}' user connection(s) to conversations`, connectionEntities);
-    return connectionEntities.map(connectionEntity => this.mapConnection(connectionEntity));
+  private async mapConnections(connections: ConnectionEntity[]): Promise<void> {
+    this.logger.log(`Mapping '${connections.length}' user connection(s) to conversations`, connections);
+    for (const connection of connections) {
+      await this.mapConnection(connection);
+    }
   }
 
   public readonly init1To1Conversations = async (connections: ConnectionEntity[], conversations: Conversation[]) => {
     if (connections.length) {
-      await Promise.allSettled(this.mapConnections(connections));
+      await this.mapConnections(connections);
     }
     await this.initTeam1To1Conversations(conversations);
   };
 
   private readonly initTeam1To1Conversations = async (conversations: Conversation[]) => {
     const team1To1Conversations = conversations.filter(conversation => conversation.isTeam1to1());
-    await Promise.allSettled(team1To1Conversations.map(conversation => this.init1to1Conversation(conversation)));
+
+    for (const conversation of team1To1Conversations) {
+      await this.init1to1Conversation(conversation);
+    }
   };
 
   /**

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -466,10 +466,16 @@ export class App {
           conversations,
           core: this.core,
           onSuccess: conversationRepository.injectJoinedAfterMigrationFinalisationMessage,
+          onError: ({id}, error) =>
+            this.logger.error(`Failed when joining a migrated mls conversation with id ${id}, error: `, error),
         });
 
         //join all the mls groups we're member of and have not yet joined (eg. we were not send welcome message)
-        await initMLSConversations(conversations, this.core);
+        await initMLSConversations(conversations, {
+          core: this.core,
+          onError: ({id}, error) =>
+            this.logger.error(`Failed when initialising mls conversation with id ${id}, error: `, error),
+        });
       }
 
       telemetry.timeStep(AppInitTimingsStep.UPDATED_FROM_NOTIFICATIONS);

--- a/src/script/mls/MLSConversations.test.ts
+++ b/src/script/mls/MLSConversations.test.ts
@@ -54,7 +54,7 @@ describe('MLSConversations', () => {
       jest.spyOn(core.service!.conversation, 'mlsGroupExistsLocally').mockResolvedValue(false);
       jest.spyOn(core.service!.conversation, 'joinByExternalCommit');
 
-      await initMLSConversations(mlsConversations, core);
+      await initMLSConversations(mlsConversations, {core});
 
       for (const conversation of mlsConversations) {
         expect(core.service?.conversation.joinByExternalCommit).toHaveBeenCalledWith(conversation.qualifiedId);
@@ -71,7 +71,7 @@ describe('MLSConversations', () => {
     jest.spyOn(core.service!.conversation!, 'mlsGroupExistsLocally').mockResolvedValue(true);
     jest.spyOn(core.service!.mls!, 'scheduleKeyMaterialRenewal');
 
-    await initMLSConversations(mlsConversations, core);
+    await initMLSConversations(mlsConversations, {core});
 
     for (const conversation of mlsConversations) {
       expect(core.service!.mls!.scheduleKeyMaterialRenewal).toHaveBeenCalledWith(conversation.groupId);

--- a/src/script/mls/MLSMigration/migrationFinaliser/joinConversationsAfterMigrationFinalisation/joinConversationsAfterMigrationFinalisation.ts
+++ b/src/script/mls/MLSMigration/migrationFinaliser/joinConversationsAfterMigrationFinalisation/joinConversationsAfterMigrationFinalisation.ts
@@ -34,12 +34,14 @@ import {initMLSConversations} from 'src/script/mls/MLSConversations';
  */
 export const joinConversationsAfterMigrationFinalisation = async ({
   conversations,
-  onSuccess,
   core,
+  onSuccess,
+  onError,
 }: {
   conversations: Conversation[];
-  onSuccess: (conversation: Conversation) => void;
   core: Account;
+  onSuccess: (conversation: Conversation) => void;
+  onError?: (conversation: Conversation, error: unknown) => void;
 }) => {
   //we filter out the conversations that are known by the clients (saved in the db) before being refetch from the backend
   //if such conversations were previously using proteus, and now are using MLS,
@@ -47,7 +49,7 @@ export const joinConversationsAfterMigrationFinalisation = async ({
   //we have to join the conversation with external commit and let user know that they might have missed some messages
   const alreadyMigratedConversations = filterGroupConversationsAlreadyMigratedToMLS(conversations);
 
-  await initMLSConversations(alreadyMigratedConversations, core, onSuccess);
+  await initMLSConversations(alreadyMigratedConversations, {core, onSuccessfulJoin: onSuccess, onError});
 };
 
 const filterGroupConversationsAlreadyMigratedToMLS = (conversations: Conversation[]) => {

--- a/src/script/mls/MLSMigration/migrationInitialiser/joinUnestablishedMixedConversations/joinUnestablishedMixedConversations.ts
+++ b/src/script/mls/MLSMigration/migrationInitialiser/joinUnestablishedMixedConversations/joinUnestablishedMixedConversations.ts
@@ -36,5 +36,9 @@ export const joinUnestablishedMixedConversations = async (
   const mixedConversations = conversations.filter(isMixedConversation);
   mlsMigrationLogger.info(`Found ${mixedConversations.length} "mixed" conversations, joining unestablished ones...`);
 
-  await initMLSConversations(mixedConversations, core);
+  await initMLSConversations(mixedConversations, {
+    core,
+    onError: ({id}, error) =>
+      mlsMigrationLogger.error(`Failed when joining a mls group of mixed conversation with id ${id}, error: `, error),
+  });
 };

--- a/test/helper/TestFactory.js
+++ b/test/helper/TestFactory.js
@@ -287,6 +287,7 @@ export class TestFactory {
       this.user_repository['userState'],
       this.team_repository['teamState'],
       conversationState,
+      this.connection_repository['connectionState'],
       core,
     );
 


### PR DESCRIPTION
## Description

Some initial bits of preventing 420 errors (too many requests) from backend. Instead of trying to join all mls groups at once, we join the one by one. Next step will be to add exponential backoff algorithm to api requests that are being used when joining with external commit (`GET: /groupinfo` and `POST: /commit-bundles`).

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;