### PR TITLE
feat: remove create group & create gust room from connect tab

### DIFF
--- a/src/script/page/LeftSidebar/panels/StartUI/PeopleTab.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/PeopleTab.tsx
@@ -49,8 +49,6 @@ import {UserState} from '../../../../user/UserState';
 export type SearchResultsData = {contacts: User[]; groups: Conversation[]; others: User[]};
 
 interface PeopleTabProps {
-  canCreateGroupConversation: boolean;
-  canCreateGuestRoom: boolean;
   canInviteTeamMembers: boolean;
   canSearchUnconnectedUsers: boolean;
   conversationRepository: ConversationRepository;
@@ -80,8 +78,6 @@ export const PeopleTab = ({
   selfUser,
   canInviteTeamMembers,
   canSearchUnconnectedUsers,
-  canCreateGroupConversation,
-  canCreateGuestRoom,
   conversationState,
   searchRepository,
   conversationRepository,

--- a/src/script/page/LeftSidebar/panels/StartUI/PeopleTab.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/PeopleTab.tsx
@@ -20,11 +20,8 @@
 import {useEffect, useRef, useState} from 'react';
 
 import {BackendErrorLabel} from '@wireapp/api-client/lib/http';
-import {amplify} from 'amplify';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import {partition} from 'underscore';
-
-import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {Icon} from 'Components/Icon';
 import {UserList, UserlistMode} from 'Components/UserList';
@@ -258,40 +255,6 @@ export const PeopleTab = ({
                 >
                   <span className="left-column-icon icon-envelope"></span>
                   <span className="column-center">{t('searchMemberInvite')}</span>
-                </button>
-              </li>
-            )}
-            {canCreateGroupConversation && (
-              <li className="left-list-item">
-                <button
-                  className="left-list-item-button"
-                  type="button"
-                  onClick={() => amplify.publish(WebAppEvents.CONVERSATION.CREATE_GROUP, 'start_ui')}
-                  data-uie-name="go-create-group"
-                >
-                  <span className="left-column-icon">
-                    <Icon.Group />
-                  </span>
-                  <span className="column-center">{t('searchCreateGroup')}</span>
-                </button>
-              </li>
-            )}
-            {canCreateGuestRoom && (
-              <li className="left-list-item">
-                <button
-                  className="left-list-item-button"
-                  type="button"
-                  onClick={() =>
-                    conversationRepository.createGuestRoom().then(conversation => {
-                      amplify.publish(WebAppEvents.CONVERSATION.SHOW, conversation, {});
-                    })
-                  }
-                  data-uie-name="do-create-guest-room"
-                >
-                  <span className="left-column-icon">
-                    <Icon.Guest />
-                  </span>
-                  <span className="column-center">{t('searchCreateGuestRoom')}</span>
                 </button>
               </li>
             )}

--- a/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
@@ -80,14 +80,8 @@ const StartUI: React.FC<StartUIProps> = ({
   selfUser,
 }) => {
   const brandName = Config.getConfig().BRAND_NAME;
-  const {
-    canInviteTeamMembers,
-    canSearchUnconnectedUsers,
-    canManageServices,
-    canChatWithServices,
-    canCreateGuestRoom,
-    canCreateGroupConversation,
-  } = generatePermissionHelpers(selfUser.teamRole());
+  const {canInviteTeamMembers, canSearchUnconnectedUsers, canManageServices, canChatWithServices} =
+    generatePermissionHelpers(selfUser.teamRole());
 
   useEffect(() => {
     void conversationRepository.loadMissingConversations();
@@ -205,8 +199,6 @@ const StartUI: React.FC<StartUIProps> = ({
           searchRepository={searchRepository}
           conversationRepository={conversationRepository}
           canInviteTeamMembers={canInviteTeamMembers()}
-          canCreateGroupConversation={canCreateGroupConversation()}
-          canCreateGuestRoom={canCreateGuestRoom()}
           userRepository={userRepository}
           onClickContact={openContact}
           onClickConversation={openConversation}


### PR DESCRIPTION
## Description
In the current implementation of “Contacts” (what is going to be called “Connect”), there are options to “Create group” and to “Create guest room” - both of these options should be covered by the implementation of the “New” button, hence should be removed from the “Connect” option.

## Screenshots/Screencast (for UI changes)
### BEFORE:
<img width="533" alt="image" src="https://github.com/wireapp/wire-webapp/assets/63250054/c01bf231-bc60-452a-bb70-235634721e4d">

### AFTER:
<img width="534" alt="image" src="https://github.com/wireapp/wire-webapp/assets/63250054/5ae790c6-ce81-4fcb-8a12-ddae8ace3643">

