### PR TITLE
refactor: store initial message in conversation entity

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -67,7 +67,6 @@ import {TeamState} from '../../team/TeamState';
 import {ElementType, MessageDetails} from '../MessagesList/Message/ContentMessage/asset/TextMessageRenderer';
 
 interface ConversationProps {
-  readonly initialMessage?: Message;
   readonly teamState: TeamState;
   selfUser: User;
   openRightSidebar: (panelState: PanelState, params: RightSidebarParams, compareEntityId?: boolean) => void;
@@ -78,7 +77,6 @@ interface ConversationProps {
 const CONFIG = Config.getConfig();
 
 export const Conversation = ({
-  initialMessage,
   teamState,
   selfUser,
   openRightSidebar,
@@ -514,7 +512,6 @@ export const Conversation = ({
           <MessagesList
             conversation={activeConversation}
             selfUser={selfUser}
-            initialMessage={initialMessage}
             conversationRepository={conversationRepository}
             messageRepository={repositories.message}
             messageActions={mainViewModel.actions}

--- a/src/script/components/MessagesList/MessageList.test.tsx
+++ b/src/script/components/MessagesList/MessageList.test.tsx
@@ -44,7 +44,6 @@ const getDefaultParams = (): React.ComponentProps<typeof MessagesList> => {
       updateParticipatingUserEntities: jest.fn(),
     } as any,
     getVisibleCallback: jest.fn(),
-    initialMessage: undefined,
     invitePeople: jest.fn(),
     isLastReceivedMessage: jest.fn(),
     messageActions: {

--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -51,7 +51,6 @@ interface MessagesListParams {
   conversation: Conversation;
   conversationRepository: ConversationRepository;
   getVisibleCallback: (conversationEntity: Conversation, messageEntity: MessageEntity) => (() => void) | undefined;
-  initialMessage?: MessageEntity;
   invitePeople: (convesation: Conversation) => void;
   messageActions: {
     deleteMessage: (conversation: Conversation, message: MessageEntity) => void;
@@ -75,7 +74,6 @@ interface MessagesListParams {
 
 export const MessagesList: FC<MessagesListParams> = ({
   conversation,
-  initialMessage,
   selfUser,
   conversationRepository,
   messageRepository,
@@ -105,6 +103,7 @@ export const MessagesList: FC<MessagesListParams> = ({
     inTeam,
     isLoadingMessages,
     hasAdditionalMessages,
+    initialMessage,
   } = useKoSubscribableChildren(conversation, [
     'inTeam',
     'isActiveParticipant',
@@ -114,6 +113,7 @@ export const MessagesList: FC<MessagesListParams> = ({
     'isGuestAndServicesRoom',
     'isLoadingMessages',
     'hasAdditionalMessages',
+    'initialMessage',
   ]);
 
   const messageListRef = useRef<HTMLDivElement | null>(null);

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -153,6 +153,7 @@ export class Conversation {
   public readonly messages_unordered: ko.ObservableArray<Message>;
   /** Sorted messages that are ready to be displayed in the conversation */
   public readonly messages: ko.PureComputed<Message[]>;
+  public readonly initialMessage: ko.Observable<Message | undefined>;
   public readonly messageTimer: ko.PureComputed<number>;
   public readonly name: ko.Observable<string>;
   public readonly notificationState: ko.PureComputed<number>;
@@ -300,6 +301,7 @@ export class Conversation {
     this.last_read_timestamp = ko.observable(0);
     this.last_server_timestamp = ko.observable(0);
     this.mutedTimestamp = ko.observable(0);
+    this.initialMessage = ko.observable();
 
     this.readOnlyState = ko.observable<CONVERSATION_READONLY_STATE | null>(null);
 

--- a/src/script/page/MainContent/MainContent.tsx
+++ b/src/script/page/MainContent/MainContent.tsx
@@ -103,7 +103,7 @@ const MainContent: FC<MainContentProps> = ({
     return null;
   }
   const {content: contentViewModel} = mainViewModel;
-  const {initialMessage, isFederated, repositories, switchContent} = contentViewModel;
+  const {isFederated, repositories, switchContent} = contentViewModel;
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const {activeConversation} = useKoSubscribableChildren(conversationState, ['activeConversation']);
@@ -236,7 +236,6 @@ const MainContent: FC<MainContentProps> = ({
 
             {contentState === ContentState.CONVERSATION && (
               <Conversation
-                initialMessage={initialMessage}
                 teamState={teamState}
                 selfUser={selfUser}
                 isRightSidebarOpen={isRightSidebarOpen}

--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -71,7 +71,6 @@ export class ContentViewModel {
   mainViewModel: MainViewModel;
   previousConversation?: Conversation;
   userRepository: UserRepository;
-  initialMessage?: Message;
 
   get isFederated() {
     return this.mainViewModel.isFederated;
@@ -135,7 +134,7 @@ export class ContentViewModel {
   }
 
   private changeConversation(conversationEntity: Conversation, messageEntity?: Message): void {
-    this.initialMessage = messageEntity;
+    conversationEntity.initialMessage(messageEntity);
     this.conversationState.activeConversation(conversationEntity);
   }
 


### PR DESCRIPTION
## Description

`initialMessage` is used to highlight the message when we use the conversation full search. Since it is tied to conversation, it should not live in a global state. This PR moves this value from ContentViewModel to the conversation entity.

## Screenshots/Screencast (for UI changes)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
