### PR TITLE
fix: Timetag width fix

### DIFF
--- a/src/script/components/MessagesList/Message/Marker/Marker.styles.ts
+++ b/src/script/components/MessagesList/Message/Marker/Marker.styles.ts
@@ -32,6 +32,7 @@ export const baseMarkerStyle = css`
 
   .message-header-label {
     border-bottom: 1px dotted var(--foreground-fade-24);
+    flex: unset;
   }
 
   .message-unread-dot {

--- a/src/script/components/MessagesList/Message/Marker/Marker.styles.ts
+++ b/src/script/components/MessagesList/Message/Marker/Marker.styles.ts
@@ -32,7 +32,6 @@ export const baseMarkerStyle = css`
 
   .message-header-label {
     border-bottom: 1px dotted var(--foreground-fade-24);
-    flex: unset;
   }
 
   .message-unread-dot {

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -175,7 +175,6 @@
 .message-header-label {
   display: flex;
   min-width: 0; // fixes ellipsis not working with flexbox (FF)
-  flex: 1;
   align-items: center;
   font-size: @font-size-small;
   font-weight: @font-weight-regular;
@@ -183,6 +182,7 @@
 
   &--verification {
     display: inline;
+    flex: 1;
   }
 
   a {


### PR DESCRIPTION
## Description

Fix timetag width.

## Screenshots/Screencast (for UI changes)

From:
<img width="1139" alt="image" src="https://github.com/wireapp/wire-webapp/assets/13432884/47eec762-8c36-47b6-9d06-cd753dfd894f">

To:
![image](https://github.com/wireapp/wire-webapp/assets/13432884/30a1ba6f-5d10-46dd-9dc4-bbfd6a080a7a)


## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
