### PR TITLE
fix: Display Media Device labels for Firefox 

### DIFF
--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -882,7 +882,10 @@ export class CallingRepository {
       if (newState === VIDEO_STATE.STOPPED) {
         selfParticipant.releaseVideoStream(true);
       } else {
-        this.warmupMediaStreams(call, false, true);
+        this.mediaDevicesHandler
+          .initializeMediaDevices(true)
+          .then(() => this.warmupMediaStreams(call, false, true))
+          .catch(error => this.logger.warn('Failed to start video stream', error));
       }
     }
     this.wCall?.setVideoSendState(this.wUser, this.serializeQualifiedId(call.conversation.qualifiedId), newState);

--- a/src/script/media/MediaDevicesHandler.test.ts
+++ b/src/script/media/MediaDevicesHandler.test.ts
@@ -144,9 +144,14 @@ describe('MediaDevicesHandler', () => {
     ],
   };
 
+  let enumerateDevicesSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    enumerateDevicesSpy = spyOn(window.navigator.mediaDevices, 'enumerateDevices');
+  });
   describe('refreshMediaDevices', () => {
-    it('filters duplicate microphones and keeps the ones marked with "communications"', () => {
-      spyOn(navigator.mediaDevices, 'enumerateDevices').and.returnValue(
+    it('filters duplicate microphones and keeps the ones marked with "communications"', done => {
+      enumerateDevicesSpy.and.returnValue(
         Promise.resolve([
           {
             deviceId: 'default',
@@ -170,14 +175,19 @@ describe('MediaDevicesHandler', () => {
       );
 
       const devicesHandler = new MediaDevicesHandler();
+      devicesHandler.getMediaDeviceAccessStream = (_: boolean) => {
+        return Promise.resolve(new MediaStream());
+      };
+      devicesHandler.initializeMediaDevices(true);
 
       setTimeout(() => {
         expect(devicesHandler.availableDevices.audioinput().length).toEqual(1);
+        done();
       });
     });
 
-    it('filters duplicate speakers', () => {
-      spyOn(navigator.mediaDevices, 'enumerateDevices').and.returnValue(
+    it('filters duplicate speakers', done => {
+      enumerateDevicesSpy.and.returnValue(
         Promise.resolve([
           ...realWorldTestSetup.cameras,
           ...realWorldTestSetup.microphones,
@@ -186,6 +196,10 @@ describe('MediaDevicesHandler', () => {
       );
 
       const devicesHandler = new MediaDevicesHandler();
+      devicesHandler.getMediaDeviceAccessStream = (_: boolean) => {
+        return Promise.resolve(new MediaStream());
+      };
+      devicesHandler.initializeMediaDevices(true);
 
       expect(realWorldTestSetup.cameras.length).toEqual(2);
       expect(realWorldTestSetup.microphones.length).toEqual(5);
@@ -195,13 +209,13 @@ describe('MediaDevicesHandler', () => {
         expect(devicesHandler.availableDevices.videoinput().length).toEqual(2);
         expect(devicesHandler.availableDevices.audioinput().length).toEqual(3);
         expect(devicesHandler.availableDevices.audiooutput().length).toEqual(4);
+        done();
       });
     });
   });
 
-  describe('constructor', () => {
+  describe('initializeMediaDevices', () => {
     it('loads available devices and listens to input devices changes', done => {
-      const enumerateDevicesSpy = spyOn(navigator.mediaDevices, 'enumerateDevices');
       enumerateDevicesSpy.and.returnValue(
         Promise.resolve([
           ...fakeWorldTestSetup.cameras,
@@ -211,8 +225,13 @@ describe('MediaDevicesHandler', () => {
       );
 
       const devicesHandler = new MediaDevicesHandler();
+      devicesHandler.getMediaDeviceAccessStream = (_: boolean) => {
+        return Promise.resolve(new MediaStream());
+      };
+      devicesHandler.initializeMediaDevices(true);
+
       setTimeout(() => {
-        expect(navigator.mediaDevices.enumerateDevices).toHaveBeenCalledTimes(1);
+        expect(enumerateDevicesSpy).toHaveBeenCalledTimes(1);
         expect(devicesHandler.availableDevices.videoinput()).toEqual(fakeWorldTestSetup.cameras);
         expect(devicesHandler.availableDevices.audiooutput()).toEqual(fakeWorldTestSetup.speakers);
 
@@ -221,7 +240,7 @@ describe('MediaDevicesHandler', () => {
         navigator.mediaDevices!.ondevicechange?.(Event.prototype);
 
         setTimeout(() => {
-          expect(navigator.mediaDevices.enumerateDevices).toHaveBeenCalledTimes(2);
+          expect(enumerateDevicesSpy).toHaveBeenCalledTimes(2);
           expect(devicesHandler.availableDevices.videoinput()).toEqual(newCameras);
           expect(devicesHandler.availableDevices.audiooutput()).toEqual([]);
           done();
@@ -232,7 +251,7 @@ describe('MediaDevicesHandler', () => {
 
   describe('currentAvailableDeviceId', () => {
     it('only exposes available device', done => {
-      spyOn(navigator.mediaDevices, 'enumerateDevices').and.returnValue(
+      enumerateDevicesSpy.and.returnValue(
         Promise.resolve([
           ...fakeWorldTestSetup.cameras,
           ...fakeWorldTestSetup.microphones,
@@ -241,6 +260,11 @@ describe('MediaDevicesHandler', () => {
       );
 
       const devicesHandler = new MediaDevicesHandler();
+      devicesHandler.getMediaDeviceAccessStream = (_: boolean) => {
+        return Promise.resolve(new MediaStream());
+      };
+      devicesHandler.initializeMediaDevices(true);
+
       setTimeout(() => {
         devicesHandler.currentDeviceId.videoinput(fakeWorldTestSetup.cameras[0].deviceId);
 

--- a/src/script/media/MediaDevicesHandler.ts
+++ b/src/script/media/MediaDevicesHandler.ts
@@ -79,6 +79,7 @@ export class MediaDevicesHandler {
   public deviceSupport: DeviceSupport;
   private previousDeviceSupport: PreviousDeviceSupport;
   private onMediaDevicesRefresh?: () => void;
+  private devicesAreInit = false;
 
   static get CONFIG() {
     return {
@@ -152,8 +153,6 @@ export class MediaDevicesHandler {
       audiooutput: this.availableDevices.audiooutput().length,
       videoinput: this.availableDevices.videoinput().length,
     };
-
-    this.initializeMediaDevices();
   }
 
   public setOnMediaDevicesRefreshHandler(handler: () => void): void {
@@ -163,13 +162,15 @@ export class MediaDevicesHandler {
   /**
    * Initialize the list of MediaDevices and subscriptions.
    */
-  private initializeMediaDevices(): void {
-    if (Runtime.isSupportingUserMedia()) {
-      this.refreshMediaDevices().then(() => {
+  public initializeMediaDevices(): Promise<MediaDeviceInfo[] | void> {
+    if (Runtime.isSupportingUserMedia() && !this.devicesAreInit) {
+      this.devicesAreInit = true;
+      return this.refreshMediaDevices().then(() => {
         this.subscribeToObservables();
         this.subscribeToDevices();
       });
     }
+    return Promise.resolve();
   }
 
   /**

--- a/src/script/media/MediaRepository.ts
+++ b/src/script/media/MediaRepository.ts
@@ -32,5 +32,8 @@ export class MediaRepository {
     this.devicesHandler = new MediaDevicesHandler();
     this.constraintsHandler = new MediaConstraintsHandler(this.devicesHandler.currentAvailableDeviceId);
     this.streamHandler = new MediaStreamHandler(this.constraintsHandler, permissionRepository);
+    this.devicesHandler.getMediaDeviceAccessStream = (withVideo: boolean): Promise<MediaStream | void> => {
+      return this.streamHandler.requestMediaSreamAccess(withVideo);
+    };
   }
 }

--- a/src/script/media/MediaStreamHandler.ts
+++ b/src/script/media/MediaStreamHandler.ts
@@ -72,6 +72,35 @@ export class MediaStreamHandler {
     }
   }
 
+  /**
+   * The method creates a media stream to enforce access rights to the camera and the microphone. If access is not possible, it starts a user pop-up
+   * @param video When `video=true` then the camera is also addressed. In many cases this is not necessary, because one
+   * track is enough to enforce the general permissions.
+   * @returns Promise with active MediaStream
+   */
+  requestMediaSreamAccess(video: boolean): Promise<MediaStream> {
+    const audio = true;
+    const screen = false;
+    return window.navigator.mediaDevices
+      .getUserMedia({audio, video})
+      .then((mediaStream: MediaStream) => {
+        return mediaStream;
+      })
+      .catch((error: Error) => {
+        const name = error.name as MEDIA_STREAM_ERROR;
+        if (
+          [
+            MEDIA_STREAM_ERROR.NOT_READABLE_ERROR,
+            MEDIA_STREAM_ERROR.NOT_ALLOWED_ERROR,
+            MEDIA_STREAM_ERROR.NOT_FOUND_ERROR,
+          ].includes(name)
+        ) {
+          this.schedulePermissionHint(audio, video, screen);
+        }
+        throw error;
+      });
+  }
+
   selectScreenToShare(showScreenSelection: () => Promise<void>): Promise<void> {
     if (this.screensharingMethod === ScreensharingMethods.DESKTOP_CAPTURER) {
       return showScreenSelection();

--- a/src/script/page/MainContent/panels/preferences/AVPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/AVPreferences.tsx
@@ -58,7 +58,7 @@ const AVPreferences = ({
   const initializeMediaDevices = async () => {
     setCheckingPermissions(true);
     try {
-      await devicesHandler?.initializeMediaDevices();
+      await devicesHandler?.initializeMediaDevices(true);
     } catch (error) {
       logger.warn(`Initialization of media devices failed: ${error.message}`, error);
     } finally {
@@ -72,6 +72,11 @@ const AVPreferences = ({
 
   return (
     <PreferencesPage title={t('preferencesAV')}>
+      {isCheckingPermissions && (
+        <div className="preferences-av-spinner-select">
+          <div className="icon-spinner spin accent-text"></div>
+        </div>
+      )}
       {!isCheckingPermissions && deviceSupport.audioinput && (
         <MicrophonePreferences
           {...{devicesHandler, streamHandler}}

--- a/src/script/page/MainContent/panels/preferences/AVPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/AVPreferences.tsx
@@ -17,9 +17,12 @@
  *
  */
 
+import {useEffect, useState} from 'react';
+
 import {MediaDeviceType} from 'src/script/media/MediaDeviceType';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
+import {getLogger} from 'Util/Logger';
 
 import {AudioOutPreferences} from './avPreferences/AudioOutPreferences';
 import {CallOptions} from './avPreferences/CallOptions';
@@ -32,6 +35,8 @@ import type {CallingRepository} from '../../../../calling/CallingRepository';
 import type {MediaRepository} from '../../../../media/MediaRepository';
 import type {PropertiesRepository} from '../../../../properties/PropertiesRepository';
 
+const logger = getLogger('AVPreferences');
+
 interface AVPreferencesProps {
   callingRepository: CallingRepository;
   mediaRepository: MediaRepository;
@@ -43,22 +48,38 @@ const AVPreferences = ({
   propertiesRepository,
   callingRepository,
 }: AVPreferencesProps) => {
+  const [isCheckingPermissions, setCheckingPermissions] = useState(false);
   const deviceSupport = useKoSubscribableChildren(devicesHandler?.deviceSupport, [
     MediaDeviceType.AUDIO_INPUT,
     MediaDeviceType.AUDIO_OUTPUT,
     MediaDeviceType.VIDEO_INPUT,
   ]);
 
+  const initializeMediaDevices = async () => {
+    setCheckingPermissions(true);
+    try {
+      await devicesHandler?.initializeMediaDevices();
+    } catch (error) {
+      logger.warn(`Initialization of media devices failed: ${error.message}`, error);
+    } finally {
+      setCheckingPermissions(false);
+    }
+  };
+
+  useEffect(() => {
+    initializeMediaDevices();
+  }, []);
+
   return (
     <PreferencesPage title={t('preferencesAV')}>
-      {deviceSupport.audioinput && (
+      {!isCheckingPermissions && deviceSupport.audioinput && (
         <MicrophonePreferences
           {...{devicesHandler, streamHandler}}
           refreshStream={() => callingRepository.refreshAudioInput()}
         />
       )}
-      {deviceSupport.audiooutput && <AudioOutPreferences {...{devicesHandler}} />}
-      {deviceSupport.videoinput && (
+      {!isCheckingPermissions && deviceSupport.audiooutput && <AudioOutPreferences {...{devicesHandler}} />}
+      {!isCheckingPermissions && deviceSupport.videoinput && (
         <CameraPreferences
           {...{devicesHandler, streamHandler}}
           refreshStream={() => callingRepository.refreshVideoInput()}

--- a/src/script/view_model/CallingViewModel.mocks.ts
+++ b/src/script/view_model/CallingViewModel.mocks.ts
@@ -28,6 +28,7 @@ import {Call} from '../calling/Call';
 import {CallingRepository} from '../calling/CallingRepository';
 import {CallState} from '../calling/CallState';
 import {Conversation} from '../entity/Conversation';
+import {MediaDevicesHandler} from '../media/MediaDevicesHandler';
 import {Core} from '../service/CoreSingleton';
 
 export const mockCallingRepository = {
@@ -44,6 +45,10 @@ export const mockCallingRepository = {
   supportsConferenceCalling: true,
 } as unknown as CallingRepository;
 
+export const mockMediaDevicesHandler = {
+  initializeMediaDevices: jest.fn(() => Promise.resolve()),
+} as unknown as MediaDevicesHandler;
+
 export const callState = new CallState();
 
 export function buildCall(conversation: Conversation, convType = CONV_TYPE.ONEONONE) {
@@ -57,7 +62,7 @@ export function buildCallingViewModel() {
   const callingViewModel = new CallingViewModel(
     mockCallingRepository,
     {} as any,
-    {} as any,
+    mockMediaDevicesHandler,
     {} as any,
     {} as any,
     {} as any,

--- a/src/style/content/preferences/av.less
+++ b/src/style/content/preferences/av.less
@@ -20,6 +20,16 @@
 .preferences-av-detail {
   margin: 16px 0 8px;
 }
+.preferences-av-spinner-select {
+  display: flex;
+
+  width: @icon-size-sm;
+  height: 150px;
+  align-items: center;
+  justify-content: center;
+  margin: auto;
+  text-align: center;
+}
 
 .preferences-av-spinner {
   width: @icon-size-sm;


### PR DESCRIPTION
## Description
In Firefox, the labels of the Media devices can only be read under certain constrains. This means that the device names cannot be displayed in the select menu. This PR is a fix for it

## Screenshots/Screencast (for UI changes)
Before this fix, the selection fields are displayed with blank labels or common names:

<img width="728" alt="Bildschirmfoto 2024-06-12 um 14 06 46" src="https://github.com/wireapp/wire-webapp/assets/1362436/90eb7775-88e8-4530-b561-bce08a52a0ed">

<img width="1031" alt="Bildschirmfoto 2024-06-12 um 18 21 16" src="https://github.com/wireapp/wire-webapp/assets/1362436/c9762ba2-2990-429f-b213-8fc4e30a6b4b">

----

With this fix, the selection fields are displayed with device names:

<img width="860" alt="Bildschirmfoto 2024-06-12 um 16 34 24" src="https://github.com/wireapp/wire-webapp/assets/1362436/183e794a-6c90-4667-8254-51d08ed54a6d">

<img width="1029" alt="Bildschirmfoto 2024-06-12 um 18 21 58" src="https://github.com/wireapp/wire-webapp/assets/1362436/52283b53-4934-449d-aedc-2e26460dbbe9">

----

# Notes
The fix has one disadvantage. I had to change the device list initialization process to avoid asking a user for audio access rights on first login starting page.

![Bildschirmfoto 2024-06-24 um 15 06 23](https://github.com/wireapp/wire-webapp/assets/1362436/5c51ec4b-8e98-4dfc-80ae-b0ca4ffd5d04)

In order to display the correct device labels, we need to make an access authorization query when creating the device list. But we should not ask for microphone and camera access when not needed. 

To avoid a permission query being displayed when starting the app, I have rewritten the `MediaDeviceHandler` and The device list is no longer created in the constructor. The method [`MediaDeviceHandler.initializeMediaDevices`](https://github.com/wireapp/wire-webapp/blob/58675eaa1ab85f2553ede4d49d875991b2627c94/src/script/media/MediaDevicesHandler.ts#L168-L176) is now integrated into the three points in our app where a call can be accepted or started. In addition, this method is also called in the device settings. So, a device list is only created before the first call or when the settings are called. 

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
