### PR TITLE
feat: show read receipt in message header (WPB-6284)

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.test.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.test.tsx
@@ -50,6 +50,7 @@ describe('message', () => {
       isLastDeliveredMessage: false,
       hideHeader: false,
       message,
+      lastMessageInGroup: new ContentMessage(),
       onClickAvatar: jest.fn(),
       onClickButton: jest.fn(),
       onClickCancelRequest: jest.fn(),

--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -46,6 +46,7 @@ import {EphemeralStatusType} from '../../../../message/EphemeralStatusType';
 import {ContextMenuEntry} from '../../../../ui/ContextMenu';
 import {EphemeralTimer} from '../EphemeralTimer';
 import {MessageTime} from '../MessageTime';
+import {ReadIndicator} from '../ReadIndicator';
 import {useMessageFocusedTabIndex} from '../util';
 export interface ContentMessageProps extends Omit<MessageActions, 'onClickResetSession'> {
   contextMenu: {entries: ko.Subscribable<ContextMenuEntry[]>};
@@ -177,6 +178,12 @@ export const ContentMessageComponent = ({
               {timeAgo}
             </MessageTime>
           </span>
+          <ReadIndicator
+            message={message}
+            is1to1Conversation={conversation.is1to1()}
+            isLastDeliveredMessage={isLastDeliveredMessage}
+            showIconOnly
+          />
         </MessageHeader>
       )}
 

--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -47,7 +47,6 @@ import {EphemeralStatusType} from '../../../../message/EphemeralStatusType';
 import {ContextMenuEntry} from '../../../../ui/ContextMenu';
 import {EphemeralTimer} from '../EphemeralTimer';
 import {MessageTime} from '../MessageTime';
-import {ReadIndicator} from '../ReadIndicator';
 import {useMessageFocusedTabIndex} from '../util';
 export interface ContentMessageProps extends Omit<MessageActions, 'onClickResetSession'> {
   contextMenu: {entries: ko.Subscribable<ContextMenuEntry[]>};

--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -27,6 +27,7 @@ import {ReadIndicator} from 'Components/MessagesList/Message/ReadIndicator';
 import {Conversation} from 'src/script/entity/Conversation';
 import {CompositeMessage} from 'src/script/entity/message/CompositeMessage';
 import {ContentMessage} from 'src/script/entity/message/ContentMessage';
+import {Message} from 'src/script/entity/message/Message';
 import {useRelativeTimestamp} from 'src/script/hooks/useRelativeTimestamp';
 import {StatusType} from 'src/script/message/StatusType';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
@@ -59,6 +60,7 @@ export interface ContentMessageProps extends Omit<MessageActions, 'onClickResetS
   isFocused: boolean;
   isLastDeliveredMessage: boolean;
   message: ContentMessage;
+  lastMessageInGroup: Message;
   onClickButton: (message: CompositeMessage, buttonId: string) => void;
   onRetry: (message: ContentMessage) => void;
   quotedMessage?: ContentMessage;
@@ -70,6 +72,7 @@ export interface ContentMessageProps extends Omit<MessageActions, 'onClickResetS
 export const ContentMessageComponent = ({
   conversation,
   message,
+  lastMessageInGroup,
   findMessage,
   selfId,
   hideHeader,
@@ -179,9 +182,9 @@ export const ContentMessageComponent = ({
             </MessageTime>
           </span>
           <ReadIndicator
-            message={message}
+            message={lastMessageInGroup}
             is1to1Conversation={conversation.is1to1()}
-            isLastDeliveredMessage={isLastDeliveredMessage}
+            isLastDeliveredMessage={isLastDeliveredMessage || lastMessageInGroup.status() === StatusType.DELIVERED}
             showIconOnly
           />
         </MessageHeader>

--- a/src/script/components/MessagesList/Message/MessageWrapper.tsx
+++ b/src/script/components/MessagesList/Message/MessageWrapper.tsx
@@ -68,6 +68,7 @@ export const MessageWrapper: React.FC<MessageParams> = ({
   isFocused,
   isSelfTemporaryGuest,
   isLastDeliveredMessage,
+  lastMessageInGroup,
   shouldShowInvitePeople,
   hideHeader,
   hasReadReceiptsTurnedOn,
@@ -184,6 +185,7 @@ export const MessageWrapper: React.FC<MessageParams> = ({
     return (
       <ContentMessageComponent
         message={message}
+        lastMessageInGroup={lastMessageInGroup}
         findMessage={findMessage}
         conversation={conversation}
         hideHeader={hideHeader}

--- a/src/script/components/MessagesList/Message/index.tsx
+++ b/src/script/components/MessagesList/Message/index.tsx
@@ -59,6 +59,7 @@ export interface MessageParams extends MessageActions {
   conversation: Conversation;
   hasReadReceiptsTurnedOn: boolean;
   isLastDeliveredMessage: boolean;
+  lastMessageInGroup: BaseMessage;
   isSelfTemporaryGuest: boolean;
   message: BaseMessage;
   /** whether the message should display the user avatar and user name before the actual content */

--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -264,6 +264,8 @@ export const MessagesList: FC<MessagesListParams> = ({
           return messages.map(message => {
             const isLastDeliveredMessage = lastDeliveredMessage?.id === message.id;
 
+            const lastMessageInGroup = group.messages[messages.length - 1];
+
             const visibleCallback = getVisibleCallback(conversation, message);
 
             const key = `${message.id || 'message'}-${message.timestamp()}`;
@@ -276,6 +278,7 @@ export const MessagesList: FC<MessagesListParams> = ({
                 key={key}
                 onVisible={visibleCallback}
                 message={message}
+                lastMessageInGroup={lastMessageInGroup}
                 hideHeader={message.timestamp() !== firstMessageTimestamp}
                 messageActions={messageActions}
                 conversation={conversation}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6284" title="WPB-6284" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-6284</a>  [Web] Message Group Header Read indicators
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

A non clickeable read receipt is added after the message header (username + timestamp)
It reflects the status of the *last* message in the group

## Screenshots/Screencast (for UI changes)

1on1:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/8b74fc95-4eb7-468e-98d9-0858ab624011)

Group:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/242a0235-dc72-46dc-bd78-c03c3606e7f7)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
