### PR TITLE
runfix: Avoid caching the config file

### DIFF
--- a/src/page/auth.ejs
+++ b/src/page/auth.ejs
@@ -25,7 +25,7 @@
 
   <body>
     <div id="main"></div>
-    <script src="../config.js?v=<%= VERSION %>"></script>
+    <script src="../config.js"></script>
     <script src="../min/dexie.js?v=<%= VERSION %>"></script>
     <script src="../min/vendor.js?v=<%= VERSION %>"></script>
     <script src="../min/runtime.js?v=<%= VERSION %>"></script>

--- a/src/page/index.ejs
+++ b/src/page/index.ejs
@@ -89,7 +89,7 @@
     </main>
 
     <script src="./min/loader.js?v=<%= VERSION %>"></script>
-    <script src="./config.js?v=<%= VERSION %>"></script>
+    <script src="./config.js"></script>
     <script src="./min/dexie.js?v=<%= VERSION %>"></script>
     <script src="./min/vendor.js?v=<%= VERSION %>"></script>
     <script src="./min/runtime.js?v=<%= VERSION %>"></script>


### PR DESCRIPTION
## Description

Recently we enabled stronger caching for JS files to improve loading performances. 
But the `config.js` file was wrongly cached, resulting on config changes not being properly dispatched. 

This fixes it by removing the `v` query param to get the config file and falling then back to the 5min caching strategy. 