### PR TITLE
runfix: improve user entity type guard [WPB-9703]

### DIFF
--- a/src/script/guards/Panel.ts
+++ b/src/script/guards/Panel.ts
@@ -26,7 +26,7 @@ export const isServiceEntity = (entity: PanelEntity): entity is ServiceEntity =>
 };
 
 export const isUserEntity = (entity: PanelEntity): entity is User => {
-  return !isServiceEntity(entity);
+  return !isServiceEntity(entity) && entity instanceof User;
 };
 
 export const isUserServiceEntity = (entity: PanelEntity): entity is User => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9703" title="WPB-9703" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9703</a>  [Web] Random crash when opening user details panel
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

We had a random crash when opening user's profile in right side panel, after clicking on user's avatar in a message.
It's hard to reproduce the issue locally, but by analysing the logs and looking at the code, we must've passed something else than `User` entity to `<GroupParticipantUser /> ` component. I've improved the guard to check whether the passed entity is really a User instance to prevent any failures like this in the future.

Crash logs:
<img width="742" alt="Screenshot 2024-06-12 at 16 28 23" src="https://github.com/wireapp/wire-webapp/assets/45733298/f7c914d3-1efd-43d0-a9e5-3db2f1be705e">

`!isServiceEntity` is not enough, because it can also be a `Conversation` or a `Message`:
<img width="539" alt="Screenshot 2024-06-14 at 11 08 39" src="https://github.com/wireapp/wire-webapp/assets/45733298/dac5ad4a-0806-4cc9-9edb-3c0b0a3fb349">

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;