### PR TITLE
fix: unread message clearing on convo change

### DIFF
--- a/src/script/entity/Conversation.test.ts
+++ b/src/script/entity/Conversation.test.ts
@@ -734,9 +734,8 @@ describe('Conversation', () => {
 
       conversation_et.release();
 
-      expect(conversation_et.messages().length).toBe(1);
-      expect(conversation_et.messages()).toEqual([incomingMessage]);
-      expect(conversation_et.unreadState().allEvents.length).toBe(1);
+      expect(conversation_et.messages().length).toBe(2);
+      expect(conversation_et.unreadState().allEvents.length).toBe(3);
     });
 
     it('should release messages if conversation has no unread messages', () => {

--- a/src/script/entity/Conversation.test.ts
+++ b/src/script/entity/Conversation.test.ts
@@ -729,13 +729,14 @@ describe('Conversation', () => {
       conversation_et.last_event_timestamp(third_timestamp);
       conversation_et.addMessage(incomingMessage);
 
-      expect(conversation_et.messages().length).toBe(1);
+      expect(conversation_et.messages()).toEqual([message_et]);
       expect(conversation_et.unreadState().allEvents.length).toBe(2);
 
       conversation_et.release();
 
-      expect(conversation_et.messages().length).toBe(2);
-      expect(conversation_et.unreadState().allEvents.length).toBe(3);
+      // Incoming message should be moved to regular messages
+      expect(conversation_et.messages()).toEqual([message_et, incomingMessage]);
+      expect(conversation_et.unreadState().allEvents.length).toBe(2);
     });
 
     it('should release messages if conversation has no unread messages', () => {

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -612,6 +612,7 @@ export class Conversation {
    * If there are any incoming messages, they will be moved to the regular messages.
    */
   release(): void {
+    // If there are no unread messages, we can remove all messages from memory (we will keep the unread messages)
     if (!this.unreadState().allEvents.length) {
       this.removeMessages();
       this.hasAdditionalMessages(true);

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -619,6 +619,7 @@ export class Conversation {
 
     if (this.incomingMessages().length) {
       this.messages_unordered.push(...this.incomingMessages());
+      this.incomingMessages.removeAll();
     }
   }
 

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -612,15 +612,13 @@ export class Conversation {
    * If there are any incoming messages, they will be moved to the regular messages.
    */
   release(): void {
-    this.messages_unordered.removeAll();
-
     if (!this.unreadState().allEvents.length) {
+      this.removeMessages();
       this.hasAdditionalMessages(true);
     }
 
     if (this.incomingMessages().length) {
       this.messages_unordered.push(...this.incomingMessages());
-      this.incomingMessages.removeAll();
     }
   }
 


### PR DESCRIPTION
## Description
Noticed an issue where unread messages would be cleared when changing conversations and going back to the original convo. 
Appears to be a regression introduced in https://github.com/wireapp/wire-webapp/pull/17158

## Screenshots/Screencast (for UI changes)

Before:
https://github.com/wireapp/wire-webapp/assets/37285713/65fb81b5-93d7-4222-8b96-f63004aba8c2

After: 
https://github.com/wireapp/wire-webapp/assets/37285713/772f3419-4049-474a-a0cb-f3228eefb053

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

