### PR TITLE
fix: duplicated link preview message [WPB-5728]

### DIFF
--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -401,6 +401,8 @@ export class MessageRepository {
       originalMessageId,
     };
 
+    // We cancel the sending of the link preview if the user has edited the message
+    // It prevents from sending a link preview for a message that has been replaced by another one
     cancelSendingLinkPreview(originalMessageId);
     try {
       const {state} = await this.sendEdit(messagePayload);

--- a/src/script/util/LinkPreviewSender.ts
+++ b/src/script/util/LinkPreviewSender.ts
@@ -1,0 +1,32 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+const shouldSendLinkPreview = new Map<string, boolean>();
+
+export const cancelSendingLinkPreview = (messageId: string) => {
+  shouldSendLinkPreview.set(messageId, false);
+};
+
+export const shouldSendLinkPreviewForMessage = (messageId: string) => {
+  return shouldSendLinkPreview.get(messageId) ?? true;
+};
+
+export const clearLinkPreviewSendingState = (messageId: string) => {
+  shouldSendLinkPreview.delete(messageId);
+};

--- a/src/script/util/LinkPreviewSender.ts
+++ b/src/script/util/LinkPreviewSender.ts
@@ -17,16 +17,16 @@
  *
  */
 
-const shouldSendLinkPreview = new Map<string, boolean>();
+const pendingLinkPreviewMessages = new Map<string, boolean>();
 
 export const cancelSendingLinkPreview = (messageId: string) => {
-  shouldSendLinkPreview.set(messageId, false);
+  pendingLinkPreviewMessages.set(messageId, false);
 };
 
 export const shouldSendLinkPreviewForMessage = (messageId: string) => {
-  return shouldSendLinkPreview.get(messageId) ?? true;
+  return pendingLinkPreviewMessages.get(messageId) ?? true;
 };
 
 export const clearLinkPreviewSendingState = (messageId: string) => {
-  shouldSendLinkPreview.delete(messageId);
+  pendingLinkPreviewMessages.delete(messageId);
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5728" title="WPB-5728" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5728</a>  [Web] Duplicate message with link preview
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

It was possible that a message containing a link preview would get sent twice if it was edited when still greyed out (in a sending state). Reason behind that is our current implementation of link preview messages. If we detect that a message contains a link and we are able to generate a preview for it, we send another message (this time with an actual preview) that will replace the initial message.

Why was "link preview" message sent twice?

1. send an initial message, with id `A` (its stuck in a sending state for a while)
2. we edit the message, so another message with id `B` is being sent, message `A` got replaced with message `B`
3. `A` message was sent successfully, we generate a preview message - `A1` for it and try to replace a message `A` with it
4. since message `A` was already replaced by `B`, it's not possible to replace `A` with `A1`, `A1` is sent as a new message
5. `B` message was sent successfully, we generate a preview message - `B1` and replace `B` with it.

So the actual issue is in point 4. above.

## Solution

The solution is to maintain a little state in a memory responsible for keeping track of handling sending a link preview message. We do not allow to generate a link preview for a message, which id exists in a state. When editing a message, we lock handling the link preview for a message we are editing (original message).

What happens now:
1. send message `A`
2. edit message `A`, it will be replaced with `A1`, lock handling a preview for message `A`
3. message `A` was sent, we try to handle link preview, but it was locked, we do not generate a preview for `A`
4. edit message was sent successfully, we generate a preview for `A1`, it was never locked, we create a preview

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
