### PR TITLE
chore: add new-navigation to ci job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
     # we want to run the CI on every PR targetting those branches
-    branches: [master, dev, release/*]
+    branches: [master, dev, release/*, new-navigation]
 
   push:
     # We also run CI on dev in order to update the coverage monitoring


### PR DESCRIPTION
## Description

Since we use new-navigation branch for our internal testing env, it's much more save to run tests before merging.