### PR TITLE
runfix: update epoch info req clients

### DIFF
--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -382,16 +382,7 @@ export class CallingRepository {
     }
     const allClients = await this.core.service!.conversation.fetchAllParticipantsClients(call.conversationId);
 
-    if (isGroupMLSConversation(conversation)) {
-      const subconversationEpochInfo = await this.subconversationService.getSubconversationEpochInfo(
-        conversation.qualifiedId,
-        conversation.groupId,
-      );
-
-      if (subconversationEpochInfo) {
-        this.setEpochInfo(conversation.qualifiedId, subconversationEpochInfo);
-      }
-    } else {
+    if (!isGroupMLSConversation(conversation)) {
       const qualifiedClients = flattenUserMap(allClients);
 
       const clients: Clients = flatten(
@@ -1649,6 +1640,22 @@ export class CallingRepository {
       this.logger.warn(`Unable to find a call for the conversation id of ${convId}`);
       return;
     }
+
+    const conversation = this.getConversationById(call.conversationId);
+
+    if (conversation && isGroupMLSConversation(conversation)) {
+      const subconversationEpochInfo = await this.subconversationService.getSubconversationEpochInfo(
+        conversation.qualifiedId,
+        conversation.groupId,
+      );
+
+      if (subconversationEpochInfo) {
+        this.setEpochInfo(conversation.qualifiedId, subconversationEpochInfo);
+      }
+
+      return;
+    }
+
     await this.pushClients(call);
   };
 


### PR DESCRIPTION
## Description

We should update epoch info only if `requestClients` handler is called, not every time we call `pushClients` which was actually called by `requestClients` but it was not the only case.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
