### PR TITLE
runfix: address misaligned system messages (WPB-9825)

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.styles.ts
@@ -19,7 +19,7 @@
 
 import {CSSObject} from '@emotion/react';
 
-export const messageBodyWrapper = (isEphemeralMessage: boolean): CSSObject => ({
+export const messageBodyWrapper = (isEphemeralMessage: boolean = false): CSSObject => ({
   display: 'grid',
   gridTemplateColumns: isEphemeralMessage
     ? '64px calc(100% - var(--delivered-state-width) - 64px) var(--delivered-state-width)'

--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.styles.ts
@@ -19,7 +19,7 @@
 
 import {CSSObject} from '@emotion/react';
 
-export const messageBodyWrapper = (isEphemeralMessage: boolean = false): CSSObject => ({
+export const messageBodyWrapper = (isEphemeralMessage = false): CSSObject => ({
   display: 'grid',
   gridTemplateColumns: isEphemeralMessage
     ? '64px calc(100% - var(--delivered-state-width) - 64px) var(--delivered-state-width)'

--- a/src/script/components/MessagesList/Message/DecryptErrorMessage.tsx
+++ b/src/script/components/MessagesList/Message/DecryptErrorMessage.tsx
@@ -73,42 +73,44 @@ const DecryptErrorMessage: React.FC<DecryptErrorMessageProps> = ({message, onCli
         </div>
       </div>
 
-      <div className="message-body message-body-decrypt-error" css={messageBodyWrapper()}>
-        <p className="message-header-decrypt-error-label" data-uie-name="status-decrypt-error">
-          {message.code && (
-            <>
-              {`${t('conversationUnableToDecryptErrorMessage')} `}
-              <span className="label-bold-xs">{message.code}</span>{' '}
-            </>
-          )}
-          {message.clientId && (
-            <>
-              {'ID: '}
-              <FormattedId idSlices={splitFingerprint(message.clientId)} smallPadding />
-            </>
-          )}
-        </p>
-
-        {message.isRecoverable && (
-          <div className="message-header-decrypt-reset-session">
-            {isResettingSession ? (
-              <Icon.LoadingIcon className="accent-fill" data-uie-name="status-loading" />
-            ) : (
-              <button
-                type="button"
-                className="button-reset-default message-header-decrypt-reset-session-action button-label accent-text"
-                onClick={() => {
-                  setIsResettingSession(true);
-                  onClickResetSession(message);
-                  setTimeout(() => setIsResettingSession(false), MotionDuration.LONG);
-                }}
-                data-uie-name="do-reset-encryption-session"
-              >
-                {t('conversationUnableToDecryptResetSession')}
-              </button>
+      <div css={messageBodyWrapper()}>
+        <div className="message-body message-body-decrypt-error">
+          <p className="message-header-decrypt-error-label" data-uie-name="status-decrypt-error">
+            {message.code && (
+              <>
+                {`${t('conversationUnableToDecryptErrorMessage')} `}
+                <span className="label-bold-xs">{message.code}</span>{' '}
+              </>
             )}
-          </div>
-        )}
+            {message.clientId && (
+              <>
+                {'ID: '}
+                <FormattedId idSlices={splitFingerprint(message.clientId)} smallPadding />
+              </>
+            )}
+          </p>
+
+          {message.isRecoverable && (
+            <div className="message-header-decrypt-reset-session">
+              {isResettingSession ? (
+                <Icon.LoadingIcon className="accent-fill" data-uie-name="status-loading" />
+              ) : (
+                <button
+                  type="button"
+                  className="button-reset-default message-header-decrypt-reset-session-action button-label accent-text"
+                  onClick={() => {
+                    setIsResettingSession(true);
+                    onClickResetSession(message);
+                    setTimeout(() => setIsResettingSession(false), MotionDuration.LONG);
+                  }}
+                  data-uie-name="do-reset-encryption-session"
+                >
+                  {t('conversationUnableToDecryptResetSession')}
+                </button>
+              )}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/script/components/MessagesList/Message/DecryptErrorMessage.tsx
+++ b/src/script/components/MessagesList/Message/DecryptErrorMessage.tsx
@@ -25,6 +25,8 @@ import {MotionDuration} from 'src/script/motion/MotionDuration';
 import {t} from 'Util/LocalizerUtil';
 import {splitFingerprint} from 'Util/StringUtil';
 
+import {messageBodyWrapper} from './ContentMessage/ContentMessage.styles';
+
 import {DecryptErrorMessage as DecryptErrorMessageEntity} from '../../../entity/message/DecryptErrorMessage';
 import {FormattedId} from '../../../page/MainContent/panels/preferences/DevicesPreferences/components/FormattedId';
 
@@ -71,7 +73,7 @@ const DecryptErrorMessage: React.FC<DecryptErrorMessageProps> = ({message, onCli
         </div>
       </div>
 
-      <div className="message-body message-body-decrypt-error">
+      <div className="message-body message-body-decrypt-error" css={messageBodyWrapper()}>
         <p className="message-header-decrypt-error-label" data-uie-name="status-decrypt-error">
           {message.code && (
             <>

--- a/src/script/components/MessagesList/Message/SystemMessage/SystemMessage.tsx
+++ b/src/script/components/MessagesList/Message/SystemMessage/SystemMessage.tsx
@@ -47,8 +47,8 @@ export const SystemMessage: React.FC<SystemMessageProps> = ({message}) => {
     return (
       <>
         <SystemMessageBase message={message} isSenderNameVisible icon={<Icon.EditIcon />} />
-        <div className="message-body font-weight-bold" css={messageBodyWrapper()}>
-          {message.name}
+        <div css={messageBodyWrapper()}>
+          <div className="message-body font-weight-bold">{message.name}</div>
         </div>
       </>
     );

--- a/src/script/components/MessagesList/Message/SystemMessage/SystemMessage.tsx
+++ b/src/script/components/MessagesList/Message/SystemMessage/SystemMessage.tsx
@@ -35,6 +35,7 @@ import {SystemMessage as SystemMessageEntity} from 'src/script/entity/message/Sy
 
 import {SystemMessageBase} from './SystemMessageBase';
 
+import {messageBodyWrapper} from '../ContentMessage/ContentMessage.styles';
 import {ProtocolUpdateMessage as ProtocolUpdateMessageComponent} from '../ProtocolUpdateMessage';
 
 export interface SystemMessageProps {
@@ -46,7 +47,9 @@ export const SystemMessage: React.FC<SystemMessageProps> = ({message}) => {
     return (
       <>
         <SystemMessageBase message={message} isSenderNameVisible icon={<Icon.EditIcon />} />
-        <div className="message-body font-weight-bold">{message.name}</div>
+        <div className="message-body font-weight-bold" css={messageBodyWrapper()}>
+          {message.name}
+        </div>
       </>
     );
   }


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9825" title="WPB-9825" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9825</a>  Error message in chat is misaligned
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

Some css refactored from less to css object were not applied to all relevant components and some system messages are misaligned.

This makes sure the correct css is applied to all element with the class `message-body`:
- decryption error system messages
- conversation name change message

## Screenshots/Screencast (for UI changes)
Before:
![Screenshot from 2024-06-27 13-31-31](https://github.com/wireapp/wire-webapp/assets/78490891/b4240619-c325-428d-b600-9dc1a1df37f6)
After:
![Screenshot from 2024-06-27 13-30-30](https://github.com/wireapp/wire-webapp/assets/78490891/64a3292b-af12-4ef6-ab64-21d7ba6ac3b2)


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;