### PR TITLE
runfix: revert special chars in folder name

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -581,7 +581,7 @@
   "conversationsPopoverNoCustomFolders": "No custom folders",
   "conversationsPopoverNotificationSettings": "Notifications",
   "conversationsPopoverNotify": "Unmute",
-  "conversationsPopoverRemoveFrom": "Remove from",
+  "conversationsPopoverRemoveFrom": "Remove from \"{{name}}\"",
   "conversationsPopoverSilence": "Mute",
   "conversationsPopoverUnarchive": "Unarchive",
   "conversationsPopoverUnblock": "Unblock",

--- a/src/script/view_model/ListViewModel.ts
+++ b/src/script/view_model/ListViewModel.ts
@@ -374,7 +374,7 @@ export class ListViewModel {
       if (customLabel) {
         entries.push({
           click: () => conversationLabelRepository.removeConversationFromLabel(customLabel, conversationEntity),
-          label: `${t('conversationsPopoverRemoveFrom')} ${customLabel.name}`,
+          label: t('conversationsPopoverRemoveFrom', customLabel.name),
         });
       }
 


### PR DESCRIPTION
This reverts commit 10003d333fac1b874c80a9506b2aa5d81e8a065c.

## Description

The solution doesn't work for the german (and probably some other) translation. This will need to be handled differently, we will do that with the incoming new navigation feature.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
