### PR TITLE
feat: add avs version to webapp [WPB-4969]

### DIFF
--- a/server/config/client.config.ts
+++ b/server/config/client.config.ts
@@ -21,7 +21,7 @@ import {ConfigGeneratorParams} from './config.types';
 import {Env} from './env';
 
 export function generateConfig(params: ConfigGeneratorParams, env: Env) {
-  const {urls, version, env: nodeEnv} = params;
+  const {urls, version, env: nodeEnv, dependencies} = params;
   return {
     APP_BASE: urls.base,
     ANALYTICS_API_KEY: env.ANALYTICS_API_KEY,
@@ -108,6 +108,7 @@ export function generateConfig(params: ConfigGeneratorParams, env: Env) {
       WHATS_NEW: env.URL_WHATS_NEW,
     },
     VERSION: version,
+    AVS_VERSION: dependencies.avs,
     WEBSITE_LABEL: env.WEBSITE_LABEL,
   } as const;
 }

--- a/server/config/config.types.ts
+++ b/server/config/config.types.ts
@@ -26,4 +26,7 @@ export type ConfigGeneratorParams = {
   };
   commit: string;
   version: string;
+  dependencies: {
+    avs: string;
+  };
 };

--- a/server/config/index.ts
+++ b/server/config/index.ts
@@ -27,7 +27,12 @@ import {Env} from './env';
 import {generateConfig as generateServerConfig} from './server.config';
 
 const versionData = readFileSync(path.resolve(__dirname, './version.json'), 'utf8');
+const packageJsonData = readFileSync(path.resolve(__dirname, '../../../package.json'), 'utf8');
+
 const version = versionData ? JSON.parse(versionData) : {version: 'unknown', commit: 'unknown'};
+const packageJson = packageJsonData ? JSON.parse(packageJsonData) : null;
+
+const readDependencyVersion = (name: string): string => packageJson?.dependencies?.[name] || 'unknown';
 
 const env = dotenv.load({
   includeProcessEnv: true,
@@ -57,6 +62,9 @@ function generateUrls() {
 const commonConfig = {
   commit: version.commit,
   version: version.version,
+  dependencies: {
+    avs: readDependencyVersion('@wireapp/avs'),
+  },
   env: env.NODE_ENV || 'production',
   urls: generateUrls(),
 };

--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -1200,6 +1200,7 @@
   "preferencesAboutSupportWebsite": "Support website",
   "preferencesAboutTermsOfUse": "Terms of use",
   "preferencesAboutVersion": "Version {{version}}",
+  "preferencesAboutAVSVersion": "AVS version {{version}}",
   "preferencesAboutWebsite": "{{brandName}} website",
   "preferencesAccount": "Account",
   "preferencesAccountAccentColor": "Set a profile color",

--- a/src/script/page/MainContent/panels/preferences/AboutPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/AboutPreferences.tsx
@@ -111,6 +111,7 @@ const AboutPreferences: React.FC<AboutPreferencesProps> = ({selfUser, teamState 
       )}
       <PreferencesSection hasSeparator>
         <p className="preferences-detail">{t('preferencesAboutVersion', config.VERSION)}</p>
+        <p className="preferences-detail">{t('preferencesAboutAVSVersion', config.AVS_VERSION)}</p>
         <p className="preferences-detail">{t('preferencesAboutCopyright')}</p>
       </PreferencesSection>
     </PreferencesPage>

--- a/src/script/util/Environment.ts
+++ b/src/script/util/Environment.ts
@@ -49,6 +49,7 @@ interface Environment {
     isProduction: typeof isProduction;
   };
   version: (showWrapperVersion?: boolean) => string;
+  avsVersion: () => string;
 }
 
 export const Environment: Environment = {
@@ -67,4 +68,5 @@ export const Environment: Environment = {
     const showElectronVersion = electronVersion && showWrapperVersion;
     return showElectronVersion ? electronVersion : Config.getConfig().VERSION;
   },
+  avsVersion: (): string => Config.getConfig().AVS_VERSION,
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4969" title="WPB-4969" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-4969</a>  [Web] AVS version should be shown in the UI for better transparency
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

Reads the avs version from package json file and adds it to about section. I've also exposed a method to report the avs version to desktop wrapper.

## Screenshots/Screencast (for UI changes)
![Screenshot 2024-06-05 at 15 08 02](https://github.com/wireapp/wire-webapp/assets/45733298/08f4f973-145b-43fb-b475-f4e491488457)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;