### PR TITLE
runfix: stop counting e2ei system messages as unread [WPB-6081]

### DIFF
--- a/src/script/conversation/ConversationCellState.ts
+++ b/src/script/conversation/ConversationCellState.ts
@@ -320,8 +320,9 @@ const _getStateUnreadMessage = {
 
       if (messageEntity.isPing()) {
         string = t('notificationPing');
-      } else if (messageEntity.hasAssetText()) {
-        string = true;
+      } else if (messageEntity.isContent() && messageEntity.hasAssetText()) {
+        const assetText = messageEntity.getFirstAsset().text;
+        string = getRenderedTextContent(assetText);
       } else if (messageEntity.isContent() && messageEntity.hasAsset()) {
         const assetEntity = messageEntity.getFirstAsset();
         const isUploaded = (assetEntity as FileAsset).status() === AssetTransferState.UPLOADED;
@@ -355,13 +356,9 @@ const _getStateUnreadMessage = {
             : t('conversationsSecondaryLineEphemeralMessage');
         }
 
-        const hasString = string && string !== true;
-        const stateText: string = hasString
-          ? (string as string)
-          : getRenderedTextContent((messageEntity.getFirstAsset() as Text).text);
         return conversationEntity.isGroup() && !messageEntity.isE2EIVerification()
-          ? `${messageEntity.unsafeSenderName()}: ${stateText}`
-          : stateText;
+          ? `${messageEntity.unsafeSenderName()}: ${string}`
+          : string;
       }
     }
     return '';

--- a/src/script/conversation/ConversationCellState.ts
+++ b/src/script/conversation/ConversationCellState.ts
@@ -309,16 +309,20 @@ const _getStateRemoved = {
 
 const _getStateUnreadMessage = {
   description: (conversationEntity: Conversation): string => {
-    const unreadMessages = conversationEntity.unreadState().allMessages;
+    const unreadState = conversationEntity.unreadState();
 
-    for (const messageEntity of unreadMessages) {
+    const {allMessages, systemMessages} = unreadState;
+
+    const allUnread = [...allMessages, ...systemMessages];
+
+    for (const messageEntity of allUnread) {
       let string;
 
       if (messageEntity.isPing()) {
         string = t('notificationPing');
       } else if (messageEntity.hasAssetText()) {
         string = true;
-      } else if (messageEntity.hasAsset()) {
+      } else if (messageEntity.isContent() && messageEntity.hasAsset()) {
         const assetEntity = messageEntity.getFirstAsset();
         const isUploaded = (assetEntity as FileAsset).status() === AssetTransferState.UPLOADED;
 
@@ -363,7 +367,11 @@ const _getStateUnreadMessage = {
     return '';
   },
   icon: () => ConversationStatusIcon.UNREAD_MESSAGES,
-  match: (conversationEntity: Conversation) => conversationEntity.unreadState().allMessages.length > 0,
+  match: (conversationEntity: Conversation) => {
+    const {allMessages, systemMessages} = conversationEntity.unreadState();
+    const hasUnreadMessages = [...allMessages, ...systemMessages].length > 0;
+    return hasUnreadMessages;
+  },
 };
 
 const _getStateUserName = {

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -45,7 +45,6 @@ import {CallMessage} from './message/CallMessage';
 import type {ContentMessage} from './message/ContentMessage';
 import type {Message} from './message/Message';
 import {PingMessage} from './message/PingMessage';
-import {SystemMessage} from './message/SystemMessage';
 import type {User} from './User';
 
 import type {Call} from '../calling/Call';
@@ -72,7 +71,7 @@ interface UnreadState {
   pings: PingMessage[];
   selfMentions: ContentMessage[];
   selfReplies: ContentMessage[];
-  systemMessages: SystemMessage[];
+  systemMessages: Message[];
 }
 
 enum TIMESTAMP_TYPE {
@@ -462,7 +461,7 @@ export class Conversation {
 
           const isE2EIVerification = messageEntity.isE2EIVerification();
 
-          if (isMissedCall || isPing || isMessage || isE2EIVerification) {
+          if (isMissedCall || isPing || isMessage) {
             unreadState.allMessages.push(messageEntity as ContentMessage);
           }
 
@@ -476,6 +475,8 @@ export class Conversation {
             unreadState.pings.push(messageEntity);
           } else if (isMessage) {
             unreadState.otherMessages.push(messageEntity as ContentMessage);
+          } else if (isE2EIVerification) {
+            unreadState.systemMessages.push(messageEntity);
           }
 
           unreadState.allEvents.push(messageEntity as ContentMessage);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6081" title="WPB-6081" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6081</a>  [Web] E2EI system message creates regular unread message notification
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

We don't want to include e2ei verification system messages in unread messages count.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;