### PR TITLE
fix: clicking on a link in link preview opens it twice [WPB-6817]

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/asset/LinkPreviewAssetComponent.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/LinkPreviewAssetComponent.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React from 'react';
+import React, {UIEvent} from 'react';
 
 import cx from 'classnames';
 
@@ -54,8 +54,13 @@ const LinkPreviewAsset: React.FC<LinkPreviewAssetProps> = ({header = false, mess
   const {isObfuscated} = useKoSubscribableChildren(message, ['isObfuscated']);
   const messageFocusedTabIndex = useMessageFocusedTabIndex(isFocusable);
 
-  const onClick = () => {
-    if (!message.isExpired()) {
+  const linkRef = React.useRef<HTMLAnchorElement>(null);
+
+  const onClick = ({target}: UIEvent) => {
+    // Clicking on the link directly will already open the link, so we don't want to open it manually
+    const wasLinkClicked = target === linkRef.current;
+
+    if (!message.isExpired() && !wasLinkClicked) {
       safeWindowOpen(preview?.url);
     }
   };
@@ -84,7 +89,7 @@ const LinkPreviewAsset: React.FC<LinkPreviewAssetProps> = ({header = false, mess
       tabIndex={messageFocusedTabIndex}
       className="link-preview-asset"
       onClick={onClick}
-      onKeyDown={e => handleKeyDown(e, onClick)}
+      onKeyDown={e => handleKeyDown(e, () => onClick(e))}
     >
       <div className="link-preview-image-container">
         {preview && previewImage ? (
@@ -123,6 +128,7 @@ const LinkPreviewAsset: React.FC<LinkPreviewAssetProps> = ({header = false, mess
                 rel="noopener noreferrer"
                 title={preview.url}
                 data-uie-name="link-preview-url"
+                ref={linkRef}
               >
                 {cleanURL(preview.url)}
               </a>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6817" title="WPB-6817" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6817</a>  [Web - Edge] Clicking on a link preview opens link twice in browser
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Clicking directly on a link in a link preview asset was opening the link twice in a new tab - once for link click (default browser behaviour) and once for the onClick event. To solve that we check whether the link element (`<a>`) was clicked directly, if so, no need to open a link manually.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;