### PR TITLE
runfix: init mls 1:1 before proteus 1:1

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1940,7 +1940,23 @@ export class ConversationRepository {
       conversation => conversation.is1to1() && !conversation.connection(),
     );
 
-    for (const conversation of team1To1Conversations) {
+    // Sort conversations so mls 1:1 conversations are initialised first
+    const sortedConverstions = team1To1Conversations.toSorted((a, b) => {
+      const aIsMLSConversation = isMLSConversation(a);
+      const bIsMLSConversation = isMLSConversation(b);
+
+      if (aIsMLSConversation && !bIsMLSConversation) {
+        return -1;
+      }
+
+      if (!aIsMLSConversation && bIsMLSConversation) {
+        return 1;
+      }
+
+      return 0;
+    });
+
+    for (const conversation of sortedConverstions) {
       try {
         await this.init1to1Conversation(conversation);
       } catch (error) {

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1941,7 +1941,7 @@ export class ConversationRepository {
     );
 
     // Sort conversations so mls 1:1 conversations are initialised first
-    const sortedConverstions = team1To1Conversations.toSorted((a, b) => {
+    const sortedConverstions = [...team1To1Conversations].sort((a, b) => {
       const aIsMLSConversation = isMLSConversation(a);
       const bIsMLSConversation = isMLSConversation(b);
 


### PR DESCRIPTION
## Description

While initialising 1:1 conversations on app load, we should start with mls conversations - no need to initialise proteus conversation first as it's very likely that it will be replaced (and deleted) with mls 1:1 conversation we will loop through later. 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
