### PR TITLE
chore(dx): add new client naming for dev environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@lexical/history": "0.13.1",
     "@lexical/react": "0.13.1",
     "@wireapp/avs": "9.6.12",
-    "@wireapp/commons": "5.2.5",
+    "@wireapp/commons": "5.2.6",
     "@wireapp/core": "45.0.5",
     "@wireapp/react-ui-kit": "9.16.0",
     "@wireapp/store-engine-dexie": "2.1.8",

--- a/src/script/auth/module/action/ClientAction.ts
+++ b/src/script/auth/module/action/ClientAction.ts
@@ -91,6 +91,7 @@ export class ClientAction {
     }
     const deviceLabel = `${Runtime.getOS()}${Runtime.getOS().version ? ` ${Runtime.getOS().version}` : ''}`;
     let deviceModel = StringUtil.capitalize(Runtime.getBrowserName());
+    const dev = Runtime.isEdgeEnvironment() ? '(Edge)' : Runtime.isStagingEnvironment() ? '(Staging)' : false;
 
     if (Runtime.isDesktopApp()) {
       if (Runtime.isMacOS()) {
@@ -103,7 +104,9 @@ export class ClientAction {
     } else if (clientType === ClientType.TEMPORARY) {
       deviceModel = `${deviceModel} (Temporary)`;
     }
-
+    if (dev) {
+      deviceModel = `${deviceModel} ${dev}`;
+    }
     return {
       classification: ClientClassification.DESKTOP,
       cookieLabel: undefined,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4720,7 +4720,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/commons@npm:5.2.5, @wireapp/commons@npm:^5.2.5":
+"@wireapp/commons@npm:5.2.6":
+  version: 5.2.6
+  resolution: "@wireapp/commons@npm:5.2.6"
+  dependencies:
+    ansi-regex: 5.0.1
+    fs-extra: 11.1.0
+    logdown: 3.3.1
+    platform: 1.3.6
+  checksum: f3dc658d900db286aad80888e81424dfee580395c5a6ef0238a1ecc34920bf4a5bedc12e8cb9104663579e87c5655f9b0c28ba9b6e29e4bf5929d5ecfd32e026
+  languageName: node
+  linkType: hard
+
+"@wireapp/commons@npm:^5.2.5":
   version: 5.2.5
   resolution: "@wireapp/commons@npm:5.2.5"
   dependencies:
@@ -17436,7 +17448,7 @@ __metadata:
     "@types/underscore": 1.11.15
     "@types/webpack-env": 1.18.4
     "@wireapp/avs": 9.6.12
-    "@wireapp/commons": 5.2.5
+    "@wireapp/commons": 5.2.6
     "@wireapp/copy-config": 2.1.16
     "@wireapp/core": 45.0.5
     "@wireapp/eslint-config": 3.0.6


### PR DESCRIPTION
## Description
Small quality of life change for devs to make our device list more readable. 
Users will need to create a new device to take advantage of the change. 

## Screenshots/Screencast (for UI changes)
<img width="316" alt="Screenshot 2024-02-28 at 16 19 20" src="https://github.com/wireapp/wire-webapp/assets/37285713/925bfda8-7133-470e-ada0-6e58693667f5">

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

### Important details for the reviewers

- be sure to look at https://github.com/wireapp/wire-web-packages/pull/6025
