### PR TITLE
runfix: re-implement indicator on settings button when a new device is added (WPB-9542)

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationTab.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationTab.tsx
@@ -31,7 +31,7 @@ interface ConversationTabProps {
   unreadConversations?: number;
   dataUieName: string;
   isActive?: boolean;
-  showNotificationBadge?: boolean;
+  showNotificationsBadge?: boolean;
 }
 
 export const ConversationTab = ({
@@ -44,7 +44,7 @@ export const ConversationTab = ({
   unreadConversations = 0,
   dataUieName,
   isActive = false,
-  showNotificationBadge = false,
+  showNotificationsBadge = false,
 }: ConversationTabProps) => {
   return (
     <button
@@ -60,10 +60,10 @@ export const ConversationTab = ({
     >
       <span className="conversations-sidebar-btn--text-wrapper">
         {Icon}
-        {(unreadConversations > 0 || showNotificationBadge) && (
+        {(unreadConversations > 0 || showNotificationsBadge) && (
           <span
             className={cx('conversations-sidebar-btn--badge', {active: isActive})}
-            data-uie-name={showNotificationBadge ? 'notification-badge' : 'unread-badge'}
+            data-uie-name={showNotificationsBadge ? 'notification-badge' : 'unread-badge'}
           />
         )}
         <span className="conversations-sidebar-btn--text">{label || title}</span>

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/ConversationTabs.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/ConversationTabs.tsx
@@ -184,7 +184,7 @@ export const ConversationTabs = ({
           }}
           conversationTabIndex={1}
           dataUieName="go-preferences"
-          showNotificationBadge={showNotificationsBadge}
+          showNotificationsBadge={showNotificationsBadge}
           isActive={currentTab === SidebarTabs.PREFERENCES}
         />
 

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -109,6 +109,7 @@ const Conversations: React.FC<ConversationsProps> = ({
   const [conversationsFilter, setConversationsFilter] = useState<string>('');
   const {classifiedDomains, isTeam} = useKoSubscribableChildren(teamState, ['classifiedDomains', 'isTeam']);
   const {connectRequests} = useKoSubscribableChildren(userState, ['connectRequests']);
+  const {notifications} = useKoSubscribableChildren(preferenceNotificationRepository, ['notifications']);
 
   const {isTemporaryGuest} = useKoSubscribableChildren(selfUser, ['isTemporaryGuest']);
 
@@ -264,6 +265,7 @@ const Conversations: React.FC<ConversationsProps> = ({
           archivedConversations={archivedConversations}
           conversationRepository={conversationRepository}
           onClickPreferences={() => onClickPreferences(ContentState.PREFERENCES_ACCOUNT)}
+          showNotificationsBadge={notifications.length > 0}
         />
       </FadingScrollbar>
 

--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -292,28 +292,6 @@
   }
 }
 
-.conversations-settings-button {
-  .button-reset-default;
-  .button-icon-large;
-  .focus-border-radius;
-  position: relative;
-  outline-offset: 0.2rem;
-}
-
-.conversations-settings {
-  position: relative;
-
-  &--badge::after {
-    .dot-md;
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    background-color: currentColor;
-    color: inherit;
-    content: '';
-  }
-}
-
 .conversations-hint {
   position: absolute;
   bottom: 0;


### PR DESCRIPTION
## Description

The indicator for new device added implemented here https://github.com/wireapp/wire-webapp/pull/17695 was removed by mistake [here](https://github.com/wireapp/wire-webapp/pull/17696/files#diff-132b191483bec5e910cf28fea492a28ab4f8fc723214520f48df2909c7cc0422L108) https://github.com/wireapp/wire-webapp/pull/17696

## Screenshots/Screencast (for UI changes)
Before:
![image](https://github.com/user-attachments/assets/c419e4b8-8670-45ce-bb72-5165d21b580b)

After:
![image](https://github.com/user-attachments/assets/a052ab94-d727-497f-b578-efe7ba0ce2f9)

