### PR TITLE
chore: remove new-navigation branch from ci job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
     # we want to run the CI on every PR targetting those branches
-    branches: [master, dev, release/*, new-navigation]
+    branches: [master, dev, release/*]
 
   push:
     # We also run CI on dev in order to update the coverage monitoring


### PR DESCRIPTION
## Description

The `new-navigation` branch was deleted, we can remove it from the list of branches where automation needs to run