### PR TITLE
runfix: download cert from device settings for basic mls deivce [WPB-9193]

### DIFF
--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.test.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.test.tsx
@@ -26,7 +26,7 @@ import {MLSStatuses, WireIdentity} from 'src/script/E2EIdentity';
 import {E2EICertificateDetails} from './E2EICertificateDetails';
 
 describe('E2EICertificateDetails', () => {
-  const generateIdentity = (status: MLSStatuses): WireIdentity => ({
+  const generateIdentity = (status: MLSStatuses, credentialType = CredentialType.X509): WireIdentity => ({
     status,
     x509Identity: {
       certificate: 'certificate',
@@ -37,7 +37,7 @@ describe('E2EICertificateDetails', () => {
       notAfter: BigInt(0),
       serialNumber: '',
     },
-    credentialType: CredentialType.Basic,
+    credentialType,
     deviceId: '',
     clientId: '',
     thumbprint: '',
@@ -49,6 +49,15 @@ describe('E2EICertificateDetails', () => {
 
   it('is e2ei identity not downloaded', async () => {
     const {getByTestId} = render(withTheme(<E2EICertificateDetails />));
+
+    const E2EIdentityStatus = getByTestId('e2ei-identity-status');
+    expect(E2EIdentityStatus.getAttribute('data-uie-value')).toEqual(MLSStatuses.NOT_ACTIVATED);
+  });
+
+  it('is e2ei identity not downloaded for basic MLS device', async () => {
+    const identity = generateIdentity(MLSStatuses.VALID, CredentialType.Basic);
+
+    const {getByTestId} = render(withTheme(<E2EICertificateDetails identity={identity} />));
 
     const E2EIdentityStatus = getByTestId('e2ei-identity-status');
     expect(E2EIdentityStatus.getAttribute('data-uie-value')).toEqual(MLSStatuses.NOT_ACTIVATED);

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.tsx
@@ -17,6 +17,7 @@
  *
  */
 
+import {CredentialType} from '@wireapp/core/lib/messagingProtocols/mls';
 import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 
 import {Button, ButtonVariant} from '@wireapp/react-ui-kit';
@@ -36,11 +37,19 @@ interface E2EICertificateDetailsProps {
   isCurrentDevice?: boolean;
 }
 
+const getCertificateState = (identity?: WireIdentity) => {
+  if (!identity || identity.credentialType === CredentialType.Basic) {
+    return MLSStatuses.NOT_ACTIVATED;
+  }
+
+  return identity.status;
+};
+
 export const E2EICertificateDetails = ({identity, isCurrentDevice}: E2EICertificateDetailsProps) => {
   const certificate = identity?.x509Identity?.certificate;
   const showModal = useCertificateDetailsModal(certificate ?? '');
 
-  const certificateState = identity?.status ?? MLSStatuses.NOT_ACTIVATED;
+  const certificateState = getCertificateState(identity);
   const isNotActivated = certificateState === MLSStatuses.NOT_ACTIVATED;
   const isValid = certificateState === MLSStatuses.VALID;
   const hasCertificate = !!certificate && Boolean(certificate.length);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9193" title="WPB-9193" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9193</a>  [Web] Missing button in settings to renew expired e2ei certificate
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

If the device is a basic MLS device, corecrypto will mark its identity status as valid. If the status is valid but the device's credential type is basic (1), we should mark the certificate status as "not activated" and allow the user to download the certificate manually.

## Screenshots/Screencast (for UI changes)

Before:
<img width="315" alt="Screenshot 2024-05-22 at 08 21 48" src="https://github.com/wireapp/wire-webapp/assets/45733298/903e1167-364f-4391-a795-2362f16f59d1">


Now:
<img width="321" alt="Screenshot 2024-05-22 at 07 49 12" src="https://github.com/wireapp/wire-webapp/assets/45733298/18aa4ecd-36a2-451d-a956-0f14e675fb00">


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
