### PR TITLE
runfix: change dark mode slow indicator styles

### DIFF
--- a/src/style/list/list.less
+++ b/src/style/list/list.less
@@ -79,11 +79,16 @@ body.theme-dark {
   padding: 4px 0px 4px 0px;
   border-radius: 24px;
   margin-top: 8px;
-  background-color: var(--gray-30);
-  color: var(--black);
+  background-color: var(--sidebar-bg);
+  color: var(--main-color);
   font-size: var(--font-size-small);
   font-weight: var(--font-weight-semibold);
   gap: 8px;
+}
+
+.slow-connection-indicator svg,
+.slow-connection-indicator svg * {
+  fill: var(--main-color);
 }
 
 .left-list-center {


### PR DESCRIPTION
## Description

Fixes the styles of slow connection indicator in the dark mode using css variables (as requested by the design team).

## Screenshots/Screencast (for UI changes)
Before:
<img width="342" alt="Screenshot 2024-06-17 at 18 16 17" src="https://github.com/wireapp/wire-webapp/assets/45733298/13ac748a-73ee-40eb-94a2-8a8c05ac071e">


Now:
<img width="332" alt="Screenshot 2024-06-17 at 18 02 01" src="https://github.com/wireapp/wire-webapp/assets/45733298/a5cb8fad-f8fb-4456-b0e6-0922b18bac73">

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
