### PR TITLE
feat: remove services tab for MLS in conversation [WPB-10776]

### DIFF
--- a/src/script/page/RightSidebar/AddParticipants/AddParticipants.tsx
+++ b/src/script/page/RightSidebar/AddParticipants/AddParticipants.tsx
@@ -19,6 +19,7 @@
 
 import {FC, useMemo, useState} from 'react';
 
+import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 import cx from 'classnames';
 
@@ -100,12 +101,7 @@ const AddParticipants: FC<AddParticipantsProps> = ({
     'isTeamOnly',
     'participating_user_ids',
   ]);
-  const {isTeam, teamMembers, teamUsers, isMLSEnabled} = useKoSubscribableChildren(teamState, [
-    'isTeam',
-    'teamMembers',
-    'teamUsers',
-    'isMLSEnabled',
-  ]);
+  const {isTeam, teamMembers, teamUsers} = useKoSubscribableChildren(teamState, ['isTeam', 'teamMembers', 'teamUsers']);
   const {connectedUsers} = useKoSubscribableChildren(userState, ['connectedUsers']);
   const {teamRole} = useKoSubscribableChildren(selfUser, ['teamRole']);
   const {services} = useKoSubscribableChildren(integrationRepository, ['services']);
@@ -139,7 +135,14 @@ const AddParticipants: FC<AddParticipantsProps> = ({
     const isService = !!firstUserEntity?.isService;
     const allowIntegrations = isGroup || isService;
 
-    return isTeam && allowIntegrations && inTeam && !isTeamOnly && isServicesEnabled;
+    return (
+      isTeam &&
+      allowIntegrations &&
+      inTeam &&
+      !isTeamOnly &&
+      isServicesEnabled &&
+      activeConversation.protocol !== ConversationProtocol.MLS
+    );
   }, [firstUserEntity?.isService, inTeam, isGroup, isGuestAndServicesRoom, isServicesRoom, isTeam, isTeamOnly]);
 
   const manageServicesUrl = getManageServicesUrl('client_landing');
@@ -205,7 +208,7 @@ const AddParticipants: FC<AddParticipantsProps> = ({
           placeholder={t('addParticipantsSearchPlaceholder')}
         />
 
-        {showIntegrations && !isMLSEnabled && (
+        {showIntegrations && (
           <div className="panel__tabs">
             <div
               role="button"

--- a/src/script/page/RightSidebar/AddParticipants/AddParticipants.tsx
+++ b/src/script/page/RightSidebar/AddParticipants/AddParticipants.tsx
@@ -100,7 +100,12 @@ const AddParticipants: FC<AddParticipantsProps> = ({
     'isTeamOnly',
     'participating_user_ids',
   ]);
-  const {isTeam, teamMembers, teamUsers} = useKoSubscribableChildren(teamState, ['isTeam', 'teamMembers', 'teamUsers']);
+  const {isTeam, teamMembers, teamUsers, isMLSEnabled} = useKoSubscribableChildren(teamState, [
+    'isTeam',
+    'teamMembers',
+    'teamUsers',
+    'isMLSEnabled',
+  ]);
   const {connectedUsers} = useKoSubscribableChildren(userState, ['connectedUsers']);
   const {teamRole} = useKoSubscribableChildren(selfUser, ['teamRole']);
   const {services} = useKoSubscribableChildren(integrationRepository, ['services']);
@@ -200,7 +205,7 @@ const AddParticipants: FC<AddParticipantsProps> = ({
           placeholder={t('addParticipantsSearchPlaceholder')}
         />
 
-        {showIntegrations && (
+        {showIntegrations && !isMLSEnabled && (
           <div className="panel__tabs">
             <div
               role="button"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10776" title="WPB-10776" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10776</a>  [Web] Disable Add Service interaction in MLS Conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Added condition to only display services in contacts search when MLS is disabled.

## Screenshots/Screencast (for UI changes)
Without MLS:
<img width="307" alt="Screenshot 2024-09-03 at 17 48 11" src="https://github.com/user-attachments/assets/f6c9058c-cf19-4d63-bbf2-c9fc2a4cd42c">

With MLS:

<img width="307" alt="Screenshot 2024-09-03 at 17 47 27" src="https://github.com/user-attachments/assets/cb45e69d-8bb4-460e-9d11-568aaa428549">

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ