### PR TITLE
runfix: address keyboard navigation issues in call ui (WPB-6075)

### DIFF
--- a/src/script/components/calling/Pagination.tsx
+++ b/src/script/components/calling/Pagination.tsx
@@ -21,6 +21,8 @@ import React from 'react';
 
 import {CSSObject} from '@emotion/react';
 
+import {handleKeyDown} from 'Util/KeyboardUtil';
+
 export interface PaginationProps {
   currentPage: number;
   onChangePage: (newPage: number) => void;
@@ -64,6 +66,7 @@ const Pagination: React.FC<PaginationProps> = ({totalPages, currentPage, onChang
             data-uie-status={isCurrentPage ? 'active' : 'inactive'}
             key={page}
             onClick={() => onChangePage(page)}
+            onKeyDown={event => handleKeyDown(event, () => onChangePage(page))}
             type="button"
             className="button-reset-default"
             css={{


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6075" title="WPB-6075" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6075</a>  [Web] Cannot use keyboard navigation to select devices in call ui
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Buttons should be able to be pressed with spacebar, to prevent typing in a conv in the background (see https://github.com/wireapp/wire-webapp/pull/16285), we add an `onKeyDown` event to buttons that need it
Additionnally, the select menus should be able to be quitted by pressing escape

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

### Important details for the reviewers
context for typing in a background conv https://github.com/wireapp/wire-webapp/pull/16285
previous iteration for allowing keyboard nav in call ui https://github.com/wireapp/wire-webapp/pull/16295