### PR TITLE
fix: do not display missed messages in connection request

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -3061,7 +3061,7 @@ export class ConversationRepository {
   private readonly onMissedEvents = (): void => {
     this.conversationState
       .filteredConversations()
-      .filter(conversationEntity => !conversationEntity.removed_from_conversation())
+      .filter(conversationEntity => !conversationEntity.removed_from_conversation() && !conversationEntity.isRequest())
       .forEach(conversationEntity => {
         const currentTimestamp = this.serverTimeHandler.toServerTimestamp();
         const missed_event = EventBuilder.buildMissed(conversationEntity, currentTimestamp);


### PR DESCRIPTION
## Description

We don't want to display "possible missed messages" system message in a connection request. There's no way for users to communicate in the conversation before the connection is accepted, so there's no way they might have missed some messages there.

## Screenshots/Screencast (for UI changes)
<img width="608" alt="Screenshot 2023-12-08 at 13 16 09" src="https://github.com/wireapp/wire-webapp/assets/45733298/9532f336-7bed-43c9-8506-0f9cf9d96858">

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
