### PR TITLE
fix: Correct search for directs & groups & folders (fix/WPB-10654)

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
@@ -31,6 +31,7 @@ import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {isKeyboardEvent} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
 import {matchQualifiedIds} from 'Util/QualifiedId';
+import {replaceAccents} from 'Util/StringUtil';
 
 import {ConnectionRequests} from './ConnectionRequests';
 
@@ -138,10 +139,18 @@ export const ConversationsList = ({
 
   const getConversationView = () => {
     if (isFolderView && currentFolder) {
+      const conversationSearchFilter = (conversation: Conversation) => {
+        const filterWord = replaceAccents(conversationsFilter.toLowerCase());
+        const conversationDisplayName = replaceAccents(conversation.display_name().toLowerCase());
+
+        return conversationDisplayName.includes(filterWord);
+      };
+
       return (
         <>
           {currentFolder
             ?.conversations()
+            .filter(conversationSearchFilter)
             .map((conversation, index) => (
               <ConversationListCell key={conversation.id} {...getCommonConversationCellProps(conversation, index)} />
             ))}

--- a/src/script/page/LeftSidebar/panels/Conversations/helpers.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/helpers.tsx
@@ -61,14 +61,14 @@ export function getTabConversations({
 
   if (currentTab === SidebarTabs.GROUPS) {
     return {
-      conversations: groupConversations.filter(conversationArchivedFilter, conversationSearchFilter),
+      conversations: groupConversations.filter(conversationArchivedFilter).filter(conversationSearchFilter),
       searchInputPlaceholder: t('searchGroupConversations'),
     };
   }
 
   if (currentTab === SidebarTabs.DIRECTS) {
     return {
-      conversations: directConversations.filter(conversationArchivedFilter, conversationSearchFilter),
+      conversations: directConversations.filter(conversationArchivedFilter).filter(conversationSearchFilter),
       searchInputPlaceholder: t('searchDirectConversations'),
     };
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10654" title="WPB-10654" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10654</a>  [Web] Fix broken search behavior in Groups / 1:1 / Folders
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Search is broken in folders, directs & groups, this PR fixes it.