### PR TITLE
fix: Make sure e2ei data is no shared accross users [WPB-6746]

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@peculiar/x509": "1.9.6",
     "@wireapp/avs": "9.6.11",
     "@wireapp/commons": "5.2.4",
-    "@wireapp/core": "44.0.8",
+    "@wireapp/core": "44.0.10",
     "@wireapp/react-ui-kit": "9.15.4",
     "@wireapp/store-engine-dexie": "2.1.7",
     "@wireapp/webapp-events": "0.20.1",

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.test.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.test.ts
@@ -121,7 +121,7 @@ describe('E2EIHandler', () => {
     await instance.initialize(params);
     void instance.attemptEnrollment();
     await wait(1);
-    expect(container.resolve(Core).service?.e2eIdentity?.registerServerCertificates).toHaveBeenCalled();
+    expect(container.resolve(Core).service?.e2eIdentity?.initialize).toHaveBeenCalled();
     expect(instance['currentStep']).toBe(E2EIHandlerStep.INITIALIZED);
   });
 
@@ -206,7 +206,7 @@ describe('E2EIHandler', () => {
     // set active certificate to be truthy
     (hasActiveCertificate as jest.Mock).mockResolvedValue(true);
 
-    jest.spyOn(container.resolve(Core).service!.e2eIdentity!, 'isEnrollmentInProgress').mockReturnValue(false);
+    jest.spyOn(container.resolve(Core).service!.e2eIdentity!, 'isEnrollmentInProgress').mockResolvedValue(false);
 
     // Spy on renewCertificate to check if it's called
     const renewCertificateSpy = jest.spyOn(handler as any, 'renewCertificate');
@@ -226,7 +226,7 @@ describe('E2EIHandler', () => {
 
     // Set active certificate to be truthy and enrollment in progress
     (hasActiveCertificate as jest.Mock).mockResolvedValue(true);
-    jest.spyOn(container.resolve(Core).service!.e2eIdentity!, 'isEnrollmentInProgress').mockReturnValue(true);
+    jest.spyOn(container.resolve(Core).service!.e2eIdentity!, 'isEnrollmentInProgress').mockResolvedValue(true);
 
     // Spy on enroll to check if it's called
     const enrollSpy = jest.spyOn(handler, 'enroll');
@@ -249,7 +249,7 @@ describe('E2EIHandler', () => {
 
     // Set active certificate to be truthy and enrollment not in progress
     (hasActiveCertificate as jest.Mock).mockResolvedValue(true);
-    jest.spyOn(container.resolve(Core).service!.e2eIdentity!, 'isEnrollmentInProgress').mockReturnValue(false);
+    jest.spyOn(container.resolve(Core).service!.e2eIdentity!, 'isEnrollmentInProgress').mockResolvedValue(false);
 
     const timeRemainingMS = 60 * TimeInMillis.DAY; // 60 days remaining
 

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -170,7 +170,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
     }
 
     // Check if an enrollment is already in progress
-    if (this.coreE2EIService.isEnrollmentInProgress()) {
+    if (await this.coreE2EIService.isEnrollmentInProgress()) {
       return this.enroll();
     }
 
@@ -249,7 +249,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
     this.oidcService = this.createOIDCService();
     await this.oidcService.clearProgress(includeOidcServiceUserData);
     // Clear the e2e identity progress
-    this.coreE2EIService.clearAllProgress();
+    await this.coreE2EIService.clearAllProgress();
   }
 
   public async enroll(userData?: User) {
@@ -264,7 +264,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
 
       if (!userData) {
         // If the enrolment is in progress, we need to get the id token from the oidc service, since oauth should have already been completed
-        if (this.coreE2EIService.isEnrollmentInProgress()) {
+        if (await this.coreE2EIService.isEnrollmentInProgress()) {
           // The redirect-url which is needed inside the OIDCService is stored in the OIDCServiceStore previously
           this.oidcService = this.createOIDCService();
           userData = await this.oidcService.handleAuthentication();
@@ -366,7 +366,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
     // Clear the oidc service progress
     await this.oidcService?.clearProgress();
     // Clear the e2e identity progress
-    this.coreE2EIService.clearAllProgress();
+    await this.coreE2EIService.clearAllProgress();
 
     const disableSnooze = await shouldEnableSoftLock(this.config!);
 
@@ -437,7 +437,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
   private async startEnrollment(enrollmentType: ModalType.CERTIFICATE_RENEWAL | ModalType.ENROLL): Promise<void> {
     // If the user has already started enrolment, don't show the notification. Instead, show the loading modal
     // This will occur after the redirect from the oauth provider
-    if (this.coreE2EIService.isEnrollmentInProgress()) {
+    if (await this.coreE2EIService.isEnrollmentInProgress()) {
       return this.enroll();
     }
 

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -135,14 +135,6 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
     };
 
     await this.coreE2EIService.initialize(discoveryUrl);
-    await this.coreE2EIService.registerServerCertificates();
-
-    try {
-      //FIXME: this doesn't work on curernt core-crypto version
-      await this.coreE2EIService.validateSelfCrl();
-    } catch (error) {
-      console.error('Error validating self CRL', error);
-    }
 
     this.currentStep = E2EIHandlerStep.INITIALIZED;
     this.emit('initialized', {enrollmentConfig: this.config});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4895,9 +4895,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:44.0.8":
-  version: 44.0.8
-  resolution: "@wireapp/core@npm:44.0.8"
+"@wireapp/core@npm:44.0.10":
+  version: 44.0.10
+  resolution: "@wireapp/core@npm:44.0.10"
   dependencies:
     "@wireapp/api-client": ^26.10.10
     "@wireapp/commons": ^5.2.5
@@ -4916,7 +4916,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: c3d43c543dd751cc0632ff2cfdc5c0da71886b23ce59391366654633585f415aaa5cfb45d56843db1c11fa9ac3079b8f8824689a1c151f6fce53ef1f8c9d3613
+  checksum: e993858b9cd92115304d49c0faf11954715836acba9a5c82d177adc951766dbcb2b0cf21e771f193a3e75366a0ee1185ec72032a825be30976a2a7c20faf5137
   languageName: node
   linkType: hard
 
@@ -17624,7 +17624,7 @@ __metadata:
     "@wireapp/avs": 9.6.11
     "@wireapp/commons": 5.2.4
     "@wireapp/copy-config": 2.1.14
-    "@wireapp/core": 44.0.8
+    "@wireapp/core": 44.0.10
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.15.4


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6746" title="WPB-6746" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6746</a>  Loading bar freezes when login with other account on same browser (Could not find E2EI ACME root CA in keystore with value)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

see 
- https://github.com/wireapp/wire-web-packages/pull/5996
- https://github.com/wireapp/wire-web-packages/pull/6000

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
