### PR TITLE
runfix: mark last message not visible on unmount [WPB-9956]

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {UIEvent, useCallback, useState} from 'react';
+import {UIEvent, useCallback, useEffect, useState} from 'react';
 
 import cx from 'classnames';
 import {container} from 'tsyringe';
@@ -123,6 +123,10 @@ export const Conversation = ({
   const smBreakpoint = useMatchMedia('max-width: 640px');
 
   const {addReadReceiptToBatch} = useReadReceiptSender(repositories.message);
+
+  useEffect(() => {
+    activeConversation?.isLastMessageVisible(true);
+  }, [activeConversation]);
 
   const uploadImages = useCallback(
     (images: File[]) => {

--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -125,6 +125,8 @@ export const Conversation = ({
   const {addReadReceiptToBatch} = useReadReceiptSender(repositories.message);
 
   useEffect(() => {
+    // When the component is mounted we want to make sure its conversation entity's last message is marked as visible
+    // not to display the jump to last message button initially
     activeConversation?.isLastMessageVisible(true);
   }, [activeConversation]);
 

--- a/src/script/components/MessagesList/Message/index.tsx
+++ b/src/script/components/MessagesList/Message/index.tsx
@@ -135,6 +135,9 @@ export const Message = (props: MessageParams & {scrollTo?: ScrollToElement}) => 
     }
   }, [isFocused]);
 
+  // When component is unmounted, it's not visible anymore
+  useEffect(() => onVisibilityLost);
+
   // set message elements focus for non content type mesages
   // some non content type message has interactive element like invite people for member message
   useEffect(() => {

--- a/src/script/components/MessagesList/Message/index.tsx
+++ b/src/script/components/MessagesList/Message/index.tsx
@@ -136,7 +136,7 @@ export const Message = (props: MessageParams & {scrollTo?: ScrollToElement}) => 
   }, [isFocused]);
 
   // When component is unmounted, it's not visible anymore
-  useEffect(() => onVisibilityLost);
+  useEffect(() => onVisibilityLost, [onVisibilityLost]);
 
   // set message elements focus for non content type mesages
   // some non content type message has interactive element like invite people for member message


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9956" title="WPB-9956" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9956</a>  [Web] Jump to last message button does not appear when jumping to a referenced message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Last message was never marked as invisible after being unmounted. Since it got unmounted, the intersection observer didn't have a chance to specify whether the element is visible or not.

The solution is to always mark the message as invisible when its component unmounts.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;