### PR TITLE
feat: Zoomable image improvements

### DIFF
--- a/src/script/components/ZoomableImage/ZoomableImage.style.ts
+++ b/src/script/components/ZoomableImage/ZoomableImage.style.ts
@@ -25,3 +25,11 @@ export const imageStyle: CSSObject = {
   maxWidth: 'none',
   height: 'auto',
 };
+
+export const containerStyle: CSSObject = {
+  width: '100%',
+  height: '100%',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+};

--- a/src/script/components/ZoomableImage/ZoomableImage.style.ts
+++ b/src/script/components/ZoomableImage/ZoomableImage.style.ts
@@ -19,18 +19,9 @@
 
 import {CSSObject} from '@emotion/react';
 
-export const imageStyle = (isZoomEnabled: boolean): CSSObject => {
-  return {
-    cursor: isZoomEnabled ? 'zoom-out !important' : 'default',
-    ...(isZoomEnabled
-      ? {
-          transition: 'transform 0.3s linear',
-          willChange: 'transform',
-        }
-      : {
-          maxWidth: '100%',
-          height: '100%',
-          objectFit: 'scale-down',
-        }),
-  };
+export const imageStyle: CSSObject = {
+  userSelect: 'none',
+  flexShrink: 0,
+  maxWidth: 'none',
+  height: 'auto',
 };

--- a/src/script/components/ZoomableImage/ZoomableImage.tsx
+++ b/src/script/components/ZoomableImage/ZoomableImage.tsx
@@ -21,6 +21,8 @@ import React, {HTMLProps, RefObject, useEffect, useRef, useState} from 'react';
 
 import {containerStyle, imageStyle} from './ZoomableImage.style';
 
+import {isHTMLImageElement} from '../../guards/HTMLElement';
+
 type Offset = {
   x: number;
   y: number;
@@ -54,12 +56,9 @@ function calculateMaxOffset(containerRef: RefObject<HTMLDivElement>, imgRef: Ref
 
   const containerRect = containerRef.current.getBoundingClientRect();
 
-  const maxXOffset = (containerRect.width - imgRef.current.naturalWidth) / 2;
-  const maxYOffset = (containerRect.height - imgRef.current.naturalHeight) / 2;
-
   return {
-    maxXOffset: maxXOffset,
-    maxYOffset: maxYOffset,
+    maxXOffset: (containerRect.width - imgRef.current.naturalWidth) / 2,
+    maxYOffset: (containerRect.height - imgRef.current.naturalHeight) / 2,
   };
 }
 
@@ -82,7 +81,11 @@ export const ZoomableImage = (props: ZoomableImageProps) => {
   const zoomScale = isZoomEnabled ? 1 : imageRatio;
 
   const handleMouseClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    const element = event.target as HTMLImageElement;
+    const element = event.target;
+
+    if (!isHTMLImageElement(element)) {
+      return;
+    }
 
     if (!canZoomImage && !isZoomEnabled) {
       return;

--- a/src/script/components/ZoomableImage/ZoomableImage.tsx
+++ b/src/script/components/ZoomableImage/ZoomableImage.tsx
@@ -139,12 +139,15 @@ export const ZoomableImage = (props: ZoomableImageProps) => {
     if (!canZoomImage && !isZoomEnabled) {
       return;
     }
+    const element = event.target;
+
+    if (!isHTMLImageElement(element)) {
+      return;
+    }
 
     if (isZoomEnabled) {
       mouseDownRef.current = true;
     }
-
-    const element = event.target as HTMLImageElement;
 
     requestAnimationFrame(() => {
       element.style.transition = 'transform 0.2s';
@@ -163,9 +166,14 @@ export const ZoomableImage = (props: ZoomableImageProps) => {
       return;
     }
 
+    const element = event.target;
+
+    if (!isHTMLImageElement(element)) {
+      return;
+    }
+
     mouseDownRef.current = false;
 
-    const element = event.target as HTMLImageElement;
     requestAnimationFrame(() => {
       element.style.cursor = 'zoom-out';
     });
@@ -176,9 +184,13 @@ export const ZoomableImage = (props: ZoomableImageProps) => {
       return;
     }
 
-    draggingRef.current = true;
+    const element = event.target;
 
-    const element = event.target as HTMLImageElement;
+    if (!isHTMLImageElement(element)) {
+      return;
+    }
+
+    draggingRef.current = true;
 
     if (element.style.transition) {
       element.style.transition = '';
@@ -234,7 +246,12 @@ export const ZoomableImage = (props: ZoomableImageProps) => {
           transform: `translate3d(${translateOffset.x}px, ${translateOffset.y}px, 0) scale(${zoomScale}, ${zoomScale})`,
         }}
         onLoad={event => {
-          const element = event.target as HTMLImageElement;
+          const element = event.target;
+
+          if (!isHTMLImageElement(element)) {
+            return;
+          }
+
           const zoomRatio = calculateZoomRatio(element);
           const imageScale = zoomRatio > 1 ? 1 : zoomRatio;
           setImageRatio(imageScale);

--- a/src/script/components/ZoomableImage/ZoomableImage.tsx
+++ b/src/script/components/ZoomableImage/ZoomableImage.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React, {HTMLProps, RefObject, useRef, useState} from 'react';
+import React, {HTMLProps, RefObject, useEffect, useRef, useState} from 'react';
 
 import {imageStyle} from './ZoomableImage.style';
 
@@ -28,100 +28,140 @@ type Offset = {
 
 const DEFAULT_OFFSET: Offset = {x: 0, y: 0};
 
-function calculateZoomRatio(parentWidth: number, parentHeight: number, naturalWidth: number, naturalHeight: number) {
-  const widthRatio = parentWidth / naturalWidth;
-  const heightRatio = parentHeight / naturalHeight;
+function calculateZoomRatio(element: HTMLImageElement) {
+  const parentElement = element.parentElement;
+
+  if (!parentElement) {
+    return 1;
+  }
+
+  const {offsetWidth: parentOffsetWidth, offsetHeight: parentOffsetHeight} = parentElement;
+  const {naturalWidth, naturalHeight} = element;
+
+  const widthRatio = parentOffsetWidth / naturalWidth;
+  const heightRatio = parentOffsetHeight / naturalHeight;
   return Math.min(widthRatio, heightRatio);
 }
 
-function calculateMaxOffset(
-  containerRef: RefObject<HTMLDivElement>,
-  imgRef: RefObject<HTMLImageElement>,
-  zoomScale: number,
-) {
+// if we will add more image zooming, we need to pass 2 props, for check if is image is zoomed and imageScale
+function calculateMaxOffset(containerRef: RefObject<HTMLDivElement>, imgRef: RefObject<HTMLImageElement>) {
   if (!containerRef.current || !imgRef.current) {
     return {
-      minX: 0,
-      maxX: 0,
-      minY: 0,
-      maxY: 0,
+      maxXOffset: 0,
+      maxYOffset: 0,
     };
   }
 
   const containerRect = containerRef.current.getBoundingClientRect();
 
-  const scaledWidth = imgRef.current.naturalWidth * zoomScale;
-  const scaledHeight = imgRef.current.naturalHeight * zoomScale;
-
-  const maxXOffset = (containerRect.width - scaledWidth) / 2;
-  const maxYOffset = (containerRect.height - scaledHeight) / 2;
+  const maxXOffset = (containerRect.width - imgRef.current.naturalWidth) / 2;
+  const maxYOffset = (containerRect.height - imgRef.current.naturalHeight) / 2;
 
   return {
-    minX: maxXOffset,
-    maxX: -maxXOffset,
-    minY: maxYOffset,
-    maxY: -maxYOffset,
+    maxXOffset: maxXOffset,
+    maxYOffset: maxYOffset,
   };
 }
 
 type ZoomableImageProps = HTMLProps<HTMLImageElement>;
 
 export const ZoomableImage = (props: ZoomableImageProps) => {
-  const imgRef = useRef<HTMLImageElement | null>(null);
+  const imageRef = useRef<HTMLImageElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const [imageRatio, setImageRatio] = useState(1);
+
+  const draggingRef = useRef(false);
+  const mouseDownRef = useRef(false);
 
   const [isZoomEnabled, setIsZoomEnabled] = useState<boolean>(false);
-  const [imageZoomRatio, setImageZoomRatio] = useState(1);
 
-  const [zoomScale, setZoomScale] = useState(1);
   const [translateOffset, setTranslateOffset] = useState<Offset>(DEFAULT_OFFSET);
   const [startOffset, setStartOffset] = useState<Offset>(DEFAULT_OFFSET);
 
-  const [isMouseDown, setIsMouseDown] = useState(false);
-  const [isDragging, setIsDragging] = useState(false);
+  const canZoomImage = imageRatio !== 1;
+  const zoomScale = isZoomEnabled ? 1 : imageRatio;
 
   const handleMouseClick = (event: React.MouseEvent<HTMLDivElement>) => {
     const element = event.target as HTMLImageElement;
 
-    if (isDragging) {
-      setIsDragging(false);
+    if (!canZoomImage && !isZoomEnabled) {
       return;
     }
 
-    setIsZoomEnabled(prevState => !prevState);
-    setZoomScale(prevScale => (prevScale === imageZoomRatio ? 1 : imageZoomRatio));
-
-    requestAnimationFrame(() => {
-      element.style.transition = 'transform 0.2s';
-      element.style.cursor = isZoomEnabled ? 'zoom-in' : 'zoom-out';
-    });
+    if (draggingRef.current) {
+      draggingRef.current = false;
+      return;
+    }
 
     if (isZoomEnabled) {
       setStartOffset(DEFAULT_OFFSET);
       setTranslateOffset(DEFAULT_OFFSET);
-      setIsDragging(false);
+      draggingRef.current = false;
+
+      setTimeout(() => {
+        requestAnimationFrame(() => {
+          element.style.transition = '';
+        });
+      }, 300);
     }
+
+    if (!draggingRef.current && !isZoomEnabled) {
+      if (!imageRef.current) {
+        return;
+      }
+
+      requestAnimationFrame(() => {
+        element.style.transition = 'transform 0.2s';
+        element.style.cursor = isZoomEnabled ? 'zoom-in' : 'zoom-out';
+      });
+
+      const {maxXOffset, maxYOffset} = calculateMaxOffset(containerRef, imageRef);
+
+      const imageRect = imageRef.current.getBoundingClientRect();
+      const imageCenterY = imageRef.current.naturalHeight / 2;
+      const imageCenterX = imageRef.current.naturalWidth / 2;
+      const currentPosX = (event.clientX - imageRect.left) / imageRatio - imageCenterX;
+      const currentPosY = (event.clientY - imageRect.top) / imageRatio - imageCenterY;
+
+      setTranslateOffset({
+        x: Math.max(maxXOffset, Math.min(-currentPosX, -maxXOffset)),
+        y: Math.max(maxYOffset, Math.min(-currentPosY, -maxYOffset)),
+      });
+    }
+
+    setIsZoomEnabled(prevState => !prevState);
   };
 
   const handleMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
-    event.preventDefault();
+    if (!canZoomImage && !isZoomEnabled) {
+      return;
+    }
 
     if (isZoomEnabled) {
-      setIsMouseDown(true);
+      mouseDownRef.current = true;
     }
+
+    const element = event.target as HTMLImageElement;
+
+    requestAnimationFrame(() => {
+      element.style.transition = 'transform 0.2s';
+    });
 
     setStartOffset({
       x: event.clientX - translateOffset.x,
       y: event.clientY - translateOffset.y,
     });
+
+    event.preventDefault();
   };
 
   const handleMouseUp = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (!isZoomEnabled && !isMouseDown) {
+    if (!isZoomEnabled && !mouseDownRef.current) {
       return;
     }
 
-    setIsMouseDown(false);
+    mouseDownRef.current = false;
+
     const element = event.target as HTMLImageElement;
     requestAnimationFrame(() => {
       element.style.cursor = 'zoom-out';
@@ -129,11 +169,11 @@ export const ZoomableImage = (props: ZoomableImageProps) => {
   };
 
   const handleMouseMove = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (!isZoomEnabled || !isMouseDown || !containerRef.current || !imgRef.current) {
+    if (!isZoomEnabled || !mouseDownRef.current || !containerRef.current || !imageRef.current) {
       return;
     }
 
-    setIsDragging(true);
+    draggingRef.current = true;
 
     const element = event.target as HTMLImageElement;
 
@@ -145,59 +185,59 @@ export const ZoomableImage = (props: ZoomableImageProps) => {
       element.style.cursor = 'grabbing';
     });
 
-    const {minX, maxX, minY, maxY} = calculateMaxOffset(containerRef, imgRef, zoomScale);
+    const {maxXOffset, maxYOffset} = calculateMaxOffset(containerRef, imageRef);
 
     setTranslateOffset({
-      x: Math.max(minX, Math.min(event.clientX - startOffset.x, maxX)),
-      y: Math.max(minY, Math.min(event.clientY - startOffset.y, maxY)),
+      x: Math.max(maxXOffset, Math.min(event.clientX - startOffset.x, -maxXOffset)),
+      y: Math.max(maxYOffset, Math.min(event.clientY - startOffset.y, -maxYOffset)),
     });
 
     event.preventDefault();
   };
 
+  const updateZoomRatio = () => {
+    if (!imageRef.current) {
+      return;
+    }
+
+    const zoomRatio = calculateZoomRatio(imageRef.current);
+    setImageRatio(zoomRatio > 1 ? 1 : zoomRatio);
+  };
+
+  useEffect(() => {
+    window.addEventListener('resize', updateZoomRatio);
+
+    return () => {
+      window.removeEventListener('resize', updateZoomRatio);
+    };
+  }, []);
+
   return (
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
     <div
+      ref={containerRef}
       css={{width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center'}}
       onClick={handleMouseClick}
       onMouseDown={handleMouseDown}
       onMouseUp={handleMouseUp}
       onMouseMove={handleMouseMove}
-      ref={containerRef}
     >
       <img
         {...props}
         alt={props.alt}
-        ref={imgRef}
+        ref={imageRef}
         css={imageStyle}
         style={{
           transform: `translate3d(${translateOffset.x}px, ${translateOffset.y}px, 0) scale(${zoomScale}, ${zoomScale})`,
-          transition: 'transform 0.2s',
         }}
         onLoad={event => {
           const element = event.target as HTMLImageElement;
-          const parentElement = element.parentElement;
-
-          if (!parentElement) {
-            return;
-          }
-
-          const {offsetWidth: parentOffsetWidth, offsetHeight: parentOffsetHeight} = parentElement;
-          const zoomRatio = calculateZoomRatio(
-            parentOffsetWidth,
-            parentOffsetHeight,
-            element.naturalWidth,
-            element.naturalHeight,
-          );
-
+          const zoomRatio = calculateZoomRatio(element);
           const imageScale = zoomRatio > 1 ? 1 : zoomRatio;
-          element.style.transform = `translate3d(0px, 0px, 0px) scale(${imageScale}, ${imageScale})`;
-          setImageZoomRatio(imageScale);
-          setZoomScale(imageScale);
+          setImageRatio(imageScale);
 
           element.width = element.naturalWidth;
           element.height = element.naturalHeight;
-
           element.style.cursor = zoomRatio < 1 ? 'zoom-in' : '';
         }}
       />

--- a/src/script/components/ZoomableImage/ZoomableImage.tsx
+++ b/src/script/components/ZoomableImage/ZoomableImage.tsx
@@ -19,7 +19,7 @@
 
 import React, {HTMLProps, RefObject, useEffect, useRef, useState} from 'react';
 
-import {imageStyle} from './ZoomableImage.style';
+import {containerStyle, imageStyle} from './ZoomableImage.style';
 
 type Offset = {
   x: number;
@@ -216,7 +216,7 @@ export const ZoomableImage = (props: ZoomableImageProps) => {
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
     <div
       ref={containerRef}
-      css={{width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center'}}
+      css={containerStyle}
       onClick={handleMouseClick}
       onMouseDown={handleMouseDown}
       onMouseUp={handleMouseUp}

--- a/src/script/guards/HTMLElement.ts
+++ b/src/script/guards/HTMLElement.ts
@@ -1,0 +1,20 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export const isHTMLImageElement = (element: any): element is HTMLImageElement => element.nodeName === 'IMG';

--- a/src/style/content/conversation/detail-view.less
+++ b/src/style/content/conversation/detail-view.less
@@ -64,7 +64,6 @@
   width: 100%;
 
   max-width: 84%;
-  max-height: 84%;
 
   flex: 1 1;
   contain: strict;


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-1445

## Description

Improved Image zoom. Now user can click on image and zoom image to original width and height of image. User can change image position by dragging on image.

Details copied from JIRA:

### Image gallery view:

- Zoom in is available for any image in the gallery view that is not shown in 100% already
- Cursor is changes to “zoom in” when zoom is available
- When clicking, Image is zoomed to 100% (naturalHeight / naturalWidth)

### Zoomed in view:

- Cursor changes to “zoom out”
- The image zooms in on the part of the image that the mouse pointer pointed to 
- The image can be scrolled in each direction with a smooth scrolling animation
- The image can be dragged in each direction
- No automatic scrolling when the cursor is moved (to reduce fidgety movement on the screen)
- No additional zoom levels (for now) – just zoom in to 100%
- When clicking, image is zoomed back to its previous scale

## Screenshots/Screencast (for UI changes)

https://github.com/wireapp/wire-webapp/assets/13432884/4a4c4c87-823e-425b-827b-2fc502c4bebe

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;