### PR TITLE
refactor: Single source of truth to know if e2ei should be enabled

### DIFF
--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -33,22 +33,13 @@ import {getCertificateDetails} from 'Util/certificateDetails';
 import {getLogger} from 'Util/Logger';
 import {formatDelayTime, TIME_IN_MILLIS} from 'Util/TimeUtil';
 import {removeUrlParameters} from 'Util/UrlUtil';
-import {supportsMLS} from 'Util/util';
 
-import {
-  hasActiveCertificate,
-  isE2EIEnabled,
-  getActiveWireIdentity,
-  MLSStatuses,
-  WireIdentity,
-} from './E2EIdentityVerification';
+import {hasActiveCertificate, getActiveWireIdentity, MLSStatuses, WireIdentity} from './E2EIdentityVerification';
 import {getModalOptions, ModalType} from './Modals';
 import {OIDCService} from './OIDCService';
 import {OIDCServiceStore} from './OIDCService/OIDCServiceStorage';
 import {getSnoozeTime, shouldEnableSoftLock} from './SnoozableTimer/delay';
 import {SnoozableTimer} from './SnoozableTimer/SnoozableTimer';
-
-import {Config} from '../Config';
 
 export enum E2EIHandlerStep {
   UNINITIALIZED = 'uninitialized',
@@ -121,20 +112,26 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
     E2EIHandler.instance = null;
   }
 
+  /**
+   * Returns true if the current instance has been configured with team settings params
+   * @returns
+   */
+  public isE2EIEnabled() {
+    return this.currentStep !== E2EIHandlerStep.UNINITIALIZED;
+  }
+
   public initialize({discoveryUrl, gracePeriodInSeconds}: E2EIHandlerParams) {
-    if (isE2EIEnabled()) {
-      const gracePeriodInMs = gracePeriodInSeconds * TIME_IN_MILLIS.SECOND;
-      this.config = {
-        discoveryUrl,
-        gracePeriodInMs,
-        timer: new SnoozableTimer({
-          gracePeriodInMS: gracePeriodInMs,
-          onGracePeriodExpired: () => this.startEnrollment(ModalType.ENROLL),
-          onSnoozeExpired: () => this.startEnrollment(ModalType.ENROLL),
-        }),
-      };
-      this.currentStep = E2EIHandlerStep.INITIALIZED;
-    }
+    const gracePeriodInMs = gracePeriodInSeconds * TIME_IN_MILLIS.SECOND;
+    this.config = {
+      discoveryUrl,
+      gracePeriodInMs,
+      timer: new SnoozableTimer({
+        gracePeriodInMS: gracePeriodInMs,
+        onGracePeriodExpired: () => this.startEnrollment(ModalType.ENROLL),
+        onSnoozeExpired: () => this.startEnrollment(ModalType.ENROLL),
+      }),
+    };
+    this.currentStep = E2EIHandlerStep.INITIALIZED;
     return this;
   }
 
@@ -228,10 +225,6 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
     const renewalDate = timeRemainingMS - totalDaysToSubtract;
 
     return renewalDate;
-  }
-
-  get isE2EIEnabled(): boolean {
-    return supportsMLS() && Config.getConfig().FEATURE.ENABLE_E2EI;
   }
 
   private async storeRedirectTargetAndRedirect(

--- a/src/script/E2EIdentity/E2EIdentityVerification.ts
+++ b/src/script/E2EIdentity/E2EIdentityVerification.ts
@@ -22,11 +22,10 @@ import {DeviceIdentity} from '@wireapp/core/lib/messagingProtocols/mls';
 import {container} from 'tsyringe';
 
 import {Core} from 'src/script/service/CoreSingleton';
-import {base64ToArray, supportsMLS} from 'Util/util';
+import {base64ToArray} from 'Util/util';
 
 import {mapMLSStatus} from './certificateDetails';
 
-import {Config} from '../Config';
 import {ConversationState} from '../conversation/ConversationState';
 
 export enum MLSStatuses {
@@ -47,10 +46,6 @@ export function getE2EIdentityService() {
     throw new Error('trying to query E2EIdentity data in an non-e2eidentity environment');
   }
   return e2eIdentityService;
-}
-
-export function isE2EIEnabled(): boolean {
-  return supportsMLS() && Config.getConfig().FEATURE.ENABLE_E2EI;
 }
 
 export async function getUsersIdentities(groupId: string, userIds: QualifiedId[]) {

--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -58,7 +58,6 @@ import {loadDraftState, saveDraftState} from './util/DraftStateUtil';
 import {Config} from '../../Config';
 import {ConversationVerificationState} from '../../conversation/ConversationVerificationState';
 import {MessageRepository, OutgoingQuote} from '../../conversation/MessageRepository';
-import {isE2EIEnabled} from '../../E2EIdentity';
 import {Conversation} from '../../entity/Conversation';
 import {ContentMessage} from '../../entity/message/ContentMessage';
 import {User} from '../../entity/User';
@@ -353,7 +352,7 @@ export const InputBar = ({
   const handleSendMessage = () => {
     const isE2EIDegraded = conversation.mlsVerificationState() === ConversationVerificationState.DEGRADED;
 
-    if (isE2EIEnabled() && isE2EIDegraded) {
+    if (isE2EIDegraded) {
       PrimaryModal.show(PrimaryModal.type.CONFIRM, {
         primaryAction: {
           action: () => {

--- a/src/script/hooks/useAppSoftLock.ts
+++ b/src/script/hooks/useAppSoftLock.ts
@@ -20,13 +20,11 @@
 import {useCallback, useEffect, useState} from 'react';
 
 import {CallingRepository} from '../calling/CallingRepository';
-import {E2EIHandler, EnrollmentConfig, isE2EIEnabled, WireIdentity} from '../E2EIdentity';
+import {E2EIHandler, EnrollmentConfig, WireIdentity} from '../E2EIdentity';
 import {shouldEnableSoftLock} from '../E2EIdentity/SnoozableTimer/delay';
 import {NotificationRepository} from '../notification/NotificationRepository';
 
 export function useAppSoftLock(callingRepository: CallingRepository, notificationRepository: NotificationRepository) {
-  const e2eiEnabled = isE2EIEnabled();
-
   const [softLockEnabled, setSoftLockEnabled] = useState(false);
 
   const handleSoftLockActivation = useCallback(
@@ -41,16 +39,16 @@ export function useAppSoftLock(callingRepository: CallingRepository, notificatio
   );
 
   useEffect(() => {
-    if (!e2eiEnabled) {
+    const e2eiHandler = E2EIHandler.getInstance();
+    if (!e2eiHandler.isE2EIEnabled()) {
       return () => {};
     }
-    const e2eiHandler = E2EIHandler.getInstance();
 
     e2eiHandler.on('identityUpdated', handleSoftLockActivation);
     return () => {
       e2eiHandler.off('identityUpdated', handleSoftLockActivation);
     };
-  }, [e2eiEnabled, handleSoftLockActivation]);
+  }, [handleSoftLockActivation]);
 
   return {softLockEnabled};
 }

--- a/src/script/hooks/useDeviceIdentities.ts
+++ b/src/script/hooks/useDeviceIdentities.ts
@@ -21,13 +21,13 @@ import {useCallback, useEffect, useState} from 'react';
 
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 
-import {E2EIHandler, getUsersIdentities, isE2EIEnabled, MLSStatuses, WireIdentity} from '../E2EIdentity';
+import {E2EIHandler, getUsersIdentities, MLSStatuses, WireIdentity} from '../E2EIdentity';
 
 export const useUserIdentity = (userId: QualifiedId, groupId?: string, updateAfterEnrollment?: boolean) => {
   const [deviceIdentities, setDeviceIdentities] = useState<WireIdentity[] | undefined>();
 
   const refreshDeviceIdentities = useCallback(async () => {
-    if (!isE2EIEnabled() || !groupId) {
+    if (!E2EIHandler.getInstance().isE2EIEnabled() || !groupId) {
       return;
     }
     const userIdentities = await getUsersIdentities(groupId, [userId]);

--- a/src/script/page/components/FeatureConfigChange/FeatureConfigChangeHandler/Features/E2EIdentity.ts
+++ b/src/script/page/components/FeatureConfigChange/FeatureConfigChangeHandler/Features/E2EIdentity.ts
@@ -19,8 +19,10 @@
 
 import {FeatureStatus, FEATURE_KEY, FeatureList} from '@wireapp/api-client/lib/team';
 
+import {Config} from 'src/script/Config';
 import {E2EIHandler} from 'src/script/E2EIdentity';
 import {Logger} from 'Util/Logger';
+import {supportsMLS} from 'Util/util';
 
 import {hasE2EIVerificationExpiration, hasMLSDefaultProtocol} from '../../../../../guards/Protocol';
 
@@ -29,6 +31,10 @@ export const configureE2EI = (logger: Logger, config: FeatureList): undefined | 
   const mlsConfig = config[FEATURE_KEY.MLS];
   // Check if MLS or MLS E2EIdentity feature is existent
   if (!hasE2EIVerificationExpiration(e2eiConfig) || !hasMLSDefaultProtocol(mlsConfig)) {
+    return undefined;
+  }
+
+  if (!supportsMLS() && Config.getConfig().FEATURE.ENABLE_E2EI) {
     return undefined;
   }
 

--- a/src/script/service/CoreSingleton.ts
+++ b/src/script/service/CoreSingleton.ts
@@ -28,7 +28,6 @@ import {createStorageEngine, DatabaseTypes} from './StoreEngineProvider';
 import {SystemCrypto, wrapSystemCrypto} from './utils/systemCryptoWrapper';
 
 import {Config} from '../Config';
-import {isE2EIEnabled} from '../E2EIdentity';
 
 declare global {
   interface Window {
@@ -63,7 +62,7 @@ export class Core extends Account {
               ? {
                   keyingMaterialUpdateThreshold: Config.getConfig().FEATURE.MLS_CONFIG_KEYING_MATERIAL_UPDATE_THRESHOLD,
                   cipherSuite: Config.getConfig().FEATURE.MLS_CONFIG_DEFAULT_CIPHERSUITE,
-                  useE2EI: isE2EIEnabled(),
+                  useE2EI: Config.getConfig().FEATURE.ENABLE_E2EI,
                 }
               : undefined,
           }

--- a/src/script/view_model/CallingViewModel.ts
+++ b/src/script/view_model/CallingViewModel.ts
@@ -42,7 +42,6 @@ import {PrimaryModal} from '../components/Modals/PrimaryModal';
 import {Config} from '../Config';
 import {ConversationState} from '../conversation/ConversationState';
 import {ConversationVerificationState} from '../conversation/ConversationVerificationState';
-import {isE2EIEnabled} from '../E2EIdentity';
 import type {Conversation} from '../entity/Conversation';
 import type {User} from '../entity/User';
 import type {ElectronDesktopCapturerSource, MediaDevicesHandler} from '../media/MediaDevicesHandler';
@@ -257,7 +256,7 @@ export class CallingViewModel {
       const memberCount = conversationEntity.participating_user_ets().length;
       const isE2EIDegraded = conversationEntity.mlsVerificationState() === ConversationVerificationState.DEGRADED;
 
-      if (isE2EIEnabled() && isE2EIDegraded) {
+      if (isE2EIDegraded) {
         showE2EICallModal(conversationEntity, callType);
       } else if (memberCount > MAX_USERS_TO_CALL_WITHOUT_CONFIRM) {
         showMaxUsersToCallModalWithoutConfirm(conversationEntity, callType);


### PR DESCRIPTION
## Description

We are currently looking at both the `FEATURE.ENABLE_E2EI` feature flag and the team setting config to know if we should start the e2ei process. 
The way we check for e2ei enable state is not consistent accros the app. 

This PR harmonizes the source of truth whether the e2ei feature is enabled or not. it's `E2EIHandler.getInstance().isE2EIEnabled()` method. 

### Before (in a e2ei disabled team)
![image](https://github.com/wireapp/wire-webapp/assets/1090716/83961c7f-d15b-4587-bac1-1939877e3026)

### After
![image](https://github.com/wireapp/wire-webapp/assets/1090716/7db43db3-393e-496b-83be-b8dad866f6f3)



## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;


