### PR TITLE
refactor: streamline softLock logic

### DIFF
--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -65,7 +65,7 @@ interface E2EIHandlerParams {
 }
 
 type Events = {
-  identityUpdate: {enrollmentConfig: EnrollmentConfig; identity: WireIdentity};
+  identityUpdated: {enrollmentConfig: EnrollmentConfig; identity: WireIdentity};
 };
 
 export type EnrollmentConfig = {
@@ -148,10 +148,10 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
     this.showE2EINotificationMessage();
     return new Promise<void>(resolve => {
       const handleSuccess = () => {
-        this.off('identityUpdate', handleSuccess);
+        this.off('identityUpdated', handleSuccess);
         resolve();
       };
-      this.on('identityUpdate', handleSuccess);
+      this.on('identityUpdated', handleSuccess);
     });
   }
 
@@ -180,7 +180,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
     // Check if it's time to renew the certificate
     if (currentTime >= renewalPromptTime) {
       await this.renewCertificate();
-      this.emit('identityUpdate', {enrollmentConfig: this.config!, identity});
+      this.emit('identityUpdated', {enrollmentConfig: this.config!, identity});
     }
   }
 
@@ -355,7 +355,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
       extraParams: {
         isRenewal: isCertificateRenewal,
       },
-      primaryActionFn: () => this.emit('identityUpdate', {enrollmentConfig: this.config!, identity}),
+      primaryActionFn: () => this.emit('identityUpdated', {enrollmentConfig: this.config!, identity}),
       secondaryActionFn: () => {
         amplify.publish(WebAppEvents.PREFERENCES.MANAGE_DEVICES);
       },

--- a/src/script/hooks/useAppSoftLock.ts
+++ b/src/script/hooks/useAppSoftLock.ts
@@ -53,9 +53,9 @@ export function useAppSoftLock(callingRepository: CallingRepository, notificatio
       return () => {};
     }
 
-    E2EIHandler.getInstance().on('identityUpdate', handleSoftLockActivation);
+    E2EIHandler.getInstance().on('identityUpdated', handleSoftLockActivation);
     return () => {
-      E2EIHandler.getInstance().off('identityUpdate', handleSoftLockActivation);
+      E2EIHandler.getInstance().off('identityUpdated', handleSoftLockActivation);
     };
   }, [e2eiEnabled]);
 

--- a/src/script/hooks/useDeviceIdentities.ts
+++ b/src/script/hooks/useDeviceIdentities.ts
@@ -42,9 +42,9 @@ export const useUserIdentity = (userId: QualifiedId, groupId?: string, updateAft
     if (!updateAfterEnrollment) {
       return () => {};
     }
-    E2EIHandler.getInstance().on('enrollmentSuccessful', refreshDeviceIdentities);
+    E2EIHandler.getInstance().on('identityUpdate', refreshDeviceIdentities);
     return () => {
-      E2EIHandler.getInstance().off('enrollmentSuccessful', refreshDeviceIdentities);
+      E2EIHandler.getInstance().off('identityUpdate', refreshDeviceIdentities);
     };
   }, [refreshDeviceIdentities, updateAfterEnrollment]);
 

--- a/src/script/hooks/useDeviceIdentities.ts
+++ b/src/script/hooks/useDeviceIdentities.ts
@@ -42,9 +42,9 @@ export const useUserIdentity = (userId: QualifiedId, groupId?: string, updateAft
     if (!updateAfterEnrollment) {
       return () => {};
     }
-    E2EIHandler.getInstance().on('identityUpdate', refreshDeviceIdentities);
+    E2EIHandler.getInstance().on('identityUpdated', refreshDeviceIdentities);
     return () => {
-      E2EIHandler.getInstance().off('identityUpdate', refreshDeviceIdentities);
+      E2EIHandler.getInstance().off('identityUpdated', refreshDeviceIdentities);
     };
   }, [refreshDeviceIdentities, updateAfterEnrollment]);
 


### PR DESCRIPTION
## Description

This harmonises the way we compute if we should enable soft lock or not. 

This changes the following parts:
- harmonising the `enrollmentSuccess` and `identityUpate` events to be a single event that always sends the `config` and `identity`
- add early return to the logic that computes the soft lock situation

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

