### PR TITLE
feat: Load some team members on app load [WPB-6484]

### DIFF
--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -388,7 +388,7 @@ export class App {
 
       const selfUser = await this.initiateSelfUser();
 
-      const {features: teamFeatures, team} = await teamRepository.initTeam(selfUser.teamId);
+      const {features: teamFeatures, members: teamMembers} = await teamRepository.initTeam(selfUser.teamId);
       const e2eiHandler = await configureE2EI(this.logger, teamFeatures);
       if (e2eiHandler) {
         /* We first try to do the initial enrollment (if the user has not yet enrolled)
@@ -445,15 +445,7 @@ export class App {
       const conversations = await conversationRepository.loadConversations();
 
       // We load all the users the self user is connected with
-      const contacts = await userRepository.loadUsers(selfUser, connections, conversations);
-
-      if (team) {
-        // If we are in the context of team, we load the team members metadata (user roles)
-        await teamRepository.updateTeamMembersByIds(
-          team,
-          contacts.filter(user => user.teamId === team.id).map(({id}) => id),
-        );
-      }
+      await userRepository.loadUsers(selfUser, connections, conversations, teamMembers);
 
       if (supportsMLS()) {
         //if mls is supported, we need to initialize the callbacks (they are used when decrypting messages)

--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
@@ -268,10 +268,10 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
     }, [activeConversation, conversationRepository]);
 
     useEffect(() => {
-      if (isTeam && isSingleUserMode) {
-        teamRepository.updateTeamMembersByIds(team, [firstParticipant.id], true);
+      if (team.id && isSingleUserMode) {
+        teamRepository.updateTeamMembersByIds(team.id, [firstParticipant.id], true);
       }
-    }, [firstParticipant, isSingleUserMode, isTeam, team, teamRepository]);
+    }, [firstParticipant, isSingleUserMode, team, teamRepository]);
 
     useEffect(() => {
       getService();

--- a/src/script/page/RightSidebar/GroupParticipantUser/GroupParticipantUser.tsx
+++ b/src/script/page/RightSidebar/GroupParticipantUser/GroupParticipantUser.tsx
@@ -77,11 +77,7 @@ const GroupParticipantUser: FC<GroupParticipantUserProps> = ({
 }) => {
   const {isGroup, roles} = useKoSubscribableChildren(activeConversation, ['isGroup', 'roles']);
   const {isTemporaryGuest, isAvailable} = useKoSubscribableChildren(currentUser, ['isTemporaryGuest', 'isAvailable']);
-  const {classifiedDomains, isTeam, team} = useKoSubscribableChildren(teamState, [
-    'classifiedDomains',
-    'isTeam',
-    'team',
-  ]);
+  const {classifiedDomains, team} = useKoSubscribableChildren(teamState, ['classifiedDomains', 'team']);
   const {isActivatedAccount} = useKoSubscribableChildren(selfUser, ['isActivatedAccount']);
 
   const canChangeRole =
@@ -124,10 +120,10 @@ const GroupParticipantUser: FC<GroupParticipantUserProps> = ({
   }, [currentUser]);
 
   useEffect(() => {
-    if (isTeam) {
-      teamRepository.updateTeamMembersByIds(team, [currentUser.id], true);
+    if (team.id) {
+      teamRepository.updateTeamMembersByIds(team.id, [currentUser.id], true);
     }
-  }, [isTeam, currentUser, teamRepository, team]);
+  }, [currentUser, teamRepository, team]);
 
   useEffect(() => {
     if (isTemporaryGuest) {

--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -28,6 +28,7 @@ import {TEAM_EVENT} from '@wireapp/api-client/lib/event/TeamEvent';
 import {FeatureStatus, FeatureList} from '@wireapp/api-client/lib/team/feature/';
 import type {PermissionsData} from '@wireapp/api-client/lib/team/member/PermissionsData';
 import type {TeamData} from '@wireapp/api-client/lib/team/team/TeamData';
+import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {amplify} from 'amplify';
 import {container} from 'tsyringe';
 
@@ -119,13 +120,14 @@ export class TeamRepository extends TypedEventEmitter<Events> {
    * @param teamId the Id of the team to init
    * @param contacts all the contacts the self user has, team members will be deduced from it.
    */
-  async initTeam(teamId?: string): Promise<{team: TeamEntity | undefined; features: FeatureList}> {
-    // async initTeam(teamId?: string): Promise<{members: QualifiedId[]; features: FeatureList}> {
+  async initTeam(
+    teamId?: string,
+  ): Promise<{team: TeamEntity | undefined; features: FeatureList; members: QualifiedId[]}> {
     const team = await this.getTeam();
     // get the fresh feature config from backend
     const {newFeatureList} = await this.updateFeatureConfig();
     if (!teamId) {
-      return {team: undefined, features: {}};
+      return {team: undefined, features: {}, members: []};
     }
     // Subscribe to team members change and update the user role and guest status
     this.teamState.teamMembers.subscribe(members => {
@@ -138,8 +140,9 @@ export class TeamRepository extends TypedEventEmitter<Events> {
       });
     });
 
+    const members = await this.loadInitialTeamMembers(teamId);
     this.scheduleTeamRefresh();
-    return {team, features: newFeatureList};
+    return {team, features: newFeatureList, members};
   }
 
   private async updateFeatureConfig(): Promise<{newFeatureList: FeatureList; prevFeatureList?: FeatureList}> {
@@ -166,6 +169,27 @@ export class TeamRepository extends TypedEventEmitter<Events> {
       }
     }, TIME_IN_MILLIS.SECOND * 30);
   };
+
+  private async getInitialTeamMembers(teamId: string): Promise<TeamMemberEntity[]> {
+    const {members} = await this.teamService.getAllTeamMembers(teamId);
+    return this.teamMapper.mapMembers(members);
+  }
+
+  /**
+   * will load the first 2000 team members in order to fill the initial state of the team
+   * This way a new user won't end up with an empty list of team members
+   * @param teamId
+   */
+  private async loadInitialTeamMembers(teamId: string): Promise<QualifiedId[]> {
+    const teamMembers = await this.getInitialTeamMembers(teamId);
+    this.teamState.memberRoles({});
+    this.teamState.memberInviters({});
+
+    this.updateMemberRoles(teamMembers);
+    return teamMembers
+      .filter(({userId}) => userId !== this.userState.self().id)
+      .map(memberEntity => ({domain: this.teamState.teamDomain() ?? '', id: memberEntity.userId}));
+  }
 
   async getTeam(): Promise<TeamEntity> {
     const teamId = this.userState.self().teamId;
@@ -205,7 +229,7 @@ export class TeamRepository extends TypedEventEmitter<Events> {
     const teamUsers = users.filter(user => user.teamId === selfTeamId);
     const newTeamMembers = teamUsers.filter(user => !knownMemberIds.includes(user.id));
     const newTeamMemberIds = newTeamMembers.map(({id}) => id);
-    await this.updateTeamMembersByIds(this.teamState.team(), newTeamMemberIds, true);
+    await this.updateTeamMembersByIds(selfTeamId, newTeamMemberIds, true);
   };
 
   async filterExternals(users: User[]): Promise<User[]> {
@@ -301,12 +325,7 @@ export class TeamRepository extends TypedEventEmitter<Events> {
     }
   }
 
-  async updateTeamMembersByIds(teamEntity: TeamEntity, memberIds: string[] = [], append = false): Promise<void> {
-    const teamId = teamEntity.id;
-    if (!teamId) {
-      return;
-    }
-
+  async updateTeamMembersByIds(teamId: string, memberIds: string[] = [], append = false): Promise<void> {
     const members = await this.teamService.getTeamMembersByIds(teamId, memberIds);
     const mappedMembers = this.teamMapper.mapMembers(members);
     const selfId = this.userState.self().id;

--- a/src/script/user/UserRepository.test.ts
+++ b/src/script/user/UserRepository.test.ts
@@ -265,7 +265,7 @@ describe('UserRepository', () => {
         const connections = createConnections(users);
         const fetchUserSpy = jest.spyOn(userService, 'getUsers').mockResolvedValue({found: users});
 
-        await userRepository.loadUsers(new User('self'), connections, []);
+        await userRepository.loadUsers(new User('self'), connections, [], []);
 
         expect(userState.users()).toHaveLength(users.length + 1);
         expect(fetchUserSpy).toHaveBeenCalledWith(users.map(user => user.qualified_id!));
@@ -277,7 +277,7 @@ describe('UserRepository', () => {
         const connections = createConnections(users);
         jest.spyOn(userService, 'getUsers').mockResolvedValue({found: users});
 
-        await userRepository.loadUsers(new User('self'), connections, []);
+        await userRepository.loadUsers(new User('self'), connections, [], []);
 
         expect(userState.users()).toHaveLength(users.length + 1);
         users.forEach(user => {
@@ -297,7 +297,7 @@ describe('UserRepository', () => {
         jest.spyOn(userRepository['userService'], 'loadUserFromDb').mockResolvedValue(partialUsers as any);
         const fetchUserSpy = jest.spyOn(userService, 'getUsers').mockResolvedValue({found: localUsers});
 
-        await userRepository.loadUsers(new User('self'), connections, []);
+        await userRepository.loadUsers(new User('self'), connections, [], []);
 
         expect(userState.users()).toHaveLength(localUsers.length + 1);
         expect(fetchUserSpy).toHaveBeenCalledWith(userIds);
@@ -312,7 +312,7 @@ describe('UserRepository', () => {
         const removeUserSpy = jest.spyOn(userService, 'removeUserFromDb').mockResolvedValue();
         jest.spyOn(userService, 'getUsers').mockResolvedValue({found: newUsers});
 
-        await userRepository.loadUsers(new User(), connections, []);
+        await userRepository.loadUsers(new User(), connections, [], []);
 
         expect(userState.users()).toHaveLength(newUsers.length + 1);
         expect(removeUserSpy).toHaveBeenCalledTimes(localUsers.length);

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -197,9 +197,17 @@ export class UserRepository extends TypedEventEmitter<Events> {
    * @param connections the connection to other users
    * @param conversations the conversation the user is part of (used to compute extra users that are part of those conversations but not directly connected to the user)
    */
-  async loadUsers(selfUser: User, connections: ConnectionEntity[], conversations: Conversation[]): Promise<User[]> {
+  async loadUsers(
+    selfUser: User,
+    connections: ConnectionEntity[],
+    conversations: Conversation[],
+    extraUsers: QualifiedId[],
+  ): Promise<User[]> {
     const conversationMembers = flatten(conversations.map(conversation => conversation.participating_user_ids()));
-    const allUserIds = connections.map(connectionEntity => connectionEntity.userId).concat(conversationMembers);
+    const allUserIds = connections
+      .map(connectionEntity => connectionEntity.userId)
+      .concat(conversationMembers)
+      .concat(extraUsers);
     const users = uniq(allUserIds, false, (userId: QualifiedId) => userId.id);
 
     // Remove all users that have non-qualified Ids in DB (there could be duplicated entries one qualified and one non-qualified)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6484" title="WPB-6484" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-6484</a>  [Web] Fetch first page of team members during slow sync
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

This will bring back the behavior of loading initial team members when loading the app. 
It allows the users to have a few team members loaded when they first search for them

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
