### PR TITLE
chore: use up to date URL environment variables (WPB-6662)

### DIFF
--- a/app-config/package.json
+++ b/app-config/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "wire-web-config-default-master": "https://github.com/wireapp/wire-web-config-wire#v0.31.21-0",
+    "wire-web-config-default-master": "https://github.com/wireapp/wire-web-config-wire#v0.31.24-0",
     "wire-web-config-default-staging": "https://github.com/wireapp/wire-web-config-default#v0.31.22"
   }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6662" title="WPB-6662" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-6662</a>  [Web] Prepare new environment variable for prod release q1 2024
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

The production environment is not currently using the correct environment variables that were changed recently

This cherry picks the bump to the correct config version