### PR TITLE
fix: Update conversation list in folder after remove conversation

### DIFF
--- a/src/script/conversation/ConversationLabelRepository.ts
+++ b/src/script/conversation/ConversationLabelRepository.ts
@@ -225,12 +225,17 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
 
   readonly removeConversationFromLabel = (label: ConversationLabel, removeConversation: Conversation): void => {
     label.conversations(label.conversations().filter(conversation => conversation !== removeConversation));
+
+    const {setCurrentTab} = useSidebarStore.getState();
+
     // Delete folder if it no longer contains any conversation
     if (!label.conversations().length) {
       this.labels.remove(label);
       // switch sidebar to recent tabs
-      const {setCurrentTab} = useSidebarStore.getState();
       setCurrentTab(SidebarTabs.RECENT);
+    } else {
+      // trigger rerender on folders to remove conversation from folder
+      setCurrentTab(SidebarTabs.FOLDER);
     }
     this.saveLabels();
   };


### PR DESCRIPTION
## Description

After removing conversation from custom folder, conversation list was not refreshed. Now after remove we will have refreshed list.

## Screenshots/Screencast (for UI changes)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
