### PR TITLE
fix: prevent code blocks from generating link previews (WPB-7138)

### DIFF
--- a/src/script/conversation/linkPreviews/helpers.test.ts
+++ b/src/script/conversation/linkPreviews/helpers.test.ts
@@ -109,14 +109,14 @@ describe('getFirstLinkWithOffset', () => {
   });
 
   it('should return the correct link and offset for a single link preceded by a code block', () => {
-    const Link = getFirstLinkWithOffset('```\ntrap.com\n```\nwire.com');
+    const Link = getFirstLinkWithOffset('```\ntrap.com `extra trap!`\n```\nwire.com');
 
     expect(Link.offset).toEqual(1);
     expect(Link.url).toEqual('wire.com');
   });
 
   it('should return the correct link and offset for a single link followed by a code block', () => {
-    const Link = getFirstLinkWithOffset('wire.com\n```\ntrap.com\n```');
+    const Link = getFirstLinkWithOffset('wire.com\n```\ntrap.com `extra trap!`\n```');
 
     expect(Link.offset).toEqual(0);
     expect(Link.url).toEqual('wire.com');

--- a/src/script/conversation/linkPreviews/helpers.test.ts
+++ b/src/script/conversation/linkPreviews/helpers.test.ts
@@ -73,7 +73,8 @@ describe('getFirstLinkWithOffset', () => {
     const singleTick = 'cool code: `wire.com`';
     const moreTicks = 'cool code: ```\nwire.com\n```';
     const manyTicks = 'cool code: ``````\nwire.com\n``````';
-    const multilineSingleTick = '\ncool code: `wire.com`';
+    const multilineSingleTick = '\ncool code:\n`wire.com`';
+    const multilineManyTicks = '\ncool code:\n```wire.com\nsome more code\n```';
     const noClosingTicks = 'cool code: ```\nwire.com';
     const ticksception = "cool code: ```\nwire.com `it's a trap!`\n```";
 
@@ -81,6 +82,7 @@ describe('getFirstLinkWithOffset', () => {
     expect(getFirstLinkWithOffset(moreTicks)).toBeUndefined();
     expect(getFirstLinkWithOffset(manyTicks)).toBeUndefined();
     expect(getFirstLinkWithOffset(multilineSingleTick)).toBeUndefined();
+    expect(getFirstLinkWithOffset(multilineManyTicks)).toBeUndefined();
     expect(getFirstLinkWithOffset(noClosingTicks)).toBeUndefined();
     expect(getFirstLinkWithOffset(ticksception)).toBeUndefined();
   });
@@ -103,6 +105,20 @@ describe('getFirstLinkWithOffset', () => {
     const Link = getFirstLinkWithOffset('Hey check wire.com PLEASE!');
 
     expect(Link.offset).toEqual(10);
+    expect(Link.url).toEqual('wire.com');
+  });
+
+  it('should return the correct link and offset for a single link preceded by a code block', () => {
+    const Link = getFirstLinkWithOffset('```\ntrap.com\n```\nwire.com');
+
+    expect(Link.offset).toEqual(1);
+    expect(Link.url).toEqual('wire.com');
+  });
+
+  it('should return the correct link and offset for a single link followed by a code block', () => {
+    const Link = getFirstLinkWithOffset('wire.com\n```\ntrap.com\n```');
+
+    expect(Link.offset).toEqual(0);
     expect(Link.url).toEqual('wire.com');
   });
 

--- a/src/script/conversation/linkPreviews/helpers.test.ts
+++ b/src/script/conversation/linkPreviews/helpers.test.ts
@@ -73,10 +73,16 @@ describe('getFirstLinkWithOffset', () => {
     const singleTick = 'cool code: `wire.com`';
     const moreTicks = 'cool code: ```\nwire.com\n```';
     const manyTicks = 'cool code: ``````\nwire.com\n``````';
+    const multilineSingleTick = '\ncool code: `wire.com`';
+    const noClosingTicks = 'cool code: ```\nwire.com';
+    const ticksception = "cool code: ```\nwire.com `it's a trap!`\n```";
 
     expect(getFirstLinkWithOffset(singleTick)).toBeUndefined();
     expect(getFirstLinkWithOffset(moreTicks)).toBeUndefined();
     expect(getFirstLinkWithOffset(manyTicks)).toBeUndefined();
+    expect(getFirstLinkWithOffset(multilineSingleTick)).toBeUndefined();
+    expect(getFirstLinkWithOffset(noClosingTicks)).toBeUndefined();
+    expect(getFirstLinkWithOffset(ticksception)).toBeUndefined();
   });
 
   it('should return the correct link and offset for a single link without text', () => {

--- a/src/script/conversation/linkPreviews/helpers.ts
+++ b/src/script/conversation/linkPreviews/helpers.ts
@@ -19,8 +19,10 @@
 
 import Linkify from 'linkify-it';
 
-const unclosedCodeBlockRegex = /(`{3,})([\s\S]*?)(?:\1|$)/g;
-const closedCodeBlockRegex = /(`+)(.*?)\1/gs;
+// Matches with a fenced code block (```), whether it is closed or not
+const codeBlockRegex = /(`{3,})([\s\S]*?)(?:\1|$)/g;
+// Matches with inline code, even if it opens or closes on a different line
+const inlineCodeRegex = /(`+)(.*?)\1/gs;
 const linkify = new Linkify();
 
 /**
@@ -29,7 +31,7 @@ const linkify = new Linkify();
  * @returns Text contains only a link
  */
 export const containsOnlyLink = (text: string): boolean => {
-  const textWithoutCode = text.trim().replace(unclosedCodeBlockRegex, '').replace(closedCodeBlockRegex, ``);
+  const textWithoutCode = text.trim().replace(codeBlockRegex, '').replace(inlineCodeRegex, ``);
   const urls = linkify.match(textWithoutCode) || [];
   return urls.length === 1 && urls[0].raw === textWithoutCode;
 };
@@ -40,7 +42,7 @@ export const containsOnlyLink = (text: string): boolean => {
  * @returns Containing link and its offset
  */
 export const getFirstLinkWithOffset = (text: string): {offset: number; url: string} | undefined => {
-  const textWithoutCode = text.trim().replace(unclosedCodeBlockRegex, '').replace(closedCodeBlockRegex, ``);
+  const textWithoutCode = text.trim().replace(codeBlockRegex, '').replace(inlineCodeRegex, ``);
 
   const links = linkify.match(textWithoutCode) || [];
   const [firstLink] = links.filter(link => ['http:', 'https:', ''].includes(link.schema));

--- a/src/script/conversation/linkPreviews/helpers.ts
+++ b/src/script/conversation/linkPreviews/helpers.ts
@@ -23,6 +23,7 @@ import Linkify from 'linkify-it';
 const codeBlockRegex = /(`{3,})([\s\S]*?)(?:\1|$)/g;
 // Matches with inline code, even if it opens or closes on a different line
 const inlineCodeRegex = /(`+)(.*?)\1/gs;
+
 const linkify = new Linkify();
 
 /**
@@ -32,6 +33,7 @@ const linkify = new Linkify();
  */
 export const containsOnlyLink = (text: string): boolean => {
   const textWithoutCode = text.trim().replace(codeBlockRegex, '').replace(inlineCodeRegex, ``);
+
   const urls = linkify.match(textWithoutCode) || [];
   return urls.length === 1 && urls[0].raw === textWithoutCode;
 };

--- a/src/script/conversation/linkPreviews/helpers.ts
+++ b/src/script/conversation/linkPreviews/helpers.ts
@@ -19,7 +19,8 @@
 
 import Linkify from 'linkify-it';
 
-const codeBlockRegex = /(`+)[^`]*?\1$/gm;
+const unclosedCodeBlockRegex = /(`{3,})([\s\S]*?)(?:\1|$)/g;
+const closedCodeBlockRegex = /(`+)(.*?)\1/gs;
 const linkify = new Linkify();
 
 /**
@@ -28,7 +29,7 @@ const linkify = new Linkify();
  * @returns Text contains only a link
  */
 export const containsOnlyLink = (text: string): boolean => {
-  const textWithoutCode = text.trim().replace(codeBlockRegex, '');
+  const textWithoutCode = text.trim().replace(unclosedCodeBlockRegex, '').replace(closedCodeBlockRegex, ``);
   const urls = linkify.match(textWithoutCode) || [];
   return urls.length === 1 && urls[0].raw === textWithoutCode;
 };
@@ -39,7 +40,7 @@ export const containsOnlyLink = (text: string): boolean => {
  * @returns Containing link and its offset
  */
 export const getFirstLinkWithOffset = (text: string): {offset: number; url: string} | undefined => {
-  const textWithoutCode = text.trim().replace(codeBlockRegex, '');
+  const textWithoutCode = text.trim().replace(unclosedCodeBlockRegex, '').replace(closedCodeBlockRegex, ``);
 
   const links = linkify.match(textWithoutCode) || [];
   const [firstLink] = links.filter(link => ['http:', 'https:', ''].includes(link.schema));


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7138" title="WPB-7138" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-7138</a>  [Web] Url inside code blocks can sometime generate link previews
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Certain links contained inside code blocks would still generate link previews.
This adapt the regular expression to take into account those cases

## Examples

- non-closed fenced code block would generate a link preview
> \```
> wire.com

- closed backticks inside a fenced code block would generate a link preview
>\```
>wire.com \`ìt's a trap!`
>\```

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
