### PR TITLE
runfix: too many requests backoff

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@lexical/react": "0.12.5",
     "@wireapp/avs": "9.6.12",
     "@wireapp/commons": "5.2.6",
-    "@wireapp/core": "45.0.12",
+    "@wireapp/core": "45.0.13",
     "@wireapp/react-ui-kit": "9.16.0",
     "@wireapp/store-engine-dexie": "2.1.8",
     "@wireapp/webapp-events": "0.20.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@lexical/react": "0.12.5",
     "@wireapp/avs": "9.6.12",
     "@wireapp/commons": "5.2.6",
-    "@wireapp/core": "45.0.11",
+    "@wireapp/core": "45.0.12",
     "@wireapp/react-ui-kit": "9.16.0",
     "@wireapp/store-engine-dexie": "2.1.8",
     "@wireapp/webapp-events": "0.20.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4684,11 +4684,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^26.10.15":
-  version: 26.10.15
-  resolution: "@wireapp/api-client@npm:26.10.15"
+"@wireapp/api-client@npm:^26.10.16":
+  version: 26.10.16
+  resolution: "@wireapp/api-client@npm:26.10.16"
   dependencies:
-    "@wireapp/commons": ^5.2.6
+    "@wireapp/commons": ^5.2.7
     "@wireapp/priority-queue": ^2.1.5
     "@wireapp/protocol-messaging": 1.44.0
     axios: 1.6.7
@@ -4701,7 +4701,7 @@ __metadata:
     tough-cookie: 4.1.3
     ws: 8.16.0
     zod: 3.22.4
-  checksum: 37567f72f0556dea4d4b519db2ae0f6661050dbbce952e86422b57b2f86d964f91c080034185deaf6be056dbc922c756b4af0e0c7b367f914a4912b9c926938f
+  checksum: fa6a5a0490e82aee7c1a72f0dc8ff0a1bfd87c4f0d5669e7977bc8bdbf879e2e2514c3d9a645a8f7d8a0eee2cf45b452a7a8770b511e2117632f3afd4fa3aef4
   languageName: node
   linkType: hard
 
@@ -4719,7 +4719,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/commons@npm:5.2.6, @wireapp/commons@npm:^5.2.6":
+"@wireapp/commons@npm:5.2.6":
   version: 5.2.6
   resolution: "@wireapp/commons@npm:5.2.6"
   dependencies:
@@ -4728,6 +4728,18 @@ __metadata:
     logdown: 3.3.1
     platform: 1.3.6
   checksum: f3dc658d900db286aad80888e81424dfee580395c5a6ef0238a1ecc34920bf4a5bedc12e8cb9104663579e87c5655f9b0c28ba9b6e29e4bf5929d5ecfd32e026
+  languageName: node
+  linkType: hard
+
+"@wireapp/commons@npm:^5.2.7":
+  version: 5.2.7
+  resolution: "@wireapp/commons@npm:5.2.7"
+  dependencies:
+    ansi-regex: 5.0.1
+    fs-extra: 11.1.0
+    logdown: 3.3.1
+    platform: 1.3.6
+  checksum: e875e242c706b6719aea8f6dea4b547e6ce189c853dcb78cdbe87d238d3c99e92a8acbf76a80f100ee9642b2638081bafa1b050d8c3fea407fe6f7ea517f6328
   languageName: node
   linkType: hard
 
@@ -4754,15 +4766,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:45.0.12":
-  version: 45.0.12
-  resolution: "@wireapp/core@npm:45.0.12"
+"@wireapp/core@npm:45.0.13":
+  version: 45.0.13
+  resolution: "@wireapp/core@npm:45.0.13"
   dependencies:
-    "@wireapp/api-client": ^26.10.15
-    "@wireapp/commons": ^5.2.6
+    "@wireapp/api-client": ^26.10.16
+    "@wireapp/commons": ^5.2.7
     "@wireapp/core-crypto": 1.0.0-rc.46
     "@wireapp/cryptobox": 12.8.0
-    "@wireapp/promise-queue": ^2.3.1
+    "@wireapp/priority-queue": ^2.1.5
+    "@wireapp/promise-queue": ^2.3.2
     "@wireapp/protocol-messaging": 1.44.0
     "@wireapp/store-engine": 5.1.5
     axios: 1.6.7
@@ -4775,7 +4788,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: 612770d3ad5282d079ea3c9ab6c92436cf85eb43238aff67fe1b4d7d37e33680949ade54297cb5b73465c422df40523553d858a45789d1fae8fc95c0ca10ec20
+  checksum: 7cfff49eb51f59c489a96418b0f731693170d421d1591fb90b2ba7eaf30c6f5b0bb709d3bac3918c272b21f1d5f2168951ab8f2c494d187f4f785f56031d3f31
   languageName: node
   linkType: hard
 
@@ -4858,10 +4871,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/promise-queue@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "@wireapp/promise-queue@npm:2.3.1"
-  checksum: 3b640650d04f7d04e3792c41b06b66cbd32da41708799881b9f06ae33ade8d50fac20a86620af8bb81bf32db6b60b124da3afcc109288a5c245f9e899d1d0058
+"@wireapp/promise-queue@npm:^2.3.2":
+  version: 2.3.2
+  resolution: "@wireapp/promise-queue@npm:2.3.2"
+  checksum: 818d97f43bcf19de3ff965b143500679ef291ba4510dca8951c18a049c4744bf7c146f29d9ac6fcc0d8ee9680e2c7d1ddabca780dd2a1af514074a2f4c0989f1
   languageName: node
   linkType: hard
 
@@ -17444,7 +17457,7 @@ __metadata:
     "@wireapp/avs": 9.6.12
     "@wireapp/commons": 5.2.6
     "@wireapp/copy-config": 2.1.14
-    "@wireapp/core": 45.0.12
+    "@wireapp/core": 45.0.13
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.16.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -4684,12 +4684,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^26.10.14":
-  version: 26.10.14
-  resolution: "@wireapp/api-client@npm:26.10.14"
+"@wireapp/api-client@npm:^26.10.15":
+  version: 26.10.15
+  resolution: "@wireapp/api-client@npm:26.10.15"
   dependencies:
     "@wireapp/commons": ^5.2.6
-    "@wireapp/priority-queue": ^2.1.4
+    "@wireapp/priority-queue": ^2.1.5
     "@wireapp/protocol-messaging": 1.44.0
     axios: 1.6.7
     axios-retry: 4.0.0
@@ -4701,7 +4701,7 @@ __metadata:
     tough-cookie: 4.1.3
     ws: 8.16.0
     zod: 3.22.4
-  checksum: 5c6ebf62bd5bb224006a70cbd228936482936f9d6b0bd843d425d2666e7035bb6696a18ac7266a71a79635e3bb52256ddef2f71400ce7f2adc40c66f9a0dab0e
+  checksum: 37567f72f0556dea4d4b519db2ae0f6661050dbbce952e86422b57b2f86d964f91c080034185deaf6be056dbc922c756b4af0e0c7b367f914a4912b9c926938f
   languageName: node
   linkType: hard
 
@@ -4754,11 +4754,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:45.0.11":
-  version: 45.0.11
-  resolution: "@wireapp/core@npm:45.0.11"
+"@wireapp/core@npm:45.0.12":
+  version: 45.0.12
+  resolution: "@wireapp/core@npm:45.0.12"
   dependencies:
-    "@wireapp/api-client": ^26.10.14
+    "@wireapp/api-client": ^26.10.15
     "@wireapp/commons": ^5.2.6
     "@wireapp/core-crypto": 1.0.0-rc.46
     "@wireapp/cryptobox": 12.8.0
@@ -4775,7 +4775,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: 588e69c2e5d64108f0164b9643e00f2260bd4fdc3f0a9ea8758327a4ec33e7446ee8300ef939e4675c88e62d4484458043e885e1171a37db0d6753873eab4453
+  checksum: 612770d3ad5282d079ea3c9ab6c92436cf85eb43238aff67fe1b4d7d37e33680949ade54297cb5b73465c422df40523553d858a45789d1fae8fc95c0ca10ec20
   languageName: node
   linkType: hard
 
@@ -4851,10 +4851,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/priority-queue@npm:^2.1.4":
-  version: 2.1.4
-  resolution: "@wireapp/priority-queue@npm:2.1.4"
-  checksum: 2e188dbcd12ff75038c66a37709d0ed99cfd58bf92210c9ef720ea39f916f95a3627a3d693e3d017c30e0a92a50a556244b62f1e6961fa2ffdc7028ed6050c7c
+"@wireapp/priority-queue@npm:^2.1.5":
+  version: 2.1.5
+  resolution: "@wireapp/priority-queue@npm:2.1.5"
+  checksum: 7d150e376a8df680ccf80518d86a455972892f66e7f837e5dec3a5c4a1cd7983223574a43c4dae24e8c0f9ac788effc1b8e82952f35c5e1940aacfee824b230a
   languageName: node
   linkType: hard
 
@@ -17444,7 +17444,7 @@ __metadata:
     "@wireapp/avs": 9.6.12
     "@wireapp/commons": 5.2.6
     "@wireapp/copy-config": 2.1.14
-    "@wireapp/core": 45.0.11
+    "@wireapp/core": 45.0.12
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.16.0


### PR DESCRIPTION
## Description

Use a priority queue for backing off when 420 - too many request error is thrown. For more details see https://github.com/wireapp/wire-web-packages/pull/6028.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;