### PR TITLE
feat: confirm reload during call [WPB-10096]

### DIFF
--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -1510,6 +1510,10 @@ export class CallingRepository {
     call.reason(reason);
   };
 
+  hasActiveCall = (): boolean => {
+    return !!this.callState.joinedCall();
+  };
+
   /*
     Note: This is in sync with our ios code base
     https://github.com/wireapp/wire-ios/blob/cf91b35d6ccbee5f03592f5bb763534341630428/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift#L182-L212

--- a/src/script/components/DetachedWindow/DetachedWindow.tsx
+++ b/src/script/components/DetachedWindow/DetachedWindow.tsx
@@ -74,13 +74,21 @@ export const DetachedWindow = ({children, name, onClose, width = 600, height = 6
 
     newWindow.document.title = window.document.title;
 
+    const onPageHide = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        return;
+      }
+      onClose();
+      newWindow.close();
+    };
+
     newWindow.addEventListener('beforeunload', onClose);
-    window.addEventListener('beforeunload', onClose);
+    window.addEventListener('pagehide', onPageHide);
 
     return () => {
       newWindow.close();
       newWindow.removeEventListener('beforeunload', onClose);
-      window.removeEventListener('beforeunload', onClose);
+      window.removeEventListener('pagehide', onPageHide);
     };
   }, [height, name, width, onClose, newWindow]);
 

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -682,6 +682,9 @@ export class App {
     window.addEventListener('beforeunload', event => {
       if (this.repository.calling.hasActiveCall()) {
         event.preventDefault();
+
+        // Included for legacy support, e.g. Chrome/Edge < 119
+        event.returnValue = true;
       }
     });
   }

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -460,6 +460,7 @@ export class App {
       onProgress(25, t('initReceivedUserData'));
       telemetry.addStatistic(AppInitStatisticsValue.CONVERSATIONS, conversations.length, 50);
       this._subscribeToUnloadEvents(selfUser);
+      this._subscribeToBeforeUnload();
 
       await conversationRepository.conversationRoleRepository.loadTeamRoles();
 
@@ -671,6 +672,17 @@ export class App {
       }
 
       this.repository.notification.clearNotifications();
+    });
+  }
+
+  /**
+   * Subscribe to 'beforeunload' to stop calls and disconnect the WebSocket.
+   */
+  private _subscribeToBeforeUnload(): void {
+    window.addEventListener('beforeunload', event => {
+      if (this.repository.calling.hasActiveCall()) {
+        event.preventDefault();
+      }
     });
   }
 


### PR DESCRIPTION
## Description

When user tries to close the tab or reload while being in the call we want the to confirm the leave with browser's default "Are you sure you want to leave?".

## Screenshots/Screencast (for UI changes)



## Checklist
<img width="278" alt="Screenshot 2024-07-16 at 16 05 49" src="https://github.com/user-attachments/assets/9c3e25ac-a370-4b13-ad6f-89d1c80c8a6a">
<img width="264" alt="Wire 2024-07-16 at 4_09 PM" src="https://github.com/user-attachments/assets/997bc619-dbb4-4fb1-8d21-3bcee21d233f">



- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
