### PR TITLE
feat: bump core to queue incoming mls messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@peculiar/x509": "1.9.6",
     "@wireapp/avs": "9.5.2",
     "@wireapp/commons": "5.2.3",
-    "@wireapp/core": "43.2.0",
+    "@wireapp/core": "43.3.0",
     "@wireapp/react-ui-kit": "9.12.3",
     "@wireapp/store-engine-dexie": "2.1.7",
     "@wireapp/webapp-events": "0.18.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4957,14 +4957,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^26.7.2":
-  version: 26.7.2
-  resolution: "@wireapp/api-client@npm:26.7.2"
+"@wireapp/api-client@npm:^26.8.0":
+  version: 26.8.0
+  resolution: "@wireapp/api-client@npm:26.8.0"
   dependencies:
     "@wireapp/commons": ^5.2.3
     "@wireapp/priority-queue": ^2.1.4
     "@wireapp/protocol-messaging": 1.44.0
-    axios: 1.6.2
+    axios: 1.6.3
     axios-retry: 3.9.1
     exponential-backoff: 3.1.1
     http-status-codes: 2.3.0
@@ -4973,9 +4973,9 @@ __metadata:
     reconnecting-websocket: 4.4.0
     spark-md5: 3.0.2
     tough-cookie: 4.1.3
-    ws: 8.15.1
+    ws: 8.16.0
     zod: 3.22.4
-  checksum: 41cdf2b889a8fa40cd813f453e389b7eca78a10b2afc84ac227371d71ed093bb839069b6cfd1af4c225d9d878e14d8a1f645b1eff6b72df5b30bcced72eecc59
+  checksum: 9b6ceadd324e4219f1d54215f276ad892d641af0c216494597fd38d962ebe0fa6374bf45b638443dd844ce3bc1891c12e7e5be784c899d1aa2ff25ca9ee15fa1
   languageName: node
   linkType: hard
 
@@ -5028,11 +5028,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:43.2.0":
-  version: 43.2.0
-  resolution: "@wireapp/core@npm:43.2.0"
+"@wireapp/core@npm:43.3.0":
+  version: 43.3.0
+  resolution: "@wireapp/core@npm:43.3.0"
   dependencies:
-    "@wireapp/api-client": ^26.7.2
+    "@wireapp/api-client": ^26.8.0
     "@wireapp/commons": ^5.2.3
     "@wireapp/core-crypto": 1.0.0-rc.21
     "@wireapp/cryptobox": 12.8.0
@@ -5040,7 +5040,7 @@ __metadata:
     "@wireapp/protocol-messaging": 1.44.0
     "@wireapp/store-engine": 5.1.5
     "@wireapp/store-engine-dexie": ^2.1.7
-    axios: 1.6.2
+    axios: 1.6.3
     bazinga64: ^6.3.4
     deepmerge-ts: 5.1.0
     hash.js: 1.1.7
@@ -5050,7 +5050,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: ea2a996c65111784be4b3befe21d5983d5d38969b9f58dea2d4a261b101a53f3dbf22504b5e0ab3842c65df2dc84188a08e848661a95bad3a605d80440533e8f
+  checksum: c7121199bf2563fe98a4526e71256581582cae4eea15353e5a95edefaf28b212fda462bd1b6a8f2b3dacaccaafe0de8c93d019d9d2595f5437c643f000861a97
   languageName: node
   linkType: hard
 
@@ -5879,6 +5879,17 @@ __metadata:
     form-data: ^4.0.0
     proxy-from-env: ^1.1.0
   checksum: 4a7429e2b784be0f2902ca2680964391eae7236faa3967715f30ea45464b98ae3f1c6f631303b13dfe721b17126b01f486c7644b9ef276bfc63112db9fd379f8
+  languageName: node
+  linkType: hard
+
+"axios@npm:1.6.3":
+  version: 1.6.3
+  resolution: "axios@npm:1.6.3"
+  dependencies:
+    follow-redirects: ^1.15.0
+    form-data: ^4.0.0
+    proxy-from-env: ^1.1.0
+  checksum: 07ef3bb83fc2dacc1ae2c97f2bbd04ef7701f5655f9037789d79ee78b698ffa50eaa8465c2017d4d3e9ce7d94cb779f730acaab32ce9036d0a4933c1e89df4da
   languageName: node
   linkType: hard
 
@@ -17701,7 +17712,7 @@ __metadata:
     "@wireapp/avs": 9.5.2
     "@wireapp/commons": 5.2.3
     "@wireapp/copy-config": 2.1.12
-    "@wireapp/core": 43.2.0
+    "@wireapp/core": 43.3.0
     "@wireapp/eslint-config": 3.0.4
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.12.3
@@ -18093,7 +18104,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:8.15.1, ws@npm:^8.11.0":
+"ws@npm:8.16.0":
+  version: 8.16.0
+  resolution: "ws@npm:8.16.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: feb3eecd2bae82fa8a8beef800290ce437d8b8063bdc69712725f21aef77c49cb2ff45c6e5e7fce622248f9c7abaee506bae0a9064067ffd6935460c7357321b
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.11.0":
   version: 8.15.1
   resolution: "ws@npm:8.15.1"
   peerDependencies:


### PR DESCRIPTION
## Description

Bumps a core version that adds a queues mechanism for incoming mls messages. For more details see https://github.com/wireapp/wire-web-packages/pull/5822.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;