### PR TITLE
feat: Static title for calling pop out window (WPB-10551)

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -339,6 +339,7 @@
   "callingRestrictedConferenceCallPersonalModalTitle": "Feature unavailable",
   "callingRestrictedConferenceCallTeamMemberModalDescription": "To start a conference call, your team needs to upgrade to the Enterprise plan.",
   "callingRestrictedConferenceCallTeamMemberModalTitle": "Feature unavailable",
+  "callingPopOutWindowTitle": "{{brandName}} Call",
   "cameraStatusOff": "off",
   "cameraStatusOn": "on",
   "chooseHandle.handlePlaceholder": "Username",

--- a/src/script/calling/CallState.ts
+++ b/src/script/calling/CallState.ts
@@ -27,6 +27,7 @@ import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {useDetachedCallingFeatureState} from 'Components/calling/DetachedCallingCell/DetachedCallingFeature.state';
 import {calculateChildWindowPosition} from 'Util/DOM/caculateChildWindowPosition';
+import {t} from 'Util/LocalizerUtil';
 import {matchQualifiedIds} from 'Util/QualifiedId';
 import {copyStyles} from 'Util/renderElement';
 
@@ -182,7 +183,7 @@ export class CallState {
     // New window is not opened on the same domain (it's about:blank), so we cannot use any of the dom loaded events to copy the styles.
     setTimeout(() => copyStyles(window.document, detachedWindow.document), 0);
 
-    detachedWindow.document.title = window.document.title;
+    detachedWindow.document.title = t('callingPopOutWindowTitle', {brandName: Config.getConfig().BRAND_NAME});
 
     detachedWindow.addEventListener('beforeunload', this.closeDetachedWindow);
     detachedWindow.addEventListener('pagehide', this.closeDetachedWindow);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10551" title="WPB-10551" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10551</a>  [Web Edge] Calling pop out view gets title from active conversation rather than from the conversation the call is happening in
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Screenshots/Screencast (for UI changes)
<img width="1022" alt="image" src="https://github.com/user-attachments/assets/6311b228-79de-4635-b15c-372528ccefa6">
