### PR TITLE
runfix: Make sure onVisible and onVisibilityLost are triggered only once WPB-6518

### DIFF
--- a/src/script/components/utils/InViewport.tsx
+++ b/src/script/components/utils/InViewport.tsx
@@ -50,6 +50,10 @@ const InViewport: React.FC<InViewportParams & React.HTMLProps<HTMLDivElement>> =
 
     let inViewport = false;
     let visible = !checkOverlay;
+
+    let onVisibleTriggered = false;
+    let onVisibilityLostTriggered = false;
+
     const releaseTrackers = () => {
       if (checkOverlay) {
         overlayedObserver.removeElement(element);
@@ -59,7 +63,11 @@ const InViewport: React.FC<InViewportParams & React.HTMLProps<HTMLDivElement>> =
 
     const triggerCallbackIfVisible = () => {
       if (inViewport && visible) {
-        onVisible();
+        if (!onVisibleTriggered) {
+          onVisible();
+          onVisibleTriggered = true;
+          onVisibilityLostTriggered = false;
+        }
 
         if (!onVisibilityLost) {
           releaseTrackers();
@@ -75,7 +83,11 @@ const InViewport: React.FC<InViewportParams & React.HTMLProps<HTMLDivElement>> =
 
         // If the element is not intersecting at all, we can trigger the onVisibilityLost callback
         if (!isPartiallyVisible) {
-          onVisibilityLost?.();
+          if (!onVisibilityLostTriggered) {
+            onVisibilityLost?.();
+            onVisibleTriggered = false;
+            onVisibilityLostTriggered = true;
+          }
         }
       },
       requireFullyInView,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6518" title="WPB-6518" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-6518</a>  [Web] Jump to last message in a conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Make sure `onVisible` and `onVisibilityLost` are triggered only once each time the element is shown/hidden.
Without this fix:
- `onVisibilityLost` (if provided) is sometimes triggered twice
- `onVisible`, if `releaseTrackers()` wasn't call, gets triggered all the time while element is visible

## Checklist

- [x] PR has been self reviewed by the author;

### Important details for the reviewers