### PR TITLE
runfix: slow connection indicator misaligned in preferences

### DIFF
--- a/src/style/list/list.less
+++ b/src/style/list/list.less
@@ -50,7 +50,7 @@
 .left-list-header-preferences {
   display: flex;
   min-height: var(--content-title-bar-height);
-  align-items: center;
+  flex-direction: column;
 
   .left-list-header-close-button {
     min-width: auto;


### PR DESCRIPTION
## Description

Slow conneciton indicator was misaligned when settings tab was opened

## Screenshots/Screencast (for UI changes)

Before:
<img width="325" alt="Screenshot 2024-07-16 at 14 14 19" src="https://github.com/user-attachments/assets/dd7a41a2-dac1-4937-b0fd-addc4c5f4229">

Now:
<img width="322" alt="Screenshot 2024-07-16 at 14 12 42" src="https://github.com/user-attachments/assets/79c54bdf-27ae-4c84-8b70-894e1d87ea0f">

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;