### PR TITLE
runfix: address read indicator design review (WPB-5369)

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -21,7 +21,6 @@ import React, {useMemo, useState, useEffect} from 'react';
 
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 
-import {ReadIndicator} from 'Components/MessagesList/Message/ReadIndicator';
 import {Conversation} from 'src/script/entity/Conversation';
 import {CompositeMessage} from 'src/script/entity/message/CompositeMessage';
 import {ContentMessage} from 'src/script/entity/message/ContentMessage';
@@ -192,13 +191,6 @@ export const ContentMessageComponent: React.FC<ContentMessageProps> = ({
               {timeAgo}
             </MessageTime>
           </span>
-
-          <ReadIndicator
-            message={message}
-            is1to1Conversation={conversation.is1to1()}
-            isLastDeliveredMessage={isLastDeliveredMessage}
-            showIconOnly
-          />
         </MessageHeader>
       )}
 

--- a/src/style/components/asset/common/common.less
+++ b/src/style/components/asset/common/common.less
@@ -24,6 +24,7 @@
   position: relative;
   display: flex;
   overflow: hidden;
+  max-width: var(--conversation-message-asset-width);
   min-height: 64px;
 
   border-radius: 12px;

--- a/src/style/components/asset/link-preview-asset.less
+++ b/src/style/components/asset/link-preview-asset.less
@@ -22,12 +22,8 @@
 
 .link-preview-asset {
   .asset-container-style;
-}
-
-.link-preview-asset {
   display: flex;
   width: 100%;
-  max-width: var(--conversation-message-asset-width);
   cursor: pointer;
 
   &.ephemeral-asset-expired {

--- a/src/style/components/asset/video-asset.less
+++ b/src/style/components/asset/video-asset.less
@@ -27,6 +27,7 @@
 
 // Video asset component
 .video-asset {
+  .asset-container-style;
   position: relative;
   display: block;
   flex: 1 1 auto;

--- a/src/style/components/asset/video-asset.less
+++ b/src/style/components/asset/video-asset.less
@@ -29,7 +29,6 @@
 .video-asset {
   position: relative;
   display: block;
-  max-width: var(--conversation-message-asset-width);
   flex: 1 1 auto;
 
   &__container {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5369" title="WPB-5369" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-5369</a>  Reactions UI improvements 1/2
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

- remove read receipt from the message header (username)
- correct width to be consistent between all assets so the read receipt shows up on the same spot

## Screenshots/Screencast (for UI changes)

Before:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/5125932d-b8ac-4b6b-bf29-64b89dfe2954)

After:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/4866bd47-4caa-4b9b-ad95-9cf26332b06f)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
