### PR TITLE
fix: emoji mouse click closes message edit [WPB-10076]

### DIFF
--- a/src/script/components/RichTextEditor/plugins/EmojiPickerPlugin/EmojiPickerPlugin.tsx
+++ b/src/script/components/RichTextEditor/plugins/EmojiPickerPlugin/EmojiPickerPlugin.tsx
@@ -181,7 +181,7 @@ export function EmojiPickerPlugin({openStateRef}: Props) {
     const {bottom, left} = getPosition();
 
     return ReactDOM.createPortal(
-      <div className="typeahead-popover emoji-menu">
+      <div data-outside-click-ignore className="typeahead-popover emoji-menu">
         <div className="conversation-input-bar-emoji-list" style={{bottom, left}}>
           {options.map((option: EmojiOption, index) => (
             <EmojiItem


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10076" title="WPB-10076" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10076</a>  [Web] Edit message, select emoji with mouse, edit disappears
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

When in message editing, the editing mode was closed when selecting an emoji with a mouse click.

This should've been already solved with https://github.com/wireapp/wire-webapp/pull/14265/files#diff-3b101911b87c73bc557d65ff8497af512fb962a35ffa6a24358dacb137bbad13R22, but the emoji picker was missing the ignore data attribute.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
