### PR TITLE
runfix: Improve read receipts info on one to one conversations [WPB-6058]

### DIFF
--- a/src/script/components/toggle/ReceiptModeToggle.tsx
+++ b/src/script/components/toggle/ReceiptModeToggle.tsx
@@ -74,7 +74,10 @@ const ReceiptModeToggle: React.FC<ReceiptModeToggleProps> = ({receiptMode, onRec
           <span className="visually-hidden">{t('receiptToggleLabel')}</span>
         </button>
       </div>
-      <p className="panel__info-text panel__info-text--margin" data-uie-name="status-info-toggle-receipt-mode">
+      <p
+        className="panel__info-text panel__info-text--margin panel__action-item__status"
+        data-uie-name="status-info-toggle-receipt-mode"
+      >
         {t('receiptToggleInfo')}
       </p>
     </Fragment>

--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
@@ -436,20 +436,22 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
               />
 
               {isSingleUserMode && (
-                <div className="conversation-details__read-receipts" data-uie-name="label-1to1-read-receipts">
-                  <strong className="panel__info-text panel__info-text--head panel__info-text--margin-bottom">
-                    {hasReceiptsEnabled
-                      ? t('conversationDetails1to1ReceiptsHeadEnabled')
-                      : t('conversationDetails1to1ReceiptsHeadDisabled')}
-                  </strong>
+                <div className="panel__info-item" data-uie-name="label-1to1-read-receipts">
+                  <span className="panel__info-item__icon">
+                    <Icon.Read />
+                  </span>
 
-                  <p className="panel__info-text panel__info-text--margin-bottom">
-                    {t('conversationDetails1to1ReceiptsFirst')}
-                  </p>
-
-                  <p className="panel__info-text panel__info-text--margin">
-                    {t('conversationDetails1to1ReceiptsSecond')}
-                  </p>
+                  <span>
+                    <span>
+                      <p>
+                        {hasReceiptsEnabled
+                          ? t('conversationDetails1to1ReceiptsHeadEnabled')
+                          : t('conversationDetails1to1ReceiptsHeadDisabled')}
+                      </p>
+                    </span>
+                    <p className="panel__action-item__status">{t('conversationDetails1to1ReceiptsFirst')}</p>
+                    <p className="panel__action-item__status">{t('conversationDetails1to1ReceiptsSecond')}</p>
+                  </span>
                 </div>
               )}
 

--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
@@ -22,6 +22,8 @@ import {forwardRef, useCallback, useEffect, useMemo, useState} from 'react';
 import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data/';
 import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 
+import {HideIcon} from '@wireapp/react-ui-kit';
+
 import {FadingScrollbar} from 'Components/FadingScrollbar';
 import {Icon} from 'Components/Icon';
 import {ConversationProtocolDetails} from 'Components/panel/ConversationProtocolDetails/ConversationProtocolDetails';
@@ -437,9 +439,7 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
 
               {isSingleUserMode && (
                 <div className="panel__info-item" data-uie-name="label-1to1-read-receipts">
-                  <span className="panel__info-item__icon">
-                    <Icon.Read />
-                  </span>
+                  <span className="panel__info-item__icon">{hasReceiptsEnabled ? <Icon.Read /> : <HideIcon />}</span>
 
                   <span>
                     <span>

--- a/src/style/panel/panel.less
+++ b/src/style/panel/panel.less
@@ -338,13 +338,12 @@
   &__action-item {
     display: flex;
     width: 100%;
-    padding: 0 16px;
+    padding-inline: 16px;
   }
 
   &__info-item {
     .with-separators;
-    padding-top: 10px;
-    padding-bottom: 10px;
+    padding-block: 10px;
     &__icon {
       min-width: 40px;
     }

--- a/src/style/panel/panel.less
+++ b/src/style/panel/panel.less
@@ -19,6 +19,26 @@
 
 @panel-width: 304px;
 
+.with-separators {
+  position: relative;
+  &::before {
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: @left-list-item-left-width;
+    border-bottom: 1px solid var(--border-color);
+    content: '';
+  }
+  &::after {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: @left-list-item-left-width;
+    border-bottom: 1px solid var(--border-color);
+    content: '';
+  }
+}
+
 .panel {
   overflow: hidden;
 
@@ -173,11 +193,8 @@
 
   &__action-item {
     .button-reset-default();
-    display: flex;
-    width: 100%;
     min-height: 56px;
     align-items: center;
-    padding: 0 16px;
 
     &--link {
       .panel__action-item__icon {
@@ -314,6 +331,22 @@
 
     &--no-border {
       border-bottom: none;
+    }
+  }
+
+  &__info-item,
+  &__action-item {
+    display: flex;
+    width: 100%;
+    padding: 0 16px;
+  }
+
+  &__info-item {
+    .with-separators;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    &__icon {
+      min-width: 40px;
     }
   }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6058" title="WPB-6058" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6058</a>  Improve display of "read receipts" setting and indication
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

### Before 

<img width="299" alt="image" src="https://github.com/wireapp/wire-webapp/assets/1090716/a85265e0-6d52-48df-83cf-4f705b589b87">


### After
<img width="301" alt="image" src="https://github.com/wireapp/wire-webapp/assets/1090716/d5c2fc95-c0d7-4a19-b8e7-513d86f11483">


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
