### PR TITLE
fix: mls thumbprint misaligned

### DIFF
--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/FormattedId.styles.ts
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/FormattedId.styles.ts
@@ -23,6 +23,7 @@ export const devicePart = (smallPadding = false): CSSObject => ({
   display: 'inline-block',
   marginRight: smallPadding ? '4px' : '12px',
   textTransform: 'uppercase',
+  whiteSpace: 'nowrap',
 
   ...(!smallPadding && {
     width: '18px',


### PR DESCRIPTION
## Description

MLS device thumbprint was sometimes misaligned due to the line-break.

## Screenshots/Screencast (for UI changes)

Before
<img width="263" alt="Screenshot 2024-03-19 at 10 32 35" src="https://github.com/wireapp/wire-webapp/assets/45733298/faa4c706-c347-44e4-abc4-081b4c03bd75">


After
<img width="251" alt="Screenshot 2024-03-19 at 10 33 35" src="https://github.com/wireapp/wire-webapp/assets/45733298/a3cb026d-6a8b-44c3-aa61-38a9b7b7ef03">


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
