### PR TITLE
runfix: set sidebar tab to recent on starting a new conversation (WPB-9509)

### DIFF
--- a/src/script/components/ConnectRequests/ConnectionRequests.tsx
+++ b/src/script/components/ConnectRequests/ConnectionRequests.tsx
@@ -27,6 +27,7 @@ import {Avatar, AVATAR_SIZE} from 'Components/Avatar';
 import {UserClassifiedBar} from 'Components/input/ClassifiedBar';
 import {UnverifiedUserWarning} from 'Components/Modals/UserModal';
 import {UserName} from 'Components/UserName';
+import {SidebarTabs, useSidebarStore} from 'src/script/page/LeftSidebar/panels/Conversations/state';
 import {useAppMainState, ViewType} from 'src/script/page/state';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
@@ -67,6 +68,8 @@ export const ConnectRequests = ({
 
   const {setCurrentView} = useAppMainState(state => state.responsiveView);
 
+  const {setCurrentTab: setCurrentSidebarTab} = useSidebarStore();
+
   const scrollToBottom = (behavior: ScrollBehavior = 'auto') => {
     if (connectRequestsRefEnd.current) {
       connectRequestsRefEnd.current.scrollIntoView({behavior});
@@ -104,6 +107,7 @@ export const ConnectRequests = ({
       /**
        * In the connect request view modal, we show an overview of all incoming connection requests. When there are multiple open connection requests, we want that the user sees them all and can accept them one-by-one. When the last open connection request gets accepted, we want the user to switch to this conversation.
        */
+      setCurrentSidebarTab(SidebarTabs.RECENT);
       return actionsViewModel.open1to1Conversation(conversationEntity);
     }
   };

--- a/src/script/components/panel/UserActions.tsx
+++ b/src/script/components/panel/UserActions.tsx
@@ -30,6 +30,7 @@ import {WebAppEvents} from '@wireapp/webapp-events';
 import * as Icon from 'Components/Icon';
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
 import {ConversationState} from 'src/script/conversation/ConversationState';
+import {SidebarTabs, useSidebarStore} from 'src/script/page/LeftSidebar/panels/Conversations/state';
 import {TeamState} from 'src/script/team/TeamState';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
@@ -141,6 +142,8 @@ const UserActions: React.FC<UserActionsProps> = ({
   ]);
   const isTeamMember = teamState.isInTeam(user);
 
+  const {setCurrentTab: setCurrentSidebarTab} = useSidebarStore();
+
   const has1to1Conversation = conversationState.has1to1ConversationWithUser(user.qualifiedId);
 
   const isNotMe = !user.isMe && isSelfActivated;
@@ -200,6 +203,7 @@ const UserActions: React.FC<UserActionsProps> = ({
           click: async () => {
             try {
               await create1to1Conversation(user, true);
+              setCurrentSidebarTab(SidebarTabs.DIRECTS);
               onAction(Actions.START_CONVERSATION);
             } catch (error) {
               if (error instanceof ClientMLSError && error.label === ClientMLSErrorLabel.NO_KEY_PACKAGES_AVAILABLE) {

--- a/src/script/components/panel/UserActions.tsx
+++ b/src/script/components/panel/UserActions.tsx
@@ -151,6 +151,7 @@ const UserActions: React.FC<UserActionsProps> = ({
   const create1to1Conversation = async (userEntity: User, showConversation: boolean): Promise<void> => {
     const conversationEntity = await actionsViewModel.getOrCreate1to1Conversation(userEntity);
     if (showConversation) {
+      setCurrentSidebarTab(SidebarTabs.RECENT);
       actionsViewModel.open1to1Conversation(conversationEntity);
     }
   };
@@ -203,7 +204,6 @@ const UserActions: React.FC<UserActionsProps> = ({
           click: async () => {
             try {
               await create1to1Conversation(user, true);
-              setCurrentSidebarTab(SidebarTabs.DIRECTS);
               onAction(Actions.START_CONVERSATION);
             } catch (error) {
               if (error instanceof ClientMLSError && error.label === ClientMLSErrorLabel.NO_KEY_PACKAGES_AVAILABLE) {
@@ -292,6 +292,7 @@ const UserActions: React.FC<UserActionsProps> = ({
               // Only open the new conversation if we aren't currently in a conversation context
               await actionsViewModel.open1to1Conversation(savedConversation);
             }
+            setCurrentSidebarTab(SidebarTabs.RECENT);
             onAction(Actions.SEND_REQUEST);
           },
           Icon: Icon.PlusIcon,

--- a/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
@@ -30,6 +30,7 @@ import {Conversation} from 'src/script/entity/Conversation';
 import {User} from 'src/script/entity/User';
 import {IntegrationRepository} from 'src/script/integration/IntegrationRepository';
 import {ServiceEntity} from 'src/script/integration/ServiceEntity';
+import {useSidebarStore, SidebarTabs} from 'src/script/page/LeftSidebar/panels/Conversations/state';
 import {UserRepository} from 'src/script/user/UserRepository';
 import {MainViewModel} from 'src/script/view_model/MainViewModel';
 import {t} from 'Util/LocalizerUtil';
@@ -93,6 +94,8 @@ const StartUI: React.FC<StartUIProps> = ({
   const [searchQuery, setSearchQuery] = useState('');
   const [activeTab, setActiveTab] = useState(Tabs.PEOPLE);
 
+  const {setCurrentTab: setCurrentSidebarTab} = useSidebarStore();
+
   const peopleSearchResults = useRef<SearchResultsData | undefined>(undefined);
 
   const openFirstConversation = async (): Promise<void> => {
@@ -113,6 +116,7 @@ const StartUI: React.FC<StartUIProps> = ({
     }
 
     const conversationEntity = await actions.getOrCreate1to1Conversation(user);
+    setCurrentSidebarTab(SidebarTabs.DIRECTS);
     return actions.open1to1Conversation(conversationEntity);
   };
 

--- a/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
@@ -116,7 +116,7 @@ const StartUI: React.FC<StartUIProps> = ({
     }
 
     const conversationEntity = await actions.getOrCreate1to1Conversation(user);
-    setCurrentSidebarTab(SidebarTabs.DIRECTS);
+    setCurrentSidebarTab(SidebarTabs.RECENT);
     return actions.open1to1Conversation(conversationEntity);
   };
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9509" title="WPB-9509" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9509</a>  [Web] Creating a conversation or group does not update the view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

Automation expects the conversation to be present in the conversation list when a new 1 on 1 conversation is started.
This switches the sidebar tab to the recent view when starting a conversation with a new connection or a team user and accepting/sending a connection request
