### PR TITLE
fix: handle searched item click to correctly navigate [WPB-10819]

### DIFF
--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -59,6 +59,7 @@ import {NOTIFICATION_STATE} from '../conversation/NotificationSetting';
 import {ConversationError} from '../error/ConversationError';
 import {isContentMessage, isDeleteMessage} from '../guards/Message';
 import {StatusType} from '../message/StatusType';
+import {ContentState, useAppState} from '../page/useAppState';
 import {ConversationRecord} from '../storage/record/ConversationRecord';
 import {TeamState} from '../team/TeamState';
 
@@ -713,13 +714,15 @@ export class Conversation {
         return false;
       }
 
-      if (this.hasLastReceivedMessageLoaded()) {
+      const {contentState} = useAppState.getState();
+      if (this.hasLastReceivedMessageLoaded() && contentState !== ContentState.COLLECTION) {
         this.updateTimestamps(messageEntity);
         this.incomingMessages.remove(({id}) => messageEntity.id === id);
         // If the last received message is currently in memory, we can add this message to the displayed messages
         this.messages_unordered.push(messageEntity);
       } else {
-        // If the conversation is not loaded, we will add this message to the incoming messages (but not to the messages displayed)
+        // If the conversation is not loaded or the search page is active
+        // we will add this message to the incoming messages (but not to the messages displayed)
         this.incomingMessages.push(messageEntity);
       }
       amplify.publish(WebAppEvents.CONVERSATION.MESSAGE.ADDED, messageEntity);

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -209,20 +209,6 @@ const Conversations: React.FC<ConversationsProps> = ({
   }, [activeConversation, conversationState, listViewModel.contentViewModel, conversations.length]);
 
   useEffect(() => {
-    amplify.subscribe(WebAppEvents.CONVERSATION.SHOW, (conversation?: Conversation) => {
-      if (!conversation) {
-        return;
-      }
-
-      const includesConversation = currentTabConversations.includes(conversation);
-
-      if (!includesConversation) {
-        setCurrentTab(SidebarTabs.RECENT);
-      }
-    });
-  }, [currentTabConversations]);
-
-  useEffect(() => {
     if (!activeConversation) {
       return () => {};
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10819" title="WPB-10819" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />WPB-10819</a>  [Web] Searched item click not working while new message is received
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
When user receive a message while searching, the upcoming message inserted into `messages_unordered list` state. On clicking the search result, `messages_unordered list` state again populated with messages including the old added message. At this moment the last message in that list is the new message which casing scroll to move at the end.

Solution:
Adding a condition to check if the search tab is active and move the message in pending messages to load later on scroll.

## Screenshots/Screencast (for UI changes)

https://github.com/user-attachments/assets/e3fdbc31-6b8d-4296-907a-e8eb9b125258

## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...
