### PR TITLE
runfix: reset timer only after user interaction with modal [WPB-9431]

### DIFF
--- a/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -181,6 +181,10 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
 
   /**
    * Will initiate the timer that will regularly prompt the user to enroll (or to renew the certificate if it is about to expire)
+   * - If the client is a brand new device (never logged in before) and the feature is enabled, the timer will start immediately, and the user will be forced to enroll
+   * - If the client is an existing MLS device, and the E2EI feature was just activated, the timer will start immediately (but the grace period will be respected)
+   * - If the client has already enrolled, but the cert is about to expire, they will be reminded to renew the certificate during the grace period
+   * - If the client has already enrolled, and the cert has already expired, they will be forced to enroll
    * @returns the delay under which the next enrollment/renewal modal will be prompted
    */
   public async startTimers() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9431" title="WPB-9431" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9431</a>  [Web] Display an enrollment modal again if there's no user interaction
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

With this PR we will reset the enrollment timer (the time user should be prompted with the enrollment modal) only after user's interaction with modal. If the user reloads the app while the modal is opened, we will show the modal over and over again until the user interacts with it.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;