### PR TITLE
chore: enable api v6 [wpb-10266]

### DIFF
--- a/src/script/Config.ts
+++ b/src/script/Config.ts
@@ -78,7 +78,7 @@ const config = {
   ALLOWED_IMAGE_TYPES: ['image/bmp', 'image/gif', 'image/jpeg', 'image/jpg', 'image/png'],
 
   /** Which min and max version of the backend api do we support */
-  SUPPORTED_API_RANGE: [1, env.ENABLE_DEV_BACKEND_API ? Infinity : 5],
+  SUPPORTED_API_RANGE: [1, env.ENABLE_DEV_BACKEND_API ? Infinity : 6],
 
   /** DataDog client api keys acces */
   dataDog: {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10266" title="WPB-10266" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10266</a>  [Web] Update API version to 6
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

The backend ticket being set to `done` https://wearezeta.atlassian.net/browse/WPB-10263 , we can enable API v6 in the webapp