### PR TITLE
fix: app crash when a top contact has been removed from the app

### DIFF
--- a/src/script/page/LeftSidebar/panels/StartUI/components/topPeople/TopContact.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/components/topPeople/TopContact.tsx
@@ -40,8 +40,8 @@ const TopContact: React.FC<TopContactProps> = ({assetRepository, user, clickOnUs
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>();
 
   useEffect(() => {
-    const subscription = connection.status.subscribe(newStatus => setConnectionStatus(newStatus));
-    return () => subscription.dispose();
+    const subscription = connection?.status.subscribe(newStatus => setConnectionStatus(newStatus));
+    return () => subscription?.dispose();
   }, [connection]);
 
   return (


### PR DESCRIPTION
## Description
fixes a crash in personal accounts when someones top contact has been deleted from the app.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;