### PR TITLE
refactor: updating supported protocols

### DIFF
--- a/src/__mocks__/@wireapp/core.ts
+++ b/src/__mocks__/@wireapp/core.ts
@@ -89,6 +89,12 @@ export class Account extends EventEmitter {
     client: {
       deleteClient: jest.fn(),
     },
+    self: {
+      putSupportedProtocols: jest.fn(),
+    },
+    user: {
+      getUserSupportedProtocols: jest.fn(),
+    },
   };
 }
 

--- a/src/script/self/SelfService.ts
+++ b/src/script/self/SelfService.ts
@@ -23,14 +23,23 @@ import type {Consent, Self} from '@wireapp/api-client/lib/self/';
 import type {UserUpdate} from '@wireapp/api-client/lib/user/';
 import {container} from 'tsyringe';
 
-import {getLogger} from 'Util/Logger';
-
 import {APIClient} from '../service/APIClientSingleton';
+import {Core} from '../service/CoreSingleton';
 
 export class SelfService {
-  private readonly logger = getLogger('ConversationService');
+  constructor(
+    private readonly apiClient = container.resolve(APIClient),
+    private readonly core = container.resolve(Core),
+  ) {}
 
-  constructor(private readonly apiClient = container.resolve(APIClient)) {}
+  private get coreSelfService() {
+    const selfService = this.core.service?.self;
+    if (!selfService) {
+      throw new Error('Self service not available');
+    }
+
+    return selfService;
+  }
 
   deleteSelf(password?: string): Promise<void> {
     return this.apiClient.api.self.deleteSelf({password});
@@ -74,11 +83,6 @@ export class SelfService {
   }
 
   public async putSupportedProtocols(supportedProtocols: ConversationProtocol[]): Promise<void> {
-    if (!this.apiClient.backendFeatures.supportsMLS) {
-      this.logger.warn('Self supported protocols were not updated, because MLS is not supported by the backend');
-      return;
-    }
-
-    return this.apiClient.api.self.putSupportedProtocols(supportedProtocols);
+    return this.coreSelfService.putSupportedProtocols(supportedProtocols);
   }
 }


### PR DESCRIPTION
## Description

Removed some validation logic when setting self/other user supported protocols since it was moved to core package some time ago. See https://github.com/wireapp/wire-web-packages/blob/main/packages/core/src/user/UserService.ts#L49 and https://github.com/wireapp/wire-web-packages/blob/main/packages/core/src/self/SelfService.ts#L75

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;