### PR TITLE
feat: Improve display of read receipts in right sidebar

### DIFF
--- a/src/script/components/toggle/ReceiptModeToggle.tsx
+++ b/src/script/components/toggle/ReceiptModeToggle.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React, {Fragment} from 'react';
+import React from 'react';
 
 import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data';
 
@@ -30,7 +30,7 @@ export interface ReceiptModeToggleProps {
   receiptMode: RECEIPT_MODE;
 }
 
-const ReceiptModeToggle: React.FC<ReceiptModeToggleProps> = ({receiptMode, onReceiptModeChanged}) => {
+const ReceiptModeToggle = ({receiptMode, onReceiptModeChanged}: ReceiptModeToggleProps) => {
   const updateValue = () => {
     const newReceiptMode = receiptMode !== RECEIPT_MODE.ON ? RECEIPT_MODE.ON : RECEIPT_MODE.OFF;
     onReceiptModeChanged(newReceiptMode);
@@ -38,8 +38,9 @@ const ReceiptModeToggle: React.FC<ReceiptModeToggleProps> = ({receiptMode, onRec
 
   const inputRef = React.useRef<HTMLInputElement>(null);
   const isChecked = receiptMode !== RECEIPT_MODE.OFF;
+
   return (
-    <Fragment>
+    <>
       <div className="panel__action-item panel__action-item--toggle">
         <label
           htmlFor="receipt-toggle-input"
@@ -50,10 +51,12 @@ const ReceiptModeToggle: React.FC<ReceiptModeToggleProps> = ({receiptMode, onRec
           <span className="panel__action-item__icon">
             <Icon.Read />
           </span>
+
           <span className="panel__action-item__summary">
             <span className="panel__action-item__text">{t('receiptToggleLabel')}</span>
           </span>
         </label>
+
         <input
           ref={inputRef}
           checked={isChecked}
@@ -64,6 +67,7 @@ const ReceiptModeToggle: React.FC<ReceiptModeToggleProps> = ({receiptMode, onRec
           onChange={() => updateValue()}
           type="checkbox"
         />
+
         <button
           className="button-label"
           aria-pressed={receiptMode !== RECEIPT_MODE.OFF}
@@ -74,13 +78,14 @@ const ReceiptModeToggle: React.FC<ReceiptModeToggleProps> = ({receiptMode, onRec
           <span className="visually-hidden">{t('receiptToggleLabel')}</span>
         </button>
       </div>
+
       <p
         className="panel__info-text panel__info-text--margin panel__action-item__status"
         data-uie-name="status-info-toggle-receipt-mode"
       >
         {t('receiptToggleInfo')}
       </p>
-    </Fragment>
+    </>
   );
 };
 

--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
@@ -442,13 +442,11 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
                   <span className="panel__info-item__icon">{hasReceiptsEnabled ? <Icon.Read /> : <HideIcon />}</span>
 
                   <span>
-                    <span>
-                      <p>
-                        {hasReceiptsEnabled
-                          ? t('conversationDetails1to1ReceiptsHeadEnabled')
-                          : t('conversationDetails1to1ReceiptsHeadDisabled')}
-                      </p>
-                    </span>
+                    <p className="panel__action-item__status-title">
+                      {hasReceiptsEnabled
+                        ? t('conversationDetails1to1ReceiptsHeadEnabled')
+                        : t('conversationDetails1to1ReceiptsHeadDisabled')}
+                    </p>
                     <p className="panel__action-item__status">{t('conversationDetails1to1ReceiptsFirst')}</p>
                     <p className="panel__action-item__status">{t('conversationDetails1to1ReceiptsSecond')}</p>
                   </span>

--- a/src/style/panel/conversation-details.less
+++ b/src/style/panel/conversation-details.less
@@ -44,7 +44,15 @@
   }
 
   &__read-receipts {
-    margin: 8px 0;
+    padding: 12px 0;
+
+    .panel__info-text--margin {
+      margin-left: 56px;
+    }
+
+    .panel__action-item {
+      min-height: auto;
+    }
   }
 
   &__admin {

--- a/src/style/panel/panel.less
+++ b/src/style/panel/panel.less
@@ -129,6 +129,17 @@
     overflow-y: auto;
     transform: translateX(0);
 
+    .conversation-details__read-receipts {
+      &::after {
+        position: absolute;
+        right: 0;
+        bottom: 0;
+        left: @left-list-item-left-width;
+        border-bottom: 1px solid var(--border-color);
+        content: '';
+      }
+    }
+
     ul {
       padding: 0;
       margin: 0;
@@ -303,6 +314,12 @@
       .subline;
       color: var(--gray-70);
       justify-self: flex-end;
+
+      &-title {
+        margin-bottom: 4px;
+        font-size: 0.875rem;
+        font-weight: 500;
+      }
 
       body.theme-dark & {
         color: var(--white);


### PR DESCRIPTION
## Description
Improve design for displaying read receipts information in right sidebar.

## Screenshots/Screencast (for UI changes)

Before:
1:1:
![image](https://github.com/wireapp/wire-webapp/assets/13432884/2c4595b3-bd92-43dc-b7f1-0d5dec532f55)

Group:
![image](https://github.com/wireapp/wire-webapp/assets/13432884/94ef2bb9-acd7-49c8-a89d-0a3dc9f70815)

After:
1:1:
![image](https://github.com/wireapp/wire-webapp/assets/13432884/235a31a2-36ea-409a-8c7e-c0b96e63f83f)

Group:
![image](https://github.com/wireapp/wire-webapp/assets/13432884/e60a9849-bb1f-4d67-a07f-0c23bd9925d9)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
