### PR TITLE
runfix: team feature config updates

### DIFF
--- a/src/script/team/TeamRepository.test.ts
+++ b/src/script/team/TeamRepository.test.ts
@@ -111,6 +111,12 @@ describe('TeamRepository', () => {
 
       jest.spyOn(teamService, 'getAllTeamFeatures').mockResolvedValue(featuresFromBackend);
 
+      teamRepo.on('featureConfigUpdated', update => {
+        expect(update.prevFeatureList).toEqual(localFeatures);
+        expect(update.newFeatureList).toEqual(featuresFromBackend);
+        expect(teamState.teamFeatures()).toEqual(featuresFromBackend);
+      });
+
       await teamRepo.initTeam();
 
       expect(teamState.teamFeatures()).toEqual(featuresFromBackend);

--- a/src/script/team/TeamRepository.test.ts
+++ b/src/script/team/TeamRepository.test.ts
@@ -86,6 +86,41 @@ describe('TeamRepository', () => {
     });
   });
 
+  describe('initTeam', () => {
+    it('updates team feature config from backend', async () => {
+      const [teamRepo, {teamService, teamState}] = buildConnectionRepository();
+      jest.spyOn(teamService, 'getTeamById').mockResolvedValue(team_metadata);
+      jest.spyOn(teamRepo, 'getSelfMember').mockResolvedValue(new TeamMemberEntity(randomUUID()));
+      jest.spyOn(teamRepo, 'emit');
+
+      const localFeatures = {
+        mls: {
+          config: {supportedProtocols: [ConversationProtocol.PROTEUS]},
+          status: FeatureStatus.ENABLED,
+        },
+      } as FeatureList;
+
+      teamState.teamFeatures(localFeatures);
+
+      const featuresFromBackend = {
+        mls: {
+          config: {supportedProtocols: [ConversationProtocol.PROTEUS, ConversationProtocol.MLS]},
+          status: FeatureStatus.ENABLED,
+        },
+      } as FeatureList;
+
+      jest.spyOn(teamService, 'getAllTeamFeatures').mockResolvedValue(featuresFromBackend);
+
+      await teamRepo.initTeam();
+
+      expect(teamState.teamFeatures()).toEqual(featuresFromBackend);
+      expect(teamRepo.emit).toHaveBeenCalledWith('featureConfigUpdated', {
+        prevFeatureList: localFeatures,
+        newFeatureList: featuresFromBackend,
+      });
+    });
+  });
+
   describe('sendAccountInfo', () => {
     it('does not crash when there is no team logo', async () => {
       const [teamRepo] = buildConnectionRepository();

--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -149,9 +149,9 @@ export class TeamRepository extends TypedEventEmitter<Events> {
     const prevFeatureList = this.teamState.teamFeatures();
     const newFeatureList = await this.teamService.getAllTeamFeatures();
 
-    this.emit('featureConfigUpdated', {prevFeatureList, newFeatureList});
-
     this.teamState.teamFeatures(newFeatureList);
+
+    this.emit('featureConfigUpdated', {prevFeatureList, newFeatureList});
 
     return {
       newFeatureList,


### PR DESCRIPTION
## Description

We should update the local state with new team feature config before dispatching the feature config updated event in case there are some event listeners that do some calculations based on a recent feature config state (e.g. currently recalculating self supported protocols after team supported protocols were updated).

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;