### PR TITLE
runfix: allow autoscrolling with placeholder images

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset/ImageAsset.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset/ImageAsset.tsx
@@ -105,8 +105,15 @@ export const ImageAsset = ({
 
   const imageAsset: CSSObject = {
     aspectRatio: isFileSharingReceivingEnabled ? `${asset.ratio}` : undefined,
-    maxWidth: asset.width,
-    maxHeight: imageUrl ? '80vh' : asset.height,
+    ...(!imageUrl?.url
+      ? {
+          maxWidth: asset.width,
+          maxHeight: asset.height,
+        }
+      : {
+          maxWidth: asset.width,
+          maxHeight: '80vh',
+        }),
   };
 
   const imageStyle: CSSObject = {


### PR DESCRIPTION
This reverts commit 3ed385cc7c257def9e75a8983d146d527daf614e.

## Description

After refactoring conditions to apply css, the rendering of placeholder images does not trigger auto scrolling


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;