### PR TITLE
runfix: address new navigation styling in dark mode (WPB-6811)

### DIFF
--- a/src/style/common/typing.less
+++ b/src/style/common/typing.less
@@ -167,7 +167,7 @@
 }
 
 .label-2 {
-  color: var(--gray-70);
+  color: var(--text-input-label);
   font-size: var(--font-size-small);
   font-weight: var(--font-weight-semibold);
   letter-spacing: 0.25px;

--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -128,34 +128,6 @@
   svg {
     margin-bottom: 4px;
   }
-
-  .people-outline path {
-    body.theme-dark & {
-      fill: var(--gray-100);
-    }
-  }
-
-  .conversations-outline,
-  .folders-outline {
-    fill: transparent;
-    body.theme-dark & path {
-      stroke: var(--gray-100);
-    }
-
-    &.active path {
-      fill: var(--accent-color-500) !important;
-      stroke: var(--accent-color-500) !important;
-    }
-  }
-
-  .conversations-outline.active {
-    path:last-child {
-      stroke: var(--gray-10) !important;
-    }
-    body.theme-dark & path:last-child {
-      stroke: var(--gray-95) !important;
-    }
-  }
 }
 
 .conversations-settings-button {

--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -98,7 +98,7 @@
 
   .conversations-sidebar-btn--badge {
     padding: 1px 4px;
-    border: 1px solid #fff;
+    border: 1px solid var(--app-bg-secondary);
     border-radius: 10px;
     background: var(--red-500);
     color: var(--button-tertiary-bg);
@@ -107,7 +107,7 @@
   }
 
   .conversations-sidebar-btn--text {
-    color: var(--gray-100);
+    color: var(--main-color);
   }
 
   &.active {
@@ -115,11 +115,11 @@
     color: var(--accent-color-500);
 
     svg {
-      fill: var(--white) !important;
+      fill: var(--app-bg-secondary) !important;
     }
 
     .conversations-sidebar-btn--text {
-      color: var(--white) !important;
+      color: var(--app-bg-secondary) !important;
     }
   }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6811" title="WPB-6811" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-6811</a>  [Web] Make sure dark mode works in the new layout
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

Use the correct css variables to address styling of the new sidebar in dark mode

## Screenshots/Screencast (for UI changes)

Before:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/19d0e7e1-feec-4509-aa51-d2140acd129f)


After:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/f9678495-725e-4308-b949-767b71f3bc29)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
