### PR TITLE
refactor: init 1to1 conversations

### DIFF
--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -377,7 +377,7 @@ describe('ConversationRepository', () => {
 
       jest.spyOn(conversationRepository['userState'], 'self').mockReturnValue(selfUser);
 
-      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(userEntity);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(userEntity.qualifiedId);
 
       expect(conversationEntity).toBe(newConversationEntity);
     });
@@ -403,6 +403,8 @@ describe('ConversationRepository', () => {
       }) as BackendConversation;
 
       const connection = new ConnectionEntity();
+      connection.userId = otherUserId;
+      connection.status(ConnectionStatus.ACCEPTED);
       connection.conversationId = proteus1to1ConversationResponse.qualified_id;
       otherUser.connection(connection);
 
@@ -413,7 +415,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'getConversationById')
         .mockResolvedValueOnce(proteus1to1ConversationResponse);
 
-      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser.qualifiedId);
 
       expect(conversationEntity?.serialize()).toEqual(proteus1to1Conversation.serialize());
       expect(conversationEntity?.readOnlyState()).toEqual(null);
@@ -443,6 +445,8 @@ describe('ConversationRepository', () => {
       }) as BackendConversation;
 
       const connection = new ConnectionEntity();
+      connection.status(ConnectionStatus.ACCEPTED);
+      connection.userId = otherUserId;
       connection.conversationId = proteus1to1ConversationResponse.qualified_id;
       otherUser.connection(connection);
 
@@ -451,7 +455,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'getConversationById')
         .mockResolvedValueOnce(proteus1to1ConversationResponse);
 
-      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser.qualifiedId);
 
       expect(conversationEntity?.readOnlyState()).toEqual(
         CONVERSATION_READONLY_STATE.READONLY_ONE_TO_ONE_SELF_UNSUPPORTED_MLS,
@@ -492,7 +496,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
         .mockResolvedValueOnce(true);
 
-      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser.qualifiedId);
 
       expect(conversationEntity?.serialize()).toEqual(mls1to1Conversation.serialize());
     });
@@ -577,7 +581,7 @@ describe('ConversationRepository', () => {
       jest.spyOn(conversationRepository['conversationService'], 'blacklistConversation');
       jest.spyOn(conversationRepository['eventRepository'], 'injectEvent').mockResolvedValueOnce(undefined);
 
-      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser.qualifiedId);
 
       expect(conversationRepository['eventService'].moveEventsToConversation).toHaveBeenCalledWith(
         proteus1to1Conversation.id,
@@ -661,7 +665,7 @@ describe('ConversationRepository', () => {
 
       const [mls1to1Conversation] = conversationRepository.mapConversations([establishedMls1to1ConversationResponse]);
 
-      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser.qualifiedId);
 
       expect(container.resolve(Core).service!.conversation.establishMLS1to1Conversation).toHaveBeenCalledWith(
         mockedGroupId,
@@ -741,7 +745,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
         .mockResolvedValueOnce(false);
 
-      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser.qualifiedId);
 
       expect(conversationEntity?.serialize()).toEqual(mls1to1Conversation.serialize());
       expect(container.resolve(Core).service!.conversation.establishMLS1to1Conversation).toHaveBeenCalled();
@@ -782,7 +786,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
         .mockResolvedValueOnce(true);
 
-      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser.qualifiedId);
 
       expect(conversationEntity?.serialize()).toEqual(mls1to1Conversation.serialize());
     });
@@ -822,7 +826,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
         .mockResolvedValueOnce(false);
 
-      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser.qualifiedId);
 
       expect(conversationEntity?.serialize()).toEqual(mls1to1Conversation.serialize());
       expect(conversationEntity?.readOnlyState()).toEqual(
@@ -865,7 +869,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
         .mockResolvedValueOnce(true);
 
-      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser);
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser.qualifiedId);
 
       expect(conversationEntity?.serialize()).toEqual(mls1to1Conversation.serialize());
       expect(conversationEntity?.readOnlyState()).toEqual(null);
@@ -943,7 +947,7 @@ describe('ConversationRepository', () => {
       });
 
       await waitFor(() => {
-        expect(conversationRepository.getInitialised1To1Conversation).toHaveBeenCalledWith(otherUser, true);
+        expect(conversationRepository.getInitialised1To1Conversation).toHaveBeenCalledWith(otherUser.qualifiedId, true);
       });
     });
 
@@ -990,6 +994,7 @@ describe('ConversationRepository', () => {
       const connection = new ConnectionEntity();
       connection.status(ConnectionStatus.SENT);
       connection.conversationId = conversation.qualifiedId;
+      connection.userId = otherUserId;
       otherUser.connection(connection);
 
       jest.spyOn(conversationRepository['conversationService'], 'removeConversationFromBlacklist');
@@ -1186,6 +1191,12 @@ describe('ConversationRepository', () => {
     it('should map a connection to an existing conversation', () => {
       conversation_et.type(CONVERSATION_TYPE.ONE_TO_ONE);
 
+      const conversationRepository = testFactory.conversation_repository!;
+      const user = new User('id', 'domain');
+      user.connection(connectionEntity);
+      connectionEntity.userId = user.qualifiedId;
+      conversationRepository['userState'].users.push(user);
+
       return testFactory.conversation_repository['mapConnection'](connectionEntity).then(
         (_conversation: Conversation) => {
           expect(testFactory.conversation_repository['fetchConversationById']).not.toHaveBeenCalled();
@@ -1196,31 +1207,40 @@ describe('ConversationRepository', () => {
     });
 
     it('should map a connection to a new conversation', () => {
-      connectionEntity.status(ConnectionStatus.ACCEPTED);
-      testFactory.conversation_repository['conversationState'].conversations.removeAll();
+      const conversationRepository = testFactory.conversation_repository!;
+      const user = new User('id1', 'domain1');
+      user.connection(connectionEntity);
+      connectionEntity.userId = user.qualifiedId;
+      conversationRepository['userState'].users.push(user);
 
-      return testFactory.conversation_repository['mapConnection'](connectionEntity).then(_conversation => {
-        expect(testFactory.conversation_repository['fetchConversationById']).toHaveBeenCalled();
+      connectionEntity.status(ConnectionStatus.ACCEPTED);
+      conversationRepository['conversationState'].conversations.removeAll();
+
+      return conversationRepository['mapConnection'](connectionEntity).then(_conversation => {
+        expect(conversationRepository['fetchConversationById']).toHaveBeenCalled();
         expect(testFactory.conversation_service.getConversationById).toHaveBeenCalled();
         expect(_conversation.connection()).toBe(connectionEntity);
       });
     });
 
     it('should map a cancelled connection to an existing conversation and filter it', () => {
+      const conversationRepository = testFactory.conversation_repository!;
+      const user = new User('id', 'domain');
+      user.connection(connectionEntity);
+      connectionEntity.userId = user.qualifiedId;
+      conversationRepository['userState'].users.push(user);
+
       conversation_et.type(CONVERSATION_TYPE.ONE_TO_ONE);
       connectionEntity.status(ConnectionStatus.CANCELLED);
 
-      return testFactory.conversation_repository['mapConnection'](connectionEntity).then(_conversation => {
+      return conversationRepository['mapConnection'](connectionEntity).then(_conversation => {
         expect(_conversation.connection()).toBe(connectionEntity);
         expect(
-          _findConversation(_conversation, testFactory.conversation_repository['conversationState'].conversations),
+          _findConversation(_conversation, conversationRepository['conversationState'].conversations),
         ).not.toBeUndefined();
 
         expect(
-          _findConversation(
-            _conversation,
-            testFactory.conversation_repository['conversationState'].filteredConversations,
-          ),
+          _findConversation(_conversation, conversationRepository['conversationState'].filteredConversations),
         ).toBeUndefined();
       });
     });
@@ -1273,8 +1293,9 @@ describe('ConversationRepository', () => {
           protocol: ConversationProtocol.MLS,
         });
 
-        const otherUserId = {id: 'f718410c-3833-479d-bd80-a5df03f38414', domain: 'test-domain'};
+        const otherUserId = {id: 'f718410c-3833-479d-bd80-a5df01138411', domain: 'test-domain'};
         const otherUser = new User(otherUserId.id, otherUserId.domain);
+        otherUser.supportedProtocols([ConversationProtocol.PROTEUS, ConversationProtocol.MLS]);
 
         conversationRepository['userState'].users.push(otherUser);
         conversation.participating_user_ids.push(otherUserId);

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -947,7 +947,9 @@ describe('ConversationRepository', () => {
       });
 
       await waitFor(() => {
-        expect(conversationRepository.getInitialised1To1Conversation).toHaveBeenCalledWith(otherUser.qualifiedId, true);
+        expect(conversationRepository.getInitialised1To1Conversation).toHaveBeenCalledWith(otherUser.qualifiedId, {
+          isLiveUpdate: true,
+        });
       });
     });
 

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1278,12 +1278,15 @@ export class ConversationRepository {
    * If there's no common protocol, it will pick the protocol that is supported by the current user and mark conversation as read-only.
    * @param userEntity User entity for whom to get the conversation
    * @param isLiveUpdate Whether the conversation is being initialised because of a live update (e.g. some websocket event)
+   * @param shouldRefreshUser Whether the user should be refetched from backend before getting the conversation
    * @returns Resolves with the initialised 1:1 conversation with requested user
    */
   public async getInitialised1To1Conversation(
     userId: QualifiedId,
-    isLiveUpdate = false,
-    shouldRefreshUser = false,
+    {isLiveUpdate = false, shouldRefreshUser = false}: {isLiveUpdate?: boolean; shouldRefreshUser?: boolean} = {
+      isLiveUpdate: false,
+      shouldRefreshUser: false,
+    },
   ): Promise<Conversation | null> {
     const user = await this.userRepository.getUserById(userId);
 
@@ -1962,7 +1965,7 @@ export class ConversationRepository {
     );
 
     try {
-      return await this.getInitialised1To1Conversation(otherUserId, false, shouldRefreshUser);
+      return await this.getInitialised1To1Conversation(otherUserId, {shouldRefreshUser});
     } catch {}
 
     return conversation;
@@ -2052,7 +2055,9 @@ export class ConversationRepository {
   ): Promise<Conversation | undefined> => {
     try {
       const userId = connectionEntity.userId;
-      const conversation = await this.getInitialised1To1Conversation(userId, source === EventSource.WEBSOCKET);
+      const conversation = await this.getInitialised1To1Conversation(userId, {
+        isLiveUpdate: source === EventSource.WEBSOCKET,
+      });
 
       if (!conversation) {
         return undefined;
@@ -2108,7 +2113,7 @@ export class ConversationRepository {
       return;
     }
 
-    await this.getInitialised1To1Conversation(user.qualifiedId, true);
+    await this.getInitialised1To1Conversation(user.qualifiedId, {isLiveUpdate: true});
   };
 
   /**
@@ -3960,7 +3965,7 @@ export class ConversationRepository {
       return;
     }
 
-    await this.getInitialised1To1Conversation(otherUserId, true);
+    await this.getInitialised1To1Conversation(otherUserId, {isLiveUpdate: true});
   }
 
   /**

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1289,11 +1289,15 @@ export class ConversationRepository {
 
     const connection = user.connection();
     if (connection) {
+      this.logger.log(`There's a connection with user ${userId.id}, getting a 1:1 conversation for the connection`);
       return this.get1to1ConversationForConnection(connection, isLiveUpdate);
     }
 
     const {protocol, isMLSSupportedByTheOtherUser, isProteusSupportedByTheOtherUser} =
       await this.getProtocolFor1to1Conversation(userId, shouldRefreshUser);
+    this.logger.log(
+      `Protocol for 1:1 conversation with user ${userId.id} is ${protocol}, isMLSSupportedByTheOtherUser: ${isMLSSupportedByTheOtherUser}, isProteusSupportedByTheOtherUser: ${isProteusSupportedByTheOtherUser}`,
+    );
 
     const localMLSConversation = this.conversationState.findMLS1to1Conversation(userId);
 
@@ -1979,6 +1983,9 @@ export class ConversationRepository {
 
     // For connection request, we simply display proteus conversation of type 3 (connect) it will be displayed as a connection request
     if (connection.isOutgoingRequest()) {
+      this.logger.log(
+        `Connection request with user ${otherUserId.id}, using proteus conversation ${proteusConversationId.id}`,
+      );
       const proteusConversation = localProteusConversation || (await this.fetchConversationById(proteusConversationId));
       proteusConversation.type(CONVERSATION_TYPE.CONNECT);
       return proteusConversation;
@@ -1995,6 +2002,9 @@ export class ConversationRepository {
     const isConnectionAccepted = connection.isConnected();
     // If it's accepted, initialise conversation so it's ready to be used
     if (isConnectionAccepted) {
+      this.logger.log(
+        `Connection with user ${otherUserId.id} is accepted, using protocol ${protocol} for 1:1 conversation`,
+      );
       if (protocol === ConversationProtocol.MLS || localMLSConversation) {
         return this.initMLS1to1Conversation(
           otherUserId,
@@ -2012,9 +2022,17 @@ export class ConversationRepository {
     // If we already know mls 1:1 conversation, we use it, even if proteus protocol was now choosen as common,
     // we do not support switching back to proteus after mls conversation was established,
     // only proteus -> mls migration is supported, never the other way around.
+
     if (localMLSConversation) {
+      this.logger.log(
+        `Connection with user ${otherUserId.id} is not accepted, using already known MLS 1:1 conversation ${localMLSConversation.id}`,
+      );
       return this.initMLS1to1Conversation(otherUserId, isMLSSupportedByTheOtherUser, shouldDelayMLSGroupEstablishment);
     }
+
+    this.logger.log(
+      `Connection with user ${otherUserId.id} is not accepted, defaulting to local proteus 1:1 conversation ${proteusConversationId.id}`,
+    );
 
     return protocol === ConversationProtocol.PROTEUS ? localProteusConversation : null;
   };

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1280,7 +1280,7 @@ export class ConversationRepository {
    * @param isLiveUpdate Whether the conversation is being initialised because of a live update (e.g. some websocket event)
    * @returns Resolves with the initialised 1:1 conversation with requested user
    */
-  async getInitialised1To1Conversation(userId: QualifiedId, isLiveUpdate = false): Promise<Conversation | null> {
+  public async getInitialised1To1Conversation(userId: QualifiedId, isLiveUpdate = false): Promise<Conversation | null> {
     const user = await this.userRepository.getUserById(userId);
 
     const connection = user.connection();
@@ -2063,7 +2063,7 @@ export class ConversationRepository {
   ): Promise<Conversation | undefined> => {
     try {
       const userId = connectionEntity.userId;
-      const conversation = await this.get1to1WithUser(userId, source === EventSource.WEBSOCKET);
+      const conversation = await this.getInitialised1To1Conversation(userId, source === EventSource.WEBSOCKET);
 
       if (!conversation) {
         return undefined;
@@ -3971,7 +3971,7 @@ export class ConversationRepository {
       return;
     }
 
-    await this.initMLS1to1Conversation(otherUserId, true);
+    await this.getInitialised1To1Conversation(otherUserId, true);
   }
 
   /**

--- a/src/script/view_model/ActionsViewModel.ts
+++ b/src/script/view_model/ActionsViewModel.ts
@@ -336,7 +336,7 @@ export class ActionsViewModel {
   };
 
   getOrCreate1to1Conversation = async (userEntity: User): Promise<Conversation> => {
-    const conversationEntity = await this.conversationRepository.getInitialised1To1Conversation(userEntity);
+    const conversationEntity = await this.conversationRepository.getInitialised1To1Conversation(userEntity.qualifiedId);
     if (conversationEntity) {
       return conversationEntity;
     }
@@ -431,7 +431,9 @@ export class ActionsViewModel {
         primaryAction: {
           action: async () => {
             await this.connectionRepository.unblockUser(userEntity);
-            const conversationEntity = await this.conversationRepository.getInitialised1To1Conversation(userEntity);
+            const conversationEntity = await this.conversationRepository.getInitialised1To1Conversation(
+              userEntity.qualifiedId,
+            );
             resolve();
             if (conversationEntity) {
               await this.conversationRepository.updateParticipatingUserEntities(conversationEntity);

--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -141,7 +141,7 @@ export class ContentViewModel {
   private readonly getConversationEntity = async (
     conversation: Conversation | string,
     domain: string | null = null,
-  ): Promise<Conversation> => {
+  ): Promise<Conversation | null> => {
     const conversationEntity = isConversationEntity(conversation)
       ? conversation
       : await this.conversationRepository.getConversationById({domain: domain || '', id: conversation});


### PR DESCRIPTION
## Description

With this PR initialising a 1:1 conversation is a single method - one flow for different cases (mapping a connection request, creating a new conversation, receiving a welcome message ect).

This will simplify the change in the flow of establishing team 1:1 conversation.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
