### PR TITLE
runfix: team mls 1to1 not established on new device

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1803,11 +1803,14 @@ export class ConversationRepository {
       throw new Error('Self user is not available!');
     }
 
-    // If its a 1:1 conversation between two users from the same team we should not establish it automatically (unless there was already a proteus 1:1 conversation),
-    // it will be established once first mls message is sent in a conversation
+    // If its a 1:1 conversation between two users from the same team we should not establish it automatically,
+    // unless there was already a proteus 1:1 conversation or the MLS group is already established on backend.
+    // It will be established once first mls message is sent in a conversation.
     const isTeamMember = !!selfUser.teamId && !!otherUser.teamId && selfUser.teamId === otherUser.teamId;
 
-    const shouldEstablishMLS1to1 = !isTeamMember || wasProteus1to1Replaced;
+    const isMLSGroupEstablishedOnBackend = mlsConversation.epoch > 0;
+
+    const shouldEstablishMLS1to1 = isMLSGroupEstablishedOnBackend || !isTeamMember || wasProteus1to1Replaced;
 
     const initialisedMLSConversation = shouldEstablishMLS1to1
       ? await this.establishMLS1to1Conversation(mlsConversation, otherUserId)


### PR DESCRIPTION
## Description

We don't want to establish mls 1:1 conversations between team members automatically (when navigating to a contact), but rather after first message in a conversation is sent. 

But if the group is already established on backend (epoch number is > 0) we want to establish a group anyway (by establishing we usually mean joining it with external commit).

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;