### PR TITLE
fix: Persist conversation labels in local storage (WPB-10465) (#17893)

### DIFF
--- a/src/script/conversation/ConversationLabelRepository.ts
+++ b/src/script/conversation/ConversationLabelRepository.ts
@@ -78,6 +78,8 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
   private allLabeledConversations: ko.Computed<Conversation[]>;
   private logger: Logger;
 
+  static LocalStorageKey = 'CONVERSATION_LABEL_REPOSITORY_PROPERTIES';
+
   constructor(
     private readonly allConversations: ko.ObservableArray<Conversation>,
     private readonly conversations: ko.PureComputed<Conversation[]>,
@@ -103,6 +105,7 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
       name,
       type,
     }));
+
     return {labels: labelJson};
   };
 
@@ -121,20 +124,37 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
         type,
       }),
     );
+
     this.labels(labels);
   };
 
   readonly saveLabels = () => {
-    this.propertiesService.putPropertiesByKey(propertiesKey, this.marshal());
+    const conversationLabelJson = this.marshal();
+    void this.propertiesService.putPropertiesByKey(propertiesKey, conversationLabelJson);
+    this.persistValues();
   };
 
   loadLabels = async () => {
     try {
+      const conversationLabelJson = localStorage.getItem(ConversationLabelRepository.LocalStorageKey);
+
+      if (conversationLabelJson) {
+        this.unmarshal(JSON.parse(conversationLabelJson));
+        this.saveLabels();
+        return;
+      }
+
       const labelProperties = await this.propertiesService.getPropertiesByKey(propertiesKey);
       this.unmarshal(labelProperties);
+      this.persistValues();
     } catch (error) {
       this.logger.warn(`No labels were loaded: ${error.message}`);
     }
+  };
+
+  private persistValues = () => {
+    const values = this.marshal();
+    localStorage.setItem(ConversationLabelRepository.LocalStorageKey, JSON.stringify(values));
   };
 
   readonly onUserEvent = (event: any) => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10465" title="WPB-10465" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10465</a>  [Web] Folders and favorites are broken
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
* fix: Persist conversation labels in local storage (WPB-10465)

* rename variable

## Description

cherry pick of 88f0e35f8847ed9f1dc8e720daf69a16d9d60905 to master for `web-2024-08-hotfix-2`
