### PR TITLE
refactor: Do not base message focus on elements indexes

### DIFF
--- a/src/script/components/MessagesList/Message/index.tsx
+++ b/src/script/components/MessagesList/Message/index.tsx
@@ -76,10 +76,8 @@ export interface MessageParams extends MessageActions {
   selfId: QualifiedId;
   shouldShowInvitePeople: boolean;
   teamState?: TeamState;
-  totalMessage: number;
-  index: number;
   isMessageFocused: boolean;
-  handleFocus: (index: number) => void;
+  handleFocus: (id: string) => void;
   handleArrowKeyDown: (e: React.KeyboardEvent) => void;
   isMsgElementsFocusable: boolean;
   setMsgElementsFocusable: (isMsgElementsFocusable: boolean) => void;
@@ -95,11 +93,9 @@ const Message: React.FC<
     lastReadTimestamp,
     onVisible,
     scrollTo,
-    totalMessage,
     isMessageFocused,
     handleFocus,
     handleArrowKeyDown,
-    index,
     isMsgElementsFocusable,
     setMsgElementsFocusable,
   } = props;
@@ -123,7 +119,7 @@ const Message: React.FC<
       scrollTo?.({center: true, element: messageElementRef.current});
 
       // for reply message, focus on the original message when original message link is clicked for keyboard users
-      handleFocus(index);
+      handleFocus(message.id);
     } else if (markerType === MessageMarkerType.UNREAD) {
       scrollTo?.({element: messageElementRef.current}, true);
     }
@@ -144,21 +140,6 @@ const Message: React.FC<
     }
     handleArrowKeyDown(event);
   };
-
-  // when a new conversation is opened using keyboard(enter), focus on the last message
-  useEffect(() => {
-    if (!messageRef.current) {
-      return;
-    }
-    if (history.state?.eventKey === 'Enter') {
-      handleFocus(totalMessage - 1);
-
-      // reset the eventKey to stop focusing on every new message user send/receive afterwards
-      // last message should be focused only when user enters a new conversation using keyboard(press enter)
-      history.state.eventKey = '';
-      window.history.replaceState(history.state, '', window.location.hash);
-    }
-  }, [totalMessage]);
 
   useEffect(() => {
     // Move element into view when it is focused
@@ -240,7 +221,7 @@ const Message: React.FC<
         role="listitem"
         onKeyDown={handleDivKeyDown}
         onClick={event => {
-          handleFocus(index);
+          handleFocus(message.id);
         }}
         className="message-wrapper"
       >

--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -231,13 +231,20 @@ const MessagesList: FC<MessagesListParams> = ({
     }
   }, [loaded]);
 
-  const defaultFocus = -1;
-  const isMsgListInfinite = false;
-  const {currentFocus, handleKeyDown, setCurrentFocus} = useRoveFocus(
-    filteredMessagesLength,
-    defaultFocus,
-    isMsgListInfinite,
-  );
+  const {currentFocus, handleKeyDown, setCurrentFocus} = useRoveFocus(filteredMessages.map(message => message.id));
+
+  // when a new conversation is opened using keyboard(enter), focus on the last message
+  useEffect(() => {
+    if (loaded && history.state?.eventKey === 'Enter') {
+      const lastMessage = filteredMessages[filteredMessages.length - 1];
+      setCurrentFocus(lastMessage?.id);
+
+      // reset the eventKey to stop focusing on every new message user send/receive afterwards
+      // last message should be focused only when user enters a new conversation using keyboard(press enter)
+      history.state.eventKey = '';
+      window.history.replaceState(history.state, '', window.location.hash);
+    }
+  }, [loaded]);
 
   if (!loaded) {
     return null;
@@ -299,9 +306,7 @@ const MessagesList: FC<MessagesListParams> = ({
               }}
               selfId={selfUser.qualifiedId}
               shouldShowInvitePeople={shouldShowInvitePeople}
-              totalMessage={filteredMessagesLength}
-              index={index}
-              isMessageFocused={currentFocus === index}
+              isMessageFocused={currentFocus === message.id}
               handleFocus={setCurrentFocus}
               handleArrowKeyDown={handleKeyDown}
               isMsgElementsFocusable={isMsgElementsFocusable}

--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -231,13 +231,13 @@ const MessagesList: FC<MessagesListParams> = ({
     }
   }, [loaded]);
 
-  const {currentFocus, handleKeyDown, setCurrentFocus} = useRoveFocus(filteredMessages.map(message => message.id));
+  const {focusedId, handleKeyDown, setFocusedId} = useRoveFocus(filteredMessages.map(message => message.id));
 
   // when a new conversation is opened using keyboard(enter), focus on the last message
   useEffect(() => {
     if (loaded && history.state?.eventKey === 'Enter') {
       const lastMessage = filteredMessages[filteredMessages.length - 1];
-      setCurrentFocus(lastMessage?.id);
+      setFocusedId(lastMessage?.id);
 
       // reset the eventKey to stop focusing on every new message user send/receive afterwards
       // last message should be focused only when user enters a new conversation using keyboard(press enter)
@@ -306,8 +306,8 @@ const MessagesList: FC<MessagesListParams> = ({
               }}
               selfId={selfUser.qualifiedId}
               shouldShowInvitePeople={shouldShowInvitePeople}
-              isMessageFocused={currentFocus === message.id}
-              handleFocus={setCurrentFocus}
+              isMessageFocused={focusedId === message.id}
+              handleFocus={setFocusedId}
               handleArrowKeyDown={handleKeyDown}
               isMsgElementsFocusable={isMsgElementsFocusable}
               setMsgElementsFocusable={setMsgElementsFocusable}

--- a/src/script/hooks/useRoveFocus.test.tsx
+++ b/src/script/hooks/useRoveFocus.test.tsx
@@ -70,4 +70,15 @@ describe('useRoveFocus', () => {
     act(() => result.current.handleKeyDown(createEvent('Enter')));
     expect(result.current.focusedId).toBe(undefined);
   });
+
+  it('should keep focused element stable as the array changes', () => {
+    const {result, rerender} = renderHook(useRoveFocus, {initialProps: ['0', '1', '2']});
+
+    act(() => result.current.setFocusedId('1'));
+    expect(result.current.focusedId).toBe('1');
+
+    // Adding one element at the end
+    rerender(['0', '2', '3', '1']);
+    expect(result.current.focusedId).toBe('1');
+  });
 });

--- a/src/script/hooks/useRoveFocus.test.tsx
+++ b/src/script/hooks/useRoveFocus.test.tsx
@@ -29,45 +29,45 @@ function createEvent(key: string) {
 describe('useRoveFocus', () => {
   it('should set the initial focus to the default value', () => {
     const {result} = renderHook(() => useRoveFocus(['0', '1', '2']));
-    expect(result.current.currentFocus).toBe(undefined);
+    expect(result.current.focusedId).toBe(undefined);
   });
 
   it('should allow manually setting the focused index and navigate using the down/up arrow keys', () => {
     const {result} = renderHook(() => useRoveFocus(['0', '1', '2']));
-    act(() => result.current.setCurrentFocus('1'));
-    expect(result.current.currentFocus).toBe('1');
+    act(() => result.current.setFocusedId('1'));
+    expect(result.current.focusedId).toBe('1');
 
     act(() => result.current.handleKeyDown(createEvent('ArrowDown')));
-    expect(result.current.currentFocus).toBe('2');
+    expect(result.current.focusedId).toBe('2');
 
     act(() => result.current.handleKeyDown(createEvent('ArrowUp')));
-    expect(result.current.currentFocus).toBe('1');
+    expect(result.current.focusedId).toBe('1');
 
     act(() => result.current.handleKeyDown(createEvent('ArrowUp')));
-    expect(result.current.currentFocus).toBe('0');
+    expect(result.current.focusedId).toBe('0');
   });
 
   it('should set the focus to the next item when the arrow down key is pressed', () => {
     const {result} = renderHook(() => useRoveFocus(['0', '1', '2']));
     act(() => result.current.handleKeyDown(createEvent('ArrowDown')));
-    expect(result.current.currentFocus).toBe('0');
+    expect(result.current.focusedId).toBe('0');
   });
 
   it('should set the focus to the previous item when the arrow up key is pressed', () => {
     const {result} = renderHook(() => useRoveFocus(['0', '1', '2']));
     act(() => result.current.handleKeyDown(createEvent('ArrowUp')));
-    expect(result.current.currentFocus).toBe('2');
+    expect(result.current.focusedId).toBe('2');
   });
 
   it('should set the focus to the first item when the tab key is pressed', () => {
     const {result} = renderHook(() => useRoveFocus(['0', '1', '2']));
     act(() => result.current.handleKeyDown(createEvent('Tab')));
-    expect(result.current.currentFocus).toBe('2');
+    expect(result.current.focusedId).toBe('2');
   });
 
   it('should not change the focus when an unsupported key is pressed', () => {
     const {result} = renderHook(() => useRoveFocus(['0', '1', '2']));
     act(() => result.current.handleKeyDown(createEvent('Enter')));
-    expect(result.current.currentFocus).toBe(undefined);
+    expect(result.current.focusedId).toBe(undefined);
   });
 });

--- a/src/script/hooks/useRoveFocus.test.tsx
+++ b/src/script/hooks/useRoveFocus.test.tsx
@@ -32,6 +32,21 @@ describe('useRoveFocus', () => {
     expect(result.current.currentFocus).toBe(undefined);
   });
 
+  it('should allow manually setting the focused index and navigate using the down/up arrow keys', () => {
+    const {result} = renderHook(() => useRoveFocus(['0', '1', '2']));
+    act(() => result.current.setCurrentFocus('1'));
+    expect(result.current.currentFocus).toBe('1');
+
+    act(() => result.current.handleKeyDown(createEvent('ArrowDown')));
+    expect(result.current.currentFocus).toBe('2');
+
+    act(() => result.current.handleKeyDown(createEvent('ArrowUp')));
+    expect(result.current.currentFocus).toBe('1');
+
+    act(() => result.current.handleKeyDown(createEvent('ArrowUp')));
+    expect(result.current.currentFocus).toBe('0');
+  });
+
   it('should set the focus to the next item when the arrow down key is pressed', () => {
     const {result} = renderHook(() => useRoveFocus(['0', '1', '2']));
     act(() => result.current.handleKeyDown(createEvent('ArrowDown')));

--- a/src/script/hooks/useRoveFocus.test.tsx
+++ b/src/script/hooks/useRoveFocus.test.tsx
@@ -17,103 +17,42 @@
  *
  */
 
-import {render, fireEvent} from '@testing-library/react';
+import {renderHook} from '@testing-library/react';
+import {act} from 'react-dom/test-utils';
 
 import {useRoveFocus} from './useRoveFocus';
 
-const renderHTML = (currentFocus: number, handleKeyDown: (e: React.KeyboardEvent) => void) => {
-  return (
-    <div role="button" tabIndex={currentFocus} onKeyDown={handleKeyDown}>
-      <div data-uie-name="current-focus">{currentFocus}</div>
-    </div>
-  );
-};
+function createEvent(key: string) {
+  return {key, preventDefault: () => {}} as KeyboardEvent;
+}
+
 describe('useRoveFocus', () => {
   it('should set the initial focus to the default value', () => {
-    const TestComponent = () => {
-      const {currentFocus} = useRoveFocus(3);
-      return <div data-uie-name="current-focus">{currentFocus}</div>;
-    };
-    const {getByTestId} = render(<TestComponent />);
-    expect(getByTestId('current-focus').textContent).toBe('0');
-  });
-
-  it('should set the initial focus to the specified value', () => {
-    const TestComponent = () => {
-      const {currentFocus} = useRoveFocus(3, 2);
-      return <div data-uie-name="current-focus">{currentFocus}</div>;
-    };
-    const {getByTestId} = render(<TestComponent />);
-    expect(getByTestId('current-focus').textContent).toBe('2');
+    const {result} = renderHook(() => useRoveFocus(['0', '1', '2']));
+    expect(result.current.currentFocus).toBe(undefined);
   });
 
   it('should set the focus to the next item when the arrow down key is pressed', () => {
-    const TestComponent = () => {
-      const {currentFocus, handleKeyDown} = useRoveFocus(3);
-      return renderHTML(currentFocus, handleKeyDown);
-    };
-    const {getByTestId} = render(<TestComponent />);
-    fireEvent.keyDown(getByTestId('current-focus'), {key: 'ArrowDown'});
-    expect(getByTestId('current-focus').textContent).toBe('1');
+    const {result} = renderHook(() => useRoveFocus(['0', '1', '2']));
+    act(() => result.current.handleKeyDown(createEvent('ArrowDown')));
+    expect(result.current.currentFocus).toBe('0');
   });
 
   it('should set the focus to the previous item when the arrow up key is pressed', () => {
-    const TestComponent = () => {
-      const {currentFocus, handleKeyDown} = useRoveFocus(3, 1);
-      return renderHTML(currentFocus, handleKeyDown);
-    };
-    const {getByTestId} = render(<TestComponent />);
-    fireEvent.keyDown(getByTestId('current-focus'), {key: 'ArrowUp'});
-    expect(getByTestId('current-focus').textContent).toBe('0');
+    const {result} = renderHook(() => useRoveFocus(['0', '1', '2']));
+    act(() => result.current.handleKeyDown(createEvent('ArrowUp')));
+    expect(result.current.currentFocus).toBe('2');
   });
 
   it('should set the focus to the first item when the tab key is pressed', () => {
-    const TestComponent = () => {
-      const {currentFocus, handleKeyDown} = useRoveFocus(3, 1);
-      return renderHTML(currentFocus, handleKeyDown);
-    };
-    const {getByTestId} = render(<TestComponent />);
-    fireEvent.keyDown(getByTestId('current-focus'), {key: 'Tab'});
-    expect(getByTestId('current-focus').textContent).toBe('0');
+    const {result} = renderHook(() => useRoveFocus(['0', '1', '2']));
+    act(() => result.current.handleKeyDown(createEvent('Tab')));
+    expect(result.current.currentFocus).toBe('2');
   });
 
   it('should not change the focus when an unsupported key is pressed', () => {
-    const TestComponent = () => {
-      const {currentFocus, handleKeyDown} = useRoveFocus(3);
-      return renderHTML(currentFocus, handleKeyDown);
-    };
-    const {getByTestId} = render(<TestComponent />);
-    fireEvent.keyDown(getByTestId('current-focus'), {key: 'UnsupportedKey'});
-    expect(getByTestId('current-focus').textContent).toBe('0');
-  });
-
-  it('should wrap around to the first item when the last item is focused and the arrow down key is pressed (if infinite is set to true)', () => {
-    const TestComponent = () => {
-      const {currentFocus, handleKeyDown} = useRoveFocus(3, 2, true);
-      return renderHTML(currentFocus, handleKeyDown);
-    };
-    const {getByTestId} = render(<TestComponent />);
-    fireEvent.keyDown(getByTestId('current-focus'), {key: 'ArrowDown'});
-    expect(getByTestId('current-focus').textContent).toBe('0');
-  });
-
-  it('should wrap around to the last item when the first item is focused and the arrow up key is pressed (if infinite is set to true)', () => {
-    const TestComponent = () => {
-      const {currentFocus, handleKeyDown} = useRoveFocus(3, 0, true);
-      return renderHTML(currentFocus, handleKeyDown);
-    };
-    const {getByTestId} = render(<TestComponent />);
-    fireEvent.keyDown(getByTestId('current-focus'), {key: 'ArrowUp'});
-    expect(getByTestId('current-focus').textContent).toBe('2');
-  });
-
-  it('should not wrap around when the last item is focused and the arrow down key is pressed (if infinite is set to false)', () => {
-    const TestComponent = () => {
-      const {currentFocus, handleKeyDown} = useRoveFocus(3, 2, false);
-      return renderHTML(currentFocus, handleKeyDown);
-    };
-    const {getByTestId} = render(<TestComponent />);
-    fireEvent.keyDown(getByTestId('current-focus'), {key: 'ArrowDown'});
-    expect(getByTestId('current-focus').textContent).not.toBe('0');
+    const {result} = renderHook(() => useRoveFocus(['0', '1', '2']));
+    act(() => result.current.handleKeyDown(createEvent('Enter')));
+    expect(result.current.currentFocus).toBe(undefined);
   });
 });

--- a/src/script/hooks/useRoveFocus.ts
+++ b/src/script/hooks/useRoveFocus.ts
@@ -25,39 +25,32 @@ import type {KeyboardEvent as ReactKeyboardEvent} from 'react';
 import {isKey, isTabKey, KEY} from 'Util/KeyboardUtil';
 
 export function useRoveFocus(elements: string[]) {
-  const [focusedIndex, setFocusedIndex] = useState<number>(-1);
+  const [focusedId, setFocusedId] = useState<string | undefined>(undefined);
 
   const lastIndex = elements.length - 1;
-  const setFocusedId = useCallback(
-    (id: string) => {
-      const index = elements.findIndex(element => element === id);
-      setFocusedIndex(index);
-    },
-    [elements],
-  );
 
   const handleKeyDown = useCallback(
     (event: ReactKeyboardEvent | KeyboardEvent) => {
+      const currentIndex = focusedId ? elements.indexOf(focusedId) : -1;
       if (isKey(event, KEY.ARROW_DOWN)) {
         event.preventDefault();
-        if (focusedIndex < elements.length - 1) {
-          setFocusedIndex(focusedIndex + 1);
+        if (currentIndex < lastIndex) {
+          setFocusedId(elements[currentIndex + 1]);
         }
       } else if (isKey(event, KEY.ARROW_UP)) {
         event.preventDefault();
-        if (focusedIndex === -1) {
-          setFocusedIndex(lastIndex);
+        if (currentIndex === -1) {
+          setFocusedId(elements[lastIndex]);
         }
-        if (focusedIndex > 0) {
-          setFocusedIndex(focusedIndex - 1);
+        if (currentIndex > 0) {
+          setFocusedId(elements[currentIndex - 1]);
         }
       } else if (isTabKey(event)) {
-        setFocusedIndex(lastIndex);
+        setFocusedId(elements[lastIndex]);
       }
     },
-    [focusedIndex, setFocusedIndex, lastIndex, elements],
+    [focusedId, elements, lastIndex],
   );
 
-  const focusedId = focusedIndex !== -1 ? elements[focusedIndex] : undefined;
   return {focusedId, handleKeyDown, setFocusedId};
 }

--- a/src/script/hooks/useRoveFocus.ts
+++ b/src/script/hooks/useRoveFocus.ts
@@ -28,7 +28,7 @@ export function useRoveFocus(elements: string[]) {
   const [focusedIndex, setFocusedIndex] = useState<number>(-1);
 
   const lastIndex = elements.length - 1;
-  const setCurrentFocus = useCallback(
+  const setFocusedId = useCallback(
     (id: string) => {
       const index = elements.findIndex(element => element === id);
       setFocusedIndex(index);
@@ -59,5 +59,5 @@ export function useRoveFocus(elements: string[]) {
   );
 
   const focusedId = focusedIndex !== -1 ? elements[focusedIndex] : undefined;
-  return {currentFocus: focusedId, handleKeyDown, setCurrentFocus};
+  return {focusedId, handleKeyDown, setFocusedId};
 }

--- a/src/script/hooks/useRoveFocus.ts
+++ b/src/script/hooks/useRoveFocus.ts
@@ -24,35 +24,40 @@ import type {KeyboardEvent as ReactKeyboardEvent} from 'react';
 
 import {isKey, isTabKey, KEY} from 'Util/KeyboardUtil';
 
-function useRoveFocus(size: number, defaultFocus = 0, infinite = true) {
-  const [currentFocus, setCurrentFocus] = useState(defaultFocus);
-  const firstItem = 0;
-  const interval = 1;
-  const lastItem = size - 1;
+export function useRoveFocus(elements: string[]) {
+  const [focusedIndex, setFocusedIndex] = useState<number>(-1);
+
+  const lastIndex = elements.length - 1;
+  const setCurrentFocus = useCallback(
+    (id: string) => {
+      const index = elements.findIndex(element => element === id);
+      setFocusedIndex(index);
+    },
+    [elements],
+  );
 
   const handleKeyDown = useCallback(
     (event: ReactKeyboardEvent | KeyboardEvent) => {
       if (isKey(event, KEY.ARROW_DOWN)) {
         event.preventDefault();
-        if (infinite) {
-          setCurrentFocus(currentFocus === lastItem ? firstItem : currentFocus + interval);
-        } else if (currentFocus !== lastItem) {
-          setCurrentFocus(currentFocus + interval);
+        if (focusedIndex < elements.length - 1) {
+          setFocusedIndex(focusedIndex + 1);
         }
       } else if (isKey(event, KEY.ARROW_UP)) {
         event.preventDefault();
-        if (infinite) {
-          setCurrentFocus(currentFocus === firstItem ? lastItem : currentFocus - interval);
-        } else if (currentFocus !== firstItem) {
-          setCurrentFocus(currentFocus - interval);
+        if (focusedIndex === -1) {
+          setFocusedIndex(lastIndex);
+        }
+        if (focusedIndex > 0) {
+          setFocusedIndex(focusedIndex - 1);
         }
       } else if (isTabKey(event)) {
-        setCurrentFocus(firstItem);
+        setFocusedIndex(lastIndex);
       }
     },
-    [currentFocus, setCurrentFocus, infinite, lastItem],
+    [focusedIndex, setFocusedIndex, lastIndex, elements],
   );
-  return {currentFocus, handleKeyDown, setCurrentFocus};
-}
 
-export {useRoveFocus};
+  const focusedId = focusedIndex !== -1 ? elements[focusedIndex] : undefined;
+  return {currentFocus: focusedId, handleKeyDown, setCurrentFocus};
+}


### PR DESCRIPTION
## Description

This will be needed when we will group messages by timestamp. 

Previously the message list was a flat list of messages. So referring to a particular index in this array, gave the correct message element. 

With the changes from https://github.com/wireapp/wire-webapp/pull/16695 we need a stronger index lookup. 

Instead we will be basing our focus on message ids rather than indexes. 

## Associated bugfix

This also prevents focus from changing when the message list is updated

### Before 

https://github.com/wireapp/wire-webapp/assets/1090716/95a3b46a-d88a-49f9-afb2-f8fe4ac0256f


### After


https://github.com/wireapp/wire-webapp/assets/1090716/0112b5b5-0474-4d79-9ce5-c0225ef03fa5



## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

