### PR TITLE
perf: Improve polling the team feature config [WPB-8734]

### DIFF
--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -161,14 +161,16 @@ export class TeamRepository extends TypedEventEmitter<Events> {
   }
 
   private readonly scheduleTeamRefresh = (): void => {
-    window.setInterval(async () => {
+    const updateTeam = async () => {
       try {
         await this.getTeam();
         await this.updateFeatureConfig();
       } catch (error) {
         this.logger.error(error);
       }
-    }, TIME_IN_MILLIS.SECOND * 30);
+    };
+    window.addEventListener('focus', updateTeam);
+    window.setInterval(updateTeam, TIME_IN_MILLIS.DAY);
   };
 
   private async getInitialTeamMembers(teamId: string): Promise<TeamMemberEntity[]> {

--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -169,6 +169,7 @@ export class TeamRepository extends TypedEventEmitter<Events> {
         this.logger.error(error);
       }
     };
+    // We want to poll the latest team data every time the app is focused and every day
     window.addEventListener('focus', updateTeam);
     window.setInterval(updateTeam, TIME_IN_MILLIS.DAY);
   };

--- a/src/script/util/DebugUtil.ts
+++ b/src/script/util/DebugUtil.ts
@@ -290,6 +290,11 @@ export class DebugUtil {
     });
   }
 
+  // Used by QA to trigger a focus event on the app (in order to trigger the update of the team feature-config)
+  simulateAppToForeground() {
+    window.dispatchEvent(new FocusEvent('focus'));
+  }
+
   setE2EICertificateTtl(ttl: number) {
     E2EIHandler.getInstance().certificateTtl = ttl;
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8734" title="WPB-8734" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-8734</a>  Webapp is polling the /features-config endpoint every 30s
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

Since the `feature-config.update` event is not fanned off by backend to clients anymore, we needed a way to get the config as early as possible when an admin made a feature change. 
The first naive implementation was to poll the config every 30s. 
Turned out this was too aggressive for backend and created performance issues. 

Now the strategy is back to having a polling every 24h + re-fetching the config whenever the app is put to the foreground. 

