### PR TITLE
runfix: do not overwrite service id when opening the service details

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -254,11 +254,7 @@ export const Conversation = ({
 
     const serviceEntity = userEntity.isService && (await repositories.integration.getServiceFromUser(userEntity));
 
-    if (serviceEntity) {
-      openRightSidebar(panelId, {entity: serviceEntity}, true);
-    } else {
-      openRightSidebar(panelId, {entity: userEntity}, true);
-    }
+    openRightSidebar(panelId, {entity: serviceEntity || userEntity}, true);
   };
 
   const showParticipants = (participants: User[]) => {

--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -255,7 +255,7 @@ export const Conversation = ({
     const serviceEntity = userEntity.isService && (await repositories.integration.getServiceFromUser(userEntity));
 
     if (serviceEntity) {
-      openRightSidebar(panelId, {entity: {...serviceEntity, id: userEntity.id}}, true);
+      openRightSidebar(panelId, {entity: serviceEntity}, true);
     } else {
       openRightSidebar(panelId, {entity: userEntity}, true);
     }

--- a/src/script/page/RightSidebar/RightSidebar.tsx
+++ b/src/script/page/RightSidebar/RightSidebar.tsx
@@ -114,7 +114,6 @@ const RightSidebar: FC<RightSidebarProps> = ({
   const conversationState = container.resolve(ConversationState);
   const {activeConversation} = useKoSubscribableChildren(conversationState, ['activeConversation']);
 
-  const [isAddMode, setIsAddMode] = useState<boolean>(false);
   const [animatePanelToLeft, setAnimatePanelToLeft] = useState<boolean>(true);
 
   const {rightSidebar} = useAppMainState.getState();
@@ -130,10 +129,9 @@ const RightSidebar: FC<RightSidebarProps> = ({
 
   const closePanel = () => rightSidebar.close();
 
-  const togglePanel = (newState: PanelState, entity: PanelEntity | null, addMode: boolean = false) => {
+  const togglePanel = (newState: PanelState, entity: PanelEntity | null, isAddMode: boolean = false) => {
     setAnimatePanelToLeft(true);
-    rightSidebar.goTo(newState, {entity});
-    setIsAddMode(addMode);
+    rightSidebar.goTo(newState, {entity, isAddMode});
   };
 
   const onBackClick = (entity: PanelEntity | null = activeConversation || null) => {
@@ -285,7 +283,7 @@ const RightSidebar: FC<RightSidebarProps> = ({
               onClose={closePanel}
               serviceEntity={serviceEntity}
               selfUser={selfUser}
-              isAddMode={isAddMode}
+              isAddMode={rightSidebar.isAddMode}
             />
           )}
 

--- a/src/script/page/state.ts
+++ b/src/script/page/state.ts
@@ -33,6 +33,7 @@ type RightSidebarParams = {
   entity: PanelEntity | null;
   showReactions?: boolean;
   highlighted?: User[];
+  isAddMode?: boolean;
 };
 
 type AppMainState = {
@@ -49,6 +50,7 @@ type AppMainState = {
     highlightedUsers: RightSidebarParams['highlighted'];
     history: PanelState[];
     showReactions: RightSidebarParams['showReactions'];
+    isAddMode: RightSidebarParams['isAddMode'];
     lastViewedMessageDetailsEntity: Message | null;
     updateEntity: (entity: RightSidebarParams['entity']) => void;
   };
@@ -99,6 +101,7 @@ const useAppMainState = create<AppMainState>((set, get) => ({
             highlightedUsers: params?.highlighted || [],
             history: [...replacedNewState, panel],
             showReactions: !!params?.showReactions,
+            isAddMode: !!params?.isAddMode,
           },
         };
       });

--- a/src/script/page/state.ts
+++ b/src/script/page/state.ts
@@ -114,6 +114,7 @@ const useAppMainState = create<AppMainState>((set, get) => ({
     highlightedUsers: [],
     history: [],
     showReactions: false,
+    isAddMode: false,
     updateEntity: (entity: RightSidebarParams['entity']) =>
       set(state => ({...state, rightSidebar: {...state.rightSidebar, entity}})),
   },


### PR DESCRIPTION
## Description

After fixing a different bug (see https://github.com/wireapp/wire-webapp/pull/17378/files#diff-42332a315c252fd2b9da98fb360d34d231ad1fd02b62c115ee191dfd6dc86fa1R236), there was an oversight and I've forgot to update another place where are opening the right conversation panel with service entity. 

We should not overwrite the service entity id with user's id when opening a right sidebar panel. It needs a service id (the one set on backend) to work properly.

Also the isAddMode was moved to the right panel opening params. When it was kept inside the react state (and right panel was not closed before opening again with the avatar click), the add button was visible even though the service was already added.

## Screenshots/Screencast (for UI changes)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
