### PR TITLE
feat: use badges with no numbers on collapsed sidebar

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationTab.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationTab.tsx
@@ -61,7 +61,11 @@ export const ConversationTab = ({
         <span className="conversations-sidebar-btn--text">{label || title}</span>
       </span>
 
-      {unreadConversations > 0 && <span className="conversations-sidebar-btn--badge">{unreadConversations}</span>}
+      {unreadConversations > 0 && (
+        <span className="conversations-sidebar-btn--badge">
+          <span className="conversations-sidebar-btn--badge-text">{unreadConversations}</span>
+        </span>
+      )}
     </button>
   );
 };

--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -53,6 +53,17 @@
         width: 16px;
         height: 16px;
       }
+
+      .conversations-sidebar-btn--badge {
+        position: absolute;
+        top: -2px;
+        right: -2px;
+        padding: 2px;
+      }
+
+      .conversations-sidebar-btn--badge-text {
+        display: none;
+      }
     }
   }
 
@@ -188,6 +199,7 @@
 
 .conversations-sidebar-btn {
   .button-reset-default;
+  position: relative;
   display: flex;
   width: 100%;
   flex-direction: row;


### PR DESCRIPTION
## Description
This PR introduces a mini version of badges on the sidebar without any numbers.

## Screenshots/Screencast (for UI changes)
<img width="41" alt="image" src="https://github.com/wireapp/wire-webapp/assets/63250054/96f807d2-492b-4d3d-8957-efee6d588e3f">
