### PR TITLE
fix(e2ei): evaluate all devices of a user for the mlsStatus

### DIFF
--- a/src/script/components/VerificationBadge/VerificationBadges.tsx
+++ b/src/script/components/VerificationBadge/VerificationBadges.tsx
@@ -81,7 +81,7 @@ const useConversationVerificationState = (conversation: Conversation) => {
   return {MLS: mlsState, proteus: proteusVerificationState};
 };
 
-const useMLSStatuses = ({identities, user}: {identities?: WireIdentity[]; user?: User}): MLSStatuses[] | undefined => {
+const getMLSStatuses = ({identities, user}: {identities?: WireIdentity[]; user?: User}): MLSStatuses[] | undefined => {
   if (!identities || !user) {
     return undefined;
   }
@@ -109,11 +109,11 @@ export const UserVerificationBadges = ({
 }) => {
   const {is_verified: isProteusVerified} = useKoSubscribableChildren(user, ['is_verified']);
   const {deviceIdentities} = useUserIdentity(user.qualifiedId, groupId, isSelfUser);
-  const mlsStatuses = useMLSStatuses({
+
+  const mlsStatuses = getMLSStatuses({
     identities: deviceIdentities,
     user,
   });
-
   const status = !mlsStatuses
     ? undefined
     : mlsStatuses.length > 0 && mlsStatuses.every(status => status === MLSStatuses.VALID)
@@ -158,12 +158,13 @@ export const DeviceVerificationBadges = ({
     }
   }, [identity]);
 
-  const mlsStatuses = useMLSStatuses({identities: identity ? [identity] : [], user});
-  const mlsStatus = mlsStatuses?.[0];
+  let status: MLSStatuses | undefined = undefined;
+  if (identity && user) {
+    const mlsStatuses = getMLSStatuses({identities: [identity], user});
+    status = mlsStatuses?.[0];
+  }
 
-  return (
-    <VerificationBadges context="device" isProteusVerified={!!device.meta?.isVerified?.()} MLSStatus={mlsStatus} />
-  );
+  return <VerificationBadges context="device" isProteusVerified={!!device.meta?.isVerified?.()} MLSStatus={status} />;
 };
 
 type ConversationVerificationBadgeProps = {

--- a/src/script/components/VerificationBadge/VerificationBadges.tsx
+++ b/src/script/components/VerificationBadge/VerificationBadges.tsx
@@ -114,11 +114,11 @@ export const UserVerificationBadges = ({
     identities: deviceIdentities,
     user,
   });
-  const status = !mlsStatuses
-    ? undefined
-    : mlsStatuses.length > 0 && mlsStatuses.every(status => status === MLSStatuses.VALID)
-      ? MLSStatuses.VALID
-      : MLSStatuses.NOT_ACTIVATED;
+
+  let status: MLSStatuses | undefined = undefined;
+  if (mlsStatuses && mlsStatuses.length > 0 && mlsStatuses.every(status => status === MLSStatuses.VALID)) {
+    status = MLSStatuses.VALID;
+  }
 
   return <VerificationBadges context="user" isProteusVerified={isProteusVerified} MLSStatus={status} />;
 };


### PR DESCRIPTION
Introduced a bug which didnt check every device of a user when it came to the E2EI verification state.

This PR fixes that logic.

Additionally, we did show a user when one of hi devices had been revoked, expired etc. This was not according to design and gets fixed as well.