### PR TITLE
runfix: do not refresh self supported protocols when loading all notifications

### DIFF
--- a/src/script/client/ClientRepository.ts
+++ b/src/script/client/ClientRepository.ts
@@ -534,13 +534,16 @@ export class ClientRepository {
    *
    * @param eventJson JSON data for event
    */
-  private readonly onUserEvent = (eventJson: UserClientAddEvent | UserClientRemoveEvent): void => {
+  private readonly onUserEvent = async (
+    eventJson: UserClientAddEvent | UserClientRemoveEvent,
+    source: EventSource,
+  ): Promise<void> => {
     if (eventJson.type === USER_EVENT.CLIENT_ADD) {
       return this.onClientAdd(eventJson);
     }
 
     if (eventJson.type === USER_EVENT.CLIENT_REMOVE) {
-      this.onClientRemove(eventJson);
+      return this.onClientRemove(eventJson, source);
     }
   };
 
@@ -558,7 +561,7 @@ export class ClientRepository {
    * @param JSON data of 'user.client-remove' event
    * @returns Resolves when the event has been handled
    */
-  private async onClientRemove(eventJson?: UserClientRemoveEvent): Promise<void> {
+  private async onClientRemove(eventJson: UserClientRemoveEvent, source: EventSource): Promise<void> {
     const clientId = eventJson?.client ? eventJson.client.id : undefined;
     if (!clientId) {
       return;
@@ -584,7 +587,7 @@ export class ClientRepository {
         'legalHoldDeactivated',
       );
     }
-    amplify.publish(WebAppEvents.CLIENT.REMOVE, this.selfUser().qualifiedId, clientId);
+    amplify.publish(WebAppEvents.CLIENT.REMOVE, this.selfUser().qualifiedId, clientId, source);
   }
 
   public async haveAllActiveSelfClientsRegisteredMLSDevice(): Promise<boolean> {


### PR DESCRIPTION
## Description

We were unnecessarily refreshing self supported protocols on every client-remove event. We should do that only if the event was coming from the web socket (and not if we have missed some messages and loaded all the notifications from scratch that could include a lot of client add/remove events).

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;