### PR TITLE
fix: Do not stick to bottom of messages list when navigating messages [WPB-2505]

### DIFF
--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -176,9 +176,13 @@ export const MessagesList: FC<MessagesListParams> = ({
       scrollingContainer.scrollTop = scrollingContainer.scrollHeight - previousScrollHeight;
     } else if (shouldStickToBottom) {
       // We only want to animate the scroll if there are new messages in the list
-      const behavior = nbMessages.current !== filteredMessagesLength ? 'smooth' : 'auto';
-      // Simple content update, we just scroll to bottom if we are in the stick to bottom threshold
-      scrollingContainer.scrollTo?.({behavior, top: scrollingContainer.scrollHeight});
+      const nbNewMessages = filteredMessagesLength - nbMessages.current;
+      if (nbNewMessages <= 1) {
+        // We only want to animate the scroll if there is a single new message (many messages added at once means we are navigating the messages list)
+        const behavior = nbMessages.current !== filteredMessagesLength ? 'smooth' : 'auto';
+        // Simple content update, we just scroll to bottom if we are in the stick to bottom threshold
+        scrollingContainer.scrollTo?.({behavior, top: scrollingContainer.scrollHeight});
+      }
     } else if (lastMessage && lastMessage.status() === StatusType.SENDING && lastMessage.user().id === selfUser.id) {
       // The self user just sent a message, we scroll straight to the bottom
       scrollingContainer.scrollTo?.({behavior: 'smooth', top: scrollingContainer.scrollHeight});


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2505" title="WPB-2505" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-2505</a>  [Web] Automatic scroll to bottom of loaded message chunk after navigation to old messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

## Screenshots/Screencast (for UI changes)

### Before

https://github.com/wireapp/wire-webapp/assets/1090716/2d7317f7-c912-42a5-b8e7-25a000387147


### After


https://github.com/wireapp/wire-webapp/assets/1090716/8ed589a8-4ba5-4f15-ae7f-2e4cc1e0a88f


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
