### PR TITLE
feat: Set default sidebar status to open

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/state.ts
+++ b/src/script/page/LeftSidebar/panels/Conversations/state.ts
@@ -91,7 +91,7 @@ const useSidebarStore = create<SidebarStore>()(
       setCurrentTab: (tab: SidebarTabs) => {
         set({currentTab: tab});
       },
-      status: SidebarStatus.CLOSED,
+      status: SidebarStatus.OPEN,
       setStatus: status => set({status: status}),
     }),
     {


### PR DESCRIPTION
## Description

The default/initial behaviour for the sidebar should be expanded. So if you start with a new account, it should be expanded