### PR TITLE
runfix: Address federated revoked devices not being detected

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@lexical/react": "0.12.5",
     "@wireapp/avs": "9.6.12",
     "@wireapp/commons": "5.2.6",
-    "@wireapp/core": "45.2.10",
+    "@wireapp/core": "45.2.11",
     "@wireapp/react-ui-kit": "9.16.0",
     "@wireapp/store-engine-dexie": "2.1.8",
     "@wireapp/webapp-events": "0.20.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4768,20 +4768,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core-crypto@npm:1.0.0-rc.51":
-  version: 1.0.0-rc.51
-  resolution: "@wireapp/core-crypto@npm:1.0.0-rc.51"
-  checksum: 57298c878b4364458206d8ec7ac462704ef82d1e526172fa1a265ad8a4dfa94ebd024ae6cf50c471c58540907ed6d4ae408d8ecd07923f6d7e0bb98170e93cfd
+"@wireapp/core-crypto@npm:1.0.0-rc.52":
+  version: 1.0.0-rc.52
+  resolution: "@wireapp/core-crypto@npm:1.0.0-rc.52"
+  checksum: 6ef44adf8dd8849eebe1a361dc30ad62c4e7739478e12a0e978fd0f61c376e0d377b75478b423768ccbe6aae0725cb862c7cbc4cdbb4b6a4d7d8135db6e57dd9
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:45.2.10":
-  version: 45.2.10
-  resolution: "@wireapp/core@npm:45.2.10"
+"@wireapp/core@npm:45.2.11":
+  version: 45.2.11
+  resolution: "@wireapp/core@npm:45.2.11"
   dependencies:
     "@wireapp/api-client": ^26.11.2
     "@wireapp/commons": ^5.2.7
-    "@wireapp/core-crypto": 1.0.0-rc.51
+    "@wireapp/core-crypto": 1.0.0-rc.52
     "@wireapp/cryptobox": 12.8.0
     "@wireapp/priority-queue": ^2.1.5
     "@wireapp/promise-queue": ^2.3.2
@@ -4797,7 +4797,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: ad18da95fccefbc3ebe543dd5e6766da9538bc4fad31f8089bd3ce00c75ac730ef85b429af2498181219a8ac6ea898759e8151010508f3f32efa453046a416d8
+  checksum: fa99253c1d18e3f367e68357905f3eabf9582a3945fb63288e1441d7553ef6809b996402da6e491365646f4cdb4fc186a3ca5aacadb222c27e235cfb04685803
   languageName: node
   linkType: hard
 
@@ -17459,7 +17459,7 @@ __metadata:
     "@wireapp/avs": 9.6.12
     "@wireapp/commons": 5.2.6
     "@wireapp/copy-config": 2.1.14
-    "@wireapp/core": 45.2.10
+    "@wireapp/core": 45.2.11
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.16.0


### PR DESCRIPTION
## Description

see https://github.com/wireapp/wire-web-packages/pull/6071

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;


