### PR TITLE
runfix: use keyboardjs library for config toolbar keyboard shortcut

### DIFF
--- a/src/script/components/ConfigToolbar/ConfigToolbar.tsx
+++ b/src/script/components/ConfigToolbar/ConfigToolbar.tsx
@@ -19,11 +19,12 @@
 
 import {useState, useEffect, useRef} from 'react';
 
+import keyboardjs from 'keyboardjs';
+
 import {Button, Input, Switch} from '@wireapp/react-ui-kit';
 
 import {Config, Configuration} from 'src/script/Config';
 import {useClickOutside} from 'src/script/hooks/useClickOutside';
-import {isMetaKey} from 'Util/KeyboardUtil';
 
 import {wrapperStyles} from './ConfigToolbar.styles';
 
@@ -34,15 +35,14 @@ export function ConfigToolbar() {
 
   // Toggle config tool on 'cmd/ctrl + shift + 2'
   useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (isMetaKey(event) && event.shiftKey && event.key === '2') {
-        setShowConfig(prev => !prev);
-      }
+    const handleKeyDown = () => {
+      setShowConfig(prev => !prev);
     };
 
-    window.addEventListener('keydown', handleKeyDown);
+    keyboardjs.bind(['command+shift+2', 'ctrl+shift+2'], handleKeyDown);
+
     return () => {
-      window.removeEventListener('keydown', handleKeyDown);
+      keyboardjs.unbind(['command+shift+2', 'ctrl+shift+2'], handleKeyDown);
     };
   }, []);
 


### PR DESCRIPTION
## Description

The util used in the original PR https://github.com/wireapp/wire-webapp/pull/18036 doesn't appear to work on Windows/Linux.

This replaces it by `keyboardjs`, the library we currently use for similar keyboard shortcuts

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ