### PR TITLE
runfix: assign full width to message list

### DIFF
--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -274,7 +274,7 @@
 // MESSAGE - BODY
 .message-body {
   position: relative;
-  max-width: calc(100% - var(--conversation-message-sender-width));
+  max-width: 100%;
   padding-left: var(--conversation-message-sender-width);
 
   .text:has(> .iframe-container) {


### PR DESCRIPTION
## Description

The left gap seems to have been implemented twice, as padding, and as a restriction on full width.
Was spotted by the action menu shifting to the left

## Screenshots/Screencast (for UI changes)

before:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/218c7f0e-3ef7-4ea6-9ddc-14168a2dc204)

after:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/8bd7bd4b-c202-4b03-b034-5dfe7b1aed98)


