### PR TITLE
fix: Scroll to conversation while user click on filtered conversation

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React, {MouseEvent as ReactMouseEvent, KeyboardEvent as ReactKeyBoardEvent, useEffect} from 'react';
+import React, {MouseEvent as ReactMouseEvent, KeyboardEvent as ReactKeyBoardEvent, useRef, useEffect} from 'react';
 
 import {css} from '@emotion/react';
 
@@ -87,8 +87,9 @@ export const ConversationsList = ({
   const {setCurrentView} = useAppMainState(state => state.responsiveView);
   const {currentTab} = useSidebarStore();
 
+  const clickedFilteredConversation = useRef<Conversation | null>(null);
+
   const {joinableCalls} = useKoSubscribableChildren(callState, ['joinableCalls']);
-  const {activeConversation} = useKoSubscribableChildren(conversationState, ['activeConversation']);
 
   const isActiveConversation = (conversation: Conversation) => conversationState.isActiveConversation(conversation);
 
@@ -124,6 +125,7 @@ export const ConversationsList = ({
       }
 
       clearSearchFilter();
+      clickedFilteredConversation.current = conversation;
     },
     isSelected: isActiveConversation,
     onJoinCall: answerCall,
@@ -132,15 +134,15 @@ export const ConversationsList = ({
   });
 
   useEffect(() => {
-    if (!activeConversation) {
-      return;
-    }
+    if (clickedFilteredConversation.current) {
+      const element = document.querySelector<HTMLElement>(`[data-uie-uid="${clickedFilteredConversation.current.id}"]`);
+      if (element) {
+        scrollToConversation(element);
+      }
 
-    const element = document.querySelector<HTMLElement>(`[data-uie-uid="${activeConversation.id}"]`);
-    if (element) {
-      scrollToConversation(element);
+      clickedFilteredConversation.current = null;
     }
-  }, [activeConversation?.id]);
+  });
 
   return (
     <>

--- a/src/script/page/LeftSidebar/panels/Conversations/helpers.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/helpers.tsx
@@ -109,6 +109,6 @@ export const scrollToConversation = (element: HTMLElement) => {
     rect.right <= (window.innerWidth || document.documentElement.clientWidth);
 
   if (!isVisible) {
-    element.scrollIntoView();
+    element.scrollIntoView({behavior: 'instant', block: 'center', inline: 'nearest'});
   }
 };


### PR DESCRIPTION
## Description

Fix scrolling to filtered conversation. Now conversation is switched immediately while user clicks on filtered conversation.

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ