### PR TITLE
fix: Add read receipt status for 1on1

### DIFF
--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -513,6 +513,10 @@
   }
 }
 
+.message-status {
+  margin-left: 12px;
+}
+
 .message-status-read {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Description

Add margin left for read receipt status, now "delivered" status is very close to message send time.

![image](https://github.com/wireapp/wire-webapp/assets/13432884/1a9fa69c-d632-47c3-8e06-0a18be6357f6)

Margin comes from figma.

## Screenshots/Screencast (for UI changes)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
