### PR TITLE
feat: add ability to delete gray messages (WPB-5840)

### DIFF
--- a/src/script/conversation/MessageRepository.test.ts
+++ b/src/script/conversation/MessageRepository.test.ts
@@ -45,6 +45,7 @@ import {CryptographyRepository} from '../cryptography/CryptographyRepository';
 import {ContentMessage} from '../entity/message/ContentMessage';
 import {EventRepository} from '../event/EventRepository';
 import {EventService} from '../event/EventService';
+import {StatusType} from '../message/StatusType';
 import {PropertiesRepository} from '../properties/PropertiesRepository';
 import {ReactionMap} from '../storage';
 import {TeamState} from '../team/TeamState';
@@ -240,6 +241,25 @@ describe('MessageRepository', () => {
           userIds: {'': {selfid: [], user1: []}},
         }),
       );
+    });
+
+    it('should send delete and deletes message for own pending/gray messages', async () => {
+      const conversation = generateConversation(CONVERSATION_TYPE.REGULAR);
+      conversation.participating_user_ets.push(new User('user1'));
+
+      const messageToDelete = new Message(createUuid());
+      messageToDelete.user(selfUser);
+      messageToDelete.status(StatusType.SENDING);
+      conversation.addMessage(messageToDelete);
+
+      const [messageRepository, {core, eventRepository}] = await buildMessageRepository();
+      jest.spyOn(core.service!.conversation, 'send').mockResolvedValue(successPayload);
+      spyOn(eventRepository.eventService, 'deleteEvent').and.returnValue(Promise.resolve());
+      spyOn(messageRepository, 'deleteMessageById');
+
+      await messageRepository.deleteMessageForEveryone(conversation, messageToDelete);
+
+      expect(messageRepository.deleteMessageById).toHaveBeenCalledWith(conversation, messageToDelete.id);
     });
   });
 

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -1008,6 +1008,11 @@ export class MessageRepository {
     const conversationId = conversation.id;
     const messageId = message.id;
 
+    // directly delete message from local database when status is sending
+    if (message.status() === StatusType.SENDING) {
+      await this.deleteMessageById(conversation, message.id);
+    }
+
     try {
       if (!message.user().isMe && !message.ephemeral_expires()) {
         throw new ConversationError(ConversationError.TYPE.WRONG_USER, ConversationError.MESSAGE.WRONG_USER);

--- a/src/script/entity/message/Message.ts
+++ b/src/script/entity/message/Message.ts
@@ -220,7 +220,7 @@ export class Message {
    * @returns `true`, if message is deletable, `false` otherwise.
    */
   isDeletable(): boolean {
-    return !this.hasUnavailableAsset(false) && !this.isComposite() && this.status() !== StatusType.SENDING;
+    return !this.hasUnavailableAsset(false) && !this.isComposite();
   }
 
   /**


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5840" title="WPB-5840" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-5840</a>  [Web] Ability to delete grey messages (messages that are not sent)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

This pull request addresses the implementation of a crucial feature - the ability for users to delete messages that were never sent, commonly referred to as "grey messages." The feature covers regular text messages, self-deleting messages, as well as pictures/assets that haven't been sent.

The implementation includes modifications to the message handling logic to recognize and handle unsent messages appropriately. The "Delete" option in the context menu now triggers the removal of the selected unsent message from both the user interface and the local database.

## Screenshots/Screencast (for UI changes)

<img width="951" alt="image" src="https://github.com/wireapp/wire-webapp/assets/63250054/a8709402-e341-45a9-8a2d-91c8516b00df">


## Checklist

- [X] PR has been self reviewed by the author;
- [X] Hard-to-understand areas of the code have been commented;
- [X] If it is a core feature, unit tests have been added;