### PR TITLE
runfix: prevent navigation panel from shifting downward if update banner is present (WPB-9895)

### DIFF
--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -35,7 +35,7 @@
     display: flex;
     overflow: auto;
     width: 220px;
-    height: 100vh;
+    height: 100%;
     flex-direction: column;
     padding: 8px;
     padding-top: 14px;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9895" title="WPB-9895" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9895</a>  [Web] Navigation panel shifts downward if update banner is present
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Hotfix for navigation panel shifts.

## Screenshots/Screencast (for UI changes)

Before:
<img width="222" alt="image" src="https://github.com/user-attachments/assets/0c51f298-1a3e-4310-b8e3-29527951b7ad">

After:
![image](https://github.com/user-attachments/assets/3f380c71-0671-4618-b4f4-f8f3faa7eda0)


## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
