### PR TITLE
feat: Adapt delivered status on last send message

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -107,7 +107,6 @@ export const ContentMessageComponent = ({
     status,
     quote,
     isObfuscated,
-    readReceipts,
   } = useKoSubscribableChildren(message, [
     'senderName',
     'timestamp',
@@ -120,7 +119,6 @@ export const ContentMessageComponent = ({
     'status',
     'quote',
     'isObfuscated',
-    'readReceipts',
   ]);
 
   const timeAgo = useRelativeTimestamp(message.timestamp());
@@ -268,7 +266,7 @@ export const ContentMessageComponent = ({
         </div>
 
         <div css={deliveredMessageIndicator}>
-          <DeliveredMessage isLastDeliveredMessage={isLastDeliveredMessage} readReceipts={readReceipts} />
+          <DeliveredMessage isLastDeliveredMessage={isLastDeliveredMessage} />
         </div>
       </div>
 

--- a/src/script/components/MessagesList/Message/DeliveredMessage/DeliveredMessage.test.tsx
+++ b/src/script/components/MessagesList/Message/DeliveredMessage/DeliveredMessage.test.tsx
@@ -22,7 +22,6 @@ import {render} from '@testing-library/react';
 import {DeliveredMessage} from './DeliveredMessage';
 
 import {withTheme} from '../../../../auth/util/test/TestUtil';
-import {ReadReceipt} from '../../../../storage';
 
 describe('DeliveredMessage', () => {
   it('should render null if isLastDeliveredMessage is false', () => {
@@ -30,16 +29,8 @@ describe('DeliveredMessage', () => {
     expect(queryByTestId('status-message-read-receipt-delivered')).toBeNull();
   });
 
-  it('should render null if readReceipts is not empty', () => {
-    const readReceipts = [{time: '123', userId: 'userId-1'}] as ReadReceipt[];
-    const {queryByTestId} = render(
-      withTheme(<DeliveredMessage isLastDeliveredMessage={true} readReceipts={readReceipts} />),
-    );
-    expect(queryByTestId('status-message-read-receipt-delivered')).toBeNull();
-  });
-
-  it('should render the delivered message icon if isLastDeliveredMessage is true and readReceipts is empty', () => {
-    const {queryByTestId} = render(withTheme(<DeliveredMessage isLastDeliveredMessage={true} readReceipts={[]} />));
+  it('should render the delivered message icon if isLastDeliveredMessage is true', () => {
+    const {queryByTestId} = render(withTheme(<DeliveredMessage isLastDeliveredMessage={true} />));
     expect(queryByTestId('status-message-read-receipt-delivered')).not.toBeNull();
   });
 });

--- a/src/script/components/MessagesList/Message/DeliveredMessage/DeliveredMessage.tsx
+++ b/src/script/components/MessagesList/Message/DeliveredMessage/DeliveredMessage.tsx
@@ -20,20 +20,13 @@
 import {OutlineCheck} from '@wireapp/react-ui-kit';
 
 import {t} from 'Util/LocalizerUtil';
-import {formatTimeShort} from 'Util/TimeUtil';
-
-import {ReadReceipt} from '../../../../storage';
 
 interface DeliveredMessageProps {
   isLastDeliveredMessage?: boolean;
-  readReceipts?: ReadReceipt[];
 }
 
-export const DeliveredMessage = ({isLastDeliveredMessage = false, readReceipts = []}: DeliveredMessageProps) => {
-  const readReceiptText = readReceipts.length ? formatTimeShort(readReceipts[0].time) : '';
-  const showDeliveredMessageIcon = isLastDeliveredMessage && readReceiptText === '';
-
-  if (!showDeliveredMessageIcon) {
+export const DeliveredMessage = ({isLastDeliveredMessage = false}: DeliveredMessageProps) => {
+  if (!isLastDeliveredMessage) {
     return null;
   }
 

--- a/src/script/components/MessagesList/Message/PingMessage.tsx
+++ b/src/script/components/MessagesList/Message/PingMessage.tsx
@@ -33,15 +33,10 @@ export interface PingMessageProps {
 }
 
 const PingMessage = ({message, is1to1Conversation, isLastDeliveredMessage}: PingMessageProps) => {
-  const {unsafeSenderName, caption, ephemeral_caption, isObfuscated, get_icon_classes, readReceipts} =
-    useKoSubscribableChildren(message, [
-      'unsafeSenderName',
-      'caption',
-      'ephemeral_caption',
-      'isObfuscated',
-      'get_icon_classes',
-      'readReceipts',
-    ]);
+  const {unsafeSenderName, caption, ephemeral_caption, isObfuscated, get_icon_classes} = useKoSubscribableChildren(
+    message,
+    ['unsafeSenderName', 'caption', 'ephemeral_caption', 'isObfuscated', 'get_icon_classes'],
+  );
 
   return (
     <div className="message-header" data-uie-name="element-message-ping">
@@ -60,7 +55,7 @@ const PingMessage = ({message, is1to1Conversation, isLastDeliveredMessage}: Ping
           <span className="ellipsis">{caption}</span>
         </p>
 
-        <DeliveredMessage isLastDeliveredMessage={isLastDeliveredMessage} readReceipts={readReceipts} />
+        <DeliveredMessage isLastDeliveredMessage={isLastDeliveredMessage} />
         <ReadReceiptStatus message={message} is1to1Conversation={is1to1Conversation} />
       </div>
     </div>


### PR DESCRIPTION
## Description

Display delivered status always on last send message by user.

## Screenshots/Screencast (for UI changes)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
