### PR TITLE
feat: Hide secondary button in soft lock modal

### DIFF
--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -345,6 +345,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
       secondaryActionFn: () => {
         this.showE2EINotificationMessage();
       },
+      hideSecondary: !!this.config?.isFreshMLSSelfClient,
     });
 
     PrimaryModal.show(modalType, modalOptions);

--- a/src/script/E2EIdentity/Modals/Modals.ts
+++ b/src/script/E2EIdentity/Modals/Modals.ts
@@ -114,7 +114,7 @@ export const getModalOptions = ({
         },
       };
       modalType =
-        hideSecondary || secondaryActionFn === undefined ? PrimaryModal.type.CONFIRM : PrimaryModal.type.ACKNOWLEDGE;
+        hideSecondary || secondaryActionFn === undefined ? PrimaryModal.type.ACKNOWLEDGE : PrimaryModal.type.CONFIRM;
       break;
 
     case ModalType.LOADING:


### PR DESCRIPTION
## Description

We don't want to display secondary buttons while we have a fresh device.

## Screenshots/Screencast (for UI changes)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
