### PR TITLE
runfix: Avoid race condition when team is deleted

### DIFF
--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -234,7 +234,9 @@ export class App {
     repositories.connection = new ConnectionRepository(new ConnectionService(), repositories.user);
     repositories.event = new EventRepository(this.service.event, this.service.notification, serverTimeHandler);
     repositories.search = new SearchRepository(repositories.user);
-    repositories.team = new TeamRepository(repositories.user, repositories.asset);
+    repositories.team = new TeamRepository(repositories.user, repositories.asset, () =>
+      this.logout(SIGN_OUT_REASON.ACCOUNT_DELETED, true),
+    );
 
     repositories.message = new MessageRepository(
       /*
@@ -689,7 +691,7 @@ export class App {
    * @param signOutReason Cause for logout
    * @param clearData Keep data in database
    */
-  private readonly logout = (signOutReason: SIGN_OUT_REASON, clearData: boolean): Promise<void> | void => {
+  private readonly logout = async (signOutReason: SIGN_OUT_REASON, clearData: boolean) => {
     if (this.isLoggingOut) {
       // Avoid triggering another logout flow if we currently are logging out.
       // This could happen if we trigger the logout flow while the user token is already invalid.

--- a/src/script/team/TeamRepository.test.ts
+++ b/src/script/team/TeamRepository.test.ts
@@ -49,8 +49,9 @@ function buildConnectionRepository() {
   const userRepository = {} as UserRepository;
   const assetRepository = {} as AssetRepository;
   const teamService = new TeamService({} as any);
+  const onMemberDeleted = jest.fn();
   return [
-    new TeamRepository(userRepository, assetRepository, teamService, userState, teamState),
+    new TeamRepository(userRepository, assetRepository, onMemberDeleted, teamService, userState, teamState),
     {userState, teamState, userRepository, assetRepository, teamService},
   ] as const;
 }

--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -277,7 +277,7 @@ export class TeamRepository extends TypedEventEmitter<Events> {
         break;
       }
       case TEAM_EVENT.MEMBER_LEAVE: {
-        this.onMemberLeave(eventJson);
+        await this.onMemberLeave(eventJson);
         break;
       }
       case TEAM_EVENT.FEATURE_CONFIG_UPDATE: {
@@ -387,7 +387,7 @@ export class TeamRepository extends TypedEventEmitter<Events> {
     await this.updateFeatureConfig();
   };
 
-  private onMemberLeave(eventJson: TeamMemberLeaveEvent): void {
+  private async onMemberLeave(eventJson: TeamMemberLeaveEvent) {
     const {
       data: {user: userId},
       team: teamId,

--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -50,7 +50,6 @@ import {TeamService} from './TeamService';
 import {TeamState} from './TeamState';
 
 import {AssetRepository} from '../assets/AssetRepository';
-import {SIGN_OUT_REASON} from '../auth/SignOutReason';
 import {User} from '../entity/User';
 import {EventSource} from '../event/EventSource';
 import {NOTIFICATION_HANDLING_STATE} from '../event/NotificationHandlingState';
@@ -87,6 +86,7 @@ export class TeamRepository extends TypedEventEmitter<Events> {
   constructor(
     userRepository: UserRepository,
     assetRepository: AssetRepository,
+    private readonly onMemberDetete: () => Promise<void>,
     readonly teamService: TeamService = new TeamService(),
     private readonly userState = container.resolve(UserState),
     private readonly teamState = container.resolve(TeamState),
@@ -273,7 +273,7 @@ export class TeamRepository extends TypedEventEmitter<Events> {
         break;
       }
       case TEAM_EVENT.DELETE: {
-        this.onDelete(eventJson);
+        await this.onDelete(eventJson);
         break;
       }
       case TEAM_EVENT.MEMBER_LEAVE: {
@@ -351,13 +351,11 @@ export class TeamRepository extends TypedEventEmitter<Events> {
     return this.teamService.getTeamById(teamId);
   }
 
-  private onDelete(eventJson: TeamDeleteEvent | TeamMemberLeaveEvent): void {
+  private async onDelete(eventJson: TeamDeleteEvent | TeamMemberLeaveEvent) {
     const {team: teamId} = eventJson;
     if (this.teamState.isTeam() && this.teamState.team().id === teamId) {
       this.teamState.isTeamDeleted(true);
-      window.setTimeout(() => {
-        amplify.publish(WebAppEvents.LIFECYCLE.SIGN_OUT, SIGN_OUT_REASON.ACCOUNT_DELETED, true);
-      }, 50);
+      await this.onMemberDetete();
     }
   }
 

--- a/test/helper/TestFactory.js
+++ b/test/helper/TestFactory.js
@@ -208,6 +208,7 @@ export class TestFactory {
     this.team_repository = new TeamRepository(
       this.user_repository,
       this.assetRepository,
+      () => Promise.resolve(),
       this.team_service,
       this.user_repository['userState'],
       new TeamState(this.user_repository['userState']),


### PR DESCRIPTION
## Description

When a team is deleted, we receive a `team.delete` event. This one is parsed and, currently, triggers an async, not awaited, process that will kill the database and the connection to the websocket. 
Because this process is not awaited (since it's a simple event fanned out through `amplify`), then other subsequent events can come in a be handled. 

This could cause a subsequent event to try to access the DB, while it's being deleted. 

The fix is to properly inject a callcack in the `TeamRepository` that will be called when the user is being deleted. 
We can then cleanly await this callback and not trigger any other event handling before this event is completely handled

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
