### PR TITLE
runfix: prevent erroneous audio repository error logs

### DIFF
--- a/src/script/audio/AudioRepository.ts
+++ b/src/script/audio/AudioRepository.ts
@@ -162,6 +162,7 @@ export class AudioRepository {
           this.logger.error(`Failed to play sound '${audioId}': ${error.message}`);
           throw error;
         }
+        break;
 
       case AUDIO_PLAY_PERMISSION.DISALLOWED_BY_MUTE_STATE:
         this.logger.debug(`Playing '${audioId}' was disallowed by mute state`);


### PR DESCRIPTION
## Description

a missing `break` in a switch statement results in always having an incorrect error log when receiving a call

```javascript
@wireapp/webapp/AudioRepository [2024-02-20 09:05:19]  Playing sound 'ringing_from_them' (loop: 'true')
@wireapp/webapp/AudioRepository [2024-02-20 09:05:19]  Playing 'ringing_from_them' was disallowed by mute state
```


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
