### PR TITLE
fix: Remove image asset width for read indicator

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset.tsx
@@ -103,7 +103,7 @@ export const ImageAsset: React.FC<ImageAssetProps> = ({
   const imageContainerStyle: CSSObject = {
     aspectRatio: isFileSharingReceivingEnabled ? `${asset.ratio}` : undefined,
     maxWidth: 'calc(100% - var(--conversation-message-sender-width))',
-    width: asset.width,
+    maxHeight: '80vh',
   };
 
   return (


### PR DESCRIPTION
## Description

Wrongly removed property and value after migration from release/q1-2024 to dev.

## Screenshots/Screencast (for UI changes)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
