### PR TITLE
fix: not clone audio tracks [WPB-9868]

### DIFF
--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -1280,7 +1280,7 @@ export class CallingRepository {
     const {conversation} = call;
 
     if (mediaType === MediaType.AUDIO) {
-      const audioTracks = mediaStream.getAudioTracks().map(track => track.clone());
+      const audioTracks = mediaStream.getAudioTracks();
       if (audioTracks.length > 0) {
         selfParticipant.setAudioStream(new MediaStream(audioTracks), true);
         this.wCall?.replaceTrack(this.serializeQualifiedId(conversation.qualifiedId), audioTracks[0]);
@@ -1299,6 +1299,11 @@ export class CallingRepository {
         return mediaStream;
       }
     }
+  }
+
+  hasActiveCall(): boolean {
+    const call = this.callState.joinedCall();
+    return !!call;
   }
 
   hasActiveCameraStream(): boolean {

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -1301,11 +1301,6 @@ export class CallingRepository {
     }
   }
 
-  hasActiveCall(): boolean {
-    const call = this.callState.joinedCall();
-    return !!call;
-  }
-
   hasActiveCameraStream(): boolean {
     const call = this.callState.joinedCall();
     if (!call) {

--- a/src/script/page/MainContent/panels/preferences/AVPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/AVPreferences.tsx
@@ -55,6 +55,7 @@ const AVPreferences = ({
         <MicrophonePreferences
           {...{devicesHandler, streamHandler}}
           refreshStream={() => callingRepository.refreshAudioInput()}
+          hasActiveCall={callingRepository.hasActiveCall()}
         />
       )}
       {deviceSupport.audiooutput && <AudioOutPreferences {...{devicesHandler}} />}

--- a/src/script/page/MainContent/panels/preferences/avPreferences/MicrophonePreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/avPreferences/MicrophonePreferences.tsx
@@ -40,12 +40,14 @@ interface MicrophonePreferencesProps {
   devicesHandler: MediaDevicesHandler;
   refreshStream: () => Promise<MediaStream>;
   streamHandler: MediaStreamHandler;
+  hasActiveCall: boolean;
 }
 
 const MicrophonePreferences: React.FC<MicrophonePreferencesProps> = ({
   devicesHandler,
   streamHandler,
   refreshStream,
+  hasActiveCall,
 }) => {
   const [isRequesting, setIsRequesting] = useState(false);
   const [stream, setStream] = useState<MediaStream>();
@@ -78,7 +80,7 @@ const MicrophonePreferences: React.FC<MicrophonePreferencesProps> = ({
 
   useEffect(
     () => () => {
-      if (stream) {
+      if (stream && !hasActiveCall) {
         streamHandler.releaseTracksFromStream(stream);
       }
     },


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9868" title="WPB-9868" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9868</a>  [Web] Tracks are not terminated after a call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

In this PR, I remove the cloning of the audio track. The cloning was necessary because the audio track is released when the device settings are closed. I have adjusted the behavior to match how we handle the video track.

## Screenshots/Screencast (for UI changes)

## Checklist

- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

