### PR TITLE
chore(github-actios): Improve performance of checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/create_docker_image.yml
+++ b/.github/workflows/create_docker_image.yml
@@ -25,8 +25,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy-to-test-env.yml
+++ b/.github/workflows/deploy-to-test-env.yml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Description

We are currently pulling the entire repo+tags on some jobs. This is not required for most jobs. 
The default value of `fetch-depth: 1` is far more performant and will only fetch a single commit (see https://github.com/actions/checkout?tab=readme-ov-file#fetch-all-history-for-all-tags-and-branches) 

### Before
![image](https://github.com/wireapp/wire-webapp/assets/1090716/ee40f9aa-7a57-495c-a0b9-04fecc1d050b)

### After
![image](https://github.com/wireapp/wire-webapp/assets/1090716/9b67dabd-b5c0-425f-96aa-65cc1f8a7d52)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

