### PR TITLE
fix: Save edited message state in editor draft [WPB-9846]

### DIFF
--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -458,18 +458,14 @@ export const InputBar = ({
   const loadDraft = async () => {
     const draftState = await loadDraftState(conversation, storageRepository, messageRepository);
 
-    if (draftState.messageReply) {
-      void draftState.messageReply.then(replyEntity => {
-        if (replyEntity?.isReplyable()) {
-          setReplyMessageEntity(replyEntity);
-        }
-      });
+    const reply = draftState.messageReply;
+    if (reply?.isReplyable()) {
+      setReplyMessageEntity(reply);
     }
 
-    if (draftState.editedMessage) {
-      void draftState.editedMessage.then(editedMessage => {
-        setEditedMessage(editedMessage);
-      });
+    const editedMessage = draftState.editedMessage;
+    if (editedMessage) {
+      setEditedMessage(editedMessage);
     }
 
     return draftState;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9846" title="WPB-9846" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9846</a>  [web] original message of edit is lost when switching conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

## Screenshots/Screencast (for UI changes)

### Before 

https://github.com/wireapp/wire-webapp/assets/1090716/32393bf1-c607-445f-ba5a-f09af71184f7

### After

https://github.com/wireapp/wire-webapp/assets/1090716/18864f12-e925-466a-84cb-6150f25719ae




