### PR TITLE
fix: enable search in folders

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -399,7 +399,6 @@
   "conversationAllWelcomeMessage": "Welcome to Wire \uD83D\uDC4B",
   "conversationButtonSeparator": "or",
   "conversationConnectWithNewUsers": "Connect with new users",
-  "conversationCreateNewGroup": "Start a new group",
   "conversationStartNewConversation": "Start a new conversation",
   "conversationFavoritesTabEmptyMessage": "Label your most beloved conversations as favorites, so you can easily keep track of them here \uD83D\uDC4D",
   "conversationFavoritesTabEmptyLinkText": "How to label conversations as favorites",

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -348,6 +348,7 @@ const Conversations: React.FC<ConversationsProps> = ({
 
             {showSearchInput && (
               <ConversationsList
+                conversationsFilter={conversationsFilter}
                 currentFolder={currentFolder}
                 conversationLabelRepository={conversationLabelRepository}
                 callState={callState}

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
@@ -54,6 +54,7 @@ interface ConversationsListProps {
   conversationLabelRepository: ConversationLabelRepository;
   currentTab: SidebarTabs;
   currentFocus: string;
+  conversationsFilter: string;
   currentFolder?: ConversationLabel;
   resetConversationFocus: () => void;
   handleArrowKeyDown: (index: number) => (e: React.KeyboardEvent) => void;
@@ -61,6 +62,7 @@ interface ConversationsListProps {
 
 export const ConversationsList = ({
   conversations,
+  conversationsFilter,
   listViewModel,
   currentTab,
   connectRequests,
@@ -134,6 +136,9 @@ export const ConversationsList = ({
         <>
           {currentFolder
             ?.conversations()
+            .filter((conversation: Conversation) =>
+              conversation.display_name().toLowerCase().includes(conversationsFilter.toLowerCase()),
+            )
             .map((conversation, index) => (
               <ConversationListCell key={conversation.id} {...getCommonConversationCellProps(conversation, index)} />
             ))}

--- a/src/script/page/LeftSidebar/panels/Conversations/EmptyConversationList/EmptyConversationList.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/EmptyConversationList/EmptyConversationList.tsx
@@ -63,7 +63,7 @@ export const EmptyConversationList = ({currentTab, onChangeTab, searchValue = ''
             data-uie-name="go-create-group"
             css={button}
           >
-            {t('conversationCreateNewGroup')}
+            {t('conversationStartNewConversation')}
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## Description
Search in conversations of a folder was completely broken/never implemented, this PR fixes it by applying the correct filtering.

## Screenshots/Screencast (for UI changes)
<img width="380" alt="image" src="https://github.com/wireapp/wire-webapp/assets/63250054/005d793e-b84e-43ff-bee7-ebb87759efe3">
<img width="384" alt="image" src="https://github.com/wireapp/wire-webapp/assets/63250054/8a7f1f65-5898-4a78-969b-989b26839cb0">
