### PR TITLE
runfix: Queue rejoining out-of-sync MLS conversations [WPB-6456]

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@peculiar/x509": "1.9.6",
     "@wireapp/avs": "9.6.9",
     "@wireapp/commons": "5.2.4",
-    "@wireapp/core": "43.13.1",
+    "@wireapp/core": "43.14.0",
     "@wireapp/react-ui-kit": "9.12.8",
     "@wireapp/store-engine-dexie": "2.1.7",
     "@wireapp/webapp-events": "0.20.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4883,9 +4883,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:43.13.1":
-  version: 43.13.1
-  resolution: "@wireapp/core@npm:43.13.1"
+"@wireapp/core@npm:43.14.0":
+  version: 43.14.0
+  resolution: "@wireapp/core@npm:43.14.0"
   dependencies:
     "@wireapp/api-client": ^26.10.5
     "@wireapp/commons": ^5.2.4
@@ -4905,7 +4905,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: 4205541d82b8bb728b35ab52743a354a2ac2aeb388d1c102d035a077592e21706a2aa5aef0ff2cdf0282b2a9b96bdbe6c2f14ac26ba2ed4638a2fd806d75220f
+  checksum: 6675761db4bac73284b05d636a78e1a39256eabcd425853392131bfa356c81840ed9910a3f00b4be2a967e2435e875efa9ab8f0941dd8110cf65faaa8797d86d
   languageName: node
   linkType: hard
 
@@ -17613,7 +17613,7 @@ __metadata:
     "@wireapp/avs": 9.6.9
     "@wireapp/commons": 5.2.4
     "@wireapp/copy-config": 2.1.14
-    "@wireapp/core": 43.13.1
+    "@wireapp/core": 43.14.0
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.12.8


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6456" title="WPB-6456" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6456</a>  [web] queue processing out-of-sync handlers when processing notification steam
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

see https://github.com/wireapp/wire-web-packages/pull/5947

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
