### PR TITLE
runfix: no audio when joining an ongoing call [WPB-6802]

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@lexical/history": "0.12.5",
     "@lexical/react": "0.12.5",
     "@peculiar/x509": "1.9.6",
-    "@wireapp/avs": "9.6.11",
+    "@wireapp/avs": "9.6.12",
     "@wireapp/commons": "5.2.4",
     "@wireapp/core": "44.0.13",
     "@wireapp/react-ui-kit": "9.15.4",

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -382,7 +382,16 @@ export class CallingRepository {
     }
     const allClients = await this.core.service!.conversation.fetchAllParticipantsClients(call.conversationId);
 
-    if (!isGroupMLSConversation(conversation)) {
+    if (isGroupMLSConversation(conversation)) {
+      const subconversationEpochInfo = await this.subconversationService.getSubconversationEpochInfo(
+        conversation.qualifiedId,
+        conversation.groupId,
+      );
+
+      if (subconversationEpochInfo) {
+        this.setEpochInfo(conversation.qualifiedId, subconversationEpochInfo);
+      }
+    } else {
       const qualifiedClients = flattenUserMap(allClients);
 
       const clients: Clients = flatten(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4834,10 +4834,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/avs@npm:9.6.11":
-  version: 9.6.11
-  resolution: "@wireapp/avs@npm:9.6.11"
-  checksum: fdc8fc9b7ba43c2cf9bedaadb8444443e78ce92e1f8c515b5aa62e762e975c65419a8c04a9c8b6142444c6e929df988ae9ea6cc6a41137d1f8d02df221a267bf
+"@wireapp/avs@npm:9.6.12":
+  version: 9.6.12
+  resolution: "@wireapp/avs@npm:9.6.12"
+  checksum: 3aec85fa8f5577319e70f5459145759573f377681fda15a944d32ed32fcc23a07782289781dc75e2a30a0da2f0670efe49d64892925c24f4e94bd39a1523e36d
   languageName: node
   linkType: hard
 
@@ -17621,7 +17621,7 @@ __metadata:
     "@types/speakingurl": 13.0.6
     "@types/underscore": 1.11.15
     "@types/webpack-env": 1.18.4
-    "@wireapp/avs": 9.6.11
+    "@wireapp/avs": 9.6.12
     "@wireapp/commons": 5.2.4
     "@wireapp/copy-config": 2.1.14
     "@wireapp/core": 44.0.13


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6802" title="WPB-6802" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6802</a>  [web] No audio in calls when starting a call while another one is ongoing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

To fix the linked issue, new version of avs expects us to update epoch info when `setReqClientsHandler` is called. Now audio is available right after joining the call even if it was already ongoing in the conversation but `incomingh` avs callback has not yet been triggered.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;