### PR TITLE
fix: use local users if they cannot be loaded from BE [WPB-5959]

### DIFF
--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -601,15 +601,15 @@ export class UserRepository extends TypedEventEmitter<Events> {
 
     const selfDomain = selfUser.qualifiedId.domain;
 
-    // When a federated backend is unreachable, try to load a user from the local database.
-    // Otherwise, we generate placeholder users locally with some default values
     const failedToLoad = failed.map(userId => {
+      // When a federated backend is unreachable, we try to load a user from the local database.
       const dbUserRecord = dbUsers?.find(user => matchQualifiedIds(user.qualified_id, userId));
 
       if (dbUserRecord && selfUser) {
         return this.userMapper.mapUserFromJson(dbUserRecord, selfDomain);
       }
 
+      // Otherwise, we generate placeholder users locally with some default values.
       return new User(userId.id, userId.domain);
     });
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5959" title="WPB-5959" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5959</a>  [Web] 1:1 MLS conversation disappears after page refresh when of user's backend goes offline
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

When initially loading a list of users, it can happen that one of the federated backends is offline (unreachable), therefore we will not receive fresh user data from the server. It's possible that we've already fetched this user before, thus we can try looking it up in local db (indexedDB) before just returning a placeholder for "unavailable user". 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
