### PR TITLE
chore: Fix running CI jobs on cherry-picked commits

### DIFF
--- a/.github/workflows/cherry-pick-release-to-dev.yml
+++ b/.github/workflows/cherry-pick-release-to-dev.yml
@@ -19,4 +19,4 @@ jobs:
         with:
           pr_branch: 'dev'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OTTO_THE_BOT_GH_TOKEN }}


### PR DESCRIPTION
## Description

as mentioned here https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs opening a PR using the default `GITHUB_TOKEN` will not trigger a `pull_request` event (and thus will not kick of CI checks). 

Using our Otto the bot token, should fix that

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
