### PR TITLE
fix: Margins between several lines of reactions too high

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React, {useMemo, useState, useEffect} from 'react';
+import {useMemo, useState, useEffect} from 'react';
 
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 
@@ -64,7 +64,7 @@ export interface ContentMessageProps extends Omit<MessageActions, 'onClickResetS
   onClickReaction: (emoji: string) => void;
 }
 
-export const ContentMessageComponent: React.FC<ContentMessageProps> = ({
+export const ContentMessageComponent = ({
   conversation,
   message,
   findMessage,
@@ -84,7 +84,7 @@ export const ContentMessageComponent: React.FC<ContentMessageProps> = ({
   isMsgElementsFocusable,
   onClickReaction,
   onClickDetails,
-}) => {
+}: ContentMessageProps) => {
   // check if current message is focused and its elements focusable
   const msgFocusState = useMemo(
     () => isMsgElementsFocusable && isMessageFocused,
@@ -261,16 +261,18 @@ export const ContentMessageComponent: React.FC<ContentMessageProps> = ({
         )}
       </div>
 
-      <MessageReactionsList
-        reactions={reactions}
-        selfUserId={selfId}
-        handleReactionClick={onClickReaction}
-        isMessageFocused={msgFocusState}
-        onTooltipReactionCountClick={() => onClickReactionDetails(message)}
-        onLastReactionKeyEvent={() => setActionMenuVisibility(false)}
-        isRemovedFromConversation={conversation.removed_from_conversation()}
-        users={conversation.allUserEntities()}
-      />
+      {!!reactions.length && (
+        <MessageReactionsList
+          reactions={reactions}
+          selfUserId={selfId}
+          handleReactionClick={onClickReaction}
+          isMessageFocused={msgFocusState}
+          onTooltipReactionCountClick={() => onClickReactionDetails(message)}
+          onLastReactionKeyEvent={() => setActionMenuVisibility(false)}
+          isRemovedFromConversation={conversation.removed_from_conversation()}
+          users={conversation.allUserEntities()}
+        />
+      )}
     </div>
   );
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiPill.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiPill.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {FC, useState} from 'react';
+import {useState} from 'react';
 
 import {Tooltip} from '@wireapp/react-ui-kit';
 
@@ -57,7 +57,7 @@ export interface EmojiPillProps {
 
 const MAX_USER_NAMES_TO_SHOW = 2;
 
-export const EmojiPill: FC<EmojiPillProps> = ({
+export const EmojiPill = ({
   emoji,
   emojiUnicode,
   handleReactionClick,
@@ -69,7 +69,7 @@ export const EmojiPill: FC<EmojiPillProps> = ({
   emojiListCount,
   hasUserReacted,
   reactingUsers,
-}) => {
+}: EmojiPillProps) => {
   const messageFocusedTabIndex = useMessageFocusedTabIndex(isMessageFocused);
   const [isOpen, setTooltipVisibility] = useState(false);
   const emojiName = getEmojiTitleFromEmojiUnicode(emojiUnicode);

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactions.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactions.styles.ts
@@ -40,13 +40,14 @@ import {CSSObject} from '@emotion/react';
 
 export const messageReactionWrapper: CSSObject = {
   display: 'flex',
+  paddingBlock: '0.5rem',
   gap: '0.5rem',
   paddingInline: 'var(--conversation-message-sender-width)',
   flexWrap: 'wrap',
   maxWidth: '100%',
   '.tooltip-content': {
     backgroundColor: 'var(--white) !important',
-    marginBottom: '0 !important',
+    marginBottom: '0.5rem !important',
     padding: '6px 8px !important',
     '.tooltip-arrow': {
       borderTopColor: 'var(--white) !important',
@@ -69,7 +70,6 @@ export const messageReactionButton: CSSObject = {
   color: 'var(--white)',
   display: 'inline-flex',
   gap: '4px',
-  margin: '0.5rem 0rem',
   padding: '3px',
   verticalAlign: 'top',
   userSelect: 'none',

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -125,7 +125,7 @@
   display: flex;
   width: 100%;
   padding-top: 6px;
-  margin-bottom: 4px;
+  margin-bottom: 2px;
   line-height: @avatar-diameter-xs;
 
   & > .message-body-actions {
@@ -307,8 +307,8 @@
   display: flex;
   max-width: @conversation-max-width;
   justify-content: space-between;
-  padding-top: 6px;
   padding-left: @conversation-message-sender-width;
+  padding-block: 4px;
 
   &-content {
     width: 100%;
@@ -722,7 +722,7 @@
 .message-asset {
   display: flex;
   align-items: flex-start;
-  margin-bottom: 6px;
+  margin-bottom: 4px;
 }
 
 .message-call,


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-6323

## Description

Changed gap between reactions and on message-body.

## Screenshots/Screencast (for UI changes)

Before:
![image](https://github.com/wireapp/wire-webapp/assets/13432884/b8bdc9bf-e866-4ca3-9a3d-19136170e7ba)

After:
![image](https://github.com/wireapp/wire-webapp/assets/13432884/d2884ce0-6d38-4b31-a95a-4a33f1d5a808)


## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
