### PR TITLE
refactor: make connection field on conversation null by default

### DIFF
--- a/src/script/conversation/ConversationSelectors.ts
+++ b/src/script/conversation/ConversationSelectors.ts
@@ -73,7 +73,7 @@ const is1to1ConversationWithUser =
     }
 
     const connection = conversation.connection();
-    if (connection.userId) {
+    if (connection?.userId) {
       return matchQualifiedIds(connection.userId, userId);
     }
 

--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -111,8 +111,11 @@ export class ConversationState {
           ConnectionStatus.PENDING,
         ];
 
+        const connection = conversationEntity.connection();
+
         return !(
-          isSelfConversation(conversationEntity) || states_to_filter.includes(conversationEntity.connection().status())
+          isSelfConversation(conversationEntity) ||
+          (connection && states_to_filter.includes(connection.status()))
         );
       });
     });

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -104,7 +104,7 @@ export class Conversation {
   public readonly archivedTimestamp: ko.Observable<number>;
   public readonly call: ko.Observable<Call | null>;
   public readonly cleared_timestamp: ko.Observable<number>;
-  public readonly connection: ko.Observable<ConnectionEntity>;
+  public readonly connection: ko.Observable<ConnectionEntity | null>;
   // TODO(Federation): Currently the 'creator' just refers to a user id but it has to become a qualified id
   public creator: string;
   public groupId?: string;
@@ -272,7 +272,7 @@ export class Conversation {
     );
 
     // in case this is a one2one conversation this is the connection to that user
-    this.connection = ko.observable(new ConnectionEntity());
+    this.connection = ko.observable(null);
     this.connection.subscribe(connectionEntity => {
       const connectedUserId = connectionEntity?.userId;
       if (connectedUserId && this.participating_user_ids().every(user => !matchQualifiedIds(user, connectedUserId))) {

--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -106,7 +106,7 @@ export class ContentViewModel {
 
     ko.computed(() => {
       if (
-        this.conversationState.activeConversation()?.connection().status() ===
+        this.conversationState.activeConversation()?.connection()?.status() ===
         ConnectionStatus.MISSING_LEGAL_HOLD_CONSENT
       ) {
         showMostRecentConversation();


### PR DESCRIPTION
## Description

Connection entity is set only on those 1:1 conversations that were created after a connection was established between two users, there's no need for empty connection entity to exist on all other conversation types. Connection field on conversation entity is now `null` by default.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
