### PR TITLE
runfix: do not group system messages with content messages

### DIFF
--- a/src/script/components/MessagesList/utils/messagesGroup.test.ts
+++ b/src/script/components/MessagesList/utils/messagesGroup.test.ts
@@ -22,7 +22,7 @@ import {TimeInMillis} from '@wireapp/commons/lib/util/TimeUtil';
 import {EventMapper} from 'src/script/conversation/EventMapper';
 import {Conversation} from 'src/script/entity/Conversation';
 import {Message} from 'src/script/entity/message/Message';
-import {createMessageAddEvent} from 'test/helper/EventGenerator';
+import {createGroupCreationEvent, createMessageAddEvent} from 'test/helper/EventGenerator';
 import {getRandomNumber} from 'Util/NumberUtil';
 import {createUuid} from 'Util/uuid';
 
@@ -54,6 +54,19 @@ describe('MessagesGroup', () => {
     const lastGroup: any = groupedMessages[groupedMessages.length - 1];
     expect(lastGroup.messages.length).toBe(sizeGroup);
     expect(lastGroup.sender).toBe(sender);
+  });
+
+  it('does not group together system messages and content messages', () => {
+    const sender = createUuid();
+    const groupCreationMessage = createGroupCreationEvent({from: sender});
+    const contentMessage = createMessageAddEvent({overrides: {from: sender}});
+
+    const allMessages = [groupCreationMessage, contentMessage].map(
+      event => eventMapper.mapJsonEvent(event, conversation) as Message,
+    );
+
+    const groupedMessages = groupMessagesBySenderAndTime(allMessages, 0);
+    expect(groupedMessages).toHaveLength(2);
   });
 
   it('adds markers for unread messages', () => {

--- a/src/script/components/MessagesList/utils/messagesGroup.ts
+++ b/src/script/components/MessagesList/utils/messagesGroup.ts
@@ -113,15 +113,19 @@ export function groupMessagesBySenderAndTime(messages: Message[], lastReadTimest
   return messages.reduce<Array<MessagesGroup | Marker>>((acc, message, index) => {
     const lastItem = acc[acc.length - 1];
     const lastGroupInfo = isMarker(lastItem) ? undefined : lastItem;
+    const previousMessage = messages[index - 1];
 
-    const marker = getMessageMarkerType(message, lastReadTimestamp, messages[index - 1]);
+    const marker = getMessageMarkerType(message, lastReadTimestamp, previousMessage);
 
     if (marker) {
       // if there is a marker to insert, we insert it before the current message
       acc.push({type: marker, timestamp: message.timestamp()});
     }
 
+    const areContentMessages = message.isContent() && previousMessage?.isContent();
+
     if (
+      areContentMessages &&
       lastGroupInfo &&
       lastGroupInfo.sender === message.from &&
       shouldGroupMessagesByTimestamp(

--- a/test/helper/EventGenerator.ts
+++ b/test/helper/EventGenerator.ts
@@ -25,6 +25,7 @@ import {
   AssetAddEvent,
   DeleteEvent,
   EventBuilder,
+  GroupCreationEvent,
   MemberLeaveEvent,
   MessageAddEvent,
   ReactionEvent,
@@ -120,6 +121,22 @@ export function createAssetAddEvent(overrides: Partial<AssetAddEvent> = {}): Ass
     id: createUuid(),
     time: new Date().toISOString(),
     type: CONVERSATION.ASSET_ADD,
+    ...overrides,
+  };
+}
+
+export function createGroupCreationEvent(overrides: Partial<GroupCreationEvent>): GroupCreationEvent {
+  return {
+    conversation: createUuid(),
+    data: {
+      userIds: [],
+      allTeamMembers: false,
+      name: '',
+    },
+    from: createUuid(),
+    id: createUuid(),
+    time: new Date().toISOString(),
+    type: CONVERSATION.GROUP_CREATION,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Description

### After
![image](https://github.com/wireapp/wire-webapp/assets/1090716/15d5e96e-cd0d-459d-89f3-820ce887b2e4)

### Before

(notice the first message in the list does not have the sender's header)
![image](https://github.com/wireapp/wire-webapp/assets/1090716/ca5ece6e-b745-4efc-ba12-e5f473c2ee7c)



## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
