### PR TITLE
fix: Ensure folder list popup appears when sidebar is force collapsed (WPB-8671)

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.tsx
@@ -63,8 +63,9 @@ export const ConversationFolderTab = ({
   const {status: sidebarStatus, setStatus: setSidebarStatus} = useSidebarStore();
   const {openFolder, isFoldersTabOpen, toggleFoldersTab, expandedFolder} = useFolderState();
   const {conversationLabelRepository} = conversationRepository;
-  const mdBreakpoint = useMatchMedia('(max-width: 1000px)');
-  const isSideBarOpen = sidebarStatus === SidebarStatus.AUTO ? mdBreakpoint : sidebarStatus === SidebarStatus.OPEN;
+  const isScreenLessThanMdBreakpoint = useMatchMedia('(max-width: 1000px)');
+  const isSideBarOpen =
+    sidebarStatus === SidebarStatus.AUTO ? !isScreenLessThanMdBreakpoint : sidebarStatus === SidebarStatus.OPEN;
 
   function toggleFolder(folderId: string) {
     openFolder(folderId);

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -140,8 +140,11 @@ const Conversations: React.FC<ConversationsProps> = ({
   const {openFolder, closeFolder, expandedFolder, isFoldersTabOpen, toggleFoldersTab} = useFolderState();
   const {currentFocus, handleKeyDown, resetConversationFocus} = useConversationFocus(conversations);
 
-  const mdBreakpoint = useMatchMedia('(max-width: 1000px)');
-  const isSideBarOpen = sidebarStatus === SidebarStatus.AUTO ? mdBreakpoint : sidebarStatus === SidebarStatus.OPEN;
+  // false when screen is larger than 1000px
+  // true when screen is smaller than 1000px
+  const isScreenLessThanMdBreakpoint = useMatchMedia('(max-width: 1000px)');
+  const isSideBarOpen =
+    sidebarStatus === SidebarStatus.AUTO ? !isScreenLessThanMdBreakpoint : sidebarStatus === SidebarStatus.OPEN;
 
   const {conversations: currentTabConversations, searchInputPlaceholder} = getTabConversations({
     currentTab,
@@ -236,7 +239,7 @@ const Conversations: React.FC<ConversationsProps> = ({
   }
 
   const sidebar = (
-    <nav className="conversations-sidebar" css={conversationsSidebarStyles(mdBreakpoint)}>
+    <nav className="conversations-sidebar" css={conversationsSidebarStyles(isScreenLessThanMdBreakpoint)}>
       <FadingScrollbar className="conversations-sidebar-items" data-is-collapsed={!isSideBarOpen}>
         <UserDetails
           user={selfUser}
@@ -304,7 +307,7 @@ const Conversations: React.FC<ConversationsProps> = ({
 
   return (
     <div className="conversations-wrapper">
-      <div className="conversations-sidebar-spacer" css={conversationsSpacerStyles(mdBreakpoint)} />
+      <div className="conversations-sidebar-spacer" css={conversationsSpacerStyles(isScreenLessThanMdBreakpoint)} />
       <ListWrapper
         id="conversations"
         headerElement={


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8671" title="WPB-8671" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-8671</a>  [Web] Folder list popup does not open if sidebar was force collapsed
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

The folder list popup does not open if the sidebar was force collapsed due to reducing the window width. However, if the sidebar was manually collapsed, the folder list popup appears as expected.

### Fix
This pull request fixes the issue by ensuring the folder list popup always appears when clicking on the folder icon, regardless of whether the sidebar was collapsed automatically due to reduced window width or manually by the user.

- Changed `isSideBarOpen` logic to correctly handle automatic sidebar collapse based on screen width.
