### PR TITLE
runfix: allow keyboard navigation in full screen device select (WPB-6075)

### DIFF
--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -546,9 +546,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                             // eslint-disable-next-line jsx-a11y/no-autofocus
                             autoFocus
                             value={selectedVideoOptions}
-                            onChange={selectedOption => {
-                              updateVideoOptions(String(selectedOption?.value));
-                            }}
+                            onChange={selectedOption => updateVideoOptions(String(selectedOption?.value))}
                             id="select-camera"
                             dataUieName="select-camera"
                             controlShouldRenderValue={false}

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -465,6 +465,9 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                     {audioOptionsOpen ? (
                       <>
                         <Select
+                          // eslint-disable-next-line jsx-a11y/no-autofocus
+                          autoFocus
+                          onBlur={() => setAudioOptionsOpen(false)}
                           value={selectedAudioOptions}
                           id="select-microphone"
                           dataUieName="select-microphone"
@@ -478,6 +481,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                               String(selectedOption?.value),
                               String(selectedOption?.value).includes('input'),
                             );
+                            setAudioOptionsOpen(false);
                           }}
                           menuPlacement="top"
                           menuIsOpen
@@ -533,8 +537,14 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                       {videoOptionsOpen ? (
                         <>
                           <Select
+                            // eslint-disable-next-line jsx-a11y/no-autofocus
+                            autoFocus
+                            onBlur={() => setVideoOptionsOpen(false)}
                             value={selectedVideoOptions}
-                            onChange={selectedOption => updateVideoOptions(String(selectedOption?.value))}
+                            onChange={selectedOption => {
+                              updateVideoOptions(String(selectedOption?.value));
+                              setVideoOptionsOpen(false);
+                            }}
                             id="select-camera"
                             dataUieName="select-camera"
                             controlShouldRenderValue={false}
@@ -564,8 +574,8 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                     !canShareScreen
                       ? videoControlDisabledStyles
                       : selfSharesScreen
-                        ? videoControlActiveStyles
-                        : videoControlInActiveStyles
+                      ? videoControlActiveStyles
+                      : videoControlInActiveStyles
                   }
                   onClick={() => toggleScreenshare(call)}
                   type="button"

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -206,6 +206,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
     setSelectedAudioOptions([microphone, speaker]);
     switchMicrophoneInput(microphone.id);
     switchSpeakerOutput(speaker.id);
+    setAudioOptionsOpen(false);
   };
 
   const videoOptions = [
@@ -238,6 +239,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
     const camera = videoOptions[0].options.find(item => item.value === selectedOption) ?? selectedVideoOptions[0];
     setSelectedVideoOptions([camera]);
     switchCameraInput(camera.id);
+    setVideoOptionsOpen(false);
   };
 
   const unreadMessagesCount = useAppState(state => state.unreadMessagesCount);
@@ -453,8 +455,11 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                   <button
                     className="device-toggle-button"
                     css={audioOptionsOpen ? videoControlActiveStyles : videoControlInActiveStyles}
-                    onClick={() => {
-                      setAudioOptionsOpen(prev => !prev);
+                    onClick={event => {
+                      const target = event.target as Element;
+                      if (!target.closest('#select-microphone')) {
+                        setAudioOptionsOpen(prev => !prev);
+                      }
                     }}
                     onBlur={event => {
                       if (!event.currentTarget.contains(event.relatedTarget)) {
@@ -467,7 +472,6 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                         <Select
                           // eslint-disable-next-line jsx-a11y/no-autofocus
                           autoFocus
-                          onBlur={() => setAudioOptionsOpen(false)}
                           value={selectedAudioOptions}
                           id="select-microphone"
                           dataUieName="select-microphone"
@@ -481,7 +485,6 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                               String(selectedOption?.value),
                               String(selectedOption?.value).includes('input'),
                             );
-                            setAudioOptionsOpen(false);
                           }}
                           menuPlacement="top"
                           menuIsOpen
@@ -525,8 +528,11 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                     <button
                       className="device-toggle-button"
                       css={videoOptionsOpen ? videoControlActiveStyles : videoControlInActiveStyles}
-                      onClick={() => {
-                        setVideoOptionsOpen(prev => !prev);
+                      onClick={event => {
+                        const target = event.target as Element;
+                        if (!target.closest('#select-camera')) {
+                          setVideoOptionsOpen(prev => !prev);
+                        }
                       }}
                       onBlur={event => {
                         if (!event.currentTarget.contains(event.relatedTarget)) {
@@ -539,11 +545,9 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                           <Select
                             // eslint-disable-next-line jsx-a11y/no-autofocus
                             autoFocus
-                            onBlur={() => setVideoOptionsOpen(false)}
                             value={selectedVideoOptions}
                             onChange={selectedOption => {
                               updateVideoOptions(String(selectedOption?.value));
-                              setVideoOptionsOpen(false);
                             }}
                             id="select-camera"
                             dataUieName="select-camera"
@@ -574,8 +578,8 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                     !canShareScreen
                       ? videoControlDisabledStyles
                       : selfSharesScreen
-                      ? videoControlActiveStyles
-                      : videoControlInActiveStyles
+                        ? videoControlActiveStyles
+                        : videoControlInActiveStyles
                   }
                   onClick={() => toggleScreenshare(call)}
                   type="button"

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -457,6 +457,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                     css={audioOptionsOpen ? videoControlActiveStyles : videoControlInActiveStyles}
                     onClick={event => {
                       const target = event.target as Element;
+                      // We want to ensure to only toggling the menu open or closed when clicking the icon, not the select menu
                       if (!target.closest('#select-microphone')) {
                         setAudioOptionsOpen(prev => !prev);
                       }
@@ -530,6 +531,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                       css={videoOptionsOpen ? videoControlActiveStyles : videoControlInActiveStyles}
                       onClick={event => {
                         const target = event.target as Element;
+                        // We want to ensure to only toggling the menu open or closed when clicking the icon, not the select menu
                         if (!target.closest('#select-camera')) {
                           setVideoOptionsOpen(prev => !prev);
                         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6075" title="WPB-6075" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6075</a>  [Web] Cannot use keyboard navigation to select devices in call ui
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

Arrow navigation doesn't work to select a device in the new select in full screen calls

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
