### PR TITLE
runfix: Do not trigger e2ei flow if feature is not enabled

### DIFF
--- a/src/script/page/components/FeatureConfigChange/FeatureConfigChangeHandler/Features/E2EIdentity.ts
+++ b/src/script/page/components/FeatureConfigChange/FeatureConfigChangeHandler/Features/E2EIdentity.ts
@@ -34,7 +34,7 @@ export const configureE2EI = (logger: Logger, config: FeatureList): undefined | 
     return undefined;
   }
 
-  if (!supportsMLS() && Config.getConfig().FEATURE.ENABLE_E2EI) {
+  if (!supportsMLS() || !Config.getConfig().FEATURE.ENABLE_E2EI) {
     return undefined;
   }
 


### PR DESCRIPTION
## Description

This condition to not trigger the e2ei enrollment flow is wrong. 
We should not enroll if we are not in an MLS env, or if the e2ei feature is not enabled

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
