### PR TITLE
refactor: conversation entity in call entity

### DIFF
--- a/src/script/calling/Call.ts
+++ b/src/script/calling/Call.ts
@@ -30,6 +30,7 @@ import {MuteState} from './CallState';
 import type {ClientId, Participant} from './Participant';
 
 import {Config} from '../Config';
+import {Conversation} from '../entity/Conversation';
 import type {MediaDevicesHandler} from '../media/MediaDevicesHandler';
 
 export type SerializedConversationId = string;
@@ -79,7 +80,7 @@ export class Call {
 
   constructor(
     public readonly initiator: QualifiedId,
-    public readonly conversationId: QualifiedId,
+    public readonly conversation: Conversation,
     public readonly conversationType: CONV_TYPE,
     private readonly selfParticipant: Participant,
     callType: CALL_TYPE,

--- a/src/script/calling/CallState.ts
+++ b/src/script/calling/CallState.ts
@@ -73,7 +73,7 @@ export class CallState {
     );
 
     this.calls.subscribe(activeCalls => {
-      const activeCallIds = activeCalls.map(call => call.conversationId);
+      const activeCallIds = activeCalls.map(call => call.conversation.qualifiedId);
       this.acceptedVersionWarnings.remove(
         acceptedId => !activeCallIds.some(callId => matchQualifiedIds(acceptedId, callId)),
       );

--- a/src/script/calling/CallingRepository.test.ts
+++ b/src/script/calling/CallingRepository.test.ts
@@ -125,7 +125,7 @@ describe('CallingRepository', () => {
       const selfClientId = callingRepository['selfClientId']!;
       const call = new Call(
         selfUserId,
-        conversation.qualifiedId,
+        conversation,
         CONV_TYPE.CONFERENCE,
         selfParticipant,
         CALL_TYPE.NORMAL,
@@ -167,7 +167,7 @@ describe('CallingRepository', () => {
       const selfClientId = callingRepository['selfClientId']!;
       const call = new Call(
         selfUserId,
-        conversation.qualifiedId,
+        conversation,
         CONV_TYPE.CONFERENCE,
         selfParticipant,
         CALL_TYPE.NORMAL,
@@ -209,7 +209,7 @@ describe('CallingRepository', () => {
 
       const call = new Call(
         selfUserId,
-        conversation.qualifiedId,
+        conversation,
         CONV_TYPE.CONFERENCE,
         selfParticipant,
         CALL_TYPE.NORMAL,
@@ -330,7 +330,7 @@ describe('CallingRepository', () => {
 
       const incomingCall = new Call(
         userId,
-        mlsConversation.qualifiedId,
+        mlsConversation,
         CONV_TYPE.CONFERENCE_MLS,
         selfParticipant,
         CALL_TYPE.NORMAL,
@@ -365,7 +365,7 @@ describe('CallingRepository', () => {
 
       const incomingCall = new Call(
         userId,
-        mlsConversation.qualifiedId,
+        mlsConversation,
         CONV_TYPE.ONEONONE,
         selfParticipant,
         CALL_TYPE.NORMAL,
@@ -387,7 +387,7 @@ describe('CallingRepository', () => {
       const userId = {domain: '', id: ''};
       const incomingCall = new Call(
         userId,
-        createConversation().qualifiedId,
+        createConversation(),
         CONV_TYPE.CONFERENCE,
         selfParticipant,
         CALL_TYPE.NORMAL,
@@ -397,7 +397,7 @@ describe('CallingRepository', () => {
 
       const activeCall = new Call(
         userId,
-        createConversation().qualifiedId,
+        createConversation(),
         CONV_TYPE.CONFERENCE,
         selfParticipant,
         CALL_TYPE.NORMAL,
@@ -407,7 +407,7 @@ describe('CallingRepository', () => {
 
       const declinedCall = new Call(
         userId,
-        createConversation().qualifiedId,
+        createConversation(),
         CONV_TYPE.CONFERENCE,
         selfParticipant,
         CALL_TYPE.NORMAL,
@@ -428,7 +428,7 @@ describe('CallingRepository', () => {
       const userId = {domain: '', id: ''};
       const call = new Call(
         userId,
-        createConversation().qualifiedId,
+        createConversation(),
         CONV_TYPE.CONFERENCE,
         selfParticipant,
         CALL_TYPE.NORMAL,
@@ -456,7 +456,7 @@ describe('CallingRepository', () => {
       const selfParticipant = createSelfParticipant();
       const call = new Call(
         {domain: '', id: ''},
-        createConversation().qualifiedId,
+        createConversation(),
         CONV_TYPE.CONFERENCE,
         selfParticipant,
         CALL_TYPE.NORMAL,
@@ -490,7 +490,7 @@ describe('CallingRepository', () => {
 
       const call = new Call(
         {domain: '', id: ''},
-        createConversation().qualifiedId,
+        createConversation(),
         0,
         selfParticipant,
         CALL_TYPE.NORMAL,
@@ -714,7 +714,7 @@ describe.skip('E2E audio call', () => {
            * Jasmine will eventually timeout if the audio is not flowing after 5s
            */
           client
-            .getStats(call.conversationId)
+            .getStats(call.conversation.qualifiedId)
             ?.then(extractAudioStats)
             .then(audioStats => {
               if (audioStats.length > 0) {

--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -485,11 +485,11 @@ export const Conversation = ({
           />
 
           {activeCalls.map(call => {
-            const conversation = conversationState.findConversation(call.conversationId);
+            const {conversation} = call;
             const callingViewModel = mainViewModel.calling;
             const callingRepository = callingViewModel.callingRepository;
 
-            if (!conversation || !smBreakpoint) {
+            if (!smBreakpoint) {
               return null;
             }
 

--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -500,7 +500,6 @@ export const Conversation = ({
                   call={call}
                   callActions={callingViewModel.callActions}
                   callingRepository={callingRepository}
-                  conversation={conversation}
                   pushToTalkKey={callingViewModel.propertiesRepository.getPreference(
                     PROPERTIES_TYPE.CALL.PUSH_TO_TALK_KEY,
                   )}

--- a/src/script/components/TitleBar/TitleBar.tsx
+++ b/src/script/components/TitleBar/TitleBar.tsx
@@ -128,7 +128,7 @@ export const TitleBar: React.FC<TitleBarProps> = ({
 
   const hasCall = useMemo(() => {
     const hasEntities = !!joinedCall;
-    return hasEntities && matchQualifiedIds(conversation.qualifiedId, joinedCall.conversationId);
+    return hasEntities && matchQualifiedIds(conversation.qualifiedId, joinedCall.conversation.qualifiedId);
   }, [conversation, joinedCall]);
 
   const showCallControls = ConversationFilter.showCallControls(conversation, hasCall);

--- a/src/script/components/calling/CallingCell.test.tsx
+++ b/src/script/components/calling/CallingCell.test.tsx
@@ -45,7 +45,7 @@ jest.mock('Components/utils/InViewport', () => ({
 
 const createCall = (state: CALL_STATE, selfUser = new User(createUuid()), selfClientId = createUuid()) => {
   const selfParticipant = new Participant(selfUser, selfClientId);
-  const call = new Call({domain: '', id: ''}, {domain: '', id: ''}, 0, selfParticipant, CALL_TYPE.NORMAL, {
+  const call = new Call({domain: '', id: ''}, new Conversation('', ''), 0, selfParticipant, CALL_TYPE.NORMAL, {
     currentAvailableDeviceId: {
       audiooutput: ko.pureComputed(() => 'test'),
     },

--- a/src/script/components/calling/CallingCell.tsx
+++ b/src/script/components/calling/CallingCell.tsx
@@ -47,7 +47,6 @@ import type {CallingRepository} from '../../calling/CallingRepository';
 import {CallingViewMode, CallState, MuteState} from '../../calling/CallState';
 import type {Participant} from '../../calling/Participant';
 import {useVideoGrid} from '../../calling/videoGridHandler';
-import type {Conversation} from '../../entity/Conversation';
 import {generateConversationUrl} from '../../router/routeGenerator';
 import {createNavigate, createNavigateKeyboard} from '../../router/routerBindings';
 import {TeamState} from '../../team/TeamState';
@@ -65,7 +64,6 @@ interface AnsweringControlsProps {
   callActions: CallActions;
   callingRepository: Pick<CallingRepository, 'supportsScreenSharing' | 'sendModeratorMute'>;
   pushToTalkKey: string | null;
-  conversation: Conversation;
   isFullUi?: boolean;
   callState?: CallState;
   classifiedDomains?: string[];
@@ -77,7 +75,6 @@ export type CallingCellProps = VideoCallProps & AnsweringControlsProps;
 type labels = {dataUieName: string; text: string};
 
 const CallingCell: React.FC<CallingCellProps> = ({
-  conversation,
   classifiedDomains,
   isTemporaryUser,
   call,
@@ -90,6 +87,7 @@ const CallingCell: React.FC<CallingCellProps> = ({
   teamState = container.resolve(TeamState),
   callState = container.resolve(CallState),
 }) => {
+  const {conversation} = call;
   const {reason, state, isCbrEnabled, startedAt, participants, maximizedParticipant, muteState} =
     useKoSubscribableChildren(call, [
       'reason',

--- a/src/script/components/calling/CallingOverlayContainer.tsx
+++ b/src/script/components/calling/CallingOverlayContainer.tsx
@@ -95,7 +95,7 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
   const {clearShowAlert} = useCallAlertState();
 
   const leave = (call: Call) => {
-    callingRepository.leaveCall(call.conversationId, LEAVE_CALL_REASON.MANUAL_LEAVE_BY_UI_CLICK);
+    callingRepository.leaveCall(call.conversation.qualifiedId, LEAVE_CALL_REASON.MANUAL_LEAVE_BY_UI_CLICK);
     callState.activeCallViewTab(CallViewTab.ALL);
     call.maximizedParticipant(null);
     clearShowAlert();
@@ -162,7 +162,7 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
     });
   };
 
-  const conversation = joinedCall && conversationState.findConversation(joinedCall.conversationId);
+  const conversation = joinedCall?.conversation;
 
   if (!joinedCall || !conversation || conversation.removed_from_conversation()) {
     return null;
@@ -172,7 +172,7 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
     <Fragment>
       {!isMinimized && !!videoGrid?.grid.length && (
         <FullscreenVideoCall
-          key={joinedCall.conversationId.id}
+          key={joinedCall.conversation.id}
           videoGrid={videoGrid}
           call={joinedCall}
           activeCallViewTab={activeCallViewTab}

--- a/src/script/components/calling/fullscreenVideoCall.test.tsx
+++ b/src/script/components/calling/fullscreenVideoCall.test.tsx
@@ -45,7 +45,7 @@ describe('fullscreenVideoCall', () => {
     spyOn(conversation, 'supportsVideoCall').and.returnValue(true);
     const selfUser = new User('');
     selfUser.isMe = true;
-    const call = new Call({domain: '', id: ''}, {domain: '', id: ''}, 0, new Participant(selfUser, ''), 0, {
+    const call = new Call({domain: '', id: ''}, new Conversation('', ''), 0, new Participant(selfUser, ''), 0, {
       currentAvailableDeviceId: {
         audiooutput: ko.pureComputed(() => 'test'),
       },

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -47,7 +47,6 @@ import type {Message} from './message/Message';
 import {PingMessage} from './message/PingMessage';
 import type {User} from './User';
 
-import type {Call} from '../calling/Call';
 import {ClientRepository} from '../client';
 import {Config} from '../Config';
 import {ConnectionEntity} from '../connection/ConnectionEntity';
@@ -103,7 +102,6 @@ export class Conversation {
   public readonly accessCodeHasPassword: ko.Observable<boolean | undefined>;
   public readonly accessState: ko.Observable<ACCESS_STATE>;
   public readonly archivedTimestamp: ko.Observable<number>;
-  public readonly call: ko.Observable<Call | null>;
   public readonly cleared_timestamp: ko.Observable<number>;
   public readonly connection: ko.Observable<ConnectionEntity | null>;
   // TODO(Federation): Currently the 'creator' just refers to a user id but it has to become a qualified id
@@ -302,8 +300,6 @@ export class Conversation {
     this.last_read_timestamp = ko.observable(0);
     this.last_server_timestamp = ko.observable(0);
     this.mutedTimestamp = ko.observable(0);
-
-    this.call = ko.observable(null);
 
     this.readOnlyState = ko.observable<CONVERSATION_READONLY_STATE | null>(null);
 

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -283,26 +283,24 @@ const Conversations: React.FC<ConversationsProps> = ({
   const callingView = (
     <>
       {activeCalls.map(call => {
-        const conversation = conversationState.findConversation(call.conversationId);
+        const {conversation} = call;
         const callingViewModel = listViewModel.callingViewModel;
         const callingRepository = callingViewModel.callingRepository;
 
         return (
-          conversation && (
-            <div className="calling-cell" key={conversation.id}>
-              <CallingCell
-                classifiedDomains={classifiedDomains}
-                call={call}
-                callActions={callingViewModel.callActions}
-                callingRepository={callingRepository}
-                pushToTalkKey={propertiesRepository.getPreference(PROPERTIES_TYPE.CALL.PUSH_TO_TALK_KEY)}
-                conversation={conversation}
-                isFullUi
-                hasAccessToCamera={callingViewModel.hasAccessToCamera()}
-                isSelfVerified={selfUser.is_verified()}
-              />
-            </div>
-          )
+          <div className="calling-cell" key={conversation.id}>
+            <CallingCell
+              classifiedDomains={classifiedDomains}
+              call={call}
+              callActions={callingViewModel.callActions}
+              callingRepository={callingRepository}
+              pushToTalkKey={propertiesRepository.getPreference(PROPERTIES_TYPE.CALL.PUSH_TO_TALK_KEY)}
+              conversation={conversation}
+              isFullUi
+              hasAccessToCamera={callingViewModel.hasAccessToCamera()}
+              isSelfVerified={selfUser.is_verified()}
+            />
+          </div>
         );
       })}
     </>

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -295,7 +295,6 @@ const Conversations: React.FC<ConversationsProps> = ({
               callActions={callingViewModel.callActions}
               callingRepository={callingRepository}
               pushToTalkKey={propertiesRepository.getPreference(PROPERTIES_TYPE.CALL.PUSH_TO_TALK_KEY)}
-              conversation={conversation}
               isFullUi
               hasAccessToCamera={callingViewModel.hasAccessToCamera()}
               isSelfVerified={selfUser.is_verified()}

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
@@ -82,7 +82,7 @@ export const ConversationsList = ({
 
   const hasJoinableCall = (conversation: Conversation) => {
     const call = joinableCalls.find((callInstance: Call) =>
-      matchQualifiedIds(callInstance.conversationId, conversation.qualifiedId),
+      matchQualifiedIds(callInstance.conversation.qualifiedId, conversation.qualifiedId),
     );
     if (!call) {
       return false;

--- a/src/script/page/LeftSidebar/panels/Conversations/GroupedConversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/GroupedConversations.tsx
@@ -19,7 +19,6 @@
 
 import React, {useEffect, useState} from 'react';
 
-import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {container} from 'tsyringe';
 
 import {ListViewModel} from 'src/script/view_model/ListViewModel';
@@ -60,7 +59,7 @@ export interface GroupedConversationsProps {
   callState: CallState;
   conversationRepository: ConversationRepository;
   conversationState: ConversationState;
-  hasJoinableCall: (conversationId: QualifiedId) => boolean;
+  hasJoinableCall: (conversation: Conversation) => boolean;
   isSelectedConversation: (conversationEntity: Conversation) => boolean;
   listViewModel: ListViewModel;
   onJoinCall: (conversationEntity: Conversation) => void;

--- a/src/script/page/LeftSidebar/panels/TemporatyGuestConversations.tsx
+++ b/src/script/page/LeftSidebar/panels/TemporatyGuestConversations.tsx
@@ -78,7 +78,6 @@ const TemporaryGuestConversations: React.FC<TemporaryGuestConversations> = ({
               data-uie-uid={conversation.id}
               data-uie-value={conversation.display_name()}
               call={call}
-              conversation={conversation}
               isTemporaryUser
               isFullUi
               isSelfVerified={false}

--- a/src/script/page/LeftSidebar/panels/TemporatyGuestConversations.tsx
+++ b/src/script/page/LeftSidebar/panels/TemporatyGuestConversations.tsx
@@ -19,8 +19,6 @@
 
 import React from 'react';
 
-import {QualifiedId} from '@wireapp/api-client/lib/user';
-
 import {CallingCell} from 'Components/calling/CallingCell';
 import {Icon} from 'Components/Icon';
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
@@ -51,7 +49,6 @@ const TemporaryGuestConversations: React.FC<TemporaryGuestConversations> = ({
 
   const {activeCalls} = useKoSubscribableChildren(callingViewModel, ['activeCalls']);
   const isAccountCreationEnabled = Config.getConfig().FEATURE.ENABLE_ACCOUNT_REGISTRATION;
-  const getConversationById = (conversationId: QualifiedId) => callingViewModel.getConversationById(conversationId);
   const openPreferences = () => {
     listViewModel.openPreferencesAccount();
   };
@@ -73,12 +70,12 @@ const TemporaryGuestConversations: React.FC<TemporaryGuestConversations> = ({
   return (
     <div id="temporary-guest" className={`temporary-guest`}>
       {activeCalls.map(call => {
-        const conversation = getConversationById(call.conversationId);
+        const {conversation} = call;
         return (
-          <div key={call.conversationId.id} className="calling-cell">
+          <div key={conversation.id} className="calling-cell">
             <CallingCell
               data-uie-name="item-call"
-              data-uie-uid={call.conversationId.id}
+              data-uie-uid={conversation.id}
               data-uie-value={conversation.display_name()}
               call={call}
               conversation={conversation}

--- a/src/script/util/DebugUtil.ts
+++ b/src/script/util/DebugUtil.ts
@@ -421,7 +421,7 @@ export class DebugUtil {
     if (!activeCall) {
       throw new Error('no active call found');
     }
-    return this.callingRepository.getStats(activeCall.conversationId);
+    return this.callingRepository.getStats(activeCall.conversation.qualifiedId);
   }
 
   /** Used by QA test automation. */

--- a/src/script/view_model/CallingViewModel.mocks.ts
+++ b/src/script/view_model/CallingViewModel.mocks.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import {QualifiedId} from '@wireapp/api-client/lib/user';
 import ko from 'knockout';
 import {container} from 'tsyringe';
 
@@ -28,6 +27,7 @@ import {CallingViewModel} from './CallingViewModel';
 import {Call} from '../calling/Call';
 import {CallingRepository} from '../calling/CallingRepository';
 import {CallState} from '../calling/CallState';
+import {Conversation} from '../entity/Conversation';
 import {Core} from '../service/CoreSingleton';
 
 export const mockCallingRepository = {
@@ -46,9 +46,8 @@ export const mockCallingRepository = {
 
 export const callState = new CallState();
 
-export function buildCall(conversationId: QualifiedId, convType = CONV_TYPE.ONEONONE) {
-  const qualifiedId = typeof conversationId === 'string' ? {id: conversationId, domain: ''} : conversationId;
-  return new Call({id: 'user1', domain: ''}, qualifiedId, convType, {} as any, CALL_TYPE.NORMAL, {
+export function buildCall(conversation: Conversation, convType = CONV_TYPE.ONEONONE) {
+  return new Call({id: 'user1', domain: ''}, conversation, convType, {} as any, CALL_TYPE.NORMAL, {
     currentAvailableDeviceId: {audiooutput: ko.observable()},
   } as any);
 }

--- a/src/script/view_model/CallingViewModel.test.ts
+++ b/src/script/view_model/CallingViewModel.test.ts
@@ -36,7 +36,8 @@ describe('CallingViewModel', () => {
   describe('answerCall', () => {
     it('answers a call directly if no call is ongoing', async () => {
       const [callingViewModel] = buildCallingViewModel();
-      const call = buildCall({id: 'conversation1', domain: ''});
+      const conversation = new Conversation('conversation1', '');
+      const call = buildCall(conversation);
       await callingViewModel.callActions.answer(call);
       expect(mockCallingRepository.answerCall).toHaveBeenCalledWith(call);
     });
@@ -44,18 +45,18 @@ describe('CallingViewModel', () => {
     it('lets the user leave previous call before answering a new one', async () => {
       jest.useFakeTimers();
       const [callingViewModel] = buildCallingViewModel();
-      const joinedCall = buildCall({id: 'conversation1', domain: ''});
+      const joinedCall = buildCall(new Conversation('conversation1', ''));
       joinedCall.state(STATE.MEDIA_ESTAB);
       callState.calls.push(joinedCall);
 
       jest.spyOn(PrimaryModal, 'show').mockImplementation((_, payload) => payload.primaryAction?.action?.());
-      const newCall = buildCall({id: 'conversation2', domain: ''});
+      const newCall = buildCall(new Conversation('conversation2', ''));
       Promise.resolve().then(() => {
         jest.runAllTimers();
       });
       await callingViewModel.callActions.answer(newCall);
       expect(mockCallingRepository.leaveCall).toHaveBeenCalledWith(
-        joinedCall.conversationId,
+        joinedCall.conversation.qualifiedId,
         LEAVE_CALL_REASON.MANUAL_LEAVE_TO_JOIN_ANOTHER_CALL,
       );
       expect(mockCallingRepository.answerCall).toHaveBeenCalledWith(newCall);
@@ -73,7 +74,7 @@ describe('CallingViewModel', () => {
     it('lets the user leave previous call before starting a new one', async () => {
       jest.useFakeTimers();
       const [callingViewModel] = buildCallingViewModel();
-      const joinedCall = buildCall({id: 'conversation1', domain: ''});
+      const joinedCall = buildCall(new Conversation('conversation1', ''));
       joinedCall.state(STATE.MEDIA_ESTAB);
       callState.calls.push(joinedCall);
 
@@ -84,7 +85,7 @@ describe('CallingViewModel', () => {
       });
       await callingViewModel.callActions.startAudio(conversation);
       expect(mockCallingRepository.leaveCall).toHaveBeenCalledWith(
-        joinedCall.conversationId,
+        joinedCall.conversation.qualifiedId,
         LEAVE_CALL_REASON.MANUAL_LEAVE_TO_JOIN_ANOTHER_CALL,
       );
       expect(mockCallingRepository.startCall).toHaveBeenCalledWith(conversation, CALL_TYPE.NORMAL);

--- a/src/script/view_model/CallingViewModel.ts
+++ b/src/script/view_model/CallingViewModel.ts
@@ -106,7 +106,7 @@ export class CallingViewModel {
     this.isSelfVerified = ko.pureComputed(() => selfUser().is_verified());
     this.activeCalls = ko.pureComputed(() =>
       this.callState.calls().filter(call => {
-        const conversation = this.conversationState.findConversation(call.conversationId);
+        const {conversation} = call;
         if (!conversation || conversation.removed_from_conversation()) {
           return false;
         }
@@ -175,7 +175,7 @@ export class CallingViewModel {
     };
 
     const answerCall = async (call: Call) => {
-      const canAnswer = await this.canInitiateCall(call.conversationId, {
+      const canAnswer = await this.canInitiateCall(call.conversation.qualifiedId, {
         action: t('modalCallSecondIncomingAction'),
         message: t('modalCallSecondIncomingMessage'),
         title: t('modalCallSecondIncomingHeadline'),
@@ -269,7 +269,7 @@ export class CallingViewModel {
           PrimaryModal.show(PrimaryModal.type.ACKNOWLEDGE, {
             primaryAction: {
               action: () => {
-                this.callingRepository.rejectCall(call.conversationId);
+                this.callingRepository.rejectCall(call.conversation.qualifiedId);
               },
             },
             text: {
@@ -286,12 +286,12 @@ export class CallingViewModel {
       changePage: (newPage, call) => {
         this.callingRepository.changeCallPage(call, newPage);
       },
-      leave: (call: Call) => {
-        this.callingRepository.leaveCall(call.conversationId, LEAVE_CALL_REASON.MANUAL_LEAVE_BY_UI_CLICK);
+      leave: ({conversation}: Call) => {
+        this.callingRepository.leaveCall(conversation.qualifiedId, LEAVE_CALL_REASON.MANUAL_LEAVE_BY_UI_CLICK);
         callState.activeCallViewTab(CallViewTab.ALL);
       },
-      reject: (call: Call) => {
-        this.callingRepository.rejectCall(call.conversationId);
+      reject: ({conversation}: Call) => {
+        this.callingRepository.rejectCall(conversation.qualifiedId);
       },
       startAudio: async (conversationEntity: Conversation) => {
         if (conversationEntity.isGroup() && !this.teamState.isConferenceCallingEnabled()) {
@@ -360,10 +360,11 @@ export class CallingViewModel {
    * @param activeCall - the call to gracefully tear down
    */
   private async gracefullyTeardownCall(activeCall: Call): Promise<void> {
+    const {conversation} = activeCall;
     if (activeCall.state() === CALL_STATE.INCOMING) {
-      this.callingRepository.rejectCall(activeCall.conversationId);
+      this.callingRepository.rejectCall(conversation.qualifiedId);
     } else {
-      this.callingRepository.leaveCall(activeCall.conversationId, LEAVE_CALL_REASON.MANUAL_LEAVE_TO_JOIN_ANOTHER_CALL);
+      this.callingRepository.leaveCall(conversation.qualifiedId, LEAVE_CALL_REASON.MANUAL_LEAVE_TO_JOIN_ANOTHER_CALL);
     }
     // We want to wait a bit to be sure the call have been tear down properly
     await new Promise(resolve => setTimeout(resolve, 1000));
@@ -384,7 +385,10 @@ export class CallingViewModel {
     const idleCallStates = [CALL_STATE.INCOMING, CALL_STATE.NONE, CALL_STATE.UNKNOWN];
     const otherActiveCall = this.callState
       .calls()
-      .find(call => !matchQualifiedIds(call.conversationId, conversationId) && !idleCallStates.includes(call.state()));
+      .find(
+        call =>
+          !matchQualifiedIds(call.conversation.qualifiedId, conversationId) && !idleCallStates.includes(call.state()),
+      );
     if (!otherActiveCall) {
       return Promise.resolve(true);
     }


### PR DESCRIPTION
## Description

This PR removes the call entity from conversation entity (as it was not used) and adds a replaces `conversationId` field with a `conversation` field in a call entity. 

Conversation without a call is possible.

Call without a conversation is not possible. This removes the need for querying a conversation in a local state based on its id.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
