### PR TITLE
runfix: assign a user and group id to containers

### DIFF
--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -56,6 +56,7 @@ podSecurityContext:
   capabilities:
     drop:
       - ALL
-  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
   seccompProfile:
     type: RuntimeDefault


### PR DESCRIPTION
These changes are needed to deploy the chart in Kubernetes version 1.28 and higher.