### PR TITLE
runfix: make assets use all available width

### DIFF
--- a/src/style/components/asset/common/common.less
+++ b/src/style/components/asset/common/common.less
@@ -24,6 +24,7 @@
   position: relative;
   display: flex;
   overflow: hidden;
+  width: 100%;
   max-width: var(--conversation-message-asset-width);
   min-height: 64px;
 


### PR DESCRIPTION
## Description

- audio files do not use all available width

## Screenshots/Screencast (for UI changes)

Before:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/c7fd0e8c-3d81-482b-8251-bd6b4f79fe3c)
After:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/45c0e321-39a1-4fab-a8cb-d33f0c556905)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
