### PR TITLE
fix: handled first message duplication on reload [WPB-10906]

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -855,7 +855,7 @@ export class ConversationRepository {
   public async getPrecedingMessages(conversationEntity: Conversation): Promise<ContentMessage[]> {
     conversationEntity.isLoadingMessages(true);
 
-    const firstMessageEntity = conversationEntity.getOldestMessage();
+    const firstMessageEntity = conversationEntity.getOldestMessageWithTimestamp();
     const upperBound =
       firstMessageEntity && firstMessageEntity.timestamp()
         ? new Date(firstMessageEntity.timestamp())

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -926,13 +926,10 @@ export class Conversation {
 
   /**
    * Get the oldest loaded message of the conversation with timestamp.
+   * Variant for getOldestMessage() which checks timestamp too.
    */
   getOldestMessageWithTimestamp(): Message | undefined {
-    return this.messages().find(
-      message =>
-        // Deleted message should be ignored since they might have a timestamp in the past (the timestamp of a delete message is the timestamp of the message that was deleted)
-        !isDeleteMessage(message) && message.timestamp(),
-    );
+    return this.messages().find(message => !isDeleteMessage(message) && message.timestamp());
   }
 
   /**

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -920,6 +920,17 @@ export class Conversation {
     return this.messages().find(
       message =>
         // Deleted message should be ignored since they might have a timestamp in the past (the timestamp of a delete message is the timestamp of the message that was deleted)
+        !isDeleteMessage(message),
+    );
+  }
+
+  /**
+   * Get the oldest loaded message of the conversation with timestamp.
+   */
+  getOldestMessageWithTimestamp(): Message | undefined {
+    return this.messages().find(
+      message =>
+        // Deleted message should be ignored since they might have a timestamp in the past (the timestamp of a delete message is the timestamp of the message that was deleted)
         !isDeleteMessage(message) && message.timestamp(),
     );
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10906" title="WPB-10906" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10906</a>  [Web] Duplication of first message in 1-1 chat
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Handled first message duplication on reload.

In PR https://github.com/wireapp/wire-webapp/pull/17977, we updated the function `getOldestMessage()` to return the last message with timestamp. This caused an issue while getting older messages on conversation load.

Solution:
Introduced a new function `getOldestMessageWithTimestamp()` and reverted the old changes.

## Screenshots/Screencast (for UI changes)
Bug:

<img width="1331" alt="Screenshot 2024-09-05 at 09 32 49" src="https://github.com/user-attachments/assets/66b7b80c-f18a-41b4-afa0-3aa3669d7c67">

Fix:

https://github.com/user-attachments/assets/5675d825-7e88-4a52-950c-58217dd04681

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ