### PR TITLE
fix: auto focus folder creation modal input [WPB-6843]

### DIFF
--- a/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
@@ -425,6 +425,7 @@ export const PrimaryModalComponent: FC = () => {
                   </label>
 
                   <input
+                    ref={ref => ref?.focus()}
                     maxLength={64}
                     className="modal__input"
                     id="modal-input"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6843" title="WPB-6843" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6843</a>  [Web] Folder name input bar is not focused during folder creation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

When conversation folder modal appears, it's text input should get the focus automatically, so user can immediately start typing folder's name and the typed is not appearing in the input bar of the active conversation that is opened in the background.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;