### PR TITLE
fix: condition that decides if we delete local conversations

### DIFF
--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -2105,7 +2105,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'getConversationById')
         .mockImplementation(async conversationId => {
           if (matchQualifiedIds(conversationId, deletedGroup.qualifiedId)) {
-            throw new ConversationError(ConversationError.TYPE.CONVERSATION_NOT_FOUND, 'Conversation not found');
+            throw new BackendError('', BackendErrorLabel.NO_CONVERSATION);
           }
           return {} as any;
         });

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -2100,7 +2100,7 @@ export class ConversationRepository {
         // We need to check if the conversation exists on backend
         await this.conversationService.getConversationById(inccessibleConversation);
       } catch (error) {
-        if (error instanceof ConversationError && error.type === ConversationError.TYPE.CONVERSATION_NOT_FOUND) {
+        if (isBackendError(error) && error.label === BackendErrorLabel.NO_CONVERSATION) {
           // Only if the conversation triggers a not found error, we delete it locally
           await this.deleteConversationLocally(inccessibleConversation, true);
         }


### PR DESCRIPTION
The functionality expected a customer Error to be thrown, but since we call the apiClient directly and this instance finally throws the 404, we get the default BackendError instead.

I changed the condition to match the case.