### PR TITLE
refactor: Move isLastReceivedMessage from the React componet

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -49,7 +49,7 @@ import {ReadOnlyConversationMessage} from './ReadOnlyConversationMessage';
 import {checkFileSharingPermission} from './utils/checkFileSharingPermission';
 
 import {ConversationState} from '../../conversation/ConversationState';
-import {Conversation as ConversationEntity} from '../../entity/Conversation';
+import {Conversation as ConversationEntity, isLastReceivedMessage} from '../../entity/Conversation';
 import {ContentMessage} from '../../entity/message/ContentMessage';
 import {DecryptErrorMessage} from '../../entity/message/DecryptErrorMessage';
 import {MemberMessage} from '../../entity/message/MemberMessage';
@@ -379,10 +379,6 @@ export const Conversation = ({
       messageListLogger.warn('Error while trying to reset session', error);
       resetProgress();
     }
-  };
-
-  const isLastReceivedMessage = (messageEntity: Message, conversationEntity: ConversationEntity): boolean => {
-    return !!messageEntity.timestamp() && messageEntity.timestamp() >= conversationEntity.last_event_timestamp();
   };
 
   const updateConversationLastRead = (conversationEntity: ConversationEntity, messageEntity: Message): void => {

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -82,6 +82,10 @@ enum TIMESTAMP_TYPE {
   MUTED = 'mutedTimestamp',
 }
 
+export const isLastReceivedMessage = (messageEntity: Message, conversationEntity: Conversation): boolean => {
+  return !!messageEntity.timestamp() && messageEntity.timestamp() >= conversationEntity.last_event_timestamp();
+};
+
 export class Conversation {
   private readonly teamState: TeamState;
   public readonly archivedState: ko.Observable<boolean>;


### PR DESCRIPTION
## Description

This function can be either a separate or a public method of `ConversationEntity`.
For now, let's keep it as a separate function in the `Conversation.ts` as a first step of refactoring it (as there is a similar method `hasLastReceivedMessageLoaded` that can sometimes replace`isLastReceivedMessage`, but they are slightly different).

## Checklist

- [x] PR has been self reviewed by the author;
