### PR TITLE
feat: new badge without number

### DIFF
--- a/src/script/conversation/ConversationLabelRepository.ts
+++ b/src/script/conversation/ConversationLabelRepository.ts
@@ -23,6 +23,7 @@ import ko from 'knockout';
 
 import {WebAppEvents} from '@wireapp/webapp-events';
 
+import {SidebarTabs, useSidebarStore} from 'src/script/page/LeftSidebar/panels/Conversations/state';
 import {t} from 'Util/LocalizerUtil';
 import {getLogger, Logger} from 'Util/Logger';
 import {TypedEventTarget} from 'Util/TypedEventTarget';
@@ -219,8 +220,12 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
 
   readonly removeConversationFromLabel = (label: ConversationLabel, removeConversation: Conversation): void => {
     label.conversations(label.conversations().filter(conversation => conversation !== removeConversation));
+    // Add conversations in a folder are deleted so folder must be deleted too
     if (!label.conversations().length) {
       this.labels.remove(label);
+      // switch sidebar to recent tabs
+      const {setCurrentTab} = useSidebarStore.getState();
+      setCurrentTab(SidebarTabs.RECENT);
     }
     this.saveLabels();
   };

--- a/src/script/conversation/ConversationLabelRepository.ts
+++ b/src/script/conversation/ConversationLabelRepository.ts
@@ -183,6 +183,11 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
       favoriteLabel.conversations(
         favoriteLabel.conversations().filter(conversation => conversation !== removedConversation),
       );
+      // trigger a rerender on sidebar to remove the conversation from favorites
+      const {currentTab, setCurrentTab} = useSidebarStore.getState();
+      if (currentTab === SidebarTabs.FAVORITES) {
+        setCurrentTab(SidebarTabs.FAVORITES);
+      }
     }
     this.saveLabels();
   };

--- a/src/script/conversation/ConversationLabelRepository.ts
+++ b/src/script/conversation/ConversationLabelRepository.ts
@@ -225,7 +225,7 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
 
   readonly removeConversationFromLabel = (label: ConversationLabel, removeConversation: Conversation): void => {
     label.conversations(label.conversations().filter(conversation => conversation !== removeConversation));
-    // Add conversations in a folder are deleted so folder must be deleted too
+    // Delete folder if it no longer contains any conversation
     if (!label.conversations().length) {
       this.labels.remove(label);
       // switch sidebar to recent tabs

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationHeader/ConversationHeader.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationHeader/ConversationHeader.tsx
@@ -24,6 +24,7 @@ import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {Icon} from 'Components/Icon';
 import {ConversationLabel} from 'src/script/conversation/ConversationLabelRepository';
+import {SidebarTabs} from 'src/script/page/LeftSidebar/panels/Conversations/state';
 import {t} from 'Util/LocalizerUtil';
 
 import {
@@ -38,7 +39,6 @@ import {
 
 import {User} from '../../../../../entity/User';
 import {generatePermissionHelpers} from '../../../../../user/UserPermission';
-import {SidebarTabs} from '../Conversations';
 
 interface ConversationHeaderProps {
   currentTab: SidebarTabs;

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.tsx
@@ -23,11 +23,10 @@ import {Config} from 'src/script/Config';
 import {createLabel} from 'src/script/conversation/ConversationLabelRepository';
 import {ConversationRepository} from 'src/script/conversation/ConversationRepository';
 import {Conversation} from 'src/script/entity/Conversation';
-import {useFolderState, useSidebarStore} from 'src/script/page/LeftSidebar/panels/Conversations/state';
+import {SidebarTabs, useFolderState, useSidebarStore} from 'src/script/page/LeftSidebar/panels/Conversations/state';
 import {ContextMenuEntry, showContextMenu} from 'src/script/ui/ContextMenu';
+import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
-
-import {SidebarTabs} from '../Conversations';
 
 interface ConversationFolderTabProps {
   title: string;
@@ -62,10 +61,11 @@ export const ConversationFolderTab = ({
     onChangeTab(type, folderId);
   }
 
-  const folders = conversationLabelRepository
-    .getLabels()
+  const {labels} = useKoSubscribableChildren(conversationLabelRepository, ['labels']);
+
+  const folders = labels
     .map(label => createLabel(label.name, conversationLabelRepository.getLabelConversations(label), label.id))
-    .filter(({conversations}) => !!conversations().length);
+    .filter(({conversations, name}) => !!conversations().length && !!name);
 
   function openFoldersContextMenu(event: React.MouseEvent<HTMLButtonElement>) {
     const entries: ContextMenuEntry[] = folders.map(folder => ({

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.tsx
@@ -156,7 +156,7 @@ export const ConversationFolderTab = ({
                 onClick={() => toggleFolder(folder.id)}
               >
                 <span>{folder.name}</span>
-                {!!unreadCount && <span className="conversations-sidebar-btn--badge">{unreadCount}</span>}
+                {!!unreadCount && <span className={cx('conversations-sidebar-btn--badge', {active: isActive})} />}
               </button>
             );
           })}

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationTab.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationTab.tsx
@@ -19,7 +19,7 @@
 
 import cx from 'classnames';
 
-import {SidebarTabs} from '../Conversations';
+import {SidebarTabs} from 'src/script/page/LeftSidebar/panels/Conversations/state';
 
 interface ConversationTabProps {
   title: string;

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationTab.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationTab.tsx
@@ -58,10 +58,9 @@ export const ConversationTab = ({
     >
       <span className="conversations-sidebar-btn--text-wrapper">
         {Icon}
+        {unreadConversations > 0 && <span className={cx('conversations-sidebar-btn--badge', {active: isActive})} />}
         <span className="conversations-sidebar-btn--text">{label || title}</span>
       </span>
-
-      {unreadConversations > 0 && <span className="conversations-sidebar-btn--badge">{unreadConversations}</span>}
     </button>
   );
 };

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/ConversationTabs.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/ConversationTabs.tsx
@@ -22,13 +22,13 @@ import {ChevronIcon, GroupIcon, InfoIcon, StarIcon} from '@wireapp/react-ui-kit'
 import {Icon} from 'Components/Icon';
 import {ConversationRepository} from 'src/script/conversation/ConversationRepository';
 import {ConversationFolderTab} from 'src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab';
+import {SidebarTabs} from 'src/script/page/LeftSidebar/panels/Conversations/state';
 import {t} from 'Util/LocalizerUtil';
 
 import {Config} from '../../../../../Config';
 import {Conversation} from '../../../../../entity/Conversation';
 import {Shortcut} from '../../../../../ui/Shortcut';
 import {ShortcutType} from '../../../../../ui/ShortcutType';
-import {SidebarTabs} from '../Conversations';
 import {ConversationTab} from '../ConversationTab';
 
 interface ConversationTabsProps {

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -43,7 +43,7 @@ import {ConversationsList} from './ConversationsList';
 import {ConversationTabs} from './ConversationTabs';
 import {EmptyConversationList} from './EmptyConversationList';
 import {getTabConversations} from './helpers';
-import {useFolderState, useSidebarStore} from './state';
+import {SidebarTabs, useFolderState, useSidebarStore} from './state';
 
 import {CallState} from '../../../../calling/CallState';
 import {createLabel, DefaultLabelIds} from '../../../../conversation/ConversationLabelRepository';
@@ -76,17 +76,6 @@ type ConversationsProps = {
   userRepository: UserRepository;
 };
 
-export enum SidebarTabs {
-  RECENT,
-  FOLDER,
-  FAVORITES,
-  GROUPS,
-  DIRECTS,
-  ARCHIVES,
-  CONNECT,
-  PREFERENCES,
-}
-
 const Conversations: React.FC<ConversationsProps> = ({
   integrationRepository,
   searchRepository,
@@ -102,7 +91,13 @@ const Conversations: React.FC<ConversationsProps> = ({
   userState = container.resolve(UserState),
   selfUser,
 }) => {
-  const {isOpen: isSideBarOpen, toggleIsOpen: toggleSidebarIsOpen, setIsOpen: setIsSidebarOpen} = useSidebarStore();
+  const {
+    isOpen: isSideBarOpen,
+    toggleIsOpen: toggleSidebarIsOpen,
+    setIsOpen: setIsSidebarOpen,
+    currentTab,
+    setCurrentTab,
+  } = useSidebarStore();
   const [conversationsFilter, setConversationsFilter] = useState<string>('');
   const {activeCalls} = useKoSubscribableChildren(callState, ['activeCalls']);
   const {classifiedDomains, isTeam} = useKoSubscribableChildren(teamState, ['classifiedDomains', 'isTeam']);
@@ -126,12 +121,6 @@ const Conversations: React.FC<ConversationsProps> = ({
 
   const {conversationLabelRepository} = conversationRepository;
   const favoriteConversations = conversationLabelRepository.getFavorites(conversations);
-
-  const initialTab = propertiesRepository.getPreference(PROPERTIES_TYPE.INTERFACE.VIEW_FOLDERS)
-    ? SidebarTabs.FOLDER
-    : SidebarTabs.RECENT;
-
-  const [currentTab, setCurrentTab] = useState<SidebarTabs>(initialTab);
 
   const isFolderTab = currentTab === SidebarTabs.FOLDER;
   const isPreferences = currentTab === SidebarTabs.PREFERENCES;

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -46,7 +46,7 @@ import {getTabConversations} from './helpers';
 import {SidebarTabs, useFolderState, useSidebarStore} from './state';
 
 import {CallState} from '../../../../calling/CallState';
-import {createLabel, DefaultLabelIds} from '../../../../conversation/ConversationLabelRepository';
+import {createLabel} from '../../../../conversation/ConversationLabelRepository';
 import {ConversationRepository} from '../../../../conversation/ConversationRepository';
 import {ConversationState} from '../../../../conversation/ConversationState';
 import {User} from '../../../../entity/User';
@@ -187,7 +187,7 @@ const Conversations: React.FC<ConversationsProps> = ({
   }, [activeConversation]);
 
   useEffect(() => {
-    const openFavorites = () => openFolder(DefaultLabelIds.Favorites);
+    const openFavorites = () => changeTab(SidebarTabs.FAVORITES);
     conversationLabelRepository.addEventListener('conversation-favorited', openFavorites);
     return () => {
       conversationLabelRepository.removeEventListener('conversation-favorited', openFavorites);

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
@@ -28,12 +28,11 @@ import {ConversationListCell} from 'Components/list/ConversationListCell';
 import {Call} from 'src/script/calling/Call';
 import {ConversationLabel, ConversationLabelRepository} from 'src/script/conversation/ConversationLabelRepository';
 import {User} from 'src/script/entity/User';
+import {SidebarTabs} from 'src/script/page/LeftSidebar/panels/Conversations/state';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {handleKeyDown, isKeyboardEvent} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
 import {matchQualifiedIds} from 'Util/QualifiedId';
-
-import {SidebarTabs} from './Conversations';
 
 import {CallState} from '../../../../calling/CallState';
 import {ConversationRepository} from '../../../../conversation/ConversationRepository';

--- a/src/script/page/LeftSidebar/panels/Conversations/EmptyConversationList/EmptyConversationList.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/EmptyConversationList/EmptyConversationList.tsx
@@ -22,12 +22,12 @@ import {amplify} from 'amplify';
 import {Button, ButtonVariant, Link, LinkVariant} from '@wireapp/react-ui-kit';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
+import {SidebarTabs} from 'src/script/page/LeftSidebar/panels/Conversations/state';
 import {t} from 'Util/LocalizerUtil';
 
 import {button, paragraph, seperator, wrapper} from './EmptyConversationList.styles';
 
 import {Config} from '../../../../../Config';
-import {SidebarTabs} from '../Conversations';
 
 interface EmptyConversationListProps {
   currentTab: SidebarTabs;

--- a/src/script/page/LeftSidebar/panels/Conversations/helpers.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/helpers.tsx
@@ -17,9 +17,8 @@
  *
  */
 
+import {SidebarTabs} from 'src/script/page/LeftSidebar/panels/Conversations/state';
 import {t} from 'Util/LocalizerUtil';
-
-import {SidebarTabs} from './Conversations';
 
 import {Conversation} from '../../../../entity/Conversation';
 

--- a/src/script/page/LeftSidebar/panels/Conversations/state.ts
+++ b/src/script/page/LeftSidebar/panels/Conversations/state.ts
@@ -57,13 +57,30 @@ const useFolderState = create<FolderState>((set, get) => ({
     }),
 }));
 
+export enum SidebarTabs {
+  RECENT,
+  FOLDER,
+  FAVORITES,
+  GROUPS,
+  DIRECTS,
+  ARCHIVES,
+  CONNECT,
+  PREFERENCES,
+}
+
 export interface SidebarStore {
   isOpen: boolean;
   setIsOpen: (isOpen: boolean) => void;
   toggleIsOpen: () => void;
+  currentTab: SidebarTabs;
+  setCurrentTab: (tab: SidebarTabs) => void;
 }
 
 const useSidebarStore = create<SidebarStore>((set, get) => ({
+  currentTab: SidebarTabs.RECENT,
+  setCurrentTab: (tab: SidebarTabs) => {
+    set({currentTab: tab});
+  },
   isOpen: true,
   setIsOpen: isOpen => set({isOpen}),
   toggleIsOpen: () => set({isOpen: !get().isOpen}),

--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -220,6 +220,7 @@
   }
 
   &--text-wrapper {
+    position: relative;
     display: flex;
     align-items: center;
     gap: 12px;
@@ -256,13 +257,22 @@
 }
 
 .conversations-sidebar-btn--badge {
-  padding: 1px 6px;
-  border: 1px solid var(--app-bg-secondary);
-  border-radius: 5px;
-  background: var(--red-500);
-  color: var(--app-bg-secondary);
+  position: absolute;
+  top: -3px;
+  left: 10px;
+  width: 6px;
+  height: 6px;
+  box-sizing: content-box;
+  border: 2px solid var(--app-bg-secondary);
+  border-radius: 6px;
+  background: var(--accent-color-500);
   font-size: @font-size-small;
   font-weight: @font-weight-semibold;
+
+  &.active {
+    border: 2px solid var(--accent-color-500);
+    background: var(--app-bg-secondary);
+  }
 }
 
 .conversations-sidebar-btn {

--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -175,12 +175,13 @@
     flex-direction: column;
     align-items: start;
     justify-content: center;
-    padding-left: 1.5rem;
+    padding: 0 0.5rem;
     gap: 4px;
   }
 
   &--item {
     .button-reset-default;
+    position: relative;
     display: flex;
     width: 100%;
     height: 28px;
@@ -188,11 +189,18 @@
     align-items: center;
     justify-content: space-between;
     padding: 6px 8px 6px 12px;
+    padding-left: 1.5rem;
     border-radius: 8px;
 
     cursor: pointer;
     font-size: 12px;
     font-weight: 400;
+
+    .conversations-sidebar-btn--badge {
+      top: 8px;
+      left: 8px;
+    }
+
     &:hover {
       background-color: var(--app-bg-secondary);
     }


### PR DESCRIPTION
## Description
This PR introduces an enhancement on the badges which indicate the tab has conversations with unread messages and has some reactivity bug fixes:
- https://github.com/wireapp/wire-webapp/pull/17342/commits/fca8eb8ecb340fc7b8cf6d690519908d6a3277a4
- https://github.com/wireapp/wire-webapp/pull/17342/commits/2c6059473de90c06c6fcbf60da953d8c27aa1d2a
- https://github.com/wireapp/wire-webapp/pull/17342/commits/682895b5211069646c582a1eba1b31b24485a341

## Screenshots/Screencast (for UI changes)

Tabs:
<img width="211" alt="image" src="https://github.com/wireapp/wire-webapp/assets/63250054/8045b27f-6e5a-4c31-99ab-7a915d291688">

Tabs Collapsed:
<img width="57" alt="image" src="https://github.com/wireapp/wire-webapp/assets/63250054/c4a657ad-bfbd-450f-984a-09e5cde659a9">


Folders:
<img width="217" alt="image" src="https://github.com/wireapp/wire-webapp/assets/63250054/a607ff56-211a-45d3-a90c-bd03c164b1b5">
