### PR TITLE
fix: jump on device details - page

### DIFF
--- a/src/script/components/VerificationBadge/VerificationBadges.tsx
+++ b/src/script/components/VerificationBadge/VerificationBadges.tsx
@@ -22,6 +22,7 @@ import {CSSProperties, useEffect, useMemo, useRef, useState} from 'react';
 import {CSSObject} from '@emotion/react';
 import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 import {stringifyQualifiedId} from '@wireapp/core/lib/util/qualifiedIdUtil';
+import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 import {container} from 'tsyringe';
 
 import {
@@ -185,12 +186,29 @@ export const ConversationVerificationBadges = ({conversation, displayTitle}: Con
   );
 };
 
-const MLSVerificationBadge = ({context, MLSStatus}: {MLSStatus?: MLSStatuses; context: VerificationBadgeContext}) => {
+const MLSVerificationBadge = ({
+  context,
+  MLSStatus,
+  tooltipId,
+}: {
+  MLSStatus?: MLSStatuses;
+  context: VerificationBadgeContext;
+  tooltipId: string;
+}) => {
   const mlsVerificationProps = {
     css: iconStyles,
     'data-uie-name': `mls-${context}-status`,
     'data-uie-value': MLSStatus,
   };
+
+  const TooltipIcon = ({children, body, ...props}: {body: string; children: React.ReactNode}) => (
+    <>
+      <div id={tooltipId} role="tooltip" aria-label={body}></div>
+      <Tooltip {...props} body={body}>
+        {children}
+      </Tooltip>
+    </>
+  );
 
   switch (MLSStatus) {
     case MLSStatuses.VALID:
@@ -201,33 +219,33 @@ const MLSVerificationBadge = ({context, MLSStatus}: {MLSStatus?: MLSStatuses; co
       };
 
       return (
-        <Tooltip body={t(translationKeys[context])} {...mlsVerificationProps}>
+        <TooltipIcon {...mlsVerificationProps} body={t(translationKeys[context])}>
           <MLSVerified />
-        </Tooltip>
+        </TooltipIcon>
       );
     case MLSStatuses.NOT_ACTIVATED:
       return (
-        <Tooltip {...mlsVerificationProps} body={t('E2EI.certificateNotDownloaded')}>
+        <TooltipIcon {...mlsVerificationProps} body={t('E2EI.certificateNotDownloaded')}>
           <CertificateExpiredIcon />
-        </Tooltip>
+        </TooltipIcon>
       );
     case MLSStatuses.EXPIRED:
       return (
-        <Tooltip {...mlsVerificationProps} body={t('E2EI.certificateExpired')}>
+        <TooltipIcon {...mlsVerificationProps} body={t('E2EI.certificateExpired')}>
           <CertificateExpiredIcon />
-        </Tooltip>
+        </TooltipIcon>
       );
     case MLSStatuses.REVOKED:
       return (
-        <Tooltip {...mlsVerificationProps} body={t('E2EI.certificateRevoked')}>
+        <TooltipIcon {...mlsVerificationProps} body={t('E2EI.certificateRevoked')}>
           <CertificateRevoked />
-        </Tooltip>
+        </TooltipIcon>
       );
     case MLSStatuses.EXPIRES_SOON:
       return (
-        <Tooltip {...mlsVerificationProps} body={t('E2EI.certificateExpiresSoon')}>
+        <TooltipIcon {...mlsVerificationProps} body={t('E2EI.certificateExpiresSoon')}>
           <ExpiresSoon />
-        </Tooltip>
+        </TooltipIcon>
       );
   }
   return null;
@@ -243,6 +261,8 @@ export const VerificationBadges = ({
   if (!MLSStatus && !isProteusVerified) {
     return null;
   }
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const id = useRef(new Date().getTime());
 
   const conversationHasProtocol = !!conversationProtocol;
 
@@ -254,19 +274,24 @@ export const VerificationBadges = ({
     ? conversationProtocol === ConversationProtocol.PROTEUS && isProteusVerified
     : isProteusVerified;
 
+  const mlsTooltipId = `mls-verified-tooltip_${id.current}`;
+  const proteusTooltipId = `proteus-verified-tooltip_${id.current}`;
+
   return (
     <div className="conversation-badges" css={{display: 'flex', alignItems: 'center', gap: '6px'}}>
       {showMLSBadge && (
-        <div css={badgeWrapper}>
+        <div css={badgeWrapper} tabIndex={TabIndex.FOCUSABLE} aria-describedby={mlsTooltipId}>
           {displayTitle && <span style={title(true)}>{t('E2EI.verified')}</span>}
-          <MLSVerificationBadge MLSStatus={MLSStatus} context={context} />
+
+          <MLSVerificationBadge MLSStatus={MLSStatus} context={context} tooltipId={mlsTooltipId} />
         </div>
       )}
 
       {showProteusBadge && (
-        <div css={badgeWrapper}>
+        <div css={badgeWrapper} tabIndex={TabIndex.FOCUSABLE} aria-describedby={proteusTooltipId}>
           {displayTitle && <span style={title(false)}>{t('proteusVerifiedDetails')}</span>}
 
+          <div id={proteusTooltipId} role="tooltip" aria-label={t('proteusDeviceVerified')}></div>
           <Tooltip body={t('proteusDeviceVerified')} css={iconStyles} data-uie-name="proteus-verified">
             <ProteusVerified data-uie-name={`proteus-${context}-verified`} />
           </Tooltip>

--- a/src/script/components/VerificationBadge/VerificationBadges.tsx
+++ b/src/script/components/VerificationBadge/VerificationBadges.tsx
@@ -258,11 +258,11 @@ export const VerificationBadges = ({
   displayTitle = false,
   context,
 }: VerificationBadgesProps) => {
+  const id = useRef(new Date().getTime());
+
   if (!MLSStatus && !isProteusVerified) {
     return null;
   }
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const id = useRef(new Date().getTime());
 
   const conversationHasProtocol = !!conversationProtocol;
 

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/Device/Device.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/Device/Device.tsx
@@ -64,8 +64,9 @@ export const Device = ({device, isSSO, onSelect, onRemove, getDeviceIdentity, de
       className="preferences-devices-card"
       onClick={onDeviceSelect}
       onKeyDown={event => handleKeyDown(event, onDeviceSelect)}
-      tabIndex={TabIndex.FOCUSABLE}
       role="button"
+      aria-label={t('accessibility.headings.preferencesDeviceDetails')}
+      tabIndex={TabIndex.FOCUSABLE}
     >
       <div className="preferences-devices-card-info">
         <div

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.tsx
@@ -73,7 +73,7 @@ export const E2EICertificateDetails = ({identity, isCurrentDevice}: E2EICertific
             onClick={() => setIsCertificateDetailsModalOpen(true)}
             data-uie-name="show-certificate-details"
             aria-label={t('E2EI.showCertificateDetails')}
-            tabIndex={TabIndex.FOCUSABLE}
+            //tabIndex={TabIndex.FOCUSABLE}
           >
             {t('E2EI.showCertificateDetails')}
           </Button>

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.tsx
@@ -19,6 +19,8 @@
 
 import {useState} from 'react';
 
+import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
+
 import {Button, ButtonVariant} from '@wireapp/react-ui-kit';
 
 import {CertificateDetailsModal} from 'Components/Modals/CertificateDetailsModal';
@@ -70,6 +72,8 @@ export const E2EICertificateDetails = ({identity, isCurrentDevice}: E2EICertific
             variant={ButtonVariant.TERTIARY}
             onClick={() => setIsCertificateDetailsModalOpen(true)}
             data-uie-name="show-certificate-details"
+            aria-label={t('E2EI.showCertificateDetails')}
+            tabIndex={TabIndex.FOCUSABLE}
           >
             {t('E2EI.showCertificateDetails')}
           </Button>
@@ -85,13 +89,25 @@ export const E2EICertificateDetails = ({identity, isCurrentDevice}: E2EICertific
         {isCurrentDevice && (
           <>
             {isNotActivated && (
-              <Button variant={ButtonVariant.TERTIARY} onClick={getCertificate} data-uie-name="get-certificate">
+              <Button
+                variant={ButtonVariant.TERTIARY}
+                onClick={getCertificate}
+                data-uie-name="get-certificate"
+                aria-label={t('E2EI.getCertificate')}
+                tabIndex={TabIndex.FOCUSABLE}
+              >
                 {t('E2EI.getCertificate')}
               </Button>
             )}
 
             {identity?.certificate && !isValid && (
-              <Button variant={ButtonVariant.TERTIARY} onClick={getCertificate} data-uie-name="update-certificate">
+              <Button
+                variant={ButtonVariant.TERTIARY}
+                onClick={getCertificate}
+                data-uie-name="update-certificate"
+                aria-label={t('E2EI.updateCertificate')}
+                tabIndex={TabIndex.FOCUSABLE}
+              >
                 {t('E2EI.updateCertificate')}
               </Button>
             )}

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.tsx
@@ -73,7 +73,7 @@ export const E2EICertificateDetails = ({identity, isCurrentDevice}: E2EICertific
             onClick={() => setIsCertificateDetailsModalOpen(true)}
             data-uie-name="show-certificate-details"
             aria-label={t('E2EI.showCertificateDetails')}
-            //tabIndex={TabIndex.FOCUSABLE}
+            tabIndex={TabIndex.FOCUSABLE}
           >
             {t('E2EI.showCertificateDetails')}
           </Button>


### PR DESCRIPTION
## Description

Trough the way we implemented accessibility in our application, by setting interactive elements manually to tabIndex="0", we force the browser after a page transition to focus the first new element. 

If the first element that has a tabIndex="0" is outside of the current viewport, the browser will "jump" there.

### Problem in action:
![Problem](https://github.com/wireapp/wire-webapp/assets/77456193/bee78c7d-fd42-453f-ac4c-0e62aa96d108)

### Solution (only for MLS Device with activated E2EI):
**added the missing tabIndex and aria-attributes to the interactive elements (buttons) and verification shields.** 

![Solution for E2Ei](https://github.com/wireapp/wire-webapp/assets/77456193/4a8b1e6f-1b24-4b19-98dc-e7dc2bbdaf48)

### Soltion for Proteus devices:
**Added the missing tabIndex and aria-tooltips to the verification shields** 