### PR TITLE
runfix: Display verification state on user modal

### DIFF
--- a/src/script/components/Modals/UserModal/UserModal.tsx
+++ b/src/script/components/Modals/UserModal/UserModal.tsx
@@ -31,6 +31,7 @@ import {ModalComponent} from 'Components/ModalComponent';
 import {EnrichedFields} from 'Components/panel/EnrichedFields';
 import {UserActions} from 'Components/panel/UserActions';
 import {UserDetails} from 'Components/panel/UserDetails';
+import {UserVerificationBadges} from 'Components/VerificationBadge';
 import {getPrivacyUnverifiedUsersUrl} from 'src/script/externalRoute';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {handleKeyDown} from 'Util/KeyboardUtil';
@@ -205,7 +206,11 @@ const UserModal: React.FC<UserModalProps> = ({
         >
           {user && (
             <>
-              <UserDetails participant={user} classifiedDomains={classifiedDomains} />
+              <UserDetails
+                participant={user}
+                classifiedDomains={classifiedDomains}
+                renderParticipantBadges={participant => <UserVerificationBadges user={participant} />}
+              />
 
               <EnrichedFields user={user} showDomain={isFederated} />
 


### PR DESCRIPTION
## Description

Fix displaying the verification state on user modals

![image](https://github.com/wireapp/wire-webapp/assets/1090716/94576b8a-ec37-42a7-84d7-f7e8359fd0d0)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
