### PR TITLE
chore: Add codecov token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,4 @@ jobs:
           fail_ci_if_error: false
           files: ./coverage/lcov.info
           flags: unittests
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Description

Since codecov-action v4, the `token` part is no longer optional. (see https://github.com/codecov/codecov-action/releases/tag/v4.0.0) 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
