### PR TITLE
runfix: remove read receipt from message header (WPB-6980)

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.test.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.test.tsx
@@ -50,7 +50,6 @@ describe('message', () => {
       isLastDeliveredMessage: false,
       hideHeader: false,
       message,
-      lastMessageInGroup: new ContentMessage(),
       onClickAvatar: jest.fn(),
       onClickButton: jest.fn(),
       onClickCancelRequest: jest.fn(),

--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -27,7 +27,6 @@ import {ReadIndicator} from 'Components/MessagesList/Message/ReadIndicator';
 import {Conversation} from 'src/script/entity/Conversation';
 import {CompositeMessage} from 'src/script/entity/message/CompositeMessage';
 import {ContentMessage} from 'src/script/entity/message/ContentMessage';
-import {Message} from 'src/script/entity/message/Message';
 import {useRelativeTimestamp} from 'src/script/hooks/useRelativeTimestamp';
 import {StatusType} from 'src/script/message/StatusType';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
@@ -59,7 +58,6 @@ export interface ContentMessageProps extends Omit<MessageActions, 'onClickResetS
   isFocused: boolean;
   isLastDeliveredMessage: boolean;
   message: ContentMessage;
-  lastMessageInGroup: Message;
   onClickButton: (message: CompositeMessage, buttonId: string) => void;
   onRetry: (message: ContentMessage) => void;
   quotedMessage?: ContentMessage;
@@ -71,7 +69,6 @@ export interface ContentMessageProps extends Omit<MessageActions, 'onClickResetS
 export const ContentMessageComponent = ({
   conversation,
   message,
-  lastMessageInGroup,
   findMessage,
   selfId,
   hideHeader,
@@ -180,12 +177,6 @@ export const ContentMessageComponent = ({
               {timeAgo}
             </MessageTime>
           </span>
-          <ReadIndicator
-            message={lastMessageInGroup}
-            is1to1Conversation={conversation.is1to1()}
-            isLastDeliveredMessage={isLastDeliveredMessage || lastMessageInGroup.status() === StatusType.DELIVERED}
-            showIconOnly
-          />
         </MessageHeader>
       )}
 

--- a/src/script/components/MessagesList/Message/MessageWrapper.tsx
+++ b/src/script/components/MessagesList/Message/MessageWrapper.tsx
@@ -68,7 +68,6 @@ export const MessageWrapper: React.FC<MessageParams> = ({
   isFocused,
   isSelfTemporaryGuest,
   isLastDeliveredMessage,
-  lastMessageInGroup,
   shouldShowInvitePeople,
   hideHeader,
   hasReadReceiptsTurnedOn,
@@ -185,7 +184,6 @@ export const MessageWrapper: React.FC<MessageParams> = ({
     return (
       <ContentMessageComponent
         message={message}
-        lastMessageInGroup={lastMessageInGroup}
         findMessage={findMessage}
         conversation={conversation}
         hideHeader={hideHeader}

--- a/src/script/components/MessagesList/Message/index.tsx
+++ b/src/script/components/MessagesList/Message/index.tsx
@@ -59,7 +59,6 @@ export interface MessageParams extends MessageActions {
   conversation: Conversation;
   hasReadReceiptsTurnedOn: boolean;
   isLastDeliveredMessage: boolean;
-  lastMessageInGroup: BaseMessage;
   isSelfTemporaryGuest: boolean;
   message: BaseMessage;
   /** whether the message should display the user avatar and user name before the actual content */

--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -264,8 +264,6 @@ export const MessagesList: FC<MessagesListParams> = ({
           return messages.map(message => {
             const isLastDeliveredMessage = lastDeliveredMessage?.id === message.id;
 
-            const lastMessageInGroup = group.messages[messages.length - 1];
-
             const visibleCallback = getVisibleCallback(conversation, message);
 
             const key = `${message.id || 'message'}-${message.timestamp()}`;
@@ -278,7 +276,6 @@ export const MessagesList: FC<MessagesListParams> = ({
                 key={key}
                 onVisible={visibleCallback}
                 message={message}
-                lastMessageInGroup={lastMessageInGroup}
                 hideHeader={message.timestamp() !== firstMessageTimestamp}
                 messageActions={messageActions}
                 conversation={conversation}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6980" title="WPB-6980" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6980</a>  Hide read indicator from message header
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

As seen [here](https://wearezeta.atlassian.net/browse/WPB-6980), we decided to not go ahead with showing a read receipt for message headers

This reverts commit 1f803f73ec4ac2504519f7b510bda841902c4713.
See original PR here:  https://github.com/wireapp/wire-webapp/pull/16851
