### PR TITLE
fix: add QA possibility to disable the countly lock

### DIFF
--- a/src/page/countlyBoomerangCustom.js
+++ b/src/page/countlyBoomerangCustom.js
@@ -92,7 +92,6 @@ Plugin being used - RT, AutoXHR, Continuity, NavigationTiming, ResourceTiming
         BOOMR.subscribe('before_beacon', function (beaconData) {
           self._internals.log('[INFO]', 'Boomerang, before_beacon:', JSON.stringify(beaconData, null, 2));
           var trace = {};
-          console.log('boomr trace device', beaconData);
           if (beaconData['rt.start'] !== 'manual' && !beaconData['http.initiator'] && beaconData['rt.quit'] !== '') {
             trace.type = 'device';
             trace.apm_metrics = {};

--- a/src/script/page/MainContent/panels/preferences/accountPreferences/DataUsageSection.tsx
+++ b/src/script/page/MainContent/panels/preferences/accountPreferences/DataUsageSection.tsx
@@ -25,7 +25,7 @@ import {amplify} from 'amplify';
 import {Checkbox, CheckboxLabel} from '@wireapp/react-ui-kit';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
-import {getWebEnvironment} from 'Util/Environment';
+import {getForcedErrorReportingStatus} from 'src/script/tracking/Countly.helpers';
 import {t} from 'Util/LocalizerUtil';
 
 import {PropertiesRepository} from '../../../../../properties/PropertiesRepository';
@@ -64,7 +64,7 @@ const DataUsageSection = ({propertiesRepository, brandName, isActivatedAccount}:
     return null;
   }
 
-  const {isProduction} = getWebEnvironment();
+  const forceErrorReporting = getForcedErrorReportingStatus();
 
   return (
     <PreferencesSection hasSeparator title={t('preferencesAccountData')} className="preferences-section-data-usage">
@@ -76,9 +76,9 @@ const DataUsageSection = ({propertiesRepository, brandName, isActivatedAccount}:
               propertiesRepository.savePreference(PROPERTIES_TYPE.PRIVACY.TELEMETRY_SHARING, isChecked);
               setOptionTelemetry(isChecked);
             }}
-            checked={isProduction ? optionTelemetry : true}
+            checked={forceErrorReporting ? true : optionTelemetry}
             data-uie-name="status-preference-telemetry"
-            disabled={!isProduction}
+            disabled={forceErrorReporting}
           >
             <CheckboxLabel htmlFor="status-preference-telemetry">
               {t('preferencesAccountDataTelemetryCheckbox')}

--- a/src/script/tracking/Countly.helpers.ts
+++ b/src/script/tracking/Countly.helpers.ts
@@ -18,13 +18,33 @@
  */
 
 import {getWebEnvironment} from 'Util/Environment';
+import {getLogger, Logger} from 'Util/Logger';
 
 import {Config} from '../Config';
 
-export function isCountlyEnabledAtCurrentEnvironment(): boolean {
-  const {isDev, isEdge, isInternal, isLocalhost, isStaging} = getWebEnvironment();
+const logger: Logger = getLogger('CountlyHelpers');
+
+// This variable is used to force the activation of error reporting on specific environments
+let forceActivateErrorReporting: boolean = false;
+
+// This method is used by QA to disable the forced activation for testing purposes
+export const disableForcedErrorReporting = (): void => {
+  forceActivateErrorReporting = false;
+};
+export const getForcedErrorReportingStatus = (): boolean => forceActivateErrorReporting;
+
+// Init the forced activation of error reporting based on the environment
+export const initForcedErrorReporting = () => {
+  const {isDev, isEdge, isInternal, isLocalhost, isStaging, name} = getWebEnvironment();
 
   if (isDev || isEdge || isInternal || isLocalhost || isStaging) {
+    forceActivateErrorReporting = true;
+    logger.warn(`Error reporting is forced to be activated on this environment: ${name}`);
+  }
+};
+
+export function isCountlyEnabledAtCurrentEnvironment(): boolean {
+  if (forceActivateErrorReporting) {
     return true;
   }
 

--- a/src/script/util/DebugUtil.ts
+++ b/src/script/util/DebugUtil.ts
@@ -63,6 +63,7 @@ import {APIClient} from '../service/APIClientSingleton';
 import {Core} from '../service/CoreSingleton';
 import {EventRecord, StorageRepository, StorageSchemata} from '../storage';
 import {TeamState} from '../team/TeamState';
+import {disableForcedErrorReporting} from '../tracking/Countly.helpers';
 import {UserRepository} from '../user/UserRepository';
 import {UserState} from '../user/UserState';
 import {ViewModelRepositories} from '../view_model/MainViewModel';
@@ -544,5 +545,10 @@ export class DebugUtil {
       },
       EventRepository.SOURCE.WEB_SOCKET,
     );
+  }
+
+  // Used by QA test automation, allows to disable or enable the forced error reporting
+  disableForcedErrorReporting() {
+    return disableForcedErrorReporting();
   }
 }


### PR DESCRIPTION
## Description

Since we enforce Countly on dev environments, QA needs the possibility to disable this forced state. 