### PR TITLE
runfix: Do not show MLS state on proteus-only env

### DIFF
--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DetailedDevice.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DetailedDevice.tsx
@@ -49,7 +49,7 @@ export const DetailedDevice: React.FC<DeviceProps> = ({
         <DeviceVerificationBadges device={device} getIdentity={getIdentity} />
       </h3>
 
-      <MLSDeviceDetails isCurrentDevice={isCurrentDevice} identity={getIdentity?.()} />
+      {getIdentity && <MLSDeviceDetails isCurrentDevice={isCurrentDevice} identity={getIdentity()} />}
 
       <ProteusDeviceDetails device={device} fingerprint={fingerprint} isProteusVerified={isProteusVerified} />
     </>


### PR DESCRIPTION
## Description

Avoids showing MLS device state on environments that do not have E2EI enabled

## Screenshots/Screencast (for UI changes)

Before
<img width="354" alt="image" src="https://github.com/wireapp/wire-webapp/assets/1090716/2306e4cd-bf6b-4bfe-bf9e-f3331d10cafa">

After
![image](https://github.com/wireapp/wire-webapp/assets/1090716/e46e5c70-f874-4fbb-9f72-047b0579df38)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
