### PR TITLE
runfix: Avoid focusing on messages with undefined ids [WPB-6509] 

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.test.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.test.tsx
@@ -46,7 +46,7 @@ describe('message', () => {
       contextMenu: {entries: ko.observable([])},
       conversation: new Conversation(),
       findMessage: jest.fn(),
-      isMessageFocused: true,
+      isFocused: true,
       isLastDeliveredMessage: false,
       hideHeader: false,
       message,

--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -52,7 +52,7 @@ export interface ContentMessageProps extends Omit<MessageActions, 'onClickResetS
   /** whether the message should display the user avatar and user name before the actual content */
   hideHeader: boolean;
   hasMarker?: boolean;
-  isMessageFocused: boolean;
+  isFocused: boolean;
   isLastDeliveredMessage: boolean;
   message: ContentMessage;
   onClickButton: (message: CompositeMessage, buttonId: string) => void;
@@ -69,7 +69,7 @@ export const ContentMessageComponent = ({
   findMessage,
   selfId,
   hideHeader,
-  isMessageFocused,
+  isFocused,
   isLastDeliveredMessage,
   contextMenu,
   onClickAvatar,
@@ -84,10 +84,7 @@ export const ContentMessageComponent = ({
   onClickDetails,
 }: ContentMessageProps) => {
   // check if current message is focused and its elements focusable
-  const msgFocusState = useMemo(
-    () => isMsgElementsFocusable && isMessageFocused,
-    [isMsgElementsFocusable, isMessageFocused],
-  );
+  const msgFocusState = useMemo(() => isMsgElementsFocusable && isFocused, [isMsgElementsFocusable, isFocused]);
   const messageFocusedTabIndex = useMessageFocusedTabIndex(msgFocusState);
   const {
     senderName,
@@ -124,8 +121,8 @@ export const ContentMessageComponent = ({
   const [isActionMenuVisible, setActionMenuVisibility] = useState(false);
   const isMenuOpen = useMessageActionsState(state => state.isMenuOpen);
   useEffect(() => {
-    setActionMenuVisibility(isMessageFocused || msgFocusState);
-  }, [msgFocusState, isMessageFocused]);
+    setActionMenuVisibility(isFocused || msgFocusState);
+  }, [msgFocusState, isFocused]);
 
   const isConversationReadonly = conversation.readOnlyState() !== null;
 

--- a/src/script/components/MessagesList/Message/MessageWrapper.tsx
+++ b/src/script/components/MessagesList/Message/MessageWrapper.tsx
@@ -61,11 +61,11 @@ const isOutgoingQuote = (quoteEntity: QuoteEntity): quoteEntity is OutgoingQuote
   return quoteEntity.hash !== undefined;
 };
 
-export const MessageWrapper: React.FC<MessageParams & {isMessageFocused: boolean}> = ({
+export const MessageWrapper: React.FC<MessageParams> = ({
   message,
   conversation,
   selfId,
-  isMessageFocused,
+  isFocused,
   isSelfTemporaryGuest,
   isLastDeliveredMessage,
   shouldShowInvitePeople,
@@ -201,7 +201,7 @@ export const MessageWrapper: React.FC<MessageParams & {isMessageFocused: boolean
         onClickParticipants={onClickParticipants}
         onClickDetails={onClickDetails}
         onRetry={onRetry}
-        isMessageFocused={isMessageFocused}
+        isFocused={isFocused}
         isMsgElementsFocusable={isMsgElementsFocusable}
         onClickReaction={handleReactionClick}
       />
@@ -214,7 +214,7 @@ export const MessageWrapper: React.FC<MessageParams & {isMessageFocused: boolean
     return <LegalHoldMessage message={message} />;
   }
   if (message.isFederationStop()) {
-    return <FederationStopMessage isMessageFocused={isMessageFocused} message={message} />;
+    return <FederationStopMessage isMessageFocused={isFocused} message={message} />;
   }
   if (message.isVerification()) {
     return <VerificationMessage message={message} />;
@@ -232,7 +232,7 @@ export const MessageWrapper: React.FC<MessageParams & {isMessageFocused: boolean
     return <CallTimeoutMessage message={message} />;
   }
   if (message.isFailedToAddUsersMessage()) {
-    return <FailedToAddUsersMessage isMessageFocused={isMessageFocused} message={message} />;
+    return <FailedToAddUsersMessage isMessageFocused={isFocused} message={message} />;
   }
   if (message.isSystem()) {
     return <SystemMessage message={message} />;

--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -118,7 +118,7 @@ export const MessagesList: FC<MessagesListParams> = ({
 
   const messageListRef = useRef<HTMLDivElement | null>(null);
   const [loaded, setLoaded] = useState(false);
-  const [focusedMessage, setFocusedMessage] = useState<string | undefined>(initialMessage?.id);
+  const [highlightedMessage, setHighlightedMessage] = useState<string | undefined>(initialMessage?.id);
   const conversationLastReadTimestamp = useRef(conversation.last_read_timestamp());
 
   const filteredMessages = filterMessages(allMessages);
@@ -277,12 +277,15 @@ export const MessagesList: FC<MessagesListParams> = ({
           }
           const {messages, firstMessageTimestamp} = group;
 
-          return messages.map((message, index) => {
+          return messages.map(message => {
             const isLastDeliveredMessage = lastDeliveredMessage?.id === message.id;
 
             const visibleCallback = getVisibleCallback(conversation, message);
 
             const key = `${message.id || 'message'}-${message.timestamp()}`;
+
+            const isHighlighted = !!highlightedMessage && highlightedMessage === message.id;
+            const isFocused = !!focusedId && focusedId === message.id;
 
             return (
               <Message
@@ -294,7 +297,7 @@ export const MessagesList: FC<MessagesListParams> = ({
                 conversation={conversation}
                 hasReadReceiptsTurnedOn={conversationRepository.expectReadReceipt(conversation)}
                 isLastDeliveredMessage={isLastDeliveredMessage}
-                isMarked={!!focusedMessage && focusedMessage === message.id}
+                isHighlighted={isHighlighted}
                 scrollTo={scrollToElement}
                 isSelfTemporaryGuest={selfUser.isTemporaryGuest()}
                 messageRepository={messageRepository}
@@ -308,8 +311,8 @@ export const MessagesList: FC<MessagesListParams> = ({
                 onClickDetails={message => showMessageDetails(message)}
                 onClickResetSession={resetSession}
                 onClickTimestamp={async function (messageId: string) {
-                  setFocusedMessage(messageId);
-                  setTimeout(() => setFocusedMessage(undefined), 5000);
+                  setHighlightedMessage(messageId);
+                  setTimeout(() => setHighlightedMessage(undefined), 5000);
                   const messageIsLoaded = conversation.getMessage(messageId);
 
                   if (!messageIsLoaded) {
@@ -320,7 +323,7 @@ export const MessagesList: FC<MessagesListParams> = ({
                 }}
                 selfId={selfUser.qualifiedId}
                 shouldShowInvitePeople={shouldShowInvitePeople}
-                isMessageFocused={focusedId === message.id}
+                isFocused={isFocused}
                 handleFocus={setFocusedId}
                 handleArrowKeyDown={handleKeyDown}
                 isMsgElementsFocusable={isMsgElementsFocusable}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6509" title="WPB-6509" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6509</a>  [Web] Edge - Conversation scrolls down automatically when entering conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

This caused a problem where loading a conversation with messages that have no ID would trigger a weird initial scroll. 

The problem is we didn't check for `undefined` focused message ID. 


## Screenshots/Screencast (for UI changes)

### Before

https://github.com/wireapp/wire-webapp/assets/1090716/b2a22cd7-6057-47e7-b007-0c851570f72f


### After

https://github.com/wireapp/wire-webapp/assets/1090716/9860aeb8-44b6-4b80-b6e4-cc4fcf3c51ec



## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

