### PR TITLE
runfix: open the view on opening deep link (WPB-9507)

### DIFF
--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -40,6 +40,7 @@ import {Conversation} from '../entity/Conversation';
 import type {Message} from '../entity/message/Message';
 import {ConversationError} from '../error/ConversationError';
 import '../page/LeftSidebar';
+import {SidebarTabs, useSidebarStore} from '../page/LeftSidebar/panels/Conversations/useSidebarStore';
 import '../page/MainContent';
 import {PanelState} from '../page/RightSidebar';
 import {useAppMainState} from '../page/state';
@@ -271,6 +272,12 @@ export class ContentViewModel {
       }
 
       throw error;
+    } finally {
+      const {currentTab, setCurrentTab} = useSidebarStore.getState();
+
+      if (currentTab === SidebarTabs.PREFERENCES) {
+        setCurrentTab(SidebarTabs.RECENT);
+      }
     }
   };
 

--- a/src/script/view_model/ListViewModel.ts
+++ b/src/script/view_model/ListViewModel.ts
@@ -285,12 +285,14 @@ export class ListViewModel {
   };
 
   readonly openConversations = (archive = false): void => {
+    const {currentTab, setCurrentTab} = useSidebarStore.getState();
     const newState = this.isActivatedAccount()
       ? archive
         ? ListState.ARCHIVE
         : ListState.CONVERSATIONS
       : ListState.TEMPORARY_GUEST;
     this.switchList(newState, false);
+    setCurrentTab(archive ? SidebarTabs.ARCHIVES : currentTab);
   };
 
   private readonly hideList = (): void => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9507" title="WPB-9507" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9507</a>  [Web] Opening conversation via deeplink does not update the view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Following a deep link to a conversation should switch to a tab where the conversation appears.
This switches the sidebar tab to Archives if the converesation is archived, and to the Recent view if the current tab is set to Preferences