### PR TITLE
fix: Archiving a convo with unread messages does not remove the unread badge

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/ConversationTabs.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/ConversationTabs.tsx
@@ -62,9 +62,8 @@ export const ConversationTabs = ({
     favoriteConversation.hasUnread(),
   ).length;
 
-  const totalUnreadArchivedConversations = archivedConversations.filter(conversation =>
-    conversation.hasUnread(),
-  ).length;
+  const filterUnreadAndArchivedConversations = (conversation: Conversation) =>
+    !conversation.is_archived() && conversation.hasUnread();
 
   const conversationTabs = [
     {
@@ -86,14 +85,14 @@ export const ConversationTabs = ({
       title: t('conversationLabelGroups'),
       dataUieName: 'go-groups-view',
       Icon: <GroupIcon />,
-      unreadConversations: groupConversations.filter(conversation => conversation.hasUnread()).length,
+      unreadConversations: groupConversations.filter(filterUnreadAndArchivedConversations).length,
     },
     {
       type: SidebarTabs.DIRECTS,
       title: t('conversationLabelDirects'),
       dataUieName: 'go-directs-view',
       Icon: <Icon.PeopleIcon />,
-      unreadConversations: directConversations.filter(conversation => conversation.hasUnread()).length,
+      unreadConversations: directConversations.filter(filterUnreadAndArchivedConversations).length,
     },
     {
       type: SidebarTabs.FOLDER,
@@ -108,7 +107,6 @@ export const ConversationTabs = ({
       label: t('conversationFooterArchive'),
       dataUieName: 'go-archive',
       Icon: <Icon.ArchiveIcon />,
-      unreadConversations: totalUnreadArchivedConversations,
     },
   ];
 

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/ConversationTabs.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/ConversationTabs.tsx
@@ -62,6 +62,10 @@ export const ConversationTabs = ({
     favoriteConversation.hasUnread(),
   ).length;
 
+  const totalUnreadArchivedConversations = archivedConversations.filter(conversation =>
+    conversation.hasUnread(),
+  ).length;
+
   const filterUnreadAndArchivedConversations = (conversation: Conversation) =>
     !conversation.is_archived() && conversation.hasUnread();
 
@@ -107,6 +111,7 @@ export const ConversationTabs = ({
       label: t('conversationFooterArchive'),
       dataUieName: 'go-archive',
       Icon: <Icon.ArchiveIcon />,
+      unreadConversations: totalUnreadArchivedConversations,
     },
   ];
 


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-10086

## Description
While archiving message, unread messages was displaying on direct/group tab, we won't to display it.

## Screenshots/Screencast (for UI changes)

Before:
<img width="540" alt="image" src="https://github.com/wireapp/wire-webapp/assets/13432884/395643a6-baae-4efb-bc23-cd61f37ee6d2">

After:
<img width="542" alt="image" src="https://github.com/wireapp/wire-webapp/assets/13432884/cf2a0f1c-2958-4b46-98d1-dd25dc0dd262">


## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
