### PR TITLE
runfix: Avoid navigation error when conversation join code is invalid

### DIFF
--- a/src/script/auth/page/ConversationJoin.tsx
+++ b/src/script/auth/page/ConversationJoin.tsx
@@ -23,6 +23,7 @@ import type {RegisterData} from '@wireapp/api-client/lib/auth';
 import {BackendErrorLabel} from '@wireapp/api-client/lib/http';
 import {useIntl} from 'react-intl';
 import {connect} from 'react-redux';
+import {Navigate} from 'react-router-dom';
 import {AnyAction, Dispatch} from 'redux';
 
 import {UrlUtil} from '@wireapp/commons';
@@ -31,7 +32,7 @@ import {Column, Columns, H1, Muted} from '@wireapp/react-ui-kit';
 import {noop} from 'Util/util';
 
 import {GuestLoginColumn, IsLoggedInColumn, Separator} from './ConversationJoinComponents';
-import {ConversationJoinFull, ConversationJoinInvalid} from './ConversationJoinInvalid';
+import {ConversationJoinFull} from './ConversationJoinInvalid';
 import {EntropyContainer} from './EntropyContainer';
 import {Login} from './Login';
 import {Page} from './Page';
@@ -50,7 +51,7 @@ import * as AuthSelector from '../module/selector/AuthSelector';
 import * as ClientSelector from '../module/selector/ClientSelector';
 import * as ConversationSelector from '../module/selector/ConversationSelector';
 import * as SelfSelector from '../module/selector/SelfSelector';
-import {QUERY_KEY} from '../route';
+import {QUERY_KEY, ROUTE} from '../route';
 import * as AccentColor from '../util/AccentColor';
 
 type Props = React.HTMLProps<HTMLDivElement>;
@@ -235,7 +236,7 @@ const ConversationJoinComponent = ({
   };
 
   if (!isValidLink) {
-    return <ConversationJoinInvalid />;
+    return <Navigate to={ROUTE.CONVERSATION_JOIN_INVALID} replace />;
   }
 
   const isFullConversation =

--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -25,7 +25,6 @@ import {BackendError, BackendErrorLabel, SyntheticErrorLabel} from '@wireapp/api
 import {StatusCodes} from 'http-status-codes';
 import {useIntl} from 'react-intl';
 import {connect} from 'react-redux';
-import {Navigate} from 'react-router';
 import {useNavigate} from 'react-router-dom';
 import {AnyAction, Dispatch} from 'redux';
 
@@ -111,7 +110,6 @@ const LoginComponent = ({
   const [conversationKey, setConversationKey] = useState<string | null>(null);
   const [conversationSubmitData, setConversationSubmitData] = useState<Partial<LoginData> | null>(null);
   const [isLinkPasswordModalOpen, setIsLinkPasswordModalOpen] = useState<boolean>(false);
-  const [isValidLink, setIsValidLink] = useState(true);
   const [validationErrors, setValidationErrors] = useState<Error[]>([]);
 
   const [twoFactorSubmitError, setTwoFactorSubmitError] = useState<string | Error>('');
@@ -163,14 +161,11 @@ const LoginComponent = ({
     if (keyAndCodeExistent) {
       setConversationCode(queryConversationCode);
       setConversationKey(queryConversationKey);
-      setIsValidLink(true);
       doCheckConversationCode(queryConversationKey, queryConversationCode).catch(error => {
         logger.warn('Invalid conversation code', error);
-        setIsValidLink(false);
       });
       doGetConversationInfoByCode(queryConversationKey, queryConversationCode).catch(error => {
         logger.warn('Failed to fetch conversation info', error);
-        setIsValidLink(false);
       });
     }
   }, []);
@@ -361,7 +356,6 @@ const LoginComponent = ({
         <EntropyContainer onSetEntropy={storeEntropy} />
       ) : (
         <Container centerText verticalCenter style={{width: '100%'}}>
-          {!isValidLink && <Navigate to={ROUTE.CONVERSATION_JOIN_INVALID} replace />}
           {!embedded && <AppAlreadyOpen />}
           {isLinkPasswordModalOpen && (
             <JoinGuestLinkPasswordModal


### PR DESCRIPTION
## Description

Will avoid this error when trying to join a conversation that has an invalid code or revoked link 

![image](https://github.com/wireapp/wire-webapp/assets/1090716/15801d4f-c311-478a-810e-dbba0cd9108a)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
