### PR TITLE
runfix: Streamline how user info (name + availability + verification) is displayed [WPB-5702]

### DIFF
--- a/src/script/components/ParticipantItemContent/ParticipantItemContent.tsx
+++ b/src/script/components/ParticipantItemContent/ParticipantItemContent.tsx
@@ -19,8 +19,8 @@
 
 import React from 'react';
 
-import {AvailabilityState} from 'Components/AvailabilityState';
 import {Icon} from 'Components/Icon';
+import {UserInfo} from 'Components/UserInfo';
 import {User} from 'src/script/entity/User';
 import {ServiceEntity} from 'src/script/integration/ServiceEntity';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
@@ -72,15 +72,16 @@ export const ParticipantItemContent = ({
     <div css={wrapper}>
       <div css={contentText}>
         <div css={nameWrapper}>
-          {!isService && showAvailabilityState && selfInTeam ? (
-            <AvailabilityState
+          {!isService ? (
+            <UserInfo
               user={participant}
               css={[userName, userAvailability, ellipsis]}
               dataUieName="status-name"
               selfString={selfString}
+              showAvailability={showAvailabilityState && selfInTeam}
             >
               {!isSelectable && renderParticipantBadges?.(participant)}
-            </AvailabilityState>
+            </UserInfo>
           ) : (
             <>
               <div css={[userName, ellipsis]} data-uie-name="status-name">
@@ -88,8 +89,6 @@ export const ParticipantItemContent = ({
 
                 {selfString && <span css={selfIndicator}>{selfString}</span>}
               </div>
-
-              {!isSelectable && !isService && renderParticipantBadges?.(participant)}
             </>
           )}
         </div>

--- a/src/script/components/UserInfo.test.tsx
+++ b/src/script/components/UserInfo.test.tsx
@@ -32,9 +32,10 @@ const defaultProps = {
   user,
   label: 'example',
   theme: false,
+  showAvailability: true,
 };
 
-describe('AvailabilityState', () => {
+describe('UserInfo', () => {
   it('renders available icon', async () => {
     user.availability(Availability.Type.AVAILABLE);
     const {getByTestId} = render(<UserInfo {...defaultProps} />);
@@ -59,5 +60,13 @@ describe('AvailabilityState', () => {
 
     const statusAvailabilityIcon = getByTestId('status-availability-icon');
     expect(statusAvailabilityIcon.getAttribute('data-uie-value')).toEqual('busy');
+  });
+
+  it('does not show availability icon if param is false', async () => {
+    user.availability(Availability.Type.AVAILABLE);
+    const {queryByTestId} = render(<UserInfo {...defaultProps} showAvailability={false} />);
+
+    const statusAvailabilityIcon = queryByTestId('status-availability-icon');
+    expect(statusAvailabilityIcon).toBeNull();
   });
 });

--- a/src/script/components/UserInfo.test.tsx
+++ b/src/script/components/UserInfo.test.tsx
@@ -21,7 +21,7 @@ import {render} from '@testing-library/react';
 
 import {Availability} from '@wireapp/protocol-messaging';
 
-import {AvailabilityState} from './AvailabilityState';
+import {UserInfo} from './UserInfo';
 
 import {User} from '../entity/User';
 
@@ -31,14 +31,13 @@ const defaultProps = {
   dataUieName: 'example-data-uie',
   user,
   label: 'example',
-  showArrow: false,
   theme: false,
 };
 
 describe('AvailabilityState', () => {
   it('renders available icon', async () => {
     user.availability(Availability.Type.AVAILABLE);
-    const {getByTestId} = render(<AvailabilityState {...defaultProps} />);
+    const {getByTestId} = render(<UserInfo {...defaultProps} />);
 
     const statusAvailabilityIcon = getByTestId('status-availability-icon');
     expect(statusAvailabilityIcon.getAttribute('data-uie-value')).toEqual('available');
@@ -47,7 +46,7 @@ describe('AvailabilityState', () => {
   it('renders away icon', async () => {
     user.availability(Availability.Type.AWAY);
 
-    const {getByTestId} = render(<AvailabilityState {...defaultProps} />);
+    const {getByTestId} = render(<UserInfo {...defaultProps} />);
 
     const statusAvailabilityIcon = getByTestId('status-availability-icon');
     expect(statusAvailabilityIcon.getAttribute('data-uie-value')).toEqual('away');
@@ -56,24 +55,9 @@ describe('AvailabilityState', () => {
   it('renders busy icon', async () => {
     user.availability(Availability.Type.BUSY);
 
-    const {getByTestId} = render(<AvailabilityState {...defaultProps} />);
+    const {getByTestId} = render(<UserInfo {...defaultProps} />);
 
     const statusAvailabilityIcon = getByTestId('status-availability-icon');
     expect(statusAvailabilityIcon.getAttribute('data-uie-value')).toEqual('busy');
-  });
-
-  it('renders availability icon with arrow', async () => {
-    user.availability(Availability.Type.BUSY);
-    const props = {
-      ...defaultProps,
-      showArrow: true,
-    };
-
-    const {getByTestId} = render(<AvailabilityState {...props} />);
-
-    const statusAvailabilityIcon = getByTestId('status-availability-icon');
-    expect(statusAvailabilityIcon.getAttribute('data-uie-value')).toEqual('busy');
-
-    expect(getByTestId('availability-arrow')).not.toBeNull();
   });
 });

--- a/src/script/components/UserInfo.tsx
+++ b/src/script/components/UserInfo.tsx
@@ -60,15 +60,17 @@ const buttonCommonStyles: CSSObject = {
   textTransform: 'uppercase',
 };
 
-const iconBaseProps = {
+const availabilityIconBaseProps = {
   className: 'availability-state-icon',
   css: iconStyles,
   'data-uie-name': 'status-availability-icon',
 };
-const iconRenderer: Record<Availability.Type, () => ReactNode> = {
-  [Availability.Type.AVAILABLE]: () => <Icon.AvailabilityAvailable {...iconBaseProps} data-uie-value="available" />,
-  [Availability.Type.AWAY]: () => <Icon.AvailabilityAway {...iconBaseProps} data-uie-value="away" />,
-  [Availability.Type.BUSY]: () => <Icon.AvailabilityBusy {...iconBaseProps} data-uie-value="busy" />,
+const availabilityIconRenderer: Record<Availability.Type, () => ReactNode> = {
+  [Availability.Type.AVAILABLE]: () => (
+    <Icon.AvailabilityAvailable {...availabilityIconBaseProps} data-uie-value="available" />
+  ),
+  [Availability.Type.AWAY]: () => <Icon.AvailabilityAway {...availabilityIconBaseProps} data-uie-value="away" />,
+  [Availability.Type.BUSY]: () => <Icon.AvailabilityBusy {...availabilityIconBaseProps} data-uie-value="busy" />,
   [Availability.Type.NONE]: () => null,
 };
 
@@ -85,7 +87,7 @@ export const UserInfo: React.FC<AvailabilityStateProps> = ({
 }) => {
   const {availability, name} = useKoSubscribableChildren(user, ['availability', 'name']);
 
-  const renderAvailabilityIcon = (showAvailability && iconRenderer[availability]) || (() => null);
+  const renderAvailabilityIcon = showAvailability && availabilityIconRenderer[availability];
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
     const {key} = event;

--- a/src/script/components/UserInfo.tsx
+++ b/src/script/components/UserInfo.tsx
@@ -85,9 +85,10 @@ export const UserInfo: React.FC<AvailabilityStateProps> = ({
   onClick,
   children,
 }) => {
-  const {availability, name} = useKoSubscribableChildren(user, ['availability', 'name']);
+  const {availability: userAvailability, name} = useKoSubscribableChildren(user, ['availability', 'name']);
 
-  const renderAvailabilityIcon = showAvailability && availabilityIconRenderer[availability];
+  const availability = showAvailability ? userAvailability : Availability.Type.NONE;
+  const renderAvailabilityIcon = availabilityIconRenderer[availability];
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
     const {key} = event;

--- a/src/script/components/UserInfo.tsx
+++ b/src/script/components/UserInfo.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React from 'react';
+import React, {ReactNode} from 'react';
 
 import {CSSObject} from '@emotion/react';
 import cx from 'classnames';
@@ -30,6 +30,7 @@ import {CSS_SQUARE} from 'Util/CSSMixin';
 import {KEY} from 'Util/KeyboardUtil';
 
 import {Icon} from './Icon';
+import {UserName} from './UserName';
 
 import {User} from '../entity/User';
 
@@ -40,8 +41,8 @@ interface AvailabilityStateProps {
   selfString?: string;
   title?: string;
   onClick?: (event: React.MouseEvent | React.KeyboardEvent) => void;
-  showArrow?: boolean;
   theme?: boolean;
+  showAvailability?: boolean;
   children?: React.ReactNode;
 }
 
@@ -59,22 +60,32 @@ const buttonCommonStyles: CSSObject = {
   textTransform: 'uppercase',
 };
 
-export const AvailabilityState: React.FC<AvailabilityStateProps> = ({
+const iconBaseProps = {
+  className: 'availability-state-icon',
+  css: iconStyles,
+  'data-uie-name': 'status-availability-icon',
+};
+const iconRenderer: Record<Availability.Type, () => ReactNode> = {
+  [Availability.Type.AVAILABLE]: () => <Icon.AvailabilityAvailable {...iconBaseProps} data-uie-value="available" />,
+  [Availability.Type.AWAY]: () => <Icon.AvailabilityAway {...iconBaseProps} data-uie-value="away" />,
+  [Availability.Type.BUSY]: () => <Icon.AvailabilityBusy {...iconBaseProps} data-uie-value="busy" />,
+  [Availability.Type.NONE]: () => null,
+};
+
+export const UserInfo: React.FC<AvailabilityStateProps> = ({
   user,
   className,
   dataUieName,
   selfString,
   title,
-  showArrow = false,
   theme = false,
+  showAvailability,
   onClick,
   children,
 }) => {
-  const {availability, name: label} = useKoSubscribableChildren(user, ['availability', 'name']);
+  const {availability, name} = useKoSubscribableChildren(user, ['availability', 'name']);
 
-  const isAvailable = availability === Availability.Type.AVAILABLE;
-  const isAway = availability === Availability.Type.AWAY;
-  const isBusy = availability === Availability.Type.BUSY;
+  const renderAvailabilityIcon = (showAvailability && iconRenderer[availability]) || (() => null);
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
     const {key} = event;
@@ -95,69 +106,20 @@ export const AvailabilityState: React.FC<AvailabilityStateProps> = ({
 
   const content = (
     <span data-uie-name={dataUieName} css={{alignItems: 'center', display: 'flex', overflow: 'hidden'}}>
-      {isAvailable && (
-        <Icon.AvailabilityAvailable
-          className="availability-state-icon"
-          css={iconStyles}
-          data-uie-name="status-availability-icon"
-          data-uie-value="available"
-        />
-      )}
+      {renderAvailabilityIcon()}
 
-      {isAway && (
-        <Icon.AvailabilityAway
-          className="availability-state-icon"
-          css={iconStyles}
-          data-uie-name="status-availability-icon"
-          data-uie-value="away"
-        />
-      )}
-
-      {isBusy && (
-        <Icon.AvailabilityBusy
-          className="availability-state-icon"
-          css={iconStyles}
-          data-uie-name="status-availability-icon"
-          data-uie-value="busy"
-        />
-      )}
-
-      {label && (
-        <span
-          className={cx('availability-state-label', {'availability-state-label--active': theme})}
-          css={{userSelect: 'none'}}
-          data-uie-name="status-label"
-          title={title || label}
-        >
-          {label}
-        </span>
-      )}
+      <span
+        className={cx('availability-state-label', {'availability-state-label--active': theme})}
+        css={{userSelect: 'none'}}
+        data-uie-name="status-label"
+        title={title || name}
+      >
+        <UserName user={user} />
+      </span>
 
       {selfString && <span css={selfIndicator}>{selfString}</span>}
 
       {children}
-
-      {showArrow && (
-        <span
-          data-uie-name="availability-arrow"
-          css={{
-            '&::before': {
-              borderLeft: '4px solid transparent',
-              borderRight: '4px solid transparent',
-              borderTop: '4px solid currentColor',
-              content: "''",
-              height: 0,
-              width: 0,
-            },
-            alignItems: 'center',
-            display: 'inline-flex',
-            marginLeft: 4,
-            marginTop: 4,
-            paddingBottom: 4,
-            ...CSS_SQUARE(16),
-          }}
-        />
-      )}
     </span>
   );
 

--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantItemContent/CallParticipantItemContent.tsx
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantItemContent/CallParticipantItemContent.tsx
@@ -21,16 +21,14 @@ import React from 'react';
 
 import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 
-import {AvailabilityState} from 'Components/AvailabilityState';
 import {Icon} from 'Components/Icon';
+import {UserInfo} from 'Components/UserInfo';
 import {User} from 'src/script/entity/User';
-import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 import {capitalizeFirstChar} from 'Util/StringUtil';
 
 import {
   selfIndicator,
-  userName,
   userAvailability,
   ellipsis,
   nameWrapper,
@@ -56,20 +54,18 @@ export const CallParticipantItemContent = ({
   showContextMenu,
   onDropdownClick,
 }: CallParticipantItemContentProps) => {
-  const {name} = useKoSubscribableChildren(user, ['name']);
   const selfString = `(${capitalizeFirstChar(t('conversationYouNominative'))})`;
 
   return (
     <div css={wrapper}>
       <div css={contentText}>
         <div css={nameWrapper(isAudioEstablished)}>
-          {selfInTeam ? (
-            <AvailabilityState user={user} css={[userAvailability, ellipsis]} dataUieName="status-name" />
-          ) : (
-            <div css={[userName, ellipsis]} data-uie-name="status-name">
-              {name}
-            </div>
-          )}
+          <UserInfo
+            user={user}
+            css={[userAvailability, ellipsis]}
+            dataUieName="status-name"
+            showAvailability={selfInTeam}
+          />
 
           {isSelf && <div css={selfIndicator}>{selfString}</div>}
         </div>

--- a/src/script/components/list/ConversationListCell.tsx
+++ b/src/script/components/list/ConversationListCell.tsx
@@ -190,13 +190,19 @@ const ConversationListCell = ({
           </div>
 
           <div className="conversation-list-cell-center">
-            <UserInfo
-              className="conversation-list-cell-availability"
-              user={conversation.firstUserEntity()!}
-              theme={isActive}
-              dataUieName="status-availability-item"
-              showAvailability={is1to1 && !!selfUser?.teamId}
-            />
+            {is1to1 ? (
+              <UserInfo
+                className="conversation-list-cell-availability"
+                user={conversation.firstUserEntity()!}
+                theme={isActive}
+                dataUieName="status-availability-item"
+                showAvailability={is1to1 && !!selfUser?.teamId}
+              />
+            ) : (
+              <span className={cx('conversation-list-cell-name', {'conversation-list-cell-name--active': isActive})}>
+                {displayName}
+              </span>
+            )}
 
             <span
               className={cx('conversation-list-cell-description', {

--- a/src/script/components/list/ConversationListCell.tsx
+++ b/src/script/components/list/ConversationListCell.tsx
@@ -29,8 +29,8 @@ import React, {
 import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 import cx from 'classnames';
 
-import {AvailabilityState} from 'Components/AvailabilityState';
 import {Avatar, AVATAR_SIZE, GroupAvatar} from 'Components/Avatar';
+import {UserInfo} from 'Components/UserInfo';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {isKey, isOneOfKeys, KEY} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
@@ -190,18 +190,13 @@ const ConversationListCell = ({
           </div>
 
           <div className="conversation-list-cell-center">
-            {is1to1 && selfUser?.teamId ? (
-              <AvailabilityState
-                className="conversation-list-cell-availability"
-                user={conversation.firstUserEntity()!}
-                theme={isActive}
-                dataUieName="status-availability-item"
-              />
-            ) : (
-              <span className={cx('conversation-list-cell-name', {'conversation-list-cell-name--active': isActive})}>
-                {displayName}
-              </span>
-            )}
+            <UserInfo
+              className="conversation-list-cell-availability"
+              user={conversation.firstUserEntity()!}
+              theme={isActive}
+              dataUieName="status-availability-item"
+              showAvailability={is1to1 && !!selfUser?.teamId}
+            />
 
             <span
               className={cx('conversation-list-cell-description', {

--- a/src/script/components/panel/UserDetails.tsx
+++ b/src/script/components/panel/UserDetails.tsx
@@ -25,12 +25,11 @@ import {container} from 'tsyringe';
 
 import {WebAppEvents} from '@wireapp/webapp-events';
 
-import {AvailabilityState} from 'Components/AvailabilityState';
 import {Avatar, AVATAR_SIZE} from 'Components/Avatar';
 import {ErrorFallback} from 'Components/ErrorFallback';
 import {Icon} from 'Components/Icon';
 import {UserClassifiedBar} from 'Components/input/ClassifiedBar';
-import {UserName} from 'Components/UserName';
+import {UserInfo} from 'Components/UserInfo';
 import {TeamState} from 'src/script/team/TeamState';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
@@ -67,19 +66,14 @@ const UserDetailsComponent: React.FC<UserDetailsProps> = ({
   return (
     <div className="panel-participant">
       <div className="panel-participant__head">
-        {teamState.isInTeam(participant) ? (
-          <AvailabilityState className="panel-participant__head__name" user={participant} dataUieName="status-name">
-            {renderParticipantBadges?.(participant)}
-          </AvailabilityState>
-        ) : (
-          <h2
-            className="panel-participant__head__name"
-            data-uie-name="status-name"
-            css={user.isAvailable ? undefined : {color: 'var(--gray-70)'}}
-          >
-            <UserName user={participant} />
-          </h2>
-        )}
+        <UserInfo
+          className="panel-participant__head__name"
+          user={participant}
+          dataUieName="status-name"
+          showAvailability={teamState.isInTeam(participant)}
+        >
+          {renderParticipantBadges?.(participant)}
+        </UserInfo>
       </div>
 
       {participant.handle && (

--- a/src/script/entity/User/User.ts
+++ b/src/script/entity/User/User.ts
@@ -50,7 +50,7 @@ export class User {
   public providerId?: string;
   public readonly accent_color: ko.PureComputed<string>;
   public readonly accent_id: ko.Observable<number>;
-  public readonly availability: ko.Observable<Availability.Type>;
+  public readonly availability = ko.observable(Availability.Type.NONE);
   public readonly connection: ko.Observable<ConnectionEntity>;
   /** does not include current client/device */
   public readonly devices: ko.ObservableArray<ClientEntity>;
@@ -218,8 +218,6 @@ export class User {
       read: () => this.isMe && !this.isOnLegalHold() && _hasPendingLegalHold(),
       write: value => _hasPendingLegalHold(value),
     });
-
-    this.availability = ko.observable(Availability.Type.NONE);
 
     this.expirationRemaining = ko.observable(0);
     this.expirationText = ko.observable('');

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -26,10 +26,10 @@ import {container} from 'tsyringe';
 
 import {WebAppEvents} from '@wireapp/webapp-events';
 
-import {AvailabilityState} from 'Components/AvailabilityState';
 import {CallingCell} from 'Components/calling/CallingCell';
 import {Icon} from 'Components/Icon';
 import {LegalHoldDot} from 'Components/LegalHoldDot';
+import {UserInfo} from 'Components/UserInfo';
 import {UserVerificationBadges} from 'Components/VerificationBadge';
 import {ListState} from 'src/script/page/useAppState';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
@@ -183,9 +183,9 @@ const Conversations: React.FC<ConversationsProps> = ({
             css={{...(showLegalHold && {gridColumn: '2/3'})}}
             onClick={event => AvailabilityContextMenu.show(event.nativeEvent, 'left-list-availability-menu')}
           >
-            <AvailabilityState user={selfUser} className="availability-state" dataUieName="status-availability">
+            <UserInfo user={selfUser} className="availability-state" dataUieName="status-availability" showAvailability>
               <UserVerificationBadges user={selfUser} groupId={conversationState.selfMLSConversation()?.groupId} />
-            </AvailabilityState>
+            </UserInfo>
           </button>
 
           {showLegalHold && (


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5702" title="WPB-5702" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5702</a>  [Web] Verified device icon in conversation details disappears after page refresh
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

This will unify how we render user info (name + availability + verification state). 

Previously we had 2 ways of displaying user names:
- if in a team => use the `AvailabilityStatus` component
- if a public user => just display the name + verification badge

Now the `UserInfo` component takes care of everything 

<img width="253" alt="image" src="https://github.com/wireapp/wire-webapp/assets/1090716/2ac7ec41-49eb-4d27-b146-22748a1fe7c5">

![image](https://github.com/wireapp/wire-webapp/assets/1090716/45ad34e9-ce21-435a-bbf9-41abaee10bb3)


## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;
