### PR TITLE
chore: bump AVS to 9.6.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@emotion/react": "11.11.3",
     "@lexical/history": "0.12.5",
     "@lexical/react": "0.12.5",
-    "@wireapp/avs": "9.6.15",
+    "@wireapp/avs": "9.6.16",
     "@wireapp/commons": "5.2.7",
     "@wireapp/core": "46.0.17-hotfix-1.2",
     "@wireapp/react-ui-kit": "9.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4714,10 +4714,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/avs@npm:9.6.15":
-  version: 9.6.15
-  resolution: "@wireapp/avs@npm:9.6.15"
-  checksum: 29b953560a06afa3fe6761cdb28b606c3629d47c4ea8148f36042848f631bf2b4d0e873ae947b92cd54b2e5229a2101e1df795ee7cdac8a645ab1c73ebe076eb
+"@wireapp/avs@npm:9.6.16":
+  version: 9.6.16
+  resolution: "@wireapp/avs@npm:9.6.16"
+  checksum: 6f683a29e1e52cc62b50c3327cb89939216116c0f04999f0364a35529f3321ddb0b443c241696567d4d37f0e071d5d5cca3739677667a3c22d0e2b6c1902f7d4
   languageName: node
   linkType: hard
 
@@ -17505,7 +17505,7 @@ __metadata:
     "@types/speakingurl": 13.0.6
     "@types/underscore": 1.11.15
     "@types/webpack-env": 1.18.4
-    "@wireapp/avs": 9.6.15
+    "@wireapp/avs": 9.6.16
     "@wireapp/commons": 5.2.7
     "@wireapp/copy-config": 2.1.14
     "@wireapp/core": 46.0.17-hotfix-1.2


### PR DESCRIPTION
<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7151" title="WPB-7151" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-7151</a>  [Web] Add flag for customer specific 1:1 calls in federated environment
  </td></table>
  <br />

## Description

A new AVS version fixes some issues with 1:1 calling over SFT
