### PR TITLE
fix: autofocus modal degraded conversation modal primary button [WPB-7082]

### DIFF
--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -355,14 +355,14 @@ export const InputBar = ({
 
     if (isE2EIDegraded) {
       PrimaryModal.show(PrimaryModal.type.CONFIRM, {
-        primaryAction: {
+        secondaryAction: {
           action: () => {
             conversation.mlsVerificationState(ConversationVerificationState.UNVERIFIED);
             sendMessage();
           },
           text: t('conversation.E2EISendAnyway'),
         },
-        secondaryAction: {
+        primaryAction: {
           action: () => {},
           text: t('conversation.E2EICancel'),
         },

--- a/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
@@ -50,7 +50,7 @@ export const PrimaryModalComponent: FC = () => {
   const updateErrorMessage = usePrimaryModalState(state => state.updateErrorMessage);
   const updateCurrentModalContent = usePrimaryModalState(state => state.updateCurrentModalContent);
   const currentId = usePrimaryModalState(state => state.currentModalId);
-  const primaryActionButtonRef = useRef<HTMLButtonElement>(null);
+  const primaryActionButtonRef = useRef<HTMLButtonElement | null>(null);
   const isModalVisible = currentId !== null;
   const {
     checkboxLabel,
@@ -216,7 +216,10 @@ export const PrimaryModalComponent: FC = () => {
 
   const primaryButton = !!primaryAction?.text && (
     <button
-      ref={primaryActionButtonRef}
+      ref={ref => {
+        ref?.focus();
+        primaryActionButtonRef.current = ref;
+      }}
       type="button"
       onClick={doAction(confirm, !!closeOnConfirm)}
       disabled={isPrimaryActionDisabled()}

--- a/src/script/components/RichTextEditor/plugins/SendPlugin.tsx
+++ b/src/script/components/RichTextEditor/plugins/SendPlugin.tsx
@@ -33,12 +33,20 @@ export function SendPlugin({onSend}: Props): null {
     return editor.registerCommand(
       KEY_ENTER_COMMAND,
       event => {
-        if (event?.shiftKey) {
+        if (!event) {
+          return false;
+        }
+
+        if (event.shiftKey) {
           return true;
         }
 
+        // When sending a message with "Enter", we want to prevent the default behavior (new line)
+        event.preventDefault();
         onSend();
-        return false;
+
+        // By returning true, we tell the editor that we've handled the event and it should stop propagation (only for the same command priority level)
+        return true;
       },
       COMMAND_PRIORITY_LOW,
     );

--- a/src/script/components/RichTextEditor/plugins/TypeaheadMenuPlugin.tsx
+++ b/src/script/components/RichTextEditor/plugins/TypeaheadMenuPlugin.tsx
@@ -453,7 +453,7 @@ function LexicalPopoverMenu<TOption extends TypeaheadOption>({
           selectOptionAndCleanUp(options[selectedIndex]);
           return true;
         },
-        COMMAND_PRIORITY_LOW,
+        COMMAND_PRIORITY_NORMAL,
       ),
     );
   }, [selectOptionAndCleanUp, close, editor, options, selectedIndex, updateSelectedIndex]);

--- a/src/style/common/button.less
+++ b/src/style/common/button.less
@@ -338,6 +338,7 @@
   }
 
   &:focus-visible {
+    border-radius: 16px;
     background-color: var(--accent-color-600);
     outline: 1px solid var(--accent-color-700);
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7082" title="WPB-7082" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7082</a>  [Web] Conversation no longer verified modal not focused
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Cherry-picked a commit from dev that fixes conversation degraded modal focus issues when trying to send a message in a degraded conversation. For more details see https://github.com/wireapp/wire-webapp/pull/17091.