### PR TITLE
runfix: set creation message timestamp to 0 after clearing content

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -2255,7 +2255,7 @@ export class ConversationRepository {
    */
   private async clearConversationContent(conversation: Conversation, timestamp: number) {
     await this.deleteMessages(conversation, timestamp);
-    await this.addCreationMessage(conversation, !!this.userState.self()?.isTemporaryGuest(), timestamp);
+    await this.addCreationMessage(conversation, !!this.userState.self()?.isTemporaryGuest());
     conversation.setTimestamp(timestamp, Conversation.TIMESTAMP_TYPE.CLEARED);
   }
 

--- a/src/script/conversation/EventBuilder.ts
+++ b/src/script/conversation/EventBuilder.ts
@@ -430,11 +430,11 @@ export const EventBuilder = {
   buildGroupCreation(
     conversationEntity: Conversation,
     isTemporaryGuest: boolean = false,
-    timestamp: number,
+    timestamp: number = 0,
   ): GroupCreationEvent {
     const {creator: creatorId} = conversationEntity;
     const selfUserId = conversationEntity.selfUser().id;
-    const isoDate = new Date(timestamp || 0).toISOString();
+    const isoDate = new Date(timestamp).toISOString();
 
     const userIds = conversationEntity.participating_user_ids().slice();
     const createdBySelf = creatorId === selfUserId || isTemporaryGuest;


### PR DESCRIPTION
## Description
When clearing a conversation content we should set conversation creation message's timestamp to 0 instead of the current date. When it was set to a current date, and we've imported a backup, creation message would appear as the most recent message (See screenshots below).

## Screenshots/Screencast (for UI changes)
Before
<img width="537" alt="Screenshot 2024-01-18 at 12 14 52" src="https://github.com/wireapp/wire-webapp/assets/45733298/490caac8-b6a6-4e08-b2e7-100bda1bf459">

After
<img width="542" alt="Screenshot 2024-01-18 at 12 17 42" src="https://github.com/wireapp/wire-webapp/assets/45733298/4dd0e239-0b7f-4d0f-a3af-59e0af70c17d">

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
