### PR TITLE
runfix: bump core with version that fixes mls non-fed calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@lexical/react": "0.12.5",
     "@wireapp/avs": "9.6.12",
     "@wireapp/commons": "5.2.7",
-    "@wireapp/core": "46.0.9",
+    "@wireapp/core": "46.0.14",
     "@wireapp/react-ui-kit": "9.16.4",
     "@wireapp/store-engine-dexie": "2.1.8",
     "@wireapp/webapp-events": "0.20.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4693,15 +4693,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^27.0.3":
-  version: 27.0.3
-  resolution: "@wireapp/api-client@npm:27.0.3"
+"@wireapp/api-client@npm:^27.0.7":
+  version: 27.0.7
+  resolution: "@wireapp/api-client@npm:27.0.7"
   dependencies:
-    "@wireapp/commons": ^5.2.7
-    "@wireapp/priority-queue": ^2.1.5
-    "@wireapp/protocol-messaging": 1.46.0
-    axios: 1.6.8
-    axios-retry: 4.1.0
+    "@wireapp/commons": ^5.2.8
+    "@wireapp/priority-queue": ^2.1.6
+    "@wireapp/protocol-messaging": 1.48.0
+    axios: 1.7.2
+    axios-retry: 4.4.0
     http-status-codes: 2.3.0
     logdown: 3.3.1
     pako: 2.1.0
@@ -4709,8 +4709,8 @@ __metadata:
     spark-md5: 3.0.2
     tough-cookie: 4.1.4
     ws: 8.17.0
-    zod: 3.23.6
-  checksum: cc3ca138c2b4159c7ce7914fc0facbe36768434be5a36f3a7935edc06252c16f4bb5697bb32b79ac5e84834eccf6ae512e23892a088146e107baa3861cc40d7f
+    zod: 3.23.8
+  checksum: a1f737399c54f652addf12e38bab8852be0bcbd5bfab90f94daeb0a6abb30e31074ff646a358b7d60463d7bf038b15bee1fa6bb5cf602142a0d89a45a94cfe07
   languageName: node
   linkType: hard
 
@@ -4728,7 +4728,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/commons@npm:5.2.7, @wireapp/commons@npm:^5.2.7":
+"@wireapp/commons@npm:5.2.7":
   version: 5.2.7
   resolution: "@wireapp/commons@npm:5.2.7"
   dependencies:
@@ -4737,6 +4737,18 @@ __metadata:
     logdown: 3.3.1
     platform: 1.3.6
   checksum: e875e242c706b6719aea8f6dea4b547e6ce189c853dcb78cdbe87d238d3c99e92a8acbf76a80f100ee9642b2638081bafa1b050d8c3fea407fe6f7ea517f6328
+  languageName: node
+  linkType: hard
+
+"@wireapp/commons@npm:^5.2.8":
+  version: 5.2.8
+  resolution: "@wireapp/commons@npm:5.2.8"
+  dependencies:
+    ansi-regex: 5.0.1
+    fs-extra: 11.2.0
+    logdown: 3.3.1
+    platform: 1.3.6
+  checksum: f10cd6f4ef687399a098abcf6734df2271f00f856554068e69fdbaf56e9b7ac08f783c1a86237ca50a716400911670c24379050a3f3a8a14c28ea2fbeb112a2c
   languageName: node
   linkType: hard
 
@@ -4763,29 +4775,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:46.0.9":
-  version: 46.0.9
-  resolution: "@wireapp/core@npm:46.0.9"
+"@wireapp/core@npm:46.0.14":
+  version: 46.0.14
+  resolution: "@wireapp/core@npm:46.0.14"
   dependencies:
-    "@wireapp/api-client": ^27.0.3
-    "@wireapp/commons": ^5.2.7
+    "@wireapp/api-client": ^27.0.7
+    "@wireapp/commons": ^5.2.8
     "@wireapp/core-crypto": 1.0.0-rc.60
     "@wireapp/cryptobox": 12.8.0
-    "@wireapp/priority-queue": ^2.1.5
-    "@wireapp/promise-queue": ^2.3.2
-    "@wireapp/protocol-messaging": 1.46.0
-    "@wireapp/store-engine": 5.1.5
-    axios: 1.6.8
-    bazinga64: ^6.3.4
-    deepmerge-ts: 5.1.0
+    "@wireapp/priority-queue": ^2.1.6
+    "@wireapp/promise-queue": ^2.3.3
+    "@wireapp/protocol-messaging": 1.48.0
+    "@wireapp/store-engine": 5.1.6
+    axios: 1.7.2
+    bazinga64: ^6.3.5
+    deepmerge-ts: 6.0.0
     hash.js: 1.1.7
     http-status-codes: 2.3.0
     idb: 8.0.0
     logdown: 3.3.1
     long: ^5.2.0
-    uuidjs: 4.2.13
-    zod: 3.23.6
-  checksum: 781caa89056713b20cd9d0e46a724d2d8ad3ddc09275b672a35928c7f94443d7bb27ad1fe95ed013b85653b551ecdf122128759e402138c0ee0f3b6b05d4f0a9
+    uuid: 9.0.1
+    zod: 3.23.8
+  checksum: c9c44c99a5f48d75dbfcfbb4252c65dd5a33acbd2a6f1df070de927e921ed622b79c4be565286af1c87ff8afc69858a4b9a5252f1e0f639e3e36f8146a5b25d6
   languageName: node
   linkType: hard
 
@@ -4861,17 +4873,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/priority-queue@npm:^2.1.5":
-  version: 2.1.5
-  resolution: "@wireapp/priority-queue@npm:2.1.5"
-  checksum: 7d150e376a8df680ccf80518d86a455972892f66e7f837e5dec3a5c4a1cd7983223574a43c4dae24e8c0f9ac788effc1b8e82952f35c5e1940aacfee824b230a
+"@wireapp/priority-queue@npm:^2.1.6":
+  version: 2.1.6
+  resolution: "@wireapp/priority-queue@npm:2.1.6"
+  checksum: 3d566d38dd8f286beba9fda4ba123f2f6ac0760ab57a3b7357a98195450b0c1d3aca1fb01bec55197dc97436b586c1aa83c4245a262979c7a9e89ea21e06895e
   languageName: node
   linkType: hard
 
-"@wireapp/promise-queue@npm:^2.3.2":
-  version: 2.3.2
-  resolution: "@wireapp/promise-queue@npm:2.3.2"
-  checksum: 818d97f43bcf19de3ff965b143500679ef291ba4510dca8951c18a049c4744bf7c146f29d9ac6fcc0d8ee9680e2c7d1ddabca780dd2a1af514074a2f4c0989f1
+"@wireapp/promise-queue@npm:^2.3.3":
+  version: 2.3.3
+  resolution: "@wireapp/promise-queue@npm:2.3.3"
+  checksum: 99b648547365508a721109adb4fa1e8ed97e6e68f8583be2aa025315552840e676b034fa0a2d5e271b06dab998a64ae2e5916c89e06ca614f5157e47d367e8bf
   languageName: node
   linkType: hard
 
@@ -4887,15 +4899,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/protocol-messaging@npm:1.46.0":
-  version: 1.46.0
-  resolution: "@wireapp/protocol-messaging@npm:1.46.0"
+"@wireapp/protocol-messaging@npm:1.48.0":
+  version: 1.48.0
+  resolution: "@wireapp/protocol-messaging@npm:1.48.0"
   dependencies:
     long: 5.2.0
-    protobufjs: 7.2.4
+    protobufjs: 7.2.5
     protobufjs-cli: 1.1.2
     typescript: 4.8.4
-  checksum: b4a75b69f0c1b03962f7215aa25da1172bc511f748e463d1aba675c71fc4482d0e5dd70bf267eef833a5fc24a9c9b65c12b0538a3cd113e4e0227335e6675e27
+  checksum: bb8929c5395a629b85eeae36dce601cf0b5aa09de11163a31ea2f21cbe843c98d18191a48a8fee4826593e9c76c94a3b4f59c35fee7d3c532c749cc4f1d4cc8c
   languageName: node
   linkType: hard
 
@@ -4940,7 +4952,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/store-engine@npm:5.1.5, @wireapp/store-engine@npm:^5.1.4":
+"@wireapp/store-engine@npm:5.1.6":
+  version: 5.1.6
+  resolution: "@wireapp/store-engine@npm:5.1.6"
+  checksum: 1a3bc0ea21622bf160231a21b5a3ebf4258ae7ae4a14de7f1b99c00bd6d626ca6962d7b14e5c97c34ebdd1db22ae91f48a5cc1198dbd17c85ffe0c11828dadd8
+  languageName: node
+  linkType: hard
+
+"@wireapp/store-engine@npm:^5.1.4":
   version: 5.1.5
   resolution: "@wireapp/store-engine@npm:5.1.5"
   checksum: 7c2e054314e0b4745bbaafa40544a6c4930eb8b8d663e8a5d77ae968f25369eccc7e91044183737942228f984e5eb9c7675efa7e598e6ec7fc2b0370e604729f
@@ -5610,14 +5629,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios-retry@npm:4.1.0":
-  version: 4.1.0
-  resolution: "axios-retry@npm:4.1.0"
+"axios-retry@npm:4.4.0":
+  version: 4.4.0
+  resolution: "axios-retry@npm:4.4.0"
   dependencies:
     is-retry-allowed: ^2.2.0
   peerDependencies:
     axios: 0.x || 1.x
-  checksum: e1e07f710d12e3367bc1e934b49f3056bc6a1d8c4b1c5cc69afb89841c5ee360fe36565894d53c043c7ea43bc7ac353b87573c8d6d721b12ac4d567be38cc117
+  checksum: 19b005bbd3e956080b27ee54fad658dbf7663fa6e884110a638b9f53db50a34c4870648143c8d9397354fedd0ede920693caa1e7c6a762d9477b4cbb48ca22f2
   languageName: node
   linkType: hard
 
@@ -5632,14 +5651,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.6.8":
-  version: 1.6.8
-  resolution: "axios@npm:1.6.8"
+"axios@npm:1.7.2":
+  version: 1.7.2
+  resolution: "axios@npm:1.7.2"
   dependencies:
     follow-redirects: ^1.15.6
     form-data: ^4.0.0
     proxy-from-env: ^1.1.0
-  checksum: bf007fa4b207d102459300698620b3b0873503c6d47bf5a8f6e43c0c64c90035a4f698b55027ca1958f61ab43723df2781c38a99711848d232cad7accbcdfcdd
+  checksum: e457e2b0ab748504621f6fa6609074ac08c824bf0881592209dfa15098ece7e88495300e02cd22ba50b3468fd712fe687e629dcb03d6a3f6a51989727405aedf
   languageName: node
   linkType: hard
 
@@ -5844,10 +5863,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bazinga64@npm:^6.3.4":
-  version: 6.3.4
-  resolution: "bazinga64@npm:6.3.4"
-  checksum: 85e3522a1d77a6842318c20cdf4da63b9ab75f9ce384ab56b43b8136cabde1515e694b273537f29d10d037f958248b663660b1083508957561fa674d6a8ac0e8
+"bazinga64@npm:^6.3.5":
+  version: 6.3.5
+  resolution: "bazinga64@npm:6.3.5"
+  checksum: d48ff74c2d849600725067525846f84a4f4bc1b9debe32c3921a9ef721326aa4fd06a354cdc0591d66b44692a7255f94f6dbf5ac1bf66f1a8e1096ee92b5dbd3
   languageName: node
   linkType: hard
 
@@ -7080,10 +7099,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deepmerge-ts@npm:5.1.0":
-  version: 5.1.0
-  resolution: "deepmerge-ts@npm:5.1.0"
-  checksum: 6b57db93c2985e4a35f24b2451db31715050d143988b7d6346f4049c9aec21a6c289514b88d3ee3d6e0697e72ef5d96ff0bbb7cb75422d56fee55ee85c7168e7
+"deepmerge-ts@npm:6.0.0":
+  version: 6.0.0
+  resolution: "deepmerge-ts@npm:6.0.0"
+  checksum: e1bcfefccaa9b70f0c75f8a590ff8b93dc0879338071ceabd7ee6d0e42c71f40f69d4697e9919ee450b8e052919c86c4694fa067e92be6634ca12371ae15656c
   languageName: node
   linkType: hard
 
@@ -8756,6 +8775,17 @@ __metadata:
     jsonfile: ^6.0.1
     universalify: ^2.0.0
   checksum: 5ca476103fa1f5ff4a9b3c4f331548f8a3c1881edaae323a4415d3153b5dc11dc6a981c8d1dd93eec8367ceee27b53f8bd27eecbbf66ffcdd04927510c171e7f
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:11.2.0":
+  version: 11.2.0
+  resolution: "fs-extra@npm:11.2.0"
+  dependencies:
+    graceful-fs: ^4.2.0
+    jsonfile: ^6.0.1
+    universalify: ^2.0.0
+  checksum: b12e42fa40ba47104202f57b8480dd098aa931c2724565e5e70779ab87605665594e76ee5fb00545f772ab9ace167fe06d2ab009c416dc8c842c5ae6df7aa7e8
   languageName: node
   linkType: hard
 
@@ -14252,9 +14282,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:7.2.4":
-  version: 7.2.4
-  resolution: "protobufjs@npm:7.2.4"
+"protobufjs@npm:7.2.5":
+  version: 7.2.5
+  resolution: "protobufjs@npm:7.2.5"
   dependencies:
     "@protobufjs/aspromise": ^1.1.2
     "@protobufjs/base64": ^1.1.2
@@ -14268,7 +14298,7 @@ __metadata:
     "@protobufjs/utf8": ^1.1.0
     "@types/node": ">=13.7.0"
     long: ^5.0.0
-  checksum: a952cdf2a5e5250c16ae651b570849b6f5b20a5475c3eef63ffb290ad239aa2916adfc1cc676f7fc93c69f48113df268761c0c246f7f023118c85bdd1a170044
+  checksum: 3770a072114061faebbb17cfd135bc4e187b66bc6f40cd8bac624368b0270871ec0cfb43a02b9fb4f029c8335808a840f1afba3c2e7ede7063b98ae6b98a703f
   languageName: node
   linkType: hard
 
@@ -16938,6 +16968,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:9.0.1":
+  version: 9.0.1
+  resolution: "uuid@npm:9.0.1"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 39931f6da74e307f51c0fb463dc2462807531dc80760a9bff1e35af4316131b4fc3203d16da60ae33f07fdca5b56f3f1dd662da0c99fea9aaeab2004780cc5f4
+  languageName: node
+  linkType: hard
+
 "uuidjs@npm:4.2.13":
   version: 4.2.13
   resolution: "uuidjs@npm:4.2.13"
@@ -17469,7 +17508,7 @@ __metadata:
     "@wireapp/avs": 9.6.12
     "@wireapp/commons": 5.2.7
     "@wireapp/copy-config": 2.1.14
-    "@wireapp/core": 46.0.9
+    "@wireapp/core": 46.0.14
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.16.4
@@ -18082,10 +18121,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:3.23.6":
-  version: 3.23.6
-  resolution: "zod@npm:3.23.6"
-  checksum: f534119e2a54e86bf77e5c6ff630ef4ec50b87dd9d9faf66dc7a663a489d37130b716ebd836cdd9d7fc6e124a1accdc0d53f388243a236c10e632dcc945eaa27
+"zod@npm:3.23.8":
+  version: 3.23.8
+  resolution: "zod@npm:3.23.8"
+  checksum: 15949ff82118f59c893dacd9d3c766d02b6fa2e71cf474d5aa888570c469dbf5446ac5ad562bb035bf7ac9650da94f290655c194f4a6de3e766f43febd432c5c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Bumps coe with version that fixes mls calls on non-federated environment. For more details see https://github.com/wireapp/wire-web-packages/pull/6290.


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;