### PR TITLE
runfix: join with external commit on orphan welcome message

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@lexical/react": "0.12.5",
     "@wireapp/avs": "9.6.12",
     "@wireapp/commons": "5.2.6",
-    "@wireapp/core": "45.2.6",
+    "@wireapp/core": "45.2.7",
     "@wireapp/react-ui-kit": "9.16.0",
     "@wireapp/store-engine-dexie": "2.1.8",
     "@wireapp/webapp-events": "0.20.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4775,9 +4775,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:45.2.6":
-  version: 45.2.6
-  resolution: "@wireapp/core@npm:45.2.6"
+"@wireapp/core@npm:45.2.7":
+  version: 45.2.7
+  resolution: "@wireapp/core@npm:45.2.7"
   dependencies:
     "@wireapp/api-client": ^26.11.2
     "@wireapp/commons": ^5.2.7
@@ -4797,7 +4797,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: c363048067e893ab86b5a082182920d6ec42bfca67d17c390ac618cb04fadd63e77018fe4df6d365e608c2736ffac6ab5055c23203896695543d2b91d951b75b
+  checksum: ce5f1601f4a27a9d40f8cb36095207a88109554574c99800775d2f765e72532b3238b1123ad952b3ad16b0eddc03466b1bee8a9ca7cf11f450c378f8375c20d0
   languageName: node
   linkType: hard
 
@@ -17459,7 +17459,7 @@ __metadata:
     "@wireapp/avs": 9.6.12
     "@wireapp/commons": 5.2.6
     "@wireapp/copy-config": 2.1.14
-    "@wireapp/core": 45.2.6
+    "@wireapp/core": 45.2.7
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.16.0


### PR DESCRIPTION
## Description

Bumps core with version that recovers from being send an orphan welcome message by joining with an external commit. For more details see https://github.com/wireapp/wire-web-packages/pull/6050.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
