### PR TITLE
feat: Improve delivered status information

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@wireapp/avs": "9.7.15",
     "@wireapp/commons": "5.2.8",
     "@wireapp/core": "46.0.14",
-    "@wireapp/react-ui-kit": "9.17.7",
+    "@wireapp/react-ui-kit": "9.18.0",
     "@wireapp/store-engine-dexie": "2.1.10",
     "@wireapp/webapp-events": "0.22.0",
     "amplify": "https://github.com/wireapp/amplify#head=master",

--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.styles.ts
@@ -21,7 +21,7 @@ import {CSSObject} from '@emotion/react';
 
 export const messageBodyWrapper: CSSObject = {
   display: 'grid',
-  gridTemplateColumns: 'calc(100% - 56px) 56px',
+  gridTemplateColumns: 'calc(100% - var(--delivered-state-width)) var(--delivered-state-width)',
   paddingLeft: 'var(--conversation-message-sender-width)',
 };
 
@@ -29,5 +29,5 @@ export const deliveredMessageIndicator: CSSObject = {
   display: 'flex',
   justifyContent: 'center',
   paddingTop: '2px',
-  width: '56px',
+  width: 'var(--delivered-state-width)',
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.styles.ts
@@ -1,0 +1,33 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {CSSObject} from '@emotion/react';
+
+export const messageBodyWrapper: CSSObject = {
+  display: 'grid',
+  gridTemplateColumns: 'calc(100% - 56px) 56px',
+  paddingLeft: 'var(--conversation-message-sender-width)',
+};
+
+export const deliveredMessageIndicator: CSSObject = {
+  display: 'flex',
+  justifyContent: 'center',
+  paddingTop: '2px',
+  width: '56px',
+};

--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -23,6 +23,7 @@ import {QualifiedId} from '@wireapp/api-client/lib/user';
 import cx from 'classnames';
 import ko from 'knockout';
 
+import {Icon} from 'Components/Icon';
 import {ReadIndicator} from 'Components/MessagesList/Message/ReadIndicator';
 import {Conversation} from 'src/script/entity/Conversation';
 import {CompositeMessage} from 'src/script/entity/message/CompositeMessage';
@@ -269,14 +270,7 @@ export const ContentMessageComponent = ({
         <div css={deliveredMessageIndicator}>
           {showDeliveredMessageIcon && (
             <div data-uie-name="status-message-read-receipt-delivered" title={t('conversationMessageDelivered')}>
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none">
-                <path
-                  fill="#676B71"
-                  fillRule="evenodd"
-                  d="M14 8A6 6 0 1 1 2 8a6 6 0 0 1 12 0Zm2 0A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-8.659 3.27 5.128-5.127-1.414-1.415-4.42 4.421-1.69-1.69-1.414 1.415 2.396 2.396.707.708.707-.708Z"
-                  clipRule="evenodd"
-                />
-              </svg>
+              <Icon.OutlineCheck />
             </div>
           )}
         </div>

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
@@ -54,7 +54,6 @@ interface ContentAssetProps {
   selfId: QualifiedId;
   isMessageFocused: boolean;
   is1to1Conversation: boolean;
-  isLastDeliveredMessage: boolean;
   onClickDetails: () => void;
 }
 
@@ -67,7 +66,6 @@ const ContentAsset = ({
   onClickButton,
   isMessageFocused,
   is1to1Conversation,
-  isLastDeliveredMessage,
   onClickDetails,
 }: ContentAssetProps) => {
   const {isObfuscated, status} = useKoSubscribableChildren(message, ['isObfuscated', 'status']);
@@ -96,12 +94,7 @@ const ContentAsset = ({
           )}
 
           {shouldRenderText && (
-            <ReadIndicator
-              message={message}
-              is1to1Conversation={is1to1Conversation}
-              isLastDeliveredMessage={isLastDeliveredMessage}
-              onClick={onClickDetails}
-            />
+            <ReadIndicator message={message} is1to1Conversation={is1to1Conversation} onClick={onClickDetails} />
           )}
 
           {previews.map(() => (
@@ -109,12 +102,7 @@ const ContentAsset = ({
               <LinkPreviewAsset message={message} isFocusable={isMessageFocused} />
 
               {!shouldRenderText && (
-                <ReadIndicator
-                  message={message}
-                  is1to1Conversation={is1to1Conversation}
-                  isLastDeliveredMessage={isLastDeliveredMessage}
-                  onClick={onClickDetails}
-                />
+                <ReadIndicator message={message} is1to1Conversation={is1to1Conversation} onClick={onClickDetails} />
               )}
             </div>
           ))}

--- a/src/script/components/MessagesList/Message/PingMessage.tsx
+++ b/src/script/components/MessagesList/Message/PingMessage.tsx
@@ -19,7 +19,9 @@
 
 import cx from 'classnames';
 
+import {Icon} from 'Components/Icon';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
+import {t} from 'Util/LocalizerUtil';
 import {checkIsMessageDelivered} from 'Util/util';
 
 import {ReadReceiptStatus} from './ReadReceiptStatus';
@@ -64,15 +66,8 @@ const PingMessage = ({message, is1to1Conversation, isLastDeliveredMessage}: Ping
         </p>
 
         {showDeliveredMessageIcon ? (
-          <div className="message-ping-delivered-icon">
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none">
-              <path
-                fill="#676B71"
-                fillRule="evenodd"
-                d="M14 8A6 6 0 1 1 2 8a6 6 0 0 1 12 0Zm2 0A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-8.659 3.27 5.128-5.127-1.414-1.415-4.42 4.421-1.69-1.69-1.414 1.415 2.396 2.396.707.708.707-.708Z"
-                clipRule="evenodd"
-              />
-            </svg>
+          <div className="message-ping-delivered-icon" title={t('conversationMessageDelivered')}>
+            <Icon.OutlineCheck />
           </div>
         ) : (
           <ReadReceiptStatus message={message} is1to1Conversation={is1to1Conversation} />

--- a/src/script/components/MessagesList/Message/PingMessage.tsx
+++ b/src/script/components/MessagesList/Message/PingMessage.tsx
@@ -20,6 +20,7 @@
 import cx from 'classnames';
 
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
+import {checkIsMessageDelivered} from 'Util/util';
 
 import {ReadReceiptStatus} from './ReadReceiptStatus';
 
@@ -32,10 +33,17 @@ export interface PingMessageProps {
 }
 
 const PingMessage = ({message, is1to1Conversation, isLastDeliveredMessage}: PingMessageProps) => {
-  const {unsafeSenderName, caption, ephemeral_caption, isObfuscated, get_icon_classes} = useKoSubscribableChildren(
-    message,
-    ['unsafeSenderName', 'caption', 'ephemeral_caption', 'isObfuscated', 'get_icon_classes'],
-  );
+  const {unsafeSenderName, caption, ephemeral_caption, isObfuscated, get_icon_classes, readReceipts} =
+    useKoSubscribableChildren(message, [
+      'unsafeSenderName',
+      'caption',
+      'ephemeral_caption',
+      'isObfuscated',
+      'get_icon_classes',
+      'readReceipts',
+    ]);
+
+  const showDeliveredMessageIcon = checkIsMessageDelivered(isLastDeliveredMessage, readReceipts);
 
   return (
     <div className="message-header" data-uie-name="element-message-ping">
@@ -45,6 +53,7 @@ const PingMessage = ({message, is1to1Conversation, isLastDeliveredMessage}: Ping
       <div
         className={cx('message-header-label', {
           'ephemeral-message-obfuscated': isObfuscated,
+          'message-header-ping-delivered': showDeliveredMessageIcon,
         })}
         title={ephemeral_caption}
         data-uie-name="element-message-ping-text"
@@ -54,11 +63,20 @@ const PingMessage = ({message, is1to1Conversation, isLastDeliveredMessage}: Ping
           <span className="ellipsis">{caption}</span>
         </p>
 
-        <ReadReceiptStatus
-          message={message}
-          is1to1Conversation={is1to1Conversation}
-          isLastDeliveredMessage={isLastDeliveredMessage}
-        />
+        {showDeliveredMessageIcon ? (
+          <div className="message-ping-delivered-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none">
+              <path
+                fill="#676B71"
+                fillRule="evenodd"
+                d="M14 8A6 6 0 1 1 2 8a6 6 0 0 1 12 0Zm2 0A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-8.659 3.27 5.128-5.127-1.414-1.415-4.42 4.421-1.69-1.69-1.414 1.415 2.396 2.396.707.708.707-.708Z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </div>
+        ) : (
+          <ReadReceiptStatus message={message} is1to1Conversation={is1to1Conversation} />
+        )}
       </div>
     </div>
   );

--- a/src/script/components/MessagesList/Message/ReadIndicator/ReadIndicator.tsx
+++ b/src/script/components/MessagesList/Message/ReadIndicator/ReadIndicator.tsx
@@ -19,7 +19,6 @@
 
 import {Icon} from 'Components/Icon';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
-import {t} from 'Util/LocalizerUtil';
 import {formatTimeShort} from 'Util/TimeUtil';
 
 import {ReadIndicatorContainer, ReadIndicatorStyles, ReadReceiptText} from './ReadIndicator.styles';
@@ -29,7 +28,6 @@ import {Message} from '../../../../entity/message/Message';
 interface ReadIndicatorProps {
   message: Message;
   is1to1Conversation?: boolean;
-  isLastDeliveredMessage?: boolean;
   showIconOnly?: boolean;
   onClick?: (message: Message) => void;
 }
@@ -37,7 +35,6 @@ interface ReadIndicatorProps {
 export const ReadIndicator = ({
   message,
   is1to1Conversation = false,
-  isLastDeliveredMessage = false,
   showIconOnly = false,
   onClick,
 }: ReadIndicatorProps) => {
@@ -45,15 +42,10 @@ export const ReadIndicator = ({
 
   if (is1to1Conversation) {
     const readReceiptText = readReceipts.length ? formatTimeShort(readReceipts[0].time) : '';
-    const showDeliveredMessage = isLastDeliveredMessage && readReceiptText === '';
 
     return (
       <div css={ReadIndicatorContainer} className="read-indicator-wrapper">
         <span css={ReadIndicatorStyles(showIconOnly)} data-uie-name="status-message-read-receipts">
-          {showDeliveredMessage && (
-            <span data-uie-name="status-message-read-receipt-delivered">{t('conversationMessageDelivered')}</span>
-          )}
-
           {showIconOnly && readReceiptText && <Icon.Read />}
 
           {!showIconOnly && !!readReceiptText && (

--- a/src/script/components/MessagesList/Message/ReadReceiptStatus.test.tsx
+++ b/src/script/components/MessagesList/Message/ReadReceiptStatus.test.tsx
@@ -36,42 +36,10 @@ const createReadReceiptMessage = (partialReadReceiptStatus: Partial<MessageEntit
 };
 
 describe('ReadReceiptStatus', () => {
-  it('is not shown when message is not last delivered message', () => {
-    const props = {
-      isMessageFocused: true,
-      is1to1Conversation: false,
-      isLastDeliveredMessage: false,
-      message: createReadReceiptMessage({
-        readReceipts: ko.observableArray([] as ReadReceipt[]),
-      }),
-    };
-
-    const {queryByTestId} = render(<ReadReceiptStatus {...props} />);
-
-    expect(queryByTestId('status-message-read-receipt-delivered')).toBeNull();
-  });
-
-  it('shows "delivered" when noone read the message', () => {
-    const props = {
-      isMessageFocused: true,
-      is1to1Conversation: false,
-      isLastDeliveredMessage: true,
-      message: createReadReceiptMessage({
-        readReceipts: ko.observableArray([] as ReadReceipt[]),
-      }),
-    };
-
-    const {queryByTestId} = render(<ReadReceiptStatus {...props} />);
-
-    expect(queryByTestId('status-message-read-receipt-delivered')).not.toBeNull();
-    expect(queryByTestId('status-message-read-receipts')).toBeNull();
-  });
-
   it('shows the read icon', () => {
     const props = {
       isMessageFocused: true,
       is1to1Conversation: false,
-      isLastDeliveredMessage: true,
       message: createReadReceiptMessage({
         readReceipts: ko.observableArray([{} as ReadReceipt]),
       }),
@@ -90,7 +58,6 @@ describe('ReadReceiptStatus', () => {
       const props = {
         isMessageFocused: true,
         is1to1Conversation: true,
-        isLastDeliveredMessage: true,
         message: createReadReceiptMessage({
           readReceipts: ko.observableArray([{time: readReceiptTime} as ReadReceipt]),
         }),
@@ -109,7 +76,6 @@ describe('ReadReceiptStatus', () => {
       const props = {
         isMessageFocused: true,
         is1to1Conversation: true,
-        isLastDeliveredMessage: true,
         message: createReadReceiptMessage({
           readReceipts: ko.observableArray([{time: readReceiptTime} as ReadReceipt]),
         }),
@@ -127,7 +93,6 @@ describe('ReadReceiptStatus', () => {
       const props = {
         isMessageFocused: true,
         is1to1Conversation: false,
-        isLastDeliveredMessage: true,
         message: createReadReceiptMessage({
           readReceipts: ko.observableArray([{} as ReadReceipt, {} as ReadReceipt]),
         }),

--- a/src/script/components/MessagesList/Message/ReadReceiptStatus.tsx
+++ b/src/script/components/MessagesList/Message/ReadReceiptStatus.tsx
@@ -29,17 +29,11 @@ import {formatTimeShort} from 'Util/TimeUtil';
 
 export interface ReadReceiptStatusProps {
   is1to1Conversation: boolean;
-  isLastDeliveredMessage: boolean;
   message: Message;
   onClickDetails?: (message: Message) => void;
 }
 
-export const ReadReceiptStatus = ({
-  message,
-  is1to1Conversation,
-  isLastDeliveredMessage,
-  onClickDetails,
-}: ReadReceiptStatusProps) => {
+export const ReadReceiptStatus = ({message, is1to1Conversation, onClickDetails}: ReadReceiptStatusProps) => {
   const [readReceiptText, setReadReceiptText] = useState('');
   const {readReceipts} = useKoSubscribableChildren(message, ['readReceipts']);
 
@@ -48,19 +42,12 @@ export const ReadReceiptStatus = ({
       const text = is1to1Conversation ? formatTimeShort(readReceipts[0].time) : readReceipts.length.toString(10);
       setReadReceiptText(text);
     }
-  }, [is1to1Conversation, readReceipts]);
+  }, [is1to1Conversation, message.expectsReadConfirmation, readReceipts]);
 
-  const showDeliveredMessage = isLastDeliveredMessage && readReceiptText === '';
   const showEyeIndicator = !!readReceiptText;
 
   return (
     <>
-      {showDeliveredMessage && (
-        <span className="message-status" data-uie-name="status-message-read-receipt-delivered">
-          {t('conversationMessageDelivered')}
-        </span>
-      )}
-
       {showEyeIndicator && (
         <button
           className={cx(

--- a/src/script/util/util.ts
+++ b/src/script/util/util.ts
@@ -22,11 +22,14 @@ import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 
 import {Runtime} from '@wireapp/commons';
 
+import {formatTimeShort} from 'Util/TimeUtil';
+
 import {isTabKey} from './KeyboardUtil';
 
 import {Config} from '../Config';
 import type {Conversation} from '../entity/Conversation';
 import {AuthError} from '../error/AuthError';
+import {ReadReceipt} from '../storage';
 
 export const checkIndexedDb = (): Promise<void> => {
   if (!Runtime.isSupportingIndexedDb()) {
@@ -315,4 +318,9 @@ export const removeAnimationsClass = (element: HTMLElement | null) => {
       }
     });
   }
+};
+
+export const checkIsMessageDelivered = (isLastDeliveredMessage: boolean, readReceipts: ReadReceipt[]) => {
+  const readReceiptText = readReceipts.length ? formatTimeShort(readReceipts[0].time) : '';
+  return isLastDeliveredMessage && readReceiptText === '';
 };

--- a/src/style/common/variables.less
+++ b/src/style/common/variables.less
@@ -389,3 +389,7 @@ body {
 
 // Margins
 @offscreen-left: -9999px;
+
+body {
+  --delivered-state-width: 56px;
+}

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -176,6 +176,13 @@
   }
 }
 
+.message-ping-delivered-icon {
+  display: flex;
+  width: 56px;
+  align-items: center;
+  justify-content: center;
+}
+
 .message-header-label {
   display: flex;
   min-width: 0; // fixes ellipsis not working with flexbox (FF)
@@ -183,6 +190,11 @@
   font-size: @font-size-small;
   font-weight: @font-weight-regular;
   white-space: normal;
+
+  &.message-header-ping-delivered {
+    width: 100%;
+    justify-content: space-between;
+  }
 
   &--verification {
     display: inline;
@@ -274,8 +286,7 @@
 // MESSAGE - BODY
 .message-body {
   position: relative;
-  padding-right: 40px;
-  padding-left: var(--conversation-message-sender-width);
+  width: 100%;
 
   .text:has(> .iframe-container) {
     margin-right: 0;

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -178,7 +178,7 @@
 
 .message-ping-delivered-icon {
   display: flex;
-  width: 56px;
+  width: var(--delivered-state-width);
   align-items: center;
   justify-content: center;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4973,9 +4973,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/react-ui-kit@npm:9.17.7":
-  version: 9.17.7
-  resolution: "@wireapp/react-ui-kit@npm:9.17.7"
+"@wireapp/react-ui-kit@npm:9.18.0":
+  version: 9.18.0
+  resolution: "@wireapp/react-ui-kit@npm:9.18.0"
   dependencies:
     "@types/color": "npm:3.0.6"
     color: "npm:4.2.3"
@@ -4990,7 +4990,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/4e5e0d00774aaf28ef1b851a4e300ea7921c04e1561346d3e91163c2c1656569e17a560ad553ce88d9c6195b4d47f873c3f6a24c41b0cd6892740516b5a9e39d
+  checksum: 10/d19ce1b920e1cc4a8e2ef435d27fa1fa42e1182d04cfe46fdce4d897e5274ec768b2ff4a5c51144e20f643700883bbd9b14130a13ce67ced061009551ee8b75f
   languageName: node
   linkType: hard
 
@@ -17454,7 +17454,7 @@ __metadata:
     "@wireapp/core": "npm:46.0.14"
     "@wireapp/eslint-config": "npm:3.0.7"
     "@wireapp/prettier-config": "npm:0.6.4"
-    "@wireapp/react-ui-kit": "npm:9.17.7"
+    "@wireapp/react-ui-kit": "npm:9.18.0"
     "@wireapp/store-engine": "npm:5.1.6"
     "@wireapp/store-engine-dexie": "npm:2.1.10"
     "@wireapp/webapp-events": "npm:0.22.0"


### PR DESCRIPTION
## Description

We have improved delivered status information. We changed message "Delivered" to icon and display it on right side of application. Now we don't display also this information on hover. It's visible all the time, until user didn't read message.

## Screenshots/Screencast (for UI changes)

Before:
<img width="815" alt="image" src="https://github.com/wireapp/wire-webapp/assets/13432884/ac5feb4e-34c6-4143-a934-0b9308b2cc26">

After:
![image](https://github.com/wireapp/wire-webapp/assets/13432884/4a082454-31a5-4d69-9869-0d958a2c1a35)


## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
