### PR TITLE
runfix: Improve background edge blurring

### DIFF
--- a/src/script/media/BackgroundBlurrer/fragmentShader.glsl
+++ b/src/script/media/BackgroundBlurrer/fragmentShader.glsl
@@ -30,7 +30,7 @@ void main() {
         }
     }
     blend = blend / pow(float((SMOOTH) * 2), 2.0);
-    //blend = texture2D(u_mask, v_texCoord).r == 1.0 ? 1.0 : 0.0;
+    //blend = texture2D(u_mask, v_texCoord).r;
     vec4 clearPixel = texture2D(u_image, v_texCoord);
     gl_FragColor = mix(blurredPixel, clearPixel, blend);
 }

--- a/src/script/media/BackgroundBlurrer/fragmentShader.glsl
+++ b/src/script/media/BackgroundBlurrer/fragmentShader.glsl
@@ -1,5 +1,4 @@
 #define BLUR_QUALITY 14 //The higher the value, the more blur. Must be an even number.
-#define SMOOTH 3 // This will create a smooth transition between the blurred and the clear part (the higher the value, the smoother)
 
 precision mediump float;
 
@@ -21,16 +20,14 @@ void main() {
             colorSum += texture2D(u_image, v_texCoord + onePixel * vec2(i, j));
         }
     }
+    // This is the blurred version of the pixel we are currently rendering
     vec4 blurredPixel = vec4((colorSum / (pow(float(BLUR_QUALITY), 2.0) * 4.0)).rgb, 1);
 
-    float blend;
-    for (int i = -SMOOTH; i < SMOOTH; i++) {
-        for (int j = -SMOOTH; j < SMOOTH; j++) {
-            blend += texture2D(u_mask, v_texCoord + onePixel * vec2(i, j)).r == 1.0 ? 1.0 : 0.0;
-        }
-    }
-    blend = blend / pow(float((SMOOTH) * 2), 2.0);
-    //blend = texture2D(u_mask, v_texCoord).r;
+    // This is the clear version of the pixel we are currently rendering
     vec4 clearPixel = texture2D(u_image, v_texCoord);
+
+    blend = texture2D(u_mask, v_texCoord).r;
+
+    // The gl_FragColor is a mix between the blurred and the clear pixel depending on the segmentation mask given
     gl_FragColor = mix(blurredPixel, clearPixel, blend);
 }

--- a/src/script/media/BackgroundBlurrer/fragmentShader.glsl
+++ b/src/script/media/BackgroundBlurrer/fragmentShader.glsl
@@ -26,7 +26,7 @@ void main() {
     // This is the clear version of the pixel we are currently rendering
     vec4 clearPixel = texture2D(u_image, v_texCoord);
 
-    blend = texture2D(u_mask, v_texCoord).r;
+    float blend = texture2D(u_mask, v_texCoord).r;
 
     // The gl_FragColor is a mix between the blurred and the clear pixel depending on the segmentation mask given
     gl_FragColor = mix(blurredPixel, clearPixel, blend);


### PR DESCRIPTION
## Description

We were previously trying to manually do a smoothing of the edge detected by the segmenter. 
But turned out the result of the segmentation is already a float value that gives how much of the clear pixel should be used compared to the blurred pixel. 

So instead of manually computing a smooth value, we can just use the segmenter's raw value 

## Screenshots/Screencast (for UI changes)

### Before
<img width="246" alt="image" src="https://github.com/wireapp/wire-webapp/assets/1090716/a06d4e68-cbb5-4dd7-baca-55c0252f2b20">


### After 
<img width="268" alt="image" src="https://github.com/wireapp/wire-webapp/assets/1090716/d122e487-f866-4678-9a18-f6232db35bab">


