### PR TITLE
runfix: apply correct color to emojis rendered as text

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiChar.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiChar.tsx
@@ -32,6 +32,7 @@ export interface EmojiImgProps {
 export const EmojiChar: FC<EmojiImgProps> = ({emoji, size, styles}) => {
   const fontSize = size ? `${size}px` : 'var(--font-size-medium)';
   const style = {
+    color: 'var(--main-color)',
     ':after': {
       content: `'${emoji}'`,
     },


### PR DESCRIPTION
## Description

If emojis are not found on the system, they display as text.
In light mode, they would appear white on a light background
![image](https://github.com/wireapp/wire-webapp/assets/78490891/73b872cb-f32a-4b9b-92b6-7d937ef824a0)


## Screenshots/Screencast (for UI changes)

Before:
![Screenshot from 2024-02-13 17-32-01](https://github.com/wireapp/wire-webapp/assets/78490891/a8e6a849-3e41-4f1e-b3e8-8df340227848)

After:
![Screenshot from 2024-02-13 17-32-08](https://github.com/wireapp/wire-webapp/assets/78490891/30579e03-c7ec-4d87-8b0c-57e77e41e7e8)



