### PR TITLE
feat: Close "Create Group" modal on Esc key press on the first step WPB-9718

### DIFF
--- a/src/script/components/ModalComponent.tsx
+++ b/src/script/components/ModalComponent.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React, {useEffect, useId, useRef, useState, useCallback} from 'react';
+import React, {useEffect, useId, useRef, useState, useCallback, HTMLProps} from 'react';
 
 import {CSSObject} from '@emotion/react';
 import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
@@ -26,7 +26,7 @@ import {noop, preventFocusOutside} from 'Util/util';
 
 import {Icon} from './Icon';
 
-interface ModalComponentProps {
+interface ModalComponentProps extends HTMLProps<HTMLDivElement> {
   children: React.ReactNode;
   isShown: boolean;
   id?: string;
@@ -93,6 +93,7 @@ const ModalComponent: React.FC<ModalComponentProps> = ({
   showLoading = false,
   wrapperCSS,
   children,
+  onKeyDown,
   ...rest
 }) => {
   const [displayNone, setDisplayNone] = useState<boolean>(!isShown);
@@ -161,7 +162,7 @@ const ModalComponent: React.FC<ModalComponentProps> = ({
           onClick={event => event.stopPropagation()}
           role="button"
           tabIndex={TabIndex.UNFOCUSABLE}
-          onKeyDown={event => event.stopPropagation()}
+          onKeyDown={event => (onKeyDown ? onKeyDown(event) : event.stopPropagation())}
           css={{...(hasVisibleClass ? ModalContentVisibleStyles : ModalContentStyles), ...wrapperCSS}}
         >
           {hasVisibleClass ? children : null}

--- a/src/script/util/KeyboardUtil.ts
+++ b/src/script/util/KeyboardUtil.ts
@@ -83,28 +83,9 @@ export const isRemovalAction = (key: string): boolean => removalKeys.includes(ke
 
 export const isSpaceOrEnterKey = (key: string): boolean => key === KEY.SPACE || key === KEY.ENTER;
 
-type KeyboardHandler = (event: KeyboardEvent) => void;
-
-const escKeyHandlers: KeyboardHandler[] = [];
-
-document.addEventListener('keydown', event => {
-  if (event.key === 'Escape') {
-    escKeyHandlers.forEach(handler => handler(event));
-  }
-});
-
-export const onEscKey = (handler: KeyboardHandler) => escKeyHandlers.push(handler);
-
-export const offEscKey = (handler: KeyboardHandler) => {
-  const index = escKeyHandlers.indexOf(handler);
-  if (index >= 0) {
-    escKeyHandlers.splice(index, 1);
-  }
-};
-
 export const handleKeyDown = (
-  event: React.KeyboardEvent<Element> | KeyboardEvent,
-  callback: (event?: React.KeyboardEvent<Element> | KeyboardEvent) => void,
+  event: ReactKeyboardEvent<Element> | KeyboardEvent,
+  callback: (event?: ReactKeyboardEvent<Element> | KeyboardEvent) => void,
 ) => {
   if (event.key === KEY.ENTER || event.key === KEY.SPACE) {
     callback(event);
@@ -112,11 +93,16 @@ export const handleKeyDown = (
   return true;
 };
 
-export const handleEnterDown = (event: React.KeyboardEvent<HTMLElement> | KeyboardEvent, callback: () => void) => {
+export const handleEnterDown = (event: ReactKeyboardEvent<HTMLElement> | KeyboardEvent, callback: () => void): void => {
   if (event.key === KEY.ENTER) {
     callback();
   }
-  return true;
+};
+
+export const handleEscDown = (event: ReactKeyboardEvent<HTMLElement> | KeyboardEvent, callback: () => void): void => {
+  if (event.key === KEY.ESC) {
+    callback();
+  }
 };
 
 /**


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9718" title="WPB-9718" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9718</a>  Close the "Create Group" modal on keypress "Escape"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

If a user is on the first step of the "create new group" modal, the "Esc" key press should close it. On the next steps, it is not so straightforward what the "Esc" should do, as there is a search input and we might need to clear it on the "Esc" press, and there is already data that the user entered and will lose if the modal is closed. We can further discuss it with the design team.

This is part of the new navigation epic, but since it's an independent universal change, we decided to implement it on `dev`

## Screenshots/Screencast (for UI changes)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
