### PR TITLE
runfix: use proteus as default supported protocol if user'S backend is offline (WPB-5752)

### DIFF
--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -720,12 +720,19 @@ export class UserRepository extends TypedEventEmitter<Events> {
         return localSupportedProtocols;
       }
     }
+    try {
+      const supportedProtocols = await this.userService.getUserSupportedProtocols(userId);
 
-    const supportedProtocols = await this.userService.getUserSupportedProtocols(userId);
-
-    //update local user entity with new supported protocols
-    await this.updateUserSupportedProtocols(userId, supportedProtocols);
-    return supportedProtocols;
+      //update local user entity with new supported protocols
+      await this.updateUserSupportedProtocols(userId, supportedProtocols);
+      return supportedProtocols;
+    } catch (error) {
+      const localSupportedProtocols = this.findUserById(userId)?.supportedProtocols();
+      if (localSupportedProtocols) {
+        return localSupportedProtocols;
+      }
+      return [ConversationProtocol.PROTEUS];
+    }
   }
 
   async getUserByHandle(fqn: QualifiedHandle): Promise<undefined | APIClientUser> {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5752" title="WPB-5752" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5752</a>  [Web] MLS 1 on 1 conversations do not load if the other user's backend is unreachable
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

1 on 1 conversations with a user from an unreachable backend never load, even if those conversation already exist locally.
It's because we cannot get a supported protocol for the user and the error from `getUserSupportedProtocols` isn't handled

### Draft

If we catch the error, we can try to get a locally supported protocol for the user, and if that fails, default to proteus

In the worst case scenario of an MLS conv existing locally, no local supported protocol in database (launching the app and the top conv is from an federated user from a currently unreachable backend), the conv would still reinitialize as MLS, as we would recognize the conversation exists here https://github.com/wireapp/wire-webapp/blob/virgile/offline-mls-1on1/src/script/conversation/ConversationRepository.ts#L1701

## Screenshots/Screencast (for UI changes)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;
