### PR TITLE
runfix: revoked cert icon

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -55,6 +55,7 @@
   "E2EI.certificateDetails": "Certificate details (PEM format)",
   "E2EI.certificateExpired": "End-to-end identity certificate expired",
   "E2EI.certificateExpiresSoon": "End-to-end identity certificate expires soon",
+  "E2EI.certificateNotDownloaded": "End-to-end identity certificate not downloaded",
   "E2EI.certificateRevoked": "End-to-end identity certificate revoked",
   "E2EI.certificateTitle": "End-to-end identity certificate",
   "E2EI.copyCertificate": "Copy to Clipboard",

--- a/src/script/E2EIdentity/SnoozableTimer/delay.ts
+++ b/src/script/E2EIdentity/SnoozableTimer/delay.ts
@@ -72,5 +72,5 @@ export async function shouldEnableSoftLock(
   if (!identity?.certificate) {
     return false;
   }
-  return [MLSStatuses.EXPIRED, MLSStatuses.REVOKED].includes(identity.status);
+  return identity.status === MLSStatuses.EXPIRED;
 }

--- a/src/script/components/VerificationBadge/VerificationBadges.test.tsx
+++ b/src/script/components/VerificationBadge/VerificationBadges.test.tsx
@@ -59,6 +59,15 @@ describe('VerificationBadges', () => {
     expect(E2EIdentityStatus.getAttribute('data-uie-value')).toEqual(MLSStatuses.EXPIRED);
   });
 
+  it('is revoked', async () => {
+    const {getByTestId} = render(
+      withTheme(<VerificationBadges context="conversation" MLSStatus={MLSStatuses.REVOKED} />),
+    );
+
+    const E2EIdentityStatus = getByTestId('mls-conversation-status');
+    expect(E2EIdentityStatus.getAttribute('data-uie-value')).toEqual(MLSStatuses.REVOKED);
+  });
+
   it('is expiring soon', async () => {
     const {getByTestId} = render(
       withTheme(<VerificationBadges context="conversation" MLSStatus={MLSStatuses.EXPIRES_SOON} />),

--- a/src/script/components/VerificationBadge/VerificationBadges.tsx
+++ b/src/script/components/VerificationBadge/VerificationBadges.tsx
@@ -137,8 +137,8 @@ const MLSVerificationBadge = ({context, MLSStatus}: {MLSStatus?: MLSStatuses; co
         </span>
       );
     case MLSStatuses.NOT_DOWNLOADED:
-      <span {...mlsVerificationProps} data-tooltip={t('E2EI.certificateRevoked')}>
-        <CertificateRevoked />
+      <span {...mlsVerificationProps} data-tooltip={t('E2EI.certificateNotDownloaded')}>
+        <CertificateExpiredIcon />
       </span>;
     case MLSStatuses.EXPIRED:
       return (
@@ -149,7 +149,7 @@ const MLSVerificationBadge = ({context, MLSStatus}: {MLSStatus?: MLSStatuses; co
     case MLSStatuses.REVOKED:
       return (
         <span {...mlsVerificationProps} data-tooltip={t('E2EI.certificateRevoked')}>
-          <CertificateExpiredIcon />
+          <CertificateRevoked />
         </span>
       );
     case MLSStatuses.EXPIRES_SOON:

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.test.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.test.tsx
@@ -52,6 +52,15 @@ describe('E2EICertificateDetails', () => {
     expect(E2EIdentityStatus.getAttribute('data-uie-value')).toEqual(MLSStatuses.EXPIRED);
   });
 
+  it('is e2ei identity revoked', async () => {
+    const identity = generateIdentity(MLSStatuses.REVOKED);
+
+    const {getByTestId} = render(withTheme(<E2EICertificateDetails identity={identity} />));
+
+    const E2EIdentityStatus = getByTestId('e2ei-identity-status');
+    expect(E2EIdentityStatus.getAttribute('data-uie-value')).toEqual(MLSStatuses.REVOKED);
+  });
+
   it('is e2ei identity verified', async () => {
     const identity = generateIdentity(MLSStatuses.VALID);
 


### PR DESCRIPTION
## Description

We were using wrong icon for revoked cert indication. It also changes the icon for cert not downloaded (which should be the same as for expired cert) - see screenshots from design file below:

not downloaded:
<img width="262" alt="Screenshot 2024-01-30 at 15 41 47" src="https://github.com/wireapp/wire-webapp/assets/45733298/e05db39d-6bab-438f-973a-192f04ef9eaa">

expired:
<img width="298" alt="Screenshot 2024-01-30 at 15 40 46" src="https://github.com/wireapp/wire-webapp/assets/45733298/1f373719-4933-4a59-bcaa-a05dbca18e08">

revoked:
<img width="146" alt="Screenshot 2024-01-30 at 15 41 35" src="https://github.com/wireapp/wire-webapp/assets/45733298/2e74610f-5123-4975-ad76-dfd2c9bc6415">

According to spec, we should not soft lock the app if cert is revoked - we let user to choose whether they want to continue using the app without cert or they want to log out and enroll again.

<img width="384" alt="Screenshot 2024-01-30 at 14 55 28" src="https://github.com/wireapp/wire-webapp/assets/45733298/89425aa9-182f-4fe7-95e6-a60a5fcc8be4">

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
