### PR TITLE
fix: show delivered status independently of read receipt setting (WPB-9040)

### DIFF
--- a/src/script/components/MessagesList/Message/ReadIndicator/ReadIndicator.tsx
+++ b/src/script/components/MessagesList/Message/ReadIndicator/ReadIndicator.tsx
@@ -43,10 +43,6 @@ export const ReadIndicator = ({
 }: ReadIndicatorProps) => {
   const {readReceipts} = useKoSubscribableChildren(message, ['readReceipts']);
 
-  if (!message.expectsReadConfirmation) {
-    return null;
-  }
-
   if (is1to1Conversation) {
     const readReceiptText = readReceipts.length ? formatTimeShort(readReceipts[0].time) : '';
     const showDeliveredMessage = isLastDeliveredMessage && readReceiptText === '';


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9040" title="WPB-9040" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9040</a>  [web] Delivered status appears tied to read receipts
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

The "delivered" read status should appear independently of read receipt settings in 1 on 1 conversations.
We have specifically prevented that in a past PR.
