### PR TITLE
chore: publish release branch to aws (#16707)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -329,6 +329,9 @@ jobs:
               "production": {
                 "targets": "[\"wire-webapp-prod-al2\"]"
               },
+              "release/q1-2024": {
+                "targets": "[\"wire-webapp-mls-al2\"]"
+              }
               "staging": {
                 "targets": "[\"wire-webapp-staging-al2\"]"
               }


### PR DESCRIPTION
## Description

cherry pick https://github.com/wireapp/wire-webapp/commit/b31cd1846da3f931fd817d4eaf166d310e953cec from `release/q1-2024` : auto deploy the release branch to aws
