### PR TITLE
fix: Persist conversation labels in local storage (WPB-10465)

### DIFF
--- a/src/script/conversation/ConversationLabelRepository.ts
+++ b/src/script/conversation/ConversationLabelRepository.ts
@@ -129,17 +129,17 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
   };
 
   readonly saveLabels = () => {
-    const values = this.marshal();
-    void this.propertiesService.putPropertiesByKey(propertiesKey, values);
+    const conversationLabelJson = this.marshal();
+    void this.propertiesService.putPropertiesByKey(propertiesKey, conversationLabelJson);
     this.persistValues();
   };
 
   loadLabels = async () => {
     try {
-      const values = localStorage.getItem(ConversationLabelRepository.LocalStorageKey);
+      const conversationLabelJson = localStorage.getItem(ConversationLabelRepository.LocalStorageKey);
 
-      if (values) {
-        this.unmarshal(JSON.parse(values));
+      if (conversationLabelJson) {
+        this.unmarshal(JSON.parse(conversationLabelJson));
         this.saveLabels();
         return;
       }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10465" title="WPB-10465" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10465</a>  [Web] Folders and favorites are broken
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

This PR tries to solve the issue of conversations being removed randomly from folders and favorites.

## Possible Issue Details

The issue was caused by inconsistent HTTP requests when adding conversations to folders:
- **Request 1**: Add convo 1 to folder 1 - SUCCESS
- **Request 2**: Add convo 2 to folder 1 - SUCCESS
- **Request 3**: Add convo 3 to folder 1 - FAILED
- **Request 4**: Add convo 4 to folder 1 - SUCCESS

When a request failed, the conversation would disappear upon restarting the app, causing data inconsistency.

## Fix Implemented

The fix involves persisting folders (conversation labels) into local storage. The changes include:
1. **Reading from Local Storage**: On app load, the app first tries to read from local storage. If local storage is empty, it fetches data from the backend and writes it to local storage.
2. **Persisting After Actions**: After every action in the `saveLabels` method, the app persists data in local storage and makes a request to persist it on the backend. This ensures data consistency even if the backend request fails.

