### PR TITLE
runfix: 1:1 conversation not being opened if remote backend is down [WPB-5752]

### DIFF
--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -726,16 +726,16 @@ export class UserRepository extends TypedEventEmitter<Events> {
       await this.updateUserSupportedProtocols(userId, supportedProtocols);
       return supportedProtocols;
     } catch (error) {
-      this.logger.warn(
-        `Failed when fetching supported protocols of user ${userId.id}, using local supported protocols as fallback: `,
-        localSupportedProtocols,
-      );
-
-      if (!localSupportedProtocols) {
-        throw error;
+      if (localSupportedProtocols) {
+        this.logger.warn(
+          `Failed when fetching supported protocols of user ${userId.id}, using local supported protocols as fallback: `,
+          localSupportedProtocols,
+        );
+        return localSupportedProtocols;
       }
 
-      return localSupportedProtocols;
+      this.logger.error(`Couldn't specify supported protocols of user ${userId.id}.`, error);
+      throw error;
     }
   }
 

--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -141,7 +141,7 @@ export class ContentViewModel {
   private readonly getConversationEntity = async (
     conversation: Conversation | string,
     domain: string | null = null,
-  ): Promise<Conversation | null> => {
+  ): Promise<Conversation> => {
     const conversationEntity = isConversationEntity(conversation)
       ? conversation
       : await this.conversationRepository.getConversationById({domain: domain || '', id: conversation});


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5752" title="WPB-5752" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5752</a>  [Web] MLS 1 on 1 conversations do not load if the other user's backend is unreachable
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

If we try to open 1:1 conversation with user whose backend is offline, we end up with uncaught error on `GET: /users/{domain}/{id}/supported-protocols`, what would result in 1:1 conversation not being open at all.

### Solution
To prevent this we implement two fallbacks:
1. If we cannot fetch supported protocols of the user from remote backend, we default to the supported protocols of the user that we already store locally.
2. If supported protocol of the user are not in the local state yet, just open a conversation without doing anything, this way it will open the conversation in the same stay it had before (when the other user was available), without modifying any readonly state.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
