### PR TITLE
fix: fullscreen image reply [WPB-5542]

### DIFF
--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -446,12 +446,14 @@ export const InputBar = ({
     amplify.subscribe(WebAppEvents.CONVERSATION.MESSAGE.REPLY, replyMessage);
     amplify.subscribe(WebAppEvents.EXTENSIONS.GIPHY.SEND, sendGiphy);
     amplify.subscribe(WebAppEvents.SHORTCUT.PING, onPingClick);
+    conversation.isTextInputReady(true);
 
     return () => {
       amplify.unsubscribeAll(WebAppEvents.SHORTCUT.PING);
       amplify.unsubscribeAll(WebAppEvents.CONVERSATION.IMAGE.SEND);
       amplify.unsubscribeAll(WebAppEvents.CONVERSATION.MESSAGE.REPLY);
       amplify.unsubscribeAll(WebAppEvents.EXTENSIONS.GIPHY.SEND);
+      conversation.isTextInputReady(false);
     };
   }, []);
 

--- a/src/script/components/Modals/DetailViewModal/index.tsx
+++ b/src/script/components/Modals/DetailViewModal/index.tsx
@@ -29,6 +29,7 @@ import {handleKeyDown, KEY} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
 import {renderElement} from 'Util/renderElement';
 import {preventFocusOutside} from 'Util/util';
+import {waitFor} from 'Util/waitFor';
 
 import {DetailViewModalFooter} from './DetailViewModalFooter';
 import {DetailViewModalHeader} from './DetailViewModalHeader';
@@ -86,9 +87,15 @@ const DetailViewModal: FC<DetailViewModalProps> = ({
     handleKeyDown(event, onCloseClick);
   };
 
-  const onReplyClick = (conversation: Conversation, message: ContentMessage) => {
+  const onReplyClick = async (conversation: Conversation, message: ContentMessage) => {
     amplify.publish(WebAppEvents.CONVERSATION.SHOW, conversation, {});
-    amplify.publish(WebAppEvents.CONVERSATION.MESSAGE.REPLY, message);
+
+    // The event above will make react to render the conversation view,
+    // so we need to wait for the text input to be ready before inserting the reply.
+    const isTextInputReady = await waitFor(() => conversation.isTextInputReady());
+    if (isTextInputReady) {
+      amplify.publish(WebAppEvents.CONVERSATION.MESSAGE.REPLY, message);
+    }
 
     onCloseClick();
   };

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -129,6 +129,7 @@ export class Conversation {
   public readonly is_cleared: ko.PureComputed<boolean>;
   /** Indicates if the conversation is currently loading messages into its state. */
   public readonly isLoadingMessages: ko.Observable<boolean>;
+  public readonly isTextInputReady: ko.PureComputed<boolean>;
   public readonly is_verified: ko.PureComputed<boolean | undefined>;
   public readonly is1to1: ko.PureComputed<boolean>;
   public readonly isActiveParticipant: ko.PureComputed<boolean>;
@@ -205,6 +206,7 @@ export class Conversation {
     this.type = ko.observable();
 
     this.isLoadingMessages = ko.observable(false);
+    this.isTextInputReady = ko.observable(false);
 
     this.participating_user_ets = ko.observableArray([]); // Does not include self user
     this.participating_user_ids = ko.observableArray([]); // Does not include self user

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -129,7 +129,7 @@ export class Conversation {
   public readonly is_cleared: ko.PureComputed<boolean>;
   /** Indicates if the conversation is currently loading messages into its state. */
   public readonly isLoadingMessages: ko.Observable<boolean>;
-  public readonly isTextInputReady: ko.PureComputed<boolean>;
+  public readonly isTextInputReady: ko.Observable<boolean>;
   public readonly is_verified: ko.PureComputed<boolean | undefined>;
   public readonly is1to1: ko.PureComputed<boolean>;
   public readonly isActiveParticipant: ko.PureComputed<boolean>;

--- a/src/script/page/AppMain.tsx
+++ b/src/script/page/AppMain.tsx
@@ -163,7 +163,7 @@ export const AppMain: FC<AppMainProps> = ({
     configureRoutes({
       '/': showMostRecentConversation,
       '/conversation/:conversationId(/:domain)': (conversationId: string, domain: string = apiContext.domain ?? '') =>
-        mainView.content.showConversation(conversationId, {}, domain),
+        mainView.content.showConversation({id: conversationId, domain}, {}),
       '/preferences/about': () => mainView.list.openPreferencesAbout(),
       '/preferences/account': () => mainView.list.openPreferencesAccount(),
       '/preferences/av': () => mainView.list.openPreferencesAudioVideo(),

--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -18,6 +18,7 @@
  */
 
 import {ConnectionStatus} from '@wireapp/api-client/lib/connection/';
+import {QualifiedId} from '@wireapp/api-client/lib/user/';
 import {amplify} from 'amplify';
 import ko from 'knockout';
 import {container} from 'tsyringe';
@@ -56,7 +57,7 @@ interface ShowConversationOptions {
 
 interface ShowConversationOverload {
   (conversation: Conversation | undefined, options: ShowConversationOptions): Promise<void>;
-  (conversationId: string, options: ShowConversationOptions, domain: string | null): Promise<void>;
+  (conversationId: QualifiedId, options: ShowConversationOptions): Promise<void>;
 }
 
 export class ContentViewModel {
@@ -138,13 +139,10 @@ export class ContentViewModel {
     this.conversationState.activeConversation(conversationEntity);
   }
 
-  private readonly getConversationEntity = async (
-    conversation: Conversation | string,
-    domain: string | null = null,
-  ): Promise<Conversation> => {
+  private readonly getConversationEntity = async (conversation: Conversation | QualifiedId): Promise<Conversation> => {
     const conversationEntity = isConversationEntity(conversation)
       ? conversation
-      : await this.conversationRepository.getConversationById({domain: domain || '', id: conversation});
+      : await this.conversationRepository.getConversationById(conversation);
 
     if (!conversationEntity.is1to1()) {
       return conversationEntity;
@@ -250,9 +248,8 @@ export class ContentViewModel {
    * @param domain Domain name
    */
   readonly showConversation: ShowConversationOverload = async (
-    conversation: Conversation | string | undefined,
+    conversation: Conversation | QualifiedId | undefined,
     options: ShowConversationOptions,
-    domain: string | null = null,
   ) => {
     const {
       exposeMessage: exposeMessageEntity,
@@ -265,7 +262,7 @@ export class ContentViewModel {
     }
 
     try {
-      const conversationEntity = await this.getConversationEntity(conversation, domain);
+      const conversationEntity = await this.getConversationEntity(conversation);
       const isConnectionBlocked = conversationEntity?.connection()?.isBlocked();
 
       if (!conversationEntity) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5542" title="WPB-5542" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5542</a>  [Web] Replies to an image from the search page do not work
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

After clicking on a reply on a asset (image) message in a full screen view, we were sending two events: 
- open a conversation
- reply to a message

Before the first event caused the conversation to be rendered (react) the other event was sent, so the input bar didn't have time to start listening to message reply event.

The fix is to add a boolean value to conversation's entity indicating whether conversation's input is ready to use, and wait for that state to be truthy before sending a message reply event.

## Screenshots/Screencast (for UI changes)

Before
![beforee](https://github.com/wireapp/wire-webapp/assets/45733298/4804ff2b-b365-40cb-b9da-7bfab15c4e00)


After
![before](https://github.com/wireapp/wire-webapp/assets/45733298/a1c71b97-6e36-45ea-8896-0894fa8e4aaa)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
