### PR TITLE
runfix: Add ARIA label to the "Jump to the last message" button WPB-6518

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -1541,5 +1541,6 @@
   "wireLinux": "{{brandName}} for Linux",
   "wireMacos": "{{brandName}} for macOS",
   "wireWindows": "{{brandName}} for Windows",
-  "wire_for_web": "{{brandName}} for Web"
+  "wire_for_web": "{{brandName}} for Web",
+  "jumpToLastMessage": "Scroll to the end of this conversation"
 }

--- a/src/script/components/MessagesList/JumpToLastMessageButton.tsx
+++ b/src/script/components/MessagesList/JumpToLastMessageButton.tsx
@@ -27,6 +27,7 @@ import {
   jumpToLastMessageButtonStyles,
   jumpToLastMessageChevronStyles,
 } from 'Components/MessagesList/MessageList.styles';
+import {t} from 'Util/LocalizerUtil';
 
 import {Conversation} from '../../entity/Conversation';
 
@@ -55,6 +56,7 @@ export const JumpToLastMessageButton = ({onGoToLastMessage, conversation}: JumpT
 
   return (
     <IconButton
+      aria-label={t('jumpToLastMessage')}
       data-uie-name="jump-to-last-message-button"
       onClick={onGoToLastMessage}
       css={jumpToLastMessageButtonStyles}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6518" title="WPB-6518" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-6518</a>  [Web] Jump to last message in a conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

Add "Scroll to the end of this conversation" ARIA label text to the "Jump to the last message" button