### PR TITLE
fix: Display the correct warning when team setting does not allow guest links [WPB-6906]

### DIFF
--- a/src/script/page/RightSidebar/GuestServicesOptions/components/GuestOptions/GuestOptions.tsx
+++ b/src/script/page/RightSidebar/GuestServicesOptions/components/GuestOptions/GuestOptions.tsx
@@ -116,9 +116,9 @@ const GuestOptions: FC<GuestOptionsProps> = ({
     return isGuestEnabled ? t('guestOptionsInfoText', Config.getConfig().BRAND_NAME) : t('guestRoomToggleInfo');
   }, [inTeam, isGuestEnabled, accessCodeHasPassword]);
 
-  const guestLinkDisabledInfo = !conversationHasGuestLinkEnabled
-    ? t('guestLinkDisabledByOtherTeam')
-    : t('guestLinkDisabled');
+  const guestLinkDisabledInfo = !isTeamStateGuestLinkEnabled
+    ? t('guestLinkDisabled')
+    : t('guestLinkDisabledByOtherTeam');
 
   const toggleGuestAccess = async () => {
     await toggleAccessState(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6906" title="WPB-6906" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6906</a>  [Web] Guest links not allowed prompt is wrong
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

The condition to display the message that guest link are disabled for the current team or for another team was wrong. 

This PR fixes it. 

### Before

![image](https://github.com/wireapp/wire-webapp/assets/1090716/beba625b-702a-434b-a7ac-37db5d5c5faa)

### After
![image](https://github.com/wireapp/wire-webapp/assets/1090716/3b218d85-3c57-4c81-bf82-d0781a28b0c8)


## Screenshots/Screencast (for UI changes)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
