### PR TITLE
runfix: don't escape folder name char (#17479)

### DIFF
--- a/src/script/view_model/ListViewModel.ts
+++ b/src/script/view_model/ListViewModel.ts
@@ -374,7 +374,7 @@ export class ListViewModel {
       if (customLabel) {
         entries.push({
           click: () => conversationLabelRepository.removeConversationFromLabel(customLabel, conversationEntity),
-          label: t('conversationsPopoverRemoveFrom', customLabel.name),
+          label: t('conversationsPopoverRemoveFrom', customLabel.name, {}, true),
         });
       }
 


### PR DESCRIPTION
## Description

Cherry pick of a fix to folder names, see https://github.com/wireapp/wire-webapp/pull/17479
