### PR TITLE
runfix: prefix cert expiry date storage

### DIFF
--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -32,7 +32,7 @@ import {formatDelayTime, TIME_IN_MILLIS} from 'Util/TimeUtil';
 import {removeUrlParameters} from 'Util/UrlUtil';
 
 import {hasActiveCertificate, getActiveWireIdentity, isFreshMLSSelfClient} from './E2EIdentityVerification';
-import {EnrollmentStore} from './Enrollment.store';
+import {getEnrollmentStore} from './Enrollment.store';
 import {getEnrollmentTimer} from './EnrollmentTimer';
 import {getModalOptions, ModalType} from './Modals';
 import {OIDCService} from './OIDCService';
@@ -70,6 +70,17 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
     }
 
     return e2eiService;
+  }
+
+  private get enrollmentStore() {
+    const selfUserId = this.userState.self()?.qualifiedId;
+
+    if (!selfUserId) {
+      throw new Error('Self user not found');
+    }
+
+    const enrollmentStore = getEnrollmentStore(selfUserId, this.core.clientId);
+    return enrollmentStore;
   }
 
   private createOIDCService() {
@@ -141,9 +152,9 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
    */
   public async startTimers() {
     // We store the first time the user was prompted with the enrollment modal
-    const storedE2eActivatedAt = EnrollmentStore.get.e2eiActivatedAt();
+    const storedE2eActivatedAt = this.enrollmentStore.get.e2eiActivatedAt();
     const e2eActivatedAt = storedE2eActivatedAt || Date.now();
-    EnrollmentStore.store.e2eiActivatedAt(e2eActivatedAt);
+    this.enrollmentStore.store.e2eiActivatedAt(e2eActivatedAt);
 
     const timerKey = 'enrollmentTimer';
     const identity = await getActiveWireIdentity();
@@ -154,12 +165,12 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
     );
 
     const task = async () => {
-      EnrollmentStore.clear.timer();
+      this.enrollmentStore.clear.timer();
       await this.processEnrollmentUponExpiry(isSnoozable);
     };
 
-    const firingDate = EnrollmentStore.get.timer() || computedFiringDate;
-    EnrollmentStore.store.timer(firingDate);
+    const firingDate = this.enrollmentStore.get.timer() || computedFiringDate;
+    this.enrollmentStore.store.timer(firingDate);
 
     const isFirstE2EIActivation = !storedE2eActivatedAt && !identity;
     if (isFirstE2EIActivation || firingDate <= Date.now()) {

--- a/src/script/E2EIdentity/Enrollment.store.ts
+++ b/src/script/E2EIdentity/Enrollment.store.ts
@@ -42,7 +42,7 @@ export const getEnrollmentStore = ({id: userId, domain}: QualifiedId, clientId: 
   const clientStoreId = constructFullyQualifiedClientId(userId, clientId, domain);
   const constructKey = (key: string) => `${clientStoreId}_${key}`;
 
-  const store = {
+  return {
     store: {
       e2eiActivatedAt: (time: number) => localStorage.setItem(constructKey(e2eActivatedAtKey), String(time)),
       timer: (time: number) => localStorage.setItem(constructKey(e2eTimer), String(time)),
@@ -56,6 +56,4 @@ export const getEnrollmentStore = ({id: userId, domain}: QualifiedId, clientId: 
       timer: () => localStorage.removeItem(constructKey(e2eTimer)),
     },
   };
-
-  return store;
 };

--- a/src/script/E2EIdentity/Enrollment.store.ts
+++ b/src/script/E2EIdentity/Enrollment.store.ts
@@ -17,20 +17,45 @@
  *
  */
 
+import {QualifiedId} from '@wireapp/api-client/lib/user';
+import {constructFullyQualifiedClientId} from '@wireapp/core/lib/util/fullyQualifiedClientIdUtils';
+
 const e2eActivatedAtKey = 'e2eActivatedAt';
 const e2eTimer = 'e2eTimer';
 
-export const EnrollmentStore = {
+interface EnrollmentStore {
   store: {
-    e2eiActivatedAt: (time: number) => localStorage.setItem(e2eActivatedAtKey, String(time)),
-    timer: (time: number) => localStorage.setItem(e2eTimer, String(time)),
-  },
+    e2eiActivatedAt: (time: number) => void;
+    timer: (time: number) => void;
+  };
   get: {
-    e2eiActivatedAt: () => Number(localStorage.getItem(e2eActivatedAtKey)),
-    timer: () => Number(localStorage.getItem(e2eTimer)),
-  },
+    e2eiActivatedAt: () => number;
+    timer: () => number;
+  };
   clear: {
-    deviceCreatedAt: () => localStorage.removeItem(e2eActivatedAtKey),
-    timer: () => localStorage.removeItem(e2eTimer),
-  },
+    deviceCreatedAt: () => void;
+    timer: () => void;
+  };
+}
+
+export const getEnrollmentStore = ({id: userId, domain}: QualifiedId, clientId: string): EnrollmentStore => {
+  const clientStoreId = constructFullyQualifiedClientId(userId, clientId, domain);
+  const constructKey = (key: string) => `${clientStoreId}_${key}`;
+
+  const store = {
+    store: {
+      e2eiActivatedAt: (time: number) => localStorage.setItem(constructKey(e2eActivatedAtKey), String(time)),
+      timer: (time: number) => localStorage.setItem(constructKey(e2eTimer), String(time)),
+    },
+    get: {
+      e2eiActivatedAt: () => Number(localStorage.getItem(constructKey(e2eActivatedAtKey))),
+      timer: () => Number(localStorage.getItem(constructKey(e2eTimer))),
+    },
+    clear: {
+      deviceCreatedAt: () => localStorage.removeItem(constructKey(e2eActivatedAtKey)),
+      timer: () => localStorage.removeItem(constructKey(e2eTimer)),
+    },
+  };
+
+  return store;
 };


### PR DESCRIPTION
## Description

A localstorage store for storing cert expiration time (a notification during the grace period about renewing a cert) was not prefixed with user/client id. It could happen that when logging in to the app with multiple accounts/devices we could get notified about cert renewal while in reality it is still valid for a long time.

A fix is to prefix the localstorage entry with fully qualified client id - user id + user domain + client id, so we're sure this value is meant for this particular user (and client).

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;