### PR TITLE
runfix: switch to the recent tab on conversation creation (WPB-9509)

### DIFF
--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -37,6 +37,7 @@ import {TextInput} from 'Components/TextInput';
 import {BaseToggle} from 'Components/toggle/BaseToggle';
 import {InfoToggle} from 'Components/toggle/InfoToggle';
 import {UserSearchableList} from 'Components/UserSearchableList';
+import {SidebarTabs, useSidebarStore} from 'src/script/page/LeftSidebar/panels/Conversations/state';
 import {generateConversationUrl} from 'src/script/router/routeGenerator';
 import {createNavigate, createNavigateKeyboard} from 'src/script/router/routerBindings';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
@@ -143,6 +144,8 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
   const isGuestEnabled = isGuestRoom || isGuestAndServicesRoom;
   const isServicesEnabled = isServicesRoom || isGuestAndServicesRoom;
 
+  const {setCurrentTab: setCurrentSidebarTab} = useSidebarStore();
+
   const contacts = useMemo(() => {
     if (showContacts) {
       if (!isTeam) {
@@ -223,6 +226,8 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
             receipt_mode: enableReadReceipts ? RECEIPT_MODE.ON : RECEIPT_MODE.OFF,
           },
         );
+
+        setCurrentSidebarTab(SidebarTabs.RECENT);
 
         if (isKeyboardEvent(event)) {
           createNavigateKeyboard(generateConversationUrl(conversation.qualifiedId), true)(event);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9509" title="WPB-9509" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9509</a>  [Web] Creating a conversation or group does not update the view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

We should switch to a tab were the conversation is visible on conversation creation for automation to run.
This addresses the issue for group conversations creation (see 1on1 here https://github.com/wireapp/wire-webapp/pull/17673)
