### PR TITLE
fix: cannot reconnect audio after re-plugging a device [WPB-713]

### DIFF
--- a/src/script/calling/CallingRepository.test.ts
+++ b/src/script/calling/CallingRepository.test.ts
@@ -72,6 +72,20 @@ const createConversation = (
   return conversation;
 };
 
+const mediaDevices = {
+  audioinput: ko.pureComputed(() => 'test'),
+  audiooutput: ko.pureComputed(() => 'test'),
+  screeninput: ko.pureComputed(() => 'test'),
+  videoinput: ko.pureComputed(() => 'test'),
+};
+
+const buildMediaDevicesHandler = () => {
+  return {
+    currentAvailableDeviceId: mediaDevices,
+    setOnMediaDevicesRefreshHandler: jest.fn(),
+  } as unknown as MediaDevicesHandler;
+};
+
 describe('CallingRepository', () => {
   const testFactory = new TestFactory();
   let callingRepository: CallingRepository;
@@ -80,13 +94,6 @@ describe('CallingRepository', () => {
   const selfUser = new User(createUuid());
   selfUser.isMe = true;
   const clientId = createUuid();
-
-  const mediaDevices = {
-    audioinput: ko.pureComputed(() => 'test'),
-    audiooutput: ko.pureComputed(() => 'test'),
-    screeninput: ko.pureComputed(() => 'test'),
-    videoinput: ko.pureComputed(() => 'test'),
-  };
 
   beforeAll(() => {
     return testFactory.exposeCallingActors().then(injectedCallingRepository => {
@@ -122,9 +129,7 @@ describe('CallingRepository', () => {
         CONV_TYPE.CONFERENCE,
         selfParticipant,
         CALL_TYPE.NORMAL,
-        {
-          currentAvailableDeviceId: mediaDevices,
-        } as unknown as MediaDevicesHandler,
+        buildMediaDevicesHandler(),
       );
 
       conversation.roles({[senderUserId.id]: DefaultConversationRoleName.WIRE_ADMIN});
@@ -166,9 +171,7 @@ describe('CallingRepository', () => {
         CONV_TYPE.CONFERENCE,
         selfParticipant,
         CALL_TYPE.NORMAL,
-        {
-          currentAvailableDeviceId: mediaDevices,
-        } as unknown as MediaDevicesHandler,
+        buildMediaDevicesHandler(),
       );
 
       conversation.roles({[senderUserId.id]: DefaultConversationRoleName.WIRE_MEMBER});
@@ -210,9 +213,7 @@ describe('CallingRepository', () => {
         CONV_TYPE.CONFERENCE,
         selfParticipant,
         CALL_TYPE.NORMAL,
-        {
-          currentAvailableDeviceId: mediaDevices,
-        } as unknown as MediaDevicesHandler,
+        buildMediaDevicesHandler(),
       );
 
       conversation.roles({[senderUserId.id]: DefaultConversationRoleName.WIRE_ADMIN});
@@ -333,9 +334,7 @@ describe('CallingRepository', () => {
         CONV_TYPE.CONFERENCE_MLS,
         selfParticipant,
         CALL_TYPE.NORMAL,
-        {
-          currentAvailableDeviceId: mediaDevices,
-        } as unknown as MediaDevicesHandler,
+        buildMediaDevicesHandler(),
       );
 
       jest.spyOn(callingRepository, 'pushClients').mockResolvedValueOnce(true);
@@ -370,9 +369,7 @@ describe('CallingRepository', () => {
         CONV_TYPE.ONEONONE,
         selfParticipant,
         CALL_TYPE.NORMAL,
-        {
-          currentAvailableDeviceId: mediaDevices,
-        } as unknown as MediaDevicesHandler,
+        buildMediaDevicesHandler(),
       );
 
       jest.spyOn(callingRepository, 'pushClients').mockResolvedValueOnce(true);
@@ -394,9 +391,7 @@ describe('CallingRepository', () => {
         CONV_TYPE.CONFERENCE,
         selfParticipant,
         CALL_TYPE.NORMAL,
-        {
-          currentAvailableDeviceId: mediaDevices,
-        } as unknown as MediaDevicesHandler,
+        buildMediaDevicesHandler(),
       );
       incomingCall.state(CALL_STATE.INCOMING);
 
@@ -406,9 +401,7 @@ describe('CallingRepository', () => {
         CONV_TYPE.CONFERENCE,
         selfParticipant,
         CALL_TYPE.NORMAL,
-        {
-          currentAvailableDeviceId: mediaDevices,
-        } as unknown as MediaDevicesHandler,
+        buildMediaDevicesHandler(),
       );
       activeCall.state(CALL_STATE.MEDIA_ESTAB);
 
@@ -418,9 +411,7 @@ describe('CallingRepository', () => {
         CONV_TYPE.CONFERENCE,
         selfParticipant,
         CALL_TYPE.NORMAL,
-        {
-          currentAvailableDeviceId: mediaDevices,
-        } as unknown as MediaDevicesHandler,
+        buildMediaDevicesHandler(),
       );
       declinedCall.state(CALL_STATE.INCOMING);
       declinedCall.reason(REASON.STILL_ONGOING);
@@ -441,9 +432,7 @@ describe('CallingRepository', () => {
         CONV_TYPE.CONFERENCE,
         selfParticipant,
         CALL_TYPE.NORMAL,
-        {
-          currentAvailableDeviceId: mediaDevices,
-        } as unknown as MediaDevicesHandler,
+        buildMediaDevicesHandler(),
       );
       const source = new window.RTCAudioSource();
       const audioTrack = source.createTrack();
@@ -471,9 +460,7 @@ describe('CallingRepository', () => {
         CONV_TYPE.CONFERENCE,
         selfParticipant,
         CALL_TYPE.NORMAL,
-        {
-          currentAvailableDeviceId: mediaDevices,
-        } as unknown as MediaDevicesHandler,
+        buildMediaDevicesHandler(),
       );
       const source = new window.RTCAudioSource();
       const audioTrack = source.createTrack();
@@ -507,9 +494,7 @@ describe('CallingRepository', () => {
         0,
         selfParticipant,
         CALL_TYPE.NORMAL,
-        {
-          currentAvailableDeviceId: mediaDevices,
-        } as unknown as MediaDevicesHandler,
+        buildMediaDevicesHandler(),
       );
       spyOn(callingRepository['callState'], 'joinedCall').and.returnValue(call);
       callingRepository.stopMediaSource(MediaType.AUDIO);
@@ -526,12 +511,6 @@ describe('CallingRepository', () => {
 });
 
 describe('CallingRepository ISO', () => {
-  const mediaDevices = {
-    audioinput: ko.pureComputed(() => 'test'),
-    audiooutput: ko.pureComputed(() => 'test'),
-    screeninput: ko.pureComputed(() => 'test'),
-    videoinput: ko.pureComputed(() => 'test'),
-  };
   describe('incoming call', () => {
     let avsUser: number;
     let avsCall: Wcall;
@@ -555,9 +534,7 @@ describe('CallingRepository ISO', () => {
         } as any, // EventRepository
         {} as any, // UserRepository
         {} as any, // MediaStreamHandler
-        {
-          currentAvailableDeviceId: mediaDevices,
-        } as unknown as MediaDevicesHandler, // mediaDevicesHandler
+        buildMediaDevicesHandler(), // mediaDevicesHandler
         {
           toServerTimestamp: jest.fn().mockImplementation(() => Date.now()),
         } as any, // ServerTimeHandler

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -252,7 +252,7 @@ export class CallingRepository {
       }
     });
 
-    mediaDevicesHandler.setOnMediaDevicesRefreshHandler(() => {
+    this.mediaDevicesHandler.setOnMediaDevicesRefreshHandler(() => {
       const activeCall = this.callState.joinedCall();
 
       if (!activeCall) {

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -251,24 +251,6 @@ export class CallingRepository {
         this.requestVideoStreams(call.conversationId, call.activeSpeakers());
       }
     });
-
-    this.mediaDevicesHandler.setOnMediaDevicesRefreshHandler(() => {
-      const activeCall = this.callState.joinedCall();
-
-      if (!activeCall) {
-        return;
-      }
-
-      const selfParticipant = activeCall.getSelfParticipant();
-
-      if (!selfParticipant.isMuted()) {
-        void this.refreshAudioInput();
-      }
-
-      if (selfParticipant.isSendingVideo()) {
-        void this.refreshVideoInput();
-      }
-    });
   }
 
   get subconversationService() {
@@ -301,6 +283,25 @@ export class CallingRepository {
 
     this.wCall = this.configureCallingApi(callingInstance);
     this.wUser = this.createWUser(this.wCall, this.serializeQualifiedId(this.selfUser.qualifiedId), clientId);
+
+    this.mediaDevicesHandler.setOnMediaDevicesRefreshHandler(() => {
+      const activeCall = this.callState.joinedCall();
+
+      if (!activeCall) {
+        return;
+      }
+
+      const selfParticipant = activeCall.getSelfParticipant();
+
+      if (!selfParticipant.isMuted()) {
+        void this.refreshAudioInput();
+      }
+
+      if (selfParticipant.isSendingVideo()) {
+        void this.refreshVideoInput();
+      }
+    });
+
     return {wCall: this.wCall, wUser: this.wUser};
   }
 

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -252,7 +252,7 @@ export class CallingRepository {
       }
     });
 
-    this.mediaDevicesHandler.setOnMediaDevicesRefreshHandler(() => {
+    mediaDevicesHandler.setOnMediaDevicesRefreshHandler(() => {
       const activeCall = this.callState.joinedCall();
 
       if (!activeCall) {

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -284,26 +284,28 @@ export class CallingRepository {
     this.wCall = this.configureCallingApi(callingInstance);
     this.wUser = this.createWUser(this.wCall, this.serializeQualifiedId(this.selfUser.qualifiedId), clientId);
 
-    this.mediaDevicesHandler.setOnMediaDevicesRefreshHandler(() => {
-      const activeCall = this.callState.joinedCall();
-
-      if (!activeCall) {
-        return;
-      }
-
-      const selfParticipant = activeCall.getSelfParticipant();
-
-      if (!selfParticipant.isMuted()) {
-        void this.refreshAudioInput();
-      }
-
-      if (selfParticipant.isSendingVideo()) {
-        void this.refreshVideoInput();
-      }
-    });
+    this.mediaDevicesHandler.setOnMediaDevicesRefreshHandler(this.onMediaDevicesRefresh);
 
     return {wCall: this.wCall, wUser: this.wUser};
   }
+
+  private onMediaDevicesRefresh = () => {
+    const activeCall = this.callState.joinedCall();
+
+    if (!activeCall) {
+      return;
+    }
+
+    const selfParticipant = activeCall.getSelfParticipant();
+
+    if (!selfParticipant.isMuted()) {
+      void this.refreshAudioInput();
+    }
+
+    if (selfParticipant.isSendingVideo()) {
+      void this.refreshVideoInput();
+    }
+  };
 
   setReady(): void {
     this.isReady = true;

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -251,6 +251,25 @@ export class CallingRepository {
         this.requestVideoStreams(call.conversationId, call.activeSpeakers());
       }
     });
+
+    this.mediaDevicesHandler.setOnMediaDevicesRefreshHandler(() => {
+      const activeCall = this.callState.joinedCall();
+
+      if (!activeCall) {
+        return;
+      }
+
+      const isSelfUserMuted = activeCall.getSelfParticipant().isMuted();
+      const isSelfSendingVideo = activeCall.getSelfParticipant().isSendingVideo();
+
+      if (!isSelfUserMuted) {
+        void this.refreshAudioInput();
+      }
+
+      if (isSelfSendingVideo) {
+        void this.refreshVideoInput();
+      }
+    });
   }
 
   get subconversationService() {

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -259,14 +259,13 @@ export class CallingRepository {
         return;
       }
 
-      const isSelfUserMuted = activeCall.getSelfParticipant().isMuted();
-      const isSelfSendingVideo = activeCall.getSelfParticipant().isSendingVideo();
+      const selfParticipant = activeCall.getSelfParticipant();
 
-      if (!isSelfUserMuted) {
+      if (!selfParticipant.isMuted()) {
         void this.refreshAudioInput();
       }
 
-      if (isSelfSendingVideo) {
+      if (selfParticipant.isSendingVideo()) {
         void this.refreshVideoInput();
       }
     });

--- a/src/script/media/MediaDevicesHandler.ts
+++ b/src/script/media/MediaDevicesHandler.ts
@@ -78,6 +78,7 @@ export class MediaDevicesHandler {
   public currentAvailableDeviceId: CurrentAvailableDeviceId;
   public deviceSupport: DeviceSupport;
   private previousDeviceSupport: PreviousDeviceSupport;
+  private onMediaDevicesRefresh?: () => void;
 
   static get CONFIG() {
     return {
@@ -153,6 +154,10 @@ export class MediaDevicesHandler {
     };
 
     this.initializeMediaDevices();
+  }
+
+  public setOnMediaDevicesRefreshHandler(handler: () => void): void {
+    this.onMediaDevicesRefresh = handler;
   }
 
   /**
@@ -245,7 +250,7 @@ export class MediaDevicesHandler {
    * Update list of available MediaDevices.
    * @returns Resolves with all MediaDevices when the list has been updated
    */
-  refreshMediaDevices(): Promise<MediaDeviceInfo[]> {
+  public async refreshMediaDevices(): Promise<MediaDeviceInfo[]> {
     const setDevices = (type: MediaDeviceType, devices: MediaDeviceInfo[]): void => {
       this.availableDevices[type](devices);
       const currentId = this.currentDeviceId[type];
@@ -265,31 +270,32 @@ export class MediaDevicesHandler {
       }
     };
 
-    return navigator.mediaDevices
-      .enumerateDevices()
-      .catch(error => {
-        this.logger.error(`Failed to update MediaDevice list: ${error.message}`, error);
-        throw error;
-      })
-      .then(mediaDevices => {
-        this.removeAllDevices();
+    try {
+      this.removeAllDevices();
+      const mediaDevices = await navigator.mediaDevices.enumerateDevices();
 
-        if (mediaDevices) {
-          const filteredDevices = this.filterMediaDevices(mediaDevices);
-
-          setDevices(MediaDeviceType.AUDIO_INPUT, filteredDevices.microphones);
-          setDevices(MediaDeviceType.AUDIO_OUTPUT, filteredDevices.speakers);
-          setDevices(MediaDeviceType.VIDEO_INPUT, filteredDevices.cameras);
-          this.previousDeviceSupport = {
-            audioinput: filteredDevices.microphones.length,
-            audiooutput: filteredDevices.speakers.length,
-            videoinput: filteredDevices.cameras.length,
-          };
-          return mediaDevices;
-        }
-
+      if (!mediaDevices) {
         throw new Error('No media devices found');
-      });
+      }
+
+      const filteredDevices = this.filterMediaDevices(mediaDevices);
+
+      setDevices(MediaDeviceType.AUDIO_INPUT, filteredDevices.microphones);
+      setDevices(MediaDeviceType.AUDIO_OUTPUT, filteredDevices.speakers);
+      setDevices(MediaDeviceType.VIDEO_INPUT, filteredDevices.cameras);
+      this.previousDeviceSupport = {
+        audioinput: filteredDevices.microphones.length,
+        audiooutput: filteredDevices.speakers.length,
+        videoinput: filteredDevices.cameras.length,
+      };
+
+      this.onMediaDevicesRefresh?.();
+
+      return mediaDevices;
+    } catch (error) {
+      this.logger.error(`Failed to update MediaDevice list: ${error instanceof Error ? error.message : ''}`, error);
+      throw error;
+    }
   }
 
   /**

--- a/src/script/media/MediaDevicesHandler.ts
+++ b/src/script/media/MediaDevicesHandler.ts
@@ -278,15 +278,15 @@ export class MediaDevicesHandler {
         throw new Error('No media devices found');
       }
 
-      const filteredDevices = this.filterMediaDevices(mediaDevices);
+      const {microphones, speakers, cameras} = this.filterMediaDevices(mediaDevices);
 
-      setDevices(MediaDeviceType.AUDIO_INPUT, filteredDevices.microphones);
-      setDevices(MediaDeviceType.AUDIO_OUTPUT, filteredDevices.speakers);
-      setDevices(MediaDeviceType.VIDEO_INPUT, filteredDevices.cameras);
+      setDevices(MediaDeviceType.AUDIO_INPUT, microphones);
+      setDevices(MediaDeviceType.AUDIO_OUTPUT, speakers);
+      setDevices(MediaDeviceType.VIDEO_INPUT, cameras);
       this.previousDeviceSupport = {
-        audioinput: filteredDevices.microphones.length,
-        audiooutput: filteredDevices.speakers.length,
-        videoinput: filteredDevices.cameras.length,
+        audioinput: microphones.length,
+        audiooutput: speakers.length,
+        videoinput: cameras.length,
       };
 
       this.onMediaDevicesRefresh?.();

--- a/test/helper/TestFactory.js
+++ b/test/helper/TestFactory.js
@@ -299,12 +299,15 @@ export class TestFactory {
    */
   async exposeCallingActors() {
     await this.exposeConversationActors();
+
+    const mediaRepository = new MediaRepository(new PermissionRepository());
+
     this.calling_repository = new CallingRepository(
       this.message_repository,
       this.event_repository,
       this.user_repository,
-      new MediaRepository(new PermissionRepository()).streamHandler,
-      new MediaRepository(new PermissionRepository()).devicesHandler,
+      mediaRepository.streamHandler,
+      mediaRepository.devicesHandler,
       serverTimeHandler,
       undefined,
       this.conversation_repository['conversationState'],

--- a/test/helper/TestFactory.js
+++ b/test/helper/TestFactory.js
@@ -242,7 +242,6 @@ export class TestFactory {
     await this.exposeTeamActors();
     await this.exposeEventActors();
     await this.exposeSelfActors();
-    await this.exposeCallingActors();
 
     this.conversation_service = new ConversationService(this.event_service);
 

--- a/test/helper/TestFactory.js
+++ b/test/helper/TestFactory.js
@@ -242,6 +242,7 @@ export class TestFactory {
     await this.exposeTeamActors();
     await this.exposeEventActors();
     await this.exposeSelfActors();
+    await this.exposeCallingActors();
 
     this.conversation_service = new ConversationService(this.event_service);
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-713" title="WPB-713" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-713</a>  Cannot reconnect to audio if headphones lost contact during ongoing call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

Whenever audio/video device is changed by a user, we refresh audio/video inputs. We were never doing it when browser detected new media device, e.g we've unplugged you headset. This resulted in not having set any input/output device at all.

With this PR, whenever browser detects there's a new audio/video device connected (and we're in an unmuted call), we refresh the audio/input source, so in case some device was disconnected, another one would be requested.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;