### PR TITLE
runfix: add cross platform shortcut for debug ui

### DIFF
--- a/src/script/util/DebugUtil.ts
+++ b/src/script/util/DebugUtil.ts
@@ -103,7 +103,7 @@ export class DebugUtil {
 
     this.logger = getLogger('DebugUtil');
 
-    keyboardjs.bind('command+shift+1', this.toggleDebugUi);
+    keyboardjs.bind(['command+shift+1', 'ctrl+shift+1'], this.toggleDebugUi);
   }
 
   /** will print all the ids of entities that show on screen (userIds, conversationIds, messageIds) */


### PR DESCRIPTION
## Description

 add `ctrl+shift+1` to the shortcut enabling the debug ui in the unlikely case someone isn't using a Mac

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;