### PR TITLE
chore: use otto-the-bot to auto merge PR

### DIFF
--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Enable auto-merge
         run: gh pr merge --auto --squash ${{github.event.pull_request.html_url}}
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.OTTO_THE_BOT_GH_TOKEN}}


### PR DESCRIPTION
## Description

`github-action` bot can cause workflow not to run (see https://github.com/orgs/community/discussions/33804). 
We should use `otto-the-bot` to auto merge cherry picked PR, instead. 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
