### PR TITLE
fix: mls status icons color on dark mode [WPB-6888]

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@wireapp/avs": "9.6.12",
     "@wireapp/commons": "5.2.6",
     "@wireapp/core": "45.2.11",
-    "@wireapp/react-ui-kit": "9.16.3",
+    "@wireapp/react-ui-kit": "9.16.4",
     "@wireapp/store-engine-dexie": "2.1.8",
     "@wireapp/webapp-events": "0.20.1",
     "amplify": "https://github.com/wireapp/amplify#head=master",

--- a/src/script/components/MessagesList/Message/E2EIVerificationMessage/E2EIVerificationMessage.styles.ts
+++ b/src/script/components/MessagesList/Message/E2EIVerificationMessage/E2EIVerificationMessage.styles.ts
@@ -29,7 +29,7 @@ export const MessageIcon: CSSObject = {
 };
 
 export const IconInfo: CSSObject = {
-  fill: 'var(--red-500)',
+  fill: 'var(--danger-color)',
 };
 
 export const Link: CSSObject = {

--- a/src/script/components/VerificationBadge/VerificationBadges.tsx
+++ b/src/script/components/VerificationBadge/VerificationBadges.tsx
@@ -66,7 +66,7 @@ const iconStyles: CSSObject = {
 };
 
 const title = (isMLSConversation = false): CSSProperties => ({
-  color: isMLSConversation ? 'var(--green-500)' : 'var(--blue-500)',
+  color: isMLSConversation ? 'var(--success-color)' : 'var(--blue-500)',
   fontSize: '12px',
   lineHeight: '14px',
   marginRight: '4px',

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.styles.ts
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.styles.ts
@@ -22,11 +22,11 @@ import {CSSObject} from '@emotion/serialize';
 import {MLSStatuses} from 'src/script/E2EIdentity';
 
 const MLSStatusColor = {
-  [MLSStatuses.VALID]: 'var(--green-500)',
-  [MLSStatuses.EXPIRED]: 'var(--red-500)',
-  [MLSStatuses.NOT_ACTIVATED]: 'var(--red-500)',
-  [MLSStatuses.EXPIRES_SOON]: 'var(--green-500)',
-  [MLSStatuses.REVOKED]: 'var(--red-500)',
+  [MLSStatuses.VALID]: 'var(--success-color)',
+  [MLSStatuses.EXPIRED]: 'var(--danger-color)',
+  [MLSStatuses.NOT_ACTIVATED]: 'var(--danger-color)',
+  [MLSStatuses.EXPIRES_SOON]: 'var(--success-color)',
+  [MLSStatuses.REVOKED]: 'var(--danger-color)',
 };
 
 type stylesProps = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4911,9 +4911,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/react-ui-kit@npm:9.16.3":
-  version: 9.16.3
-  resolution: "@wireapp/react-ui-kit@npm:9.16.3"
+"@wireapp/react-ui-kit@npm:9.16.4":
+  version: 9.16.4
+  resolution: "@wireapp/react-ui-kit@npm:9.16.4"
   dependencies:
     "@types/color": 3.0.6
     color: 4.2.3
@@ -4928,7 +4928,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: b0f767b70f42c1baabb8cea661fd35e47b8bcb63067a10ada0f48e82b9978fa2dbfc7dbefb602cb7eb8fbf6525555b0c634864303433ca44a8e28314b4028b33
+  checksum: e8ec9640216342d4de6de875174f461ca9ba52685d9d8f87425dec91c71948daf486e7b53d96f322ed9df46b29217002a476640ab238d0e7fa5ab61ce724d2b8
   languageName: node
   linkType: hard
 
@@ -17462,7 +17462,7 @@ __metadata:
     "@wireapp/core": 45.2.11
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
-    "@wireapp/react-ui-kit": 9.16.3
+    "@wireapp/react-ui-kit": 9.16.4
     "@wireapp/store-engine": ^5.1.4
     "@wireapp/store-engine-dexie": 2.1.8
     "@wireapp/webapp-events": 0.20.1


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6888" title="WPB-6888" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6888</a>  Green shield on dark mode uses wrong color
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

Adds dark mode support for mls status icons. For more details see https://github.com/wireapp/wire-web-packages/pull/6085.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
