### PR TITLE
feat: retreive current device certificate from CoreCrypto

### DIFF
--- a/src/__mocks__/@wireapp/core.ts
+++ b/src/__mocks__/@wireapp/core.ts
@@ -37,8 +37,6 @@ export class Account extends EventEmitter {
     e2eIdentity: {
       isEnrollmentInProgress: jest.fn(),
       clearAllProgress: jest.fn(),
-      hasActiveCertificate: jest.fn(),
-      getCertificateData: jest.fn(),
       getUsersIdentities: jest.fn(() => new Map()),
       getDeviceIdentities: jest.fn(),
       getConversationState: jest.fn(),

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.test.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.test.ts
@@ -64,6 +64,7 @@ jest.mock('./Modals', () => ({
 
 jest.mock('./E2EIdentityVerification', () => ({
   hasActiveCertificate: jest.fn().mockResolvedValue(false),
+  getActiveCertificate: jest.fn().mockResolvedValue('certificate data'),
   isE2EIEnabled: jest.fn().mockReturnValue(true),
 }));
 
@@ -195,9 +196,6 @@ describe('E2EIHandler', () => {
   it('should call renewCertificate when conditions are met', async () => {
     const handler = E2EIHandler.getInstance();
 
-    // Mock getCurrentDeviceCertificateData to return a specific string
-    handler['getCurrentDeviceCertificateData'] = jest.fn().mockReturnValue('certificate data');
-
     // set active certificate to be truthy
     (hasActiveCertificate as jest.Mock).mockResolvedValue(true);
 
@@ -216,9 +214,6 @@ describe('E2EIHandler', () => {
 
   it('should handle enrollment in progress', async () => {
     const handler = E2EIHandler.getInstance();
-
-    // Mock getCurrentDeviceCertificateData to return a specific string
-    handler['getCurrentDeviceCertificateData'] = jest.fn().mockReturnValue('certificate data');
 
     // Set active certificate to be truthy and enrollment in progress
     (hasActiveCertificate as jest.Mock).mockResolvedValue(true);
@@ -240,9 +235,6 @@ describe('E2EIHandler', () => {
 
   it('should not call renewCertificate when the renewal time is in the future', async () => {
     const handler = E2EIHandler.getInstance();
-
-    // Mock getCurrentDeviceCertificateData to return a specific string
-    handler['getCurrentDeviceCertificateData'] = jest.fn().mockReturnValue('certificate data');
 
     // Set active certificate to be truthy and enrollment not in progress
     (hasActiveCertificate as jest.Mock).mockResolvedValue(true);
@@ -284,9 +276,6 @@ describe('E2EIHandler', () => {
 
   it('for invalid certificate user can not get another certificate until deleting a client', async () => {
     const handler = E2EIHandler.getInstance();
-
-    // Mock getCurrentDeviceCertificateData to return a specific string
-    handler['getCurrentDeviceCertificateData'] = jest.fn().mockReturnValue('certificate data');
 
     // Set active certificate to be true
     (hasActiveCertificate as jest.Mock).mockResolvedValue(true);

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -128,7 +128,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
   }
 
   public async handleCertificateRenewal(): Promise<void> {
-    const certificate = await this.getCurrentDeviceCertificateData();
+    const certificate = await getActiveCertificate();
 
     if (!certificate) {
       return;
@@ -223,16 +223,6 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
     await this.oidcService.clearProgress();
     // Clear the e2e identity progress
     this.coreE2EIService.clearAllProgress();
-  }
-
-  private async getCurrentDeviceCertificateData() {
-    const activeCertificate = await getActiveCertificate();
-
-    if (!activeCertificate.length) {
-      return undefined;
-    }
-
-    return activeCertificate;
   }
 
   public async enroll(refreshActiveCertificate = false, userData?: User) {

--- a/src/script/E2EIdentity/E2EIdentityVerification.ts
+++ b/src/script/E2EIdentity/E2EIdentityVerification.ts
@@ -92,14 +92,15 @@ const fetchSelfDeviceIdentity = async (): Promise<WireIdentity | undefined> => {
 };
 
 export async function hasActiveCertificate(): Promise<boolean> {
-  return Boolean((await getActiveCertificate()).length);
+  const activeCertificate = await getActiveCertificate();
+  return typeof activeCertificate === 'string' && Boolean(activeCertificate.length);
 }
 
-export async function getActiveCertificate(): Promise<string> {
+export async function getActiveCertificate(): Promise<string | undefined> {
   const selfDeviceIdentity = await fetchSelfDeviceIdentity();
 
   if (!selfDeviceIdentity) {
-    return '';
+    return undefined;
   }
 
   return selfDeviceIdentity.certificate;

--- a/src/script/E2EIdentity/E2EIdentityVerification.ts
+++ b/src/script/E2EIdentity/E2EIdentityVerification.ts
@@ -27,6 +27,7 @@ import {base64ToArray, supportsMLS} from 'Util/util';
 import {mapMLSStatus} from './certificateDetails';
 
 import {Config} from '../Config';
+import {ConversationState} from '../conversation/ConversationState';
 
 export enum MLSStatuses {
   VALID = 'valid',
@@ -73,8 +74,35 @@ export async function getConversationVerificationState(groupId: string) {
 /**
  * Checks if E2EI has active certificate.
  */
-export function hasActiveCertificate() {
-  return getE2EIdentityService().hasActiveCertificate();
+const fetchSelfDeviceIdentity = async (): Promise<WireIdentity | undefined> => {
+  const conversationState = container.resolve(ConversationState);
+  const selfMLSConversation = conversationState.getSelfMLSConversation();
+  const userIdentities = await getUsersIdentities(
+    selfMLSConversation.groupId,
+    selfMLSConversation.allUserEntities().map(user => user.qualifiedId),
+  );
+  const currentClientId = selfMLSConversation.selfUser()?.localClient?.id;
+  const userId = selfMLSConversation.selfUser()?.id;
+
+  if (userId && currentClientId) {
+    const identity = userIdentities.get(userId)?.find(identity => identity.deviceId === currentClientId);
+    return identity;
+  }
+  return undefined;
+};
+
+export async function hasActiveCertificate(): Promise<boolean> {
+  return Boolean((await getActiveCertificate()).length);
+}
+
+export async function getActiveCertificate(): Promise<string> {
+  const selfDeviceIdentity = await fetchSelfDeviceIdentity();
+
+  if (!selfDeviceIdentity) {
+    return '';
+  }
+
+  return selfDeviceIdentity.certificate;
 }
 
 export async function isFreshMLSSelfClient() {

--- a/src/script/page/components/FeatureConfigChange/FeatureConfigChangeHandler/Features/E2EIdentity.ts
+++ b/src/script/page/components/FeatureConfigChange/FeatureConfigChangeHandler/Features/E2EIdentity.ts
@@ -48,7 +48,7 @@ export const handleE2EIdentityFeatureChange = async (logger: Logger, config: Fea
     const freshMLSSelfClient = await isFreshMLSSelfClient();
 
     // Either get the current E2EIdentity handler instance or create a new one
-    E2EIHandler.getInstance().initialize({
+    await E2EIHandler.getInstance().initialize({
       discoveryUrl: e2eiConfig.config.acmeDiscoveryUrl!,
       gracePeriodInSeconds: e2eiConfig.config.verificationExpiration,
       isFreshMLSSelfClient: freshMLSSelfClient,


### PR DESCRIPTION
This PR changes the location where we get the current device certificate from localStorage to CoreCrypto. CC is our single point of truth regarding Identities and Certificates.