### PR TITLE
chore: Allow targetting locally running backend

### DIFF
--- a/.env.localhost
+++ b/.env.localhost
@@ -5,7 +5,7 @@ APP_BASE="https://local.zinfra.io:8081"
 
 FORCED_CONFIG_URL="https://github.com/wireapp/wire-web-config-wire"
 
-CSP_EXTRA_CONNECT_SRC="http://localhost:32123, ws://localhost:32123, https://*.zinfra.io, https://*.wire.link, https://*.wire.com, https://api.raygun.io, wss://*.zinfra.io, wss://*.wire.link, wss://prod-nginz-ssl.wire.com, https://wire.count.ly, https://balderdash.hogwash.work:9000, https://balderdash.hogwash.work:5556, https://accounts.google.com, https://oauth2.googleapis.com/token"
+CSP_EXTRA_CONNECT_SRC="http://localhost:4570, http://localhost:32123, ws://localhost:32123, https://*.zinfra.io, https://*.wire.link, https://*.wire.com, https://api.raygun.io, wss://*.zinfra.io, wss://*.wire.link, wss://prod-nginz-ssl.wire.com, https://wire.count.ly, https://balderdash.hogwash.work:9000, https://balderdash.hogwash.work:5556, https://accounts.google.com, https://oauth2.googleapis.com/token"
 CSP_EXTRA_IMG_SRC="https://*.zinfra.io, https://*.wire.com, https://*.wire.link"
 CSP_EXTRA_SCRIPT_SRC="http://localhost:32123, https://*.zinfra.io, https://*.wire.com, https://*.wire.link, https://api.raygun.io"
 ENFORCE_HTTPS="false"
@@ -30,3 +30,7 @@ BACKEND_WS="wss://staging-nginz-ssl.zinfra.io"
 # BACKEND_REST="https://prod-nginz-https.wire.com"
 # BACKEND_WS="wss://prod-nginz-ssl.wire.com"
 
+# local
+# BACKEND_REST="http://localhost:8080"
+# BACKEND_WS="ws://localhost:8080"
+# APP_BASE="http://localhost:8081"

--- a/.env.localhost
+++ b/.env.localhost
@@ -30,7 +30,7 @@ BACKEND_WS="wss://staging-nginz-ssl.zinfra.io"
 # BACKEND_REST="https://prod-nginz-https.wire.com"
 # BACKEND_WS="wss://prod-nginz-ssl.wire.com"
 
-# local
+# Use these vars if you are running a local backend. (Rare)
 # BACKEND_REST="http://localhost:8080"
 # BACKEND_WS="ws://localhost:8080"
 # APP_BASE="http://localhost:8081"

--- a/server/Server.ts
+++ b/server/Server.ts
@@ -236,7 +236,7 @@ class Server {
       if (this.server) {
         reject('Server is already running.');
       } else if (this.config.PORT_HTTP) {
-        if (this.config.DEVELOPMENT) {
+        if (this.config.DEVELOPMENT && this.config.DEVELOPMENT_ENABLE_TLS) {
           const options = {
             cert: fs.readFileSync(this.config.SSL_CERTIFICATE_PATH),
             key: fs.readFileSync(this.config.SSL_CERTIFICATE_KEY_PATH),

--- a/server/config/server.config.ts
+++ b/server/config/server.config.ts
@@ -99,6 +99,7 @@ export function generateConfig(params: ConfigGeneratorParams, env: Env) {
     BACKEND_REST: urls.api,
     BACKEND_WS: urls.ws,
     DEVELOPMENT: nodeEnv === 'development',
+    DEVELOPMENT_ENABLE_TLS: urls.base.startsWith('https://'),
     ENFORCE_HTTPS: env.ENFORCE_HTTPS != 'false',
     ENVIRONMENT: nodeEnv,
     GOOGLE_WEBMASTER_ID: env.GOOGLE_WEBMASTER_ID,


### PR DESCRIPTION
## Description

`http://localhost:4570` serves the fake S3 service when running backend locally. So it needs to be part of `connect-src` in the CSP header.

The backend doesn't run with TLS for client API locally, so it needs to be connected to without TLS. If the webapp server runs on TLS, the websocket connection is automatically upgraded to TLS too, so the webapp server also needs to run without TLS.

Finally there were some CSP issues when running webapp server on runs on `http://local.zinfra.io:8081`, moving it to `http://localhost:8081` fixes it. I am not sure what this one is.

## Screenshots/Screencast (for UI changes)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- can be reviewed commit-by-commit
