### PR TITLE
fix: Wait for conversation to be known before triggering verification checks

### DIFF
--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
@@ -25,6 +25,7 @@ import {getConversationVerificationState, getUsersIdentities, MLSStatuses} from 
 import {E2EIVerificationMessageType} from 'src/script/message/E2EIVerificationMessageType';
 import {Core} from 'src/script/service/CoreSingleton';
 import {Logger, getLogger} from 'Util/Logger';
+import {waitFor} from 'Util/waitFor';
 
 import {isMLSConversation, MLSConversation} from '../../ConversationSelectors';
 import {ConversationState} from '../../ConversationState';
@@ -88,10 +89,14 @@ class MLSConversationVerificationStateHandler {
   }
 
   private checkConversationVerificationState = async ({groupId}: {groupId: string}): Promise<void> => {
-    const conversation = getConversationByGroupId({conversationState: this.conversationState, groupId});
+    // There could be a race condition where we would receive an epoch update for a conversation that is not yet known by the webapp.
+    // We just wait for it to be available and then check the verification state
+    const conversation = await waitFor(() =>
+      getConversationByGroupId({conversationState: this.conversationState, groupId}),
+    );
+
     if (!conversation) {
-      this.logger.warn(`Epoch changed but conversationEntity can't be found`);
-      return;
+      return this.logger.warn(`Epoch changed but conversation could not be found after waiting for 5 seconds`);
     }
 
     if (!isMLSConversation(conversation)) {

--- a/src/script/util/waitFor.test.ts
+++ b/src/script/util/waitFor.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {waitFor} from './waitFor';
+
+describe('waitFor', () => {
+  it('should resolve if condition is true', async () => {
+    const condition = jest.fn().mockReturnValue(true);
+
+    const result = await waitFor(condition);
+
+    expect(result).toBe(true);
+  });
+
+  it('should resolve if condition is true after some time', async () => {
+    const condition = jest.fn().mockReturnValue(false);
+    setTimeout(() => condition.mockReturnValue('hello'), 100);
+
+    const result = await waitFor(condition);
+
+    expect(result).toBe('hello');
+  });
+
+  it('should resolve with undefined if condition is never true', async () => {
+    const condition = jest.fn().mockReturnValue(false);
+
+    const result = await waitFor(condition, 50, 50);
+
+    expect(result).toBe(undefined);
+  });
+});

--- a/src/script/util/waitFor.test.ts
+++ b/src/script/util/waitFor.test.ts
@@ -20,6 +20,10 @@
 import {waitFor} from './waitFor';
 
 describe('waitFor', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
   it('should resolve if condition is true', async () => {
     const condition = jest.fn().mockReturnValue(true);
 
@@ -32,16 +36,20 @@ describe('waitFor', () => {
     const condition = jest.fn().mockReturnValue(false);
     setTimeout(() => condition.mockReturnValue('hello'), 100);
 
-    const result = await waitFor(condition);
+    const promise = waitFor(condition, 200, 50);
+    jest.advanceTimersByTime(101);
 
+    const result = await promise;
     expect(result).toBe('hello');
   });
 
   it('should resolve with undefined if condition is never true', async () => {
     const condition = jest.fn().mockReturnValue(false);
 
-    const result = await waitFor(condition, 50, 50);
+    const promise = waitFor(condition, 50, 50);
+    jest.runAllTimers();
 
+    const result = await promise;
     expect(result).toBe(undefined);
   });
 });

--- a/src/script/util/waitFor.ts
+++ b/src/script/util/waitFor.ts
@@ -1,0 +1,40 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export function waitFor<T>(condition: () => T, timeout: number = 5000, interval: number = 100): Promise<T | undefined> {
+  return new Promise(resolve => {
+    if (condition()) {
+      return resolve(condition());
+    }
+
+    const timeoutId = setTimeout(() => {
+      clearInterval(intervalId);
+      resolve(undefined);
+    }, timeout);
+
+    const intervalId = setInterval(() => {
+      const result = condition();
+      if (result) {
+        clearTimeout(timeoutId);
+        clearInterval(intervalId);
+        resolve(result);
+      }
+    }, interval);
+  });
+}


### PR DESCRIPTION
## Description

This will make sure when we receive an `epochChange` event from the core that the conversation does exist in the webapp as well (and be able to update the verification state of that conversation accordingly) 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

