### PR TITLE
runfix: Properly send read receipts for 1to1 conversation asset messages

### DIFF
--- a/src/script/assets/AssetRepository.ts
+++ b/src/script/assets/AssetRepository.ts
@@ -46,7 +46,6 @@ interface CompressedImage {
 
 export interface AssetUploadOptions extends AssetOptions {
   domain?: string;
-  expectsReadConfirmation: boolean;
   legalHoldStatus?: LegalHoldStatus;
 }
 
@@ -194,7 +193,6 @@ export class AssetRepository {
     ]);
 
     const options: AssetUploadOptions = {
-      expectsReadConfirmation: false,
       public: true,
       retention: AssetRetentionPolicy.ETERNAL,
     };

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -26,7 +26,11 @@ import {
   MessageSendingStatus,
   RemoteConversations,
 } from '@wireapp/api-client/lib/conversation';
-import {MemberLeaveReason, ConversationReceiptModeUpdateData} from '@wireapp/api-client/lib/conversation/data';
+import {
+  MemberLeaveReason,
+  ConversationReceiptModeUpdateData,
+  RECEIPT_MODE,
+} from '@wireapp/api-client/lib/conversation/data';
 import {CONVERSATION_TYPING} from '@wireapp/api-client/lib/conversation/data/ConversationTypingData';
 import {
   ConversationCreateEvent,
@@ -4199,11 +4203,11 @@ export class ConversationRepository {
 
   expectReadReceipt(conversationEntity: Conversation): boolean {
     if (conversationEntity.is1to1()) {
-      return !!this.propertyRepository.receiptMode();
+      return this.propertyRepository.receiptMode() === RECEIPT_MODE.ON;
     }
 
     if (conversationEntity.teamId && conversationEntity.isGroup()) {
-      return !!conversationEntity.receiptMode();
+      return conversationEntity.receiptMode() === RECEIPT_MODE.ON;
     }
 
     return false;


### PR DESCRIPTION
## Description

This will make sure when sending assets in a 1:1 conversation that we set the `expect_read_confirmation` message header properly. 
Also fixes a regression where read-receipt would be sent even though the sender did not request a read receipt. 