### PR TITLE
feat: Improved delivered status indicator WPB-9170

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.test.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.test.tsx
@@ -47,7 +47,6 @@ describe('message', () => {
       conversation: new Conversation(),
       findMessage: jest.fn(),
       isFocused: true,
-      isLastDeliveredMessage: false,
       hideHeader: false,
       message,
       onClickAvatar: jest.fn(),
@@ -64,6 +63,7 @@ describe('message', () => {
       onRetry: jest.fn(),
       selfId: {domain: '', id: createUuid()},
       isMsgElementsFocusable: true,
+      rightMarginWidth: 10,
     };
   });
 

--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -23,7 +23,6 @@ import {QualifiedId} from '@wireapp/api-client/lib/user';
 import cx from 'classnames';
 import ko from 'knockout';
 
-import {DeliveredIndicator} from 'Components/MessagesList/Message/DeliveredIndicator/DeliveredIndicator';
 import {ReadIndicator} from 'Components/MessagesList/Message/ReadIndicator';
 import {Conversation} from 'src/script/entity/Conversation';
 import {CompositeMessage} from 'src/script/entity/message/CompositeMessage';
@@ -59,7 +58,6 @@ export interface ContentMessageProps extends Omit<MessageActions, 'onClickResetS
   hideHeader: boolean;
   hasMarker?: boolean;
   isFocused: boolean;
-  isLastDeliveredMessage: boolean;
   message: ContentMessage;
   onClickButton: (message: CompositeMessage, buttonId: string) => void;
   onRetry: (message: ContentMessage) => void;
@@ -67,6 +65,7 @@ export interface ContentMessageProps extends Omit<MessageActions, 'onClickResetS
   selfId: QualifiedId;
   isMsgElementsFocusable: boolean;
   onClickReaction: (emoji: string) => void;
+  rightMarginWidth: number;
 }
 
 export const ContentMessageComponent = ({
@@ -76,7 +75,6 @@ export const ContentMessageComponent = ({
   selfId,
   hideHeader,
   isFocused,
-  isLastDeliveredMessage,
   contextMenu,
   onClickAvatar,
   onClickImage,
@@ -88,9 +86,9 @@ export const ContentMessageComponent = ({
   isMsgElementsFocusable,
   onClickReaction,
   onClickDetails,
+  rightMarginWidth,
 }: ContentMessageProps) => {
   const messageRef = useRef<HTMLDivElement | null>(null);
-  const [deliveryIndicatorRef, setDeliveryIndicatorRef] = useState<HTMLDivElement | null>(null);
 
   // check if current message is focused and its elements focusable
   const msgFocusState = useMemo(() => isMsgElementsFocusable && isFocused, [isMsgElementsFocusable, isFocused]);
@@ -166,138 +164,129 @@ export const ContentMessageComponent = ({
   useClickOutside(messageRef, hideActionMenuVisibility);
 
   return (
-    <>
+    <div
+      aria-label={messageAriaLabel}
+      className="content-message-wrapper"
+      ref={contentMessageWrapperRef}
+      onMouseEnter={() => {
+        // open another floating action menu if none already open
+        if (!isMenuOpen) {
+          setActionMenuVisibility(true);
+        }
+      }}
+      onMouseLeave={() => {
+        // close floating message actions when no active menu is open like context menu/emoji picker
+        if (!isMenuOpen) {
+          setActionMenuVisibility(false);
+        }
+      }}
+    >
+      {(was_edited || !hideHeader) && (
+        <MessageHeader onClickAvatar={onClickAvatar} message={message} focusTabIndex={messageFocusedTabIndex}>
+          {was_edited && (
+            <span className="message-header-label-icon icon-edit" title={message.displayEditedTimestamp()}></span>
+          )}
+
+          <span className="content-message-timestamp">
+            <MessageTime timestamp={timestamp} data-timestamp-type="normal">
+              {timeAgo}
+            </MessageTime>
+          </span>
+        </MessageHeader>
+      )}
+
       <div
-        aria-label={messageAriaLabel}
-        className="content-message-wrapper"
-        css={{
-          width: `calc(100% - ${deliveryIndicatorRef?.offsetWidth || 0}px)`,
-        }}
-        ref={contentMessageWrapperRef}
-        onMouseEnter={() => {
-          // open another floating action menu if none already open
-          if (!isMenuOpen) {
-            setActionMenuVisibility(true);
-          }
-        }}
-        onMouseLeave={() => {
-          // close floating message actions when no active menu is open like context menu/emoji picker
-          if (!isMenuOpen) {
-            setActionMenuVisibility(false);
-          }
-        }}
+        className={cx('message-body', {
+          'message-asset': isAssetMessage,
+          'message-quoted': !!quote,
+          'ephemeral-asset-expired': isObfuscated && isAssetMessage,
+          'icon-file': isObfuscated && isFileMessage,
+          'icon-movie': isObfuscated && isVideoMessage,
+        })}
+        {...(ephemeralCaption && {title: ephemeralCaption})}
       >
-        {(was_edited || !hideHeader) && (
-          <MessageHeader onClickAvatar={onClickAvatar} message={message} focusTabIndex={messageFocusedTabIndex}>
-            {was_edited && (
-              <span className="message-header-label-icon icon-edit" title={message.displayEditedTimestamp()}></span>
-            )}
-
-            <span className="content-message-timestamp">
-              <MessageTime timestamp={timestamp} data-timestamp-type="normal">
-                {timeAgo}
-              </MessageTime>
-            </span>
-          </MessageHeader>
+        {ephemeral_status === EphemeralStatusType.ACTIVE && (
+          <div className="message-ephemeral-timer">
+            <EphemeralTimer message={message} />
+          </div>
         )}
 
-        <div
-          className={cx('message-body', {
-            'message-asset': isAssetMessage,
-            'message-quoted': !!quote,
-            'ephemeral-asset-expired': isObfuscated && isAssetMessage,
-            'icon-file': isObfuscated && isFileMessage,
-            'icon-movie': isObfuscated && isVideoMessage,
-          })}
-          {...(ephemeralCaption && {title: ephemeralCaption})}
-        >
-          {ephemeral_status === EphemeralStatusType.ACTIVE && (
-            <div className="message-ephemeral-timer">
-              <EphemeralTimer message={message} />
-            </div>
-          )}
-
-          {quote && (
-            <Quote
-              conversation={conversation}
-              quote={quote}
-              selfId={selfId}
-              findMessage={findMessage}
-              showDetail={onClickImage}
-              focusMessage={onClickTimestamp}
-              handleClickOnMessage={onClickMessage}
-              showUserDetails={onClickAvatar}
-              isMessageFocused={msgFocusState}
-            />
-          )}
-
-          {assets.map(asset => (
-            <ContentAsset
-              key={asset.type}
-              asset={asset}
-              message={message}
-              selfId={selfId}
-              onClickButton={onClickButton}
-              onClickImage={onClickImage}
-              onClickMessage={onClickMessage}
-              isMessageFocused={msgFocusState}
-              is1to1Conversation={conversation.is1to1()}
-              onClickDetails={() => onClickDetails(message)}
-            />
-          ))}
-
-          {isAssetMessage && (
-            <ReadIndicator message={message} is1to1Conversation={conversation.is1to1()} onClick={onClickDetails} />
-          )}
-
-          {!isConversationReadonly && isActionMenuVisible && (
-            <MessageActionsMenu
-              isMsgWithHeader={!hideHeader}
-              message={message}
-              handleActionMenuVisibility={setActionMenuVisibility}
-              contextMenu={contextMenu}
-              isMessageFocused={msgFocusState}
-              handleReactionClick={onClickReaction}
-              reactionsTotalCount={reactions.length}
-              isRemovedFromConversation={conversation.removed_from_conversation()}
-            />
-          )}
-        </div>
-
-        {[StatusType.FAILED, StatusType.FEDERATION_ERROR].includes(status) && (
-          <CompleteFailureToSendWarning
-            {...(status === StatusType.FEDERATION_ERROR && {unreachableDomain: conversation.domain})}
+        {quote && (
+          <Quote
+            conversation={conversation}
+            quote={quote}
+            selfId={selfId}
+            findMessage={findMessage}
+            showDetail={onClickImage}
+            focusMessage={onClickTimestamp}
+            handleClickOnMessage={onClickMessage}
+            showUserDetails={onClickAvatar}
             isMessageFocused={msgFocusState}
-            onRetry={() => onRetry(message)}
           />
         )}
 
-        {failedToSend && (
-          <PartialFailureToSendWarning
+        {assets.map(asset => (
+          <ContentAsset
+            key={asset.type}
+            asset={asset}
+            message={message}
+            selfId={selfId}
+            onClickButton={onClickButton}
+            onClickImage={onClickImage}
+            onClickMessage={onClickMessage}
             isMessageFocused={msgFocusState}
-            failedToSend={failedToSend}
-            knownUsers={conversation.allUserEntities()}
+            is1to1Conversation={conversation.is1to1()}
+            onClickDetails={() => onClickDetails(message)}
           />
+        ))}
+
+        {isAssetMessage && (
+          <ReadIndicator message={message} is1to1Conversation={conversation.is1to1()} onClick={onClickDetails} />
         )}
 
-        {!!reactions.length && (
-          <MessageReactionsList
-            reactions={reactions}
-            selfUserId={selfId}
+        {!isConversationReadonly && isActionMenuVisible && (
+          <MessageActionsMenu
+            isMsgWithHeader={!hideHeader}
+            message={message}
+            handleActionMenuVisibility={setActionMenuVisibility}
+            contextMenu={contextMenu}
+            isMessageFocused={msgFocusState}
             handleReactionClick={onClickReaction}
-            isMessageFocused={msgFocusState}
-            onTooltipReactionCountClick={() => onClickReactionDetails(message)}
-            onLastReactionKeyEvent={() => setActionMenuVisibility(false)}
+            reactionsTotalCount={reactions.length}
             isRemovedFromConversation={conversation.removed_from_conversation()}
-            users={conversation.allUserEntities()}
+            rightMarginWidth={rightMarginWidth}
           />
         )}
       </div>
-      <DeliveredIndicator
-        ref={setDeliveryIndicatorRef}
-        isLastDeliveredMessage={isLastDeliveredMessage}
-        height={messageRef.current?.offsetHeight}
-      />
-    </>
+
+      {[StatusType.FAILED, StatusType.FEDERATION_ERROR].includes(status) && (
+        <CompleteFailureToSendWarning
+          {...(status === StatusType.FEDERATION_ERROR && {unreachableDomain: conversation.domain})}
+          isMessageFocused={msgFocusState}
+          onRetry={() => onRetry(message)}
+        />
+      )}
+
+      {failedToSend && (
+        <PartialFailureToSendWarning
+          isMessageFocused={msgFocusState}
+          failedToSend={failedToSend}
+          knownUsers={conversation.allUserEntities()}
+        />
+      )}
+
+      {!!reactions.length && (
+        <MessageReactionsList
+          reactions={reactions}
+          selfUserId={selfId}
+          handleReactionClick={onClickReaction}
+          isMessageFocused={msgFocusState}
+          onTooltipReactionCountClick={() => onClickReactionDetails(message)}
+          onLastReactionKeyEvent={() => setActionMenuVisibility(false)}
+          isRemovedFromConversation={conversation.removed_from_conversation()}
+          users={conversation.allUserEntities()}
+        />
+      )}
+    </div>
   );
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageActions.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageActions.styles.ts
@@ -25,20 +25,20 @@ export const messageActionsGroup: CSSObject = {
   padding: '2px',
 };
 
-export const messageBodyActions: CSSObject = {
+export const messageBodyActions = (rightMarginWidth: number): CSSObject => ({
   display: 'inline-flex',
   alignItems: 'center',
   minHeight: '32px',
   minWidth: '40px',
   position: 'absolute',
-  right: '16px',
+  right: `${16 - rightMarginWidth}px`,
   top: '-34px',
   userSelect: 'none',
   '@media (max-width: @screen-md-min)': {
     height: '45px',
     flexDirection: 'column',
   },
-};
+});
 
 export const messageActionsMenuButton = (isReactable = true): CSSObject => {
   const defaultStyle: CSSObject = {

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageActions.test.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageActions.test.tsx
@@ -34,6 +34,7 @@ const defaultProps: MessageActionsMenuProps = {
   handleReactionClick: jest.fn(),
   reactionsTotalCount: 0,
   isRemovedFromConversation: false,
+  rightMarginWidth: 10,
 };
 
 describe('MessageActions', () => {

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageActions.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageActions.tsx
@@ -63,6 +63,7 @@ export interface MessageActionsMenuProps {
   handleReactionClick: (emoji: string) => void;
   reactionsTotalCount: number;
   isRemovedFromConversation: boolean;
+  rightMarginWidth: number;
 }
 
 const MessageActionsMenu: FC<MessageActionsMenuProps> = ({
@@ -74,6 +75,7 @@ const MessageActionsMenu: FC<MessageActionsMenuProps> = ({
   handleReactionClick,
   reactionsTotalCount,
   isRemovedFromConversation,
+  rightMarginWidth,
 }) => {
   const {entries: menuEntries} = useKoSubscribableChildren(contextMenu, ['entries']);
   const messageFocusedTabIndex = useMessageFocusedTabIndex(isMessageFocused);
@@ -163,7 +165,7 @@ const MessageActionsMenu: FC<MessageActionsMenuProps> = ({
     }
   });
   return (
-    <div css={{...messageBodyActions, ...messageReactionTop}} ref={wrapperRef}>
+    <div css={{...messageBodyActions(rightMarginWidth), ...messageReactionTop}} ref={wrapperRef}>
       <div
         css={messageActionsGroup}
         role="group"

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
@@ -54,7 +54,6 @@ interface ContentAssetProps {
   selfId: QualifiedId;
   isMessageFocused: boolean;
   is1to1Conversation: boolean;
-  isLastDeliveredMessage: boolean;
   onClickDetails: () => void;
 }
 
@@ -67,7 +66,6 @@ const ContentAsset = ({
   onClickButton,
   isMessageFocused,
   is1to1Conversation,
-  isLastDeliveredMessage,
   onClickDetails,
 }: ContentAssetProps) => {
   const {isObfuscated, status} = useKoSubscribableChildren(message, ['isObfuscated', 'status']);
@@ -96,12 +94,7 @@ const ContentAsset = ({
           )}
 
           {shouldRenderText && (
-            <ReadIndicator
-              message={message}
-              is1to1Conversation={is1to1Conversation}
-              isLastDeliveredMessage={isLastDeliveredMessage}
-              onClick={onClickDetails}
-            />
+            <ReadIndicator message={message} is1to1Conversation={is1to1Conversation} onClick={onClickDetails} />
           )}
 
           {previews.map(() => (
@@ -109,12 +102,7 @@ const ContentAsset = ({
               <LinkPreviewAsset message={message} isFocusable={isMessageFocused} />
 
               {!shouldRenderText && (
-                <ReadIndicator
-                  message={message}
-                  is1to1Conversation={is1to1Conversation}
-                  isLastDeliveredMessage={isLastDeliveredMessage}
-                  onClick={onClickDetails}
-                />
+                <ReadIndicator message={message} is1to1Conversation={is1to1Conversation} onClick={onClickDetails} />
               )}
             </div>
           ))}

--- a/src/script/components/MessagesList/Message/DeliveredIndicator/DeliveredIndicator.styles.ts
+++ b/src/script/components/MessagesList/Message/DeliveredIndicator/DeliveredIndicator.styles.ts
@@ -19,24 +19,20 @@
 
 import {CSSObject} from '@emotion/react';
 
-export const DeliveryIndicatorContainerStyles = (height?: number): CSSObject => ({
-  display: 'flex',
+export const DeliveryIndicatorStyles = (visible: boolean): CSSObject => ({
   boxSizing: 'border-box',
-  justifyContent: 'center',
-  alignItems: 'center',
   position: 'absolute',
   top: 0,
   right: 0,
+  transform: 'translateX(100%)',
   overflow: 'unset',
-  padding: '0 24px 0 16px',
-  height: height ? `${height}px` : 'min-content',
-});
-
-export const DeliveredIndicatorStyles = (isLastDeliveredMessage: boolean): CSSObject => ({
+  padding: '7px 24px 7px 16px',
   color: 'var(--content-message-timestamp)',
   fontSize: 'var(--font-size-small)',
   fontWeight: 'var(--font-weight-regular)',
+  lineHeight: 'var(--line-height-sm)',
   wordWrap: 'normal',
+  whiteSpace: 'normal',
   width: 'min-content',
-  visibility: isLastDeliveredMessage ? 'unset' : 'hidden',
+  visibility: visible ? 'unset' : 'hidden',
 });

--- a/src/script/components/MessagesList/Message/DeliveredIndicator/DeliveredIndicator.styles.ts
+++ b/src/script/components/MessagesList/Message/DeliveredIndicator/DeliveredIndicator.styles.ts
@@ -1,0 +1,42 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {CSSObject} from '@emotion/react';
+
+export const DeliveryIndicatorContainerStyles = (height?: number): CSSObject => ({
+  display: 'flex',
+  boxSizing: 'border-box',
+  justifyContent: 'center',
+  alignItems: 'center',
+  position: 'absolute',
+  top: 0,
+  right: 0,
+  overflow: 'unset',
+  padding: '0 24px 0 16px',
+  height: height ? `${height}px` : 'min-content',
+});
+
+export const DeliveredIndicatorStyles = (isLastDeliveredMessage: boolean): CSSObject => ({
+  color: 'var(--content-message-timestamp)',
+  fontSize: 'var(--font-size-small)',
+  fontWeight: 'var(--font-weight-regular)',
+  wordWrap: 'normal',
+  width: 'min-content',
+  visibility: isLastDeliveredMessage ? 'unset' : 'hidden',
+});

--- a/src/script/components/MessagesList/Message/DeliveredIndicator/DeliveredIndicator.test.tsx
+++ b/src/script/components/MessagesList/Message/DeliveredIndicator/DeliveredIndicator.test.tsx
@@ -1,0 +1,40 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render} from '@testing-library/react';
+
+import {DeliveredIndicator} from './DeliveredIndicator';
+
+describe('DeliveredIndicator', () => {
+  it('should have displayName', () => {
+    expect(DeliveredIndicator.displayName).toBe('DeliveredIndicator');
+  });
+
+  it('shows "delivered" when it is the last delivered message, no height provided', () => {
+    const {getByTestId} = render(<DeliveredIndicator isLastDeliveredMessage />);
+
+    expect(getByTestId('status-message-read-receipt-delivered')).toBeTruthy();
+  });
+
+  it('hides "delivered" when it is not the last delivered message, height provided', () => {
+    const {queryByTestId} = render(<DeliveredIndicator isLastDeliveredMessage={false} />);
+
+    expect(queryByTestId('status-message-read-receipt-delivered')).toBeNull();
+  });
+});

--- a/src/script/components/MessagesList/Message/DeliveredIndicator/DeliveredIndicator.test.tsx
+++ b/src/script/components/MessagesList/Message/DeliveredIndicator/DeliveredIndicator.test.tsx
@@ -26,13 +26,13 @@ describe('DeliveredIndicator', () => {
     expect(DeliveredIndicator.displayName).toBe('DeliveredIndicator');
   });
 
-  it('shows "delivered" when it is the last delivered message, no height provided', () => {
+  it('shows "delivered" when it is the last delivered message', () => {
     const {getByTestId} = render(<DeliveredIndicator isLastDeliveredMessage />);
 
     expect(getByTestId('status-message-read-receipt-delivered')).toBeTruthy();
   });
 
-  it('hides "delivered" when it is not the last delivered message, height provided', () => {
+  it('hides "delivered" when it is not the last delivered message', () => {
     const {queryByTestId} = render(<DeliveredIndicator isLastDeliveredMessage={false} />);
 
     expect(queryByTestId('status-message-read-receipt-delivered')).toBeNull();

--- a/src/script/components/MessagesList/Message/DeliveredIndicator/DeliveredIndicator.tsx
+++ b/src/script/components/MessagesList/Message/DeliveredIndicator/DeliveredIndicator.tsx
@@ -38,7 +38,7 @@ const DeliveredIndicatorComponent: ForwardRefRenderFunction<HTMLDivElement, Deli
     <div css={DeliveryIndicatorContainerStyles(height)} ref={ref}>
       <span
         css={DeliveredIndicatorStyles(isLastDeliveredMessage)}
-        data-uie-name="status-message-read-receipt-delivered"
+        data-uie-name={isLastDeliveredMessage ? 'status-message-read-receipt-delivered' : undefined}
       >
         {t('conversationMessageDelivered')}
       </span>

--- a/src/script/components/MessagesList/Message/DeliveredIndicator/DeliveredIndicator.tsx
+++ b/src/script/components/MessagesList/Message/DeliveredIndicator/DeliveredIndicator.tsx
@@ -19,29 +19,24 @@
 
 import {forwardRef, ForwardRefRenderFunction} from 'react';
 
-import {
-  DeliveredIndicatorStyles,
-  DeliveryIndicatorContainerStyles,
-} from 'Components/MessagesList/Message/DeliveredIndicator/DeliveredIndicator.styles';
+import {DeliveryIndicatorStyles} from 'Components/MessagesList/Message/DeliveredIndicator/DeliveredIndicator.styles';
 import {t} from 'Util/LocalizerUtil';
 
 export interface DeliveredIndicatorProps {
-  height?: number;
   isLastDeliveredMessage: boolean;
 }
 
 const DeliveredIndicatorComponent: ForwardRefRenderFunction<HTMLDivElement, DeliveredIndicatorProps> = (
-  {height, isLastDeliveredMessage},
+  {isLastDeliveredMessage},
   ref,
 ) => {
   return (
-    <div css={DeliveryIndicatorContainerStyles(height)} ref={ref}>
-      <span
-        css={DeliveredIndicatorStyles(isLastDeliveredMessage)}
-        data-uie-name={isLastDeliveredMessage ? 'status-message-read-receipt-delivered' : undefined}
-      >
-        {t('conversationMessageDelivered')}
-      </span>
+    <div
+      css={DeliveryIndicatorStyles(isLastDeliveredMessage)}
+      data-uie-name={isLastDeliveredMessage ? 'status-message-read-receipt-delivered' : undefined}
+      ref={ref}
+    >
+      {t('conversationMessageDelivered')}
     </div>
   );
 };

--- a/src/script/components/MessagesList/Message/DeliveredIndicator/DeliveredIndicator.tsx
+++ b/src/script/components/MessagesList/Message/DeliveredIndicator/DeliveredIndicator.tsx
@@ -1,0 +1,50 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {forwardRef, ForwardRefRenderFunction} from 'react';
+
+import {
+  DeliveredIndicatorStyles,
+  DeliveryIndicatorContainerStyles,
+} from 'Components/MessagesList/Message/DeliveredIndicator/DeliveredIndicator.styles';
+import {t} from 'Util/LocalizerUtil';
+
+export interface DeliveredIndicatorProps {
+  height?: number;
+  isLastDeliveredMessage: boolean;
+}
+
+const DeliveredIndicatorComponent: ForwardRefRenderFunction<HTMLDivElement, DeliveredIndicatorProps> = (
+  {height, isLastDeliveredMessage},
+  ref,
+) => {
+  return (
+    <div css={DeliveryIndicatorContainerStyles(height)} ref={ref}>
+      <span
+        css={DeliveredIndicatorStyles(isLastDeliveredMessage)}
+        data-uie-name="status-message-read-receipt-delivered"
+      >
+        {t('conversationMessageDelivered')}
+      </span>
+    </div>
+  );
+};
+
+export const DeliveredIndicator = forwardRef(DeliveredIndicatorComponent);
+DeliveredIndicator.displayName = 'DeliveredIndicator';

--- a/src/script/components/MessagesList/Message/MessageWrapper.tsx
+++ b/src/script/components/MessagesList/Message/MessageWrapper.tsx
@@ -26,6 +26,7 @@ import {container} from 'tsyringe';
 
 import {WebAppEvents} from '@wireapp/webapp-events';
 
+import {DeliveredIndicator} from 'Components/MessagesList/Message/DeliveredIndicator/DeliveredIndicator';
 import {E2EIVerificationMessage} from 'Components/MessagesList/Message/E2EIVerificationMessage';
 import {OutgoingQuote} from 'src/script/conversation/MessageRepository';
 import {ContentMessage} from 'src/script/entity/message/ContentMessage';
@@ -85,6 +86,7 @@ export const MessageWrapper: React.FC<MessageParams> = ({
   messageActions,
   teamState = container.resolve(TeamState),
   isMsgElementsFocusable,
+  rightMarginWidth,
 }) => {
   const findMessage = async (conversation: Conversation, messageId: string) => {
     const event =
@@ -180,31 +182,35 @@ export const MessageWrapper: React.FC<MessageParams> = ({
     }
     return void messageRepository.toggleReaction(conversation, message, reaction, selfId);
   };
+
   if (message.isContent()) {
     return (
-      <ContentMessageComponent
-        message={message}
-        findMessage={findMessage}
-        conversation={conversation}
-        hideHeader={hideHeader}
-        selfId={selfId}
-        isLastDeliveredMessage={isLastDeliveredMessage}
-        onClickMessage={onClickMessage}
-        onClickTimestamp={onClickTimestamp}
-        onClickReactionDetails={onClickReactionDetails}
-        onClickButton={clickButton}
-        onClickAvatar={onClickAvatar}
-        contextMenu={{entries: contextMenuEntries}}
-        onClickCancelRequest={onClickCancelRequest}
-        onClickImage={onClickImage}
-        onClickInvitePeople={onClickInvitePeople}
-        onClickParticipants={onClickParticipants}
-        onClickDetails={onClickDetails}
-        onRetry={onRetry}
-        isFocused={isFocused}
-        isMsgElementsFocusable={isMsgElementsFocusable}
-        onClickReaction={handleReactionClick}
-      />
+      <>
+        <ContentMessageComponent
+          message={message}
+          findMessage={findMessage}
+          conversation={conversation}
+          hideHeader={hideHeader}
+          selfId={selfId}
+          onClickMessage={onClickMessage}
+          onClickTimestamp={onClickTimestamp}
+          onClickReactionDetails={onClickReactionDetails}
+          onClickButton={clickButton}
+          onClickAvatar={onClickAvatar}
+          contextMenu={{entries: contextMenuEntries}}
+          onClickCancelRequest={onClickCancelRequest}
+          onClickImage={onClickImage}
+          onClickInvitePeople={onClickInvitePeople}
+          onClickParticipants={onClickParticipants}
+          onClickDetails={onClickDetails}
+          onRetry={onRetry}
+          isFocused={isFocused}
+          isMsgElementsFocusable={isMsgElementsFocusable}
+          onClickReaction={handleReactionClick}
+          rightMarginWidth={rightMarginWidth}
+        />
+        {isLastDeliveredMessage && <DeliveredIndicator isLastDeliveredMessage={isLastDeliveredMessage} />}
+      </>
     );
   }
   if (message.isUnableToDecrypt()) {
@@ -254,11 +260,10 @@ export const MessageWrapper: React.FC<MessageParams> = ({
   }
   if (message.isPing()) {
     return (
-      <PingMessage
-        message={message}
-        is1to1Conversation={conversation.is1to1()}
-        isLastDeliveredMessage={isLastDeliveredMessage}
-      />
+      <>
+        <PingMessage message={message} is1to1Conversation={conversation.is1to1()} />
+        {isLastDeliveredMessage && <DeliveredIndicator isLastDeliveredMessage={isLastDeliveredMessage} />}
+      </>
     );
   }
   if (message.isFileTypeRestricted()) {

--- a/src/script/components/MessagesList/Message/PingMessage.test.tsx
+++ b/src/script/components/MessagesList/Message/PingMessage.test.tsx
@@ -22,7 +22,7 @@ import ko from 'knockout';
 
 import {PingMessage as PingMessageEntity} from 'src/script/entity/message/PingMessage';
 
-import {PingMessage} from './PingMessage';
+import {PingMessage, PingMessageProps} from './PingMessage';
 
 import {ReadReceipt} from '../../../storage';
 
@@ -42,10 +42,8 @@ describe('PingMessage', () => {
     const caption = 'caption';
     const sender = 'sender';
 
-    const props = {
-      isMessageFocused: true,
+    const props: PingMessageProps = {
       is1to1Conversation: false,
-      isLastDeliveredMessage: false,
       message: createPingMessage({
         caption: ko.pureComputed(() => 'caption'),
         unsafeSenderName: ko.pureComputed(() => 'sender'),

--- a/src/script/components/MessagesList/Message/PingMessage.tsx
+++ b/src/script/components/MessagesList/Message/PingMessage.tsx
@@ -19,6 +19,7 @@
 
 import cx from 'classnames';
 
+import {DeliveredIndicator} from 'Components/MessagesList/Message/DeliveredIndicator/DeliveredIndicator';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 
 import {ReadReceiptStatus} from './ReadReceiptStatus';
@@ -38,29 +39,28 @@ const PingMessage = ({message, is1to1Conversation, isLastDeliveredMessage}: Ping
   );
 
   return (
-    <div className="message-header" data-uie-name="element-message-ping">
-      <div className="message-header-icon">
-        <div className={`icon-ping ${get_icon_classes}`} />
-      </div>
-      <div
-        className={cx('message-header-label', {
-          'ephemeral-message-obfuscated': isObfuscated,
-        })}
-        title={ephemeral_caption}
-        data-uie-name="element-message-ping-text"
-      >
-        <p className="message-header-label__multiline">
-          <span className="message-header-sender-name">{unsafeSenderName}</span>
-          <span className="ellipsis">{caption}</span>
-        </p>
+    <>
+      <div className="message-header" data-uie-name="element-message-ping">
+        <div className="message-header-icon">
+          <div className={`icon-ping ${get_icon_classes}`} />
+        </div>
+        <div
+          className={cx('message-header-label', {
+            'ephemeral-message-obfuscated': isObfuscated,
+          })}
+          title={ephemeral_caption}
+          data-uie-name="element-message-ping-text"
+        >
+          <p className="message-header-label__multiline">
+            <span className="message-header-sender-name">{unsafeSenderName}</span>
+            <span className="ellipsis">{caption}</span>
+          </p>
 
-        <ReadReceiptStatus
-          message={message}
-          is1to1Conversation={is1to1Conversation}
-          isLastDeliveredMessage={isLastDeliveredMessage}
-        />
+          <ReadReceiptStatus message={message} is1to1Conversation={is1to1Conversation} />
+        </div>
       </div>
-    </div>
+      <DeliveredIndicator isLastDeliveredMessage={isLastDeliveredMessage} />
+    </>
   );
 };
 

--- a/src/script/components/MessagesList/Message/PingMessage.tsx
+++ b/src/script/components/MessagesList/Message/PingMessage.tsx
@@ -19,7 +19,6 @@
 
 import cx from 'classnames';
 
-import {DeliveredIndicator} from 'Components/MessagesList/Message/DeliveredIndicator/DeliveredIndicator';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 
 import {ReadReceiptStatus} from './ReadReceiptStatus';
@@ -29,38 +28,34 @@ import {PingMessage as PingMessageEntity} from '../../../entity/message/PingMess
 export interface PingMessageProps {
   message: PingMessageEntity;
   is1to1Conversation: boolean;
-  isLastDeliveredMessage: boolean;
 }
 
-const PingMessage = ({message, is1to1Conversation, isLastDeliveredMessage}: PingMessageProps) => {
+const PingMessage = ({message, is1to1Conversation}: PingMessageProps) => {
   const {unsafeSenderName, caption, ephemeral_caption, isObfuscated, get_icon_classes} = useKoSubscribableChildren(
     message,
     ['unsafeSenderName', 'caption', 'ephemeral_caption', 'isObfuscated', 'get_icon_classes'],
   );
 
   return (
-    <>
-      <div className="message-header" data-uie-name="element-message-ping">
-        <div className="message-header-icon">
-          <div className={`icon-ping ${get_icon_classes}`} />
-        </div>
-        <div
-          className={cx('message-header-label', {
-            'ephemeral-message-obfuscated': isObfuscated,
-          })}
-          title={ephemeral_caption}
-          data-uie-name="element-message-ping-text"
-        >
-          <p className="message-header-label__multiline">
-            <span className="message-header-sender-name">{unsafeSenderName}</span>
-            <span className="ellipsis">{caption}</span>
-          </p>
-
-          <ReadReceiptStatus message={message} is1to1Conversation={is1to1Conversation} />
-        </div>
+    <div className="message-header" data-uie-name="element-message-ping">
+      <div className="message-header-icon">
+        <div className={`icon-ping ${get_icon_classes}`} />
       </div>
-      <DeliveredIndicator isLastDeliveredMessage={isLastDeliveredMessage} />
-    </>
+      <div
+        className={cx('message-header-label', {
+          'ephemeral-message-obfuscated': isObfuscated,
+        })}
+        title={ephemeral_caption}
+        data-uie-name="element-message-ping-text"
+      >
+        <p className="message-header-label__multiline">
+          <span className="message-header-sender-name">{unsafeSenderName}</span>
+          <span className="ellipsis">{caption}</span>
+        </p>
+
+        <ReadReceiptStatus message={message} is1to1Conversation={is1to1Conversation} />
+      </div>
+    </div>
   );
 };
 

--- a/src/script/components/MessagesList/Message/ReadIndicator/ReadIndicator.styles.ts
+++ b/src/script/components/MessagesList/Message/ReadIndicator/ReadIndicator.styles.ts
@@ -33,6 +33,7 @@ export const ReadReceiptText: CSSObject = {
   display: 'inline-flex',
   alignItems: 'center',
   verticalAlign: 'text-bottom',
+  whiteSpace: 'nowrap',
 };
 
 export const ReadIndicatorStyles = (showIconOnly = false): CSSObject => ({

--- a/src/script/components/MessagesList/Message/ReadIndicator/ReadIndicator.tsx
+++ b/src/script/components/MessagesList/Message/ReadIndicator/ReadIndicator.tsx
@@ -19,7 +19,6 @@
 
 import {Icon} from 'Components/Icon';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
-import {t} from 'Util/LocalizerUtil';
 import {formatTimeShort} from 'Util/TimeUtil';
 
 import {ReadIndicatorContainer, ReadIndicatorStyles, ReadReceiptText} from './ReadIndicator.styles';
@@ -29,7 +28,6 @@ import {Message} from '../../../../entity/message/Message';
 interface ReadIndicatorProps {
   message: Message;
   is1to1Conversation?: boolean;
-  isLastDeliveredMessage?: boolean;
   showIconOnly?: boolean;
   onClick?: (message: Message) => void;
 }
@@ -37,7 +35,6 @@ interface ReadIndicatorProps {
 export const ReadIndicator = ({
   message,
   is1to1Conversation = false,
-  isLastDeliveredMessage = false,
   showIconOnly = false,
   onClick,
 }: ReadIndicatorProps) => {
@@ -45,15 +42,10 @@ export const ReadIndicator = ({
 
   if (is1to1Conversation) {
     const readReceiptText = readReceipts.length ? formatTimeShort(readReceipts[0].time) : '';
-    const showDeliveredMessage = isLastDeliveredMessage && readReceiptText === '';
 
     return (
       <div css={ReadIndicatorContainer} className="read-indicator-wrapper">
         <span css={ReadIndicatorStyles(showIconOnly)} data-uie-name="status-message-read-receipts">
-          {showDeliveredMessage && (
-            <span data-uie-name="status-message-read-receipt-delivered">{t('conversationMessageDelivered')}</span>
-          )}
-
           {showIconOnly && readReceiptText && <Icon.Read />}
 
           {!showIconOnly && !!readReceiptText && (

--- a/src/script/components/MessagesList/Message/ReadReceiptStatus.test.tsx
+++ b/src/script/components/MessagesList/Message/ReadReceiptStatus.test.tsx
@@ -51,22 +51,6 @@ describe('ReadReceiptStatus', () => {
     expect(queryByTestId('status-message-read-receipt-delivered')).toBeNull();
   });
 
-  it('shows "delivered" when noone read the message', () => {
-    const props = {
-      isMessageFocused: true,
-      is1to1Conversation: false,
-      isLastDeliveredMessage: true,
-      message: createReadReceiptMessage({
-        readReceipts: ko.observableArray([] as ReadReceipt[]),
-      }),
-    };
-
-    const {queryByTestId} = render(<ReadReceiptStatus {...props} />);
-
-    expect(queryByTestId('status-message-read-receipt-delivered')).not.toBeNull();
-    expect(queryByTestId('status-message-read-receipts')).toBeNull();
-  });
-
   it('shows the read icon', () => {
     const props = {
       isMessageFocused: true,

--- a/src/script/components/MessagesList/Message/ReadReceiptStatus.tsx
+++ b/src/script/components/MessagesList/Message/ReadReceiptStatus.tsx
@@ -29,17 +29,11 @@ import {formatTimeShort} from 'Util/TimeUtil';
 
 export interface ReadReceiptStatusProps {
   is1to1Conversation: boolean;
-  isLastDeliveredMessage: boolean;
   message: Message;
   onClickDetails?: (message: Message) => void;
 }
 
-export const ReadReceiptStatus = ({
-  message,
-  is1to1Conversation,
-  isLastDeliveredMessage,
-  onClickDetails,
-}: ReadReceiptStatusProps) => {
+export const ReadReceiptStatus = ({message, is1to1Conversation, onClickDetails}: ReadReceiptStatusProps) => {
   const [readReceiptText, setReadReceiptText] = useState('');
   const {readReceipts} = useKoSubscribableChildren(message, ['readReceipts']);
 
@@ -50,17 +44,10 @@ export const ReadReceiptStatus = ({
     }
   }, [is1to1Conversation, readReceipts]);
 
-  const showDeliveredMessage = isLastDeliveredMessage && readReceiptText === '';
   const showEyeIndicator = !!readReceiptText;
 
   return (
     <>
-      {showDeliveredMessage && (
-        <span className="message-status" data-uie-name="status-message-read-receipt-delivered">
-          {t('conversationMessageDelivered')}
-        </span>
-      )}
-
       {showEyeIndicator && (
         <button
           className={cx(

--- a/src/script/components/MessagesList/Message/index.tsx
+++ b/src/script/components/MessagesList/Message/index.tsx
@@ -81,6 +81,7 @@ export interface MessageParams extends MessageActions {
   handleArrowKeyDown: (e: React.KeyboardEvent) => void;
   isMsgElementsFocusable: boolean;
   setMsgElementsFocusable: (isMsgElementsFocusable: boolean) => void;
+  rightMarginWidth: number;
 }
 
 export const Message = (props: MessageParams & {scrollTo?: ScrollToElement}) => {
@@ -96,6 +97,7 @@ export const Message = (props: MessageParams & {scrollTo?: ScrollToElement}) => 
     handleArrowKeyDown,
     isMsgElementsFocusable,
     setMsgElementsFocusable,
+    rightMarginWidth,
   } = props;
   const messageElementRef = useRef<HTMLDivElement>(null);
   const {status, ephemeral_expires} = useKoSubscribableChildren(message, ['status', 'ephemeral_expires']);
@@ -151,6 +153,7 @@ export const Message = (props: MessageParams & {scrollTo?: ScrollToElement}) => 
       hideHeader={hideHeader}
       isFocused={isFocused}
       isMsgElementsFocusable={isMsgElementsFocusable}
+      rightMarginWidth={rightMarginWidth}
     />
   );
 

--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -24,6 +24,7 @@ import cx from 'classnames';
 
 import {FadingScrollbar} from 'Components/FadingScrollbar';
 import {JumpToLastMessageButton} from 'Components/MessagesList/JumpToLastMessageButton';
+import {DeliveredIndicator} from 'Components/MessagesList/Message/DeliveredIndicator/DeliveredIndicator';
 import {filterMessages} from 'Components/MessagesList/utils/messagesFilter';
 import {ConversationRepository} from 'src/script/conversation/ConversationRepository';
 import {MessageRepository} from 'src/script/conversation/MessageRepository';
@@ -120,6 +121,8 @@ export const MessagesList: FC<MessagesListParams> = ({
   const [loaded, setLoaded] = useState(false);
   const [highlightedMessage, setHighlightedMessage] = useState<string | undefined>(conversation.initialMessage()?.id);
   const conversationLastReadTimestamp = useRef(conversation.last_read_timestamp());
+
+  const [rightMarginWidth, setRightMarginWidth] = useState<number>(0);
 
   const filteredMessages = filterMessages(allMessages);
   const filteredMessagesLength = filteredMessages.length;
@@ -268,15 +271,26 @@ export const MessagesList: FC<MessagesListParams> = ({
     }
   };
 
+  const setDeliveredIndicatorWidth = (element: HTMLDivElement) => {
+    if (element?.offsetWidth > 0) {
+      setRightMarginWidth(element?.offsetWidth);
+    }
+  };
+
   return (
     <>
+      {rightMarginWidth === 0 && <DeliveredIndicator ref={setDeliveredIndicatorWidth} isLastDeliveredMessage={false} />}
       <FadingScrollbar
         ref={messageListRef}
         id="message-list"
         className={cx('message-list', {'is-right-panel-open': isRightSidebarOpen})}
         tabIndex={TabIndex.UNFOCUSABLE}
       >
-        <div ref={setMessagesContainer} className={cx('messages', {'flex-center': verticallyCenterMessage()})}>
+        <div
+          ref={setMessagesContainer}
+          className={cx('messages', {'flex-center': verticallyCenterMessage()})}
+          css={{marginRight: `${rightMarginWidth}px`}}
+        >
           {groupedMessages.flatMap((group, groupIndex) => {
             if (isMarker(group)) {
               return (
@@ -355,6 +369,7 @@ export const MessagesList: FC<MessagesListParams> = ({
                   handleArrowKeyDown={handleKeyDown}
                   isMsgElementsFocusable={isMsgElementsFocusable}
                   setMsgElementsFocusable={setMsgElementsFocusable}
+                  rightMarginWidth={rightMarginWidth}
                 />
               );
             });

--- a/src/style/components/asset/file-asset.less
+++ b/src/style/components/asset/file-asset.less
@@ -22,7 +22,7 @@
   width: 100%;
   flex-wrap: wrap;
   align-self: center;
-  padding: 12px;
+  padding: 12px 0 12px 12px;
 }
 
 .file {

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -467,6 +467,7 @@
       flex-direction: column;
       .message-status-read__count {
         margin-left: 0;
+        white-space: nowrap;
       }
     }
   }

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -274,7 +274,6 @@
 // MESSAGE - BODY
 .message-body {
   position: relative;
-  padding-right: 40px;
   padding-left: var(--conversation-message-sender-width);
 
   .text:has(> .iframe-container) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9170" title="WPB-9170" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-9170</a>  Improve  hover states and paddings for delivered status
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

Now the conversation should have additional empty space at the right, and the last delivered message should contain a translated "Delivered" indicator, visible always (instead of on mouse over).
This feature design was made considering that most of the webapp/desktop users use it on res 800px+, design improvements for smaller screens will be defined later.
After this version is deployed, we might implement another design with checkboxes (under a separate ticket) that can be toggled using debug

_**Note 1:**_ _for the first implementation, where each message had an additional div to the right:_ I assumed that any message header would be short enough to not wrap it into the container that takes `100% - ${deliveredIndicatorWidth}px`. It might be the improvement for the next design iteration to address the small screen look

**_Note 2:_** _for the second implementation, where the entire `MessageList` has a margin:_ Now the `MessageList` has to add and immediately remove the "Delivered" indicator to identify its width. Another option could be to add a static margin (of ~100px) and listen to the message components when one of them will have to add this indicator, then adjust the margin width. Another option could be that each message component could have a margin, but I'm not sure what we will win here


## Screenshots/Screencast (for UI changes)

![Screenshot 2024-06-10 at 21 32 32](https://github.com/wireapp/wire-webapp/assets/24770159/6aa88fcd-5ab8-4bd6-a99c-c8fd1ff2dd7b)

![Screenshot 2024-06-10 at 21 32 59](https://github.com/wireapp/wire-webapp/assets/24770159/6b2b6f4b-a027-4040-96fb-ff732bd60b23)

![Screenshot 2024-06-10 at 21 33 36](https://github.com/wireapp/wire-webapp/assets/24770159/44adbd4d-887d-4ff2-a644-938e2e38aefe)

![Screenshot 2024-06-10 at 21 34 06](https://github.com/wireapp/wire-webapp/assets/24770159/127f1f76-2acc-448b-b29b-6bb8aae50a72)

![Screenshot 2024-06-10 at 21 35 36](https://github.com/wireapp/wire-webapp/assets/24770159/05af8a21-18be-46a8-ba2c-3f233fa7d722)

![Screenshot 2024-06-12 at 11 50 17](https://github.com/wireapp/wire-webapp/assets/24770159/81fe6928-1402-4152-b14a-f6bfda205841)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;
