### PR TITLE
fix: legal hold modal styling issues

### DIFF
--- a/src/style/common/modal.less
+++ b/src/style/common/modal.less
@@ -320,7 +320,7 @@
 
       &__left {
         right: unset;
-        left: -6px;
+        left: 16px;
       }
     }
     &__icon {

--- a/src/style/common/modal.less
+++ b/src/style/common/modal.less
@@ -357,7 +357,7 @@
     left: 0;
     display: flex;
     justify-content: flex-end;
-    padding: 20px;
+    margin: 20px;
     background-color: var(--modal-bg);
     --button-color: var(--accent-color);
 

--- a/src/style/panel/participant-devices.less
+++ b/src/style/panel/participant-devices.less
@@ -42,6 +42,7 @@
   }
 
   &__device-list {
+    padding: 0;
     margin-top: 8px;
   }
 


### PR DESCRIPTION
## Description

Fixes some styling issues with legal hold modal.

## Screenshots/Screencast (for UI changes)
Before:
Outilne cut off:
<img width="424" alt="Screenshot 2024-06-18 at 12 16 39" src="https://github.com/wireapp/wire-webapp/assets/45733298/ebe3f016-172d-4e3e-ae4d-6db8e5ee72b4">
Back arrow misplaced and extra padding in the devices list:
<img width="415" alt="Screenshot 2024-06-18 at 12 35 51" src="https://github.com/wireapp/wire-webapp/assets/45733298/402ded7a-5e15-4820-aba4-8b4b1d141b0a">


Now:
Outline is in place (used margin instead of internal padding)
<img width="410" alt="Screenshot 2024-06-18 at 12 16 23" src="https://github.com/wireapp/wire-webapp/assets/45733298/3bf8f82b-0a2d-4914-ba35-776c9fdbf118">
Arrow is in place and extra padding got removed
<img width="409" alt="Screenshot 2024-06-18 at 12 35 25" src="https://github.com/wireapp/wire-webapp/assets/45733298/7c2c2da3-1d65-46ef-951c-034319471a3b">



## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
