### PR TITLE
runfix: Independently filter selected users and selectable users [WPB-6342]

### DIFF
--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -399,7 +399,6 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
             input={participantsInput}
             setInput={setParticipantsInput}
             selectedUsers={selectedContacts}
-            setSelectedUsers={setSelectedContacts}
             placeholder={t('groupCreationParticipantsPlaceholder')}
             onEnter={clickOnCreate}
           />

--- a/src/script/components/SearchInput.tsx
+++ b/src/script/components/SearchInput.tsx
@@ -21,7 +21,7 @@ import React, {useEffect, useLayoutEffect, useRef} from 'react';
 
 import cx from 'classnames';
 
-import {isRemovalAction, isEnterKey} from 'Util/KeyboardUtil';
+import {isEnterKey} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
 
 import {Icon} from './Icon';
@@ -37,14 +37,12 @@ interface SearchInputProps {
   placeholder: string;
   selectedUsers?: User[];
   setInput: (input: string) => void;
-  setSelectedUsers?: (users: User[]) => void;
 }
 
 export const SearchInput: React.FC<SearchInputProps> = ({
   onEnter,
   input,
   selectedUsers = [],
-  setSelectedUsers = () => {},
   placeholder,
   setInput,
   forceDark,
@@ -84,11 +82,9 @@ export const SearchInput: React.FC<SearchInputProps> = ({
             maxLength={MAX_HANDLE_LENGTH}
             onChange={event => setInput(event.target.value)}
             onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
-              if (isRemovalAction(event.key) && emptyInput) {
-                setSelectedUsers(selectedUsers.slice(0, -1));
-              } else if (isEnterKey(event.nativeEvent)) {
+              if (isEnterKey(event.nativeEvent)) {
                 event.preventDefault();
-                onEnter?.(event);
+                void onEnter?.(event);
               }
               return true;
             }}

--- a/src/script/components/UserList/UserList.tsx
+++ b/src/script/components/UserList/UserList.tsx
@@ -219,9 +219,7 @@ export const UserList = ({
     const isSelected = (userEntity: User): boolean =>
       isSelectable && !!selectedUsers?.some(user => user.id === userEntity.id);
 
-    const currentUsers = truncatedUsers.filter(user => isSelected(user));
-
-    const selectedUsersCount = currentUsers.length;
+    const selectedUsersCount = selectedUsers.length;
     const hasSelectedUsers = selectedUsersCount > 0;
 
     const toggleFolder = (folderName: UserListSections) => {
@@ -255,7 +253,7 @@ export const UserList = ({
               className={cx('search-list', cssClasses)}
             >
               {isSelectedContactsOpen &&
-                currentUsers.map((user, index) => {
+                selectedUsers.map((user, index) => {
                   const isLastItem = index === selectedUsersCount - 1;
 
                   return renderListItem(user, isLastItem);

--- a/src/script/components/UserSearchableList.tsx
+++ b/src/script/components/UserSearchableList.tsx
@@ -74,6 +74,8 @@ export const UserSearchableList: React.FC<UserListProps> = ({
   const [filteredUsers, setFilteredUsers] = useState<User[]>([]);
   const [remoteTeamMembers, setRemoteTeamMembers] = useState<User[]>([]);
 
+  const filteredSelectedUsers = selectedUsers ? searchRepository.searchUserInSet(filter, selectedUsers) : undefined;
+
   const selfInTeam = teamState.isInTeam(selfUser);
 
   /**
@@ -108,6 +110,7 @@ export const UserSearchableList: React.FC<UserListProps> = ({
           teamRepository.isSelfConnectedTo(user.id) ||
           user.username() === normalizedQuery,
       );
+
     if (normalizedQuery !== '' && selfInTeam && allowRemoteSearch) {
       fetchMembersFromBackend(filter, results);
     }
@@ -160,7 +163,7 @@ export const UserSearchableList: React.FC<UserListProps> = ({
         <UserList
           {...userListProps}
           users={userList}
-          selectedUsers={selectedUsers}
+          selectedUsers={filteredSelectedUsers}
           highlightedUsers={highlightedUsers}
           onSelectUser={toggleUserSelection}
           selfUser={selfUser}

--- a/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
@@ -150,7 +150,6 @@ const StartUI: React.FC<StartUIProps> = ({
         <SearchInput
           input={searchQuery}
           placeholder={t('searchPeoplePlaceholder')}
-          selectedUsers={[]}
           setInput={setSearchQuery}
           onEnter={openFirstConversation}
           forceDark

--- a/src/script/page/RightSidebar/AddParticipants/AddParticipants.tsx
+++ b/src/script/page/RightSidebar/AddParticipants/AddParticipants.tsx
@@ -196,7 +196,6 @@ const AddParticipants: FC<AddParticipantsProps> = ({
           input={searchInput}
           setInput={onSearchInput}
           selectedUsers={selectedContacts}
-          setSelectedUsers={setSelectedContacts}
           placeholder={t('addParticipantsSearchPlaceholder')}
         />
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6342" title="WPB-6342" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6342</a>  [Web] Not all selcected users are displayed when creating a group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

The problem is: we currently try to match the selected users with the list of available users. 
But, in case a selected user is not in the list of locally known users, then we are not going to display this user in the selected user list. 

Instead of using the list of users as the source of truth for the `selectedUsers` we instead use the `selectedUsers` array directly that will filter independently with the search query given by the user. 

## Screenshots/Screencast (for UI changes)

### Before 


https://github.com/wireapp/wire-webapp/assets/1090716/e58b1211-4c6b-4d58-99a7-8425ad321fba

### After


https://github.com/wireapp/wire-webapp/assets/1090716/43d45db7-ddde-4dde-a8e7-61b6bde988f7



## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
