### PR TITLE
fix: Only show countly consent modal if countly is enabled

### DIFF
--- a/src/script/properties/PropertiesRepository.ts
+++ b/src/script/properties/PropertiesRepository.ts
@@ -139,6 +139,10 @@ export class PropertiesRepository {
   }
 
   checkTelemetrySharingPermission(): void {
+    if (!isCountlyEnabledAtCurrentEnvironment()) {
+      return;
+    }
+
     const isTelemetryPreferenceSet = this.getPreference(PROPERTIES_TYPE.PRIVACY.TELEMETRY_SHARING) !== undefined;
 
     const toggleTelemetrySharing = (value: boolean) => {


### PR DESCRIPTION
## Description

We should not show Countly user data sharing consent modal if environment variables related to Countly are not not set (COUNTLY_API_KEY, COUNTLY_ALLOWED_BACKEND)