### PR TITLE
runfix: adress responsivness of the preferences sections (WPB-7214)

### DIFF
--- a/src/script/page/MainContent/panels/preferences/avPreferences/DeviceSelect.tsx
+++ b/src/script/page/MainContent/panels/preferences/avPreferences/DeviceSelect.tsx
@@ -57,7 +57,7 @@ const DeviceSelect: React.FC<DeviceSelectProps> = ({
       className={cx('preferences-option', {
         'preferences-av-select-disabled': disabled,
       })}
-      css={{width: 'var(--preferences-width)'}}
+      css={{width: '100%'}}
     >
       <div className="preferences-option-icon preferences-av-select-icon">
         <DeviceIcon />

--- a/src/script/page/MainContent/panels/preferences/components/PreferencesPage.styles.ts
+++ b/src/script/page/MainContent/panels/preferences/components/PreferencesPage.styles.ts
@@ -1,0 +1,44 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {CSSObject} from '@emotion/react';
+
+export const wrapperStyle: CSSObject = {
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  containerType: 'inline-size',
+};
+
+export const buttonsStyle: CSSObject = {
+  marginBottom: 0,
+};
+
+export const contentStyle: CSSObject = {
+  width: '100%',
+  height: '100%',
+  padding: '32px 32px 32px 72px',
+  overflowX: 'hidden',
+  '@container (max-width: 768px)': {
+    padding: '40px',
+  },
+  '@container (max-width: 480px)': {
+    padding: '20px',
+  },
+};

--- a/src/script/page/MainContent/panels/preferences/components/PreferencesPage.styles.ts
+++ b/src/script/page/MainContent/panels/preferences/components/PreferencesPage.styles.ts
@@ -35,6 +35,15 @@ export const contentStyle: CSSObject = {
   height: '100%',
   padding: '32px 32px 32px 72px',
   overflowX: 'hidden',
+
+  // Rely on viewport media queries if container queries are not supported by the browser
+  '@media (max-width: 768px)': {
+    padding: '40px',
+  },
+  '@media (max-width: 480px)': {
+    padding: '20px',
+  },
+  // Container queries are supported by recent browsers and allow a more flexible responsive design
   '@container (max-width: 768px)': {
     padding: '40px',
   },

--- a/src/script/page/MainContent/panels/preferences/components/PreferencesPage.tsx
+++ b/src/script/page/MainContent/panels/preferences/components/PreferencesPage.tsx
@@ -25,6 +25,8 @@ import {FadingScrollbar} from 'Components/FadingScrollbar';
 import {RootContext} from 'src/script/page/RootProvider';
 import {useAppMainState, ViewType} from 'src/script/page/state';
 
+import {buttonsStyle, contentStyle, wrapperStyle} from './PreferencesPage.styles';
+
 interface PreferencesPageProps {
   children: React.ReactNode;
   title: string;
@@ -42,13 +44,13 @@ const PreferencesPage: FC<PreferencesPageProps> = ({title, children}) => {
   const goHome = () => root?.content.loadPreviousContent();
 
   return (
-    <div role="tabpanel" aria-labelledby={title} style={{display: 'flex', flexDirection: 'column', height: '100vh'}}>
+    <div role="tabpanel" aria-labelledby={title} css={wrapperStyle}>
       <div className="preferences-titlebar">
         {smBreakpoint && isCentralColumn && (
           <IconButton
             variant={IconButtonVariant.SECONDARY}
             className="conversation-title-bar-icon icon-back"
-            css={{marginBottom: 0}}
+            css={buttonsStyle}
             onClick={() => setCurrentView(ViewType.LEFT_SIDEBAR)}
           />
         )}
@@ -57,12 +59,14 @@ const PreferencesPage: FC<PreferencesPageProps> = ({title, children}) => {
           <IconButton
             variant={IconButtonVariant.SECONDARY}
             className="conversation-title-bar-icon icon-close"
-            css={{marginBottom: 0}}
+            css={buttonsStyle}
             onClick={goHome}
           />
         )}
       </div>
-      <FadingScrollbar className="preferences-content">{children}</FadingScrollbar>
+      <FadingScrollbar className="preferences-content" css={contentStyle}>
+        {children}
+      </FadingScrollbar>
     </div>
   );
 };

--- a/src/style/content/preferences.less
+++ b/src/style/content/preferences.less
@@ -37,26 +37,6 @@
   color: var(--main-color);
 }
 
-.preferences-content {
-  width: 100%;
-  min-width: var(--preferences-width);
-  height: 100%;
-  padding: 32px 32px 32px 72px;
-  overflow-x: hidden;
-
-  @media (max-width: @screen-md-min) {
-    padding: 40px;
-  }
-
-  @media (max-width: @screen-sm) {
-    padding: 20px;
-  }
-
-  input {
-    color: var(--background);
-  }
-}
-
 .preferences-button {
   margin-top: 8px;
 }

--- a/src/style/content/preferences.less
+++ b/src/style/content/preferences.less
@@ -152,7 +152,7 @@
 
 .preferences-section {
   display: flex;
-  width: var(--preferences-width);
+  max-width: var(--preferences-width);
   flex-direction: column;
   align-items: flex-start;
   padding: 0;
@@ -170,7 +170,7 @@
 }
 
 .preferences-separator {
-  width: var(--preferences-width);
+  max-width: var(--preferences-width);
   height: 1px;
   border: 0;
   margin: 22px 0 22px;
@@ -187,7 +187,7 @@
 }
 
 .preferences-wrapper {
-  width: var(--preferences-width);
+  max-width: var(--preferences-width);
 
   .buttons-group {
     justify-content: center;

--- a/src/style/content/preferences/devices.less
+++ b/src/style/content/preferences/devices.less
@@ -51,7 +51,8 @@
 
 .preferences-devices-card {
   display: flex;
-  width: var(--preferences-width);
+  width: 100%;
+  max-width: var(--preferences-width);
   align-items: center;
   justify-content: space-between;
 
@@ -164,7 +165,7 @@
 }
 
 .preferences-devices-separator {
-  width: var(--preferences-width);
+  max-width: var(--preferences-width);
   margin-bottom: 32px;
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7214" title="WPB-7214" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7214</a>  [Web] Implement responsiveness using container queries instead of viewport media queries
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

We can use [container queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries) to have the content of the preference pages be responsive with its container instead of the viewport.

Standard media queries are used as a fallback.

This allows the preferences page to be responvive regardless of the state of the new sidebar

## Screenshots/Screencast (for UI changes)
#### Before: (layout breaks just before going into responsive design with the sidebar opened)
![Kooha-2024-05-15-14-58-52](https://github.com/wireapp/wire-webapp/assets/78490891/4f94b31a-fd7a-4123-8f39-0df911c7028b)

#### After:
![Kooha-2024-05-15-15-11-30](https://github.com/wireapp/wire-webapp/assets/78490891/1bcc9537-9f25-45bb-8be5-14e56c2515f1)
