### PR TITLE
runfix: do not overwrite removing stale client task

### DIFF
--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -1034,6 +1034,11 @@ export class CallingRepository {
         continue;
       }
 
+      // If there is already a task for the client, don't overwrite it
+      if (TaskScheduler.hasActiveTask(key)) {
+        continue;
+      }
+
       // otherwise, remove the client from subconversation if it won't establish their audio state in 3 mins timeout
       const firingDate = new Date().getTime() + TIME_IN_MILLIS.MINUTE * 3;
 


### PR DESCRIPTION
## Description

If a call member is not established (aestab = 0) we're scheduling a task to remove it after 3 mins of inactivity. The problem is the task was always overwritten so the 3mins have never elapsed. We should not set up a new task if we have a pending task to remove the client.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;