### PR TITLE
fix: Hide none status availability

### DIFF
--- a/src/script/components/Avatar/UserAvatar/UserAvatar.tsx
+++ b/src/script/components/Avatar/UserAvatar/UserAvatar.tsx
@@ -113,7 +113,7 @@ export const UserAvatar: React.FunctionComponent<UserAvatarProps> = ({
 
       {!isImageGrey && <AvatarBorder />}
 
-      {typeof availability === 'number' && (
+      {typeof availability === 'number' && availability !== AvailabilityType.Type.NONE && (
         <div css={AvailabilityWrapper}>
           <AvailabilityIcon availability={availability} />
         </div>


### PR DESCRIPTION
## Description

Hide none status availability, it renders empty white dot if AvailabilityStatus is 0.

## Screenshots/Screencast (for UI changes)

Before:
![image](https://github.com/wireapp/wire-webapp/assets/13432884/8ae1c9ff-0db3-4c62-b2c9-358c62e0a547)

After:
![image](https://github.com/wireapp/wire-webapp/assets/13432884/044b977e-c84a-4e32-b97a-be82f46b3b4c)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
