### PR TITLE
runfix: prevent loading of unreachable users (WPB-7377)

### DIFF
--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -110,7 +110,8 @@ export class ConversationState {
 
     this.directConversations = ko.pureComputed(() => {
       return this.sortedConversations().filter(
-        conversation => conversation.is1to1() && conversation.firstUserEntity()?.isAvailable(),
+        conversation =>
+          conversation.is1to1() && (conversation.firstUserEntity()?.isAvailable() || conversation.hasContentMessages()),
       );
     });
 

--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -109,7 +109,9 @@ export class ConversationState {
     });
 
     this.directConversations = ko.pureComputed(() => {
-      return this.sortedConversations().filter(conversation => conversation.is1to1());
+      return this.sortedConversations().filter(
+        conversation => conversation.is1to1() && conversation.firstUserEntity()?.isAvailable(),
+      );
     });
 
     this.filteredConversations = ko.pureComputed(() => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7377" title="WPB-7377" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7377</a>  App crashes when selecting '1:1 conversations'
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

The condition for which conversation to show in the 1 on 1 tab is liable to crash the app with unavailable users

This assigns the correct condition to show 1 on 1 conversations (make sure `isAvailable` is true or that the conversation has messages)

Further testing with QA is necessary to confirms it fixes the crash