### PR TITLE
runfix: do not focus primary button in modal [WPB-7082]

### DIFF
--- a/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
@@ -50,7 +50,7 @@ export const PrimaryModalComponent: FC = () => {
   const updateErrorMessage = usePrimaryModalState(state => state.updateErrorMessage);
   const updateCurrentModalContent = usePrimaryModalState(state => state.updateCurrentModalContent);
   const currentId = usePrimaryModalState(state => state.currentModalId);
-  const primaryActionButtonRef = useRef<HTMLButtonElement | null>(null);
+  const primaryActionButtonRef = useRef<HTMLButtonElement>(null);
   const isModalVisible = currentId !== null;
   const {
     checkboxLabel,
@@ -216,10 +216,7 @@ export const PrimaryModalComponent: FC = () => {
 
   const primaryButton = !!primaryAction?.text && (
     <button
-      ref={ref => {
-        ref?.focus();
-        primaryActionButtonRef.current = ref;
-      }}
+      ref={primaryActionButtonRef}
       type="button"
       onClick={doAction(confirm, !!closeOnConfirm)}
       disabled={isPrimaryActionDisabled()}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7082" title="WPB-7082" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7082</a>  [Web] Conversation no longer verified modal not focused
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

After aligning with design team, we want to reverts one change from https://github.com/wireapp/wire-webapp/pull/17092 - we don't want the primary button being auto-focused by default.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
