### PR TITLE
fix: show enrollment modal for existing clients after e2ei activation [WPB-9816]

### DIFF
--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -152,7 +152,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
       } else {
         // If we have an enrollment in progress but we are not coming back from an idp redirect, we need to clear the progress and start over
         await this.coreE2EIService.clearAllProgress();
-        await this.startEnrollment(ModalType.ENROLL, false);
+        await this.startEnrollment(ModalType.ENROLL, !isFreshClient);
       }
     } else if (isFreshClient) {
       // When the user logs in to a new device in an environment that has e2ei enabled, they should be forced to enroll

--- a/src/script/E2EIdentity/EnrollmentTimer/EnrollmentTimer.test.ts
+++ b/src/script/E2EIdentity/EnrollmentTimer/EnrollmentTimer.test.ts
@@ -30,6 +30,22 @@ describe('e2ei delays', () => {
     jest.setSystemTime(1709050878009);
   });
 
+  it('should return an immediate delay at feature activation', () => {
+    const delay = getEnrollmentTimer(
+      {
+        x509Identity: {
+          certificate: ' ',
+          notAfter: (Date.now() + TimeInMillis.MINUTE * 10) / 1000,
+        },
+      } as any,
+      Date.now(),
+      TimeInMillis.DAY * 30,
+      true,
+    );
+
+    expect(delay).toEqual({firingDate: Date.now(), isSnoozable: true});
+  });
+
   it('should return an immediate delay if the identity is expired', () => {
     const delay = getEnrollmentTimer({status: MLSStatuses.EXPIRED} as any, Date.now(), gracePeriod);
 

--- a/src/script/E2EIdentity/EnrollmentTimer/EnrollmentTimer.ts
+++ b/src/script/E2EIdentity/EnrollmentTimer/EnrollmentTimer.ts
@@ -91,6 +91,7 @@ export function getEnrollmentTimer(
   identity: WireIdentity | undefined,
   e2eiActivatedAt: number,
   teamGracePeriodDuration: number,
+  isFirstActivation: boolean = false,
 ) {
   if (identity?.status === MLSStatuses.EXPIRED) {
     return {isSnoozable: false, firingDate: Date.now()};
@@ -98,6 +99,11 @@ export function getEnrollmentTimer(
 
   const deadline = getGracePeriod(identity, e2eiActivatedAt, teamGracePeriodDuration);
   const nextTick = getNextTick(deadline);
+
+  // For the first activation, we want to trigger the timer immediately
+  if (isFirstActivation) {
+    return {isSnoozable: nextTick > 0, firingDate: Date.now()};
+  }
 
   // When logging in to a old device that doesn't have an identity yet, we trigger an enrollment timer
   return {isSnoozable: nextTick > 0, firingDate: Date.now() + nextTick};


### PR DESCRIPTION
We did automatically "snooze" the certificate enrollment for existing clients, after e2ei feature activation.
This was not supposed to happen, instead we need to show the activation modal to the user, and he/she needs to take action to either enroll or snooze him-/herself