### PR TITLE
chore(ci): fix bash condition to publish chart versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -143,7 +143,7 @@ jobs:
 
           helm repo add charts-webapp s3://public.wire.com/charts-webapp
 
-          if [ "${{github.ref}}" =~ "/refs/tags" ]; then
+          if [[ "${{github.ref}}" =~ "/refs/tags" ]]; then
             chart_version="$(./bin/chart-next-version.sh release)"
           else
             chart_version="$(./bin/chart-next-version.sh prerelease)"


### PR DESCRIPTION
## Description

The condition to generate a prod/staging release was wrong. Bash needs `[[` in order to use regexp. see https://unix.stackexchange.com/questions/306111/what-is-the-difference-between-the-bash-operators-vs-vs-vs
