### PR TITLE
runfix: remove groups from open conversation on search

### DIFF
--- a/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
@@ -97,12 +97,9 @@ const StartUI: React.FC<StartUIProps> = ({
 
   const openFirstConversation = async (): Promise<void> => {
     if (peopleSearchResults.current) {
-      const {contacts, groups} = peopleSearchResults.current;
+      const {contacts} = peopleSearchResults.current;
       if (contacts.length > 0) {
         return openContact(contacts[0]);
-      }
-      if (groups.length > 0) {
-        return openConversation(groups[0]);
       }
     }
   };


### PR DESCRIPTION
## Description

Follow up of https://github.com/wireapp/wire-webapp/pull/17450

Groups are no longer shown in the connect tab, only people.
`groups` has been removed from `SearchResultData`' s type definition, but an instance of it was overlooked in thee StartUi logic 
