### PR TITLE
runfix: get all conversation user identities from core-crypto

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@peculiar/x509": "1.9.6",
     "@wireapp/avs": "9.6.9",
     "@wireapp/commons": "5.2.4",
-    "@wireapp/core": "43.12.0",
+    "@wireapp/core": "43.12.1",
     "@wireapp/react-ui-kit": "9.12.8",
     "@wireapp/store-engine-dexie": "2.1.7",
     "@wireapp/webapp-events": "0.20.1",

--- a/src/__mocks__/@wireapp/core.ts
+++ b/src/__mocks__/@wireapp/core.ts
@@ -38,6 +38,7 @@ export class Account extends EventEmitter {
       isEnrollmentInProgress: jest.fn(),
       clearAllProgress: jest.fn(),
       getUsersIdentities: jest.fn(() => new Map()),
+      getAllGroupUsersIdentities: jest.fn(() => new Map()),
       getDeviceIdentities: jest.fn(),
       getConversationState: jest.fn(),
       registerServerCertificates: jest.fn(),

--- a/src/script/E2EIdentity/E2EIdentityVerification.ts
+++ b/src/script/E2EIdentity/E2EIdentityVerification.ts
@@ -48,9 +48,7 @@ export function getE2EIdentityService() {
   return e2eIdentityService;
 }
 
-export async function getUsersIdentities(groupId: string, userIds: QualifiedId[]) {
-  const userVerifications = await getE2EIdentityService().getUsersIdentities(groupId, userIds);
-
+function mapUserIdentities(userVerifications: Map<string, DeviceIdentity[]>): Map<string, WireIdentity[]> {
   const mappedUsers = new Map<string, WireIdentity[]>();
 
   for (const [userId, identities] of userVerifications.entries()) {
@@ -61,6 +59,16 @@ export async function getUsersIdentities(groupId: string, userIds: QualifiedId[]
   }
 
   return mappedUsers;
+}
+
+export async function getUsersIdentities(groupId: string, userIds: QualifiedId[]) {
+  const userVerifications = await getE2EIdentityService().getUsersIdentities(groupId, userIds);
+  return mapUserIdentities(userVerifications);
+}
+
+export async function getAllGroupUsersIdentities(groupId: string) {
+  const userVerifications = await getE2EIdentityService().getAllGroupUsersIdentities(groupId);
+  return mapUserIdentities(userVerifications);
 }
 
 export async function getConversationVerificationState(groupId: string) {

--- a/src/script/E2EIdentity/E2EIdentityVerification.ts
+++ b/src/script/E2EIdentity/E2EIdentityVerification.ts
@@ -81,10 +81,7 @@ export async function getConversationVerificationState(groupId: string) {
 const fetchSelfDeviceIdentity = async (): Promise<WireIdentity | undefined> => {
   const conversationState = container.resolve(ConversationState);
   const selfMLSConversation = conversationState.getSelfMLSConversation();
-  const userIdentities = await getUsersIdentities(
-    selfMLSConversation.groupId,
-    selfMLSConversation.allUserEntities().map(user => user.qualifiedId),
-  );
+  const userIdentities = await getAllGroupUsersIdentities(selfMLSConversation.groupId);
   const currentClientId = selfMLSConversation.selfUser()?.localClient?.id;
   const userId = selfMLSConversation.selfUser()?.id;
 

--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
@@ -24,8 +24,8 @@ import {container} from 'tsyringe';
 
 import {
   getActiveWireIdentity,
+  getAllGroupUsersIdentities,
   getConversationVerificationState,
-  getUsersIdentities,
   MLSStatuses,
 } from 'src/script/E2EIdentity';
 import {Conversation} from 'src/script/entity/Conversation';
@@ -68,7 +68,7 @@ class MLSConversationVerificationStateHandler {
   private async degradeConversation(conversation: MLSConversation) {
     const state = ConversationVerificationState.DEGRADED;
     conversation.mlsVerificationState(state);
-    const userIdentities = await getUsersIdentities(conversation.groupId, conversation.participating_user_ids());
+    const userIdentities = await getAllGroupUsersIdentities(conversation.groupId);
     const degradedUsers: QualifiedId[] = [];
     for (const [userId, identities] of userIdentities.entries()) {
       if (identities.some(identity => identity.status !== MLSStatuses.VALID)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4883,9 +4883,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:43.12.0":
-  version: 43.12.0
-  resolution: "@wireapp/core@npm:43.12.0"
+"@wireapp/core@npm:43.12.1":
+  version: 43.12.1
+  resolution: "@wireapp/core@npm:43.12.1"
   dependencies:
     "@wireapp/api-client": ^26.10.3
     "@wireapp/commons": ^5.2.4
@@ -4905,7 +4905,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: 47ae64f187a6a7f56d0f40ef4129a0360b5237bcf46b874911326e9e741d51165674d5d994b245b13e155eea23b450f58a95ba9f1f356aef5a1b23d3745be1b9
+  checksum: 84defc221ac5254cd0aa5710f24489c34c4670886b6c3e844cc8342a19a71bb60d059e83449afba650bf0abc207639238ae538841c2066081f953935e1dc45f0
   languageName: node
   linkType: hard
 
@@ -17613,7 +17613,7 @@ __metadata:
     "@wireapp/avs": 9.6.9
     "@wireapp/commons": 5.2.4
     "@wireapp/copy-config": 2.1.14
-    "@wireapp/core": 43.12.0
+    "@wireapp/core": 43.12.1
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.12.8


### PR DESCRIPTION
## Description

When calculating the list of degraded users in a conversation, we were using `conversation.particupating_user_ids()` which is not always up-to-date with mls group state in core-crypto. Before receiving member-join event the list of participants was still empty even though user was already a member of mls group.

We will use `coreCrypto.getClientIds` instead - see merged `core` package PR for more details: https://github.com/wireapp/wire-web-packages/pull/5926.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
