### PR TITLE
feat: establish 1on1 mls conversation with new removal key [WPB-10744]

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@lexical/react": "0.12.5",
     "@wireapp/avs": "9.6.18",
     "@wireapp/commons": "5.2.7",
-    "@wireapp/core": "46.1.0-hotfix-1.0",
+    "@wireapp/core": "46.1.0-hotfix-1.7",
     "@wireapp/react-ui-kit": "9.16.4",
     "@wireapp/store-engine-dexie": "2.1.8",
     "@wireapp/webapp-events": "0.20.1",
@@ -212,7 +212,7 @@
     "translate:merge": "formatjs extract --format './bin/translations_extract_formatter.js' --out-file './src/i18n/en-US.json' './src/script/strings.ts'"
   },
   "resolutions": {
-    "@wireapp/api-client": "27.1.0-hotfix-1.0",
+    "@wireapp/api-client": "27.1.0-hotfix-1.6",
     "libsodium": "0.7.10",
     "xml2js": "0.5.0",
     "@stablelib/utf8": "1.0.2",

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -986,7 +986,7 @@ export class CallingRepository {
   }
 
   private readonly leave1on1MLSConference = async (conversationId: QualifiedId) => {
-    await this.subconversationService.leave1on1ConferenceSubconversation(conversationId);
+    await this.subconversationService.leaveConferenceSubconversation(conversationId);
 
     const conversationIdStr = this.serializeQualifiedId(conversationId);
     this.wCall?.end(this.wUser, conversationIdStr);

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -532,7 +532,7 @@ describe('ConversationRepository', () => {
 
       jest
         .spyOn(conversationRepository['conversationService'], 'getMLS1to1Conversation')
-        .mockResolvedValueOnce(mls1to1ConversationResponse);
+        .mockResolvedValueOnce({conversation: mls1to1ConversationResponse});
 
       jest
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
@@ -590,8 +590,7 @@ describe('ConversationRepository', () => {
 
       jest
         .spyOn(conversationRepository['conversationService'], 'getMLS1to1Conversation')
-        .mockResolvedValueOnce(mls1to1ConversationResponse);
-
+        .mockResolvedValueOnce({conversation: mls1to1ConversationResponse});
       jest
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
         .mockResolvedValueOnce(false);
@@ -675,8 +674,7 @@ describe('ConversationRepository', () => {
 
       jest
         .spyOn(conversationRepository['conversationService'], 'getMLS1to1Conversation')
-        .mockResolvedValueOnce(mls1to1ConversationResponse);
-
+        .mockResolvedValueOnce({conversation: mls1to1ConversationResponse});
       jest
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
         .mockResolvedValueOnce(false);
@@ -742,7 +740,7 @@ describe('ConversationRepository', () => {
 
       jest
         .spyOn(conversationRepository['conversationService'], 'getMLS1to1Conversation')
-        .mockResolvedValueOnce(mls1to1ConversationResponse);
+        .mockResolvedValueOnce({conversation: mls1to1ConversationResponse});
 
       jest
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
@@ -765,7 +763,7 @@ describe('ConversationRepository', () => {
 
       jest
         .spyOn(conversationRepository['conversationService'], 'getMLS1to1Conversation')
-        .mockResolvedValueOnce(establishedMls1to1ConversationResponse);
+        .mockResolvedValueOnce({conversation: establishedMls1to1ConversationResponse});
       jest
         .spyOn(container.resolve(Core).service!.conversation, 'establishMLS1to1Conversation')
         .mockResolvedValueOnce(establishedMls1to1ConversationResponse);
@@ -814,7 +812,7 @@ describe('ConversationRepository', () => {
 
       jest
         .spyOn(conversationRepository['conversationService'], 'getMLS1to1Conversation')
-        .mockResolvedValueOnce(establishedMls1to1ConversationResponse);
+        .mockResolvedValueOnce({conversation: establishedMls1to1ConversationResponse});
       jest
         .spyOn(container.resolve(Core).service!.conversation, 'establishMLS1to1Conversation')
         .mockResolvedValueOnce(establishedMls1to1ConversationResponse);
@@ -1041,7 +1039,7 @@ describe('ConversationRepository', () => {
 
       jest
         .spyOn(conversationRepository['conversationService'], 'getMLS1to1Conversation')
-        .mockResolvedValueOnce(mls1to1ConversationResponse);
+        .mockResolvedValueOnce({conversation: mls1to1ConversationResponse});
 
       jest
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1573,7 +1573,7 @@ export class ConversationRepository {
    * @returns MLS conversation entity
    */
   private readonly fetchMLS1to1Conversation = async (otherUserId: QualifiedId): Promise<MLSConversation> => {
-    const remoteConversation = await this.conversationService.getMLS1to1Conversation(otherUserId);
+    const {conversation: remoteConversation} = await this.conversationService.getMLS1to1Conversation(otherUserId);
     const [conversation] = this.mapConversations([remoteConversation]);
 
     if (!isMLSConversation(conversation)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4693,9 +4693,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:27.1.0-hotfix-1.0":
-  version: 27.1.0-hotfix-1.0
-  resolution: "@wireapp/api-client@npm:27.1.0-hotfix-1.0"
+"@wireapp/api-client@npm:27.1.0-hotfix-1.6":
+  version: 27.1.0-hotfix-1.6
+  resolution: "@wireapp/api-client@npm:27.1.0-hotfix-1.6"
   dependencies:
     "@wireapp/commons": ^5.2.8
     "@wireapp/priority-queue": ^2.1.6
@@ -4710,7 +4710,7 @@ __metadata:
     tough-cookie: 4.1.4
     ws: 8.17.1
     zod: 3.23.8
-  checksum: dc119718f533ffc1e62b2eba4953ad87ab16937dc1703ad6d01e100702014ef9d0319fc3fa5600307a81bc60e1d136436ed0061d3f4ae62106c783882424634f
+  checksum: 67cd6dc7c69c9ca8ed64bf10f29d6990449f89515fcada30685f20fad494683da709c423e9f0b5846f8173aacd0252ecd40573340f14401dda9f594ca4097c75
   languageName: node
   linkType: hard
 
@@ -4775,11 +4775,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:46.1.0-hotfix-1.0":
-  version: 46.1.0-hotfix-1.0
-  resolution: "@wireapp/core@npm:46.1.0-hotfix-1.0"
+"@wireapp/core@npm:46.1.0-hotfix-1.7":
+  version: 46.1.0-hotfix-1.7
+  resolution: "@wireapp/core@npm:46.1.0-hotfix-1.7"
   dependencies:
-    "@wireapp/api-client": ^27.1.0-hotfix-1.0
+    "@wireapp/api-client": ^27.1.0-hotfix-1.6
     "@wireapp/commons": ^5.2.8
     "@wireapp/core-crypto": 1.0.2
     "@wireapp/cryptobox": 12.8.0
@@ -4797,7 +4797,7 @@ __metadata:
     long: ^5.2.0
     uuid: 9.0.1
     zod: 3.23.8
-  checksum: 276a6edc57c72f9b912cc292745400d97d0c881bd5b9af833f8d298ba8a48c9ad0e8ab5647e40c749a6ef93994682bab60b2b6f74285d24625f025c6423ddd5c
+  checksum: be7fda878e279ded238b15810d6cbbec0e8f613e6e8fc8efa1c75d9547eb5113872f639aa99f30668ebfc94495594ad737eecc0a8f491ff2b8b397ddbc6837fb
   languageName: node
   linkType: hard
 
@@ -17508,7 +17508,7 @@ __metadata:
     "@wireapp/avs": 9.6.18
     "@wireapp/commons": 5.2.7
     "@wireapp/copy-config": 2.1.14
-    "@wireapp/core": 46.1.0-hotfix-1.0
+    "@wireapp/core": 46.1.0-hotfix-1.7
     "@wireapp/eslint-config": 3.0.5
     "@wireapp/prettier-config": 0.6.3
     "@wireapp/react-ui-kit": 9.16.4


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10744" title="WPB-10744" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10744</a>  [Web] Use proper MLS removal key with federated 1:1 conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

- Bump core to 46.1.0-hotfix-1.7, see https://github.com/wireapp/wire-web-packages/pull/6502
- Remove calls to `subconversationService.leave1on1ConferenceSubconversation()`

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ