### PR TITLE
fix: Make sure device verification state is in sync with fingerprint

### DIFF
--- a/src/script/components/userDevices/DeviceDetails.tsx
+++ b/src/script/components/userDevices/DeviceDetails.tsx
@@ -153,7 +153,7 @@ export const DeviceDetails = ({
               type="checkbox"
               name="toggle"
               id="toggle"
-              defaultChecked={isVerified}
+              checked={isVerified}
               onChange={clickToToggleDeviceVerification}
             />
 


### PR DESCRIPTION
## Description

This PR will make sure we unverify a device if a session reset changes its fingerprint

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
