### PR TITLE
fix: button width when folder has long name [WPB-10476]

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationHeader/ConversationHeader.styles.ts
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationHeader/ConversationHeader.styles.ts
@@ -36,6 +36,7 @@ export const label: CSSObject = {
   textOverflow: 'ellipsis',
   overflow: 'hidden',
   whiteSpace: 'nowrap',
+  flex: 1,
 };
 
 export const button: CSSObject = {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10476" title="WPB-10476" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10476</a>  [Web] Create group "+" button shrinks with long folder name
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
Fixed button width when conversation has long name
## Screenshots/Screencast (for UI changes)
<img width="423" alt="Screenshot 2024-08-21 at 14 42 23" src="https://github.com/user-attachments/assets/988907ff-aa6d-496b-9c80-fa55758c5d75">

## Checklist

- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
