### PR TITLE
runfix: don't hide dropdown if clicked inside of it

### DIFF
--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -456,7 +456,11 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                     onClick={() => {
                       setAudioOptionsOpen(prev => !prev);
                     }}
-                    onBlur={() => setAudioOptionsOpen(false)}
+                    onBlur={event => {
+                      if (!event.currentTarget.contains(event.relatedTarget)) {
+                        setAudioOptionsOpen(false);
+                      }
+                    }}
                   >
                     {audioOptionsOpen ? (
                       <>
@@ -520,7 +524,11 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                       onClick={() => {
                         setVideoOptionsOpen(prev => !prev);
                       }}
-                      onBlur={() => setVideoOptionsOpen(false)}
+                      onBlur={event => {
+                        if (!event.currentTarget.contains(event.relatedTarget)) {
+                          setVideoOptionsOpen(false);
+                        }
+                      }}
                     >
                       {videoOptionsOpen ? (
                         <>


### PR DESCRIPTION
## Description

It was not possible to change audio/video device using dropdown menu in fullscreen calling view. The reason behind that is `onBlur` event was fired before onChange event.

Solution for that is not to hide audio/video menu when clicked inside of the dropdown menu.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
