### PR TITLE
runfix: reset verification state on leave [WPB-6864]

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@peculiar/x509": "1.9.6",
     "@wireapp/avs": "9.6.12",
     "@wireapp/commons": "5.2.5",
-    "@wireapp/core": "45.0.3",
+    "@wireapp/core": "file:.yalc/@wireapp/core",
     "@wireapp/react-ui-kit": "9.16.0",
     "@wireapp/store-engine-dexie": "2.1.8",
     "@wireapp/webapp-events": "0.20.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@peculiar/x509": "1.9.6",
     "@wireapp/avs": "9.6.12",
     "@wireapp/commons": "5.2.5",
-    "@wireapp/core": "file:.yalc/@wireapp/core",
+    "@wireapp/core": "45.0.4",
     "@wireapp/react-ui-kit": "9.16.0",
     "@wireapp/store-engine-dexie": "2.1.8",
     "@wireapp/webapp-events": "0.20.1",

--- a/src/script/E2EIdentity/E2EIdentityVerification.ts
+++ b/src/script/E2EIdentity/E2EIdentityVerification.ts
@@ -63,12 +63,12 @@ function mapUserIdentities(userVerifications: Map<string, DeviceIdentity[]>): Ma
 
 export async function getUsersIdentities(groupId: string, userIds: QualifiedId[]) {
   const userVerifications = await getE2EIdentityService().getUsersIdentities(groupId, userIds);
-  return mapUserIdentities(userVerifications);
+  return userVerifications && mapUserIdentities(userVerifications);
 }
 
 export async function getAllGroupUsersIdentities(groupId: string) {
   const userVerifications = await getE2EIdentityService().getAllGroupUsersIdentities(groupId);
-  return mapUserIdentities(userVerifications);
+  return userVerifications && mapUserIdentities(userVerifications);
 }
 
 export async function getConversationVerificationState(groupId: string) {
@@ -82,6 +82,11 @@ const fetchSelfDeviceIdentity = async (): Promise<WireIdentity | undefined> => {
   const conversationState = container.resolve(ConversationState);
   const selfMLSConversation = conversationState.getSelfMLSConversation();
   const userIdentities = await getAllGroupUsersIdentities(selfMLSConversation.groupId);
+
+  if (!userIdentities) {
+    return undefined;
+  }
+
   const currentClientId = selfMLSConversation.selfUser()?.localClient?.id;
   const userId = selfMLSConversation.selfUser()?.id;
 

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -2464,7 +2464,8 @@ export class ConversationRepository {
    * @param mlsConversation mls conversation
    */
   async wipeMLSCapableConversation(conversation: MLSCapableConversation) {
-    return this.conversationService.wipeMLSCapableConversation(conversation);
+    await this.conversationService.wipeMLSCapableConversation(conversation);
+    conversation.mlsVerificationState(ConversationVerificationState.UNVERIFIED);
   }
 
   async leaveGuestRoom(): Promise<void> {

--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.test.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.test.ts
@@ -61,9 +61,27 @@ describe('MLSConversationVerificationStateHandler', () => {
   });
 
   describe('checkConversationVerificationState', () => {
+    it('should reset to unverified if mls group does not exist anymore', async () => {
+      let triggerEpochChange: Function = () => {};
+      conversation.mlsVerificationState(ConversationVerificationState.VERIFIED);
+      jest.spyOn(core.service!.mls!, 'conversationExists').mockResolvedValueOnce(false);
+
+      jest
+        .spyOn(core.service!.mls!, 'on')
+        .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
+
+      registerMLSConversationVerificationStateHandler(undefined, undefined, conversationState, core);
+
+      triggerEpochChange({groupId});
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(conversation.mlsVerificationState()).toBe(ConversationVerificationState.UNVERIFIED);
+    });
+
     it('should degrade conversation', async () => {
       let triggerEpochChange: Function = () => {};
       conversation.mlsVerificationState(ConversationVerificationState.VERIFIED);
+      jest.spyOn(core.service!.mls!, 'conversationExists').mockResolvedValueOnce(true);
+
       jest.spyOn(e2eIdentity, 'getConversationVerificationState').mockResolvedValue(E2eiConversationState.NotVerified);
       jest
         .spyOn(core.service!.mls!, 'on')
@@ -79,6 +97,9 @@ describe('MLSConversationVerificationStateHandler', () => {
     it('should not degrade conversation if it is not verified', async () => {
       let triggerEpochChange: Function = () => {};
       conversation.mlsVerificationState(ConversationVerificationState.UNVERIFIED);
+
+      jest.spyOn(core.service!.mls!, 'conversationExists').mockResolvedValueOnce(true);
+
       jest.spyOn(e2eIdentity, 'getConversationVerificationState').mockResolvedValue(E2eiConversationState.NotVerified);
       jest
         .spyOn(core.service!.mls!, 'on')
@@ -94,6 +115,9 @@ describe('MLSConversationVerificationStateHandler', () => {
     it('should verify conversation', async () => {
       let triggerEpochChange: Function = () => {};
       conversation.mlsVerificationState(ConversationVerificationState.DEGRADED);
+
+      jest.spyOn(core.service!.mls!, 'conversationExists').mockResolvedValueOnce(true);
+
       jest.spyOn(e2eIdentity, 'getConversationVerificationState').mockResolvedValue(E2eiConversationState.Verified);
       jest
         .spyOn(core.service!.mls!, 'on')
@@ -108,6 +132,9 @@ describe('MLSConversationVerificationStateHandler', () => {
 
     it('should wait for conversation to be known', async () => {
       let triggerEpochChange: Function = () => {};
+
+      jest.spyOn(core.service!.mls!, 'conversationExists').mockResolvedValueOnce(true);
+
       const newConversation = new Conversation(createUuid(), '', ConversationProtocol.MLS);
       newConversation.groupId = 'AAEAAAOygT3TL0wljoaNabgK4yIAZWxuYS53aXJlLmxpbms=';
 

--- a/src/script/hooks/useDeviceIdentities.ts
+++ b/src/script/hooks/useDeviceIdentities.ts
@@ -31,7 +31,7 @@ export const useUserIdentity = (userId: QualifiedId, groupId?: string, updateAft
       return;
     }
     const userIdentities = await getUsersIdentities(groupId, [userId]);
-    setDeviceIdentities(userIdentities.get(userId.id) ?? []);
+    setDeviceIdentities(userIdentities?.get(userId.id) ?? undefined);
   }, [userId.id, groupId]);
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -361,12 +361,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.22.15, @babel/parser@npm:^7.23.6, @babel/parser@npm:^7.9.4":
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.22.15, @babel/parser@npm:^7.23.6":
   version: 7.23.6
   resolution: "@babel/parser@npm:7.23.6"
   bin:
     parser: ./bin/babel-parser.js
   checksum: 140801c43731a6c41fd193f5c02bc71fd647a0360ca616b23d2db8be4b9739b9f951a03fc7c2db4f9b9214f4b27c1074db0f18bc3fa653783082d5af7c8860d5
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.9.4":
+  version: 7.23.9
+  resolution: "@babel/parser@npm:7.23.9"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: e7cd4960ac8671774e13803349da88d512f9292d7baa952173260d3e8f15620a28a3701f14f709d769209022f9e7b79965256b8be204fc550cfe783cdcabe7c7
   languageName: node
   linkType: hard
 
@@ -4197,7 +4206,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:>=13.7.0":
+"@types/node@npm:*":
   version: 20.11.0
   resolution: "@types/node@npm:20.11.0"
   dependencies:
@@ -4210,6 +4219,15 @@ __metadata:
   version: 16.9.1
   resolution: "@types/node@npm:16.9.1"
   checksum: 41afcf183a22d59323a0199dd7e0f46591247f45fc08a4434edb26d56dc279ae4fdb80f37989ddd7a0f45e3857c4933e6e82057ede09c5a829f77e373e680375
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:>=13.7.0":
+  version: 20.11.20
+  resolution: "@types/node@npm:20.11.20"
+  dependencies:
+    undici-types: ~5.26.4
+  checksum: 79d339622fed1c0e64297c8b9f558815a91edb9fea3acb69c1201b919d450e12915cf98b1a96b2d2c121bf86f30b62b6de3708f8894c5319f8dfb3a991e3ccdd
   languageName: node
   linkType: hard
 
@@ -4882,9 +4900,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@file:.yalc/@wireapp/core::locator=wire-webapp%40workspace%3A.":
-  version: 45.0.3
-  resolution: "@wireapp/core@file:.yalc/@wireapp/core#.yalc/@wireapp/core::hash=0d2982&locator=wire-webapp%40workspace%3A."
+"@wireapp/core@npm:45.0.4":
+  version: 45.0.4
+  resolution: "@wireapp/core@npm:45.0.4"
   dependencies:
     "@wireapp/api-client": ^26.10.12
     "@wireapp/commons": ^5.2.5
@@ -4903,7 +4921,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: c02d0d23a05d8a51e829acd10071755fbdfb1d85a6557dd7a27e19fc5691de45b8e5c1acb96659aa84d731756c77d9df348246bff41a4a5c0e8bb341dc33708d
+  checksum: e9b3af41c2092c589f20eda71a79336489008ebcddeb42076c298a2b694bd9318ea83d8141e998b3d5ea5729535f95c01b305b8a7750b8e90e9f63bac5f6e708
   languageName: node
   linkType: hard
 
@@ -15345,7 +15363,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.1.2, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.3, semver@npm:^7.5.4":
+"semver@npm:^7.1.2":
+  version: 7.6.0
+  resolution: "semver@npm:7.6.0"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: 7427f05b70786c696640edc29fdd4bc33b2acf3bbe1740b955029044f80575fc664e1a512e4113c3af21e767154a94b4aa214bf6cd6e42a1f6dba5914e0b208c
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.3, semver@npm:^7.5.4":
   version: 7.5.4
   resolution: "semver@npm:7.5.4"
   dependencies:
@@ -17603,7 +17632,7 @@ __metadata:
     "@wireapp/avs": 9.6.12
     "@wireapp/commons": 5.2.5
     "@wireapp/copy-config": 2.1.14
-    "@wireapp/core": "file:.yalc/@wireapp/core"
+    "@wireapp/core": 45.0.4
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.16.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -4882,9 +4882,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:45.0.3":
+"@wireapp/core@file:.yalc/@wireapp/core::locator=wire-webapp%40workspace%3A.":
   version: 45.0.3
-  resolution: "@wireapp/core@npm:45.0.3"
+  resolution: "@wireapp/core@file:.yalc/@wireapp/core#.yalc/@wireapp/core::hash=0d2982&locator=wire-webapp%40workspace%3A."
   dependencies:
     "@wireapp/api-client": ^26.10.12
     "@wireapp/commons": ^5.2.5
@@ -4903,7 +4903,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: f268ff0b5e02d72d764cab8ad5623d19233ba55ba6a81851fd68fd253c09a343bb40b335be09cb5a10ebf4347b39de9874455f903624345e0141c5edc7d2e19b
+  checksum: c02d0d23a05d8a51e829acd10071755fbdfb1d85a6557dd7a27e19fc5691de45b8e5c1acb96659aa84d731756c77d9df348246bff41a4a5c0e8bb341dc33708d
   languageName: node
   linkType: hard
 
@@ -17603,7 +17603,7 @@ __metadata:
     "@wireapp/avs": 9.6.12
     "@wireapp/commons": 5.2.5
     "@wireapp/copy-config": 2.1.14
-    "@wireapp/core": 45.0.3
+    "@wireapp/core": "file:.yalc/@wireapp/core"
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.16.0


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6864" title="WPB-6864" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6864</a>  [Web] Remove mls verification state after leaving/being removed from the group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Before
Group was still marked as verified, errors in the console
![before](https://github.com/wireapp/wire-webapp/assets/45733298/393732a9-1262-4280-9c58-32854715bbe0)

### After
Group mls verification state is reset to default (verified), no errors
![after](https://github.com/wireapp/wire-webapp/assets/45733298/788732cd-fcb9-4033-a0d1-e28aaabe145e)


## Description

getUserIdentities can now return `undefined` in case mls group does not exist anymore. Before trying to degrade/verify conversation state we should check if mls conversation does exist. If it does not - we reset mls verification state to the initial value (unverified).

Also whenever we leave the group (or get removed from it), we also reset the state to the initial value.

Needs https://github.com/wireapp/wire-web-packages/pull/6018 to be merged first.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;