### PR TITLE
runfix: Avoid loosing the blurred background state when call is minimized

### DIFF
--- a/src/script/components/calling/CallingOverlayContainer.tsx
+++ b/src/script/components/calling/CallingOverlayContainer.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React, {Fragment, useEffect, useState} from 'react';
+import React, {Fragment, useEffect} from 'react';
 
 import {container} from 'tsyringe';
 
@@ -70,7 +70,6 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
     state: currentCallState,
     muteState,
   } = useKoSubscribableChildren(joinedCall!, ['maximizedParticipant', 'state', 'muteState']);
-  const [hasBlurredBackground, setHasBlurredBackground] = useState(false);
 
   const isMuted = muteState !== MuteState.NOT_MUTED;
 
@@ -150,15 +149,11 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
           mediaDevicesHandler={mediaDevicesHandler}
           isMuted={isMuted}
           muteState={muteState}
-          hasBlurredBackground={hasBlurredBackground}
           isChoosingScreen={isChoosingScreen}
           switchCameraInput={switchCameraInput}
           switchMicrophoneInput={switchMicrophoneInput}
           switchSpeakerOutput={switchSpeakerOutput}
-          switchBlurredBackground={status => {
-            setHasBlurredBackground(status);
-            callingRepository.switchVideoBackgroundBlur(status);
-          }}
+          switchBlurredBackground={status => callingRepository.switchVideoBackgroundBlur(status)}
           setMaximizedParticipant={setMaximizedParticipant}
           setActiveCallViewTab={setActiveCallViewTab}
           toggleMute={toggleMute}

--- a/src/script/components/calling/CallingOverlayContainer.tsx
+++ b/src/script/components/calling/CallingOverlayContainer.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React, {Fragment, useEffect} from 'react';
+import React, {Fragment, useEffect, useState} from 'react';
 
 import {container} from 'tsyringe';
 
@@ -70,6 +70,7 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
     state: currentCallState,
     muteState,
   } = useKoSubscribableChildren(joinedCall!, ['maximizedParticipant', 'state', 'muteState']);
+  const [hasBlurredBackground, setHasBlurredBackground] = useState(false);
 
   const isMuted = muteState !== MuteState.NOT_MUTED;
 
@@ -149,11 +150,15 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
           mediaDevicesHandler={mediaDevicesHandler}
           isMuted={isMuted}
           muteState={muteState}
+          hasBlurredBackground={hasBlurredBackground}
           isChoosingScreen={isChoosingScreen}
           switchCameraInput={switchCameraInput}
           switchMicrophoneInput={switchMicrophoneInput}
           switchSpeakerOutput={switchSpeakerOutput}
-          switchBlurredBackground={status => callingRepository.switchVideoBackgroundBlur(status)}
+          switchBlurredBackground={status => {
+            setHasBlurredBackground(status);
+            callingRepository.switchVideoBackgroundBlur(status);
+          }}
           setMaximizedParticipant={setMaximizedParticipant}
           setActiveCallViewTab={setActiveCallViewTab}
           toggleMute={toggleMute}

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -70,6 +70,7 @@ export interface FullscreenVideoCallProps {
   conversation: Conversation;
   isChoosingScreen: boolean;
   isMuted: boolean;
+  hasBlurredBackground: boolean;
   leave: (call: Call) => void;
   maximizedParticipant: Participant | null;
   mediaDevicesHandler: MediaDevicesHandler;
@@ -94,6 +95,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
   conversation,
   isChoosingScreen,
   isMuted,
+  hasBlurredBackground,
   muteState,
   mediaDevicesHandler,
   videoGrid,
@@ -147,7 +149,6 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
     MediaDeviceType.AUDIO_INPUT,
     MediaDeviceType.AUDIO_OUTPUT,
   ]);
-  const [hasBlurredBackground, setHasBlurredBackground] = useState(false);
   const [audioOptionsOpen, setAudioOptionsOpen] = useState(false);
   const [videoOptionsOpen, setVideoOptionsOpen] = useState(false);
   const minimize = () => callState.viewMode(CallingViewMode.MINIMIZED);
@@ -262,10 +263,8 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
   const updateVideoOptions = (selectedOption: string | BlurredBackgroundStatus) => {
     const camera = videoOptions[0].options.find(item => item.value === selectedOption) ?? selectedVideoOptions[0];
     if (selectedOption === BlurredBackgroundStatus.ON) {
-      setHasBlurredBackground(true);
       switchBlurredBackground(true);
     } else if (selectedOption === BlurredBackgroundStatus.OFF) {
-      setHasBlurredBackground(false);
       switchBlurredBackground(false);
     } else {
       switchCameraInput(camera.id);

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -70,7 +70,6 @@ export interface FullscreenVideoCallProps {
   conversation: Conversation;
   isChoosingScreen: boolean;
   isMuted: boolean;
-  hasBlurredBackground: boolean;
   leave: (call: Call) => void;
   maximizedParticipant: Participant | null;
   mediaDevicesHandler: MediaDevicesHandler;
@@ -95,7 +94,6 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
   conversation,
   isChoosingScreen,
   isMuted,
-  hasBlurredBackground,
   muteState,
   mediaDevicesHandler,
   videoGrid,
@@ -120,6 +118,9 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
     'sharesScreen',
     'sharesCamera',
   ]);
+
+  const {blurredVideoStream} = useKoSubscribableChildren(selfParticipant, ['blurredVideoStream']);
+  const hasBlurredBackground = !!blurredVideoStream;
 
   const {
     activeSpeakers,


### PR DESCRIPTION
## Description

Avoid duplication of state and use a single source of truth to know if the self user has blurred background enabled or not
