### PR TITLE
chore: publish release branch to aws

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -329,6 +329,9 @@ jobs:
               "production": {
                 "targets": "[\"wire-webapp-prod-al2\"]"
               },
+              "release/q1-2024": {
+                "targets": "[\"wire-webapp-mls-al2\"]"
+              }
               "staging": {
                 "targets": "[\"wire-webapp-staging-al2\"]"
               }


### PR DESCRIPTION
## Description

publish the `release/q1-2024` branch to aws so automation can run on staging backend