### PR TITLE
runfix: Split sender group when new unread messages arrive

### DIFF
--- a/src/script/components/MessagesList/utils/messagesGroup.test.ts
+++ b/src/script/components/MessagesList/utils/messagesGroup.test.ts
@@ -136,4 +136,35 @@ describe('MessagesGroup', () => {
     expect(firstMarkerIndex).toBe(nbPrevHourMessages);
     expect(marker.type).toBe('day');
   });
+
+  it('splits current group when new unread messages are detected', () => {
+    const nbReadMessages = getRandomNumber(1, 10);
+    const nbUnreadMessages = getRandomNumber(1, 10);
+    const lastReadTimestamp = 10;
+    const senderId = 'same-sender';
+
+    const readMessages = [...Array(nbReadMessages)].map((_, index) =>
+      createMessageAddEvent({overrides: {from: senderId, time: new Date(index).toISOString()}}),
+    );
+    const unreadMessages = [...Array(nbUnreadMessages)].map((_, index) =>
+      createMessageAddEvent({
+        overrides: {from: senderId, time: new Date(lastReadTimestamp + 1 + index).toISOString()},
+      }),
+    );
+
+    const allMessages = [...readMessages, ...unreadMessages].map(
+      event => eventMapper.mapJsonEvent(event, conversation) as Message,
+    );
+
+    const groupedMessages = groupMessagesBySenderAndTime(allMessages, lastReadTimestamp);
+    /* There should be :
+      - one group for read messages from the sender
+      - one marker for unread messages
+      - one group for unread messages from the sender
+    */
+    expect(groupedMessages).toHaveLength(3);
+    expect((groupedMessages[0] as any).messages).toHaveLength(nbReadMessages);
+    expect(isMarker(groupedMessages[1])).toBeTruthy();
+    expect((groupedMessages[2] as any).messages).toHaveLength(nbUnreadMessages);
+  });
 });

--- a/src/script/components/MessagesList/utils/messagesGroup.ts
+++ b/src/script/components/MessagesList/utils/messagesGroup.ts
@@ -111,8 +111,6 @@ function shouldGroupMessagesByTimestamp(
  */
 export function groupMessagesBySenderAndTime(messages: Message[], lastReadTimestamp: number) {
   return messages.reduce<Array<MessagesGroup | Marker>>((acc, message, index) => {
-    const lastItem = acc[acc.length - 1];
-    const lastGroupInfo = isMarker(lastItem) ? undefined : lastItem;
     const previousMessage = messages[index - 1];
 
     const marker = getMessageMarkerType(message, lastReadTimestamp, previousMessage);
@@ -121,6 +119,9 @@ export function groupMessagesBySenderAndTime(messages: Message[], lastReadTimest
       // if there is a marker to insert, we insert it before the current message
       acc.push({type: marker, timestamp: message.timestamp()});
     }
+
+    const lastItem = acc[acc.length - 1];
+    const lastGroupInfo = isMarker(lastItem) ? undefined : lastItem;
 
     const areContentMessages = message.isContent() && previousMessage?.isContent();
 


### PR DESCRIPTION
## Description

sender-time grouping was incorrectly placing the `unread` marker. The problem was: we are adding the marker at the end of the current group. Which means the `just now` marker would appear at the end of the group and not before the first unread message

## Screenshots/Screencast (for UI changes)

### After
![image](https://github.com/wireapp/wire-webapp/assets/1090716/7ffa3055-0a07-4828-8fd1-6f3e08b71314)


### Before

![image](https://github.com/wireapp/wire-webapp/assets/1090716/75ad2d3b-18ad-449f-95fc-660829a4f87d)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
