### PR TITLE
runfix: Update self identity verification when enrollment is successful

### DIFF
--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -90,7 +90,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
     E2EIHandler.instance = null;
   }
 
-  public initialize({discoveryUrl, gracePeriodInSeconds}: E2EIHandlerParams): void {
+  public initialize({discoveryUrl, gracePeriodInSeconds}: E2EIHandlerParams) {
     if (isE2EIEnabled()) {
       if (!hasActiveCertificate()) {
         const gracePeriodInMs = gracePeriodInSeconds * TIME_IN_MILLIS.SECOND;
@@ -106,6 +106,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
         this.showE2EINotificationMessage();
       }
     }
+    return this;
   }
 
   private async storeRedirectTargetAndRedirect(targetURL: string): Promise<void> {
@@ -175,7 +176,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
       setTimeout(() => {
         removeCurrentModal();
       }, 0);
-      this.showErrorMessage();
+      await this.showErrorMessage();
     }
   }
 

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -19,6 +19,8 @@
 
 import {container} from 'tsyringe';
 
+import {TypedEventEmitter} from '@wireapp/commons';
+
 import {PrimaryModal, removeCurrentModal} from 'Components/Modals/PrimaryModal';
 import {Core} from 'src/script/service/CoreSingleton';
 import {UserState} from 'src/script/user/UserState';
@@ -45,25 +47,19 @@ interface E2EIHandlerParams {
   gracePeriodInSeconds: number;
 }
 
-export class E2EIHandler {
+type Events = {enrollmentSuccessful: void};
+
+type EnrollmentConfig = {
+  timer: DelayTimerService;
+  discoveryUrl: string;
+  gracePeriodInMs: number;
+};
+export class E2EIHandler extends TypedEventEmitter<Events> {
   private static instance: E2EIHandler | null = null;
   private readonly core = container.resolve(Core);
   private readonly userState = container.resolve(UserState);
-  private timer: DelayTimerService;
-  private discoveryUrl: string;
-  private gracePeriodInMS: number;
+  private config?: EnrollmentConfig;
   private currentStep: E2EIHandlerStep | null = E2EIHandlerStep.UNINITIALIZED;
-
-  private constructor({discoveryUrl, gracePeriodInSeconds}: E2EIHandlerParams) {
-    // ToDo: Do these values need to te able to be updated? Should we use a singleton with update fn?
-    this.discoveryUrl = discoveryUrl;
-    this.gracePeriodInMS = gracePeriodInSeconds * TIME_IN_MILLIS.SECOND;
-    this.timer = DelayTimerService.getInstance({
-      gracePeriodInMS: this.gracePeriodInMS,
-      gracePeriodExpiredCallback: () => null,
-      delayPeriodExpiredCallback: () => null,
-    });
-  }
 
   private get coreE2EIService() {
     const e2eiService = this.core.service?.e2eIdentity;
@@ -82,13 +78,8 @@ export class E2EIHandler {
    * @param params The params to create the grace period timer
    * @returns The singleton instance of GracePeriodTimer
    */
-  public static getInstance(params?: E2EIHandlerParams) {
-    if (!E2EIHandler.instance) {
-      if (!params) {
-        throw new Error('GracePeriodTimer is not initialized. Please call getInstance with params.');
-      }
-      E2EIHandler.instance = new E2EIHandler(params);
-    }
+  public static getInstance() {
+    E2EIHandler.instance = E2EIHandler.instance ?? new E2EIHandler();
     return E2EIHandler.instance;
   }
 
@@ -99,23 +90,19 @@ export class E2EIHandler {
     E2EIHandler.instance = null;
   }
 
-  /**
-   * @param E2EIHandlerParams The params to create the grace period timer
-   */
-  public updateParams({gracePeriodInSeconds, discoveryUrl}: E2EIHandlerParams) {
-    this.gracePeriodInMS = gracePeriodInSeconds * TIME_IN_MILLIS.SECOND;
-    this.discoveryUrl = discoveryUrl;
-    this.timer.updateParams({
-      gracePeriodInMS: this.gracePeriodInMS,
-      gracePeriodExpiredCallback: () => null,
-      delayPeriodExpiredCallback: () => null,
-    });
-    this.initialize();
-  }
-
-  public initialize(): void {
+  public initialize({discoveryUrl, gracePeriodInSeconds}: E2EIHandlerParams): void {
     if (isE2EIEnabled()) {
       if (!hasActiveCertificate()) {
+        const gracePeriodInMs = gracePeriodInSeconds * TIME_IN_MILLIS.SECOND;
+        this.config = {
+          discoveryUrl,
+          gracePeriodInMs,
+          timer: DelayTimerService.getInstance({
+            gracePeriodInMS: gracePeriodInMs,
+            gracePeriodExpiredCallback: () => null,
+            delayPeriodExpiredCallback: () => null,
+          }),
+        };
         this.showE2EINotificationMessage();
       }
     }
@@ -129,6 +116,9 @@ export class E2EIHandler {
   }
 
   public async enroll(refreshActiveCertificate: boolean = false) {
+    if (!this.config) {
+      throw new Error('Trying to enroll for E2EI without initializing the E2EIHandler');
+    }
     try {
       // Notify user about E2EI enrolment in progress
       this.currentStep = E2EIHandlerStep.ENROLL;
@@ -152,7 +142,7 @@ export class E2EIHandler {
         throw new Error('Username or handle not found');
       }
       const data = await this.core.enrollE2EI({
-        discoveryUrl: this.discoveryUrl,
+        discoveryUrl: this.config.discoveryUrl,
         displayName,
         handle,
         oAuthIdToken,
@@ -179,6 +169,7 @@ export class E2EIHandler {
       this.showSuccessMessage();
       // Remove the url parameters after enrolment
       removeUrlParameters();
+      this.emit('enrollmentSuccessful');
     } catch (error) {
       this.currentStep = E2EIHandlerStep.ERROR;
       setTimeout(() => {
@@ -256,8 +247,8 @@ export class E2EIHandler {
 
     // Only initialize the timer when the it is uninitialized
     if (this.currentStep === E2EIHandlerStep.UNINITIALIZED) {
-      this.timer.updateParams({
-        gracePeriodInMS: this.gracePeriodInMS,
+      this.config?.timer.updateParams({
+        gracePeriodInMS: this.config.gracePeriodInMs,
         gracePeriodExpiredCallback: () => {
           this.showE2EINotificationMessage();
         },
@@ -269,13 +260,13 @@ export class E2EIHandler {
     }
 
     // If the timer is not active, show the notification
-    if (!this.timer.isDelayTimerActive()) {
+    if (this.config && !this.config.timer.isDelayTimerActive()) {
       const {modalOptions, modalType} = getModalOptions({
-        hideSecondary: !this.timer.isSnoozeTimeAvailable(),
+        hideSecondary: !this.config.timer.isSnoozeTimeAvailable(),
         primaryActionFn: () => this.enroll(),
         secondaryActionFn: () => {
           this.currentStep = E2EIHandlerStep.SNOOZE;
-          this.timer.delayPrompt();
+          this.config?.timer.delayPrompt();
         },
         type: ModalType.ENROLL,
         hideClose: true,

--- a/src/script/page/components/FeatureConfigChange/FeatureConfigChangeHandler/Features/E2EIdentity.ts
+++ b/src/script/page/components/FeatureConfigChange/FeatureConfigChangeHandler/Features/E2EIdentity.ts
@@ -45,10 +45,9 @@ export const handleE2EIdentityFeatureChange = (logger: Logger, config: FeatureLi
       return;
     }
     // Either get the current E2EIdentity handler instance or create a new one
-    const e2eHandler = E2EIHandler.getInstance({
+    E2EIHandler.getInstance().initialize({
       discoveryUrl: e2eiConfig.config.acmeDiscoveryUrl!,
       gracePeriodInSeconds: e2eiConfig.config.verificationExpiration,
     });
-    e2eHandler.initialize();
   }
 };


### PR DESCRIPTION
## Description

This will allow the selfUser's verification state to be recomputed once the enrolment process is done


https://github.com/wireapp/wire-webapp/assets/1090716/e033d6ae-5732-4a24-8972-0ee130b0a84d


## Screenshots/Screencast (for UI changes)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
