### PR TITLE
runfix: assign correct background color to emoji picker's input

### DIFF
--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -870,7 +870,7 @@
   border-top: 1px solid var(--message-actions-border-hover);
 }
 
-.EmojiPickerReact .epr-search-container input.epr-search {
+.EmojiPickerReact .epr-search-container input {
   body.theme-dark & {
     border: 1px solid var(--gray-70);
     border-radius: 12px;


### PR DESCRIPTION
## Description

The emoji picker's input stopped using our custom background color in dark mode after a change in the library

## Screenshots/Screencast (for UI changes)

Before:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/3c04ddd2-1e7c-448f-a789-ecfdd6c1962a)
![image](https://github.com/wireapp/wire-webapp/assets/78490891/fd7483ea-c51a-4217-be68-b19a3c1c4312)


After:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/15305e48-064d-4a76-8d55-01a37678bd13)
![image](https://github.com/wireapp/wire-webapp/assets/78490891/1a40401f-9e25-4609-80e9-96a44172e6de)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
