### PR TITLE
runfix: check allowed backend urls in isCountlyEnabled functionality

### DIFF
--- a/src/script/tracking/EventTrackingRepository.ts
+++ b/src/script/tracking/EventTrackingRepository.ts
@@ -42,9 +42,10 @@ import {ClientEvent} from '../event/Client';
 import {TeamState} from '../team/TeamState';
 
 export function isCountlyEnabled(): boolean {
-  const allowedBackendUrls = Config.getConfig()
-    .COUNTLY_ALLOWED_BACKEND.split(',')
-    .map(url => url.trim());
+  const allowedBackendUrls =
+    Config.getConfig()
+      .COUNTLY_ALLOWED_BACKEND?.split(',')
+      .map(url => url.trim()) || [];
 
   return (
     !!Config.getConfig().COUNTLY_API_KEY &&


### PR DESCRIPTION
## Description

Fix for application crash while COUNTLY_ALLOWED_BACKEND in config is not passed (undefined).

## Screenshots/Screencast (for UI changes)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
