### PR TITLE
runfix: display link previews correctly along with code blocks (WPB-7171)

### DIFF
--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -283,6 +283,7 @@
 
   &:not(&.message-quoted):has(.message-quote__text--full pre) {
     display: flex;
+    flex-wrap: wrap;
   }
 
   .text {
@@ -679,6 +680,7 @@
 // MESSAGE SPACING
 .message-asset {
   display: flex;
+  flex-basis: 100%;
   align-items: flex-start;
   padding-block: 6px;
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7171" title="WPB-7171" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7171</a>  [Web] code blocks break layout of link previews
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Link previews would display incorrectly if sent along a message that contains a fenced code block

The message-body is assigned `display: flex` if a code block is part of the text payload see [here](https://github.com/wireapp/wire-webapp/pull/16926/files) and would mess with the layout of link previews

## Screenshots/Screencast (for UI changes)
Before:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/88edd5e7-bdb6-4a1d-81a2-e52c8d13adf4)

After:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/a171d14c-79f7-46c8-b33c-ae78ff617688)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
