### PR TITLE
fix: when grace period is over select the enrolment type based on certificate availability

### DIFF
--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -128,14 +128,20 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
       gracePeriodInMs,
       timer: new SnoozableTimer({
         gracePeriodInMS: gracePeriodInMs,
-        onGracePeriodExpired: () => this.startEnrollment(ModalType.ENROLL),
-        onSnoozeExpired: () => this.startEnrollment(ModalType.ENROLL),
+        onGracePeriodExpired: () => this.processEnrollmentUponExpiry(),
+        onSnoozeExpired: () => this.processEnrollmentUponExpiry(),
       }),
     };
 
     await this.coreE2EIService.registerServerCertificates(discoveryUrl);
     this.currentStep = E2EIHandlerStep.INITIALIZED;
     return this;
+  }
+
+  private async processEnrollmentUponExpiry() {
+    const hasCertificate = await hasActiveCertificate();
+    const enrollmentType = hasCertificate ? ModalType.CERTIFICATE_RENEWAL : ModalType.ENROLL;
+    await this.startEnrollment(enrollmentType);
   }
 
   public async attemptEnrollment(): Promise<void> {


### PR DESCRIPTION
## Description
when grace period is over select the enrolment type based on certificate availability

## Screenshots/Screencast (for UI changes)

### BEFORE:
User with valid certificate still gets enrolment modal

<img width="1512" alt="Screenshot 2024-01-23 at 10 10 57" src="https://github.com/wireapp/wire-webapp/assets/28754444/a73b5b62-8f9e-4aa9-8a68-075a00c79f61">

### AFTER:
User with  valid certificate still gets renewal modal

<img width="1512" alt="Wire 2024-01-23 at 12_08 PM" src="https://github.com/wireapp/wire-webapp/assets/28754444/793e557d-85ca-4671-af0e-239ec8431349">


## Checklist

- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;
