### PR TITLE
fix: open a 1:1 with a bot from conversation details [WPB-5887]

### DIFF
--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
@@ -233,7 +233,7 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
       const serviceEntity = await integrationRepository.getServiceFromUser(entity);
 
       if (serviceEntity) {
-        togglePanel(PanelState.GROUP_PARTICIPANT_SERVICE, {...serviceEntity, id: entity.id});
+        togglePanel(PanelState.GROUP_PARTICIPANT_SERVICE, serviceEntity);
       }
     };
 

--- a/src/script/page/RightSidebar/GroupParticipantService/GroupParticipantService.tsx
+++ b/src/script/page/RightSidebar/GroupParticipantService/GroupParticipantService.tsx
@@ -27,7 +27,6 @@ import {ServiceDetails} from 'Components/panel/ServiceDetails';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {handleKeyDown} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
-import {matchQualifiedIds} from 'Util/QualifiedId';
 
 import {Conversation} from '../../../entity/Conversation';
 import {User} from '../../../entity/User';
@@ -46,7 +45,6 @@ interface GroupParticipantServiceProps {
   onBack: () => void;
   onClose: () => void;
   serviceEntity: ServiceEntity;
-  userEntity: User;
   selfUser: User;
   isAddMode?: boolean;
 }
@@ -60,29 +58,28 @@ const GroupParticipantService: FC<GroupParticipantServiceProps> = ({
   onBack,
   onClose,
   serviceEntity,
-  userEntity,
   selfUser,
   isAddMode = false,
 }) => {
   const {
     inTeam,
     isActiveParticipant,
-    participating_user_ids: participatingUserIds,
-  } = useKoSubscribableChildren(activeConversation, ['inTeam', 'isActiveParticipant', 'participating_user_ids']);
+    participating_user_ets: participatingUserEts,
+  } = useKoSubscribableChildren(activeConversation, ['inTeam', 'isActiveParticipant', 'participating_user_ets']);
   const {teamRole} = useKoSubscribableChildren(selfUser, ['teamRole']);
 
   const {canChatWithServices} = generatePermissionHelpers(teamRole);
 
-  const selectedInConversation = participatingUserIds.some(user => matchQualifiedIds(userEntity, user));
+  const serviceUser = participatingUserEts.find(user => user.serviceId === serviceEntity.id);
 
-  const showActions = isActiveParticipant && selectedInConversation && inTeam;
+  const showActions = isActiveParticipant && serviceUser && inTeam;
 
   const onOpen = () => {
     actionsViewModel.open1to1ConversationWithService(serviceEntity);
   };
 
-  const onRemove = () => {
-    actionsViewModel.removeFromConversation(activeConversation, userEntity);
+  const onRemove = (user: User) => {
+    actionsViewModel.removeFromConversation(activeConversation, user);
     onBack();
   };
 
@@ -125,8 +122,8 @@ const GroupParticipantService: FC<GroupParticipantServiceProps> = ({
             tabIndex={TabIndex.FOCUSABLE}
             className="panel__action-item"
             data-uie-name="do-remove"
-            onClick={onRemove}
-            onKeyDown={event => handleKeyDown(event, onRemove)}
+            onClick={() => onRemove(serviceUser)}
+            onKeyDown={event => handleKeyDown(event, () => onRemove(serviceUser))}
           >
             <span className="panel__action-item__icon">
               <Icon.Minus />

--- a/src/script/page/RightSidebar/RightSidebar.tsx
+++ b/src/script/page/RightSidebar/RightSidebar.tsx
@@ -284,7 +284,6 @@ const RightSidebar: FC<RightSidebarProps> = ({
               onBack={onBackClick}
               onClose={closePanel}
               serviceEntity={serviceEntity}
-              userEntity={userServiceEntity}
               selfUser={selfUser}
               isAddMode={isAddMode}
             />


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5887" title="WPB-5887" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5887</a>  Opening conversation with bots from member list doesn't work
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

It was not possible to open a 1:1 conversation with a bot (service) from the conversation panel. The reason was we were overwriting service's id with user's id (a user that was added to a conversation as a service). 

The fix is to use original service id and to keep the ability to remove service's user, just try to find a conversation member with the matching `serviceId` field.

Before
![before](https://github.com/wireapp/wire-webapp/assets/45733298/c7968d4f-6759-401b-9ff6-e3d22b89b64b)


After
![after](https://github.com/wireapp/wire-webapp/assets/45733298/9f78d4e2-12e2-4cde-9ec9-5459ecf83a46)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
