### PR TITLE
feat: Navigation folders empty state support

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -475,6 +475,7 @@
   "conversationFederationIndicator": "Federated",
   "conversationFileAssetRestricted": "Receiving files is prohibited",
   "conversationFooterArchive": "Archive",
+  "conversationFoldersEmptyText": "Add your conversations to folders to stay organized. [link]Learn more[/link]",
   "conversationFooterContacts": "Contacts",
   "conversationGuestIndicator": "Guest",
   "conversationImageAssetRestricted": "Receiving images is prohibited",

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.tsx
@@ -19,10 +19,12 @@
 
 import cx from 'classnames';
 
+import {Config} from 'src/script/Config';
 import {createLabel} from 'src/script/conversation/ConversationLabelRepository';
 import {ConversationRepository} from 'src/script/conversation/ConversationRepository';
 import {Conversation} from 'src/script/entity/Conversation';
 import {useFolderState} from 'src/script/page/LeftSidebar/panels/Conversations/state';
+import {replaceLink, t} from 'Util/LocalizerUtil';
 
 import {SidebarTabs} from '../Conversations';
 
@@ -77,6 +79,8 @@ export const ConversationFolderTab = ({
     return total;
   }
 
+  const learnMoreReplacement = replaceLink(Config.getConfig().URL.SUPPORT.INDEX);
+
   return (
     <div className={cx('conversations-sidebar-folders-wrapper', {active: isFoldersTabOpen})}>
       <button
@@ -98,6 +102,14 @@ export const ConversationFolderTab = ({
       </button>
       <div className={cx('conversations-sidebar-folders', {active: isFoldersTabOpen})}>
         <div className="conversations-sidebar-folders--inner-wrapper">
+          {folders.length === 0 && (
+            <div
+              className="conversations-sidebar-folders--empty"
+              dangerouslySetInnerHTML={{
+                __html: t('conversationFoldersEmptyText', {}, learnMoreReplacement),
+              }}
+            />
+          )}
           {folders.map(folder => {
             const unreadCount = getTotalUnreadConversationMessages(folder.conversations());
             const isActive = folder.id === expandedFolder;

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.tsx
@@ -96,9 +96,6 @@ export const ConversationFolderTab = ({
           {Icon}
           <span className="conversations-sidebar-btn--text">{label || title}</span>
         </span>
-        {unreadConversations.length > 0 && (
-          <span className="conversations-sidebar-btn--badge">{unreadConversations.length}</span>
-        )}
       </button>
       <div className={cx('conversations-sidebar-folders', {active: isFoldersTabOpen})}>
         <div className="conversations-sidebar-folders--inner-wrapper">

--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -81,7 +81,7 @@
 
   .conversations-sidebar-items {
     position: fixed;
-    z-index: 999999;
+    z-index: 1000;
     display: flex;
     overflow: auto;
     width: 220px;

--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -172,6 +172,11 @@
 .conversations-sidebar-folders {
   padding: 0.5rem 0;
 
+  &--empty {
+    font-size: 14px;
+    font-weight: 400;
+  }
+
   &--inner-wrapper {
     display: flex;
     overflow: hidden;


### PR DESCRIPTION
## Description
This PR adds a default empty state UI for when user has not created any folders yet

## Screenshots/Screencast (for UI changes)

![image](https://github.com/wireapp/wire-webapp/assets/63250054/7fb91cba-c77a-48f4-a190-89f336bd3d2f)