### PR TITLE
runfix: switch to the folder tab on adding conversation to folder (WPB-9510)

### DIFF
--- a/src/script/conversation/ConversationLabelRepository.ts
+++ b/src/script/conversation/ConversationLabelRepository.ts
@@ -251,15 +251,18 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
   };
 
   readonly addConversationToLabel = (label: ConversationLabel, conversation: Conversation): void => {
+    const {setCurrentTab} = useSidebarStore.getState();
     if (!label.conversations().includes(conversation)) {
       this.removeConversationFromAllLabels(conversation);
       label.conversations.push(conversation);
       amplify.publish(WebAppEvents.CONTENT.EXPAND_FOLDER, label.id);
       this.saveLabels();
+      setCurrentTab(SidebarTabs.FOLDER);
     }
   };
 
   readonly addConversationToNewLabel = (conversation: Conversation) => {
+    const {setCurrentTab} = useSidebarStore.getState();
     PrimaryModal.show(PrimaryModal.type.INPUT, {
       primaryAction: {
         action: (name: string) => {
@@ -268,6 +271,7 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
           this.labels.push(newFolder);
           amplify.publish(WebAppEvents.CONTENT.EXPAND_FOLDER, newFolder.id);
           this.saveLabels();
+          setCurrentTab(SidebarTabs.FOLDER);
         },
         text: t('modalCreateFolderAction'),
       },


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9510" title="WPB-9510" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9510</a>  [Web] Moving a convo to a custom folder does not update the conversation list
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

this switches the view to the folder tab when adding a conversation to a new folder or an existing one