### PR TITLE
fix: Hide select icon for view call

### DIFF
--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -682,6 +682,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                   </button>
                 </li>
               </div>
+
               {!horizontalXsBreakpoint && (
                 <div
                   css={{
@@ -698,7 +699,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                             toggleCallView();
                           }
                         }}
-                        className="video-controls__button video-controls__button--small"
+                        className="video-controls__button video-controls__button--small video-controls__view-mode"
                         onClick={toggleCallView}
                         onKeyDown={event => handleKeyDown(event, toggleCallView)}
                         css={isCallViewOpen ? videoControlActiveStyles : videoControlInActiveStyles}
@@ -737,6 +738,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                       </button>
                     </li>
                   )}
+
                   {Config.getConfig().FEATURE.ENABLE_IN_CALL_REACTIONS && (
                     <li className="video-controls__item">
                       {showEmojisBar && (

--- a/src/style/foundation/video-calling.less
+++ b/src/style/foundation/video-calling.less
@@ -195,6 +195,10 @@
     min-width: 157px;
   }
 
+  &__view-mode div[class$='-Control'] {
+    display: none;
+  }
+
   &__button {
     .button-reset-default;
     position: relative;


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-10507

## Description

Hide chevron icon for view call mode. Chevron icon appears randomly while participant list is open.

## Screenshots/Screencast (for UI changes)

Before:
![image](https://github.com/user-attachments/assets/ec07fca2-7eaa-4291-87a2-d4cb747c6e94)

After:
<img width="263" alt="image" src="https://github.com/user-attachments/assets/42c8926a-c718-49ef-be81-ef6bcb35d12d">


## Checklist

- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
