### PR TITLE
runfix: migrate messages from proteus to mls 1:1

### DIFF
--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -585,8 +585,8 @@ describe('ConversationRepository', () => {
       const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser.qualifiedId);
 
       expect(conversationRepository['eventService'].moveEventsToConversation).toHaveBeenCalledWith(
-        proteus1to1Conversation.id,
-        mls1to1Conversation.id,
+        proteus1to1Conversation.qualifiedId,
+        mls1to1Conversation.qualifiedId,
       );
 
       expect(conversationEntity?.serialize()).toEqual(mls1to1Conversation.serialize());

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1631,7 +1631,7 @@ export class ConversationRepository {
 
     await Promise.allSettled(
       proteusConversations.map(proteusConversation =>
-        this.eventService.moveEventsToConversation(proteusConversation.id, mlsConversation.id),
+        this.eventService.moveEventsToConversation(proteusConversation.qualifiedId, mlsConversation.qualifiedId),
       ),
     );
 

--- a/src/script/event/EventService.ts
+++ b/src/script/event/EventService.ts
@@ -18,6 +18,7 @@
  */
 
 import {CONVERSATION_EVENT} from '@wireapp/api-client/lib/event/';
+import {QualifiedId} from '@wireapp/api-client/lib/user/';
 import type {Dexie} from 'dexie';
 import {container} from 'tsyringe';
 
@@ -478,14 +479,15 @@ export class EventService {
    * @param conversationId - conversation id from which events should be moved
    * @param newConversationId - conversation id to which events should be moved
    */
-  public async moveEventsToConversation(conversationId: string, newConversationId: string) {
+  public async moveEventsToConversation(conversationId: QualifiedId, newConversationId: QualifiedId) {
     const eventsToSkip = [CLIENT_CONVERSATION_EVENT.ONE2ONE_CREATION];
 
-    const events = await this.loadAllConversationEvents(conversationId, eventsToSkip);
+    const events = await this.loadAllConversationEvents(conversationId.id, eventsToSkip);
 
     const eventsToMove = events.map(event => ({
       ...event,
-      conversation: newConversationId,
+      conversation: newConversationId.id,
+      qualified_conversation: newConversationId,
     }));
 
     return Promise.all(

--- a/test/unit_tests/event/EventServiceCommon.js
+++ b/test/unit_tests/event/EventServiceCommon.js
@@ -509,7 +509,8 @@ const testEventServiceClass = (testedServiceName, className) => {
     });
 
     describe('loadAllConversationEvents', () => {
-      const conversationId = 'conversation-id';
+      const conversationId = {id: 'conversation-id', domain: 'conversation-domain'};
+      const otherConversationId = {id: 'other-conversation-id', domain: 'other-conversation-domain'};
 
       afterEach(() => {
         testFactory.storage_service.clearStores();
@@ -520,13 +521,15 @@ const testEventServiceClass = (testedServiceName, className) => {
         const numberOfOtherConversationEvents = 1;
 
         const conversationEvents = Array.from({length: numberOfConversationEvents}, () => ({
-          conversation: conversationId,
+          conversation: conversationId.id,
+          qualified_conversation: conversationId,
           id: createUuid(),
           time: '2016-08-04T13:27:55.182Z',
         }));
 
         const otherConversationEvents = Array.from({length: numberOfOtherConversationEvents}, () => ({
-          conversation: 'other-conversation-id',
+          conversation: otherConversationId.id,
+          qualified_conversation: otherConversationId,
           id: createUuid(),
           time: '2016-08-04T13:27:55.182Z',
         }));
@@ -537,7 +540,7 @@ const testEventServiceClass = (testedServiceName, className) => {
 
         const eventService = testFactory[testedServiceName];
 
-        const foundConversationEvents = await eventService.loadAllConversationEvents(conversationId);
+        const foundConversationEvents = await eventService.loadAllConversationEvents(conversationId.id);
 
         expect(foundConversationEvents.length).toBe(numberOfConversationEvents);
       });
@@ -548,13 +551,15 @@ const testEventServiceClass = (testedServiceName, className) => {
         const numberOfEventsToSkip = 2;
 
         const conversationEvents = Array.from({length: numberOfConversationEvents}, () => ({
-          conversation: conversationId,
+          conversation: conversationId.id,
+          qualified_conversation: conversationId,
           id: createUuid(),
           time: '2016-08-04T13:27:55.182Z',
         }));
 
         const conversationEventsToSkip = Array.from({length: numberOfEventsToSkip}, () => ({
-          conversation: conversationId,
+          conversation: conversationId.id,
+          qualified_conversation: conversationId,
           id: createUuid(),
           time: '2016-08-04T13:27:55.182Z',
           type: skipTypes[0],
@@ -566,15 +571,15 @@ const testEventServiceClass = (testedServiceName, className) => {
 
         const eventService = testFactory[testedServiceName];
 
-        const foundConversationEvents = await eventService.loadAllConversationEvents(conversationId, skipTypes);
+        const foundConversationEvents = await eventService.loadAllConversationEvents(conversationId.id, skipTypes);
 
         expect(foundConversationEvents.length).toBe(numberOfConversationEvents);
       });
     });
 
     describe('moveEventsToConversation', () => {
-      const oldConversationId = 'old-conversation-id';
-      const newConversationId = 'new-conversation-id';
+      const oldConversationId = {id: 'old-conversation-id', domain: 'old-conversation-domain'};
+      const newConversationId = {id: 'new-conversation-id', domain: 'new-conversation-domain'};
 
       afterEach(() => {
         testFactory.storage_service.clearStores();
@@ -584,7 +589,8 @@ const testEventServiceClass = (testedServiceName, className) => {
         const numberOfConversationEvents = 3;
 
         const conversationEvents = Array.from({length: numberOfConversationEvents}, () => ({
-          conversation: oldConversationId,
+          conversation: oldConversationId.id,
+          qualified_conversation: oldConversationId,
           id: createUuid(),
           time: '2016-08-04T13:27:55.182Z',
         }));
@@ -595,15 +601,15 @@ const testEventServiceClass = (testedServiceName, className) => {
 
         const eventService = testFactory[testedServiceName];
 
-        const loadedOldConversationEvents = await eventService.loadAllConversationEvents(oldConversationId);
-        const loadedNewConversationEvents = await eventService.loadAllConversationEvents(newConversationId);
+        const loadedOldConversationEvents = await eventService.loadAllConversationEvents(oldConversationId.id);
+        const loadedNewConversationEvents = await eventService.loadAllConversationEvents(newConversationId.id);
         expect(loadedOldConversationEvents.length).toBe(numberOfConversationEvents);
         expect(loadedNewConversationEvents.length).toBe(0);
 
         await eventService.moveEventsToConversation(oldConversationId, newConversationId);
 
-        const loadedOldConversationEventsAfterMove = await eventService.loadAllConversationEvents(oldConversationId);
-        const loadedNewConversationEventsAfterMove = await eventService.loadAllConversationEvents(newConversationId);
+        const loadedOldConversationEventsAfterMove = await eventService.loadAllConversationEvents(oldConversationId.id);
+        const loadedNewConversationEventsAfterMove = await eventService.loadAllConversationEvents(newConversationId.id);
         expect(loadedOldConversationEventsAfterMove.length).toBe(0);
         expect(loadedNewConversationEventsAfterMove.length).toBe(numberOfConversationEvents);
       });


### PR DESCRIPTION
## Description

When migrating messages from proteus 1:1 conversation to mls 1:1 conversation, we were not changing the qualified conversation id field of the event. We are referring to this filed when e.g reacting to a messages, so it was not possible to react to a migrated message.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
