### PR TITLE
fix: Persist conversation when mls verification state is updated

### DIFF
--- a/src/script/conversation/ConversationMapper.ts
+++ b/src/script/conversation/ConversationMapper.ts
@@ -62,6 +62,7 @@ export interface SelfStatusUpdateDatabaseData {
   receipt_mode: number;
   status: number;
   verification_state: ConversationVerificationState;
+  mlsVerificationState: ConversationVerificationState;
 }
 
 type Roles = {[userId: string]: DefaultConversationRoleName | string};
@@ -131,6 +132,7 @@ export class ConversationMapper {
       receipt_mode,
       status,
       verification_state,
+      mlsVerificationState,
     } = selfState;
 
     if (archived_timestamp) {
@@ -177,6 +179,10 @@ export class ConversationMapper {
 
     if (verification_state !== undefined) {
       conversationEntity.verification_state(verification_state);
+    }
+
+    if (mlsVerificationState !== undefined) {
+      conversationEntity.mlsVerificationState(mlsVerificationState);
     }
 
     if (legal_hold_status) {

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -584,6 +584,7 @@ export class Conversation {
       this.status,
       this.type,
       this.verification_state,
+      this.mlsVerificationState,
     ].forEach(property => (property as ko.Observable).subscribe(this.persistState));
   }
 


### PR DESCRIPTION
## Description

This will ensure that verification state are persisted and loaded from the DB when the app is reloaded.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
