### PR TITLE
chore: remove deprecated globals

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,8 @@
   },
   "globals": {
     "React": "readonly",
-    "JSX": "readonly"
+    "JSX": "readonly",
+    "amplify": "readonly"
   },
   "ignorePatterns": [
     ".git/",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,12 +4,8 @@
     "jasmine": true
   },
   "globals": {
-    "amplify": true,
-    "ko": true,
-    "sinon": true,
-    "wire": true,
-    "z": true,
-    "RTCAudioSource": true
+    "React": "readonly",
+    "JSX": "readonly"
   },
   "ignorePatterns": [
     ".git/",
@@ -42,7 +38,6 @@
     "@typescript-eslint/no-floating-promises": "warn",
     "@typescript-eslint/typedef": "off",
     "no-dupe-class-members": "off",
-    "no-undef": "off",
     "no-unsanitized/property": "off",
     "prefer-promise-reject-errors": "off",
     "valid-jsdoc": "off",

--- a/src/script/auth/configureEnvironment.ts
+++ b/src/script/auth/configureEnvironment.ts
@@ -17,16 +17,8 @@
  *
  */
 
-import {amplify} from 'amplify';
-import jQuery from 'jquery';
-
 import '../event/Client';
 import '../message/MessageCategorization';
 import '../message/MessageCategory';
 import '../service/BackendEnvironment';
 import '../storage/StorageSchemata';
-
-window.amplify = amplify;
-window.jQuery = jQuery;
-// eslint-disable-next-line id-length
-window.$ = jQuery;

--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -20,6 +20,7 @@
 import React, {useMemo, useState, useEffect} from 'react';
 
 import {QualifiedId} from '@wireapp/api-client/lib/user';
+import ko from 'knockout';
 
 import {Conversation} from 'src/script/entity/Conversation';
 import {CompositeMessage} from 'src/script/entity/message/CompositeMessage';

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageActions.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageActions.tsx
@@ -20,6 +20,7 @@
 import {FC, useCallback, useRef, useState} from 'react';
 
 import {amplify} from 'amplify';
+import ko from 'knockout';
 
 import {WebAppEvents} from '@wireapp/webapp-events';
 

--- a/src/script/properties/PropertiesRepository.ts
+++ b/src/script/properties/PropertiesRepository.ts
@@ -21,6 +21,7 @@ import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data';
 import {ConsentType} from '@wireapp/api-client/lib/self/';
 import {AudioPreference, NotificationPreference, WebappProperties} from '@wireapp/api-client/lib/user/data/';
 import {amplify} from 'amplify';
+import jquery from 'jquery';
 import ko from 'knockout';
 
 import {WebAppEvents} from '@wireapp/webapp-events';
@@ -185,7 +186,7 @@ export class PropertiesRepository {
     return this.propertiesService
       .getPropertiesByKey(PropertiesRepository.CONFIG.WEBAPP_ACCOUNT_SETTINGS)
       .then(properties => {
-        $.extend(true, this.properties, properties);
+        jquery.extend(true, this.properties, properties);
       })
       .catch(() => {
         this.logger.warn(

--- a/src/script/tracking/countly-skd-web.d.ts
+++ b/src/script/tracking/countly-skd-web.d.ts
@@ -35,7 +35,7 @@ declare module 'countly-sdk-web' {
     begin_session(): void;
     change_id(newId: string, merge: boolean): void;
     userData: UserData;
-    add_event: (eventData: EventData) => void;
+    add_event: (eventData: any) => void;
   }
 
   const Countly: Countly;

--- a/src/script/util/DebugUtil.ts
+++ b/src/script/util/DebugUtil.ts
@@ -32,6 +32,7 @@ import {FeatureStatus} from '@wireapp/api-client/lib/team/feature/';
 import type {QualifiedId} from '@wireapp/api-client/lib/user';
 import {DatabaseKeys} from '@wireapp/core/lib/notification/NotificationDatabaseRepository';
 import Dexie from 'dexie';
+import jquery from 'jquery';
 import keyboardjs from 'keyboardjs';
 import {$createTextNode, $getRoot, LexicalEditor} from 'lexical';
 import {container} from 'tsyringe';
@@ -72,7 +73,7 @@ export class DebugUtil {
   private readonly eventRepository: EventRepository;
   private readonly storageRepository: StorageRepository;
   private readonly messageRepository: MessageRepository;
-  public readonly $: JQueryStatic;
+  public readonly $ = jquery;
   /** Used by QA test automation. */
   public readonly userRepository: UserRepository;
   /** Used by QA test automation. */
@@ -88,7 +89,6 @@ export class DebugUtil {
     private readonly core = container.resolve(Core),
     private readonly apiClient = container.resolve(APIClient),
   ) {
-    this.$ = $;
     this.Dexie = Dexie;
 
     const {calling, client, connection, conversation, event, user, storage, message} = repositories;

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -17,11 +17,14 @@
  *
  */
 
+import {amplify} from 'amplify';
+
 import {WireModule} from './Wire.types';
 
 declare global {
   interface Window {
     wire: WireModule;
+    amplify: amplify.Static;
     z: any;
   }
 }

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -17,23 +17,11 @@
  *
  */
 
-import {amplify} from 'amplify';
-import jQuery from 'jquery';
-import ko from 'knockout';
-
-import {t} from 'Util/LocalizerUtil';
-
 import {WireModule} from './Wire.types';
 
 declare global {
   interface Window {
-    $: typeof jQuery;
-    amplify: amplify.Static;
-    jQuery: typeof jQuery;
-    ko: typeof ko;
-    t: typeof t;
     wire: WireModule;
-    wSSOCapable: boolean;
     z: any;
   }
 }

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -131,11 +131,7 @@ module.exports = {
   },
   plugins: [
     new webpack.ProvidePlugin({
-      $: 'jquery',
       Buffer: ['buffer', 'Buffer'],
-      _: 'underscore',
-      jQuery: 'jquery',
-      ko: 'knockout',
     }),
     new WorkboxPlugin.InjectManifest({
       maximumFileSizeToCacheInBytes: process.env.NODE_ENV !== 'production' ? 10 * 1024 * 1024 : undefined,


### PR DESCRIPTION
## Description

Those are relics from the past, let's get rid of the globals that we used to use everywhere

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
