### PR TITLE
fix: Opening the preferences as a temporary user shows the new nav

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -105,6 +105,8 @@ const Conversations: React.FC<ConversationsProps> = ({
   const {classifiedDomains, isTeam} = useKoSubscribableChildren(teamState, ['classifiedDomains', 'isTeam']);
   const {connectRequests} = useKoSubscribableChildren(userState, ['connectRequests']);
 
+  const {isTemporaryGuest} = useKoSubscribableChildren(selfUser, ['isTemporaryGuest']);
+
   const {
     activeConversation,
     unreadConversations,
@@ -326,7 +328,7 @@ const Conversations: React.FC<ConversationsProps> = ({
           />
         }
         hasHeader={!isPreferences}
-        sidebar={sidebar}
+        {...(!isTemporaryGuest && {sidebar})}
         before={callingView}
       >
         {isPreferences ? (
@@ -334,6 +336,9 @@ const Conversations: React.FC<ConversationsProps> = ({
             onPreferenceItemClick={onClickPreferences}
             teamRepository={teamRepository}
             preferenceNotificationRepository={preferenceNotificationRepository}
+            {...(isTemporaryGuest && {
+              onClose: onExitPreferences,
+            })}
           />
         ) : (
           <>

--- a/src/script/page/LeftSidebar/panels/Preferences.tsx
+++ b/src/script/page/LeftSidebar/panels/Preferences.tsx
@@ -43,7 +43,16 @@ type PreferencesProps = {
   onPreferenceItemClick: (itemId: ContentState) => void;
   teamRepository: Pick<TeamRepository, 'getTeam'>;
   preferenceNotificationRepository: Pick<PreferenceNotificationRepository, 'getNotifications'>;
+  onClose?: () => void;
 };
+
+interface PreferencesItemProps {
+  IconComponent: React.FC;
+  isSelected: boolean;
+  label: string;
+  onSelect: () => void;
+  uieName: string;
+}
 
 const showNotification = (type: string, aggregatedNotifications: Notification[]) => {
   switch (type) {
@@ -80,41 +89,34 @@ const showNotification = (type: string, aggregatedNotifications: Notification[])
 
 const NEW_DEVICE_NOTIFICATION_STATES = [ContentState.PREFERENCES_ACCOUNT, ContentState.PREFERENCES_DEVICES];
 
-const PreferenceItem: React.FC<{
-  IconComponent: React.FC;
-  isSelected: boolean;
-  label: string;
-  onSelect: () => void;
-  uieName: string;
-}> = ({onSelect, isSelected, label, uieName, IconComponent}) => {
-  return (
-    <li
-      role="tab"
-      aria-selected={isSelected}
-      aria-controls={label}
-      tabIndex={TabIndex.UNFOCUSABLE}
-      className="left-list-item"
+const PreferenceItem = ({onSelect, isSelected, label, uieName, IconComponent}: PreferencesItemProps) => (
+  <li
+    role="tab"
+    aria-selected={isSelected}
+    aria-controls={label}
+    tabIndex={TabIndex.UNFOCUSABLE}
+    className="left-list-item"
+  >
+    <button
+      type="button"
+      className={`left-list-item-button ${isSelected ? 'left-list-item-button--active' : ''}`}
+      onClick={onSelect}
+      data-uie-name={uieName}
     >
-      <button
-        type="button"
-        className={`left-list-item-button ${isSelected ? 'left-list-item-button--active' : ''}`}
-        onClick={onSelect}
-        data-uie-name={uieName}
-      >
-        <span className="left-column-icon">
-          <IconComponent />
-        </span>
-        <span className="column-center">{label}</span>
-      </button>
-    </li>
-  );
-};
+      <span className="left-column-icon">
+        <IconComponent />
+      </span>
+      <span className="column-center">{label}</span>
+    </button>
+  </li>
+);
 
-const Preferences: React.FC<PreferencesProps> = ({
+const Preferences = ({
   teamRepository,
   preferenceNotificationRepository,
   onPreferenceItemClick,
-}) => {
+  onClose,
+}: PreferencesProps) => {
   const contentState = useAppState(state => state.contentState);
 
   useEffect(() => {
@@ -167,7 +169,12 @@ const Preferences: React.FC<PreferencesProps> = ({
   ];
 
   return (
-    <ListWrapper id="preferences" header={t('preferencesHeadline')} headerUieName="preferences-header-title">
+    <ListWrapper
+      id="preferences"
+      header={t('preferencesHeadline')}
+      headerUieName="preferences-header-title"
+      onClose={onClose}
+    >
       <ul
         role="tablist"
         aria-label={t('tooltipPreferencesTabs')}

--- a/src/script/view_model/ListViewModel.ts
+++ b/src/script/view_model/ListViewModel.ts
@@ -39,6 +39,7 @@ import type {ConversationRepository} from '../conversation/ConversationRepositor
 import {ConversationState} from '../conversation/ConversationState';
 import type {Conversation} from '../entity/Conversation';
 import type {User} from '../entity/User';
+import {SidebarTabs, useSidebarStore} from '../page/LeftSidebar/panels/Conversations/state';
 import {PanelState} from '../page/RightSidebar';
 import {useAppMainState} from '../page/state';
 import {ContentState, ListState, useAppState} from '../page/useAppState';
@@ -236,6 +237,9 @@ export class ListViewModel {
 
   openPreferencesAccount = async (): Promise<void> => {
     await this.teamRepository.getTeam();
+
+    const {setCurrentTab} = useSidebarStore.getState();
+    setCurrentTab(SidebarTabs.PREFERENCES);
 
     this.switchList(ListState.PREFERENCES);
     this.contentViewModel.switchContent(ContentState.PREFERENCES_ACCOUNT);

--- a/src/style/list/list.less
+++ b/src/style/list/list.less
@@ -48,7 +48,13 @@
 }
 
 .left-list-header-preferences {
+  display: flex;
   min-height: var(--content-title-bar-height);
+  align-items: center;
+
+  .left-list-header-close-button {
+    min-width: auto;
+  }
 }
 
 body.theme-dark {


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-10086

## Description
Hide new-navigation for temporary user. Now if temp user click on open preferences, user is switched to preferences, also added close icon to preferences for temp user.

## Screenshots/Screencast (for UI changes)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
