### PR TITLE
fix: Fix loading following messages condition WPB-9465

### DIFF
--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -35,7 +35,6 @@ import {User} from 'src/script/entity/User';
 import {useRoveFocus} from 'src/script/hooks/useRoveFocus';
 import {ServiceEntity} from 'src/script/integration/ServiceEntity';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
-import {isLastReceivedMessage} from 'Util/conversationMessages';
 import {onHitTopOrBottom} from 'Util/DOM/onHitTopOrBottom';
 import {useResizeObserver} from 'Util/DOM/resizeObserver';
 
@@ -46,7 +45,6 @@ import {groupMessagesBySenderAndTime, isMarker} from './utils/messagesGroup';
 import {updateScroll, FocusedElement} from './utils/scrollUpdater';
 
 import {Conversation} from '../../entity/Conversation';
-import {isContentMessage} from '../../guards/Message';
 
 interface MessagesListParams {
   cancelConnectionRequest: (message: MemberMessage) => void;
@@ -186,13 +184,8 @@ export const MessagesList: FC<MessagesListParams> = ({
   const loadFollowingMessages = () => {
     const lastMessage = conversation.getNewestMessage();
 
-    if (lastMessage) {
-      if (!isLastReceivedMessage(lastMessage, conversation)) {
-        // if the last loaded message is not the last of the conversation, we load the subsequent messages
-        if (isContentMessage(lastMessage)) {
-          conversationRepository.getSubsequentMessages(conversation, lastMessage);
-        }
-      }
+    if (lastMessage && !conversation.hasLastReceivedMessageLoaded()) {
+      conversationRepository.getSubsequentMessages(conversation, lastMessage);
     }
   };
 

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -972,7 +972,7 @@ export class ConversationRepository {
    * Get subsequent messages starting with the given message.
    * @returns Resolves with the messages
    */
-  async getSubsequentMessages(conversationEntity: Conversation, messageEntity: ContentMessage) {
+  async getSubsequentMessages(conversationEntity: Conversation, messageEntity: Message) {
     const messageDate = new Date(messageEntity.timestamp());
     conversationEntity.isLoadingMessages(true);
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9465" title="WPB-9465" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9465</a>  [web] Conversation scrolling stops loading following messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

This fixes the part of the problem. 
TODO: If messages are all read, the scrolling will trigger the next messages loading. But if the messages (30+ missed calls and some content messages after them) are not read, the scroll to the last message will not trigger the loading, new sent messages will appear, but the missed messages will not be shown
TODO: in most cases
```
const lastMessage = conversation.getNewestMessage();
if (!isLastReceivedMessage(lastMessage, conversation))
```
can be replaced with `!conversation.hasLastReceivedMessageLoaded()`, I'd do this refactoring within this fix too. 

Also, the `isLastReceivedMessage` can be a public method of `conversation`

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
