### PR TITLE
fix: read indicators for assets in 1:1 conversation

### DIFF
--- a/src/script/event/preprocessor/ReceiptsMiddleware.ts
+++ b/src/script/event/preprocessor/ReceiptsMiddleware.ts
@@ -17,8 +17,6 @@
  *
  */
 
-import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data';
-
 import {ConfirmationEvent} from 'src/script/conversation/EventBuilder';
 import {User} from 'src/script/entity/User';
 import {getLogger, Logger} from 'Util/Logger';
@@ -52,10 +50,7 @@ export class ReceiptsMiddleware implements EventMiddleware {
       case ClientEvent.CONVERSATION.MESSAGE_ADD: {
         const qualifiedConversation = event.qualified_conversation || {domain: '', id: event.conversation};
         return this.conversationRepository.getConversationById(qualifiedConversation).then(conversation => {
-          if (conversation && conversation.isGroup()) {
-            const expectsReadConfirmation = conversation.receiptMode() === RECEIPT_MODE.ON;
-            event.data.expects_read_confirmation = !!expectsReadConfirmation;
-          }
+          event.data.expects_read_confirmation = this.conversationRepository.expectReadReceipt(conversation);
           return event;
         });
       }


### PR DESCRIPTION
## Description

Previously we not setting expects_read_confirmation for assets, so we never will have information about read indicator for asset.

## Screenshots/Screencast (for UI changes)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
