### PR TITLE
refactor: remove extra folders from folders view

### DIFF
--- a/src/script/conversation/ConversationLabelRepository.ts
+++ b/src/script/conversation/ConversationLabelRepository.ts
@@ -72,15 +72,6 @@ export const createLabel = (
   type,
 });
 
-export const createLabelGroups = (groups: Conversation[] = []) =>
-  createLabel(t('conversationLabelGroups'), groups, DefaultLabelIds.Groups);
-
-export const createLabelPeople = (contacts: Conversation[] = []) =>
-  createLabel(t('conversationLabelPeople'), contacts, DefaultLabelIds.Contacts);
-
-export const createLabelFavorites = (favorites: Conversation[] = []) =>
-  createLabel(t('conversationLabelFavorites'), favorites, DefaultLabelIds.Favorites);
-
 export class ConversationLabelRepository extends TypedEventTarget<{type: 'conversation-favorited'}> {
   labels: ko.ObservableArray<ConversationLabel>;
   private allLabeledConversations: ko.Computed<Conversation[]>;

--- a/src/script/page/LeftSidebar/panels/Conversations/GroupedConversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/GroupedConversations.tsx
@@ -33,8 +33,6 @@ import {
   ConversationLabel,
   ConversationLabelRepository,
   createLabel,
-  createLabelGroups,
-  createLabelPeople,
 } from '../../../../conversation/ConversationLabelRepository';
 import type {ConversationRepository} from '../../../../conversation/ConversationRepository';
 import {ConversationState} from '../../../../conversation/ConversationState';
@@ -75,7 +73,6 @@ const GroupedConversations: React.FC<GroupedConversationsProps> = ({
   callState = container.resolve(CallState),
 }) => {
   const {conversationLabelRepository} = conversationRepository;
-  const {visibleConversations: conversations} = useKoSubscribableChildren(conversationState, ['visibleConversations']);
 
   useKoSubscribableChildren(callState, ['activeCalls']);
 
@@ -84,18 +81,12 @@ const GroupedConversations: React.FC<GroupedConversationsProps> = ({
 
   useLabels(conversationLabelRepository);
 
-  const groups = conversationLabelRepository.getGroupsWithoutLabel(conversations);
-  const contacts = conversationLabelRepository.getContactsWithoutLabel(conversations);
   const custom = conversationLabelRepository
     .getLabels()
     .map(label => createLabel(label.name, conversationLabelRepository.getLabelConversations(label), label.id))
     .filter(({conversations}) => !!conversations().length);
 
-  const folders = [
-    ...(groups.length > 0 ? [createLabelGroups(groups)] : []),
-    ...(contacts.length > 0 ? [createLabelPeople(contacts)] : []),
-    ...custom,
-  ];
+  const folders = [...custom];
 
   return (
     <ul className="conversation-folder-list">

--- a/src/script/page/LeftSidebar/panels/Conversations/GroupedConversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/GroupedConversations.tsx
@@ -81,12 +81,10 @@ const GroupedConversations: React.FC<GroupedConversationsProps> = ({
 
   useLabels(conversationLabelRepository);
 
-  const custom = conversationLabelRepository
+  const folders = conversationLabelRepository
     .getLabels()
     .map(label => createLabel(label.name, conversationLabelRepository.getLabelConversations(label), label.id))
     .filter(({conversations}) => !!conversations().length);
-
-  const folders = [...custom];
 
   return (
     <ul className="conversation-folder-list">


### PR DESCRIPTION
# Description
Hence we have dedicated tabs for groups and direct conversations the folders of groups & people have to be removed.

# Preview
<img width="215" alt="image" src="https://github.com/wireapp/wire-webapp/assets/63250054/49ecd508-54e8-47a1-9273-7681c068c136">
