### PR TITLE
runfix: Re-render message when a link preview is generated [WPB-6449]

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
@@ -71,6 +71,7 @@ const ContentAsset = ({
   onClickDetails,
 }: ContentAssetProps) => {
   const {isObfuscated, status} = useKoSubscribableChildren(message, ['isObfuscated', 'status']);
+  const {previews} = useKoSubscribableChildren(asset as Text, ['previews']);
 
   switch (asset.type) {
     case AssetType.TEXT:
@@ -103,7 +104,7 @@ const ContentAsset = ({
             />
           )}
 
-          {(asset as Text).previews().map(preview => (
+          {previews.map(() => (
             <div key={asset.id} className="message-asset">
               <LinkPreviewAsset message={message} isFocusable={isMessageFocused} />
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6449" title="WPB-6449" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6449</a>  [Web] Link previews don't appear automatically
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

This will fix an issue where link previews are not re-rendering when generated

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

