### PR TITLE
runfix: Do not ignore self user when receiving a member-leave event [WPB-6374]

### DIFF
--- a/src/script/user/UserFilter.ts
+++ b/src/script/user/UserFilter.ts
@@ -26,9 +26,7 @@ import {User} from '../entity/User';
 
 export class UserFilter {
   static isParticipant(conversationEntity: Conversation, userId: QualifiedId) {
-    const index = conversationEntity
-      .participating_user_ets()
-      .findIndex((user: User) => matchQualifiedIds(userId, user));
+    const index = conversationEntity.allUserEntities().findIndex((user: User) => matchQualifiedIds(userId, user));
     return index !== -1;
   }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6374" title="WPB-6374" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6374</a>  [Web] I do not get feedback when leaving a group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

When leaving a conversation, to know if we should inject the system message `you left`, we need to know if you are still part of the conversation. 
But, we were using a list of participants that ignored the selfUser (thus, the event being filtered)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
