### PR TITLE
feat: add favorites, groups & directs tabs (WPB-5946)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@wireapp/avs": "9.6.9",
     "@wireapp/commons": "5.2.5",
     "@wireapp/core": "44.0.1",
-    "@wireapp/react-ui-kit": "9.15.3",
+    "@wireapp/react-ui-kit": "9.16.0",
     "@wireapp/store-engine-dexie": "2.1.7",
     "@wireapp/webapp-events": "0.20.1",
     "amplify": "https://github.com/wireapp/amplify#head=master",

--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -483,6 +483,7 @@
   "conversationJustNow": "Just now",
   "conversationLabelFavorites": "Favorites",
   "conversationLabelGroups": "Groups",
+  "conversationLabelDirects": "1:1 Conversations",
   "conversationLabelPeople": "People",
   "conversationLikesCaptionPlural": "[bold]{{firstUser}}[/bold] and [bold]{{secondUser}}[/bold]",
   "conversationLikesCaptionPluralMoreThan2": "[bold]{{userNames}}[/bold] and [showmore]{{number}} more[/showmore]",

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -82,6 +82,7 @@ export enum ConversationViewStyle {
   FOLDER,
   FAVORITES,
   GROUPS,
+  DIRECTS,
 }
 
 const Conversations: React.FC<ConversationsProps> = ({
@@ -119,7 +120,9 @@ const Conversations: React.FC<ConversationsProps> = ({
 
   const favoriteConversations = conversationLabelRepository.getFavorites(conversations);
   const groupConversations = conversations.filter(conversation => conversation.isGroup());
+  const directConversations = conversations.filter(conversation => conversation.is1to1());
   const totalUnreadGroupConversations = groupConversations.filter(conversation => conversation.hasUnread()).length;
+  const totalUnreadDirectConversations = groupConversations.filter(conversation => conversation.hasUnread()).length;
 
   const totalUnreadConversations = unreadConversations.length;
 
@@ -149,6 +152,7 @@ const Conversations: React.FC<ConversationsProps> = ({
   const isFolderViewStyle = viewStyle === ConversationViewStyle.FOLDER;
   const isFavoritesViewStyle = viewStyle === ConversationViewStyle.FAVORITES;
   const isGroupsViewStyle = viewStyle === ConversationViewStyle.GROUPS;
+  const isDirectsViewStyle = viewStyle === ConversationViewStyle.DIRECTS;
 
   const hasNoConversations = conversations.length + connectRequests.length === 0;
   const {isOpen: isFolderOpen, openFolder} = useFolderState();
@@ -256,7 +260,7 @@ const Conversations: React.FC<ConversationsProps> = ({
       <div
         role="tablist"
         aria-label={t('accessibility.headings.sidebar')}
-        aria-owns="tab-1 tab-2 tab-3 tab-4 tab-5 tab-6"
+        aria-owns="tab-1 tab-2 tab-3 tab-4 tab-5 tab-6 tab-7"
         className="conversations-sidebar-list"
       >
         <div className="conversations-sidebar-title">{t('videoCallOverlayConversations')}</div>
@@ -325,6 +329,26 @@ const Conversations: React.FC<ConversationsProps> = ({
           id="tab-4"
           type="button"
           role="tab"
+          className={cx(`conversations-sidebar-btn`, {active: isDirectsViewStyle})}
+          onClick={() => setViewStyle(ConversationViewStyle.DIRECTS)}
+          title={t('conversationLabelDirects')}
+          data-uie-name="go-favorites-view"
+          data-uie-status={isDirectsViewStyle ? 'active' : 'inactive'}
+          aria-selected={isDirectsViewStyle}
+        >
+          <span className="conversations-sidebar-btn--text-wrapper">
+            <Icon.People />
+            <span className="conversations-sidebar-btn--text">{t('conversationLabelDirects')}</span>
+          </span>
+          {totalUnreadDirectConversations > 0 && (
+            <span className="conversations-sidebar-btn--badge">{totalUnreadDirectConversations}</span>
+          )}
+        </button>
+
+        <button
+          id="tab-5"
+          type="button"
+          role="tab"
           className={cx(`conversations-sidebar-btn`, {active: isFolderViewStyle})}
           onClick={() => setViewStyle(ConversationViewStyle.FOLDER)}
           title={t('folderViewTooltip')}
@@ -343,7 +367,7 @@ const Conversations: React.FC<ConversationsProps> = ({
 
         {archivedConversations.length > 0 && (
           <button
-            id="tab-5"
+            id="tab-6"
             type="button"
             className="conversations-sidebar-btn"
             data-uie-name="go-archive"
@@ -361,7 +385,7 @@ const Conversations: React.FC<ConversationsProps> = ({
         )}
         <div className="conversations-sidebar-title">{t('conversationFooterContacts')}</div>
         <button
-          id="tab-6"
+          id="tab-7"
           type="button"
           className="conversations-sidebar-btn"
           onClick={() => switchList(ListState.START_UI)}
@@ -414,6 +438,10 @@ const Conversations: React.FC<ConversationsProps> = ({
 
     if (viewStyle === ConversationViewStyle.GROUPS) {
       return groupConversations;
+    }
+
+    if (viewStyle === ConversationViewStyle.DIRECTS) {
+      return directConversations;
     }
 
     if (viewStyle === ConversationViewStyle.FAVORITES) {

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -255,6 +255,13 @@ const Conversations: React.FC<ConversationsProps> = ({
     </>
   );
 
+  function changeViewStyle(viewStyle: ConversationViewStyle) {
+    if (viewStyle !== ConversationViewStyle.RECENT) {
+      setConversationsFilter('');
+    }
+    setViewStyle(viewStyle);
+  }
+
   const sidebar = (
     <nav className="conversations-sidebar">
       <div
@@ -270,7 +277,7 @@ const Conversations: React.FC<ConversationsProps> = ({
           type="button"
           role="tab"
           className={cx(`conversations-sidebar-btn`, {active: isRecentViewStyle})}
-          onClick={() => setViewStyle(ConversationViewStyle.RECENT)}
+          onClick={() => changeViewStyle(ConversationViewStyle.RECENT)}
           title={t('conversationViewTooltip')}
           data-uie-name="go-recent-view"
           data-uie-status={isRecentViewStyle ? 'active' : 'inactive'}
@@ -290,7 +297,7 @@ const Conversations: React.FC<ConversationsProps> = ({
           type="button"
           role="tab"
           className={cx(`conversations-sidebar-btn`, {active: isFavoritesViewStyle})}
-          onClick={() => setViewStyle(ConversationViewStyle.FAVORITES)}
+          onClick={() => changeViewStyle(ConversationViewStyle.FAVORITES)}
           title={t('conversationLabelFavorites')}
           data-uie-name="go-favorites-view"
           data-uie-status={isFavoritesViewStyle ? 'active' : 'inactive'}
@@ -310,7 +317,7 @@ const Conversations: React.FC<ConversationsProps> = ({
           type="button"
           role="tab"
           className={cx(`conversations-sidebar-btn`, {active: isGroupsViewStyle})}
-          onClick={() => setViewStyle(ConversationViewStyle.GROUPS)}
+          onClick={() => changeViewStyle(ConversationViewStyle.GROUPS)}
           title={t('conversationLabelGroups')}
           data-uie-name="go-favorites-view"
           data-uie-status={isGroupsViewStyle ? 'active' : 'inactive'}
@@ -330,7 +337,7 @@ const Conversations: React.FC<ConversationsProps> = ({
           type="button"
           role="tab"
           className={cx(`conversations-sidebar-btn`, {active: isDirectsViewStyle})}
-          onClick={() => setViewStyle(ConversationViewStyle.DIRECTS)}
+          onClick={() => changeViewStyle(ConversationViewStyle.DIRECTS)}
           title={t('conversationLabelDirects')}
           data-uie-name="go-favorites-view"
           data-uie-status={isDirectsViewStyle ? 'active' : 'inactive'}
@@ -350,7 +357,7 @@ const Conversations: React.FC<ConversationsProps> = ({
           type="button"
           role="tab"
           className={cx(`conversations-sidebar-btn`, {active: isFolderViewStyle})}
-          onClick={() => setViewStyle(ConversationViewStyle.FOLDER)}
+          onClick={() => changeViewStyle(ConversationViewStyle.FOLDER)}
           title={t('folderViewTooltip')}
           data-uie-name="go-folder-view"
           data-uie-status={isFolderViewStyle ? 'active' : 'inactive'}

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -122,7 +122,7 @@ const Conversations: React.FC<ConversationsProps> = ({
   const groupConversations = conversations.filter(conversation => conversation.isGroup());
   const directConversations = conversations.filter(conversation => conversation.is1to1());
   const totalUnreadGroupConversations = groupConversations.filter(conversation => conversation.hasUnread()).length;
-  const totalUnreadDirectConversations = groupConversations.filter(conversation => conversation.hasUnread()).length;
+  const totalUnreadDirectConversations = directConversations.filter(conversation => conversation.hasUnread()).length;
 
   const totalUnreadConversations = unreadConversations.length;
 

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -24,7 +24,7 @@ import {amplify} from 'amplify';
 import cx from 'classnames';
 import {container} from 'tsyringe';
 
-import {CircleCloseIcon, Input, SearchIcon} from '@wireapp/react-ui-kit';
+import {CircleCloseIcon, Input, SearchIcon, StarIcon} from '@wireapp/react-ui-kit';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {CallingCell} from 'Components/calling/CallingCell';
@@ -289,7 +289,7 @@ const Conversations: React.FC<ConversationsProps> = ({
           aria-selected={isFavoritesViewStyle}
         >
           <span className="conversations-sidebar-btn--text-wrapper">
-            <Icon.ConversationsOutline />
+            <StarIcon />
             <span className="conversations-sidebar-btn--text">{t('conversationLabelFavorites')}</span>
           </span>
           {totalUnreadFavoriteConversations > 0 && (

--- a/src/script/page/LeftSidebar/panels/Conversations/GroupedConversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/GroupedConversations.tsx
@@ -33,7 +33,6 @@ import {
   ConversationLabel,
   ConversationLabelRepository,
   createLabel,
-  createLabelFavorites,
   createLabelGroups,
   createLabelPeople,
 } from '../../../../conversation/ConversationLabelRepository';
@@ -85,7 +84,6 @@ const GroupedConversations: React.FC<GroupedConversationsProps> = ({
 
   useLabels(conversationLabelRepository);
 
-  const favorites = conversationLabelRepository.getFavorites(conversations);
   const groups = conversationLabelRepository.getGroupsWithoutLabel(conversations);
   const contacts = conversationLabelRepository.getContactsWithoutLabel(conversations);
   const custom = conversationLabelRepository
@@ -94,7 +92,6 @@ const GroupedConversations: React.FC<GroupedConversationsProps> = ({
     .filter(({conversations}) => !!conversations().length);
 
   const folders = [
-    ...(favorites.length > 0 ? [createLabelFavorites(favorites)] : []),
     ...(groups.length > 0 ? [createLabelGroups(groups)] : []),
     ...(contacts.length > 0 ? [createLabelPeople(contacts)] : []),
     ...custom,

--- a/src/style/foundation/framework.less
+++ b/src/style/foundation/framework.less
@@ -28,6 +28,7 @@
 
   .left-column {
     position: relative;
+    display: flex;
     min-width: @conversation-list-width;
     flex: 0 0 auto;
     border-right: 1px solid var(--sidebar-border-color);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4992,9 +4992,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/react-ui-kit@npm:9.15.3":
-  version: 9.15.3
-  resolution: "@wireapp/react-ui-kit@npm:9.15.3"
+"@wireapp/react-ui-kit@npm:9.16.0":
+  version: 9.16.0
+  resolution: "@wireapp/react-ui-kit@npm:9.16.0"
   dependencies:
     "@types/color": 3.0.6
     color: 4.2.3
@@ -5009,7 +5009,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: a39658ee797f9d61af24c457a2d68918c1d08c5565c2f630de20906000253a5333905c0ae4010159b7421ac4585b9ca9036a4151360a6da5d48a99633562aca2
+  checksum: 2e863cb084c63bf0c9b9c13adaedaa791ceeaf226c298f3a12a5be5b10ef068d8c3a90fd65188dba82b4394f45bd8a0cfaa14d38a8877c95a5c87a71cde2dcb1
   languageName: node
   linkType: hard
 
@@ -17531,7 +17531,7 @@ __metadata:
     "@wireapp/core": 44.0.1
     "@wireapp/eslint-config": 3.0.6
     "@wireapp/prettier-config": 0.6.3
-    "@wireapp/react-ui-kit": 9.15.3
+    "@wireapp/react-ui-kit": 9.16.0
     "@wireapp/store-engine": ^5.1.4
     "@wireapp/store-engine-dexie": 2.1.7
     "@wireapp/webapp-events": 0.20.1


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5946" title="WPB-5946" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-5946</a>  Add Favorites, Groups and 1:1 conversations to sidebar
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# Favorite Conversations Tab
This new feature aims to streamline organization and prioritize essential interactions for our users.

# What's New?
Favorite Conversations Tab: Added a dedicated tab in the sidebar exclusively for your favorite conversations. Now, you can easily access and manage your most important discussions without sifting through folders or clutter.

<img width="545" alt="image" src="https://github.com/wireapp/wire-webapp/assets/63250054/693dbdec-93ca-406c-a239-ad131b457616">

# Favorites, Groups & People Folder Removed:
With the introduction of the new tabs, the folders of Favorites, Groups & People are removed from the folders view. This means for example that instead of having a separate folder for favorites, you'll now find all your favorite conversations conveniently located within the dedicated tab in the sidebar.