### PR TITLE
fix: prevent reactions from showing zero (WPB-9607)

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiPill.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiPill.tsx
@@ -118,47 +118,49 @@ export const EmojiPill = ({
   ]);
 
   return (
-    <Tooltip
-      body={
-        <div css={messageReactionButtonTooltip}>
-          <EmojiChar styles={messageReactionButtonTooltipImage} emoji={emoji} />
-          <p css={messageReactionButtonTooltipText}>
-            {content}{' '}
-            {emojiCount > 1
-              ? t('conversationLikesCaptionReactedPlural', {emojiName})
-              : t('conversationLikesCaptionReactedSingular', {emojiName})}
-          </p>
-        </div>
-      }
-    >
-      <button
-        css={{...messageReactionButton, ...getReactionsButtonCSS(isActive, isRemovedFromConversation)}}
-        aria-label={
-          emojiCount > 1
-            ? t('accessibility.messageReactionDetailsPlural', {emojiCount: emojiCount.toString(), emojiName})
-            : t('accessibility.messageReactionDetailsSingular', {emojiCount: emojiCount.toString(), emojiName})
+    emojiCount && (
+      <Tooltip
+        body={
+          <div css={messageReactionButtonTooltip}>
+            <EmojiChar styles={messageReactionButtonTooltipImage} emoji={emoji} />
+            <p css={messageReactionButtonTooltipText}>
+              {content}{' '}
+              {emojiCount > 1
+                ? t('conversationLikesCaptionReactedPlural', {emojiName})
+                : t('conversationLikesCaptionReactedSingular', {emojiName})}
+            </p>
+          </div>
         }
-        title={emojiName}
-        aria-pressed={isActive}
-        type="button"
-        tabIndex={messageFocusedTabIndex}
-        className="button-reset-default"
-        data-uie-name="emoji-pill"
-        onClick={() => {
-          handleReactionClick(emoji);
-        }}
-        onKeyDown={event => {
-          // is last reaction then on tab key press it should hide the reaction menu
-          if (index === emojiListCount - 1) {
-            if (!event.shiftKey && isTabKey(event)) {
-              onLastReactionKeyEvent();
-            }
-          }
-        }}
       >
-        <EmojiChar emoji={emoji} />
-        <span css={messageReactionCount(isActive)}>{emojiCount}</span>
-      </button>
-    </Tooltip>
+        <button
+          css={{...messageReactionButton, ...getReactionsButtonCSS(isActive, isRemovedFromConversation)}}
+          aria-label={
+            emojiCount > 1
+              ? t('accessibility.messageReactionDetailsPlural', {emojiCount: emojiCount.toString(), emojiName})
+              : t('accessibility.messageReactionDetailsSingular', {emojiCount: emojiCount.toString(), emojiName})
+          }
+          title={emojiName}
+          aria-pressed={isActive}
+          type="button"
+          tabIndex={messageFocusedTabIndex}
+          className="button-reset-default"
+          data-uie-name="emoji-pill"
+          onClick={() => {
+            handleReactionClick(emoji);
+          }}
+          onKeyDown={event => {
+            // is last reaction then on tab key press it should hide the reaction menu
+            if (index === emojiListCount - 1) {
+              if (!event.shiftKey && isTabKey(event)) {
+                onLastReactionKeyEvent();
+              }
+            }
+          }}
+        >
+          <EmojiChar emoji={emoji} />
+          <span css={messageReactionCount(isActive)}>{emojiCount}</span>
+        </button>
+      </Tooltip>
+    )
   );
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiPill.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiPill.tsx
@@ -118,7 +118,7 @@ export const EmojiPill = ({
   ]);
 
   return (
-    emojiCount && (
+    !!emojiCount && (
       <Tooltip
         body={
           <div css={messageReactionButtonTooltip}>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9607" title="WPB-9607" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9607</a>  [Web] Reactions show the number zero when the reacting user leaves the conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

Reactions show the number zero when the reacting user leaves the conversation

## Screenshots/Screencast (for UI changes)
Before:
![Screenshot from 2024-06-07 13-48-09](https://github.com/wireapp/wire-webapp/assets/78490891/534cbfd2-c8a6-48c9-89a1-49a5739adf98)
After:
![Kooha-2024-06-07-13-59-42](https://github.com/wireapp/wire-webapp/assets/78490891/fcf799d0-e018-4ce3-96d2-1845211870bf)

