### PR TITLE
runfix: switch to the recent tab on conversation creation with a service (WPB-9509)

### DIFF
--- a/src/script/components/Modals/ServiceModal/ServiceModal.tsx
+++ b/src/script/components/Modals/ServiceModal/ServiceModal.tsx
@@ -22,6 +22,7 @@ import React from 'react';
 import {Avatar, AVATAR_SIZE} from 'Components/Avatar';
 import * as Icon from 'Components/Icon';
 import {ModalComponent} from 'Components/ModalComponent';
+import {SidebarTabs, useSidebarStore} from 'src/script/page/LeftSidebar/panels/Conversations/state';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 import {renderElement} from 'Util/renderElement';
@@ -44,8 +45,11 @@ const ServiceModal: React.FC<ServiceModalProps> = ({
   actionsViewModel,
   onClose,
 }) => {
+  const {setCurrentTab: setCurrentSidebarTab} = useSidebarStore();
+
   const onOpenService = () => {
     onClose?.();
+    setCurrentSidebarTab(SidebarTabs.RECENT);
     actionsViewModel.open1to1ConversationWithService(service);
   };
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9509" title="WPB-9509" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9509</a>  [Web] Creating a conversation or group does not update the view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
 Automation expects a conversation to be visible on the sidebar when created.
 This ensures this is the case when creating a 1on1 conversation with a bot/service
