### PR TITLE
fix: handle leaving a 1:1 call over SFT [WPB-7151]

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@lexical/react": "0.12.5",
     "@wireapp/avs": "9.6.15",
     "@wireapp/commons": "5.2.7",
-    "@wireapp/core": "46.0.17-hotfix-1.1",
+    "@wireapp/core": "46.0.17-hotfix-1.2",
     "@wireapp/react-ui-kit": "9.16.4",
     "@wireapp/store-engine-dexie": "2.1.8",
     "@wireapp/webapp-events": "0.20.1",

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -985,6 +985,14 @@ export class CallingRepository {
     return this.conversationState.findConversation(conversationId);
   }
 
+  private readonly leave1on1MLSConference = async (conversationId: QualifiedId) => {
+    await this.subconversationService.leave1on1ConferenceSubconversation(conversationId);
+
+    const conversationIdStr = this.serializeQualifiedId(conversationId);
+    this.wCall?.end(this.wUser, conversationIdStr);
+    callingSubscriptions.removeCall(conversationId);
+  };
+
   private readonly leaveMLSConference = async (conversationId: QualifiedId) => {
     await this.subconversationService.leaveConferenceSubconversation(conversationId);
     callingSubscriptions.removeCall(conversationId);
@@ -1410,13 +1418,18 @@ export class CallingRepository {
     Warnings.hideWarning(Warnings.TYPE.CALL_QUALITY_POOR);
     const conversationId = this.parseQualifiedId(convId);
     const call = this.findCall(conversationId);
+    const conversation = this.getConversationById(conversationId);
     if (!call) {
       return;
     }
 
     // There's nothing we need to do for non-mls calls
     if (call.conversationType === CONV_TYPE.CONFERENCE_MLS) {
-      await this.leaveMLSConference(conversationId);
+      if (!conversation?.is1to1()) {
+        await this.leaveMLSConference(conversationId);
+      } else {
+        await this.leave1on1MLSConference(conversationId);
+      }
     }
 
     if (reason === REASON.NORMAL) {
@@ -1666,11 +1679,41 @@ export class CallingRepository {
       userId: this.parseQualifiedId(member.userid),
     }));
 
+    this.handleOneToOneMlsCallParticipantLeave(conversationId, members);
     this.updateParticipantList(call, members);
     this.updateParticipantMutedState(call, members);
     this.updateParticipantVideoState(call, members);
     this.updateParticipantAudioState(call, members);
     this.handleCallParticipantChange(conversationId, members);
+  };
+
+  private readonly handleOneToOneMlsCallParticipantLeave = (
+    conversationId: QualifiedId,
+    members: QualifiedWcallMember[],
+  ) => {
+    const conversation = this.getConversationById(conversationId);
+    const call = this.findCall(conversationId);
+
+    const [, nextOtherMember] = members;
+
+    if (!conversation || !this.isMLSConference(conversation) || !conversation?.is1to1() || !call || !nextOtherMember) {
+      return;
+    }
+
+    const currentOtherParticipant = call
+      .participants()
+      .find(participant => matchQualifiedIds(nextOtherMember.userId, participant.user.qualifiedId));
+
+    if (!currentOtherParticipant) {
+      return;
+    }
+
+    const isCurrentlyEstablished = currentOtherParticipant.isAudioEstablished();
+    const {aestab: newEstablishedStatus} = nextOtherMember;
+
+    if (isCurrentlyEstablished && newEstablishedStatus === AUDIO_STATE.CONNECTING) {
+      void this.leave1on1MLSConference(conversationId);
+    }
   };
 
   private readonly requestClients = async (wUser: number, convId: SerializedConversationId, __: number) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4775,9 +4775,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:46.0.17-hotfix-1.1":
-  version: 46.0.17-hotfix-1.1
-  resolution: "@wireapp/core@npm:46.0.17-hotfix-1.1"
+"@wireapp/core@npm:46.0.17-hotfix-1.2":
+  version: 46.0.17-hotfix-1.2
+  resolution: "@wireapp/core@npm:46.0.17-hotfix-1.2"
   dependencies:
     "@wireapp/api-client": ^27.1.0-hotfix-1.0
     "@wireapp/commons": ^5.2.8
@@ -4797,7 +4797,7 @@ __metadata:
     long: ^5.2.0
     uuid: 9.0.1
     zod: 3.23.8
-  checksum: e345882a734ea8d37c800f360fa4777389a63249ac532c3c5f1eb5c51ca618155f5e9138c0c7cb1e582d5a8947c515073d24c8e1b2ec2df4de3f7e60c88e31be
+  checksum: 03a428e43bcc5e4accea630d643ee871023eed738a39c73c49c59cbd7c712bf14fd7747667a9392084032e7d599b356914f26fbfdb5e0eb2e7a58358318e4113
   languageName: node
   linkType: hard
 
@@ -17508,7 +17508,7 @@ __metadata:
     "@wireapp/avs": 9.6.15
     "@wireapp/commons": 5.2.7
     "@wireapp/copy-config": 2.1.14
-    "@wireapp/core": 46.0.17-hotfix-1.1
+    "@wireapp/core": 46.0.17-hotfix-1.2
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.16.4


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7151" title="WPB-7151" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-7151</a>  [Web] Add flag for customer specific 1:1 calls in federated environment
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description
see https://wearezeta.atlassian.net/wiki/spaces/PAD/pages/1314750477/2024-07-29+1+1+calls+over+SFT#Do-not-leave-the-subconversation

There's currently 2 issues with having 1:1 calls over SFT:
- SFT calls are treated like group calls, so one user would stay in the call if the second participants hangs up (the call should terminate in that case if 1:1)
- Participants were atempting to leave the MLS subconversation, which may cause issue with users from different federated backends.

### Solution (Temporary)
- The remaining participant leaves the call if audio is no longer established from the other participant
- Both participant attempt to delete the subconversation when the call is terminated see https://github.com/wireapp/wire-web-packages/pull/6434


## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;
