### PR TITLE
fix: Enable remote search on group creation modal (WPB-6356)

### DIFF
--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -407,21 +407,19 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
 
         {stateIsParticipants && selfUser && (
           <FadingScrollbar className="group-creation__list">
-            {filteredContacts.length > 0 && (
-              <UserSearchableList
-                selfUser={selfUser}
-                users={filteredContacts}
-                filter={participantsInput}
-                selected={selectedContacts}
-                isSelectable
-                onUpdateSelectedUsers={setSelectedContacts}
-                searchRepository={searchRepository}
-                teamRepository={teamRepository}
-                conversationRepository={conversationRepository}
-                noUnderline
-                allowRemoteSearch
-              />
-            )}
+            <UserSearchableList
+              selfUser={selfUser}
+              users={filteredContacts}
+              filter={participantsInput}
+              selected={selectedContacts}
+              isSelectable
+              onUpdateSelectedUsers={setSelectedContacts}
+              searchRepository={searchRepository}
+              teamRepository={teamRepository}
+              conversationRepository={conversationRepository}
+              noUnderline
+              allowRemoteSearch
+            />
           </FadingScrollbar>
         )}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6356" title="WPB-6356" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6356</a>  [Web] Can't find team members in group creation if I don't have any interactions yet
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

BEFORE:
<img width="332" alt="image" src="https://github.com/wireapp/wire-webapp/assets/63250054/1b8d5915-1d5b-4804-b31e-4fdf52efb33f">


AFTER:
<img width="408" alt="image" src="https://github.com/wireapp/wire-webapp/assets/63250054/7a12b798-72e5-423d-bf14-fe90dbe43631">
