### PR TITLE
fix(actions): prevent command injection in GHA workflow (WPB-9709)

### DIFF
--- a/.github/workflows/deploy-to-test-env.yml
+++ b/.github/workflows/deploy-to-test-env.yml
@@ -28,8 +28,10 @@ jobs:
     steps:
       - name: Print environment variables
         run: |
-          echo -e "branch = ${{github.ref_name}}"
-          echo -e "env = ${{inputs.env}}"
+          echo -e "branch = ${GITHUB_REF_NAME}"
+          echo -e "env = ${ENV}"
+        env:
+          ENV: ${{ inputs.env }}
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description
It was possible to run arbitrary commands in the context of the GitHub Actions workflow by using an unsanitized user input (`env`) in a run step.

As a best practice, we shall try to sanitize any user input, which can be done by passing it through an env var.


## References
- https://wearezeta.atlassian.net/wiki/spaces/SC/pages/1216053328/How+to+avoid+Command+Injection+via+Github+Actions+or+CI+jobs+in+general
- https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#example-of-a-script-injection-attack
- related to [WPB-9709](https://wearezeta.atlassian.net/browse/WPB-9709)

## Checklist

- [x] PR has been self reviewed by the author;


<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9709" title="WPB-9709" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9709</a>  Fix GHA pipeline command injection vulnerabilities
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


[WPB-9709]: https://wearezeta.atlassian.net/browse/WPB-9709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ