### PR TITLE
fix: add emoji unicode label to emotion classname [WPB-5875]

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiChar.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiChar.tsx
@@ -19,7 +19,9 @@
 
 import {FC} from 'react';
 
-import {CSSObject} from '@emotion/react';
+import {CSSObject, css} from '@emotion/react';
+
+import {getEmojiUnicode} from 'Util/EmojiUtil';
 
 export interface EmojiImgProps {
   emoji: string;
@@ -27,12 +29,20 @@ export interface EmojiImgProps {
   styles?: CSSObject;
 }
 
-export const EmojiChar: FC<EmojiImgProps> = ({emoji: unicode, size, styles}) => {
+export const EmojiChar: FC<EmojiImgProps> = ({emoji, size, styles}) => {
   const fontSize = size ? `${size}px` : 'var(--font-size-medium)';
   const style = {
     ':after': {
-      content: `'${unicode}'`,
+      content: `'${`${emoji}`}'`,
     },
   };
-  return <span aria-hidden={true} css={{fontSize, ...style, ...styles}}></span>;
+
+  const unicode = getEmojiUnicode(emoji);
+  const cssStyles = css({
+    fontSize,
+    ...style,
+    ...styles,
+    label: unicode,
+  });
+  return <span aria-hidden={true} css={cssStyles}></span>;
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5875" title="WPB-5875" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5875</a>  [Web] Display Issue with Emoji Reactions 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

It seems like `emotion` library is having some troubles with calculating classnames for elements which differ only with the `content` css property (which is dynamic).
![Screenshot 2024-01-04 at 12 29 40](https://github.com/wireapp/wire-webapp/assets/45733298/759c6c29-3b31-4f71-bd95-e50c44d80325)

Solution for that is to help emotion constructing a classname by adding a label to it. For that, we will use a emoji's unicode which is different for each emoji.

Before:
<img width="470" alt="Screenshot 2024-01-04 at 12 19 12" src="https://github.com/wireapp/wire-webapp/assets/45733298/1be230d3-b1aa-48e1-bc23-ec7a35dd31e9">
<img width="218" alt="Screenshot 2024-01-04 at 12 27 26" src="https://github.com/wireapp/wire-webapp/assets/45733298/9b875ad9-65db-4065-873c-e75ed33ca33a">



After:
<img width="510" alt="Screenshot 2024-01-04 at 12 20 35" src="https://github.com/wireapp/wire-webapp/assets/45733298/51def8c8-0f8c-4cd4-a5dc-21d3d74a290f">
<img width="230" alt="Screenshot 2024-01-04 at 12 28 03" src="https://github.com/wireapp/wire-webapp/assets/45733298/6858073c-8955-45a4-a3f9-5c626734cdc6">



## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;