### PR TITLE
feat: hide services in conversation details when protocol is MLS [WPB-10925]

### DIFF
--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
@@ -19,6 +19,7 @@
 
 import {forwardRef, useCallback, useEffect, useMemo, useState} from 'react';
 
+import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data/';
 import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 import {amplify} from 'amplify';
@@ -164,7 +165,10 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
     const showOptionTimedMessages =
       isActiveGroupParticipant && roleRepository.canToggleTimeout(activeConversation) && isSelfDeletingMessagesEnabled;
     const showOptionServices =
-      isActiveGroupParticipant && !!teamId && roleRepository.canToggleGuests(activeConversation);
+      isActiveGroupParticipant &&
+      !!teamId &&
+      roleRepository.canToggleGuests(activeConversation) &&
+      activeConversation.protocol !== ConversationProtocol.MLS;
     const showOptionReadReceipts = !!teamId && roleRepository.canToggleReadReceipts(activeConversation);
 
     const showSectionOptions =


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10925" title="WPB-10925" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10925</a>  [Web] In an MLS group, in the group details there should be no option to turn on Services
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Hide services section from conversation details when protocol is MLS.

## Screenshots/Screencast (for UI changes)

https://github.com/user-attachments/assets/5de15234-2b40-4574-a8d4-be14b81bd113


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ