### PR TITLE
chore: update types/node version from 18.11.18 to 22.5.5

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -30,7 +30,7 @@
     "@types/geolite2": "2.0.0",
     "@types/hbs": "4.0.4",
     "@types/jest": "^29.5.13",
-    "@types/node": "18.11.18",
+    "@types/node": "22.5.5",
     "jest": "29.7.0",
     "rimraf": "6.0.1",
     "typescript": "5.6.2"

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1060,10 +1060,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:18.11.18":
-  version: 18.11.18
-  resolution: "@types/node@npm:18.11.18"
-  checksum: 10/da05cf3a0036ef05cd695ac4cb265948593acbe723ba818f0ca0ce466b13ba99e1aac3a363086d6b8c7ea8f30c9233478e0293ac878a6f4b1d5515b10c392257
+"@types/node@npm:22.5.5":
+  version: 22.5.5
+  resolution: "@types/node@npm:22.5.5"
+  dependencies:
+    undici-types: "npm:~6.19.2"
+  checksum: 10/172d02c8e6d921699edcf559c28b3805616bd6481af1b3cb0299f89ad9a6f33b71050434c06ce7b503166054a26275344187c443f99f745d0b12601372452f19
   languageName: node
   linkType: hard
 
@@ -5521,6 +5523,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~6.19.2":
+  version: 6.19.8
+  resolution: "undici-types@npm:6.19.8"
+  checksum: 10/cf0b48ed4fc99baf56584afa91aaffa5010c268b8842f62e02f752df209e3dea138b372a60a963b3b2576ed932f32329ce7ddb9cb5f27a6c83040d8cd74b7a70
+  languageName: node
+  linkType: hard
+
 "unique-filename@npm:^3.0.0":
   version: 3.0.0
   resolution: "unique-filename@npm:3.0.0"
@@ -5667,7 +5676,7 @@ __metadata:
     "@types/geolite2": "npm:2.0.0"
     "@types/hbs": "npm:4.0.4"
     "@types/jest": "npm:^29.5.13"
-    "@types/node": "npm:18.11.18"
+    "@types/node": "npm:22.5.5"
     "@wireapp/commons": "npm:5.2.10"
     dotenv: "npm:16.4.5"
     dotenv-extended: "npm:2.9.0"


### PR DESCRIPTION
## Description

Bumps [@types/node](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/node) from 18.11.18 to 22.5.5.