### PR TITLE
runfix: address new navigation bug reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@wireapp/avs": "9.7.15",
     "@wireapp/commons": "5.2.8",
     "@wireapp/core": "46.0.10",
-    "@wireapp/react-ui-kit": "9.17.5",
+    "@wireapp/react-ui-kit": "9.17.6",
     "@wireapp/store-engine-dexie": "2.1.10",
     "@wireapp/webapp-events": "0.21.1",
     "amplify": "https://github.com/wireapp/amplify#head=master",

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DeviceDetailsPreferences/DeviceDetailsPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DeviceDetailsPreferences/DeviceDetailsPreferences.tsx
@@ -28,6 +28,7 @@ import {t} from 'Util/LocalizerUtil';
 
 import {Config} from '../../../../../../../Config';
 import {MotionDuration} from '../../../../../../../motion/MotionDuration';
+import {contentStyle} from '../../../components/PreferencesPage.styles';
 import {DetailedDevice} from '../DetailedDevice';
 
 interface DevicesPreferencesProps {
@@ -79,7 +80,7 @@ export const DeviceDetailsPreferences: React.FC<DevicesPreferencesProps> = ({
     >
       <h2 className="preferences-titlebar">{t('preferencesDeviceDetails')}</h2>
 
-      <div className="preferences-content">
+      <div className="preferences-content" css={contentStyle}>
         <fieldset className="preferences-section">
           <legend className="preferences-devices-details">
             <button

--- a/src/style/panel/panel.less
+++ b/src/style/panel/panel.less
@@ -388,6 +388,18 @@
         .focus-offset;
         .focus-border-radius;
       }
+
+      &:first-child {
+        flex-grow: 1;
+        margin-left: var(--content-title-bar-height);
+        text-align: center;
+      }
+
+      &:last-child {
+        flex-grow: 1;
+        margin-right: var(--content-title-bar-height);
+        text-align: center;
+      }
     }
 
     &--reverse {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6090,9 +6090,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/react-ui-kit@npm:9.17.5":
-  version: 9.17.5
-  resolution: "@wireapp/react-ui-kit@npm:9.17.5"
+"@wireapp/react-ui-kit@npm:9.17.6":
+  version: 9.17.6
+  resolution: "@wireapp/react-ui-kit@npm:9.17.6"
   dependencies:
     "@types/color": "npm:3.0.6"
     color: "npm:4.2.3"
@@ -6107,7 +6107,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/ef790239b59f6b62368db947c6d424a9bc295668e8305dc1a90b38cb4da01ae4ff8106ce0f1ff3f355c1b8503fe6ee9ad6bf5d8eaf63486c19b3ff9f7db26468
+  checksum: 10/f716f0de455f589bada921aa41023fc5387159a81714320c42d70a1b5fc410b37d531801acf35b9306b708da58c097d9fd414e273108c45d35314b228e1377fa
   languageName: node
   linkType: hard
 
@@ -18614,7 +18614,7 @@ __metadata:
     "@wireapp/core": "npm:46.0.10"
     "@wireapp/eslint-config": "npm:3.0.7"
     "@wireapp/prettier-config": "npm:0.6.4"
-    "@wireapp/react-ui-kit": "npm:9.17.5"
+    "@wireapp/react-ui-kit": "npm:9.17.6"
     "@wireapp/store-engine": "npm:5.1.6"
     "@wireapp/store-engine-dexie": "npm:2.1.10"
     "@wireapp/webapp-events": "npm:0.21.1"


### PR DESCRIPTION
## Description

Addresses bug reports from user feedback:
- Search input close icons doesn't appear in dark mode
- Message detail title is misaligned
- Preferences' device detail layout is broken


## Screenshots/Screencast (for UI changes)
Before:
![Screenshot from 2024-06-05 18-00-47](https://github.com/wireapp/wire-webapp/assets/78490891/753c4fce-554e-4d0c-95f0-6b679d8fd7dd)
![image](https://github.com/wireapp/wire-webapp/assets/78490891/be9d0cd5-dbe6-46e7-8d4e-fcb9dada6046)
![image](https://github.com/wireapp/wire-webapp/assets/78490891/f9d29012-7606-426d-83fe-afadd3573544)

After:
![Screenshot from 2024-06-05 18-04-46](https://github.com/wireapp/wire-webapp/assets/78490891/8aa7b93a-448d-4844-8d5c-174f4483d48e)
![image](https://github.com/wireapp/wire-webapp/assets/78490891/d5010b55-c025-4d33-94dd-a5fef0e0f63a)
![image](https://github.com/wireapp/wire-webapp/assets/78490891/ef617063-7355-426c-8e03-c2fad44830ab)

