### PR TITLE
fix: truncate username in sidebar (WPB-9796)

### DIFF
--- a/src/script/page/LeftSidebar/UserDetails/UserDetails.styles.ts
+++ b/src/script/page/LeftSidebar/UserDetails/UserDetails.styles.ts
@@ -91,6 +91,9 @@ export const userHandle = (isSideBarOpen: boolean): CSSObject => ({
   fontWeight: 'var(--font-weight-regular)',
   lineHeight: 'var(--line-height-md)',
   gridArea: 'userHandle',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
 });
 
 export const legalHold: CSSObject = {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9796" title="WPB-9796" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9796</a>  [Wrapper] Shortcut for adding people to conversation works for 1:1 convos
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

**Before:**
![telegram-cloud-photo-size-4-5965222705697507300-x](https://github.com/user-attachments/assets/caa4888d-8661-476b-87ca-4275a5e51340)

**After:**
![telegram-cloud-photo-size-4-5965222705697507301-x](https://github.com/user-attachments/assets/d396bb2b-dbdc-4826-bd02-d01039d17a38)
