### PR TITLE
runfix: bump core to fix rejoining conference subconversations

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@peculiar/x509": "1.9.6",
     "@wireapp/avs": "9.6.9",
     "@wireapp/commons": "5.2.4",
-    "@wireapp/core": "43.11.2",
+    "@wireapp/core": "43.12.0",
     "@wireapp/react-ui-kit": "9.12.8",
     "@wireapp/store-engine-dexie": "2.1.7",
     "@wireapp/webapp-events": "0.20.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4812,14 +4812,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^26.10.1":
-  version: 26.10.1
-  resolution: "@wireapp/api-client@npm:26.10.1"
+"@wireapp/api-client@npm:^26.10.3":
+  version: 26.10.3
+  resolution: "@wireapp/api-client@npm:26.10.3"
   dependencies:
     "@wireapp/commons": ^5.2.4
     "@wireapp/priority-queue": ^2.1.4
     "@wireapp/protocol-messaging": 1.44.0
-    axios: 1.6.5
+    axios: 1.6.7
     axios-retry: 4.0.0
     exponential-backoff: 3.1.1
     http-status-codes: 2.3.0
@@ -4830,7 +4830,7 @@ __metadata:
     tough-cookie: 4.1.3
     ws: 8.16.0
     zod: 3.22.4
-  checksum: 896affd13be653b7dfe1bf67b028c32f91b03ce446da0e5019e50a8524532cb31c8c6d06b46927bea379a0ddf6b5f12f68f7d29e5ecda6445bfcd8f435472802
+  checksum: 3fb211267ce6ac5927bcb6598d8f0d209b022318d50fcb2e17c379a800b9b93a19026f13708f29cd92b66a26ad7fbf79e751e95d8ec4f95731b24d67196d9f94
   languageName: node
   linkType: hard
 
@@ -4876,26 +4876,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core-crypto@npm:1.0.0-rc.33":
-  version: 1.0.0-rc.33
-  resolution: "@wireapp/core-crypto@npm:1.0.0-rc.33"
-  checksum: 44b88f4b7a1ec2ce9c13ce48329c53193c91833f13345abf28e3bfcf51f41ab510187d1192dcf76293c23b9fa4167e67ee1bd084a9739f2dc598ca7987258d27
+"@wireapp/core-crypto@npm:1.0.0-rc.36":
+  version: 1.0.0-rc.36
+  resolution: "@wireapp/core-crypto@npm:1.0.0-rc.36"
+  checksum: 108f5e983abb35ff65b4d1a62804e69dbc72c9953a5a51401163fab44a8e8dbb63139b66d3d85864f4de21812aa1cda8605f8cfa6161d839f9b8f872f11c4e2b
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:43.11.2":
-  version: 43.11.2
-  resolution: "@wireapp/core@npm:43.11.2"
+"@wireapp/core@npm:43.12.0":
+  version: 43.12.0
+  resolution: "@wireapp/core@npm:43.12.0"
   dependencies:
-    "@wireapp/api-client": ^26.10.1
+    "@wireapp/api-client": ^26.10.3
     "@wireapp/commons": ^5.2.4
-    "@wireapp/core-crypto": 1.0.0-rc.33
+    "@wireapp/core-crypto": 1.0.0-rc.36
     "@wireapp/cryptobox": 12.8.0
     "@wireapp/promise-queue": ^2.2.9
     "@wireapp/protocol-messaging": 1.44.0
     "@wireapp/store-engine": 5.1.5
     "@wireapp/store-engine-dexie": ^2.1.7
-    axios: 1.6.5
+    axios: 1.6.7
     bazinga64: ^6.3.4
     deepmerge-ts: 5.1.0
     hash.js: 1.1.7
@@ -4905,7 +4905,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: 685d047c9dd296e528ae8500e6b82c1ad6aa07762fd6ae549672028e8f9741cc88c3dbab15959b68d3b0fc47870daab7ba30d3b2127c15d256409551165df002
+  checksum: 47ae64f187a6a7f56d0f40ef4129a0360b5237bcf46b874911326e9e741d51165674d5d994b245b13e155eea23b450f58a95ba9f1f356aef5a1b23d3745be1b9
   languageName: node
   linkType: hard
 
@@ -5760,6 +5760,17 @@ __metadata:
     form-data: ^4.0.0
     proxy-from-env: ^1.1.0
   checksum: e28d67b2d9134cb4608c44d8068b0678cfdccc652742e619006f27264a30c7aba13b2cd19c6f1f52ae195b5232734925928fb192d5c85feea7edd2f273df206d
+  languageName: node
+  linkType: hard
+
+"axios@npm:1.6.7":
+  version: 1.6.7
+  resolution: "axios@npm:1.6.7"
+  dependencies:
+    follow-redirects: ^1.15.4
+    form-data: ^4.0.0
+    proxy-from-env: ^1.1.0
+  checksum: 87d4d429927d09942771f3b3a6c13580c183e31d7be0ee12f09be6d5655304996bb033d85e54be81606f4e89684df43be7bf52d14becb73a12727bf33298a082
   languageName: node
   linkType: hard
 
@@ -17602,7 +17613,7 @@ __metadata:
     "@wireapp/avs": 9.6.9
     "@wireapp/commons": 5.2.4
     "@wireapp/copy-config": 2.1.14
-    "@wireapp/core": 43.11.2
+    "@wireapp/core": 43.12.0
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.12.8


### PR DESCRIPTION
## Description

Bumps core-crypto with version rc36 that enables us to dispatch new crl distribution points.

New version of core also fixes the issue with mistakenly rejoining a parent conversation on its subconversation's epoch mismatch.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
