### PR TITLE
runfix: adjust padding of messages

### DIFF
--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -307,8 +307,8 @@
   display: flex;
   max-width: @conversation-max-width;
   justify-content: space-between;
+  padding-top: 6px;
   padding-left: @conversation-message-sender-width;
-  padding-block: 4px 8px;
 
   &-content {
     width: 100%;
@@ -383,7 +383,6 @@
   position: relative;
   display: flex;
   max-width: var(--conversation-message-asset-width);
-  margin: 0 0 24px;
   cursor: pointer;
 
   &--no-image {
@@ -723,7 +722,7 @@
 .message-asset {
   display: flex;
   align-items: flex-start;
-  margin-top: 8px;
+  margin-bottom: 6px;
 }
 
 .message-call,


### PR DESCRIPTION
## Description

Align padding between messages with design specs

#### Design review:

- too much padding between messages sent in quick succession
- too large a gap between images and reactions

#### Automation issues:

- Too much bottom margin on images breaks automation

## Screenshots/Screencast (for UI changes)

Before:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/f1b04394-7800-40bb-82ca-4d7a55f6d977)
![image](https://github.com/wireapp/wire-webapp/assets/78490891/05e4242d-e64d-4a6d-9053-08232929c225)


After:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/2e401d69-d2d3-4b8c-abb0-d5a7b5e0bbc0)
![image](https://github.com/wireapp/wire-webapp/assets/78490891/fff1f865-4964-4e4d-a309-15b4c196b426)



## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
