### PR TITLE
runfix: Always show verification badge on user lists

### DIFF
--- a/src/script/components/ParticipantItemContent/ParticipantItemContent.tsx
+++ b/src/script/components/ParticipantItemContent/ParticipantItemContent.tsx
@@ -50,7 +50,6 @@ export interface ParticipantItemContentProps {
   showArrow?: boolean;
   onDropdownClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   showAvailabilityState?: boolean;
-  isSelectable?: boolean;
   isProteusVerified?: boolean;
   isMLSVerified?: boolean;
 }
@@ -64,7 +63,6 @@ export const ParticipantItemContent = ({
   hasUsernameInfo = false,
   showArrow = false,
   showAvailabilityState = false,
-  isSelectable = false,
 }: ParticipantItemContentProps) => {
   const {name} = useKoSubscribableChildren(participant, ['name']);
 
@@ -82,7 +80,7 @@ export const ParticipantItemContent = ({
               selfString={selfString}
               showAvailability={showAvailabilityState && selfInTeam}
             >
-              {!isSelectable && <UserVerificationBadges user={participant} groupId={groupId} />}
+              <UserVerificationBadges user={participant} groupId={groupId} />
             </UserInfo>
           ) : (
             <>

--- a/src/script/components/UserList/components/UserListItem/UserListItem.tsx
+++ b/src/script/components/UserList/components/UserListItem/UserListItem.tsx
@@ -54,10 +54,6 @@ export interface UserListItemProps {
   showArrow: boolean;
 }
 
-interface RenderParticipantProps {
-  isSelectable?: boolean;
-}
-
 export const UserListItem = ({
   groupId,
   canSelect,
@@ -110,7 +106,7 @@ export const UserListItem = ({
 
   const contentInfoText = getContentInfoText();
 
-  const RenderParticipant = ({isSelectable = false}: RenderParticipantProps) => {
+  const RenderParticipant = () => {
     return (
       <div css={listItem(noInteraction)} data-uie-name="item-user" data-uie-value={userName}>
         <Avatar avatarSize={AVATAR_SIZE.SMALL} participant={user} aria-hidden="true" css={{margin: '0 16px'}} />
@@ -123,7 +119,6 @@ export const UserListItem = ({
           {...(isSelf && {selfString})}
           hasUsernameInfo={hasUsernameInfo}
           showAvailabilityState
-          isSelectable={isSelectable}
         />
 
         <UserStatusBadges
@@ -159,7 +154,7 @@ export const UserListItem = ({
           >
             <CheckboxLabel htmlFor={checkboxId}>
               <div {...dataUieValues}>
-                <RenderParticipant isSelectable />
+                <RenderParticipant />
               </div>
             </CheckboxLabel>
           </Checkbox>


### PR DESCRIPTION
## Description

The `VerificationBadge` should not be conditioned anymore on the userList, we should always display it 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
