### PR TITLE
fix: remove from folder copy with special chars [WPB-7390]

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -581,7 +581,7 @@
   "conversationsPopoverNoCustomFolders": "No custom folders",
   "conversationsPopoverNotificationSettings": "Notifications",
   "conversationsPopoverNotify": "Unmute",
-  "conversationsPopoverRemoveFrom": "Remove from \"{{name}}\"",
+  "conversationsPopoverRemoveFrom": "Remove from",
   "conversationsPopoverSilence": "Mute",
   "conversationsPopoverUnarchive": "Unarchive",
   "conversationsPopoverUnblock": "Unblock",

--- a/src/script/view_model/ListViewModel.ts
+++ b/src/script/view_model/ListViewModel.ts
@@ -374,7 +374,7 @@ export class ListViewModel {
       if (customLabel) {
         entries.push({
           click: () => conversationLabelRepository.removeConversationFromLabel(customLabel, conversationEntity),
-          label: t('conversationsPopoverRemoveFrom', customLabel.name),
+          label: `${t('conversationsPopoverRemoveFrom')} ${customLabel.name}`,
         });
       }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7390" title="WPB-7390" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7390</a>  [Web] Conversation context options shows '&amp' in option to remove convo from folder
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Removes the string replacement from the json file and adds it to the string template directly, so the special characters like `&` can be used and won't be escaped.

Before:
<img width="479" alt="Screenshot 2024-05-27 at 16 27 24" src="https://github.com/wireapp/wire-webapp/assets/45733298/5580ddbc-de66-49b9-a30f-bf2540567bf7">


Now:
<img width="457" alt="Screenshot 2024-05-27 at 16 26 45" src="https://github.com/wireapp/wire-webapp/assets/45733298/1a88fccf-31a0-48cc-ba07-d5eeb5971c32">


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;