### PR TITLE
runfix: don't try to migrate 1:1 conversation with deleted user

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1933,7 +1933,20 @@ export class ConversationRepository {
       // If both users support mls or mls conversation is already known, we use it
       // we never go back to proteus conversation, even if one of the users do not support mls anymore
       // (e.g. due to the change of supported protocols in team configuration)
-      if (protocol === ConversationProtocol.MLS || localMLSConversation) {
+      if (localMLSConversation) {
+        return this.initMLS1to1Conversation(otherUserId, isMLSSupportedByTheOtherUser);
+      }
+
+      if (protocol === ConversationProtocol.MLS) {
+        // If the other user is deleted on backend, just open a proteus conversation and do not try to migrate it to mls.
+        if (isProteusConversation(conversation)) {
+          const otherUser = await this.userRepository.getUserById(otherUserId);
+          if (otherUser.isDeleted) {
+            this.logger.warn(`User ${otherUserId.id} is deleted, opening proteus conversation`);
+            return conversation;
+          }
+        }
+
         return this.initMLS1to1Conversation(otherUserId, isMLSSupportedByTheOtherUser);
       }
 

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1930,13 +1930,14 @@ export class ConversationRepository {
       // If there's local mls conversation, we want to use it
       const localMLSConversation = this.conversationState.findMLS1to1Conversation(otherUserId);
 
-      // If both users support mls or mls conversation is already known, we use it
+      // If mls conversation is already known, we use it
       // we never go back to proteus conversation, even if one of the users do not support mls anymore
       // (e.g. due to the change of supported protocols in team configuration)
       if (localMLSConversation) {
         return this.initMLS1to1Conversation(otherUserId, isMLSSupportedByTheOtherUser);
       }
 
+      // If both users support mls, we will initialise mls 1:1 conversation (unless it's a proteus 1:1 conversation with a user that has been deleted)
       if (protocol === ConversationProtocol.MLS) {
         // If the other user is deleted on backend, just open a proteus conversation and do not try to migrate it to mls.
         if (isProteusConversation(conversation)) {


### PR DESCRIPTION
## Description

Do not try to migrate a proteus 1:1 conversation to mls with a user that was deleted on backend. This won't be possible anyway, because it's not possible to fetch mls 1:1 conversation with a user we're not connected with (or a deleted user).

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

