### PR TITLE
runfix: broken connection request after app reload

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1732,7 +1732,9 @@ export class ConversationRepository {
 
     // For connection request, we simply display proteus conversation of type 3 (connect) it will be displayed as a connection request
     if (connectionEntity.isOutgoingRequest()) {
-      return localProteusConversation || this.fetchConversationById(proteusConversationId);
+      const proteusConversation = localProteusConversation || (await this.fetchConversationById(proteusConversationId));
+      proteusConversation.type(CONVERSATION_TYPE.CONNECT);
+      return proteusConversation;
     }
 
     const isConnectionAccepted = connectionEntity.isConnected();


### PR DESCRIPTION
## Description

There was an issue with connection requests after reloading the webapp that was introduced by MLS 1:1 conversations feature merge. We were never mapping an outgoing connection request to type 3 (`CONNECT`) of conversation after webapp was reloaded. 

Such a conversation had type 2 (`ONE_ON_ONE`) type mapped from backend even though the connection was not yet accepted. When trying to naviagate to the outgoing connection request, webapp tried to open it as 1:1 conversation what resulted in an error (users are not connected). 

<img width="986" alt="Screenshot 2023-12-07 at 15 56 51" src="https://github.com/wireapp/wire-webapp/assets/45733298/78aeccfa-11f8-4a02-a76f-8ee3ed8ffb9f">

## Solution
The solution is to simply always map outgoing connection request to type 3 of conversation.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
