### PR TITLE
fix: replace carriage return with a new line char

### DIFF
--- a/src/script/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/script/components/RichTextEditor/RichTextEditor.tsx
@@ -44,6 +44,7 @@ import {GlobalEventsPlugin} from './plugins/GlobalEventsPlugin';
 import {HistoryPlugin} from './plugins/HistoryPlugin';
 import {findAndTransformEmoji, ReplaceEmojiPlugin} from './plugins/InlineEmojiReplacementPlugin';
 import {MentionsPlugin} from './plugins/MentionsPlugin';
+import {ReplaceCarriageReturnPlugin} from './plugins/ReplaceCarriageReturnPlugin/ReplaceCarriageReturnPlugin';
 import {SendPlugin} from './plugins/SendPlugin';
 import {TextChangePlugin} from './plugins/TextChangePlugin';
 
@@ -166,6 +167,8 @@ export const RichTextEditor = ({
           <HistoryPlugin />
 
           {replaceEmojis && <ReplaceEmojiPlugin />}
+
+          <ReplaceCarriageReturnPlugin />
 
           <PlainTextPlugin
             contentEditable={<ContentEditable className="conversation-input-bar-text" data-uie-name="input-message" />}

--- a/src/script/components/RichTextEditor/plugins/ReplaceCarriageReturnPlugin/ReplaceCarriageReturnPlugin.ts
+++ b/src/script/components/RichTextEditor/plugins/ReplaceCarriageReturnPlugin/ReplaceCarriageReturnPlugin.ts
@@ -1,0 +1,54 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {useEffect} from 'react';
+
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {mergeRegister} from '@lexical/utils';
+import {COMMAND_PRIORITY_LOW, PASTE_COMMAND, TextNode} from 'lexical';
+
+function replaceCarriageReturnWithLineFeed(input: string) {
+  // ASCII code for Carriage Return ("\r") is 13
+  return input
+    .split('')
+    .map(char => (char.charCodeAt(0) === 13 ? '\n' : char))
+    .join('');
+}
+
+export const ReplaceCarriageReturnPlugin = () => {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    return mergeRegister(
+      editor.registerCommand(
+        PASTE_COMMAND,
+        () => {
+          const unregister = editor.registerNodeTransform(TextNode, newNode => {
+            newNode.setTextContent(replaceCarriageReturnWithLineFeed(newNode.getTextContent()));
+            unregister();
+          });
+          return false;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+    );
+  }, [editor]);
+
+  return null;
+};

--- a/src/script/components/RichTextEditor/plugins/ReplaceCarriageReturnPlugin/ReplaceCarriageReturnPlugin.ts
+++ b/src/script/components/RichTextEditor/plugins/ReplaceCarriageReturnPlugin/ReplaceCarriageReturnPlugin.ts
@@ -31,7 +31,7 @@ function replaceCarriageReturnWithLineFeed(input: string) {
     .join('');
 }
 
-export const ReplaceCarriageReturnPlugin = () => {
+export const ReplaceCarriageReturnPlugin = (): null => {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {


### PR DESCRIPTION
## Description

Some systems (especially old macs - pre OS X versions) insert "\r" char (13 in ascii) as a new line character instead of \n. Our input doesn't understand this char and new line is not visible (even though after sending a message it is).

The solution is to create a plugin that will replace any "\r" with "\n" whenever the content is pasted into the input.

## Screenshots/Screencast (for UI changes)

![Kapture 2024-07-11 at 11 55 30](https://github.com/wireapp/wire-webapp/assets/45733298/7965bf45-9369-4a9f-88ff-4ee6662fdedd)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
