### PR TITLE
fix: Do not intercept right click on rendered message links [WPB-6546]

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -279,10 +279,6 @@ export const Conversation = ({
   };
 
   const handleMarkdownLinkClick = (event: MouseEvent | KeyboardEvent, messageDetails: MessageDetails) => {
-    if (isAuxRightClickEvent(event)) {
-      // Default browser behavior on right click
-      return true;
-    }
     const href = messageDetails.href!;
     PrimaryModal.show(PrimaryModal.type.CONFIRM, {
       primaryAction: {
@@ -325,7 +321,7 @@ export const Conversation = ({
       userDomain: '',
     },
   ) => {
-    if (isMouseRightClickEvent(event)) {
+    if (isMouseRightClickEvent(event) || isAuxRightClickEvent(event)) {
       // Default browser behavior on right click
       return true;
     }


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6546" title="WPB-6546" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6546</a>  Right click on email link opens standard email app instead of option to copy the link
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->




## Description

A right click should not trigger the custom click handler and let the browser handle it with the default behavior. 

## Screenshots

### Before 


https://github.com/wireapp/wire-webapp/assets/1090716/b0b6cf00-74c4-4f09-80a8-9be91f6110b3


### After 


https://github.com/wireapp/wire-webapp/assets/1090716/6a36fda0-78ed-4fbe-b484-f300c074031a


