### PR TITLE
fix: mls verified icon color based on theme [WPB-6888]

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@wireapp/avs": "9.6.12",
     "@wireapp/commons": "5.2.6",
     "@wireapp/core": "45.2.11",
-    "@wireapp/react-ui-kit": "9.16.0",
+    "@wireapp/react-ui-kit": "9.16.3",
     "@wireapp/store-engine-dexie": "2.1.8",
     "@wireapp/webapp-events": "0.20.1",
     "amplify": "https://github.com/wireapp/amplify#head=master",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4911,9 +4911,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/react-ui-kit@npm:9.16.0":
-  version: 9.16.0
-  resolution: "@wireapp/react-ui-kit@npm:9.16.0"
+"@wireapp/react-ui-kit@npm:9.16.3":
+  version: 9.16.3
+  resolution: "@wireapp/react-ui-kit@npm:9.16.3"
   dependencies:
     "@types/color": 3.0.6
     color: 4.2.3
@@ -4928,7 +4928,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 2e863cb084c63bf0c9b9c13adaedaa791ceeaf226c298f3a12a5be5b10ef068d8c3a90fd65188dba82b4394f45bd8a0cfaa14d38a8877c95a5c87a71cde2dcb1
+  checksum: b0f767b70f42c1baabb8cea661fd35e47b8bcb63067a10ada0f48e82b9978fa2dbfc7dbefb602cb7eb8fbf6525555b0c634864303433ca44a8e28314b4028b33
   languageName: node
   linkType: hard
 
@@ -17462,7 +17462,7 @@ __metadata:
     "@wireapp/core": 45.2.11
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
-    "@wireapp/react-ui-kit": 9.16.0
+    "@wireapp/react-ui-kit": 9.16.3
     "@wireapp/store-engine": ^5.1.4
     "@wireapp/store-engine-dexie": 2.1.8
     "@wireapp/webapp-events": 0.20.1


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6888" title="WPB-6888" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6888</a>  Green shield on dark mode uses wrong color
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Bumps react-ui-kit with version that fixes wrong color on mls verified icon when on dark mode. For more details and screenshots see https://github.com/wireapp/wire-web-packages/pull/6084

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
