### PR TITLE
fix: focus add participants search input [WPB-6818]

### DIFF
--- a/src/script/page/RightSidebar/AddParticipants/AddParticipants.tsx
+++ b/src/script/page/RightSidebar/AddParticipants/AddParticipants.tsx
@@ -189,6 +189,7 @@ const AddParticipants: FC<AddParticipantsProps> = ({
         onClose={onClose}
         title={headerText}
         titleDataUieName="status-people-selected"
+        shouldFocusFirstButton={false}
       />
 
       <div className="panel__content panel__content--fill">

--- a/src/script/page/RightSidebar/ConversationParticipants/ConversationParticipants.tsx
+++ b/src/script/page/RightSidebar/ConversationParticipants/ConversationParticipants.tsx
@@ -89,6 +89,7 @@ const ConversationParticipants: FC<ConversationParticipantsProps> = ({
         onClose={onClose}
         goBackUie="go-back-conversation-participants"
         title={t('conversationParticipantsTitle')}
+        shouldFocusFirstButton={false}
       />
 
       <div className="panel__content conversation-participants__content">

--- a/src/script/page/RightSidebar/PanelHeader/PanelHeader.tsx
+++ b/src/script/page/RightSidebar/PanelHeader/PanelHeader.tsx
@@ -43,6 +43,7 @@ export interface PanelHeaderProps {
   title?: string;
   handleBlur?: () => void;
   onToggleMute?: () => void;
+  shouldFocusFirstButton?: boolean;
 }
 
 const PanelHeader: FC<PanelHeaderProps> = ({
@@ -61,11 +62,12 @@ const PanelHeader: FC<PanelHeaderProps> = ({
   handleBlur = noop,
   onGoBack = noop,
   onToggleMute = noop,
+  shouldFocusFirstButton = true,
 }: PanelHeaderProps) => {
   const panelHeaderRef = useRef<HTMLHeadingElement>(null);
 
   useEffect(() => {
-    if (!!panelHeaderRef.current) {
+    if (!!panelHeaderRef.current && shouldFocusFirstButton) {
       const nextElementToFocus = panelHeaderRef.current.querySelector('button');
       // TO-DO Remove setTimeout after replacing transition group animation libray
       // triggering focus method without setTimeout is not working due to right side bar animation
@@ -73,7 +75,7 @@ const PanelHeader: FC<PanelHeaderProps> = ({
         nextElementToFocus?.focus();
       }, 0);
     }
-  }, []);
+  }, [shouldFocusFirstButton]);
 
   return (
     <header className={cx('panel__header', {'panel__header--reverse': isReverse}, className)} ref={panelHeaderRef}>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6818" title="WPB-6818" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6818</a>  [Web] Add participant to a group search bar is not focused
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Search input was not focused after opening "Add participants" panel.

The reason is we are always focusing the first button (the "back" button) once `PanelHeader` component is being opened what usually makes sense, but in case of opening a panel that also contains the search input, we should focus the input instead, so the user can start typing straight away without a need to navigate to the input manually. 

To fix that we are adding a optional `shouldFocusFirstButton` prop to `PanelHeader` component which is set to `true` by default. Whenever we want to prevent the default behaviour, this should be set to false explicitly, what I've done in two component where it's rendered next to the search input:
- Add participants panel
- People panel (group members list with filter search option)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
