### PR TITLE
chore: deploy the new-navigation branch on the edge environment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -268,10 +268,13 @@ jobs:
           map: |
             {
               "dev": {
-                "targets": "[\"wire-webapp-dev-al2\", \"wire-webapp-edge-al2\" ]"
+                "targets": "[\"wire-webapp-dev-al2\"]"
               },
               "master": {
                 "targets": "[\"wire-webapp-master-al2\"]"
+              },
+              "new-navigation": {
+                "targets": "[\"wire-webapp-edge-al2\"]"
               },
               "production": {
                 "targets": "[\"wire-webapp-prod-al2\"]"


### PR DESCRIPTION
## Description

This sets the deploy target of the `new-navigation` branch to `edge`
