### PR TITLE
fix: don't load self convo's messages into memory [WPB-6166]

### DIFF
--- a/src/script/backup/BackupRepository.test.ts
+++ b/src/script/backup/BackupRepository.test.ts
@@ -199,13 +199,11 @@ describe('BackupRepository', () => {
       const conversation = generateConversation({
         id: {id: 'conversation1', domain: 'staging2'},
         type: CONVERSATION_TYPE.ONE_TO_ONE,
-        overwites: {type: CONVERSATION_TYPE.ONE_TO_ONE},
       }).serialize();
 
       const selfConversation = generateConversation({
         id: {id: 'conversation2', domain: 'staging2'},
         type: CONVERSATION_TYPE.SELF,
-        overwites: {type: CONVERSATION_TYPE.SELF},
       }).serialize();
 
       const files = {

--- a/src/script/backup/BackupRepository.test.ts
+++ b/src/script/backup/BackupRepository.test.ts
@@ -48,7 +48,7 @@ const conversation = generateConversation({
     status: 0,
     type: 2,
   },
-});
+}).serialize();
 
 const messages = [
   {
@@ -132,8 +132,8 @@ describe('BackupRepository', () => {
       };
       const importSpy = jest.spyOn(backupService, 'importEntities');
 
-      await storageService.save(StorageSchemata.OBJECT_STORE.EVENTS, undefined, verificationEvent);
-      await storageService.save(StorageSchemata.OBJECT_STORE.EVENTS, undefined, textEvent);
+      await storageService.save(StorageSchemata.OBJECT_STORE.EVENTS, '', verificationEvent);
+      await storageService.save(StorageSchemata.OBJECT_STORE.EVENTS, '', textEvent);
       const blob = await backupRepository.generateHistory(user, 'client1', noop, password);
 
       await backupRepository.importHistory(new User('user1'), blob, noop, noop);
@@ -148,7 +148,7 @@ describe('BackupRepository', () => {
       const [backupRepository, {storageService}] = await buildBackupRepository();
       const password = '';
       await Promise.all([
-        ...messages.map(message => storageService.save(eventStoreName, undefined, message)),
+        ...messages.map(message => storageService.save(eventStoreName, '', message)),
         storageService.save('conversations', conversationId, conversation),
       ]);
 
@@ -227,7 +227,7 @@ describe('BackupRepository', () => {
         expect.arrayContaining([expect.objectContaining({id: conversation.id})]),
       );
       expect(conversationRepository.updateConversations).not.toHaveBeenCalledWith(
-        expect.arrayContaining([expect.objectContaining({id: conversation.id})]),
+        expect.arrayContaining([expect.objectContaining({id: selfConversation.id})]),
       );
 
       expect(importSpy).toHaveBeenCalledWith(

--- a/src/script/backup/BackupRepository.ts
+++ b/src/script/backup/BackupRepository.ts
@@ -41,6 +41,7 @@ import {
 import {preprocessConversations, preprocessEvents, preprocessUsers} from './recordPreprocessors';
 
 import type {ConversationRepository} from '../conversation/ConversationRepository';
+import {isUsableConversation} from '../conversation/ConversationSelectors';
 import type {Conversation} from '../entity/Conversation';
 import {User} from '../entity/User';
 import {EventRecord, UserRecord} from '../storage';
@@ -381,7 +382,9 @@ export class BackupRepository {
     // Run all the database migrations on the imported data
     await this.backupService.runDbSchemaUpdates(archiveVersion);
 
-    await this.conversationRepository.updateConversations(importedConversations);
+    const usableConversations = importedConversations.filter(isUsableConversation);
+
+    await this.conversationRepository.updateConversations(usableConversations);
     await this.conversationRepository.initAllLocal1To1Conversations();
     // doesn't need to be awaited
     void this.conversationRepository.checkForDeletedConversations();

--- a/src/script/backup/BackupRepository.ts
+++ b/src/script/backup/BackupRepository.ts
@@ -41,7 +41,7 @@ import {
 import {preprocessConversations, preprocessEvents, preprocessUsers} from './recordPreprocessors';
 
 import type {ConversationRepository} from '../conversation/ConversationRepository';
-import {isUsableConversation} from '../conversation/ConversationSelectors';
+import {isReadableConversation} from '../conversation/ConversationSelectors';
 import type {Conversation} from '../entity/Conversation';
 import {User} from '../entity/User';
 import {EventRecord, UserRecord} from '../storage';
@@ -382,9 +382,9 @@ export class BackupRepository {
     // Run all the database migrations on the imported data
     await this.backupService.runDbSchemaUpdates(archiveVersion);
 
-    const usableConversations = importedConversations.filter(isUsableConversation);
+    const readableConversations = importedConversations.filter(isReadableConversation);
 
-    await this.conversationRepository.updateConversations(usableConversations);
+    await this.conversationRepository.updateConversations(readableConversations);
     await this.conversationRepository.initAllLocal1To1Conversations();
     // doesn't need to be awaited
     void this.conversationRepository.checkForDeletedConversations();

--- a/src/script/conversation/ConversationSelectors.ts
+++ b/src/script/conversation/ConversationSelectors.ts
@@ -98,7 +98,7 @@ export const isProteus1to1ConversationWithUser = (userId: QualifiedId) =>
 export const isMLS1to1ConversationWithUser = (userId: QualifiedId) =>
   is1to1ConversationWithUser(userId, ConversationProtocol.MLS);
 
-export const isUsableConversation = (conversation: Conversation): boolean => {
+export const isReadableConversation = (conversation: Conversation): boolean => {
   const states_to_filter = [
     ConnectionStatus.MISSING_LEGAL_HOLD_CONSENT,
     ConnectionStatus.BLOCKED,

--- a/src/script/conversation/ConversationSelectors.ts
+++ b/src/script/conversation/ConversationSelectors.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {ConnectionStatus} from '@wireapp/api-client/lib/connection/';
 import {CONVERSATION_TYPE, ConversationProtocol} from '@wireapp/api-client/lib/conversation/';
 import {QualifiedId} from '@wireapp/api-client/lib/user/';
 
@@ -96,3 +97,16 @@ export const isProteus1to1ConversationWithUser = (userId: QualifiedId) =>
 
 export const isMLS1to1ConversationWithUser = (userId: QualifiedId) =>
   is1to1ConversationWithUser(userId, ConversationProtocol.MLS);
+
+export const isUsableConversation = (conversation: Conversation): boolean => {
+  const states_to_filter = [
+    ConnectionStatus.MISSING_LEGAL_HOLD_CONSENT,
+    ConnectionStatus.BLOCKED,
+    ConnectionStatus.CANCELLED,
+    ConnectionStatus.PENDING,
+  ];
+
+  const connection = conversation.connection();
+
+  return !(isSelfConversation(conversation) || (connection && states_to_filter.includes(connection.status())));
+};

--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -31,7 +31,7 @@ import {
   isMLSConversation,
   isProteus1to1ConversationWithUser,
   isSelfConversation,
-  isUsableConversation,
+  isReadableConversation,
 } from './ConversationSelectors';
 
 import {Conversation} from '../entity/Conversation';
@@ -103,7 +103,7 @@ export class ConversationState {
     });
 
     this.filteredConversations = ko.pureComputed(() => {
-      return this.conversations().filter(isUsableConversation);
+      return this.conversations().filter(isReadableConversation);
     });
 
     this.connectedUsers = ko.pureComputed(() => {

--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import {ConnectionStatus} from '@wireapp/api-client/lib/connection/';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import ko from 'knockout';
 import {container, singleton} from 'tsyringe';
@@ -32,6 +31,7 @@ import {
   isMLSConversation,
   isProteus1to1ConversationWithUser,
   isSelfConversation,
+  isUsableConversation,
 } from './ConversationSelectors';
 
 import {Conversation} from '../entity/Conversation';
@@ -103,21 +103,7 @@ export class ConversationState {
     });
 
     this.filteredConversations = ko.pureComputed(() => {
-      return this.conversations().filter(conversationEntity => {
-        const states_to_filter = [
-          ConnectionStatus.MISSING_LEGAL_HOLD_CONSENT,
-          ConnectionStatus.BLOCKED,
-          ConnectionStatus.CANCELLED,
-          ConnectionStatus.PENDING,
-        ];
-
-        const connection = conversationEntity.connection();
-
-        return !(
-          isSelfConversation(conversationEntity) ||
-          (connection && states_to_filter.includes(connection.status()))
-        );
-      });
+      return this.conversations().filter(isUsableConversation);
     });
 
     this.connectedUsers = ko.pureComputed(() => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6166" title="WPB-6166" target="_blank"><img alt="Spike" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10820?size=medium" />WPB-6166</a>  [Web] [4hrs] Investigate possible memory leakages due to backup restore
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

After importing a backup we are loading all the unread messages into the conversations. It could happen that a user has a lot  of events sent inside their self conversation (type `1`). 

Since self conversation is never appearing in the ui, there's no way for user to read a message in this conversation. We should never load messages of self conversation into the memory.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
