### PR TITLE
feat: persist sidebar open/close state

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationHeader/ConversationHeader.styles.ts
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationHeader/ConversationHeader.styles.ts
@@ -33,6 +33,9 @@ export const label: CSSObject = {
   fontWeight: 'var(--font-weight-semibold)',
   fontSize: 'var(--font-size-base)',
   paddingBlock: '8px',
+  textOverflow: 'ellipsis',
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
 };
 
 export const button: CSSObject = {

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.tsx
@@ -19,12 +19,14 @@
 
 import cx from 'classnames';
 
+import {useMatchMedia} from '@wireapp/react-ui-kit';
+
 import {Config} from 'src/script/Config';
 import {createLabel} from 'src/script/conversation/ConversationLabelRepository';
 import {ConversationRepository} from 'src/script/conversation/ConversationRepository';
 import {Conversation} from 'src/script/entity/Conversation';
 import {
-  SidebarOpenStatus,
+  SidebarStatus,
   SidebarTabs,
   useFolderState,
   useSidebarStore,
@@ -57,9 +59,11 @@ export const ConversationFolderTab = ({
   unreadConversations = [],
   dataUieName,
 }: ConversationFolderTabProps) => {
-  const {isOpen: isSidebarOpen, openStatus: sideBarOpenStatus, setOpenStatus: setSideBarOpenStatus} = useSidebarStore();
+  const {status: sidebarStatus, setStatus: setSidebarStatus} = useSidebarStore();
   const {openFolder, isFoldersTabOpen, toggleFoldersTab, expandedFolder} = useFolderState();
   const {conversationLabelRepository} = conversationRepository;
+  const mdBreakpoint = useMatchMedia('(max-width: 1000px)');
+  const isSideBarOpen = sidebarStatus === SidebarStatus.AUTO ? mdBreakpoint : sidebarStatus === SidebarStatus.OPEN;
 
   function toggleFolder(folderId: string) {
     openFolder(folderId);
@@ -91,13 +95,13 @@ export const ConversationFolderTab = ({
   }
 
   function handleToggleFoldersTab(event: React.MouseEvent<HTMLButtonElement>) {
-    if (isSidebarOpen(sideBarOpenStatus)) {
+    if (isSideBarOpen) {
       toggleFoldersTab();
       return;
     }
 
     if (folders.length === 0) {
-      setSideBarOpenStatus(SidebarOpenStatus.OPEN);
+      setSidebarStatus(SidebarStatus.OPEN);
       return;
     }
 

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.tsx
@@ -23,7 +23,12 @@ import {Config} from 'src/script/Config';
 import {createLabel} from 'src/script/conversation/ConversationLabelRepository';
 import {ConversationRepository} from 'src/script/conversation/ConversationRepository';
 import {Conversation} from 'src/script/entity/Conversation';
-import {SidebarTabs, useFolderState, useSidebarStore} from 'src/script/page/LeftSidebar/panels/Conversations/state';
+import {
+  SidebarOpenStatus,
+  SidebarTabs,
+  useFolderState,
+  useSidebarStore,
+} from 'src/script/page/LeftSidebar/panels/Conversations/state';
 import {ContextMenuEntry, showContextMenu} from 'src/script/ui/ContextMenu';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
@@ -52,7 +57,7 @@ export const ConversationFolderTab = ({
   unreadConversations = [],
   dataUieName,
 }: ConversationFolderTabProps) => {
-  const {isOpen: isSidebarOpen, setIsOpen: setIsSidebarOpen} = useSidebarStore();
+  const {isOpen: isSidebarOpen, openStatus: sideBarOpenStatus, setOpenStatus: setSideBarOpenStatus} = useSidebarStore();
   const {openFolder, isFoldersTabOpen, toggleFoldersTab, expandedFolder} = useFolderState();
   const {conversationLabelRepository} = conversationRepository;
 
@@ -86,13 +91,13 @@ export const ConversationFolderTab = ({
   }
 
   function handleToggleFoldersTab(event: React.MouseEvent<HTMLButtonElement>) {
-    if (isSidebarOpen) {
+    if (isSidebarOpen(sideBarOpenStatus)) {
       toggleFoldersTab();
       return;
     }
 
     if (folders.length === 0) {
-      setIsSidebarOpen(true);
+      setSideBarOpenStatus(SidebarOpenStatus.OPEN);
       return;
     }
 

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -49,7 +49,7 @@ import {ConversationsList} from './ConversationsList';
 import {ConversationTabs} from './ConversationTabs';
 import {EmptyConversationList} from './EmptyConversationList';
 import {getTabConversations} from './helpers';
-import {SidebarTabs, useFolderState, useSidebarStore} from './state';
+import {SidebarOpenStatus, SidebarTabs, useFolderState, useSidebarStore} from './state';
 
 import {CallingViewMode, CallState} from '../../../../calling/CallState';
 import {createLabel} from '../../../../conversation/ConversationLabelRepository';
@@ -98,10 +98,11 @@ const Conversations: React.FC<ConversationsProps> = ({
   selfUser,
 }) => {
   const {
-    isOpen: isSideBarOpen,
-    toggleIsOpen: toggleSidebarIsOpen,
-    setIsOpen: setIsSidebarOpen,
     currentTab,
+    isOpen: isSideBarOpen,
+    openStatus: sideBarOpenStatus,
+    setOpenStatus: setSidebarOpenStatus,
+    toggleOpenStatus: toggleSidebarIsOpen,
     setCurrentTab,
   } = useSidebarStore();
   const [conversationsFilter, setConversationsFilter] = useState<string>('');
@@ -173,8 +174,10 @@ const Conversations: React.FC<ConversationsProps> = ({
   const mdBreakpoint = useMatchMedia('(max-width: 1000px)');
 
   useEffect(() => {
-    setIsSidebarOpen(!mdBreakpoint);
-  }, [mdBreakpoint, setIsSidebarOpen]);
+    if (sideBarOpenStatus !== SidebarOpenStatus.MANUAL_OPEN && sideBarOpenStatus !== SidebarOpenStatus.MANUAL_CLOSED) {
+      setSidebarOpenStatus(mdBreakpoint ? SidebarOpenStatus.CLOSED : SidebarOpenStatus.OPEN);
+    }
+  }, [mdBreakpoint, setSidebarOpenStatus, sideBarOpenStatus]);
 
   useEffect(() => {
     if (activeConversation && !conversationState.isVisible(activeConversation)) {
@@ -250,7 +253,7 @@ const Conversations: React.FC<ConversationsProps> = ({
           user={selfUser}
           groupId={conversationState.selfMLSConversation()?.groupId}
           isTeam={isTeam}
-          isSideBarOpen={isSideBarOpen}
+          isSideBarOpen={isSideBarOpen(sideBarOpenStatus)}
         />
 
         <ConversationTabs
@@ -267,7 +270,7 @@ const Conversations: React.FC<ConversationsProps> = ({
       </FadingScrollbar>
 
       <IconButton
-        css={conversationsSidebarHandleStyles(isSideBarOpen)}
+        css={conversationsSidebarHandleStyles(isSideBarOpen(sideBarOpenStatus))}
         className="conversations-sidebar-handle"
         onClick={toggleSidebar}
       >

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -248,7 +248,7 @@ const Conversations: React.FC<ConversationsProps> = ({
 
   const sidebar = (
     <nav className="conversations-sidebar" css={conversationsSidebarStyles(mdBreakpoint)}>
-      <FadingScrollbar className="conversations-sidebar-items" data-is-collapsed={!isSideBarOpen}>
+      <FadingScrollbar className="conversations-sidebar-items" data-is-collapsed={!isSideBarOpen(sideBarOpenStatus)}>
         <UserDetails
           user={selfUser}
           groupId={conversationState.selfMLSConversation()?.groupId}

--- a/src/script/page/LeftSidebar/panels/Conversations/EmptyConversationList/EmptyConversationList.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/EmptyConversationList/EmptyConversationList.tsx
@@ -47,7 +47,7 @@ export const EmptyConversationList = ({currentTab, onChangeTab, searchValue = ''
     </Button>
   );
 
-  if (currentTab === SidebarTabs.RECENT) {
+  if (currentTab === SidebarTabs.RECENT || currentTab === SidebarTabs.FOLDER) {
     return (
       <div css={wrapper}>
         <div>

--- a/src/script/page/LeftSidebar/panels/Conversations/state.ts
+++ b/src/script/page/LeftSidebar/panels/Conversations/state.ts
@@ -69,49 +69,35 @@ export enum SidebarTabs {
   PREFERENCES,
 }
 
-export const SidebarOpenStatus = {
+export const SidebarStatus = {
   OPEN: 'OPEN',
   CLOSED: 'CLOSED',
-  MANUAL_OPEN: 'MANUAL_OPEN',
-  MANUAL_CLOSED: 'MANUAL_CLOSED',
+  AUTO: 'AUTO',
 } as const;
 
-export type SidebarOpenStatus = (typeof SidebarOpenStatus)[keyof typeof SidebarOpenStatus];
+export type SidebarStatus = (typeof SidebarStatus)[keyof typeof SidebarStatus];
 
 export interface SidebarStore {
-  openStatus: SidebarOpenStatus;
-  setOpenStatus: (status: SidebarOpenStatus) => void;
-  toggleOpenStatus: () => void;
+  status: SidebarStatus;
+  setStatus: (status: SidebarStatus) => void;
   currentTab: SidebarTabs;
-  isOpen: (openStatus: SidebarOpenStatus) => boolean;
   setCurrentTab: (tab: SidebarTabs) => void;
 }
 
 const useSidebarStore = create<SidebarStore>()(
   persist(
-    (set, get) => ({
+    set => ({
       currentTab: SidebarTabs.RECENT,
       setCurrentTab: (tab: SidebarTabs) => {
         set({currentTab: tab});
       },
-      openStatus: SidebarOpenStatus.CLOSED,
-      setOpenStatus: status => set({openStatus: status}),
-      isOpen: (openStatus: SidebarOpenStatus) => {
-        return openStatus === SidebarOpenStatus.MANUAL_OPEN || openStatus === SidebarOpenStatus.OPEN;
-      },
-      toggleOpenStatus: () => {
-        const currentStatus = get().openStatus;
-        const newStatus =
-          currentStatus === SidebarOpenStatus.MANUAL_OPEN || currentStatus === SidebarOpenStatus.OPEN
-            ? SidebarOpenStatus.MANUAL_CLOSED
-            : SidebarOpenStatus.MANUAL_OPEN;
-        set({openStatus: newStatus});
-      },
+      status: SidebarStatus.CLOSED,
+      setStatus: status => set({status: status}),
     }),
     {
       name: 'sidebar-store',
       storage: createJSONStorage(() => localStorage),
-      partialize: state => ({openStatus: state.openStatus}),
+      partialize: state => ({status: state.status}),
     },
   ),
 );

--- a/src/script/page/LeftSidebar/panels/Conversations/state.ts
+++ b/src/script/page/LeftSidebar/panels/Conversations/state.ts
@@ -109,9 +109,9 @@ const useSidebarStore = create<SidebarStore>()(
       },
     }),
     {
-      name: 'sidebar-store', // name of the item in the storage (must be unique)
-      storage: createJSONStorage(() => localStorage), // (optional) by default, 'localStorage' is used
-      partialize: state => ({openStatus: state.openStatus}), // persist openStatus
+      name: 'sidebar-store',
+      storage: createJSONStorage(() => localStorage),
+      partialize: state => ({openStatus: state.openStatus}),
     },
   ),
 );

--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -167,6 +167,12 @@
     font-size: 12px;
     font-weight: 400;
 
+    > span {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
     .conversations-sidebar-btn--badge {
       top: 8px;
       left: 8px;


### PR DESCRIPTION
## Description
# Persist Sidebar Open/Close State

This pull request introduces a feature to persist the open/close state of the sidebar across sessions. The state is saved to `localStorage` using Zustand's `persist` middleware. This ensures that the sidebar retains its state even after a page refresh or browser restart.

### Changes

1. **Define Sidebar Open Status Constants**:
   - Introduced `SidebarOpenStatus` as an object with `OPEN`, `CLOSED`, `MANUAL_OPEN`, and `MANUAL_CLOSED` states.
   - Created a type `SidebarOpenStatus` for better TypeScript support.

2. **Update Zustand Store**:
   - Added `openStatus` to track the sidebar's state.
   - Updated actions to handle setting and toggling the `openStatus`.
   - Used Zustand's `persist` middleware to store the `openStatus` in `localStorage`.

3. **Update Sidebar Component**:
   - Modified the `useEffect` hook to respect the manually set `openStatus`.
   - Ensured that the sidebar state is set based on the `openStatus` and screen size breakpoint.

## Screenshots/Screencast (for UI changes)

https://github.com/wireapp/wire-webapp/assets/63250054/32357127-9266-4eac-8cd5-f4badd1d612e

