### PR TITLE
runfix: correct size of placeholder images

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset/ImageAsset.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset/ImageAsset.tsx
@@ -100,16 +100,15 @@ export const ImageAsset = ({
   });
 
   const imageContainerStyle: CSSObject = {
-    ...(!imageUrl?.url ? {maxWidth: '100%'} : {maxWidth: 'var(--conversation-message-asset-width)'}),
+    maxWidth: 'var(--conversation-message-asset-width)',
   };
 
   const imageAsset: CSSObject = {
     aspectRatio: isFileSharingReceivingEnabled ? `${asset.ratio}` : undefined,
     ...(!imageUrl?.url
       ? {
-          maxWidth: '100%',
-          width: asset.width,
-          height: asset.height,
+          maxWidth: asset.width,
+          maxHeight: asset.height,
         }
       : {
           maxWidth: asset.width,

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset/ImageAsset.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset/ImageAsset.tsx
@@ -105,15 +105,8 @@ export const ImageAsset = ({
 
   const imageAsset: CSSObject = {
     aspectRatio: isFileSharingReceivingEnabled ? `${asset.ratio}` : undefined,
-    ...(!imageUrl?.url
-      ? {
-          maxWidth: asset.width,
-          maxHeight: asset.height,
-        }
-      : {
-          maxWidth: asset.width,
-          maxHeight: '80vh',
-        }),
+    maxWidth: asset.width,
+    maxHeight: imageUrl ? '80vh' : asset.height,
   };
 
   const imageStyle: CSSObject = {


### PR DESCRIPTION
## Description

Placeholder image do not have the correct size
Their width and height is set to the actual size of the asset where it should be their max width/height

## Screenshots/Screencast (for UI changes)

Before:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/11d670bd-7e9c-442c-a753-6fceac385de2)


After:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/faeedef5-e80a-4e07-bd3a-0dd57c3dd60b)

Actual size:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/ec870f07-b481-4ae1-a5a7-143e1c9572d9)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
