### PR TITLE
runfix: start grace period timers

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@lexical/react": "0.12.5",
     "@wireapp/avs": "9.6.12",
     "@wireapp/commons": "5.2.6",
-    "@wireapp/core": "45.1.1",
+    "@wireapp/core": "45.2.0",
     "@wireapp/react-ui-kit": "9.16.0",
     "@wireapp/store-engine-dexie": "2.1.8",
     "@wireapp/webapp-events": "0.20.1",

--- a/src/__mocks__/@wireapp/core.ts
+++ b/src/__mocks__/@wireapp/core.ts
@@ -86,6 +86,7 @@ export class Account extends EventEmitter {
       establishMLS1to1Conversation: jest.fn(),
       blacklistConversation: jest.fn(),
       removeConversationFromBlacklist: jest.fn(),
+      getMLSSelfConversation: jest.fn(),
     },
     subconversation: {
       joinConferenceSubconversation: jest.fn(),

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.test.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.test.ts
@@ -162,6 +162,9 @@ describe('E2EIHandler', () => {
 
     jest.spyOn(coreMock.service!.e2eIdentity!, 'isEnrollmentInProgress').mockResolvedValue(false);
     jest.spyOn(coreMock.service!.e2eIdentity!, 'isFreshMLSSelfClient').mockResolvedValue(false);
+    jest
+      .spyOn(coreMock.service!.conversation!, 'getMLSSelfConversation')
+      .mockResolvedValue({group_id: 'groupId'} as any);
 
     const taskMock = jest.spyOn(LowPrecisionTaskScheduler, 'addTask');
 

--- a/src/script/E2EIdentity/E2EIdentityVerification.ts
+++ b/src/script/E2EIdentity/E2EIdentityVerification.ts
@@ -90,16 +90,13 @@ export async function getConversationVerificationState(groupId: string) {
  * Checks if E2EI has active certificate.
  */
 const getSelfDeviceIdentity = async (): Promise<WireIdentity | undefined> => {
-  let selfMLSConversationGroupId: string;
-  try {
-    // Try to get the self MLS conversation from the conversation state
-    const conversationState = container.resolve(ConversationState);
-    selfMLSConversationGroupId = conversationState.getSelfMLSConversation().groupId;
-  } catch {
-    // If the conversation state is not available, try to get the self MLS conversation from backend
-    const selfMLSConversation = await getCoreConversationService().getMLSSelfConversation();
-    selfMLSConversationGroupId = selfMLSConversation.group_id;
-  }
+  const conversationState = container.resolve(ConversationState);
+
+  // Try to get the self MLS conversation from the conversation state
+  // If the conversation state is not available, try to get the self MLS conversation from backend
+  const selfMLSConversationGroupId =
+    conversationState.selfMLSConversation()?.groupId ||
+    (await getCoreConversationService().getMLSSelfConversation()).group_id;
 
   const userIdentities = await getAllGroupUsersIdentities(selfMLSConversationGroupId);
 

--- a/src/script/E2EIdentity/E2EIdentityVerification.ts
+++ b/src/script/E2EIdentity/E2EIdentityVerification.ts
@@ -95,7 +95,7 @@ const getSelfDeviceIdentity = async (): Promise<WireIdentity | undefined> => {
   // Try to get the self MLS conversation from the conversation state
   // If the conversation state is not available, try to get the self MLS conversation from backend
   const selfMLSConversationGroupId =
-    conversationState.selfMLSConversation()?.groupId ||
+    conversationState.selfMLSConversation()?.groupId ??
     (await getCoreConversationService().getMLSSelfConversation()).group_id;
 
   const userIdentities = await getAllGroupUsersIdentities(selfMLSConversationGroupId);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4684,9 +4684,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^26.10.16":
-  version: 26.10.16
-  resolution: "@wireapp/api-client@npm:26.10.16"
+"@wireapp/api-client@npm:^26.11.0":
+  version: 26.11.0
+  resolution: "@wireapp/api-client@npm:26.11.0"
   dependencies:
     "@wireapp/commons": ^5.2.7
     "@wireapp/priority-queue": ^2.1.5
@@ -4701,7 +4701,7 @@ __metadata:
     tough-cookie: 4.1.3
     ws: 8.16.0
     zod: 3.22.4
-  checksum: fa6a5a0490e82aee7c1a72f0dc8ff0a1bfd87c4f0d5669e7977bc8bdbf879e2e2514c3d9a645a8f7d8a0eee2cf45b452a7a8770b511e2117632f3afd4fa3aef4
+  checksum: c1b86d0435c58cd8dd659d1470fdd92f3841e4ec60564b0661b1b6045f03e894863cb9e6b0ab3f07d160c4b1dd88d2713caf7e31ba7fa619b71e01a95a32a92e
   languageName: node
   linkType: hard
 
@@ -4766,11 +4766,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:45.1.1":
-  version: 45.1.1
-  resolution: "@wireapp/core@npm:45.1.1"
+"@wireapp/core@npm:45.2.0":
+  version: 45.2.0
+  resolution: "@wireapp/core@npm:45.2.0"
   dependencies:
-    "@wireapp/api-client": ^26.10.16
+    "@wireapp/api-client": ^26.11.0
     "@wireapp/commons": ^5.2.7
     "@wireapp/core-crypto": 1.0.0-rc.46
     "@wireapp/cryptobox": 12.8.0
@@ -4788,7 +4788,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: e0f200b89b4a5afb893b2b5d4da7bd5db20b5a2900cde3be11f9490df1812f5532d79c5382888761a65491eb0596e65bcd37757038800526126995be347676c8
+  checksum: c61b5fa5296a844f7abe466f73b733131a2a48fdf8021889b7c86141705c6c53d5848936cec89c3eed4308807d18e93e155412af46c51c9e15e3b2191518a867
   languageName: node
   linkType: hard
 
@@ -17457,7 +17457,7 @@ __metadata:
     "@wireapp/avs": 9.6.12
     "@wireapp/commons": 5.2.6
     "@wireapp/copy-config": 2.1.14
-    "@wireapp/core": 45.1.1
+    "@wireapp/core": 45.2.0
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.16.0


### PR DESCRIPTION
## Description

After cert get expired, and when trying to renew it, app gets reloaded, in app init flow, we call `startTimers`. This method was trying to check self devices identity by loading the self mls conversation (its groupId) from the local state. It's possible that we call startTimers before all the conversations are loaded into the local store, what resulted in an error that self mls conversation was not found - see screenshot below.

![Screenshot 2024-03-04 at 15 07 55](https://github.com/wireapp/wire-webapp/assets/45733298/a006fdab-bb47-4418-b853-530cddf6e3d6)

The fix is to fetch the self mls conversation from backend if it's not yet known locally, and get the conversation's groupId from there.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;