### PR TITLE
fix: group creation focus lost on keydown event [WPB-6340]

### DIFF
--- a/src/script/components/ModalComponent.tsx
+++ b/src/script/components/ModalComponent.tsx
@@ -161,7 +161,7 @@ const ModalComponent: React.FC<ModalComponentProps> = ({
           onClick={event => event.stopPropagation()}
           role="button"
           tabIndex={TabIndex.UNFOCUSABLE}
-          onKeyDown={noop}
+          onKeyDown={event => event.stopPropagation()}
           css={{...(hasVisibleClass ? ModalContentVisibleStyles : ModalContentStyles), ...wrapperCSS}}
         >
           {hasVisibleClass ? children : null}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6340" title="WPB-6340" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6340</a>  [Web] Conversation input gets focused when group creation modal has no focused elements
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Anytime we start typing in the document (and no "editable" element is currently focused), active conversation's input bar is getting focussed (we assume user want to type a message when a conversation is opened).

This should not happen though, when an modal is open and currently focused - we want to stay in a modal's context and not type in the input that is somewhere in the background.

The fix is to stop event propagation for  `onKeyDown` event handler on modal component's wrapper, the same way it is done for the `onClick` event.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;