### PR TITLE
fix: reply bar and goto last msg btn overlap [WPB-10267]

### DIFF
--- a/src/script/components/MessagesList/MessageList.styles.ts
+++ b/src/script/components/MessagesList/MessageList.styles.ts
@@ -25,6 +25,8 @@ export const jumpToLastMessageButtonStyles: CSSObject = {
   height: '40px',
   borderRadius: '100%',
   bottom: '56px',
+  marginBottom: '10px',
+  zIndex: 1,
 
   '@media (max-width: 768px)': {
     bottom: '100px',

--- a/src/style/content/conversation/input-bar.less
+++ b/src/style/content/conversation/input-bar.less
@@ -272,7 +272,7 @@
 .input-bar__reply {
   display: flex;
   width: 100%;
-  padding: 12px 16px 0 30px;
+  padding: 12px 16px 10px 30px;
   animation: reply-box 0.15s ease-out;
   background-color: var(--input-bar-bg);
   fill: var(--main-color);

--- a/src/style/content/conversation/input-bar.less
+++ b/src/style/content/conversation/input-bar.less
@@ -287,6 +287,7 @@
     display: flex;
     overflow: hidden;
     max-width: 640px;
+    margin-right: 40px;
     margin-left: 28px;
     font-weight: 400;
   }


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10267" title="WPB-10267" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10267</a>  [Web] Reply quote overlaps 'jump to bottom' button in conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Description
Fixed reply bar and goto last message button overlap.

## Screenshots/Screencast (for UI changes)
Before:
<img width="1343" alt="Screenshot 2024-08-21 at 12 58 51" src="https://github.com/user-attachments/assets/d8c176d1-f665-4d9b-9b88-e489b0916cd9">

After:
<img width="1343" alt="Screenshot 2024-08-21 at 12 58 17" src="https://github.com/user-attachments/assets/5cb64a84-abb3-4aef-a809-5a1a38269cc0">

<img width="575" alt="Screenshot 2024-08-21 at 13 19 06" src="https://github.com/user-attachments/assets/01645a80-3751-4645-b80e-abfc35914e3c">

<img width="382" alt="Screenshot 2024-08-21 at 13 50 09" src="https://github.com/user-attachments/assets/d6d00eb3-4824-4636-9ea5-6e5ab21d1194">

## Checklist

- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
