### PR TITLE
runfix: revoke modal copy

### DIFF
--- a/src/script/E2EIdentity/Modals/Modals.ts
+++ b/src/script/E2EIdentity/Modals/Modals.ts
@@ -124,7 +124,6 @@ export const getModalOptions = ({
     case ModalType.SELF_CERTIFICATE_REVOKED:
       options = {
         text: {
-          closeBtnLabel: t('acme.selfCertificateRevoked.button.cancel'),
           htmlMessage: t('acme.selfCertificateRevoked.text'),
           title: t('acme.selfCertificateRevoked.title'),
         },
@@ -132,6 +131,7 @@ export const getModalOptions = ({
           action: primaryActionFn,
           text: t('acme.selfCertificateRevoked.button.primary'),
         },
+        confirmCancelBtnLabel: t('acme.selfCertificateRevoked.button.cancel'),
       };
       modalType = PrimaryModal.type.CONFIRM;
       break;

--- a/src/script/E2EIdentity/Modals/Modals.ts
+++ b/src/script/E2EIdentity/Modals/Modals.ts
@@ -132,6 +132,8 @@ export const getModalOptions = ({
           text: t('acme.selfCertificateRevoked.button.primary'),
         },
         confirmCancelBtnLabel: t('acme.selfCertificateRevoked.button.cancel'),
+        allButtonsFullWidth: true,
+        primaryBtnFirst: true,
       };
       modalType = PrimaryModal.type.CONFIRM;
       break;

--- a/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
@@ -68,6 +68,8 @@ export const PrimaryModalComponent: FC = () => {
     copyPassword,
     hideCloseBtn = false,
     passwordOptional = false,
+    allButtonsFullWidth = false,
+    primaryBtnFirst,
   } = content;
 
   const isPassword = currentType === PrimaryModalType.PASSWORD;
@@ -195,6 +197,40 @@ export const PrimaryModalComponent: FC = () => {
       closeAction?.action?.();
     }
   };
+
+  const secondaryButtons = secondaryActions
+    .filter((action): action is Action => action !== null && !!action.text)
+    .map(action => (
+      <button
+        key={`${action.text}-${action.uieName}`}
+        type="button"
+        onClick={doAction(action.action, true, true)}
+        data-uie-name={action.uieName}
+        className={cx('modal__button modal__button--secondary', {
+          'modal__button--full': hasMultipleSecondary || allButtonsFullWidth,
+        })}
+      >
+        {action.text}
+      </button>
+    ));
+
+  const primaryButton = !!primaryAction?.text && (
+    <button
+      ref={primaryActionButtonRef}
+      type="button"
+      onClick={doAction(confirm, !!closeOnConfirm)}
+      disabled={isPrimaryActionDisabled()}
+      className={cx('modal__button modal__button--primary', {
+        'modal__button--full': hasMultipleSecondary || allButtonsFullWidth,
+      })}
+      data-uie-name="do-action"
+      key={`modal-primary-button`}
+    >
+      {primaryAction.text}
+    </button>
+  );
+
+  const buttons = primaryBtnFirst ? [primaryButton, ...secondaryButtons] : [...secondaryButtons, primaryButton];
 
   return (
     <div
@@ -428,36 +464,12 @@ export const PrimaryModalComponent: FC = () => {
                   <Loading />
                 </div>
               ) : (
-                <div className={cx('modal__buttons', {'modal__buttons--column': hasMultipleSecondary})}>
-                  {secondaryActions
-                    .filter((action): action is Action => action !== null && !!action.text)
-                    .map(action => (
-                      <button
-                        key={`${action.text}-${action.uieName}`}
-                        type="button"
-                        onClick={doAction(action.action, true, true)}
-                        data-uie-name={action.uieName}
-                        className={cx('modal__button modal__button--secondary', {
-                          'modal__button--full': hasMultipleSecondary,
-                        })}
-                      >
-                        {action.text}
-                      </button>
-                    ))}
-                  {primaryAction?.text && (
-                    <button
-                      ref={primaryActionButtonRef}
-                      type="button"
-                      onClick={doAction(confirm, !!closeOnConfirm)}
-                      disabled={isPrimaryActionDisabled()}
-                      className={cx('modal__button modal__button--primary', {
-                        'modal__button--full': hasMultipleSecondary,
-                      })}
-                      data-uie-name="do-action"
-                    >
-                      {primaryAction.text}
-                    </button>
-                  )}
+                <div
+                  className={cx('modal__buttons', {
+                    'modal__buttons--column': hasMultipleSecondary || allButtonsFullWidth,
+                  })}
+                >
+                  {buttons}
                 </div>
               )}
             </FadingScrollbar>

--- a/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
@@ -69,7 +69,7 @@ export const PrimaryModalComponent: FC = () => {
     hideCloseBtn = false,
     passwordOptional = false,
     allButtonsFullWidth = false,
-    primaryBtnFirst,
+    primaryBtnFirst = false,
   } = content;
 
   const isPassword = currentType === PrimaryModalType.PASSWORD;

--- a/src/script/components/Modals/PrimaryModal/PrimaryModalState.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModalState.tsx
@@ -135,6 +135,8 @@ const updateCurrentModalContent = (type: PrimaryModalType, options: ModalOptions
     passwordOptional = false,
     text = {} as Text,
     confirmCancelBtnLabel,
+    allButtonsFullWidth = false,
+    primaryBtnFirst = false,
   } = options;
 
   const content = {
@@ -155,6 +157,8 @@ const updateCurrentModalContent = (type: PrimaryModalType, options: ModalOptions
     titleText: text.title ?? '',
     passwordOptional,
     confirmCancelBtnLabel,
+    allButtonsFullWidth,
+    primaryBtnFirst,
   };
 
   switch (type) {

--- a/src/script/components/Modals/PrimaryModal/PrimaryModalState.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModalState.tsx
@@ -134,6 +134,7 @@ const updateCurrentModalContent = (type: PrimaryModalType, options: ModalOptions
     hideCloseBtn = false,
     passwordOptional = false,
     text = {} as Text,
+    confirmCancelBtnLabel,
   } = options;
 
   const content = {
@@ -153,6 +154,7 @@ const updateCurrentModalContent = (type: PrimaryModalType, options: ModalOptions
     hideCloseBtn,
     titleText: text.title ?? '',
     passwordOptional,
+    confirmCancelBtnLabel,
   };
 
   switch (type) {
@@ -200,7 +202,10 @@ const updateCurrentModalContent = (type: PrimaryModalType, options: ModalOptions
       break;
     }
     case PrimaryModalType.CONFIRM: {
-      content.secondaryAction = {text: t('modalConfirmSecondary'), ...content.secondaryAction};
+      content.secondaryAction = {
+        text: content.confirmCancelBtnLabel || t('modalConfirmSecondary'),
+        ...content.secondaryAction,
+      };
       break;
     }
     case PrimaryModalType.INPUT:

--- a/src/script/components/Modals/PrimaryModal/PrimaryModalTypes.ts
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModalTypes.ts
@@ -52,6 +52,8 @@ export interface ModalOptions {
   text?: Text;
   passwordOptional?: boolean;
   confirmCancelBtnLabel?: string;
+  allButtonsFullWidth?: boolean;
+  primaryBtnFirst?: boolean;
 }
 
 export enum PrimaryModalType {
@@ -89,6 +91,8 @@ export interface ModalContent {
   titleText: string;
   hideCloseBtn?: boolean;
   passwordOptional?: boolean;
+  allButtonsFullWidth?: boolean;
+  primaryBtnFirst?: boolean;
 }
 
 export type ModalItem = {id: string; options: ModalOptions; type: PrimaryModalType};

--- a/src/script/components/Modals/PrimaryModal/PrimaryModalTypes.ts
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModalTypes.ts
@@ -51,6 +51,7 @@ export interface ModalOptions {
   hideCloseBtn?: boolean;
   text?: Text;
   passwordOptional?: boolean;
+  confirmCancelBtnLabel?: string;
 }
 
 export enum PrimaryModalType {


### PR DESCRIPTION
## Description

This PR adds ability for confirmation type of primary modal to change the close button's copy (it was "cancel" by default) and also to change the order of which buttons are listed (see screenshots below).

Default (as usual):
<img width="388" alt="default" src="https://github.com/wireapp/wire-webapp/assets/45733298/7bd1d9a7-1c44-49ea-9060-fe4d24a7a881">

`primaryBtnFirst` will make sure primary button is listed first on a buttons list
<img width="386" alt="primary first" src="https://github.com/wireapp/wire-webapp/assets/45733298/a2a11fed-258a-4e34-8c63-7372dfa32935">

`allButtonsFullWidth` will force all the buttons to be listed one under the other (with full-width)
<img width="382" alt="all-buttons-full" src="https://github.com/wireapp/wire-webapp/assets/45733298/d684cc2c-9410-40af-8c5e-c081cf393a81">

And combinations of the two - one button under the other with primary one listed as first (this is what's required for the revocation modal).
<img width="384" alt="Screenshot 2024-01-30 at 14 55 28" src="https://github.com/wireapp/wire-webapp/assets/45733298/3ec77403-d33a-4757-8f43-c335fde1eb89">


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
