### PR TITLE
runfix: import backup from migrated db version [WPB-5906]

### DIFF
--- a/src/script/backup/BackupRepository.test.ts
+++ b/src/script/backup/BackupRepository.test.ts
@@ -28,7 +28,7 @@ import {WebWorker} from 'Util/worker';
 import {BackUpHeader, DecodedHeader, ENCRYPTED_BACKUP_FORMAT, ENCRYPTED_BACKUP_VERSION} from './BackUpHeader';
 import {BackupRepository, Filename} from './BackupRepository';
 import {BackupService} from './BackupService';
-import {CancelError, DifferentAccountError, IncompatibleBackupError, IncompatiblePlatformError} from './Error';
+import {CancelError, DifferentAccountError, IncompatiblePlatformError} from './Error';
 import {handleZipEvent} from './zipWorker';
 
 import {ConversationRepository} from '../conversation/ConversationRepository';
@@ -170,12 +170,6 @@ describe('BackupRepository', () => {
         {
           expectedError: DifferentAccountError,
           metaChanges: {user_id: 'fail'},
-        },
-      ],
-      [
-        {
-          expectedError: IncompatibleBackupError,
-          metaChanges: {version: 13}, // version 14 contains a migration script, thus will generate an error
         },
       ],
       [

--- a/src/script/backup/BackupService.ts
+++ b/src/script/backup/BackupService.ts
@@ -67,6 +67,15 @@ export class BackupService {
     ] as const;
   }
 
+  async runDbSchemaUpdates(): Promise<void> {
+    const {db} = this.storageService;
+    if (!db) {
+      this.logger.warn('Database schema will not run because the database is not initialized');
+      return;
+    }
+    return db.runDbSchemaUpdates();
+  }
+
   /**
    * Will import all entities in the Database.
    * If a primaryKey generator is given, it will only import the entities that are not already in the DB

--- a/src/script/backup/BackupService.ts
+++ b/src/script/backup/BackupService.ts
@@ -67,13 +67,13 @@ export class BackupService {
     ] as const;
   }
 
-  async runDbSchemaUpdates(): Promise<void> {
+  async runDbSchemaUpdates(archiveVersion: number): Promise<void> {
     const {db} = this.storageService;
     if (!db) {
       this.logger.warn('Database schema will not run because the database is not initialized');
       return;
     }
-    return db.runDbSchemaUpdates();
+    return db.runDbSchemaUpdates(archiveVersion);
   }
 
   /**

--- a/src/script/storage/DexieDatabase.ts
+++ b/src/script/storage/DexieDatabase.ts
@@ -49,15 +49,7 @@ export class DexieDatabase extends Dexie {
     super(dbName);
     this.logger = getLogger(`Dexie (${dbName})`);
 
-    StorageSchemata.SCHEMATA.forEach(({schema, upgrade, version}) => {
-      const versionInstance = this.version(version).stores(schema);
-      if (upgrade) {
-        versionInstance.upgrade((transaction: Transaction) => {
-          this.logger.warn(`Database upgrade to version '${version}'`);
-          upgrade(transaction, this);
-        });
-      }
-    });
+    void this.initDbSchema();
 
     this.amplify = this.table(StorageSchemata.OBJECT_STORE.AMPLIFY);
     this.clients = this.table(StorageSchemata.OBJECT_STORE.CLIENTS);
@@ -70,4 +62,27 @@ export class DexieDatabase extends Dexie {
     this.users = this.table(StorageSchemata.OBJECT_STORE.USERS);
     this.groupIds = this.table(StorageSchemata.OBJECT_STORE.GROUP_IDS);
   }
+
+  private readonly initDbSchema = async (): Promise<void> => {
+    StorageSchemata.SCHEMATA.forEach(({schema, upgrade, version}) => {
+      const versionInstance = this.version(version).stores(schema);
+      if (upgrade) {
+        versionInstance.upgrade((transaction: Transaction) => {
+          this.logger.warn(`Database upgrade to version '${version}'`);
+          upgrade(transaction, this);
+        });
+      }
+    });
+  };
+
+  public readonly runDbSchemaUpdates = async (): Promise<void> => {
+    for (const {upgrade, version} of StorageSchemata.SCHEMATA) {
+      if (upgrade) {
+        await this.transaction('rw', this.tables, transaction => {
+          this.logger.info(`Running DB schema update for version '${version}'`);
+          upgrade(transaction, this);
+        });
+      }
+    }
+  };
 }

--- a/src/script/storage/DexieDatabase.ts
+++ b/src/script/storage/DexieDatabase.ts
@@ -75,9 +75,10 @@ export class DexieDatabase extends Dexie {
     });
   };
 
-  public readonly runDbSchemaUpdates = async (): Promise<void> => {
+  public readonly runDbSchemaUpdates = async (archiveVersion: number): Promise<void> => {
     for (const {upgrade, version} of StorageSchemata.SCHEMATA) {
-      if (upgrade) {
+      // If the archive version is greater than the current version, run the upgrade
+      if (upgrade && version > archiveVersion) {
         await this.transaction('rw', this.tables, transaction => {
           this.logger.info(`Running DB schema update for version '${version}'`);
           upgrade(transaction, this);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5906" title="WPB-5906" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5906</a>  [Web] Backup from Prod cannot be restored on Edge
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

Previously it was not possible to import a backup that was made on some older version of wire if there were some DB schema migration in between that version and the current one. In that case we were just throwing an "incompatible backup version error". 

With this PR, importing a backup made from older version should be possible. After history is imported we will also run schema upgrade scripts to assure that all the upgrades that should have taken place during db migration while updating wire were made.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
