### PR TITLE
fix: cmd+shift+k should not open add users modal in 1:1 [WPB-9796]

### DIFF
--- a/src/script/components/TitleBar/TitleBar.tsx
+++ b/src/script/components/TitleBar/TitleBar.tsx
@@ -163,6 +163,10 @@ export const TitleBar: React.FC<TitleBarProps> = ({
   );
 
   const showAddParticipant = useCallback(() => {
+    if (is1to1) {
+      return;
+    }
+
     if (!isActiveParticipant) {
       return showDetails(false);
     }
@@ -172,20 +176,18 @@ export const TitleBar: React.FC<TitleBarProps> = ({
     } else {
       amplify.publish(WebAppEvents.CONVERSATION.CREATE_GROUP, 'conversation_details', firstUserEntity);
     }
-  }, [firstUserEntity, isActiveParticipant, isGroup, showDetails]);
+  }, [firstUserEntity, isActiveParticipant, isGroup, showDetails, is1to1]);
 
   useEffect(() => {
     // TODO remove the titlebar for now to ensure that buttons are clickable in macOS wrappers
     window.setTimeout(() => document.querySelector('.titlebar')?.remove(), TIME_IN_MILLIS.SECOND);
 
-    window.setTimeout(() => {
-      amplify.subscribe(WebAppEvents.SHORTCUT.PEOPLE, () => showDetails(false));
-      amplify.subscribe(WebAppEvents.SHORTCUT.ADD_PEOPLE, () => {
-        if (isActivatedAccount) {
-          showAddParticipant();
-        }
-      });
-    }, 50);
+    amplify.subscribe(WebAppEvents.SHORTCUT.PEOPLE, () => showDetails(false));
+    amplify.subscribe(WebAppEvents.SHORTCUT.ADD_PEOPLE, () => {
+      if (isActivatedAccount) {
+        showAddParticipant();
+      }
+    });
 
     return () => {
       amplify.unsubscribeAll(WebAppEvents.SHORTCUT.PEOPLE);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9796" title="WPB-9796" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9796</a>  [Wrapper] Shortcut for adding people to conversation works for 1:1 convos
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

We don't want to open "add participants" view if 1:1 conversation is an active conversation.

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
