### PR TITLE
feat: Scroll to filtered conversation and filter groups

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React, {MouseEvent as ReactMouseEvent, KeyboardEvent as ReactKeyBoardEvent} from 'react';
+import React, {MouseEvent as ReactMouseEvent, KeyboardEvent as ReactKeyBoardEvent, useEffect} from 'react';
 
 import {css} from '@emotion/react';
 
@@ -88,6 +88,7 @@ export const ConversationsList = ({
   const {currentTab} = useSidebarStore();
 
   const {joinableCalls} = useKoSubscribableChildren(callState, ['joinableCalls']);
+  const {activeConversation} = useKoSubscribableChildren(conversationState, ['activeConversation']);
 
   const isActiveConversation = (conversation: Conversation) => conversationState.isActiveConversation(conversation);
 
@@ -122,10 +123,6 @@ export const ConversationsList = ({
         createNavigate(generateConversationUrl(conversation.qualifiedId))(event);
       }
 
-      setTimeout(() => {
-        scrollToConversation(event.target as HTMLElement);
-      }, 300);
-
       clearSearchFilter();
     },
     isSelected: isActiveConversation,
@@ -133,6 +130,17 @@ export const ConversationsList = ({
     rightClick: openContextMenu,
     showJoinButton: hasJoinableCall(conversation),
   });
+
+  useEffect(() => {
+    if (!activeConversation) {
+      return;
+    }
+
+    const element = document.querySelector<HTMLElement>(`[data-uie-uid="${activeConversation.id}"]`);
+    if (element) {
+      scrollToConversation(element);
+    }
+  }, [activeConversation?.id]);
 
   return (
     <>

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
@@ -33,6 +33,7 @@ import {matchQualifiedIds} from 'Util/QualifiedId';
 import {ConnectionRequests} from './ConnectionRequests';
 import {ConversationView} from './ConversationView';
 import {FilteredGroupConversations} from './FilteredGroupConversations';
+import {scrollToConversation} from './helpers';
 
 import {CallState} from '../../../../calling/CallState';
 import {ConversationRepository} from '../../../../conversation/ConversationRepository';
@@ -121,6 +122,10 @@ export const ConversationsList = ({
         createNavigate(generateConversationUrl(conversation.qualifiedId))(event);
       }
 
+      setTimeout(() => {
+        scrollToConversation(event.target as HTMLElement);
+      }, 300);
+
       clearSearchFilter();
     },
     isSelected: isActiveConversation,
@@ -153,6 +158,7 @@ export const ConversationsList = ({
         <FilteredGroupConversations
           archivedConversations={archivedConversations}
           conversationRepository={conversationRepository}
+          conversations={conversations}
           conversationsFilter={conversationsFilter}
           currentFolder={currentFolder}
           favoriteConversations={favoriteConversations}

--- a/src/script/page/LeftSidebar/panels/Conversations/FilteredGroupConversations/FilteredGroupConversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/FilteredGroupConversations/FilteredGroupConversations.tsx
@@ -32,6 +32,7 @@ import {SidebarTabs, useSidebarStore} from '../useSidebarStore';
 interface FilteredGroupConversationsProps {
   archivedConversations: Conversation[];
   conversationsFilter?: string;
+  conversations: Conversation[];
   conversationRepository: ConversationRepository;
   currentFolder?: ConversationLabel;
   favoriteConversations: Conversation[];
@@ -42,6 +43,7 @@ interface FilteredGroupConversationsProps {
 export const FilteredGroupConversations = ({
   archivedConversations,
   conversationRepository,
+  conversations,
   conversationsFilter = '',
   currentFolder,
   favoriteConversations,
@@ -74,7 +76,7 @@ export const FilteredGroupConversations = ({
       filteredGroup = filteredGroup.filter(item => !archivedConversations.includes(item));
     }
 
-    return filteredGroup;
+    return filteredGroup.filter(item => !conversations.includes(item));
   };
 
   const filteredGroupConversations = getFilteredGroupConversations();

--- a/src/script/page/LeftSidebar/panels/Conversations/helpers.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/helpers.tsx
@@ -109,6 +109,6 @@ export const scrollToConversation = (element: HTMLElement) => {
     rect.right <= (window.innerWidth || document.documentElement.clientWidth);
 
   if (!isVisible) {
-    element.scrollIntoView({behavior: 'smooth', block: 'center', inline: 'nearest'});
+    element.scrollIntoView();
   }
 };

--- a/src/script/page/LeftSidebar/panels/Conversations/helpers.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/helpers.tsx
@@ -99,3 +99,16 @@ export const conversationSearchFilter = (filter: string) => (conversation: Conve
 
   return conversationDisplayName.includes(filterWord);
 };
+
+export const scrollToConversation = (element: HTMLElement) => {
+  const rect = element.getBoundingClientRect();
+  const isVisible =
+    rect.top >= 0 &&
+    rect.left >= 0 &&
+    rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+    rect.right <= (window.innerWidth || document.documentElement.clientWidth);
+
+  if (!isVisible) {
+    element.scrollIntoView({behavior: 'smooth', block: 'center', inline: 'nearest'});
+  }
+};


### PR DESCRIPTION
## Description

Previously if we filter conversations, we see duplicates in Groups section. Now we see only 1 result on top.
Also if we click on filtered conversation now we scrolling selected conversation into view.

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ