### PR TITLE
runfix: refresh mls conversation state

### DIFF
--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -349,7 +349,8 @@ export const InputBar = ({
     resetDraftState();
   };
 
-  const handleSendMessage = () => {
+  const handleSendMessage = async () => {
+    await conversationRepository.refreshMLSConversationVerificationState(conversation);
     const isE2EIDegraded = conversation.mlsVerificationState() === ConversationVerificationState.DEGRADED;
 
     if (isE2EIDegraded) {

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -337,12 +337,10 @@ export class ConversationRepository {
     );
   };
 
-  public refreshMLSConversationVerificationState = (conversation: Conversation) => {
-    if (!this.mlsConversationVerificationStateHandler) {
-      return;
+  public refreshMLSConversationVerificationState = async (conversation: Conversation) => {
+    if (this.mlsConversationVerificationStateHandler) {
+      await this.mlsConversationVerificationStateHandler.checkConversationVerificationState(conversation);
     }
-
-    return this.mlsConversationVerificationStateHandler.checkConversationVerificationState(conversation);
   };
 
   checkMessageTimer(messageEntity: ContentMessage): void {

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -339,7 +339,7 @@ export class ConversationRepository {
 
   public refreshMLSConversationVerificationState = throttle((conversation: Conversation) => {
     if (!this.mlsConversationVerificationStateHandler) {
-      throw new Error('MLSConversationVerificationStateHandler is not registered');
+      return;
     }
 
     return this.mlsConversationVerificationStateHandler.checkConversationVerificationState(conversation);

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -96,8 +96,14 @@ import {ConversationState} from './ConversationState';
 import {ConversationStateHandler} from './ConversationStateHandler';
 import {ConversationStatus} from './ConversationStatus';
 import {ConversationVerificationState} from './ConversationVerificationState';
-import {ProteusConversationVerificationStateHandler} from './ConversationVerificationStateHandler';
-import {OnConversationVerificationStateChange} from './ConversationVerificationStateHandler/shared';
+import {
+  MLSConversationVerificationStateHandler,
+  ProteusConversationVerificationStateHandler,
+} from './ConversationVerificationStateHandler';
+import {
+  OnConversationE2EIVerificationStateChange,
+  OnConversationVerificationStateChange,
+} from './ConversationVerificationStateHandler/shared';
 import {EventMapper} from './EventMapper';
 import {MessageRepository} from './MessageRepository';
 import {NOTIFICATION_STATE} from './NotificationSetting';
@@ -173,6 +179,7 @@ export class ConversationRepository {
   private readonly logger: Logger;
   public readonly stateHandler: ConversationStateHandler;
   public readonly proteusVerificationStateHandler: ProteusConversationVerificationStateHandler;
+  private mlsConversationVerificationStateHandler?: MLSConversationVerificationStateHandler;
 
   static get CONFIG() {
     return {
@@ -315,6 +322,28 @@ export class ConversationRepository {
       this.scheduleMissingUsersAndConversationsMetadataRefresh();
     }
   }
+
+  public registerMLSConversationVerificationStateHandler = (
+    domain: string,
+    onConversationVerificationStateChange: OnConversationE2EIVerificationStateChange = () => {},
+    onSelfClientCertificateRevoked: () => Promise<void> = async () => {},
+  ): void => {
+    this.mlsConversationVerificationStateHandler = new MLSConversationVerificationStateHandler(
+      domain,
+      onConversationVerificationStateChange,
+      onSelfClientCertificateRevoked,
+      this.conversationState,
+      this.core,
+    );
+  };
+
+  public refreshMLSConversationVerificationState = (conversation: Conversation): Promise<void> => {
+    if (!this.mlsConversationVerificationStateHandler) {
+      throw new Error('MLSConversationVerificationStateHandler is not registered');
+    }
+
+    return this.mlsConversationVerificationStateHandler.checkConversationVerificationState(conversation);
+  };
 
   checkMessageTimer(messageEntity: ContentMessage): void {
     this.ephemeralHandler.checkMessageTimer(messageEntity, this.serverTimeHandler.getTimeOffset());

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -48,7 +48,7 @@ import {MLSCreateConversationResponse} from '@wireapp/core/lib/conversation';
 import {amplify} from 'amplify';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import {container} from 'tsyringe';
-import {flatten, throttle} from 'underscore';
+import {flatten} from 'underscore';
 
 import {Asset as ProtobufAsset, Confirmation, LegalHoldStatus} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
@@ -337,13 +337,13 @@ export class ConversationRepository {
     );
   };
 
-  public refreshMLSConversationVerificationState = throttle((conversation: Conversation) => {
+  public refreshMLSConversationVerificationState = (conversation: Conversation) => {
     if (!this.mlsConversationVerificationStateHandler) {
       return;
     }
 
     return this.mlsConversationVerificationStateHandler.checkConversationVerificationState(conversation);
-  }, 3000);
+  };
 
   checkMessageTimer(messageEntity: ContentMessage): void {
     this.ephemeralHandler.checkMessageTimer(messageEntity, this.serverTimeHandler.getTimeOffset());

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -48,7 +48,7 @@ import {MLSCreateConversationResponse} from '@wireapp/core/lib/conversation';
 import {amplify} from 'amplify';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import {container} from 'tsyringe';
-import {flatten} from 'underscore';
+import {flatten, throttle} from 'underscore';
 
 import {Asset as ProtobufAsset, Confirmation, LegalHoldStatus} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
@@ -337,13 +337,13 @@ export class ConversationRepository {
     );
   };
 
-  public refreshMLSConversationVerificationState = (conversation: Conversation): Promise<void> => {
+  public refreshMLSConversationVerificationState = throttle((conversation: Conversation) => {
     if (!this.mlsConversationVerificationStateHandler) {
       throw new Error('MLSConversationVerificationStateHandler is not registered');
     }
 
     return this.mlsConversationVerificationStateHandler.checkConversationVerificationState(conversation);
-  };
+  }, 3000);
 
   checkMessageTimer(messageEntity: ContentMessage): void {
     this.ephemeralHandler.checkMessageTimer(messageEntity, this.serverTimeHandler.getTimeOffset());

--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.test.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.test.ts
@@ -26,10 +26,27 @@ import {Core} from 'src/script/service/CoreSingleton';
 import {createUuid} from 'Util/uuid';
 import {waitFor} from 'Util/waitFor';
 
-import {registerMLSConversationVerificationStateHandler} from './MLSStateHandler';
+import {MLSConversationVerificationStateHandler} from './MLSStateHandler';
+
+const createMLSConversationVerificationStateHandler = (
+  domain: string,
+  onConversationVerificationStateChange: OnConversationE2EIVerificationStateChange,
+  onSelfClientCertificateRevoked: () => Promise<void>,
+  conversationState: ConversationState,
+  core: Core,
+) => {
+  return new MLSConversationVerificationStateHandler(
+    domain,
+    onConversationVerificationStateChange,
+    onSelfClientCertificateRevoked,
+    conversationState,
+    core,
+  );
+};
 
 import {ConversationState} from '../../ConversationState';
 import {ConversationVerificationState} from '../../ConversationVerificationState';
+import {OnConversationE2EIVerificationStateChange} from '../shared';
 
 describe('MLSConversationVerificationStateHandler', () => {
   const conversationState = new ConversationState();
@@ -48,7 +65,13 @@ describe('MLSConversationVerificationStateHandler', () => {
     core.service!.mls = undefined;
 
     const t = () =>
-      registerMLSConversationVerificationStateHandler('domain', undefined, undefined, conversationState, core);
+      createMLSConversationVerificationStateHandler(
+        'domain',
+        () => {},
+        async () => {},
+        conversationState,
+        core,
+      );
 
     expect(t).not.toThrow();
   });
@@ -56,7 +79,13 @@ describe('MLSConversationVerificationStateHandler', () => {
   it('should do nothing if e2eIdentity service is not available', () => {
     core.service!.e2eIdentity = undefined;
 
-    registerMLSConversationVerificationStateHandler('domain', undefined, undefined, conversationState, core);
+    createMLSConversationVerificationStateHandler(
+      'domain',
+      () => {},
+      async () => {},
+      conversationState,
+      core,
+    );
 
     expect(core.service?.mls?.on).not.toHaveBeenCalled();
   });
@@ -71,7 +100,13 @@ describe('MLSConversationVerificationStateHandler', () => {
         .spyOn(core.service!.mls!, 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
-      registerMLSConversationVerificationStateHandler('domain', undefined, undefined, conversationState, core);
+      createMLSConversationVerificationStateHandler(
+        'domain',
+        () => {},
+        async () => {},
+        conversationState,
+        core,
+      );
 
       triggerEpochChange({groupId});
       await new Promise(resolve => setTimeout(resolve, 0));
@@ -88,7 +123,13 @@ describe('MLSConversationVerificationStateHandler', () => {
         .spyOn(core.service!.mls!, 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
-      registerMLSConversationVerificationStateHandler('domain', undefined, undefined, conversationState, core);
+      createMLSConversationVerificationStateHandler(
+        'domain',
+        () => {},
+        async () => {},
+        conversationState,
+        core,
+      );
 
       triggerEpochChange({groupId});
       await new Promise(resolve => setTimeout(resolve, 0));
@@ -106,7 +147,13 @@ describe('MLSConversationVerificationStateHandler', () => {
         .spyOn(core.service!.mls!, 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
-      registerMLSConversationVerificationStateHandler('domain', undefined, undefined, conversationState, core);
+      createMLSConversationVerificationStateHandler(
+        'domain',
+        () => {},
+        async () => {},
+        conversationState,
+        core,
+      );
 
       triggerEpochChange({groupId});
       await new Promise(resolve => setTimeout(resolve, 0));
@@ -124,7 +171,13 @@ describe('MLSConversationVerificationStateHandler', () => {
         .spyOn(core.service!.mls!, 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
-      registerMLSConversationVerificationStateHandler('domain', undefined, undefined, conversationState, core);
+      createMLSConversationVerificationStateHandler(
+        'domain',
+        () => {},
+        async () => {},
+        conversationState,
+        core,
+      );
 
       triggerEpochChange({groupId});
       await new Promise(resolve => setTimeout(resolve, 0));
@@ -144,7 +197,13 @@ describe('MLSConversationVerificationStateHandler', () => {
         .spyOn(core.service!.mls!, 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
-      registerMLSConversationVerificationStateHandler('domain', undefined, undefined, conversationState, core);
+      createMLSConversationVerificationStateHandler(
+        'domain',
+        () => {},
+        async () => {},
+        conversationState,
+        core,
+      );
 
       triggerEpochChange({groupId: newConversation.groupId});
       setTimeout(() => {

--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.test.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.test.ts
@@ -28,25 +28,8 @@ import {waitFor} from 'Util/waitFor';
 
 import {MLSConversationVerificationStateHandler} from './MLSStateHandler';
 
-const createMLSConversationVerificationStateHandler = (
-  domain: string,
-  onConversationVerificationStateChange: OnConversationE2EIVerificationStateChange,
-  onSelfClientCertificateRevoked: () => Promise<void>,
-  conversationState: ConversationState,
-  core: Core,
-) => {
-  return new MLSConversationVerificationStateHandler(
-    domain,
-    onConversationVerificationStateChange,
-    onSelfClientCertificateRevoked,
-    conversationState,
-    core,
-  );
-};
-
 import {ConversationState} from '../../ConversationState';
 import {ConversationVerificationState} from '../../ConversationVerificationState';
-import {OnConversationE2EIVerificationStateChange} from '../shared';
 
 describe('MLSConversationVerificationStateHandler', () => {
   const conversationState = new ConversationState();
@@ -65,7 +48,7 @@ describe('MLSConversationVerificationStateHandler', () => {
     core.service!.mls = undefined;
 
     const t = () =>
-      createMLSConversationVerificationStateHandler(
+      new MLSConversationVerificationStateHandler(
         'domain',
         () => {},
         async () => {},
@@ -79,7 +62,7 @@ describe('MLSConversationVerificationStateHandler', () => {
   it('should do nothing if e2eIdentity service is not available', () => {
     core.service!.e2eIdentity = undefined;
 
-    createMLSConversationVerificationStateHandler(
+    new MLSConversationVerificationStateHandler(
       'domain',
       () => {},
       async () => {},
@@ -100,7 +83,7 @@ describe('MLSConversationVerificationStateHandler', () => {
         .spyOn(core.service!.mls!, 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
-      createMLSConversationVerificationStateHandler(
+      new MLSConversationVerificationStateHandler(
         'domain',
         () => {},
         async () => {},
@@ -123,7 +106,7 @@ describe('MLSConversationVerificationStateHandler', () => {
         .spyOn(core.service!.mls!, 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
-      createMLSConversationVerificationStateHandler(
+      new MLSConversationVerificationStateHandler(
         'domain',
         () => {},
         async () => {},
@@ -147,7 +130,7 @@ describe('MLSConversationVerificationStateHandler', () => {
         .spyOn(core.service!.mls!, 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
-      createMLSConversationVerificationStateHandler(
+      new MLSConversationVerificationStateHandler(
         'domain',
         () => {},
         async () => {},
@@ -171,7 +154,7 @@ describe('MLSConversationVerificationStateHandler', () => {
         .spyOn(core.service!.mls!, 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
-      createMLSConversationVerificationStateHandler(
+      new MLSConversationVerificationStateHandler(
         'domain',
         () => {},
         async () => {},
@@ -197,7 +180,7 @@ describe('MLSConversationVerificationStateHandler', () => {
         .spyOn(core.service!.mls!, 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
-      createMLSConversationVerificationStateHandler(
+      new MLSConversationVerificationStateHandler(
         'domain',
         () => {},
         async () => {},

--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
@@ -21,7 +21,6 @@ import {CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {E2eiConversationState} from '@wireapp/core/lib/messagingProtocols/mls';
 import {StringifiedQualifiedId, stringifyQualifiedId} from '@wireapp/core/lib/util/qualifiedIdUtil';
-import {container} from 'tsyringe';
 
 import {
   getActiveWireIdentity,
@@ -47,7 +46,7 @@ enum UserVerificationState {
   SOME_INVALID = 1,
 }
 
-class MLSConversationVerificationStateHandler {
+export class MLSConversationVerificationStateHandler {
   private readonly logger: Logger;
 
   public constructor(
@@ -197,7 +196,7 @@ class MLSConversationVerificationStateHandler {
     return this.checkConversationVerificationState(conversation);
   };
 
-  private checkConversationVerificationState = async (conversation: Conversation): Promise<void> => {
+  public checkConversationVerificationState = async (conversation: Conversation): Promise<void> => {
     const isSelfConversation = conversation.type() === CONVERSATION_TYPE.SELF;
     if (!isMLSConversation(conversation) || isSelfConversation) {
       return;
@@ -236,20 +235,4 @@ export const checkUserHandle = (identity: WireIdentity, user: User): boolean => 
   // We only want to check the username part of the handle
   const {username, domain} = user;
   return identityHandle.includes(`${username()}@${domain}`);
-};
-
-export const registerMLSConversationVerificationStateHandler = (
-  domain: string,
-  onConversationVerificationStateChange: OnConversationE2EIVerificationStateChange = () => {},
-  onSelfClientCertificateRevoked: () => Promise<void> = async () => {},
-  conversationState: ConversationState = container.resolve(ConversationState),
-  core: Core = container.resolve(Core),
-): void => {
-  new MLSConversationVerificationStateHandler(
-    domain,
-    onConversationVerificationStateChange,
-    onSelfClientCertificateRevoked,
-    conversationState,
-    core,
-  );
 };

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -825,7 +825,7 @@ export class MessageRepository {
     }
 
     if (isMLS) {
-      void this.conversationRepositoryProvider().refreshMLSConversationVerificationState(conversation);
+      await this.conversationRepositoryProvider().refreshMLSConversationVerificationState(conversation);
     }
 
     const sendOptions: Parameters<typeof conversationService.send>[0] = isMLS

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -824,10 +824,6 @@ export class MessageRepository {
       await this.conversationRepositoryProvider().makeSureMLS1to1ConversationIsEstablished(conversation);
     }
 
-    if (isMLS) {
-      await this.conversationRepositoryProvider().refreshMLSConversationVerificationState(conversation);
-    }
-
     const sendOptions: Parameters<typeof conversationService.send>[0] = isMLS
       ? {
           groupId: conversation.groupId,

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -824,6 +824,10 @@ export class MessageRepository {
       await this.conversationRepositoryProvider().makeSureMLS1to1ConversationIsEstablished(conversation);
     }
 
+    if (isMLS) {
+      void this.conversationRepositoryProvider().refreshMLSConversationVerificationState(conversation);
+    }
+
     const sendOptions: Parameters<typeof conversationService.send>[0] = isMLS
       ? {
           groupId: conversation.groupId,

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -59,7 +59,6 @@ import {ConnectionService} from '../connection/ConnectionService';
 import {ConversationRepository} from '../conversation/ConversationRepository';
 import {ConversationService} from '../conversation/ConversationService';
 import {ConversationVerificationState} from '../conversation/ConversationVerificationState';
-import {registerMLSConversationVerificationStateHandler} from '../conversation/ConversationVerificationStateHandler';
 import {OnConversationE2EIVerificationStateChange} from '../conversation/ConversationVerificationStateHandler/shared';
 import {EventBuilder} from '../conversation/EventBuilder';
 import {MessageRepository} from '../conversation/MessageRepository';
@@ -450,7 +449,7 @@ export class App {
       if (supportsMLS()) {
         //if mls is supported, we need to initialize the callbacks (they are used when decrypting messages)
         conversationRepository.initMLSConversationRecoveredListener();
-        registerMLSConversationVerificationStateHandler(
+        conversationRepository.registerMLSConversationVerificationStateHandler(
           selfUser.qualifiedId.domain,
           this.updateConversationE2EIVerificationState,
           this.showClientCertificateRevokedWarning,

--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -33,7 +33,6 @@ import type {MainViewModel, ViewModelRepositories} from './MainViewModel';
 
 import {Config} from '../Config';
 import type {ConversationRepository} from '../conversation/ConversationRepository';
-import {isMLSConversation} from '../conversation/ConversationSelectors';
 import {ConversationState} from '../conversation/ConversationState';
 import {MessageRepository} from '../conversation/MessageRepository';
 import {Conversation} from '../entity/Conversation';
@@ -298,9 +297,7 @@ export class ContentViewModel {
         this.conversationState.activeConversation(conversationEntity);
       }
 
-      if (isMLSConversation(conversationEntity)) {
-        void this.conversationRepository.refreshMLSConversationVerificationState(conversationEntity);
-      }
+      void this.conversationRepository.refreshMLSConversationVerificationState(conversationEntity);
       const messageEntity = openFirstSelfMention ? conversationEntity.getFirstUnreadSelfMention() : exposeMessageEntity;
       this.changeConversation(conversationEntity, messageEntity);
       this.showAndNavigate(conversationEntity, openNotificationSettings);

--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -33,6 +33,7 @@ import type {MainViewModel, ViewModelRepositories} from './MainViewModel';
 
 import {Config} from '../Config';
 import type {ConversationRepository} from '../conversation/ConversationRepository';
+import {isMLSConversation} from '../conversation/ConversationSelectors';
 import {ConversationState} from '../conversation/ConversationState';
 import {MessageRepository} from '../conversation/MessageRepository';
 import {Conversation} from '../entity/Conversation';
@@ -297,7 +298,9 @@ export class ContentViewModel {
         this.conversationState.activeConversation(conversationEntity);
       }
 
-      void this.conversationRepository.refreshMLSConversationVerificationState(conversationEntity);
+      if (isMLSConversation(conversationEntity)) {
+        void this.conversationRepository.refreshMLSConversationVerificationState(conversationEntity);
+      }
       const messageEntity = openFirstSelfMention ? conversationEntity.getFirstUnreadSelfMention() : exposeMessageEntity;
       this.changeConversation(conversationEntity, messageEntity);
       this.showAndNavigate(conversationEntity, openNotificationSettings);

--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -297,6 +297,7 @@ export class ContentViewModel {
         this.conversationState.activeConversation(conversationEntity);
       }
 
+      void this.conversationRepository.refreshMLSConversationVerificationState(conversationEntity);
       const messageEntity = openFirstSelfMention ? conversationEntity.getFirstUnreadSelfMention() : exposeMessageEntity;
       this.changeConversation(conversationEntity, messageEntity);
       this.showAndNavigate(conversationEntity, openNotificationSettings);


### PR DESCRIPTION
## Description

There's no trigger from core-crypto (or anywhere else) when a cert is getting expired. We were evaluating the mls conversation state every time an epoch has changed in a conversation. Since cert expiration does not trigger the epoch change, we would not refresh conversation's state until next epoch update.

This PR adds two triggers when we refresh conversation's mls verification state:
- every tame we navigate to a conversation
- every time when a message is sent

A refresh method is throttled with 3s of delay so we don't fire it too often when spamming messages or spam-clicking on a conversation list item.

When recording a gif below I've mocked the behaviour to always degrade the conversation.
![Kapture 2024-03-12 at 14 08 40](https://github.com/wireapp/wire-webapp/assets/45733298/c436a93f-6480-4cab-940a-60a4b4c1d323)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
