### PR TITLE
chore: bump avs to 9.6.18 [WPB-10927]

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@emotion/react": "11.11.3",
     "@lexical/history": "0.12.5",
     "@lexical/react": "0.12.5",
-    "@wireapp/avs": "9.6.16",
+    "@wireapp/avs": "9.6.18",
     "@wireapp/commons": "5.2.7",
     "@wireapp/core": "46.1.0-hotfix-1.0",
     "@wireapp/react-ui-kit": "9.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4714,10 +4714,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/avs@npm:9.6.16":
-  version: 9.6.16
-  resolution: "@wireapp/avs@npm:9.6.16"
-  checksum: 6f683a29e1e52cc62b50c3327cb89939216116c0f04999f0364a35529f3321ddb0b443c241696567d4d37f0e071d5d5cca3739677667a3c22d0e2b6c1902f7d4
+"@wireapp/avs@npm:9.6.18":
+  version: 9.6.18
+  resolution: "@wireapp/avs@npm:9.6.18"
+  checksum: d7a72b37006fd30710ebae4e795b39f0159f301dbd80fe3838f34ea3e053c88d778191700b4c6d9ae57d0bff5d2856cae1f30b11074922e714acb832672beed5
   languageName: node
   linkType: hard
 
@@ -17505,7 +17505,7 @@ __metadata:
     "@types/speakingurl": 13.0.6
     "@types/underscore": 1.11.15
     "@types/webpack-env": 1.18.4
-    "@wireapp/avs": 9.6.16
+    "@wireapp/avs": 9.6.18
     "@wireapp/commons": 5.2.7
     "@wireapp/copy-config": 2.1.14
     "@wireapp/core": 46.1.0-hotfix-1.0


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10927" title="WPB-10927" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10927</a>  [Web] Update to AVS 9.6.18
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

AVS 9.6.18 has no differences relative to 9.6.16 apart from removing some tests that are not relevant anymore

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ