### PR TITLE
fix: side scrolling in message list

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset/ImageAsset.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset/ImageAsset.tsx
@@ -125,7 +125,7 @@ export const ImageAsset = ({
   const imageAsset: CSSObject = {
     aspectRatio: isFileSharingReceivingEnabled ? `${asset.ratio}` : undefined,
     maxHeight: '80vh',
-    maxWidth: imageWidth,
+    maxWidth: !imageUrl?.url ? '100%' : imageWidth,
 
     ...(!imageUrl?.url &&
       !isImageWidthLargerThanDefined && {

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset/ImageAsset.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset/ImageAsset.tsx
@@ -106,12 +106,11 @@ export const ImageAsset = ({
   };
 
   const isImageWidthLargerThanDefined = parseInt(asset.width, 10) >= MAX_ASSET_WIDTH;
-  const imageWidth = isImageWidthLargerThanDefined ? `${MAX_ASSET_WIDTH}px` : asset.width;
 
   const imageAsset: CSSObject = {
     aspectRatio: isFileSharingReceivingEnabled ? `${asset.ratio}` : undefined,
     maxHeight: '80vh',
-    maxWidth: !imageUrl?.url ? '100%' : imageWidth,
+    maxWidth: 'max-content',
 
     ...(!imageUrl?.url &&
       !isImageWidthLargerThanDefined && {
@@ -120,7 +119,7 @@ export const ImageAsset = ({
   };
 
   const imageStyle: CSSObject = {
-    width: imageWidth,
+    width: 'max-content',
     maxWidth: '100%',
     height: 'auto',
   };

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -19,8 +19,9 @@
 
 // MEMBER LIST
 .message-list {
-  overflow: auto;
   flex: 1 1;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .messages {

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -19,9 +19,8 @@
 
 // MEMBER LIST
 .message-list {
+  overflow: auto;
   flex: 1 1;
-  overflow-x: hidden;
-  overflow-y: auto;
 }
 
 .messages {


### PR DESCRIPTION
## Description

We had an issue with the chat being able to side-scroll.
This is caused by setting a max-image width with a fixed pixel value, sometimes bigger than the viewport. This causes placeholder images of very big images to be rendered with too much width.


## Screenshots/Screencast (for UI changes)

## Checklist

- [X] PR has been self reviewed by the author;
- [X] Hard-to-understand areas of the code have been commented;
- [X] If it is a core feature, unit tests have been added;

