### PR TITLE
fix: locking the user out of the app permanentely with applock [WPB-7192, WPB-7193]

### DIFF
--- a/src/script/page/AppLock/AppLock.tsx
+++ b/src/script/page/AppLock/AppLock.tsx
@@ -149,12 +149,16 @@ const AppLock: React.FC<AppLockProps> = ({
   useEffect(() => {
     const hasBeenEnabled = !prevAppLockEnabled.current && isAppLockEnabled;
 
+    if (hasBeenEnabled) {
+      showAppLock(APPLOCK_STATE.SETUP);
+      return;
+    }
     if (isAppLockEnabled) {
       if (!appLockState.hasPassphrase()) {
         appLockRepository.setDisabled();
         return;
       }
-      showAppLock(hasBeenEnabled ? APPLOCK_STATE.SETUP : APPLOCK_STATE.LOCKED);
+      showAppLock(APPLOCK_STATE.LOCKED);
     }
     prevAppLockEnabled.current = isAppLockEnabled;
   }, [isAppLockEnabled]);

--- a/src/script/page/AppLock/AppLock.tsx
+++ b/src/script/page/AppLock/AppLock.tsx
@@ -87,7 +87,7 @@ const AppLock: React.FC<AppLockProps> = ({
 
   const MAX_RETRIES = 3;
   const signUserOut = (count?: number) => {
-    if (count && count <= MAX_RETRIES) {
+    if (!!count && count <= MAX_RETRIES) {
       return;
     }
     amplify.publish(WebAppEvents.LIFECYCLE.SIGN_OUT, SIGN_OUT_REASON.USER_REQUESTED);

--- a/src/script/page/AppLock/AppLock.tsx
+++ b/src/script/page/AppLock/AppLock.tsx
@@ -86,8 +86,8 @@ const AppLock: React.FC<AppLockProps> = ({
   ]);
 
   const MAX_RETRIES = 3;
-  const signUserOut = (count: number) => {
-    if (count <= MAX_RETRIES) {
+  const signUserOut = (count?: number) => {
+    if (count && count <= MAX_RETRIES) {
       return;
     }
     amplify.publish(WebAppEvents.LIFECYCLE.SIGN_OUT, SIGN_OUT_REASON.USER_REQUESTED);
@@ -97,7 +97,7 @@ const AppLock: React.FC<AppLockProps> = ({
     new MutationObserver(mutationRecords => {
       const [{attributeName}] = mutationRecords;
       if (attributeName === 'style') {
-        amplify.publish(WebAppEvents.LIFECYCLE.SIGN_OUT, SIGN_OUT_REASON.USER_REQUESTED);
+        signUserOut();
       }
     }),
   );

--- a/src/script/page/AppLock/AppLock.tsx
+++ b/src/script/page/AppLock/AppLock.tsx
@@ -112,8 +112,7 @@ const AppLock: React.FC<AppLockProps> = ({
           clearInterval(interval);
           return;
         }
-        retries++;
-        signUserOut(retries);
+        signUserOut(retries++);
       }, 500);
     }),
   );

--- a/src/script/page/AppLock/AppLock.tsx
+++ b/src/script/page/AppLock/AppLock.tsx
@@ -78,11 +78,20 @@ const AppLock: React.FC<AppLockProps> = ({
   const [setupPassphrase, setSetupPassphrase] = useState('');
   const [inactivityTimeoutId, setInactivityTimeoutId] = useState<number>();
   const [scheduledTimeoutId, setScheduledTimeoutId] = useState<number>();
+  const prevAppLockEnabled = useRef(appLockState.isAppLockEnabled());
   const {isAppLockActivated, isAppLockEnabled, isAppLockEnforced} = useKoSubscribableChildren(appLockState, [
     'isAppLockActivated',
     'isAppLockEnabled',
     'isAppLockEnforced',
   ]);
+
+  const MAX_RETRIES = 3;
+  const signUserOut = (count: number) => {
+    if (count <= MAX_RETRIES) {
+      return;
+    }
+    amplify.publish(WebAppEvents.LIFECYCLE.SIGN_OUT, SIGN_OUT_REASON.USER_REQUESTED);
+  };
 
   const {current: appObserver} = useRef(
     new MutationObserver(mutationRecords => {
@@ -95,10 +104,17 @@ const AppLock: React.FC<AppLockProps> = ({
 
   const {current: modalObserver} = useRef(
     new MutationObserver(() => {
-      const modalInDOM = document.querySelector('[data-uie-name="applock-modal"]');
-      if (!modalInDOM) {
-        amplify.publish(WebAppEvents.LIFECYCLE.SIGN_OUT, SIGN_OUT_REASON.USER_REQUESTED);
-      }
+      let retries = 0;
+
+      const interval = setInterval(() => {
+        const isModalVisible = document.querySelector('[data-uie-name="applock-modal"]') !== null;
+        if (isModalVisible) {
+          clearInterval(interval);
+          return;
+        }
+        retries++;
+        signUserOut(retries);
+      }, 500);
     }),
   );
 
@@ -131,11 +147,16 @@ const AppLock: React.FC<AppLockProps> = ({
   }, []);
 
   useEffect(() => {
+    const hasBeenEnabled = !prevAppLockEnabled.current && isAppLockEnabled;
+
     if (isAppLockEnabled) {
-      showAppLock();
-    } else if (appLockState.hasPassphrase()) {
-      appLockRepository.removeCode();
+      if (!appLockState.hasPassphrase()) {
+        appLockRepository.setDisabled();
+        return;
+      }
+      showAppLock(hasBeenEnabled ? APPLOCK_STATE.SETUP : APPLOCK_STATE.LOCKED);
     }
+    prevAppLockEnabled.current = isAppLockEnabled;
   }, [isAppLockEnabled]);
 
   useEffect(() => {
@@ -168,8 +189,8 @@ const AppLock: React.FC<AppLockProps> = ({
     };
   }, [state, isVisible]);
 
-  const showAppLock = () => {
-    setState(appLockState.hasPassphrase() ? APPLOCK_STATE.LOCKED : APPLOCK_STATE.SETUP);
+  const showAppLock = (state: APPLOCK_STATE) => {
+    setState(state);
     setIsVisible(true);
   };
 
@@ -239,7 +260,7 @@ const AppLock: React.FC<AppLockProps> = ({
     setSetupPassphrase('');
   };
   const onCancelAppLock = () => {
-    appLockRepository.setEnabled(false);
+    appLockRepository.setDisabled();
     setIsVisible(false);
   };
 

--- a/src/script/user/AppLockRepository.ts
+++ b/src/script/user/AppLockRepository.ts
@@ -99,6 +99,7 @@ export class AppLockRepository {
   public setDisabled = () => {
     this.appLockState.isActivatedInPreferences(false);
     window.localStorage.removeItem(this.getEnabledStorageKey());
+    window.localStorage.removeItem(this.getPassphraseStorageKey());
   };
 
   public setCode = async (code: string): Promise<void> => {

--- a/src/script/user/AppLockRepository.ts
+++ b/src/script/user/AppLockRepository.ts
@@ -50,9 +50,9 @@ export class AppLockRepository {
     this.handleDisabledOnTeam(this.appLockState.isAppLockDisabledOnTeam());
   }
 
-  getStoredPassphrase = (): string => window.localStorage.getItem(this.getPassphraseStorageKey());
+  public getStoredPassphrase = (): string => window.localStorage.getItem(this.getPassphraseStorageKey());
 
-  getStoredEnabled = (): string => window.localStorage.getItem(this.getEnabledStorageKey());
+  public getStoredEnabled = (): string => window.localStorage.getItem(this.getEnabledStorageKey());
 
   handlePassphraseStorageEvent = ({key, oldValue}: StorageEvent): void => {
     const storageKey = this.getPassphraseStorageKey();
@@ -75,17 +75,14 @@ export class AppLockRepository {
     window.removeEventListener('storage', this.handlePassphraseStorageEvent);
   };
 
-  setEnabled = (enabled: boolean) => {
+  public setEnabled = (enabled: boolean) => {
     if (enabled) {
       window.localStorage.setItem(this.getEnabledStorageKey(), 'true');
       this.appLockState.isActivatedInPreferences(true);
     } else {
       PrimaryModal.show(PrimaryModal.type.CONFIRM, {
         primaryAction: {
-          action: () => {
-            this.appLockState.isActivatedInPreferences(false);
-            window.localStorage.removeItem(this.getEnabledStorageKey());
-          },
+          action: this.setDisabled,
           text: t('AppLockDisableTurnOff'),
         },
         secondaryAction: {
@@ -99,7 +96,12 @@ export class AppLockRepository {
     }
   };
 
-  setCode = async (code: string): Promise<void> => {
+  public setDisabled = () => {
+    this.appLockState.isActivatedInPreferences(false);
+    window.localStorage.removeItem(this.getEnabledStorageKey());
+  };
+
+  public setCode = async (code: string): Promise<void> => {
     this.stopPassphraseObserver();
     await sodium.ready;
     const hashed = sodium.crypto_pwhash_str(
@@ -112,13 +114,13 @@ export class AppLockRepository {
     this.appLockState.hasPassphrase(true);
   };
 
-  removeCode = () => {
+  public removeCode = () => {
     this.stopPassphraseObserver();
     window.localStorage.removeItem(this.getPassphraseStorageKey());
     this.appLockState.hasPassphrase(false);
   };
 
-  checkCode = async (code: string): Promise<boolean> => {
+  public checkCode = async (code: string): Promise<boolean> => {
     const hashedCode = this.getStoredPassphrase();
     await sodium.ready;
     return sodium.crypto_pwhash_str_verify(hashedCode, code);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7192" title="WPB-7192" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7192</a>  [Web] Cancelling setting up voluntary app lock can softlock the account
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->



<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7193" title="WPB-7193" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7193</a>  [Web] Reloading the app while setting app lock pw does not cancel the process
  </td></table>
  <br />