### PR TITLE
runfix: prevent esc from ignoring restart on download path modal

### DIFF
--- a/src/script/page/components/FeatureConfigChange/FeatureConfigChangeNotifier/FeatureConfigChangeNotifier.ts
+++ b/src/script/page/components/FeatureConfigChange/FeatureConfigChangeNotifier/FeatureConfigChangeNotifier.ts
@@ -243,6 +243,13 @@ export function FeatureConfigChangeNotifier({teamState, selfUserId}: Props): nul
           primaryAction: message.primaryAction,
           hideCloseBtn: isEnforceDownloadPath,
           preventClose: isEnforceDownloadPath,
+          close: isEnforceDownloadPath
+            ? () => {
+                if (Runtime.isDesktopApp() && config[featureKey]?.status !== FeatureStatus.DISABLED) {
+                  amplify.publish(WebAppEvents.LIFECYCLE.RESTART);
+                }
+              }
+            : undefined,
         });
       });
     }


### PR DESCRIPTION
## Description
prevents ESC from skipping the restart event firing. 
doesnt cause double firing if the modal is closed via the button. the first restart goes off the the app restarts immediately. 

## Screenshots/Screencast (for UI changes)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
