### PR TITLE
feat: Display user status even if not in the same team (WPB-9759)

### DIFF
--- a/src/script/components/Avatar/UserAvatar/UserAvatar.tsx
+++ b/src/script/components/Avatar/UserAvatar/UserAvatar.tsx
@@ -102,7 +102,6 @@ export const UserAvatar = ({
   const avatarImgAlt = avatarAlt ? avatarAlt : `${t('userProfileImageAlt')} ${name}`;
 
   const hasAvailabilityState = typeof availability === 'number' && availability !== AvailabilityType.Type.NONE;
-  const inTeam = teamState.isInTeam(participant);
 
   return (
     <AvatarWrapper
@@ -134,7 +133,7 @@ export const UserAvatar = ({
 
       {(!isImageGrey || isBlocked) && <AvatarBorder isTransparent={!isBlocked} />}
 
-      {inTeam && !hideAvailabilityStatus && hasAvailabilityState && (
+      {!hideAvailabilityStatus && hasAvailabilityState && (
         <AvailabilityIcon availability={availability} avatarSize={avatarSize} />
       )}
     </AvatarWrapper>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9759" title="WPB-9759" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9759</a>  [Web] Missing status icon for users in different team
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
Currently we have check to see if the user is in the same team then we show the user status, this PR changes this behavior in a way to show the status if has a value and removes the logic of checking if user is in the same team.

## Screenshots/Screencast (for UI changes)
<img width="376" alt="image" src="https://github.com/user-attachments/assets/a2263783-8eed-431a-9fee-b503f325e377">
(user Deniz Agha is on a different team)