### PR TITLE
runfix: Inject member leave event in non team context when user is deleted [WPB-6585]

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -3099,8 +3099,10 @@ export class ConversationRepository {
             deletedUsers.map(async qualifiedUserId => {
               const user = this.userState.users().find(user => matchQualifiedIds(user.qualifiedId, qualifiedUserId));
               return !user?.teamId
-                ? this.onMemberLeave(conversationEntity, eventJson)
-                : this.teamMemberLeave(user?.teamId, user?.qualifiedId, new Date(eventJson.time).getTime());
+                ? // If we are in the team, we display the team member removed from the team message
+                  this.onMemberLeave(conversationEntity, eventJson)
+                : // in case we are not in a team, we just display the message that says a user left the conversation
+                  this.teamMemberLeave(user?.teamId, user?.qualifiedId, new Date(eventJson.time).getTime());
             }),
           );
         }

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -3102,7 +3102,7 @@ export class ConversationRepository {
                 ? // If we are in the team, we display the team member removed from the team message
                   this.onMemberLeave(conversationEntity, eventJson)
                 : // in case we are not in a team, we just display the message that says a user left the conversation
-                  this.teamMemberLeave(user?.teamId, user?.qualifiedId, new Date(eventJson.time).getTime());
+                  this.teamMemberLeave(user.teamId, user.qualifiedId, new Date(eventJson.time).getTime());
             }),
           );
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6585" title="WPB-6585" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6585</a>  [Web] Temporary guest users - when being removed from group, system message does not always show and user still on member list
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

Make sure we handle deleted users in a non-team context (in which case we inject a member-leave event in the conversations)

## Checklist

- [x] PR has been self reviewed by the author;
- [x]  Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
