### PR TITLE
runfix: Harmonize uie-names of verification badges

### DIFF
--- a/src/script/components/TitleBar/TitleBar.test.tsx
+++ b/src/script/components/TitleBar/TitleBar.test.tsx
@@ -202,11 +202,11 @@ describe('TitleBar', () => {
         verification_state: ko.observable<ConversationVerificationState>(state),
       });
 
-      const {container} = render(
+      const {queryByTestId} = render(
         withTheme(<TitleBar {...getDefaultProps(callingRepository, conversation)} selfUser={selfUser} />),
       );
 
-      const verifiedIcon = container.querySelector('[data-uie-name="conversation-title-bar-verified-icon"]');
+      const verifiedIcon = queryByTestId('proteus-conversations-verified');
       expect(verifiedIcon).toBeNull();
     },
   );
@@ -217,11 +217,11 @@ describe('TitleBar', () => {
       verification_state: ko.observable<ConversationVerificationState>(ConversationVerificationState.VERIFIED),
     });
 
-    const {container} = render(
+    const {getByTestId} = render(
       withTheme(<TitleBar {...getDefaultProps(callingRepository, conversation)} selfUser={selfUser} />),
     );
 
-    const verifiedIcon = container.querySelector('[data-uie-name="conversation-title-bar-verified-icon"]');
+    const verifiedIcon = getByTestId('proteus-conversation-verified');
     expect(verifiedIcon).not.toBeNull();
   });
 

--- a/src/script/components/VerificationBadge/VerificationBadges.test.tsx
+++ b/src/script/components/VerificationBadge/VerificationBadges.test.tsx
@@ -59,7 +59,7 @@ describe('VerificationBadges', () => {
     expect(E2EIdentityStatus.getAttribute('data-uie-value')).toEqual(MLSStatuses.EXPIRED);
   });
 
-  it('is expires soon', async () => {
+  it('is expiring soon', async () => {
     const {getByTestId} = render(
       withTheme(<VerificationBadges context="conversation" MLSStatus={MLSStatuses.EXPIRES_SOON} />),
     );

--- a/src/script/components/VerificationBadge/VerificationBadges.test.tsx
+++ b/src/script/components/VerificationBadge/VerificationBadges.test.tsx
@@ -26,35 +26,43 @@ import {VerificationBadges} from './VerificationBadges';
 
 describe('VerificationBadges', () => {
   it('is mls verified', async () => {
-    const {getByTestId} = render(withTheme(<VerificationBadges MLSStatus={MLSStatuses.VALID} />));
+    const {getByTestId} = render(
+      withTheme(<VerificationBadges context="conversation" MLSStatus={MLSStatuses.VALID} />),
+    );
 
     const E2EIdentityStatus = getByTestId('mls-status');
     expect(E2EIdentityStatus.getAttribute('data-uie-value')).toEqual(MLSStatuses.VALID);
   });
 
   it('is proteus verified', async () => {
-    const {getByTestId} = render(withTheme(<VerificationBadges isProteusVerified />));
+    const {getByTestId} = render(withTheme(<VerificationBadges context="conversation" isProteusVerified />));
 
     const E2EIdentityStatus = getByTestId('proteus-verified');
     expect(E2EIdentityStatus).not.toBeNull();
   });
 
   it('is not downloaded', async () => {
-    const {getByTestId} = render(withTheme(<VerificationBadges MLSStatus={MLSStatuses.NOT_DOWNLOADED} />));
+    const {getByTestId} = render(
+      withTheme(<VerificationBadges context="conversation" MLSStatus={MLSStatuses.NOT_DOWNLOADED} />),
+    );
 
     const E2EIdentityStatus = getByTestId('mls-status');
     expect(E2EIdentityStatus.getAttribute('data-uie-value')).toEqual(MLSStatuses.NOT_DOWNLOADED);
   });
 
   it('is expired', async () => {
-    const {getByTestId} = render(withTheme(<VerificationBadges MLSStatus={MLSStatuses.EXPIRED} />));
+    const {getByTestId} = render(
+      withTheme(<VerificationBadges context="conversation" MLSStatus={MLSStatuses.EXPIRED} />),
+    );
 
     const E2EIdentityStatus = getByTestId('mls-status');
     expect(E2EIdentityStatus.getAttribute('data-uie-value')).toEqual(MLSStatuses.EXPIRED);
   });
 
   it('is expires soon', async () => {
-    const {getByTestId} = render(withTheme(<VerificationBadges MLSStatus={MLSStatuses.EXPIRES_SOON} />));
+    const {getByTestId} = render(
+      withTheme(<VerificationBadges context="conversation" MLSStatus={MLSStatuses.EXPIRES_SOON} />),
+    );
 
     const E2EIdentityStatus = getByTestId('mls-status');
     expect(E2EIdentityStatus.getAttribute('data-uie-value')).toEqual(MLSStatuses.EXPIRES_SOON);

--- a/src/script/components/VerificationBadge/VerificationBadges.test.tsx
+++ b/src/script/components/VerificationBadge/VerificationBadges.test.tsx
@@ -30,7 +30,7 @@ describe('VerificationBadges', () => {
       withTheme(<VerificationBadges context="conversation" MLSStatus={MLSStatuses.VALID} />),
     );
 
-    const E2EIdentityStatus = getByTestId('mls-status');
+    const E2EIdentityStatus = getByTestId('mls-conversation-status');
     expect(E2EIdentityStatus.getAttribute('data-uie-value')).toEqual(MLSStatuses.VALID);
   });
 
@@ -46,7 +46,7 @@ describe('VerificationBadges', () => {
       withTheme(<VerificationBadges context="conversation" MLSStatus={MLSStatuses.NOT_DOWNLOADED} />),
     );
 
-    const E2EIdentityStatus = getByTestId('mls-status');
+    const E2EIdentityStatus = getByTestId('mls-conversation-status');
     expect(E2EIdentityStatus.getAttribute('data-uie-value')).toEqual(MLSStatuses.NOT_DOWNLOADED);
   });
 
@@ -55,7 +55,7 @@ describe('VerificationBadges', () => {
       withTheme(<VerificationBadges context="conversation" MLSStatus={MLSStatuses.EXPIRED} />),
     );
 
-    const E2EIdentityStatus = getByTestId('mls-status');
+    const E2EIdentityStatus = getByTestId('mls-conversation-status');
     expect(E2EIdentityStatus.getAttribute('data-uie-value')).toEqual(MLSStatuses.EXPIRED);
   });
 
@@ -64,7 +64,7 @@ describe('VerificationBadges', () => {
       withTheme(<VerificationBadges context="conversation" MLSStatus={MLSStatuses.EXPIRES_SOON} />),
     );
 
-    const E2EIdentityStatus = getByTestId('mls-status');
+    const E2EIdentityStatus = getByTestId('mls-conversation-status');
     expect(E2EIdentityStatus.getAttribute('data-uie-value')).toEqual(MLSStatuses.EXPIRES_SOON);
   });
 });

--- a/src/script/components/VerificationBadge/VerificationBadges.tsx
+++ b/src/script/components/VerificationBadge/VerificationBadges.tsx
@@ -100,15 +100,15 @@ type ConversationVerificationBadgeProps = {
   displayTitle?: boolean;
 };
 export const ConversationVerificationBadges = ({conversation, displayTitle}: ConversationVerificationBadgeProps) => {
-  const verificationState = useConversationVerificationState(conversation);
+  const {MLS, proteus} = useConversationVerificationState(conversation);
 
   return (
     <VerificationBadges
       context="conversation"
       conversationProtocol={conversation.protocol}
-      MLSStatus={verificationState.MLS}
+      MLSStatus={MLS}
       displayTitle={displayTitle}
-      isProteusVerified={verificationState.proteus === ConversationVerificationState.VERIFIED}
+      isProteusVerified={proteus === ConversationVerificationState.VERIFIED}
     />
   );
 };

--- a/src/script/components/VerificationBadge/VerificationBadges.tsx
+++ b/src/script/components/VerificationBadge/VerificationBadges.tsx
@@ -19,6 +19,7 @@
 
 import {CSSProperties} from 'react';
 
+import {CSSObject} from '@emotion/react';
 import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 
 import {
@@ -47,12 +48,12 @@ interface VerificationBadgesProps {
   context: VerificationBadgeContext;
 }
 
-const badgeWrapper: CSSProperties = {
+const badgeWrapper: CSSObject = {
   display: 'flex',
   alignItems: 'center',
 };
 
-const iconStyles: CSSProperties = {
+const iconStyles: CSSObject = {
   display: 'flex',
   alignItems: 'center',
 };
@@ -115,43 +116,34 @@ export const ConversationVerificationBadges = ({conversation, displayTitle}: Con
 const MLSVerificationBadge = ({context, MLSStatus}: {MLSStatus?: MLSStatuses; context: VerificationBadgeContext}) => {
   const mlsVerificationProps = {
     className: 'with-tooltip with-tooltip--external',
-    style: iconStyles,
+    css: iconStyles,
     'data-uie-name': `mls-${context}-status`,
+    'data-uie-value': MLSStatus,
   };
 
   switch (MLSStatus) {
     case MLSStatuses.VALID:
       return (
-        <span {...mlsVerificationProps} data-tooltip={t('E2EI.deviceVerified')} data-uie-value={MLSStatuses.VALID}>
+        <span {...mlsVerificationProps} data-tooltip={t('E2EI.deviceVerified')}>
           <MLSVerified />
         </span>
       );
     case MLSStatuses.NOT_DOWNLOADED:
-      <span
-        {...mlsVerificationProps}
-        data-tooltip={t('E2EI.certificateRevoked')}
-        data-uie-value={MLSStatuses.NOT_DOWNLOADED}
-      >
+      <span {...mlsVerificationProps} data-tooltip={t('E2EI.certificateRevoked')}>
         <CertificateRevoked />
       </span>;
     case MLSStatuses.EXPIRED:
       return (
-        <span
-          {...mlsVerificationProps}
-          data-tooltip={t('E2EI.certificateExpired')}
-          data-uie-value={MLSStatuses.EXPIRED}
-        >
+        <span {...mlsVerificationProps} data-tooltip={t('E2EI.certificateExpired')}>
           <CertificateExpiredIcon />
         </span>
       );
     case MLSStatuses.EXPIRES_SOON:
-      <span
-        {...mlsVerificationProps}
-        data-tooltip={t('E2EI.certificateExpiresSoon')}
-        data-uie-value={MLSStatuses.EXPIRES_SOON}
-      >
-        <ExpiresSoon />
-      </span>;
+      return (
+        <span {...mlsVerificationProps} data-tooltip={t('E2EI.certificateExpiresSoon')}>
+          <ExpiresSoon />
+        </span>
+      );
   }
   return null;
 };
@@ -178,22 +170,22 @@ export const VerificationBadges = ({
     : isProteusVerified;
 
   return (
-    <div className="conversation-badges" style={{display: 'flex', alignItems: 'center', gap: '6px'}}>
+    <div className="conversation-badges" css={{display: 'flex', alignItems: 'center', gap: '6px'}}>
       {showMLSBadge && (
-        <div style={badgeWrapper}>
+        <div css={badgeWrapper}>
           {displayTitle && <span style={title(true)}>{t('E2EI.verified')}</span>}
           <MLSVerificationBadge MLSStatus={MLSStatus} context={context} />
         </div>
       )}
 
       {showProteusBadge && (
-        <div style={badgeWrapper}>
+        <div css={badgeWrapper}>
           {displayTitle && <span style={title(false)}>{t('proteusVerifiedDetails')}</span>}
 
           <span
             className="with-tooltip with-tooltip--external"
             data-tooltip={t('proteusDeviceVerified')}
-            style={iconStyles}
+            css={iconStyles}
             data-uie-name="proteus-verified"
           >
             <ProteusVerified data-uie-name={`proteus-${context}-verified`} />

--- a/src/script/components/VerificationBadge/VerificationBadges.tsx
+++ b/src/script/components/VerificationBadge/VerificationBadges.tsx
@@ -116,7 +116,7 @@ const MLSVerificationBadge = ({context, MLSStatus}: {MLSStatus?: MLSStatuses; co
   const mlsVerificationProps = {
     className: 'with-tooltip with-tooltip--external',
     style: iconStyles,
-    'data-uie-name': 'mls-${context}-status',
+    'data-uie-name': `mls-${context}-status`,
   };
 
   switch (MLSStatus) {
@@ -128,10 +128,8 @@ const MLSVerificationBadge = ({context, MLSStatus}: {MLSStatus?: MLSStatuses; co
       );
     case MLSStatuses.NOT_DOWNLOADED:
       <span
-        className="with-tooltip with-tooltip--external"
+        {...mlsVerificationProps}
         data-tooltip={t('E2EI.certificateRevoked')}
-        style={iconStyles}
-        data-uie-name="mls-status"
         data-uie-value={MLSStatuses.NOT_DOWNLOADED}
       >
         <CertificateRevoked />

--- a/src/script/components/VerificationBadge/VerificationBadges.tsx
+++ b/src/script/components/VerificationBadge/VerificationBadges.tsx
@@ -113,18 +113,17 @@ export const ConversationVerificationBadges = ({conversation, displayTitle}: Con
 };
 
 const MLSVerificationBadge = ({context, MLSStatus}: {MLSStatus?: MLSStatuses; context: VerificationBadgeContext}) => {
-  const mlsVerificationUieName = `mls-${context}-verified`;
   const mlsVerificationProps = {
     className: 'with-tooltip with-tooltip--external',
     style: iconStyles,
-    'data-uie-name': 'mls-status',
+    'data-uie-name': 'mls-${context}-status',
   };
 
   switch (MLSStatus) {
     case MLSStatuses.VALID:
       return (
         <span {...mlsVerificationProps} data-tooltip={t('E2EI.deviceVerified')} data-uie-value={MLSStatuses.VALID}>
-          <MLSVerified data-uie-name={mlsVerificationUieName} />
+          <MLSVerified />
         </span>
       );
     case MLSStatuses.NOT_DOWNLOADED:
@@ -135,7 +134,7 @@ const MLSVerificationBadge = ({context, MLSStatus}: {MLSStatus?: MLSStatuses; co
         data-uie-name="mls-status"
         data-uie-value={MLSStatuses.NOT_DOWNLOADED}
       >
-        <CertificateRevoked data-uie-name={mlsVerificationUieName} />
+        <CertificateRevoked />
       </span>;
     case MLSStatuses.EXPIRED:
       return (
@@ -144,7 +143,7 @@ const MLSVerificationBadge = ({context, MLSStatus}: {MLSStatus?: MLSStatuses; co
           data-tooltip={t('E2EI.certificateExpired')}
           data-uie-value={MLSStatuses.EXPIRED}
         >
-          <CertificateExpiredIcon data-uie-name={mlsVerificationUieName} />
+          <CertificateExpiredIcon />
         </span>
       );
     case MLSStatuses.EXPIRES_SOON:
@@ -153,7 +152,7 @@ const MLSVerificationBadge = ({context, MLSStatus}: {MLSStatus?: MLSStatuses; co
         data-tooltip={t('E2EI.certificateExpiresSoon')}
         data-uie-value={MLSStatuses.EXPIRES_SOON}
       >
-        <ExpiresSoon data-uie-name={mlsVerificationUieName} />
+        <ExpiresSoon />
       </span>;
   }
   return null;

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.tsx
@@ -66,7 +66,7 @@ export const E2EICertificateDetails = ({identity, isCurrentDevice}: E2EICertific
           <strong css={styles.e2eiStatus(certificateState)}>{t(`E2EI.${certificateState}`)}</strong>
         </p>
 
-        <VerificationBadges MLSStatus={certificateState} />
+        <VerificationBadges MLSStatus={certificateState} context="device" />
       </div>
 
       <div css={styles.buttonsGroup}>

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/ProteusDeviceDetails.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/ProteusDeviceDetails.tsx
@@ -71,7 +71,7 @@ export const ProteusDeviceDetails = ({device, fingerprint, isProteusVerified}: P
             {isProteusVerified ? (
               <>
                 <span>{t('proteusVerified')}</span>
-                <VerificationBadges isProteusVerified />
+                <VerificationBadges isProteusVerified context="device" />
               </>
             ) : (
               <span>{t('proteusNotVerified')}</span>


### PR DESCRIPTION
## Description

will add `uie-names` to verification badges. 
The pattern of the uie-name will look like this 

```js
`proteus-${user | conversation | device}-verified`

`mls-${user | conversation | device}-status`
```

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
