### PR TITLE
runfix: handle a crash during change to mixed protocol

### DIFF
--- a/src/script/mls/MLSConversations.ts
+++ b/src/script/mls/MLSConversations.ts
@@ -62,23 +62,49 @@ export async function initMLSGroupConversations(
   );
 
   for (const mlsConversation of mlsGroupConversations) {
-    try {
-      const {groupId, qualifiedId} = mlsConversation;
+    await initMLSGroupConversation(mlsConversation, {core, onSuccessfulJoin, onError});
+  }
+}
 
-      const doesMLSGroupExist = await conversationService.mlsGroupExistsLocally(groupId);
+/**
+ * Will initialize a single MLS conversation that the user is member of but that are not yet locally established.
+ *
+ * @param mlsConversation - the conversation to initialize
+ * @param core - the instance of the core
+ */
+export async function initMLSGroupConversation(
+  mlsConversation: MLSCapableConversation,
+  {
+    core,
+    onSuccessfulJoin,
+    onError,
+  }: {
+    core: Account;
+    onSuccessfulJoin?: (conversation: Conversation) => void;
+    onError?: (conversation: Conversation, error: unknown) => void;
+  },
+): Promise<void> {
+  const {mls: mlsService, conversation: conversationService} = core.service || {};
+  if (!mlsService || !conversationService) {
+    throw new Error('MLS or Conversation service is not available!');
+  }
 
-      //if group is already established, we just schedule periodic key material updates
-      if (doesMLSGroupExist) {
-        await mlsService.scheduleKeyMaterialRenewal(groupId);
-        continue;
-      }
+  try {
+    const {groupId, qualifiedId} = mlsConversation;
 
-      //otherwise we should try joining via external commit
-      await conversationService.joinByExternalCommit(qualifiedId);
-      onSuccessfulJoin?.(mlsConversation);
-    } catch (error) {
-      onError?.(mlsConversation, error);
+    const doesMLSGroupExist = await conversationService.mlsGroupExistsLocally(groupId);
+
+    //if group is already established, we just schedule periodic key material updates
+    if (doesMLSGroupExist) {
+      await mlsService.scheduleKeyMaterialRenewal(groupId);
+      return;
     }
+
+    //otherwise we should try joining via external commit
+    await conversationService.joinByExternalCommit(qualifiedId);
+    onSuccessfulJoin?.(mlsConversation);
+  } catch (error) {
+    onError?.(mlsConversation, error);
   }
 }
 

--- a/src/script/mls/MLSMigration/MLSMigration.ts
+++ b/src/script/mls/MLSMigration/MLSMigration.ts
@@ -169,7 +169,10 @@ const migrateConversationsToMLS = async ({
   await initialiseMigrationOfProteusConversations(selfTeamGroupConversations, selfUserId, conversationHandler);
 
   const allGroupConversations = conversationHandler.getAllGroupConversations();
-  await joinUnestablishedMixedConversations(allGroupConversations, {core});
+  await joinUnestablishedMixedConversations(allGroupConversations, selfUserId, {
+    core,
+    conversationHandler,
+  });
 
   await finaliseMigrationOfMixedConversations(
     selfTeamGroupConversations,

--- a/src/script/mls/MLSMigration/migrationInitialiser/joinUnestablishedMixedConversations/joinUnestablishedMixedConversations.ts
+++ b/src/script/mls/MLSMigration/migrationInitialiser/joinUnestablishedMixedConversations/joinUnestablishedMixedConversations.ts
@@ -21,10 +21,9 @@ import {QualifiedId} from '@wireapp/api-client/lib/user';
 
 import {Account} from '@wireapp/core';
 
-import {isMixedConversation} from 'src/script/conversation/ConversationSelectors';
+import {isMixedConversation, MixedConversation} from 'src/script/conversation/ConversationSelectors';
 import {Conversation} from 'src/script/entity/Conversation';
-import {initMLSGroupConversations} from 'src/script/mls/MLSConversations';
-import {partition} from 'Util/ArrayUtil';
+import {initMLSGroupConversation} from 'src/script/mls/MLSConversations';
 
 import {mlsMigrationLogger} from '../../MLSMigrationLogger';
 
@@ -50,36 +49,48 @@ export const joinUnestablishedMixedConversations = async (
   const mixedConversations = conversations.filter(isMixedConversation);
   mlsMigrationLogger.info(`Found ${mixedConversations.length} "mixed" conversations, joining unestablished ones...`);
 
-  const [establishedMixedConversations, unestablishedMixedConversations] = partition(
-    mixedConversations,
-    mixedConversation => mixedConversation.epoch > 0,
-  );
+  for (const conversation of mixedConversations) {
+    await joinUnestablishedMixedConversation(conversation, selfUserId, {core, conversationHandler});
+  }
+};
 
-  await initMLSGroupConversations(establishedMixedConversations, {
-    core,
-    onError: ({id}, error) =>
-      mlsMigrationLogger.error(`Failed when joining a mls group of mixed conversation with id ${id}, error: `, error),
-  });
+export const joinUnestablishedMixedConversation = async (
+  mixedConversation: MixedConversation,
+  selfUserId: QualifiedId,
+  {core, conversationHandler}: JoinUnestablishedMixedConversationsParams,
+  shouldRetry = true,
+) => {
+  if (mixedConversation.epoch > 0) {
+    return initMLSGroupConversation(mixedConversation, {
+      core,
+      onError: ({id}, error) =>
+        mlsMigrationLogger.error(`Failed when joining a mls group of mixed conversation with id ${id}, error: `, error),
+    });
+  }
 
   // It's possible that the client has updated the protocol to mixed and then crashed, before it has established the MLS group.
   // In this case, we should try to establish the MLS group again.
-  for (const conversation of unestablishedMixedConversations) {
-    mlsMigrationLogger.info(`Trying to establish MLS group for mixed conversation with id ${conversation.id}`);
+  mlsMigrationLogger.info(`Trying to establish MLS group for mixed conversation with id ${mixedConversation.id}`);
 
-    const otherUsersToAdd = conversation.participating_user_ids();
+  const otherUsersToAdd = mixedConversation.participating_user_ids();
 
-    try {
-      await conversationHandler.tryEstablishingMLSGroup({
-        conversationId: conversation.qualifiedId,
-        groupId: conversation.groupId,
-        qualifiedUsers: otherUsersToAdd,
-        selfUserId: selfUserId,
-      });
-    } catch (error) {
-      mlsMigrationLogger.error(
-        `Failed to establish MLS group for mixed conversation with id ${conversation.id}, error: `,
-        error,
-      );
+  try {
+    await conversationHandler.tryEstablishingMLSGroup({
+      conversationId: mixedConversation.qualifiedId,
+      groupId: mixedConversation.groupId,
+      qualifiedUsers: otherUsersToAdd,
+      selfUserId: selfUserId,
+    });
+  } catch (error) {
+    mlsMigrationLogger.error(
+      `Failed to establish MLS group for mixed conversation with id ${mixedConversation.id}, error: `,
+      error,
+    );
+    if (!shouldRetry) {
+      return;
     }
+
+    mlsMigrationLogger.info(`Retrying to join unestablished mixed conversation with id ${mixedConversation.id}`);
+    await joinUnestablishedMixedConversation(mixedConversation, selfUserId, {core, conversationHandler}, false);
   }
 };


### PR DESCRIPTION
## Description

The flow of updating the conversation's protocol to mixed is:
- update the protocol to mixed
- backend will assign a MLS group_id to the conversation (and set the epoch number to 0)
- client initialises the group and tries to add as many other users and possible
- other users/clients can join a group with an external commit

### Problem
It's possible that the client just updates the protocol and crashes (or just reloads the app). In this case, the mls group was not yet established and the client, when loading the app again, will try joining it with an external commit. This will not work as the group was not established on backend (epoch 0) and it's not possible to fetch the groupInfo. Mixed group would get stuck on epoch 0 and no web client would try to establish it again.

### Solution

Before trying to join the mixed group with an external commit, check it's epoch number, if it's below 1 (eq to 0), instead of joining with ext commit, try establishing it.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
