### PR TITLE
runfix: Avoid using localStorage before cookies have been checked

### DIFF
--- a/src/script/E2EIdentity/OIDCService/OIDCServiceStorage.ts
+++ b/src/script/E2EIdentity/OIDCService/OIDCServiceStorage.ts
@@ -29,11 +29,19 @@ const OIDCServiceStore = {
   },
   get: {
     clientData: (): OidcClientData => {
+      // MOCK: store targetURL and clientData in OIDCServiceStore
+      // TODO: remove this once we have a proper OIDC service
+      return {
+        id: 'wireapp',
+        secret: 'dUpVSGx2dVdFdGQ0dmsxWGhDalQ0SldU',
+      };
+      /*
       const clientData = localStorage.getItem(clientDataKey);
       if (!clientData) {
         throw new Error('No client data found in OIDCServiceStore');
       }
       return JSON.parse(clientData);
+      */
     },
     targetURL: () => localStorage.getItem(TargetURLKey),
   },

--- a/src/script/E2EIdentity/OIDCService/index.ts
+++ b/src/script/E2EIdentity/OIDCService/index.ts
@@ -20,13 +20,6 @@
 import {OIDCService} from './OIDCService';
 import {OIDCServiceStore} from './OIDCServiceStorage';
 
-// MOCK: store targetURL and clientData in OIDCServiceStore
-// TODO: remove this once we have a proper OIDC service
-OIDCServiceStore.store.clientData({
-  id: 'wireapp',
-  secret: 'dUpVSGx2dVdFdGQ0dmsxWGhDalQ0SldU',
-});
-
 // lots of hardcoded values here, but this is just for testing until we have a proper OIDC service
 export const getOIDCServiceInstance = (): OIDCService => {
   const targetURL = OIDCServiceStore.get.targetURL();


### PR DESCRIPTION
## Description

Avoids a crash when starting the app with cookies disabled

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
