### PR TITLE
runfix: Initialize soft lock upon e2eHandler initialization

### DIFF
--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -56,6 +56,7 @@ interface E2EIHandlerParams {
 
 type Events = {
   identityUpdated: {enrollmentConfig: EnrollmentConfig; identity?: WireIdentity};
+  initialized: {enrollmentConfig: EnrollmentConfig};
 };
 
 export type EnrollmentConfig = {
@@ -143,6 +144,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
     }
 
     this.currentStep = E2EIHandlerStep.INITIALIZED;
+    this.emit('initialized', {enrollmentConfig: this.config});
     return this;
   }
 

--- a/src/script/calling/CallState.ts
+++ b/src/script/calling/CallState.ts
@@ -43,16 +43,14 @@ export class CallState {
   public readonly calls: ko.ObservableArray<Call> = ko.observableArray();
   /** List of calls that can be joined by the user */
   public readonly joinableCalls: ko.PureComputed<Call[]>;
-  public readonly acceptedVersionWarnings: ko.ObservableArray<QualifiedId> = ko.observableArray<QualifiedId>();
-  public readonly cbrEncoding: ko.Observable<number> = ko.observable(
-    Config.getConfig().FEATURE.ENFORCE_CONSTANT_BITRATE ? 1 : 0,
-  );
-  readonly selectableScreens: ko.Observable<ElectronDesktopCapturerSource[]> = ko.observable([]);
-  readonly selectableWindows: ko.Observable<ElectronDesktopCapturerSource[]> = ko.observable([]);
+  public readonly acceptedVersionWarnings = ko.observableArray<QualifiedId>();
+  public readonly cbrEncoding = ko.observable(Config.getConfig().FEATURE.ENFORCE_CONSTANT_BITRATE ? 1 : 0);
+  readonly selectableScreens = ko.observable<ElectronDesktopCapturerSource[]>([]);
+  readonly selectableWindows = ko.observable<ElectronDesktopCapturerSource[]>([]);
   /** call that is current active (connecting or connected) */
   public readonly activeCalls: ko.PureComputed<Call[]>;
   public readonly joinedCall: ko.PureComputed<Call | undefined>;
-  public readonly activeCallViewTab: ko.Observable<string> = ko.observable(CallViewTab.ALL);
+  public readonly activeCallViewTab = ko.observable(CallViewTab.ALL);
   readonly isChoosingScreen: ko.PureComputed<boolean>;
   readonly isSpeakersViewActive: ko.PureComputed<boolean>;
 

--- a/src/script/components/calling/CallingOverlayContainer.tsx
+++ b/src/script/components/calling/CallingOverlayContainer.tsx
@@ -106,7 +106,7 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
     call.maximizedParticipant(participant);
   };
 
-  const setActiveCallViewTab = (tab: string) => {
+  const setActiveCallViewTab = (tab: CallViewTab) => {
     callState.activeCallViewTab(tab);
     if (tab === CallViewTab.ALL && joinedCall) {
       callingRepository.requestCurrentPageVideoStreams(joinedCall);

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -71,7 +71,7 @@ export interface FullscreenVideoCallProps {
   mediaDevicesHandler: MediaDevicesHandler;
   multitasking: Multitasking;
   muteState: MuteState;
-  setActiveCallViewTab: (tab: string) => void;
+  setActiveCallViewTab: (tab: CallViewTab) => void;
   setMaximizedParticipant: (call: Call, participant: Participant | null) => void;
   switchCameraInput: (deviceId: string) => void;
   switchMicrophoneInput: (deviceId: string) => void;
@@ -605,7 +605,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                   <ButtonGroup
                     items={Object.values(CallViewTabs)}
                     onChangeItem={item => {
-                      setActiveCallViewTab(item);
+                      setActiveCallViewTab(item as CallViewTab);
                       setMaximizedParticipant(call, null);
                     }}
                     currentItem={activeCallViewTab}

--- a/src/script/hooks/useAppSoftLock.test.ts
+++ b/src/script/hooks/useAppSoftLock.test.ts
@@ -50,6 +50,8 @@ describe('useAppSoftLock', () => {
   it('should not do anything if e2ei is not enabled', () => {
     E2EIHandlerMock.getInstance.mockReturnValue({
       isE2EIEnabled: jest.fn(() => false),
+      on: jest.fn(),
+      off: jest.fn(),
     } as any);
     const {result} = renderHook(() => useAppSoftLock(callingRepository, notificationRepository));
     expect(result.current).toEqual({softLockEnabled: false});

--- a/src/script/hooks/useAppSoftLock.ts
+++ b/src/script/hooks/useAppSoftLock.ts
@@ -40,12 +40,11 @@ export function useAppSoftLock(callingRepository: CallingRepository, notificatio
 
   useEffect(() => {
     const e2eiHandler = E2EIHandler.getInstance();
-    if (!e2eiHandler.isE2EIEnabled()) {
-      return () => {};
-    }
 
+    e2eiHandler.on('initialized', handleSoftLockActivation);
     e2eiHandler.on('identityUpdated', handleSoftLockActivation);
     return () => {
+      e2eiHandler.off('initialized', handleSoftLockActivation);
       e2eiHandler.off('identityUpdated', handleSoftLockActivation);
     };
   }, [handleSoftLockActivation]);


### PR DESCRIPTION
## Description

This will make sure we do initialize the softLock as soon as the e2e enrollmenet class is initialized with the team config. 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
