### PR TITLE
feat(e2ei): check all e2ei certs in a conversation against their users name and handle (WPB-6194)

### DIFF
--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
@@ -141,7 +141,7 @@ class MLSConversationVerificationStateHandler {
   }> => {
     const userIdentities = await getAllGroupUsersIdentities(conversation.groupId);
     const processedUserIds: Set<string> = new Set();
-    let problemFound = false;
+    let userVerificationState = UserVerificationState.ALL_VALID;
 
     if (userIdentities) {
       for (const [userId, identities] of userIdentities.entries()) {
@@ -159,7 +159,7 @@ class MLSConversationVerificationStateHandler {
 
         if (!identity || !user) {
           this.logger.warn(`Could not find user or identity for userId: ${userId}`);
-          problemFound = true;
+          userVerificationState = UserVerificationState.SOME_INVALID;
           break;
         }
 
@@ -167,14 +167,14 @@ class MLSConversationVerificationStateHandler {
         const matchingHandle = this.checkUserHandle(identity, user);
         if (!matchingHandle || !matchingName) {
           this.logger.warn(`User identity and user entity do not match for userId: ${userId}`);
-          problemFound = true;
+          userVerificationState = UserVerificationState.SOME_INVALID;
           break;
         }
       }
     }
 
     return {
-      userVerificationState: problemFound ? UserVerificationState.SOME_INVALID : UserVerificationState.ALL_VALID,
+      userVerificationState,
       userIdentities,
     };
   };

--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
@@ -189,7 +189,6 @@ class MLSConversationVerificationStateHandler {
   private onEpochChanged = async ({groupId}: {groupId: string}): Promise<void> => {
     // There could be a race condition where we would receive an epoch update for a conversation that is not yet known by the webapp.
     // We just wait for it to be available and then check the verification state
-
     const conversation = await waitFor(() =>
       getConversationByGroupId({conversationState: this.conversationState, groupId}),
     );


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6194" title="WPB-6194" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6194</a>  [Web] Clients should verify user identifiers inside certificate
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

CoreCrypto only provides us with the information if the stored certificate for a client is still valid and active. 

It can not tell us if the certificate still matches the current user information of the user.
This needs to be checked on app side, since the user information might have been changed since the certificate had ben issued.