### PR TITLE
runfix: establishing mls 1to1 between team members

### DIFF
--- a/src/__mocks__/@wireapp/core.ts
+++ b/src/__mocks__/@wireapp/core.ts
@@ -58,6 +58,7 @@ export class Account extends EventEmitter {
       emit: jest.fn(),
       off: jest.fn(),
       scheduleKeyMaterialRenewal: jest.fn(),
+      isConversationEstablished: jest.fn(),
     },
     asset: {
       uploadAsset: jest.fn(),

--- a/src/script/conversation/ConversationFilter.test.ts
+++ b/src/script/conversation/ConversationFilter.test.ts
@@ -78,7 +78,7 @@ describe('ConversationFilter', () => {
       };
       const [conversationEntity] = ConversationMapper.mapConversations([conversationData]);
       expect(conversationEntity.is1to1()).toBeFalsy();
-      expect(conversationEntity['isTeam1to1']()).toBeFalsy();
+      expect(conversationEntity['isProteusTeam1to1']()).toBeFalsy();
       expect(conversationEntity.isGroup()).toBeFalsy();
       expect(conversationEntity.participating_user_ids().length).toBe(1);
       expect(conversationEntity.removed_from_conversation()).toBeFalsy();
@@ -133,7 +133,7 @@ describe('ConversationFilter', () => {
       };
       const [conversationEntity] = ConversationMapper.mapConversations([conversationData]);
       expect(conversationEntity.is1to1()).toBeTruthy();
-      expect(conversationEntity['isTeam1to1']()).toBeFalsy();
+      expect(conversationEntity['isProteusTeam1to1']()).toBeFalsy();
       expect(conversationEntity.isGroup()).toBeFalsy();
       expect(conversationEntity.participating_user_ids().length).toBe(1);
       expect(conversationEntity.removed_from_conversation()).toBeFalsy();

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1405,7 +1405,7 @@ export class ConversationRepository {
    *
    * @param proteusConversation - proteus 1:1 conversation
    * @param mlsConversation - mls 1:1 conversation
-   * @returns {shouldOpenMLS1to1Conversation} - whether proteus 1:1 was active conversation and mls 1:1 conversation should be opened in the UI
+   * @returns {shouldOpenMLS1to1Conversation, wasProteus1to1Replaced} - whether proteus 1:1 was replaced with mls and whether it was an active conversation and mls 1:1 conversation should be opened in the UI
    */
   private readonly replaceProteus1to1WithMLS = async (
     otherUserId: QualifiedId,

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1632,10 +1632,14 @@ export class ConversationRepository {
     // If mls is supported by the other user, we can establish the group and remove readonly state from the conversation.
     await this.updateConversationReadOnlyState(mlsConversation, null);
 
+    const selfUser = this.userState.self();
+    if (!selfUser) {
+      throw new Error('Self user is not available!');
+    }
+
     // If its a 1:1 conversation between two users from the same team we should not establish it automatically,
     // it will be established once first mls message is sent in a conversation
-    const selfUser = this.userState.self();
-    const isTeamMember = !!selfUser && !!selfUser.teamId && !!otherUser.teamId && selfUser.teamId === otherUser.teamId;
+    const isTeamMember = !!selfUser.teamId && !!otherUser.teamId && selfUser.teamId === otherUser.teamId;
 
     const initialisedMLSConversation = isTeamMember
       ? mlsConversation

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1491,6 +1491,27 @@ export class ConversationRepository {
     return this.conversationService.removeConversationFromBlacklist(conversationId);
   }
 
+  public readonly makeSureMLS1to1ConversationIsEstablished = async (mlsConversation: MLSConversation) => {
+    const isMLSGroupEstablished = await this.conversationService.isMLSGroupEstablishedLocally(mlsConversation.groupId);
+    if (isMLSGroupEstablished) {
+      return;
+    }
+
+    const selfUser = this.userState.self();
+
+    if (!selfUser) {
+      throw new Error('Self user not found');
+    }
+
+    const otherUserId = this.getUserIdOf1to1Conversation(mlsConversation);
+
+    if (!otherUserId) {
+      throw new Error('Other user not found');
+    }
+
+    await this.establishMLS1to1Conversation(mlsConversation, otherUserId);
+  };
+
   /**
    * Will establish mls 1:1 conversation.
    * If proteus conversation is provided, it will be replaced with mls 1:1 conversation.

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1918,6 +1918,7 @@ export class ConversationRepository {
   }
 
   public readonly init1To1Conversations = async (connections: ConnectionEntity[], conversations: Conversation[]) => {
+    // It's important to map connections first, so connection entities get attached to the conversation entities.
     if (connections.length) {
       await this.mapConnections(connections);
     }
@@ -1929,7 +1930,10 @@ export class ConversationRepository {
   };
 
   private readonly initTeam1To1Conversations = async (conversations: Conversation[]) => {
-    const team1To1Conversations = conversations.filter(conversation => conversation.isProteusTeam1to1());
+    // Team owned 1:1 conversations are: legacy group conversations with only 1 other user and mls 1:1 conversations between two users without connection.
+    const team1To1Conversations = conversations.filter(
+      conversation => conversation.is1to1() && !conversation.connection(),
+    );
 
     for (const conversation of team1To1Conversations) {
       try {

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1904,7 +1904,7 @@ export class ConversationRepository {
   };
 
   private readonly initTeam1To1Conversations = async (conversations: Conversation[]) => {
-    const team1To1Conversations = conversations.filter(conversation => conversation.isTeam1to1());
+    const team1To1Conversations = conversations.filter(conversation => conversation.isProteusTeam1to1());
 
     for (const conversation of team1To1Conversations) {
       try {

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1410,11 +1410,11 @@ export class ConversationRepository {
   private readonly replaceProteus1to1WithMLS = async (
     otherUserId: QualifiedId,
     mlsConversation: MLSConversation,
-  ): Promise<{shouldOpenMLS1to1Conversation: boolean}> => {
+  ): Promise<{shouldOpenMLS1to1Conversation: boolean; wasProteus1to1Replaced: boolean}> => {
     const proteusConversations = this.conversationState.findProteus1to1Conversations(otherUserId);
 
     if (!proteusConversations || proteusConversations.length < 1) {
-      return {shouldOpenMLS1to1Conversation: false};
+      return {shouldOpenMLS1to1Conversation: false, wasProteus1to1Replaced: false};
     }
 
     this.logger.info(`Replacing proteus 1:1 conversation(s) with mls 1:1 conversation ${mlsConversation.id}`);
@@ -1480,7 +1480,7 @@ export class ConversationRepository {
 
     const shouldOpenMLS1to1Conversation = wasProteus1to1ActiveConversation && !isMLS1to1ActiveConversation;
 
-    return {shouldOpenMLS1to1Conversation};
+    return {shouldOpenMLS1to1Conversation, wasProteus1to1Replaced: true};
   };
 
   private async blacklistConversation(conversationId: QualifiedId) {
@@ -1595,7 +1595,10 @@ export class ConversationRepository {
     }
 
     // If proteus 1:1 conversation with the same user is known, we have to make sure it is replaced with mls 1:1 conversation.
-    const {shouldOpenMLS1to1Conversation} = await this.replaceProteus1to1WithMLS(otherUserId, mlsConversation);
+    const {shouldOpenMLS1to1Conversation, wasProteus1to1Replaced} = await this.replaceProteus1to1WithMLS(
+      otherUserId,
+      mlsConversation,
+    );
 
     if (mlsConversation.participating_user_ids.length === 0) {
       ConversationMapper.updateProperties(mlsConversation, {participating_user_ids: [otherUser.qualifiedId]});
@@ -1637,13 +1640,15 @@ export class ConversationRepository {
       throw new Error('Self user is not available!');
     }
 
-    // If its a 1:1 conversation between two users from the same team we should not establish it automatically,
+    // If its a 1:1 conversation between two users from the same team we should not establish it automatically (unless there was already a proteus 1:1 conversation),
     // it will be established once first mls message is sent in a conversation
     const isTeamMember = !!selfUser.teamId && !!otherUser.teamId && selfUser.teamId === otherUser.teamId;
 
-    const initialisedMLSConversation = isTeamMember
-      ? mlsConversation
-      : await this.establishMLS1to1Conversation(mlsConversation, otherUserId);
+    const shouldEstablishMLS1to1 = !isTeamMember || wasProteus1to1Replaced;
+
+    const initialisedMLSConversation = shouldEstablishMLS1to1
+      ? await this.establishMLS1to1Conversation(mlsConversation, otherUserId)
+      : mlsConversation;
 
     if (shouldOpenMLS1to1Conversation) {
       // If proteus conversation was previously active conversaiton, we want to make mls 1:1 conversation active.

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -17,7 +17,12 @@
  *
  */
 
-import {ConversationProtocol, MessageSendingStatus, QualifiedUserClients} from '@wireapp/api-client/lib/conversation';
+import {
+  CONVERSATION_TYPE,
+  ConversationProtocol,
+  MessageSendingStatus,
+  QualifiedUserClients,
+} from '@wireapp/api-client/lib/conversation';
 import {BackendErrorLabel} from '@wireapp/api-client/lib/http/';
 import {QualifiedId, RequestCancellationError} from '@wireapp/api-client/lib/user';
 import {
@@ -791,7 +796,15 @@ export class MessageRepository {
     // Configure ephemeral messages
     conversationService.messageTimer.setConversationLevelTimer(conversation.id, conversation.messageTimer());
 
-    const sendOptions: Parameters<typeof conversationService.send>[0] = isMLSConversation(conversation)
+    const isMLS = isMLSConversation(conversation);
+    const is1to1 = conversation.type() === CONVERSATION_TYPE.ONE_TO_ONE;
+
+    //Before sending a message in MLS 1:1 conversation we need to make sure that the group is established
+    if (isMLS && is1to1) {
+      await this.conversationRepositoryProvider().makeSureMLS1to1ConversationIsEstablished(conversation);
+    }
+
+    const sendOptions: Parameters<typeof conversationService.send>[0] = isMLS
       ? {
           groupId: conversation.groupId,
           payload,

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -89,7 +89,7 @@ export class Conversation {
   public readonly archivedState: ko.Observable<boolean>;
   public readonly readOnlyState: ko.Observable<CONVERSATION_READONLY_STATE | null>;
   private readonly incomingMessages: ko.ObservableArray<Message>;
-  public readonly isTeam1to1: ko.PureComputed<boolean>;
+  public readonly isProteusTeam1to1: ko.PureComputed<boolean>;
   public readonly last_server_timestamp: ko.Observable<number>;
   private readonly logger: Logger;
   public readonly mutedState: ko.Observable<number>;
@@ -235,18 +235,18 @@ export class Conversation {
     this.isTeamOnly = ko.pureComputed(() => this.accessState() === ACCESS_STATE.TEAM.TEAM_ONLY);
     this.withAllTeamMembers = ko.observable(false);
 
-    this.isTeam1to1 = ko.pureComputed(() => {
+    this.isProteusTeam1to1 = ko.pureComputed(() => {
       const isGroupConversation = this.type() === CONVERSATION_TYPE.REGULAR;
       const hasOneParticipant = this.participating_user_ids().length === 1;
       return isGroupConversation && hasOneParticipant && this.teamId && !this.name();
     });
     this.isGroup = ko.pureComputed(() => {
       const isGroupConversation = this.type() === CONVERSATION_TYPE.REGULAR;
-      return isGroupConversation && !this.isTeam1to1();
+      return isGroupConversation && !this.isProteusTeam1to1();
     });
     this.is1to1 = ko.pureComputed(() => {
       const is1to1Conversation = this.type() === CONVERSATION_TYPE.ONE_TO_ONE;
-      return is1to1Conversation || this.isTeam1to1();
+      return is1to1Conversation || this.isProteusTeam1to1();
     });
     this.isRequest = ko.pureComputed(
       () =>

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -85,7 +85,7 @@ import {IntegrationRepository} from '../integration/IntegrationRepository';
 import {IntegrationService} from '../integration/IntegrationService';
 import {startNewVersionPolling} from '../lifecycle/newVersionHandler';
 import {MediaRepository} from '../media/MediaRepository';
-import {initMLSGroupConversations, registerUninitializedSelfAndTeamConversations} from '../mls';
+import {initMLSGroupConversations, initialiseSelfAndTeamConversations} from '../mls';
 import {joinConversationsAfterMigrationFinalisation} from '../mls/MLSMigration/migrationFinaliser';
 import {NotificationRepository} from '../notification/NotificationRepository';
 import {PreferenceNotificationRepository} from '../notification/PreferenceNotificationRepository';
@@ -460,7 +460,7 @@ export class App {
 
       if (supportsMLS()) {
         //add the potential `self` and `team` conversations
-        await registerUninitializedSelfAndTeamConversations(conversations, selfUser, clientEntity.id, this.core);
+        await initialiseSelfAndTeamConversations(conversations, selfUser, clientEntity.id, this.core);
 
         //join all the mls groups that are known by the user but were migrated to mls
         await joinConversationsAfterMigrationFinalisation({

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -85,7 +85,7 @@ import {IntegrationRepository} from '../integration/IntegrationRepository';
 import {IntegrationService} from '../integration/IntegrationService';
 import {startNewVersionPolling} from '../lifecycle/newVersionHandler';
 import {MediaRepository} from '../media/MediaRepository';
-import {initMLSConversations, registerUninitializedSelfAndTeamConversations} from '../mls';
+import {initMLSGroupConversations, registerUninitializedSelfAndTeamConversations} from '../mls';
 import {joinConversationsAfterMigrationFinalisation} from '../mls/MLSMigration/migrationFinaliser';
 import {NotificationRepository} from '../notification/NotificationRepository';
 import {PreferenceNotificationRepository} from '../notification/PreferenceNotificationRepository';
@@ -472,7 +472,7 @@ export class App {
         });
 
         //join all the mls groups we're member of and have not yet joined (eg. we were not send welcome message)
-        await initMLSConversations(conversations, {
+        await initMLSGroupConversations(conversations, {
           core: this.core,
           onError: ({id}, error) =>
             this.logger.error(`Failed when initialising mls conversation with id ${id}, error: `, error),

--- a/src/script/mls/MLSConversations.test.ts
+++ b/src/script/mls/MLSConversations.test.ts
@@ -23,7 +23,7 @@ import {randomUUID} from 'crypto';
 
 import {Account} from '@wireapp/core';
 
-import {initMLSConversations, registerUninitializedSelfAndTeamConversations} from './MLSConversations';
+import {initMLSGroupConversations, registerUninitializedSelfAndTeamConversations} from './MLSConversations';
 
 import {MLSConversation} from '../conversation/ConversationSelectors';
 import {Conversation} from '../entity/Conversation';
@@ -54,7 +54,7 @@ describe('MLSConversations', () => {
       jest.spyOn(core.service!.conversation, 'mlsGroupExistsLocally').mockResolvedValue(false);
       jest.spyOn(core.service!.conversation, 'joinByExternalCommit');
 
-      await initMLSConversations(mlsConversations, {core});
+      await initMLSGroupConversations(mlsConversations, {core});
 
       for (const conversation of mlsConversations) {
         expect(core.service?.conversation.joinByExternalCommit).toHaveBeenCalledWith(conversation.qualifiedId);
@@ -71,7 +71,7 @@ describe('MLSConversations', () => {
     jest.spyOn(core.service!.conversation!, 'mlsGroupExistsLocally').mockResolvedValue(true);
     jest.spyOn(core.service!.mls!, 'scheduleKeyMaterialRenewal');
 
-    await initMLSConversations(mlsConversations, {core});
+    await initMLSGroupConversations(mlsConversations, {core});
 
     for (const conversation of mlsConversations) {
       expect(core.service!.mls!.scheduleKeyMaterialRenewal).toHaveBeenCalledWith(conversation.groupId);

--- a/src/script/mls/MLSConversations.test.ts
+++ b/src/script/mls/MLSConversations.test.ts
@@ -33,7 +33,7 @@ function createMLSConversation(type?: CONVERSATION_TYPE): MLSConversation {
   const conversation = new Conversation(randomUUID(), '', ConversationProtocol.MLS);
   conversation.groupId = `groupid-${randomUUID()}`;
   conversation.epoch = 0;
-  if (type) {
+  if (type !== undefined) {
     conversation.type(type);
   }
   return conversation as MLSConversation;
@@ -44,12 +44,12 @@ function createMLSConversations(nbConversations: number, type?: CONVERSATION_TYP
 }
 
 describe('MLSConversations', () => {
-  describe('initMLSConversations', () => {
+  describe('initMLSGroupConversations', () => {
     it('joins all the unestablished MLS groups', async () => {
       const core = new Account();
       const nbMLSConversations = 5 + Math.ceil(Math.random() * 10);
 
-      const mlsConversations = createMLSConversations(nbMLSConversations);
+      const mlsConversations = createMLSConversations(nbMLSConversations, CONVERSATION_TYPE.REGULAR);
 
       jest.spyOn(core.service!.conversation, 'mlsGroupExistsLocally').mockResolvedValue(false);
       jest.spyOn(core.service!.conversation, 'joinByExternalCommit');
@@ -66,7 +66,7 @@ describe('MLSConversations', () => {
     const core = new Account();
     const nbMLSConversations = 5 + Math.ceil(Math.random() * 10);
 
-    const mlsConversations = createMLSConversations(nbMLSConversations);
+    const mlsConversations = createMLSConversations(nbMLSConversations, CONVERSATION_TYPE.REGULAR);
 
     jest.spyOn(core.service!.conversation!, 'mlsGroupExistsLocally').mockResolvedValue(true);
     jest.spyOn(core.service!.mls!, 'scheduleKeyMaterialRenewal');

--- a/src/script/mls/MLSConversations.test.ts
+++ b/src/script/mls/MLSConversations.test.ts
@@ -23,7 +23,7 @@ import {randomUUID} from 'crypto';
 
 import {Account} from '@wireapp/core';
 
-import {initMLSGroupConversations, registerUninitializedSelfAndTeamConversations} from './MLSConversations';
+import {initMLSGroupConversations, initialiseSelfAndTeamConversations} from './MLSConversations';
 
 import {MLSConversation} from '../conversation/ConversationSelectors';
 import {Conversation} from '../entity/Conversation';
@@ -92,7 +92,7 @@ describe('MLSConversations', () => {
       const mlsConversations = createMLSConversations(nbMLSConversations);
       const conversations = [teamConversation, ...mlsConversations, selfConversation];
 
-      await registerUninitializedSelfAndTeamConversations(conversations, new User(), 'client-1', core);
+      await initialiseSelfAndTeamConversations(conversations, new User(), 'client-1', core);
 
       expect(core.service!.mls!.registerConversation).toHaveBeenCalledTimes(2);
     });
@@ -112,7 +112,7 @@ describe('MLSConversations', () => {
       const mlsConversations = createMLSConversations(nbMLSConversations);
       const conversations = [teamConversation, ...mlsConversations, selfConversation];
 
-      await registerUninitializedSelfAndTeamConversations(conversations, new User(), 'clientId', core);
+      await initialiseSelfAndTeamConversations(conversations, new User(), 'clientId', core);
 
       expect(core.service!.mls!.registerConversation).toHaveBeenCalledTimes(0);
     });

--- a/src/script/mls/MLSConversations.ts
+++ b/src/script/mls/MLSConversations.ts
@@ -27,6 +27,7 @@ import {
   isMLSConversation,
   isSelfConversation,
   isTeamConversation,
+  MLSCapableConversation,
   MLSConversation,
 } from '../conversation/ConversationSelectors';
 import {Conversation} from '../entity/Conversation';
@@ -38,7 +39,7 @@ import {User} from '../entity/User';
  * @param conversations - all the conversations that the user is part of
  * @param core - the instance of the core
  */
-export async function initMLSConversations(
+export async function initMLSGroupConversations(
   conversations: Conversation[],
   {
     core,
@@ -55,9 +56,12 @@ export async function initMLSConversations(
     throw new Error('MLS or Conversation service is not available!');
   }
 
-  const mlsConversations = conversations.filter(isMLSCapableConversation);
+  const mlsGroupConversations = conversations.filter(
+    (conversation): conversation is MLSCapableConversation =>
+      conversation.isGroup() && isMLSCapableConversation(conversation),
+  );
 
-  for (const mlsConversation of mlsConversations) {
+  for (const mlsConversation of mlsGroupConversations) {
     try {
       const {groupId, qualifiedId} = mlsConversation;
 
@@ -76,7 +80,7 @@ export async function initMLSConversations(
         return onSuccessfulJoin(mlsConversation);
       }
     } catch (error) {
-      return onError?.(mlsConversation, error);
+      onError?.(mlsConversation, error);
     }
   }
 }

--- a/src/script/mls/MLSConversations.ts
+++ b/src/script/mls/MLSConversations.ts
@@ -122,7 +122,7 @@ export async function initialiseSelfAndTeamConversations(
       // If the conversation is already established, we don't need to do anything.
       const isGroupAlreadyEstablished = await mlsService.isConversationEstablished(conversation.groupId);
       if (isGroupAlreadyEstablished) {
-        return;
+        return Promise.resolve();
       }
 
       // Otherwise, we need to join the conversation via external commit.

--- a/src/script/mls/MLSMigration/migrationFinaliser/joinConversationsAfterMigrationFinalisation/joinConversationsAfterMigrationFinalisation.ts
+++ b/src/script/mls/MLSMigration/migrationFinaliser/joinConversationsAfterMigrationFinalisation/joinConversationsAfterMigrationFinalisation.ts
@@ -23,7 +23,7 @@ import {Account} from '@wireapp/core';
 
 import {MLSConversation, isMLSConversation} from 'src/script/conversation/ConversationSelectors';
 import {Conversation} from 'src/script/entity/Conversation';
-import {initMLSConversations} from 'src/script/mls/MLSConversations';
+import {initMLSGroupConversations} from 'src/script/mls/MLSConversations';
 
 /**
  * Will compare the list of initial conversations stored in the local database with conversations fetched from the backend.
@@ -49,7 +49,7 @@ export const joinConversationsAfterMigrationFinalisation = async ({
   //we have to join the conversation with external commit and let user know that they might have missed some messages
   const alreadyMigratedConversations = filterGroupConversationsAlreadyMigratedToMLS(conversations);
 
-  await initMLSConversations(alreadyMigratedConversations, {core, onSuccessfulJoin: onSuccess, onError});
+  await initMLSGroupConversations(alreadyMigratedConversations, {core, onSuccessfulJoin: onSuccess, onError});
 };
 
 const filterGroupConversationsAlreadyMigratedToMLS = (conversations: Conversation[]) => {

--- a/src/script/mls/MLSMigration/migrationInitialiser/joinUnestablishedMixedConversations/joinUnestablishedMixedConversations.ts
+++ b/src/script/mls/MLSMigration/migrationInitialiser/joinUnestablishedMixedConversations/joinUnestablishedMixedConversations.ts
@@ -21,7 +21,7 @@ import {Account} from '@wireapp/core';
 
 import {isMixedConversation} from 'src/script/conversation/ConversationSelectors';
 import {Conversation} from 'src/script/entity/Conversation';
-import {initMLSConversations} from 'src/script/mls/MLSConversations';
+import {initMLSGroupConversations} from 'src/script/mls/MLSConversations';
 
 import {mlsMigrationLogger} from '../../MLSMigrationLogger';
 
@@ -36,7 +36,7 @@ export const joinUnestablishedMixedConversations = async (
   const mixedConversations = conversations.filter(isMixedConversation);
   mlsMigrationLogger.info(`Found ${mixedConversations.length} "mixed" conversations, joining unestablished ones...`);
 
-  await initMLSConversations(mixedConversations, {
+  await initMLSGroupConversations(mixedConversations, {
     core,
     onError: ({id}, error) =>
       mlsMigrationLogger.error(`Failed when joining a mls group of mixed conversation with id ${id}, error: `, error),


### PR DESCRIPTION
## Description

According to spec, team-owned 1:1 MLS conversations should not be established automatically, it should happen only right before a user tries to send a message in a chat. We want to get rid of the behaviour where 1:1 conversation appeared at the top of the list if we were searched by somebody else.

To change this behaviour we're no longer establishing 1:1 mls conversations with two team members every time when 1:1 is initialised. Before every message is sent, we make sure mls 1:1 conversation is established. If it's not yet, we will first establish it and then send a message in a conversation.

Before:
![before](https://github.com/wireapp/wire-webapp/assets/45733298/dc96d719-3a5f-4104-8dee-af158c841d87)

After:
![after](https://github.com/wireapp/wire-webapp/assets/45733298/e421e3fc-401f-4fe9-be0c-d72512e7f69d)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

