### PR TITLE
fix: Conversation scrolling stops loading following messages

### DIFF
--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -188,7 +188,7 @@ export const MessagesList: FC<MessagesListParams> = ({
     if (lastMessage) {
       if (!isLastReceivedMessage(lastMessage, conversation)) {
         // if the last loaded message is not the last of the conversation, we load the subsequent messages
-        conversationRepository.getSubsequentMessages(conversation, lastMessage as ContentMessage);
+        conversationRepository.getSubsequentMessages(conversation, lastMessage);
       }
     }
   };

--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -46,7 +46,6 @@ import {groupMessagesBySenderAndTime, isMarker} from './utils/messagesGroup';
 import {updateScroll, FocusedElement} from './utils/scrollUpdater';
 
 import {Conversation} from '../../entity/Conversation';
-import {isContentMessage} from '../../guards/Message';
 
 interface MessagesListParams {
   cancelConnectionRequest: (message: MemberMessage) => void;
@@ -189,9 +188,7 @@ export const MessagesList: FC<MessagesListParams> = ({
     if (lastMessage) {
       if (!isLastReceivedMessage(lastMessage, conversation)) {
         // if the last loaded message is not the last of the conversation, we load the subsequent messages
-        if (isContentMessage(lastMessage)) {
-          conversationRepository.getSubsequentMessages(conversation, lastMessage);
-        }
+        conversationRepository.getSubsequentMessages(conversation, lastMessage as ContentMessage);
       }
     }
   };

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -972,7 +972,7 @@ export class ConversationRepository {
    * Get subsequent messages starting with the given message.
    * @returns Resolves with the messages
    */
-  async getSubsequentMessages(conversationEntity: Conversation, messageEntity: ContentMessage) {
+  async getSubsequentMessages(conversationEntity: Conversation, messageEntity: Message) {
     const messageDate = new Date(messageEntity.timestamp());
     conversationEntity.isLoadingMessages(true);
 


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-9465

## Description

Probably something was wrong while refactoring. Previously we not checking all messages, probably this if checking will fix this issue.

Previously code:

```
readonly loadFollowingMessages = () => {
    const lastMessage = this.conversation().getLastMessage();

    if (lastMessage) {
      if (!this.isLastReceivedMessage(lastMessage, this.conversation())) {
        // if the last loaded message is not the last of the conversation, we load the subsequent messages
        this.conversationRepository.getSubsequentMessages(this.conversation(), lastMessage as ContentMessage);
      }
    }
  };

```

## Screenshots/Screencast (for UI changes)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
