### PR TITLE
fix: Sort mentions before parsing them [WPB-9472]

### DIFF
--- a/src/script/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/script/components/RichTextEditor/RichTextEditor.tsx
@@ -93,7 +93,13 @@ const createMentionEntity = (user: Pick<User, 'id' | 'name' | 'domain'>, mention
 };
 
 const parseMentions = (editor: LexicalEditor, textValue: string, mentions: User[]) => {
-  const editorMentions = editor.getEditorState().read(() => $nodesOfType(MentionNode).map(node => node.__value));
+  const editorMentions = editor.getEditorState().read(() =>
+    $nodesOfType(MentionNode)
+      // The nodes given by lexical are not sorted by their position in the text. Instead they are sorted according to the moment they were inserted into the global text.
+      // We need to manually sort the nodes by their position before parsing the mentions in the entire text
+      .sort((m1, m2) => (m1.isBefore(m2) ? -1 : 1))
+      .map(node => node.getValue()),
+  );
   let position = -1;
 
   return editorMentions.flatMap(mention => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9472" title="WPB-9472" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9472</a>  [web] mentions are breaking when prepended to a message already containing a mention
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

When we parse mentions in the text we have a state machine that progress in the text in which we are parsing mentions. 
So we work under the assumption that mentions are sorted by their position in the text. 

Which is not the case when calling `$getNodeOfType` from Lexical. 
We can force the sorting to happen by using the `isBefore(node)` method of a node. 

## Screenshots/Screencast (for UI changes)

### Before


https://github.com/wireapp/wire-webapp/assets/1090716/49ed6e61-e720-4fc7-ab64-5eedde345cf5

### After


https://github.com/wireapp/wire-webapp/assets/1090716/7b4e4074-fd12-4a3d-b42c-61388b341e3c

