### PR TITLE
fix: Enforce download path change if featureStatus is not changed

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -644,6 +644,7 @@
   "featureConfigChangeModalAudioVideoHeadline": "There has been a change in {{brandName}}",
   "featureConfigChangeModalDownloadPathDisabled": "Enforced Download Path is disabled. You will need to restart the app if you want to save downloads in a new location.",
   "featureConfigChangeModalDownloadPathEnabled": "Enforced Download Path is enabled. The App will restart for the new settings to take effect.",
+  "featureConfigChangeModalDownloadPathChanged": "Enforced Download Path location is changed. The App will restart for the new settings to take effect.",
   "featureConfigChangeModalDownloadPathHeadline": "There has been a change in {{brandName}}",
   "featureConfigChangeModalConferenceCallingEnabled": "Your team was upgraded to {{brandName}} Enterprise, which gives you access to features such as conference calls and more. [link]Learn more about {{brandName}} Enterprise[/link]",
   "featureConfigChangeModalConferenceCallingTitle": "{{brandName}} Enterprise",

--- a/src/script/page/components/FeatureConfigChange/FeatureConfigChangeNotifier/FeatureConfigChangeNotifier.test.tsx
+++ b/src/script/page/components/FeatureConfigChange/FeatureConfigChangeNotifier/FeatureConfigChangeNotifier.test.tsx
@@ -19,6 +19,7 @@
 
 import {act, render, waitFor} from '@testing-library/react';
 import {FeatureStatus, FEATURE_KEY, FeatureList} from '@wireapp/api-client/lib/team/feature';
+import {Runtime} from '@wireapp/commons/lib/util/Runtime';
 
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
 import en from 'I18n/en-US.json';
@@ -36,6 +37,8 @@ describe('FeatureConfigChangeNotifier', () => {
   beforeEach(() => {
     showModalSpy.mockClear();
     localStorage.clear();
+    jest.spyOn(Runtime, 'isDesktopApp').mockReturnValue(true);
+    jest.spyOn(Runtime, 'isWindows').mockReturnValue(true);
   });
 
   const baseConfig: FeatureList = {
@@ -95,6 +98,7 @@ describe('FeatureConfigChangeNotifier', () => {
         ...baseConfig,
         [feature]: {
           status: FeatureStatus.ENABLED,
+          ...(feature === FEATURE_KEY.ENFORCE_DOWNLOAD_PATH && {config: {enforcedDownloadLocation: 'dlpath'}}),
         },
       });
     });
@@ -116,6 +120,7 @@ describe('FeatureConfigChangeNotifier', () => {
         ...baseConfig,
         [feature]: {
           status: FeatureStatus.DISABLED,
+          ...(feature === FEATURE_KEY.ENFORCE_DOWNLOAD_PATH && {config: {enforcedDownloadLocation: ''}}),
         },
       });
     });

--- a/src/script/page/components/FeatureConfigChange/FeatureConfigChangeNotifier/FeatureConfigChangeNotifier.ts
+++ b/src/script/page/components/FeatureConfigChange/FeatureConfigChangeNotifier/FeatureConfigChangeNotifier.ts
@@ -90,6 +90,10 @@ const featureNotifications: Partial<
       Runtime.isWindows()
     ) {
       const status = wasTurnedOnOrOff(oldConfig, newConfig);
+      const configStatus = newConfig?.config?.enforcedDownloadLocation !== oldConfig?.config?.enforcedDownloadLocation;
+      if (!status && !configStatus) {
+        return undefined;
+      }
       amplify.publish(
         WebAppEvents.TEAM.DOWNLOAD_PATH_UPDATE,
         newConfig.status === FeatureStatus.ENABLED ? newConfig.config.enforcedDownloadLocation : undefined,


### PR DESCRIPTION
## Description
Catches a missing edge case for DL path changing.
In the case where the DL path is updated without the feature being turned on or off we should still make sure we enforce the change. 

follow up for: https://github.com/wireapp/wire-webapp/pull/16460

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;