### PR TITLE
fix: prevent SSO login redirect for guest conversations (8827)

### DIFF
--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -123,6 +123,9 @@ const LoginComponent = ({
 
   const features = Config.getConfig().FEATURE;
 
+  const showBackButton =
+    !embedded && (features.ENABLE_DOMAIN_DISCOVERY || features.ENABLE_SSO || features.ENABLE_ACCOUNT_REGISTRATION);
+
   const [showEntropyForm, setShowEntropyForm] = useState(false);
   const isEntropyRequired = features.ENABLE_EXTRA_CLIENT_ENTROPY;
   const onEntropyGenerated = useRef<((entropy: Uint8Array) => void) | undefined>();
@@ -350,12 +353,11 @@ const LoginComponent = ({
 
   return (
     <Page>
-      {!embedded &&
-        (features.ENABLE_DOMAIN_DISCOVERY || features.ENABLE_SSO || features.ENABLE_ACCOUNT_REGISTRATION) && (
-          <IsMobile>
-            <div style={{margin: 16}}>{backArrow}</div>
-          </IsMobile>
-        )}
+      {showBackButton && (
+        <IsMobile>
+          <div style={{margin: 16}}>{backArrow}</div>
+        </IsMobile>
+      )}
       {isEntropyRequired && showEntropyForm ? (
         <EntropyContainer onSetEntropy={storeEntropy} />
       ) : (
@@ -378,9 +380,7 @@ const LoginComponent = ({
             {!embedded && (
               <IsMobile not>
                 <Column style={{display: 'flex'}}>
-                  {(features.ENABLE_DOMAIN_DISCOVERY ||
-                    features.ENABLE_SSO ||
-                    features.ENABLE_ACCOUNT_REGISTRATION) && <div style={{margin: 'auto'}}>{backArrow}</div>}
+                  {showBackButton && <div style={{margin: 'auto'}}>{backArrow}</div>}
                 </Column>
               </IsMobile>
             )}

--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -120,8 +120,10 @@ const LoginComponent = ({
 
   const isOauth = UrlUtil.hasURLParameter(QUERY_KEY.SCOPE, window.location.hash);
 
+  const features = Config.getConfig().FEATURE;
+
   const [showEntropyForm, setShowEntropyForm] = useState(false);
-  const isEntropyRequired = Config.getConfig().FEATURE.ENABLE_EXTRA_CLIENT_ENTROPY;
+  const isEntropyRequired = features.ENABLE_EXTRA_CLIENT_ENTROPY;
   const onEntropyGenerated = useRef<((entropy: Uint8Array) => void) | undefined>();
   const entropy = useRef<Uint8Array | undefined>();
 
@@ -348,9 +350,7 @@ const LoginComponent = ({
   return (
     <Page>
       {!embedded &&
-        (Config.getConfig().FEATURE.ENABLE_DOMAIN_DISCOVERY ||
-          Config.getConfig().FEATURE.ENABLE_SSO ||
-          Config.getConfig().FEATURE.ENABLE_ACCOUNT_REGISTRATION) && (
+        (features.ENABLE_DOMAIN_DISCOVERY || features.ENABLE_SSO || features.ENABLE_ACCOUNT_REGISTRATION) && (
           <IsMobile>
             <div style={{margin: 16}}>{backArrow}</div>
           </IsMobile>
@@ -377,11 +377,9 @@ const LoginComponent = ({
             {!embedded && (
               <IsMobile not>
                 <Column style={{display: 'flex'}}>
-                  {(Config.getConfig().FEATURE.ENABLE_DOMAIN_DISCOVERY ||
-                    Config.getConfig().FEATURE.ENABLE_SSO ||
-                    Config.getConfig().FEATURE.ENABLE_ACCOUNT_REGISTRATION) && (
-                    <div style={{margin: 'auto'}}>{backArrow}</div>
-                  )}
+                  {(features.ENABLE_DOMAIN_DISCOVERY ||
+                    features.ENABLE_SSO ||
+                    features.ENABLE_ACCOUNT_REGISTRATION) && <div style={{margin: 'auto'}}>{backArrow}</div>}
                 </Column>
               </IsMobile>
             )}
@@ -471,7 +469,7 @@ const LoginComponent = ({
                     >
                       {_(loginStrings.forgotPassword)}
                     </Link>
-                    {!embedded && Config.getConfig().FEATURE.ENABLE_PHONE_LOGIN && (
+                    {!embedded && features.ENABLE_PHONE_LOGIN && (
                       <RouterLink
                         variant={LinkVariant.PRIMARY}
                         style={{paddingTop: '12px', textAlign: 'center'}}

--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -32,6 +32,7 @@ import {Runtime, UrlUtil} from '@wireapp/commons';
 import {
   ArrowIcon,
   Button,
+  ButtonVariant,
   Checkbox,
   CheckboxLabel,
   CodeInput,
@@ -61,7 +62,7 @@ import {EntropyContainer} from './EntropyContainer';
 import {Page} from './Page';
 
 import {Config} from '../../Config';
-import {loginStrings, verifyStrings} from '../../strings';
+import {indexStrings, loginStrings, verifyStrings} from '../../strings';
 import {AppAlreadyOpen} from '../component/AppAlreadyOpen';
 import {Exception} from '../component/Exception';
 import {JoinGuestLinkPasswordModal} from '../component/JoinGuestLinkPasswordModal';
@@ -478,6 +479,17 @@ const LoginComponent = ({
                       >
                         {_(loginStrings.phoneLogin)}
                       </RouterLink>
+                    )}
+                    {embedded && (features.ENABLE_DOMAIN_DISCOVERY || features.ENABLE_SSO) && (
+                      <Button
+                        type="button"
+                        variant={ButtonVariant.SECONDARY}
+                        onClick={() => navigate(`${ROUTE.SSO}/${defaultSSOCode ?? ''}`)}
+                        style={{marginTop: '16px'}}
+                        data-uie-name="go-sso-login"
+                      >
+                        {_(features.ENABLE_DOMAIN_DISCOVERY ? indexStrings.enterprise : indexStrings.ssoLogin)}
+                      </Button>
                     )}
                   </>
                 )}

--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -148,11 +148,11 @@ const LoginComponent = ({
   }, []);
 
   useEffect(() => {
-    // Redirect to prefilled SSO login if default SSO code is set on backend
-    if (defaultSSOCode) {
+    // Redirect to prefilled SSO login if default SSO code is set on backend unless we're following the guest link flow
+    if (defaultSSOCode && !embedded) {
       navigate(`${ROUTE.SSO}/${defaultSSOCode}`);
     }
-  }, [defaultSSOCode, navigate]);
+  }, [defaultSSOCode, embedded, navigate]);
 
   useEffect(() => {
     const queryConversationCode = UrlUtil.getURLParameter(QUERY_KEY.CONVERSATION_CODE) || null;

--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -121,13 +121,17 @@ const LoginComponent = ({
 
   const isOauth = UrlUtil.hasURLParameter(QUERY_KEY.SCOPE, window.location.hash);
 
-  const features = Config.getConfig().FEATURE;
+  const {
+    ENABLE_ACCOUNT_REGISTRATION: isAccountRegistrationEnabled,
+    ENABLE_DOMAIN_DISCOVERY: isDomainDiscoveryEnabled,
+    ENABLE_EXTRA_CLIENT_ENTROPY: isEntropyRequired,
+    ENABLE_PHONE_LOGIN: isPhoneLoginEnabled,
+    ENABLE_SSO: isSSOEnabled,
+  } = Config.getConfig().FEATURE;
 
-  const showBackButton =
-    !embedded && (features.ENABLE_DOMAIN_DISCOVERY || features.ENABLE_SSO || features.ENABLE_ACCOUNT_REGISTRATION);
+  const showBackButton = !embedded && (isDomainDiscoveryEnabled || isSSOEnabled || isAccountRegistrationEnabled);
 
   const [showEntropyForm, setShowEntropyForm] = useState(false);
-  const isEntropyRequired = features.ENABLE_EXTRA_CLIENT_ENTROPY;
   const onEntropyGenerated = useRef<((entropy: Uint8Array) => void) | undefined>();
   const entropy = useRef<Uint8Array | undefined>();
 
@@ -470,7 +474,7 @@ const LoginComponent = ({
                     >
                       {_(loginStrings.forgotPassword)}
                     </Link>
-                    {!embedded && features.ENABLE_PHONE_LOGIN && (
+                    {!embedded && isPhoneLoginEnabled && (
                       <RouterLink
                         variant={LinkVariant.PRIMARY}
                         style={{paddingTop: '12px', textAlign: 'center'}}
@@ -480,7 +484,7 @@ const LoginComponent = ({
                         {_(loginStrings.phoneLogin)}
                       </RouterLink>
                     )}
-                    {embedded && (features.ENABLE_DOMAIN_DISCOVERY || features.ENABLE_SSO) && (
+                    {embedded && (isDomainDiscoveryEnabled || isSSOEnabled) && (
                       <Button
                         type="button"
                         variant={ButtonVariant.SECONDARY}
@@ -488,7 +492,7 @@ const LoginComponent = ({
                         style={{marginTop: '16px'}}
                         data-uie-name="go-sso-login"
                       >
-                        {_(features.ENABLE_DOMAIN_DISCOVERY ? indexStrings.enterprise : indexStrings.ssoLogin)}
+                        {_(isDomainDiscoveryEnabled ? indexStrings.enterprise : indexStrings.ssoLogin)}
                       </Button>
                     )}
                   </>


### PR DESCRIPTION
## Description

#### Issue:
Users from a backend that provides default SSO code were not able to invite guest to conversations, as the guest login would be skipped by the SSO redirection

#### Solution:
- we prevent the redirection to the sso login if a conversation code is provided
- we add a SSO login button to the guest login flow

## Screenshots  / Screencasts
#### Before:
[Screencast from 2024-04-22 15-29-18.webm](https://github.com/wireapp/wire-webapp/assets/78490891/f57ee636-6839-4e8a-abeb-6ab8c29e2a88)

#### After:
Guest login page:
![Screenshot from 2024-04-22 17-18-57](https://github.com/wireapp/wire-webapp/assets/78490891/22b9a06b-531c-4395-af63-273bfc79acba)


