### PR TITLE
runfix: Disable background blurring if webgl is not available

### DIFF
--- a/server/Server.ts
+++ b/server/Server.ts
@@ -169,6 +169,7 @@ class Server {
     this.app.use('/proto', express.static(path.join(__dirname, 'static/proto')));
     this.app.use('/style', express.static(path.join(__dirname, 'static/style')));
     this.app.use('/worker', express.static(path.join(__dirname, 'static/worker')));
+    this.app.use('/assets', express.static(path.join(__dirname, 'static/assets')));
 
     this.app.get('/favicon.ico', (_req, res) => res.sendFile(path.join(__dirname, 'static/image/favicon.ico')));
     if (!this.config.DEVELOPMENT) {

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -218,6 +218,8 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
     label: t('videoCallbackgroundBlurHeadline'),
     options: [
       {
+        // Blurring is not possible if webgl context is not available
+        isDisabled: !document.createElement('canvas').getContext('webgl2'),
         label: t('videoCallbackgroundBlur'),
         value: BlurredBackgroundStatus.ON,
         dataUieName: 'blur',


### PR DESCRIPTION
## Description

The blurred background feature needs a version of the wrapper that includes this fix https://github.com/wireapp/wire-desktop/pull/7940
In order to account for older wrapper version, we need to disable the feature in case the wrapper doesn't support hardware acceleration.

## Screenshots/Screencast (for UI changes)

![Screenshot 2024-06-13 at 10 11 03](https://github.com/wireapp/wire-webapp/assets/1090716/dfe9e6e0-ad43-4dab-b2c9-a810bdaaeaf0)
