### PR TITLE
fix: Do not ask user confirmation when disabling appLock without password

### DIFF
--- a/src/script/user/AppLockRepository.ts
+++ b/src/script/user/AppLockRepository.ts
@@ -79,12 +79,12 @@ export class AppLockRepository {
     if (enabled) {
       window.localStorage.setItem(this.getEnabledStorageKey(), 'true');
       this.appLockState.isActivatedInPreferences(true);
-    } else {
+    } else if (this.appLockState.hasPassphrase()) {
+      // If the user has set a passphrase we want to ask confirmation before disabling the feature
       PrimaryModal.show(PrimaryModal.type.CONFIRM, {
         primaryAction: {
           action: () => {
-            this.appLockState.isActivatedInPreferences(false);
-            window.localStorage.removeItem(this.getEnabledStorageKey());
+            this.removeCode();
           },
           text: t('AppLockDisableTurnOff'),
         },
@@ -96,6 +96,8 @@ export class AppLockRepository {
           message: t('AppLockDisableInfo'),
         },
       });
+    } else {
+      this.removeCode();
     }
   };
 

--- a/src/script/user/AppLockRepository.ts
+++ b/src/script/user/AppLockRepository.ts
@@ -50,9 +50,9 @@ export class AppLockRepository {
     this.handleDisabledOnTeam(this.appLockState.isAppLockDisabledOnTeam());
   }
 
-  public getStoredPassphrase = (): string => window.localStorage.getItem(this.getPassphraseStorageKey());
+  getStoredPassphrase = (): string => window.localStorage.getItem(this.getPassphraseStorageKey());
 
-  public getStoredEnabled = (): string => window.localStorage.getItem(this.getEnabledStorageKey());
+  getStoredEnabled = (): string => window.localStorage.getItem(this.getEnabledStorageKey());
 
   handlePassphraseStorageEvent = ({key, oldValue}: StorageEvent): void => {
     const storageKey = this.getPassphraseStorageKey();
@@ -75,14 +75,17 @@ export class AppLockRepository {
     window.removeEventListener('storage', this.handlePassphraseStorageEvent);
   };
 
-  public setEnabled = (enabled: boolean) => {
+  setEnabled = (enabled: boolean) => {
     if (enabled) {
       window.localStorage.setItem(this.getEnabledStorageKey(), 'true');
       this.appLockState.isActivatedInPreferences(true);
     } else {
       PrimaryModal.show(PrimaryModal.type.CONFIRM, {
         primaryAction: {
-          action: this.setDisabled,
+          action: () => {
+            this.appLockState.isActivatedInPreferences(false);
+            window.localStorage.removeItem(this.getEnabledStorageKey());
+          },
           text: t('AppLockDisableTurnOff'),
         },
         secondaryAction: {
@@ -96,13 +99,7 @@ export class AppLockRepository {
     }
   };
 
-  public setDisabled = () => {
-    this.appLockState.isActivatedInPreferences(false);
-    window.localStorage.removeItem(this.getEnabledStorageKey());
-    window.localStorage.removeItem(this.getPassphraseStorageKey());
-  };
-
-  public setCode = async (code: string): Promise<void> => {
+  setCode = async (code: string): Promise<void> => {
     this.stopPassphraseObserver();
     await sodium.ready;
     const hashed = sodium.crypto_pwhash_str(
@@ -115,13 +112,13 @@ export class AppLockRepository {
     this.appLockState.hasPassphrase(true);
   };
 
-  public removeCode = () => {
+  removeCode = () => {
     this.stopPassphraseObserver();
     window.localStorage.removeItem(this.getPassphraseStorageKey());
     this.appLockState.hasPassphrase(false);
   };
 
-  public checkCode = async (code: string): Promise<boolean> => {
+  checkCode = async (code: string): Promise<boolean> => {
     const hashedCode = this.getStoredPassphrase();
     await sodium.ready;
     return sodium.crypto_pwhash_str_verify(hashedCode, code);

--- a/src/script/user/AppLockRepository.ts
+++ b/src/script/user/AppLockRepository.ts
@@ -76,6 +76,10 @@ export class AppLockRepository {
   };
 
   setEnabled = (enabled: boolean) => {
+    const disableFeature = () => {
+      this.appLockState.isActivatedInPreferences(false);
+      window.localStorage.removeItem(this.getEnabledStorageKey());
+    };
     if (enabled) {
       window.localStorage.setItem(this.getEnabledStorageKey(), 'true');
       this.appLockState.isActivatedInPreferences(true);
@@ -83,9 +87,7 @@ export class AppLockRepository {
       // If the user has set a passphrase we want to ask confirmation before disabling the feature
       PrimaryModal.show(PrimaryModal.type.CONFIRM, {
         primaryAction: {
-          action: () => {
-            this.removeCode();
-          },
+          action: disableFeature,
           text: t('AppLockDisableTurnOff'),
         },
         secondaryAction: {
@@ -97,7 +99,7 @@ export class AppLockRepository {
         },
       });
     } else {
-      this.removeCode();
+      disableFeature();
     }
   };
 


### PR DESCRIPTION
## Description

This will prevent the confirmation modal from showing up when the user disables the appLock when no password has been set yet.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
