### PR TITLE
runfix: adjust responsive design to new sidebar (WPB-7212)

### DIFF
--- a/src/script/components/TitleBar/TitleBar.tsx
+++ b/src/script/components/TitleBar/TitleBar.tsx
@@ -141,8 +141,8 @@ export const TitleBar: React.FC<TitleBarProps> = ({
   const peopleTooltip = t('tooltipConversationPeople', shortcut);
 
   // To be changed when design chooses a breakpoint, the conditional can be integrated to the ui-kit directly
-  const mdBreakpoint = useMatchMedia('max-width: 768px');
-  const smBreakpoint = useMatchMedia('max-width: 640px');
+  const mdBreakpoint = useMatchMedia('max-width: 1000px');
+  const smBreakpoint = useMatchMedia('max-width: 720px');
 
   const {close: closeRightSidebar} = useAppMainState(state => state.rightSidebar);
 

--- a/src/script/page/AppMain.tsx
+++ b/src/script/page/AppMain.tsx
@@ -121,7 +121,7 @@ export const AppMain: FC<AppMainProps> = ({
   };
 
   // To be changed when design chooses a breakpoint, the conditional can be integrated to the ui-kit directly
-  const smBreakpoint = useMatchMedia('max-width: 640px');
+  const smBreakpoint = useMatchMedia('max-width: 720px');
 
   const {currentView} = useAppMainState(state => state.responsiveView);
   const isLeftSidebarVisible = currentView == ViewType.LEFT_SIDEBAR;

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -22,7 +22,7 @@ import React, {useEffect, useState} from 'react';
 import {amplify} from 'amplify';
 import {container} from 'tsyringe';
 
-import {ChevronIcon} from '@wireapp/react-ui-kit';
+import {ChevronIcon, useMatchMedia} from '@wireapp/react-ui-kit';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {CallingCell} from 'Components/calling/CallingCell';
@@ -164,6 +164,8 @@ const Conversations: React.FC<ConversationsProps> = ({
 
   const hasNoConversations = conversations.length + connectRequests.length === 0;
 
+  const mdBreakpoint = useMatchMedia('(max-width: 1000px)');
+
   useEffect(() => {
     if (activeConversation && !conversationState.isVisible(activeConversation)) {
       // If the active conversation is not visible, switch to the recent view
@@ -240,7 +242,7 @@ const Conversations: React.FC<ConversationsProps> = ({
 
   const sidebar = (
     <div className="conversations-sidebar-wrapper">
-      <nav className="conversations-sidebar" data-is-collapsed={isSidebarCollapsed}>
+      <nav className="conversations-sidebar" data-is-collapsed={isSidebarCollapsed || mdBreakpoint}>
         <div className="conversations-sidebar-items">
           <div className="conversations-sidebar-items-children">
             <UserDetails
@@ -261,17 +263,19 @@ const Conversations: React.FC<ConversationsProps> = ({
               onClickPreferences={() => onClickPreferences(ContentState.PREFERENCES_ACCOUNT)}
             />
           </div>
-          <button
-            type="button"
-            role="tab"
-            className="conversations-sidebar-handle"
-            data-is-collapsed={isSidebarCollapsed}
-            onClick={() => setIsSidebarCollapsed(previous => !previous)}
-          >
-            <div className="conversations-sidebar-handle-icon" data-is-collapsed={isSidebarCollapsed}>
-              <ChevronIcon width={12} height={12} />
-            </div>
-          </button>
+          {!mdBreakpoint && (
+            <button
+              type="button"
+              role="tab"
+              className="conversations-sidebar-handle"
+              data-is-collapsed={isSidebarCollapsed || mdBreakpoint}
+              onClick={() => setIsSidebarCollapsed(previous => !previous)}
+            >
+              <div className="conversations-sidebar-handle-icon" data-is-collapsed={isSidebarCollapsed}>
+                <ChevronIcon width={12} height={12} />
+              </div>
+            </button>
+          )}
         </div>
       </nav>
     </div>

--- a/src/style/foundation/framework.less
+++ b/src/style/foundation/framework.less
@@ -111,8 +111,10 @@
     top: 64px;
   }
 
-  @media (max-width: calc(@screen-sm-min*2)) {
-    .left-column {
+  @media (max-width: 720px) {
+    .left-column,
+    .conversations,
+    .conversations-wrapper {
       width: 100%;
     }
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7212" title="WPB-7212" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-7212</a>  Adjust resizability of Webapp including the new sidebar
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description
new breakpoints for responsiveness of the app have been defined for the new design:
see https://www.figma.com/file/jnygr7PEOk1yHgjBF18udc/Desktop?type=design&node-id=1669-8189&mode=design&t=Wsd41BtWN7pgHruF-0

In this iteration, the sidebar is always collapsed with a width under 1000px

## Screenshots/Screencast (for UI changes)
Before:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/5fce0bf9-fe73-4552-852f-1002f29fdbf4)

After:
![Kooha-2024-04-02-17-58-21](https://github.com/wireapp/wire-webapp/assets/78490891/a03e82e8-f815-4a32-8ce1-58b088a29c50)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
