### PR TITLE
feat: add countly performance tracking [WPB-8918]

### DIFF
--- a/server/Server.ts
+++ b/server/Server.ts
@@ -67,6 +67,7 @@ class Server {
     this.initStaticRoutes();
     this.initWebpack();
     this.initSiteMap(this.config);
+    this.app.use('/libs', express.static(path.join(__dirname, 'libs')));
     this.app.use(Root());
     this.app.use(HealthCheckRoute());
     this.app.use(ConfigRoute(this.config, this.clientConfig));

--- a/server/bin/copy_server_assets.js
+++ b/server/bin/copy_server_assets.js
@@ -24,9 +24,20 @@ const path = require('path');
 
 const srcFolder = '../';
 const distFolder = '../dist/';
+const npmModulesFolder = '../../node_modules/';
 
 const assetFolders = ['.ebextensions/', 'robots/', 'templates/', 'certificate'];
 
 assetFolders.forEach(assetFolder => {
   fs.copySync(path.resolve(__dirname, srcFolder, assetFolder), path.resolve(__dirname, distFolder, assetFolder));
 });
+
+// copy countly.min.js and the official countly boomerang plugin
+fs.copySync(
+  path.resolve(__dirname, npmModulesFolder, 'countly-sdk-web/lib/countly.min.js'),
+  path.resolve(__dirname, distFolder, 'libs/countly/countly.min.js'),
+);
+fs.copySync(
+  path.resolve(__dirname, npmModulesFolder, 'countly-sdk-web/plugin/boomerang'),
+  path.resolve(__dirname, distFolder, 'libs/countly'),
+);

--- a/src/page/auth.ejs
+++ b/src/page/auth.ejs
@@ -21,6 +21,10 @@
 
     <script src="../min/basicBrowserFeatureCheck.js?v=<%= VERSION %>"></script>
     <script src="../min/checkBrowser.js?v=<%= VERSION %>"></script>
+
+    <script src='../libs/countly/boomerang.min.js?v=<%= VERSION %>' type='text/javascript'></script>
+    <script src='../libs/countly/countly.min.js?v=<%= VERSION %>' type='text/javascript'></script>
+    <script src='../libs/countly/countly_boomerang.js?v=<%= VERSION %>' type='text/javascript'></script>
   </head>
 
   <body>

--- a/src/page/index.ejs
+++ b/src/page/index.ejs
@@ -6,10 +6,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="geoip" content="{{ country }}" />
-    <link href="/image/favicon.ico?<%= VERSION %>" type="image/x-icon" rel="shortcut icon" sizes="48x48" />
-    <link href="/image/meta/wire-icon-256.png?<%= VERSION %>" rel="icon" sizes="256x256" type="image/png" />
-    <link href="/image/meta/wire-icon-128.png?<%= VERSION %>" rel="icon" sizes="128x128" type="image/png" />
-    <link href="/image/meta/wire-icon-64.png?<%= VERSION %>" rel="icon" sizes="64x64" type="image/png" />
+    <link href="./image/favicon.ico?<%= VERSION %>" type="image/x-icon" rel="shortcut icon" sizes="48x48" />
+    <link href="./image/meta/wire-icon-256.png?<%= VERSION %>" rel="icon" sizes="256x256" type="image/png" />
+    <link href="./image/meta/wire-icon-128.png?<%= VERSION %>" rel="icon" sizes="128x128" type="image/png" />
+    <link href="./image/meta/wire-icon-64.png?<%= VERSION %>" rel="icon" sizes="64x64" type="image/png" />
 
     <meta property="og:title" content="<%= OPEN_GRAPH_TITLE %>" />
     <meta property="og:description" name="description" content="<%= OPEN_GRAPH_DESCRIPTION %>" />
@@ -21,6 +21,10 @@
 
     <script src="./min/basicBrowserFeatureCheck.js?v=<%= VERSION %>"></script>
     <script src="./min/checkBrowser.js?v=<%= VERSION %>"></script>
+
+    <script src='./libs/countly/boomerang.min.js?v=<%= VERSION %>' type='text/javascript'></script>
+    <script src='./libs/countly/countly.min.js?v=<%= VERSION %>' type='text/javascript'></script>
+    <script src='./libs/countly/countly_boomerang.js?v=<%= VERSION %>' type='text/javascript'></script>
   </head>
 
   <body>

--- a/src/script/tracking/countly-skd-web.d.ts
+++ b/src/script/tracking/countly-skd-web.d.ts
@@ -17,28 +17,62 @@
  *
  */
 
-declare module 'countly-sdk-web' {
-  export interface UserData {
-    set_once: (keyValues: {[key: string]: any}) => void;
+import {Segmentation} from './Segmentation';
+
+import type {ContributedSegmentations} from '../conversation/MessageRepository';
+
+type Keys = keyof typeof Segmentation;
+type Values = (typeof Segmentation)[Keys];
+
+export interface UserData {
+  set_once: (keyValues: {[key: string]: any}) => void;
+  set: (key: string, value: any) => void;
+  increment: (key: string) => void;
+  incrementBy: (key: string, value: number) => void;
+  save: () => void;
+}
+
+export interface CountlyEvent {
+  key: string;
+  count?: number;
+  sum?: number;
+  dur?: number;
+  segmentation?: ContributedSegmentations | Values;
+}
+
+export interface Countly {
+  init: (config: any) => Countly;
+  debug: boolean;
+
+  opt_out: () => void;
+  opt_in: () => void;
+
+  begin_session: (noHeartBeat?: boolean) => void;
+  end_session: () => void;
+
+  track_pageview: (page: string) => void;
+  track_clicks: () => void;
+
+  storage: 'localstorage' | 'cookie';
+  use_session_cookie: boolean;
+
+  /* APM tracking, provided by the countly plugin script countly_boomerang.js
+   Does not come with the countly.min.js script and has to be loaded separately
+   Relies on the boomerang.min.js script and the countly.min.js script
+   */
+  track_performance: () => void;
+
+  add_event: (event: CountlyEvent) => void;
+  userData: {
     set: (key: string, value: any) => void;
-    increment: (key: string) => void;
-    incrementBy: (key: string, value: number) => void;
     save: () => void;
-  }
+  };
+  change_id: (newId: string, merge?: boolean) => void;
+}
 
-  export interface Countly {
-    q: any[];
-    app_key: string;
-    url: string;
-    init(conf?: {app_key?: string; [key: string]: any}): Countly;
-    end_session(): void;
-    begin_session(): void;
-    change_id(newId: string, merge: boolean): void;
-    userData: UserData;
-    add_event: (eventData: any) => void;
+declare global {
+  interface Window {
+    // Countly is a global object provided by the countly.min.js script
+    Countly: Countly;
   }
-
-  const Countly: Countly;
-  // eslint-disable-next-line import/no-default-export
-  export default Countly;
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8918" title="WPB-8918" target="_blank"><img alt="Epic" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10807?size=medium" />WPB-8918</a>  [Web] Performance Analytics
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

We need to implement performance tracking into our web application.
We use the official countly plugin for that.

To archive this, we need to remove the direct usage of the NPM module and rely on the scripts being loaded into the Dom. This needs to happen BEFORE our app loads.


## Checklist

- [ x ] PR has been self reviewed by the author;
- [ x ] Hard-to-understand areas of the code have been commented;
- [ x ] If it is a core feature, unit tests have been added;

