### PR TITLE
runfix: mark connection as unknown if it does not exist at all

### DIFF
--- a/src/script/entity/User/User.ts
+++ b/src/script/entity/User/User.ts
@@ -180,7 +180,10 @@ export class User {
     this.isIgnored = ko.pureComputed(() => !!this.connection()?.isIgnored());
     this.isIncomingRequest = ko.pureComputed(() => !!this.connection()?.isIncomingRequest());
     this.isOutgoingRequest = ko.pureComputed(() => !!this.connection()?.isOutgoingRequest());
-    this.isUnknown = ko.pureComputed(() => !!this.connection()?.isUnknown());
+    this.isUnknown = ko.pureComputed(() => {
+      const connection = this.connection();
+      return !connection || connection.isUnknown();
+    });
     this.isExternal = ko.pureComputed(() => this.teamRole() === TEAM_ROLE.PARTNER);
     this.isRequest = ko.pureComputed(() => !!this.connection()?.isRequest());
 


### PR DESCRIPTION
## Description

My last PR https://github.com/wireapp/wire-webapp/pull/16437 introduced a regression - connect button was not visible when trying to create a connection with user from a different team. To keep the current behaviour, we should mark a connection as unknown even if it does not exist at all - it's `null`.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
