### PR TITLE
runfix: Do not degrade conversation if it was not verified

### DIFF
--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.test.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.test.ts
@@ -75,6 +75,21 @@ describe('MLSConversationVerificationStateHandler', () => {
       expect(conversation.mlsVerificationState()).toBe(ConversationVerificationState.DEGRADED);
     });
 
+    it('should not degrade conversation if it is not verified', async () => {
+      let triggerEpochChange: Function = () => {};
+      conversation.mlsVerificationState(ConversationVerificationState.UNVERIFIED);
+      jest.spyOn(e2eIdentity, 'getConversationVerificationState').mockResolvedValue(E2eiConversationState.Degraded);
+      jest
+        .spyOn(core.service!.mls!, 'on')
+        .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
+
+      registerMLSConversationVerificationStateHandler(undefined, conversationState, core);
+
+      triggerEpochChange({groupId});
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(conversation.mlsVerificationState()).toBe(ConversationVerificationState.UNVERIFIED);
+    });
+
     it('should verify conversation', async () => {
       let triggerEpochChange: Function = () => {};
       conversation.mlsVerificationState(ConversationVerificationState.DEGRADED);

--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
@@ -102,7 +102,7 @@ class MLSConversationVerificationStateHandler {
 
     if (
       verificationState === E2eiConversationState.Degraded &&
-      conversation.mlsVerificationState() !== ConversationVerificationState.DEGRADED
+      conversation.mlsVerificationState() === ConversationVerificationState.VERIFIED
     ) {
       return this.degradeConversation(conversation);
     } else if (


### PR DESCRIPTION
## Description

Avoid triggering the `degradation` hooks when first initializing a new e2ei device. 

![image](https://github.com/wireapp/wire-webapp/assets/1090716/cc9ad18f-ca44-4ad0-9ef9-74cc81181858)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
