### PR TITLE
runfix: don't show fav folder in folders [WPB-9511]

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.test.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.test.tsx
@@ -1,0 +1,97 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render} from '@testing-library/react';
+
+import * as Icon from 'Components/Icon';
+import {createLabel, LabelType} from 'src/script/conversation/ConversationLabelRepository';
+import {Conversation} from 'src/script/entity/Conversation';
+import {TestFactory} from 'test/helper/TestFactory';
+
+import {ConversationFolderTab} from './ConversationFolderTab';
+
+import {SidebarTabs} from '../state';
+
+const getProps = async (conversations: Conversation[] = []) => {
+  const testFactory = new TestFactory();
+  const conversationRepository = await testFactory.exposeConversationActors();
+
+  conversationRepository['conversationState'].conversations(conversations);
+
+  return {
+    props: {
+      title: 'title',
+      label: 'label',
+      type: SidebarTabs.FOLDER,
+      conversationTabIndex: 0,
+      onChangeTab: () => {},
+      Icon: <Icon.FoldersOutline />,
+      conversationRepository,
+      unreadConversations: [],
+      dataUieName: 'dataUieName',
+    },
+    conversationRepository,
+  };
+};
+
+describe('ConversationFolderTab', () => {
+  it('should render empty folders list', async () => {
+    const {props} = await getProps();
+    const {getByText} = render(<ConversationFolderTab {...props} />);
+
+    expect(getByText('conversationFoldersEmptyText')).toBeDefined();
+  });
+
+  it('should list custom folders only', async () => {
+    const favoriteConversation = new Conversation('id', 'domain');
+    favoriteConversation.name('favoriteConversation');
+
+    const customFolderConversation = new Conversation('id2', 'domain2');
+    customFolderConversation.name('customFolderConversation');
+
+    const {props, conversationRepository} = await getProps([favoriteConversation, customFolderConversation]);
+    conversationRepository['conversationLabelRepository'].addConversationToFavorites(favoriteConversation);
+
+    const customFolderName = 'customFolder';
+    const customFolder = createLabel(customFolderName, [customFolderConversation], 'id', LabelType.Custom);
+
+    const customFolderName2 = 'customFolder2';
+    const customFolder2 = createLabel(customFolderName2, [customFolderConversation], 'id', LabelType.Custom);
+
+    const customFavoriteFolderName = 'customFavoriteFolder';
+    const customFavoriteFolder = createLabel(
+      customFavoriteFolderName,
+      [favoriteConversation],
+      'id',
+      LabelType.Favorite,
+    );
+
+    conversationRepository['conversationLabelRepository'].labels([customFolder, customFolder2, customFavoriteFolder]);
+
+    conversationRepository['conversationLabelRepository'].addConversationToLabel(
+      customFolder,
+      customFolderConversation,
+    );
+    const {queryByText} = render(<ConversationFolderTab {...props} />);
+
+    expect(queryByText(customFolderName)).not.toBeNull();
+    expect(queryByText(customFolderName2)).not.toBeNull();
+    expect(queryByText(customFavoriteFolderName)).toBeNull();
+  });
+});

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.test.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.test.tsx
@@ -26,7 +26,7 @@ import {TestFactory} from 'test/helper/TestFactory';
 
 import {ConversationFolderTab} from './ConversationFolderTab';
 
-import {SidebarTabs} from '../state';
+import {SidebarTabs} from '../useSidebarStore';
 
 const getProps = async (conversations: Conversation[] = []) => {
   const testFactory = new TestFactory();

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.test.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.test.tsx
@@ -43,7 +43,7 @@ const getProps = async (conversations: Conversation[] = []) => {
       onChangeTab: () => {},
       Icon: <Icon.FoldersOutline />,
       conversationRepository,
-      unreadConversations: [],
+      unreadConversations: [] as Conversation[],
       dataUieName: 'dataUieName',
     },
     conversationRepository,

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.tsx
@@ -21,7 +21,7 @@ import cx from 'classnames';
 
 import * as Icons from 'Components/Icon';
 import {Config} from 'src/script/Config';
-import {createLabel} from 'src/script/conversation/ConversationLabelRepository';
+import {createLabel, LabelType} from 'src/script/conversation/ConversationLabelRepository';
 import {ConversationRepository} from 'src/script/conversation/ConversationRepository';
 import {Conversation} from 'src/script/entity/Conversation';
 import {useFolderStore} from 'src/script/page/LeftSidebar/panels/Conversations/useFoldersStore';
@@ -71,6 +71,7 @@ export const ConversationFolderTab = ({
   const {labels} = useKoSubscribableChildren(conversationLabelRepository, ['labels']);
 
   const folders = labels
+    .filter(label => label.type !== LabelType.Favorite)
     .map(label => createLabel(label.name, conversationLabelRepository.getLabelConversations(label), label.id))
     .filter(({conversations, name}) => !!conversations().length && !!name);
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9511" title="WPB-9511" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9511</a>  [Web] Marking convo as favorite creates custom folder containing all conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

We were missing a check if the custom folder is not a favorites folder. Favorites folder should not appear in custom folders list because there's a separate section for favorite conversations.

## Screenshots/Screencast (for UI changes)

Before:
<img width="538" alt="Screenshot 2024-07-22 at 13 43 58" src="https://github.com/user-attachments/assets/deac9c90-beb8-4160-96c1-6132eee7db39">

Now:
<img width="537" alt="Screenshot 2024-07-22 at 13 43 04" src="https://github.com/user-attachments/assets/4235125a-4b3c-4fc7-aa06-28a36cb8687f">

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
