### PR TITLE
runfix: e2ei basic device enrollment [WPB-9816]

### DIFF
--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {CredentialType} from '@wireapp/core/lib/messagingProtocols/mls';
 import {LowPrecisionTaskScheduler} from '@wireapp/core/lib/util/LowPrecisionTaskScheduler';
 import {amplify} from 'amplify';
 import {SigninResponse} from 'oidc-client-ts';
@@ -196,7 +197,10 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
     const firingDate = this.enrollmentStore.get.timer() || computedFiringDate;
     this.enrollmentStore.store.timer(firingDate);
 
-    const isFirstE2EIActivation = !storedE2eActivatedAt && (!identity || identity.status === MLSStatuses.NOT_ACTIVATED);
+    const isNotActivated = identity?.status === MLSStatuses.NOT_ACTIVATED;
+    const isBasicDevice = identity?.credentialType === CredentialType.Basic;
+
+    const isFirstE2EIActivation = !storedE2eActivatedAt && (!identity || isNotActivated || isBasicDevice);
     if (isFirstE2EIActivation || firingDate <= Date.now()) {
       // We want to automatically trigger the enrollment modal if it's a devices in team that just activated e2eidentity
       // Or if the timer is supposed to fire now

--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -153,7 +153,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
       } else {
         // If we have an enrollment in progress but we are not coming back from an idp redirect, we need to clear the progress and start over
         await this.coreE2EIService.clearAllProgress();
-        await this.startEnrollment(ModalType.ENROLL, false);
+        await this.startEnrollment(ModalType.ENROLL, !isFreshClient);
       }
     } else if (isFreshClient) {
       // When the user logs in to a new device in an environment that has e2ei enabled, they should be forced to enroll

--- a/src/script/E2EIdentity/EnrollmentTimer/EnrollmentTimer.test.ts
+++ b/src/script/E2EIdentity/EnrollmentTimer/EnrollmentTimer.test.ts
@@ -30,22 +30,6 @@ describe('e2ei delays', () => {
     jest.setSystemTime(1709050878009);
   });
 
-  it('should return an immediate delay at feature activation', () => {
-    const delay = getEnrollmentTimer(
-      {
-        x509Identity: {
-          certificate: ' ',
-          notAfter: (Date.now() + TimeInMillis.MINUTE * 10) / 1000,
-        },
-      } as any,
-      Date.now(),
-      TimeInMillis.DAY * 30,
-      true,
-    );
-
-    expect(delay).toEqual({firingDate: Date.now(), isSnoozable: true});
-  });
-
   it('should return an immediate delay if the identity is expired', () => {
     const delay = getEnrollmentTimer({status: MLSStatuses.EXPIRED} as any, Date.now(), gracePeriod);
 

--- a/src/script/E2EIdentity/EnrollmentTimer/EnrollmentTimer.ts
+++ b/src/script/E2EIdentity/EnrollmentTimer/EnrollmentTimer.ts
@@ -91,7 +91,6 @@ export function getEnrollmentTimer(
   identity: WireIdentity | undefined,
   e2eiActivatedAt: number,
   teamGracePeriodDuration: number,
-  isFirstActivation: boolean = false,
 ) {
   if (identity?.status === MLSStatuses.EXPIRED) {
     return {isSnoozable: false, firingDate: Date.now()};
@@ -99,11 +98,6 @@ export function getEnrollmentTimer(
 
   const deadline = getGracePeriod(identity, e2eiActivatedAt, teamGracePeriodDuration);
   const nextTick = getNextTick(deadline);
-
-  // For the first activation, we want to trigger the timer immediately
-  if (isFirstActivation) {
-    return {isSnoozable: nextTick > 0, firingDate: Date.now()};
-  }
 
   // When logging in to a old device that doesn't have an identity yet, we trigger an enrollment timer
   return {isSnoozable: nextTick > 0, firingDate: Date.now() + nextTick};


### PR DESCRIPTION
## Description

Improves the handling of displaying the enrollment modal for an existing client after enabling the e2ei feature.

## Screenshots/Screencast (for UI changes)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
