### PR TITLE
runfix: Avoid using the keycloak refresh token [WPB-6897]

### DIFF
--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -239,7 +239,10 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
         handle,
         teamId,
         getOAuthToken: async authenticationChallenge => {
-          const userData = await this.getUserData(isCertificateRenewal, authenticationChallenge);
+          // For now we cannot do silent login as keycloak refresh token extension is not supported
+          // We can fix this condition when the plugin is enabled on keycloak
+          const silent = false && isCertificateRenewal;
+          const userData = await this.getUserData(silent, authenticationChallenge);
           if (!userData) {
             throw new Error('No user data received');
           }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6897" title="WPB-6897" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-6897</a>  Do not use refresh token for E2EI certificate renewal
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

Turns out the keycloak extension will not be installed on the targetted server for the release. 
We need to avoid using the refresh token as it will generate invalid identities. 

So we will always go through the entire enrollment flow even for renewals

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
