### PR TITLE
refactor: make a connection field on user entity null by default

### DIFF
--- a/src/script/components/ConnectRequests/ConnectionRequests.tsx
+++ b/src/script/components/ConnectRequests/ConnectionRequests.tsx
@@ -51,10 +51,16 @@ export const ConnectRequests = ({
   const mainViewModel = useContext(RootContext);
   const {classifiedDomains} = useKoSubscribableChildren(teamState, ['classifiedDomains']);
   const {connectRequests: unsortedConnectionRequests} = useKoSubscribableChildren(userState, ['connectRequests']);
-  const connectionRequests = unsortedConnectionRequests.sort(
-    (user1, user2) =>
-      new Date(user1.connection().lastUpdate).getTime() - new Date(user2.connection().lastUpdate).getTime(),
-  );
+  const connectionRequests = unsortedConnectionRequests.sort((user1, user2) => {
+    const user1Connection = user1.connection();
+    const user2Connection = user2.connection();
+
+    if (!user1Connection || !user2Connection) {
+      return 0;
+    }
+
+    return new Date(user1Connection.lastUpdate).getTime() - new Date(user2Connection.lastUpdate).getTime();
+  });
 
   // To be changed when design chooses a breakpoint, the conditional can be integrated to the ui-kit directly
   const smBreakpoint = useMatchMedia('max-width: 640px');

--- a/src/script/components/panel/UserActions.test.tsx
+++ b/src/script/components/panel/UserActions.test.tsx
@@ -22,6 +22,7 @@ import {ConnectionStatus} from '@wireapp/api-client/lib/connection/';
 import ko from 'knockout';
 
 import {withTheme} from 'src/script/auth/util/test/TestUtil';
+import {ConnectionEntity} from 'src/script/connection/ConnectionEntity';
 import {ConversationRoleRepository} from 'src/script/conversation/ConversationRoleRepository';
 import {Conversation} from 'src/script/entity/Conversation';
 import {User} from 'src/script/entity/User';
@@ -92,8 +93,12 @@ describe('UserActions', () => {
 
   it('generates actions for another user profile to which I am connected', () => {
     const user = new User('');
+    const connection = new ConnectionEntity();
+    user.connection(connection);
+
     jest.spyOn(user, 'isAvailable').mockImplementation(ko.pureComputed(() => true));
     const conversation = new Conversation();
+    conversation.connection(connection);
     jest.spyOn(conversation, 'isGroup').mockImplementation(ko.pureComputed(() => true));
     jest.spyOn(conversation, 'participating_user_ids').mockImplementation(ko.observableArray([new User()]));
     user.connection()?.status(ConnectionStatus.ACCEPTED);
@@ -147,6 +152,9 @@ describe('UserActions', () => {
   it('displays buttons instead of a list when a single action is available in user modal', () => {
     const user = new User('');
     const conversation = new Conversation();
+    const connection = new ConnectionEntity();
+    user.connection(connection);
+    conversation.connection(connection);
     user.connection()?.status(ConnectionStatus.UNKNOWN);
     jest.spyOn(user, 'isAvailable').mockImplementation(ko.pureComputed(() => true));
     const conversationRoleRepository: Partial<ConversationRoleRepository> = {canRemoveParticipants: () => false};
@@ -174,6 +182,9 @@ describe('UserActions', () => {
   it('displays a list when a single action is available in sidebar', () => {
     const user = new User('');
     const conversation = new Conversation();
+    const connection = new ConnectionEntity();
+    user.connection(connection);
+    conversation.connection(connection);
     user.connection()?.status(ConnectionStatus.UNKNOWN);
     jest.spyOn(user, 'isAvailable').mockImplementation(ko.pureComputed(() => true));
     const conversationRoleRepository: Partial<ConversationRoleRepository> = {canRemoveParticipants: () => false};
@@ -200,6 +211,9 @@ describe('UserActions', () => {
   it('displays a list when multiple actions are available in user modal', () => {
     const user = new User('');
     const conversation = new Conversation();
+    const connection = new ConnectionEntity();
+    user.connection(connection);
+    conversation.connection(connection);
     user.connection()?.status(ConnectionStatus.SENT);
     jest.spyOn(user, 'isAvailable').mockImplementation(ko.pureComputed(() => true));
     const conversationRoleRepository: Partial<ConversationRoleRepository> = {canRemoveParticipants: () => false};

--- a/src/script/components/panel/UserActions.test.tsx
+++ b/src/script/components/panel/UserActions.test.tsx
@@ -96,7 +96,7 @@ describe('UserActions', () => {
     const conversation = new Conversation();
     jest.spyOn(conversation, 'isGroup').mockImplementation(ko.pureComputed(() => true));
     jest.spyOn(conversation, 'participating_user_ids').mockImplementation(ko.observableArray([new User()]));
-    user.connection().status(ConnectionStatus.ACCEPTED);
+    user.connection()?.status(ConnectionStatus.ACCEPTED);
     const conversationRoleRepository: Partial<ConversationRoleRepository> = {canRemoveParticipants: () => true};
 
     const props = {
@@ -125,7 +125,7 @@ describe('UserActions', () => {
     const conversation = new Conversation();
     jest.spyOn(conversation, 'isGroup').mockImplementation(ko.pureComputed(() => true));
     jest.spyOn(conversation, 'participating_user_ids').mockImplementation(ko.observableArray([new User()]));
-    user.connection().status(ConnectionStatus.ACCEPTED);
+    user.connection()?.status(ConnectionStatus.ACCEPTED);
     const conversationRoleRepository: Partial<ConversationRoleRepository> = {canRemoveParticipants: () => true};
 
     const props = {
@@ -147,7 +147,7 @@ describe('UserActions', () => {
   it('displays buttons instead of a list when a single action is available in user modal', () => {
     const user = new User('');
     const conversation = new Conversation();
-    user.connection().status(ConnectionStatus.UNKNOWN);
+    user.connection()?.status(ConnectionStatus.UNKNOWN);
     jest.spyOn(user, 'isAvailable').mockImplementation(ko.pureComputed(() => true));
     const conversationRoleRepository: Partial<ConversationRoleRepository> = {canRemoveParticipants: () => false};
 
@@ -174,7 +174,7 @@ describe('UserActions', () => {
   it('displays a list when a single action is available in sidebar', () => {
     const user = new User('');
     const conversation = new Conversation();
-    user.connection().status(ConnectionStatus.UNKNOWN);
+    user.connection()?.status(ConnectionStatus.UNKNOWN);
     jest.spyOn(user, 'isAvailable').mockImplementation(ko.pureComputed(() => true));
     const conversationRoleRepository: Partial<ConversationRoleRepository> = {canRemoveParticipants: () => false};
 
@@ -200,7 +200,7 @@ describe('UserActions', () => {
   it('displays a list when multiple actions are available in user modal', () => {
     const user = new User('');
     const conversation = new Conversation();
-    user.connection().status(ConnectionStatus.SENT);
+    user.connection()?.status(ConnectionStatus.SENT);
     jest.spyOn(user, 'isAvailable').mockImplementation(ko.pureComputed(() => true));
     const conversationRoleRepository: Partial<ConversationRoleRepository> = {canRemoveParticipants: () => false};
 

--- a/src/script/components/panel/UserActions.tsx
+++ b/src/script/components/panel/UserActions.tsx
@@ -80,7 +80,13 @@ export interface UserActionsProps {
 }
 
 function createPlaceholder1to1Conversation(user: User, selfUser: User) {
-  const {id, domain} = user.connection().conversationId;
+  const userConnection = user.connection();
+
+  if (!userConnection) {
+    throw new Error(`There's no connection with user ${user.qualifiedId.id}.`);
+  }
+
+  const {id, domain} = userConnection.conversationId;
   const conversation = new Conversation(id, domain);
   conversation.name(user.name());
   conversation.selfUser(selfUser);
@@ -89,7 +95,7 @@ function createPlaceholder1to1Conversation(user: User, selfUser: User) {
   conversation.participating_user_ets([user]);
   conversation.accessState(ACCESS_STATE.PERSONAL.ONE2ONE);
   conversation.last_event_timestamp(Date.now());
-  conversation.connection(user.connection());
+  conversation.connection(userConnection);
   return conversation;
 }
 

--- a/src/script/connection/ConnectionRepository.test.ts
+++ b/src/script/connection/ConnectionRepository.test.ts
@@ -58,7 +58,7 @@ describe('ConnectionRepository', () => {
 
     it('sets the connection status to cancelled', () => {
       const user = createConnection();
-      connectionRepository.addConnectionEntity(user.connection());
+      connectionRepository.addConnectionEntity(user.connection()!);
       jest.spyOn(connectionService, 'putConnections').mockResolvedValue({} as any);
       return connectionRepository.cancelRequest(user).then(() => {
         expect(connectionService.putConnections).toHaveBeenCalled();
@@ -67,7 +67,7 @@ describe('ConnectionRepository', () => {
 
     it('switches the conversation if requested', () => {
       const user = createConnection();
-      connectionRepository.addConnectionEntity(user.connection());
+      connectionRepository.addConnectionEntity(user.connection()!);
       const amplifySpy = jasmine.createSpy('conversation_show');
       amplify.subscribe(WebAppEvents.CONVERSATION.SHOW, amplifySpy);
 
@@ -83,8 +83,8 @@ describe('ConnectionRepository', () => {
 
     it('should return the expected connection for the given conversation id', () => {
       const userA = createConnection();
-      connectionRepository.addConnectionEntity(userA.connection());
-      const connectionEntity = connectionRepository.getConnectionByConversationId(userA.connection().conversationId);
+      connectionRepository.addConnectionEntity(userA.connection()!);
+      const connectionEntity = connectionRepository.getConnectionByConversationId(userA.connection()!.conversationId);
 
       expect(connectionEntity).toBe(userA.connection());
 

--- a/src/script/connection/ConnectionRepository.ts
+++ b/src/script/connection/ConnectionRepository.ts
@@ -318,7 +318,7 @@ export class ConnectionRepository {
    * @returns Promise that resolves when the connection status was updated
    */
   private async updateStatus(userEntity: User, newStatus: ConnectionStatus): Promise<void> {
-    const currentStatus = userEntity.connection().status();
+    const currentStatus = userEntity.connection()?.status();
     try {
       const response = await this.connectionService.putConnections(userEntity.qualifiedId, newStatus);
       const connectionEvent = {connection: response, user: {name: userEntity.name()}};

--- a/src/script/entity/User/User.ts
+++ b/src/script/entity/User/User.ts
@@ -51,7 +51,7 @@ export class User {
   public readonly accent_color: ko.PureComputed<string>;
   public readonly accent_id: ko.Observable<number>;
   public readonly availability = ko.observable(Availability.Type.NONE);
-  public readonly connection: ko.Observable<ConnectionEntity>;
+  public readonly connection: ko.Observable<ConnectionEntity | null>;
   /** does not include current client/device */
   public readonly devices: ko.ObservableArray<ClientEntity>;
   public localClient: ClientEntity | undefined;
@@ -171,17 +171,18 @@ export class User {
     this.previewPictureResource = ko.observable().extend({rateLimit: {method: 'notifyWhenChangesStop', timeout: 100}});
     this.mediumPictureResource = ko.observable().extend({rateLimit: {method: 'notifyWhenChangesStop', timeout: 100}});
 
-    this.connection = ko.observable(new ConnectionEntity());
+    this.connection = ko.observable<ConnectionEntity | null>(null);
 
-    this.isBlocked = ko.pureComputed(() => this.connection().isBlocked() || this.isBlockedLegalHold());
-    this.isBlockedLegalHold = ko.pureComputed(() => this.connection().isMissingLegalHoldConsent());
-    this.isCanceled = ko.pureComputed(() => this.connection().isCanceled());
-    this.isConnected = ko.pureComputed(() => this.connection().isConnected());
-    this.isIgnored = ko.pureComputed(() => this.connection().isIgnored());
-    this.isIncomingRequest = ko.pureComputed(() => this.connection().isIncomingRequest());
-    this.isOutgoingRequest = ko.pureComputed(() => this.connection().isOutgoingRequest());
-    this.isUnknown = ko.pureComputed(() => this.connection().isUnknown());
+    this.isBlocked = ko.pureComputed(() => !!this.connection()?.isBlocked() || this.isBlockedLegalHold());
+    this.isBlockedLegalHold = ko.pureComputed(() => !!this.connection()?.isMissingLegalHoldConsent());
+    this.isCanceled = ko.pureComputed(() => !!this.connection()?.isCanceled());
+    this.isConnected = ko.pureComputed(() => !!this.connection()?.isConnected());
+    this.isIgnored = ko.pureComputed(() => !!this.connection()?.isIgnored());
+    this.isIncomingRequest = ko.pureComputed(() => !!this.connection()?.isIncomingRequest());
+    this.isOutgoingRequest = ko.pureComputed(() => !!this.connection()?.isOutgoingRequest());
+    this.isUnknown = ko.pureComputed(() => !!this.connection()?.isUnknown());
     this.isExternal = ko.pureComputed(() => this.teamRole() === TEAM_ROLE.PARTNER);
+    this.isRequest = ko.pureComputed(() => !!this.connection()?.isRequest());
 
     this.isGuest = ko.observable(false);
     this.isDirectGuest = ko.pureComputed(() => {
@@ -191,8 +192,6 @@ export class User {
     this.isActivatedAccount = ko.pureComputed(() => !this.isTemporaryGuest());
     this.teamRole = ko.observable(TEAM_ROLE.NONE);
     this.teamId = undefined;
-
-    this.isRequest = ko.pureComputed(() => this.connection().isRequest());
 
     /* Placeholder for a future feature allowing 3rd party user verification
       As it is not implemented yet, it always returns false for now */
@@ -248,7 +247,7 @@ export class User {
   }
 
   markConnectionAsUnknown() {
-    this.connection().status(ConnectionStatus.UNKNOWN);
+    this.connection()?.status(ConnectionStatus.UNKNOWN);
   }
 
   addClient(new_client_et: ClientEntity): boolean {

--- a/src/script/user/UserRepository.test.ts
+++ b/src/script/user/UserRepository.test.ts
@@ -282,7 +282,7 @@ describe('UserRepository', () => {
         expect(userState.users()).toHaveLength(users.length + 1);
         users.forEach(user => {
           const localUser = userState.users().find(u => matchQualifiedIds(u.qualifiedId, user.qualified_id));
-          expect(localUser?.connection().userId).toEqual(user.qualified_id);
+          expect(localUser?.connection()?.userId).toEqual(user.qualified_id);
         });
       });
 

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -365,7 +365,9 @@ export class UserRepository extends TypedEventEmitter<Events> {
 
     userEntities.forEach(userEntity => {
       const connectionEntity = connectionEntities.find(({userId}) => matchQualifiedIds(userId, userEntity));
-      userEntity.connection(connectionEntity);
+      if (connectionEntity) {
+        userEntity.connection(connectionEntity);
+      }
     });
     return this.assignAllClients();
   }


### PR DESCRIPTION
## Description

This PR makes connection field (observable) `null` by default on user entity. Not every user has a connection, there's no need to set an empty connection entity as a default value.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
