### PR TITLE
ci: use prerelase names with dot

### DIFF
--- a/bin/chart-next-version.sh
+++ b/bin/chart-next-version.sh
@@ -67,11 +67,8 @@ if [ "$bump_type" = "prerelease" ]; then
     # this is a first prelease
     # so let's create a new release (bump minor)
     # and create a first prerelease for it
-    # we initialize prerelease counter to 100000 instead of 0
-    # so that prereleases are lexicographically ordered.
-    # That way helm search always shows the latest version by default.
     version_next=$(./bin/semver bump minor "$version_latest")
-    version_new=$(./bin/semver bump prerelease pre100000 "$version_next")
+    version_new=$(./bin/semver bump prerelease pre.1 "$version_next")
   else
     version_new=$(./bin/semver bump prerelease "$version_latest")
   fi

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Wire webapp in Kubernetes
 name: webapp
-version: 0.1.0
+version: 0.4.0


### PR DESCRIPTION
## Description

Followup to https://github.com/wireapp/wire-webapp/pull/16370

This PR updates the way the Helm chart prelrease versions are created. You are supposed to put a `.` before the counter. That way the semver ordering is like you expected. Concretely

- `0.4.0-pre9` is bigger than `0.4.0-pre10`. You are doing it wrong

- `0.4.0-pre.9` is smaller than `0.4.0-pre.10`. That's right :+1:

The bump in `Chart.yaml` is to trigger a new prerelease