### PR TITLE
runfix: Live update team setting config when possible

### DIFF
--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -22,6 +22,7 @@ import type {
   TeamConversationDeleteEvent,
   TeamDeleteEvent,
   TeamEvent,
+  TeamFeatureConfigurationUpdateEvent,
   TeamMemberLeaveEvent,
 } from '@wireapp/api-client/lib/event';
 import {TEAM_EVENT} from '@wireapp/api-client/lib/event/TeamEvent';
@@ -276,6 +277,10 @@ export class TeamRepository extends TypedEventEmitter<Events> {
         this.onMemberLeave(eventJson);
         break;
       }
+      case TEAM_EVENT.FEATURE_CONFIG_UPDATE: {
+        await this.onFeatureConfigUpdate(eventJson, source);
+        break;
+      }
       case TEAM_EVENT.CONVERSATION_CREATE:
       default: {
         this.onUnhandled(eventJson);
@@ -366,6 +371,19 @@ export class TeamRepository extends TypedEventEmitter<Events> {
     if (shouldFetchConfig) {
       await this.updateFeatureConfig();
     }
+  };
+
+  private readonly onFeatureConfigUpdate = async (
+    event: TeamFeatureConfigurationUpdateEvent,
+    source: EventSource,
+  ): Promise<void> => {
+    if (source !== EventSource.WEBSOCKET) {
+      // Ignore notification stream events
+      return;
+    }
+
+    // When we receive a `feature-config.update` event, we will refetch the entire feature config
+    await this.updateFeatureConfig();
   };
 
   private onMemberLeave(eventJson: TeamMemberLeaveEvent): void {


### PR DESCRIPTION
## Description

Some small teams will still emit the `feature-config.update` event when the config is updated on `team-settings`. 

We still have the code that refreshes the config every 30s but we also handle live updates when they are dispatched by the backend. 

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
