### PR TITLE
ci: fix helm release version bumps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -143,7 +143,7 @@ jobs:
 
           helm repo add charts-webapp s3://public.wire.com/charts-webapp
 
-          if [ "${{github.ref}}" =~ "/refs/tags" ]; then
+          if [ ! "$TAG" = "" ]; then
             chart_version="$(./bin/chart-next-version.sh release)"
           else
             chart_version="$(./bin/chart-next-version.sh prerelease)"


### PR DESCRIPTION
This PR should fix the following bug: tagged commits don't get a proper version bump for their helm chart 
