### PR TITLE
runfix: address archived conversations bugs (WPB-9493 WPB-9768)

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -350,7 +350,8 @@ const Conversations: React.FC<ConversationsProps> = ({
               />
             )}
 
-            {((showSearchInput && currentTabConversations.length === 0) || hasNoConversations) && (
+            {((showSearchInput && currentTabConversations.length === 0) ||
+              (hasNoConversations && currentTab !== SidebarTabs.ARCHIVES)) && (
               <EmptyConversationList
                 currentTab={currentTab}
                 onChangeTab={changeTab}

--- a/src/script/page/LeftSidebar/panels/Conversations/helpers.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/helpers.tsx
@@ -44,6 +44,8 @@ export function getTabConversations({
   const conversationSearchFilter = (conversation: Conversation) =>
     conversation.display_name().toLowerCase().includes(conversationsFilter.toLowerCase());
 
+  const conversationArchivedFilter = (conversation: Conversation) => !archivedConversations.includes(conversation);
+
   if ([SidebarTabs.FOLDER, SidebarTabs.RECENT].includes(currentTab)) {
     return {
       conversations: conversations.filter(conversationSearchFilter),
@@ -53,14 +55,14 @@ export function getTabConversations({
 
   if (currentTab === SidebarTabs.GROUPS) {
     return {
-      conversations: groupConversations.filter(conversationSearchFilter),
+      conversations: groupConversations.filter(conversationArchivedFilter, conversationSearchFilter),
       searchInputPlaceholder: t('searchGroupConversations'),
     };
   }
 
   if (currentTab === SidebarTabs.DIRECTS) {
     return {
-      conversations: directConversations.filter(conversationSearchFilter),
+      conversations: directConversations.filter(conversationArchivedFilter, conversationSearchFilter),
       searchInputPlaceholder: t('searchDirectConversations'),
     };
   }


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9493" title="WPB-9493" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9493</a>  [Web] After archiving whole conversation list, the archive shows empty state
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

[WPB-9768](https://wearezeta.atlassian.net/browse/WPB-9768)
## Description

Addresses 2 bugs with archived conversations in the new navigation
- archived conversations would show up in the 1on1 and group tabs
- when all conversations are archived, the archive tab would show the empty state ("no conversation is archived") above the conversations





[WPB-9768]: https://wearezeta.atlassian.net/browse/WPB-9768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ