### PR TITLE
runfix: address design review (WPB-8687 7374 7357)

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/ConversationTabs.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/ConversationTabs.tsx
@@ -146,7 +146,9 @@ export const ConversationTabs = ({
           );
         })}
 
-        <div className="conversations-sidebar-title">{t('conversationFooterContacts')}</div>
+        <div className="conversations-sidebar-title" css={{marginBlock: '32px 0'}}>
+          {t('conversationFooterContacts')}
+        </div>
 
         <ConversationTab
           title={t('searchConnect', Shortcut.getShortcutTooltip(ShortcutType.START))}

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.styles.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.styles.tsx
@@ -27,3 +27,34 @@ export const conversationsSidebarStyles = (mdBreakpoint: Boolean): CSSObject => 
   position: mdBreakpoint ? 'fixed' : 'relative',
   zIndex: mdBreakpoint ? '1000' : 'auto',
 });
+
+export const conversationsSidebarHandleStyles = (rotate: Boolean): CSSObject => ({
+  position: 'absolute',
+  zIndex: '1000',
+  top: '8px',
+  right: '-12px',
+  width: '24px',
+  height: '24px',
+  borderWidth: '2px',
+  transform: rotate ? 'rotate(180deg)' : 'rotate(0deg)',
+  '&:hover': {
+    borderColor: 'var(--accent-color-300)',
+    backgroundColor: 'var(--accent-color-50)',
+    'body.theme-default &': {
+      '& svg': {fill: 'var(--accent-color)'},
+    },
+    'body.theme-dark &': {
+      borderColor: 'var(--accent-color-800)',
+      backgroundColor: 'var(--accent-color-800)',
+    },
+  },
+  '&:focus': {
+    borderColor: 'var(--accent-color)',
+  },
+});
+
+export const conversationsSidebarHandleIconStyles: CSSObject = {
+  marginLeft: '1px',
+  width: '12px',
+  height: '12px',
+};

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -22,7 +22,7 @@ import React, {useEffect, useState} from 'react';
 import {amplify} from 'amplify';
 import {container} from 'tsyringe';
 
-import {ChevronIcon, useMatchMedia} from '@wireapp/react-ui-kit';
+import {ChevronIcon, IconButton, useMatchMedia} from '@wireapp/react-ui-kit';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {CallingCell} from 'Components/calling/CallingCell';
@@ -39,7 +39,12 @@ import {UserRepository} from 'src/script/user/UserRepository';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 
 import {ConversationHeader} from './ConversationHeader';
-import {conversationsSpacerStyles, conversationsSidebarStyles} from './Conversations.styles';
+import {
+  conversationsSpacerStyles,
+  conversationsSidebarStyles,
+  conversationsSidebarHandleStyles,
+  conversationsSidebarHandleIconStyles,
+} from './Conversations.styles';
 import {ConversationsList} from './ConversationsList';
 import {ConversationTabs} from './ConversationTabs';
 import {EmptyConversationList} from './EmptyConversationList';
@@ -257,15 +262,13 @@ const Conversations: React.FC<ConversationsProps> = ({
         />
       </FadingScrollbar>
 
-      <button
-        type="button"
-        role="tab"
+      <IconButton
+        css={conversationsSidebarHandleStyles(isSideBarOpen)}
         className="conversations-sidebar-handle"
-        data-is-collapsed={!isSideBarOpen}
         onClick={toggleSidebar}
       >
-        <ChevronIcon width={12} height={12} />
-      </button>
+        <ChevronIcon css={conversationsSidebarHandleIconStyles} />
+      </IconButton>
     </nav>
   );
 

--- a/src/script/page/MainContent/panels/preferences/components/PreferencesPage.styles.ts
+++ b/src/script/page/MainContent/panels/preferences/components/PreferencesPage.styles.ts
@@ -26,6 +26,10 @@ export const wrapperStyle: CSSObject = {
   containerType: 'inline-size',
 };
 
+export const titleStyle = (smallScreen: boolean): CSSObject => ({
+  paddingRight: smallScreen ? '40px' : 0,
+});
+
 export const buttonsStyle: CSSObject = {
   marginBottom: 0,
 };

--- a/src/script/page/MainContent/panels/preferences/components/PreferencesPage.tsx
+++ b/src/script/page/MainContent/panels/preferences/components/PreferencesPage.tsx
@@ -17,15 +17,14 @@
  *
  */
 
-import {useContext, FC} from 'react';
+import {FC} from 'react';
 
 import {IconButton, IconButtonVariant, useMatchMedia} from '@wireapp/react-ui-kit';
 
 import {FadingScrollbar} from 'Components/FadingScrollbar';
-import {RootContext} from 'src/script/page/RootProvider';
 import {useAppMainState, ViewType} from 'src/script/page/state';
 
-import {buttonsStyle, contentStyle, wrapperStyle} from './PreferencesPage.styles';
+import {buttonsStyle, contentStyle, titleStyle, wrapperStyle} from './PreferencesPage.styles';
 
 interface PreferencesPageProps {
   children: React.ReactNode;
@@ -39,10 +38,6 @@ const PreferencesPage: FC<PreferencesPageProps> = ({title, children}) => {
   const {currentView, setCurrentView} = useAppMainState(state => state.responsiveView);
   const isCentralColumn = currentView == ViewType.CENTRAL_COLUMN;
 
-  const root = useContext(RootContext);
-
-  const goHome = () => root?.content.loadPreviousContent();
-
   return (
     <div role="tabpanel" aria-labelledby={title} css={wrapperStyle}>
       <div className="preferences-titlebar">
@@ -54,15 +49,9 @@ const PreferencesPage: FC<PreferencesPageProps> = ({title, children}) => {
             onClick={() => setCurrentView(ViewType.LEFT_SIDEBAR)}
           />
         )}
-        <h2 className="preferences-titlebar">{title}</h2>
-        {smBreakpoint && isCentralColumn && (
-          <IconButton
-            variant={IconButtonVariant.SECONDARY}
-            className="conversation-title-bar-icon icon-close"
-            css={buttonsStyle}
-            onClick={goHome}
-          />
-        )}
+        <h2 className="preferences-titlebar" css={titleStyle(smBreakpoint && isCentralColumn)}>
+          {title}
+        </h2>
       </div>
       <FadingScrollbar className="preferences-content" css={contentStyle}>
         {children}

--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -53,30 +53,6 @@
       }
     }
   }
-
-  .conversations-sidebar-handle {
-    .button-reset-default;
-
-    position: absolute;
-    z-index: 1000;
-    top: 8px;
-    right: -12px;
-
-    display: flex;
-    width: 24px;
-    height: 24px;
-    align-items: center;
-    justify-content: center;
-    border: 1px solid var(--border-color);
-    border-radius: 20px;
-    background-color: var(--app-bg-secondary);
-    cursor: pointer;
-    transform: rotate(180deg);
-
-    &[data-is-collapsed='true'] {
-      transform: rotate(0deg);
-    }
-  }
 }
 
 .conversations-sidebar-list {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8687" title="WPB-8687" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-8687</a>  [Web] Different ways to close preferences in responsive design end in different views
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
 <table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7374" title="WPB-7374" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7374</a>  Padding between "Contact" and "conversation" sections
  </td></table>
 <table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7357" title="WPB-7357" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7357</a>[Web] Behavior of collapsable side bar
  </td></table>
  <br />


## Description

Address design review of the new navigation
- collapse button lacks hover states
- the extra close button in preferences / responsive view isn't necessary
- missing padding between "Conversations" and "Contacts" in the sidebar

## Screenshots/Screencast (for UI changes)
Before:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/d187057d-c941-4ff3-ba6c-c7557634e307)
![image](https://github.com/wireapp/wire-webapp/assets/78490891/940c8ef0-6b05-437e-a732-8147c2f674ae)
![image](https://github.com/wireapp/wire-webapp/assets/78490891/31a8b24e-2d92-49c9-9c36-7209c1c557ff)

After:
![image](https://github.com/wireapp/wire-webapp/assets/78490891/50f0689b-9e9c-45eb-89da-61718befe2f9)
![image](https://github.com/wireapp/wire-webapp/assets/78490891/d174d919-2994-424b-bdbd-cbdb840ef219)
![image](https://github.com/wireapp/wire-webapp/assets/78490891/f5748aae-7aa9-4e26-91c3-bc1b4cbce88b)

