### PR TITLE
runfix: Avoid unmount messages when scrolling in the message list

### DIFF
--- a/src/script/components/MessagesList/Message/index.tsx
+++ b/src/script/components/MessagesList/Message/index.tsx
@@ -182,9 +182,7 @@ export const Message: React.FC<MessageParams & {scrollTo?: ScrollToElement}> = p
         ref={messageRef}
         role="listitem"
         onKeyDown={handleDivKeyDown}
-        onClick={event => {
-          handleFocus(message.id);
-        }}
+        onClick={() => handleFocus(message.id)}
         className="message-wrapper"
       >
         {wrappedContent}

--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -253,7 +253,7 @@ export const MessagesList: FC<MessagesListParams> = ({
       tabIndex={TabIndex.UNFOCUSABLE}
     >
       <div ref={setMessageContainer} className={cx('messages', {'flex-center': verticallyCenterMessage()})}>
-        {groupedMessages.map(group => {
+        {groupedMessages.flatMap(group => {
           if (isMarker(group)) {
             return (
               <MarkerComponent key={`${group.type}-${group.timestamp}`} scrollTo={scrollToElement} marker={group} />


### PR DESCRIPTION
## Description

There is a bug when a message is in focus and the user scrolls up the messages list, then, when loading extra messages, then the list scrolls back to the focused element.

The reason for this is that the element unmounts and remounts when the list is changed. 
This is due to the grouped nature of our message list now and the fact that we were giving nested arrays to `React` for re-rendering. This caused react to trash the entire message list and re-create it (then triggering again the code that would focus the element). 

Basically, we previously had something like 

```jsx
function MessageList() {
  const groupedMessages = [
    {groupId: 'group1', messages: [/*...*/]}, 
    {groupId: 'group2', messages: [/*...*/]}
  ]
  return (<ul>
    {groupedMessages.map(group => {
      // 💥  this returned a new array to React, `key` are then ignored by React
      return group.messages.map(renderFunction); 
    })};
  </ul>(
}
```

The solution is just to return a flatten array to react (then `key` are not ignored by Reat anymore). 

## Screenshots/Screencast (for UI changes)

### After


https://github.com/wireapp/wire-webapp/assets/1090716/54dc3ffe-bc72-4a97-8b21-ef59edafb0ad



### Before



https://github.com/wireapp/wire-webapp/assets/1090716/0e3339fe-4fd7-4b0a-9f20-939e9a2fdfd0




## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
