### PR TITLE
fix: group creation members message misaligned [WPB-7165]

### DIFF
--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -159,6 +159,7 @@
   .flex-center;
   width: var(--conversation-message-sender-width);
   max-height: @avatar-diameter-xs;
+  flex-shrink: 0;
 
   align-self: center;
   color: var(--background);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7165" title="WPB-7165" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7165</a>  Text is misaligned in the conversation header when sidebar is open
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Fixed group creation members message being misaligned (pushed to the left) for flex containers.

## Screenshots/Screencast (for UI changes)

Before
<img width="769" alt="Screenshot 2024-03-18 at 16 52 32" src="https://github.com/wireapp/wire-webapp/assets/45733298/930770a3-3e50-44c5-a37d-51909409bb3e">


After
<img width="769" alt="Screenshot 2024-03-18 at 16 52 58" src="https://github.com/wireapp/wire-webapp/assets/45733298/b7e9412d-8764-41e2-bf3e-0396b9c0f84f">


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
