### PR TITLE
runfix: prevent showing guest icon for federated users (WPB-5550)

### DIFF
--- a/src/script/components/panel/UserDetails.tsx
+++ b/src/script/components/panel/UserDetails.tsx
@@ -107,7 +107,7 @@ const UserDetailsComponent: React.FC<UserDetailsProps> = ({
         </div>
       )}
 
-      {user.isGuest && user.isAvailable && (
+      {user.isGuest && user.isAvailable && !participant.isFederated && (
         <div className="panel-participant__label" data-uie-name="status-guest">
           <Icon.Guest />
           <span>{t('conversationGuestIndicator')}</span>

--- a/src/script/components/panel/UserDetails.tsx
+++ b/src/script/components/panel/UserDetails.tsx
@@ -57,7 +57,13 @@ const UserDetailsComponent: React.FC<UserDetailsProps> = ({
   classifiedDomains,
   teamState = container.resolve(TeamState),
 }) => {
-  const user = useKoSubscribableChildren(participant, ['isGuest', 'isTemporaryGuest', 'expirationText', 'isAvailable']);
+  const user = useKoSubscribableChildren(participant, [
+    'isGuest',
+    'isDirectGuest',
+    'isTemporaryGuest',
+    'expirationText',
+    'isAvailable',
+  ]);
 
   useEffect(() => {
     // This will trigger a user refresh
@@ -107,7 +113,7 @@ const UserDetailsComponent: React.FC<UserDetailsProps> = ({
         </div>
       )}
 
-      {user.isGuest && user.isAvailable && !participant.isFederated && (
+      {user.isDirectGuest && user.isAvailable && (
         <div className="panel-participant__label" data-uie-name="status-guest">
           <Icon.Guest />
           <span>{t('conversationGuestIndicator')}</span>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5550" title="WPB-5550" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5550</a>  [Web] Unclassified user has a guest icon on sending connection request not being a guest
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

Federated users should not show up as guests in the ui (the information is redundant, they can't be part of the user's team)

## Screenshots/Screencast (for UI changes)

Before:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/e17ef7ce-c1e4-41ce-a14d-14eb9d531892)

After:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/559c206b-7eed-40fb-a544-2d4356097afa)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
