### PR TITLE
runfix: feature change notifier logic

### DIFF
--- a/src/script/page/components/FeatureConfigChange/FeatureConfigChangeNotifier/FeatureConfigChangeNotifier.test.tsx
+++ b/src/script/page/components/FeatureConfigChange/FeatureConfigChangeNotifier/FeatureConfigChangeNotifier.test.tsx
@@ -201,6 +201,7 @@ describe('FeatureConfigChangeNotifier', () => {
         expect(showModalSpy).toHaveBeenCalledWith(PrimaryModal.type.ACKNOWLEDGE, {
           hideCloseBtn: false,
           primaryAction: undefined,
+          preventClose: false,
           text: expect.objectContaining({
             htmlMessage: expectedText,
           }),

--- a/src/script/page/components/FeatureConfigChange/FeatureConfigChangeNotifier/FeatureConfigChangeNotifier.ts
+++ b/src/script/page/components/FeatureConfigChange/FeatureConfigChangeNotifier/FeatureConfigChangeNotifier.ts
@@ -208,6 +208,8 @@ export function FeatureConfigChangeNotifier({teamState, selfUserId}: Props): nul
       Object.entries(featureNotifications).forEach(([feature, getMessage]) => {
         const featureKey = feature as FEATURE_KEY;
         const message = getMessage(previous?.[featureKey], config[featureKey]);
+        const isEnforceDownloadPath = featureKey === FEATURE_KEY.ENFORCE_DOWNLOAD_PATH;
+
         if (!message) {
           return;
         }
@@ -224,8 +226,8 @@ export function FeatureConfigChangeNotifier({teamState, selfUserId}: Props): nul
             }),
           },
           primaryAction: message.primaryAction,
-          hideCloseBtn: featureKey === FEATURE_KEY.ENFORCE_DOWNLOAD_PATH,
-          preventClose: featureKey === FEATURE_KEY.ENFORCE_DOWNLOAD_PATH,
+          hideCloseBtn: isEnforceDownloadPath,
+          preventClose: isEnforceDownloadPath,
         });
       });
     }

--- a/src/script/page/components/FeatureConfigChange/FeatureConfigChangeNotifier/FeatureConfigChangeNotifier.ts
+++ b/src/script/page/components/FeatureConfigChange/FeatureConfigChangeNotifier/FeatureConfigChangeNotifier.ts
@@ -85,7 +85,6 @@ const featureNotifications: Partial<
       'config' in newConfig &&
       oldConfig &&
       'config' in oldConfig &&
-      newConfig?.config?.enforcedDownloadLocation !== oldConfig?.config?.enforcedDownloadLocation &&
       Runtime.isDesktopApp() &&
       Runtime.isWindows()
     ) {
@@ -226,6 +225,7 @@ export function FeatureConfigChangeNotifier({teamState, selfUserId}: Props): nul
           },
           primaryAction: message.primaryAction,
           hideCloseBtn: featureKey === FEATURE_KEY.ENFORCE_DOWNLOAD_PATH,
+          preventClose: featureKey === FEATURE_KEY.ENFORCE_DOWNLOAD_PATH,
         });
       });
     }


### PR DESCRIPTION
## Description
fixes an issue with the feature change modal not always showing up with enforced download path is changed. 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;