### PR TITLE
fix: align setting header to the left (WPB-8832)

### DIFF
--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -22,10 +22,6 @@
   background-color: var(--app-bg);
 }
 
-.conversations .left-list-header-text {
-  text-align: center;
-}
-
 .conversations-sidebar {
   position: relative;
 

--- a/src/style/list/list.less
+++ b/src/style/list/list.less
@@ -48,9 +48,8 @@
 }
 
 .left-list-header-preferences {
-  display: grid;
+  display: flex;
   min-height: var(--content-title-bar-height);
-  place-content: center;
 }
 
 body.theme-dark {
@@ -62,13 +61,11 @@ body.theme-dark {
 .left-list-header-text {
   .ellipsis-nowrap;
   .heading-h3;
+  .text;
   display: inline-block;
   width: 100%;
 
   align-self: center;
-  grid-column: 2 / span 2;
-  justify-self: center;
-  text-align: center;
 }
 
 .left-list-header-close-button {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8832" title="WPB-8832" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-8832</a>  Text alignment and background color still wrong in Settings view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

The new navigation's design has the header in the middle sidebar left aligned instead of centered

## Screenshots/Screencast (for UI changes)
Before:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/a7c71217-0f33-477a-9436-b44e51faeaaa)

After:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/eea63305-49d6-455c-a034-9939d3d760c0)
