### PR TITLE
runfix: replace error with warning when conversation is not found

### DIFF
--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
@@ -90,7 +90,7 @@ class MLSConversationVerificationStateHandler {
   private checkConversationVerificationState = async ({groupId}: {groupId: string}): Promise<void> => {
     const conversation = getConversationByGroupId({conversationState: this.conversationState, groupId});
     if (!conversation) {
-      this.logger.error(`Epoch changed but conversationEntity can't be found`);
+      this.logger.warn(`Epoch changed but conversationEntity can't be found`);
       return;
     }
 


### PR DESCRIPTION
## Description

Replaces error log with a warning message when receiving `newEpoch` event from core but the conversation is not yet known by the webapp. It should fix the MLS automation (unexpected error statement will disappear from the console).

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
