### PR TITLE
fix: Allow new device to be legal-hold-ready [WPB-6429]

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@peculiar/x509": "1.9.6",
     "@wireapp/avs": "9.6.9",
     "@wireapp/commons": "5.2.4",
-    "@wireapp/core": "43.13.0",
+    "@wireapp/core": "43.13.1",
     "@wireapp/react-ui-kit": "9.12.8",
     "@wireapp/store-engine-dexie": "2.1.7",
     "@wireapp/webapp-events": "0.20.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4812,9 +4812,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^26.10.4":
-  version: 26.10.4
-  resolution: "@wireapp/api-client@npm:26.10.4"
+"@wireapp/api-client@npm:^26.10.5":
+  version: 26.10.5
+  resolution: "@wireapp/api-client@npm:26.10.5"
   dependencies:
     "@wireapp/commons": ^5.2.4
     "@wireapp/priority-queue": ^2.1.4
@@ -4830,7 +4830,7 @@ __metadata:
     tough-cookie: 4.1.3
     ws: 8.16.0
     zod: 3.22.4
-  checksum: 5e76ebd05cf7faaf0ee8d617524824dd1889db688fff7327789a07be35e1b5a64a3a54cf2de99bb4b273469fc0f8c85f3d2cf5ce04657d6c07fcc74bdb0afb94
+  checksum: 69d7c02bacdd9e5a0dc793f2087c176e8ed28e90109be813d1f1246be563ee901726367c25cefc73519ea84ddf1a70ae25ef5dc14988fde573f72999a0f04fb7
   languageName: node
   linkType: hard
 
@@ -4883,11 +4883,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:43.13.0":
-  version: 43.13.0
-  resolution: "@wireapp/core@npm:43.13.0"
+"@wireapp/core@npm:43.13.1":
+  version: 43.13.1
+  resolution: "@wireapp/core@npm:43.13.1"
   dependencies:
-    "@wireapp/api-client": ^26.10.4
+    "@wireapp/api-client": ^26.10.5
     "@wireapp/commons": ^5.2.4
     "@wireapp/core-crypto": 1.0.0-rc.36
     "@wireapp/cryptobox": 12.8.0
@@ -4905,7 +4905,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: 06781b5e27ac28fa59a2062f734714ca96a18fa33a45c4463719fe28aace7c5b694eef2330d4ceec1e94bc3d349f432e63cbe573432ab4756463b70ccb153cfd
+  checksum: 4205541d82b8bb728b35ab52743a354a2ac2aeb388d1c102d035a077592e21706a2aa5aef0ff2cdf0282b2a9b96bdbe6c2f14ac26ba2ed4638a2fd806d75220f
   languageName: node
   linkType: hard
 
@@ -17613,7 +17613,7 @@ __metadata:
     "@wireapp/avs": 9.6.9
     "@wireapp/commons": 5.2.4
     "@wireapp/copy-config": 2.1.14
-    "@wireapp/core": 43.13.0
+    "@wireapp/core": 43.13.1
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.12.8


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6429" title="WPB-6429" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6429</a>  [web] freshly registered clients are not created with the legalhold-implicit-consent capabilities
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

see https://github.com/wireapp/wire-web-packages/pull/5945

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
