### PR TITLE
test: replace console error with warning to fix automation case

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1735,7 +1735,7 @@ export class ConversationRepository {
     const otherUserId = this.getUserIdOf1to1Conversation(conversation);
 
     if (!otherUserId) {
-      this.logger.error(`Could not find other user id in 1:1 conversation ${conversation.id}`);
+      this.logger.warn(`Could not find other user id in 1:1 conversation ${conversation.id}`);
       return conversation;
     }
 


### PR DESCRIPTION
## Description

When we cannot find the user id of 1:1 conversation, log a warning in a console instead of an error. (This should remove unexpected error statement from one automation scenario).

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
