### PR TITLE
fix: improve visibility of join button for temporary guests (WPB-3550)

### DIFF
--- a/src/script/components/calling/CallingCell.tsx
+++ b/src/script/components/calling/CallingCell.tsx
@@ -123,7 +123,6 @@ const CallingCell: React.FC<CallingCellProps> = ({
   const {activeCallViewTab} = useKoSubscribableChildren(callState, ['activeCallViewTab']);
   const isMuted = muteState !== MuteState.NOT_MUTED;
 
-  const isStillOngoing = reason === CALL_REASON.STILL_ONGOING;
   const isDeclined = !!reason && [CALL_REASON.STILL_ONGOING, CALL_REASON.ANSWERED_ELSEWHERE].includes(reason);
 
   const isOutgoing = state === CALL_STATE.OUTGOING;
@@ -173,7 +172,6 @@ const CallingCell: React.FC<CallingCellProps> = ({
   const disableVideoButton = isOutgoingVideoCall || isVideoUnsupported;
   const disableScreenButton = !callingRepository.supportsScreenSharing;
 
-  const showJoinButton = conversation && isStillOngoing && temporaryUserStyle;
   const [showParticipants, setShowParticipants] = useState(false);
   const isModerator = selfUser && roles[selfUser.id] === DefaultConversationRoleName.WIRE_ADMIN;
 
@@ -304,19 +302,7 @@ const CallingCell: React.FC<CallingCellProps> = ({
         </p>
       )}
 
-      {showJoinButton && isFullUi && (
-        <button
-          className="call-ui__button call-ui__button--green call-ui__button--join"
-          style={{margin: '40px 16px 0px'}}
-          onClick={() => callActions.answer(call)}
-          type="button"
-          data-uie-name="do-call-controls-call-join"
-        >
-          {t('callJoin')}
-        </button>
-      )}
-
-      {conversation && !isDeclined && (
+      {conversation && (!isDeclined || temporaryUserStyle) && (
         <div
           className="conversation-list-calling-cell-background"
           data-uie-name="item-call"
@@ -448,7 +434,7 @@ const CallingCell: React.FC<CallingCellProps> = ({
             <ConversationClassifiedBar conversation={conversation} classifiedDomains={classifiedDomains} />
           )}
 
-          {!isDeclined && (
+          {(!isDeclined || temporaryUserStyle) && (
             <>
               <div className="conversation-list-calling-cell-controls">
                 <ul className="conversation-list-calling-cell-controls-left">
@@ -538,7 +524,7 @@ const CallingCell: React.FC<CallingCellProps> = ({
                     </li>
                   )}
 
-                  {(isIncoming || isOutgoing) && (
+                  {(isIncoming || isOutgoing) && !isDeclined && (
                     <li className="conversation-list-calling-cell-controls-item">
                       <button
                         ref={element => {

--- a/src/script/components/calling/CallingCell.tsx
+++ b/src/script/components/calling/CallingCell.tsx
@@ -434,174 +434,170 @@ const CallingCell: React.FC<CallingCellProps> = ({
             <ConversationClassifiedBar conversation={conversation} classifiedDomains={classifiedDomains} />
           )}
 
-          {(!isDeclined || isTemporaryUser) && (
-            <>
-              <div className="conversation-list-calling-cell-controls">
-                <ul className="conversation-list-calling-cell-controls-left">
-                  {isFullUi && (
-                    <>
-                      <li className="conversation-list-calling-cell-controls-item">
-                        <button
-                          className={cx('call-ui__button', {'call-ui__button--active': !isMuted})}
-                          onClick={() => callActions.toggleMute(call, !isMuted)}
-                          data-uie-name="do-toggle-mute"
-                          data-uie-value={isMuted ? 'active' : 'inactive'}
-                          title={t('videoCallOverlayMicrophone')}
-                          type="button"
-                          role="switch"
-                          aria-checked={!isMuted}
-                          disabled={isConnecting}
-                        >
-                          {isMuted ? <Icon.MicOff className="small-icon" /> : <Icon.MicOn className="small-icon" />}
-                        </button>
-                      </li>
-
-                      {showVideoButton && (
-                        <li className="conversation-list-calling-cell-controls-item">
-                          <button
-                            className={cx('call-ui__button', {'call-ui__button--active': selfSharesCamera})}
-                            onClick={() => callActions.toggleCamera(call)}
-                            disabled={disableVideoButton}
-                            data-uie-name="do-toggle-video"
-                            title={t('videoCallOverlayCamera')}
-                            type="button"
-                            role="switch"
-                            aria-checked={selfSharesCamera}
-                            data-uie-value={selfSharesCamera ? 'active' : 'inactive'}
-                          >
-                            {selfSharesCamera ? (
-                              <Icon.Camera className="small-icon" />
-                            ) : (
-                              <Icon.CameraOff className="small-icon" />
-                            )}
-                          </button>
-                        </li>
-                      )}
-
-                      {isOngoing && (
-                        <li className="conversation-list-calling-cell-controls-item">
-                          <button
-                            className={cx('call-ui__button', {
-                              'call-ui__button--active': selfSharesScreen,
-                              'call-ui__button--disabled': disableScreenButton,
-                              'with-tooltip with-tooltip--bottom': disableScreenButton,
-                            })}
-                            data-tooltip={disableScreenButton ? t('videoCallScreenShareNotSupported') : undefined}
-                            onClick={() => callActions.toggleScreenshare(call)}
-                            type="button"
-                            data-uie-name="do-call-controls-toggle-screenshare"
-                            data-uie-value={selfSharesScreen ? 'active' : 'inactive'}
-                            data-uie-enabled={disableScreenButton ? 'false' : 'true'}
-                            title={t('videoCallOverlayShareScreen')}
-                          >
-                            {selfSharesScreen ? (
-                              <Icon.Screenshare className="small-icon" />
-                            ) : (
-                              <Icon.ScreenshareOff className="small-icon" />
-                            )}
-                          </button>
-                        </li>
-                      )}
-                    </>
-                  )}
-                </ul>
-
-                <ul className="conversation-list-calling-cell-controls-right">
-                  {showParticipantsButton && isFullUi && (
-                    <li className="conversation-list-calling-cell-controls-item">
-                      <button
-                        className={cx('call-ui__button call-ui__button--participants', {
-                          'call-ui__button--active': showParticipants,
-                        })}
-                        onClick={() => setShowParticipants(prevState => !prevState)}
-                        type="button"
-                        data-uie-name="do-toggle-participants"
-                        aria-pressed={showParticipants}
-                      >
-                        <span>{t('callParticipants', participants.length)}</span>
-                        <Icon.ChevronRight className="chevron" />
-                      </button>
-                    </li>
-                  )}
-
-                  {(isIncoming || isOutgoing) && !isDeclined && (
-                    <li className="conversation-list-calling-cell-controls-item">
-                      <button
-                        ref={element => {
-                          if (showAlert && !isGroup) {
-                            element?.focus();
-                          }
-                        }}
-                        className="call-ui__button call-ui__button--red call-ui__button--large"
-                        onClick={() => (isIncoming ? callActions.reject(call) : callActions.leave(call))}
-                        onBlur={() => clearShowAlert()}
-                        title={!isGroup && showAlert ? call1To1StartedAlert : t('videoCallOverlayHangUp')}
-                        aria-label={!isGroup && showAlert ? call1To1StartedAlert : t('videoCallOverlayHangUp')}
-                        type="button"
-                        data-uie-name="do-call-controls-call-decline"
-                      >
-                        <Icon.Hangup className="small-icon" style={{maxWidth: 17}} />
-                      </button>
-                    </li>
-                  )}
-
-                  {isIncoming && (
-                    <li className="conversation-list-calling-cell-controls-item">
-                      {isDeclined ? (
-                        <button
-                          className="call-ui__button call-ui__button--green call-ui__button--join call-ui__button--join--large "
-                          onClick={answerCall}
-                          type="button"
-                          data-uie-name="do-call-controls-call-join"
-                        >
-                          {t('callJoin')}
-                        </button>
-                      ) : (
-                        <button
-                          className="call-ui__button call-ui__button--green call-ui__button--large"
-                          onClick={answerCall}
-                          type="button"
-                          title={t('callAccept')}
-                          aria-label={t('callAccept')}
-                          data-uie-name="do-call-controls-call-accept"
-                        >
-                          <Icon.Pickup className="small-icon" />
-                        </button>
-                      )}
-                    </li>
-                  )}
-                </ul>
-              </div>
-
+          <div className="conversation-list-calling-cell-controls">
+            <ul className="conversation-list-calling-cell-controls-left">
               {isFullUi && (
-                <div
-                  className={cx('call-ui__participant-list__wrapper', {
-                    'call-ui__participant-list__wrapper--active': showParticipants,
-                  })}
-                >
-                  <FadingScrollbar className="call-ui__participant-list__container">
-                    <ul className="call-ui__participant-list" data-uie-name="list-call-ui-participants">
-                      {participants
-                        .slice()
-                        .sort((participantA, participantB) => sortUsersByPriority(participantA.user, participantB.user))
-                        .map((participant, index, participantsArray) => (
-                          <li key={participant.clientId} className="call-ui__participant-list__participant">
-                            <CallParticipantsListItem
-                              key={participant.clientId}
-                              callParticipant={participant}
-                              selfInTeam={selfUser && teamState.isInTeam(selfUser)}
-                              isSelfVerified={isSelfVerified}
-                              showContextMenu={!!isModerator}
-                              onContextMenu={event => getParticipantContext(event, participant)}
-                              isLast={participantsArray.length === index}
-                            />
-                          </li>
-                        ))}
-                    </ul>
-                  </FadingScrollbar>
-                </div>
+                <>
+                  <li className="conversation-list-calling-cell-controls-item">
+                    <button
+                      className={cx('call-ui__button', {'call-ui__button--active': !isMuted})}
+                      onClick={() => callActions.toggleMute(call, !isMuted)}
+                      data-uie-name="do-toggle-mute"
+                      data-uie-value={isMuted ? 'active' : 'inactive'}
+                      title={t('videoCallOverlayMicrophone')}
+                      type="button"
+                      role="switch"
+                      aria-checked={!isMuted}
+                      disabled={isConnecting}
+                    >
+                      {isMuted ? <Icon.MicOff className="small-icon" /> : <Icon.MicOn className="small-icon" />}
+                    </button>
+                  </li>
+
+                  {showVideoButton && (
+                    <li className="conversation-list-calling-cell-controls-item">
+                      <button
+                        className={cx('call-ui__button', {'call-ui__button--active': selfSharesCamera})}
+                        onClick={() => callActions.toggleCamera(call)}
+                        disabled={disableVideoButton}
+                        data-uie-name="do-toggle-video"
+                        title={t('videoCallOverlayCamera')}
+                        type="button"
+                        role="switch"
+                        aria-checked={selfSharesCamera}
+                        data-uie-value={selfSharesCamera ? 'active' : 'inactive'}
+                      >
+                        {selfSharesCamera ? (
+                          <Icon.Camera className="small-icon" />
+                        ) : (
+                          <Icon.CameraOff className="small-icon" />
+                        )}
+                      </button>
+                    </li>
+                  )}
+
+                  {isOngoing && (
+                    <li className="conversation-list-calling-cell-controls-item">
+                      <button
+                        className={cx('call-ui__button', {
+                          'call-ui__button--active': selfSharesScreen,
+                          'call-ui__button--disabled': disableScreenButton,
+                          'with-tooltip with-tooltip--bottom': disableScreenButton,
+                        })}
+                        data-tooltip={disableScreenButton ? t('videoCallScreenShareNotSupported') : undefined}
+                        onClick={() => callActions.toggleScreenshare(call)}
+                        type="button"
+                        data-uie-name="do-call-controls-toggle-screenshare"
+                        data-uie-value={selfSharesScreen ? 'active' : 'inactive'}
+                        data-uie-enabled={disableScreenButton ? 'false' : 'true'}
+                        title={t('videoCallOverlayShareScreen')}
+                      >
+                        {selfSharesScreen ? (
+                          <Icon.Screenshare className="small-icon" />
+                        ) : (
+                          <Icon.ScreenshareOff className="small-icon" />
+                        )}
+                      </button>
+                    </li>
+                  )}
+                </>
               )}
-            </>
+            </ul>
+
+            <ul className="conversation-list-calling-cell-controls-right">
+              {showParticipantsButton && isFullUi && (
+                <li className="conversation-list-calling-cell-controls-item">
+                  <button
+                    className={cx('call-ui__button call-ui__button--participants', {
+                      'call-ui__button--active': showParticipants,
+                    })}
+                    onClick={() => setShowParticipants(prevState => !prevState)}
+                    type="button"
+                    data-uie-name="do-toggle-participants"
+                    aria-pressed={showParticipants}
+                  >
+                    <span>{t('callParticipants', participants.length)}</span>
+                    <Icon.ChevronRight className="chevron" />
+                  </button>
+                </li>
+              )}
+
+              {(isIncoming || isOutgoing) && !isDeclined && (
+                <li className="conversation-list-calling-cell-controls-item">
+                  <button
+                    ref={element => {
+                      if (showAlert && !isGroup) {
+                        element?.focus();
+                      }
+                    }}
+                    className="call-ui__button call-ui__button--red call-ui__button--large"
+                    onClick={() => (isIncoming ? callActions.reject(call) : callActions.leave(call))}
+                    onBlur={() => clearShowAlert()}
+                    title={!isGroup && showAlert ? call1To1StartedAlert : t('videoCallOverlayHangUp')}
+                    aria-label={!isGroup && showAlert ? call1To1StartedAlert : t('videoCallOverlayHangUp')}
+                    type="button"
+                    data-uie-name="do-call-controls-call-decline"
+                  >
+                    <Icon.Hangup className="small-icon" style={{maxWidth: 17}} />
+                  </button>
+                </li>
+              )}
+
+              {isIncoming && (
+                <li className="conversation-list-calling-cell-controls-item">
+                  {isDeclined ? (
+                    <button
+                      className="call-ui__button call-ui__button--green call-ui__button--join call-ui__button--join--large "
+                      onClick={answerCall}
+                      type="button"
+                      data-uie-name="do-call-controls-call-join"
+                    >
+                      {t('callJoin')}
+                    </button>
+                  ) : (
+                    <button
+                      className="call-ui__button call-ui__button--green call-ui__button--large"
+                      onClick={answerCall}
+                      type="button"
+                      title={t('callAccept')}
+                      aria-label={t('callAccept')}
+                      data-uie-name="do-call-controls-call-accept"
+                    >
+                      <Icon.Pickup className="small-icon" />
+                    </button>
+                  )}
+                </li>
+              )}
+            </ul>
+          </div>
+
+          {isFullUi && (
+            <div
+              className={cx('call-ui__participant-list__wrapper', {
+                'call-ui__participant-list__wrapper--active': showParticipants,
+              })}
+            >
+              <FadingScrollbar className="call-ui__participant-list__container">
+                <ul className="call-ui__participant-list" data-uie-name="list-call-ui-participants">
+                  {participants
+                    .slice()
+                    .sort((participantA, participantB) => sortUsersByPriority(participantA.user, participantB.user))
+                    .map((participant, index, participantsArray) => (
+                      <li key={participant.clientId} className="call-ui__participant-list__participant">
+                        <CallParticipantsListItem
+                          key={participant.clientId}
+                          callParticipant={participant}
+                          selfInTeam={selfUser && teamState.isInTeam(selfUser)}
+                          isSelfVerified={isSelfVerified}
+                          showContextMenu={!!isModerator}
+                          onContextMenu={event => getParticipantContext(event, participant)}
+                          isLast={participantsArray.length === index}
+                        />
+                      </li>
+                    ))}
+                </ul>
+              </FadingScrollbar>
+            </div>
           )}
         </div>
       )}

--- a/src/script/components/calling/CallingCell.tsx
+++ b/src/script/components/calling/CallingCell.tsx
@@ -69,7 +69,7 @@ interface AnsweringControlsProps {
   isFullUi?: boolean;
   callState?: CallState;
   classifiedDomains?: string[];
-  temporaryUserStyle?: boolean;
+  isTemporaryUser?: boolean;
 }
 
 export type CallingCellProps = VideoCallProps & AnsweringControlsProps;
@@ -79,7 +79,7 @@ type labels = {dataUieName: string; text: string};
 const CallingCell: React.FC<CallingCellProps> = ({
   conversation,
   classifiedDomains,
-  temporaryUserStyle,
+  isTemporaryUser,
   call,
   callActions,
   isFullUi = false,
@@ -302,7 +302,7 @@ const CallingCell: React.FC<CallingCellProps> = ({
         </p>
       )}
 
-      {conversation && (!isDeclined || temporaryUserStyle) && (
+      {conversation && (!isDeclined || isTemporaryUser) && (
         <div
           className="conversation-list-calling-cell-background"
           data-uie-name="item-call"
@@ -336,7 +336,7 @@ const CallingCell: React.FC<CallingCellProps> = ({
                   : `${isOngoing ? `${ongoingCallAlert} ` : ''}${t('accessibility.openConversation', conversationName)}`
               }
             >
-              {!temporaryUserStyle && (
+              {!isTemporaryUser && (
                 <div className="conversation-list-cell-left">
                   {isGroup && <GroupAvatar users={conversationParticipants} />}
                   {!isGroup && !!conversationParticipants.length && (
@@ -346,7 +346,7 @@ const CallingCell: React.FC<CallingCellProps> = ({
               )}
               <h2
                 className={cx('conversation-list-cell-center ', {
-                  'conversation-list-cell-center-no-left': temporaryUserStyle,
+                  'conversation-list-cell-center-no-left': isTemporaryUser,
                 })}
               >
                 <span className="conversation-list-cell-name">{conversationName}</span>
@@ -434,7 +434,7 @@ const CallingCell: React.FC<CallingCellProps> = ({
             <ConversationClassifiedBar conversation={conversation} classifiedDomains={classifiedDomains} />
           )}
 
-          {(!isDeclined || temporaryUserStyle) && (
+          {(!isDeclined || isTemporaryUser) && (
             <>
               <div className="conversation-list-calling-cell-controls">
                 <ul className="conversation-list-calling-cell-controls-left">
@@ -547,16 +547,27 @@ const CallingCell: React.FC<CallingCellProps> = ({
 
                   {isIncoming && (
                     <li className="conversation-list-calling-cell-controls-item">
-                      <button
-                        className="call-ui__button call-ui__button--green call-ui__button--large"
-                        onClick={answerCall}
-                        type="button"
-                        title={t('callAccept')}
-                        aria-label={t('callAccept')}
-                        data-uie-name="do-call-controls-call-accept"
-                      >
-                        <Icon.Pickup className="small-icon" />
-                      </button>
+                      {isDeclined ? (
+                        <button
+                          className="call-ui__button call-ui__button--green call-ui__button--join call-ui__button--join--large "
+                          onClick={answerCall}
+                          type="button"
+                          data-uie-name="do-call-controls-call-join"
+                        >
+                          {t('callJoin')}
+                        </button>
+                      ) : (
+                        <button
+                          className="call-ui__button call-ui__button--green call-ui__button--large"
+                          onClick={answerCall}
+                          type="button"
+                          title={t('callAccept')}
+                          aria-label={t('callAccept')}
+                          data-uie-name="do-call-controls-call-accept"
+                        >
+                          <Icon.Pickup className="small-icon" />
+                        </button>
+                      )}
                     </li>
                   )}
                 </ul>

--- a/src/script/page/LeftSidebar/panels/TemporatyGuestConversations.tsx
+++ b/src/script/page/LeftSidebar/panels/TemporatyGuestConversations.tsx
@@ -48,7 +48,7 @@ const TemporaryGuestConversations: React.FC<TemporaryGuestConversations> = ({
     'expirationRemainingText',
   ]);
 
-  const {activeCalls} = useKoSubscribableChildren(callingViewModel, ['activeCalls']);
+  const {calls} = useKoSubscribableChildren(callingViewModel, ['calls']);
   const isAccountCreationEnabled = Config.getConfig().FEATURE.ENABLE_ACCOUNT_REGISTRATION;
   const getConversationById = (conversationId: QualifiedId) => callingViewModel.getConversationById(conversationId);
   const openPreferences = () => {
@@ -71,7 +71,7 @@ const TemporaryGuestConversations: React.FC<TemporaryGuestConversations> = ({
 
   return (
     <div id="temporary-guest" className={`temporary-guest`}>
-      {activeCalls.map(call => {
+      {calls.map(call => {
         const conversation = getConversationById(call.conversationId);
         return (
           <div key={call.conversationId.id} className="calling-cell">

--- a/src/script/page/LeftSidebar/panels/TemporatyGuestConversations.tsx
+++ b/src/script/page/LeftSidebar/panels/TemporatyGuestConversations.tsx
@@ -48,7 +48,7 @@ const TemporaryGuestConversations: React.FC<TemporaryGuestConversations> = ({
     'expirationRemainingText',
   ]);
 
-  const {calls} = useKoSubscribableChildren(callingViewModel, ['calls']);
+  const {activeCalls} = useKoSubscribableChildren(callingViewModel, ['activeCalls']);
   const isAccountCreationEnabled = Config.getConfig().FEATURE.ENABLE_ACCOUNT_REGISTRATION;
   const getConversationById = (conversationId: QualifiedId) => callingViewModel.getConversationById(conversationId);
   const openPreferences = () => {
@@ -71,7 +71,7 @@ const TemporaryGuestConversations: React.FC<TemporaryGuestConversations> = ({
 
   return (
     <div id="temporary-guest" className={`temporary-guest`}>
-      {calls.map(call => {
+      {activeCalls.map(call => {
         const conversation = getConversationById(call.conversationId);
         return (
           <div key={call.conversationId.id} className="calling-cell">
@@ -81,7 +81,7 @@ const TemporaryGuestConversations: React.FC<TemporaryGuestConversations> = ({
               data-uie-value={conversation.display_name()}
               call={call}
               conversation={conversation}
-              temporaryUserStyle
+              isTemporaryUser
               isFullUi
               isSelfVerified={false}
               callActions={callingViewModel.callActions}

--- a/src/style/components/list/conversation-list-calling-cell.less
+++ b/src/style/components/list/conversation-list-calling-cell.less
@@ -46,6 +46,9 @@
     &--join {
       font-size: @font-size-medium;
       font-weight: @font-weight-bold;
+      &--large {
+        width: 200px;
+      }
     }
 
     &--participants {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3550" title="WPB-3550" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-3550</a>  [WEB] Improve visibility of "join call" button in a guest conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

When a temporary guest joins a conversation where a call is already ongoing, the join button is easily missed

We decided to show the call ui in that case, even if the call is declined (a temporary guest only has access to 1 conversation, no other groups or 1on1)

## Screenshots/Screencast (for UI changes)

Before:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/15a35579-bb23-494a-ac22-92d6f4003f50)

After:
![Screenshot from 2024-02-14 17-00-09](https://github.com/wireapp/wire-webapp/assets/78490891/ad2fa18e-c463-404e-a768-446442cd45b8)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;