### PR TITLE
runfix: 1:1 conversation with user without key packages (#17371)

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -1172,6 +1172,7 @@
   "ongoingGroupVideoCall": "Ongoing video conference call with {{conversationName}}, your camera is {{cameraStatus}}.",
   "ongoingVideoCall": "Ongoing video call with {{conversationName}}, your camera is {{cameraStatus}}.",
   "otherUserNotSupportMLSMsg": "You can't communicate with {{participantName}} anymore, as you two now use different protocols. When {{participantName}} gets an update, you can call and send messages and files again.",
+  "otherUserNoAvailableKeyPackages": "You can't communicate with {{participantName}} at the moment. When {{participantName}} logs in again, you can call and send messages and files again.",
   "participantDevicesDetailHeadline": "Verify that this matches the fingerprint shown on [bold]{{user}}’s device[/bold].",
   "participantDevicesDetailHowTo": "How do I do that?",
   "participantDevicesDetailResetSession": "Reset session",

--- a/src/script/components/Conversation/ReadOnlyConversationMessage/ReadOnlyConversationMessage.test.tsx
+++ b/src/script/components/Conversation/ReadOnlyConversationMessage/ReadOnlyConversationMessage.test.tsx
@@ -101,4 +101,14 @@ describe('ReadOnlyConversationMessage', () => {
 
     expect(getByText('conversationWithBlockedUser')).toBeDefined();
   });
+
+  it("renders a conversation with a user that don't have any key pakages available", () => {
+    const conversation = generateConversation(CONVERSATION_READONLY_STATE.READONLY_ONE_TO_ONE_NO_KEY_PACKAGES, false);
+
+    const {getByText} = render(
+      withTheme(<ReadOnlyConversationMessage reloadApp={() => {}} conversation={conversation} />),
+    );
+
+    expect(getByText('otherUserNoAvailableKeyPackages')).toBeDefined();
+  });
 });

--- a/src/script/components/Conversation/ReadOnlyConversationMessage/ReadOnlyConversationMessage.tsx
+++ b/src/script/components/Conversation/ReadOnlyConversationMessage/ReadOnlyConversationMessage.tsx
@@ -100,6 +100,19 @@ export const ReadOnlyConversationMessage: FC<ReadOnlyConversationMessageProps> =
             </>
           </ReadOnlyConversationMessageBase>
         );
+      case CONVERSATION_READONLY_STATE.READONLY_ONE_TO_ONE_NO_KEY_PACKAGES:
+        return (
+          <ReadOnlyConversationMessageBase>
+            <span>
+              {replaceReactComponents(t('otherUserNoAvailableKeyPackages'), [
+                {
+                  exactMatch: '{{participantName}}',
+                  render: () => <strong>{user.name()}</strong>,
+                },
+              ])}
+            </span>
+          </ReadOnlyConversationMessageBase>
+        );
     }
   }
 

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -41,6 +41,7 @@ import {
 } from '@wireapp/api-client/lib/event/';
 import {BackendError, BackendErrorLabel} from '@wireapp/api-client/lib/http';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
+import {ClientMLSError, ClientMLSErrorLabel} from '@wireapp/core/lib/messagingProtocols/mls';
 import {amplify} from 'amplify';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import ko from 'knockout';
@@ -1016,6 +1017,55 @@ describe('ConversationRepository', () => {
       expect(conversationEntity?.serialize()).toEqual(mls1to1Conversation.serialize());
       expect(conversationEntity?.readOnlyState()).toEqual(
         CONVERSATION_READONLY_STATE.READONLY_ONE_TO_ONE_OTHER_UNSUPPORTED_MLS,
+      );
+    });
+
+    it('marks mls 1:1 conversation as read-only if both users support mls but the other user has no keys available', async () => {
+      const conversationRepository = testFactory.conversation_repository!;
+      const userRepository = testFactory.user_repository!;
+
+      const otherUserId = {id: 'a718410c-3833-479d-bd80-a5df03f38414', domain: 'test-domain'};
+      const otherUser = new User(otherUserId.id, otherUserId.domain);
+      otherUser.supportedProtocols([ConversationProtocol.MLS]);
+      userRepository['userState'].users.push(otherUser);
+
+      const selfUserId = {id: '1a9da9ca-a495-47a8-ac70-9ffbe924b2d0', domain: 'test-domain'};
+      const selfUser = new User(selfUserId.id, selfUserId.domain);
+      selfUser.supportedProtocols([ConversationProtocol.MLS]);
+      jest.spyOn(conversationRepository['userState'], 'self').mockReturnValue(selfUser);
+
+      const mls1to1ConversationResponse = generateAPIConversation({
+        id: {id: '0aab891e-ccf1-4dba-9d74-bacec64b5b1e', domain: 'test-domain'},
+        type: CONVERSATION_TYPE.ONE_TO_ONE,
+        protocol: ConversationProtocol.MLS,
+        overwites: {group_id: 'groupId'},
+      }) as BackendMLSConversation;
+
+      const noKeysError = new ClientMLSError(ClientMLSErrorLabel.NO_KEY_PACKAGES_AVAILABLE);
+
+      jest
+        .spyOn(container.resolve(Core).service!.conversation, 'establishMLS1to1Conversation')
+        .mockRejectedValueOnce(noKeysError);
+
+      const [mls1to1Conversation] = conversationRepository.mapConversations([mls1to1ConversationResponse]);
+
+      const connection = new ConnectionEntity();
+      connection.conversationId = mls1to1Conversation.qualifiedId;
+      connection.userId = otherUserId;
+      otherUser.connection(connection);
+      mls1to1Conversation.connection(connection);
+
+      conversationRepository['conversationState'].conversations.push(mls1to1Conversation);
+
+      jest
+        .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
+        .mockResolvedValueOnce(false);
+
+      const conversationEntity = await conversationRepository.getInitialised1To1Conversation(otherUser.qualifiedId);
+
+      expect(conversationEntity?.serialize()).toEqual(mls1to1Conversation.serialize());
+      expect(conversationEntity?.readOnlyState()).toEqual(
+        CONVERSATION_READONLY_STATE.READONLY_ONE_TO_ONE_NO_KEY_PACKAGES,
       );
     });
 

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -49,6 +49,7 @@ import {BackendErrorLabel} from '@wireapp/api-client/lib/http/';
 import type {BackendError} from '@wireapp/api-client/lib/http/';
 import type {QualifiedId} from '@wireapp/api-client/lib/user/';
 import {MLSCreateConversationResponse} from '@wireapp/core/lib/conversation';
+import {ClientMLSError, ClientMLSErrorLabel} from '@wireapp/core/lib/messagingProtocols/mls';
 import {amplify} from 'amplify';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import {container} from 'tsyringe';
@@ -171,11 +172,13 @@ type IncomingEvent = ConversationEvent | ClientConversationEvent;
 export enum CONVERSATION_READONLY_STATE {
   READONLY_ONE_TO_ONE_SELF_UNSUPPORTED_MLS = 'READONLY_ONE_TO_ONE_SELF_UNSUPPORTED_MLS',
   READONLY_ONE_TO_ONE_OTHER_UNSUPPORTED_MLS = 'READONLY_ONE_TO_ONE_OTHER_UNSUPPORTED_MLS',
+  READONLY_ONE_TO_ONE_NO_KEY_PACKAGES = 'READONLY_ONE_TO_ONE_NO_KEY_PACKAGES',
 }
 
 interface GetInitialised1To1ConversationOptions {
   isLiveUpdate?: boolean;
   shouldRefreshUser?: boolean;
+  mls?: {allowUnestablished?: boolean};
 }
 
 type ConversaitonWithServiceParams = {
@@ -1336,7 +1339,11 @@ export class ConversationRepository {
        * We have to add a delay to make sure the welcome message is not wasted, in case the self client would establish mls group themselves before receiving the welcome.
        */
       const shouldDelayMLSGroupEstablishment = options.isLiveUpdate && isMLSSupportedByTheOtherUser;
-      return this.initMLS1to1Conversation(userId, isMLSSupportedByTheOtherUser, shouldDelayMLSGroupEstablishment);
+      return this.initMLS1to1Conversation(userId, {
+        isMLSSupportedByTheOtherUser,
+        shouldDelayGroupEstablishment: shouldDelayMLSGroupEstablishment,
+        allowUnestablished: options.mls?.allowUnestablished,
+      });
     }
 
     // There's no connection so it's a proteus conversation with a team member
@@ -1512,14 +1519,6 @@ export class ConversationRepository {
         }
       }
     }
-  };
-
-  private readonly updateConversationReadOnlyState = async (
-    conversationEntity: Conversation,
-    conversationReadOnlyState: CONVERSATION_READONLY_STATE | null,
-  ) => {
-    conversationEntity.readOnlyState(conversationReadOnlyState);
-    await this.saveConversationStateInDb(conversationEntity);
   };
 
   private readonly getProtocolFor1to1Conversation = async (
@@ -1759,8 +1758,11 @@ export class ConversationRepository {
    */
   private readonly initMLS1to1Conversation = async (
     otherUserId: QualifiedId,
-    isMLSSupportedByTheOtherUser: boolean,
-    shouldDelayGroupEstablishment = false,
+    {
+      isMLSSupportedByTheOtherUser,
+      shouldDelayGroupEstablishment = false,
+      allowUnestablished = true,
+    }: {isMLSSupportedByTheOtherUser: boolean; shouldDelayGroupEstablishment?: boolean; allowUnestablished?: boolean},
   ): Promise<MLSConversation> => {
     // When receiving some live updates via websocket, e.g. after connection request is accepted, both sides (users) of connection will react to conversation status update event.
     // We want to reduce the possibility of two users trying to establish an MLS group at the same time.
@@ -1819,11 +1821,24 @@ export class ConversationRepository {
       throw new Error('Self user is not available!');
     }
 
-    const initialisedMLSConversation = await this.establishMLS1to1Conversation(mlsConversation, otherUserId);
+    let initialisedMLSConversation: MLSConversation = mlsConversation;
+
+    try {
+      initialisedMLSConversation = await this.establishMLS1to1Conversation(mlsConversation, otherUserId);
+      initialisedMLSConversation.readOnlyState(null);
+    } catch (error) {
+      this.logger.warn(`Failed to establish MLS 1:1 conversation with user ${otherUserId.id}`, error);
+      if (!allowUnestablished) {
+        throw error;
+      }
+
+      if (error instanceof ClientMLSError && error.label === ClientMLSErrorLabel.NO_KEY_PACKAGES_AVAILABLE) {
+        initialisedMLSConversation.readOnlyState(CONVERSATION_READONLY_STATE.READONLY_ONE_TO_ONE_NO_KEY_PACKAGES);
+      }
+    }
 
     // If mls is supported by the other user, we can establish the group and remove readonly state from the conversation.
-    initialisedMLSConversation.readOnlyState(null);
-    await this.update1To1ConversationParticipants(mlsConversation, otherUserId);
+    await this.update1To1ConversationParticipants(initialisedMLSConversation, otherUserId);
     await this.saveConversation(initialisedMLSConversation);
 
     if (shouldOpenMLS1to1Conversation) {
@@ -1868,16 +1883,13 @@ export class ConversationRepository {
     // If proteus is not supported by the other user we have to mark conversation as readonly
     if (!doesOtherUserSupportProteus) {
       await this.blacklistConversation(proteusConversationId);
-      await this.updateConversationReadOnlyState(
-        proteusConversation,
-        CONVERSATION_READONLY_STATE.READONLY_ONE_TO_ONE_SELF_UNSUPPORTED_MLS,
-      );
+      proteusConversation.readOnlyState(CONVERSATION_READONLY_STATE.READONLY_ONE_TO_ONE_SELF_UNSUPPORTED_MLS);
       return proteusConversation;
     }
 
     // If proteus is supported by the other user, we just return a proteus conversation and remove readonly state from it.
     await this.removeConversationFromBlacklist(proteusConversationId);
-    await this.updateConversationReadOnlyState(proteusConversation, null);
+    await proteusConversation.readOnlyState(null);
     return proteusConversation;
   };
 
@@ -1992,11 +2004,10 @@ export class ConversationRepository {
         `Connection with user ${otherUserId.id} is accepted, using protocol ${protocol} for 1:1 conversation`,
       );
       if (protocol === ConversationProtocol.MLS || localMLSConversation) {
-        return this.initMLS1to1Conversation(
-          otherUserId,
+        return this.initMLS1to1Conversation(otherUserId, {
           isMLSSupportedByTheOtherUser,
-          shouldDelayMLSGroupEstablishment,
-        );
+          shouldDelayGroupEstablishment: shouldDelayMLSGroupEstablishment,
+        });
       }
 
       if (protocol === ConversationProtocol.PROTEUS) {
@@ -2013,7 +2024,10 @@ export class ConversationRepository {
       this.logger.log(
         `Connection with user ${otherUserId.id} is not accepted, using already known MLS 1:1 conversation ${localMLSConversation.id}`,
       );
-      return this.initMLS1to1Conversation(otherUserId, isMLSSupportedByTheOtherUser, shouldDelayMLSGroupEstablishment);
+      return this.initMLS1to1Conversation(otherUserId, {
+        isMLSSupportedByTheOtherUser,
+        shouldDelayGroupEstablishment: shouldDelayMLSGroupEstablishment,
+      });
     }
 
     this.logger.log(

--- a/src/script/view_model/ActionsViewModel.ts
+++ b/src/script/view_model/ActionsViewModel.ts
@@ -330,7 +330,10 @@ export class ActionsViewModel {
   };
 
   getOrCreate1to1Conversation = async (userEntity: User): Promise<Conversation> => {
-    const conversationEntity = await this.conversationRepository.getInitialised1To1Conversation(userEntity.qualifiedId);
+    const conversationEntity = await this.conversationRepository.getInitialised1To1Conversation(
+      userEntity.qualifiedId,
+      {mls: {allowUnestablished: false}},
+    );
     if (conversationEntity) {
       return conversationEntity;
     }


### PR DESCRIPTION
Cherry-picked a commit from the release branch that handles an error when cannot establish a MLS 1:1 conversation when the other user has no key packages available. For more details see https://github.com/wireapp/wire-webapp/pull/17371.