### PR TITLE
runfix: received messages not visible

### DIFF
--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -703,9 +703,8 @@ export class Conversation {
         return false;
       }
 
-      this.updateTimestamps(messageEntity);
-
       if (this.hasLastReceivedMessageLoaded()) {
+        this.updateTimestamps(messageEntity);
         this.incomingMessages.remove(({id}) => messageEntity.id === id);
         // If the last received message is currently in memory, we can add this message to the displayed messages
         this.messages_unordered.push(messageEntity);


### PR DESCRIPTION
## Description

Yesterday's change introduced a regression with received messages not being visible https://github.com/wireapp/wire-webapp/pull/17158/files#diff-8571c5df99ca8b8d228f479233d4ba1b639b77d7558abb70d375a450d4dc63c5R705-R709.

This was a leftover from debugging, this should be included inside the if statement as it was before.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
