### PR TITLE
fix: Read receipts color, change reactions popover colour

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -83,6 +83,7 @@ export const ContentMessageComponent: React.FC<ContentMessageProps> = ({
   onRetry,
   isMsgElementsFocusable,
   onClickReaction,
+  onClickDetails,
 }) => {
   // check if current message is focused and its elements focusable
   const msgFocusState = useMemo(
@@ -182,6 +183,7 @@ export const ContentMessageComponent: React.FC<ContentMessageProps> = ({
             message={message}
             is1to1Conversation={conversation.is1to1()}
             isLastDeliveredMessage={isLastDeliveredMessage}
+            onClickDetails={onClickDetails}
           />
         </MessageHeader>
       )}

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactions.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactions.styles.ts
@@ -46,11 +46,19 @@ export const messageReactionWrapper: CSSObject = {
   maxWidth: '100%',
   marginRight: 'var(--conversation-message-timestamp-width)',
   '.tooltip-content': {
-    backgroundColor: 'var(--gray-95) !important',
+    backgroundColor: 'var(--white) !important',
     marginBottom: '0 !important',
     padding: '6px 8px !important',
     '.tooltip-arrow': {
-      borderTopColor: 'var(--gray-95) !important',
+      borderTopColor: 'var(--white) !important',
+
+      'body.theme-dark &': {
+        borderTopColor: 'var(--gray-95) !important',
+      },
+    },
+
+    'body.theme-dark &': {
+      backgroundColor: 'var(--gray-95) !important',
     },
   },
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactions.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactions.styles.ts
@@ -78,7 +78,7 @@ export const messageReactionButton: CSSObject = {
 export const messageReactionButtonTooltip: CSSObject = {
   display: 'flex',
   flexDirection: 'column',
-  maxWidth: 165,
+  maxWidth: 145,
   whiteSpace: 'break-spaces',
 };
 export const messageReactionButtonTooltipImage: CSSObject = {

--- a/src/script/components/MessagesList/Message/ReadReceiptStatus.tsx
+++ b/src/script/components/MessagesList/Message/ReadReceiptStatus.tsx
@@ -22,7 +22,7 @@ import {useEffect, useState} from 'react';
 import cx from 'classnames';
 
 import {Icon} from 'Components/Icon';
-import {Message} from 'src/script/entity/message/Message';
+import {Message as BaseMessage, Message} from 'src/script/entity/message/Message';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 import {formatTimeShort} from 'Util/TimeUtil';
@@ -31,7 +31,7 @@ export interface ReadReceiptStatusProps {
   is1to1Conversation: boolean;
   isLastDeliveredMessage: boolean;
   message: Message;
-  onClickDetails?: any;
+  onClickDetails?: (message: BaseMessage) => void;
 }
 
 const ReadReceiptStatus = ({

--- a/src/script/components/MessagesList/Message/ReadReceiptStatus.tsx
+++ b/src/script/components/MessagesList/Message/ReadReceiptStatus.tsx
@@ -34,7 +34,7 @@ export interface ReadReceiptStatusProps {
   onClickDetails?: (message: Message) => void;
 }
 
-const ReadReceiptStatus = ({
+export const ReadReceiptStatus = ({
   message,
   is1to1Conversation,
   isLastDeliveredMessage,
@@ -60,6 +60,7 @@ const ReadReceiptStatus = ({
           {t('conversationMessageDelivered')}
         </span>
       )}
+
       {showEyeIndicator && (
         <button
           className={cx(
@@ -69,7 +70,11 @@ const ReadReceiptStatus = ({
           )}
           data-uie-name="status-message-read-receipts"
           aria-label={t('accessibility.messageDetailsReadReceipts', readReceiptText)}
-          onClick={() => onClickDetails?.(message)}
+          onClick={() => {
+            if (!is1to1Conversation) {
+              onClickDetails?.(message);
+            }
+          }}
         >
           <Icon.Read />
           <span className="message-status-read__count" data-uie-name="status-message-read-receipt-count">
@@ -80,5 +85,3 @@ const ReadReceiptStatus = ({
     </>
   );
 };
-
-export {ReadReceiptStatus};

--- a/src/script/components/MessagesList/Message/ReadReceiptStatus.tsx
+++ b/src/script/components/MessagesList/Message/ReadReceiptStatus.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React, {useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 
 import cx from 'classnames';
 
@@ -31,9 +31,15 @@ export interface ReadReceiptStatusProps {
   is1to1Conversation: boolean;
   isLastDeliveredMessage: boolean;
   message: Message;
+  onClickDetails?: any;
 }
 
-const ReadReceiptStatus: React.FC<ReadReceiptStatusProps> = ({message, is1to1Conversation, isLastDeliveredMessage}) => {
+const ReadReceiptStatus = ({
+  message,
+  is1to1Conversation,
+  isLastDeliveredMessage,
+  onClickDetails,
+}: ReadReceiptStatusProps) => {
   const [readReceiptText, setReadReceiptText] = useState('');
   const {readReceipts} = useKoSubscribableChildren(message, ['readReceipts']);
 
@@ -55,16 +61,21 @@ const ReadReceiptStatus: React.FC<ReadReceiptStatusProps> = ({message, is1to1Con
         </span>
       )}
       {showEyeIndicator && (
-        <div
-          className={cx('message-status-read', is1to1Conversation && 'message-status-read__one-on-one')}
+        <button
+          className={cx(
+            'message-status-read',
+            is1to1Conversation && 'message-status-read__one-on-one',
+            !!onClickDetails && 'message-status-read__clickable',
+          )}
           data-uie-name="status-message-read-receipts"
           aria-label={t('accessibility.messageDetailsReadReceipts', readReceiptText)}
+          onClick={() => onClickDetails?.(message)}
         >
           <Icon.Read />
           <span className="message-status-read__count" data-uie-name="status-message-read-receipt-count">
             {readReceiptText}
           </span>
-        </div>
+        </button>
       )}
     </>
   );

--- a/src/script/components/MessagesList/Message/ReadReceiptStatus.tsx
+++ b/src/script/components/MessagesList/Message/ReadReceiptStatus.tsx
@@ -22,7 +22,7 @@ import {useEffect, useState} from 'react';
 import cx from 'classnames';
 
 import {Icon} from 'Components/Icon';
-import {Message as BaseMessage, Message} from 'src/script/entity/message/Message';
+import {Message} from 'src/script/entity/message/Message';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 import {formatTimeShort} from 'Util/TimeUtil';
@@ -31,7 +31,7 @@ export interface ReadReceiptStatusProps {
   is1to1Conversation: boolean;
   isLastDeliveredMessage: boolean;
   message: Message;
-  onClickDetails?: (message: BaseMessage) => void;
+  onClickDetails?: (message: Message) => void;
 }
 
 const ReadReceiptStatus = ({

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -507,8 +507,7 @@
     .action-pill-style;
   }
 
-  .time,
-  .message-status {
+  .time {
     .subline;
     color: var(--gray-70);
     font-size: 12px !important;
@@ -523,18 +522,35 @@
 
 .message-status {
   margin-left: 12px;
+
+  .subline;
+  color: var(--gray-70);
+  font-size: 11px !important;
+  pointer-events: none;
+  user-select: none;
+
+  body.theme-dark & {
+    color: var(--gray-60);
+  }
 }
 
 .message-status-read {
   display: flex;
   align-items: center;
+  padding: 0;
+  border: none;
   margin-left: 12px;
-
-  .subline;
+  background: transparent;
   color: var(--gray-70);
-  font-size: 12px !important;
+  font-size: 11px !important;
   pointer-events: none;
   user-select: none;
+
+  .subline;
+
+  &__clickable {
+    pointer-events: all;
+  }
 
   body.theme-dark & {
     color: var(--gray-60);

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -537,15 +537,13 @@
 .message-status-read {
   display: flex;
   align-items: center;
-  padding: 0;
-  border: none;
   margin-left: 12px;
-  background: transparent;
   color: var(--gray-70);
   font-size: 11px !important;
   pointer-events: none;
   user-select: none;
 
+  .button-reset-default;
   .subline;
 
   &__clickable {


### PR DESCRIPTION
## Description

Fix for delivered colour and font size, also changed background colour for reactions popover for light theme. 
Also read receipts is clickable now.

## Screenshots/Screencast (for UI changes)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
