### PR TITLE
runfix: multiple proteus 1:1 conversations with a team member [WPB-9063]

### DIFF
--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -380,6 +380,46 @@ describe('ConversationRepository', () => {
       expect(conversationRepository['conversationService'].getMLS1to1Conversation).not.toHaveBeenCalled();
     });
 
+    it('returns a selected proteus 1:1 conversation with a team member even if there are multiple conversations with the same user', async () => {
+      const conversationRepository = testFactory.conversation_repository!;
+
+      const teamId = 'teamId';
+      const domain = 'test-domain';
+
+      const otherUserId = {id: 'f718411c-3833-479d-bd80-af03f38416', domain};
+      const otherUser = new User(otherUserId.id, otherUserId.domain);
+      otherUser.teamId = teamId;
+
+      otherUser.supportedProtocols([ConversationProtocol.PROTEUS]);
+
+      conversationRepository['userState'].users.push(otherUser);
+
+      const selfUserId = {id: '109da91a-a495-47a870-9ffbe924b2d1', domain};
+      const selfUser = new User(selfUserId.id, selfUserId.domain);
+      selfUser.teamId = teamId;
+      selfUser.supportedProtocols([ConversationProtocol.PROTEUS]);
+      jest.spyOn(conversationRepository['userState'], 'self').mockReturnValue(selfUser);
+
+      const proteus1to1Conversation = _generateConversation({
+        type: CONVERSATION_TYPE.ONE_TO_ONE,
+        protocol: ConversationProtocol.PROTEUS,
+        users: [otherUser],
+        overwites: {team_id: teamId, domain},
+      });
+
+      const proteus1to1Conversation2 = _generateConversation({
+        type: CONVERSATION_TYPE.ONE_TO_ONE,
+        protocol: ConversationProtocol.PROTEUS,
+        users: [otherUser],
+        overwites: {team_id: teamId, domain},
+      });
+
+      conversationRepository['conversationState'].conversations.push(proteus1to1Conversation, proteus1to1Conversation2);
+
+      const conversationEntity = await conversationRepository.init1to1Conversation(proteus1to1Conversation2, true);
+      expect(conversationEntity).toEqual(proteus1to1Conversation2);
+    });
+
     it('just returns a proteus conversation with a bot/service', async () => {
       const conversationRepository = testFactory.conversation_repository!;
       const userRepository = testFactory.user_repository!;

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1821,15 +1821,15 @@ export class ConversationRepository {
 
     const initialisedMLSConversation = await this.establishMLS1to1Conversation(mlsConversation, otherUserId);
 
-    if (shouldOpenMLS1to1Conversation) {
-      // If proteus conversation was previously active conversaiton, we want to make mls 1:1 conversation active.
-      amplify.publish(WebAppEvents.CONVERSATION.SHOW, initialisedMLSConversation, {});
-    }
-
     // If mls is supported by the other user, we can establish the group and remove readonly state from the conversation.
     initialisedMLSConversation.readOnlyState(null);
     await this.update1To1ConversationParticipants(mlsConversation, otherUserId);
     await this.saveConversation(initialisedMLSConversation);
+
+    if (shouldOpenMLS1to1Conversation) {
+      // If proteus conversation was previously active conversaiton, we want to make mls 1:1 conversation active.
+      amplify.publish(WebAppEvents.CONVERSATION.SHOW, initialisedMLSConversation, {});
+    }
     return initialisedMLSConversation;
   };
 

--- a/test/helper/ConversationGenerator.ts
+++ b/test/helper/ConversationGenerator.ts
@@ -122,6 +122,7 @@ export function generateConversation({
 
   if (users) {
     conversation.participating_user_ets(users);
+    conversation.participating_user_ids(users.map(user => user.qualifiedId));
   }
 
   return conversation;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9063" title="WPB-9063" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9063</a>  [Web] Can't open 1:1 chat anymore after receiving a heic image
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Due to some bug in the past, it's possible to have two (or more) proteus 1:1 conversations with a team member (since they are really group conversations with some special configuration).

When opening a conversation, instead of finding a conversation with a matching user, try search by the known conversation id.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;