### PR TITLE
feat: Reactions popover is stuck on a message

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {useMemo, useState, useEffect, useCallback, useRef} from 'react';
+import {useMemo, useState, useEffect, useRef} from 'react';
 
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import cx from 'classnames';
@@ -42,6 +42,7 @@ import {CompleteFailureToSendWarning, PartialFailureToSendWarning} from './Warni
 
 import {MessageActions} from '..';
 import type {FileAsset as FileAssetType} from '../../../../entity/message/FileAsset';
+import {useClickOutside} from '../../../../hooks/useClickOutside';
 import {EphemeralStatusType} from '../../../../message/EphemeralStatusType';
 import {ContextMenuEntry} from '../../../../ui/ContextMenu';
 import {EphemeralTimer} from '../EphemeralTimer';
@@ -152,22 +153,14 @@ export const ContentMessageComponent = ({
 
   const isAssetMessage = isFileMessage || isAudioMessage || isVideoMessage || isImageMessage;
 
-  const handleOutsideClick = useCallback(
-    (event: Event) => {
-      if (messageRef.current && !messageRef.current.contains(event.target as Node) && isFocused) {
-        setActionMenuVisibility(false);
-      }
-    },
-    [isFocused],
-  );
+  const hideActionMenuVisibility = () => {
+    if (isFocused) {
+      setActionMenuVisibility(false);
+    }
+  };
 
-  useEffect(() => {
-    window.addEventListener('click', handleOutsideClick);
-
-    return () => {
-      window.removeEventListener('click', handleOutsideClick);
-    };
-  }, [handleOutsideClick]);
+  // Closing another ActionMenu on outside click
+  useClickOutside(messageRef, hideActionMenuVisibility);
 
   return (
     <div

--- a/src/script/components/MessagesList/Message/index.tsx
+++ b/src/script/components/MessagesList/Message/index.tsx
@@ -82,7 +82,7 @@ export interface MessageParams extends MessageActions {
   setMsgElementsFocusable: (isMsgElementsFocusable: boolean) => void;
 }
 
-export const Message: React.FC<MessageParams & {scrollTo?: ScrollToElement}> = props => {
+export const Message = (props: MessageParams & {scrollTo?: ScrollToElement}) => {
   const {
     message,
     isHighlighted,
@@ -96,7 +96,6 @@ export const Message: React.FC<MessageParams & {scrollTo?: ScrollToElement}> = p
     setMsgElementsFocusable,
   } = props;
   const messageElementRef = useRef<HTMLDivElement>(null);
-  const messageRef = useRef<HTMLDivElement>(null);
   const {status, ephemeral_expires} = useKoSubscribableChildren(message, ['status', 'ephemeral_expires']);
   const messageFocusedTabIndex = useMessageFocusedTabIndex(isFocused);
 
@@ -114,7 +113,7 @@ export const Message: React.FC<MessageParams & {scrollTo?: ScrollToElement}> = p
   const handleDivKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     // when a message is focused set its elements focusable
     if (!event.shiftKey && isTabKey(event)) {
-      if (!messageRef.current) {
+      if (!messageElementRef.current) {
         return;
       }
       setMsgElementsFocusable(true);
@@ -130,21 +129,21 @@ export const Message: React.FC<MessageParams & {scrollTo?: ScrollToElement}> = p
   useEffect(() => {
     // Move element into view when it is focused
     if (isFocused) {
-      messageRef.current?.focus();
+      messageElementRef.current?.focus();
     }
   }, [isFocused]);
 
   // set message elements focus for non content type mesages
   // some non content type message has interactive element like invite people for member message
   useEffect(() => {
-    if (!messageRef.current || message.isContent()) {
+    if (!messageElementRef.current || message.isContent()) {
       return;
     }
-    const interactiveMsgElements = getAllFocusableElements(messageRef.current);
+    const interactiveMsgElements = getAllFocusableElements(messageElementRef.current);
     setElementsTabIndex(interactiveMsgElements, isMsgElementsFocusable && isFocused);
   }, [isFocused, isMsgElementsFocusable, message]);
 
-  const content = (
+  const messageContent = (
     <MessageWrapper
       {...props}
       hideHeader={hideHeader}
@@ -153,15 +152,8 @@ export const Message: React.FC<MessageParams & {scrollTo?: ScrollToElement}> = p
     />
   );
 
-  const wrappedContent = onVisible ? (
-    <InViewport requireFullyInView allowBiggerThanViewport checkOverlay onVisible={onVisible}>
-      {content}
-    </InViewport>
-  ) : (
-    content
-  );
-
   return (
+    /*eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions*/
     <div
       className={cx('message', {
         'message-marked': isHighlighted,
@@ -175,18 +167,17 @@ export const Message: React.FC<MessageParams & {scrollTo?: ScrollToElement}> = p
       data-uie-send-status={status}
       data-uie-name="item-message"
       role="list"
+      tabIndex={messageFocusedTabIndex}
+      onKeyDown={handleDivKeyDown}
+      onClick={() => handleFocus(message.id)}
     >
-      {/*eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions*/}
-      <div
-        tabIndex={messageFocusedTabIndex}
-        ref={messageRef}
-        role="listitem"
-        onKeyDown={handleDivKeyDown}
-        onClick={() => handleFocus(message.id)}
-        className="message-wrapper"
-      >
-        {wrappedContent}
-      </div>
+      {onVisible ? (
+        <InViewport requireFullyInView allowBiggerThanViewport checkOverlay onVisible={onVisible}>
+          {messageContent}
+        </InViewport>
+      ) : (
+        messageContent
+      )}
     </div>
   );
 };

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -99,7 +99,7 @@
 
 .content-message {
   &:has(.message-header) {
-    margint-top: 6px;
+    margin-top: 6px;
   }
 }
 

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -37,6 +37,18 @@
 // MESSAGE
 .message {
   position: relative;
+  outline-offset: -0.1rem;
+
+  &.content-message {
+    &:hover,
+    &:focus-visible {
+      background-color: #fff;
+
+      body.theme-dark & {
+        background-color: var(--gray-90);
+      }
+    }
+  }
 
   & * {
     .accent-selection;
@@ -87,7 +99,7 @@
 
 .content-message {
   &:has(.message-header) {
-    padding-top: 6px;
+    margint-top: 6px;
   }
 }
 
@@ -107,15 +119,6 @@
 
 .content-message-wrapper {
   padding-block: 6px;
-
-  &:hover,
-  &:focus-visible {
-    background-color: #fff;
-
-    body.theme-dark & {
-      background-color: var(--gray-90);
-    }
-  }
 }
 
 .message-marked {
@@ -262,10 +265,6 @@
 .message-header-icon-external svg {
   width: 16px;
   height: 16px;
-}
-
-.message-wrapper {
-  outline-offset: -0.1rem;
 }
 
 .message-mention {


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-6515

## Description
We have bug with stucked Reaction popover, now if we click outside element, reaction popover closing.
You can debug it by:

Click on message
Change message by arrows
Click outside message-wrapper
Now reaction popover closing.

## Screenshots/Screencast (for UI changes)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
