### PR TITLE
feat: hide services toggle when MLS as default protocol [WPB-10924]

### DIFF
--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -186,6 +186,16 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
     };
   }, [stateIsParticipants]);
 
+  useEffect(() => {
+    if (selectedProtocol.value === ConversationProtocol.MLS && isServicesEnabled) {
+      clickOnToggleServicesMode();
+    }
+
+    if (selectedProtocol.value === ConversationProtocol.PROTEUS && !isServicesEnabled) {
+      clickOnToggleServicesMode();
+    }
+  }, [selectedProtocol]);
+
   if (!mainViewModel) {
     return null;
   }
@@ -476,16 +486,18 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
                   toggleName={t('guestOptionsTitle')}
                   toggleId="guests"
                 />
-                <BaseToggle
-                  className="modal-style"
-                  isChecked={isServicesEnabled}
-                  setIsChecked={clickOnToggleServicesMode}
-                  extendedInfo
-                  extendedInfoText={t('servicesRoomToggleInfoExtended')}
-                  infoText={t('servicesRoomToggleInfo')}
-                  toggleName={t('servicesOptionsTitle')}
-                  toggleId="services"
-                />
+                {selectedProtocol.value !== ConversationProtocol.MLS && (
+                  <BaseToggle
+                    className="modal-style"
+                    isChecked={isServicesEnabled}
+                    setIsChecked={clickOnToggleServicesMode}
+                    extendedInfo
+                    extendedInfoText={t('servicesRoomToggleInfoExtended')}
+                    infoText={t('servicesRoomToggleInfo')}
+                    toggleName={t('servicesOptionsTitle')}
+                    toggleId="services"
+                  />
+                )}
                 <InfoToggle
                   className="modal-style"
                   dataUieName="read-receipts"

--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -26,7 +26,7 @@ import {amplify} from 'amplify';
 import cx from 'classnames';
 import {container} from 'tsyringe';
 
-import {Button, ButtonVariant, Select} from '@wireapp/react-ui-kit';
+import {Button, ButtonVariant, Option, Select} from '@wireapp/react-ui-kit';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {FadingScrollbar} from 'Components/FadingScrollbar';
@@ -306,6 +306,21 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
     setNameError('');
   };
 
+  const onProtocolChange = (option: Option | null) => {
+    if (!isProtocolOption(option)) {
+      return;
+    }
+
+    setSelectedProtocol(option);
+
+    if (
+      (selectedProtocol.value === ConversationProtocol.MLS && isServicesEnabled) ||
+      (selectedProtocol.value === ConversationProtocol.PROTEUS && !isServicesEnabled)
+    ) {
+      clickOnToggleServicesMode();
+    }
+  };
+
   const groupNameLength = groupName.length;
 
   const hasNameError = nameError.length > 0;
@@ -511,11 +526,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
                   <>
                     <Select
                       id="select-protocol"
-                      onChange={option => {
-                        if (isProtocolOption(option)) {
-                          setSelectedProtocol(option);
-                        }
-                      }}
+                      onChange={onProtocolChange}
                       dataUieName="select-protocol"
                       options={protocolOptions}
                       value={selectedProtocol}

--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -304,8 +304,8 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
     setSelectedProtocol(option);
 
     if (
-      (selectedProtocol.value === ConversationProtocol.MLS && isServicesEnabled) ||
-      (selectedProtocol.value === ConversationProtocol.PROTEUS && !isServicesEnabled)
+      (option.value === ConversationProtocol.MLS && isServicesEnabled) ||
+      (option.value === ConversationProtocol.PROTEUS && !isServicesEnabled)
     ) {
       clickOnToggleServicesMode();
     }

--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -186,16 +186,6 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
     };
   }, [stateIsParticipants]);
 
-  useEffect(() => {
-    if (selectedProtocol.value === ConversationProtocol.MLS && isServicesEnabled) {
-      clickOnToggleServicesMode();
-    }
-
-    if (selectedProtocol.value === ConversationProtocol.PROTEUS && !isServicesEnabled) {
-      clickOnToggleServicesMode();
-    }
-  }, [selectedProtocol]);
-
   if (!mainViewModel) {
     return null;
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10924" title="WPB-10924" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10924</a>  [Web] Hide and set to off the ability to toggle services in during group creation if MLS is standard protocol
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Hide service toggle from group creation modal when default protocol is MLS.

## Screenshots/Screencast (for UI changes)

https://github.com/user-attachments/assets/3288a236-265f-49b0-ad46-4d04eaaeebee

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ