### PR TITLE
runfix: use fading scrollbar for new sidebar (WPB-7412)

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -26,6 +26,7 @@ import {ChevronIcon, useMatchMedia} from '@wireapp/react-ui-kit';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {CallingCell} from 'Components/calling/CallingCell';
+import {FadingScrollbar} from 'Components/FadingScrollbar';
 import {IntegrationRepository} from 'src/script/integration/IntegrationRepository';
 import {Preferences} from 'src/script/page/LeftSidebar/panels/Preferences';
 import {StartUI} from 'src/script/page/LeftSidebar/panels/StartUI';
@@ -243,7 +244,7 @@ const Conversations: React.FC<ConversationsProps> = ({
   const sidebar = (
     <div className="conversations-sidebar-wrapper">
       <nav className="conversations-sidebar" data-is-collapsed={isSidebarCollapsed || mdBreakpoint}>
-        <div className="conversations-sidebar-items">
+        <FadingScrollbar className="conversations-sidebar-items">
           <div className="conversations-sidebar-items-children">
             <UserDetails
               user={selfUser}
@@ -276,7 +277,7 @@ const Conversations: React.FC<ConversationsProps> = ({
               </div>
             </button>
           )}
-        </div>
+        </FadingScrollbar>
       </nav>
     </div>
   );


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7412" title="WPB-7412" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7412</a>  [Web] New side bar scrollbar doesn't fade
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Vertical scrollbar for the new navigation doesn't fade

## Screenshots/Screencast (for UI changes)
![Kooha-2024-04-04-16-38-20](https://github.com/wireapp/wire-webapp/assets/78490891/c3d6d277-f042-4059-9ee3-68e640993f72)

