### PR TITLE
runfix: verify mls state on welcome message [WPB-6794] (#16913)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@peculiar/x509": "1.9.7",
     "@wireapp/avs": "9.6.12",
     "@wireapp/commons": "5.2.5",
-    "@wireapp/core": "45.0.1",
+    "@wireapp/core": "45.0.2",
     "@wireapp/react-ui-kit": "9.16.0",
     "@wireapp/store-engine-dexie": "2.1.8",
     "@wireapp/webapp-events": "0.20.1",

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -40,7 +40,6 @@ import {
   ConversationTypingEvent,
   CONVERSATION_EVENT,
   ConversationProtocolUpdateEvent,
-  ConversationMLSWelcomeEvent,
 } from '@wireapp/api-client/lib/event';
 import {BackendErrorLabel} from '@wireapp/api-client/lib/http/';
 import type {BackendError} from '@wireapp/api-client/lib/http/';
@@ -3233,7 +3232,7 @@ export class ConversationRepository {
         return this.onRename(conversationEntity, eventJson, eventSource === EventRepository.SOURCE.WEB_SOCKET);
 
       case CONVERSATION_EVENT.MLS_WELCOME_MESSAGE:
-        return this.onMLSWelcomeMessage(conversationEntity, eventJson);
+        return this.onMLSWelcomeMessage(conversationEntity);
 
       case ClientEvent.CONVERSATION.ASSET_ADD:
         return this.onAssetAdd(conversationEntity, eventJson);
@@ -3920,10 +3919,9 @@ export class ConversationRepository {
    * User has received a welcome message in a conversation.
    *
    * @param conversationEntity Conversation entity user has received a welcome message in
-   * @param eventJson JSON data of 'conversation.mls-welcome' event
    * @returns Resolves when the event was handled
    */
-  private async onMLSWelcomeMessage(conversationEntity: Conversation, eventJson: ConversationMLSWelcomeEvent) {
+  private async onMLSWelcomeMessage(conversationEntity: Conversation) {
     // If we receive a welcome message in mls 1:1 conversation, we need to make sure proteus 1:1 is hidden (if it exists)
 
     if (conversationEntity.type() !== CONVERSATION_TYPE.ONE_TO_ONE || !isMLSConversation(conversationEntity)) {

--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
@@ -61,9 +61,8 @@ class MLSConversationVerificationStateHandler {
   }
 
   /**
-   * This function checks if the conversation is verified and if it is, it will degrade it
+   * Changes mls verification state to "degraded"
    * @param conversation
-   * @param userIds
    */
   private async degradeConversation(conversation: MLSConversation) {
     const state = ConversationVerificationState.DEGRADED;
@@ -85,9 +84,8 @@ class MLSConversationVerificationStateHandler {
   }
 
   /**
-   * This function checks if the conversation is degraded and if it is, it will verify it
+   * Changes mls verification state to "verified"
    * @param conversation
-   * @param userIds
    */
   private async verifyConversation(conversation: MLSConversation) {
     const state = ConversationVerificationState.VERIFIED;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4830,9 +4830,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^26.10.10":
-  version: 26.10.10
-  resolution: "@wireapp/api-client@npm:26.10.10"
+"@wireapp/api-client@npm:^26.10.11":
+  version: 26.10.11
+  resolution: "@wireapp/api-client@npm:26.10.11"
   dependencies:
     "@wireapp/commons": ^5.2.5
     "@wireapp/priority-queue": ^2.1.4
@@ -4848,7 +4848,7 @@ __metadata:
     tough-cookie: 4.1.3
     ws: 8.16.0
     zod: 3.22.4
-  checksum: b1610c4e8e0661e48d5df6de1d055231cabb2bee74d1dc74aeda8d242d97a79df72e7f4177f7ed17aeb7a30be04dd471283a44657423bbebe99cafdcaf866e37
+  checksum: 929574d2ed50a52da0a9e407010802d996efe531f37a7a13c7bad94b2837e221acaee2422ccbf0d213e5515358877ace91ddf1eb86af89b41501354ff82761f9
   languageName: node
   linkType: hard
 
@@ -4901,11 +4901,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:45.0.1":
-  version: 45.0.1
-  resolution: "@wireapp/core@npm:45.0.1"
+"@wireapp/core@npm:45.0.2":
+  version: 45.0.2
+  resolution: "@wireapp/core@npm:45.0.2"
   dependencies:
-    "@wireapp/api-client": ^26.10.10
+    "@wireapp/api-client": ^26.10.11
     "@wireapp/commons": ^5.2.5
     "@wireapp/core-crypto": 1.0.0-rc.43
     "@wireapp/cryptobox": 12.8.0
@@ -4922,7 +4922,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: 80f731cb0ea289fcb3526faa1b7c87747e980bd5a307e306c1dc23cbd4a8fe86e96eb6670e71aac4b923a7d0fdf85fe47553b4f85517e0eaef1c307c35918568
+  checksum: 8b5c2eb1b41ac1f33de2cfa83549f06a93b0d874e0252a974c8bb9422f9561f7fabd724491d54065c30b9bfa0baeea90e4df3e8482ee55ab5f274f44ca303d85
   languageName: node
   linkType: hard
 
@@ -17615,7 +17615,7 @@ __metadata:
     "@wireapp/avs": 9.6.12
     "@wireapp/commons": 5.2.5
     "@wireapp/copy-config": 2.1.16
-    "@wireapp/core": 45.0.1
+    "@wireapp/core": 45.0.2
     "@wireapp/eslint-config": 3.0.6
     "@wireapp/prettier-config": 0.6.4
     "@wireapp/react-ui-kit": 9.16.0


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6794" title="WPB-6794" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6794</a>  [Web] MLS conversation with verified users is not marked as verified right after creation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Cherry-picked a commit from the release branch bumping a core that emits `newEpoch` event after mls welcome message is processed. For more details see https://github.com/wireapp/wire-webapp/pull/16913.