### PR TITLE
refactor: use call state view mode instead of multitasking

### DIFF
--- a/src/script/calling/CallState.ts
+++ b/src/script/calling/CallState.ts
@@ -38,6 +38,11 @@ export enum MuteState {
   REMOTE_FORCE_MUTED,
 }
 
+export enum CallingViewMode {
+  FULL_SCREEN_GRID = 'full-screen-grid',
+  MINIMIZED = 'minimized',
+}
+
 @singleton()
 export class CallState {
   public readonly calls: ko.ObservableArray<Call> = ko.observableArray();
@@ -53,6 +58,7 @@ export class CallState {
   public readonly activeCallViewTab = ko.observable(CallViewTab.ALL);
   readonly isChoosingScreen: ko.PureComputed<boolean>;
   readonly isSpeakersViewActive: ko.PureComputed<boolean>;
+  public readonly viewMode = ko.observable<CallingViewMode>(CallingViewMode.MINIMIZED);
 
   constructor() {
     this.joinedCall = ko.pureComputed(() => this.calls().find(call => call.state() === CALL_STATE.MEDIA_ESTAB));

--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -501,7 +501,6 @@ export const Conversation = ({
                   callActions={callingViewModel.callActions}
                   callingRepository={callingRepository}
                   conversation={conversation}
-                  multitasking={callingViewModel.multitasking}
                   pushToTalkKey={callingViewModel.propertiesRepository.getPreference(
                     PROPERTIES_TYPE.CALL.PUSH_TO_TALK_KEY,
                   )}

--- a/src/script/components/calling/CallingCell.test.tsx
+++ b/src/script/components/calling/CallingCell.test.tsx
@@ -73,7 +73,6 @@ const createProps = async () => {
     conversation,
     hasAccessToCamera: true,
     isSelfVerified: true,
-    multitasking: {isMinimized: ko.observable(false)},
     teamState: mockTeamState,
     videoGrid: {grid: [], thumbnail: undefined},
   } as CallingCellProps;

--- a/src/script/components/calling/CallingOverlayContainer.tsx
+++ b/src/script/components/calling/CallingOverlayContainer.tsx
@@ -31,14 +31,13 @@ import {FullscreenVideoCall} from './FullscreenVideoCall';
 
 import {Call} from '../../calling/Call';
 import {CallingRepository} from '../../calling/CallingRepository';
-import {CallState, MuteState} from '../../calling/CallState';
+import {CallingViewMode, CallState, MuteState} from '../../calling/CallState';
 import {LEAVE_CALL_REASON} from '../../calling/enum/LeaveCallReason';
 import {Participant} from '../../calling/Participant';
 import {useVideoGrid} from '../../calling/videoGridHandler';
 import {ConversationState} from '../../conversation/ConversationState';
 import {ElectronDesktopCapturerSource} from '../../media/MediaDevicesHandler';
 import {MediaRepository} from '../../media/MediaRepository';
-import {Multitasking} from '../../notification/NotificationRepository';
 import {CallViewTab} from '../../view_model/CallingViewModel';
 
 export interface CallingContainerProps {
@@ -46,18 +45,18 @@ export interface CallingContainerProps {
   readonly mediaRepository: MediaRepository;
   readonly callState?: CallState;
   readonly conversationState?: ConversationState;
-  readonly multitasking: Multitasking;
 }
 
 const CallingContainer: React.FC<CallingContainerProps> = ({
-  multitasking,
   mediaRepository,
   callingRepository,
   callState = container.resolve(CallState),
   conversationState = container.resolve(ConversationState),
 }) => {
   const {streamHandler: mediaStreamHandler, devicesHandler: mediaDevicesHandler} = mediaRepository;
-  const {isMinimized} = useKoSubscribableChildren(multitasking, ['isMinimized']);
+  const {viewMode} = useKoSubscribableChildren(callState, ['viewMode']);
+  const isMinimized = viewMode === CallingViewMode.MINIMIZED;
+
   const {activeCallViewTab, joinedCall, selectableScreens, selectableWindows, isChoosingScreen} =
     useKoSubscribableChildren(callState, [
       'activeCallViewTab',
@@ -77,10 +76,10 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
 
   useEffect(() => {
     if (currentCallState === CALL_STATE.MEDIA_ESTAB && joinedCall?.initialType === CALL_TYPE.VIDEO) {
-      multitasking.isMinimized(false);
+      callState.viewMode(CallingViewMode.FULL_SCREEN_GRID);
     }
     if (currentCallState === undefined) {
-      multitasking.isMinimized(true);
+      callState.viewMode(CallingViewMode.MINIMIZED);
     }
   }, [currentCallState]);
 
@@ -155,9 +154,9 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
 
     mediaStreamHandler.selectScreenToShare(showScreenSelection).then(() => {
       const isAudioCall = [CALL_TYPE.NORMAL, CALL_TYPE.FORCED_AUDIO].includes(call.initialType);
-      const isFullScreenVideoCall = call.initialType === CALL_TYPE.VIDEO && !multitasking.isMinimized();
+      const isFullScreenVideoCall = call.initialType === CALL_TYPE.VIDEO && !isMinimized;
       if (isAudioCall || isFullScreenVideoCall) {
-        multitasking.isMinimized(true);
+        callState.viewMode(CallingViewMode.MINIMIZED);
       }
       return callingRepository.toggleScreenshare(call);
     });
@@ -178,7 +177,6 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
           call={joinedCall}
           activeCallViewTab={activeCallViewTab}
           conversation={conversation}
-          multitasking={multitasking}
           canShareScreen={callingRepository.supportsScreenSharing}
           maximizedParticipant={maximizedParticipant}
           mediaDevicesHandler={mediaDevicesHandler}

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -48,12 +48,11 @@ import {GroupVideoGrid} from './GroupVideoGrid';
 import {Pagination} from './Pagination';
 
 import type {Call} from '../../calling/Call';
-import {MuteState} from '../../calling/CallState';
+import {CallingViewMode, CallState, MuteState} from '../../calling/CallState';
 import type {Participant} from '../../calling/Participant';
 import type {Grid} from '../../calling/videoGridHandler';
 import type {Conversation} from '../../entity/Conversation';
 import {ElectronDesktopCapturerSource, MediaDevicesHandler} from '../../media/MediaDevicesHandler';
-import type {Multitasking} from '../../notification/NotificationRepository';
 import {useAppState} from '../../page/useAppState';
 import {TeamState} from '../../team/TeamState';
 import {CallViewTab, CallViewTabs} from '../../view_model/CallingViewModel';
@@ -69,7 +68,6 @@ export interface FullscreenVideoCallProps {
   leave: (call: Call) => void;
   maximizedParticipant: Participant | null;
   mediaDevicesHandler: MediaDevicesHandler;
-  multitasking: Multitasking;
   muteState: MuteState;
   setActiveCallViewTab: (tab: CallViewTab) => void;
   setMaximizedParticipant: (call: Call, participant: Participant | null) => void;
@@ -77,6 +75,7 @@ export interface FullscreenVideoCallProps {
   switchMicrophoneInput: (deviceId: string) => void;
   switchSpeakerOutput: (deviceId: string) => void;
   teamState?: TeamState;
+  callState?: CallState;
   toggleCamera: (call: Call) => void;
   toggleMute: (call: Call, muteState: boolean) => void;
   toggleScreenshare: (call: Call) => void;
@@ -91,7 +90,6 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
   isMuted,
   muteState,
   mediaDevicesHandler,
-  multitasking,
   videoGrid,
   maximizedParticipant,
   activeCallViewTab,
@@ -106,6 +104,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
   leave,
   changePage,
   teamState = container.resolve(TeamState),
+  callState = container.resolve(CallState),
 }) => {
   const selfParticipant = call.getSelfParticipant();
   const {sharesScreen: selfSharesScreen, sharesCamera: selfSharesCamera} = useKoSubscribableChildren(selfParticipant, [
@@ -143,7 +142,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
   ]);
   const [audioOptionsOpen, setAudioOptionsOpen] = React.useState(false);
   const [videoOptionsOpen, setVideoOptionsOpen] = React.useState(false);
-  const minimize = () => multitasking.isMinimized(true);
+  const minimize = () => callState.viewMode(CallingViewMode.MINIMIZED);
 
   const showToggleVideo =
     isVideoCallingEnabled &&

--- a/src/script/components/calling/fullscreenVideoCall.test.tsx
+++ b/src/script/components/calling/fullscreenVideoCall.test.tsx
@@ -69,7 +69,6 @@ describe('fullscreenVideoCall', () => {
           videoinput: ko.observable(''),
         },
       } as MediaDevicesHandler,
-      multitasking: {isMinimized: ko.observable(false)},
       videoGrid: {grid: [], thumbnail: null} as Grid,
     };
     return props as FullscreenVideoCallProps;

--- a/src/script/notification/NotificationRepository.test.ts
+++ b/src/script/notification/NotificationRepository.test.ts
@@ -60,7 +60,7 @@ import {createUuid} from 'Util/uuid';
 import {NotificationRepository} from './NotificationRepository';
 
 import {AudioRepository} from '../audio/AudioRepository';
-import {CallState} from '../calling/CallState';
+import {CallingViewMode, CallState} from '../calling/CallState';
 import {ConnectionEntity} from '../connection/ConnectionEntity';
 import {ConversationState} from '../conversation/ConversationState';
 import {Message} from '../entity/message/Message';
@@ -99,7 +99,6 @@ describe('NotificationRepository', () => {
   let calculateTitleLength: (sectionString: string) => number;
 
   let notification_content: any;
-  const contentViewModelState: any = {};
 
   beforeEach(() => {
     [notificationRepository] = buildNotificationRepository();
@@ -140,11 +139,6 @@ describe('NotificationRepository', () => {
 
     const {setContentState} = useAppState.getState();
     setContentState(ContentState.CONVERSATION);
-    contentViewModelState.multitasking = {
-      isMinimized: () => true,
-    };
-    notificationRepository.setContentViewModelStates(contentViewModelState.state, contentViewModelState.multitasking);
-
     const showNotificationSpy = jest.spyOn(notificationRepository as any, 'showNotification');
 
     calculateTitleLength = sectionString => {
@@ -266,13 +260,14 @@ describe('NotificationRepository', () => {
       conversationState.activeConversation(conversation);
       document.hasFocus = () => true;
       spyOn(callState, 'joinedCall').and.returnValue(true);
+      jest.spyOn(callState, 'viewMode').mockReturnValueOnce(CallingViewMode.MINIMIZED);
 
       return notificationRepository
         .notify(message, undefined, conversation)
         .then(() => {
           expect(notificationRepository['showNotification']).not.toHaveBeenCalled();
 
-          contentViewModelState.multitasking.isMinimized = () => false;
+          jest.spyOn(callState, 'viewMode').mockReturnValueOnce(CallingViewMode.FULL_SCREEN_GRID);
 
           return notificationRepository.notify(message, undefined, conversation);
         })

--- a/src/script/page/AppMain.tsx
+++ b/src/script/page/AppMain.tsx
@@ -88,8 +88,6 @@ export const AppMain: FC<AppMainProps> = ({
     throw new Error('API Context has not been set');
   }
 
-  const contentState = useAppState(state => state.contentState);
-
   const {repository: repositories} = app;
 
   const {availability: userAvailability, isActivatedAccount} = useKoSubscribableChildren(selfUser, [
@@ -127,8 +125,6 @@ export const AppMain: FC<AppMainProps> = ({
   const isLeftSidebarVisible = currentView == ViewType.LEFT_SIDEBAR;
 
   const initializeApp = async () => {
-    repositories.notification.setContentViewModelStates(contentState, mainView.multitasking);
-
     const showMostRecentConversation = () => {
       const isShowingConversation = useAppState.getState().isShowingConversation();
       if (!isShowingConversation) {
@@ -269,11 +265,7 @@ export const AppMain: FC<AppMainProps> = ({
           {!locked && (
             <>
               <FeatureConfigChangeNotifier selfUserId={selfUser.id} teamState={teamState} />
-              <CallingContainer
-                multitasking={mainView.multitasking}
-                callingRepository={repositories.calling}
-                mediaRepository={repositories.media}
-              />
+              <CallingContainer callingRepository={repositories.calling} mediaRepository={repositories.media} />
 
               <LegalHoldModal
                 selfUser={selfUser}

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -300,7 +300,6 @@ const Conversations: React.FC<ConversationsProps> = ({
                 isFullUi
                 hasAccessToCamera={callingViewModel.hasAccessToCamera()}
                 isSelfVerified={selfUser.is_verified()}
-                multitasking={callingViewModel.multitasking}
               />
             </div>
           )

--- a/src/script/page/LeftSidebar/panels/TemporatyGuestConversations.tsx
+++ b/src/script/page/LeftSidebar/panels/TemporatyGuestConversations.tsx
@@ -88,7 +88,6 @@ const TemporaryGuestConversations: React.FC<TemporaryGuestConversations> = ({
               callActions={callingViewModel.callActions}
               callingRepository={callingViewModel.callingRepository}
               hasAccessToCamera={callingViewModel.hasAccessToCamera()}
-              multitasking={callingViewModel.multitasking}
               pushToTalkKey={callingViewModel.propertiesRepository.getPreference(PROPERTIES_TYPE.CALL.PUSH_TO_TALK_KEY)}
             />
           </div>

--- a/src/script/view_model/CallingViewModel.mocks.ts
+++ b/src/script/view_model/CallingViewModel.mocks.ts
@@ -64,10 +64,8 @@ export function buildCallingViewModel() {
     {} as any,
     {} as any,
     {} as any,
-    {} as any,
     undefined,
     callState,
-    undefined,
   );
 
   return [callingViewModel, {core: mockCore}] as const;

--- a/src/script/view_model/CallingViewModel.ts
+++ b/src/script/view_model/CallingViewModel.ts
@@ -36,7 +36,7 @@ import type {AudioRepository} from '../audio/AudioRepository';
 import {AudioType} from '../audio/AudioType';
 import type {Call} from '../calling/Call';
 import {CallingRepository} from '../calling/CallingRepository';
-import {CallState} from '../calling/CallState';
+import {CallingViewMode, CallState} from '../calling/CallState';
 import {LEAVE_CALL_REASON} from '../calling/enum/LeaveCallReason';
 import {PrimaryModal} from '../components/Modals/PrimaryModal';
 import {Config} from '../Config';
@@ -46,7 +46,6 @@ import type {Conversation} from '../entity/Conversation';
 import type {User} from '../entity/User';
 import type {ElectronDesktopCapturerSource, MediaDevicesHandler} from '../media/MediaDevicesHandler';
 import type {MediaStreamHandler} from '../media/MediaStreamHandler';
-import type {Multitasking} from '../notification/NotificationRepository';
 import type {PermissionRepository} from '../permission/PermissionRepository';
 import {PermissionStatusState} from '../permission/PermissionStatusState';
 import {PropertiesRepository} from '../properties/PropertiesRepository';
@@ -100,7 +99,6 @@ export class CallingViewModel {
     readonly teamRepository: TeamRepository,
     readonly propertiesRepository: PropertiesRepository,
     private readonly selfUser: ko.Observable<User>,
-    readonly multitasking: Multitasking,
     private readonly conversationState = container.resolve(ConversationState),
     readonly callState = container.resolve(CallState),
     private readonly teamState = container.resolve(TeamState),
@@ -346,9 +344,10 @@ export class CallingViewModel {
 
         this.mediaStreamHandler.selectScreenToShare(showScreenSelection).then(() => {
           const isAudioCall = [CALL_TYPE.NORMAL, CALL_TYPE.FORCED_AUDIO].includes(call.initialType);
-          const isFullScreenVideoCall = call.initialType === CALL_TYPE.VIDEO && !this.multitasking.isMinimized();
+          const isFullScreenVideoCall =
+            call.initialType === CALL_TYPE.VIDEO && this.callState.viewMode() === CallingViewMode.FULL_SCREEN_GRID;
           if (isAudioCall || isFullScreenVideoCall) {
-            this.multitasking.isMinimized(true);
+            this.callState.viewMode(CallingViewMode.MINIMIZED);
           }
           return this.callingRepository.toggleScreenshare(call);
         });

--- a/src/script/view_model/MainViewModel.ts
+++ b/src/script/view_model/MainViewModel.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import ko from 'knockout';
 import {container} from 'tsyringe';
 
 import {ActionsViewModel} from './ActionsViewModel';
@@ -38,7 +37,7 @@ import type {EventRepository} from '../event/EventRepository';
 import type {GiphyRepository} from '../extension/GiphyRepository';
 import type {IntegrationRepository} from '../integration/IntegrationRepository';
 import type {MediaRepository} from '../media/MediaRepository';
-import type {Multitasking, NotificationRepository} from '../notification/NotificationRepository';
+import type {NotificationRepository} from '../notification/NotificationRepository';
 import type {PreferenceNotificationRepository} from '../notification/PreferenceNotificationRepository';
 import type {PermissionRepository} from '../permission/PermissionRepository';
 import type {PropertiesRepository} from '../properties/PropertiesRepository';
@@ -84,7 +83,6 @@ export class MainViewModel {
   calling: CallingViewModel;
   content: ContentViewModel;
   list: ListViewModel;
-  multitasking: Multitasking;
   private readonly core = container.resolve(Core);
 
   static get CONFIG() {
@@ -102,10 +100,6 @@ export class MainViewModel {
 
   constructor(repositories: ViewModelRepositories) {
     const userState = container.resolve(UserState);
-
-    this.multitasking = {
-      isMinimized: ko.observable(true),
-    };
 
     this.actions = new ActionsViewModel(
       repositories.self,
@@ -126,7 +120,6 @@ export class MainViewModel {
       repositories.team,
       repositories.properties,
       userState.self,
-      this.multitasking,
     );
     this.content = new ContentViewModel(this, repositories);
     this.list = new ListViewModel(this, repositories);


### PR DESCRIPTION
## Description

Removes `multitasking` state and adds `viewMode` to `callState`. It simplifies the current calling view logic and makes it easier to extend the ui with more "modes" in the future.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
