### PR TITLE
fix: read indicator displaying

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -20,7 +20,9 @@
 import {useMemo, useState, useEffect} from 'react';
 
 import {QualifiedId} from '@wireapp/api-client/lib/user';
+import cx from 'classnames';
 
+import {ReadIndicator} from 'Components/MessagesList/Message/ReadIndicator';
 import {Conversation} from 'src/script/entity/Conversation';
 import {CompositeMessage} from 'src/script/entity/message/CompositeMessage';
 import {ContentMessage} from 'src/script/entity/message/ContentMessage';
@@ -40,6 +42,7 @@ import {Quote} from './MessageQuote';
 import {CompleteFailureToSendWarning, PartialFailureToSendWarning} from './Warnings';
 
 import {MessageActions} from '..';
+import type {FileAsset as FileAssetType} from '../../../../entity/message/FileAsset';
 import {EphemeralStatusType} from '../../../../message/EphemeralStatusType';
 import {ContextMenuEntry} from '../../../../ui/ContextMenu';
 import {EphemeralTimer} from '../EphemeralTimer';
@@ -94,7 +97,7 @@ export const ContentMessageComponent = ({
   const {
     senderName,
     timestamp,
-    ephemeral_caption,
+    ephemeral_caption: ephemeralCaption,
     ephemeral_status,
     assets,
     was_edited,
@@ -103,6 +106,7 @@ export const ContentMessageComponent = ({
     status,
     user,
     quote,
+    isObfuscated,
   } = useKoSubscribableChildren(message, [
     'senderName',
     'timestamp',
@@ -115,6 +119,7 @@ export const ContentMessageComponent = ({
     'status',
     'user',
     'quote',
+    'isObfuscated',
   ]);
 
   const shouldShowMessageHeader = (): boolean => {
@@ -153,18 +158,28 @@ export const ContentMessageComponent = ({
 
   const isConversationReadonly = conversation.readOnlyState() !== null;
 
+  const contentMessageWrapperRef = (element: HTMLDivElement | null) => {
+    setTimeout(() => {
+      if (element?.parentElement?.querySelector(':hover') === element) {
+        // Trigger the action menu in case the component is rendered with the mouse already hovering over it
+        setActionMenuVisibility(true);
+      }
+    });
+  };
+
+  const asset = assets[0];
+  const isFileMessage = (asset as FileAssetType).isFile();
+  const isAudioMessage = (asset as FileAssetType).isAudio();
+  const isVideoMessage = (asset as FileAssetType).isVideo();
+  const isImageMessage = (asset as FileAssetType).isImage();
+
+  const isAssetMessage = isFileMessage || isAudioMessage || isVideoMessage || isImageMessage;
+
   return (
     <div
       aria-label={messageAriaLabel}
       className="content-message-wrapper"
-      ref={element => {
-        setTimeout(() => {
-          if (element?.parentElement?.querySelector(':hover') === element) {
-            // Trigger the action menu in case the component is rendered with the mouse already hovering over it
-            setActionMenuVisibility(true);
-          }
-        });
-      }}
+      ref={contentMessageWrapperRef}
       onMouseEnter={() => {
         // open another floating action menu if none already open
         if (!isMenuOpen) {
@@ -192,60 +207,75 @@ export const ContentMessageComponent = ({
         </MessageHeader>
       )}
 
-      <div className="message-body">
-        <div className="message-body-content" title={ephemeral_caption}>
-          {ephemeral_status === EphemeralStatusType.ACTIVE && (
-            <div className="message-ephemeral-timer">
-              <EphemeralTimer message={message} />
-            </div>
-          )}
+      <div
+        className={cx('message-body', {
+          'message-asset': isAssetMessage,
+          'ephemeral-asset-expired': isObfuscated,
+          'icon-file': isObfuscated && isFileMessage,
+          'icon-movie': isObfuscated && isVideoMessage,
+        })}
+        {...(ephemeralCaption && {title: ephemeralCaption})}
+      >
+        {ephemeral_status === EphemeralStatusType.ACTIVE && (
+          <div className="message-ephemeral-timer">
+            <EphemeralTimer message={message} />
+          </div>
+        )}
 
-          {quote && (
-            <Quote
-              conversation={conversation}
-              quote={quote}
-              selfId={selfId}
-              findMessage={findMessage}
-              showDetail={onClickImage}
-              focusMessage={onClickTimestamp}
-              handleClickOnMessage={onClickMessage}
-              showUserDetails={onClickAvatar}
-              isMessageFocused={msgFocusState}
-            />
-          )}
+        {quote && (
+          <Quote
+            conversation={conversation}
+            quote={quote}
+            selfId={selfId}
+            findMessage={findMessage}
+            showDetail={onClickImage}
+            focusMessage={onClickTimestamp}
+            handleClickOnMessage={onClickMessage}
+            showUserDetails={onClickAvatar}
+            isMessageFocused={msgFocusState}
+          />
+        )}
 
-          {assets.map(asset => (
-            <ContentAsset
-              key={asset.type}
-              asset={asset}
-              message={message}
-              selfId={selfId}
-              onClickButton={onClickButton}
-              onClickImage={onClickImage}
-              onClickMessage={onClickMessage}
-              isMessageFocused={msgFocusState}
-              is1to1Conversation={conversation.is1to1()}
-              isLastDeliveredMessage={isLastDeliveredMessage}
-              onClickDetails={() => onClickDetails(message)}
-            />
-          ))}
+        {assets.map(asset => (
+          <ContentAsset
+            key={asset.type}
+            asset={asset}
+            message={message}
+            selfId={selfId}
+            onClickButton={onClickButton}
+            onClickImage={onClickImage}
+            onClickMessage={onClickMessage}
+            isMessageFocused={msgFocusState}
+            is1to1Conversation={conversation.is1to1()}
+            isLastDeliveredMessage={isLastDeliveredMessage}
+            onClickDetails={() => onClickDetails(message)}
+          />
+        ))}
 
-          {failedToSend && (
-            <PartialFailureToSendWarning
-              isMessageFocused={msgFocusState}
-              failedToSend={failedToSend}
-              knownUsers={conversation.allUserEntities()}
-            />
-          )}
+        {failedToSend && (
+          <PartialFailureToSendWarning
+            isMessageFocused={msgFocusState}
+            failedToSend={failedToSend}
+            knownUsers={conversation.allUserEntities()}
+          />
+        )}
 
-          {[StatusType.FAILED, StatusType.FEDERATION_ERROR].includes(status) && (
-            <CompleteFailureToSendWarning
-              {...(status === StatusType.FEDERATION_ERROR && {unreachableDomain: conversation.domain})}
-              isMessageFocused={msgFocusState}
-              onRetry={() => onRetry(message)}
-            />
-          )}
-        </div>
+        {[StatusType.FAILED, StatusType.FEDERATION_ERROR].includes(status) && (
+          <CompleteFailureToSendWarning
+            {...(status === StatusType.FEDERATION_ERROR && {unreachableDomain: conversation.domain})}
+            isMessageFocused={msgFocusState}
+            onRetry={() => onRetry(message)}
+          />
+        )}
+
+        {isAssetMessage && (
+          <ReadIndicator
+            message={message}
+            is1to1Conversation={conversation.is1to1()}
+            isLastDeliveredMessage={isLastDeliveredMessage}
+            onClick={onClickDetails}
+          />
+        )}
 
         {!isConversationReadonly && isActionMenuVisible && (
           <MessageActionsMenu

--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -167,11 +167,11 @@ export const ContentMessageComponent = ({
     });
   };
 
-  const asset = assets[0];
-  const isFileMessage = (asset as FileAssetType).isFile();
-  const isAudioMessage = (asset as FileAssetType).isAudio();
-  const isVideoMessage = (asset as FileAssetType).isVideo();
-  const isImageMessage = (asset as FileAssetType).isImage();
+  const asset = assets?.[0];
+  const isFileMessage = !!(asset as FileAssetType)?.isFile();
+  const isAudioMessage = !!(asset as FileAssetType)?.isAudio();
+  const isVideoMessage = !!(asset as FileAssetType)?.isVideo();
+  const isImageMessage = !!(asset as FileAssetType)?.isImage();
 
   const isAssetMessage = isFileMessage || isAudioMessage || isVideoMessage || isImageMessage;
 

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset.tsx
@@ -102,8 +102,7 @@ export const ImageAsset: React.FC<ImageAssetProps> = ({
 
   const imageContainerStyle: CSSObject = {
     aspectRatio: isFileSharingReceivingEnabled ? `${asset.ratio}` : undefined,
-    maxWidth: 'var(--conversation-message-asset-width)',
-    width: asset.width,
+    maxWidth: 'calc(100% - var(--conversation-message-sender-width))',
     maxHeight: '80vh',
   };
 

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer/TextMessageRenderer.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/TextMessageRenderer/TextMessageRenderer.tsx
@@ -19,6 +19,8 @@
 
 import {useEffect, FC, useState, HTMLProps, useRef} from 'react';
 
+import cx from 'classnames';
+
 import {isKeyDownEvent} from 'src/script/guards/Event';
 import {isAuxClickEvent, isClickEvent} from 'src/script/guards/Mouse';
 import {getAllFocusableElements, setElementsTabIndex} from 'Util/focusUtil';
@@ -132,8 +134,6 @@ const TextMessage: FC<TextMessageRendererProps> = ({
     }
   };
 
-  const extraClasses = showFullText ? 'message-quote__text--full' : '';
-
   const toggleShowMore = () => setShowFullText(prev => !prev);
 
   return (
@@ -152,9 +152,12 @@ const TextMessage: FC<TextMessageRendererProps> = ({
         onKeyUp={handleInteraction}
         dangerouslySetInnerHTML={{__html: text}}
         dir="auto"
-        className={`${className} ${extraClasses}`}
+        className={cx(className, {
+          'message-quote__text--full': showFullText,
+        })}
         {...props}
       />
+
       {canShowMore && (
         <ShowMoreButton onClick={toggleShowMore} isFocusable={isFocusable} active={showFullText}></ShowMoreButton>
       )}

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
@@ -119,71 +119,33 @@ const ContentAsset = ({
           ))}
         </>
       );
+
     case AssetType.FILE:
       if ((asset as FileAssetType).isFile()) {
-        return (
-          <div className={`message-asset ${isObfuscated ? 'ephemeral-asset-expired icon-file' : ''}`}>
-            <FileAsset message={message} isFocusable={isMessageFocused} />
-
-            <ReadIndicator
-              message={message}
-              is1to1Conversation={is1to1Conversation}
-              isLastDeliveredMessage={isLastDeliveredMessage}
-              onClick={onClickDetails}
-            />
-          </div>
-        );
+        return <FileAsset message={message} isFocusable={isMessageFocused} />;
       }
 
       if ((asset as FileAssetType).isAudio()) {
-        return (
-          <div className={`message-asset ${isObfuscated ? 'ephemeral-asset-expired' : ''}`}>
-            <AudioAsset message={message} isFocusable={isMessageFocused} />
-
-            <ReadIndicator
-              message={message}
-              is1to1Conversation={is1to1Conversation}
-              isLastDeliveredMessage={isLastDeliveredMessage}
-              onClick={onClickDetails}
-            />
-          </div>
-        );
+        return <AudioAsset message={message} isFocusable={isMessageFocused} />;
       }
 
       if ((asset as FileAssetType).isVideo()) {
-        return (
-          <div className={`message-asset ${isObfuscated ? 'ephemeral-asset-expired icon-movie' : ''}`}>
-            <VideoAsset message={message} isFocusable={isMessageFocused} />
-
-            <ReadIndicator
-              message={message}
-              is1to1Conversation={is1to1Conversation}
-              isLastDeliveredMessage={isLastDeliveredMessage}
-              onClick={onClickDetails}
-            />
-          </div>
-        );
+        return <VideoAsset message={message} isFocusable={isMessageFocused} />;
       }
+
     case AssetType.IMAGE:
       return (
-        <div className={`message-asset ${isObfuscated ? 'ephemeral-asset-expired' : ''}`}>
-          <ImageAsset
-            asset={asset as MediumImage}
-            message={message}
-            onClick={onClickImage}
-            isFocusable={isMessageFocused}
-          />
-
-          <ReadIndicator
-            message={message}
-            is1to1Conversation={is1to1Conversation}
-            isLastDeliveredMessage={isLastDeliveredMessage}
-            onClick={onClickDetails}
-          />
-        </div>
+        <ImageAsset
+          asset={asset as MediumImage}
+          message={message}
+          onClick={onClickImage}
+          isFocusable={isMessageFocused}
+        />
       );
+
     case AssetType.LOCATION:
       return <LocationAsset asset={asset as Location} />;
+
     case AssetType.BUTTON:
       const assetId = asset.id;
       if (!(message instanceof CompositeMessage && asset instanceof Button && assetId)) {
@@ -199,6 +161,7 @@ const ContentAsset = ({
         />
       );
   }
+
   return null;
 };
 

--- a/src/script/components/MessagesList/Message/PingMessage.tsx
+++ b/src/script/components/MessagesList/Message/PingMessage.tsx
@@ -45,7 +45,7 @@ const PingMessage: React.FC<PingMessageProps> = ({message, is1to1Conversation, i
         <div className={`icon-ping ${get_icon_classes}`} />
       </div>
       <div
-        className={cx('message-body-content', 'message-header-label', {
+        className={cx('message-header-label', {
           'ephemeral-message-obfuscated': isObfuscated,
         })}
         title={ephemeral_caption}

--- a/src/script/components/MessagesList/Message/ReadIndicator/ReadIndicator.styles.ts
+++ b/src/script/components/MessagesList/Message/ReadIndicator/ReadIndicator.styles.ts
@@ -22,6 +22,7 @@ import {CSSObject} from '@emotion/react';
 export const ReadIndicatorContainer: CSSObject = {
   display: 'inline-block',
   marginLeft: '12px',
+  lineHeight: 1,
 
   '.message-asset &': {
     marginLeft: '12px',

--- a/src/script/components/MessagesList/Message/ReadIndicator/ReadIndicator.styles.ts
+++ b/src/script/components/MessagesList/Message/ReadIndicator/ReadIndicator.styles.ts
@@ -19,6 +19,15 @@
 
 import {CSSObject} from '@emotion/react';
 
+export const ReadIndicatorContainer: CSSObject = {
+  display: 'inline-block',
+  marginLeft: '12px',
+
+  '.message-asset &': {
+    marginLeft: '12px',
+  },
+};
+
 export const ReadReceiptText: CSSObject = {
   display: 'inline-flex',
   alignItems: 'center',
@@ -43,10 +52,6 @@ export const ReadIndicatorStyles = (showIconOnly = false): CSSObject => ({
     alignItems: 'center',
     marginLeft: '8px',
   }),
-
-  '.message-asset &': {
-    marginLeft: '12px',
-  },
 
   ...(!showIconOnly && {
     opacity: 0,

--- a/src/script/components/MessagesList/Message/ReadIndicator/ReadIndicator.tsx
+++ b/src/script/components/MessagesList/Message/ReadIndicator/ReadIndicator.tsx
@@ -22,7 +22,7 @@ import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 import {formatTimeShort} from 'Util/TimeUtil';
 
-import {ReadIndicatorStyles, ReadReceiptText} from './ReadIndicator.styles';
+import {ReadIndicatorContainer, ReadIndicatorStyles, ReadReceiptText} from './ReadIndicator.styles';
 
 import {Message} from '../../../../entity/message/Message';
 
@@ -52,19 +52,21 @@ export const ReadIndicator = ({
     const showDeliveredMessage = isLastDeliveredMessage && readReceiptText === '';
 
     return (
-      <span css={ReadIndicatorStyles(showIconOnly)} data-uie-name="status-message-read-receipts">
-        {showDeliveredMessage && (
-          <span data-uie-name="status-message-read-receipt-delivered">{t('conversationMessageDelivered')}</span>
-        )}
+      <div css={ReadIndicatorContainer} className="read-indicator-wrapper">
+        <span css={ReadIndicatorStyles(showIconOnly)} data-uie-name="status-message-read-receipts">
+          {showDeliveredMessage && (
+            <span data-uie-name="status-message-read-receipt-delivered">{t('conversationMessageDelivered')}</span>
+          )}
 
-        {showIconOnly && readReceiptText && <Icon.Read />}
+          {showIconOnly && readReceiptText && <Icon.Read />}
 
-        {!showIconOnly && !!readReceiptText && (
-          <div css={ReadReceiptText} data-uie-name="status-message-read-receipt-text">
-            <Icon.Read /> {readReceiptText}
-          </div>
-        )}
-      </span>
+          {!showIconOnly && !!readReceiptText && (
+            <div css={ReadReceiptText} data-uie-name="status-message-read-receipt-text">
+              <Icon.Read /> {readReceiptText}
+            </div>
+          )}
+        </span>
+      </div>
     );
   }
 
@@ -83,15 +85,17 @@ export const ReadIndicator = ({
   }
 
   return (
-    <button
-      css={ReadIndicatorStyles(false)}
-      onClick={() => onClick?.(message)}
-      className="button-reset-default read-indicator"
-      data-uie-name="status-message-read-receipts"
-    >
-      <div css={ReadReceiptText} data-uie-name="status-message-read-receipt-count">
-        <Icon.Read /> {readReceiptCount}
-      </div>
-    </button>
+    <div css={ReadIndicatorContainer} className="read-indicator-wrapper">
+      <button
+        css={ReadIndicatorStyles(false)}
+        onClick={() => onClick?.(message)}
+        className="button-reset-default read-indicator"
+        data-uie-name="status-message-read-receipts"
+      >
+        <div css={ReadReceiptText} data-uie-name="status-message-read-receipt-count">
+          <Icon.Read /> {readReceiptCount}
+        </div>
+      </button>
+    </div>
   );
 };

--- a/src/style/common/variables.less
+++ b/src/style/common/variables.less
@@ -239,6 +239,7 @@ body {
 @conversation-message-sender-width: 64px;
 
 body {
+  --conversation-max-width: @conversation-max-width;
   --conversation-message-sender-width: @conversation-message-sender-width;
   --conversation-message-asset-width: 800px;
 }

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -323,19 +323,15 @@
 // MESSAGE - BODY
 .message-body {
   position: relative;
-  display: flex;
-  max-width: @conversation-max-width;
-  justify-content: space-between;
-  padding-left: @conversation-message-sender-width;
+  max-width: calc(100% - var(--conversation-message-sender-width));
+  padding-left: var(--conversation-message-sender-width);
 
-  &-content {
-    width: 100%;
-    max-width: calc(@conversation-max-width - var(--conversation-message-sender-width));
-    height: fit-content;
+  .text:has(> .iframe-container) {
+    margin-right: 0;
+  }
 
-    .text:has(> .iframe-container) {
-      margin-right: 0;
-    }
+  &:has(.message-quote__text--full pre) {
+    display: flex;
   }
 
   .text {
@@ -344,7 +340,6 @@
 
     display: inline;
     min-width: 0;
-    margin-right: 12px;
     line-height: @line-height-lg;
     white-space: pre-wrap;
     word-wrap: break-word;

--- a/src/style/content/conversation/message-quote.less
+++ b/src/style/content/conversation/message-quote.less
@@ -71,6 +71,11 @@
 
       pre {
         overflow: auto;
+        max-width: var(--conversation-message-asset-width);
+        padding: 16px;
+        border-radius: 12px;
+        background: var(--foreground-fade-8);
+        margin-block: 4px;
         text-overflow: unset;
       }
     }


### PR DESCRIPTION
## Description

Fixed displaying read indicators after assets/codeblocks and text.
Now all read indicators displays behind image while images is small or large, not to faar..

Also updated code block design.

## Screenshots/Screencast (for UI changes)

![image](https://github.com/wireapp/wire-webapp/assets/13432884/fa788804-4540-4efb-b098-c5296267b783)

![image](https://github.com/wireapp/wire-webapp/assets/13432884/f3decfaa-7734-4e70-8370-b9ef6d5c1ef6)


## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
