### PR TITLE
fix: remove user details avatar flicker [WPB-5299]

### DIFF
--- a/src/script/page/RightSidebar/RightSidebar.tsx
+++ b/src/script/page/RightSidebar/RightSidebar.tsx
@@ -215,6 +215,7 @@ const RightSidebar: FC<RightSidebarProps> = ({
 
           {currentState === PanelState.GROUP_PARTICIPANT_USER && userEntity && (
             <GroupParticipantUser
+              key={userEntity.id}
               onBack={onBackClick}
               onClose={closePanel}
               goToRoot={goToRoot}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5299" title="WPB-5299" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5299</a>  [Web] Profile picture for account without profile picture taken from previously looked at contact
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Fixes a profile avatar flicker that we can see when clicking on a user avatar when the user details of some other users is already opened. See gifs below. The solution is to add a key prop to the component so we're sure it's being reset every time we switch to a different user.

## Screenshots/Screencast (for UI changes)
Before
![before](https://github.com/wireapp/wire-webapp/assets/45733298/9eb23e35-0e08-461b-9bf3-d2b5d41f55a3)


After
![after](https://github.com/wireapp/wire-webapp/assets/45733298/c50ace07-e4c4-4b92-9ceb-fe119e5d72a5)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
