### PR TITLE
fix: message search reload [WPB-7237]

### DIFF
--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -103,7 +103,7 @@ export const MessagesList: FC<MessagesListParams> = ({
     isGuestAndServicesRoom,
     isActiveParticipant,
     inTeam,
-    is_pending: isPending,
+    isLoadingMessages,
     hasAdditionalMessages,
   } = useKoSubscribableChildren(conversation, [
     'inTeam',
@@ -112,7 +112,7 @@ export const MessagesList: FC<MessagesListParams> = ({
     'lastDeliveredMessage',
     'isGuestRoom',
     'isGuestAndServicesRoom',
-    'is_pending',
+    'isLoadingMessages',
     'hasAdditionalMessages',
   ]);
 
@@ -176,7 +176,7 @@ export const MessagesList: FC<MessagesListParams> = ({
   useLayoutEffect(syncScrollPosition, [syncScrollPosition]);
 
   const loadPrecedingMessages = async (): Promise<void> => {
-    const shouldPullMessages = !isPending && hasAdditionalMessages;
+    const shouldPullMessages = !isLoadingMessages && hasAdditionalMessages;
 
     if (shouldPullMessages) {
       await conversationRepository.getPrecedingMessages(conversation);

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -4152,7 +4152,7 @@ export class ConversationRepository {
    * @param conversationEntity Conversation fetch events and users for
    */
   private async fetchUsersAndEvents(conversationEntity: Conversation) {
-    if (!conversationEntity.is_loaded() && !conversationEntity.is_pending()) {
+    if (!conversationEntity.is_pending()) {
       await this.updateParticipatingUserEntities(conversationEntity);
       await this.getUnreadEvents(conversationEntity);
     }

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -836,7 +836,7 @@ export class ConversationRepository {
    * @returns Resolves with the messages
    */
   public async getPrecedingMessages(conversationEntity: Conversation): Promise<ContentMessage[]> {
-    conversationEntity.is_pending(true);
+    conversationEntity.isLoadingMessages(true);
 
     const firstMessageEntity = conversationEntity.getOldestMessage();
     const upperBound =
@@ -851,7 +851,7 @@ export class ConversationRepository {
       Config.getConfig().MESSAGES_FETCH_LIMIT,
     )) as EventRecord[];
     const mappedMessageEntities = await this.addPrecedingEventsToConversation(events, conversationEntity);
-    conversationEntity.is_pending(false);
+    conversationEntity.isLoadingMessages(false);
     return mappedMessageEntities;
   }
 
@@ -932,7 +932,7 @@ export class ConversationRepository {
     const messageDate = new Date(messageEntity.timestamp());
     const conversationId = conversationEntity.id;
 
-    conversationEntity.is_pending(true);
+    conversationEntity.isLoadingMessages(true);
 
     const precedingMessages = (await this.eventService.loadPrecedingEvents(
       conversationId,
@@ -947,7 +947,7 @@ export class ConversationRepository {
     )) as EventRecord[];
     const messages = precedingMessages.concat(followingMessages);
     const mappedMessageEntities = await this.addEventsToConversation(messages, conversationEntity);
-    conversationEntity.is_pending(false);
+    conversationEntity.isLoadingMessages(false);
     return mappedMessageEntities;
   }
 
@@ -957,7 +957,7 @@ export class ConversationRepository {
    */
   async getSubsequentMessages(conversationEntity: Conversation, messageEntity: ContentMessage) {
     const messageDate = new Date(messageEntity.timestamp());
-    conversationEntity.is_pending(true);
+    conversationEntity.isLoadingMessages(true);
 
     const events = (await this.eventService.loadFollowingEvents(
       conversationEntity.id,
@@ -965,7 +965,7 @@ export class ConversationRepository {
       Config.getConfig().MESSAGES_FETCH_LIMIT,
     )) as EventRecord[];
     const mappedMessageEntities = await this.addEventsToConversation(events, conversationEntity, {prepend: false});
-    conversationEntity.is_pending(false);
+    conversationEntity.isLoadingMessages(false);
     return mappedMessageEntities;
   }
 
@@ -1009,7 +1009,7 @@ export class ConversationRepository {
       : new Date(conversationEntity.getLatestTimestamp(this.serverTimeHandler.toServerTimestamp()) + 1);
 
     if (lower_bound < upper_bound) {
-      conversationEntity.is_pending(true);
+      conversationEntity.isLoadingMessages(true);
 
       try {
         const events = (await this.eventService.loadPrecedingEvents(
@@ -1025,7 +1025,7 @@ export class ConversationRepository {
       } catch (error) {
         this.logger.info(`Could not load unread events for conversation: ${conversationEntity.id}`, error);
       }
-      conversationEntity.is_pending(false);
+      conversationEntity.isLoadingMessages(false);
     }
   }
 
@@ -4152,7 +4152,7 @@ export class ConversationRepository {
    * @param conversationEntity Conversation fetch events and users for
    */
   private async fetchUsersAndEvents(conversationEntity: Conversation) {
-    if (!conversationEntity.is_pending()) {
+    if (!conversationEntity.isLoadingMessages()) {
       await this.updateParticipatingUserEntities(conversationEntity);
       await this.getUnreadEvents(conversationEntity);
     }

--- a/src/script/entity/Conversation.test.ts
+++ b/src/script/entity/Conversation.test.ts
@@ -48,6 +48,7 @@ describe('Conversation', () => {
 
   const first_timestamp = new Date('2017-09-26T09:21:14.225Z').getTime();
   const second_timestamp = new Date('2017-09-26T10:27:18.837Z').getTime();
+  const third_timestamp = new Date('2017-09-26T11:29:21.837Z').getTime();
 
   beforeEach(() => {
     conversation_et = new Conversation();
@@ -718,18 +719,23 @@ describe('Conversation', () => {
   });
 
   describe('release', () => {
-    it('should not release messages if conversation has unread messages', () => {
+    it('if there are any incoming messages, they should be moved to regular messages', () => {
       const message_et = new Message(createUuid());
       message_et.timestamp(second_timestamp);
       conversation_et.addMessage(message_et);
       conversation_et.last_read_timestamp(first_timestamp);
 
+      const incomingMessage = new Message(createUuid());
+      conversation_et.last_event_timestamp(third_timestamp);
+      conversation_et.addMessage(incomingMessage);
+
       expect(conversation_et.messages().length).toBe(1);
-      expect(conversation_et.unreadState().allEvents.length).toBe(1);
+      expect(conversation_et.unreadState().allEvents.length).toBe(2);
 
       conversation_et.release();
 
       expect(conversation_et.messages().length).toBe(1);
+      expect(conversation_et.messages()).toEqual([incomingMessage]);
       expect(conversation_et.unreadState().allEvents.length).toBe(1);
     });
 

--- a/src/script/entity/Conversation.test.ts
+++ b/src/script/entity/Conversation.test.ts
@@ -717,38 +717,6 @@ describe('Conversation', () => {
     });
   });
 
-  describe('messages_visible', () => {
-    it('should return no messages if conversation ID is empty', () => {
-      expect(conversation_et.id).toBe('');
-      expect(conversation_et.messages_visible().length).toBe(0);
-    });
-
-    it('returns visible unmerged pings', () => {
-      const timestamp = Date.now();
-      conversation_et.id = createUuid();
-
-      const ping_message_1 = new PingMessage();
-      ping_message_1.timestamp(timestamp - 4000);
-      ping_message_1.id = createUuid();
-
-      const ping_message_2 = new PingMessage();
-      ping_message_2.timestamp(timestamp - 2000);
-      ping_message_2.id = createUuid();
-
-      const ping_message_3 = new PingMessage();
-      ping_message_3.timestamp(timestamp);
-      ping_message_3.id = createUuid();
-
-      conversation_et.addMessage(ping_message_1);
-      conversation_et.addMessage(ping_message_2);
-      conversation_et.addMessage(ping_message_3);
-
-      expect(conversation_et.messages_unordered().length).toBe(3);
-      expect(conversation_et.messages().length).toBe(3);
-      expect(conversation_et.messages_visible().length).toBe(3);
-    });
-  });
-
   describe('release', () => {
     it('should not release messages if conversation has unread messages', () => {
       const message_et = new Message(createUuid());

--- a/src/script/entity/Conversation.test.ts
+++ b/src/script/entity/Conversation.test.ts
@@ -777,7 +777,6 @@ describe('Conversation', () => {
       conversation_et.release();
 
       expect(conversation_et.hasAdditionalMessages()).toBeTruthy();
-      expect(conversation_et.is_loaded()).toBeFalsy();
       expect(conversation_et.messages().length).toBe(0);
       expect(conversation_et.unreadState().allEvents.length).toBe(0);
     });

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -149,6 +149,7 @@ export class Conversation {
   public readonly legalHoldStatus: ko.Observable<LegalHoldStatus>;
   public readonly localMessageTimer: ko.Observable<number>;
   public readonly messages_unordered: ko.ObservableArray<Message>;
+  // Sorted messages that are ready to be displayed in the conversation
   public readonly messages: ko.PureComputed<Message[]>;
   public readonly messageTimer: ko.PureComputed<number>;
   public readonly name: ko.Observable<string>;

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -127,7 +127,7 @@ export class Conversation {
   public readonly lastDeliveredMessage: ko.PureComputed<Message | undefined>;
   public readonly is_archived: ko.Observable<boolean>;
   public readonly is_cleared: ko.PureComputed<boolean>;
-  //* Indicates if the conversation is currently loading messages into its state. */
+  /** Indicates if the conversation is currently loading messages into its state. */
   public readonly isLoadingMessages: ko.Observable<boolean>;
   public readonly is_verified: ko.PureComputed<boolean | undefined>;
   public readonly is1to1: ko.PureComputed<boolean>;

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -149,7 +149,7 @@ export class Conversation {
   public readonly legalHoldStatus: ko.Observable<LegalHoldStatus>;
   public readonly localMessageTimer: ko.Observable<number>;
   public readonly messages_unordered: ko.ObservableArray<Message>;
-  // Sorted messages that are ready to be displayed in the conversation
+  /** Sorted messages that are ready to be displayed in the conversation */
   public readonly messages: ko.PureComputed<Message[]>;
   public readonly messageTimer: ko.PureComputed<number>;
   public readonly name: ko.Observable<string>;

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -128,7 +128,7 @@ export class Conversation {
   public readonly is_archived: ko.Observable<boolean>;
   public readonly is_cleared: ko.PureComputed<boolean>;
   //* Indicates if the conversation is currently loading messages into its state. */
-  public readonly is_pending: ko.Observable<boolean>;
+  public readonly isLoadingMessages: ko.Observable<boolean>;
   public readonly is_verified: ko.PureComputed<boolean | undefined>;
   public readonly is1to1: ko.PureComputed<boolean>;
   public readonly isActiveParticipant: ko.PureComputed<boolean>;
@@ -204,7 +204,7 @@ export class Conversation {
     this.teamId = undefined;
     this.type = ko.observable();
 
-    this.is_pending = ko.observable(false);
+    this.isLoadingMessages = ko.observable(false);
 
     this.participating_user_ets = ko.observableArray([]); // Does not include self user
     this.participating_user_ids = ko.observableArray([]); // Does not include self user

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -599,12 +599,19 @@ export class Conversation {
   }
 
   /**
-   * Remove all message from conversation unless there are unread messages.
+   * Remove all the messages from conversation.
+   * If there are any incoming messages, they will be moved to the regular messages.
    */
   release(): void {
+    this.messages_unordered.removeAll();
+
     if (!this.unreadState().allEvents.length) {
-      this.removeMessages();
       this.hasAdditionalMessages(true);
+    }
+
+    if (this.incomingMessages().length) {
+      this.messages_unordered.push(...this.incomingMessages());
+      this.incomingMessages.removeAll();
     }
   }
 
@@ -693,8 +700,10 @@ export class Conversation {
       if (alreadyAdded) {
         return false;
       }
+
+      this.updateTimestamps(messageEntity);
+
       if (this.hasLastReceivedMessageLoaded()) {
-        this.updateTimestamps(messageEntity);
         this.incomingMessages.remove(({id}) => messageEntity.id === id);
         // If the last received message is currently in memory, we can add this message to the displayed messages
         this.messages_unordered.push(messageEntity);

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -127,6 +127,7 @@ export class Conversation {
   public readonly lastDeliveredMessage: ko.PureComputed<Message | undefined>;
   public readonly is_archived: ko.Observable<boolean>;
   public readonly is_cleared: ko.PureComputed<boolean>;
+  //* Indicates if the conversation is currently loading messages into its state. */
   public readonly is_pending: ko.Observable<boolean>;
   public readonly is_verified: ko.PureComputed<boolean | undefined>;
   public readonly is1to1: ko.PureComputed<boolean>;

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -127,7 +127,6 @@ export class Conversation {
   public readonly lastDeliveredMessage: ko.PureComputed<Message | undefined>;
   public readonly is_archived: ko.Observable<boolean>;
   public readonly is_cleared: ko.PureComputed<boolean>;
-  public readonly is_loaded: ko.Observable<boolean>;
   public readonly is_pending: ko.Observable<boolean>;
   public readonly is_verified: ko.PureComputed<boolean | undefined>;
   public readonly is1to1: ko.PureComputed<boolean>;
@@ -204,7 +203,6 @@ export class Conversation {
     this.teamId = undefined;
     this.type = ko.observable();
 
-    this.is_loaded = ko.observable(false);
     this.is_pending = ko.observable(false);
 
     this.participating_user_ets = ko.observableArray([]); // Does not include self user
@@ -611,7 +609,6 @@ export class Conversation {
   release(): void {
     if (!this.unreadState().allEvents.length) {
       this.removeMessages();
-      this.is_loaded(false);
       this.hasAdditionalMessages(true);
     }
   }

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -149,7 +149,6 @@ export class Conversation {
   public readonly legalHoldStatus: ko.Observable<LegalHoldStatus>;
   public readonly localMessageTimer: ko.Observable<number>;
   public readonly messages_unordered: ko.ObservableArray<Message>;
-  public readonly messages_visible: ko.PureComputed<Message[]>;
   public readonly messages: ko.PureComputed<Message[]>;
   public readonly messageTimer: ko.PureComputed<number>;
   public readonly name: ko.Observable<string>;
@@ -423,10 +422,6 @@ export class Conversation {
     this.hasContentMessages = ko.observable(
       [...this.messages(), ...this.incomingMessages()].some(message => message.isContent()),
     );
-
-    this.messages_visible = ko
-      .pureComputed(() => (!this.id ? [] : this.messages().filter(messageEntity => messageEntity.visible())))
-      .extend({trackArrayChanges: true});
 
     // Calling
     this.unreadState = ko.pureComputed(() => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7237" title="WPB-7237" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7237</a>  [Web] Cannot read more messages after leaving the search mode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

When being in a search mode, when new messages are sent, we don't load them to `.messages()` ko state directly (as they are messages that are being currently displayed to the user) but we load them to `.incomingMessages`. Also, always when navigation out of conversation we "release" it, meaning we delete all its messages from the memory (mentioned above `.messages()` state).

Previously we were never clearing conversation's messages if it contained any unread events (including messages from `.incomingMessages()`), what caused old searched messages still to be loaded when navigating back to the conversation.

The fix is to always clear conversation's messages when switching to a different conversation, and if it contained any incoming messages, move them to the regular messages (those displayed to the user).

This PR also removes conversation's:
- `is_loaded` state that was set initially to `false` and never updated
- `messages_visible` that was calculated and never consumed

## Screenshots/Screencast (for UI changes)

Before
![before 01 48 03](https://github.com/wireapp/wire-webapp/assets/45733298/9fd551d8-47cc-4346-9c17-af865c4297a3)


After
![after 18 33 56](https://github.com/wireapp/wire-webapp/assets/45733298/b8a7626d-52b8-4cd3-9336-e26e77cd87f9)




## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
