### PR TITLE
feat: auto clear navigation search input on Escape press

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationHeader/ConversationHeader.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationHeader/ConversationHeader.tsx
@@ -82,7 +82,21 @@ export const ConversationHeader = ({
     amplify.subscribe(WebAppEvents.SHORTCUT.SEARCH, () => {
       inputRef?.current?.focus();
     });
-  }, []);
+
+    const input = inputRef.current;
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setSearchValue('');
+      }
+    }
+
+    input?.addEventListener('keydown', onKeyDown);
+
+    return () => {
+      input?.removeEventListener('keydown', onKeyDown);
+    };
+  }, [setSearchValue]);
 
   return (
     <>

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationHeader/ConversationHeader.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationHeader/ConversationHeader.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {useEffect, useRef} from 'react';
+import {KeyboardEvent, useEffect, useRef} from 'react';
 
 import {amplify} from 'amplify';
 
@@ -82,21 +82,13 @@ export const ConversationHeader = ({
     amplify.subscribe(WebAppEvents.SHORTCUT.SEARCH, () => {
       inputRef?.current?.focus();
     });
+  }, []);
 
-    const input = inputRef.current;
-
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key === 'Escape') {
-        setSearchValue('');
-      }
+  function onKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === 'Escape') {
+      setSearchValue('');
     }
-
-    input?.addEventListener('keydown', onKeyDown);
-
-    return () => {
-      input?.removeEventListener('keydown', onKeyDown);
-    };
-  }, [setSearchValue]);
+  }
 
   return (
     <>
@@ -121,6 +113,7 @@ export const ConversationHeader = ({
 
       {showSearchInput && (
         <Input
+          onKeyDown={onKeyDown}
           ref={inputRef}
           className="label-1"
           value={searchValue}


### PR DESCRIPTION
## Description
This pull request introduces a feature that enhances the user experience by automatically clearing the navigation search input when the Escape key is pressed. This allows users to quickly reset their search input without manual deletion.

## Changes
- **Added Event Listener for Escape Key:**
  - An event listener is added to the navigation search input field to detect when the Escape key is pressed.
  - When the Escape key is pressed, the input field is cleared by setting its value to an empty string.

## Benefits
- Improves user experience by providing a quick and intuitive way to clear the search input field.
- Increases efficiency by reducing the need for manual deletion of search queries.

## Implementation Details
- The event listener is attached to the navigation search input field.
- The input field's value is set to an empty string (`""`) upon detecting the Escape key press.
