### PR TITLE
feat: add margin for E2EI Status

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -68,7 +68,7 @@
   "E2EI.not_downloaded": "Not downloaded",
   "E2EI.serialNumber": "Serial number: ",
   "E2EI.showCertificateDetails": "Show Certificate Details",
-  "E2EI.status": "Status: ",
+  "E2EI.status": "Status:",
   "E2EI.updateCertificate": "Update Certificate",
   "E2EI.valid": "Valid",
   "E2EI.verified": "Verified (End-to-end Identity)",

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.styles.ts
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.styles.ts
@@ -60,6 +60,7 @@ export const styles: stylesProps = {
   },
   e2eiStatus: (MLSStatus?: MLSStatuses) => ({
     color: MLSStatus ? MLSStatusColor[MLSStatus] : 'var(--green-500)',
+    marginLeft: '4px',
   }),
   serialNumberWrapper: {
     marginBlock: '6px',


### PR DESCRIPTION
## Description

Added margin for E2EI status. Before there is no spacing.

## Screenshots/Screencast (for UI changes)

![image](https://github.com/wireapp/wire-webapp/assets/13432884/4eb543e0-d133-4b8a-b4c0-f17c813a9379)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
