### PR TITLE
runfix: ensure the sidebar always occupies 100% height (WPB-9895)

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.styles.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.styles.tsx
@@ -24,7 +24,7 @@ export const conversationsSpacerStyles = (mdBreakpoint: Boolean): CSSObject => (
 });
 
 export const conversationsSidebarStyles = (mdBreakpoint: Boolean): CSSObject => ({
-  position: mdBreakpoint ? 'fixed' : 'relative',
+  position: mdBreakpoint ? 'absolute' : 'relative',
   zIndex: mdBreakpoint ? '1000' : 'auto',
 });
 

--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -24,6 +24,7 @@
 
 .conversations-sidebar {
   position: relative;
+  height: 100%;
 
   &:hover {
     .conversations-sidebar-handle {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9895" title="WPB-9895" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9895</a>  [Web] Navigation panel shifts downward if update banner is present
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

https://github.com/wireapp/wire-webapp/pull/17809 introduces an issue where the sidebar doesn't take the full  height when it's position is `fixed` (when the app reaches a min-width breakpoint).

Changing the position to `absolute` and assigning a `100%` height to the wrapper div solved the problem

## Screenshots/Screencast (for UI changes)
Before:
![image](https://github.com/user-attachments/assets/e84fc936-8e51-41c7-a2e4-34dfbedd5022)

After:
![image](https://github.com/user-attachments/assets/51c574a5-3931-4736-8cdb-2f103ae1a7e7)


