### PR TITLE
fix: revert enumerate media device label for firefox iii [WPB-9688] 

### DIFF
--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -1197,12 +1197,8 @@ export class CallingRepository {
     return this.mediaStreamHandler.requestMediaStream(audio, camera, screen, isGroup).then(stream => {
       return this.mediaDevicesHandler
         .initializeMediaDevices(camera)
-        .then(() => {
-          return stream;
-        })
-        .catch(() => {
-          return stream;
-        });
+        .then(() => stream)
+        .catch(() => stream);
     });
   }
 

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -1194,7 +1194,16 @@ export class CallingRepository {
   };
 
   private getMediaStream({audio = false, camera = false, screen = false}: MediaStreamQuery, isGroup: boolean) {
-    return this.mediaStreamHandler.requestMediaStream(audio, camera, screen, isGroup);
+    return this.mediaStreamHandler.requestMediaStream(audio, camera, screen, isGroup).then(stream => {
+      return this.mediaDevicesHandler
+        .initializeMediaDevices(camera)
+        .then(() => {
+          return stream;
+        })
+        .catch(() => {
+          return stream;
+        });
+    });
   }
 
   private handleMediaStreamError(call: Call, requestedStreams: MediaStreamQuery, error: Error | unknown): void {

--- a/src/script/hooks/useInitializeMediaDevices.ts
+++ b/src/script/hooks/useInitializeMediaDevices.ts
@@ -1,0 +1,52 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {useEffect, useState} from 'react';
+
+import {getLogger} from 'Util/Logger';
+
+import {MediaDevicesHandler} from '../media/MediaDevicesHandler';
+import {MediaStreamHandler} from '../media/MediaStreamHandler';
+
+const logger = getLogger('useInitializeMediaDevices');
+
+export const useInitializeMediaDevices = (devicesHandler: MediaDevicesHandler, streamHandler: MediaStreamHandler) => {
+  const [isMediaDevicesAreInitialized, setCheckingPermissions] = useState(false);
+
+  const initializeMediaDevices = async () => {
+    setCheckingPermissions(true);
+    try {
+      await streamHandler.requestMediaStreamAccess(true).then(stream => {
+        devicesHandler?.initializeMediaDevices().then(() => {
+          stream?.getTracks().forEach(track => track.stop());
+        });
+      });
+    } catch (error) {
+      logger.warn(`Initialization of media devices failed:`, error);
+    } finally {
+      setCheckingPermissions(false);
+    }
+  };
+
+  useEffect(() => {
+    initializeMediaDevices();
+  }, []);
+
+  return {isMediaDevicesAreInitialized: isMediaDevicesAreInitialized};
+};

--- a/src/script/hooks/useInitializeMediaDevices.ts
+++ b/src/script/hooks/useInitializeMediaDevices.ts
@@ -32,10 +32,10 @@ export const useInitializeMediaDevices = (devicesHandler: MediaDevicesHandler, s
   const initializeMediaDevices = async () => {
     setCheckingPermissions(true);
     try {
-      await streamHandler.requestMediaStreamAccess(true).then(stream => {
+      await streamHandler.requestMediaStreamAccess(true).then((stream: MediaStream | void) => {
         devicesHandler?.initializeMediaDevices().then(() => {
-          if (stream !== undefined) {
-            stream?.getTracks().forEach(track => track.stop());
+          if (stream) {
+            stream.getTracks().forEach(track => track.stop());
           }
         });
       });

--- a/src/script/hooks/useInitializeMediaDevices.ts
+++ b/src/script/hooks/useInitializeMediaDevices.ts
@@ -34,7 +34,9 @@ export const useInitializeMediaDevices = (devicesHandler: MediaDevicesHandler, s
     try {
       await streamHandler.requestMediaStreamAccess(true).then(stream => {
         devicesHandler?.initializeMediaDevices().then(() => {
-          stream?.getTracks().forEach(track => track.stop());
+          if (stream !== undefined) {
+            stream?.getTracks().forEach(track => track.stop());
+          }
         });
       });
     } catch (error) {

--- a/src/script/media/MediaDevicesHandler.test.ts
+++ b/src/script/media/MediaDevicesHandler.test.ts
@@ -144,9 +144,14 @@ describe('MediaDevicesHandler', () => {
     ],
   };
 
+  let enumerateDevicesSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    enumerateDevicesSpy = spyOn(window.navigator.mediaDevices, 'enumerateDevices');
+  });
   describe('refreshMediaDevices', () => {
-    it('filters duplicate microphones and keeps the ones marked with "communications"', () => {
-      spyOn(navigator.mediaDevices, 'enumerateDevices').and.returnValue(
+    it('filters duplicate microphones and keeps the ones marked with "communications"', done => {
+      enumerateDevicesSpy.and.returnValue(
         Promise.resolve([
           {
             deviceId: 'default',
@@ -170,14 +175,16 @@ describe('MediaDevicesHandler', () => {
       );
 
       const devicesHandler = new MediaDevicesHandler();
+      devicesHandler.initializeMediaDevices(true);
 
       setTimeout(() => {
         expect(devicesHandler.availableDevices.audioinput().length).toEqual(1);
+        done();
       });
     });
 
-    it('filters duplicate speakers', () => {
-      spyOn(navigator.mediaDevices, 'enumerateDevices').and.returnValue(
+    it('filters duplicate speakers', done => {
+      enumerateDevicesSpy.and.returnValue(
         Promise.resolve([
           ...realWorldTestSetup.cameras,
           ...realWorldTestSetup.microphones,
@@ -186,6 +193,7 @@ describe('MediaDevicesHandler', () => {
       );
 
       const devicesHandler = new MediaDevicesHandler();
+      devicesHandler.initializeMediaDevices(true);
 
       expect(realWorldTestSetup.cameras.length).toEqual(2);
       expect(realWorldTestSetup.microphones.length).toEqual(5);
@@ -195,13 +203,13 @@ describe('MediaDevicesHandler', () => {
         expect(devicesHandler.availableDevices.videoinput().length).toEqual(2);
         expect(devicesHandler.availableDevices.audioinput().length).toEqual(3);
         expect(devicesHandler.availableDevices.audiooutput().length).toEqual(4);
+        done();
       });
     });
   });
 
-  describe('constructor', () => {
+  describe('initializeMediaDevices', () => {
     it('loads available devices and listens to input devices changes', done => {
-      const enumerateDevicesSpy = spyOn(navigator.mediaDevices, 'enumerateDevices');
       enumerateDevicesSpy.and.returnValue(
         Promise.resolve([
           ...fakeWorldTestSetup.cameras,
@@ -211,8 +219,10 @@ describe('MediaDevicesHandler', () => {
       );
 
       const devicesHandler = new MediaDevicesHandler();
+      devicesHandler.initializeMediaDevices(true);
+
       setTimeout(() => {
-        expect(navigator.mediaDevices.enumerateDevices).toHaveBeenCalledTimes(1);
+        expect(enumerateDevicesSpy).toHaveBeenCalledTimes(2);
         expect(devicesHandler.availableDevices.videoinput()).toEqual(fakeWorldTestSetup.cameras);
         expect(devicesHandler.availableDevices.audiooutput()).toEqual(fakeWorldTestSetup.speakers);
 
@@ -221,7 +231,7 @@ describe('MediaDevicesHandler', () => {
         navigator.mediaDevices!.ondevicechange?.(Event.prototype);
 
         setTimeout(() => {
-          expect(navigator.mediaDevices.enumerateDevices).toHaveBeenCalledTimes(2);
+          expect(enumerateDevicesSpy).toHaveBeenCalledTimes(3);
           expect(devicesHandler.availableDevices.videoinput()).toEqual(newCameras);
           expect(devicesHandler.availableDevices.audiooutput()).toEqual([]);
           done();
@@ -232,7 +242,7 @@ describe('MediaDevicesHandler', () => {
 
   describe('currentAvailableDeviceId', () => {
     it('only exposes available device', done => {
-      spyOn(navigator.mediaDevices, 'enumerateDevices').and.returnValue(
+      enumerateDevicesSpy.and.returnValue(
         Promise.resolve([
           ...fakeWorldTestSetup.cameras,
           ...fakeWorldTestSetup.microphones,
@@ -241,6 +251,8 @@ describe('MediaDevicesHandler', () => {
       );
 
       const devicesHandler = new MediaDevicesHandler();
+      devicesHandler.initializeMediaDevices(true);
+
       setTimeout(() => {
         devicesHandler.currentDeviceId.videoinput(fakeWorldTestSetup.cameras[0].deviceId);
 

--- a/src/script/media/MediaDevicesHandler.ts
+++ b/src/script/media/MediaDevicesHandler.ts
@@ -365,7 +365,7 @@ export class MediaDevicesHandler {
    * permissionm
    * @returns All enumerated MediaDeviceInfos
    */
-  private async enumerateMediaDevices(forceCamera: boolean = false): Promise<MediaDeviceInfo[]> {
+  private async enumerateMediaDevices(forceCamera = false): Promise<MediaDeviceInfo[]> {
     // The browser will set the device labels obtained from navigator.mediaDevices.enumerateDevices() to blank strings
     // if there is no longer an active MediaStream, even if the application was previously temporarily authorized to
     // access the devices by calling navigator.mediaDevices.getUserMedia().

--- a/src/script/media/MediaDevicesHandler.ts
+++ b/src/script/media/MediaDevicesHandler.ts
@@ -289,7 +289,7 @@ export class MediaDevicesHandler {
 
     try {
       this.removeAllDevices();
-      const mediaDevices = await this.enumerateMediaDevices(camera);
+      const mediaDevices = await window.navigator.mediaDevices.enumerateDevices();
 
       if (!mediaDevices) {
         throw new Error('No media devices found');
@@ -357,34 +357,6 @@ export class MediaDevicesHandler {
     this.logger.info(`Detected '${screenSources.length}' sources for screen sharing from Electron`);
     this.availableDevices.screeninput(screenSources);
     return screenSources;
-  }
-
-  /**
-   * Enumerates all known Media Devices Infos of a System.
-   * @param forceCamera If `forceCamera=true`, then an audio and video track is created to enforce the device access
-   * permissionm
-   * @returns All enumerated MediaDeviceInfos
-   */
-  private async enumerateMediaDevices(forceCamera = false): Promise<MediaDeviceInfo[]> {
-    // The browser will set the device labels obtained from navigator.mediaDevices.enumerateDevices() to blank strings
-    // if there is no longer an active MediaStream, even if the application was previously temporarily authorized to
-    // access the devices by calling navigator.mediaDevices.getUserMedia().
-
-    // @TODO: Fix Issue
-    // You can use this method to generate a camera stream even in the audio case. This way, the device labels can be displayed in any case.
-    // const constraints = (forceCamera)? {video: true} : {audio: true};
-    // const mediaPromise = navigator.mediaDevices.getUserMedia(constraints)
-    // return mediaPromise.then(stream => {
-    //   if (!stream) {
-    //     return [];
-    //   }
-    //   return window.navigator.mediaDevices.enumerateDevices().then( devices  => {
-    //     stream.getTracks().forEach((t) => t.stop());
-    //     return devices;
-    //   });
-    // });
-
-    return window.navigator.mediaDevices.enumerateDevices();
   }
 
   /**

--- a/src/script/media/MediaDevicesHandler.ts
+++ b/src/script/media/MediaDevicesHandler.ts
@@ -172,7 +172,7 @@ export class MediaDevicesHandler {
    * @camera: boolean, Only when the camera is queried can the entire device list be accessed.
    * @return Promise<void>
    */
-  public async initializeMediaDevices(camera: boolean = false): Promise<void> {
+  public async initializeMediaDevices(camera = false): Promise<void> {
     if (Runtime.isSupportingUserMedia() && !this.devicesAreInit) {
       return this.refreshMediaDevices(camera).then(() => {
         this.subscribeToObservables();

--- a/src/script/media/MediaDevicesHandler.ts
+++ b/src/script/media/MediaDevicesHandler.ts
@@ -267,7 +267,7 @@ export class MediaDevicesHandler {
    * This ensures that the video device labels can also be read. This is necessary for initializing the entire device list.
    * @returns Resolves with all MediaDevices when the list has been updated
    */
-  public async refreshMediaDevices(camera: boolean = false): Promise<MediaDeviceInfo[]> {
+  public async refreshMediaDevices(camera = false): Promise<MediaDeviceInfo[]> {
     const setDevices = (type: MediaDeviceType, devices: MediaDeviceInfo[]): void => {
       this.availableDevices[type](devices);
       const currentId = this.currentDeviceId[type];

--- a/src/script/media/MediaDevicesHandler.ts
+++ b/src/script/media/MediaDevicesHandler.ts
@@ -80,6 +80,7 @@ export class MediaDevicesHandler {
   public deviceSupport: DeviceSupport;
   private previousDeviceSupport: PreviousDeviceSupport;
   private onMediaDevicesRefresh?: () => void;
+  private devicesAreInit = false;
 
   static get CONFIG() {
     return {
@@ -154,7 +155,12 @@ export class MediaDevicesHandler {
       videoinput: this.availableDevices.videoinput().length,
     };
 
-    this.initializeMediaDevices();
+    // The device list must be queried once to obtain the device IDs. This way, the frontend knows whether cameras
+    // and microphones exist and can request them specifically during a call. Additionally, the app needs to know
+    // the device IDs; otherwise, we will receive a Media-Query-Constraint error when querying the devices, as we
+    // explicitly query by the device ID.
+    // The false parameter ensures that we only load the list temporarily.
+    this.initializeMediaDevices(false);
   }
 
   public setOnMediaDevicesRefreshHandler(handler: () => void): void {
@@ -163,14 +169,22 @@ export class MediaDevicesHandler {
 
   /**
    * Initialize the list of MediaDevices and subscriptions.
+   * @camera: boolean, Only when the camera is queried can the entire device list be accessed.
+   * @return Promise<void>
    */
-  private initializeMediaDevices(): void {
-    if (Runtime.isSupportingUserMedia()) {
-      this.refreshMediaDevices().then(() => {
+  public async initializeMediaDevices(camera: boolean = false): Promise<void> {
+    if (Runtime.isSupportingUserMedia() && !this.devicesAreInit) {
+      return this.refreshMediaDevices(camera).then(() => {
         this.subscribeToObservables();
         this.subscribeToDevices();
+        // The web browser cannot access the device labels without a camera stream.
+        // The device list is only complete when the camera was initialized.
+        if (camera) {
+          this.devicesAreInit = true;
+        }
       });
     }
+    return Promise.resolve();
   }
 
   /**
@@ -249,9 +263,11 @@ export class MediaDevicesHandler {
 
   /**
    * Update list of available MediaDevices.
+   * @param [camera=false] If `camera=true`, a video track is also created when the device list is read.
+   * This ensures that the video device labels can also be read. This is necessary for initializing the entire device list.
    * @returns Resolves with all MediaDevices when the list has been updated
    */
-  public async refreshMediaDevices(): Promise<MediaDeviceInfo[]> {
+  public async refreshMediaDevices(camera: boolean = false): Promise<MediaDeviceInfo[]> {
     const setDevices = (type: MediaDeviceType, devices: MediaDeviceInfo[]): void => {
       this.availableDevices[type](devices);
       const currentId = this.currentDeviceId[type];
@@ -273,7 +289,7 @@ export class MediaDevicesHandler {
 
     try {
       this.removeAllDevices();
-      const mediaDevices = await navigator.mediaDevices.enumerateDevices();
+      const mediaDevices = await this.enumerateMediaDevices(camera);
 
       if (!mediaDevices) {
         throw new Error('No media devices found');
@@ -341,6 +357,34 @@ export class MediaDevicesHandler {
     this.logger.info(`Detected '${screenSources.length}' sources for screen sharing from Electron`);
     this.availableDevices.screeninput(screenSources);
     return screenSources;
+  }
+
+  /**
+   * Enumerates all known Media Devices Infos of a System.
+   * @param forceCamera If `forceCamera=true`, then an audio and video track is created to enforce the device access
+   * permissionm
+   * @returns All enumerated MediaDeviceInfos
+   */
+  private async enumerateMediaDevices(forceCamera: boolean = false): Promise<MediaDeviceInfo[]> {
+    // The browser will set the device labels obtained from navigator.mediaDevices.enumerateDevices() to blank strings
+    // if there is no longer an active MediaStream, even if the application was previously temporarily authorized to
+    // access the devices by calling navigator.mediaDevices.getUserMedia().
+
+    // @TODO: Fix Issue
+    // You can use this method to generate a camera stream even in the audio case. This way, the device labels can be displayed in any case.
+    // const constraints = (forceCamera)? {video: true} : {audio: true};
+    // const mediaPromise = navigator.mediaDevices.getUserMedia(constraints)
+    // return mediaPromise.then(stream => {
+    //   if (!stream) {
+    //     return [];
+    //   }
+    //   return window.navigator.mediaDevices.enumerateDevices().then( devices  => {
+    //     stream.getTracks().forEach((t) => t.stop());
+    //     return devices;
+    //   });
+    // });
+
+    return window.navigator.mediaDevices.enumerateDevices();
   }
 
   /**

--- a/src/script/media/MediaStreamErrorTypes.test.ts
+++ b/src/script/media/MediaStreamErrorTypes.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {isMediaStreamDeviceError, isMediaStreamReadDeviceError} from './MediaStreamErrorTypes';
+
+describe('MediaStreamErrorTypes', () => {
+  describe('isMediaStreamDeviceError', () => {
+    it('detects device errors', () => {
+      expect(isMediaStreamDeviceError('NotFoundError')).toBeTruthy();
+      expect(isMediaStreamDeviceError('AbortError')).toBeTruthy();
+      expect(isMediaStreamDeviceError('NotReadableError')).toBeTruthy();
+    });
+
+    it('recognizes that an error is not a device error', () => {
+      expect(isMediaStreamDeviceError('NotAllowedError')).toBeFalsy();
+      expect(isMediaStreamDeviceError('NotSupportedError')).toBeFalsy();
+      expect(isMediaStreamDeviceError('OverConstrainedError')).toBeFalsy();
+      expect(isMediaStreamDeviceError('SecurityError')).toBeFalsy();
+      expect(isMediaStreamDeviceError('TypeError')).toBeFalsy();
+      expect(isMediaStreamDeviceError('FooBar')).toBeFalsy();
+      expect(isMediaStreamDeviceError('')).toBeFalsy();
+    });
+  });
+
+  describe('isMediaStreamReadDeviceError', () => {
+    it('detects device read errors', () => {
+      expect(isMediaStreamReadDeviceError('NotFoundError')).toBeTruthy();
+      expect(isMediaStreamReadDeviceError('NotAllowedError')).toBeTruthy();
+      expect(isMediaStreamReadDeviceError('NotReadableError')).toBeTruthy();
+    });
+
+    it('recognizes that an error is not a device read error', () => {
+      expect(isMediaStreamReadDeviceError('AbortError')).toBeFalsy();
+      expect(isMediaStreamReadDeviceError('NotSupportedError')).toBeFalsy();
+      expect(isMediaStreamReadDeviceError('OverConstrainedError')).toBeFalsy();
+      expect(isMediaStreamReadDeviceError('SecurityError')).toBeFalsy();
+      expect(isMediaStreamReadDeviceError('TypeError')).toBeFalsy();
+      expect(isMediaStreamReadDeviceError('FooBar')).toBeFalsy();
+      expect(isMediaStreamReadDeviceError('')).toBeFalsy();
+    });
+  });
+});

--- a/src/script/media/MediaStreamErrorTypes.ts
+++ b/src/script/media/MediaStreamErrorTypes.ts
@@ -40,6 +40,6 @@ export function isMediaStreamReadDeviceError(errorStr: string): boolean {
       MEDIA_STREAM_ERROR.NOT_READABLE_ERROR,
       MEDIA_STREAM_ERROR.NOT_ALLOWED_ERROR,
       MEDIA_STREAM_ERROR.NOT_FOUND_ERROR,
-    ].filter(errorType => errorType == errorStr).length > 0
+    ].includes(errorStr)
   );
 }

--- a/src/script/media/MediaStreamErrorTypes.ts
+++ b/src/script/media/MediaStreamErrorTypes.ts
@@ -31,15 +31,13 @@ export const MEDIA_STREAM_ERROR_TYPES = {
 };
 
 export function isMediaStreamDeviceError(errorStr: string): boolean {
-  return MEDIA_STREAM_ERROR_TYPES.DEVICE.includes(errorStr);
+  return MEDIA_STREAM_ERROR_TYPES.DEVICE.includes(errorStr as MEDIA_STREAM_ERROR);
 }
 
 export function isMediaStreamReadDeviceError(errorStr: string): boolean {
-  return (
-    [
-      MEDIA_STREAM_ERROR.NOT_READABLE_ERROR,
-      MEDIA_STREAM_ERROR.NOT_ALLOWED_ERROR,
-      MEDIA_STREAM_ERROR.NOT_FOUND_ERROR,
-    ].includes(errorStr)
-  );
+  return [
+    MEDIA_STREAM_ERROR.NOT_READABLE_ERROR,
+    MEDIA_STREAM_ERROR.NOT_ALLOWED_ERROR,
+    MEDIA_STREAM_ERROR.NOT_FOUND_ERROR,
+  ].includes(errorStr as MEDIA_STREAM_ERROR);
 }

--- a/src/script/media/MediaStreamErrorTypes.ts
+++ b/src/script/media/MediaStreamErrorTypes.ts
@@ -29,3 +29,17 @@ export const MEDIA_STREAM_ERROR_TYPES = {
   ],
   PERMISSION: [MEDIA_STREAM_ERROR.NOT_ALLOWED_ERROR, MEDIA_STREAM_ERROR.SECURITY_ERROR],
 };
+
+export function isMediaStreamDeviceError(errorStr: string): boolean {
+  return MEDIA_STREAM_ERROR_TYPES.DEVICE.filter(errorType => errorType == errorStr).length > 0;
+}
+
+export function isMediaStreamReadDeviceError(errorStr: string): boolean {
+  return (
+    [
+      MEDIA_STREAM_ERROR.NOT_READABLE_ERROR,
+      MEDIA_STREAM_ERROR.NOT_ALLOWED_ERROR,
+      MEDIA_STREAM_ERROR.NOT_FOUND_ERROR,
+    ].filter(errorType => errorType == errorStr).length > 0
+  );
+}

--- a/src/script/media/MediaStreamErrorTypes.ts
+++ b/src/script/media/MediaStreamErrorTypes.ts
@@ -31,7 +31,7 @@ export const MEDIA_STREAM_ERROR_TYPES = {
 };
 
 export function isMediaStreamDeviceError(errorStr: string): boolean {
-  return MEDIA_STREAM_ERROR_TYPES.DEVICE.filter(errorType => errorType == errorStr).length > 0;
+  return MEDIA_STREAM_ERROR_TYPES.DEVICE.includes(errorStr);
 }
 
 export function isMediaStreamReadDeviceError(errorStr: string): boolean {

--- a/src/script/media/MediaStreamHandler.ts
+++ b/src/script/media/MediaStreamHandler.ts
@@ -78,17 +78,15 @@ export class MediaStreamHandler {
    * track is enough to enforce the general permissions.
    * @returns Promise with active MediaStream
    */
-  requestMediaStreamAccess(video: boolean): Promise<MediaStream> {
-    const audio = true;
-    const screen = false;
+  requestMediaStreamAccess(video: boolean): Promise<void | MediaStream> {
     return window.navigator.mediaDevices
-      .getUserMedia({audio, video})
+      .getUserMedia({audio: true, video})
       .then((mediaStream: MediaStream) => mediaStream)
       .catch((error: Error) => {
         if (!isMediaStreamReadDeviceError(error.name)) {
           throw error;
         }
-        this.schedulePermissionHint(audio, video, screen);
+        this.schedulePermissionHint(true, video, false);
       });
   }
 

--- a/src/script/media/MediaStreamHandler.ts
+++ b/src/script/media/MediaStreamHandler.ts
@@ -78,7 +78,7 @@ export class MediaStreamHandler {
    * track is enough to enforce the general permissions.
    * @returns Promise with active MediaStream
    */
-  requestMediaSreamAccess(video: boolean): Promise<MediaStream> {
+  requestMediaStreamAccess(video: boolean): Promise<MediaStream> {
     const audio = true;
     const screen = false;
     return window.navigator.mediaDevices

--- a/src/script/media/MediaStreamHandler.ts
+++ b/src/script/media/MediaStreamHandler.ts
@@ -23,7 +23,7 @@ import {getLogger, Logger} from 'Util/Logger';
 
 import {MediaConstraintsHandler, ScreensharingMethods} from './MediaConstraintsHandler';
 import {MEDIA_STREAM_ERROR} from './MediaStreamError';
-import {MEDIA_STREAM_ERROR_TYPES} from './MediaStreamErrorTypes';
+import {isMediaStreamReadDeviceError, MEDIA_STREAM_ERROR_TYPES} from './MediaStreamErrorTypes';
 import {MediaType} from './MediaType';
 
 import {MediaError} from '../error/MediaError';
@@ -70,6 +70,28 @@ export class MediaStreamHandler {
         ? new MediaError(MediaError.TYPE.MEDIA_STREAM_PERMISSION, MediaError.MESSAGE.MEDIA_STREAM_PERMISSION)
         : error;
     }
+  }
+
+  /**
+   * The method creates a media stream to enforce access rights to the camera and the microphone. If access is not possible, it starts a user pop-up
+   * @param video When `video=true` then the camera is also addressed. In many cases this is not necessary, because one
+   * track is enough to enforce the general permissions.
+   * @returns Promise with active MediaStream
+   */
+  requestMediaSreamAccess(video: boolean): Promise<MediaStream> {
+    const audio = true;
+    const screen = false;
+    return window.navigator.mediaDevices
+      .getUserMedia({audio, video})
+      .then((mediaStream: MediaStream) => {
+        return mediaStream;
+      })
+      .catch((error: Error) => {
+        if (isMediaStreamReadDeviceError(error.name)) {
+          this.schedulePermissionHint(audio, video, screen);
+        }
+        throw error;
+      });
   }
 
   selectScreenToShare(showScreenSelection: () => Promise<void>): Promise<void> {

--- a/src/script/media/MediaStreamHandler.ts
+++ b/src/script/media/MediaStreamHandler.ts
@@ -83,9 +83,7 @@ export class MediaStreamHandler {
     const screen = false;
     return window.navigator.mediaDevices
       .getUserMedia({audio, video})
-      .then((mediaStream: MediaStream) => {
-        return mediaStream;
-      })
+      .then((mediaStream: MediaStream) => mediaStream)
       .catch((error: Error) => {
         if (!isMediaStreamReadDeviceError(error.name)) {
           throw error;

--- a/src/script/media/MediaStreamHandler.ts
+++ b/src/script/media/MediaStreamHandler.ts
@@ -87,10 +87,10 @@ export class MediaStreamHandler {
         return mediaStream;
       })
       .catch((error: Error) => {
-        if (isMediaStreamReadDeviceError(error.name)) {
-          this.schedulePermissionHint(audio, video, screen);
+        if (!isMediaStreamReadDeviceError(error.name)) {
+          throw error;
         }
-        throw error;
+        this.schedulePermissionHint(audio, video, screen);
       });
   }
 

--- a/src/script/media/MediaStreamHandler.ts
+++ b/src/script/media/MediaStreamHandler.ts
@@ -78,7 +78,7 @@ export class MediaStreamHandler {
    * track is enough to enforce the general permissions.
    * @returns Promise with active MediaStream
    */
-  requestMediaStreamAccess(video: boolean): Promise<void | MediaStream> {
+  requestMediaStreamAccess(video: boolean): Promise<MediaStream | void> {
     return window.navigator.mediaDevices
       .getUserMedia({audio: true, video})
       .then((mediaStream: MediaStream) => mediaStream)

--- a/src/script/page/MainContent/panels/preferences/AVPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/AVPreferences.tsx
@@ -58,7 +58,7 @@ const AVPreferences = ({
   const initializeMediaDevices = async () => {
     setCheckingPermissions(true);
     try {
-      await streamHandler.requestMediaSreamAccess(true).then(stream => {
+      await streamHandler.requestMediaStreamAccess(true).then(stream => {
         devicesHandler?.initializeMediaDevices().then(() => {
           stream?.getTracks().forEach(track => track.stop());
         });

--- a/src/script/page/MainContent/panels/preferences/AVPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/AVPreferences.tsx
@@ -17,9 +17,12 @@
  *
  */
 
+import {useEffect, useState} from 'react';
+
 import {MediaDeviceType} from 'src/script/media/MediaDeviceType';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
+import {getLogger} from 'Util/Logger';
 
 import {AudioOutPreferences} from './avPreferences/AudioOutPreferences';
 import {CallOptions} from './avPreferences/CallOptions';
@@ -32,6 +35,8 @@ import type {CallingRepository} from '../../../../calling/CallingRepository';
 import type {MediaRepository} from '../../../../media/MediaRepository';
 import type {PropertiesRepository} from '../../../../properties/PropertiesRepository';
 
+const logger = getLogger('AVPreferences');
+
 interface AVPreferencesProps {
   callingRepository: CallingRepository;
   mediaRepository: MediaRepository;
@@ -43,22 +48,47 @@ const AVPreferences = ({
   propertiesRepository,
   callingRepository,
 }: AVPreferencesProps) => {
+  const [isCheckingPermissions, setCheckingPermissions] = useState(false);
   const deviceSupport = useKoSubscribableChildren(devicesHandler?.deviceSupport, [
     MediaDeviceType.AUDIO_INPUT,
     MediaDeviceType.AUDIO_OUTPUT,
     MediaDeviceType.VIDEO_INPUT,
   ]);
 
+  const initializeMediaDevices = async () => {
+    setCheckingPermissions(true);
+    try {
+      await streamHandler.requestMediaSreamAccess(true).then(stream => {
+        devicesHandler?.initializeMediaDevices().then(() => {
+          stream?.getTracks().forEach(track => track.stop());
+        });
+      });
+    } catch (error) {
+      logger.warn(`Initialization of media devices failed: ${error.message}`, error);
+    } finally {
+      setCheckingPermissions(false);
+    }
+  };
+
+  useEffect(() => {
+    initializeMediaDevices();
+  }, []);
+
   return (
     <PreferencesPage title={t('preferencesAV')}>
-      {deviceSupport.audioinput && (
+      {isCheckingPermissions && (
+        <div className="preferences-av-spinner-select">
+          <div className="icon-spinner spin accent-text"></div>
+        </div>
+      )}
+      {!isCheckingPermissions && deviceSupport.audioinput && (
         <MicrophonePreferences
           {...{devicesHandler, streamHandler}}
           refreshStream={() => callingRepository.refreshAudioInput()}
         />
       )}
-      {deviceSupport.audiooutput && <AudioOutPreferences {...{devicesHandler}} />}
-      {deviceSupport.videoinput && (
+      {!isCheckingPermissions && deviceSupport.audiooutput && <AudioOutPreferences {...{devicesHandler}} />}
+      {!isCheckingPermissions && deviceSupport.videoinput && (
         <CameraPreferences
           {...{devicesHandler, streamHandler}}
           refreshStream={() => callingRepository.refreshVideoInput()}

--- a/src/script/view_model/CallingViewModel.mocks.ts
+++ b/src/script/view_model/CallingViewModel.mocks.ts
@@ -28,6 +28,7 @@ import {Call} from '../calling/Call';
 import {CallingRepository} from '../calling/CallingRepository';
 import {CallState} from '../calling/CallState';
 import {Conversation} from '../entity/Conversation';
+import {MediaDevicesHandler} from '../media/MediaDevicesHandler';
 import {Core} from '../service/CoreSingleton';
 
 export const mockCallingRepository = {
@@ -44,6 +45,10 @@ export const mockCallingRepository = {
   supportsConferenceCalling: true,
 } as unknown as CallingRepository;
 
+export const mockMediaDevicesHandler = {
+  initializeMediaDevices: jest.fn(() => Promise.resolve()),
+} as unknown as MediaDevicesHandler;
+
 export const callState = new CallState();
 
 export function buildCall(conversation: Conversation, convType = CONV_TYPE.ONEONONE) {
@@ -57,7 +62,7 @@ export function buildCallingViewModel() {
   const callingViewModel = new CallingViewModel(
     mockCallingRepository,
     {} as any,
-    {} as any,
+    mockMediaDevicesHandler,
     {} as any,
     {} as any,
     {} as any,

--- a/src/style/content/preferences/av.less
+++ b/src/style/content/preferences/av.less
@@ -20,6 +20,16 @@
 .preferences-av-detail {
   margin: 16px 0 8px;
 }
+.preferences-av-spinner-select {
+  display: flex;
+
+  width: @icon-size-sm;
+  height: 150px;
+  align-items: center;
+  justify-content: center;
+  margin: auto;
+  text-align: center;
+}
 
 .preferences-av-spinner {
   width: @icon-size-sm;


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9688" title="WPB-9688" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9688</a>  [web] In Firefox the device label are not read from getUserMedia. This means that the menus are empty.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->





This reverts commit 84b89bdabc9ea27f85178d8be131dcdb85b7b3c4.

## Description

This PR brings back the fix for Firefox labels. Please compare it with the previous one that was reverted:
https://github.com/wireapp/wire-webapp/pull/17757

Please check this ticket as well to understand the reasons for the need for this PR.:

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10545" title="WPB-10545" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10545</a>  [AVS-WEB] Improvements of the concept of Device List.
  </td></table>



## Screenshots/Screencast (for UI changes)

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

### Important details for the reviewers

Since the changes are relatively large, I'll leave comments and create it as a draft for now.

And this solution is not perfect because the new picture-in-picture mode hides the permission pop-up.

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
