### PR TITLE
runfix: Enroll to E2EI before joining conversations

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@peculiar/x509": "1.9.6",
     "@wireapp/avs": "9.5.13",
     "@wireapp/commons": "5.2.4",
-    "@wireapp/core": "43.5.1",
+    "@wireapp/core": "43.5.2",
     "@wireapp/react-ui-kit": "9.12.5",
     "@wireapp/store-engine-dexie": "2.1.7",
     "@wireapp/webapp-events": "0.18.3",

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.test.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.test.ts
@@ -43,6 +43,7 @@ jest.mock('./OIDCService', () => {
         profile: 'sub',
       }),
       clearProgress: jest.fn(),
+      handleAuthentication: jest.fn().mockResolvedValue({}),
       // ... other methods of OIDCService
     })),
     getOIDCServiceInstance: jest.fn(), // if needed
@@ -76,6 +77,10 @@ jest.mock('Util/certificateDetails', () => ({
     certificateCreationTime: new Date().getTime() - 10 * 24 * 60 * 60 * 1000,
   }),
 }));
+
+function wait(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
 
 describe('E2EIHandler', () => {
   const params = {discoveryUrl: 'http://example.com', gracePeriodInSeconds: 30};
@@ -116,6 +121,8 @@ describe('E2EIHandler', () => {
   it('should set currentStep to INITIALIZE after initialize is called', async () => {
     const instance = E2EIHandler.getInstance();
     await instance.initialize(params);
+    void instance.attemptEnrollment();
+    await wait(1);
     expect(instance['currentStep']).toBe(E2EIHandlerStep.INITIALIZED);
   });
 
@@ -143,7 +150,9 @@ describe('E2EIHandler', () => {
   });
 
   it('should display user info message when initialized', async () => {
-    await E2EIHandler.getInstance().initialize(params);
+    const instance = await E2EIHandler.getInstance().initialize(params);
+    void instance.attemptEnrollment();
+    await wait(1);
     expect(getModalOptions).toHaveBeenCalledWith(
       expect.objectContaining({
         type: ModalType.ENROLL,
@@ -206,6 +215,8 @@ describe('E2EIHandler', () => {
 
     // Initialize E2EI
     await handler.initialize(params);
+    void handler.attemptRenewal();
+    await wait(1);
 
     // Assert that renewCertificate was called
     expect(getCertificateDetails as jest.Mock).toHaveBeenCalled();
@@ -224,6 +235,8 @@ describe('E2EIHandler', () => {
 
     // Initialize E2EI
     await handler.initialize(params);
+    void handler.attemptRenewal();
+    await wait(1);
 
     // Assert that enroll was called to continue the current enrollment
     expect(enrollSpy).toHaveBeenCalled();
@@ -253,6 +266,8 @@ describe('E2EIHandler', () => {
 
     // Initialize E2EI
     await handler.initialize(params);
+    void handler.attemptRenewal();
+    await wait(1);
 
     expect(getCertificateDetails as jest.Mock).toHaveBeenCalled();
     expect(renewCertificateSpy).not.toHaveBeenCalled();
@@ -269,6 +284,8 @@ describe('E2EIHandler', () => {
 
     // Initialize E2EI
     await handler.initialize(params);
+    void handler.attemptEnrollment();
+    await wait(1);
 
     expect(renewCertificateSpy).not.toHaveBeenCalled();
     expect(showE2EINotificationMessageSpy).toHaveBeenCalled();
@@ -294,6 +311,8 @@ describe('E2EIHandler', () => {
 
     // Initialize E2EI
     await handler.initialize(params);
+    void handler.attemptRenewal();
+    await wait(1);
 
     expect(renewCertificateSpy).not.toHaveBeenCalled();
     expect(showE2EINotificationMessageSpy).not.toHaveBeenCalled();

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -274,9 +274,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
 
       // Notify user about E2EI enrolment success
       // This setTimeout is needed because there was a timing with the success modal and the loading modal
-      setTimeout(() => {
-        removeCurrentModal();
-      }, 0);
+      setTimeout(removeCurrentModal, 0);
 
       this.currentStep = E2EIHandlerStep.SUCCESS;
       this.showSuccessMessage();
@@ -285,15 +283,11 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
       // clear the oidc service progress/data and successful enrolment
       await this.cleanUp(false);
     } catch (error) {
-      this.logger.error('E2EI enrollment failed', error);
-
       this.currentStep = E2EIHandlerStep.ERROR;
 
-      setTimeout(() => {
-        removeCurrentModal();
-      }, 0);
-      console.error('E2EI enrolment failed', error);
+      setTimeout(removeCurrentModal, 0);
       await this.showErrorMessage();
+      throw error;
     }
   }
 

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -126,7 +126,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
       // If the client already has a certificate, we don't need to start the enrollment
       return;
     }
-    await this.showE2EINotificationMessage();
+    this.showE2EINotificationMessage();
     return new Promise<void>(resolve => {
       const handleSuccess = () => {
         this.off('enrollmentSuccessful', handleSuccess);
@@ -295,7 +295,6 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
 
       setTimeout(removeCurrentModal, 0);
       await this.showErrorMessage();
-      throw error;
     }
   }
 

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -317,9 +317,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
     }
     const {modalOptions, modalType} = getModalOptions({
       type: ModalType.SUCCESS,
-      primaryActionFn: () => {
-        this.emit('enrollmentSuccessful');
-      },
+      primaryActionFn: () => this.emit('enrollmentSuccessful'),
       hideSecondary: true,
       hideClose: false,
     });
@@ -377,7 +375,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
     }
   }
 
-  private showModal(modalType: ModalType = ModalType.ENROLL): Promise<void> {
+  private showModal(modalType: ModalType = ModalType.ENROLL) {
     // Check if config is defined and timer is available
     const isSnoozeTimeAvailable = this.config?.timer.isSnoozeTimeAvailable() ?? false;
 

--- a/src/script/E2EIdentity/E2EIdentityVerification.ts
+++ b/src/script/E2EIdentity/E2EIdentityVerification.ts
@@ -95,11 +95,7 @@ const fetchSelfDeviceIdentity = async (): Promise<WireIdentity | undefined> => {
 };
 
 export async function hasActiveCertificate(): Promise<boolean> {
-  const identity = await getActiveWireIdentity();
-  if (!identity?.certificate) {
-    return false;
-  }
-  return typeof identity.certificate === 'string' && Boolean(identity.certificate.length);
+  return getE2EIdentityService().isE2EIEnabled();
 }
 
 export async function getActiveWireIdentity(): Promise<WireIdentity | undefined> {

--- a/src/script/E2EIdentity/E2EIdentityVerification.ts
+++ b/src/script/E2EIdentity/E2EIdentityVerification.ts
@@ -53,9 +53,6 @@ export function isE2EIEnabled(): boolean {
 }
 
 export async function getUsersIdentities(groupId: string, userIds: QualifiedId[]) {
-  if (await isFreshMLSSelfClient()) {
-    return new Map<string, WireIdentity[]>();
-  }
   const userVerifications = await getE2EIdentityService().getUsersIdentities(groupId, userIds);
 
   const mappedUsers = new Map<string, WireIdentity[]>();
@@ -99,9 +96,6 @@ export async function hasActiveCertificate(): Promise<boolean> {
 }
 
 export async function getActiveWireIdentity(): Promise<WireIdentity | undefined> {
-  if (await isFreshMLSSelfClient()) {
-    return undefined;
-  }
   const selfDeviceIdentity = await fetchSelfDeviceIdentity();
 
   if (!selfDeviceIdentity) {

--- a/src/script/E2EIdentity/E2EIdentityVerification.ts
+++ b/src/script/E2EIdentity/E2EIdentityVerification.ts
@@ -92,6 +92,7 @@ const fetchSelfDeviceIdentity = async (): Promise<WireIdentity | undefined> => {
 };
 
 export async function hasActiveCertificate(): Promise<boolean> {
+  // isE2EIEnabled() is the name of the CC method that tells us if a user has a valid certificate (and is enrolled to E2EI)
   return getE2EIdentityService().isE2EIEnabled();
 }
 

--- a/src/script/E2EIdentity/E2EIdentityVerification.ts
+++ b/src/script/E2EIdentity/E2EIdentityVerification.ts
@@ -53,6 +53,9 @@ export function isE2EIEnabled(): boolean {
 }
 
 export async function getUsersIdentities(groupId: string, userIds: QualifiedId[]) {
+  if (await isFreshMLSSelfClient()) {
+    return new Map<string, WireIdentity[]>();
+  }
   const userVerifications = await getE2EIdentityService().getUsersIdentities(groupId, userIds);
 
   const mappedUsers = new Map<string, WireIdentity[]>();
@@ -100,6 +103,9 @@ export async function hasActiveCertificate(): Promise<boolean> {
 }
 
 export async function getActiveWireIdentity(): Promise<WireIdentity | undefined> {
+  if (await isFreshMLSSelfClient()) {
+    return undefined;
+  }
   const selfDeviceIdentity = await fetchSelfDeviceIdentity();
 
   if (!selfDeviceIdentity) {

--- a/src/script/components/AppContainer/AppContainer.tsx
+++ b/src/script/components/AppContainer/AppContainer.tsx
@@ -22,6 +22,7 @@ import {FC, useEffect} from 'react';
 import {ClientType} from '@wireapp/api-client/lib/client/';
 import {container} from 'tsyringe';
 
+import {PrimaryModalComponent} from 'Components/Modals/PrimaryModal/PrimaryModal';
 import {SIGN_OUT_REASON} from 'src/script/auth/SignOutReason';
 import {useSingleInstance} from 'src/script/hooks/useSingleInstance';
 import {PROPERTIES_TYPE} from 'src/script/properties/PropertiesType';
@@ -75,8 +76,11 @@ export const AppContainer: FC<AppProps> = ({config, clientType}) => {
   }
 
   return (
-    <AppLoader init={onProgress => app.initApp(clientType, onProgress)}>
-      {selfUser => <AppMain app={app} selfUser={selfUser} mainView={mainView} />}
-    </AppLoader>
+    <>
+      <AppLoader init={onProgress => app.initApp(clientType, onProgress)}>
+        {selfUser => <AppMain app={app} selfUser={selfUser} mainView={mainView} />}
+      </AppLoader>
+      <PrimaryModalComponent />
+    </>
   );
 };

--- a/src/script/components/AppContainer/AppContainer.tsx
+++ b/src/script/components/AppContainer/AppContainer.tsx
@@ -27,6 +27,7 @@ import {SIGN_OUT_REASON} from 'src/script/auth/SignOutReason';
 import {useSingleInstance} from 'src/script/hooks/useSingleInstance';
 import {PROPERTIES_TYPE} from 'src/script/properties/PropertiesType';
 
+import {useAccentColor} from './hooks/useAccentColor';
 import {useTheme} from './hooks/useTheme';
 
 import {Configuration} from '../../Config';
@@ -50,6 +51,7 @@ export const AppContainer: FC<AppProps> = ({config, clientType}) => {
   window.wire.app = app;
   const mainView = new MainViewModel(app.repository);
   useTheme(() => app.repository.properties.getPreference(PROPERTIES_TYPE.INTERFACE.THEME));
+  useAccentColor();
 
   const {hasOtherInstance, registerInstance} = useSingleInstance();
 

--- a/src/script/components/AppContainer/hooks/useAccentColor.ts
+++ b/src/script/components/AppContainer/hooks/useAccentColor.ts
@@ -1,0 +1,50 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {useEffect} from 'react';
+
+import ko from 'knockout';
+import {container} from 'tsyringe';
+
+import {UserState} from 'src/script/user/UserState';
+
+function setAccentColor(accentColor?: number) {
+  if (!accentColor) {
+    return;
+  }
+  const classes = document.body.className
+    .split(' ')
+    .filter(elementClass => !elementClass.startsWith('main-accent-color-'))
+    .concat(`main-accent-color-${accentColor}`);
+  document.body.className = classes.join(' ');
+}
+
+export function useAccentColor() {
+  const userState = container.resolve(UserState);
+  useEffect(() => {
+    const accentColor = ko.pureComputed(() => {
+      const selfUser = userState.self();
+      return selfUser?.accent_id();
+    });
+    const subscription = accentColor.subscribe(accent_color => {
+      setAccentColor(accent_color);
+    });
+    return () => subscription.dispose();
+  }, []);
+}

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -424,10 +424,8 @@ export class App {
       onProgress(10);
       telemetry.timeStep(AppInitTimingsStep.INITIALIZED_CRYPTOGRAPHY);
 
-      const teamMembers = await teamRepository.initTeam(selfUser.teamId);
-      if (await handleE2EIdentityFeatureChange(this.logger, teamRepository['teamState'].teamFeatures())) {
-        return selfUser;
-      }
+      const {members: teamMembers, features: teamFeatures} = await teamRepository.initTeam(selfUser.teamId);
+      await handleE2EIdentityFeatureChange(this.logger, teamFeatures);
 
       telemetry.timeStep(AppInitTimingsStep.RECEIVED_USER_DATA);
 

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -89,6 +89,7 @@ import {initMLSGroupConversations, initialiseSelfAndTeamConversations} from '../
 import {joinConversationsAfterMigrationFinalisation} from '../mls/MLSMigration/migrationFinaliser';
 import {NotificationRepository} from '../notification/NotificationRepository';
 import {PreferenceNotificationRepository} from '../notification/PreferenceNotificationRepository';
+import {handleE2EIdentityFeatureChange} from '../page/components/FeatureConfigChange/FeatureConfigChangeHandler/Features/E2EIdentity';
 import {PermissionRepository} from '../permission/PermissionRepository';
 import {PropertiesRepository} from '../properties/PropertiesRepository';
 import {PropertiesService} from '../properties/PropertiesService';
@@ -424,6 +425,10 @@ export class App {
       telemetry.timeStep(AppInitTimingsStep.INITIALIZED_CRYPTOGRAPHY);
 
       const teamMembers = await teamRepository.initTeam(selfUser.teamId);
+      if (await handleE2EIdentityFeatureChange(this.logger, teamRepository['teamState'].teamFeatures())) {
+        return selfUser;
+      }
+
       telemetry.timeStep(AppInitTimingsStep.RECEIVED_USER_DATA);
 
       const connections = await connectionRepository.getConnections();

--- a/src/script/page/AppMain.tsx
+++ b/src/script/page/AppMain.tsx
@@ -31,7 +31,6 @@ import {ErrorFallback} from 'Components/ErrorFallback';
 import {GroupCreationModal} from 'Components/Modals/GroupCreation/GroupCreationModal';
 import {LegalHoldModal} from 'Components/Modals/LegalHoldModal/LegalHoldModal';
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
-import {PrimaryModalComponent} from 'Components/Modals/PrimaryModal/PrimaryModal';
 import {showUserModal, UserModal} from 'Components/Modals/UserModal';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 
@@ -271,11 +270,11 @@ const AppMain: FC<AppMainProps> = ({
 
               <AppLock clientRepository={repositories.client} />
               <WarningsContainer onRefresh={app.refresh} />
-              <FeatureConfigChangeNotifier selfUserId={selfUser.id} teamState={teamState} />
-              <FeatureConfigChangeHandler teamState={teamState} />
 
               {!isFreshMLSSelfClient && (
                 <>
+                  <FeatureConfigChangeNotifier selfUserId={selfUser.id} teamState={teamState} />
+                  <FeatureConfigChangeHandler teamState={teamState} />
                   <CallingContainer
                     multitasking={mainView.multitasking}
                     callingRepository={repositories.calling}
@@ -296,7 +295,6 @@ const AppMain: FC<AppMainProps> = ({
 
               {/*The order of these elements matter to show proper modals stack upon each other*/}
               <UserModal selfUser={selfUser} userRepository={repositories.user} />
-              <PrimaryModalComponent />
               <GroupCreationModal userState={userState} teamState={teamState} />
             </ErrorBoundary>
           </RootProvider>

--- a/src/script/page/AppMain.tsx
+++ b/src/script/page/AppMain.tsx
@@ -72,7 +72,7 @@ interface AppMainProps {
   conversationState?: ConversationState;
 }
 
-const AppMain: FC<AppMainProps> = ({
+export const AppMain: FC<AppMainProps> = ({
   app,
   mainView,
   selfUser,
@@ -95,11 +95,10 @@ const AppMain: FC<AppMainProps> = ({
     repositories.notification,
   );
 
-  const {
-    accent_id,
-    availability: userAvailability,
-    isActivatedAccount,
-  } = useKoSubscribableChildren(selfUser, ['accent_id', 'availability', 'isActivatedAccount']);
+  const {availability: userAvailability, isActivatedAccount} = useKoSubscribableChildren(selfUser, [
+    'availability',
+    'isActivatedAccount',
+  ]);
 
   const teamState = container.resolve(TeamState);
   const userState = container.resolve(UserState);
@@ -224,7 +223,6 @@ const AppMain: FC<AppMainProps> = ({
     <StyledApp
       themeId={THEME_ID.DEFAULT}
       css={{backgroundColor: 'unset', height: '100%'}}
-      className={`main-accent-color-${accent_id} show`}
       id="wire-main"
       data-uie-name="status-webapp"
       data-uie-value="is-loaded"
@@ -303,5 +301,3 @@ const AppMain: FC<AppMainProps> = ({
     </StyledApp>
   );
 };
-
-export {AppMain};

--- a/src/script/page/components/FeatureConfigChange/FeatureConfigChangeHandler/FeatureConfigChangeHandler.tsx
+++ b/src/script/page/components/FeatureConfigChange/FeatureConfigChangeHandler/FeatureConfigChangeHandler.tsx
@@ -22,7 +22,7 @@ import {useEffect} from 'react';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {getLogger} from 'Util/Logger';
 
-import {handleE2EIdentityFeatureChange} from './Features/E2EIdentity';
+import {configureE2EI} from './Features/E2EIdentity';
 
 import {TeamState} from '../../../../team/TeamState';
 
@@ -38,7 +38,7 @@ export function FeatureConfigChangeHandler({teamState}: Props): null {
   useEffect(() => {
     if (config) {
       // initialize feature handlers
-      handleE2EIdentityFeatureChange(logger, config);
+      configureE2EI(logger, config);
     }
   }, [config]);
 

--- a/src/script/page/components/FeatureConfigChange/FeatureConfigChangeHandler/Features/E2EIdentity.ts
+++ b/src/script/page/components/FeatureConfigChange/FeatureConfigChangeHandler/Features/E2EIdentity.ts
@@ -24,12 +24,12 @@ import {Logger} from 'Util/Logger';
 
 import {hasE2EIVerificationExpiration, hasMLSDefaultProtocol} from '../../../../../guards/Protocol';
 
-export const handleE2EIdentityFeatureChange = async (logger: Logger, config: FeatureList) => {
+export const handleE2EIdentityFeatureChange = async (logger: Logger, config: FeatureList): Promise<boolean> => {
   const e2eiConfig = config[FEATURE_KEY.MLSE2EID];
   const mlsConfig = config[FEATURE_KEY.MLS];
   // Check if MLS or MLS E2EIdentity feature is existent
   if (!hasE2EIVerificationExpiration(e2eiConfig) || !hasMLSDefaultProtocol(mlsConfig)) {
-    return;
+    return false;
   }
 
   // Check if E2EIdentity feature is enabled
@@ -37,12 +37,12 @@ export const handleE2EIdentityFeatureChange = async (logger: Logger, config: Fea
     // Check if MLS feature is enabled
     if (mlsConfig?.status !== FeatureStatus.ENABLED) {
       logger.info('Warning: E2EIdentity feature enabled but MLS feature is not active');
-      return;
+      return false;
     }
     // Check if E2EIdentity feature has a server discoveryUrl
     if (!e2eiConfig.config || !e2eiConfig.config.acmeDiscoveryUrl || e2eiConfig.config.acmeDiscoveryUrl.length <= 0) {
       logger.info('Warning: E2EIdentity feature enabled but no discoveryUrl provided');
-      return;
+      return false;
     }
 
     const freshMLSSelfClient = await isFreshMLSSelfClient();
@@ -53,5 +53,7 @@ export const handleE2EIdentityFeatureChange = async (logger: Logger, config: Fea
       gracePeriodInSeconds: e2eiConfig.config.verificationExpiration,
       isFreshMLSSelfClient: freshMLSSelfClient,
     });
+    return true;
   }
+  return false;
 };

--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -120,12 +120,12 @@ export class TeamRepository extends TypedEventEmitter<Events> {
     );
   }
 
-  async initTeam(teamId?: string): Promise<QualifiedId[]> {
+  async initTeam(teamId?: string): Promise<{members: QualifiedId[]; features: FeatureList}> {
     const team = await this.getTeam();
     // get the fresh feature config from backend
-    await this.updateFeatureConfig();
+    const {newFeatureList} = await this.updateFeatureConfig();
     if (!teamId) {
-      return [];
+      return {members: [], features: {}};
     }
     this.teamState.teamMembers.subscribe(members => {
       // Subscribe to team members change and update the user role and guest status
@@ -139,7 +139,7 @@ export class TeamRepository extends TypedEventEmitter<Events> {
     });
     const members = await this.loadTeamMembers(team);
     this.scheduleTeamRefresh();
-    return members;
+    return {members, features: newFeatureList};
   }
 
   private async updateFeatureConfig(): Promise<{newFeatureList: FeatureList; prevFeatureList?: FeatureList}> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5037,9 +5037,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:43.5.1":
-  version: 43.5.1
-  resolution: "@wireapp/core@npm:43.5.1"
+"@wireapp/core@npm:43.5.2":
+  version: 43.5.2
+  resolution: "@wireapp/core@npm:43.5.2"
   dependencies:
     "@wireapp/api-client": ^26.8.2
     "@wireapp/commons": ^5.2.4
@@ -5059,7 +5059,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: c0c80ac0d9014453067c90338101c5492abfda058a848ff7203448fc3d0c0cc489cc66588642acf9be2e478ad2672b0c593286e24d414ca04c7d452dac83bcff
+  checksum: fe8a9854707f4b23790479d93f5d1da38dd5caccd350d96bf18e3aad56434fa8b4209f5866ba0eed562d86bb4c388fca2a227d51eedce82ba5bdf6aae2143b2b
   languageName: node
   linkType: hard
 
@@ -17769,7 +17769,7 @@ __metadata:
     "@wireapp/avs": 9.5.13
     "@wireapp/commons": 5.2.4
     "@wireapp/copy-config": 2.1.13
-    "@wireapp/core": 43.5.1
+    "@wireapp/core": 43.5.2
     "@wireapp/eslint-config": 3.0.4
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.12.5


### PR DESCRIPTION
## Description

We currently have a problem in the enrollement flow:
- the user logs in
- a MLS device will be created with basic credentials keyPackages
- we load all the conversations
- we join all the conversation via external commits
- we finally trigger the enrollment flow

The problem is we already joined the conversation before we had the chance to upgrade the credentials of the user with certified ones. 

The new flow goes as follow:
- the user logs in
- a MLS device is create with basic credentials keyPackages
- we trigger the enrollement process (if needed)
- we wait for the user to have a valid certificate
- then we load all the conversations
- and we join the conversations

So now we directly join converstaions with valid x509 certificates

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
