### PR TITLE
runfix: check mls conversation verification state on welcome

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@peculiar/x509": "1.9.6",
     "@wireapp/avs": "9.6.12",
     "@wireapp/commons": "5.2.4",
-    "@wireapp/core": "45.0.0",
+    "@wireapp/core": "45.0.2",
     "@wireapp/react-ui-kit": "9.15.4",
     "@wireapp/store-engine-dexie": "2.1.7",
     "@wireapp/webapp-events": "0.20.1",

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -40,7 +40,6 @@ import {
   CONVERSATION_EVENT,
 } from '@wireapp/api-client/lib/event/';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
-import {E2eiConversationState} from '@wireapp/core/lib/messagingProtocols/mls';
 import {amplify} from 'amplify';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import ko from 'knockout';
@@ -73,7 +72,6 @@ import {escapeRegex} from 'Util/SanitizationUtil';
 import {createUuid} from 'Util/uuid';
 
 import {CONVERSATION_READONLY_STATE, ConversationRepository} from './ConversationRepository';
-import {ConversationVerificationState} from './ConversationVerificationState';
 
 import {entities, payload} from '../../../test/api/payloads';
 import {TestFactory} from '../../../test/helper/TestFactory';
@@ -1865,49 +1863,6 @@ describe('ConversationRepository', () => {
     });
 
     describe('conversation.mls-welcome', () => {
-      it('should check mls verification state after being added to a mls group', async () => {
-        const conversationRepository = testFactory.conversation_repository!;
-        const onConversationVerificationStateChange = jest.fn();
-
-        conversationRepository.registerMLSConversationVerificationStateHandler(
-          onConversationVerificationStateChange,
-          jest.fn(),
-        );
-
-        const mockedGroupId = 'AAEAAKA0LuGtiU7NjqqlZIE2dQUAZWxuYS53aXJlLmxpbms=';
-
-        const conversation = _generateConversation({
-          groupId: mockedGroupId,
-          type: CONVERSATION_TYPE.REGULAR,
-          protocol: ConversationProtocol.MLS,
-        });
-
-        conversation.mlsVerificationState(ConversationVerificationState.UNVERIFIED);
-
-        await conversationRepository['saveConversation'](conversation);
-
-        const welcomeEvent: ConversationMLSWelcomeEvent = {
-          conversation: conversation.id,
-          data: conversation.groupId!,
-          from: 'd5a39ffb-6ce3-4cc8-9048-0e15d031b4c5',
-          time: '2015-04-27T11:42:31.475Z',
-          type: CONVERSATION_EVENT.MLS_WELCOME_MESSAGE,
-        };
-
-        const coreE2EIService = container.resolve(Core).service!.e2eIdentity!;
-
-        jest.spyOn(coreE2EIService, 'getConversationState').mockResolvedValueOnce(E2eiConversationState.Verified);
-
-        await conversationRepository['handleConversationEvent'](welcomeEvent);
-
-        expect(onConversationVerificationStateChange).toHaveBeenCalledWith({
-          conversationEntity: conversation,
-          conversationVerificationState: ConversationVerificationState.VERIFIED,
-        });
-
-        expect(conversation.mlsVerificationState()).toEqual(ConversationVerificationState.VERIFIED);
-      });
-
       it('should initialise mls 1:1 conversation after receiving a welcome', async () => {
         const conversationRepository = testFactory.conversation_repository!;
         const mockedGroupId = 'AAEAAKA0LuGtiU7NjqqlZIE2dQUAZWxuYS53aXJlLmxpbms=';

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -3946,7 +3946,11 @@ export class ConversationRepository {
   private async onMLSWelcomeMessage(conversationEntity: Conversation) {
     // If we receive a welcome message in mls 1:1 conversation, we need to make sure proteus 1:1 is hidden (if it exists)
 
-    if (conversationEntity.type() === CONVERSATION_TYPE.ONE_TO_ONE && isMLSConversation(conversationEntity)) {
+    if (!isMLSConversation(conversationEntity)) {
+      return;
+    }
+
+    if (conversationEntity.type() === CONVERSATION_TYPE.ONE_TO_ONE) {
       const [otherUserId] = conversationEntity.participating_user_ids();
 
       if (otherUserId) {

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -3957,9 +3957,6 @@ export class ConversationRepository {
         await this.initMLS1to1Conversation(otherUserId, true);
       }
     }
-
-    // After the welcome message is received (we were added to a conversation), we need to check mls conversation verification state
-    await this.mlsConversationVerificationStateHandler?.checkConversationVerificationState(conversationEntity);
   }
 
   /**

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -179,7 +179,7 @@ export class ConversationRepository {
   private readonly logger: Logger;
   public readonly stateHandler: ConversationStateHandler;
   public readonly proteusVerificationStateHandler: ProteusConversationVerificationStateHandler;
-  private mlsConversationVerificationStateHandler: MLSConversationVerificationStateHandler;
+  private mlsConversationVerificationStateHandler?: MLSConversationVerificationStateHandler;
 
   static get CONFIG() {
     return {
@@ -354,14 +354,12 @@ export class ConversationRepository {
   public registerMLSConversationVerificationStateHandler = (
     onConversationVerificationStateChange: OnConversationE2EIVerificationStateChange = () => {},
     onSelfClientCertificateRevoked: () => Promise<void> = async () => {},
-    conversationState: ConversationState = container.resolve(ConversationState),
-    core: Core = container.resolve(Core),
   ): void => {
     this.mlsConversationVerificationStateHandler = new MLSConversationVerificationStateHandler(
       onConversationVerificationStateChange,
       onSelfClientCertificateRevoked,
-      conversationState,
-      core,
+      this.conversationState,
+      this.core,
     );
   };
 
@@ -3024,6 +3022,7 @@ export class ConversationRepository {
     }
 
     const {conversation, qualified_conversation, data: eventData, type} = eventJson;
+
     const dataConversationId: string = (eventData as any)?.conversationId;
     // data.conversationId is always the conversationId that should be read first. If not found we can fallback to qualified_conversation or conversation
     const conversationId: QualifiedId = dataConversationId
@@ -3956,7 +3955,7 @@ export class ConversationRepository {
     }
 
     // After the welcome message is received (we were added to a conversation), we need to check mls conversation verification state
-    await this.mlsConversationVerificationStateHandler.checkConversationVerificationState(conversationEntity);
+    await this.mlsConversationVerificationStateHandler?.checkConversationVerificationState(conversationEntity);
   }
 
   /**

--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.test.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.test.ts
@@ -26,10 +26,25 @@ import {Core} from 'src/script/service/CoreSingleton';
 import {createUuid} from 'Util/uuid';
 import {waitFor} from 'Util/waitFor';
 
-import {registerMLSConversationVerificationStateHandler} from './MLSStateHandler';
+import {MLSConversationVerificationStateHandler} from './MLSStateHandler';
 
 import {ConversationState} from '../../ConversationState';
 import {ConversationVerificationState} from '../../ConversationVerificationState';
+import {OnConversationE2EIVerificationStateChange} from '../shared';
+
+const createHandler = (
+  onConversationVerificationStateChange: OnConversationE2EIVerificationStateChange = () => {},
+  onSelfClientCertificateRevoked: () => Promise<void> = async () => {},
+  conversationState: ConversationState,
+  core: Core,
+): void => {
+  new MLSConversationVerificationStateHandler(
+    onConversationVerificationStateChange,
+    onSelfClientCertificateRevoked,
+    conversationState,
+    core,
+  );
+};
 
 describe('MLSConversationVerificationStateHandler', () => {
   const conversationState = new ConversationState();
@@ -47,7 +62,7 @@ describe('MLSConversationVerificationStateHandler', () => {
   it('should do nothing if MLS service is not available', () => {
     core.service!.mls = undefined;
 
-    const t = () => registerMLSConversationVerificationStateHandler(undefined, undefined, conversationState, core);
+    const t = () => createHandler(undefined, undefined, conversationState, core);
 
     expect(t).not.toThrow();
   });
@@ -55,7 +70,7 @@ describe('MLSConversationVerificationStateHandler', () => {
   it('should do nothing if e2eIdentity service is not available', () => {
     core.service!.e2eIdentity = undefined;
 
-    registerMLSConversationVerificationStateHandler(undefined, undefined, conversationState, core);
+    createHandler(undefined, undefined, conversationState, core);
 
     expect(core.service?.mls?.on).not.toHaveBeenCalled();
   });
@@ -69,7 +84,7 @@ describe('MLSConversationVerificationStateHandler', () => {
         .spyOn(core.service!.mls!, 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
-      registerMLSConversationVerificationStateHandler(undefined, undefined, conversationState, core);
+      createHandler(undefined, undefined, conversationState, core);
 
       triggerEpochChange({groupId});
       await new Promise(resolve => setTimeout(resolve, 0));
@@ -84,7 +99,7 @@ describe('MLSConversationVerificationStateHandler', () => {
         .spyOn(core.service!.mls!, 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
-      registerMLSConversationVerificationStateHandler(undefined, undefined, conversationState, core);
+      createHandler(undefined, undefined, conversationState, core);
 
       triggerEpochChange({groupId});
       await new Promise(resolve => setTimeout(resolve, 0));
@@ -99,7 +114,7 @@ describe('MLSConversationVerificationStateHandler', () => {
         .spyOn(core.service!.mls!, 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
-      registerMLSConversationVerificationStateHandler(undefined, undefined, conversationState, core);
+      createHandler(undefined, undefined, conversationState, core);
 
       triggerEpochChange({groupId});
       await new Promise(resolve => setTimeout(resolve, 0));
@@ -116,7 +131,7 @@ describe('MLSConversationVerificationStateHandler', () => {
         .spyOn(core.service!.mls!, 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
-      registerMLSConversationVerificationStateHandler(undefined, undefined, conversationState, core);
+      createHandler(undefined, undefined, conversationState, core);
 
       triggerEpochChange({groupId: newConversation.groupId});
       setTimeout(() => {

--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.test.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.test.ts
@@ -32,7 +32,7 @@ import {ConversationState} from '../../ConversationState';
 import {ConversationVerificationState} from '../../ConversationVerificationState';
 import {OnConversationE2EIVerificationStateChange} from '../shared';
 
-const createHandler = (
+const createMLSConversationVerificationHandler = (
   onConversationVerificationStateChange: OnConversationE2EIVerificationStateChange = () => {},
   onSelfClientCertificateRevoked: () => Promise<void> = async () => {},
   conversationState: ConversationState,
@@ -62,7 +62,7 @@ describe('MLSConversationVerificationStateHandler', () => {
   it('should do nothing if MLS service is not available', () => {
     core.service!.mls = undefined;
 
-    const t = () => createHandler(undefined, undefined, conversationState, core);
+    const t = () => createMLSConversationVerificationHandler(undefined, undefined, conversationState, core);
 
     expect(t).not.toThrow();
   });
@@ -70,7 +70,7 @@ describe('MLSConversationVerificationStateHandler', () => {
   it('should do nothing if e2eIdentity service is not available', () => {
     core.service!.e2eIdentity = undefined;
 
-    createHandler(undefined, undefined, conversationState, core);
+    createMLSConversationVerificationHandler(undefined, undefined, conversationState, core);
 
     expect(core.service?.mls?.on).not.toHaveBeenCalled();
   });
@@ -84,7 +84,7 @@ describe('MLSConversationVerificationStateHandler', () => {
         .spyOn(core.service!.mls!, 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
-      createHandler(undefined, undefined, conversationState, core);
+      createMLSConversationVerificationHandler(undefined, undefined, conversationState, core);
 
       triggerEpochChange({groupId});
       await new Promise(resolve => setTimeout(resolve, 0));
@@ -99,7 +99,7 @@ describe('MLSConversationVerificationStateHandler', () => {
         .spyOn(core.service!.mls!, 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
-      createHandler(undefined, undefined, conversationState, core);
+      createMLSConversationVerificationHandler(undefined, undefined, conversationState, core);
 
       triggerEpochChange({groupId});
       await new Promise(resolve => setTimeout(resolve, 0));
@@ -114,7 +114,7 @@ describe('MLSConversationVerificationStateHandler', () => {
         .spyOn(core.service!.mls!, 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
-      createHandler(undefined, undefined, conversationState, core);
+      createMLSConversationVerificationHandler(undefined, undefined, conversationState, core);
 
       triggerEpochChange({groupId});
       await new Promise(resolve => setTimeout(resolve, 0));
@@ -131,7 +131,7 @@ describe('MLSConversationVerificationStateHandler', () => {
         .spyOn(core.service!.mls!, 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
-      createHandler(undefined, undefined, conversationState, core);
+      createMLSConversationVerificationHandler(undefined, undefined, conversationState, core);
 
       triggerEpochChange({groupId: newConversation.groupId});
       setTimeout(() => {

--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
@@ -60,9 +60,8 @@ export class MLSConversationVerificationStateHandler {
   }
 
   /**
-   * This function checks if the conversation is verified and if it is, it will degrade it
+   * Degrades the conversation
    * @param conversation
-   * @param userIds
    */
   private async degradeConversation(conversation: MLSConversation) {
     const state = ConversationVerificationState.DEGRADED;
@@ -84,9 +83,8 @@ export class MLSConversationVerificationStateHandler {
   }
 
   /**
-   * This function checks if the conversation is degraded and if it is, it will verify it
+   * Verifies the conversation
    * @param conversation
-   * @param userIds
    */
   private async verifyConversation(conversation: MLSConversation) {
     const state = ConversationVerificationState.VERIFIED;

--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
@@ -20,7 +20,6 @@
 import {CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {E2eiConversationState} from '@wireapp/core/lib/messagingProtocols/mls';
-import {container} from 'tsyringe';
 
 import {
   getActiveWireIdentity,
@@ -39,7 +38,7 @@ import {ConversationState} from '../../ConversationState';
 import {ConversationVerificationState} from '../../ConversationVerificationState';
 import {getConversationByGroupId, OnConversationE2EIVerificationStateChange} from '../shared';
 
-class MLSConversationVerificationStateHandler {
+export class MLSConversationVerificationStateHandler {
   private readonly logger: Logger;
 
   public constructor(
@@ -139,7 +138,7 @@ class MLSConversationVerificationStateHandler {
     return this.checkConversationVerificationState(conversation);
   };
 
-  private checkConversationVerificationState = async (conversation: Conversation): Promise<void> => {
+  public checkConversationVerificationState = async (conversation: Conversation): Promise<void> => {
     const isSelfConversation = conversation.type() === CONVERSATION_TYPE.SELF;
     if (!isMLSConversation(conversation) || isSelfConversation) {
       return;
@@ -160,17 +159,3 @@ class MLSConversationVerificationStateHandler {
     }
   };
 }
-
-export const registerMLSConversationVerificationStateHandler = (
-  onConversationVerificationStateChange: OnConversationE2EIVerificationStateChange = () => {},
-  onSelfClientCertificateRevoked: () => Promise<void> = async () => {},
-  conversationState: ConversationState = container.resolve(ConversationState),
-  core: Core = container.resolve(Core),
-): void => {
-  new MLSConversationVerificationStateHandler(
-    onConversationVerificationStateChange,
-    onSelfClientCertificateRevoked,
-    conversationState,
-    core,
-  );
-};

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -59,7 +59,6 @@ import {ConnectionService} from '../connection/ConnectionService';
 import {ConversationRepository} from '../conversation/ConversationRepository';
 import {ConversationService} from '../conversation/ConversationService';
 import {ConversationVerificationState} from '../conversation/ConversationVerificationState';
-import {registerMLSConversationVerificationStateHandler} from '../conversation/ConversationVerificationStateHandler';
 import {OnConversationE2EIVerificationStateChange} from '../conversation/ConversationVerificationStateHandler/shared';
 import {EventBuilder} from '../conversation/EventBuilder';
 import {MessageRepository} from '../conversation/MessageRepository';
@@ -458,7 +457,7 @@ export class App {
       if (supportsMLS()) {
         //if mls is supported, we need to initialize the callbacks (they are used when decrypting messages)
         conversationRepository.initMLSConversationRecoveredListener();
-        registerMLSConversationVerificationStateHandler(
+        conversationRepository.registerMLSConversationVerificationStateHandler(
           this.updateConversationE2EIVerificationState,
           this.showClientCertificateRevokedWarning,
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4812,9 +4812,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^26.10.10":
-  version: 26.10.10
-  resolution: "@wireapp/api-client@npm:26.10.10"
+"@wireapp/api-client@npm:^26.10.11":
+  version: 26.10.11
+  resolution: "@wireapp/api-client@npm:26.10.11"
   dependencies:
     "@wireapp/commons": ^5.2.5
     "@wireapp/priority-queue": ^2.1.4
@@ -4830,7 +4830,7 @@ __metadata:
     tough-cookie: 4.1.3
     ws: 8.16.0
     zod: 3.22.4
-  checksum: b1610c4e8e0661e48d5df6de1d055231cabb2bee74d1dc74aeda8d242d97a79df72e7f4177f7ed17aeb7a30be04dd471283a44657423bbebe99cafdcaf866e37
+  checksum: 929574d2ed50a52da0a9e407010802d996efe531f37a7a13c7bad94b2837e221acaee2422ccbf0d213e5515358877ace91ddf1eb86af89b41501354ff82761f9
   languageName: node
   linkType: hard
 
@@ -4895,11 +4895,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:45.0.0":
-  version: 45.0.0
-  resolution: "@wireapp/core@npm:45.0.0"
+"@wireapp/core@npm:45.0.2":
+  version: 45.0.2
+  resolution: "@wireapp/core@npm:45.0.2"
   dependencies:
-    "@wireapp/api-client": ^26.10.10
+    "@wireapp/api-client": ^26.10.11
     "@wireapp/commons": ^5.2.5
     "@wireapp/core-crypto": 1.0.0-rc.43
     "@wireapp/cryptobox": 12.8.0
@@ -4916,7 +4916,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: cd5898cfc51c576de066e951a639c4bdaa9ecc3f7db54e4d7aec203ea7b267d2a27576fa42542f9e65325578c7317065fd8ecc07c567f6992ee03689801eb9f8
+  checksum: 8b5c2eb1b41ac1f33de2cfa83549f06a93b0d874e0252a974c8bb9422f9561f7fabd724491d54065c30b9bfa0baeea90e4df3e8482ee55ab5f274f44ca303d85
   languageName: node
   linkType: hard
 
@@ -17616,7 +17616,7 @@ __metadata:
     "@wireapp/avs": 9.6.12
     "@wireapp/commons": 5.2.4
     "@wireapp/copy-config": 2.1.14
-    "@wireapp/core": 45.0.0
+    "@wireapp/core": 45.0.2
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.15.4


### PR DESCRIPTION
## Description

We want to check mls verification state (verified/non-verified/degraded) every time group membership change. 

Currently we were re-evaluating the state every time MLS group's epoch changed, what makes sense most of the time when we are a group member already.

We were never checking the state when being added to a group with a welcome message, therefore until we received first epoch update conversation was still unverified for us. A fix is to also re-evaluate the mls verification state also after mls welcome message is received.

This PR also moves mls verification state handler to a conversation repo as it's private dependency.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;