### PR TITLE
perf: Optimize detecting deleted conversation after a backup restore [WPB-6166]

### DIFF
--- a/src/script/backup/BackupRepository.test.ts
+++ b/src/script/backup/BackupRepository.test.ts
@@ -84,6 +84,7 @@ async function buildBackupRepository() {
     .mockImplementation(conversations => conversations.map(c => generateConversation({type: c.type, overwites: c})));
   jest.spyOn(conversationRepository, 'updateConversationStates');
   jest.spyOn(conversationRepository, 'updateConversations');
+  jest.spyOn(conversationRepository, 'syncDeletedConversations').mockResolvedValue(undefined);
   return [
     new BackupRepository(backupService, conversationRepository),
     {backupService, conversationRepository, storageService},
@@ -279,7 +280,7 @@ describe('BackupRepository', () => {
       expect(mockGenerateChaCha20Key).toHaveBeenCalledWith(decodedHeader);
     });
 
-    test('compressHistoryFiles does not call the encryption function if no password is provided', async () => {
+    it('compressHistoryFiles does not call the encryption function if no password is provided', async () => {
       // Mocked values
       const password = '';
       const clientId = 'ClientId';
@@ -298,7 +299,8 @@ describe('BackupRepository', () => {
       expect(mockEncodeHeader).not.toHaveBeenCalled();
       expect(mockGenerateChaCha20Key).not.toHaveBeenCalled();
     });
-    test('compressHistoryFiles returns a Blob object with the correct type', async () => {
+
+    it('compressHistoryFiles returns a Blob object with the correct type', async () => {
       // Mocked values...
       const password = 'Password';
       const clientId = 'ClientId';

--- a/src/script/backup/BackupRepository.ts
+++ b/src/script/backup/BackupRepository.ts
@@ -387,7 +387,7 @@ export class BackupRepository {
     await this.conversationRepository.updateConversations(readableConversations);
     await this.conversationRepository.initAllLocal1To1Conversations();
     // doesn't need to be awaited
-    void this.conversationRepository.checkForDeletedConversations();
+    void this.conversationRepository.syncDeletedConversations();
   }
 
   private async importConversations(

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -1962,7 +1962,7 @@ describe('ConversationRepository', () => {
         await conversationRepository['saveConversation'](deletedGroup);
 
         const currentNbConversations = conversationRepository['conversationState'].conversations().length;
-        await testFactory.conversation_repository.checkForDeletedConversations();
+        await testFactory.conversation_repository.syncDeletedConversations();
 
         expect(conversationRepository['conversationState'].conversations()).toHaveLength(currentNbConversations - 1);
       });

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -1947,22 +1947,16 @@ describe('ConversationRepository', () => {
 
     describe('checkForDeletedConversations', () => {
       it('removes conversations that have been deleted on the backend', async () => {
-        const existingGroup = _generateConversation();
         const deletedGroup = _generateConversation();
         const conversationRepository = testFactory.conversation_repository!;
 
-        spyOn(testFactory.conversation_service, 'getConversationById').and.callFake(({id}) => {
-          if (id === deletedGroup.id) {
-            // eslint-disable-next-line prefer-promise-reject-errors
-            return Promise.reject({code: HTTP_STATUS.NOT_FOUND});
-          }
-          return Promise.resolve();
+        jest.spyOn(testFactory.conversation_service!, 'getConversationByIds').mockResolvedValue({
+          not_found: [deletedGroup],
         });
-        await conversationRepository['saveConversation'](existingGroup);
         await conversationRepository['saveConversation'](deletedGroup);
 
         const currentNbConversations = conversationRepository['conversationState'].conversations().length;
-        await testFactory.conversation_repository.syncDeletedConversations();
+        await testFactory.conversation_repository!.syncDeletedConversations();
 
         expect(conversationRepository['conversationState'].conversations()).toHaveLength(currentNbConversations - 1);
       });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6166" title="WPB-6166" target="_blank"><img alt="Spike" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10820?size=medium" />WPB-6166</a>  [Web] [4hrs] Investigate possible memory leakages due to backup restore
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

After a successful backup restore, we try to locally delete conversations that are deleted on backend. 
Previously we didn't have a way to get those deleted conversation other than querying every single conversation and checking if the response is a `404` on backend. 

Now we can optimize this and query all the conversations at once and check which ones are `not_found`. 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
