### PR TITLE
fix: Mitigate UI flickering when quotes are loaded

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/MessageQuote.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageQuote.tsx
@@ -27,6 +27,7 @@ import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {Icon} from 'Components/Icon';
 import {AssetImage} from 'Components/Image';
+import {Text} from 'src/script/entity/message/Text';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {includesOnlyEmojis} from 'Util/EmojiUtil';
 import {t} from 'Util/LocalizerUtil';
@@ -40,11 +41,21 @@ import {VideoAsset} from './asset/VideoAsset';
 
 import {MessageActions} from '..';
 import type {Conversation} from '../../../../entity/Conversation';
-import type {ContentMessage} from '../../../../entity/message/ContentMessage';
-import type {User} from '../../../../entity/User';
+import {ContentMessage} from '../../../../entity/message/ContentMessage';
+import {User} from '../../../../entity/User';
 import {ConversationError} from '../../../../error/ConversationError';
 import {QuoteEntity} from '../../../../message/QuoteEntity';
 import {useMessageFocusedTabIndex} from '../util';
+
+function createPlaceholderMessage() {
+  const message = new ContentMessage();
+  const user = new User();
+  user.name(' ');
+  message.user(user);
+  const textAsset = new Text('fake-text', ' ');
+  message.assets.push(textAsset);
+  return message;
+}
 
 export interface QuoteProps {
   conversation: Conversation;
@@ -110,26 +121,22 @@ export const Quote: FC<QuoteProps> = ({
     }
   }, [quote, error]);
 
-  return !quotedMessage && !error ? (
-    <div />
-  ) : (
+  return (
     <div className="message-quote" data-uie-name="quote-item">
       {error ? (
         <div className="message-quote__error" data-uie-name="label-error-quote">
           {t('replyQuoteError')}
         </div>
       ) : (
-        quotedMessage && (
-          <QuotedMessage
-            quotedMessage={quotedMessage}
-            selfId={selfId}
-            focusMessage={focusMessage}
-            handleClickOnMessage={handleClickOnMessage}
-            showDetail={showDetail}
-            showUserDetails={showUserDetails}
-            isMessageFocused={isMessageFocused}
-          />
-        )
+        <QuotedMessage
+          quotedMessage={quotedMessage ?? createPlaceholderMessage()}
+          selfId={selfId}
+          focusMessage={focusMessage}
+          handleClickOnMessage={handleClickOnMessage}
+          showDetail={showDetail}
+          showUserDetails={showUserDetails}
+          isMessageFocused={isMessageFocused}
+        />
       )}
     </div>
   );
@@ -154,13 +161,13 @@ const QuotedMessage: FC<QuotedMessageProps> = ({
   showUserDetails,
   isMessageFocused,
 }) => {
-  const {
-    user: quotedUser,
-    assets: quotedAssets,
-    senderName,
-    was_edited,
-    timestamp,
-  } = useKoSubscribableChildren(quotedMessage, ['user', 'assets', 'senderName', 'was_edited', 'timestamp']);
+  const {user, assets, senderName, was_edited, timestamp} = useKoSubscribableChildren(quotedMessage, [
+    'user',
+    'assets',
+    'senderName',
+    'was_edited',
+    'timestamp',
+  ]);
   const messageFocusedTabIndex = useMessageFocusedTabIndex(isMessageFocused);
 
   return (
@@ -169,7 +176,7 @@ const QuotedMessage: FC<QuotedMessageProps> = ({
         <button
           type="button"
           className="button-reset-default text-left"
-          onClick={() => showUserDetails(quotedUser)}
+          onClick={() => showUserDetails(user)}
           data-uie-name="label-name-quote"
           tabIndex={messageFocusedTabIndex}
         >
@@ -181,7 +188,7 @@ const QuotedMessage: FC<QuotedMessageProps> = ({
           </span>
         )}
       </div>
-      {quotedAssets.map((asset, index) => (
+      {assets.map((asset, index) => (
         <Fragment key={index}>
           {asset.isImage() && (
             <div data-uie-name="media-picture-quote">


### PR DESCRIPTION
## Description

Since quoted messages are loaded async, we first display an empty DOM element and then the quote. 
This creates a quite huge bump in the UI when the quote finally loads. 

To mitigate this, we could render a fake quoted message first and then wait for the real message to come in. This will, at least, roughly take up the space that the quote should take in the end (not an exact height, but should at least mitigate flickering)

## Screenshots/Screencast (for UI changes)

### Before 

https://github.com/wireapp/wire-webapp/assets/1090716/a40ab6e5-f517-420d-aa1c-fbd62fd41d04

### After


https://github.com/wireapp/wire-webapp/assets/1090716/29a239d9-1538-457f-9b25-c54dea9fe404



## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

