### PR TITLE
runfix: Display emoji icons as style not text

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiChar.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiChar.tsx
@@ -28,10 +28,11 @@ export interface EmojiImgProps {
 }
 
 export const EmojiChar: FC<EmojiImgProps> = ({emoji: unicode, size, styles}) => {
-  const fontSize = size ? `${size}px` : 'var(--font-size-xsmall)';
-  return (
-    <span aria-hidden={true} css={{fontSize, ...styles}}>
-      {unicode}
-    </span>
-  );
+  const fontSize = size ? `${size}px` : 'var(--font-size-medium)';
+  const style = {
+    ':after': {
+      content: `'${unicode}'`,
+    },
+  };
+  return <span aria-hidden={true} css={{fontSize, ...style, ...styles}}></span>;
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactions.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactions.styles.ts
@@ -61,7 +61,7 @@ export const messageReactionButton: CSSObject = {
 };
 
 export const messageReactionButtonTooltip: CSSObject = {display: 'flex', maxWidth: 130, whiteSpace: 'break-spaces'};
-export const messageReactionButtonTooltipImage: CSSObject = {marginRight: 8};
+export const messageReactionButtonTooltipImage: CSSObject = {marginRight: 8, lineHeight: '2.5em'};
 export const messageReactionDetailsMargin: CSSObject = {marginRight: '0.4rem'};
 export const reactionsCountAlignment: CSSObject = {display: 'flex', alignItems: 'center'};
 export const messageReactionButtonTooltipText: CSSObject = {fontSize: '0.7rem'};


### PR DESCRIPTION
## Description

Will make the emoji icon part of the style and not the text content of the application

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
