### PR TITLE
feat: Use new telemetry key (WPB-9972)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@mediapipe/tasks-vision": "0.10.14",
     "@wireapp/avs": "9.9.3",
     "@wireapp/commons": "5.2.10",
-    "@wireapp/core": "46.3.1",
+    "@wireapp/core": "46.3.2",
     "@wireapp/react-ui-kit": "9.23.2",
     "@wireapp/store-engine-dexie": "2.1.12",
     "@wireapp/webapp-events": "0.24.0",

--- a/src/script/page/MainContent/panels/preferences/accountPreferences/DataUsageSection.tsx
+++ b/src/script/page/MainContent/panels/preferences/accountPreferences/DataUsageSection.tsx
@@ -42,7 +42,7 @@ interface DataUsageSectionProps {
 
 const DataUsageSection = ({propertiesRepository, brandName, isActivatedAccount}: DataUsageSectionProps) => {
   const [optionTelemetry, setOptionTelemetry] = useState(
-    propertiesRepository.properties.settings.privacy.telemetry_sharing,
+    propertiesRepository.properties.settings.privacy.telemetry_data_sharing,
   );
   const [optionMarketingSharing, setOptionMarketingSharing] = useState(
     propertiesRepository.properties.settings.privacy.marketing_consent,
@@ -50,7 +50,7 @@ const DataUsageSection = ({propertiesRepository, brandName, isActivatedAccount}:
 
   useEffect(() => {
     const updateProperties = ({settings}: WebappProperties): void => {
-      setOptionTelemetry(settings.privacy.telemetry_sharing);
+      setOptionTelemetry(settings.privacy.telemetry_data_sharing);
       setOptionMarketingSharing(settings.privacy.marketing_consent);
     };
     amplify.subscribe(WebAppEvents.PROPERTIES.UPDATED, updateProperties);

--- a/src/script/properties/PropertiesRepository.ts
+++ b/src/script/properties/PropertiesRepository.ts
@@ -67,7 +67,7 @@ export class PropertiesRepository {
   public readonly receiptMode: ko.Observable<RECEIPT_MODE>;
   public readonly typingIndicatorMode: ko.Observable<CONVERSATION_TYPING_INDICATOR_MODE>;
   private readonly selfService: SelfService;
-  private readonly selfUser: ko.Observable<User>;
+  private readonly selfUser: ko.Observable<User | undefined>;
   public properties: WebappProperties;
 
   constructor(propertiesService: PropertiesService, selfService: SelfService) {
@@ -96,7 +96,7 @@ export class PropertiesRepository {
           send: true,
         },
         privacy: {
-          telemetry_sharing: undefined,
+          telemetry_data_sharing: undefined,
           marketing_consent: PropertiesRepository.CONFIG.WIRE_MARKETING_CONSENT.defaultValue,
         },
         sound: {
@@ -114,7 +114,7 @@ export class PropertiesRepository {
 
   public getUserConsentStatus() {
     const {
-      privacy: {marketing_consent: marketingConsent, telemetry_sharing: telemetryConsent},
+      privacy: {marketing_consent: marketingConsent, telemetry_data_sharing: telemetryConsent},
     } = this.properties.settings;
 
     let userConsentStatus = UserConsentStatus.ALL_DENIED;
@@ -186,7 +186,7 @@ export class PropertiesRepository {
   init(selfUserEntity: User): Promise<void> | Promise<WebappProperties> {
     this.selfUser(selfUserEntity);
 
-    return this.selfUser().isTemporaryGuest() ? this.initTemporaryGuestAccount() : this.initActivatedAccount();
+    return this.selfUser()?.isTemporaryGuest() ? this.initTemporaryGuestAccount() : this.initActivatedAccount();
   }
 
   private fetchWebAppAccountSettings(): Promise<void> {
@@ -237,7 +237,7 @@ export class PropertiesRepository {
     if (updatedPreference !== this.getPreference(propertiesType)) {
       this.setPreference(propertiesType, updatedPreference);
 
-      const savePromise = this.selfUser().isTemporaryGuest()
+      const savePromise = this.selfUser()?.isTemporaryGuest()
         ? this.savePreferenceTemporaryGuestAccount(propertiesType, updatedPreference)
         : this.savePreferenceActivatedAccount(propertiesType, updatedPreference);
 

--- a/src/script/user/UserRepository.test.ts
+++ b/src/script/user/UserRepository.test.ts
@@ -106,7 +106,7 @@ describe('UserRepository', () => {
           value: {
             settings: {
               privacy: {
-                telemetry_sharing: true,
+                telemetry_data_sharing: true,
               },
             },
             version: 1,
@@ -119,7 +119,7 @@ describe('UserRepository', () => {
           value: {
             settings: {
               privacy: {
-                telemetry_sharing: false,
+                telemetry_data_sharing: false,
               },
             },
             version: 1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5598,14 +5598,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^27.4.1":
-  version: 27.4.1
-  resolution: "@wireapp/api-client@npm:27.4.1"
+"@wireapp/api-client@npm:^27.5.0":
+  version: 27.5.0
+  resolution: "@wireapp/api-client@npm:27.5.0"
   dependencies:
     "@wireapp/commons": "npm:^5.2.10"
     "@wireapp/priority-queue": "npm:^2.1.8"
     "@wireapp/protocol-messaging": "npm:1.49.0"
-    axios: "npm:1.7.4"
+    axios: "npm:1.7.5"
     axios-retry: "npm:4.5.0"
     http-status-codes: "npm:2.3.0"
     logdown: "npm:3.3.1"
@@ -5615,7 +5615,7 @@ __metadata:
     tough-cookie: "npm:4.1.4"
     ws: "npm:8.18.0"
     zod: "npm:3.23.8"
-  checksum: 10/272449c10cd168181ced8b44db15e76d0d1eb682c3a3579701e8c1b05629c0185b77b4fa56636d9a08f0e141f1ba57eada4b23a2533306fbbf2bc1af80fde9df
+  checksum: 10/0e361751f4836d5a8c3608cc8b5c859fc0bde442d8e660e0a74e38565a6d23c34d67ad4f54e7f12ce6a5717af665b89539e206bd0d64d1c8e99fcb39e949dc56
   languageName: node
   linkType: hard
 
@@ -5669,11 +5669,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:46.3.1":
-  version: 46.3.1
-  resolution: "@wireapp/core@npm:46.3.1"
+"@wireapp/core@npm:46.3.2":
+  version: 46.3.2
+  resolution: "@wireapp/core@npm:46.3.2"
   dependencies:
-    "@wireapp/api-client": "npm:^27.4.1"
+    "@wireapp/api-client": "npm:^27.5.0"
     "@wireapp/commons": "npm:^5.2.10"
     "@wireapp/core-crypto": "npm:1.0.2"
     "@wireapp/cryptobox": "npm:12.8.0"
@@ -5681,7 +5681,7 @@ __metadata:
     "@wireapp/promise-queue": "npm:^2.3.5"
     "@wireapp/protocol-messaging": "npm:1.49.0"
     "@wireapp/store-engine": "npm:5.1.8"
-    axios: "npm:1.7.4"
+    axios: "npm:1.7.5"
     bazinga64: "npm:^6.3.8"
     deepmerge-ts: "npm:6.0.0"
     hash.js: "npm:1.1.7"
@@ -5691,7 +5691,7 @@ __metadata:
     long: "npm:^5.2.0"
     uuid: "npm:9.0.1"
     zod: "npm:3.23.8"
-  checksum: 10/b2521ac37a7ed3770d6952f6f57c27799f960eb3b4b5a4600612817cebc43daebe86f3e9aea70153bfc827d3e2f3c5a7b479712950a6cf6362dfd3681a663269
+  checksum: 10/739405f76898fb8f14eaaafcdd67bebb012d91a9dde2e84b1c0bba99a8336a5abe1048a9aebd04d1ef22956b295a563588d9345394384de351152088094a2a25
   languageName: node
   linkType: hard
 
@@ -6519,6 +6519,17 @@ __metadata:
     form-data: "npm:^4.0.0"
     proxy-from-env: "npm:^1.1.0"
   checksum: 10/7a1429be1e3d0c2e1b96d4bba4d113efbfabc7c724bed107beb535c782c7bea447ff634886b0c7c43395a264d085450d009eb1154b5f38a8bae49d469fdcbc61
+  languageName: node
+  linkType: hard
+
+"axios@npm:1.7.5":
+  version: 1.7.5
+  resolution: "axios@npm:1.7.5"
+  dependencies:
+    follow-redirects: "npm:^1.15.6"
+    form-data: "npm:^4.0.0"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10/6cbcfe943a84089f420a900a3a3aeb54ee94dcc9c2b81b150434896357be5d1079eff0b1bbb628597371e79f896b1bc5776df04184756ba99656ff31df9a75bf
   languageName: node
   linkType: hard
 
@@ -18208,7 +18219,7 @@ __metadata:
     "@wireapp/avs": "npm:9.9.3"
     "@wireapp/commons": "npm:5.2.10"
     "@wireapp/copy-config": "npm:2.2.5"
-    "@wireapp/core": "npm:46.3.1"
+    "@wireapp/core": "npm:46.3.2"
     "@wireapp/eslint-config": "npm:3.0.7"
     "@wireapp/prettier-config": "npm:0.6.4"
     "@wireapp/react-ui-kit": "npm:9.23.2"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9972" title="WPB-9972" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-9972</a>  [Web] data collection for free users 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
This PR integrates the new telemetry key name implemented in https://github.com/wireapp/wire-web-packages/pull/6485

With this PR we also fix the issue that when user clicks on disagree on the data sharing consent modal and then goes to preferences, the corresponding checkbox for it is checked even though user has clicked on disagree.