### PR TITLE
runfix: display error message for mls conversation creation with offline backend (WPB-3695)

### DIFF
--- a/src/script/components/MessagesList/Message/FailedToAddUsersMessage.test.tsx
+++ b/src/script/components/MessagesList/Message/FailedToAddUsersMessage.test.tsx
@@ -150,7 +150,7 @@ describe('FailedToAddUsersMessage', () => {
     const message = createFailedToAddUsersMessage({
       users: [qualifiedId1, qualifiedId2],
       reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS,
-      backends: ['test-2.domain'],
+      backends: ['test.domain', 'test-2.domain'],
     });
 
     const {getByText, getAllByText} = render(
@@ -171,7 +171,7 @@ describe('FailedToAddUsersMessage', () => {
     const details = getAllByText(
       (_, element) =>
         element?.textContent ===
-        'Arjita and Tom could not be added to the group as the backend of test-2.domain could not be reached.',
+        'Arjita and Tom could not be added to the group as the backend of test.domain, test-2.domain could not be reached.',
     );
 
     expect(details.length).toBeGreaterThanOrEqual(1);

--- a/src/script/components/MessagesList/Message/FailedToAddUsersMessage.tsx
+++ b/src/script/components/MessagesList/Message/FailedToAddUsersMessage.tsx
@@ -25,7 +25,7 @@ import {container} from 'tsyringe';
 import {Button, ButtonVariant, Link, LinkVariant} from '@wireapp/react-ui-kit';
 
 import {Icon} from 'Components/Icon';
-import {UserName} from 'Components/UserName';
+import {getUserName} from 'Components/UserName';
 import {Config} from 'src/script/Config';
 import {User} from 'src/script/entity/User';
 import {UserState} from 'src/script/user/UserState';
@@ -76,10 +76,10 @@ const MessageDetails = ({users, children, reason, domains}: MessageDetailsProps)
         css={warning}
         dangerouslySetInnerHTML={{
           __html: t(`${baseTranslationKey}${errorMessageType[reason]}`, {
-            name: UserName({user: users[0]}),
+            name: getUserName(users[0]),
             names: users
               .slice(1)
-              .map(user => UserName({user}))
+              .map(user => getUserName(user))
               .join(', '),
             domain: domainStr,
           }),

--- a/src/script/components/MessagesList/Message/FailedToAddUsersMessage.tsx
+++ b/src/script/components/MessagesList/Message/FailedToAddUsersMessage.tsx
@@ -61,7 +61,11 @@ const MessageDetails = ({users, children, reason, domains}: MessageDetailsProps)
   const baseTranslationKey =
     users.length === 1 ? 'failedToAddParticipantsSingularDetails' : 'failedToAddParticipantsPluralDetails';
 
-  const domainStr = domains.join(', ');
+  const getUsername = (name: string) => (name.length > 0 ? name : t('unavailableUser'));
+
+  const uniqueDomains = Array.from(new Set(domains));
+
+  const domainStr = uniqueDomains.join(', ');
 
   return (
     <p
@@ -73,10 +77,10 @@ const MessageDetails = ({users, children, reason, domains}: MessageDetailsProps)
         css={warning}
         dangerouslySetInnerHTML={{
           __html: t(`${baseTranslationKey}${errorMessageType[reason]}`, {
-            name: users[0].name(),
+            name: getUsername(users[0].name()),
             names: users
               .slice(1)
-              .map(user => user.name())
+              .map(user => getUsername(user.name()))
               .join(', '),
             domain: domainStr,
           }),
@@ -174,7 +178,7 @@ const FailedToAddUsersMessage: React.FC<FailedToAddUsersMessageProps> = ({
       </div>
       <div className="message-body" css={{flexDirection: 'column'}}>
         {isOpen && (
-          <MessageDetails users={users} reason={message.reason} domains={message.backends}>
+          <MessageDetails users={users} reason={message.reason} domains={users.map(user => user.domain)}>
             {learnMore}
           </MessageDetails>
         )}

--- a/src/script/components/MessagesList/Message/FailedToAddUsersMessage.tsx
+++ b/src/script/components/MessagesList/Message/FailedToAddUsersMessage.tsx
@@ -25,6 +25,7 @@ import {container} from 'tsyringe';
 import {Button, ButtonVariant, Link, LinkVariant} from '@wireapp/react-ui-kit';
 
 import {Icon} from 'Components/Icon';
+import {UserName} from 'Components/UserName';
 import {Config} from 'src/script/Config';
 import {User} from 'src/script/entity/User';
 import {UserState} from 'src/script/user/UserState';
@@ -61,8 +62,6 @@ const MessageDetails = ({users, children, reason, domains}: MessageDetailsProps)
   const baseTranslationKey =
     users.length === 1 ? 'failedToAddParticipantsSingularDetails' : 'failedToAddParticipantsPluralDetails';
 
-  const getUsername = (name: string) => (name.length > 0 ? name : t('unavailableUser'));
-
   const uniqueDomains = Array.from(new Set(domains));
 
   const domainStr = uniqueDomains.join(', ');
@@ -77,10 +76,10 @@ const MessageDetails = ({users, children, reason, domains}: MessageDetailsProps)
         css={warning}
         dangerouslySetInnerHTML={{
           __html: t(`${baseTranslationKey}${errorMessageType[reason]}`, {
-            name: getUsername(users[0].name()),
+            name: UserName({user: users[0]}),
             names: users
               .slice(1)
-              .map(user => getUsername(user.name()))
+              .map(user => UserName({user}))
               .join(', '),
             domain: domainStr,
           }),

--- a/src/script/components/UserName.tsx
+++ b/src/script/components/UserName.tsx
@@ -36,6 +36,14 @@ export function useUserName(user: User) {
 }
 
 /**
+ * same as above, but using the current value of isAvailable and name instead of the knockout subscribable
+ * @param user the user to get the name for
+ */
+export function getUserName(user: User) {
+  return user.isAvailable() ? user.name() : t('unavailableUser');
+}
+
+/**
  * component that will display the username, if available, otherwise a string indicating that the user is unavailable
  */
 export function UserName({user}: UserNameProps) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3695" title="WPB-3695" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-3695</a>  [Web] MLS Conversation creation when a participant is on a remote offline backend
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description
We handle errors during MLS conversation creation correctly but we do not get the name of the unreachable backends in the response
Additionally, we do not display anything if the username is not in memory anymore

## Screenshots/Screencast (for UI changes)
#### Before
![Screenshot from 2023-12-01 18-05-57](https://github.com/wireapp/wire-webapp/assets/78490891/0769261d-3829-4534-bc87-5bb9eb1ce3de)
![Screenshot from 2023-12-04 15-07-00](https://github.com/wireapp/wire-webapp/assets/78490891/02576386-8120-45ef-8e7a-7b6f41444895)

#### After
![image](https://github.com/wireapp/wire-webapp/assets/78490891/5e7a0ac9-7619-41ed-a0dd-92e1afaa97a3)
![image](https://github.com/wireapp/wire-webapp/assets/78490891/5ca94290-bcf3-4abc-9d9c-87630dc62633)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
