### PR TITLE
runfix: register mls verification state handler after fetching conversations

### DIFF
--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
@@ -26,7 +26,7 @@ import {E2EIVerificationMessageType} from 'src/script/message/E2EIVerificationMe
 import {Core} from 'src/script/service/CoreSingleton';
 import {Logger, getLogger} from 'Util/Logger';
 
-import {MLSConversation} from '../../ConversationSelectors';
+import {isMLSConversation, MLSConversation} from '../../ConversationSelectors';
 import {ConversationState} from '../../ConversationState';
 import {ConversationVerificationState} from '../../ConversationVerificationState';
 import {getConversationByGroupId, OnConversationE2EIVerificationStateChange} from '../shared';
@@ -91,6 +91,10 @@ class MLSConversationVerificationStateHandler {
     const conversation = getConversationByGroupId({conversationState: this.conversationState, groupId});
     if (!conversation) {
       this.logger.error(`Epoch changed but conversationEntity can't be found`);
+      return;
+    }
+
+    if (!isMLSConversation(conversation)) {
       return;
     }
 

--- a/src/script/conversation/ConversationVerificationStateHandler/shared/conversation/index.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/shared/conversation/index.ts
@@ -65,7 +65,7 @@ export const getConversationByGroupId = ({
   conversationState,
   groupId,
 }: GetConversationByGroupIdParams): MLSConversation | undefined => {
-  const conversation = conversationState.filteredConversations().find(conversation => conversation.groupId === groupId);
+  const conversation = conversationState.conversations().find(conversation => conversation.groupId === groupId);
   return conversation && isMLSConversation(conversation) ? conversation : undefined;
 };
 

--- a/src/script/conversation/ConversationVerificationStateHandler/shared/conversation/index.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/shared/conversation/index.ts
@@ -19,7 +19,7 @@
 
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 
-import {isMLSConversation, MLSConversation} from 'src/script/conversation/ConversationSelectors';
+import {isMLSCapableConversation, MLSCapableConversation} from 'src/script/conversation/ConversationSelectors';
 import {ConversationState} from 'src/script/conversation/ConversationState';
 import {ConversationVerificationState} from 'src/script/conversation/ConversationVerificationState';
 import {Conversation} from 'src/script/entity/Conversation';
@@ -64,9 +64,9 @@ interface GetConversationByGroupIdParams {
 export const getConversationByGroupId = ({
   conversationState,
   groupId,
-}: GetConversationByGroupIdParams): MLSConversation | undefined => {
+}: GetConversationByGroupIdParams): MLSCapableConversation | undefined => {
   const conversation = conversationState.conversations().find(conversation => conversation.groupId === groupId);
-  return conversation && isMLSConversation(conversation) ? conversation : undefined;
+  return conversation && isMLSCapableConversation(conversation) ? conversation : undefined;
 };
 
 /**

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -374,10 +374,6 @@ export class App {
         throw new ClientError(CLIENT_ERROR_TYPE.NO_VALID_CLIENT, 'Client has been deleted on backend');
       }
 
-      if (supportsMLS()) {
-        registerMLSConversationVerificationStateHandler(this.updateConversationE2EIVerificationState);
-      }
-
       this.core.on(CoreEvents.NEW_SESSION, ({userId, clientId}) => {
         const newClient = {class: ClientClassification.UNKNOWN, id: clientId};
         userRepository.addClientToUser(userId, newClient, true);
@@ -476,6 +472,8 @@ export class App {
           onError: ({id}, error) =>
             this.logger.error(`Failed when initialising mls conversation with id ${id}, error: `, error),
         });
+
+        registerMLSConversationVerificationStateHandler(this.updateConversationE2EIVerificationState);
       }
 
       telemetry.timeStep(AppInitTimingsStep.UPDATED_FROM_NOTIFICATIONS);

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -432,6 +432,7 @@ export class App {
       if (supportsMLS()) {
         //if mls is supported, we need to initialize the callbacks (they are used when decrypting messages)
         conversationRepository.initMLSConversationRecoveredListener();
+        registerMLSConversationVerificationStateHandler(this.updateConversationE2EIVerificationState);
       }
 
       onProgress(25, t('initReceivedUserData'));
@@ -472,8 +473,6 @@ export class App {
           onError: ({id}, error) =>
             this.logger.error(`Failed when initialising mls conversation with id ${id}, error: `, error),
         });
-
-        registerMLSConversationVerificationStateHandler(this.updateConversationE2EIVerificationState);
       }
 
       telemetry.timeStep(AppInitTimingsStep.UPDATED_FROM_NOTIFICATIONS);


### PR DESCRIPTION
## Description

Verification state handler should be initialised after fetching the conversation list from backend but before processing messages queue. We should also not use `filteredConversations` when trying to find mls group by its groupId since it filters out self mls conversation. There was an unexpected error statement because of that:

![Screenshot 2023-11-30 at 13 19 01](https://github.com/wireapp/wire-webapp/assets/45733298/1763347b-9cab-4bb2-bb70-4cfcdb4cda64)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
