### PR TITLE
runfix: Avoid sending countly device ID before self conversation is joined

### DIFF
--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -492,10 +492,10 @@ export class App {
       telemetry.timeStep(AppInitTimingsStep.UPDATED_FROM_NOTIFICATIONS);
       telemetry.addStatistic(AppInitStatisticsValue.NOTIFICATIONS, totalNotifications, 100);
 
-      eventTrackerRepository.init(propertiesRepository.properties.settings.privacy.telemetry_sharing);
       onProgress(97.5, t('initUpdatedFromNotifications', this.config.BRAND_NAME));
 
       const clientEntities = await clientRepository.updateClientsForSelf();
+      await eventTrackerRepository.init(propertiesRepository.properties.settings.privacy.telemetry_sharing);
 
       onProgress(99);
 

--- a/src/script/mls/MLSConversations.ts
+++ b/src/script/mls/MLSConversations.ts
@@ -75,10 +75,7 @@ export async function initMLSGroupConversations(
 
       //otherwise we should try joining via external commit
       await conversationService.joinByExternalCommit(qualifiedId);
-
-      if (onSuccessfulJoin) {
-        return onSuccessfulJoin(mlsConversation);
-      }
+      onSuccessfulJoin?.(mlsConversation);
     } catch (error) {
       onError?.(mlsConversation, error);
     }


### PR DESCRIPTION
## Description

This prevent this error from happening when creating a new MLS device. 

![image](https://github.com/wireapp/wire-webapp/assets/1090716/0b75db37-11fc-4d48-b192-66e43a3b3ec6)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
