### PR TITLE
runfix: Show enrollment modal the first time e2ei is enabled

### DIFF
--- a/src/script/E2EIdentity/E2EIdentityEnrollment.test.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.test.ts
@@ -28,6 +28,7 @@ import {UserState} from 'src/script/user/UserState';
 import * as util from 'Util/util';
 
 import {E2EIHandler} from './E2EIdentityEnrollment';
+import {EnrollmentStore} from './Enrollment.store';
 import {OIDCServiceStore} from './OIDCService/OIDCServiceStorage';
 
 import {ConversationState} from '../conversation/ConversationState';
@@ -69,6 +70,8 @@ describe('E2EIHandler', () => {
     E2EIHandler.resetInstance();
     // Clear all mocks before each test
     jest.clearAllMocks();
+    EnrollmentStore.clear.deviceCreatedAt();
+    EnrollmentStore.clear.timer();
 
     // Mock the Config to enable e2eIdentity
     (util.supportsMLS as jest.Mock).mockReturnValue(true);
@@ -160,6 +163,7 @@ describe('E2EIHandler', () => {
     const conversationState = container.resolve(ConversationState);
     jest.spyOn(conversationState, 'getSelfMLSConversation').mockReturnValue(new Conversation() as any);
 
+    EnrollmentStore.store.e2eiActivatedAt(Date.now());
     jest.spyOn(coreMock.service!.e2eIdentity!, 'isEnrollmentInProgress').mockResolvedValue(false);
     jest.spyOn(coreMock.service!.e2eIdentity!, 'isFreshMLSSelfClient').mockResolvedValue(false);
     jest

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -141,7 +141,8 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
    */
   public async startTimers() {
     // We store the first time the user was prompted with the enrollment modal
-    const e2eActivatedAt = EnrollmentStore.get.e2eiActivatedAt() || Date.now();
+    const storedE2eActivatedAt = EnrollmentStore.get.e2eiActivatedAt();
+    const e2eActivatedAt = storedE2eActivatedAt || Date.now();
     EnrollmentStore.store.e2eiActivatedAt(e2eActivatedAt);
 
     const timerKey = 'enrollmentTimer';
@@ -160,7 +161,10 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
     const firingDate = EnrollmentStore.get.timer() || computedFiringDate;
     EnrollmentStore.store.timer(firingDate);
 
-    if (firingDate <= Date.now()) {
+    const isFirstE2EIActivation = !storedE2eActivatedAt;
+    if (isFirstE2EIActivation || firingDate <= Date.now()) {
+      // We want to automatically trigger the enrollment modal if it's a devices in team that just activated e2eidentity
+      // Or if the timer is supposed to fire now
       void task();
     } else {
       LowPrecisionTaskScheduler.addTask({


### PR DESCRIPTION
## Description

This will trigger the enrollment modal for existing devices that load the app in an e2ei enabled team for the first time

## Screenshots/Screencast (for UI changes)

https://github.com/wireapp/wire-webapp/assets/1090716/332087d8-455f-41a4-9beb-bfdbe1d602a2


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
