### PR TITLE
runfix: add basic types to countly sdk

### DIFF
--- a/src/script/tracking/EventTrackingRepository.ts
+++ b/src/script/tracking/EventTrackingRepository.ts
@@ -18,6 +18,7 @@
  */
 
 import {amplify} from 'amplify';
+import Countly from 'countly-sdk-web';
 import {container} from 'tsyringe';
 
 import {WebAppEvents} from '@wireapp/webapp-events';
@@ -42,8 +43,6 @@ import {ClientEvent} from '../event/Client';
 import {TeamState} from '../team/TeamState';
 import {ROLE as TEAM_ROLE} from '../user/UserPermission';
 import {UserState} from '../user/UserState';
-
-const Countly = require('countly-sdk-web');
 
 export class EventTrackingRepository {
   private isProductReportingActivated: boolean;

--- a/src/script/tracking/countly-skd-web.d.ts
+++ b/src/script/tracking/countly-skd-web.d.ts
@@ -1,0 +1,44 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+declare module 'countly-sdk-web' {
+  export interface UserData {
+    set_once: (keyValues: {[key: string]: any}) => void;
+    set: (key: string, value: any) => void;
+    increment: (key: string) => void;
+    incrementBy: (key: string, value: number) => void;
+    save: () => void;
+  }
+
+  export interface Countly {
+    q: any[];
+    app_key: string;
+    url: string;
+    init(conf?: {app_key?: string; [key: string]: any}): Countly;
+    end_session(): void;
+    begin_session(): void;
+    change_id(newId: string, merge: boolean): void;
+    userData: UserData;
+    add_event: (eventData: EventData) => void;
+  }
+
+  const Countly: Countly;
+  // eslint-disable-next-line import/no-default-export
+  export default Countly;
+}


### PR DESCRIPTION
## Description

Will add basic types for the `countly-sdk-web`

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

