### PR TITLE
fix: do not try to initialise 1:1 conversation with a bot

### DIFF
--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -377,6 +377,37 @@ describe('ConversationRepository', () => {
       expect(conversationEntity).toEqual(proteus1to1Conversation);
       expect(conversationRepository['conversationService'].getMLS1to1Conversation).not.toHaveBeenCalled();
     });
+
+    it('just returns a proteus conversation with a bot/service', async () => {
+      const conversationRepository = testFactory.conversation_repository!;
+      const userRepository = testFactory.user_repository!;
+
+      const otherUserId = {id: 'f718410c-1733-479d-bd80-af03f38416', domain: 'test-domain'};
+      const otherUser = new User(otherUserId.id, otherUserId.domain);
+      otherUser.isService = true;
+      otherUser.supportedProtocols([ConversationProtocol.PROTEUS]);
+
+      userRepository['userState'].users.push(otherUser);
+
+      const selfUserId = {id: '109da9ca-a417-47a870-9ffbe924b2d1', domain: 'test-domain'};
+      const selfUser = new User(selfUserId.id, selfUserId.domain);
+      selfUser.supportedProtocols([ConversationProtocol.PROTEUS, ConversationProtocol.MLS]);
+      jest.spyOn(conversationRepository['userState'], 'self').mockReturnValueOnce(selfUser);
+
+      const proteus1to1Conversation = _generateConversation({
+        type: CONVERSATION_TYPE.REGULAR,
+        protocol: ConversationProtocol.PROTEUS,
+        overwites: {team_id: 'teamId'},
+      });
+
+      proteus1to1Conversation.participating_user_ids([otherUserId]);
+      proteus1to1Conversation.participating_user_ets([otherUser]);
+
+      jest.spyOn(conversationRepository['conversationService'], 'getMLS1to1Conversation');
+
+      const conversationEntity = await conversationRepository.init1to1Conversation(proteus1to1Conversation, true);
+      expect(conversationEntity).toEqual(proteus1to1Conversation);
+    });
   });
 
   describe('getInitialised1To1Conversation', () => {

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1945,6 +1945,12 @@ export class ConversationRepository {
       return conversation;
     }
 
+    // If it is a 1:1 conversaiton with a bot/service, just open a conversation.
+    if (otherUser.isService) {
+      this.logger.warn(`User ${otherUserId.id} is a service, opening proteus conversation`);
+      return conversation;
+    }
+
     this.logger.info(
       `Initialising 1:1 conversation ${conversation.id} of type ${conversation.type()} with user ${otherUserId.id}`,
     );


### PR DESCRIPTION
## Description

We should not try to initialise proteus/mls conversation with a bot based on its supported protocols (it does not maintain this list). If it's a 1:1 conversation with a bot, we can just simply return it.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
