### PR TITLE
runfix: update conversation participant list on team member leave event

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -2745,19 +2745,35 @@ export class ConversationRepository {
     const userEntity = await this.userRepository.getUserById(userId);
     const eventInjections = this.conversationState
       .conversations()
-      .filter(conversationEntity => {
-        const conversationInTeam = conversationEntity.teamId === teamId;
-        const userIsParticipant = UserFilter.isParticipant(conversationEntity, userId);
-        return conversationInTeam && userIsParticipant && !conversationEntity.removed_from_conversation();
+      .filter(conversation => {
+        const conversationInTeam = conversation.teamId === teamId;
+        const userIsParticipant = UserFilter.isParticipant(conversation, userId);
+        return conversationInTeam && userIsParticipant && !conversation.removed_from_conversation();
       })
-      .map(conversationEntity => {
-        const leaveEvent = EventBuilder.buildTeamMemberLeave(conversationEntity, userEntity, isoDate);
-        //FIXME: we are never removing the user from participating_user_ids
-        return this.eventRepository.injectEvent(leaveEvent);
+      .map(async conversation => {
+        const leaveEvent = EventBuilder.buildTeamMemberLeave(conversation, userEntity, isoDate);
+        await this.eventRepository.injectEvent(leaveEvent);
+        await this.clearUsersFromConversation(conversation, [userEntity]);
       });
     userEntity.isDeleted = true;
     return Promise.all(eventInjections);
   };
+
+  /**
+   * Will remove users from the conversation and update its participants list accordingly.
+   *
+   * @param conversation - conversation to remove users from
+   * @param users - users to remove from the conversation
+   */
+  private async clearUsersFromConversation(conversation: Conversation, users: User[]) {
+    users.forEach(user => {
+      conversation.participating_user_ids.remove(userId => matchQualifiedIds(userId, user));
+      if (user.isTemporaryGuest()) {
+        user.clearExpirationTimeout();
+      }
+    });
+    await this.updateParticipatingUserEntities(conversation);
+  }
 
   /**
    * Set the notification state of a conversation.
@@ -3678,18 +3694,10 @@ export class ConversationRepository {
     }
 
     const {messageEntity} = await this.addEventToConversation(conversationEntity, eventJson);
-    (messageEntity as MemberMessage)
-      .userEntities()
-      .filter(userEntity => !userEntity.isMe)
-      .forEach(userEntity => {
-        conversationEntity.participating_user_ids.remove(userId => matchQualifiedIds(userId, userEntity));
 
-        if (userEntity.isTemporaryGuest()) {
-          userEntity.clearExpirationTimeout();
-        }
-      });
+    const usersToRemove = (messageEntity as MemberMessage).userEntities().filter(userEntity => !userEntity.isMe);
 
-    await this.updateParticipatingUserEntities(conversationEntity);
+    await this.clearUsersFromConversation(conversationEntity, usersToRemove);
 
     this.proteusVerificationStateHandler.onMemberLeft(conversationEntity);
 

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -2752,6 +2752,7 @@ export class ConversationRepository {
       })
       .map(conversationEntity => {
         const leaveEvent = EventBuilder.buildTeamMemberLeave(conversationEntity, userEntity, isoDate);
+        //FIXME: we are never removing the user from participating_user_ids
         return this.eventRepository.injectEvent(leaveEvent);
       });
     userEntity.isDeleted = true;


### PR DESCRIPTION
## Description

After receiving team member leave event, we were never removing removed users' ids from conversation entity's `participating_user_ids` field and `participating_user_ets` later on, what could result in multiple removal system messages being inserted.

We base the logic of whether to display the message or not on `participating_user_ets` containing the user we have received a remove event for. There are two checks:
- https://github.com/wireapp/wire-webapp/blob/runfix/removed-from-team-message/src/script/conversation/ConversationRepository.ts#L2750
- https://github.com/wireapp/wire-webapp/blob/runfix/removed-from-team-message/src/script/event/preprocessor/EventStorageMiddleware/EventStorageMiddleware.ts#L108

Conversation entity was only update in case of receiving a `conversation.member-leave` event, see https://github.com/wireapp/wire-webapp/blob/f863ba6f479bc191000fea255240a6618b31a110/src/script/conversation/ConversationRepository.ts#L3684

It was never done for `team.member-leave` event. So in case `team.member-leave` was received first, when `conversation.member-leave` was received later, the user was still apparently a conversation member (what was not true).

## Screenshots/Screencast (for UI changes)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
