### PR TITLE
runfix: mls 1to1 migration system message

### DIFF
--- a/src/script/conversation/ConversationSelectors.ts
+++ b/src/script/conversation/ConversationSelectors.ts
@@ -18,7 +18,11 @@
  */
 
 import {ConnectionStatus} from '@wireapp/api-client/lib/connection/';
-import {CONVERSATION_TYPE, ConversationProtocol} from '@wireapp/api-client/lib/conversation/';
+import {
+  CONVERSATION_TYPE,
+  ConversationProtocol,
+  Conversation as BackendConversation,
+} from '@wireapp/api-client/lib/conversation/';
 import {QualifiedId} from '@wireapp/api-client/lib/user/';
 
 import {matchQualifiedIds} from 'Util/QualifiedId';
@@ -56,6 +60,38 @@ export function isSelfConversation(conversation: Conversation): boolean {
 
 export function isTeamConversation(conversation: Conversation): boolean {
   return conversation.type() === CONVERSATION_TYPE.GLOBAL_TEAM;
+}
+
+export function isProteusTeam1to1Conversation({
+  name,
+  type,
+  inTeam,
+  otherMembersLength,
+}: {
+  name: string | undefined;
+  type: CONVERSATION_TYPE;
+  inTeam: boolean;
+  otherMembersLength: number;
+}): boolean {
+  const isGroupConversation = type === CONVERSATION_TYPE.REGULAR;
+  const hasOneParticipant = otherMembersLength === 1;
+  return isGroupConversation && hasOneParticipant && inTeam && !name;
+}
+
+export function isBackendProteus1to1Conversation(conversation: BackendConversation): boolean {
+  const isProteus1to1 =
+    conversation.protocol === ConversationProtocol.PROTEUS && conversation.type === CONVERSATION_TYPE.ONE_TO_ONE;
+
+  const {name, type, team, members} = conversation;
+
+  return (
+    isProteusTeam1to1Conversation({
+      name,
+      type,
+      inTeam: !!team,
+      otherMembersLength: members.others.length,
+    }) || isProteus1to1
+  );
 }
 
 export function isConnectionRequestConversation(conversation: Conversation): boolean {

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -53,7 +53,7 @@ import {Config} from '../Config';
 import {ConnectionEntity} from '../connection/ConnectionEntity';
 import {ACCESS_STATE} from '../conversation/AccessState';
 import {ConversationRepository, CONVERSATION_READONLY_STATE} from '../conversation/ConversationRepository';
-import {isSelfConversation} from '../conversation/ConversationSelectors';
+import {isProteusTeam1to1Conversation, isSelfConversation} from '../conversation/ConversationSelectors';
 import {ConversationStatus} from '../conversation/ConversationStatus';
 import {ConversationVerificationState} from '../conversation/ConversationVerificationState';
 import {NOTIFICATION_STATE} from '../conversation/NotificationSetting';
@@ -234,11 +234,14 @@ export class Conversation {
     this.isTeamOnly = ko.pureComputed(() => this.accessState() === ACCESS_STATE.TEAM.TEAM_ONLY);
     this.withAllTeamMembers = ko.observable(false);
 
-    this.isProteusTeam1to1 = ko.pureComputed(() => {
-      const isGroupConversation = this.type() === CONVERSATION_TYPE.REGULAR;
-      const hasOneParticipant = this.participating_user_ids().length === 1;
-      return isGroupConversation && hasOneParticipant && this.teamId && !this.name();
-    });
+    this.isProteusTeam1to1 = ko.pureComputed(() =>
+      isProteusTeam1to1Conversation({
+        name: this.name(),
+        type: this.type(),
+        inTeam: !!this.teamId,
+        otherMembersLength: this.participating_user_ids().length,
+      }),
+    );
     this.isGroup = ko.pureComputed(() => {
       const isGroupConversation = this.type() === CONVERSATION_TYPE.REGULAR;
       return isGroupConversation && !this.isProteusTeam1to1();


### PR DESCRIPTION
## Description

When loading the app for the first time on a new client, we should verify whether there are no proteus 1:1 conversations found on backend, with user we have established a MLS 1:1 conversation with. 

If such a conversation is found, we should blacklist it so it's never refetched from backend.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
