### PR TITLE
fix: Show more button in replies has the wrong color

### DIFF
--- a/src/style/content/conversation/message-quote.less
+++ b/src/style/content/conversation/message-quote.less
@@ -77,7 +77,7 @@
 
     &__show-more {
       display: block;
-      color: @w-blue;
+      color: var(--accent-color-500);
       cursor: pointer;
       font-size: @font-size-small;
       font-weight: @font-weight-regular;
@@ -85,15 +85,12 @@
 
       .disclose-icon {
         margin-left: 4px;
-        svg {
-          fill: currentColor;
-          transform: rotate(90deg);
-        }
+        color: var(--foreground);
+        fill: currentColor;
+        transform: rotate(90deg);
 
         &.upside-down {
-          svg {
-            transform: rotate(-90deg);
-          }
+          transform: rotate(-90deg);
         }
       }
     }


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-4632

## Description
Changed colour for "Show more" button and fixed changes with arrow.

## Screenshots/Screencast (for UI changes)
Before:
<img width="378" alt="image" src="https://github.com/wireapp/wire-webapp/assets/13432884/b980c9ec-441d-4f0e-8c27-0ef3138ea81d">

<img width="943" alt="image" src="https://github.com/wireapp/wire-webapp/assets/13432884/f4e79abb-96e4-4c23-8056-2a295f1b0091">

After:
![image](https://github.com/wireapp/wire-webapp/assets/13432884/94e104d4-d9e8-4d35-b0b5-991c8fb86303)
 
![image](https://github.com/wireapp/wire-webapp/assets/13432884/74541684-5fe8-40ba-bfc8-c3f71e5950cc)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
