### PR TITLE
fix: Remove modal about removed user from conversation

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -102,14 +102,18 @@ export const Conversation = ({
     'isFileSharingSendingEnabled',
   ]);
 
-  const {is1to1, isRequest, isReadOnlyConversation} = useKoSubscribableChildren(activeConversation!, [
-    'is1to1',
-    'isRequest',
-    'readOnlyState',
-    'participating_user_ets',
-    'connection',
-    'isReadOnlyConversation',
-  ]);
+  const {is1to1, isRequest, isReadOnlyConversation, isActiveParticipant} = useKoSubscribableChildren(
+    activeConversation!,
+    [
+      'is1to1',
+      'isRequest',
+      'readOnlyState',
+      'participating_user_ets',
+      'connection',
+      'isReadOnlyConversation',
+      'isActiveParticipant',
+    ],
+  );
 
   const inTeam = teamState.isInTeam(selfUser);
 
@@ -479,7 +483,7 @@ export const Conversation = ({
             callActions={mainViewModel.calling.callActions}
             openRightSidebar={openRightSidebar}
             isRightSidebarOpen={isRightSidebarOpen}
-            isReadOnlyConversation={isReadOnlyConversation}
+            isReadOnlyConversation={isReadOnlyConversation || !isActiveParticipant}
           />
 
           {activeCalls.map(call => {
@@ -534,7 +538,7 @@ export const Conversation = ({
           />
 
           {isConversationLoaded &&
-            (isReadOnlyConversation ? (
+            (isReadOnlyConversation || !isActiveParticipant ? (
               <ReadOnlyConversationMessage reloadApp={reloadApp} conversation={activeConversation} />
             ) : (
               <InputBar

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -3161,15 +3161,6 @@ export class ConversationRepository {
           ConversationError.TYPE.CONVERSATION_NOT_FOUND,
         ];
 
-        const isRemovedFromConversation = (error as unknown as BackendError).label === BackendErrorLabel.ACCESS_DENIED;
-        if (isRemovedFromConversation) {
-          const messageText = t('conversationNotFoundMessage');
-          const titleText = t('conversationNotFoundTitle', Config.getConfig().BRAND_NAME);
-
-          this.showModal(messageText, titleText);
-          return;
-        }
-
         if (!ignoredErrorTypes.includes(error.type)) {
           throw error;
         }


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-10201

## Description

Currently we displaying modal about user removed from conversation. On Android we don't have any modal about not access to conversation. We have information about user removed in system messages in conversation and in conversation list as subtitle.

## Screenshots/Screencast (for UI changes)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
