### PR TITLE
runfix: display error message for MLS offline message sending (WPB-3697)

### DIFF
--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -1224,7 +1224,11 @@ export class MessageRepository {
     try {
       const messageEntity = await this.getMessageInConversationById(conversationEntity, eventId);
       const errorStatus =
-        isBackendError(error) && error.label === BackendErrorLabel.FEDERATION_REMOTE_ERROR
+        isBackendError(error) &&
+        error.label ===
+          (BackendErrorLabel.FEDERATION_REMOTE_ERROR ||
+            BackendErrorLabel.FEDERATION_NOT_AVAILABLE ||
+            BackendErrorLabel.SERVER_ERROR)
           ? StatusType.FEDERATION_ERROR
           : StatusType.FAILED;
       messageEntity.status(errorStatus);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3697" title="WPB-3697" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-3697</a>  [Web] Sending MLS messages when a remote backend is offline
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description
Include all possible backend error labels when failing to send a message because of unreachable backend

## Screenshots/Screencast (for UI changes)
#### Before
![image](https://github.com/wireapp/wire-webapp/assets/78490891/58e03c8c-1174-440c-96ce-2070678c5e84)
#### After
![image](https://github.com/wireapp/wire-webapp/assets/78490891/c3789610-d0f1-41b4-9bff-b687b8404a05)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
