### PR TITLE
fix: not clone audio tracks

### DIFF
--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -1238,9 +1238,9 @@ export class CallingRepository {
     const {conversation} = call;
 
     if (mediaType === MediaType.AUDIO) {
-      const audioTracks = mediaStream.getAudioTracks().map(track => track.clone());
+      const audioTracks: MediaStreamTrack[] = mediaStream.getAudioTracks();
       if (audioTracks.length > 0) {
-        selfParticipant.setAudioStream(new MediaStream(audioTracks), true);
+        selfParticipant.setAudioStream(new MediaStream([audioTracks[0]]), true);
         this.wCall?.replaceTrack(this.serializeQualifiedId(conversation.qualifiedId), audioTracks[0]);
       }
     }
@@ -1252,10 +1252,10 @@ export class CallingRepository {
         this.wCall?.replaceTrack(this.serializeQualifiedId(conversation.qualifiedId), videoTracks[0]);
         // Remove the previous video stream
         if (updateSelfParticipant) {
-          selfParticipant.setVideoStream(mediaStream, true);
+          selfParticipant.setVideoStream(new MediaStream([videoTracks[0]]), true);
         }
-        return mediaStream;
       }
+      return mediaStream;
     }
   }
 


### PR DESCRIPTION
## Description
When you change the audio device during a call, the first track does not terminate and remains enabled in the background. The track should terminate and be closed. However, the track remain indefinitely, until you close the Browser tab. The reason for this behavior is a cloned track that is no longer taken care of.

## Screenshots/Screencast (for UI changes)

https://github.com/wireapp/wire-webapp/assets/1362436/4529c0c0-2996-42bd-a779-3b5a200a80b2


## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
