### PR TITLE
runfix: prevent error messages from displaying incorrectly

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -235,14 +235,6 @@ export const ContentMessageComponent = ({
           />
         ))}
 
-        {failedToSend && (
-          <PartialFailureToSendWarning
-            isMessageFocused={msgFocusState}
-            failedToSend={failedToSend}
-            knownUsers={conversation.allUserEntities()}
-          />
-        )}
-
         {isAssetMessage && (
           <ReadIndicator
             message={message}

--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -243,14 +243,6 @@ export const ContentMessageComponent = ({
           />
         )}
 
-        {[StatusType.FAILED, StatusType.FEDERATION_ERROR].includes(status) && (
-          <CompleteFailureToSendWarning
-            {...(status === StatusType.FEDERATION_ERROR && {unreachableDomain: conversation.domain})}
-            isMessageFocused={msgFocusState}
-            onRetry={() => onRetry(message)}
-          />
-        )}
-
         {isAssetMessage && (
           <ReadIndicator
             message={message}
@@ -273,6 +265,22 @@ export const ContentMessageComponent = ({
           />
         )}
       </div>
+
+      {[StatusType.FAILED, StatusType.FEDERATION_ERROR].includes(status) && (
+        <CompleteFailureToSendWarning
+          {...(status === StatusType.FEDERATION_ERROR && {unreachableDomain: conversation.domain})}
+          isMessageFocused={msgFocusState}
+          onRetry={() => onRetry(message)}
+        />
+      )}
+
+      {failedToSend && (
+        <PartialFailureToSendWarning
+          isMessageFocused={msgFocusState}
+          failedToSend={failedToSend}
+          knownUsers={conversation.allUserEntities()}
+        />
+      )}
 
       {!!reactions.length && (
         <MessageReactionsList

--- a/src/script/components/MessagesList/Message/ContentMessage/Warnings/CompleteFailureToSend/CompleteFailureToSend.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/Warnings/CompleteFailureToSend/CompleteFailureToSend.tsx
@@ -23,7 +23,7 @@ import {useMessageFocusedTabIndex} from 'Components/MessagesList/Message/util';
 import {Config} from 'src/script/Config';
 import {t} from 'Util/LocalizerUtil';
 
-import {backendErrorLink, warning} from '../Warnings.styles';
+import {backendErrorLink, button, warning, wrapper} from '../Warnings.styles';
 
 type Props = {
   isMessageFocused: boolean;
@@ -36,7 +36,7 @@ const config = Config.getConfig();
 export const CompleteFailureToSendWarning = ({isMessageFocused, onRetry, unreachableDomain}: Props) => {
   const messageFocusedTabIndex = useMessageFocusedTabIndex(isMessageFocused);
   return (
-    <>
+    <div css={wrapper}>
       {unreachableDomain ? (
         <p>
           <span
@@ -60,10 +60,16 @@ export const CompleteFailureToSendWarning = ({isMessageFocused, onRetry, unreach
         <p css={warning}>{t('messageCouldNotBeSentConnectivityIssues')}</p>
       )}
       <div css={{display: 'flex'}}>
-        <Button tabIndex={messageFocusedTabIndex} type="button" variant={ButtonVariant.TERTIARY} onClick={onRetry}>
+        <Button
+          css={button}
+          tabIndex={messageFocusedTabIndex}
+          type="button"
+          variant={ButtonVariant.TERTIARY}
+          onClick={onRetry}
+        >
           {t('messageCouldNotBeSentRetry')}
         </Button>
       </div>
-    </>
+    </div>
   );
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/Warnings/PartialFailureToSend/PartialFailureToSend.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/Warnings/PartialFailureToSend/PartialFailureToSend.tsx
@@ -30,7 +30,7 @@ import {Config} from 'src/script/Config';
 import {t} from 'Util/LocalizerUtil';
 import {matchQualifiedIds} from 'Util/QualifiedId';
 
-import {backendErrorLink, warning, wrapper} from '../Warnings.styles';
+import {backendErrorLink, button, warning, wrapper} from '../Warnings.styles';
 
 export type User = {qualifiedId: QualifiedId; name: () => string};
 type Props = {
@@ -191,6 +191,7 @@ export const PartialFailureToSendWarning = ({failedToSend, isMessageFocused, kno
             </>
           )}
           <Button
+            css={button}
             type="button"
             tabIndex={messageFocusedTabIndex}
             variant={ButtonVariant.TERTIARY}

--- a/src/script/components/MessagesList/Message/ContentMessage/Warnings/PartialFailureToSend/PartialFailureToSend.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/Warnings/PartialFailureToSend/PartialFailureToSend.tsx
@@ -30,7 +30,7 @@ import {Config} from 'src/script/Config';
 import {t} from 'Util/LocalizerUtil';
 import {matchQualifiedIds} from 'Util/QualifiedId';
 
-import {backendErrorLink, warning} from '../Warnings.styles';
+import {backendErrorLink, warning, wrapper} from '../Warnings.styles';
 
 export type User = {qualifiedId: QualifiedId; name: () => string};
 type Props = {
@@ -125,7 +125,7 @@ export const PartialFailureToSendWarning = ({failedToSend, isMessageFocused, kno
   }
 
   return (
-    <div>
+    <div css={wrapper}>
       <p css={warning}>
         <Bold css={warning}>{message.head}</Bold> {message.rest}
       </p>

--- a/src/script/components/MessagesList/Message/ContentMessage/Warnings/Warnings.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/Warnings/Warnings.styles.ts
@@ -19,8 +19,18 @@
 
 import {CSSObject} from '@emotion/react';
 
-export const warning: CSSObject = {color: 'var(--danger-color)', fontSize: 'var(--font-size-small)'};
+export const warning: CSSObject = {
+  color: 'var(--danger-color)',
+  fontSize: 'var(--font-size-small)',
+};
+export const wrapper: CSSObject = {
+  paddingLeft: 'var(--conversation-message-sender-width)',
+  marginTop: '6px',
+};
 export const backendErrorLink: CSSObject = {
   fontSize: 'var(--font-size-small)',
   '&:visited:hover, &:hover': {color: 'var(--blue-500)'},
+};
+export const button: CSSObject = {
+  marginBlock: '4px 0',
 };


### PR DESCRIPTION
## Description

Warning messages related to failure to send do not display correctly on asset messages

## Screenshots/Screencast (for UI changes)
Before:
![Screenshot from 2024-02-28 13-56-12](https://github.com/wireapp/wire-webapp/assets/78490891/b0b387b3-63eb-4f54-b7d9-367ce6be3dd3)

After:
![Screenshot from 2024-02-28 14-01-42](https://github.com/wireapp/wire-webapp/assets/78490891/c8761ff9-dfab-4cc0-8bc8-293380ba75dd)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;