### PR TITLE
runfix: do not allow a new client to snooze the enrollment [WPB-8878]

### DIFF
--- a/src/script/E2EIdentity/E2EIdentityEnrollment.test.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.test.ts
@@ -38,18 +38,20 @@ import {Conversation} from '../entity/Conversation';
 import {User} from '../entity/User';
 
 jest.mock('./OIDCService', () => {
+  const mockedUserData = {
+    id_token: 'ID_TOKEN',
+    access_token: 'ACCESS_TOKEN',
+    refresh_token: 'REFRESH_TOKEN  ',
+    token_type: 'auth',
+    profile: 'sub',
+  };
   return {
     // Mock the OIDCService class
     OIDCService: jest.fn().mockImplementation(() => ({
-      handleSilentAuthentication: jest.fn().mockResolvedValue({
-        id_token: 'ID_TOKEN',
-        access_token: 'ACCESS_TOKEN',
-        refresh_token: 'REFRESH_TOKEN  ',
-        token_type: 'auth',
-        profile: 'sub',
-      }),
+      handleSilentAuthentication: jest.fn().mockResolvedValue(mockedUserData),
       clearProgress: jest.fn(),
       handleAuthentication: jest.fn().mockResolvedValue({}),
+      getUser: jest.fn().mockResolvedValue(mockedUserData),
       // ... other methods of OIDCService
     })),
     getOIDCServiceInstance: jest.fn(), // if needed

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.test.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.test.ts
@@ -151,6 +151,19 @@ describe('E2EIHandler', () => {
 
   it('continues in progress enrollment', async () => {
     jest.spyOn(coreMock.service!.e2eIdentity!, 'isEnrollmentInProgress').mockResolvedValue(true);
+
+    // mock window search params (code, session_state, state)
+    const searchParams = new URLSearchParams();
+    searchParams.append('code', 'CODE');
+    searchParams.append('session_state', 'SESSION_STATE');
+    searchParams.append('state', 'STATE');
+
+    Object.defineProperty(window, 'location', {
+      value: {
+        search: searchParams.toString(),
+      },
+    });
+
     const enrollPromise = E2EIHandler.getInstance().initialize(params);
     await waitFor(() => {
       expect(modalMock).toHaveBeenCalledWith(

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.test.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.test.ts
@@ -38,20 +38,18 @@ import {Conversation} from '../entity/Conversation';
 import {User} from '../entity/User';
 
 jest.mock('./OIDCService', () => {
-  const mockedUserData = {
-    id_token: 'ID_TOKEN',
-    access_token: 'ACCESS_TOKEN',
-    refresh_token: 'REFRESH_TOKEN  ',
-    token_type: 'auth',
-    profile: 'sub',
-  };
   return {
     // Mock the OIDCService class
     OIDCService: jest.fn().mockImplementation(() => ({
-      handleSilentAuthentication: jest.fn().mockResolvedValue(mockedUserData),
+      handleSilentAuthentication: jest.fn().mockResolvedValue({
+        id_token: 'ID_TOKEN',
+        access_token: 'ACCESS_TOKEN',
+        refresh_token: 'REFRESH_TOKEN  ',
+        token_type: 'auth',
+        profile: 'sub',
+      }),
       clearProgress: jest.fn(),
       handleAuthentication: jest.fn().mockResolvedValue({}),
-      getUser: jest.fn().mockResolvedValue(mockedUserData),
       // ... other methods of OIDCService
     })),
     getOIDCServiceInstance: jest.fn(), // if needed

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -330,14 +330,11 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
     // Clear the e2e identity progress
     await this.coreE2EIService.clearAllProgress();
 
-    // A fresh MLS client should be forced to enrol.
-    const shouldHideSnooze = (await isFreshMLSSelfClient()) || !snoozable;
-
-    return new Promise<void>(async resolve => {
+    return new Promise<void>(resolve => {
       const {modalOptions, modalType} = getModalOptions({
         type: ModalType.ERROR,
         hideClose: true,
-        hideSecondary: shouldHideSnooze,
+        hideSecondary: !snoozable,
         primaryActionFn: async () => {
           await this.enroll(snoozable);
           resolve();

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -141,26 +141,14 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
 
     await this.coreE2EIService.initialize(discoveryUrl);
 
-    const isEnrollmentInProgress = await this.coreE2EIService.isEnrollmentInProgress();
-
-    if (isEnrollmentInProgress && (await this.hasUserAuthData())) {
-      // If we have an enrollment in progress and we have user's auth data, we can just finish it (meaning we are coming back from an idp redirect with proper url params)
+    if (await this.coreE2EIService.isEnrollmentInProgress()) {
+      // If we have an enrollment in progress, we can just finish it (meaning we are coming back from an idp redirect)
       await this.enroll();
     } else if (await isFreshMLSSelfClient()) {
       // When the user logs in to a new device in an environment that has e2ei enabled, they should be forced to enroll
-      await this.cleanUp(true);
       await this.startEnrollment(ModalType.ENROLL, false);
     }
     return this;
-  }
-
-  private async hasUserAuthData(): Promise<boolean> {
-    try {
-      const userData = await this.getUserData(true);
-      return !!userData;
-    } catch {
-      return false;
-    }
   }
 
   /**

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -143,12 +143,28 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
 
     if (await this.coreE2EIService.isEnrollmentInProgress()) {
       // If we have an enrollment in progress, we can just finish it (meaning we are coming back from an idp redirect)
-      await this.enroll();
+      if (this.wasJustRedirected()) {
+        await this.enroll();
+      } else {
+        // If we have an enrollment in progress but we are not coming back from an idp redirect, we need to clear the progress and start over
+        await this.coreE2EIService.clearAllProgress();
+        await this.startEnrollment(ModalType.ENROLL, false);
+      }
     } else if (await isFreshMLSSelfClient()) {
       // When the user logs in to a new device in an environment that has e2ei enabled, they should be forced to enroll
       await this.startEnrollment(ModalType.ENROLL, false);
     }
     return this;
+  }
+
+  public wasJustRedirected() {
+    const searchParams = new URLSearchParams(window.location.search);
+
+    const hasState = searchParams.has('state');
+    const hasSessionState = searchParams.has('session_state');
+    const hasCode = searchParams.has('code');
+
+    return hasState && hasSessionState && hasCode;
   }
 
   /**

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -330,11 +330,14 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
     // Clear the e2e identity progress
     await this.coreE2EIService.clearAllProgress();
 
-    return new Promise<void>(resolve => {
+    // A fresh MLS client should be forced to enrol.
+    const shouldHideSnooze = (await isFreshMLSSelfClient()) || !snoozable;
+
+    return new Promise<void>(async resolve => {
       const {modalOptions, modalType} = getModalOptions({
         type: ModalType.ERROR,
         hideClose: true,
-        hideSecondary: !snoozable,
+        hideSecondary: shouldHideSnooze,
         primaryActionFn: async () => {
           await this.enroll(snoozable);
           resolve();

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -19,6 +19,7 @@
 
 import {LowPrecisionTaskScheduler} from '@wireapp/core/lib/util/LowPrecisionTaskScheduler';
 import {amplify} from 'amplify';
+import {SigninResponse} from 'oidc-client-ts';
 import {container} from 'tsyringe';
 
 import {TypedEventEmitter} from '@wireapp/commons';
@@ -160,11 +161,9 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
   public wasJustRedirected() {
     const searchParams = new URLSearchParams(window.location.search);
 
-    const hasState = searchParams.has('state');
-    const hasSessionState = searchParams.has('session_state');
-    const hasCode = searchParams.has('code');
+    const {state, session_state, code} = new SigninResponse(searchParams);
 
-    return hasState && hasSessionState && hasCode;
+    return !!state && !!session_state && !!code;
   }
 
   /**

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -141,14 +141,26 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
 
     await this.coreE2EIService.initialize(discoveryUrl);
 
-    if (await this.coreE2EIService.isEnrollmentInProgress()) {
-      // If we have an enrollment in progress, we can just finish it (meaning we are coming back from an idp redirect)
+    const isEnrollmentInProgress = await this.coreE2EIService.isEnrollmentInProgress();
+
+    if (isEnrollmentInProgress && (await this.hasUserAuthData())) {
+      // If we have an enrollment in progress and we have user's auth data, we can just finish it (meaning we are coming back from an idp redirect with proper url params)
       await this.enroll();
     } else if (await isFreshMLSSelfClient()) {
       // When the user logs in to a new device in an environment that has e2ei enabled, they should be forced to enroll
+      await this.cleanUp(true);
       await this.startEnrollment(ModalType.ENROLL, false);
     }
     return this;
+  }
+
+  private async hasUserAuthData(): Promise<boolean> {
+    try {
+      const userData = await this.getUserData(true);
+      return !!userData;
+    } catch {
+      return false;
+    }
   }
 
   /**


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8878" title="WPB-8878" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-8878</a>  [Web] Possible to log in on C3 without enrolling for certificate
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

We should not allow a completely new MLS client to snooze the enrolment retry-process after it has failed for the first time.

If there's no user data after coming back from the redirect, we should try the enrollment flow from scratch.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;