### PR TITLE
runfix: Avoid filtering member leave events on the notification stream

### DIFF
--- a/src/script/event/EventProcessor.ts
+++ b/src/script/event/EventProcessor.ts
@@ -30,5 +30,5 @@ export interface EventProcessor {
 }
 
 export interface EventMiddleware {
-  processEvent(event: IncomingEvent): Promise<IncomingEvent>;
+  processEvent(event: IncomingEvent, source: EventSource): Promise<IncomingEvent>;
 }

--- a/src/script/event/EventRepository.ts
+++ b/src/script/event/EventRepository.ts
@@ -417,7 +417,7 @@ export class EventRepository {
   private async processEvent(event: IncomingEvent | ClientConversationEvent, source: EventSource) {
     try {
       for (const eventProcessMiddleware of this.eventProcessMiddlewares) {
-        event = await eventProcessMiddleware.processEvent(event);
+        event = await eventProcessMiddleware.processEvent(event, source);
       }
     } catch (error) {
       if (error instanceof EventValidationError) {

--- a/src/script/event/preprocessor/EventStorageMiddleware/EventStorageMiddleware.ts
+++ b/src/script/event/preprocessor/EventStorageMiddleware/EventStorageMiddleware.ts
@@ -34,6 +34,7 @@ import type {EventRecord} from '../../../storage';
 import {CONVERSATION} from '../../Client';
 import {EventMiddleware, IncomingEvent} from '../../EventProcessor';
 import {EventService} from '../../EventService';
+import {EventSource} from '../../EventSource';
 import {eventShouldBeStored} from '../../EventTypeHandling';
 
 export class EventStorageMiddleware implements EventMiddleware {
@@ -43,7 +44,7 @@ export class EventStorageMiddleware implements EventMiddleware {
     private readonly conversationState: ConversationState = container.resolve(ConversationState),
   ) {}
 
-  async processEvent(event: IncomingEvent) {
+  async processEvent(event: IncomingEvent, source: EventSource) {
     const shouldSaveEvent = eventShouldBeStored(event);
     if (!shouldSaveEvent) {
       return event;
@@ -57,7 +58,7 @@ export class EventStorageMiddleware implements EventMiddleware {
     const duplicateEvent = eventId ? await this.eventService.loadEvent(event.conversation, eventId) : undefined;
 
     // We first validate that the event is valid
-    this.validateEvent(event, duplicateEvent);
+    this.validateEvent(event, source, duplicateEvent);
     // Then ask the different handlers which DB operations to perform
     const operation = await this.getDbOperation(event, duplicateEvent);
     // And finally execute the operation
@@ -79,10 +80,10 @@ export class EventStorageMiddleware implements EventMiddleware {
     return {type: 'insert', event};
   }
 
-  private validateEvent(event: HandledEvents, duplicateEvent?: EventRecord) {
-    if (event.type === CONVERSATION_EVENT.MEMBER_LEAVE) {
+  private validateEvent(event: HandledEvents, source: EventSource, duplicateEvent?: EventRecord) {
+    if (event.type === CONVERSATION_EVENT.MEMBER_LEAVE && source !== EventSource.NOTIFICATION_STREAM) {
       /*
-        When we receive a `member-leave` event,
+        When we receive a `member-leave` event that is not from the notification stream
         we should check that the user is actually still part of the
         conversation before forwarding the event. If the user is already not part
         of the conversation, then we can throw a validation error


### PR DESCRIPTION
## Description

Since the handling of `member-leave` events is stateful (it needs the local state of the conversation to know if the event should be skipped), we cannot run this check when the app is loading since the conversation will have the freshest state (freshly fetched from BE). 
So we should avoid filtering events that come from the notification stream

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
