### PR TITLE
fix: Do not close pop out window when closing a different call (WPB-10470)

### DIFF
--- a/src/script/calling/CallState.ts
+++ b/src/script/calling/CallState.ts
@@ -97,6 +97,7 @@ export class CallState {
   readonly isSpeakersViewActive: ko.PureComputed<boolean>;
   public readonly viewMode = ko.observable<CallingViewMode>(CallingViewMode.MINIMIZED);
   public readonly detachedWindow = ko.observable<Window | null>(null);
+  public readonly detachedWindowCallQualifiedId = ko.observable<QualifiedId | null>(null);
   public readonly desktopScreenShareMenu = ko.observable<DesktopScreenShareMenu>(DesktopScreenShareMenu.NONE);
 
   constructor() {
@@ -138,6 +139,7 @@ export class CallState {
 
   closeDetachedWindow = () => {
     this.detachedWindow(null);
+    this.detachedWindowCallQualifiedId(null);
     amplify.unsubscribe(WebAppEvents.PROPERTIES.UPDATE.INTERFACE.THEME, this.handleThemeUpdateEvent);
     this.viewMode(CallingViewMode.MINIMIZED);
   };
@@ -199,6 +201,8 @@ export class CallState {
 
       this.detachedWindow(detachedWindow);
     }
+
+    this.detachedWindowCallQualifiedId(this.joinedCall()?.conversation.qualifiedId ?? null);
 
     const detachedWindow = this.detachedWindow();
     if (!detachedWindow) {

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -1483,7 +1483,14 @@ export class CallingRepository {
       return;
     }
 
-    void this.callState.setViewModeMinimized();
+    if (
+      matchQualifiedIds(
+        call.conversation.qualifiedId,
+        this.callState.detachedWindowCallQualifiedId() ?? {id: '', domain: ''},
+      )
+    ) {
+      void this.callState.setViewModeMinimized();
+    }
 
     // There's nothing we need to do for non-mls calls
     if (call.conversationType === CONV_TYPE.CONFERENCE_MLS) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10470" title="WPB-10470" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10470</a>  [Web Edge] Pop out view just closes / minimizes randomly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

This PR addresses an issue where the popped-out calling view would randomly close or revert back into the main window when a second call is received and then declined or ignored.

### Reproduction Steps
1. Be on an active call.
2. Pop out the calling UI into a separate window.
3. Receive another incoming call.
4. Decline the incoming call or let it ring without accepting.

### Expected Behavior
- The second call is declined, or the ringing stops.
- The popped-out calling view remains in its detached window.

### Actual Behavior
- The second call is declined, or the ringing stops.
- The popped-out calling view unexpectedly pops back into the main application window.

### Fix Details

The issue was fixed by adding the `detachedWindowCallQualifiedId` to the call state and incorporating the following check:

```javascript
if (
  matchQualifiedIds(
    call.conversation.qualifiedId,
    this.callState.detachedWindowCallQualifiedId() ?? {id: '', domain: ''},
  )
) {
  void this.callState.setViewModeMinimized();
}
