### PR TITLE
fix: multiple proteus 1:1 conversations with team member [WPB-9063]

### DIFF
--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -346,37 +346,6 @@ describe('ConversationRepository', () => {
       const conversationEntity = await conversationRepository.init1to1Conversation(proteus1to1Conversation2, true);
       expect(conversationEntity).toEqual(proteus1to1Conversation2);
     });
-
-    it('just returns a proteus conversation with a bot/service', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
-      const userRepository = testFactory.user_repository!;
-
-      const otherUserId = {id: 'f718410c-1733-479d-bd80-af03f38416', domain: 'test-domain'};
-      const otherUser = new User(otherUserId.id, otherUserId.domain);
-      otherUser.isService = true;
-      otherUser.supportedProtocols([ConversationProtocol.PROTEUS]);
-
-      userRepository['userState'].users.push(otherUser);
-
-      const selfUserId = {id: '109da9ca-a417-47a870-9ffbe924b2d1', domain: 'test-domain'};
-      const selfUser = new User(selfUserId.id, selfUserId.domain);
-      selfUser.supportedProtocols([ConversationProtocol.PROTEUS, ConversationProtocol.MLS]);
-      jest.spyOn(conversationRepository['userState'], 'self').mockReturnValueOnce(selfUser);
-
-      const proteus1to1Conversation = _generateConversation({
-        type: CONVERSATION_TYPE.REGULAR,
-        protocol: ConversationProtocol.PROTEUS,
-        overwites: {team_id: 'teamId'},
-      });
-
-      proteus1to1Conversation.participating_user_ids([otherUserId]);
-      proteus1to1Conversation.participating_user_ets([otherUser]);
-
-      jest.spyOn(conversationRepository['conversationService'], 'getMLS1to1Conversation');
-
-      const conversationEntity = await conversationRepository.init1to1Conversation(proteus1to1Conversation, true);
-      expect(conversationEntity).toEqual(proteus1to1Conversation);
-    });
   });
 
   describe('getInitialised1To1Conversation', () => {

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1292,6 +1292,7 @@ export class ConversationRepository {
    * @param userEntity User entity for whom to get the conversation
    * @param isLiveUpdate Whether the conversation is being initialised because of a live update (e.g. some websocket event)
    * @param shouldRefreshUser Whether the user should be refetched from backend before getting the conversation
+   * @param knownConversationId Known conversation ID - if provided, we will try to find the conversation with this exact ID (needed for proteus 1:1 conversation with a team member)
    * @returns Resolves with the initialised 1:1 conversation with requested user
    */
   public async getInitialised1To1Conversation(
@@ -1300,6 +1301,7 @@ export class ConversationRepository {
       isLiveUpdate: false,
       shouldRefreshUser: false,
     },
+    knownConversationId?: QualifiedId,
   ): Promise<Conversation | null> {
     const user = await this.userRepository.getUserById(userId);
 
@@ -1326,57 +1328,39 @@ export class ConversationRepository {
       return this.initMLS1to1Conversation(userId, isMLSSupportedByTheOtherUser, shouldDelayMLSGroupEstablishment);
     }
 
-    const proteusConversation = await this.getOrCreateProteus1To1Conversation(user);
+    // There's no connection so it's a proteus conversation with a team member
+    const selfUser = this.userState.self();
+    const inCurrentTeam = selfUser && selfUser.teamId && user.teamId === selfUser.teamId;
 
-    if (!proteusConversation) {
+    if (!inCurrentTeam) {
+      // It's not possible to create a 1:1 conversation with a user from another team without a connection
       return null;
     }
+
+    const proteusConversation = await this.getOrCreateProteusTeam1to1Conversation(user, knownConversationId);
 
     return this.initProteus1to1Conversation(proteusConversation.qualifiedId, isProteusSupportedByTheOtherUser);
   }
 
   /**
-   * Get or create a proteus 1:1 conversation with a user.
-   * If a conversation does not exist, but user is in the current team, or there's a connection with this user, proteus 1:1 conversation will be created and saved.
+   * Get or create a proteus 1:1 conversation with a team member. If a conversation does not exist, it will be created.
+   * This is a legacy type of 1:1 conversation, which really is a group conversation with only two members.
+   * Due to some bug in the past, it's possible that there are multiple proteus 1:1 conversations with the same user,
+   * so we have to make sure we get the right one (with the knownConversationId parameter)
    * @param userEntity User entity for whom to get the conversation
-   * @returns Resolves with the conversation with requested user (if in the current team or there's an existing connection with this user), otherwise `null`
-   */
-  private async getOrCreateProteus1To1Conversation(userEntity: User): Promise<Conversation | null> {
-    const selfUser = this.userState.self();
-    const inCurrentTeam = selfUser && selfUser.teamId && userEntity.teamId === selfUser.teamId;
-
-    if (inCurrentTeam) {
-      return this.getOrCreateProteusTeam1to1Conversation(userEntity);
-    }
-
-    const userConnection = userEntity.connection();
-
-    if (!userConnection) {
-      return null;
-    }
-
-    const conversationId = userConnection.conversationId;
-    try {
-      const conversationEntity = await this.getConversationById(conversationId);
-      conversationEntity.connection(userConnection);
-      await this.updateParticipatingUserEntities(conversationEntity);
-      return conversationEntity;
-    } catch (error) {
-      const isConversationNotFound =
-        error instanceof ConversationError && error.type === ConversationError.TYPE.CONVERSATION_NOT_FOUND;
-      if (!isConversationNotFound) {
-        throw error;
-      }
-      return null;
-    }
-  }
-
-  /**
-   * Get or create a proteus team 1to1 conversation with a user. If a conversation does not exist, it will be created.
-   * @param userEntity User entity for whom to get the conversation
+   * @param knownConversationId Known conversation ID - if provided, we will try to find the conversation with this exact ID
    * @returns Resolves with the conversation with requested user
    */
-  private async getOrCreateProteusTeam1to1Conversation(userEntity: User): Promise<Conversation> {
+  private async getOrCreateProteusTeam1to1Conversation(
+    userEntity: User,
+    knownConversationId?: QualifiedId,
+  ): Promise<Conversation> {
+    const exactConversation = knownConversationId && this.conversationState.findConversation(knownConversationId);
+
+    if (exactConversation) {
+      return exactConversation;
+    }
+
     const matchingConversationEntity = this.conversationState.conversations().find(conversationEntity => {
       if (!conversationEntity.is1to1()) {
         // Disregard conversations that are not 1:1
@@ -1826,15 +1810,15 @@ export class ConversationRepository {
 
     const initialisedMLSConversation = await this.establishMLS1to1Conversation(mlsConversation, otherUserId);
 
-    if (shouldOpenMLS1to1Conversation) {
-      // If proteus conversation was previously active conversaiton, we want to make mls 1:1 conversation active.
-      amplify.publish(WebAppEvents.CONVERSATION.SHOW, initialisedMLSConversation, {});
-    }
-
     // If mls is supported by the other user, we can establish the group and remove readonly state from the conversation.
     initialisedMLSConversation.readOnlyState(null);
     await this.update1To1ConversationParticipants(mlsConversation, otherUserId);
     await this.saveConversation(initialisedMLSConversation);
+
+    if (shouldOpenMLS1to1Conversation) {
+      // If proteus conversation was previously active conversaiton, we want to make mls 1:1 conversation active.
+      amplify.publish(WebAppEvents.CONVERSATION.SHOW, initialisedMLSConversation, {});
+    }
     return initialisedMLSConversation;
   };
 
@@ -1944,7 +1928,7 @@ export class ConversationRepository {
     );
 
     try {
-      return await this.getInitialised1To1Conversation(otherUserId, {shouldRefreshUser});
+      return await this.getInitialised1To1Conversation(otherUserId, {shouldRefreshUser}, conversation.qualifiedId);
     } catch {}
 
     return conversation;

--- a/test/helper/ConversationGenerator.ts
+++ b/test/helper/ConversationGenerator.ts
@@ -122,6 +122,7 @@ export function generateConversation({
 
   if (users) {
     conversation.participating_user_ets(users);
+    conversation.participating_user_ids(users.map(user => user.qualifiedId));
   }
 
   return conversation;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9063" title="WPB-9063" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9063</a>  [Web] Can't open 1:1 chat anymore after receiving a heic image
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

Cherry-picked a commit from dev that fixes a bug where it's not possible to open a 1:1 conversation with a team member in case there are more than one conversations with the same user. For more details see https://github.com/wireapp/wire-webapp/pull/17382.

## Screenshots/Screencast (for UI changes)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;