### PR TITLE
chore: Auto merge cherry picked commits to dev

### DIFF
--- a/.github/workflows/cherry-pick-release-to-dev.yml
+++ b/.github/workflows/cherry-pick-release-to-dev.yml
@@ -20,3 +20,10 @@ jobs:
           pr_branch: 'dev'
         env:
           GITHUB_TOKEN: ${{ secrets.OTTO_THE_BOT_GH_TOKEN }}
+
+      # Add the auto-merge flag
+      - name: Enable auto-merge
+        run: gh pr edit ${{ github.event.pull_request.id }} --add-label auto-merge
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.WEBTEAM_AUTOMERGE_TOKEN}}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,15 +16,10 @@ jobs:
         with:
           github-token: '${{secrets.WEBTEAM_AUTOMERGE_TOKEN}}'
 
-      - name: Approve a PR
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.WEBTEAM_AUTOMERGE_TOKEN}}
-
-      - name: Enable auto-merge for Dependabot PRs
+      # Add the auto-merge flag if the PR is a minor or patch version update
+      - name: Enable auto-merge for minor and patch updates
         if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: gh pr edit ${{ github.event.pull_request.id }} --add-label auto-merge
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.WEBTEAM_AUTOMERGE_TOKEN}}

--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -1,0 +1,26 @@
+name: Dependabot auto-merge
+on:
+  pull_request_target:
+    types: ['labeled']
+
+permissions:
+  pull-requests: write
+  contents: write
+
+## This job will auto merge PR that has been labeled with 'auto-merge'
+jobs:
+  activate-auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'auto-merge' }}
+    steps:
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.WEBTEAM_AUTOMERGE_TOKEN}}
+
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.WEBTEAM_AUTOMERGE_TOKEN}}

--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -1,4 +1,4 @@
-name: Dependabot auto-merge
+name: auto-merge flagged PR
 on:
   pull_request_target:
     types: ['labeled']

--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -1,6 +1,6 @@
 name: auto-merge flagged PR
 on:
-  pull_request_target:
+  pull_request:
     types: ['labeled']
 
 permissions:

--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.label.name == 'auto-merge' }}
     steps:
-      - name: Approve a PR
+      - name: Approve PR
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.WEBTEAM_AUTOMERGE_TOKEN}}
 
-      - name: Enable auto-merge for Dependabot PRs
+      - name: Enable auto-merge
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
## Description

This will make sure cherry-picked commits from release branches to `dev` will be auto merged once CI is green. 

This also refactors the logic to auto merge dependabot PR (it will now add the `auto-merge` flag that will trigger the new `pr-auto-merge` job)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
