### PR TITLE
runfix: assign right margin to message list

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageActions.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageActions.styles.ts
@@ -31,7 +31,7 @@ export const messageBodyActions: CSSObject = {
   minHeight: '32px',
   minWidth: '40px',
   position: 'absolute',
-  right: 0,
+  right: '16px',
   top: '-34px',
   userSelect: 'none',
   '@media (max-width: @screen-md-min)': {

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageActions.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageActions.styles.ts
@@ -31,7 +31,7 @@ export const messageBodyActions: CSSObject = {
   minHeight: '32px',
   minWidth: '40px',
   position: 'absolute',
-  right: '16px',
+  right: 0,
   top: '-34px',
   userSelect: 'none',
   '@media (max-width: @screen-md-min)': {

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -274,8 +274,8 @@
 // MESSAGE - BODY
 .message-body {
   position: relative;
-  max-width: 100%;
   padding-left: var(--conversation-message-sender-width);
+  margin-right: 16px;
 
   .text:has(> .iframe-container) {
     margin-right: 0;

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -274,8 +274,8 @@
 // MESSAGE - BODY
 .message-body {
   position: relative;
+  padding-right: 40px;
   padding-left: var(--conversation-message-sender-width);
-  margin-right: 16px;
 
   .text:has(> .iframe-container) {
     margin-right: 0;


### PR DESCRIPTION
## Description

The message list is missing a 40px right padding

## Screenshots/Screencast (for UI changes)
![image](https://github.com/wireapp/wire-webapp/assets/78490891/d3577577-75bd-42f8-bc3e-0ccef4c6d63f)

