### PR TITLE
runfix: Make sure newly created 1to1 conversation have updated user entities

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1311,7 +1311,9 @@ export class ConversationRepository {
     const connection = user.connection();
     if (connection) {
       this.logger.log(`There's a connection with user ${userId.id}, getting a 1:1 conversation for the connection`);
-      return this.get1to1ConversationForConnection(connection, options);
+      const conversation = await this.get1to1ConversationForConnection(connection, options);
+      // In case we got a conversation back, we make sure the participating user entities are up to date
+      return conversation ? this.updateParticipatingUserEntities(conversation) : null;
     }
 
     const {protocol, isMLSSupportedByTheOtherUser, isProteusSupportedByTheOtherUser} =


### PR DESCRIPTION
## Description

Cherry-picked a commit from the release branch that fixes an issue with a proteus 1:1 conversation not being created after accepting a connection request. For more details see https://github.com/wireapp/wire-webapp/pull/17278.

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
