### PR TITLE
runfix: write blurred background js file to an accessible server path

### DIFF
--- a/src/script/media/VideoBackgroundBlur.ts
+++ b/src/script/media/VideoBackgroundBlur.ts
@@ -74,7 +74,7 @@ function startBlurProcess(
 }
 
 async function createSegmenter(canvas: HTMLCanvasElement): Promise<ImageSegmenter> {
-  const video = await FilesetResolver.forVisionTasks('./mediapipe/wasm');
+  const video = await FilesetResolver.forVisionTasks('/min/mediapipe/wasm');
   return ImageSegmenter.createFromOptions(video, {
     baseOptions: {
       modelAssetPath: QualitySettings.segmentationModel,

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -156,7 +156,7 @@ module.exports = {
         {
           context: 'node_modules/@mediapipe/tasks-vision/wasm',
           from: '*',
-          to: `${dist}/mediapipe/wasm`,
+          to: `${dist}/min/mediapipe/wasm`,
         },
         // copying all static resources (audio, images, fonts...)
         {from: 'resource', to: dist},


### PR DESCRIPTION
## Description

We were previously writing mediapipe js asset files to the `/mediapipe` root dir. 
But this directory is not accessible to the express server that runs the webapp. 

Instead we need to move the js file to the `/min` directory that is configured to be accessible through http. 
