### PR TITLE
runfix: return mls feature config even if it's disabled [WPB-9143]

### DIFF
--- a/src/script/page/components/FeatureConfigChange/FeatureConfigChangeHandler/Features/MLS.ts
+++ b/src/script/page/components/FeatureConfigChange/FeatureConfigChangeHandler/Features/MLS.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {FeatureStatus, FEATURE_KEY, FeatureList} from '@wireapp/api-client/lib/team';
+import {FEATURE_KEY, FeatureList} from '@wireapp/api-client/lib/team';
 
 import {supportsMLS} from 'Util/util';
 
@@ -25,6 +25,5 @@ export const getMLSConfig = (config: FeatureList): FeatureList[FEATURE_KEY.MLS] 
   if (!supportsMLS()) {
     return undefined;
   }
-  const mlsConfig = config[FEATURE_KEY.MLS];
-  return mlsConfig?.status !== FeatureStatus.ENABLED ? undefined : mlsConfig;
+  return config[FEATURE_KEY.MLS];
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9143" title="WPB-9143" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9143</a>  [Web] Can not send or receive messages after migration
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

We will always register an MLS device if it's supported by the app (`FEATURE_ENABLE_MLS` flag is enabled) and the backend (MLS removal key is present). MLS feature doesn't need to be enabled in the team settings.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;