### PR TITLE
runfix: Allow blurred background to be enabled before the call starts

### DIFF
--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -130,7 +130,7 @@ export class CallingRepository {
   private readonly acceptVersionWarning: (conversationId: QualifiedId) => void;
   private readonly callLog: string[];
   private readonly logger: Logger;
-  private isBlurred = localStorage.getItem('isBlurred') === 'true';
+  private enableBackgroundBlur = false;
   private avsVersion: number = 0;
   private incomingCallCallback: (call: Call) => void;
   private isReady: boolean = false;
@@ -276,8 +276,7 @@ export class CallingRepository {
     if (!videoFeed) {
       return;
     }
-    this.isBlurred = enable;
-    localStorage.setItem('isBlurred', enable.toString());
+    this.enableBackgroundBlur = enable;
     const newVideoFeed = enable ? ((await selfParticipant.setBlurredBackground(true)) as MediaStream) : videoFeed;
     this.changeMediaSource(newVideoFeed, MediaType.VIDEO, false);
   }
@@ -531,7 +530,7 @@ export class CallingRepository {
       const mediaStream = await this.getMediaStream({audio, camera}, call.isGroupOrConference);
       if (call.state() !== CALL_STATE.NONE) {
         selfParticipant.updateMediaStream(mediaStream, true);
-        await selfParticipant.setBlurredBackground(this.isBlurred);
+        await selfParticipant.setBlurredBackground(this.enableBackgroundBlur);
         if (camera) {
           call.getSelfParticipant().videoState(VIDEO_STATE.STARTED);
         }
@@ -1779,7 +1778,7 @@ export class CallingRepository {
         const mediaStream = await this.getMediaStream(missingStreams, call.isGroupOrConference);
         this.mediaStreamQuery = undefined;
         selfParticipant.updateMediaStream(mediaStream, true);
-        await selfParticipant.setBlurredBackground(this.isBlurred);
+        await selfParticipant.setBlurredBackground(this.enableBackgroundBlur);
         return selfParticipant.getMediaStream();
       } catch (error) {
         this.mediaStreamQuery = undefined;

--- a/src/script/calling/Participant.ts
+++ b/src/script/calling/Participant.ts
@@ -39,7 +39,7 @@ export class Participant {
   public readonly hasPausedVideo: ko.PureComputed<boolean>;
   public readonly sharesScreen: ko.PureComputed<boolean>;
   public readonly sharesCamera: ko.PureComputed<boolean>;
-  public readonly startedScreenSharingAt = observable<number | undefined>();
+  public readonly startedScreenSharingAt = observable<number>(0);
   public readonly isActivelySpeaking = observable(false);
   public readonly isSendingVideo: ko.PureComputed<boolean>;
   public readonly isAudioEstablished = observable(false);

--- a/src/script/calling/Participant.ts
+++ b/src/script/calling/Participant.ts
@@ -18,7 +18,7 @@
  */
 
 import {QualifiedId} from '@wireapp/api-client/lib/user';
-import ko, {observable, pureComputed, computed} from 'knockout';
+import ko, {observable, pureComputed} from 'knockout';
 
 import {VIDEO_STATE} from '@wireapp/avs';
 
@@ -32,28 +32,26 @@ export type ClientId = string;
 
 export class Participant {
   // Video
-  public videoState: ko.Observable<VIDEO_STATE>;
-  public videoStream: ko.Observable<MediaStream | undefined>;
-  public blurredVideoStream = observable<{stream: MediaStream; release: () => void} | undefined>();
-  public isBlurred = observable(false);
-  public hasActiveVideo: ko.PureComputed<boolean>;
-  public hasPausedVideo: ko.PureComputed<boolean>;
-  public sharesScreen: ko.PureComputed<boolean>;
-  public sharesCamera: ko.PureComputed<boolean>;
-  public startedScreenSharingAt: ko.Observable<number>;
-  public isActivelySpeaking: ko.Observable<boolean>;
-  public isSendingVideo: ko.PureComputed<boolean>;
-  public isAudioEstablished: ko.Observable<boolean>;
+  public readonly videoState = observable(VIDEO_STATE.STOPPED);
+  public readonly videoStream = observable<MediaStream | undefined>();
+  public readonly blurredVideoStream = observable<{stream: MediaStream; release: () => void} | undefined>();
+  public readonly hasActiveVideo: ko.PureComputed<boolean>;
+  public readonly hasPausedVideo: ko.PureComputed<boolean>;
+  public readonly sharesScreen: ko.PureComputed<boolean>;
+  public readonly sharesCamera: ko.PureComputed<boolean>;
+  public readonly startedScreenSharingAt = observable<number | undefined>();
+  public readonly isActivelySpeaking = observable(false);
+  public readonly isSendingVideo: ko.PureComputed<boolean>;
+  public readonly isAudioEstablished = observable(false);
 
   // Audio
-  public audioStream: ko.Observable<MediaStream | undefined>;
-  public isMuted: ko.Observable<boolean>;
+  public readonly audioStream = observable<MediaStream | undefined>();
+  public readonly isMuted = observable(false);
 
   constructor(
-    public user: User,
-    public clientId: ClientId,
+    public readonly user: User,
+    public readonly clientId: ClientId,
   ) {
-    this.videoState = observable(VIDEO_STATE.STOPPED);
     this.hasActiveVideo = pureComputed(() => {
       return (this.sharesCamera() || this.sharesScreen()) && !!this.videoStream();
     });
@@ -66,16 +64,9 @@ export class Participant {
     this.hasPausedVideo = pureComputed(() => {
       return this.videoState() === VIDEO_STATE.PAUSED;
     });
-    this.videoStream = observable();
-    this.audioStream = observable();
-    this.isActivelySpeaking = observable(false);
-    this.startedScreenSharingAt = observable();
-    this.isMuted = observable(false);
     this.isSendingVideo = pureComputed(() => {
       return this.videoState() !== VIDEO_STATE.STOPPED;
     });
-    this.isAudioEstablished = observable(false);
-    computed(async () => {});
   }
 
   public releaseBlurredVideoStream(): void {

--- a/src/script/media/BackgroundBlurrer/fragmentShader.glsl
+++ b/src/script/media/BackgroundBlurrer/fragmentShader.glsl
@@ -1,4 +1,4 @@
-#define BLUR_QUALITY 8 //The higher the value, the more blur. Must be an even number.
+#define BLUR_QUALITY 14 //The higher the value, the more blur. Must be an even number.
 #define SMOOTH 3 // This will create a smooth transition between the blurred and the clear part (the higher the value, the smoother)
 
 precision mediump float;

--- a/src/script/media/VideoBackgroundBlur.ts
+++ b/src/script/media/VideoBackgroundBlur.ts
@@ -32,7 +32,7 @@ enum FRAMERATE {
 
 const QualitySettings = {
   segmentationModel: SEGMENTATION_MODEL.PERFORMANCE,
-  framerate: FRAMERATE.HIGH,
+  framerate: FRAMERATE.LOW,
 };
 
 // Calculate the FPS interval


### PR DESCRIPTION
## Description

This PR will allow the video call background blur setting to be saved and reused across calls. 
We, for now, persist the user preference only for the current session. Later the setting will be saved to a persistent storage and allowed to be changed in the audio/video settings. 

This PR also increase the blurring effect. 

