### PR TITLE
feat: Read receipts and reactions tooltip improvement

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactions.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactions.styles.ts
@@ -51,6 +51,7 @@ export const messageReactionWrapper: CSSObject = {
     padding: '6px 8px !important',
     '.tooltip-arrow': {
       borderTopColor: 'var(--white) !important',
+      filter: 'none !important',
 
       'body.theme-dark &': {
         borderTopColor: 'var(--gray-95) !important',

--- a/src/script/components/MessagesList/Message/ReadReceiptStatus.tsx
+++ b/src/script/components/MessagesList/Message/ReadReceiptStatus.tsx
@@ -70,11 +70,11 @@ export const ReadReceiptStatus = ({
           )}
           data-uie-name="status-message-read-receipts"
           aria-label={t('accessibility.messageDetailsReadReceipts', readReceiptText)}
-          onClick={() => {
-            if (!is1to1Conversation) {
+          {...(!is1to1Conversation && {
+            onClick: () => {
               onClickDetails?.(message);
-            }
-          }}
+            },
+          })}
         >
           <Icon.Read />
           <span className="message-status-read__count" data-uie-name="status-message-read-receipt-count">

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -569,6 +569,10 @@
     opacity: 1;
   }
 
+  &__one-on-one {
+    pointer-events: none;
+  }
+
   @media (max-width: @screen-md-min) {
     &__one-on-one {
       height: 24px;


### PR DESCRIPTION
## Description

Read receipts now is not clickable for 1to1 conversation.
Tooltip arrow for reactions tooltip overlapping content fi.

## Screenshots/Screencast (for UI changes)

Prev:
<img width="377" alt="image" src="https://github.com/wireapp/wire-webapp/assets/13432884/46f8610c-e5bc-4eb1-b2f5-6e44d60b8293">

Now:
![image](https://github.com/wireapp/wire-webapp/assets/13432884/c0654420-1f47-468b-ab90-09982310d4ff)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
