### PR TITLE
chore(ci): fix bash condition to publish chart versions (#17321)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -143,7 +143,7 @@ jobs:
 
           helm repo add charts-webapp s3://public.wire.com/charts-webapp
 
-          if [ "${{github.ref}}" =~ "/refs/tags" ]; then
+          if [[ "${{github.ref}}" =~ "/refs/tags" ]]; then
             chart_version="$(./bin/chart-next-version.sh release)"
           else
             chart_version="$(./bin/chart-next-version.sh prerelease)"


### PR DESCRIPTION
## Description

Following cherry-pick of the publish pipeline here https://github.com/wireapp/wire-webapp/pull/17440, this is a cherry-pick of the follow up commit to address a release name not generating properly https://github.com/wireapp/wire-webapp/pull/17321
