### PR TITLE
runfix: use correct conversation icon (WPB-7373)

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/ConversationTabs.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/ConversationTabs.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {ChevronIcon, GroupIcon, InfoIcon, StarIcon} from '@wireapp/react-ui-kit';
+import {ChevronIcon, GroupIcon, InfoIcon, MessageIcon, StarIcon} from '@wireapp/react-ui-kit';
 
 import {Icon} from 'Components/Icon';
 import {ConversationRepository} from 'src/script/conversation/ConversationRepository';
@@ -69,7 +69,7 @@ export const ConversationTabs = ({
       type: SidebarTabs.RECENT,
       title: t('conversationViewTooltip'),
       dataUieName: 'go-recent-view',
-      Icon: <Icon.ConversationsOutline />,
+      Icon: <MessageIcon />,
       unreadConversations: unreadConversations.length,
     },
     {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7373" title="WPB-7373" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7373</a>  "All conversations" icon should have the correct hover state
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

We were using an old Icon for conversations that doesn't match the new design see [figma](https://www.figma.com/design/jnygr7PEOk1yHgjBF18udc/Desktop?node-id=1690-22173)

## Screenshots/Screencast (for UI changes)
Before:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/f551415a-a28e-4eb8-89e1-0a930947c65f)

After:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/e596b935-74a7-4eed-a2dd-fcf67f7be2c9)

