### PR TITLE
fix: Disable automatic scroll detection when messages are being loaded [WPB-5402] 

### DIFF
--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -337,12 +337,14 @@ export const MessagesList: FC<MessagesListParams> = ({
                     const messageIsLoaded = conversation.getMessage(messageId);
 
                     if (!messageIsLoaded) {
+                      setLoaded(false); // this will block automatic scroll triggers (like loading extra messages)
                       const messageEntity = await messageRepository.getMessageInConversationById(
                         conversation,
                         messageId,
                       );
                       conversation.removeMessages();
                       conversationRepository.getMessagesWithOffset(conversation, messageEntity);
+                      setLoaded(true); // unblock automatic scroll triggers
                     }
                   }}
                   selfId={selfUser.qualifiedId}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5402" title="WPB-5402" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5402</a>  [Web] Jumping to a quoted message and scrolling down misses a lot of messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

When we click on the `original message` button of a quote (that is not currently in the loaded messages), we:
- first clear up all the messages (emptying the message list)
- load the original message by ID
- load messages before and after that message

The thing is: emptying the message list triggers a scroll event that will automatically load more messages (the last ones). 

This is conflicting as we are loading both the messages around the `original` message AND the last messages, but not the messages in between. 

This PR fixes this behavior by setting the `loaded` state to `false` before changing anything in the `message list`. 
This prevents all the scroll events to be ignored while we load the messages.

## Screenshots/Screencast (for UI changes)

### Before

The conversation only has a handful of messages and is missing a lot of messages in between

https://github.com/wireapp/wire-webapp/assets/1090716/01039f90-cc98-4ef4-9460-0082dfcb00a1

### After

All the messages between the original message and the latest received messages are here

https://github.com/wireapp/wire-webapp/assets/1090716/4bdec83b-ff80-4b58-8404-7f1d66cbd6c4



