### PR TITLE
runfix: position system message timestamps correctly (WPB-6232)

### DIFF
--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -157,7 +157,6 @@
 .message-header-label {
   display: flex;
   min-width: 0; // fixes ellipsis not working with flexbox (FF)
-  flex: 1;
   align-items: center;
   font-size: @font-size-small;
   font-weight: @font-weight-regular;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6232" title="WPB-6232" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-6232</a>  [Web] Change position of timestamps on system messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

address inconsistency of system messages timestamp position with the rest of the app

## Screenshots/Screencast (for UI changes)

Before:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/01aa2fd3-86a5-4256-ae8c-a5d3245c20ea)

After:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/6c1510f3-3ee2-4b3d-a60e-a285ed985656)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
