### PR TITLE
chore: cherry-pick MLS 1:1 conversation over SFT to dev [WPB-10120]

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@mediapipe/tasks-vision": "0.10.15",
     "@wireapp/avs": "9.9.3",
     "@wireapp/commons": "5.2.10",
-    "@wireapp/core": "46.3.2",
+    "@wireapp/core": "46.4.0",
     "@wireapp/react-ui-kit": "9.23.4",
     "@wireapp/store-engine-dexie": "2.1.12",
     "@wireapp/webapp-events": "0.24.0",

--- a/src/script/calling/CallingRepository.test.ts
+++ b/src/script/calling/CallingRepository.test.ts
@@ -250,7 +250,8 @@ describe('CallingRepository', () => {
   });
 
   describe('startCall', () => {
-    it.each([ConversationProtocol.PROTEUS, ConversationProtocol.MLS])(
+    //FIXME: Unskip after hardcoded value is removed from CallingRepository.ts
+    it.skip.each([ConversationProtocol.PROTEUS, ConversationProtocol.MLS])(
       'starts a ONEONONE call for proteus or MLS 1:1 conversation',
       async protocol => {
         const conversation = createConversation(CONVERSATION_TYPE.ONE_TO_ONE, protocol);
@@ -300,7 +301,8 @@ describe('CallingRepository', () => {
       );
     });
 
-    it('does not subscribe to epoch updates after initiating a call in 1:1 mls conversation', async () => {
+    //FIXME: Unskip after hardcoded value is removed from CallingRepository.ts
+    it.skip('does not subscribe to epoch updates after initiating a call in 1:1 mls conversation', async () => {
       const conversationId = {domain: 'example.com', id: 'conversation1'};
 
       const groupId = 'groupId';
@@ -353,7 +355,8 @@ describe('CallingRepository', () => {
       );
     });
 
-    it('does not subscribe to epoch updates after answering a call in mls 1:1 conversation', async () => {
+    //FIXME: Unskip after hardcoded value is removed from CallingRepository.ts
+    it.skip('does not subscribe to epoch updates after answering a call in mls 1:1 conversation', async () => {
       const conversationId = {domain: 'example.com', id: 'conversation2'};
       const selfParticipant = createSelfParticipant();
       const userId = {domain: '', id: ''};

--- a/src/script/calling/CallingRepository.test.ts
+++ b/src/script/calling/CallingRepository.test.ts
@@ -250,8 +250,7 @@ describe('CallingRepository', () => {
   });
 
   describe('startCall', () => {
-    //FIXME: Unskip after hardcoded value is removed from CallingRepository.ts
-    it.skip.each([ConversationProtocol.PROTEUS, ConversationProtocol.MLS])(
+    it.each([ConversationProtocol.PROTEUS, ConversationProtocol.MLS])(
       'starts a ONEONONE call for proteus or MLS 1:1 conversation',
       async protocol => {
         const conversation = createConversation(CONVERSATION_TYPE.ONE_TO_ONE, protocol);
@@ -301,8 +300,7 @@ describe('CallingRepository', () => {
       );
     });
 
-    //FIXME: Unskip after hardcoded value is removed from CallingRepository.ts
-    it.skip('does not subscribe to epoch updates after initiating a call in 1:1 mls conversation', async () => {
+    it('does not subscribe to epoch updates after initiating a call in 1:1 mls conversation', async () => {
       const conversationId = {domain: 'example.com', id: 'conversation1'};
 
       const groupId = 'groupId';
@@ -355,8 +353,7 @@ describe('CallingRepository', () => {
       );
     });
 
-    //FIXME: Unskip after hardcoded value is removed from CallingRepository.ts
-    it.skip('does not subscribe to epoch updates after answering a call in mls 1:1 conversation', async () => {
+    it('does not subscribe to epoch updates after answering a call in mls 1:1 conversation', async () => {
       const conversationId = {domain: 'example.com', id: 'conversation2'};
       const selfParticipant = createSelfParticipant();
       const userId = {domain: '', id: ''};

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -71,7 +71,7 @@ import {ClientId, Participant, UserId} from './Participant';
 
 import {PrimaryModal} from '../components/Modals/PrimaryModal';
 import {Config} from '../Config';
-import {isGroupMLSConversation, isMLSConversation, MLSConversation} from '../conversation/ConversationSelectors';
+import {isMLSConversation, MLSConversation} from '../conversation/ConversationSelectors';
 import {ConversationState} from '../conversation/ConversationState';
 import {ConversationVerificationState} from '../conversation/ConversationVerificationState';
 import {EventBuilder} from '../conversation/EventBuilder';
@@ -104,7 +104,9 @@ interface MediaStreamQuery {
   screen?: boolean;
 }
 
-export type QualifiedWcallMember = Omit<WcallMember, 'userid'> & {userId: QualifiedId};
+export type QualifiedWcallMember = Omit<WcallMember, 'userid'> & {
+  userId: QualifiedId;
+};
 
 interface SendMessageTarget {
   clients: WcallClient[];
@@ -128,7 +130,11 @@ enum CALL_DIRECTION {
   OUTGOING = 'outgoing',
 }
 
-type SubconversationData = {epoch: number; secretKey: string; members: SubconversationEpochInfoMember[]};
+type SubconversationData = {
+  epoch: number;
+  secretKey: string;
+  members: SubconversationEpochInfoMember[];
+};
 
 export class CallingRepository {
   private readonly acceptVersionWarning: (conversationId: QualifiedId) => void;
@@ -410,6 +416,10 @@ export class CallingRepository {
     activeCall?.muteState(isMuted ? this.nextMuteState : MuteState.NOT_MUTED);
   };
 
+  private readonly isMLSConference = (conversation: Conversation): conversation is MLSConversation => {
+    return isMLSConversation(conversation) && this.getConversationType(conversation) === CONV_TYPE.CONFERENCE_MLS;
+  };
+
   public async pushClients(call: Call | undefined = this.callState.joinedCall(), checkMismatch?: boolean) {
     if (!call) {
       return false;
@@ -418,12 +428,15 @@ export class CallingRepository {
 
     const allClients = await this.core.service!.conversation.fetchAllParticipantsClients(conversation.qualifiedId);
 
-    if (!isGroupMLSConversation(conversation)) {
+    if (!this.isMLSConference(conversation)) {
       const qualifiedClients = flattenUserMap(allClients);
 
       const clients: Clients = flatten(
         qualifiedClients.map(({data, userId}) =>
-          data.map(clientid => ({clientid, userid: this.serializeQualifiedId(userId)})),
+          data.map(clientid => ({
+            clientid,
+            userid: this.serializeQualifiedId(userId),
+          })),
         ),
       );
 
@@ -659,7 +672,10 @@ export class CallingRepository {
   private extractTargetedConversationId(event: CallingEvent): QualifiedId {
     const {targetConversation, conversation, qualified_conversation} = event;
     const targetedConversationId = targetConversation || qualified_conversation;
-    const conversationId = targetedConversationId ?? {domain: '', id: conversation};
+    const conversationId = targetedConversationId ?? {
+      domain: '',
+      id: conversation,
+    };
 
     return conversationId;
   }
@@ -808,7 +824,7 @@ export class CallingRepository {
       this.serializeQualifiedId(conversation.qualifiedId),
       this.serializeQualifiedId(userId),
       conversation && isMLSConversation(conversation) ? senderClientId : clientId,
-      conversation && isGroupMLSConversation(conversation) ? CONV_TYPE.CONFERENCE_MLS : CONV_TYPE.CONFERENCE,
+      conversation && this.getConversationType(conversation),
     );
 
     if (res !== 0) {
@@ -830,14 +846,20 @@ export class CallingRepository {
   //##############################################################################
 
   private getConversationType(conversation: Conversation): CONV_TYPE {
-    if (!conversation.isGroup()) {
-      return CONV_TYPE.ONEONONE;
+    //FIXME: Remove this line when the feature flag is available on backend
+    const useSFTForOneToOneCalls = true;
+    // const useSFTForOneToOneCalls =
+    //   this.teamState.teamFeatures()?.[FEATURE_KEY.CONFERENCE_CALLING]?.config?.useSFTForOneToOneCalls;
+
+    if (conversation.isGroup() || useSFTForOneToOneCalls) {
+      if (isMLSConversation(conversation)) {
+        return CONV_TYPE.CONFERENCE_MLS;
+      }
+
+      return this.supportsConferenceCalling ? CONV_TYPE.CONFERENCE : CONV_TYPE.GROUP;
     }
 
-    if (isGroupMLSConversation(conversation)) {
-      return CONV_TYPE.CONFERENCE_MLS;
-    }
-    return this.supportsConferenceCalling ? CONV_TYPE.CONFERENCE : CONV_TYPE.GROUP;
+    return CONV_TYPE.ONEONONE;
   }
 
   async startCall(conversation: Conversation, callType: CALL_TYPE): Promise<void | Call> {
@@ -895,7 +917,7 @@ export class CallingRepository {
         this.removeCall(call);
       }
 
-      if (isGroupMLSConversation(conversation)) {
+      if (this.isMLSConference(conversation)) {
         await this.joinMlsConferenceSubconversation(conversation);
       }
 
@@ -1033,7 +1055,7 @@ export class CallingRepository {
         [Segmentation.CALL.DIRECTION]: this.getCallDirection(call),
       });
 
-      if (!conversation || !isGroupMLSConversation(conversation)) {
+      if (!conversation || !this.isMLSConference(conversation)) {
         return;
       }
 
@@ -1067,7 +1089,7 @@ export class CallingRepository {
 
   private readonly updateConferenceSubconversationEpoch = async (conversationId: QualifiedId) => {
     const conversation = this.getConversationById(conversationId);
-    if (!conversation || !isGroupMLSConversation(conversation)) {
+    if (!conversation || !this.isMLSConference(conversation)) {
       return;
     }
 
@@ -1086,7 +1108,7 @@ export class CallingRepository {
 
   private readonly handleCallParticipantChange = (conversationId: QualifiedId, members: QualifiedWcallMember[]) => {
     const conversation = this.getConversationById(conversationId);
-    if (!conversation || !isGroupMLSConversation(conversation)) {
+    if (!conversation || !this.isMLSConference(conversation)) {
       return;
     }
 
@@ -1455,7 +1477,9 @@ export class CallingRepository {
   };
 
   readonly sendInCallEmoji = async (emojis: string, call: Call) => {
-    void this.messageRepository.sendInCallEmoji(call.conversation, {[emojis]: 1});
+    void this.messageRepository.sendInCallEmoji(call.conversation, {
+      [emojis]: 1,
+    });
   };
 
   readonly sendModeratorMute = (conversationId: QualifiedId, participants: Participant[]) => {
@@ -1520,7 +1544,10 @@ export class CallingRepository {
     if (
       matchQualifiedIds(
         call.conversation.qualifiedId,
-        this.callState.detachedWindowCallQualifiedId() ?? {id: '', domain: ''},
+        this.callState.detachedWindowCallQualifiedId() ?? {
+          id: '',
+          domain: '',
+        },
       )
     ) {
       void this.callState.setViewModeMinimized();
@@ -1655,7 +1682,11 @@ export class CallingRepository {
     if (!conversation || !this.selfUser || !this.selfClientId) {
       this.logger.warn(
         'Unable to process incoming call',
-        JSON.stringify({conversationId, selfClientId: this.selfClientId, selfUser: this.selfUser}),
+        JSON.stringify({
+          conversationId,
+          selfClientId: this.selfClientId,
+          selfUser: this.selfUser,
+        }),
       );
       return;
     }
@@ -1795,7 +1826,7 @@ export class CallingRepository {
 
     const {conversation} = call;
 
-    if (isGroupMLSConversation(conversation)) {
+    if (conversation && this.isMLSConference(conversation)) {
       const subconversationEpochInfo = await this.subconversationService.getSubconversationEpochInfo(
         conversation.qualifiedId,
         conversation.groupId,

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -1072,10 +1072,10 @@ export class CallingRepository {
   }
 
   private readonly leave1on1MLSConference = async (conversationId: QualifiedId) => {
-  if (isCountlyEnabledAtCurrentEnvironment()) {
+    if (isCountlyEnabledAtCurrentEnvironment()) {
       this.showCallQualityFeedbackModal();
     }
-    
+
     await this.subconversationService.leaveConferenceSubconversation(conversationId);
 
     const conversationIdStr = this.serializeQualifiedId(conversationId);

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -19,6 +19,7 @@
 
 import type {CallConfigData} from '@wireapp/api-client/lib/account/CallConfigData';
 import {QualifiedUserClients} from '@wireapp/api-client/lib/conversation';
+import {FEATURE_KEY} from '@wireapp/api-client/lib/team';
 import type {QualifiedId} from '@wireapp/api-client/lib/user';
 import type {WebappProperties} from '@wireapp/api-client/lib/user/data';
 import {MessageSendingState} from '@wireapp/core/lib/conversation';
@@ -846,10 +847,8 @@ export class CallingRepository {
   //##############################################################################
 
   private getConversationType(conversation: Conversation): CONV_TYPE {
-    //FIXME: Remove this line when the feature flag is available on backend
-    const useSFTForOneToOneCalls = true;
-    // const useSFTForOneToOneCalls =
-    //   this.teamState.teamFeatures()?.[FEATURE_KEY.CONFERENCE_CALLING]?.config?.useSFTForOneToOneCalls;
+    const useSFTForOneToOneCalls =
+      this.teamState.teamFeatures()?.[FEATURE_KEY.CONFERENCE_CALLING]?.config?.useSFTForOneToOneCalls;
 
     if (conversation.isGroup() || useSFTForOneToOneCalls) {
       if (isMLSConversation(conversation)) {

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -1072,6 +1072,10 @@ export class CallingRepository {
   }
 
   private readonly leave1on1MLSConference = async (conversationId: QualifiedId) => {
+  if (isCountlyEnabledAtCurrentEnvironment()) {
+      this.showCallQualityFeedbackModal();
+    }
+    
     await this.subconversationService.leaveConferenceSubconversation(conversationId);
 
     const conversationIdStr = this.serializeQualifiedId(conversationId);

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -1073,7 +1073,7 @@ export class CallingRepository {
   }
 
   private readonly leave1on1MLSConference = async (conversationId: QualifiedId) => {
-    await this.subconversationService.leave1on1ConferenceSubconversation(conversationId);
+    await this.subconversationService.leaveConferenceSubconversation(conversationId);
 
     const conversationIdStr = this.serializeQualifiedId(conversationId);
     this.wCall?.end(this.wUser, conversationIdStr);

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -636,7 +636,7 @@ describe('ConversationRepository', () => {
 
       jest
         .spyOn(conversationRepository['conversationService'], 'getMLS1to1Conversation')
-        .mockResolvedValueOnce(mls1to1ConversationResponse);
+        .mockResolvedValueOnce({conversation: mls1to1ConversationResponse});
 
       jest
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
@@ -694,8 +694,7 @@ describe('ConversationRepository', () => {
 
       jest
         .spyOn(conversationRepository['conversationService'], 'getMLS1to1Conversation')
-        .mockResolvedValueOnce(mls1to1ConversationResponse);
-
+        .mockResolvedValueOnce({conversation: mls1to1ConversationResponse});
       jest
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
         .mockResolvedValueOnce(false);
@@ -779,8 +778,7 @@ describe('ConversationRepository', () => {
 
       jest
         .spyOn(conversationRepository['conversationService'], 'getMLS1to1Conversation')
-        .mockResolvedValueOnce(mls1to1ConversationResponse);
-
+        .mockResolvedValueOnce({conversation: mls1to1ConversationResponse});
       jest
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
         .mockResolvedValueOnce(false);
@@ -846,7 +844,7 @@ describe('ConversationRepository', () => {
 
       jest
         .spyOn(conversationRepository['conversationService'], 'getMLS1to1Conversation')
-        .mockResolvedValueOnce(mls1to1ConversationResponse);
+        .mockResolvedValueOnce({conversation: mls1to1ConversationResponse});
 
       jest
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')
@@ -869,7 +867,7 @@ describe('ConversationRepository', () => {
 
       jest
         .spyOn(conversationRepository['conversationService'], 'getMLS1to1Conversation')
-        .mockResolvedValueOnce(establishedMls1to1ConversationResponse);
+        .mockResolvedValueOnce({conversation: establishedMls1to1ConversationResponse});
       jest
         .spyOn(container.resolve(Core).service!.conversation, 'establishMLS1to1Conversation')
         .mockResolvedValueOnce(establishedMls1to1ConversationResponse);
@@ -918,7 +916,7 @@ describe('ConversationRepository', () => {
 
       jest
         .spyOn(conversationRepository['conversationService'], 'getMLS1to1Conversation')
-        .mockResolvedValueOnce(establishedMls1to1ConversationResponse);
+        .mockResolvedValueOnce({conversation: establishedMls1to1ConversationResponse});
       jest
         .spyOn(container.resolve(Core).service!.conversation, 'establishMLS1to1Conversation')
         .mockResolvedValueOnce(establishedMls1to1ConversationResponse);
@@ -1145,7 +1143,7 @@ describe('ConversationRepository', () => {
 
       jest
         .spyOn(conversationRepository['conversationService'], 'getMLS1to1Conversation')
-        .mockResolvedValueOnce(mls1to1ConversationResponse);
+        .mockResolvedValueOnce({conversation: mls1to1ConversationResponse});
 
       jest
         .spyOn(conversationRepository['conversationService'], 'isMLSGroupEstablishedLocally')

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1589,7 +1589,7 @@ export class ConversationRepository {
    * @returns MLS conversation entity
    */
   private readonly fetchMLS1to1Conversation = async (otherUserId: QualifiedId): Promise<MLSConversation> => {
-    const remoteConversation = await this.conversationService.getMLS1to1Conversation(otherUserId);
+    const {conversation: remoteConversation} = await this.conversationService.getMLS1to1Conversation(otherUserId);
     const [conversation] = this.mapConversations([remoteConversation]);
 
     if (!isMLSConversation(conversation)) {

--- a/src/script/page/components/FeatureConfigChange/FeatureConfigChangeNotifier/FeatureConfigChangeNotifier.test.tsx
+++ b/src/script/page/components/FeatureConfigChange/FeatureConfigChangeNotifier/FeatureConfigChangeNotifier.test.tsx
@@ -55,7 +55,6 @@ describe('FeatureConfigChangeNotifier', () => {
     [FEATURE_KEY.CONFERENCE_CALLING]: {
       config: {useSFTForOneToOneCalls: false},
       status: FeatureStatus.DISABLED,
-      config: {},
     },
     [FEATURE_KEY.CONVERSATION_GUEST_LINKS]: {
       status: FeatureStatus.DISABLED,

--- a/src/script/page/components/FeatureConfigChange/FeatureConfigChangeNotifier/FeatureConfigChangeNotifier.test.tsx
+++ b/src/script/page/components/FeatureConfigChange/FeatureConfigChangeNotifier/FeatureConfigChangeNotifier.test.tsx
@@ -53,6 +53,7 @@ describe('FeatureConfigChangeNotifier', () => {
       config: {enforcedTimeoutSeconds: 0},
     },
     [FEATURE_KEY.CONFERENCE_CALLING]: {
+      config: {useSFTForOneToOneCalls: false},
       status: FeatureStatus.DISABLED,
       config: {},
     },

--- a/src/script/team/TeamService.ts
+++ b/src/script/team/TeamService.ts
@@ -86,6 +86,7 @@ export class TeamService {
           status: FeatureStatus.DISABLED,
         },
         [FEATURE_KEY.CONFERENCE_CALLING]: {
+          config: {useSFTForOneToOneCalls: false},
           status: FeatureStatus.ENABLED,
           config: {
             useSFTForOneToOneCalls: false,

--- a/src/script/team/TeamService.ts
+++ b/src/script/team/TeamService.ts
@@ -88,9 +88,6 @@ export class TeamService {
         [FEATURE_KEY.CONFERENCE_CALLING]: {
           config: {useSFTForOneToOneCalls: false},
           status: FeatureStatus.ENABLED,
-          config: {
-            useSFTForOneToOneCalls: false,
-          },
         },
         [FEATURE_KEY.DIGITAL_SIGNATURES]: {
           status: FeatureStatus.ENABLED,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5563,14 +5563,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^27.5.0":
-  version: 27.5.0
-  resolution: "@wireapp/api-client@npm:27.5.0"
+"@wireapp/api-client@npm:^27.6.0":
+  version: 27.6.0
+  resolution: "@wireapp/api-client@npm:27.6.0"
   dependencies:
     "@wireapp/commons": "npm:^5.2.10"
     "@wireapp/priority-queue": "npm:^2.1.8"
-    "@wireapp/protocol-messaging": "npm:1.49.0"
-    axios: "npm:1.7.5"
+    "@wireapp/protocol-messaging": "npm:1.50.0"
+    axios: "npm:1.7.7"
     axios-retry: "npm:4.5.0"
     http-status-codes: "npm:2.3.0"
     logdown: "npm:3.3.1"
@@ -5580,7 +5580,7 @@ __metadata:
     tough-cookie: "npm:4.1.4"
     ws: "npm:8.18.0"
     zod: "npm:3.23.8"
-  checksum: 10/0e361751f4836d5a8c3608cc8b5c859fc0bde442d8e660e0a74e38565a6d23c34d67ad4f54e7f12ce6a5717af665b89539e206bd0d64d1c8e99fcb39e949dc56
+  checksum: 10/91811a1634c6bde4b6776e4be658d4168dc6abc8a295414ad8630248edb00d424883c3c646a29f728b15988662ee4b517465c6d4e785a91a9d271a4cacb6c9b5
   languageName: node
   linkType: hard
 
@@ -5634,19 +5634,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:46.3.2":
-  version: 46.3.2
-  resolution: "@wireapp/core@npm:46.3.2"
+"@wireapp/core@npm:46.4.0":
+  version: 46.4.0
+  resolution: "@wireapp/core@npm:46.4.0"
   dependencies:
-    "@wireapp/api-client": "npm:^27.5.0"
+    "@wireapp/api-client": "npm:^27.6.0"
     "@wireapp/commons": "npm:^5.2.10"
     "@wireapp/core-crypto": "npm:1.0.2"
     "@wireapp/cryptobox": "npm:12.8.0"
     "@wireapp/priority-queue": "npm:^2.1.8"
     "@wireapp/promise-queue": "npm:^2.3.5"
-    "@wireapp/protocol-messaging": "npm:1.49.0"
+    "@wireapp/protocol-messaging": "npm:1.50.0"
     "@wireapp/store-engine": "npm:5.1.8"
-    axios: "npm:1.7.5"
+    axios: "npm:1.7.7"
     bazinga64: "npm:^6.3.8"
     deepmerge-ts: "npm:6.0.0"
     hash.js: "npm:1.1.7"
@@ -5656,7 +5656,7 @@ __metadata:
     long: "npm:^5.2.0"
     uuid: "npm:9.0.1"
     zod: "npm:3.23.8"
-  checksum: 10/739405f76898fb8f14eaaafcdd67bebb012d91a9dde2e84b1c0bba99a8336a5abe1048a9aebd04d1ef22956b295a563588d9345394384de351152088094a2a25
+  checksum: 10/6f1d5f177c4c0af706676bdd59c2279dc1a26ed885d800563200c0532cbe85a47ebc698f94e101ec7727a7d4c32bc79f87fb5aea387b41ee00c68ef70a7b67cf
   languageName: node
   linkType: hard
 
@@ -5758,15 +5758,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/protocol-messaging@npm:1.49.0":
-  version: 1.49.0
-  resolution: "@wireapp/protocol-messaging@npm:1.49.0"
+"@wireapp/protocol-messaging@npm:1.50.0":
+  version: 1.50.0
+  resolution: "@wireapp/protocol-messaging@npm:1.50.0"
   dependencies:
     long: "npm:5.2.0"
     protobufjs: "npm:7.2.5"
     protobufjs-cli: "npm:1.1.2"
     typescript: "npm:4.8.4"
-  checksum: 10/664cd77ca91340b3d0b2a01bde851dddef306fd2f6a591a15922b4c56e6d2248ba4d7ae52cd6d07c81794fd6a822e39b910eb9941d4b27a7ae20ec062a728403
+  checksum: 10/a3e006f067a035e8adbbfa7f3c164a4c20966ffcf4579847aba27fdedea4aa683e5a8e67b48d7640710b49aed7c8982bca64ace550e9d1fef1e550663c7e3c74
   languageName: node
   linkType: hard
 
@@ -6473,17 +6473,6 @@ __metadata:
   peerDependencies:
     axios: 0.x || 1.x
   checksum: 10/39ed05248757387a44dde94255df8ad54088aece50574c6ce9a1cd02b9e40252f7390285cea54ded04e33a3a549e462d5bdacc8d3178221b7cd40e8aff09ba46
-  languageName: node
-  linkType: hard
-
-"axios@npm:1.7.5":
-  version: 1.7.5
-  resolution: "axios@npm:1.7.5"
-  dependencies:
-    follow-redirects: "npm:^1.15.6"
-    form-data: "npm:^4.0.0"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10/6cbcfe943a84089f420a900a3a3aeb54ee94dcc9c2b81b150434896357be5d1079eff0b1bbb628597371e79f896b1bc5776df04184756ba99656ff31df9a75bf
   languageName: node
   linkType: hard
 
@@ -18191,7 +18180,7 @@ __metadata:
     "@wireapp/avs": "npm:9.9.3"
     "@wireapp/commons": "npm:5.2.10"
     "@wireapp/copy-config": "npm:2.2.7"
-    "@wireapp/core": "npm:46.3.2"
+    "@wireapp/core": "npm:46.4.0"
     "@wireapp/eslint-config": "npm:3.0.7"
     "@wireapp/prettier-config": "npm:0.6.4"
     "@wireapp/react-ui-kit": "npm:9.23.4"


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10120" title="WPB-10120" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10120</a>  [Web] Release MLS capable clients before MLS migration release
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

This cherry picks the latest changes to MLS 1:1 conversation that couldn't be merged back to dev until now (waiting for a backend config on the release/q1-2024 environments):

- treat 1:1 calls as conference calls as per client request (behind b-e feature flag)
- handle leaving those calls (adding logic to leave when the other participant left)
- use a removal key provided in the conversation creation endpoint for 1:1 federated conversations
- bump core to 46.4.0, see https://github.com/wireapp/wire-web-packages/pull/6502

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ