### PR TITLE
feat: deprecated husky migration

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 yarn lint-staged

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "lint:other": "yarn prettier --list-different && yarn stylelint",
     "lint:code": "eslint --ext .js,.ts,.tsx .",
     "check:circular-dependencies": "dpdm --no-warning --no-tree -T  ./src/script/auth/main.tsx ./src/script/main/app.ts",
-    "postinstall": "yarn configure && cd server && yarn && cd .. && husky install",
+    "postinstall": "yarn configure && cd server && yarn && cd .. && husky",
     "prettier": "prettier --ignore-path .prettierignore \"**/*.{json,md,yml}\"",
     "release:staging": "git checkout dev && git pull && ts-node ./bin/release_tag.ts staging",
     "release:production": "git checkout master && git pull && ts-node ./bin/release_tag.ts production",


### PR DESCRIPTION
## Description

Fix deprecated husky warning. 

There is description how to migrate husky: https://github.com/typicode/husky/releases/tag/v9.0.1.

## Screenshots/Screencast (for UI changes)
Before:
<img width="550" alt="image" src="https://github.com/user-attachments/assets/fcdb2438-ae8e-4d2a-b67a-8c4698893e13">

After:
<img width="643" alt="image" src="https://github.com/user-attachments/assets/0094372e-f949-4216-9410-5dce230bef97">

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
