### PR TITLE
fix: handled screen share on popup window [WPB-10672]

### DIFF
--- a/src/script/components/calling/CallingOverlayContainer.tsx
+++ b/src/script/components/calling/CallingOverlayContainer.tsx
@@ -52,13 +52,16 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
   toggleScreenshare,
 }) => {
   const {devicesHandler: mediaDevicesHandler} = mediaRepository;
-  const {viewMode} = useKoSubscribableChildren(callState, ['viewMode']);
-  const isFullScreenOrDetached = [CallingViewMode.DETACHED_WINDOW, CallingViewMode.FULL_SCREEN].includes(viewMode);
+  const {activeCallViewTab, joinedCall, hasAvailableScreensToShare, desktopScreenShareMenu, viewMode} =
+    useKoSubscribableChildren(callState, [
+      'activeCallViewTab',
+      'joinedCall',
+      'hasAvailableScreensToShare',
+      'desktopScreenShareMenu',
+      'viewMode',
+    ]);
 
-  const {activeCallViewTab, joinedCall, hasAvailableScreensToShare, desktopScreenShareMenu} = useKoSubscribableChildren(
-    callState,
-    ['activeCallViewTab', 'joinedCall', 'hasAvailableScreensToShare', 'desktopScreenShareMenu'],
-  );
+  const isFullScreenOrDetached = [CallingViewMode.DETACHED_WINDOW, CallingViewMode.FULL_SCREEN].includes(viewMode);
 
   const {
     maximizedParticipant,
@@ -130,7 +133,10 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
     return null;
   }
 
-  const toggleDetachedWindowScreenShare = (call: Call) => {
+  const toggleScreenShare = (call: Call) => {
+    if (viewMode === CallingViewMode.DETACHED_WINDOW) {
+      callState.setViewModeMinimized();
+    }
     toggleScreenshare(call, DesktopScreenShareMenu.DETACHED_WINDOW);
   };
 
@@ -162,7 +168,7 @@ const CallingContainer: React.FC<CallingContainerProps> = ({
           setActiveCallViewTab={setActiveCallViewTab}
           toggleMute={toggleMute}
           toggleCamera={toggleCamera}
-          toggleScreenshare={toggleDetachedWindowScreenShare}
+          toggleScreenshare={toggleScreenShare}
           leave={leave}
           changePage={changePage}
         />


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10672" title="WPB-10672" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10672</a>  [Web] Pop out call window covers browser's screen selection screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
As a user, when we try to share the screen from popup window, the screen sharing options gets hidden behind the popup and we have to manually focus the main window and select options there.

Technical limitation:
It is impossible to focus back on main window from popup window.

Solution:
The best possible solution is to minimize the call view when the screen sharing initiated from popup window.
For better UX, it is better not to move focus back and forth between windows.

## Screenshots/Screencast (for UI changes)

https://github.com/user-attachments/assets/efe57355-bc06-4fc1-9090-3983311d8df8

## Checklist

- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
