### PR TITLE
fix(countly): collect data for non team users, start countly in offline mode

### DIFF
--- a/server/Server.ts
+++ b/server/Server.ts
@@ -213,6 +213,7 @@ class Server {
       APP_BASE: this.config.APP_BASE,
       OPEN_GRAPH: this.config.OPEN_GRAPH,
       VERSION: this.config.VERSION,
+      COUNTLY_API_KEY: this.config.COUNTLY_API_KEY,
     };
   }
 

--- a/server/Server.ts
+++ b/server/Server.ts
@@ -214,6 +214,7 @@ class Server {
       OPEN_GRAPH: this.config.OPEN_GRAPH,
       VERSION: this.config.VERSION,
       COUNTLY_API_KEY: this.config.COUNTLY_API_KEY,
+      COUNTLY_NONCE: this.config.COUNTLY_NONCE,
     };
   }
 

--- a/server/config/server.config.ts
+++ b/server/config/server.config.ts
@@ -42,7 +42,7 @@ const defaultCSP = {
   imgSrc: ["'self'", 'blob:', 'data:', 'https://*.giphy.com'],
   manifestSrc: ["'self'"],
   mediaSrc: ["'self'", 'blob:', 'data:'],
-  scriptSrc: ["'self'", "'unsafe-eval'"],
+  scriptSrc: ["'self'", "'unsafe-eval', 'nonce-countly'"],
   styleSrc: ["'self'", "'unsafe-inline'"],
   workerSrc: ["'self'", 'blob:'],
 };

--- a/server/config/server.config.ts
+++ b/server/config/server.config.ts
@@ -94,7 +94,7 @@ function mergedCSP(
     manifestSrc: [...defaultCSP.manifestSrc, ...parseCommaSeparatedList(env.CSP_EXTRA_MANIFEST_SRC)],
     mediaSrc: [...defaultCSP.mediaSrc, ...parseCommaSeparatedList(env.CSP_EXTRA_MEDIA_SRC)],
     objectSrc: objectSrc.length > 0 ? objectSrc : ["'none'"],
-    scriptSrc: [...defaultCSP.scriptSrc, ...parseCommaSeparatedList(env.CSP_EXTRA_SCRIPT_SRC), `${countlyCSPNonce}`],
+    scriptSrc: [...defaultCSP.scriptSrc, ...parseCommaSeparatedList(env.CSP_EXTRA_SCRIPT_SRC), countlyCSPNonce],
     styleSrc: [...defaultCSP.styleSrc, ...parseCommaSeparatedList(env.CSP_EXTRA_STYLE_SRC)],
     workerSrc: [...defaultCSP.workerSrc, ...parseCommaSeparatedList(env.CSP_EXTRA_WORKER_SRC)],
   };

--- a/server/config/server.config.ts
+++ b/server/config/server.config.ts
@@ -115,6 +115,7 @@ export function generateConfig(params: ConfigGeneratorParams, env: Env) {
       ALLOWED_HOSTS: ['app.wire.com'],
       DISALLOW: readFile(ROBOTS_DISALLOW_FILE, 'User-agent: *\r\nDisallow: /'),
     },
+    COUNTLY_API_KEY: env.COUNTLY_API_KEY || '',
     SSL_CERTIFICATE_KEY_PATH:
       env.SSL_CERTIFICATE_KEY_PATH || path.join(__dirname, '../certificate/development-key.pem'),
     SSL_CERTIFICATE_PATH: env.SSL_CERTIFICATE_PATH || path.join(__dirname, '../certificate/development-cert.pem'),

--- a/server/config/server.config.ts
+++ b/server/config/server.config.ts
@@ -19,8 +19,8 @@
 
 import fs from 'fs-extra';
 import logdown from 'logdown';
+import {v4 as uuidv4} from 'uuid';
 
-import crypto from 'crypto';
 import path from 'path';
 
 import {ConfigGeneratorParams} from './config.types';
@@ -71,17 +71,11 @@ function parseCommaSeparatedList(list: string = ''): string[] {
 
 // create random nonce for CSP headers with 256 bits of entropy
 function generateCSPNonce() {
-  const current_date = new Date().valueOf().toString();
-  const random = Math.random().toString();
-  crypto
-    .createHash('sha1')
-    .update(current_date + random)
-    .digest('hex');
-  const arr = Array.from(current_date).join('');
+  const uuid = uuidv4();
 
   return {
-    value: arr,
-    cspString: `'nonce-${arr}'`,
+    value: uuid,
+    cspString: `'nonce-${uuid}'`,
   };
 }
 

--- a/src/page/auth.ejs
+++ b/src/page/auth.ejs
@@ -25,6 +25,16 @@
     <script src='../libs/countly/boomerang.min.js?v=<%= VERSION %>' type='text/javascript'></script>
     <script src='../libs/countly/countly.min.js?v=<%= VERSION %>' type='text/javascript'></script>
     <script src='../libs/countly/countly_boomerang.js?v=<%= VERSION %>' type='text/javascript'></script>
+    <script type='text/javascript' nonce="countly">
+      Countly.init({
+        debug:false,
+        app_key:"<%= COUNTLY_API_KEY %>",
+        url: "https://countly.wire.com/",
+        offline_mode: true,
+        use_session_cookie: false,
+        storage: 'localstorage'
+      });
+    </script>
   </head>
 
   <body>

--- a/src/page/auth.ejs
+++ b/src/page/auth.ejs
@@ -25,7 +25,7 @@
     <script src='../libs/countly/boomerang.min.js?v=<%= VERSION %>' type='text/javascript'></script>
     <script src='../libs/countly/countly.min.js?v=<%= VERSION %>' type='text/javascript'></script>
     <script src='../libs/countly/countly_boomerang.js?v=<%= VERSION %>' type='text/javascript'></script>
-    <script type='text/javascript' nonce="countly">
+    <script type='text/javascript' nonce="<%= COUNTLY_NONCE %>">
       Countly.init({
         debug:false,
         app_key:"<%= COUNTLY_API_KEY %>",

--- a/src/page/index.ejs
+++ b/src/page/index.ejs
@@ -25,7 +25,7 @@
     <script src='./libs/countly/boomerang.min.js?v=<%= VERSION %>' type='text/javascript'></script>
     <script src='./libs/countly/countly.min.js?v=<%= VERSION %>' type='text/javascript'></script>
     <script src='./libs/countly/countly_boomerang.js?v=<%= VERSION %>' type='text/javascript'></script>
-    <script type='text/javascript' nonce="countly">
+    <script type='text/javascript' nonce="<%= COUNTLY_NONCE %>">
       Countly.init({
         debug:false,
         app_key:"<%= COUNTLY_API_KEY %>",

--- a/src/page/index.ejs
+++ b/src/page/index.ejs
@@ -25,6 +25,16 @@
     <script src='./libs/countly/boomerang.min.js?v=<%= VERSION %>' type='text/javascript'></script>
     <script src='./libs/countly/countly.min.js?v=<%= VERSION %>' type='text/javascript'></script>
     <script src='./libs/countly/countly_boomerang.js?v=<%= VERSION %>' type='text/javascript'></script>
+    <script type='text/javascript' nonce="countly">
+      Countly.init({
+        debug:false,
+        app_key:"<%= COUNTLY_API_KEY %>",
+        url: "https://countly.wire.com/",
+        offline_mode: true,
+        use_session_cookie: false,
+        storage: 'localstorage'
+      });
+    </script>
   </head>
 
   <body>

--- a/src/script/tracking/EventTrackingRepository.ts
+++ b/src/script/tracking/EventTrackingRepository.ts
@@ -29,7 +29,6 @@ import {includesString} from 'Util/StringUtil';
 import {getParameter} from 'Util/UrlUtil';
 import {createUuid} from 'Util/uuid';
 
-import {Countly} from './countly-skd-web';
 import {isCountlyEnabledAtCurrentEnvironment} from './Countly.helpers';
 import {EventName} from './EventName';
 import {getPlatform} from './Helpers';
@@ -48,7 +47,6 @@ export class EventTrackingRepository {
   private countlyDeviceId: string;
   private readonly logger: Logger;
   isErrorReportingActivated: boolean;
-  private countly: Countly | undefined;
 
   static get CONFIG() {
     return {
@@ -89,7 +87,7 @@ export class EventTrackingRepository {
         await this.startProductReporting(this.countlyDeviceId);
         stopOnFinish = true;
       }
-      this.countly?.change_id(newId, true);
+      window.Countly.change_id(newId, true);
       storeValue(EventTrackingRepository.CONFIG.USER_ANALYTICS.COUNTLY_DEVICE_ID_LOCAL_STORAGE_KEY, newId);
       this.logger.info(`Countly tracking id has been changed from ${this.countlyDeviceId} to ${newId}`);
       this.countlyDeviceId = newId;
@@ -160,11 +158,6 @@ export class EventTrackingRepository {
       }
     }
 
-    const isTeam = this.teamState.isTeam();
-    if (!isTeam) {
-      return; // Countly should not be enabled for non-team users
-    }
-
     this.logger.info(`Initialize analytics and error reporting: ${isTelemtryConsentGiven}`);
 
     amplify.subscribe(WebAppEvents.PROPERTIES.UPDATE.PRIVACY.TELEMETRY_SHARING, this.toggleCountly);
@@ -188,24 +181,19 @@ export class EventTrackingRepository {
 
   private async startProductReporting(trackingId?: string): Promise<void> {
     // This is a global object provided by the countly.min.js script
-    if (!window?.Countly) {
-      return;
-    }
 
     if (!isCountlyEnabledAtCurrentEnvironment() || this.isProductReportingActivated) {
       return;
     }
     this.isProductReportingActivated = true;
 
-    this.countly = window.Countly.init({
-      app_key: window.wire.env.COUNTLY_API_KEY,
-      app_version: Config.getConfig().VERSION,
-      debug: !Environment.frontend.isProduction(),
-      device_id: trackingId || this.countlyDeviceId,
-      url: 'https://countly.wire.com/',
-      use_session_cookie: false,
-      storage: 'localstorage',
-    });
+    // Add Parameters to previous Countly object
+    window.Countly.app_version = Config.getConfig().VERSION;
+    window.Countly.debug = !Environment.frontend.isProduction();
+    window.Countly.use_session_cookie = false;
+    window.Countly.storage = 'localstorage';
+    window.Countly.disable_offline_mode(trackingId || this.countlyDeviceId);
+    window.Countly.change_id(trackingId || this.countlyDeviceId, true);
 
     this.startProductReportingSession();
     this.subscribeToProductEvents();
@@ -226,7 +214,7 @@ export class EventTrackingRepository {
 
   private readonly stopProductReportingSession = (): void => {
     if (this.isProductReportingActivated === true) {
-      this.countly?.end_session();
+      window.Countly.end_session();
     }
   };
 
@@ -244,9 +232,9 @@ export class EventTrackingRepository {
 
   private startProductReportingSession(): void {
     if (this.isProductReportingActivated === true) {
-      this.countly?.begin_session();
+      window.Countly.begin_session();
       // enable APM
-      this.countly?.track_performance();
+      window.Countly.track_performance();
       if (this.sendAppOpenEvent) {
         this.sendAppOpenEvent = false;
         this.trackProductReportingEvent(EventName.APP_OPEN);
@@ -261,9 +249,9 @@ export class EventTrackingRepository {
       };
       Object.entries(userData).forEach(entry => {
         const [key, value] = entry;
-        this.countly?.userData.set(key, value);
+        window.Countly.userData.set(key, value);
       });
-      this.countly?.userData.save();
+      window.Countly.userData.save();
 
       const segmentation = {
         [Segmentation.COMMON.APP_VERSION]: Config.getConfig().VERSION,
@@ -271,7 +259,7 @@ export class EventTrackingRepository {
         ...customSegmentations,
       };
 
-      this.countly?.add_event({
+      window.Countly.add_event({
         key: eventName,
         segmentation,
       });

--- a/src/script/tracking/EventTrackingRepository.ts
+++ b/src/script/tracking/EventTrackingRepository.ts
@@ -81,6 +81,11 @@ export class EventTrackingRepository {
   };
 
   public migrateDeviceId = async (newId: string) => {
+    if (!window.Countly) {
+      this.logger.warn('Countly is not available');
+      return;
+    }
+
     try {
       let stopOnFinish = false;
       if (!this.isProductReportingActivated) {
@@ -182,6 +187,11 @@ export class EventTrackingRepository {
   private async startProductReporting(trackingId?: string): Promise<void> {
     // This is a global object provided by the countly.min.js script
 
+    if (!window.Countly) {
+      this.logger.warn('Countly is not available');
+      return;
+    }
+
     if (!isCountlyEnabledAtCurrentEnvironment() || this.isProductReportingActivated) {
       return;
     }
@@ -213,6 +223,11 @@ export class EventTrackingRepository {
   }
 
   private readonly stopProductReportingSession = (): void => {
+    if (!window.Countly) {
+      this.logger.warn('Countly is not available');
+      return;
+    }
+
     if (this.isProductReportingActivated === true) {
       window.Countly.end_session();
     }
@@ -231,6 +246,11 @@ export class EventTrackingRepository {
   }
 
   private startProductReportingSession(): void {
+    if (!window.Countly) {
+      this.logger.warn('Countly is not available');
+      return;
+    }
+
     if (this.isProductReportingActivated === true) {
       window.Countly.begin_session();
       // enable APM
@@ -243,6 +263,11 @@ export class EventTrackingRepository {
   }
 
   private trackProductReportingEvent(eventName: string, customSegmentations?: ContributedSegmentations): void {
+    if (!window.Countly) {
+      this.logger.warn('Countly is not available');
+      return;
+    }
+
     if (this.isProductReportingActivated === true) {
       const userData = {
         [UserData.IS_TEAM]: this.teamState.isTeam(),

--- a/src/script/tracking/countly-skd-web.d.ts
+++ b/src/script/tracking/countly-skd-web.d.ts
@@ -47,12 +47,16 @@ export interface Countly {
   opt_out: () => void;
   opt_in: () => void;
 
+  enable_offline_mode: () => void;
+  disable_offline_mode: (userId: string) => void;
+
   begin_session: (noHeartBeat?: boolean) => void;
   end_session: () => void;
 
   track_pageview: (page: string) => void;
   track_clicks: () => void;
 
+  app_version: string;
   storage: 'localstorage' | 'cookie';
   use_session_cookie: boolean;
 
@@ -67,6 +71,8 @@ export interface Countly {
     set: (key: string, value: any) => void;
     save: () => void;
   };
+
+  get_device_id: () => string;
   change_id: (newId: string, merge?: boolean) => void;
 }
 

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -46,6 +46,7 @@ const templateParameters = {
   OPEN_GRAPH_DESCRIPTION: serverConfig.OPEN_GRAPH.DESCRIPTION,
   OPEN_GRAPH_IMAGE_URL: serverConfig.OPEN_GRAPH.IMAGE_URL,
   COUNTLY_API_KEY: serverConfig.COUNTLY_API_KEY,
+  COUNTLY_NONCE: serverConfig.COUNTLY_NONCE,
 };
 
 module.exports = {

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -45,6 +45,7 @@ const templateParameters = {
   OPEN_GRAPH_TITLE: serverConfig.OPEN_GRAPH.TITLE,
   OPEN_GRAPH_DESCRIPTION: serverConfig.OPEN_GRAPH.DESCRIPTION,
   OPEN_GRAPH_IMAGE_URL: serverConfig.OPEN_GRAPH.IMAGE_URL,
+  COUNTLY_API_KEY: serverConfig.COUNTLY_API_KEY,
 };
 
 module.exports = {


### PR DESCRIPTION
## Description

To track apm data we need to collect them early on.

The solution is to start countly in offline-mode before our application script runs. 
This leads to data being collected locally (NOT BEING SENT TO THE SERVER). 
And as soon as the users consent is read, we switch the countly userId, turn off offline-mode and migrate the previously collected data.

Also removes the block for collecting data of non-team members.

