### PR TITLE
chore: Make cherry-pick PR title semantically correct

### DIFF
--- a/.github/workflows/rename-cherry-pick-pr.yml
+++ b/.github/workflows/rename-cherry-pick-pr.yml
@@ -1,0 +1,19 @@
+name: rename-auto-cherry-pick-pr
+on: pull_request
+
+permissions:
+  pull-requests: write
+  contents: write
+
+# This job will remove the AUTO: prefix from the PR title
+jobs:
+  rename-auto-cherry-pick-pr:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.pull_request.title, 'AUTO:')
+    steps:
+      - name: Make title semantic
+        run: |
+          TITLE="${{github.event.pull_request.title}}"
+          SEMANTIC_TITLE="${TITLE/AUTO: /}"
+          echo "new semantic title: $SEMANTIC_TITLE"
+          gh pr edit ${{github.event.pull_request.id}} --title "$SEMANTIC_TITLE"


### PR DESCRIPTION
## Description

This is a temporary fix until https://github.com/gorillio/github-action-cherry-pick/issues/11 is solved. 

Gist is: we cannot put a custom prefix on automatically cherry-picked commits. So this job will actually remove the `AUTO: ` prefix from any PR created. 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
