### PR TITLE
fix: Allow user to type while calling pop out window is open (WPB-10463)

### DIFF
--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React, {useState, useEffect} from 'react';
+import React, {useState} from 'react';
 
 import {DefaultConversationRoleName} from '@wireapp/api-client/lib/conversation/';
 import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
@@ -40,7 +40,6 @@ import {MediaDeviceType} from 'src/script/media/MediaDeviceType';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {handleKeyDown, isEscapeKey} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
-import {preventFocusOutside} from 'Util/util';
 
 import {CallingParticipantList} from './CallingCell/CallIngParticipantList';
 import {Duration} from './Duration';
@@ -334,17 +333,6 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
   // To be changed when design chooses a breakpoint, the conditional can be integrated to the ui-kit directly
   const horizontalSmBreakpoint = useActiveWindowMatchMedia('max-width: 680px');
   const horizontalXsBreakpoint = useActiveWindowMatchMedia('max-width: 500px');
-
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent): void => {
-      event.preventDefault();
-      preventFocusOutside(event, 'video-calling');
-    };
-    document.addEventListener('keydown', onKeyDown);
-    return () => {
-      document.removeEventListener('keydown', onKeyDown);
-    };
-  }, []);
 
   const callGroupStartedAlert = t(isGroupCall ? 'startedVideoGroupCallingAlert' : 'startedVideoCallingAlert', {
     conversationName,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10463" title="WPB-10463" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10463</a>  [Web Edge] With popped out calling view, i cannot type into the message input bar
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
This PR removes the `useEffect` hook that was previously used to handle keyboard events in the video calling feature.

#### Context

Back when we did not have Picture-in-Picture (PiP) functionality, we added a `useEffect` to listen for `keydown` events and prevent typing outside of the video calling interface. This was intended to avoid accidental typing or interactions in the main application while the video calling view was active.

However, with the introduction of PiP, the video calling maximized view now operates as a separate window. As a result, the previous workaround of blocking all key interactions in the parent window is no longer necessary and actually interferes with normal usage.

#### Changes

- **Deleted the entire `useEffect` block** responsible for handling and preventing default actions on `keydown` events.

This change restores normal keyboard interaction in the parent window while the PiP window is open, ensuring a better user experience.

