### PR TITLE
chore: Use @wireapp/core to generate secret keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@peculiar/x509": "1.9.5",
     "@wireapp/avs": "9.5.2",
     "@wireapp/commons": "5.2.3",
-    "@wireapp/core": "42.25.2",
+    "@wireapp/core": "43.0.0",
     "@wireapp/react-ui-kit": "9.12.0",
     "@wireapp/store-engine-dexie": "2.1.6",
     "@wireapp/webapp-events": "0.18.3",

--- a/src/script/service/CoreSingleton.ts
+++ b/src/script/service/CoreSingleton.ts
@@ -65,9 +65,7 @@ export class Core extends Account {
   constructor(apiClient = container.resolve(APIClient)) {
     const enableCoreCrypto = supportsMLS() || Config.getConfig().FEATURE.USE_CORE_CRYPTO;
     super(apiClient, {
-      createStore: async storeName => {
-        return createStorageEngine(storeName, DatabaseTypes.PERMANENT);
-      },
+      createStore: storeName => createStorageEngine(storeName, DatabaseTypes.PERMANENT),
 
       coreCryptoConfig: enableCoreCrypto
         ? {

--- a/src/script/service/CoreSingleton.ts
+++ b/src/script/service/CoreSingleton.ts
@@ -17,11 +17,12 @@
  *
  */
 
+import {generateSecretKey as generateKey} from '@wireapp/core/lib/secretStore/secretKeyGenerator';
 import {container, singleton} from 'tsyringe';
 
 import {Account} from '@wireapp/core';
 
-import {supportsCoreCryptoProteus, supportsMLS} from 'Util/util';
+import {supportsMLS} from 'Util/util';
 
 import {APIClient} from './APIClientSingleton';
 import {createStorageEngine, DatabaseTypes} from './StoreEngineProvider';
@@ -45,33 +46,44 @@ declare global {
   }
 }
 
+const generateSecretKey = async (storeName: string, keyId: string, keySize: number) => {
+  return generateKey({
+    keyId,
+    keySize,
+    dbName: `secrets-${storeName}`,
+    /*
+     * When in an electron context, the window.systemCrypto will be populated by the renderer process.
+     * We then give those crypto primitives to the key generator that will use them to encrypt secrets.
+     * When in a browser context, then this systemCrypto will be undefined and the key generator will then use it's internal encryption system
+     */
+    systemCrypto: window.systemCrypto,
+  });
+};
+
 @singleton()
 export class Core extends Account {
   constructor(apiClient = container.resolve(APIClient)) {
+    const enableCoreCrypto = supportsMLS() || Config.getConfig().FEATURE.USE_CORE_CRYPTO;
     super(apiClient, {
-      createStore: (storeName, context) => {
+      createStore: async storeName => {
         return createStorageEngine(storeName, DatabaseTypes.PERMANENT);
       },
-      cryptoProtocolConfig: {
-        coreCrypoWasmFilePath: '/min/core-crypto.wasm',
-        mls: supportsMLS()
-          ? {
-              keyingMaterialUpdateThreshold: Config.getConfig().FEATURE.MLS_CONFIG_KEYING_MATERIAL_UPDATE_THRESHOLD,
-              defaultCiphersuite: Config.getConfig().FEATURE.MLS_CONFIG_DEFAULT_CIPHERSUITE,
-              useE2EI: isE2EIEnabled(),
-            }
-          : undefined,
 
-        proteus: supportsCoreCryptoProteus(),
-        /*
-         * When in an electron context, the window.systemCrypto will be populated by the renderer process.
-         * We then give those crypto primitives to the core that will use them when encrypting MLS secrets.
-         * When in a browser context, then this systemCrypto will be undefined and the core will then use it's internal encryption system
-         */
-        systemCrypto: window.systemCrypto,
+      coreCryptoConfig: enableCoreCrypto
+        ? {
+            wasmFilePath: '/min/core-crypto.wasm',
+            mls: supportsMLS()
+              ? {
+                  keyingMaterialUpdateThreshold: Config.getConfig().FEATURE.MLS_CONFIG_KEYING_MATERIAL_UPDATE_THRESHOLD,
+                  defaultCiphersuite: Config.getConfig().FEATURE.MLS_CONFIG_DEFAULT_CIPHERSUITE,
+                  useE2EI: isE2EIEnabled(),
+                }
+              : undefined,
 
-        useCoreCrypto: Config.getConfig().FEATURE.USE_CORE_CRYPTO,
-      },
+            generateSecretKey,
+          }
+        : undefined,
+
       nbPrekeys: 100,
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6202,9 +6202,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:42.25.2":
-  version: 42.25.2
-  resolution: "@wireapp/core@npm:42.25.2"
+"@wireapp/core@npm:43.0.0":
+  version: 43.0.0
+  resolution: "@wireapp/core@npm:43.0.0"
   dependencies:
     "@wireapp/api-client": ^26.6.0
     "@wireapp/commons": ^5.2.3
@@ -6224,7 +6224,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: f44a5c1eeea7e9c13c1a5bc01e19411229f8a1e067243927d604982eb910e0f6cd0489d38568301620e7b9604e68e0cc72fea8d9d0a125376fb556a8c0de6c68
+  checksum: 59a7fe9592d979fcea7acec8c161bc5b48df1db5b1c86034feeb525e8ba30e89c407e7bcfa62404115da6ca0fdf309c8265ef042bf46be86b735ed1515801aa6
   languageName: node
   linkType: hard
 
@@ -19268,7 +19268,7 @@ __metadata:
     "@wireapp/avs": 9.5.2
     "@wireapp/commons": 5.2.3
     "@wireapp/copy-config": 2.1.12
-    "@wireapp/core": 42.25.2
+    "@wireapp/core": 43.0.0
     "@wireapp/eslint-config": 3.0.4
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.12.0


### PR DESCRIPTION
## Description

Adapt the webapp to use the new key generator from `@wireapp/core` 
see https://github.com/wireapp/wire-web-packages/pull/5756

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

