### PR TITLE
runfix: Make sure we instantiate the app only once

### DIFF
--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -65,7 +65,7 @@ interface E2EIHandlerParams {
 }
 
 type Events = {
-  identityUpdated: {enrollmentConfig: EnrollmentConfig; identity: WireIdentity};
+  identityUpdated: {enrollmentConfig: EnrollmentConfig; identity?: WireIdentity};
 };
 
 export type EnrollmentConfig = {
@@ -343,10 +343,6 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
     if (this.currentStep !== E2EIHandlerStep.SUCCESS) {
       return;
     }
-    const identity = await getActiveWireIdentity();
-    if (!identity) {
-      return;
-    }
 
     const {modalOptions, modalType} = getModalOptions({
       type: ModalType.SUCCESS,
@@ -355,7 +351,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
       extraParams: {
         isRenewal: isCertificateRenewal,
       },
-      primaryActionFn: () => this.emit('identityUpdated', {enrollmentConfig: this.config!, identity}),
+      primaryActionFn: () => this.emit('identityUpdated', {enrollmentConfig: this.config!}),
       secondaryActionFn: () => {
         amplify.publish(WebAppEvents.PREFERENCES.MANAGE_DEVICES);
       },

--- a/src/script/components/AppContainer/AppContainer.tsx
+++ b/src/script/components/AppContainer/AppContainer.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {FC, useEffect} from 'react';
+import {FC, useEffect, useMemo} from 'react';
 
 import {ClientType} from '@wireapp/api-client/lib/client/';
 import {container} from 'tsyringe';
@@ -49,7 +49,8 @@ interface AppProps {
 
 export const AppContainer: FC<AppProps> = ({config, clientType}) => {
   setAppLocale();
-  const app = new App(container.resolve(Core), container.resolve(APIClient), config);
+  const app = useMemo(() => new App(container.resolve(Core), container.resolve(APIClient), config), []);
+
   // Publishing application on the global scope for debug and testing purposes.
   window.wire.app = app;
   const mainView = new MainViewModel(app.repository);


### PR DESCRIPTION
## Description

Fixes an issue where a second instance of the `App` could be created when the softLock status is updated

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
