### PR TITLE
runfix: Only subscribe to enrollment success for the selfUser

### DIFF
--- a/src/script/components/VerificationBadge/VerificationBadges.tsx
+++ b/src/script/components/VerificationBadge/VerificationBadges.tsx
@@ -74,8 +74,16 @@ const useConversationVerificationState = (conversation: Conversation) => {
   return {MLS: mlsState, proteus: proteusVerificationState};
 };
 
-export const UserVerificationBadges = ({user, groupId}: {user: User; groupId?: string}) => {
-  const {status: MLSStatus} = useUserIdentity(user.qualifiedId, groupId);
+export const UserVerificationBadges = ({
+  user,
+  groupId,
+  isSelfUser,
+}: {
+  user: User;
+  groupId?: string;
+  isSelfUser?: boolean;
+}) => {
+  const {status: MLSStatus} = useUserIdentity(user.qualifiedId, groupId, isSelfUser);
   const {is_verified: isProteusVerified} = useKoSubscribableChildren(user, ['is_verified']);
 
   return <VerificationBadges context="user" isProteusVerified={isProteusVerified} MLSStatus={MLSStatus} />;

--- a/src/script/hooks/useDeviceIdentities.ts
+++ b/src/script/hooks/useDeviceIdentities.ts
@@ -23,7 +23,7 @@ import {QualifiedId} from '@wireapp/api-client/lib/user';
 
 import {E2EIHandler, getUsersIdentities, isE2EIEnabled, MLSStatuses, WireIdentity} from '../E2EIdentity';
 
-export const useUserIdentity = (userId: QualifiedId, groupId?: string) => {
+export const useUserIdentity = (userId: QualifiedId, groupId?: string, updateAfterEnrollment?: boolean) => {
   const [deviceIdentities, setDeviceIdentities] = useState<WireIdentity[] | undefined>();
 
   const refreshDeviceIdentities = useCallback(async () => {
@@ -39,11 +39,14 @@ export const useUserIdentity = (userId: QualifiedId, groupId?: string) => {
   }, [refreshDeviceIdentities]);
 
   useEffect(() => {
+    if (!updateAfterEnrollment) {
+      return () => {};
+    }
     E2EIHandler.getInstance().on('enrollmentSuccessful', refreshDeviceIdentities);
     return () => {
       E2EIHandler.getInstance().off('enrollmentSuccessful', refreshDeviceIdentities);
     };
-  });
+  }, [refreshDeviceIdentities, updateAfterEnrollment]);
 
   return {
     deviceIdentities,

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -184,7 +184,11 @@ const Conversations: React.FC<ConversationsProps> = ({
             onClick={event => AvailabilityContextMenu.show(event.nativeEvent, 'left-list-availability-menu')}
           >
             <UserInfo user={selfUser} className="availability-state" dataUieName="status-availability" showAvailability>
-              <UserVerificationBadges user={selfUser} groupId={conversationState.selfMLSConversation()?.groupId} />
+              <UserVerificationBadges
+                user={selfUser}
+                isSelfUser
+                groupId={conversationState.selfMLSConversation()?.groupId}
+              />
             </UserInfo>
           </button>
 


### PR DESCRIPTION
## Description

Will fix the too many listeners error on `enrollmentSuccessful` event.

Since we only need to subscribe to this event for the `selfUser` this PR adds a params to avoid subscribing for other users

![image](https://github.com/wireapp/wire-webapp/assets/1090716/2f1f03cf-4f39-4c36-b7e0-7fcc6e7dbcae)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
