### PR TITLE
fix: prevent progress bar flicker on app init (WPB-7378)

### DIFF
--- a/src/style/components/loading-bar.less
+++ b/src/style/components/loading-bar.less
@@ -47,6 +47,7 @@
     var(--background-fade-8) 14px
   );
   background-size: @rotatedSize 4px;
+  margin-inline: auto;
 
   > div {
     width: 0;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7378" title="WPB-7378" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7378</a>  Initial loading/decrypting messages view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

The progress bar would get out of center and flicker if a user has a particularly long name on initializing the app

## Screenshots/Screencast (for UI changes)
Before
![Kooha-2024-05-14-13-29-04](https://github.com/wireapp/wire-webapp/assets/78490891/e189d963-de23-4b86-b81d-73b274089d1a)

After
![Kooha-2024-05-14-13-29-24](https://github.com/wireapp/wire-webapp/assets/78490891/6f3815cd-33f9-4db8-87f7-e93c52b4392d)

