### PR TITLE
runfix: system message keys claiming failure [WPB-6641]

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@peculiar/x509": "1.9.6",
     "@wireapp/avs": "9.6.11",
     "@wireapp/commons": "5.2.4",
-    "@wireapp/core": "44.0.12",
+    "@wireapp/core": "44.0.13",
     "@wireapp/react-ui-kit": "9.15.4",
     "@wireapp/store-engine-dexie": "2.1.7",
     "@wireapp/webapp-events": "0.20.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@peculiar/x509": "1.9.6",
     "@wireapp/avs": "9.6.11",
     "@wireapp/commons": "5.2.4",
-    "@wireapp/core": "44.0.11",
+    "@wireapp/core": "44.0.12",
     "@wireapp/react-ui-kit": "9.15.4",
     "@wireapp/store-engine-dexie": "2.1.7",
     "@wireapp/webapp-events": "0.20.1",

--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -636,6 +636,11 @@
   "extensionsGiphyMessage": "{{tag}} • via giphy.com",
   "extensionsGiphyNoGifs": "Oops, no gifs",
   "extensionsGiphyRandom": "Random",
+
+  "failedToAddParticipantsPluralDetailsOfflineForTooLong": "[bold]{{names}}[/bold] and [bold]{{name}}[/bold] could not be added to the group as they have been offline for too long.",
+  "failedToAddParticipantSingularOfflineForTooLong": "[bold]{{name}}[/bold] could not be added to the group as they have been offline for too long.",
+  "failedToAddParticipantsSingularDetailsOfflineForTooLong": "[bold]{{name}}[/bold] could not be added to the group as they have been offline for too long.",
+
   "failedToAddParticipantSingularNonFederatingBackends": "[bold]{{name}}[/bold] could not be added to the group as their backend doesn't federate with the backends of all group participants.",
   "failedToAddParticipantSingularOfflineBackend": "[bold]{{name}}[/bold] could not be added to the group as the backend of [bold]{{domain}}[/bold] could not be reached.",
   "failedToAddParticipantsPlural": "[bold]{{total}} participants[/bold] could not be added to the group.",

--- a/src/script/components/MessagesList/Message/FailedToAddUsersMessage.test.tsx
+++ b/src/script/components/MessagesList/Message/FailedToAddUsersMessage.test.tsx
@@ -41,7 +41,7 @@ const createFailedToAddUsersMessage = ({
   reason?: AddUsersFailureReasons;
   backends?: string[];
 }) => {
-  return new FailedToAddUsersMessageEntity(users, reason, backends, Date.now());
+  return new FailedToAddUsersMessageEntity([{reason, users, backends}], Date.now());
 };
 
 function createUser(qualifiedId: QualifiedId, name: string) {

--- a/src/script/components/MessagesList/Message/FailedToAddUsersMessage.tsx
+++ b/src/script/components/MessagesList/Message/FailedToAddUsersMessage.tsx
@@ -48,6 +48,7 @@ export interface FailedToAddUsersMessageProps {
 const errorMessageType = {
   [AddUsersFailureReasons.NON_FEDERATING_BACKENDS]: 'NonFederatingBackends',
   [AddUsersFailureReasons.UNREACHABLE_BACKENDS]: 'OfflineBackend',
+  [AddUsersFailureReasons.OFFLINE_FOR_TOO_LONG]: 'OfflineForTooLong',
 } as const;
 
 const config = Config.getConfig();
@@ -103,13 +104,15 @@ const FailedToAddUsersMessage: React.FC<FailedToAddUsersMessageProps> = ({
   const {users: allUsers} = useKoSubscribableChildren(userState, ['users']);
 
   const [users, total] = useMemo(() => {
-    const users: User[] = message.qualifiedIds.reduce<User[]>((previous, current) => {
+    //FIXME: 0
+    const users: User[] = message.data[0].users.reduce<User[]>((previous, current) => {
       const foundUser = allUsers.find(user => matchQualifiedIds(current, user.qualifiedId));
       return foundUser ? [...previous, foundUser] : previous;
     }, []);
     const total = users.length;
     return [users, total];
-  }, [allUsers, message.qualifiedIds]);
+    //FIXME: 0
+  }, [allUsers, message.data[0].users]);
 
   if (users.length === 0) {
     return null;
@@ -146,10 +149,11 @@ const FailedToAddUsersMessage: React.FC<FailedToAddUsersMessageProps> = ({
         >
           {total <= 1 && (
             <p data-uie-name="1-user-not-added-details" data-uie-value={users[0].id}>
+              {/* FIXME: [0] */}
               <span
                 css={warning}
                 dangerouslySetInnerHTML={{
-                  __html: t(`failedToAddParticipantSingular${errorMessageType[message.reason]}`, {
+                  __html: t(`failedToAddParticipantSingular${errorMessageType[message.data[0].reason]}`, {
                     name: getUserName(users[0]),
                     domain: users[0].domain,
                   }),
@@ -177,7 +181,8 @@ const FailedToAddUsersMessage: React.FC<FailedToAddUsersMessageProps> = ({
       </div>
       <div className="message-body" css={{flexDirection: 'column'}}>
         {isOpen && (
-          <MessageDetails users={users} reason={message.reason} domains={users.map(user => user.domain)}>
+          // FIXME: [0]
+          <MessageDetails users={users} reason={message.data[0].reason} domains={users.map(user => user.domain)}>
             {learnMore}
           </MessageDetails>
         )}

--- a/src/script/components/MessagesList/Message/FailedToAddUsersMessage.tsx
+++ b/src/script/components/MessagesList/Message/FailedToAddUsersMessage.tsx
@@ -17,9 +17,9 @@
  *
  */
 
-import React, {ReactNode, useMemo, useState} from 'react';
+import React, {useMemo, useState} from 'react';
 
-import {AddUsersFailureReasons} from '@wireapp/core/lib/conversation';
+import {AddUsersFailure, AddUsersFailureReasons} from '@wireapp/core/lib/conversation';
 import {container} from 'tsyringe';
 
 import {Button, ButtonVariant, Link, LinkVariant} from '@wireapp/react-ui-kit';
@@ -45,27 +45,68 @@ export interface FailedToAddUsersMessageProps {
   userState?: UserState;
 }
 
-const errorMessageType = {
-  [AddUsersFailureReasons.NON_FEDERATING_BACKENDS]: 'NonFederatingBackends',
-  [AddUsersFailureReasons.UNREACHABLE_BACKENDS]: 'OfflineBackend',
-  [AddUsersFailureReasons.OFFLINE_FOR_TOO_LONG]: 'OfflineForTooLong',
-} as const;
-
 const config = Config.getConfig();
 
+const reasonToMessageDataMap = {
+  [AddUsersFailureReasons.NON_FEDERATING_BACKENDS]: {
+    link: {
+      url: config.URL.SUPPORT.OFFLINE_BACKEND,
+      name: 'go-offline-backend',
+    },
+    translationLabel: 'NonFederatingBackends',
+  },
+  [AddUsersFailureReasons.UNREACHABLE_BACKENDS]: {
+    link: {url: config.URL.SUPPORT.OFFLINE_BACKEND, name: 'go-offline-backend'},
+    translationLabel: 'OfflineBackend',
+  },
+  [AddUsersFailureReasons.OFFLINE_FOR_TOO_LONG]: {
+    link: {url: config.URL.SUPPORT.OFFLINE_BACKEND, name: 'go-offline-backend'},
+    translationLabel: 'OfflineForTooLong',
+  },
+} as const;
+
 interface MessageDetailsProps {
-  children: ReactNode;
-  users: User[];
-  reason: AddUsersFailureReasons;
-  domains: string[];
+  failure: AddUsersFailure;
+  isMessageFocused: boolean;
+  allUsers: User[];
 }
-const MessageDetails = ({users, children, reason, domains}: MessageDetailsProps) => {
+
+const MessageDetails = ({failure, isMessageFocused, allUsers}: MessageDetailsProps) => {
+  const messageFocusedTabIndex = useMessageFocusedTabIndex(isMessageFocused);
+
+  const {users: userIds, reason} = failure;
+
+  const users = useMemo(() => {
+    const users: User[] = userIds.reduce<User[]>((previous, current) => {
+      const foundUser = allUsers.find(user => matchQualifiedIds(current, user.qualifiedId));
+      return foundUser ? [...previous, foundUser] : previous;
+    }, []);
+    return users;
+  }, [allUsers, userIds]);
+
   const baseTranslationKey =
     users.length === 1 ? 'failedToAddParticipantsSingularDetails' : 'failedToAddParticipantsPluralDetails';
 
-  const uniqueDomains = Array.from(new Set(domains));
+  const uniqueDomains = 'backends' in failure ? Array.from(new Set(failure.backends)) : undefined;
+  const domainStr = uniqueDomains && uniqueDomains.join(', ');
 
-  const domainStr = uniqueDomains.join(', ');
+  const {link, translationLabel} = reasonToMessageDataMap[reason];
+
+  const learnMoreLink = (
+    <>
+      {' '}
+      <Link
+        tabIndex={messageFocusedTabIndex}
+        targetBlank
+        variant={LinkVariant.PRIMARY}
+        href={link.url}
+        data-uie-name={link.name}
+        css={backendErrorLink}
+      >
+        {t('offlineBackendLearnMore')}
+      </Link>
+    </>
+  );
 
   return (
     <p
@@ -76,17 +117,17 @@ const MessageDetails = ({users, children, reason, domains}: MessageDetailsProps)
       <span
         css={warning}
         dangerouslySetInnerHTML={{
-          __html: t(`${baseTranslationKey}${errorMessageType[reason]}`, {
+          __html: t(`${baseTranslationKey}${translationLabel}`, {
             name: getUserName(users[0]),
             names: users
               .slice(1)
               .map(user => getUserName(user))
               .join(', '),
-            domain: domainStr,
+            ...(domainStr && {domain: domainStr}),
           }),
         }}
       />
-      {children}
+      {learnMoreLink}
     </p>
   );
 };
@@ -102,21 +143,18 @@ const FailedToAddUsersMessage: React.FC<FailedToAddUsersMessageProps> = ({
   const {timestamp} = useKoSubscribableChildren(message, ['timestamp']);
 
   const {users: allUsers} = useKoSubscribableChildren(userState, ['users']);
+  const {failures} = message;
 
-  const [users, total] = useMemo(() => {
-    //FIXME: 0
-    const users: User[] = message.data[0].users.reduce<User[]>((previous, current) => {
-      const foundUser = allUsers.find(user => matchQualifiedIds(current, user.qualifiedId));
-      return foundUser ? [...previous, foundUser] : previous;
-    }, []);
-    const total = users.length;
-    return [users, total];
-    //FIXME: 0
-  }, [allUsers, message.data[0].users]);
+  const allUserIds = useMemo(() => failures.flatMap(failure => failure.users), [failures]);
+  const totalNumberOfUsers = allUserIds.length;
 
-  if (users.length === 0) {
+  if (allUserIds.length === 0) {
     return null;
   }
+
+  // These will be used if we've only failed to add a single user
+  const firstUser = allUsers.find(user => matchQualifiedIds(allUserIds[0], user.qualifiedId));
+  const {link, translationLabel} = reasonToMessageDataMap[failures[0].reason];
 
   const learnMore = (
     <>
@@ -125,8 +163,8 @@ const FailedToAddUsersMessage: React.FC<FailedToAddUsersMessageProps> = ({
         tabIndex={messageFocusedTabIndex}
         targetBlank
         variant={LinkVariant.PRIMARY}
-        href={config.URL.SUPPORT.OFFLINE_BACKEND}
-        data-uie-name="go-offline-backend"
+        href={link.url}
+        data-uie-name={link.name}
         css={backendErrorLink}
       >
         {t('offlineBackendLearnMore')}
@@ -145,28 +183,27 @@ const FailedToAddUsersMessage: React.FC<FailedToAddUsersMessageProps> = ({
         <div
           className="message-header-label"
           data-uie-name="element-message-failed-to-add-users"
-          data-uie-value={total <= 1 ? '1-user-not-added' : 'multi-users-not-added'}
+          data-uie-value={totalNumberOfUsers <= 1 ? '1-user-not-added' : 'multi-users-not-added'}
         >
-          {total <= 1 && (
-            <p data-uie-name="1-user-not-added-details" data-uie-value={users[0].id}>
-              {/* FIXME: [0] */}
+          {totalNumberOfUsers <= 1 && firstUser && (
+            <p data-uie-name="1-user-not-added-details" data-uie-value={firstUser.id}>
               <span
                 css={warning}
                 dangerouslySetInnerHTML={{
-                  __html: t(`failedToAddParticipantSingular${errorMessageType[message.data[0].reason]}`, {
-                    name: getUserName(users[0]),
-                    domain: users[0].domain,
+                  __html: t(`failedToAddParticipantSingular${translationLabel}`, {
+                    name: getUserName(firstUser),
+                    domain: firstUser.domain,
                   }),
                 }}
               />
               {learnMore}
             </p>
           )}
-          {total > 1 && (
+          {totalNumberOfUsers > 1 && (
             <p
               css={warning}
               dangerouslySetInnerHTML={{
-                __html: t(`failedToAddParticipantsPlural`, {total: total.toString()}),
+                __html: t(`failedToAddParticipantsPlural`, {total: totalNumberOfUsers.toString()}),
               }}
             />
           )}
@@ -180,14 +217,12 @@ const FailedToAddUsersMessage: React.FC<FailedToAddUsersMessageProps> = ({
         </p>
       </div>
       <div className="message-body" css={{flexDirection: 'column'}}>
-        {isOpen && (
-          // FIXME: [0]
-          <MessageDetails users={users} reason={message.data[0].reason} domains={users.map(user => user.domain)}>
-            {learnMore}
-          </MessageDetails>
-        )}
+        {isOpen &&
+          failures.map((failure, index) => (
+            <MessageDetails allUsers={allUsers} isMessageFocused={isMessageFocused} key={index} failure={failure} />
+          ))}
 
-        {total > 1 && (
+        {totalNumberOfUsers > 1 && (
           <div>
             <Button
               tabIndex={messageFocusedTabIndex}

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -457,7 +457,7 @@ export class ConversationRepository {
 
       const {failedToAdd} = response;
 
-      if (failedToAdd) {
+      if (failedToAdd && failedToAdd.length) {
         const failedToAddUsersEvent = EventBuilder.buildFailedToAddUsersEvent(
           failedToAdd,
           conversationEntity,
@@ -2325,7 +2325,7 @@ export class ConversationRepository {
         if (memberJoinEvent) {
           await this.eventRepository.injectEvent(memberJoinEvent, EventRepository.SOURCE.BACKEND_RESPONSE);
         }
-        if (failedToAdd) {
+        if (failedToAdd && failedToAdd.length) {
           await this.eventRepository.injectEvent(
             EventBuilder.buildFailedToAddUsersEvent(failedToAdd, conversation, this.userState.self().id),
             EventRepository.SOURCE.INJECTED,
@@ -2339,14 +2339,18 @@ export class ConversationRepository {
           groupId: conversation.groupId,
           qualifiedUsers,
         });
-        if (!!events.length && isMLSConversation(conversation)) {
-          events.forEach(event => this.eventRepository.injectEvent(event));
-        }
-        if (failedToAdd) {
-          await this.eventRepository.injectEvent(
-            EventBuilder.buildFailedToAddUsersEvent(failedToAdd, conversation, this.userState.self().id),
-            EventRepository.SOURCE.INJECTED,
-          );
+
+        if (isMLSConversation(conversation)) {
+          if (events.length) {
+            events.forEach(event => this.eventRepository.injectEvent(event));
+          }
+
+          if (failedToAdd && failedToAdd.length) {
+            await this.eventRepository.injectEvent(
+              EventBuilder.buildFailedToAddUsersEvent(failedToAdd, conversation, this.userState.self().id),
+              EventRepository.SOURCE.INJECTED,
+            );
+          }
         }
       }
     } catch (error) {

--- a/src/script/conversation/EventBuilder.ts
+++ b/src/script/conversation/EventBuilder.ts
@@ -24,7 +24,7 @@ import {
   ConversationOtrMessageAddEvent,
 } from '@wireapp/api-client/lib/event';
 import type {QualifiedId} from '@wireapp/api-client/lib/user';
-import {AddUsersFailureReasons} from '@wireapp/core/lib/conversation';
+import {AddUsersFailure} from '@wireapp/core/lib/conversation';
 import {ReactionType} from '@wireapp/core/lib/conversation/ReactionType';
 import {DecryptionError} from '@wireapp/core/lib/errors/DecryptionError';
 
@@ -210,14 +210,7 @@ export type CallingTimeoutEvent = ConversationEvent<
   CONVERSATION.CALL_TIME_OUT,
   {reason: AVS_REASON.NOONE_JOINED | AVS_REASON.EVERYONE_LEFT}
 >;
-export type FailedToAddUsersMessageEvent = ConversationEvent<
-  CONVERSATION.FAILED_TO_ADD_USERS,
-  {
-    qualifiedIds: QualifiedId[];
-    reason: AddUsersFailureReasons;
-    backends: string[];
-  }
->;
+export type FailedToAddUsersMessageEvent = ConversationEvent<CONVERSATION.FAILED_TO_ADD_USERS, AddUsersFailure[]>;
 
 export interface ErrorEvent
   extends ConversationEvent<CONVERSATION.UNABLE_TO_DECRYPT | CONVERSATION.INCOMING_MESSAGE_TOO_BIG> {
@@ -365,17 +358,13 @@ export const EventBuilder = {
   },
 
   buildFailedToAddUsersEvent(
-    failedToAdd: {users: QualifiedId[]; reason: AddUsersFailureReasons; backends: string[]},
+    failedToAdd: AddUsersFailure[],
     conversation: Conversation,
     userId: string,
   ): FailedToAddUsersMessageEvent {
     return {
       ...buildQualifiedId(conversation),
-      data: {
-        qualifiedIds: failedToAdd.users,
-        reason: failedToAdd.reason,
-        backends: failedToAdd.backends,
-      },
+      data: failedToAdd,
       from: userId,
       id: createUuid(),
       time: conversation.getNextIsoDate(),

--- a/src/script/conversation/EventMapper.ts
+++ b/src/script/conversation/EventMapper.ts
@@ -532,7 +532,7 @@ export class EventMapper {
   }
 
   _mapEventFailedToAddUsers({data, time}: FailedToAddUsersMessageEvent) {
-    return new FailedToAddUsersMessage(data.qualifiedIds, data.reason, data.backends, parseInt(time, 10));
+    return new FailedToAddUsersMessage(data, parseInt(time, 10));
   }
 
   _mapEventFederationStop({data, time}: FederationStopEvent) {

--- a/src/script/entity/message/FailedToAddUsersMessage.ts
+++ b/src/script/entity/message/FailedToAddUsersMessage.ts
@@ -25,7 +25,7 @@ import {SuperType} from '../../message/SuperType';
 
 export class FailedToAddUsersMessage extends Message {
   constructor(
-    public readonly data: AddUsersFailure[],
+    public readonly failures: AddUsersFailure[],
     time: number,
   ) {
     super();

--- a/src/script/entity/message/FailedToAddUsersMessage.ts
+++ b/src/script/entity/message/FailedToAddUsersMessage.ts
@@ -17,8 +17,7 @@
  *
  */
 
-import {QualifiedId} from '@wireapp/api-client/lib/user';
-import {AddUsersFailureReasons} from '@wireapp/core/lib/conversation';
+import {AddUsersFailure} from '@wireapp/core/lib/conversation';
 
 import {Message} from './Message';
 
@@ -26,9 +25,7 @@ import {SuperType} from '../../message/SuperType';
 
 export class FailedToAddUsersMessage extends Message {
   constructor(
-    public readonly qualifiedIds: QualifiedId[],
-    public readonly reason: AddUsersFailureReasons,
-    public readonly backends: string[] = [],
+    public readonly data: AddUsersFailure[],
     time: number,
   ) {
     super();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4895,9 +4895,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:44.0.12":
-  version: 44.0.12
-  resolution: "@wireapp/core@npm:44.0.12"
+"@wireapp/core@npm:44.0.13":
+  version: 44.0.13
+  resolution: "@wireapp/core@npm:44.0.13"
   dependencies:
     "@wireapp/api-client": ^26.10.10
     "@wireapp/commons": ^5.2.5
@@ -4916,7 +4916,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: a4ba8b9b4e662e71e13c3a9380ae948a08821076512ed8143aacb90a6f4fbf29eb9b655eb1aff37bd3dcf7a1fa930216af4f76887c3c8a23a72ac1f6b108bfe5
+  checksum: b20f6214dd0251e4cc41f24dd743feed0e69c1137350feb3a6b2267dd5e3615062d237c7e664f5f43d7028b851aa4ebbcb0a662568379e12bc846e5cb3c26c85
   languageName: node
   linkType: hard
 
@@ -17624,7 +17624,7 @@ __metadata:
     "@wireapp/avs": 9.6.11
     "@wireapp/commons": 5.2.4
     "@wireapp/copy-config": 2.1.14
-    "@wireapp/core": 44.0.12
+    "@wireapp/core": 44.0.13
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.15.4

--- a/yarn.lock
+++ b/yarn.lock
@@ -4895,9 +4895,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:44.0.11":
-  version: 44.0.11
-  resolution: "@wireapp/core@npm:44.0.11"
+"@wireapp/core@npm:44.0.12":
+  version: 44.0.12
+  resolution: "@wireapp/core@npm:44.0.12"
   dependencies:
     "@wireapp/api-client": ^26.10.10
     "@wireapp/commons": ^5.2.5
@@ -4916,7 +4916,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: 089ad246eac60dbb58112be40b13458edb12a36d0a5b68a0a0d98e8ced7ea1152037f7e121129369b0ddba37999a1d4152429a6d26d045d1ffc5efc7a084a964
+  checksum: a4ba8b9b4e662e71e13c3a9380ae948a08821076512ed8143aacb90a6f4fbf29eb9b655eb1aff37bd3dcf7a1fa930216af4f76887c3c8a23a72ac1f6b108bfe5
   languageName: node
   linkType: hard
 
@@ -17624,7 +17624,7 @@ __metadata:
     "@wireapp/avs": 9.6.11
     "@wireapp/commons": 5.2.4
     "@wireapp/copy-config": 2.1.14
-    "@wireapp/core": 44.0.11
+    "@wireapp/core": 44.0.12
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.15.4


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6641" title="WPB-6641" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6641</a>  [Web] User is not informed if another user cannot be added to a group (during group creation or when adding)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

Now adding user failure reason is an array (because of how adding multiple users to a MLS conversation works)
For more details see https://github.com/wireapp/wire-web-packages/pull/6002.

This PR adds a copy for not being able to add a user to the group because of the lack of their keys on backend.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;