### PR TITLE
fix: Correctly match users with umlaut characters in new navigation search (WPB-10394)

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.test.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.test.tsx
@@ -106,17 +106,4 @@ describe('ConversationsList', () => {
       expect(getByText(userName)).toBeDefined();
     });
   });
-
-  it('should render only those 1:1 conversations that match the search filter', () => {
-    const unserNames = ['Alice', 'Bob', 'Charlie'];
-    const conversations = unserNames.map(create1to1Conversation);
-
-    const {queryByText} = renderComponent(conversations, 'Alice');
-
-    ['Bob', 'Charlie'].forEach(userName => {
-      expect(queryByText(userName)).toBeNull();
-    });
-
-    expect(queryByText('Alice')).not.toBeNull();
-  });
 });

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
@@ -137,15 +137,11 @@ export const ConversationsList = ({
   const isFolderView = currentTab === SidebarTabs.FOLDER;
 
   const getConversationView = () => {
-    const filterByName = (conversation: Conversation) =>
-      conversation.display_name().toLowerCase().includes(conversationsFilter.toLowerCase());
-
     if (isFolderView && currentFolder) {
       return (
         <>
           {currentFolder
             ?.conversations()
-            .filter(filterByName)
             .map((conversation, index) => (
               <ConversationListCell key={conversation.id} {...getCommonConversationCellProps(conversation, index)} />
             ))}
@@ -155,7 +151,7 @@ export const ConversationsList = ({
 
     return (
       <>
-        {conversations.filter(filterByName).map((conversation, index) => (
+        {conversations.map((conversation, index) => (
           <ConversationListCell key={conversation.id} {...getCommonConversationCellProps(conversation, index)} />
         ))}
       </>

--- a/src/script/page/LeftSidebar/panels/Conversations/helpers.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/helpers.tsx
@@ -19,12 +19,13 @@
 
 import {SidebarTabs} from 'src/script/page/LeftSidebar/panels/Conversations/useSidebarStore';
 import {t} from 'Util/LocalizerUtil';
+import {replaceAccents} from 'Util/StringUtil';
 
 import {Conversation} from '../../../../entity/Conversation';
-import {replaceAccents} from 'Util/StringUtil';
 
 interface GetTabConversationsProps {
   currentTab: SidebarTabs;
+
   conversations: Conversation[];
   groupConversations: Conversation[];
   directConversations: Conversation[];

--- a/src/script/page/LeftSidebar/panels/Conversations/helpers.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/helpers.tsx
@@ -21,6 +21,7 @@ import {SidebarTabs} from 'src/script/page/LeftSidebar/panels/Conversations/useS
 import {t} from 'Util/LocalizerUtil';
 
 import {Conversation} from '../../../../entity/Conversation';
+import {replaceAccents} from 'Util/StringUtil';
 
 interface GetTabConversationsProps {
   currentTab: SidebarTabs;
@@ -41,8 +42,12 @@ export function getTabConversations({
   archivedConversations,
   conversationsFilter,
 }: GetTabConversationsProps) {
-  const conversationSearchFilter = (conversation: Conversation) =>
-    conversation.display_name().toLowerCase().includes(conversationsFilter.toLowerCase());
+  const conversationSearchFilter = (conversation: Conversation) => {
+    const filterWord = replaceAccents(conversationsFilter.toLowerCase());
+    const conversationDisplayName = replaceAccents(conversation.display_name().toLowerCase());
+
+    return conversationDisplayName.includes(filterWord);
+  };
 
   const conversationArchivedFilter = (conversation: Conversation) => !archivedConversations.includes(conversation);
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10394" title="WPB-10394" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10394</a>  [web] search in new-nav misses special characters
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Screenshots/Screencast (for UI changes)

### BEFORE:
<img width="377" alt="image" src="https://github.com/user-attachments/assets/dca2e4cf-d3a1-4b1d-b860-1730a57a6055">

### AFTER
<img width="382" alt="image" src="https://github.com/user-attachments/assets/65924bfc-217d-4c6b-90e6-c7e79dbcbfc9">
