### PR TITLE
runfix: group messages sent within the same minute (WPB-3595)

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -29,7 +29,7 @@ import {useRelativeTimestamp} from 'src/script/hooks/useRelativeTimestamp';
 import {StatusType} from 'src/script/message/StatusType';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {getMessageAriaLabel} from 'Util/conversationMessages';
-import {fromUnixTime, TIME_IN_MILLIS} from 'Util/TimeUtil';
+import {shouldGroupMessagesByTimestamp} from 'Util/MessagesGroupingUtil';
 
 import {ContentAsset} from './asset';
 import {MessageActionsMenu} from './MessageActions/MessageActions';
@@ -126,22 +126,10 @@ export const ContentMessageComponent: React.FC<ContentMessageProps> = ({
       return true;
     }
 
-    // Interval in seconds, within which messages are grouped together
-    const GROUPED_MESSAGE_INTERVAL = 30 * TIME_IN_MILLIS.SECOND;
-
-    const currentMessageDate = fromUnixTime(message.timestamp() / TIME_IN_MILLIS.SECOND);
-    const previousMessageDate = fromUnixTime(previousMessage.timestamp() / TIME_IN_MILLIS.SECOND);
-
     const currentMessageTime = message.timestamp();
     const previousMessageTime = previousMessage.timestamp();
 
-    const currentMinute = currentMessageDate.getMinutes();
-    const previousMinute = previousMessageDate.getMinutes();
-
-    const isSentWithinTheSameMinute = currentMinute == previousMinute;
-    const isSentWithinTimeInterval = currentMessageTime - previousMessageTime <= GROUPED_MESSAGE_INTERVAL;
-
-    if (!isSentWithinTheSameMinute && !isSentWithinTimeInterval) {
+    if (!shouldGroupMessagesByTimestamp(previousMessageTime, previousMessageTime, currentMessageTime)) {
       return true;
     }
 

--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -129,6 +129,7 @@ export const ContentMessageComponent: React.FC<ContentMessageProps> = ({
     const currentMessageTime = message.timestamp();
     const previousMessageTime = previousMessage.timestamp();
 
+    // We intend to change the first parameter to the timestamp of the first message in a group when structure allows it
     if (!shouldGroupMessagesByTimestamp(previousMessageTime, previousMessageTime, currentMessageTime)) {
       return true;
     }

--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -29,7 +29,7 @@ import {useRelativeTimestamp} from 'src/script/hooks/useRelativeTimestamp';
 import {StatusType} from 'src/script/message/StatusType';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {getMessageAriaLabel} from 'Util/conversationMessages';
-import {TIME_IN_MILLIS} from 'Util/TimeUtil';
+import {fromUnixTime, TIME_IN_MILLIS} from 'Util/TimeUtil';
 
 import {ContentAsset} from './asset';
 import {MessageActionsMenu} from './MessageActions/MessageActions';
@@ -129,10 +129,19 @@ export const ContentMessageComponent: React.FC<ContentMessageProps> = ({
     // Interval in seconds, within which messages are grouped together
     const GROUPED_MESSAGE_INTERVAL = 30 * TIME_IN_MILLIS.SECOND;
 
-    const currentMessageDate = message.timestamp();
-    const previousMessageDate = previousMessage.timestamp();
+    const currentMessageDate = fromUnixTime(message.timestamp() / TIME_IN_MILLIS.SECOND);
+    const previousMessageDate = fromUnixTime(previousMessage.timestamp() / TIME_IN_MILLIS.SECOND);
 
-    if (currentMessageDate - previousMessageDate >= GROUPED_MESSAGE_INTERVAL) {
+    const currentMessageTime = message.timestamp();
+    const previousMessageTime = previousMessage.timestamp();
+
+    const currentMinute = currentMessageDate.getMinutes();
+    const previousMinute = previousMessageDate.getMinutes();
+
+    const isSentWithinTheSameMinute = currentMinute == previousMinute;
+    const isSentWithinTimeInterval = currentMessageTime - previousMessageTime <= GROUPED_MESSAGE_INTERVAL;
+
+    if (!isSentWithinTheSameMinute && !isSentWithinTimeInterval) {
       return true;
     }
 

--- a/src/script/util/MessagesGroupingUtil.test.ts
+++ b/src/script/util/MessagesGroupingUtil.test.ts
@@ -37,7 +37,7 @@ describe('shouldGroupMessagesByTimestamp', () => {
 
   it('should return false for messages sent in different minutes and more than 30 seconds apart', () => {
     const firstMessageTimestamp = 1 * TIME_IN_MILLIS.SECOND; // clock shows 0 min 1 sec
-    const previousMessageTimestamp = 25 * TIME_IN_MILLIS.SECOND; // clock shows 0 min 26 sec
+    const previousMessageTimestamp = 25 * TIME_IN_MILLIS.SECOND; // clock shows 0 min 25 sec
     const currentMessageTimestamp = firstMessageTimestamp + 59 * TIME_IN_MILLIS.SECOND; // clock shows 1 min 00 sec
 
     const result = shouldGroupMessagesByTimestamp(

--- a/src/script/util/MessagesGroupingUtil.test.ts
+++ b/src/script/util/MessagesGroupingUtil.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {TIME_IN_MILLIS} from 'Util/TimeUtil';
+
+import {shouldGroupMessagesByTimestamp} from './MessagesGroupingUtil';
+
+describe('shouldGroupMessagesByTimestamp', () => {
+  it('should return true for 2 messages sent within the same minute, 58 seconds appart', () => {
+    const firstMessageTimestamp = 1 * TIME_IN_MILLIS.SECOND; // Happy new year 1970!
+    const previousMessageTimestamp = 1 * TIME_IN_MILLIS.SECOND;
+    const currentMessageTimestamp = firstMessageTimestamp + 58 * TIME_IN_MILLIS.SECOND; // 58 seconds later
+
+    const result = shouldGroupMessagesByTimestamp(
+      firstMessageTimestamp,
+      previousMessageTimestamp,
+      currentMessageTimestamp,
+    );
+    expect(result).toBe(true);
+  });
+
+  it('should return false for messages sent in different minutes and more than 30 seconds apart', () => {
+    const firstMessageTimestamp = 1 * TIME_IN_MILLIS.SECOND; // clock shows 0 min 1 sec
+    const previousMessageTimestamp = 25 * TIME_IN_MILLIS.SECOND; // clock shows 0 min 26 sec
+    const currentMessageTimestamp = firstMessageTimestamp + 59 * TIME_IN_MILLIS.SECOND; // clock shows 1 min 00 sec
+
+    const result = shouldGroupMessagesByTimestamp(
+      firstMessageTimestamp,
+      previousMessageTimestamp,
+      currentMessageTimestamp,
+    );
+    expect(result).toBe(false);
+  });
+
+  it('should return true for messages sent in different minutes and less than 30 seconds apart', () => {
+    const firstMessageTimestamp = 1 * TIME_IN_MILLIS.SECOND; // clock shows 0 min 1 sec
+    const previousMessageTimestamp = 40 * TIME_IN_MILLIS.SECOND; // clock shows 0 min 40 sec
+    const currentMessageTimestamp = 60 * TIME_IN_MILLIS.SECOND; // clock shows 1 min 00 sec
+
+    const result = shouldGroupMessagesByTimestamp(
+      firstMessageTimestamp,
+      previousMessageTimestamp,
+      currentMessageTimestamp,
+    );
+    expect(result).toBe(true);
+  });
+});

--- a/src/script/util/MessagesGroupingUtil.ts
+++ b/src/script/util/MessagesGroupingUtil.ts
@@ -19,6 +19,14 @@
 
 import {fromUnixTime, TIME_IN_MILLIS} from 'Util/TimeUtil';
 
+/**
+ * Determines whether a message should be grouped with a previous one based on timestamp,
+ * a message should be grouped if it's sent within the same minute on the clock than the first message in the group
+ * or if it's sent within a timeframe (30 seconds) of the previous one
+ * @param firstMessageTimestamp unix timestamp of the first message in the group
+ * @param previousMessageTimestamp timestamp of the previous message
+ * @param currentMessageTimestamp timestamp of the current message
+ */
 export function shouldGroupMessagesByTimestamp(
   firstMessageTimestamp: number,
   previousMessageTimestamp: number,

--- a/src/script/util/MessagesGroupingUtil.ts
+++ b/src/script/util/MessagesGroupingUtil.ts
@@ -1,0 +1,43 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {fromUnixTime, TIME_IN_MILLIS} from 'Util/TimeUtil';
+
+export function shouldGroupMessagesByTimestamp(
+  firstMessageTimestamp: number,
+  previousMessageTimestamp: number,
+  currentMessageTimestamp: number,
+) {
+  // Interval in seconds, within which messages are grouped together
+  const GROUPED_MESSAGE_INTERVAL = 30 * TIME_IN_MILLIS.SECOND;
+
+  const currentMessageDate = fromUnixTime(currentMessageTimestamp / TIME_IN_MILLIS.SECOND);
+  const firstMessageDate = fromUnixTime(firstMessageTimestamp / TIME_IN_MILLIS.SECOND);
+
+  const currentMinute = currentMessageDate.getMinutes();
+  const previousMinute = firstMessageDate.getMinutes();
+
+  const isSentWithinTheSameMinute = currentMinute == previousMinute;
+  const isSentWithinTimeInterval = currentMessageTimestamp - previousMessageTimestamp <= GROUPED_MESSAGE_INTERVAL;
+
+  if (isSentWithinTheSameMinute || isSentWithinTimeInterval) {
+    return true;
+  }
+  return false;
+}

--- a/src/script/util/MessagesGroupingUtil.ts
+++ b/src/script/util/MessagesGroupingUtil.ts
@@ -41,7 +41,7 @@ export function shouldGroupMessagesByTimestamp(
   const currentMinute = currentMessageDate.getMinutes();
   const previousMinute = firstMessageDate.getMinutes();
 
-  const isSentWithinTheSameMinute = currentMinute == previousMinute;
+  const isSentWithinTheSameMinute = currentMinute === previousMinute;
   const isSentWithinTimeInterval = currentMessageTimestamp - previousMessageTimestamp <= GROUPED_MESSAGE_INTERVAL;
 
   if (isSentWithinTheSameMinute || isSentWithinTimeInterval) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3595" title="WPB-3595" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-3595</a>  [Web] [Reactions] Group messages in the chat by user and timestamp
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

We want to group messages sent by the same user if they're sent within a 30s timeframe *and* if they're sent within the same minute.

The "within the same minute" logic was removed there: https://github.com/wireapp/wire-webapp/pull/16631

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
