### PR TITLE
fix: clone audio track to avoid ending track

### DIFF
--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -1280,9 +1280,9 @@ export class CallingRepository {
     const {conversation} = call;
 
     if (mediaType === MediaType.AUDIO) {
-      const audioTracks: MediaStreamTrack[] = mediaStream.getAudioTracks();
+      const audioTracks = mediaStream.getAudioTracks().map(track => track.clone());
       if (audioTracks.length > 0) {
-        selfParticipant.setAudioStream(new MediaStream([audioTracks[0]]), true);
+        selfParticipant.setAudioStream(new MediaStream(audioTracks), true);
         this.wCall?.replaceTrack(this.serializeQualifiedId(conversation.qualifiedId), audioTracks[0]);
       }
     }

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -1294,10 +1294,10 @@ export class CallingRepository {
         this.wCall?.replaceTrack(this.serializeQualifiedId(conversation.qualifiedId), videoTracks[0]);
         // Remove the previous video stream
         if (updateSelfParticipant) {
-          selfParticipant.setVideoStream(new MediaStream([videoTracks[0]]), true);
+          selfParticipant.setVideoStream(mediaStream, true);
         }
+        return mediaStream;
       }
-      return mediaStream;
     }
   }
 


### PR DESCRIPTION
## Description

When the device selection page is current track will be stopped.. Currently cloning saves us from ending the track in the call.

## Screenshots/Screencast (for UI changes)

## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

Cloning tracks is bad behavior because. This can cause side effects. The original track can still exist and record even though the conference has ended. Or the sent track cannot be muted.

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
