### PR TITLE
feat: account settings button in 1:1 read receipts

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -423,7 +423,7 @@
   "conversationDetails1to1ReceiptsFirst": "If both sides turn on read receipts, you can see when messages are read.",
   "conversationDetails1to1ReceiptsHeadDisabled": "You have disabled read receipts",
   "conversationDetails1to1ReceiptsHeadEnabled": "You have enabled read receipts",
-  "conversationDetails1to1ReceiptsSecond": "You can change this option in your account settings.",
+  "conversationDetails1to1ReceiptsSecond": "You can change this option in your [button]account settings[/button].",
   "conversationDetailsActionAddParticipants": "Add participants",
   "conversationDetailsActionArchive": "Archive",
   "conversationDetailsActionBlock": "Block",

--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
@@ -21,8 +21,10 @@ import {forwardRef, useCallback, useEffect, useMemo, useState} from 'react';
 
 import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data/';
 import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
+import {amplify} from 'amplify';
 
 import {HideIcon} from '@wireapp/react-ui-kit';
+import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {FadingScrollbar} from 'Components/FadingScrollbar';
 import {Icon} from 'Components/Icon';
@@ -35,6 +37,7 @@ import {ServiceList} from 'Components/ServiceList/ServiceList';
 import {UserList} from 'Components/UserList';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
+import {replaceReactComponents} from 'Util/LocalizerUtil/ReactLocalizerUtil';
 import {sortUsersByPriority} from 'Util/StringUtil';
 import {formatDuration} from 'Util/TimeUtil';
 
@@ -448,7 +451,26 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
                         : t('conversationDetails1to1ReceiptsHeadDisabled')}
                     </p>
                     <p className="panel__action-item__status">{t('conversationDetails1to1ReceiptsFirst')}</p>
-                    <p className="panel__action-item__status">{t('conversationDetails1to1ReceiptsSecond')}</p>
+                    <p className="panel__action-item__status">
+                      {replaceReactComponents(t('conversationDetails1to1ReceiptsSecond'), [
+                        {
+                          start: '[button]',
+                          end: '[/button]',
+                          render: text => (
+                            <button
+                              className="button-reset-default"
+                              css={{
+                                textDecoration: 'underline',
+                              }}
+                              key={text}
+                              onClick={() => amplify.publish(WebAppEvents.PREFERENCES.MANAGE_ACCOUNT)}
+                            >
+                              {text}
+                            </button>
+                          ),
+                        },
+                      ])}
+                    </p>
                   </span>
                 </div>
               )}


### PR DESCRIPTION
## Description

Adds a link (button) to account's settings in preferences tab to 1:1 conversation's read receipts text.

## Screenshots/Screencast (for UI changes)

Before
<img width="300" alt="Screenshot 2024-03-28 at 17 31 20" src="https://github.com/wireapp/wire-webapp/assets/45733298/daf9b2e3-6673-4a8b-b2a9-fcfcae537fdc">


After
![after](https://github.com/wireapp/wire-webapp/assets/45733298/f1e9e280-ab35-4fe4-8a5e-e37c32508ca0)



## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
