### PR TITLE
runfix: prevent group call pagination arrow from disappearing (WPB-6245)

### DIFF
--- a/src/script/components/calling/FullscreenVideoCall.styles.ts
+++ b/src/script/components/calling/FullscreenVideoCall.styles.ts
@@ -87,4 +87,5 @@ export const paginationButtonStyles: CSSObject = {
   position: 'absolute',
   top: 'calc(50% - 75px)',
   width: 56,
+  zIndex: 1,
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6245" title="WPB-6245" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6245</a>  [Web] Pagination arrow disappears in call ui
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

The pagination arrow would disappear when clicking the video grid under it in large video call
Setting it to the same z-index fixes the issue

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
