### PR TITLE
runfix: update the view on opening deep link from the connect tab (WPB-9507)

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/useSidebarStore.ts
+++ b/src/script/page/LeftSidebar/panels/Conversations/useSidebarStore.ts
@@ -60,8 +60,9 @@ const useSidebarStore = create<SidebarStore>()(
       storage: createJSONStorage(() => localStorage),
       partialize: state => ({
         status: state.status,
-        currentTab:
-          state.currentTab === SidebarTabs.PREFERENCES || SidebarTabs.CONNECT ? SidebarTabs.RECENT : state.currentTab,
+        currentTab: [SidebarTabs.PREFERENCES, SidebarTabs.CONNECT].includes(state.currentTab)
+          ? SidebarTabs.RECENT
+          : state.currentTab,
       }),
     },
   ),

--- a/src/script/page/LeftSidebar/panels/Conversations/useSidebarStore.ts
+++ b/src/script/page/LeftSidebar/panels/Conversations/useSidebarStore.ts
@@ -60,7 +60,8 @@ const useSidebarStore = create<SidebarStore>()(
       storage: createJSONStorage(() => localStorage),
       partialize: state => ({
         status: state.status,
-        currentTab: state.currentTab === SidebarTabs.PREFERENCES ? SidebarTabs.RECENT : state.currentTab,
+        currentTab:
+          state.currentTab === SidebarTabs.PREFERENCES || SidebarTabs.CONNECT ? SidebarTabs.RECENT : state.currentTab,
       }),
     },
   ),

--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -275,7 +275,7 @@ export class ContentViewModel {
     } finally {
       const {currentTab, setCurrentTab} = useSidebarStore.getState();
 
-      if (currentTab === SidebarTabs.PREFERENCES) {
+      if (currentTab === SidebarTabs.PREFERENCES || SidebarTabs.CONNECT) {
         setCurrentTab(SidebarTabs.RECENT);
       }
     }

--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -275,7 +275,7 @@ export class ContentViewModel {
     } finally {
       const {currentTab, setCurrentTab} = useSidebarStore.getState();
 
-      if (currentTab === SidebarTabs.PREFERENCES || SidebarTabs.CONNECT) {
+      if ([SidebarTabs.PREFERENCES, SidebarTabs.CONNECT].includes(currentTab)) {
         setCurrentTab(SidebarTabs.RECENT);
       }
     }


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9507" title="WPB-9507" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9507</a>  [Web] Opening conversation via deeplink does not update the view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

Opening a deep link from the connect tab should switch the sidebar to a view where the conversation is displayed, this switches to the Recent view

Since the app initialize opening the last conversation, we do not store the state of the sidebar when it's set to Connect (in addition to Preferences), since this state does not show the conversation list
