### PR TITLE
feat: view port observer on lost visibility

### DIFF
--- a/src/script/components/utils/InViewport.tsx
+++ b/src/script/components/utils/InViewport.tsx
@@ -88,6 +88,7 @@ const InViewport: React.FC<InViewportParams & React.HTMLProps<HTMLDivElement>> =
       });
     }
     return () => {
+      // If the element is unmounted, we can trigger the onVisibilityLost callback and release the trackers
       onVisibilityLost?.();
       releaseTrackers();
     };

--- a/src/script/components/utils/InViewport.tsx
+++ b/src/script/components/utils/InViewport.tsx
@@ -24,7 +24,7 @@ import {viewportObserver} from 'Util/DOM/viewportObserver';
 
 interface InViewportParams {
   onVisible: () => void;
-  onNotVisible?: () => void;
+  onVisibilityLost?: () => void;
   requireFullyInView?: boolean;
   allowBiggerThanViewport?: boolean;
   /** Will check if the element is overlayed by something else. Can be used to be sure the user could actually see the element. Should not be used to do lazy loading as the overlayObserver has quite a long debounce time */
@@ -34,7 +34,7 @@ interface InViewportParams {
 const InViewport: React.FC<InViewportParams & React.HTMLProps<HTMLDivElement>> = ({
   children,
   onVisible,
-  onNotVisible,
+  onVisibilityLost,
   requireFullyInView = false,
   checkOverlay = false,
   allowBiggerThanViewport = false,
@@ -61,7 +61,7 @@ const InViewport: React.FC<InViewportParams & React.HTMLProps<HTMLDivElement>> =
       if (inViewport && visible) {
         onVisible();
 
-        if (!onNotVisible) {
+        if (!onVisibilityLost) {
           releaseTrackers();
         }
       }
@@ -73,9 +73,9 @@ const InViewport: React.FC<InViewportParams & React.HTMLProps<HTMLDivElement>> =
         inViewport = isInViewport;
         triggerCallbackIfVisible();
 
-        // If the element is not intersecting at all, we can trigger the onNotVisible callback
+        // If the element is not intersecting at all, we can trigger the onVisibilityLost callback
         if (!isPartiallyVisible) {
-          onNotVisible?.();
+          onVisibilityLost?.();
         }
       },
       requireFullyInView,
@@ -88,7 +88,7 @@ const InViewport: React.FC<InViewportParams & React.HTMLProps<HTMLDivElement>> =
       });
     }
     return () => releaseTrackers();
-  }, [allowBiggerThanViewport, requireFullyInView, checkOverlay, onVisible, onNotVisible]);
+  }, [allowBiggerThanViewport, requireFullyInView, checkOverlay, onVisible, onVisibilityLost]);
 
   return (
     <div ref={domNode} {...props} css={{minHeight: '1px'}}>

--- a/src/script/components/utils/InViewport.tsx
+++ b/src/script/components/utils/InViewport.tsx
@@ -87,7 +87,10 @@ const InViewport: React.FC<InViewportParams & React.HTMLProps<HTMLDivElement>> =
         triggerCallbackIfVisible();
       });
     }
-    return () => releaseTrackers();
+    return () => {
+      onVisibilityLost?.();
+      releaseTrackers();
+    };
   }, [allowBiggerThanViewport, requireFullyInView, checkOverlay, onVisible, onVisibilityLost]);
 
   return (

--- a/src/script/util/DOM/viewportObserver.ts
+++ b/src/script/util/DOM/viewportObserver.ts
@@ -23,14 +23,15 @@ const observedElements = new Map<
     allowBiggerThanViewport?: boolean;
     requireFullyInView?: boolean;
     onVisible?: Function;
-    onChange?: (isVisible: boolean, isIntersecting?: boolean) => void;
+    onVisibilityChange?: (isVisible: boolean, isPartiallyVisible: boolean) => void;
   }
 >();
 const tolerance = 0.8;
 
 const onIntersect: IntersectionObserverCallback = entries => {
   entries.forEach(({intersectionRatio, isIntersecting, target: element, rootBounds}) => {
-    const {onVisible, onChange, requireFullyInView, allowBiggerThanViewport} = observedElements.get(element) || {};
+    const {onVisible, onVisibilityChange, requireFullyInView, allowBiggerThanViewport} =
+      observedElements.get(element) || {};
     const isFullyInView = intersectionRatio >= tolerance;
 
     const isBiggerThanRoot = () => {
@@ -43,8 +44,8 @@ const onIntersect: IntersectionObserverCallback = entries => {
 
     const isVisible = isIntersecting && (!requireFullyInView || isFullyInView || isBiggerThanRoot());
 
-    if (onChange) {
-      onChange(!!isVisible, isIntersecting);
+    if (onVisibilityChange) {
+      onVisibilityChange(!!isVisible, isIntersecting);
     } else if (isVisible) {
       removeElement(element);
       return onVisible?.();
@@ -80,18 +81,22 @@ const onElementInViewport = (
  * Will track an element and trigger the callback whenever the intersecting state changes
  *
  * @param element the element to observe
- * @param onChange the callback to call when the element intersects or not
+ * @param onVisibilityChange the callback to call when the element intersects or not
  * @param requireFullyInView should the element be fully in view
  * @param allowBiggerThanViewport should fire when element is bigger than viewport
  */
 const trackElement = (
   element: HTMLElement,
-  onChange: (isVisible: boolean, isInterseting?: boolean) => void,
+  onVisibilityChange: (isVisible: boolean, isPartiallyVisible: boolean) => void,
   requireFullyInView = false,
   allowBiggerThanViewport = false,
 ): void => {
   if (element) {
-    observedElements.set(element, {allowBiggerThanViewport, onChange, requireFullyInView});
+    observedElements.set(element, {
+      allowBiggerThanViewport,
+      onVisibilityChange,
+      requireFullyInView,
+    });
     return observer.observe(element);
   }
 };

--- a/src/script/util/DOM/viewportObserver.ts
+++ b/src/script/util/DOM/viewportObserver.ts
@@ -17,7 +17,15 @@
  *
  */
 
-const observedElements = new Map();
+const observedElements = new Map<
+  Element,
+  {
+    allowBiggerThanViewport?: boolean;
+    requireFullyInView?: boolean;
+    onVisible?: Function;
+    onChange?: (isVisible: boolean) => void;
+  }
+>();
 const tolerance = 0.8;
 
 const onIntersect: IntersectionObserverCallback = entries => {
@@ -36,10 +44,10 @@ const onIntersect: IntersectionObserverCallback = entries => {
     const isVisible = isIntersecting && (!requireFullyInView || isFullyInView || isBiggerThanRoot());
 
     if (onChange) {
-      onChange(isVisible);
+      onChange(!!isVisible);
     } else if (isVisible) {
       removeElement(element);
-      return onVisible && onVisible();
+      return onVisible?.();
     }
   });
 };
@@ -78,7 +86,7 @@ const onElementInViewport = (
  */
 const trackElement = (
   element: HTMLElement,
-  onChange: Function,
+  onChange: (isVisible: boolean) => void,
   requireFullyInView = false,
   allowBiggerThanViewport = false,
 ): void => {

--- a/src/script/util/DOM/viewportObserver.ts
+++ b/src/script/util/DOM/viewportObserver.ts
@@ -23,7 +23,7 @@ const observedElements = new Map<
     allowBiggerThanViewport?: boolean;
     requireFullyInView?: boolean;
     onVisible?: Function;
-    onChange?: (isVisible: boolean) => void;
+    onChange?: (isVisible: boolean, isIntersecting?: boolean) => void;
   }
 >();
 const tolerance = 0.8;
@@ -44,7 +44,7 @@ const onIntersect: IntersectionObserverCallback = entries => {
     const isVisible = isIntersecting && (!requireFullyInView || isFullyInView || isBiggerThanRoot());
 
     if (onChange) {
-      onChange(!!isVisible);
+      onChange(!!isVisible, isIntersecting);
     } else if (isVisible) {
       removeElement(element);
       return onVisible?.();
@@ -86,7 +86,7 @@ const onElementInViewport = (
  */
 const trackElement = (
   element: HTMLElement,
-  onChange: (isVisible: boolean) => void,
+  onChange: (isVisible: boolean, isInterseting?: boolean) => void,
   requireFullyInView = false,
   allowBiggerThanViewport = false,
 ): void => {


### PR DESCRIPTION
## Description

Adds an ability to subscribe to visibility loss after the changing the visibility from "visible", to "not visible at all" (not intersecting at all).

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;