### PR TITLE
runfix: align ephemeral messages to the left

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -184,7 +184,7 @@ export const ContentMessageComponent = ({
         className={cx('message-body', {
           'message-asset': isAssetMessage,
           'message-quoted': !!quote,
-          'ephemeral-asset-expired': isObfuscated,
+          'ephemeral-asset-expired': isObfuscated && isAssetMessage,
           'icon-file': isObfuscated && isFileMessage,
           'icon-movie': isObfuscated && isVideoMessage,
         })}

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -712,7 +712,6 @@
 
 .ephemeral-asset-expired {
   .bg-color-ephemeral;
-  .flex-center;
 
   color: #fff;
 

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -712,6 +712,7 @@
 
 .ephemeral-asset-expired {
   .bg-color-ephemeral;
+  .flex-center;
 
   color: #fff;
 


### PR DESCRIPTION
## Description

Changes in the message list structure made the ephemeral messages centered

The `.ephemeral-asset-expired` class was passed to non asset messages by mistake
see diff of previous change [here](https://github.com/wireapp/wire-webapp/pull/16887/files#diff-3f9b5143b3065b819bb2706445ea4f06a160b30ab205f034543be319d47166efL125-L165)

## Screenshots/Screencast (for UI changes)

Before: 
![Screenshot from 2024-03-15 10-35-34](https://github.com/wireapp/wire-webapp/assets/78490891/13857266-f59b-4060-9620-af9ceb4c099f)

After:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/ba3f8185-bcac-4ec0-a126-ed5ddd9a22a4)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
