### PR TITLE
perf: Improve polling the team feature config [WPB-8734]

### DIFF
--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -160,14 +160,17 @@ export class TeamRepository extends TypedEventEmitter<Events> {
   }
 
   private readonly scheduleTeamRefresh = (): void => {
-    window.setInterval(async () => {
+    const updateTeam = async () => {
       try {
         await this.getTeam();
         await this.updateFeatureConfig();
       } catch (error) {
         this.logger.error(error);
       }
-    }, TIME_IN_MILLIS.SECOND * 30);
+    };
+    // We want to poll the latest team data every time the app is focused and every day
+    window.addEventListener('focus', updateTeam);
+    window.setInterval(updateTeam, TIME_IN_MILLIS.DAY);
   };
 
   private async getInitialTeamMembers(teamId: string): Promise<TeamMemberEntity[]> {

--- a/src/script/util/DebugUtil.ts
+++ b/src/script/util/DebugUtil.ts
@@ -280,6 +280,11 @@ export class DebugUtil {
     });
   }
 
+  // Used by QA to trigger a focus event on the app (in order to trigger the update of the team feature-config)
+  simulateAppToForeground() {
+    window.dispatchEvent(new FocusEvent('focus'));
+  }
+
   setE2EICertificateTtl(ttl: number) {
     E2EIHandler.getInstance().certificateTtl = ttl;
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8734" title="WPB-8734" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-8734</a>  Webapp is polling the /features-config endpoint every 30s
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Cherry-picked a commit from the dev branch that improves the team feature config polling https://github.com/wireapp/wire-webapp/pull/17274.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
