### PR TITLE
runfix: add missing coma in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -331,7 +331,7 @@ jobs:
               },
               "release/q1-2024": {
                 "targets": "[\"wire-webapp-mls-al2\"]"
-              }
+              },
               "staging": {
                 "targets": "[\"wire-webapp-staging-al2\"]"
               }


### PR DESCRIPTION
## Description
a missing coma is preventing the publish workflow from running
