### PR TITLE
Revert "fix: Navigation panel shifts downward if update banner is present (#17809)"

### DIFF
--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -35,7 +35,7 @@
     display: flex;
     overflow: auto;
     width: 220px;
-    height: 100%;
+    height: 100vh;
     flex-direction: column;
     padding: 8px;
     padding-top: 14px;


### PR DESCRIPTION
This reverts commit fb76cf4669e391b0ab5225b7327e2c3cb3e07020.
