### PR TITLE
fix: Auto close change participants view on outside click (WPB-10503)

### DIFF
--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -684,29 +684,31 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                         aria-checked={!isMuted}
                         title={t('videoCallOverlayChangeViewMode')}
                       >
-                        <Select
-                          // eslint-disable-next-line jsx-a11y/no-autofocus
-                          autoFocus
-                          value={selectedCallViewOption}
-                          id="select-call-view"
-                          dataUieName="select-call-view"
-                          controlShouldRenderValue={false}
-                          isClearable={false}
-                          backspaceRemovesValue={false}
-                          hideSelectedOptions={false}
-                          options={callViewOptions}
-                          onChange={selectedOption => {
-                            if (isCallViewOption(selectedOption)) {
-                              setActiveCallViewTab(selectedOption.value);
-                              setMaximizedParticipant(call, null);
-                            }
-                          }}
-                          onKeyDown={event => isEscapeKey(event) && setAudioOptionsOpen(false)}
-                          menuPlacement="top"
-                          menuIsOpen={isCallViewOpen}
-                          wrapperCSS={{marginBottom: 0, width: 0, height: 0}}
-                          menuCSS={{right: 0, bottom: 10}}
-                        />
+                        {isCallViewOpen && (
+                          <Select
+                            // eslint-disable-next-line jsx-a11y/no-autofocus
+                            autoFocus
+                            value={selectedCallViewOption}
+                            id="select-call-view"
+                            dataUieName="select-call-view"
+                            controlShouldRenderValue={false}
+                            isClearable={false}
+                            backspaceRemovesValue={false}
+                            hideSelectedOptions={false}
+                            options={callViewOptions}
+                            onChange={selectedOption => {
+                              if (isCallViewOption(selectedOption)) {
+                                setActiveCallViewTab(selectedOption.value);
+                                setMaximizedParticipant(call, null);
+                              }
+                            }}
+                            onKeyDown={event => isEscapeKey(event) && setAudioOptionsOpen(false)}
+                            menuPlacement="top"
+                            menuIsOpen={isCallViewOpen}
+                            wrapperCSS={{marginBottom: 0, width: 0, height: 0}}
+                            menuCSS={{right: 0, bottom: 10}}
+                          />
+                        )}
                         <GridIcon width={16} height={16} />
                       </button>
                     </li>
@@ -739,6 +741,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                         </div>
                       )}
                       <button
+                        title={t('callReactions')}
                         css={showEmojisBar ? videoControlActiveStyles : videoControlInActiveStyles}
                         className="video-controls__button video-controls__button--small"
                         onClick={() => setShowEmojisBar(prev => !prev)}
@@ -747,9 +750,6 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                         data-uie-name="do-call-controls-video-call-cancel"
                       >
                         <EmojiIcon />
-                        <span id="show-emoji-bar" className="video-controls__button__label">
-                          {t('callReactions')}
-                        </span>
                       </button>
                     </li>
                   )}

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -669,6 +669,11 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                   {participants.length > 2 && (
                     <li className="video-controls__item">
                       <button
+                        onBlur={event => {
+                          if (!event.currentTarget.contains(event.relatedTarget) && isCallViewOpen) {
+                            toggleCallView();
+                          }
+                        }}
                         className="video-controls__button video-controls__button--small"
                         onClick={toggleCallView}
                         onKeyDown={event => handleKeyDown(event, toggleCallView)}
@@ -737,6 +742,11 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                         css={showEmojisBar ? videoControlActiveStyles : videoControlInActiveStyles}
                         className="video-controls__button video-controls__button--small"
                         onClick={() => setShowEmojisBar(prev => !prev)}
+                        onBlur={event => {
+                          if (!event.currentTarget.contains(event.relatedTarget)) {
+                            setShowEmojisBar(false);
+                          }
+                        }}
                         type="button"
                         aria-labelledby="show-emoji-bar"
                         data-uie-name="do-call-controls-video-call-cancel"

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -742,11 +742,6 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                         css={showEmojisBar ? videoControlActiveStyles : videoControlInActiveStyles}
                         className="video-controls__button video-controls__button--small"
                         onClick={() => setShowEmojisBar(prev => !prev)}
-                        onBlur={event => {
-                          if (!event.currentTarget.contains(event.relatedTarget)) {
-                            setShowEmojisBar(false);
-                          }
-                        }}
                         type="button"
                         aria-labelledby="show-emoji-bar"
                         data-uie-name="do-call-controls-video-call-cancel"


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10503" title="WPB-10503" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10503</a>  [Web] View mode does not automatically close if other option in calling pop out is chosen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description
This PR makes the change participants view option auto close on outside click


## Screenshots/Screencast (for UI changes)

https://github.com/user-attachments/assets/fde6475f-65ed-4a5c-8e7c-0015be84a457

