### PR TITLE
fix: handle error when creating a conversation with a bot

### DIFF
--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -100,6 +100,7 @@ function buildConversationRepository() {
     deleteConversation: () => {},
     deleteConversationFromDb: () => {},
     wipeMLSCapableConversation: () => {},
+    postBots: () => {},
   } as ConversationService;
   const messageRepository = {setClientMismatchHandler: () => {}} as unknown as MessageRepository;
   // @ts-ignore
@@ -1115,6 +1116,56 @@ describe('ConversationRepository', () => {
       await waitFor(() => {
         expect(conversationRepository.getInitialised1To1Conversation).not.toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('create1to1ConversationWithService', () => {
+    it('creates a 1:1 conversation with a service', async () => {
+      const [conversationRepository, {conversationService}] = buildConversationRepository();
+
+      const serviceId = 'service-id';
+      const providerId = 'provider-id';
+
+      const createdConversation = new Conversation('id', 'domain');
+
+      const memberJoinEvent: ConversationMemberJoinEvent = {
+        conversation: conversation_et.id,
+        data: {
+          user_ids: ['9028624e-bfef-490a-ba61-01683f5ccc83'],
+        },
+        from: 'd5a39ffb-6ce3-4cc8-9048-0e15d031b4c5',
+        time: '2015-04-27T11:42:31.475Z',
+        type: CONVERSATION_EVENT.MEMBER_JOIN,
+      };
+
+      jest.spyOn(conversationRepository, 'createGroupConversation').mockResolvedValueOnce(createdConversation);
+      jest.spyOn(conversationService, 'postBots').mockResolvedValueOnce(memberJoinEvent);
+
+      await conversationRepository.create1to1ConversationWithService({providerId, serviceId});
+
+      expect(conversationRepository.createGroupConversation).toHaveBeenCalled();
+    });
+
+    it('deletes the conversation when adding a service failed', async () => {
+      const [conversationRepository, {teamState, conversationService}] = buildConversationRepository();
+
+      const serviceId = 'service-id';
+      const providerId = 'provider-id';
+
+      const teamId = createUuid();
+
+      teamState.team({id: teamId} as any);
+
+      const createdConversation = new Conversation('id', 'domain');
+
+      jest.spyOn(conversationRepository, 'createGroupConversation').mockResolvedValueOnce(createdConversation);
+      jest.spyOn(conversationService, 'postBots').mockRejectedValueOnce(new Error(''));
+
+      await expect(async () => {
+        await conversationRepository.create1to1ConversationWithService({providerId, serviceId});
+        expect(conversationRepository.createGroupConversation).toHaveBeenCalled();
+        expect(conversationRepository.deleteConversation).toHaveBeenCalledWith(createdConversation);
+      }).rejects.toThrow();
     });
   });
 

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -101,6 +101,7 @@ function buildConversationRepository() {
     deleteConversationFromDb: () => {},
     wipeMLSCapableConversation: () => {},
     postBots: () => {},
+    saveConversationStateInDb: () => {},
   } as ConversationService;
   const messageRepository = {setClientMismatchHandler: () => {}} as unknown as MessageRepository;
   // @ts-ignore

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -2464,8 +2464,7 @@ export class ConversationRepository {
    */
   public async addServiceToExistingConversation(
     conversationEntity: Conversation,
-    providerId: string,
-    serviceId: string,
+    {providerId, serviceId}: {providerId: string; serviceId: string},
   ) {
     try {
       await this.addService(conversationEntity, {providerId, serviceId});

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -178,6 +178,11 @@ interface GetInitialised1To1ConversationOptions {
   shouldRefreshUser?: boolean;
 }
 
+type ConversaitonWithServiceParams = {
+  serviceId: string;
+  providerId: string;
+};
+
 export class ConversationRepository {
   private isBlockingNotificationHandling: boolean;
   private readonly ephemeralHandler: ConversationEphemeralHandler;
@@ -2397,10 +2402,7 @@ export class ConversationRepository {
   async create1to1ConversationWithService({
     providerId,
     serviceId,
-  }: {
-    providerId: string;
-    serviceId: string;
-  }): Promise<Conversation> {
+  }: ConversaitonWithServiceParams): Promise<Conversation> {
     try {
       const conversationEntity = await this.createGroupConversation([], undefined, ACCESS_STATE.TEAM.GUESTS_SERVICES);
 
@@ -2438,10 +2440,7 @@ export class ConversationRepository {
    * @param serviceId ID of service
    * @returns Resolves when service was added
    */
-  private async addService(
-    conversationEntity: Conversation,
-    {providerId, serviceId}: {providerId: string; serviceId: string},
-  ) {
+  private async addService(conversationEntity: Conversation, {providerId, serviceId}: ConversaitonWithServiceParams) {
     return this.conversationService.postBots(conversationEntity.id, providerId, serviceId).then((response: any) => {
       const event = response?.event;
       if (event) {
@@ -2464,7 +2463,7 @@ export class ConversationRepository {
    */
   public async addServiceToExistingConversation(
     conversationEntity: Conversation,
-    {providerId, serviceId}: {providerId: string; serviceId: string},
+    {providerId, serviceId}: ConversaitonWithServiceParams,
   ) {
     try {
       await this.addService(conversationEntity, {providerId, serviceId});

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -2412,7 +2412,7 @@ export class ConversationRepository {
       }
 
       try {
-        await this.addService(conversationEntity, providerId, serviceId);
+        await this.addService(conversationEntity, {providerId, serviceId});
         return conversationEntity;
       } catch (error) {
         // If we fail to add the service to the newly created conversation, we should delete the conversation
@@ -2438,7 +2438,10 @@ export class ConversationRepository {
    * @param serviceId ID of service
    * @returns Resolves when service was added
    */
-  private async addService(conversationEntity: Conversation, providerId: string, serviceId: string) {
+  private async addService(
+    conversationEntity: Conversation,
+    {providerId, serviceId}: {providerId: string; serviceId: string},
+  ) {
     return this.conversationService.postBots(conversationEntity.id, providerId, serviceId).then((response: any) => {
       const event = response?.event;
       if (event) {
@@ -2465,7 +2468,7 @@ export class ConversationRepository {
     serviceId: string,
   ) {
     try {
-      await this.addService(conversationEntity, providerId, serviceId);
+      await this.addService(conversationEntity, {providerId, serviceId});
     } catch (error) {
       if (isBackendError(error)) {
         return this.handleAddToConversationError(error, conversationEntity, [{domain: '', id: serviceId}]);

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -2388,6 +2388,49 @@ export class ConversationRepository {
   }
 
   /**
+   * Add service to conversation.
+   *
+   * @param serviceId serviceId ID of the service
+   * @param providerId providerId ID of the provider
+   * @returns Resolves when conversation with the integration was created
+   */
+  async create1to1ConversationWithService({
+    providerId,
+    serviceId,
+  }: {
+    providerId: string;
+    serviceId: string;
+  }): Promise<Conversation> {
+    try {
+      const conversationEntity = await this.createGroupConversation([], undefined, ACCESS_STATE.TEAM.GUESTS_SERVICES);
+
+      if (!conversationEntity) {
+        throw new ConversationError(
+          ConversationError.TYPE.CONVERSATION_NOT_FOUND,
+          ConversationError.MESSAGE.CONVERSATION_NOT_FOUND,
+        );
+      }
+
+      try {
+        await this.addService(conversationEntity, providerId, serviceId);
+        return conversationEntity;
+      } catch (error) {
+        // If we fail to add the service to the newly created conversation, we should delete the conversation
+        await this.deleteConversation(conversationEntity);
+        throw error;
+      }
+    } catch (error) {
+      PrimaryModal.show(PrimaryModal.type.ACKNOWLEDGE, {
+        text: {
+          message: t('modalIntegrationUnavailableMessage'),
+          title: t('modalIntegrationUnavailableHeadline'),
+        },
+      });
+      throw error;
+    }
+  }
+
+  /**
    * Add a service to an existing conversation.
    *
    * @param conversationEntity Conversation to add service to
@@ -2395,20 +2438,40 @@ export class ConversationRepository {
    * @param serviceId ID of service
    * @returns Resolves when service was added
    */
-  addService(conversationEntity: Conversation, providerId: string, serviceId: string) {
-    return this.conversationService
-      .postBots(conversationEntity.id, providerId, serviceId)
-      .then((response: any) => {
-        const event = response?.event;
-        if (event) {
-          const logMessage = `Successfully added service to conversation '${conversationEntity.display_name()}'`;
-          this.logger.debug(logMessage, response);
-          return this.eventRepository.injectEvent(response.event, EventRepository.SOURCE.BACKEND_RESPONSE);
-        }
+  private async addService(conversationEntity: Conversation, providerId: string, serviceId: string) {
+    return this.conversationService.postBots(conversationEntity.id, providerId, serviceId).then((response: any) => {
+      const event = response?.event;
+      if (event) {
+        const logMessage = `Successfully added service to conversation '${conversationEntity.display_name()}'`;
+        this.logger.debug(logMessage, response);
+        return this.eventRepository.injectEvent(response.event, EventRepository.SOURCE.BACKEND_RESPONSE);
+      }
 
-        return event;
-      })
-      .catch(error => this.handleAddToConversationError(error, conversationEntity, [{domain: '', id: serviceId}]));
+      return event;
+    });
+  }
+
+  /**
+   * Add a service to an existing conversation.
+   *
+   * @param conversationEntity Conversation to add service to
+   * @param providerId ID of service provider
+   * @param serviceId ID of service
+   * @returns Resolves when service was added
+   */
+  public async addServiceToExistingConversation(
+    conversationEntity: Conversation,
+    providerId: string,
+    serviceId: string,
+  ) {
+    try {
+      await this.addService(conversationEntity, providerId, serviceId);
+    } catch (error) {
+      if (isBackendError(error)) {
+        return this.handleAddToConversationError(error, conversationEntity, [{domain: '', id: serviceId}]);
+      }
+      throw error;
+    }
   }
 
   private deleteConnectionRequestConversation = async (userId: QualifiedId) => {

--- a/src/script/integration/IntegrationRepository.ts
+++ b/src/script/integration/IntegrationRepository.ts
@@ -115,7 +115,7 @@ export class IntegrationRepository {
     const {id: serviceId, name, providerId} = serviceEntity;
     this.logger.info(`Adding service '${name}' to conversation '${conversationEntity.id}'`);
 
-    return this.conversationRepository.addServiceToExistingConversation(conversationEntity, providerId, serviceId);
+    return this.conversationRepository.addServiceToExistingConversation(conversationEntity, {providerId, serviceId});
   }
 
   /**

--- a/src/script/integration/IntegrationRepository.ts
+++ b/src/script/integration/IntegrationRepository.ts
@@ -21,7 +21,6 @@ import type {ConversationMemberJoinEvent} from '@wireapp/api-client/lib/event/';
 import ko from 'knockout';
 import {container} from 'tsyringe';
 
-import {t} from 'Util/LocalizerUtil';
 import {getLogger, Logger} from 'Util/Logger';
 import {compareTransliteration, sortByPriority} from 'Util/StringUtil';
 
@@ -30,14 +29,11 @@ import type {IntegrationService} from './IntegrationService';
 import {ProviderEntity} from './ProviderEntity';
 import {ServiceEntity} from './ServiceEntity';
 
-import {PrimaryModal} from '../components/Modals/PrimaryModal';
-import {ACCESS_STATE} from '../conversation/AccessState';
 import type {ConversationRepository} from '../conversation/ConversationRepository';
 import {ConversationState} from '../conversation/ConversationState';
 import {MemberLeaveEvent} from '../conversation/EventBuilder';
 import type {Conversation} from '../entity/Conversation';
 import type {User} from '../entity/User';
-import {ConversationError} from '../error/ConversationError';
 import type {TeamRepository} from '../team/TeamRepository';
 import {TeamState} from '../team/TeamState';
 
@@ -112,14 +108,14 @@ export class IntegrationRepository {
    * @param serviceEntity Service to be added to conversation
    * @param method Method used to add service
    */
-  addService(
+  addServiceToExistingConversation(
     conversationEntity: Conversation,
     serviceEntity: ServiceEntity,
   ): Promise<ConversationMemberJoinEvent | void> {
     const {id: serviceId, name, providerId} = serviceEntity;
     this.logger.info(`Adding service '${name}' to conversation '${conversationEntity.id}'`);
 
-    return this.conversationRepository.addService(conversationEntity, providerId, serviceId);
+    return this.conversationRepository.addServiceToExistingConversation(conversationEntity, providerId, serviceId);
   }
 
   /**
@@ -129,30 +125,9 @@ export class IntegrationRepository {
    * @returns Resolves when conversation with the integration was created
    */
   async create1to1ConversationWithService(serviceEntity: ServiceEntity): Promise<Conversation> {
-    try {
-      const conversationEntity = await this.conversationRepository.createGroupConversation(
-        [],
-        undefined,
-        ACCESS_STATE.TEAM.GUESTS_SERVICES,
-      );
-
-      if (conversationEntity) {
-        return await this.addService(conversationEntity, serviceEntity).then(() => conversationEntity);
-      }
-
-      throw new ConversationError(
-        ConversationError.TYPE.CONVERSATION_NOT_FOUND,
-        ConversationError.MESSAGE.CONVERSATION_NOT_FOUND,
-      );
-    } catch (error) {
-      PrimaryModal.show(PrimaryModal.type.ACKNOWLEDGE, {
-        text: {
-          message: t('modalIntegrationUnavailableMessage'),
-          title: t('modalIntegrationUnavailableHeadline'),
-        },
-      });
-      throw error;
-    }
+    const {id: serviceId, name, providerId} = serviceEntity;
+    this.logger.info(`Creating a conversation with a service '${name}'.'`);
+    return this.conversationRepository.create1to1ConversationWithService({providerId, serviceId});
   }
 
   /**

--- a/src/script/page/RightSidebar/GroupParticipantService/GroupParticipantService.tsx
+++ b/src/script/page/RightSidebar/GroupParticipantService/GroupParticipantService.tsx
@@ -87,7 +87,7 @@ const GroupParticipantService: FC<GroupParticipantServiceProps> = ({
   };
 
   const onAdd = () => {
-    integrationRepository.addService(activeConversation, serviceEntity);
+    integrationRepository.addServiceToExistingConversation(activeConversation, serviceEntity);
     goToRoot();
   };
 


### PR DESCRIPTION
## Description

If we fail adding a service to newly created 1:1 conversation with bot, we should deleted the conversation so the empty group conversation does not appear in the UI.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
