### PR TITLE
feat: Image zoom for tiny images

### DIFF
--- a/src/script/components/ZoomableImage/ZoomableImage.tsx
+++ b/src/script/components/ZoomableImage/ZoomableImage.tsx
@@ -57,8 +57,12 @@ function calculateMaxOffset(containerRef: RefObject<HTMLDivElement>, imgRef: Ref
   const containerRect = containerRef.current.getBoundingClientRect();
 
   return {
-    maxXOffset: (containerRect.width - imgRef.current.naturalWidth) / 2,
-    maxYOffset: (containerRect.height - imgRef.current.naturalHeight) / 2,
+    maxXOffset:
+      imgRef.current.naturalWidth >= containerRect.width ? (containerRect.width - imgRef.current.naturalWidth) / 2 : 0,
+    maxYOffset:
+      imgRef.current.naturalHeight >= containerRect.height
+        ? (containerRect.height - imgRef.current.naturalHeight) / 2
+        : 0,
   };
 }
 
@@ -108,15 +112,15 @@ export const ZoomableImage = (props: ZoomableImageProps) => {
       }, 300);
     }
 
+    requestAnimationFrame(() => {
+      element.style.transition = 'transform 0.2s';
+      element.style.cursor = isZoomEnabled ? 'zoom-in' : 'zoom-out';
+    });
+
     if (!draggingRef.current && !isZoomEnabled) {
       if (!imageRef.current) {
         return;
       }
-
-      requestAnimationFrame(() => {
-        element.style.transition = 'transform 0.2s';
-        element.style.cursor = isZoomEnabled ? 'zoom-in' : 'zoom-out';
-      });
 
       const {maxXOffset, maxYOffset} = calculateMaxOffset(containerRef, imageRef);
 


### PR DESCRIPTION
## Description

Fix for zooming not wide image but long - zoom to middle of screen instead of to random position. Same for not long but wide image - zoom to middle of screen.

Fixed also cursor while image is zoomed.

## Screenshots/Screencast (for UI changes)

Before:
<img width="723" alt="image" src="https://github.com/wireapp/wire-webapp/assets/13432884/75d80298-76bc-47ce-a73f-f942aa9cadb8">

<img width="734" alt="image" src="https://github.com/wireapp/wire-webapp/assets/13432884/da74dcde-722e-4f66-a128-ad7a31d77a8d">


Now: 
![image](https://github.com/wireapp/wire-webapp/assets/13432884/71c0a42b-9c30-49b0-8973-67d0822fbf3c)

![image](https://github.com/wireapp/wire-webapp/assets/13432884/4dd3b33a-f686-4d53-90bb-6ebad81eace6)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
