### PR TITLE
fix: Do not stick to bottom of messages list when navigating messages [WPB-2505]

### DIFF
--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -178,7 +178,6 @@ export const MessagesList: FC<MessagesListParams> = ({
   const loadPrecedingMessages = async (): Promise<void> => {
     const shouldPullMessages = !isPending && hasAdditionalMessages;
 
-
     if (shouldPullMessages) {
       await conversationRepository.getPrecedingMessages(conversation);
     }

--- a/src/script/components/MessagesList/utils/scrollUpdater.test.ts
+++ b/src/script/components/MessagesList/utils/scrollUpdater.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Message} from 'src/script/entity/message/Message';
+
+import {updateScroll} from './scrollUpdater';
+
+const createScrollingContainer = (scrollSize: number, scrollTop: number) => {
+  const container = document.createElement('div');
+  Object.defineProperty(container, 'clientHeight', {configurable: true, value: 100});
+  Object.defineProperty(container, 'scrollHeight', {configurable: true, value: scrollSize});
+  container.scrollTop = scrollTop;
+  return container;
+};
+
+const stickToBottomThreshold = 100;
+
+describe('updateScroll', () => {
+  it('should go to the bottom when the content is first loaded', () => {
+    const container = createScrollingContainer(500, 0);
+
+    const messages = [new Message()];
+    // container was empty
+    const prevScrollHeight = 0;
+    const prevNbMessages = 0;
+    const selfUserId = 'user1';
+
+    expect(container.scrollTop).toBe(0);
+
+    updateScroll(container, {
+      focusedElement: null,
+      prevScrollHeight,
+      prevNbMessages,
+      messages,
+      selfUserId,
+    });
+
+    // container should be scrolled to the bottom
+    expect(container.scrollTop).toBe(500);
+  });
+
+  it(`should stick to the bottom if we are under the ${stickToBottomThreshold}px threshold`, () => {
+    const container = createScrollingContainer(500, 500 - stickToBottomThreshold - 1);
+
+    const messages = [new Message()];
+    // container was empty
+    const prevScrollHeight = 0;
+    const prevNbMessages = 0;
+    const selfUserId = 'user1';
+
+    expect(container.scrollTop).toBe(0);
+
+    updateScroll(container, {
+      focusedElement: null,
+      prevScrollHeight,
+      prevNbMessages,
+      messages,
+      selfUserId,
+    });
+
+    // container should be scrolled to the bottom
+    expect(container.scrollTop).toBe(500);
+  });
+});

--- a/src/script/components/MessagesList/utils/scrollUpdater.ts
+++ b/src/script/components/MessagesList/utils/scrollUpdater.ts
@@ -34,16 +34,6 @@ export function updateScroll(
   container: HTMLElement,
   {focusedElement, prevScrollHeight, prevNbMessages, messages, selfUserId}: MessageListContext,
 ) {
-  /*
-  console.log('felix', {
-    container,
-    focusedElement,
-    prevScrollHeight,
-    prevNbMessages,
-    messages,
-    selfUserId,
-  });
-  */
   const newNbMessages = messages.length;
   const lastMessage = messages[newNbMessages - 1];
   const scrollBottomPosition = container.scrollTop + container.clientHeight;

--- a/src/script/components/MessagesList/utils/scrollUpdater.ts
+++ b/src/script/components/MessagesList/utils/scrollUpdater.ts
@@ -1,0 +1,76 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Message} from 'src/script/entity/message/Message';
+import {StatusType} from 'src/script/message/StatusType';
+
+export type FocusedElement = {center?: boolean; element: Element};
+
+type MessageListContext = {
+  focusedElement: FocusedElement | null;
+  prevScrollHeight: number;
+  prevNbMessages: number;
+  messages: Message[];
+  selfUserId: string;
+};
+
+export function updateScroll(
+  container: HTMLElement,
+  {focusedElement, prevScrollHeight, prevNbMessages, messages, selfUserId}: MessageListContext,
+) {
+  /*
+  console.log('felix', {
+    container,
+    focusedElement,
+    prevScrollHeight,
+    prevNbMessages,
+    messages,
+    selfUserId,
+  });
+  */
+  const newNbMessages = messages.length;
+  const lastMessage = messages[newNbMessages - 1];
+  const scrollBottomPosition = container.scrollTop + container.clientHeight;
+  const shouldStickToBottom = prevScrollHeight - scrollBottomPosition < 100;
+
+  if (focusedElement) {
+    // If we have an element we want to focus
+    const {element, center} = focusedElement;
+    const elementPosition = element.getBoundingClientRect();
+    const containerPosition = container.getBoundingClientRect();
+    const scrollBy = container.scrollTop + elementPosition.top - containerPosition.top;
+    container.scrollTo?.({top: scrollBy - (center ? container.offsetHeight / 2 : 0)});
+  } else if (container.scrollTop === 0 && container.scrollHeight > prevScrollHeight) {
+    // If we hit the top and new messages were loaded, we keep the scroll position stable
+    container.scrollTop = container.scrollHeight - prevScrollHeight;
+  } else if (shouldStickToBottom) {
+    // We only want to animate the scroll if there are new messages in the list
+    const nbNewMessages = newNbMessages - prevNbMessages;
+    if (nbNewMessages <= 1) {
+      // We only want to animate the scroll if there is a single new message (many messages added at once means we are navigating the messages list)
+      const behavior = prevNbMessages !== newNbMessages ? 'smooth' : 'auto';
+      // Simple content update, we just scroll to bottom if we are in the stick to bottom threshold
+      container.scrollTo?.({behavior, top: container.scrollHeight});
+    }
+  } else if (lastMessage && lastMessage.status() === StatusType.SENDING && lastMessage.user().id === selfUserId) {
+    // The self user just sent a message, we scroll straight to the bottom
+    container.scrollTo?.({behavior: 'smooth', top: container.scrollHeight});
+  }
+  return container.scrollHeight;
+}

--- a/src/script/util/DOM/resizeObserver.ts
+++ b/src/script/util/DOM/resizeObserver.ts
@@ -58,5 +58,5 @@ export const useResizeObserver = (
       observedElements.delete(element);
       resizeObserver.unobserve(element);
     };
-  }, [element]);
+  }, [element, callback]);
 };

--- a/src/script/util/DOM/resizeObserver.ts
+++ b/src/script/util/DOM/resizeObserver.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {useEffect} from 'react';
+import {useLayoutEffect} from 'react';
 
 const observedElements = new Map<Element, (element: Element) => void>();
 
@@ -46,7 +46,8 @@ export const useResizeObserver = (
   callback: (element: Element | HTMLDivElement) => void,
   element?: Element | HTMLDivElement | null,
 ) => {
-  useEffect(() => {
+  // We need to use a layout effect here as we want to make sure the observer is set up (and removed!) before the component is rendered
+  useLayoutEffect(() => {
     if (!element) {
       return () => {};
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2505" title="WPB-2505" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-2505</a>  [Web] Automatic scroll to bottom of loaded message chunk after navigation to old messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

This will avoid automatic scrolling when we reach the bottom of the messages list and the app loads more subsequent messages. 

## Screenshots/Screencast (for UI changes)

### Before

https://github.com/wireapp/wire-webapp/assets/1090716/2d7317f7-c912-42a5-b8e7-25a000387147

### After

https://github.com/wireapp/wire-webapp/assets/1090716/8ed589a8-4ba5-4f15-ae7f-2e4cc1e0a88f

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

