### PR TITLE
runfix: add more corecrypto errors to be ignored [WPB-6451]

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@peculiar/x509": "1.9.6",
     "@wireapp/avs": "9.6.12",
     "@wireapp/commons": "5.2.4",
-    "@wireapp/core": "45.0.0",
+    "@wireapp/core": "45.0.1",
     "@wireapp/react-ui-kit": "9.15.4",
     "@wireapp/store-engine-dexie": "2.1.7",
     "@wireapp/webapp-events": "0.20.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4895,9 +4895,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:45.0.0":
-  version: 45.0.0
-  resolution: "@wireapp/core@npm:45.0.0"
+"@wireapp/core@npm:45.0.1":
+  version: 45.0.1
+  resolution: "@wireapp/core@npm:45.0.1"
   dependencies:
     "@wireapp/api-client": ^26.10.10
     "@wireapp/commons": ^5.2.5
@@ -4916,7 +4916,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: cd5898cfc51c576de066e951a639c4bdaa9ecc3f7db54e4d7aec203ea7b267d2a27576fa42542f9e65325578c7317065fd8ecc07c567f6992ee03689801eb9f8
+  checksum: 80f731cb0ea289fcb3526faa1b7c87747e980bd5a307e306c1dc23cbd4a8fe86e96eb6670e71aac4b923a7d0fdf85fe47553b4f85517e0eaef1c307c35918568
   languageName: node
   linkType: hard
 
@@ -17616,7 +17616,7 @@ __metadata:
     "@wireapp/avs": 9.6.12
     "@wireapp/commons": 5.2.4
     "@wireapp/copy-config": 2.1.14
-    "@wireapp/core": 45.0.0
+    "@wireapp/core": 45.0.1
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.15.4


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6451" title="WPB-6451" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6451</a>  [Web] Ignore some CoreCrypto errors when decrypting
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Add core version that ignores more corecrypto errors when decrypting messages. For more details see https://github.com/wireapp/wire-web-packages/pull/6005

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;