### PR TITLE
runfix: Make sure newly created 1to1 conversation have updated users

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1306,7 +1306,9 @@ export class ConversationRepository {
     const connection = user.connection();
     if (connection) {
       this.logger.log(`There's a connection with user ${userId.id}, getting a 1:1 conversation for the connection`);
-      return this.get1to1ConversationForConnection(connection, options);
+      const conversation = await this.get1to1ConversationForConnection(connection, options);
+      // In case we got a conversation back, we make sure the participating user entities are up to date
+      return conversation ? this.updateParticipatingUserEntities(conversation) : null;
     }
 
     const {protocol, isMLSSupportedByTheOtherUser, isProteusSupportedByTheOtherUser} =


### PR DESCRIPTION
## Description

This fixes a bug where, if you have multiple connection requests, then accepting one will not add the newly created conversation in the conversation list instantly.


## Screenshots/Screencast (for UI changes)

### Before

https://github.com/wireapp/wire-webapp/assets/1090716/f5d7476a-7acb-4585-8285-7a81d2dd7321

### After

https://github.com/wireapp/wire-webapp/assets/1090716/4813a669-6af2-4b8e-97bc-57d5541e1940

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
