### PR TITLE
runfix: Fix certificate renewal process [WPB-6795]

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@peculiar/x509": "1.9.6",
     "@wireapp/avs": "9.6.11",
     "@wireapp/commons": "5.2.4",
-    "@wireapp/core": "44.0.13",
+    "@wireapp/core": "45.0.0",
     "@wireapp/react-ui-kit": "9.15.4",
     "@wireapp/store-engine-dexie": "2.1.7",
     "@wireapp/webapp-events": "0.20.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "long": "5.2.3",
     "markdown-it": "14.0.0",
     "murmurhash": "2.0.1",
-    "oidc-client-ts": "^2.4.0",
+    "oidc-client-ts": "3.0.1",
     "platform": "1.3.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.test.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.test.ts
@@ -26,7 +26,7 @@ import {UserState} from 'src/script/user/UserState';
 import {getCertificateDetails} from 'Util/certificateDetails';
 import * as util from 'Util/util';
 
-import {E2EIHandler, E2EIHandlerStep} from './E2EIdentityEnrollment';
+import {E2EIHandler} from './E2EIdentityEnrollment';
 import {hasActiveCertificate} from './E2EIdentityVerification';
 import {getModalOptions, ModalType} from './Modals';
 import {OIDCServiceStore} from './OIDCService/OIDCServiceStorage';
@@ -122,26 +122,6 @@ describe('E2EIHandler', () => {
     void instance.attemptEnrollment();
     await wait(1);
     expect(container.resolve(Core).service?.e2eIdentity?.initialize).toHaveBeenCalled();
-    expect(instance['currentStep']).toBe(E2EIHandlerStep.INITIALIZED);
-  });
-
-  it('should set currentStep to SUCCESS when enrollE2EI is called and enrollment succeeds', async () => {
-    jest.spyOn(container.resolve(Core), 'enrollE2EI').mockResolvedValueOnce({status: 'successful'});
-
-    const instance = await E2EIHandler.getInstance().initialize(params);
-    void instance['enroll']();
-    await wait(1);
-    expect(instance['currentStep']).toBe(E2EIHandlerStep.SUCCESS);
-  });
-
-  it('should set currentStep to ERROR when enrolE2EI is called and enrolment fails', async () => {
-    // Mock the Core service to return an error
-    jest.spyOn(container.resolve(Core), 'enrollE2EI').mockImplementationOnce(jest.fn(() => Promise.reject()));
-
-    const instance = await E2EIHandler.getInstance().initialize(params);
-    void instance['enroll']();
-    await wait(1);
-    expect(instance['currentStep']).toBe(E2EIHandlerStep.ERROR);
   });
 
   it('should display user info message when initialized', async () => {
@@ -156,7 +136,7 @@ describe('E2EIHandler', () => {
   });
 
   it('should throw error if trying to enroll with no config given', async () => {
-    await expect(E2EIHandler.getInstance().enroll()).rejects.toEqual(
+    await expect(E2EIHandler.getInstance()['enroll']()).rejects.toEqual(
       new Error('Trying to enroll for E2EI without initializing the E2EIHandler'),
     );
   });
@@ -229,7 +209,7 @@ describe('E2EIHandler', () => {
     jest.spyOn(container.resolve(Core).service!.e2eIdentity!, 'isEnrollmentInProgress').mockResolvedValue(true);
 
     // Spy on enroll to check if it's called
-    const enrollSpy = jest.spyOn(handler, 'enroll');
+    const enrollSpy = jest.spyOn(handler as any, 'enroll');
 
     // Initialize E2EI
     await handler.initialize(params);

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -404,10 +404,6 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
     PrimaryModal.show(determinedModalType, modalOptions);
   }
 
-  private getOauthToken = async () => {
-    // The redirect-url which is needed inside the OIDCService is stored in the OIDCServiceStore previously
-  };
-
   private async startEnrollment(enrollmentType: ModalType.CERTIFICATE_RENEWAL | ModalType.ENROLL): Promise<void> {
     // If the user has already started enrolment, don't show the notification. Instead, show the loading modal
     // This will occur after the redirect from the oauth provider

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -257,7 +257,8 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
       if (!displayName || !handle || !teamId) {
         throw new Error('Username, handle or teamId not found');
       }
-      const enrollmentState = await this.core.enrollE2EI({
+
+      await this.core.enrollE2EI({
         discoveryUrl: this.config.discoveryUrl,
         displayName,
         handle,
@@ -279,11 +280,6 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
         },
         certificateTtl: this.certificateTtl,
       });
-      // If the data is false or we dont get the ACMEChallenge, enrolment failed
-
-      if (enrollmentState.status === 'authentication') {
-        // If the data is authentication flow data, we need to kick off the oauth flow to get an oauth token
-      }
 
       // Notify user about E2EI enrolment success
       // This setTimeout is needed because there was a timing with the success modal and the loading modal

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -354,7 +354,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
         hideClose: true,
         hideSecondary: disableSnooze,
         primaryActionFn: async () => {
-          await this.attemptEnrollment();
+          await this.enroll();
           resolve();
         },
         secondaryActionFn: async () => {

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -245,7 +245,6 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
     silent: boolean,
     challengeData?: {keyAuth: string; challenge: {url: string; target: string}},
   ) {
-    this.oidcService = this.createOIDCService();
     let userData;
 
     if (challengeData) {
@@ -253,10 +252,12 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
       // We need to first authenticate the user (either silently if we are renewing the certificate, or by redirection if it an initial enrollment)
       const {challenge, keyAuth} = challengeData;
       OIDCServiceStore.store.targetURL(challenge.target);
-      userData = await this.oidcService.authenticate(keyAuth, challenge.url, silent);
+      const oidcService = this.createOIDCService();
+      userData = await oidcService.authenticate(keyAuth, challenge.url, silent);
     } else {
+      const oidcService = this.createOIDCService();
       // If there is no challengeData, that means we have already authenticated the user and we just need to get the userdata
-      userData = await this.oidcService.getUser();
+      userData = await oidcService.getUser();
     }
     if (!userData) {
       throw new Error('No user data received');

--- a/src/script/components/MessagesList/Message/E2EIVerificationMessage/E2EIVerificationMessage.tsx
+++ b/src/script/components/MessagesList/Message/E2EIVerificationMessage/E2EIVerificationMessage.tsx
@@ -86,7 +86,7 @@ export const E2EIVerificationMessage = ({message, conversation}: E2EIVerificatio
 
   const getCertificate = async () => {
     try {
-      await E2EIHandler.getInstance().enroll();
+      await E2EIHandler.getInstance().attemptEnrollment();
     } catch (error) {
       logger.error('Failed to enroll user certificate: ', error);
     }

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.tsx
@@ -50,7 +50,7 @@ export const E2EICertificateDetails = ({identity, isCurrentDevice}: E2EICertific
 
   const getCertificate = async () => {
     try {
-      await E2EIHandler.getInstance().enroll();
+      await E2EIHandler.getInstance().attemptEnrollment();
     } catch (error) {
       logger.error('Cannot get E2EI instance: ', error);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4888,20 +4888,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core-crypto@npm:1.0.0-rc.41":
-  version: 1.0.0-rc.41
-  resolution: "@wireapp/core-crypto@npm:1.0.0-rc.41"
-  checksum: e9b41fac8ecaac3f4934aca8bd58deeae4f45aa597caa9c880bee6df2acf9a5973a06f93b459fb1b3005df30a258df6b5dc9dfda42c45ea4a22c6697e0d9596c
+"@wireapp/core-crypto@npm:1.0.0-rc.43":
+  version: 1.0.0-rc.43
+  resolution: "@wireapp/core-crypto@npm:1.0.0-rc.43"
+  checksum: 2481ae8a6322c999e5b5260c34dcb6162d79afa568c0cc444975d90828831acd35b759140e63d994d2cad6a82e74b482408b306460a32c028006c4689407ca3a
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:44.0.13":
-  version: 44.0.13
-  resolution: "@wireapp/core@npm:44.0.13"
+"@wireapp/core@npm:45.0.0":
+  version: 45.0.0
+  resolution: "@wireapp/core@npm:45.0.0"
   dependencies:
     "@wireapp/api-client": ^26.10.10
     "@wireapp/commons": ^5.2.5
-    "@wireapp/core-crypto": 1.0.0-rc.41
+    "@wireapp/core-crypto": 1.0.0-rc.43
     "@wireapp/cryptobox": 12.8.0
     "@wireapp/promise-queue": ^2.2.10
     "@wireapp/protocol-messaging": 1.44.0
@@ -4916,7 +4916,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: b20f6214dd0251e4cc41f24dd743feed0e69c1137350feb3a6b2267dd5e3615062d237c7e664f5f43d7028b851aa4ebbcb0a662568379e12bc846e5cb3c26c85
+  checksum: cd5898cfc51c576de066e951a639c4bdaa9ecc3f7db54e4d7aec203ea7b267d2a27576fa42542f9e65325578c7317065fd8ecc07c567f6992ee03689801eb9f8
   languageName: node
   linkType: hard
 
@@ -6865,13 +6865,6 @@ __metadata:
     shebang-command: ^2.0.0
     which: ^2.0.1
   checksum: 671cc7c7288c3a8406f3c69a3ae2fc85555c04169e9d611def9a675635472614f1c0ed0ef80955d5b6d4e724f6ced67f0ad1bb006c2ea643488fcfef994d7f52
-  languageName: node
-  linkType: hard
-
-"crypto-js@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "crypto-js@npm:4.2.0"
-  checksum: f051666dbc077c8324777f44fbd3aaea2986f198fe85092535130d17026c7c2ccf2d23ee5b29b36f7a4a07312db2fae23c9094b644cc35f7858b1b4fcaf27774
   languageName: node
   linkType: hard
 
@@ -11443,10 +11436,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jwt-decode@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "jwt-decode@npm:3.1.2"
-  checksum: 20a4b072d44ce3479f42d0d2c8d3dabeb353081ba4982e40b83a779f2459a70be26441be6c160bfc8c3c6eadf9f6380a036fbb06ac5406b5674e35d8c4205eeb
+"jwt-decode@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "jwt-decode@npm:4.0.0"
+  checksum: 390e2edcb31a92e86c8cbdd1edeea4c0d62acd371f8a8f0a8878e499390c0ecf4c658b365c4e941e4ef37d0170e4ca650aaa49f99a45c0b9695a235b210154b0
   languageName: node
   linkType: hard
 
@@ -12870,13 +12863,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"oidc-client-ts@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "oidc-client-ts@npm:2.4.0"
+"oidc-client-ts@npm:3.0.1":
+  version: 3.0.1
+  resolution: "oidc-client-ts@npm:3.0.1"
   dependencies:
-    crypto-js: ^4.2.0
-    jwt-decode: ^3.1.2
-  checksum: 8467db689298221f706d3358961efb0ddc789f6bd7d4765e71ae5fe62067999d2ce6e8e7584b9d991b8caa6f7fb383f75841e1cfa9e05808c34632de374f5e68
+    jwt-decode: ^4.0.0
+  checksum: 08a21a40304131642ffc6a4e9ecc3a51bf476967dfbf4b60dbdb84f79b42489fda2ba447d9276ecb575a4ca75d94f652deac38065553688bff614c9d763f6c03
   languageName: node
   linkType: hard
 
@@ -17624,7 +17616,7 @@ __metadata:
     "@wireapp/avs": 9.6.11
     "@wireapp/commons": 5.2.4
     "@wireapp/copy-config": 2.1.14
-    "@wireapp/core": 44.0.13
+    "@wireapp/core": 45.0.0
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.15.4
@@ -17682,7 +17674,7 @@ __metadata:
     markdown-it: 14.0.0
     murmurhash: 2.0.1
     node-fetch: 2.7.0
-    oidc-client-ts: ^2.4.0
+    oidc-client-ts: 3.0.1
     os-browserify: 0.3.0
     path-browserify: 1.0.1
     platform: 1.3.6


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6795" title="WPB-6795" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6795</a>  [web] Renewal of certificate ends on an error
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Main problem with renewal was that we did not pass any `claims` to the silent authentication. Which made the token we generated not valid. 

The rest is mostly flow improvements (making the webapp not needing to be aware of the oAuth step we are at)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

