### PR TITLE
fix: use updated version of @stablelib/utf8 [WPB-5844]

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,7 +217,8 @@
   },
   "resolutions": {
     "libsodium": "0.7.10",
-    "xml2js": "0.5.0"
+    "xml2js": "0.5.0",
+    "@stablelib/utf8": "1.0.2"
   },
   "version": "0.27.0",
   "packageManager": "yarn@3.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5133,10 +5133,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stablelib/utf8@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@stablelib/utf8@npm:1.0.0"
-  checksum: 87423b27c33616bf5bd78974361d5d5918f3a3057c3ac0e03358e3be5972e89ebea5f0188065559da718d2352fb6fbdb4afcee152eecdefdd76e4c88dfa269b8
+"@stablelib/utf8@npm:1.0.2":
+  version: 1.0.2
+  resolution: "@stablelib/utf8@npm:1.0.2"
+  checksum: 3ab01baa4eb36eece44a310bf6b2e4313e8d585fc04dbcf8a5dc2d239f06071f34038b85aad6fbd98e9969f0b3b0584fcb541fe5e512c8f0cc0982b9fe1290a3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5844" title="WPB-5844" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5844</a>  Encryption fails when unicode emojis or reactions are added
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Currently, trying to send a reaction to a message with encrypted DB will yield the following error.

![image-20231211-150443](https://github.com/wireapp/wire-webapp/assets/77456193/57d19bcc-a2cd-4f08-aa28-a338e6138361)

The library update will fix this problem for us.