### PR TITLE
fix: Display quality feedback while user leave a call

### DIFF
--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -1169,7 +1169,7 @@ export class CallingRepository {
   }
 
   readonly showCallQualityFeedbackModal = () => {
-    if (!this.selfUser) {
+    if (!this.selfUser || !this.hasActiveCall()) {
       return;
     }
 
@@ -1191,14 +1191,14 @@ export class CallingRepository {
   };
 
   readonly leaveCall = (conversationId: QualifiedId, reason: LEAVE_CALL_REASON): void => {
+    if (isCountlyEnabledAtCurrentEnvironment()) {
+      this.showCallQualityFeedbackModal();
+    }
+
     this.logger.info(`Ending call with reason ${reason} \n Stack trace: `, new Error().stack);
     const conversationIdStr = this.serializeQualifiedId(conversationId);
     delete this.poorCallQualityUsers[conversationIdStr];
     this.wCall?.end(this.wUser, conversationIdStr);
-
-    if (isCountlyEnabledAtCurrentEnvironment()) {
-      this.showCallQualityFeedbackModal();
-    }
   };
 
   muteCall(call: Call, shouldMute: boolean, reason?: MuteState): void {


### PR DESCRIPTION
## Description

Previously quality feedback modal was displayed also while user not join to the call. Now quality feedback modal will be displayed while user will join to call and call will be finished.

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ