### PR TITLE
runfix: 1:1 conversation with user without key packages

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -1167,7 +1167,7 @@
   "ongoingGroupVideoCall": "Ongoing video conference call with {{conversationName}}, your camera is {{cameraStatus}}.",
   "ongoingVideoCall": "Ongoing video call with {{conversationName}}, your camera is {{cameraStatus}}.",
   "otherUserNotSupportMLSMsg": "You can't communicate with {{participantName}} anymore, as you two now use different protocols. When {{participantName}} gets an update, you can call and send messages and files again.",
-  "otherUserNoAvailableKeyPackages": "This user has no available keys.",
+  "otherUserNoAvailableKeyPackages": "You can't communicate with {{participantName}} at the moment. When {{participantName}} logs in again, you can call and send messages and files again.",
   "participantDevicesDetailHeadline": "Verify that this matches the fingerprint shown on [bold]{{user}}’s device[/bold].",
   "participantDevicesDetailHowTo": "How do I do that?",
   "participantDevicesDetailResetSession": "Reset session",

--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -1167,6 +1167,7 @@
   "ongoingGroupVideoCall": "Ongoing video conference call with {{conversationName}}, your camera is {{cameraStatus}}.",
   "ongoingVideoCall": "Ongoing video call with {{conversationName}}, your camera is {{cameraStatus}}.",
   "otherUserNotSupportMLSMsg": "You can't communicate with {{participantName}} anymore, as you two now use different protocols. When {{participantName}} gets an update, you can call and send messages and files again.",
+  "otherUserNoAvailableKeyPackages": "This user has no available keys.",
   "participantDevicesDetailHeadline": "Verify that this matches the fingerprint shown on [bold]{{user}}’s device[/bold].",
   "participantDevicesDetailHowTo": "How do I do that?",
   "participantDevicesDetailResetSession": "Reset session",

--- a/src/script/components/Conversation/ReadOnlyConversationMessage/ReadOnlyConversationMessage.test.tsx
+++ b/src/script/components/Conversation/ReadOnlyConversationMessage/ReadOnlyConversationMessage.test.tsx
@@ -91,4 +91,14 @@ describe('ReadOnlyConversationMessage', () => {
 
     expect(reloadAppMock).toHaveBeenCalled();
   });
+
+  it("renders a conversation with a user that don't have any key pakages available", () => {
+    const conversation = generateConversation(CONVERSATION_READONLY_STATE.READONLY_ONE_TO_ONE_NO_KEY_PACKAGES, true);
+
+    const {getByText} = render(
+      withTheme(<ReadOnlyConversationMessage reloadApp={() => {}} conversation={conversation} />),
+    );
+
+    expect(getByText('otherUserNoAvailableKeyPackages')).toBeDefined();
+  });
 });

--- a/src/script/components/Conversation/ReadOnlyConversationMessage/ReadOnlyConversationMessage.tsx
+++ b/src/script/components/Conversation/ReadOnlyConversationMessage/ReadOnlyConversationMessage.tsx
@@ -90,7 +90,14 @@ export const ReadOnlyConversationMessage: FC<ReadOnlyConversationMessageProps> =
       case CONVERSATION_READONLY_STATE.READONLY_ONE_TO_ONE_NO_KEY_PACKAGES:
         return (
           <ReadOnlyConversationMessageBase>
-            <span>{t('otherUserNoAvailableKeyPackages')}</span>
+            <span>
+              {replaceReactComponents(t('otherUserNoAvailableKeyPackages'), [
+                {
+                  exactMatch: '{{participantName}}',
+                  render: () => <strong>{user.name()}</strong>,
+                },
+              ])}
+            </span>
           </ReadOnlyConversationMessageBase>
         );
     }

--- a/src/script/components/Conversation/ReadOnlyConversationMessage/ReadOnlyConversationMessage.tsx
+++ b/src/script/components/Conversation/ReadOnlyConversationMessage/ReadOnlyConversationMessage.tsx
@@ -87,6 +87,12 @@ export const ReadOnlyConversationMessage: FC<ReadOnlyConversationMessageProps> =
             </>
           </ReadOnlyConversationMessageBase>
         );
+      case CONVERSATION_READONLY_STATE.READONLY_ONE_TO_ONE_NO_KEY_PACKAGES:
+        return (
+          <ReadOnlyConversationMessageBase>
+            <span>{t('otherUserNoAvailableKeyPackages')}</span>
+          </ReadOnlyConversationMessageBase>
+        );
     }
   }
 

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1503,14 +1503,6 @@ export class ConversationRepository {
     }
   };
 
-  private readonly updateConversationReadOnlyState = async (
-    conversationEntity: Conversation,
-    conversationReadOnlyState: CONVERSATION_READONLY_STATE | null,
-  ) => {
-    conversationEntity.readOnlyState(conversationReadOnlyState);
-    await this.saveConversationStateInDb(conversationEntity);
-  };
-
   private readonly getProtocolFor1to1Conversation = async (
     otherUserId: QualifiedId,
     shouldRefreshUser = false,
@@ -1857,16 +1849,13 @@ export class ConversationRepository {
     // If proteus is not supported by the other user we have to mark conversation as readonly
     if (!doesOtherUserSupportProteus) {
       await this.blacklistConversation(proteusConversationId);
-      await this.updateConversationReadOnlyState(
-        proteusConversation,
-        CONVERSATION_READONLY_STATE.READONLY_ONE_TO_ONE_SELF_UNSUPPORTED_MLS,
-      );
+      proteusConversation.readOnlyState(CONVERSATION_READONLY_STATE.READONLY_ONE_TO_ONE_SELF_UNSUPPORTED_MLS);
       return proteusConversation;
     }
 
     // If proteus is supported by the other user, we just return a proteus conversation and remove readonly state from it.
     await this.removeConversationFromBlacklist(proteusConversationId);
-    await this.updateConversationReadOnlyState(proteusConversation, null);
+    await proteusConversation.readOnlyState(null);
     return proteusConversation;
   };
 

--- a/src/script/view_model/ActionsViewModel.ts
+++ b/src/script/view_model/ActionsViewModel.ts
@@ -336,7 +336,10 @@ export class ActionsViewModel {
   };
 
   getOrCreate1to1Conversation = async (userEntity: User): Promise<Conversation> => {
-    const conversationEntity = await this.conversationRepository.getInitialised1To1Conversation(userEntity.qualifiedId);
+    const conversationEntity = await this.conversationRepository.getInitialised1To1Conversation(
+      userEntity.qualifiedId,
+      {mls: {allowUnestablished: false}},
+    );
     if (conversationEntity) {
       return conversationEntity;
     }


### PR DESCRIPTION
## Description

Handles a 1:1 conversation with a user that don't have any key packages available to establish a MLS 1:1 conversation.

## Screenshots/Screencast (for UI changes)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
