### PR TITLE
runfix: Remove E2EI feature flag [WPB-6467]

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@peculiar/x509": "1.9.6",
     "@wireapp/avs": "9.6.9",
     "@wireapp/commons": "5.2.4",
-    "@wireapp/core": "43.14.3",
+    "@wireapp/core": "44.0.0",
     "@wireapp/react-ui-kit": "9.15.1",
     "@wireapp/store-engine-dexie": "2.1.7",
     "@wireapp/webapp-events": "0.20.1",

--- a/server/config/client.config.ts
+++ b/server/config/client.config.ts
@@ -55,7 +55,6 @@ export function generateConfig(params: ConfigGeneratorParams, env: Env) {
       ENABLE_EXTRA_CLIENT_ENTROPY: env.FEATURE_ENABLE_EXTRA_CLIENT_ENTROPY == 'true',
       ENABLE_MEDIA_EMBEDS: env.FEATURE_ENABLE_MEDIA_EMBEDS != 'false',
       ENABLE_MLS: env.FEATURE_ENABLE_MLS == 'true',
-      ENABLE_E2EI: env.FEATURE_ENABLE_MLS == 'true' && env.FEATURE_ENABLE_E2EI == 'true',
       ENABLE_PHONE_LOGIN: env.FEATURE_ENABLE_PHONE_LOGIN != 'false',
       ENABLE_PROTEUS_CORE_CRYPTO: env.FEATURE_ENABLE_PROTEUS_CORE_CRYPTO == 'true',
       ENABLE_SSO: env.FEATURE_ENABLE_SSO == 'true',

--- a/server/config/env.ts
+++ b/server/config/env.ts
@@ -80,9 +80,6 @@ export type Env = {
   /** will enable the MLS protocol */
   FEATURE_ENABLE_MLS?: string;
 
-  /** will enable the E2E-Identification protocol, needs active FEATURE_ENABLE_MLS to work */
-  FEATURE_ENABLE_E2EI?: string;
-
   FEATURE_USE_CORE_CRYPTO?: string;
 
   FEATURE_MLS_CONFIG_KEYING_MATERIAL_UPDATE_THRESHOLD?: string;

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.test.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.test.ts
@@ -21,7 +21,6 @@ import {TimeInMillis} from '@wireapp/commons/lib/util/TimeUtil';
 import {container} from 'tsyringe';
 
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
-import {Config} from 'src/script/Config';
 import {Core} from 'src/script/service/CoreSingleton';
 import {UserState} from 'src/script/user/UserState';
 import {getCertificateDetails} from 'Util/certificateDetails';
@@ -95,9 +94,8 @@ describe('E2EIHandler', () => {
     // Clear all mocks before each test
     jest.clearAllMocks();
 
-    // Mock the Config service to return true for ENABLE_E2EI
+    // Mock the Config to enable e2eIdentity
     (util.supportsMLS as jest.Mock).mockReturnValue(true);
-    Config.getConfig = jest.fn().mockReturnValue({FEATURE: {ENABLE_E2EI: true}});
 
     jest.spyOn(PrimaryModal, 'show');
 

--- a/src/script/auth/module/action/ClientAction.ts
+++ b/src/script/auth/module/action/ClientAction.ts
@@ -22,6 +22,8 @@ import {ClientInfo} from '@wireapp/core/lib/client/';
 
 import {Runtime} from '@wireapp/commons';
 
+import {getE2EIConfig} from 'src/script/page/components/FeatureConfigChange/FeatureConfigChangeHandler/Features/E2EIdentity';
+
 import {ClientActionCreator} from './creator/';
 
 import * as StringUtil from '../../util/stringUtil';
@@ -62,7 +64,11 @@ export class ClientAction {
     entropyData?: Uint8Array,
   ): ThunkAction => {
     return async (dispatch, getState, {core, actions: {clientAction}}) => {
-      const localClient = await core.initClient();
+      const teamConfig = (await core.service?.team.getTeamFeatureConfig()) ?? {};
+      const hasE2EIEnabled = !!getE2EIConfig(teamConfig);
+
+      const localClient = await core.getLocalClient();
+
       const creationStatus = localClient
         ? {isNew: false, client: localClient}
         : {
@@ -74,6 +80,7 @@ export class ClientAction {
             ),
           };
 
+      await core.initClient(creationStatus.client, hasE2EIEnabled);
       dispatch(ClientActionCreator.successfulInitializeClient(creationStatus));
     };
   };

--- a/src/script/page/components/FeatureConfigChange/FeatureConfigChangeHandler/Features/E2EIdentity.ts
+++ b/src/script/page/components/FeatureConfigChange/FeatureConfigChangeHandler/Features/E2EIdentity.ts
@@ -19,14 +19,17 @@
 
 import {FeatureStatus, FEATURE_KEY, FeatureList} from '@wireapp/api-client/lib/team';
 
-import {Config} from 'src/script/Config';
 import {E2EIHandler} from 'src/script/E2EIdentity';
 import {Logger} from 'Util/Logger';
 import {supportsMLS} from 'Util/util';
 
 import {hasE2EIVerificationExpiration, hasMLSDefaultProtocol} from '../../../../../guards/Protocol';
 
-export const configureE2EI = (logger: Logger, config: FeatureList): undefined | Promise<E2EIHandler> => {
+export const getE2EIConfig = (config: FeatureList): FeatureList[FEATURE_KEY.MLSE2EID] | undefined => {
+  if (!supportsMLS()) {
+    return undefined;
+  }
+
   const e2eiConfig = config[FEATURE_KEY.MLSE2EID];
   const mlsConfig = config[FEATURE_KEY.MLS];
   // Check if MLS or MLS E2EIdentity feature is existent
@@ -34,28 +37,30 @@ export const configureE2EI = (logger: Logger, config: FeatureList): undefined | 
     return undefined;
   }
 
-  if (!supportsMLS() || !Config.getConfig().FEATURE.ENABLE_E2EI) {
+  // Check if E2EIdentity feature is enabled
+  if (e2eiConfig?.status !== FeatureStatus.ENABLED) {
     return undefined;
   }
 
-  // Check if E2EIdentity feature is enabled
-  if (e2eiConfig?.status === FeatureStatus.ENABLED) {
-    // Check if MLS feature is enabled
-    if (mlsConfig?.status !== FeatureStatus.ENABLED) {
-      logger.info('Warning: E2EIdentity feature enabled but MLS feature is not active');
-      return undefined;
-    }
-    // Check if E2EIdentity feature has a server discoveryUrl
-    if (!e2eiConfig.config || !e2eiConfig.config.acmeDiscoveryUrl || e2eiConfig.config.acmeDiscoveryUrl.length <= 0) {
-      logger.info('Warning: E2EIdentity feature enabled but no discoveryUrl provided');
-      return undefined;
-    }
-
-    // Either get the current E2EIdentity handler instance or create a new one
-    return E2EIHandler.getInstance().initialize({
-      discoveryUrl: e2eiConfig.config.acmeDiscoveryUrl!,
-      gracePeriodInSeconds: e2eiConfig.config.verificationExpiration,
-    });
+  // Check if MLS feature is enabled
+  if (mlsConfig?.status !== FeatureStatus.ENABLED) {
+    return undefined;
   }
-  return undefined;
+  // Check if E2EIdentity feature has a server discoveryUrl
+  if (!e2eiConfig.config || !e2eiConfig.config.acmeDiscoveryUrl || e2eiConfig.config.acmeDiscoveryUrl.length <= 0) {
+    return undefined;
+  }
+  return e2eiConfig;
+};
+
+export const configureE2EI = (logger: Logger, config: FeatureList): undefined | Promise<E2EIHandler> => {
+  // Either get the current E2EIdentity handler instance or create a new one
+  const e2eiConfig = getE2EIConfig(config);
+  if (!e2eiConfig) {
+    return undefined;
+  }
+  return E2EIHandler.getInstance().initialize({
+    discoveryUrl: e2eiConfig.config.acmeDiscoveryUrl!,
+    gracePeriodInSeconds: e2eiConfig.config.verificationExpiration,
+  });
 };

--- a/src/script/service/CoreSingleton.ts
+++ b/src/script/service/CoreSingleton.ts
@@ -40,12 +40,21 @@ export class Core extends Account {
   public key?: Uint8Array;
 
   constructor(apiClient = container.resolve(APIClient)) {
-    const enableCoreCrypto = supportsMLS() || Config.getConfig().FEATURE.USE_CORE_CRYPTO;
+    const {
+      FEATURE: {
+        USE_CORE_CRYPTO,
+        MLS_CONFIG_DEFAULT_CIPHERSUITE,
+        MLS_CONFIG_KEYING_MATERIAL_UPDATE_THRESHOLD,
+        ENABLE_ENCRYPTION_AT_REST,
+      },
+    } = Config.getConfig();
+
+    const enableCoreCrypto = supportsMLS() || USE_CORE_CRYPTO;
     super(apiClient, {
       createStore: async (storeName, key) => {
         this.key = key;
         return createStorageEngine(storeName, DatabaseTypes.PERMANENT, {
-          key: Config.getConfig().FEATURE.ENABLE_ENCRYPTION_AT_REST ? key : undefined,
+          key: ENABLE_ENCRYPTION_AT_REST ? key : undefined,
         });
       },
 
@@ -60,9 +69,8 @@ export class Core extends Account {
             wasmFilePath: '/min/core-crypto.wasm',
             mls: supportsMLS()
               ? {
-                  keyingMaterialUpdateThreshold: Config.getConfig().FEATURE.MLS_CONFIG_KEYING_MATERIAL_UPDATE_THRESHOLD,
-                  cipherSuite: Config.getConfig().FEATURE.MLS_CONFIG_DEFAULT_CIPHERSUITE,
-                  useE2EI: Config.getConfig().FEATURE.ENABLE_E2EI,
+                  keyingMaterialUpdateThreshold: MLS_CONFIG_KEYING_MATERIAL_UPDATE_THRESHOLD,
+                  cipherSuite: MLS_CONFIG_DEFAULT_CIPHERSUITE,
                 }
               : undefined,
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4895,9 +4895,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:43.14.3":
-  version: 43.14.3
-  resolution: "@wireapp/core@npm:43.14.3"
+"@wireapp/core@npm:44.0.0":
+  version: 44.0.0
+  resolution: "@wireapp/core@npm:44.0.0"
   dependencies:
     "@wireapp/api-client": ^26.10.6
     "@wireapp/commons": ^5.2.5
@@ -4917,7 +4917,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: f5a519f3787ea234740c92e2c7a581cecb13573f3eb78338ea1af5bb72c2ef3c868903879fd544a2c78b991b27f032504f8afb0a759cf66aaed363c7e568b8c3
+  checksum: 297c6896ebabdd838abac0c51eff5dffa602fa4c05e8fbccd2f3c497f2b56ece596c8f1218c789446961efa795905e76fb7c556de41938d588f65e5fdf33ff6d
   languageName: node
   linkType: hard
 
@@ -17625,7 +17625,7 @@ __metadata:
     "@wireapp/avs": 9.6.9
     "@wireapp/commons": 5.2.4
     "@wireapp/copy-config": 2.1.14
-    "@wireapp/core": 43.14.3
+    "@wireapp/core": 44.0.0
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.15.1


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6467" title="WPB-6467" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6467</a>  [Web] UI says "Something went wrong" but user gets a valid certificate
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

Now the team feature config becomes the single source of truth whether e2ei should be enabled or not. 

The core has also changed to allow this: 
- now the `initClient` will take a boolean to say whether e2ei enrollment will happen (to avoid uploading identity to the backend before the enrollment is done) (see https://github.com/wireapp/wire-web-packages/pull/5972)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
