### PR TITLE
fix: Filter conversation doesnt work properly

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationHeader/ConversationHeader.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationHeader/ConversationHeader.tsx
@@ -48,6 +48,7 @@ interface ConversationHeaderProps {
   setSearchValue: (searchValue: string) => void;
   searchInputPlaceholder: string;
   currentFolder?: ConversationLabel;
+  setIsConversationFilterFocused: (isFocused: boolean) => void;
 }
 
 export const ConversationHeader = ({
@@ -58,6 +59,7 @@ export const ConversationHeader = ({
   setSearchValue,
   currentFolder,
   searchInputPlaceholder,
+  setIsConversationFilterFocused,
 }: ConversationHeaderProps) => {
   const {canCreateGroupConversation} = generatePermissionHelpers(selfUser.teamRole());
   const isFolderView = currentTab === SidebarTabs.FOLDER;
@@ -97,6 +99,8 @@ export const ConversationHeader = ({
         <Input
           className="label-1"
           value={searchValue}
+          onFocus={() => setIsConversationFilterFocused(true)}
+          onBlur={() => setIsConversationFilterFocused(false)}
           onChange={event => setSearchValue(event.currentTarget.value)}
           startContent={<SearchIcon width={14} height={14} css={searchIconStyles} />}
           endContent={

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -105,6 +105,7 @@ const Conversations: React.FC<ConversationsProps> = ({
     setCurrentTab,
   } = useSidebarStore();
   const [conversationsFilter, setConversationsFilter] = useState<string>('');
+  const [isConversationFilterFocused, setIsConversationFilterFocused] = useState(false);
   const {classifiedDomains, isTeam} = useKoSubscribableChildren(teamState, ['classifiedDomains', 'isTeam']);
   const {connectRequests} = useKoSubscribableChildren(userState, ['connectRequests']);
 
@@ -144,6 +145,7 @@ const Conversations: React.FC<ConversationsProps> = ({
   const {setCurrentView} = useAppMainState(state => state.responsiveView);
   const {openFolder, closeFolder, expandedFolder, isFoldersTabOpen, toggleFoldersTab} = useFolderState();
   const {currentFocus, handleKeyDown, resetConversationFocus} = useConversationFocus(conversations);
+
   const {conversations: currentTabConversations, searchInputPlaceholder} = getTabConversations({
     currentTab,
     conversations,
@@ -201,6 +203,8 @@ const Conversations: React.FC<ConversationsProps> = ({
     };
   }, []);
 
+  const clearConversationFilter = () => setConversationsFilter('');
+
   function changeTab(nextTab: SidebarTabs, folderId?: string) {
     if (!folderId) {
       closeFolder();
@@ -215,7 +219,7 @@ const Conversations: React.FC<ConversationsProps> = ({
       onExitPreferences();
     }
 
-    setConversationsFilter('');
+    clearConversationFilter();
     setCurrentTab(nextTab);
   }
 
@@ -314,6 +318,7 @@ const Conversations: React.FC<ConversationsProps> = ({
             searchValue={conversationsFilter}
             setSearchValue={setConversationsFilter}
             searchInputPlaceholder={searchInputPlaceholder}
+            setIsConversationFilterFocused={setIsConversationFilterFocused}
           />
         }
         hasHeader={!isPreferences}
@@ -364,6 +369,8 @@ const Conversations: React.FC<ConversationsProps> = ({
                 conversations={currentTabConversations}
                 conversationRepository={conversationRepository}
                 resetConversationFocus={resetConversationFocus}
+                clearSearchFilter={clearConversationFilter}
+                isConversationFilterFocused={isConversationFilterFocused}
               />
             )}
           </>

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
@@ -58,6 +58,8 @@ interface ConversationsListProps {
   currentFolder?: ConversationLabel;
   resetConversationFocus: () => void;
   handleArrowKeyDown: (index: number) => (e: React.KeyboardEvent) => void;
+  clearSearchFilter: () => void;
+  isConversationFilterFocused: boolean;
 }
 
 export const ConversationsList = ({
@@ -72,6 +74,8 @@ export const ConversationsList = ({
   currentFolder,
   resetConversationFocus,
   handleArrowKeyDown,
+  clearSearchFilter,
+  isConversationFilterFocused,
 }: ConversationsListProps) => {
   const contentState = useAppState(state => state.contentState);
 
@@ -110,7 +114,7 @@ export const ConversationsList = ({
   };
 
   const getCommonConversationCellProps = (conversation: Conversation, index: number) => ({
-    isFocused: currentFocus === conversation.id,
+    isFocused: !isConversationFilterFocused && currentFocus === conversation.id,
     handleArrowKeyDown: handleArrowKeyDown(index),
     resetConversationFocus: resetConversationFocus,
     dataUieName: 'item-conversation',
@@ -121,6 +125,8 @@ export const ConversationsList = ({
       } else {
         createNavigate(generateConversationUrl(conversation.qualifiedId))(event);
       }
+
+      clearSearchFilter();
     },
     isSelected: isActiveConversation,
     onJoinCall: answerCall,


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-9587

## Description
While we filtering conversation we losing focus while we have space or smth. Now its fixed and we doesn't loose focus while we have focused search conversation input. 
Also now selecting conversation clearing filter.

## Screenshots/Screencast (for UI changes)

Before:

https://github.com/wireapp/wire-webapp/assets/13432884/f3336f84-4a9d-46f9-889e-fce016ed6d3e

https://github.com/wireapp/wire-webapp/assets/13432884/df15fb35-4a3a-4010-9108-f1c81c997aed

Now:

https://github.com/wireapp/wire-webapp/assets/13432884/cd18b578-9470-422b-9db7-8e1a833136aa

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
