### PR TITLE
runfix: initialising 1:1 conversation between team members

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@lexical/react": "0.12.5",
     "@wireapp/avs": "9.6.12",
     "@wireapp/commons": "5.2.7",
-    "@wireapp/core": "45.3.2",
+    "@wireapp/core": "45.3.3",
     "@wireapp/react-ui-kit": "9.16.4",
     "@wireapp/store-engine-dexie": "2.1.8",
     "@wireapp/webapp-events": "0.20.1",

--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -708,6 +708,7 @@
   "groupParticipantActionIncomingRequest": "Accept request",
   "groupParticipantActionLeave": "Leave group…",
   "groupParticipantActionOpenConversation": "Open conversation",
+  "groupParticipantActionStartConversation": "Start conversation",
   "groupParticipantActionPending": "Pending",
   "groupParticipantActionRemove": "Remove from group…",
   "groupParticipantActionSelfProfile": "Open profile",

--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -975,6 +975,8 @@
   "modalConversationClearHeadline": "Clear content?",
   "modalConversationClearMessage": "This will clear the conversation history on all your devices.",
   "modalConversationClearOption": "Also leave the conversation",
+  "modal1To1ConversationCreateErrorNoKeyPackagesHeadline": "Unable to start conversation",
+  "modal1To1ConversationCreateErrorNoKeyPackagesMessage": "You can’t start the conversation with {{name}} right now.<br/>{{name}} needs to open Wire or log in again first.<br/>Please try again later.",
   "modalConversationDeleteErrorHeadline": "Group not deleted",
   "modalConversationDeleteErrorMessage": "An error occurred while trying to delete the group {{name}}. Please try again.",
   "modalConversationDeleteGroupAction": "Delete",

--- a/src/script/components/Modals/UserModal/UserModal.tsx
+++ b/src/script/components/Modals/UserModal/UserModal.tsx
@@ -153,6 +153,8 @@ const UserModal: React.FC<UserModalProps> = ({
   ]);
   const isFederated = core.backendFeatures?.isFederated;
 
+  const isSameTeam = user && user.teamId && selfUser.teamId && user.teamId === selfUser.teamId;
+
   useEffect(() => {
     if (userId) {
       userRepository
@@ -210,7 +212,7 @@ const UserModal: React.FC<UserModalProps> = ({
 
             <EnrichedFields user={user} showDomain={isFederated} />
 
-            {!isTrusted && <UnverifiedUserWarning user={user} />}
+            {!isTrusted && !isSameTeam && <UnverifiedUserWarning user={user} />}
 
             <UserModalUserActionsSection
               user={user}

--- a/src/script/components/panel/SingleAction/SingleAction.tsx
+++ b/src/script/components/panel/SingleAction/SingleAction.tsx
@@ -33,11 +33,17 @@ export interface MenuItem {
 export interface SingleActionProps {
   item: MenuItem;
   onCancel: (action: any) => void;
+  oneButtonPerRow?: boolean;
 }
 
-const SingleAction = ({item, onCancel}: SingleActionProps) => {
+const SingleAction = ({item, onCancel, oneButtonPerRow = false}: SingleActionProps) => {
   return (
-    <FlexBox justify="space-evenly" className="modal__buttons">
+    <FlexBox
+      flexWrap={oneButtonPerRow ? 'wrap-reverse' : 'nowrap'}
+      css={{rowGap: '8px'}}
+      justify="space-evenly"
+      className="modal__buttons"
+    >
       <Button
         variant={ButtonVariant.SECONDARY}
         onClick={onCancel}

--- a/src/script/components/panel/UserActions.test.tsx
+++ b/src/script/components/panel/UserActions.test.tsx
@@ -19,13 +19,19 @@
 
 import {render} from '@testing-library/react';
 import {ConnectionStatus} from '@wireapp/api-client/lib/connection/';
+import {ConversationProtocol, CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation/';
 import ko from 'knockout';
+import {container} from 'tsyringe';
 
 import {withTheme} from 'src/script/auth/util/test/TestUtil';
 import {ConnectionEntity} from 'src/script/connection/ConnectionEntity';
 import {ConversationRoleRepository} from 'src/script/conversation/ConversationRoleRepository';
+import {ConversationState} from 'src/script/conversation/ConversationState';
 import {Conversation} from 'src/script/entity/Conversation';
 import {User} from 'src/script/entity/User';
+import {TeamEntity} from 'src/script/team/TeamEntity';
+import {TeamState} from 'src/script/team/TeamState';
+import {UserState} from 'src/script/user/UserState';
 import {ActionsViewModel} from 'src/script/view_model/ActionsViewModel';
 import {noop} from 'Util/util';
 
@@ -39,6 +45,14 @@ const getAllActions = (queryFunction: (id: string) => HTMLElement | null) =>
     .filter(action => action !== null);
 
 describe('UserActions', () => {
+  const conversationState = container.resolve(ConversationState);
+  const teamState = container.resolve(TeamState);
+  const userState = container.resolve(UserState);
+
+  afterEach(() => {
+    conversationState.conversations.removeAll();
+  });
+
   it('generates actions for self user profile', () => {
     const user = new User('');
     user.isMe = true;
@@ -94,7 +108,12 @@ describe('UserActions', () => {
   it('generates actions for another user profile to which I am connected', () => {
     const user = new User('');
     const connection = new ConnectionEntity();
+
     user.connection(connection);
+    user.teamId = 'teamId';
+
+    const selfUser = new User('');
+    selfUser.teamId = 'teamId2';
 
     jest.spyOn(user, 'isAvailable').mockImplementation(ko.pureComputed(() => true));
     const conversation = new Conversation();
@@ -102,6 +121,10 @@ describe('UserActions', () => {
     jest.spyOn(conversation, 'isGroup').mockImplementation(ko.pureComputed(() => true));
     jest.spyOn(conversation, 'participating_user_ids').mockImplementation(ko.observableArray([new User()]));
     user.connection()?.status(ConnectionStatus.ACCEPTED);
+    connection.userId = user.qualifiedId;
+
+    conversationState.conversations.push(conversation);
+
     const conversationRoleRepository: Partial<ConversationRoleRepository> = {canRemoveParticipants: () => true};
 
     const props = {
@@ -110,7 +133,7 @@ describe('UserActions', () => {
       conversationRoleRepository: conversationRoleRepository as ConversationRoleRepository,
       isSelfActivated: true,
       onAction: noop,
-      selfUser: new User(''),
+      selfUser,
       user,
     };
 
@@ -120,6 +143,94 @@ describe('UserActions', () => {
     expect(allActions).toHaveLength(3);
 
     [Actions.OPEN_CONVERSATION, Actions.BLOCK].forEach(action => {
+      const identifier = ActionIdentifier[action];
+      expect(queryByTestId(identifier)).not.toBeNull();
+    });
+  });
+
+  it("shows start conversation if there's no existing conversation between two users from the same team", () => {
+    const user = new User('');
+
+    const team = new TeamEntity('teamId');
+    teamState.team(team);
+
+    user.teamId = team.id;
+
+    const selfUser = new User('');
+    selfUser.teamId = team.id;
+
+    userState.self(selfUser);
+
+    jest.spyOn(user, 'isAvailable').mockImplementation(ko.pureComputed(() => true));
+    const conversation = new Conversation();
+    conversation.participating_user_ids([user]);
+
+    const conversationRoleRepository: Partial<ConversationRoleRepository> = {canRemoveParticipants: () => true};
+
+    const props = {
+      actionsViewModel,
+      conversation,
+      conversationRoleRepository: conversationRoleRepository as ConversationRoleRepository,
+      isSelfActivated: true,
+      onAction: noop,
+      selfUser,
+      user,
+    };
+
+    const {queryByTestId} = render(<UserActions {...props} />);
+
+    const allActions = getAllActions(queryByTestId);
+    expect(allActions).toHaveLength(2);
+
+    [Actions.START_CONVERSATION, Actions.REMOVE].forEach(action => {
+      const identifier = ActionIdentifier[action];
+      expect(queryByTestId(identifier)).not.toBeNull();
+    });
+  });
+
+  it("shows open conversation if there's an existing conversation between two users from the same team", () => {
+    const teamDomain = 'team-domain';
+    const user = new User('userid1', teamDomain);
+
+    const team = new TeamEntity('teamId');
+    teamState.team(team);
+
+    user.teamId = team.id;
+
+    const selfUser = new User('userid2', teamDomain);
+    selfUser.teamId = team.id;
+
+    userState.self(selfUser);
+
+    jest.spyOn(user, 'isAvailable').mockImplementation(ko.pureComputed(() => true));
+    const conversation = new Conversation();
+    jest.spyOn(conversation, 'participating_user_ids').mockImplementation(ko.observableArray([user]));
+
+    const one2oneConversation = new Conversation('123', 'domain', ConversationProtocol.PROTEUS);
+    one2oneConversation.type(CONVERSATION_TYPE.ONE_TO_ONE);
+    one2oneConversation.participating_user_ids.push(user.qualifiedId);
+    one2oneConversation.participating_user_ets.push(user);
+
+    conversationState.conversations.push(one2oneConversation);
+
+    const conversationRoleRepository: Partial<ConversationRoleRepository> = {canRemoveParticipants: () => true};
+
+    const props = {
+      actionsViewModel,
+      conversation,
+      conversationRoleRepository: conversationRoleRepository as ConversationRoleRepository,
+      isSelfActivated: true,
+      onAction: noop,
+      selfUser,
+      user,
+    };
+
+    const {queryByTestId} = render(<UserActions {...props} />);
+
+    const allActions = getAllActions(queryByTestId);
+    expect(allActions).toHaveLength(2);
+
+    [Actions.OPEN_CONVERSATION, Actions.REMOVE].forEach(action => {
       const identifier = ActionIdentifier[action];
       expect(queryByTestId(identifier)).not.toBeNull();
     });

--- a/src/script/components/panel/UserActions.tsx
+++ b/src/script/components/panel/UserActions.tsx
@@ -202,7 +202,7 @@ const UserActions: React.FC<UserActionsProps> = ({
               onAction(Actions.START_CONVERSATION);
             } catch (error) {
               if (error instanceof ClientMLSError && error.label === ClientMLSErrorLabel.NO_KEY_PACKAGES_AVAILABLE) {
-                PrimaryModal.show(PrimaryModal.type.ACKNOWLEDGE, {
+                return PrimaryModal.show(PrimaryModal.type.ACKNOWLEDGE, {
                   text: {
                     title: t('modal1To1ConversationCreateErrorNoKeyPackagesHeadline'),
                     htmlMessage: t('modal1To1ConversationCreateErrorNoKeyPackagesMessage', user.name()),

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1699,27 +1699,6 @@ export class ConversationRepository {
     return this.conversationService.removeConversationFromBlacklist(conversationId);
   }
 
-  public readonly makeSureMLS1to1ConversationIsEstablished = async (mlsConversation: MLSConversation) => {
-    const isMLSGroupEstablished = await this.conversationService.isMLSGroupEstablishedLocally(mlsConversation.groupId);
-    if (isMLSGroupEstablished) {
-      return;
-    }
-
-    const selfUser = this.userState.self();
-
-    if (!selfUser) {
-      throw new Error('Self user not found');
-    }
-
-    const otherUserId = this.getUserIdOf1to1Conversation(mlsConversation);
-
-    if (!otherUserId) {
-      throw new Error('Other user not found');
-    }
-
-    await this.establishMLS1to1Conversation(mlsConversation, otherUserId);
-  };
-
   /**
    * Will establish mls 1:1 conversation.
    * If proteus conversation is provided, it will be replaced with mls 1:1 conversation.

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1816,26 +1816,18 @@ export class ConversationRepository {
       throw new Error('Self user is not available!');
     }
 
-    try {
-      const initialisedMLSConversation = await this.establishMLS1to1Conversation(mlsConversation, otherUserId);
+    const initialisedMLSConversation = await this.establishMLS1to1Conversation(mlsConversation, otherUserId);
 
-      if (shouldOpenMLS1to1Conversation) {
-        // If proteus conversation was previously active conversaiton, we want to make mls 1:1 conversation active.
-        amplify.publish(WebAppEvents.CONVERSATION.SHOW, initialisedMLSConversation, {});
-      }
-
-      // If mls is supported by the other user, we can establish the group and remove readonly state from the conversation.
-      initialisedMLSConversation.readOnlyState(null);
-      await this.update1To1ConversationParticipants(mlsConversation, otherUserId);
-      await this.saveConversation(initialisedMLSConversation);
-      return initialisedMLSConversation;
-    } catch (error) {
-      this.logger.error(
-        `Failed to establish MLS 1:1 conversation with user ${otherUserId.id}, deleting the conversation from the local state:`,
-        error,
-      );
-      throw error;
+    if (shouldOpenMLS1to1Conversation) {
+      // If proteus conversation was previously active conversaiton, we want to make mls 1:1 conversation active.
+      amplify.publish(WebAppEvents.CONVERSATION.SHOW, initialisedMLSConversation, {});
     }
+
+    // If mls is supported by the other user, we can establish the group and remove readonly state from the conversation.
+    initialisedMLSConversation.readOnlyState(null);
+    await this.update1To1ConversationParticipants(mlsConversation, otherUserId);
+    await this.saveConversation(initialisedMLSConversation);
+    return initialisedMLSConversation;
   };
 
   private update1To1ConversationParticipants = async (conversation: Conversation, otherUserId: QualifiedId) => {

--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -214,6 +214,16 @@ export class ConversationState {
     return mlsConversation || null;
   }
 
+  has1to1ConversationWithUser(userId: QualifiedId): boolean {
+    const foundMLSConversation = this.findMLS1to1Conversation(userId);
+    if (foundMLSConversation) {
+      return true;
+    }
+
+    const foundProteusConversations = this.findProteus1to1Conversations(userId);
+    return !!foundProteusConversations && foundProteusConversations.length > 0;
+  }
+
   isSelfConversation(conversationId: QualifiedId): boolean {
     const selfConversationIds: QualifiedId[] = [this.selfProteusConversation(), this.selfMLSConversation()]
       .filter((conversation): conversation is Conversation => !!conversation)

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -17,12 +17,7 @@
  *
  */
 
-import {
-  CONVERSATION_TYPE,
-  ConversationProtocol,
-  MessageSendingStatus,
-  QualifiedUserClients,
-} from '@wireapp/api-client/lib/conversation';
+import {ConversationProtocol, MessageSendingStatus, QualifiedUserClients} from '@wireapp/api-client/lib/conversation';
 import {BackendErrorLabel} from '@wireapp/api-client/lib/http/';
 import {QualifiedId, RequestCancellationError} from '@wireapp/api-client/lib/user';
 import {
@@ -816,15 +811,7 @@ export class MessageRepository {
     // Configure ephemeral messages
     conversationService.messageTimer.setConversationLevelTimer(conversation.id, conversation.messageTimer());
 
-    const isMLS = isMLSConversation(conversation);
-    const is1to1 = conversation.type() === CONVERSATION_TYPE.ONE_TO_ONE;
-
-    //Before sending a message in MLS 1:1 conversation we need to make sure that the group is established
-    if (isMLS && is1to1) {
-      await this.conversationRepositoryProvider().makeSureMLS1to1ConversationIsEstablished(conversation);
-    }
-
-    const sendOptions: Parameters<typeof conversationService.send>[0] = isMLS
+    const sendOptions: Parameters<typeof conversationService.send>[0] = isMLSConversation(conversation)
       ? {
           groupId: conversation.groupId,
           payload,

--- a/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
@@ -117,6 +117,13 @@ const StartUI: React.FC<StartUIProps> = ({
   };
 
   const openContact = async (user: User) => {
+    const isSameTeam = user.teamId && selfUser.teamId && user.teamId === selfUser.teamId;
+    const has1to1Conversation = conversationState.has1to1ConversationWithUser(user.qualifiedId);
+
+    if (isSameTeam && !has1to1Conversation) {
+      return showUserModal({domain: user.domain, id: user.id});
+    }
+
     const conversationEntity = await actions.getOrCreate1to1Conversation(user);
     return actions.open1to1Conversation(conversationEntity);
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4763,9 +4763,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:45.3.2":
-  version: 45.3.2
-  resolution: "@wireapp/core@npm:45.3.2"
+"@wireapp/core@npm:45.3.3":
+  version: 45.3.3
+  resolution: "@wireapp/core@npm:45.3.3"
   dependencies:
     "@wireapp/api-client": ^26.12.0
     "@wireapp/commons": ^5.2.7
@@ -4785,7 +4785,7 @@ __metadata:
     long: ^5.2.0
     uuidjs: 4.2.13
     zod: 3.22.4
-  checksum: 8d39a74dd280d24957169b403629422881dff68d3122be6e1fc23a27bcd6b5c8e7acee7e09a3f4bc37fd742e9914619b90e2b004cf86f58c14ef1e319170df00
+  checksum: 97d21de3a6002a3af6aee34f35d0a1db81884ec2e3675bb806ea79433d6d04d500b2bcac7f574142848e42a4af05f0358b934a0d5238e2664a901f77aa4b153e
   languageName: node
   linkType: hard
 
@@ -17457,7 +17457,7 @@ __metadata:
     "@wireapp/avs": 9.6.12
     "@wireapp/commons": 5.2.7
     "@wireapp/copy-config": 2.1.14
-    "@wireapp/core": 45.3.2
+    "@wireapp/core": 45.3.3
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.16.4


### PR DESCRIPTION
## Description

Changes the way team 1:1 conversations are being initialised.

Previously: 
- proteus: conversation is created when navigating to a user in a contact list 
- mls: conversation is opened (but not established yet - the other user is not added) when navigating to a user in a contact list and established when trying to send a first message in a conversation

Now:
For both proteus and mls protocol: after navigating to a user in a contact list:
- if there's no conversation between users: we open a modal with basic user info and "start conversation" button, when button is clicked and:
  - we were able to claim key packages of the other user: mls 1:1 conversation is established
  - we couldn't claim key packages: aknowledge modal is opened
  - if proteus protocol was picked for communication, we simply create 1:1 proteus conversation
- if there's an existing conversation between users we simply open it

## Screenshots/Screencast (for UI changes)

<img width="386" alt="Screenshot 2024-04-05 at 14 38 56" src="https://github.com/wireapp/wire-webapp/assets/45733298/1aa98383-5d0d-45ea-a14a-bc1d920adb64">


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
