### PR TITLE
chore: use node20 environment for staging

### DIFF
--- a/.github/workflows/deploy-to-test-env.yml
+++ b/.github/workflows/deploy-to-test-env.yml
@@ -11,7 +11,6 @@ on:
           - wire-webapp-qa-al2-migration
           - wire-webapp-mls-al2
           - wire-webapp-dev
-          - wire-webapp-staging
           - wire-webapp-prod
           - wire-webapp-qa
           - wire-webapp-mls

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -283,7 +283,7 @@ jobs:
                 "targets": "[\"wire-webapp-mls-al2\"]"
               },
               "staging": {
-                "targets": "[\"wire-webapp-staging-al2\"]"
+                "targets": "[\"wire-webapp-staging\"]"
               }
             }
           export_to: env


### PR DESCRIPTION
## Description

This will start using the `wire-webapp-staging` (running node20) as the deployment target for staging bumps. 
