### PR TITLE
feat: create own screen share conditions for one to one call [WPB-9950] 

### DIFF
--- a/src/script/media/MediaConstraintsHandler.test.ts
+++ b/src/script/media/MediaConstraintsHandler.test.ts
@@ -80,39 +80,41 @@ describe('MediaConstraintsHandler', () => {
     it('returns constraints to get the screen stream if browser supports getDisplayMedia in conference call', () => {
       const constraintsHandler = createConstraintsHandler();
 
-      const constraints = constraintsHandler.getScreenStreamConstraints(
+      const constraints: MediaStreamConstraints | undefined = constraintsHandler.getScreenStreamConstraints(
         ScreensharingMethods.DISPLAY_MEDIA,
         true,
-      ) as any;
+      );
 
-      expect(constraints.audio).toBe(false);
-      expect(constraints.video.height).toEqual(
+      expect(constraints?.audio).toBe(false);
+      expect((constraints?.video as MediaTrackConstraints).height).toEqual(
         jasmine.objectContaining({ideal: jasmine.any(Number), max: jasmine.any(Number)}),
       );
+      expect((constraints?.video as MediaTrackConstraints).frameRate).toEqual(jasmine.any(Number));
     });
 
     it('returns constraints to get the screen stream if browser supports getDisplayMedia in one to one call', () => {
       const constraintsHandler = createConstraintsHandler();
 
-      const constraints = constraintsHandler.getScreenStreamConstraints(
+      const constraints: MediaStreamConstraints | undefined = constraintsHandler.getScreenStreamConstraints(
         ScreensharingMethods.DISPLAY_MEDIA,
         false,
-      ) as any;
+      );
 
-      expect(constraints.audio).toBe(false);
-      expect(constraints.video.height).toBeUndefined();
+      expect(constraints?.audio).toBe(false);
+      expect((constraints?.video as MediaTrackConstraints).height).toBeUndefined();
+      expect((constraints?.video as MediaTrackConstraints).frameRate).toEqual(jasmine.any(Number));
     });
 
     it('returns constraints to get the screen stream if browser uses desktopCapturer in conference call', () => {
       const constraintsHandler = createConstraintsHandler();
 
-      const constraints = constraintsHandler.getScreenStreamConstraints(
+      const constraints: MediaStreamConstraints | undefined = constraintsHandler.getScreenStreamConstraints(
         ScreensharingMethods.DESKTOP_CAPTURER,
         true,
-      ) as any;
+      );
 
-      expect(constraints.audio).toBe(false);
-      expect(constraints.video.mandatory).toEqual(
+      expect(constraints?.audio).toBe(false);
+      expect((constraints?.video as MediaTrackConstraintsExt).mandatory).toEqual(
         jasmine.objectContaining({maxHeight: jasmine.any(Number), minHeight: jasmine.any(Number)}),
       );
     });
@@ -120,22 +122,28 @@ describe('MediaConstraintsHandler', () => {
     it('returns constraints to get the screen stream if browser uses desktopCapturer in one to one call', () => {
       const constraintsHandler = createConstraintsHandler();
 
-      const constraints = constraintsHandler.getScreenStreamConstraints(
+      const constraints: MediaStreamConstraints | undefined = constraintsHandler.getScreenStreamConstraints(
         ScreensharingMethods.DESKTOP_CAPTURER,
         false,
-      ) as any;
+      );
 
-      expect(constraints.audio).toBe(false);
-      expect(constraints.video.mandatory).toEqual({chromeMediaSource: 'desktop', chromeMediaSourceId: 'camera'});
+      expect(constraints?.audio).toBe(false);
+      expect((constraints?.video as MediaTrackConstraintsExt).mandatory).toEqual({
+        chromeMediaSource: 'desktop',
+        chromeMediaSourceId: 'camera',
+      });
     });
 
     it('returns constraints to get the screen stream if browser uses getUserMedia in conference call', () => {
       const constraintsHandler = createConstraintsHandler();
 
-      const constraints = constraintsHandler.getScreenStreamConstraints(ScreensharingMethods.USER_MEDIA, true) as any;
+      const constraints: MediaStreamConstraints | undefined = constraintsHandler.getScreenStreamConstraints(
+        ScreensharingMethods.USER_MEDIA,
+        true,
+      );
 
-      expect(constraints.audio).toBe(false);
-      expect(constraints.video).toEqual(
+      expect(constraints?.audio).toBe(false);
+      expect(constraints?.video as MediaTrackConstraints).toEqual(
         jasmine.objectContaining({
           frameRate: jasmine.any(Number),
           height: {exact: jasmine.any(Number)},
@@ -147,10 +155,13 @@ describe('MediaConstraintsHandler', () => {
     it('returns constraints to get the screen stream if browser uses getUserMedia in one to one call', () => {
       const constraintsHandler = createConstraintsHandler();
 
-      const constraints = constraintsHandler.getScreenStreamConstraints(ScreensharingMethods.USER_MEDIA, false) as any;
+      const constraints: MediaStreamConstraints | undefined = constraintsHandler.getScreenStreamConstraints(
+        ScreensharingMethods.USER_MEDIA,
+        false,
+      );
 
-      expect(constraints.audio).toBe(false);
-      expect(constraints.video).toEqual(
+      expect(constraints?.audio).toBe(false);
+      expect(constraints?.video as MediaTrackConstraints).toEqual(
         jasmine.objectContaining({
           frameRate: jasmine.any(Number),
           mediaSource: 'screen',
@@ -181,3 +192,7 @@ describe('MediaConstraintsHandler', () => {
     });
   });
 });
+
+type MediaTrackConstraintsExt = MediaTrackConstraints & {
+  mandatory: {chromeMediaSource: string; chromeMediaSourceId?: string; maxHeight?: number; minHeight?: number};
+};

--- a/src/script/media/MediaConstraintsHandler.test.ts
+++ b/src/script/media/MediaConstraintsHandler.test.ts
@@ -77,28 +77,77 @@ describe('MediaConstraintsHandler', () => {
   });
 
   describe('getScreenStreamConstraints', () => {
-    it('returns constraints to get the screen stream if browser supports getDisplayMedia', () => {
+    it('returns constraints to get the screen stream if browser supports getDisplayMedia in conference call', () => {
       const constraintsHandler = createConstraintsHandler();
 
-      const constraints = constraintsHandler.getScreenStreamConstraints(ScreensharingMethods.DISPLAY_MEDIA) as any;
+      const constraints = constraintsHandler.getScreenStreamConstraints(
+        ScreensharingMethods.DISPLAY_MEDIA,
+        true,
+      ) as any;
+
+      expect(constraints.audio).toBe(false);
+      expect(constraints.video.height).toEqual(
+        jasmine.objectContaining({ideal: jasmine.any(Number), max: jasmine.any(Number)}),
+      );
+    });
+
+    it('returns constraints to get the screen stream if browser supports getDisplayMedia in one to one call', () => {
+      const constraintsHandler = createConstraintsHandler();
+
+      const constraints = constraintsHandler.getScreenStreamConstraints(
+        ScreensharingMethods.DISPLAY_MEDIA,
+        false,
+      ) as any;
 
       expect(constraints.audio).toBe(false);
       expect(constraints.video.height).toBeUndefined();
     });
 
-    it('returns constraints to get the screen stream if browser uses desktopCapturer', () => {
+    it('returns constraints to get the screen stream if browser uses desktopCapturer in conference call', () => {
       const constraintsHandler = createConstraintsHandler();
 
-      const constraints = constraintsHandler.getScreenStreamConstraints(ScreensharingMethods.DESKTOP_CAPTURER) as any;
+      const constraints = constraintsHandler.getScreenStreamConstraints(
+        ScreensharingMethods.DESKTOP_CAPTURER,
+        true,
+      ) as any;
+
+      expect(constraints.audio).toBe(false);
+      expect(constraints.video.mandatory).toEqual(
+        jasmine.objectContaining({maxHeight: jasmine.any(Number), minHeight: jasmine.any(Number)}),
+      );
+    });
+
+    it('returns constraints to get the screen stream if browser uses desktopCapturer in one to one call', () => {
+      const constraintsHandler = createConstraintsHandler();
+
+      const constraints = constraintsHandler.getScreenStreamConstraints(
+        ScreensharingMethods.DESKTOP_CAPTURER,
+        false,
+      ) as any;
 
       expect(constraints.audio).toBe(false);
       expect(constraints.video.mandatory).toEqual({chromeMediaSource: 'desktop', chromeMediaSourceId: 'camera'});
     });
 
-    it('returns constraints to get the screen stream if browser uses getUserMedia', () => {
+    it('returns constraints to get the screen stream if browser uses getUserMedia in conference call', () => {
       const constraintsHandler = createConstraintsHandler();
 
-      const constraints = constraintsHandler.getScreenStreamConstraints(ScreensharingMethods.USER_MEDIA) as any;
+      const constraints = constraintsHandler.getScreenStreamConstraints(ScreensharingMethods.USER_MEDIA, true) as any;
+
+      expect(constraints.audio).toBe(false);
+      expect(constraints.video).toEqual(
+        jasmine.objectContaining({
+          frameRate: jasmine.any(Number),
+          height: {exact: jasmine.any(Number)},
+          mediaSource: 'screen',
+        }),
+      );
+    });
+
+    it('returns constraints to get the screen stream if browser uses getUserMedia in one to one call', () => {
+      const constraintsHandler = createConstraintsHandler();
+
+      const constraints = constraintsHandler.getScreenStreamConstraints(ScreensharingMethods.USER_MEDIA, false) as any;
 
       expect(constraints.audio).toBe(false);
       expect(constraints.video).toEqual(

--- a/src/script/media/MediaConstraintsHandler.ts
+++ b/src/script/media/MediaConstraintsHandler.ts
@@ -93,7 +93,9 @@ export class MediaConstraintsHandler {
         },
         VIDEO: {
           [VIDEO_QUALITY_MODE.FULL_HD]: {
-            frameRate: 30,
+            frameRate: 15,
+            height: 1080,
+            width: 1920,
           },
           [VIDEO_QUALITY_MODE.GROUP]: {
             frameRate: 15,
@@ -102,6 +104,8 @@ export class MediaConstraintsHandler {
           },
           [VIDEO_QUALITY_MODE.HD]: {
             frameRate: 15,
+            height: 720,
+            width: 1280,
           },
           [VIDEO_QUALITY_MODE.MOBILE]: {
             frameRate: 15,

--- a/src/script/media/MediaStreamHandler.ts
+++ b/src/script/media/MediaStreamHandler.ts
@@ -155,7 +155,7 @@ export class MediaStreamHandler {
     hasPermission: boolean,
   ): Promise<MediaStream> {
     const mediaConstraints = screen
-      ? this.constraintsHandler.getScreenStreamConstraints(this.screensharingMethod)
+      ? this.constraintsHandler.getScreenStreamConstraints(this.screensharingMethod, isGroup)
       : this.constraintsHandler.getMediaStreamConstraints(audio, video, isGroup);
 
     const willPromptForPermission = !hasPermission && !Runtime.isDesktopApp();


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9950" title="WPB-9950" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-9950</a>  [AVS] Change Screen Share constrains for better Screen Share quality in 1:1 Call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

This is a follow-up pull request from this [Pull Request](https://github.com/wireapp/wire-webapp/pull/17843)
We are only improving the screen share quality for the one-to-one calls. Improvements for the conference call will follow in a separate Pull Request

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

I have also removed the video stream improvements. This is to ensure that no unwanted effects occur. We will also adjust these when we adjust the conference call. 
