### PR TITLE
feat: add multi window support to context menu

### DIFF
--- a/src/script/components/DetachedWindow/DetachedWindow.tsx
+++ b/src/script/components/DetachedWindow/DetachedWindow.tsx
@@ -26,6 +26,7 @@ import {createPortal} from 'react-dom';
 
 import {StyledApp, THEME_ID} from '@wireapp/react-ui-kit';
 
+import {useActiveWindow} from 'src/script/hooks/useActiveWindow';
 import {calculateChildWindowPosition} from 'Util/DOM/caculateChildWindowPosition';
 
 import '../../../style/default.less';
@@ -63,6 +64,8 @@ export const DetachedWindow = ({children, name, onClose, width = 600, height = 6
       `,
     );
   }, [height, name, width]);
+
+  useActiveWindow(newWindow);
 
   useEffect(() => {
     if (!newWindow) {

--- a/src/script/hooks/useActiveWindow.ts
+++ b/src/script/hooks/useActiveWindow.ts
@@ -1,0 +1,48 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {useEffect} from 'react';
+
+import {create} from 'zustand';
+
+type ActiveWindowState = {
+  activeWindow: Window;
+  setActiveWindow: (newWindow: Window) => void;
+};
+
+export const useActiveWindowState = create<ActiveWindowState>((set, get) => ({
+  activeWindow: window,
+  setActiveWindow: (newWindow: Window) => set({activeWindow: newWindow}),
+}));
+
+export const useActiveWindow = (windowObj: Window | null) => {
+  const {setActiveWindow} = useActiveWindowState();
+
+  const windowRef = windowObj || window;
+
+  useEffect(() => {
+    const handleFocus = () => setActiveWindow(windowRef);
+
+    windowRef.addEventListener('focus', handleFocus);
+
+    return () => {
+      windowRef.removeEventListener('focus', handleFocus);
+    };
+  }, [setActiveWindow, windowRef]);
+};

--- a/src/script/page/AppMain.tsx
+++ b/src/script/page/AppMain.tsx
@@ -47,6 +47,7 @@ import {useAppState, ContentState} from './useAppState';
 
 import {ConversationState} from '../conversation/ConversationState';
 import {User} from '../entity/User';
+import {useActiveWindow} from '../hooks/useActiveWindow';
 import {useInitializeRootFontSize} from '../hooks/useRootFontSize';
 import {App} from '../main/app';
 import {initialiseMLSMigrationFlow} from '../mls/MLSMigration';
@@ -81,6 +82,8 @@ export const AppMain: FC<AppMainProps> = ({
   locked,
 }) => {
   const apiContext = app.getAPIContext();
+
+  useActiveWindow(window);
 
   useInitializeRootFontSize();
 

--- a/src/script/ui/ContextMenu.tsx
+++ b/src/script/ui/ContextMenu.tsx
@@ -29,6 +29,8 @@ import {IgnoreOutsideClickWrapper} from 'Components/InputBar/util/clickHandlers'
 import {useMessageActionsState} from 'Components/MessagesList/Message/ContentMessage/MessageActions/MessageActions.state';
 import {isEnterKey, isEscapeKey, isKey, isOneOfKeys, isSpaceKey, KEY} from 'Util/KeyboardUtil';
 
+import {useActiveWindowState} from '../hooks/useActiveWindow';
+
 export interface ContextMenuEntry {
   availability?: Availability.Type;
   click?: (event?: MouseEvent) => void;
@@ -49,14 +51,16 @@ interface ContextMenuProps {
   resetMenuStates?: () => void;
 }
 
-let container: HTMLDivElement;
+let container: HTMLDivElement | undefined;
 let previouslyFocused: HTMLElement;
 let reactRoot: Root;
 
 const cleanUp = () => {
+  const {activeWindow} = useActiveWindowState.getState();
+
   if (container) {
     reactRoot.unmount();
-    document.body.removeChild(container);
+    activeWindow.document.body.removeChild(container);
     container = undefined;
   }
 };
@@ -72,14 +76,17 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
   posY,
   resetMenuStates,
 }) => {
+  const {activeWindow} = useActiveWindowState();
   const [mainElement, setMainElement] = useState<HTMLUListElement>();
   const [selected, setSelected] = useState<ContextMenuEntry>();
 
   const style = useMemo<React.CSSProperties>(() => {
     const left =
-      mainElement && window.innerWidth - posX < mainElement.offsetWidth ? posX - mainElement.offsetWidth : posX;
+      mainElement && activeWindow.innerWidth - posX < mainElement.offsetWidth ? posX - mainElement.offsetWidth : posX;
     const top = Math.max(
-      mainElement && window.innerHeight - posY < mainElement.offsetHeight ? posY - mainElement.offsetHeight : posY,
+      mainElement && activeWindow.innerHeight - posY < mainElement.offsetHeight
+        ? posY - mainElement.offsetHeight
+        : posY,
       0,
     );
     return {
@@ -96,7 +103,9 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
 
       // context menu options such as 10 seconds etc begings with digit which is an invalid querySelector
       // param append btn- to avoid such errors
-      const selectedButton = document.querySelector(`#${getButtonId(labelWithoutQuotes!)}`) as HTMLButtonElement;
+      const selectedButton = activeWindow.document.querySelector(
+        `#${getButtonId(labelWithoutQuotes!)}`,
+      ) as HTMLButtonElement;
       selectedButton?.focus();
     }
   }, [selected]);
@@ -146,18 +155,18 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
       }
     };
 
-    window.addEventListener('wheel', onWheel);
-    window.addEventListener('keydown', onKeyDown);
-    window.addEventListener('mousedown', onMouseDown);
-    window.addEventListener('resize', cleanUp);
+    activeWindow.addEventListener('wheel', onWheel);
+    activeWindow.addEventListener('keydown', onKeyDown);
+    activeWindow.addEventListener('mousedown', onMouseDown);
+    activeWindow.addEventListener('resize', cleanUp);
 
     return () => {
-      window.removeEventListener('wheel', onWheel);
-      window.removeEventListener('keydown', onKeyDown);
-      window.removeEventListener('mousedown', onMouseDown);
-      window.removeEventListener('resize', cleanUp);
+      activeWindow.removeEventListener('wheel', onWheel);
+      activeWindow.removeEventListener('keydown', onKeyDown);
+      activeWindow.removeEventListener('mousedown', onMouseDown);
+      activeWindow.removeEventListener('resize', cleanUp);
     };
-  }, [mainElement, selected]);
+  }, [mainElement, selected, activeWindow]);
 
   const {handleMenuOpen} = useMessageActionsState();
   const resetMsgMenuStates = (isOutsideClick = false) => {
@@ -176,7 +185,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
         <ul
           className={contextMenuClassName}
           ref={setMainElement}
-          style={{maxHeight: window.innerHeight, ...style}}
+          style={{maxHeight: activeWindow.innerHeight, ...style}}
           role="menu"
         >
           {entries.map((entry, index) =>
@@ -237,14 +246,15 @@ export const showContextMenu = (
   identifier: string,
   resetMenuStates?: () => void,
 ) => {
+  const {activeWindow} = useActiveWindowState.getState();
   event.preventDefault();
   event.stopPropagation();
 
-  previouslyFocused = document.activeElement as HTMLElement;
+  previouslyFocused = activeWindow.document.activeElement as HTMLElement;
   cleanUp();
 
-  container = document.createElement('div');
-  document.body.appendChild(container);
+  container = activeWindow.document.createElement('div');
+  activeWindow.document.body.appendChild(container);
   reactRoot = createRoot(container);
   reactRoot.render(
     <ContextMenu


### PR DESCRIPTION
## Description

Adds multi-window support to context menu by tracking newly opened/focused windows and setting it as a currently active window. This will be useful for detached calling window view.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;