### PR TITLE
runfix: Allow clicking on small images

### DIFF
--- a/src/script/components/Image/Image.styles.ts
+++ b/src/script/components/Image/Image.styles.ts
@@ -19,17 +19,19 @@
 
 import {CSSObject} from '@emotion/react';
 
-export const imageWrapperStyle = {
-  width: '100%',
-};
+export function getWrapperStyles(interactive: boolean) {
+  return {
+    cursor: interactive ? 'pointer' : 'default',
+    width: '100%',
+  };
+}
 
-export function getImageStyle(sizes: {ratio: number; width: string} | undefined, interactive: boolean): CSSObject {
+export function getImageStyle(sizes: {ratio: number; width: string} | undefined): CSSObject {
   return {
     aspectRatio: `${sizes?.ratio}`,
     maxWidth: '100%',
     maxHeight: '100%',
     width: sizes?.width,
-    cursor: interactive ? 'pointer' : 'default',
     objectFit: 'contain',
     objectPosition: 'left',
   };

--- a/src/script/components/Image/Image.tsx
+++ b/src/script/components/Image/Image.tsx
@@ -25,7 +25,7 @@ import {container} from 'tsyringe';
 
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 
-import {getImageStyle, imageWrapperStyle} from './Image.styles';
+import {getImageStyle, getWrapperStyles} from './Image.styles';
 import {RestrictedImage} from './RestrictedImage';
 
 import {AssetRemoteData} from '../../assets/AssetRemoteData';
@@ -116,14 +116,14 @@ export const Image = ({
   return (
     <InViewport
       onVisible={() => setIsInViewport(true)}
-      css={imageWrapperStyle}
+      css={getWrapperStyles(!!onClick)}
       className={cx(className, {'loading-dots': isLoading})}
+      onClick={onClick}
       data-uie-status={isLoading ? 'loading' : 'loaded'}
       {...props}
     >
       <img
-        css={{...getImageStyle(imageSizes, !!onClick), ...imageStyles}}
-        onClick={onClick}
+        css={{...getImageStyle(imageSizes), ...imageStyles}}
         src={assetUrl}
         role="presentation"
         alt={alt}


### PR DESCRIPTION
## Description

instead of adding the click handler on the image itself, we put it in the container. 
That allows ease of click on small images (when the container is bigger than the image)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
