### PR TITLE
feat: Encrypt enrollment oauth stored data [WPB-6034]

### DIFF
--- a/src/script/E2EIdentity/E2EIdentityEnrollment.test.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.test.ts
@@ -105,6 +105,7 @@ describe('E2EIHandler', () => {
       .spyOn(container.resolve(UserState), 'self')
       .mockReturnValue({name: () => 'John Doe', username: () => 'johndoe'});
     jest.spyOn(container.resolve(Core), 'enrollE2EI').mockResolvedValue(true);
+    container.resolve(Core).key = new Uint8Array();
   });
 
   it('should create instance with valid params', async () => {

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -242,22 +242,19 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
       // Notify user about E2EI enrolment in progress
       this.currentStep = E2EIHandlerStep.ENROLL;
       this.showLoadingMessage();
-      let oAuthIdToken: string | undefined;
 
       if (!userData) {
         // If the enrolment is in progress, we need to get the id token from the oidc service, since oauth should have already been completed
         if (this.coreE2EIService.isEnrollmentInProgress()) {
           // The redirect-url which is needed inside the OIDCService is stored in the OIDCServiceStore previously
           this.oidcService = new OIDCService();
-          const userData = await this.oidcService.handleAuthentication();
+          userData = await this.oidcService.handleAuthentication();
           if (!userData) {
             throw new Error('Received no user data from OIDC service');
           }
-          oAuthIdToken = userData?.id_token;
         }
-      } else {
-        oAuthIdToken = userData?.id_token;
       }
+      const oAuthIdToken = userData?.id_token;
 
       const displayName = this.userState.self()?.name();
       const handle = this.userState.self()?.username();

--- a/src/script/E2EIdentity/OIDCService/OIDCService.ts
+++ b/src/script/E2EIdentity/OIDCService/OIDCService.ts
@@ -101,14 +101,12 @@ export class OIDCService {
     return this.userManager.clearStaleState();
   }
 
-  public handleSilentAuthentication(): Promise<User | null> {
+  public async handleSilentAuthentication(): Promise<User | null> {
     try {
-      return this.userManager.signinSilent().then(user => {
-        return user;
-      });
+      return this.userManager.signinSilent();
     } catch (error) {
       this.logger.log('Silent authentication with refresh token failed', error);
-      return Promise.resolve(null);
     }
+    return null;
   }
 }

--- a/src/script/E2EIdentity/OIDCService/OIDCService.ts
+++ b/src/script/E2EIdentity/OIDCService/OIDCService.ts
@@ -17,12 +17,55 @@
  *
  */
 
+import {Encoder, Decoder} from 'bazinga64';
 import {UserManager, User, UserManagerSettings, WebStorageStateStore} from 'oidc-client-ts';
 
 import {clearKeysStartingWith} from 'Util/localStorage';
 import {Logger, getLogger} from 'Util/Logger';
 
 import {OIDCServiceStore} from './OIDCServiceStorage';
+
+const secretKey = await crypto.subtle.importKey('raw', new Uint8Array(32), 'AES-GCM', false, ['encrypt', 'decrypt']);
+export class EncryptedStorage {
+  static async setItem(key: string, value: string) {
+    try {
+      const iv = window.crypto.getRandomValues(new Uint8Array(12));
+      const encryptedValue = await window.crypto.subtle.encrypt(
+        {name: 'AES-GCM', iv},
+        secretKey,
+        Encoder.toBase64(value).asBytes,
+      );
+      const base64Value = Encoder.toBase64(encryptedValue).asString;
+      window.localStorage.setItem(key, JSON.stringify({value: base64Value, iv: Array.from(iv)}));
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  }
+
+  static async getItem(key: string) {
+    const entry = localStorage.getItem(key);
+    if (entry) {
+      const {value, iv} = JSON.parse(entry);
+      const decrypted = await crypto.subtle.decrypt(
+        {name: 'AES-GCM', iv: new Uint8Array(iv)},
+        secretKey,
+        Decoder.fromBase64(value).asBytes,
+      );
+      return Decoder.fromBase64(Array.from(new Uint8Array(decrypted))).asString;
+    }
+    return null;
+  }
+
+  static removeItem(key: string) {
+    localStorage.removeItem(key);
+  }
+
+  static clear() {
+    localStorage.clear();
+  }
+  static key() {}
+}
 
 export class OIDCService {
   private readonly userManager: UserManager;
@@ -66,8 +109,10 @@ export class OIDCService {
         access_type: 'offline',
         prompt: 'consent',
       },
-      stateStore: new WebStorageStateStore({store: window.localStorage}),
-      userStore: new WebStorageStateStore({store: window.localStorage}),
+      stateStore: new WebStorageStateStore({store: window.sessionStorage}),
+      userStore: new WebStorageStateStore({
+        store: EncryptedStorage,
+      }),
     };
 
     this.userManager = new UserManager(dexioConfig);

--- a/src/script/E2EIdentity/OIDCService/OauthEncryptedStore.ts
+++ b/src/script/E2EIdentity/OIDCService/OauthEncryptedStore.ts
@@ -66,7 +66,7 @@ export class EncryptedStorage {
   async clear() {
     localStorage.clear();
   }
-  async key() {
+  async key(): Promise<null> {
     return null;
   }
 }

--- a/src/script/E2EIdentity/OIDCService/OauthEncryptedStore.ts
+++ b/src/script/E2EIdentity/OIDCService/OauthEncryptedStore.ts
@@ -21,6 +21,7 @@ import {Encoder, Decoder} from 'bazinga64';
 
 export class EncryptedStorage {
   private encryptionKey: Promise<CryptoKey>;
+  length = Promise.resolve(0);
 
   constructor(secretKey: Uint8Array) {
     this.encryptionKey = crypto.subtle.importKey('raw', secretKey, 'AES-GCM', false, ['encrypt', 'decrypt']);
@@ -58,12 +59,14 @@ export class EncryptedStorage {
     return null;
   }
 
-  removeItem(key: string) {
+  async removeItem(key: string) {
     localStorage.removeItem(key);
   }
 
-  clear() {
+  async clear() {
     localStorage.clear();
   }
-  key() {}
+  async key() {
+    return null;
+  }
 }

--- a/src/script/E2EIdentity/OIDCService/OauthEncryptedStore.ts
+++ b/src/script/E2EIdentity/OIDCService/OauthEncryptedStore.ts
@@ -1,0 +1,69 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Encoder, Decoder} from 'bazinga64';
+
+export class EncryptedStorage {
+  private encryptionKey: Promise<CryptoKey>;
+
+  constructor(secretKey: Uint8Array) {
+    this.encryptionKey = crypto.subtle.importKey('raw', secretKey, 'AES-GCM', false, ['encrypt', 'decrypt']);
+  }
+
+  async setItem(key: string, value: string) {
+    try {
+      const encryptionKey = await this.encryptionKey;
+      const iv = window.crypto.getRandomValues(new Uint8Array(12));
+      const encryptedValue = await window.crypto.subtle.encrypt(
+        {name: 'AES-GCM', iv},
+        encryptionKey,
+        Encoder.toBase64(value).asBytes,
+      );
+      const base64Value = Encoder.toBase64(encryptedValue).asString;
+      window.localStorage.setItem(key, JSON.stringify({value: base64Value, iv: Array.from(iv)}));
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  }
+
+  async getItem(key: string) {
+    const entry = localStorage.getItem(key);
+    if (entry) {
+      const encryptionKey = await this.encryptionKey;
+      const {value, iv} = JSON.parse(entry);
+      const decrypted = await crypto.subtle.decrypt(
+        {name: 'AES-GCM', iv: new Uint8Array(iv)},
+        encryptionKey,
+        Decoder.fromBase64(value).asBytes,
+      );
+      return Decoder.fromBase64(Array.from(new Uint8Array(decrypted))).asString;
+    }
+    return null;
+  }
+
+  removeItem(key: string) {
+    localStorage.removeItem(key);
+  }
+
+  clear() {
+    localStorage.clear();
+  }
+  key() {}
+}

--- a/src/script/service/CoreSingleton.ts
+++ b/src/script/service/CoreSingleton.ts
@@ -38,10 +38,13 @@ declare global {
 
 @singleton()
 export class Core extends Account {
+  public key?: Uint8Array;
+
   constructor(apiClient = container.resolve(APIClient)) {
     const enableCoreCrypto = supportsMLS() || Config.getConfig().FEATURE.USE_CORE_CRYPTO;
     super(apiClient, {
       createStore: async (storeName, key) => {
+        this.key = key;
         return createStorageEngine(storeName, DatabaseTypes.PERMANENT, {
           key: Config.getConfig().FEATURE.ENABLE_ENCRYPTION_AT_REST ? key : undefined,
         });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6034" title="WPB-6034" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6034</a>  [web] use safe storage to store oauth data 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

This will encrypt the data stored for oauth (like access token or refresh token). 

For encryption we use the key that is generate by the core that is given back to the webapp. 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
