### PR TITLE
runfix: prevent unmounted images to cause horizontal scrolling

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset/ImageAsset.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset/ImageAsset.tsx
@@ -100,13 +100,14 @@ export const ImageAsset = ({
   });
 
   const imageContainerStyle: CSSObject = {
-    maxWidth: 'var(--conversation-message-asset-width)',
+    ...(!imageUrl?.url ? {maxWidth: '100%'} : {maxWidth: 'var(--conversation-message-asset-width)'}),
   };
 
   const imageAsset: CSSObject = {
     aspectRatio: isFileSharingReceivingEnabled ? `${asset.ratio}` : undefined,
     ...(!imageUrl?.url
       ? {
+          maxWidth: '100%',
           width: asset.width,
           height: asset.height,
         }


### PR DESCRIPTION
## Description

unmounted images were extending the witdh of the message list to the full list of the asset, causing horizontal scrolling

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
