### PR TITLE
runfix: Deregister the single instance of the app as late as possible

### DIFF
--- a/src/script/components/AppContainer/AppContainer.tsx
+++ b/src/script/components/AppContainer/AppContainer.tsx
@@ -64,7 +64,10 @@ export const AppContainer: FC<AppProps> = ({config, clientType}) => {
       return;
     }
     const killInstance = registerInstance();
-    window.addEventListener('beforeunload', killInstance);
+    /* We need to wait the very last moment to de-register the instance.
+     * If we do it too early (like beforeunload event) then the app could detect it's no longer the single instance running and redirect to the login page
+     */
+    window.addEventListener('pagehide', killInstance);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Description

We currently have this mechanism that detects if another instance of Wire is running in the same browser. 
In case another instance is started, then the app kills itself and redirects to the login page. 

This mechanism works like this:
- when loading the app, we save a cookie with a random instanceId
- then we start polling this cookie regularly and check that the value is still the current instance ID
- if this cookie value change, then we redirect the user to the login page

Problem is: on window unload we do reset the value of the cookie. 
But if we do it too early then the trigger that redirects the user to the login page will trigger even before we have the chance to navigate to the new URL. 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
