### PR TITLE
runfix: ensure images are always in viewport

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset/ImageAsset.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset/ImageAsset.tsx
@@ -50,6 +50,9 @@ export const ImageAsset = ({asset, message, onClick}: ImageAssetProps) => {
 
   const imageContainerStyle: CSSObject = {
     maxWidth: 'var(--conversation-message-asset-width)',
+    // Images should be in the viewport regardless of the window's size
+    // To ensure this, we calculate the maximum height as:
+    // 100vh - TitleBar(45px) - ImagePadding(12px) - TypingIndicator(40px) - ClassifiedBar(1rem) - InputBar(56px)
     maxHeight: 'calc(100vh - 155px - 1rem)',
     width: asset.width,
     aspectRatio: asset.ratio,

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset/ImageAsset.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/ImageAsset/ImageAsset.tsx
@@ -50,7 +50,7 @@ export const ImageAsset = ({asset, message, onClick}: ImageAssetProps) => {
 
   const imageContainerStyle: CSSObject = {
     maxWidth: 'var(--conversation-message-asset-width)',
-    maxHeight: '80vh',
+    maxHeight: 'calc(100vh - 155px - 1rem)',
     width: asset.width,
     aspectRatio: asset.ratio,
   };


### PR DESCRIPTION
## Description

Automation checks if a vertical image is shown correctly in viewport, it currently fails depending of the size of the window.
a max height of `80vh` will not be adequate if the ui elements with fixed pixed value exeed 20% of the viewport height, we can replace it with `calc(100vh - ammountOfPixels)`

## Screenshots/Screencast (for UI changes)
Before:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/4a09f68d-1c5b-4ad5-9045-8a4dc3fc41c7)

After:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/303d6cce-8b81-49a0-bead-a8fa8bf0aaac)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
