### PR TITLE
runfix: Fix accent color in dark mode

### DIFF
--- a/src/style/common/accent-color.less
+++ b/src/style/common/accent-color.less
@@ -312,7 +312,7 @@ each(.colors(), .(@color-key, @color-name) {
     @icon-secondary-active-border-dark: '@{name}-dark-800' ;
     @indicator-range-input-thumb-dark: '@{name}-dark-300';
     @toggle-button-unselected-bg-dark: '@{name}-dark-800';
-    .main-accent-color-@{color-key} {
+    &.main-accent-color-@{color-key} {
       --button-primary-hover: @@button-primary-hover-dark;
       --button-primary-focus-border: @@button-primary-focus-border-dark;
       --button-primary-active: @@button-primary-active-dark;


### PR DESCRIPTION
## Description

since #16498 the accent-color class is placed directly on the `body`. We need to adapt the selectors to account for this change. 

### Before
<img width="817" alt="image" src="https://github.com/wireapp/wire-webapp/assets/1090716/b21acc5f-02b2-4952-b583-eec711419563">


### After
<img width="794" alt="image" src="https://github.com/wireapp/wire-webapp/assets/1090716/346137fb-d2a1-49a1-9081-4c52936cc8ee">


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
