### PR TITLE
chore: use backend config for 1 on 1 SFT calls

### DIFF
--- a/src/script/calling/CallingRepository.test.ts
+++ b/src/script/calling/CallingRepository.test.ts
@@ -246,8 +246,7 @@ describe('CallingRepository', () => {
   });
 
   describe('startCall', () => {
-    //FIXME: Unskip after hardcoded value is removed from CallingRepository.ts
-    it.skip.each([ConversationProtocol.PROTEUS, ConversationProtocol.MLS])(
+    it.each([ConversationProtocol.PROTEUS, ConversationProtocol.MLS])(
       'starts a ONEONONE call for proteus or MLS 1:1 conversation',
       async protocol => {
         const conversation = createConversation(CONVERSATION_TYPE.ONE_TO_ONE, protocol);
@@ -297,8 +296,7 @@ describe('CallingRepository', () => {
       );
     });
 
-    //FIXME: Unskip after hardcoded value is removed from CallingRepository.ts
-    it.skip('does not subscribe to epoch updates after initiating a call in 1:1 mls conversation', async () => {
+    it('does not subscribe to epoch updates after initiating a call in 1:1 mls conversation', async () => {
       const conversationId = {domain: 'example.com', id: 'conversation1'};
 
       const groupId = 'groupId';
@@ -353,8 +351,7 @@ describe('CallingRepository', () => {
       );
     });
 
-    //FIXME: Unskip after hardcoded value is removed from CallingRepository.ts
-    it.skip('does not subscribe to epoch updates after answering a call in mls 1:1 conversation', async () => {
+    it('does not subscribe to epoch updates after answering a call in mls 1:1 conversation', async () => {
       const conversationId = {domain: 'example.com', id: 'conversation2'};
       const selfParticipant = createSelfParticipant();
       const userId = {domain: '', id: ''};

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -19,6 +19,7 @@
 
 import type {CallConfigData} from '@wireapp/api-client/lib/account/CallConfigData';
 import {QualifiedUserClients} from '@wireapp/api-client/lib/conversation';
+import {FEATURE_KEY} from '@wireapp/api-client/lib/team';
 import type {QualifiedId} from '@wireapp/api-client/lib/user';
 import type {WebappProperties} from '@wireapp/api-client/lib/user/data';
 import {MessageSendingState} from '@wireapp/core/lib/conversation';
@@ -766,10 +767,8 @@ export class CallingRepository {
   //##############################################################################
 
   private getConversationType(conversation: Conversation): CONV_TYPE {
-    //FIXME: Remove this line when the feature flag is available on backend
-    const useSFTForOneToOneCalls = true;
-    // const useSFTForOneToOneCalls =
-    //   this.teamState.teamFeatures()?.[FEATURE_KEY.CONFERENCE_CALLING]?.config?.useSFTForOneToOneCalls;
+    const useSFTForOneToOneCalls =
+      this.teamState.teamFeatures()?.[FEATURE_KEY.CONFERENCE_CALLING]?.config?.useSFTForOneToOneCalls;
 
     if (conversation.isGroup() || useSFTForOneToOneCalls) {
       if (isMLSConversation(conversation)) {


### PR DESCRIPTION

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7151" title="WPB-7151" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-7151</a>  [Web] Add flag for customer specific 1:1 calls in federated environment
  </td></table>
  <br />

## Description

see https://github.com/wireapp/wire-webapp/pull/17759

The backend configuration is now correct for 1:1 SFT call , we can use the backend feature flag instead of hardcoding the value in the feature branch

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ