### PR TITLE
fix: handle connection requests with deleted users [WPB-4356]

### DIFF
--- a/src/script/connection/ConnectionRepository.test.ts
+++ b/src/script/connection/ConnectionRepository.test.ts
@@ -36,7 +36,7 @@ import {UserRepository} from '../user/UserRepository';
 function buildConnectionRepository() {
   const connectionState = new ConnectionState();
   const connectionService = new ConnectionService();
-  const userRepository = {} as UserRepository;
+  const userRepository = {fetchUser: jest.fn()} as unknown as UserRepository;
   return [
     new ConnectionRepository(connectionService, userRepository, connectionState),
     {connectionState, userRepository, connectionService},

--- a/src/script/connection/ConnectionRepository.test.ts
+++ b/src/script/connection/ConnectionRepository.test.ts
@@ -36,7 +36,7 @@ import {UserRepository} from '../user/UserRepository';
 function buildConnectionRepository() {
   const connectionState = new ConnectionState();
   const connectionService = new ConnectionService();
-  const userRepository = {fetchUser: jest.fn()} as unknown as UserRepository;
+  const userRepository = {refreshUser: jest.fn()} as unknown as UserRepository;
   return [
     new ConnectionRepository(connectionService, userRepository, connectionState),
     {connectionState, userRepository, connectionService},

--- a/src/script/connection/ConnectionRepository.ts
+++ b/src/script/connection/ConnectionRepository.ts
@@ -52,7 +52,7 @@ export class ConnectionRepository {
   private readonly connectionService: ConnectionService;
   private readonly userRepository: UserRepository;
   private readonly logger: Logger;
-  private deleteConnectionRequestConversation?: (userId: QualifiedId) => Promise<void>;
+  private onDeleteConnectionRequestConversation?: (userId: QualifiedId) => Promise<void>;
 
   static get CONFIG(): Record<string, BackendEventType[]> {
     return {
@@ -392,15 +392,15 @@ export class ConnectionRepository {
       user.connection(null);
     }
 
-    await this.deleteConnectionRequestConversation?.(user.qualifiedId);
+    await this.onDeleteConnectionRequestConversation?.(user.qualifiedId);
   }
 
   /**
    * Set callback for deleting a connection request conversation.
    * @param callback Callback function
    */
-  public onDeleteConnectionRequestConversation(callback: (userId: QualifiedId) => Promise<void>): void {
-    this.deleteConnectionRequestConversation = callback;
+  public setDeleteConnectionRequestConversationHandler(callback: (userId: QualifiedId) => Promise<void>): void {
+    this.onDeleteConnectionRequestConversation = callback;
   }
 
   /**

--- a/src/script/connection/ConnectionRepository.ts
+++ b/src/script/connection/ConnectionRepository.ts
@@ -115,6 +115,12 @@ export class ConnectionRepository {
       connectionEntity = ConnectionMapper.mapConnectionFromJson(connectionData);
     }
 
+    const user = await this.userRepository.getUserById(connectionEntity.userId);
+    // If this is the connection request, but the user does not exist anymore, no need to attach a connection to a user or a conversation
+    if (user?.isDeleted && connectionEntity.status() === ConnectionStatus.SENT) {
+      return;
+    }
+
     // Attach connection to user
     await this.attachConnectionToUser(connectionEntity);
 

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -2020,7 +2020,7 @@ describe('ConversationRepository', () => {
           .mockResolvedValue(localConversations as unknown as ConversationDatabaseData[]);
         jest.spyOn(conversationService, 'saveConversationsInDb').mockImplementation(data => Promise.resolve(data));
 
-        const conversations = await conversationRepository.loadConversations();
+        const conversations = await conversationRepository.loadConversations([]);
 
         expect(conversations).toHaveLength(remoteConversations.found.length);
       });
@@ -2065,7 +2065,7 @@ describe('ConversationRepository', () => {
           .mockResolvedValue(localConversations as unknown as ConversationDatabaseData[]);
         jest.spyOn(conversationService, 'saveConversationsInDb').mockImplementation(data => Promise.resolve(data));
 
-        const conversations = await conversationRepository.loadConversations();
+        const conversations = await conversationRepository.loadConversations([]);
 
         expect(conversations).toHaveLength(1);
       });
@@ -2110,7 +2110,7 @@ describe('ConversationRepository', () => {
           .mockResolvedValue(localConversations as unknown as ConversationDatabaseData[]);
         jest.spyOn(conversationService, 'saveConversationsInDb').mockImplementation(data => Promise.resolve(data));
 
-        const conversations = await conversationRepository.loadConversations();
+        const conversations = await conversationRepository.loadConversations([]);
 
         expect(conversations).toHaveLength(remoteConversations.found.length);
       });
@@ -2152,7 +2152,7 @@ describe('ConversationRepository', () => {
           .spyOn(conversationService, 'getAllConversations')
           .mockResolvedValue(remoteConversations as unknown as RemoteConversations);
 
-        await conversationRepository.loadConversations();
+        await conversationRepository.loadConversations([]);
 
         expect(conversationState.missingConversations).toHaveLength(remoteConversations.failed.length);
       });

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -280,6 +280,8 @@ export class ConversationRepository {
         : this.messageRepository.requestUserSendingPermission(conversation, shouldWarnLegalHold, consentType);
     });
 
+    this.connectionRepository.onDeleteConnectionRequestConversation(this.deleteConnectionRequestConversation);
+
     this.logger = getLogger('ConversationRepository');
 
     this.event_mapper = new EventMapper();
@@ -2355,6 +2357,18 @@ export class ConversationRepository {
       })
       .catch(error => this.handleAddToConversationError(error, conversationEntity, [{domain: '', id: serviceId}]));
   }
+
+  private deleteConnectionRequestConversation = async (userId: QualifiedId) => {
+    const connection = this.connectionState
+      .connections()
+      .find(connection => matchQualifiedIds(connection.userId, userId));
+
+    if (!connection) {
+      return;
+    }
+
+    return this.deleteConversationLocally(connection.conversationId, true);
+  };
 
   private handleAddToConversationError(error: BackendError, conversationEntity: Conversation, userIds: QualifiedId[]) {
     switch (error.label) {

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -757,7 +757,7 @@ export class ConversationRepository {
       conversationsData = (await this.conversationService.saveConversationsInDb(data)) as any[];
     }
 
-    const allConversationEntities = this.mapConversations(conversationsData);
+    const allConversationEntities = conversationsData.length ? this.mapConversations(conversationsData) : [];
     const newConversationEntities = allConversationEntities.filter(
       allConversations =>
         !this.conversationState

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -280,7 +280,7 @@ export class ConversationRepository {
         : this.messageRepository.requestUserSendingPermission(conversation, shouldWarnLegalHold, consentType);
     });
 
-    this.connectionRepository.onDeleteConnectionRequestConversation(this.deleteConnectionRequestConversation);
+    this.connectionRepository.setDeleteConnectionRequestConversationHandler(this.deleteConnectionRequestConversation);
 
     this.logger = getLogger('ConversationRepository');
 

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -442,7 +442,7 @@ export class App {
 
       telemetry.addStatistic(AppInitStatisticsValue.CONNECTIONS, connections.length, 50);
 
-      const conversations = await conversationRepository.loadConversations();
+      const conversations = await conversationRepository.loadConversations(connections);
 
       // We load all the users the self user is connected with
       await userRepository.loadUsers(selfUser, connections, conversations, teamMembers);

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -691,7 +691,7 @@ export class UserRepository extends TypedEventEmitter<Events> {
     return userData;
   }
 
-  private async fetchUser(userId: QualifiedId): Promise<User> {
+  public async fetchUser(userId: QualifiedId): Promise<User> {
     const [userEntity] = await this.fetchUsers([userId]);
     return userEntity;
   }

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -691,7 +691,7 @@ export class UserRepository extends TypedEventEmitter<Events> {
     return userData;
   }
 
-  public async fetchUser(userId: QualifiedId): Promise<User> {
+  private async fetchUser(userId: QualifiedId): Promise<User> {
     const [userEntity] = await this.fetchUsers([userId]);
     return userEntity;
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4356" title="WPB-4356" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4356</a>  Web/Desktop - Connection request from a deleted profile cannot be removed/ignored
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

- filter out connection requests with deleted users - connection request is a conversation of type 3 (CONNECT)
- delete outgoing connection request when trying to cancel it and it fails because of the other user being deleted.
- delete incoming connection request when trying to accept/ignore it if the other user is deleted

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;