### PR TITLE
runfix: address responsivness of new navigation v2 (WPB-7212)

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.styles.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.styles.tsx
@@ -1,0 +1,29 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {CSSObject} from '@emotion/react';
+
+export const conversationsSpacerStyles = (mdBreakpoint: Boolean): CSSObject => ({
+  minWidth: mdBreakpoint ? '64px' : '0',
+});
+
+export const conversationsSidebarStyles = (mdBreakpoint: Boolean): CSSObject => ({
+  position: mdBreakpoint ? 'fixed' : 'relative',
+  zIndex: mdBreakpoint ? '1000' : 'auto',
+});

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -298,6 +298,7 @@ const Conversations: React.FC<ConversationsProps> = ({
 
   return (
     <div className="conversations-wrapper">
+      <div css={isSideBarOpen && mdBreakpoint && {minWidth: '64px'}} />
       <ListWrapper
         id="conversations"
         headerElement={

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -237,7 +237,7 @@ const Conversations: React.FC<ConversationsProps> = ({
   }
 
   const sidebar = (
-    <nav className="conversations-sidebar">
+    <nav className="conversations-sidebar" css={isSideBarOpen && mdBreakpoint && {position: 'fixed', zIndex: '1000'}}>
       <FadingScrollbar className="conversations-sidebar-items" data-is-collapsed={!isSideBarOpen}>
         <UserDetails
           user={selfUser}
@@ -259,17 +259,15 @@ const Conversations: React.FC<ConversationsProps> = ({
         />
       </FadingScrollbar>
 
-      {!mdBreakpoint && (
-        <button
-          type="button"
-          role="tab"
-          className="conversations-sidebar-handle"
-          data-is-collapsed={!isSideBarOpen || mdBreakpoint}
-          onClick={toggleSidebar}
-        >
-          <ChevronIcon width={12} height={12} />
-        </button>
-      )}
+      <button
+        type="button"
+        role="tab"
+        className="conversations-sidebar-handle"
+        data-is-collapsed={!isSideBarOpen}
+        onClick={toggleSidebar}
+      >
+        <ChevronIcon width={12} height={12} />
+      </button>
     </nav>
   );
 

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -39,6 +39,7 @@ import {UserRepository} from 'src/script/user/UserRepository';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 
 import {ConversationHeader} from './ConversationHeader';
+import {conversationsSpacerStyles, conversationsSidebarStyles} from './Conversations.styles';
 import {ConversationsList} from './ConversationsList';
 import {ConversationTabs} from './ConversationTabs';
 import {EmptyConversationList} from './EmptyConversationList';
@@ -237,7 +238,7 @@ const Conversations: React.FC<ConversationsProps> = ({
   }
 
   const sidebar = (
-    <nav className="conversations-sidebar" css={isSideBarOpen && mdBreakpoint && {position: 'fixed', zIndex: '1000'}}>
+    <nav className="conversations-sidebar" css={conversationsSidebarStyles(mdBreakpoint)}>
       <FadingScrollbar className="conversations-sidebar-items" data-is-collapsed={!isSideBarOpen}>
         <UserDetails
           user={selfUser}
@@ -298,7 +299,7 @@ const Conversations: React.FC<ConversationsProps> = ({
 
   return (
     <div className="conversations-wrapper">
-      <div css={isSideBarOpen && mdBreakpoint && {minWidth: '64px'}} />
+      <div className="conversations-sidebar-spacer" css={conversationsSpacerStyles(mdBreakpoint)} />
       <ListWrapper
         id="conversations"
         headerElement={

--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -38,10 +38,7 @@
     padding: 8px;
     border-right: 1px solid var(--border-color);
     background: var(--sidebar-bg);
-
-    @media (min-width: 1000px) {
-      transition: width 0.3s ease-in-out;
-    }
+    transition: width 0.3s ease-in-out;
 
     &[data-is-collapsed='true'] {
       width: 64px;

--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -38,7 +38,10 @@
     padding: 8px;
     border-right: 1px solid var(--border-color);
     background: var(--sidebar-bg);
-    transition: width 0.3s ease-in-out;
+
+    @media (min-width: 1000px) {
+      transition: width 0.3s ease-in-out;
+    }
 
     &[data-is-collapsed='true'] {
       width: 64px;
@@ -61,7 +64,6 @@
   .conversations-sidebar-handle {
     .button-reset-default;
 
-    position: relative;
     position: absolute;
     z-index: 1000;
     top: 8px;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7212" title="WPB-7212" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-7212</a>  Adjust resizability of Webapp including the new sidebar
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

The new navigation doesn't show the button to expand the sidebar at a smaller screen width.
This allows expanding the sidebar, as an overlay on top of the content below the breakpoint.

## Screenshots/Screencast (for UI changes)
![Kooha-2024-05-07-15-13-45](https://github.com/wireapp/wire-webapp/assets/78490891/a11ab6b8-5df0-4eeb-b3dc-60ed09d165eb)

