### PR TITLE
runfix: add breakpoint to bottom positioning

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -126,6 +126,7 @@ export const Conversation = ({
 
   // To be changed when design chooses a breakpoint, the conditional can be integrated to the ui-kit directly
   const smBreakpoint = useMatchMedia('max-width: 640px');
+  const mdBreakpoint = useMatchMedia('max-width: 768px');
 
   const {addReadReceiptToBatch} = useReadReceiptSender(repositories.message);
 
@@ -559,7 +560,7 @@ export const Conversation = ({
             conversation={activeConversation}
             css={{
               position: 'absolute',
-              bottom: '56px',
+              bottom: mdBreakpoint ? '100px' : '56px',
               right: '10px',
               height: '40px',
               borderRadius: '100%',


### PR DESCRIPTION
We can adjusst the bottom positioning according to a breakpoint
![Kooha-2024-05-29-11-20-50](https://github.com/wireapp/wire-webapp/assets/78490891/206c45a8-1798-45e2-8920-106c0eebebf5)
