### PR TITLE
runfix: show preferences titlebar back button (WPB-7212)

### DIFF
--- a/src/script/page/MainContent/panels/preferences/components/PreferencesPage.tsx
+++ b/src/script/page/MainContent/panels/preferences/components/PreferencesPage.tsx
@@ -32,7 +32,7 @@ interface PreferencesPageProps {
 
 const PreferencesPage: FC<PreferencesPageProps> = ({title, children}) => {
   // To be changed when design chooses a breakpoint, the conditional can be integrated to the ui-kit directly
-  const smBreakpoint = useMatchMedia('max-width: 640px');
+  const smBreakpoint = useMatchMedia('max-width: 720px');
 
   const {currentView, setCurrentView} = useAppMainState(state => state.responsiveView);
   const isCentralColumn = currentView == ViewType.CENTRAL_COLUMN;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7212" title="WPB-7212" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-7212</a>  Adjust resizability of Webapp including the new sidebar
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

The breakpoint change for the new navigation was not applied to the preferences titlebar

## Screenshots/Screencast (for UI changes)
Before:
![Kooha-2024-04-03-12-18-33](https://github.com/wireapp/wire-webapp/assets/78490891/cae84ca3-8853-4e6c-b81f-bd6018ab606a)

After:
![Kooha-2024-04-03-12-16-41](https://github.com/wireapp/wire-webapp/assets/78490891/3e81a896-5a8e-450d-b68a-6cba76be5e7b)
