### PR TITLE
fix: Read indicator displaying

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -140,7 +140,7 @@ export const ContentMessageComponent = ({
     });
   };
 
-  const asset = assets?.[0] as FileAssetType;
+  const asset = assets?.[0] as FileAssetType | undefined;
   const isFileMessage = !!asset?.isFile();
   const isAudioMessage = !!asset?.isAudio();
   const isVideoMessage = !!asset?.isVideo();

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset.tsx
@@ -102,9 +102,8 @@ export const ImageAsset: React.FC<ImageAssetProps> = ({
 
   const imageContainerStyle: CSSObject = {
     aspectRatio: isFileSharingReceivingEnabled ? `${asset.ratio}` : undefined,
-    maxWidth: 'var(--conversation-message-asset-width)',
+    maxWidth: 'calc(100% - var(--conversation-message-sender-width))',
     width: asset.width,
-    maxHeight: '80vh',
   };
 
   return (

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
@@ -122,69 +122,30 @@ const ContentAsset = ({
       );
     case AssetType.FILE:
       if ((asset as FileAssetType).isFile()) {
-        return (
-          <div className={`message-asset ${isObfuscated ? 'ephemeral-asset-expired icon-file' : ''}`}>
-            <FileAsset message={message} isFocusable={isMessageFocused} />
-
-            <ReadIndicator
-              message={message}
-              is1to1Conversation={is1to1Conversation}
-              isLastDeliveredMessage={isLastDeliveredMessage}
-              onClick={onClickDetails}
-            />
-          </div>
-        );
+        return <FileAsset message={message} isFocusable={isMessageFocused} />;
       }
 
       if ((asset as FileAssetType).isAudio()) {
-        return (
-          <div className={`message-asset ${isObfuscated ? 'ephemeral-asset-expired' : ''}`}>
-            <AudioAsset message={message} isFocusable={isMessageFocused} />
-
-            <ReadIndicator
-              message={message}
-              is1to1Conversation={is1to1Conversation}
-              isLastDeliveredMessage={isLastDeliveredMessage}
-              onClick={onClickDetails}
-            />
-          </div>
-        );
+        return <AudioAsset message={message} isFocusable={isMessageFocused} />;
       }
 
       if ((asset as FileAssetType).isVideo()) {
-        return (
-          <div className={`message-asset ${isObfuscated ? 'ephemeral-asset-expired icon-movie' : ''}`}>
-            <VideoAsset message={message} isFocusable={isMessageFocused} />
-
-            <ReadIndicator
-              message={message}
-              is1to1Conversation={is1to1Conversation}
-              isLastDeliveredMessage={isLastDeliveredMessage}
-              onClick={onClickDetails}
-            />
-          </div>
-        );
+        return <VideoAsset message={message} isFocusable={isMessageFocused} />;
       }
+
     case AssetType.IMAGE:
       return (
-        <div className={`message-asset ${isObfuscated ? 'ephemeral-asset-expired' : ''}`}>
-          <ImageAsset
-            asset={asset as MediumImage}
-            message={message}
-            onClick={onClickImage}
-            isFocusable={isMessageFocused}
-          />
-
-          <ReadIndicator
-            message={message}
-            is1to1Conversation={is1to1Conversation}
-            isLastDeliveredMessage={isLastDeliveredMessage}
-            onClick={onClickDetails}
-          />
-        </div>
+        <ImageAsset
+          asset={asset as MediumImage}
+          message={message}
+          onClick={onClickImage}
+          isFocusable={isMessageFocused}
+        />
       );
+
     case AssetType.LOCATION:
       return <LocationAsset asset={asset as Location} />;
+
     case AssetType.BUTTON:
       const assetId = asset.id;
       if (!(message instanceof CompositeMessage && asset instanceof Button && assetId)) {
@@ -200,6 +161,7 @@ const ContentAsset = ({
         />
       );
   }
+
   return null;
 };
 

--- a/src/script/components/MessagesList/Message/PingMessage.tsx
+++ b/src/script/components/MessagesList/Message/PingMessage.tsx
@@ -17,8 +17,6 @@
  *
  */
 
-import React from 'react';
-
 import cx from 'classnames';
 
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
@@ -33,7 +31,7 @@ export interface PingMessageProps {
   isLastDeliveredMessage: boolean;
 }
 
-const PingMessage: React.FC<PingMessageProps> = ({message, is1to1Conversation, isLastDeliveredMessage}) => {
+const PingMessage = ({message, is1to1Conversation, isLastDeliveredMessage}: PingMessageProps) => {
   const {unsafeSenderName, caption, ephemeral_caption, isObfuscated, get_icon_classes} = useKoSubscribableChildren(
     message,
     ['unsafeSenderName', 'caption', 'ephemeral_caption', 'isObfuscated', 'get_icon_classes'],
@@ -45,7 +43,7 @@ const PingMessage: React.FC<PingMessageProps> = ({message, is1to1Conversation, i
         <div className={`icon-ping ${get_icon_classes}`} />
       </div>
       <div
-        className={cx('message-body-content', 'message-header-label', {
+        className={cx('message-header-label', {
           'ephemeral-message-obfuscated': isObfuscated,
         })}
         title={ephemeral_caption}

--- a/src/script/components/MessagesList/Message/ReadIndicator/ReadIndicator.styles.ts
+++ b/src/script/components/MessagesList/Message/ReadIndicator/ReadIndicator.styles.ts
@@ -19,6 +19,16 @@
 
 import {CSSObject} from '@emotion/react';
 
+export const ReadIndicatorContainer: CSSObject = {
+  display: 'inline-block',
+  marginLeft: '12px',
+  lineHeight: 1,
+
+  '.message-asset &': {
+    marginLeft: '12px',
+  },
+};
+
 export const ReadReceiptText: CSSObject = {
   display: 'inline-flex',
   alignItems: 'center',
@@ -43,10 +53,6 @@ export const ReadIndicatorStyles = (showIconOnly = false): CSSObject => ({
     alignItems: 'center',
     marginLeft: '8px',
   }),
-
-  '.message-asset &': {
-    marginLeft: '12px',
-  },
 
   ...(!showIconOnly && {
     opacity: 0,

--- a/src/script/components/MessagesList/Message/ReadIndicator/ReadIndicator.tsx
+++ b/src/script/components/MessagesList/Message/ReadIndicator/ReadIndicator.tsx
@@ -22,7 +22,7 @@ import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 import {formatTimeShort} from 'Util/TimeUtil';
 
-import {ReadIndicatorStyles, ReadReceiptText} from './ReadIndicator.styles';
+import {ReadIndicatorContainer, ReadIndicatorStyles, ReadReceiptText} from './ReadIndicator.styles';
 
 import {Message} from '../../../../entity/message/Message';
 
@@ -52,19 +52,21 @@ export const ReadIndicator = ({
     const showDeliveredMessage = isLastDeliveredMessage && readReceiptText === '';
 
     return (
-      <span css={ReadIndicatorStyles(showIconOnly)} data-uie-name="status-message-read-receipts">
-        {showDeliveredMessage && (
-          <span data-uie-name="status-message-read-receipt-delivered">{t('conversationMessageDelivered')}</span>
-        )}
+      <div css={ReadIndicatorContainer} className="read-indicator-wrapper">
+        <span css={ReadIndicatorStyles(showIconOnly)} data-uie-name="status-message-read-receipts">
+          {showDeliveredMessage && (
+            <span data-uie-name="status-message-read-receipt-delivered">{t('conversationMessageDelivered')}</span>
+          )}
 
-        {showIconOnly && readReceiptText && <Icon.Read />}
+          {showIconOnly && readReceiptText && <Icon.Read />}
 
-        {!showIconOnly && !!readReceiptText && (
-          <div css={ReadReceiptText} data-uie-name="status-message-read-receipt-text">
-            <Icon.Read /> {readReceiptText}
-          </div>
-        )}
-      </span>
+          {!showIconOnly && !!readReceiptText && (
+            <div css={ReadReceiptText} data-uie-name="status-message-read-receipt-text">
+              <Icon.Read /> {readReceiptText}
+            </div>
+          )}
+        </span>
+      </div>
     );
   }
 
@@ -83,15 +85,17 @@ export const ReadIndicator = ({
   }
 
   return (
-    <button
-      css={ReadIndicatorStyles(false)}
-      onClick={() => onClick?.(message)}
-      className="button-reset-default read-indicator"
-      data-uie-name="status-message-read-receipts"
-    >
-      <div css={ReadReceiptText} data-uie-name="status-message-read-receipt-count">
-        <Icon.Read /> {readReceiptCount}
-      </div>
-    </button>
+    <div css={ReadIndicatorContainer} className="read-indicator-wrapper">
+      <button
+        css={ReadIndicatorStyles(false)}
+        onClick={() => onClick?.(message)}
+        className="button-reset-default read-indicator"
+        data-uie-name="status-message-read-receipts"
+      >
+        <div css={ReadReceiptText} data-uie-name="status-message-read-receipt-count">
+          <Icon.Read /> {readReceiptCount}
+        </div>
+      </button>
+    </div>
   );
 };

--- a/src/style/common/variables.less
+++ b/src/style/common/variables.less
@@ -239,6 +239,7 @@ body {
 @conversation-message-sender-width: 64px;
 
 body {
+  --conversation-max-width: @conversation-max-width;
   --conversation-message-sender-width: @conversation-message-sender-width;
   --conversation-message-asset-width: 800px;
 }

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -274,19 +274,15 @@
 // MESSAGE - BODY
 .message-body {
   position: relative;
-  display: flex;
-  max-width: @conversation-max-width;
-  justify-content: space-between;
-  padding-left: @conversation-message-sender-width;
+  max-width: calc(100% - var(--conversation-message-sender-width));
+  padding-left: var(--conversation-message-sender-width);
 
-  &-content {
-    width: 100%;
-    max-width: calc(@conversation-max-width - var(--conversation-message-sender-width));
-    height: fit-content;
+  .text:has(> .iframe-container) {
+    margin-right: 0;
+  }
 
-    .text:has(> .iframe-container) {
-      margin-right: 0;
-    }
+  &:has(.message-quote__text--full pre) {
+    display: flex;
   }
 
   .text {
@@ -295,7 +291,6 @@
 
     display: inline;
     min-width: 0;
-    margin-right: 12px;
     line-height: @line-height-lg;
     white-space: pre-wrap;
     word-wrap: break-word;

--- a/src/style/content/conversation/message-quote.less
+++ b/src/style/content/conversation/message-quote.less
@@ -71,6 +71,11 @@
 
       pre {
         overflow: auto;
+        max-width: var(--conversation-message-asset-width);
+        padding: 16px;
+        border-radius: 12px;
+        background: var(--foreground-fade-8);
+        margin-block: 4px;
         text-overflow: unset;
       }
     }


### PR DESCRIPTION
## Description

Fixed displaying read indicators after assets/codeblocks and text.
Now all read indicators displays behind image while images is small or large, not to faar..

Also updated code block design.

## Screenshots/Screencast (for UI changes)

![image](https://github.com/wireapp/wire-webapp/assets/13432884/fa788804-4540-4efb-b098-c5296267b783)

![image](https://github.com/wireapp/wire-webapp/assets/13432884/f3decfaa-7734-4e70-8370-b9ef6d5c1ef6)


## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
