### PR TITLE
runfix: use fading scrollbar for new sidebar (WPB-7412)

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -26,6 +26,7 @@ import {ChevronIcon, useMatchMedia} from '@wireapp/react-ui-kit';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {CallingCell} from 'Components/calling/CallingCell';
+import {FadingScrollbar} from 'Components/FadingScrollbar';
 import {IntegrationRepository} from 'src/script/integration/IntegrationRepository';
 import {Preferences} from 'src/script/page/LeftSidebar/panels/Preferences';
 import {StartUI} from 'src/script/page/LeftSidebar/panels/StartUI';
@@ -256,7 +257,7 @@ const Conversations: React.FC<ConversationsProps> = ({
 
   const sidebar = (
     <nav className="conversations-sidebar">
-      <div className="conversations-sidebar-items" data-is-collapsed={!isSideBarOpen || mdBreakpoint}>
+      <FadingScrollbar className="conversations-sidebar-items" data-is-collapsed={!isSideBarOpen || mdBreakpoint}>
         {!(!isSideBarOpen || mdBreakpoint) && (
           <UserDetails
             user={selfUser}
@@ -276,7 +277,7 @@ const Conversations: React.FC<ConversationsProps> = ({
           conversationRepository={conversationRepository}
           onClickPreferences={() => onClickPreferences(ContentState.PREFERENCES_ACCOUNT)}
         />
-      </div>
+      </FadingScrollbar>
 
       {!mdBreakpoint && (
         <button

--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -31,7 +31,7 @@
 
   .conversations-sidebar-items {
     display: flex;
-    overflow: hidden;
+    overflow: auto;
     width: 220px;
     height: 100vh;
     flex-direction: column;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7412" title="WPB-7412" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7412</a>  [Web] New side bar scrollbar doesn't fade
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

- see https://github.com/wireapp/wire-webapp/pull/17215 , the change was reverted by mistake