### PR TITLE
chore: Autodeploy to q1-2024 backend branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,6 +77,10 @@ jobs:
             wire_builds_target_branches='["dev"]'
           fi
 
+          if [ "$version_tag" == "release/q1-2024" ]; then
+            wire_builds_target_branches='["q1-2024"]'
+          fi
+
           echo "wire_builds_target_branches: $wire_builds_target_branches"
           echo "wire_builds_target_branches=$wire_builds_target_branches" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Description

This will deploy any changes on the `release/q1-2024` branch to the corresponding backend release branch (namely `q1-2024`)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;
