### PR TITLE
runfix: wrap buttons to new line

### DIFF
--- a/src/script/components/panel/SingleAction/SingleAction.styles.ts
+++ b/src/script/components/panel/SingleAction/SingleAction.styles.ts
@@ -19,7 +19,10 @@
 
 import {CSSObject} from '@emotion/react';
 
-export const singleActionButtonStyle: CSSObject = {
+export const singleActionButtonStyle = (oneButtonPerRow = false): CSSObject => ({
   width: '100%',
-  margin: '0 8px',
-};
+  margin: 0,
+  flex: oneButtonPerRow ? '1' : '1 1 125px',
+  minWidth: 'unset',
+  overflow: 'unset',
+});

--- a/src/script/components/panel/SingleAction/SingleAction.tsx
+++ b/src/script/components/panel/SingleAction/SingleAction.tsx
@@ -39,8 +39,12 @@ export interface SingleActionProps {
 const SingleAction = ({item, onCancel, oneButtonPerRow = false}: SingleActionProps) => {
   return (
     <FlexBox
-      flexWrap={oneButtonPerRow ? 'wrap-reverse' : 'nowrap'}
-      css={{rowGap: '8px'}}
+      css={{
+        rowGap: 8,
+        columnGap: 16,
+        flexDirection: oneButtonPerRow ? 'column-reverse' : 'row',
+        flexWrap: 'wrap-reverse',
+      }}
       justify="space-evenly"
       className="modal__buttons"
     >
@@ -48,11 +52,11 @@ const SingleAction = ({item, onCancel, oneButtonPerRow = false}: SingleActionPro
         variant={ButtonVariant.SECONDARY}
         onClick={onCancel}
         data-uie-name="do-close"
-        css={singleActionButtonStyle}
+        css={singleActionButtonStyle(oneButtonPerRow)}
       >
         {t('modalConfirmSecondary')}
       </Button>
-      <Button onClick={item.click} data-uie-name={item.identifier} css={singleActionButtonStyle}>
+      <Button onClick={item.click} data-uie-name={item.identifier} css={singleActionButtonStyle(oneButtonPerRow)}>
         {item.label}
       </Button>
     </FlexBox>


### PR DESCRIPTION
## Description

Wrap action buttons to a new line if there's not enough text space.

## Screenshots/Screencast (for UI changes)

Before:
<img width="379" alt="Screenshot 2024-07-12 at 12 15 18" src="https://github.com/user-attachments/assets/820f65d8-8a8f-455a-8c48-28462b90ee8f">

Now:
<img width="381" alt="Screenshot 2024-07-12 at 12 08 16" src="https://github.com/user-attachments/assets/dd465e29-9520-4100-985b-e7c065671a7d">


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
