### PR TITLE
fix: Logout user if unable to get self user

### DIFF
--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -372,7 +372,14 @@ export class App {
       onProgress(2.5);
       telemetry.timeStep(AppInitTimingsStep.RECEIVED_ACCESS_TOKEN);
 
-      const selfUser = await this.repository.user.getSelf([{position: 'App.initiateSelfUser', vendor: 'webapp'}]);
+      let selfUser: User;
+
+      try {
+        selfUser = await this.repository.user.getSelf([{position: 'App.initiateSelfUser', vendor: 'webapp'}]);
+      } catch (error) {
+        await this.logout(SIGN_OUT_REASON.SESSION_EXPIRED, false);
+        return undefined;
+      }
 
       await initializeDataDog(this.config, selfUser.qualifiedId);
       onProgress(5, t('initReceivedSelfUser', selfUser.name()));


### PR DESCRIPTION

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10603" title="WPB-10603" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10603</a> [Web] App stuck on loading
  </td></table>
  <br />

## Description

An uncaught error when calling `getSelf` can cause a frozen state on login when the zuid cookie is expired and the token is invalid.

Catching the error and logging out of the app allows the user to log back in

## Screenshots/Screencast (for UI changes)
<img width="603" alt="Screenshot 2024-08-22 at 11 01 45" src="https://github.com/user-attachments/assets/b79b22fb-515a-4386-add2-dc433606cd33">

## Checklist

- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;
