### PR TITLE
fix: address backup buttons color in dark mode (WPB-7186)

### DIFF
--- a/src/script/components/HistoryExport/HistoryExport.tsx
+++ b/src/script/components/HistoryExport/HistoryExport.tsx
@@ -207,14 +207,9 @@ const HistoryExport = ({switchContent, user, clientState = container.resolve(Cli
         <>
           <LoadingBar progress={loadingProgress} message={loadingMessage} className="with-cancel" />
 
-          <button
-            type="button"
-            className="cancel-button accent-text"
-            onClick={onCancel}
-            data-uie-name="do-cancel-history-export"
-          >
+          <Button variant={ButtonVariant.SECONDARY} onClick={onCancel} data-uie-name="do-cancel-history-export">
             {t('backupCancel')}
-          </button>
+          </Button>
         </>
       )}
 

--- a/src/script/components/HistoryExport/HistoryExport.tsx
+++ b/src/script/components/HistoryExport/HistoryExport.tsx
@@ -21,6 +21,8 @@ import {useContext, useEffect, useState} from 'react';
 
 import {container} from 'tsyringe';
 
+import {Button, ButtonVariant, FlexBox} from '@wireapp/react-ui-kit';
+
 import {LoadingBar} from 'Components/LoadingBar/LoadingBar';
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
 import {ClientState} from 'src/script/client/ClientState';
@@ -226,22 +228,20 @@ const HistoryExport = ({switchContent, user, clientState = container.resolve(Cli
             <p className="history-message__info" data-uie-name="status-history-export-success-info">
               {t('backupExportSuccessSecondary')}
             </p>
+            <FlexBox className="history-message__buttons" justify="center">
+              <Button
+                variant={ButtonVariant.SECONDARY}
+                onClick={dismissExport}
+                data-uie-name="do-cancel-history-export"
+              >
+                {t('backupCancel')}
+              </Button>
 
-            <div className="history-message__buttons">
-              <button className="button" onClick={downloadArchiveFile} data-uie-name="do-save-history-export">
+              <Button onClick={downloadArchiveFile} data-uie-name="do-save-history-export">
                 {t('backupExportSaveFileAction')}
-              </button>
-            </div>
+              </Button>
+            </FlexBox>
           </div>
-
-          <button
-            type="button"
-            className="cancel-button accent-text"
-            onClick={dismissExport}
-            data-uie-name="do-cancel-history-export"
-          >
-            {t('backupCancel')}
-          </button>
         </>
       )}
 
@@ -254,20 +254,19 @@ const HistoryExport = ({switchContent, user, clientState = container.resolve(Cli
           <p className="history-message__info" data-uie-name="status-history-export-error-info">
             {t('backupExportGenericErrorSecondary')}
           </p>
-
-          <div className="history-message__buttons">
-            <button
-              className="button button-inverted"
-              onClick={exportHistory}
-              data-uie-name="do-try-again-history-export-error"
+          <FlexBox justify="center" className="history-message__buttons">
+            <Button
+              variant={ButtonVariant.SECONDARY}
+              data-uie-name="do-dismiss-history-export-error"
+              onClick={dismissExport}
             >
-              {t('backupTryAgain')}
-            </button>
-
-            <button className="button" data-uie-name="do-dismiss-history-export-error" onClick={dismissExport}>
               {t('backupCancel')}
-            </button>
-          </div>
+            </Button>
+
+            <Button onClick={exportHistory} data-uie-name="do-try-again-history-export-error">
+              {t('backupTryAgain')}
+            </Button>
+          </FlexBox>
         </div>
       )}
     </div>

--- a/src/script/components/HistoryImport/HistoryImport.tsx
+++ b/src/script/components/HistoryImport/HistoryImport.tsx
@@ -216,14 +216,9 @@ const HistoryImport = ({user, backupRepository, file, switchContent}: HistoryImp
           <>
             <LoadingBar progress={loadingProgress} message={loadingMessage} className="with-cancel" />
 
-            <button
-              type="button"
-              className="cancel-button accent-text"
-              onClick={onCancel}
-              data-uie-name="do-cancel-history-import"
-            >
+            <Button variant={ButtonVariant.SECONDARY} onClick={onCancel} data-uie-name="do-cancel-history-import">
               {t('backupCancel')}
-            </button>
+            </Button>
           </>
         )}
 

--- a/src/style/content/history-export-import.less
+++ b/src/style/content/history-export-import.less
@@ -15,17 +15,6 @@
     }
   }
 
-  .cancel-button {
-    .button-reset-default;
-
-    margin-bottom: 56px;
-    cursor: pointer;
-    font-size: @font-size-medium;
-    font-weight: @font-weight-regular;
-    line-height: @line-height-sm;
-    user-select: none;
-  }
-
   .history-message {
     margin: auto;
     text-align: center;

--- a/src/style/content/history-export-import.less
+++ b/src/style/content/history-export-import.less
@@ -30,16 +30,13 @@
     margin: auto;
     text-align: center;
 
-    check-icon {
+    svg {
+      width: 32px;
+      height: 32px;
       margin-bottom: 16px;
 
-      svg {
-        width: 32px;
-        height: 32px;
-
-        path {
-          fill: @w-blue;
-        }
+      path {
+        fill: var(--success-color);
       }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7186" title="WPB-7186" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7186</a>  [Web] Confirm button after a backup has the wrong color in dark mode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Confirm/Cnacel buttons after a succesfull or failed backup didn't have a design aligned with the rest of the app.
This uses the ui-kit for those button

## Screenshots/Screencast (for UI changes)
Before:
![Screenshot from 2024-03-19 13-04-46](https://github.com/wireapp/wire-webapp/assets/78490891/045f4754-9679-451e-8677-6a50f75de000)
![image](https://github.com/wireapp/wire-webapp/assets/78490891/73f0fee7-b07a-4781-94fe-5e3881291830)
![image](https://github.com/wireapp/wire-webapp/assets/78490891/e3e8020b-8b16-456f-b120-822afda00b10)


After
![Screenshot from 2024-03-19 13-02-28](https://github.com/wireapp/wire-webapp/assets/78490891/b0bfdc39-7107-4912-a4d0-3ec1344ea19e)
![image](https://github.com/wireapp/wire-webapp/assets/78490891/3fa53ed4-227b-44c4-9261-f047b9ccd4a0)
![Screenshot from 2024-03-19 14-04-17](https://github.com/wireapp/wire-webapp/assets/78490891/6d40d439-503b-4932-aff5-67420ca00588)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
