### PR TITLE
chore(copy): updating outdated text [WPB-7110]

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -1181,7 +1181,7 @@
   "participantDevicesHeader": "Devices",
   "participantDevicesHeadline": "{{brandName}} gives every device a unique fingerprint. Compare them with {{user}} and verify your conversation.",
   "participantDevicesLearnMore": "Learn more",
-  "participantDevicesOutdatedClientMessage": "{{user}} is using an old version of {{brandName}}. No devices are shown here.",
+  "participantDevicesNoClients": "{{user}} has no devices attached to their account and won’t get your messages or calls at the moment.",
   "participantDevicesProteusDeviceVerification": "Proteus Device Verification",
   "participantDevicesProteusKeyFingerprint": "Proteus Key Fingerprint",
   "participantDevicesSelfAllDevices": "Show all my devices",

--- a/src/script/components/userDevices/NoDevicesFound.tsx
+++ b/src/script/components/userDevices/NoDevicesFound.tsx
@@ -24,9 +24,7 @@ import cx from 'classnames';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 
-import {Config} from '../../Config';
 import type {User} from '../../entity/User';
-import {externalUrl} from '../../externalRoute';
 
 interface NoDevicesFoundProps {
   noPadding: boolean;
@@ -40,20 +38,11 @@ const NoDevicesFound: React.FC<NoDevicesFoundProps> = ({user, noPadding}) => {
     <div className={cx('participant-devices__header', {'participant-devices__header--padding': !noPadding})}>
       <p className="participant-devices__text-block panel__info-text" data-uie-name="status-devices-headline">
         {user
-          ? t('participantDevicesOutdatedClientMessage', {
-              brandName: Config.getConfig().BRAND_NAME,
+          ? t('participantDevicesNoClients', {
               user: userName,
             })
           : ''}
       </p>
-      <a
-        className="participant-devices__link accent-text"
-        href={externalUrl.privacyPolicy}
-        rel="nofollow noopener noreferrer"
-        target="_blank"
-      >
-        {t('participantDevicesLearnMore')}
-      </a>
     </div>
   );
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7110" title="WPB-7110" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7110</a>  Fix dead "Learn more" link
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
removed an instance of old and outdated text. 
This is around a case where a user has deleted all of their clients. 
It used to be possible with an old verison of the backend but currently it is more likely (although still extremely rare) if a user deletes all their clients
This text shows up in the device panel for a user if they have no devices.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
