### PR TITLE
perf: Init e2ei enrollment process as early as possible

### DIFF
--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -444,11 +444,16 @@ export class App {
 
       const conversations = await conversationRepository.loadConversations();
 
+      // We load all the users the self user is connected with
       const contacts = await userRepository.loadUsers(selfUser, connections, conversations);
-      await teamRepository.updateTeamMembersByIds(
-        team,
-        contacts.filter(user => user.teamId === team.id).map(({id}) => id),
-      );
+
+      if (team) {
+        // If we are in the context of team, we load the team members metadata (user roles)
+        await teamRepository.updateTeamMembersByIds(
+          team,
+          contacts.filter(user => user.teamId === team.id).map(({id}) => id),
+        );
+      }
 
       if (supportsMLS()) {
         //if mls is supported, we need to initialize the callbacks (they are used when decrypting messages)

--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -124,10 +124,7 @@ export class TeamRepository extends TypedEventEmitter<Events> {
    * @param teamId the Id of the team to init
    * @param contacts all the contacts the self user has, team members will be deduced from it.
    */
-  async initTeam(
-    teamId: string,
-    contacts: User[] = [],
-  ): Promise<{team: TeamEntity | undefined; features: FeatureList}> {
+  async initTeam(teamId?: string): Promise<{team: TeamEntity | undefined; features: FeatureList}> {
     // async initTeam(teamId?: string): Promise<{members: QualifiedId[]; features: FeatureList}> {
     const team = await this.getTeam();
     // get the fresh feature config from backend
@@ -135,11 +132,6 @@ export class TeamRepository extends TypedEventEmitter<Events> {
     if (!teamId) {
       return {team: undefined, features: {}};
     }
-    await this.updateTeamMembersByIds(
-      team,
-      contacts.filter(user => user.teamId === teamId).map(({id}) => id),
-    );
-
     // Subscribe to team members change and update the user role and guest status
     this.teamState.teamMembers.subscribe(members => {
       this.userRepository.mapGuestStatus(members);


### PR DESCRIPTION
## Description

In order to fire up the e2ei enrollment process as soon as possible, we need to make the `initTeam` method a 2 step process. 

The first step will:
- load the team config (in order to know if the e2ei is enabled for the team). 

The second step will:
- load all the team members metadata (after we have loaded all the contacts). 

This will make a rather big change in user account having a lot of conversations/contacts. 


### Before

https://github.com/wireapp/wire-webapp/assets/1090716/75efb00a-a05b-4d6e-b600-8bcb56813e77

### After

https://github.com/wireapp/wire-webapp/assets/1090716/b9b14481-db57-4867-bc80-8e02fa4c050d



## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
