### PR TITLE
runfix: implement missing locator for automation (WPB-9506)

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.tsx
@@ -165,7 +165,12 @@ export const ConversationFolderTab = ({
                 onClick={() => toggleFolder(folder.id)}
               >
                 <span>{folder.name}</span>
-                {!!unreadCount && <span className={cx('conversations-sidebar-btn--badge', {active: isActive})} />}
+                {!!unreadCount && (
+                  <span
+                    className={cx('conversations-sidebar-btn--badge', {active: isActive})}
+                    data-uie-name="unread-badge"
+                  />
+                )}
               </button>
             );
           })}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9506" title="WPB-9506" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9506</a>  [Web] Implement locators for automation on the new navigation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Implement the `unread-badge` locator for elements in the folder list

One `data-uie-name` required by QA was missing in https://github.com/wireapp/wire-webapp/pull/17508  for that specific case
