### PR TITLE
fix: handle missing pages between messages in conversation [WPB-10820]

### DIFF
--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -715,14 +715,18 @@ export class Conversation {
       }
 
       const {contentState} = useAppState.getState();
-      if (this.hasLastReceivedMessageLoaded() && contentState !== ContentState.COLLECTION) {
+
+      // When the search tab is active, push message to incomming message and update the timestamps
+      if (contentState === ContentState.COLLECTION) {
+        this.incomingMessages.push(messageEntity);
+        this.updateTimestamps(messageEntity);
+      } else if (this.hasLastReceivedMessageLoaded()) {
         this.updateTimestamps(messageEntity);
         this.incomingMessages.remove(({id}) => messageEntity.id === id);
         // If the last received message is currently in memory, we can add this message to the displayed messages
         this.messages_unordered.push(messageEntity);
       } else {
-        // If the conversation is not loaded or the search page is active
-        // we will add this message to the incoming messages (but not to the messages displayed)
+        // If the conversation is not loaded, we will add this message to the incoming messages (but not to the messages displayed)
         this.incomingMessages.push(messageEntity);
       }
       amplify.publish(WebAppEvents.CONVERSATION.MESSAGE.ADDED, messageEntity);
@@ -916,7 +920,7 @@ export class Conversation {
     return this.messages().find(
       message =>
         // Deleted message should be ignored since they might have a timestamp in the past (the timestamp of a delete message is the timestamp of the message that was deleted)
-        !isDeleteMessage(message),
+        !isDeleteMessage(message) && message.timestamp(),
     );
   }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10820" title="WPB-10820" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />WPB-10820</a>  [Web] Missing historic messages between found message on scrolling down
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
Fixed missing pages between message in conversation.

**Solution:**

- When we receive a message while searching, we move the message to incoming messages list. We must update last_event_timestamp with the timestamp of received message to pull that message in future. To reproduce it, open search, receive a message in same conversation, select a 16th last message in the conversation then scroll down. You will not be able to see last message.
https://github.com/wireapp/wire-webapp/blob/e55cecebc6c0647c9c32b329691b8d08ba810bd2/src/script/entity/Conversation.ts#L722

- There is a bug when you search for the first item in the conversation and then try to scroll up 2 times to get all the preceding messages, then scroll down to last message. All the pages between first and last will be skipped. Due to the 0 timestamp value of the first message the `upperBound` is calculated with the wrong date. See:
https://github.com/wireapp/wire-webapp/blob/e55cecebc6c0647c9c32b329691b8d08ba810bd2/src/script/conversation/ConversationRepository.ts#L855
To fix this the we should get the oldest message that contain timestamp.
  https://github.com/wireapp/wire-webapp/blob/e55cecebc6c0647c9c32b329691b8d08ba810bd2/src/script/entity/Conversation.ts#L923


## Screenshots/Screencast (for UI changes)


https://github.com/user-attachments/assets/11e1c650-18db-4b8e-b34a-5a25f04d1874

https://github.com/user-attachments/assets/cc41962c-0ac2-42a0-b86c-5c7bc2e50cf8



## Checklist

- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

### Important details for the reviewers

(Delete this section if unnecessary)

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ...