### PR TITLE
runfix: don't escape folder name char

### DIFF
--- a/src/script/view_model/ListViewModel.ts
+++ b/src/script/view_model/ListViewModel.ts
@@ -374,7 +374,7 @@ export class ListViewModel {
       if (customLabel) {
         entries.push({
           click: () => conversationLabelRepository.removeConversationFromLabel(customLabel, conversationEntity),
-          label: t('conversationsPopoverRemoveFrom', customLabel.name),
+          label: t('conversationsPopoverRemoveFrom', customLabel.name, {}, true),
         });
       }
 


### PR DESCRIPTION
## Description

Since the context menu option is rendered as a react element (and not the `dangerouslySetInnerHTML`) it's safe to skip the char escaping since it will be stringified in the end enyway. See https://github.com/wireapp/wire-webapp/blob/runfix/remove-from-char-escaped/src/script/ui/ContextMenu.tsx#L217. 

This fixes https://github.com/wireapp/wire-webapp/pull/17475 in a proper way (the prev solution won't work for at least german translation).

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;