### PR TITLE
runfix: reset verification state on leave [WPB-6864] (#16928)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@lexical/react": "0.13.1",
     "@wireapp/avs": "9.6.12",
     "@wireapp/commons": "5.2.5",
-    "@wireapp/core": "45.0.2",
+    "@wireapp/core": "45.0.4",
     "@wireapp/react-ui-kit": "9.16.0",
     "@wireapp/store-engine-dexie": "2.1.8",
     "@wireapp/webapp-events": "0.20.1",

--- a/src/script/E2EIdentity/E2EIdentityVerification.ts
+++ b/src/script/E2EIdentity/E2EIdentityVerification.ts
@@ -63,12 +63,12 @@ function mapUserIdentities(userVerifications: Map<string, DeviceIdentity[]>): Ma
 
 export async function getUsersIdentities(groupId: string, userIds: QualifiedId[]) {
   const userVerifications = await getE2EIdentityService().getUsersIdentities(groupId, userIds);
-  return mapUserIdentities(userVerifications);
+  return userVerifications && mapUserIdentities(userVerifications);
 }
 
 export async function getAllGroupUsersIdentities(groupId: string) {
   const userVerifications = await getE2EIdentityService().getAllGroupUsersIdentities(groupId);
-  return mapUserIdentities(userVerifications);
+  return userVerifications && mapUserIdentities(userVerifications);
 }
 
 export async function getConversationVerificationState(groupId: string) {
@@ -82,6 +82,11 @@ const fetchSelfDeviceIdentity = async (): Promise<WireIdentity | undefined> => {
   const conversationState = container.resolve(ConversationState);
   const selfMLSConversation = conversationState.getSelfMLSConversation();
   const userIdentities = await getAllGroupUsersIdentities(selfMLSConversation.groupId);
+
+  if (!userIdentities) {
+    return undefined;
+  }
+
   const currentClientId = selfMLSConversation.selfUser()?.localClient?.id;
   const userId = selfMLSConversation.selfUser()?.id;
 

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -2464,7 +2464,8 @@ export class ConversationRepository {
    * @param mlsConversation mls conversation
    */
   async wipeMLSCapableConversation(conversation: MLSCapableConversation) {
-    return this.conversationService.wipeMLSCapableConversation(conversation);
+    await this.conversationService.wipeMLSCapableConversation(conversation);
+    conversation.mlsVerificationState(ConversationVerificationState.UNVERIFIED);
   }
 
   async leaveGuestRoom(): Promise<void> {

--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.test.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.test.ts
@@ -61,9 +61,27 @@ describe('MLSConversationVerificationStateHandler', () => {
   });
 
   describe('checkConversationVerificationState', () => {
+    it('should reset to unverified if mls group does not exist anymore', async () => {
+      let triggerEpochChange: Function = () => {};
+      conversation.mlsVerificationState(ConversationVerificationState.VERIFIED);
+      jest.spyOn(core.service!.mls!, 'conversationExists').mockResolvedValueOnce(false);
+
+      jest
+        .spyOn(core.service!.mls!, 'on')
+        .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
+
+      registerMLSConversationVerificationStateHandler(undefined, undefined, conversationState, core);
+
+      triggerEpochChange({groupId});
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(conversation.mlsVerificationState()).toBe(ConversationVerificationState.UNVERIFIED);
+    });
+
     it('should degrade conversation', async () => {
       let triggerEpochChange: Function = () => {};
       conversation.mlsVerificationState(ConversationVerificationState.VERIFIED);
+      jest.spyOn(core.service!.mls!, 'conversationExists').mockResolvedValueOnce(true);
+
       jest.spyOn(e2eIdentity, 'getConversationVerificationState').mockResolvedValue(E2eiConversationState.NotVerified);
       jest
         .spyOn(core.service!.mls!, 'on')
@@ -79,6 +97,9 @@ describe('MLSConversationVerificationStateHandler', () => {
     it('should not degrade conversation if it is not verified', async () => {
       let triggerEpochChange: Function = () => {};
       conversation.mlsVerificationState(ConversationVerificationState.UNVERIFIED);
+
+      jest.spyOn(core.service!.mls!, 'conversationExists').mockResolvedValueOnce(true);
+
       jest.spyOn(e2eIdentity, 'getConversationVerificationState').mockResolvedValue(E2eiConversationState.NotVerified);
       jest
         .spyOn(core.service!.mls!, 'on')
@@ -94,6 +115,9 @@ describe('MLSConversationVerificationStateHandler', () => {
     it('should verify conversation', async () => {
       let triggerEpochChange: Function = () => {};
       conversation.mlsVerificationState(ConversationVerificationState.DEGRADED);
+
+      jest.spyOn(core.service!.mls!, 'conversationExists').mockResolvedValueOnce(true);
+
       jest.spyOn(e2eIdentity, 'getConversationVerificationState').mockResolvedValue(E2eiConversationState.Verified);
       jest
         .spyOn(core.service!.mls!, 'on')
@@ -108,6 +132,9 @@ describe('MLSConversationVerificationStateHandler', () => {
 
     it('should wait for conversation to be known', async () => {
       let triggerEpochChange: Function = () => {};
+
+      jest.spyOn(core.service!.mls!, 'conversationExists').mockResolvedValueOnce(true);
+
       const newConversation = new Conversation(createUuid(), '', ConversationProtocol.MLS);
       newConversation.groupId = 'AAEAAAOygT3TL0wljoaNabgK4yIAZWxuYS53aXJlLmxpbms=';
 

--- a/src/script/hooks/useDeviceIdentities.ts
+++ b/src/script/hooks/useDeviceIdentities.ts
@@ -31,7 +31,7 @@ export const useUserIdentity = (userId: QualifiedId, groupId?: string, updateAft
       return;
     }
     const userIdentities = await getUsersIdentities(groupId, [userId]);
-    setDeviceIdentities(userIdentities.get(userId.id) ?? []);
+    setDeviceIdentities(userIdentities?.get(userId.id) ?? undefined);
   }, [userId.id, groupId]);
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4081,7 +4081,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:>=13.7.0":
+"@types/node@npm:*":
   version: 20.11.19
   resolution: "@types/node@npm:20.11.19"
   dependencies:
@@ -4097,7 +4097,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^20.11.20":
+"@types/node@npm:>=13.7.0, @types/node@npm:^20.11.20":
   version: 20.11.20
   resolution: "@types/node@npm:20.11.20"
   dependencies:
@@ -4755,9 +4755,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:45.0.2":
-  version: 45.0.2
-  resolution: "@wireapp/core@npm:45.0.2"
+"@wireapp/core@npm:45.0.4":
+  version: 45.0.4
+  resolution: "@wireapp/core@npm:45.0.4"
   dependencies:
     "@wireapp/api-client": ^26.10.11
     "@wireapp/commons": ^5.2.5
@@ -4776,7 +4776,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: 8b5c2eb1b41ac1f33de2cfa83549f06a93b0d874e0252a974c8bb9422f9561f7fabd724491d54065c30b9bfa0baeea90e4df3e8482ee55ab5f274f44ca303d85
+  checksum: e9b3af41c2092c589f20eda71a79336489008ebcddeb42076c298a2b694bd9318ea83d8141e998b3d5ea5729535f95c01b305b8a7750b8e90e9f63bac5f6e708
   languageName: node
   linkType: hard
 
@@ -15182,7 +15182,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.1.2, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.3, semver@npm:^7.5.4":
+"semver@npm:^7.1.2":
+  version: 7.6.0
+  resolution: "semver@npm:7.6.0"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: 7427f05b70786c696640edc29fdd4bc33b2acf3bbe1740b955029044f80575fc664e1a512e4113c3af21e767154a94b4aa214bf6cd6e42a1f6dba5914e0b208c
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.3, semver@npm:^7.5.4":
   version: 7.5.4
   resolution: "semver@npm:7.5.4"
   dependencies:
@@ -17427,7 +17438,7 @@ __metadata:
     "@wireapp/avs": 9.6.12
     "@wireapp/commons": 5.2.5
     "@wireapp/copy-config": 2.1.16
-    "@wireapp/core": 45.0.2
+    "@wireapp/core": 45.0.4
     "@wireapp/eslint-config": 3.0.6
     "@wireapp/prettier-config": 0.6.4
     "@wireapp/react-ui-kit": 9.16.0


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6864" title="WPB-6864" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6864</a>  [Web] Remove mls verification state after leaving/being removed from the group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Cherry-picking a PR from the release branch that handles resetting mls verification state after leaving or being removed from a conversation. For more details see https://github.com/wireapp/wire-webapp/pull/16928.