### PR TITLE
refactor: initialising 1:1 conversation

### DIFF
--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -948,7 +948,9 @@ describe('ConversationRepository', () => {
       });
 
       await waitFor(() => {
-        expect(conversationRepository.getInitialised1To1Conversation).toHaveBeenCalledWith(otherUser.qualifiedId, true);
+        expect(conversationRepository.getInitialised1To1Conversation).toHaveBeenCalledWith(otherUser.qualifiedId, {
+          isLiveUpdate: true,
+        });
       });
     });
 

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -378,7 +378,7 @@ describe('ConversationRepository', () => {
 
       jest.spyOn(conversationRepository['userState'], 'self').mockReturnValue(selfUser);
 
-      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(userEntity);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(userEntity.qualifiedId);
 
       expect(conversationEntity).toBe(newConversationEntity);
     });
@@ -404,6 +404,8 @@ describe('ConversationRepository', () => {
       }) as BackendConversation;
 
       const connection = new ConnectionEntity();
+      connection.userId = otherUserId;
+      connection.status(ConnectionStatus.ACCEPTED);
       connection.conversationId = proteus1to1ConversationResponse.qualified_id;
       otherUser.connection(connection);
 
@@ -414,7 +416,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'getConversationById')
         .mockResolvedValueOnce(proteus1to1ConversationResponse);
 
-      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser.qualifiedId);
 
       expect(conversationEntity?.serialize()).toEqual(proteus1to1Conversation.serialize());
       expect(conversationEntity?.readOnlyState()).toEqual(null);
@@ -444,6 +446,8 @@ describe('ConversationRepository', () => {
       }) as BackendConversation;
 
       const connection = new ConnectionEntity();
+      connection.status(ConnectionStatus.ACCEPTED);
+      connection.userId = otherUserId;
       connection.conversationId = proteus1to1ConversationResponse.qualified_id;
       otherUser.connection(connection);
 
@@ -452,7 +456,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'getConversationById')
         .mockResolvedValueOnce(proteus1to1ConversationResponse);
 
-      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser.qualifiedId);
 
       expect(conversationEntity?.readOnlyState()).toEqual(
         CONVERSATION_READONLY_STATE.READONLY_ONE_TO_ONE_SELF_UNSUPPORTED_MLS,
@@ -493,7 +497,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
         .mockResolvedValueOnce(true);
 
-      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser.qualifiedId);
 
       expect(conversationEntity?.serialize()).toEqual(mls1to1Conversation.serialize());
     });
@@ -578,7 +582,7 @@ describe('ConversationRepository', () => {
       jest.spyOn(conversationRepository['conversationService'], 'blacklistConversation');
       jest.spyOn(conversationRepository['eventRepository'], 'injectEvent').mockResolvedValueOnce(undefined);
 
-      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser.qualifiedId);
 
       expect(conversationRepository['eventService'].moveEventsToConversation).toHaveBeenCalledWith(
         proteus1to1Conversation.id,
@@ -662,7 +666,7 @@ describe('ConversationRepository', () => {
 
       const [mls1to1Conversation] = conversationRepository.mapConversations([establishedMls1to1ConversationResponse]);
 
-      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser.qualifiedId);
 
       expect(container.resolve(Core).service!.conversation.establishMLS1to1Conversation).toHaveBeenCalledWith(
         mockedGroupId,
@@ -742,7 +746,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
         .mockResolvedValueOnce(false);
 
-      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser.qualifiedId);
 
       expect(conversationEntity?.serialize()).toEqual(mls1to1Conversation.serialize());
       expect(container.resolve(Core).service!.conversation.establishMLS1to1Conversation).toHaveBeenCalled();
@@ -783,7 +787,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
         .mockResolvedValueOnce(true);
 
-      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser.qualifiedId);
 
       expect(conversationEntity?.serialize()).toEqual(mls1to1Conversation.serialize());
     });
@@ -823,7 +827,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
         .mockResolvedValueOnce(false);
 
-      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser.qualifiedId);
 
       expect(conversationEntity?.serialize()).toEqual(mls1to1Conversation.serialize());
       expect(conversationEntity?.readOnlyState()).toEqual(
@@ -866,7 +870,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
         .mockResolvedValueOnce(true);
 
-      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser.qualifiedId);
 
       expect(conversationEntity?.serialize()).toEqual(mls1to1Conversation.serialize());
       expect(conversationEntity?.readOnlyState()).toEqual(null);
@@ -944,7 +948,7 @@ describe('ConversationRepository', () => {
       });
 
       await waitFor(() => {
-        expect(conversationRepository.getInitialised1To1Conversation).toHaveBeenCalledWith(otherUser, true);
+        expect(conversationRepository.getInitialised1To1Conversation).toHaveBeenCalledWith(otherUser.qualifiedId, true);
       });
     });
 
@@ -991,6 +995,7 @@ describe('ConversationRepository', () => {
       const connection = new ConnectionEntity();
       connection.status(ConnectionStatus.SENT);
       connection.conversationId = conversation.qualifiedId;
+      connection.userId = otherUserId;
       otherUser.connection(connection);
 
       jest.spyOn(conversationRepository['conversationService'], 'removeConversationFromBlacklist');
@@ -1187,6 +1192,12 @@ describe('ConversationRepository', () => {
     it('should map a connection to an existing conversation', () => {
       conversation_et.type(CONVERSATION_TYPE.ONE_TO_ONE);
 
+      const conversationRepository = testFactory.conversation_repository!;
+      const user = new User('id', 'domain');
+      user.connection(connectionEntity);
+      connectionEntity.userId = user.qualifiedId;
+      conversationRepository['userState'].users.push(user);
+
       return testFactory.conversation_repository['mapConnection'](connectionEntity).then(
         (_conversation: Conversation) => {
           expect(testFactory.conversation_repository['fetchConversationById']).not.toHaveBeenCalled();
@@ -1197,31 +1208,40 @@ describe('ConversationRepository', () => {
     });
 
     it('should map a connection to a new conversation', () => {
-      connectionEntity.status(ConnectionStatus.ACCEPTED);
-      testFactory.conversation_repository['conversationState'].conversations.removeAll();
+      const conversationRepository = testFactory.conversation_repository!;
+      const user = new User('id1', 'domain1');
+      user.connection(connectionEntity);
+      connectionEntity.userId = user.qualifiedId;
+      conversationRepository['userState'].users.push(user);
 
-      return testFactory.conversation_repository['mapConnection'](connectionEntity).then(_conversation => {
-        expect(testFactory.conversation_repository['fetchConversationById']).toHaveBeenCalled();
+      connectionEntity.status(ConnectionStatus.ACCEPTED);
+      conversationRepository['conversationState'].conversations.removeAll();
+
+      return conversationRepository['mapConnection'](connectionEntity).then(_conversation => {
+        expect(conversationRepository['fetchConversationById']).toHaveBeenCalled();
         expect(testFactory.conversation_service.getConversationById).toHaveBeenCalled();
         expect(_conversation.connection()).toBe(connectionEntity);
       });
     });
 
     it('should map a cancelled connection to an existing conversation and filter it', () => {
+      const conversationRepository = testFactory.conversation_repository!;
+      const user = new User('id', 'domain');
+      user.connection(connectionEntity);
+      connectionEntity.userId = user.qualifiedId;
+      conversationRepository['userState'].users.push(user);
+
       conversation_et.type(CONVERSATION_TYPE.ONE_TO_ONE);
       connectionEntity.status(ConnectionStatus.CANCELLED);
 
-      return testFactory.conversation_repository['mapConnection'](connectionEntity).then(_conversation => {
+      return conversationRepository['mapConnection'](connectionEntity).then(_conversation => {
         expect(_conversation.connection()).toBe(connectionEntity);
         expect(
-          _findConversation(_conversation, testFactory.conversation_repository['conversationState'].conversations),
+          _findConversation(_conversation, conversationRepository['conversationState'].conversations),
         ).not.toBeUndefined();
 
         expect(
-          _findConversation(
-            _conversation,
-            testFactory.conversation_repository['conversationState'].filteredConversations,
-          ),
+          _findConversation(_conversation, conversationRepository['conversationState'].filteredConversations),
         ).toBeUndefined();
       });
     });
@@ -1274,8 +1294,9 @@ describe('ConversationRepository', () => {
           protocol: ConversationProtocol.MLS,
         });
 
-        const otherUserId = {id: 'f718410c-3833-479d-bd80-a5df03f38414', domain: 'test-domain'};
+        const otherUserId = {id: 'f718410c-3833-479d-bd80-a5df01138411', domain: 'test-domain'};
         const otherUser = new User(otherUserId.id, otherUserId.domain);
+        otherUser.supportedProtocols([ConversationProtocol.PROTEUS, ConversationProtocol.MLS]);
 
         conversationRepository['userState'].users.push(otherUser);
         conversation.participating_user_ids.push(otherUserId);

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1286,12 +1286,15 @@ export class ConversationRepository {
    * If there's no common protocol, it will pick the protocol that is supported by the current user and mark conversation as read-only.
    * @param userEntity User entity for whom to get the conversation
    * @param isLiveUpdate Whether the conversation is being initialised because of a live update (e.g. some websocket event)
+   * @param shouldRefreshUser Whether the user should be refetched from backend before getting the conversation
    * @returns Resolves with the initialised 1:1 conversation with requested user
    */
   public async getInitialised1To1Conversation(
     userId: QualifiedId,
-    isLiveUpdate = false,
-    shouldRefreshUser = false,
+    {isLiveUpdate = false, shouldRefreshUser = false}: {isLiveUpdate?: boolean; shouldRefreshUser?: boolean} = {
+      isLiveUpdate: false,
+      shouldRefreshUser: false,
+    },
   ): Promise<Conversation | null> {
     const user = await this.userRepository.getUserById(userId);
 
@@ -1970,7 +1973,7 @@ export class ConversationRepository {
     );
 
     try {
-      return await this.getInitialised1To1Conversation(otherUserId, false, shouldRefreshUser);
+      return await this.getInitialised1To1Conversation(otherUserId, {shouldRefreshUser});
     } catch {}
 
     return conversation;
@@ -2060,7 +2063,9 @@ export class ConversationRepository {
   ): Promise<Conversation | undefined> => {
     try {
       const userId = connectionEntity.userId;
-      const conversation = await this.getInitialised1To1Conversation(userId, source === EventSource.WEBSOCKET);
+      const conversation = await this.getInitialised1To1Conversation(userId, {
+        isLiveUpdate: source === EventSource.WEBSOCKET,
+      });
 
       if (!conversation) {
         return undefined;
@@ -2116,7 +2121,7 @@ export class ConversationRepository {
       return;
     }
 
-    await this.getInitialised1To1Conversation(user.qualifiedId, true);
+    await this.getInitialised1To1Conversation(user.qualifiedId, {isLiveUpdate: true});
   };
 
   /**
@@ -3975,7 +3980,7 @@ export class ConversationRepository {
       return;
     }
 
-    await this.getInitialised1To1Conversation(otherUserId, true);
+    await this.getInitialised1To1Conversation(otherUserId, {isLiveUpdate: true});
   }
 
   /**

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1288,7 +1288,7 @@ export class ConversationRepository {
    * @param isLiveUpdate Whether the conversation is being initialised because of a live update (e.g. some websocket event)
    * @returns Resolves with the initialised 1:1 conversation with requested user
    */
-  async getInitialised1To1Conversation(userId: QualifiedId, isLiveUpdate = false): Promise<Conversation | null> {
+  public async getInitialised1To1Conversation(userId: QualifiedId, isLiveUpdate = false): Promise<Conversation | null> {
     const user = await this.userRepository.getUserById(userId);
 
     const connection = user.connection();
@@ -2071,7 +2071,7 @@ export class ConversationRepository {
   ): Promise<Conversation | undefined> => {
     try {
       const userId = connectionEntity.userId;
-      const conversation = await this.get1to1WithUser(userId, source === EventSource.WEBSOCKET);
+      const conversation = await this.getInitialised1To1Conversation(userId, source === EventSource.WEBSOCKET);
 
       if (!conversation) {
         return undefined;
@@ -3986,7 +3986,7 @@ export class ConversationRepository {
       return;
     }
 
-    await this.initMLS1to1Conversation(otherUserId, true);
+    await this.getInitialised1To1Conversation(otherUserId, true);
   }
 
   /**

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1314,6 +1314,32 @@ export class ConversationRepository {
     return this.initProteus1to1Conversation(proteusConversation.qualifiedId, isProteusSupportedByTheOtherUser);
   }
 
+  async get1to1WithUser(userId: QualifiedId, isLiveUpdate = false): Promise<Conversation | null> {
+    const user = await this.userRepository.getUserById(userId);
+
+    const {protocol, isMLSSupportedByTheOtherUser, isProteusSupportedByTheOtherUser} =
+      await this.getProtocolFor1to1Conversation(userId);
+
+    const localMLSConversation = this.conversationState.findMLS1to1Conversation(userId);
+
+    if (protocol === ConversationProtocol.MLS || localMLSConversation) {
+      /**
+       * When mls 1:1 conversation initialisation is triggered by some live update (e.g other user updates their supported protocols), it's very likely that we will also receive a welcome message shortly.
+       * We have to add a delay to make sure the welcome message is not wasted, in case the self client would establish mls group themselves before receiving the welcome.
+       */
+      const shouldDelayMLSGroupEstablishment = isLiveUpdate && isMLSSupportedByTheOtherUser;
+      return this.initMLS1to1Conversation(userId, isMLSSupportedByTheOtherUser, shouldDelayMLSGroupEstablishment);
+    }
+
+    const proteusConversation = await this.getOrCreateProteus1To1Conversation(user);
+
+    if (!proteusConversation) {
+      return null;
+    }
+
+    return this.initProteus1to1Conversation(proteusConversation.qualifiedId, isProteusSupportedByTheOtherUser);
+  }
+
   /**
    * Get or create a proteus 1:1 conversation with a user.
    * If a conversation does not exist, but user is in the current team, or there's a connection with this user, proteus 1:1 conversation will be created and saved.

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1033,7 +1033,7 @@ export class ConversationRepository {
    * Update conversation with a user you just unblocked
    */
   private readonly onUnblockUser = async (user_et: User): Promise<void> => {
-    const conversationEntity = await this.getInitialised1To1Conversation(user_et);
+    const conversationEntity = await this.getInitialised1To1Conversation(user_et.qualifiedId);
     if (conversationEntity) {
       conversationEntity.status(ConversationStatus.CURRENT_MEMBER);
     }
@@ -1288,34 +1288,13 @@ export class ConversationRepository {
    * @param isLiveUpdate Whether the conversation is being initialised because of a live update (e.g. some websocket event)
    * @returns Resolves with the initialised 1:1 conversation with requested user
    */
-  async getInitialised1To1Conversation(userEntity: User, isLiveUpdate = false): Promise<Conversation | null> {
-    const {qualifiedId: otherUserId} = userEntity;
-
-    const {protocol, isMLSSupportedByTheOtherUser, isProteusSupportedByTheOtherUser} =
-      await this.getProtocolFor1to1Conversation(otherUserId);
-
-    const localMLSConversation = this.conversationState.findMLS1to1Conversation(otherUserId);
-
-    if (protocol === ConversationProtocol.MLS || localMLSConversation) {
-      /**
-       * When mls 1:1 conversation initialisation is triggered by some live update (e.g other user updates their supported protocols), it's very likely that we will also receive a welcome message shortly.
-       * We have to add a delay to make sure the welcome message is not wasted, in case the self client would establish mls group themselves before receiving the welcome.
-       */
-      const shouldDelayMLSGroupEstablishment = isLiveUpdate && isMLSSupportedByTheOtherUser;
-      return this.initMLS1to1Conversation(otherUserId, isMLSSupportedByTheOtherUser, shouldDelayMLSGroupEstablishment);
-    }
-
-    const proteusConversation = await this.getOrCreateProteus1To1Conversation(userEntity);
-
-    if (!proteusConversation) {
-      return null;
-    }
-
-    return this.initProteus1to1Conversation(proteusConversation.qualifiedId, isProteusSupportedByTheOtherUser);
-  }
-
-  async get1to1WithUser(userId: QualifiedId, isLiveUpdate = false): Promise<Conversation | null> {
+  async getInitialised1To1Conversation(userId: QualifiedId, isLiveUpdate = false): Promise<Conversation | null> {
     const user = await this.userRepository.getUserById(userId);
+
+    const connection = user.connection();
+    if (connection) {
+      return this.get1to1ConversationForConnection(connection, isLiveUpdate);
+    }
 
     const {protocol, isMLSSupportedByTheOtherUser, isProteusSupportedByTheOtherUser} =
       await this.getProtocolFor1to1Conversation(userId);
@@ -2022,34 +2001,35 @@ export class ConversationRepository {
     return conversation;
   };
 
-  private readonly getConnectionConversation = async (connectionEntity: ConnectionEntity, source?: EventSource) => {
+  private readonly get1to1ConversationForConnection = async (
+    connection: ConnectionEntity,
+    isLiveUpdate: boolean,
+  ): Promise<Conversation | null> => {
     // As of how backed works now (August 2023), proteus 1:1 conversations will always be created, even if both users support MLS conversation.
     // Proteus 1:1 conversation is created right after a connection request is sent.
     // Therefore, conversationId filed on connectionEntity will always indicate proteus 1:1 conversation.
     // We need to manually check if mls 1:1 conversation can be used instead.
     // If mls 1:1 conversation is used, proteus 1:1 conversation will be deleted locally.
 
-    const {conversationId: proteusConversationId, userId: otherUserId} = connectionEntity;
-    const localProteusConversation = this.conversationState.findConversation(proteusConversationId);
+    const {conversationId: proteusConversationId, userId: otherUserId} = connection;
+    const localProteusConversation = this.conversationState.findConversation(proteusConversationId) || null;
 
     // For connection request, we simply display proteus conversation of type 3 (connect) it will be displayed as a connection request
-    if (connectionEntity.isOutgoingRequest()) {
+    if (connection.isOutgoingRequest()) {
       const proteusConversation = localProteusConversation || (await this.fetchConversationById(proteusConversationId));
       proteusConversation.type(CONVERSATION_TYPE.CONNECT);
       return proteusConversation;
     }
 
-    const isConnectionAccepted = connectionEntity.isConnected();
-
     // Check what protocol should be used for 1:1 conversation
     const {protocol, isMLSSupportedByTheOtherUser, isProteusSupportedByTheOtherUser} =
       await this.getProtocolFor1to1Conversation(otherUserId);
 
-    const isWebSocketEvent = source === EventSource.WEBSOCKET;
-    const shouldDelayMLSGroupEstablishment = isWebSocketEvent && isMLSSupportedByTheOtherUser;
+    const shouldDelayMLSGroupEstablishment = isLiveUpdate && isMLSSupportedByTheOtherUser;
 
     const localMLSConversation = this.conversationState.findMLS1to1Conversation(otherUserId);
 
+    const isConnectionAccepted = connection.isConnected();
     // If it's accepted, initialise conversation so it's ready to be used
     if (isConnectionAccepted) {
       if (protocol === ConversationProtocol.MLS || localMLSConversation) {
@@ -2073,7 +2053,7 @@ export class ConversationRepository {
       return this.initMLS1to1Conversation(otherUserId, isMLSSupportedByTheOtherUser, shouldDelayMLSGroupEstablishment);
     }
 
-    return protocol === ConversationProtocol.PROTEUS ? localProteusConversation : undefined;
+    return protocol === ConversationProtocol.PROTEUS ? localProteusConversation : null;
   };
 
   /**
@@ -2090,7 +2070,8 @@ export class ConversationRepository {
     source?: EventSource,
   ): Promise<Conversation | undefined> => {
     try {
-      const conversation = await this.getConnectionConversation(connectionEntity, source);
+      const userId = connectionEntity.userId;
+      const conversation = await this.get1to1WithUser(userId, source === EventSource.WEBSOCKET);
 
       if (!conversation) {
         return undefined;
@@ -2146,7 +2127,7 @@ export class ConversationRepository {
       return;
     }
 
-    await this.getInitialised1To1Conversation(user, true);
+    await this.getInitialised1To1Conversation(user.qualifiedId, true);
   };
 
   /**

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1288,7 +1288,11 @@ export class ConversationRepository {
    * @param isLiveUpdate Whether the conversation is being initialised because of a live update (e.g. some websocket event)
    * @returns Resolves with the initialised 1:1 conversation with requested user
    */
-  public async getInitialised1To1Conversation(userId: QualifiedId, isLiveUpdate = false): Promise<Conversation | null> {
+  public async getInitialised1To1Conversation(
+    userId: QualifiedId,
+    isLiveUpdate = false,
+    shouldRefreshUser = false,
+  ): Promise<Conversation | null> {
     const user = await this.userRepository.getUserById(userId);
 
     const connection = user.connection();
@@ -1297,7 +1301,7 @@ export class ConversationRepository {
     }
 
     const {protocol, isMLSSupportedByTheOtherUser, isProteusSupportedByTheOtherUser} =
-      await this.getProtocolFor1to1Conversation(userId);
+      await this.getProtocolFor1to1Conversation(userId, shouldRefreshUser);
 
     const localMLSConversation = this.conversationState.findMLS1to1Conversation(userId);
 
@@ -1938,7 +1942,7 @@ export class ConversationRepository {
   public readonly init1to1Conversation = async (
     conversation: Conversation,
     shouldRefreshUser = false,
-  ): Promise<Conversation> => {
+  ): Promise<Conversation | null> => {
     if (!conversation.is1to1()) {
       throw new Error('Conversation is not 1:1');
     }
@@ -1950,52 +1954,19 @@ export class ConversationRepository {
       return conversation;
     }
 
+    const otherUser = await this.userRepository.getUserById(otherUserId);
+    // If the other user is deleted on backend, just open a conversation and do not try to migrate it to mls.
+    if (otherUser.isDeleted) {
+      this.logger.warn(`User ${otherUserId.id} is deleted, opening proteus conversation`);
+      return conversation;
+    }
+
     this.logger.info(
       `Initialising 1:1 conversation ${conversation.id} of type ${conversation.type()} with user ${otherUserId.id}`,
     );
 
     try {
-      const {protocol, isMLSSupportedByTheOtherUser, isProteusSupportedByTheOtherUser} =
-        await this.getProtocolFor1to1Conversation(otherUserId, shouldRefreshUser);
-      this.logger.info(
-        `Protocol for 1:1 conversation ${conversation.id} with user ${otherUserId.id} is ${protocol}, ${JSON.stringify({
-          isMLSSupportedByTheOtherUser,
-          isProteusSupportedByTheOtherUser,
-        })}`,
-      );
-
-      // When called with mls conversation, we just make sure it is initialised.
-      if (isMLSConversation(conversation)) {
-        return this.initMLS1to1Conversation(otherUserId, isMLSSupportedByTheOtherUser);
-      }
-
-      // If there's local mls conversation, we want to use it
-      const localMLSConversation = this.conversationState.findMLS1to1Conversation(otherUserId);
-
-      // If mls conversation is already known, we use it
-      // we never go back to proteus conversation, even if one of the users do not support mls anymore
-      // (e.g. due to the change of supported protocols in team configuration)
-      if (localMLSConversation) {
-        return this.initMLS1to1Conversation(otherUserId, isMLSSupportedByTheOtherUser);
-      }
-
-      // If both users support mls, we will initialise mls 1:1 conversation (unless it's a proteus 1:1 conversation with a user that has been deleted)
-      if (protocol === ConversationProtocol.MLS) {
-        // If the other user is deleted on backend, just open a proteus conversation and do not try to migrate it to mls.
-        if (isProteusConversation(conversation)) {
-          const otherUser = await this.userRepository.getUserById(otherUserId);
-          if (otherUser.isDeleted) {
-            this.logger.warn(`User ${otherUserId.id} is deleted, opening proteus conversation`);
-            return conversation;
-          }
-        }
-
-        return this.initMLS1to1Conversation(otherUserId, isMLSSupportedByTheOtherUser);
-      }
-
-      if (protocol === ConversationProtocol.PROTEUS && isProteusConversation(conversation)) {
-        return this.initProteus1to1Conversation(conversation.qualifiedId, isProteusSupportedByTheOtherUser);
-      }
+      return await this.getInitialised1To1Conversation(otherUserId, false, shouldRefreshUser);
     } catch {}
 
     return conversation;

--- a/src/script/view_model/ActionsViewModel.ts
+++ b/src/script/view_model/ActionsViewModel.ts
@@ -336,7 +336,7 @@ export class ActionsViewModel {
   };
 
   getOrCreate1to1Conversation = async (userEntity: User): Promise<Conversation> => {
-    const conversationEntity = await this.conversationRepository.getInitialised1To1Conversation(userEntity);
+    const conversationEntity = await this.conversationRepository.getInitialised1To1Conversation(userEntity.qualifiedId);
     if (conversationEntity) {
       return conversationEntity;
     }
@@ -431,7 +431,9 @@ export class ActionsViewModel {
         primaryAction: {
           action: async () => {
             await this.connectionRepository.unblockUser(userEntity);
-            const conversationEntity = await this.conversationRepository.getInitialised1To1Conversation(userEntity);
+            const conversationEntity = await this.conversationRepository.getInitialised1To1Conversation(
+              userEntity.qualifiedId,
+            );
             resolve();
             if (conversationEntity) {
               await this.conversationRepository.updateParticipatingUserEntities(conversationEntity);

--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -141,7 +141,7 @@ export class ContentViewModel {
   private readonly getConversationEntity = async (
     conversation: Conversation | string,
     domain: string | null = null,
-  ): Promise<Conversation> => {
+  ): Promise<Conversation | null> => {
     const conversationEntity = isConversationEntity(conversation)
       ? conversation
       : await this.conversationRepository.getConversationById({domain: domain || '', id: conversation});


### PR DESCRIPTION
## Description

With this PR initialising a 1:1 conversation is a single method - one flow for different cases (mapping a connection request, creating a new conversation, receiving a welcome message ect)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
