### PR TITLE
chore: downgrade mediapipe/tasks-vision to 0.10.15

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,8 @@ updates:
 
     ignore:
       - dependency-name: '@wireapp/avs'
+      # Wait until we have next release with wasm folder
+      - dependency-name: '@mediapipe/tasks-vision'
 
   # Server dependencies
   - package-ecosystem: npm

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,8 @@ updates:
       - dependency-name: '@wireapp/avs'
       # Wait until we have next release with wasm folder
       - dependency-name: '@mediapipe/tasks-vision'
+        versions:
+          - '0.10.16'
 
   # Server dependencies
   - package-ecosystem: npm

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@emotion/react": "11.11.4",
     "@lexical/history": "0.17.1",
     "@lexical/react": "0.17.1",
-    "@mediapipe/tasks-vision": "0.10.16",
+    "@mediapipe/tasks-vision": "0.10.15",
     "@wireapp/avs": "9.9.3",
     "@wireapp/commons": "5.2.10",
     "@wireapp/core": "46.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4171,10 +4171,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mediapipe/tasks-vision@npm:0.10.16":
-  version: 0.10.16
-  resolution: "@mediapipe/tasks-vision@npm:0.10.16"
-  checksum: 10/85632a013088bb9b43fb47749750ba952aacbaa247e8f243ddffe12361d046d63c3a4d4cedc58ba18768540c5a44dbf22ed77806f63570208e542b53ea019870
+"@mediapipe/tasks-vision@npm:0.10.15":
+  version: 0.10.15
+  resolution: "@mediapipe/tasks-vision@npm:0.10.15"
+  checksum: 10/08e30e4d1778b675002b4ecb98f62c5a980af2cdd2e6ea30d1d1d96c4643c10d73ca86fed7181ef25a8c24bfde32550af4918d0d2e2fe4ac0d4469ce509e537f
   languageName: node
   linkType: hard
 
@@ -18160,7 +18160,7 @@ __metadata:
     "@formatjs/cli": "npm:6.2.12"
     "@lexical/history": "npm:0.17.1"
     "@lexical/react": "npm:0.17.1"
-    "@mediapipe/tasks-vision": "npm:0.10.16"
+    "@mediapipe/tasks-vision": "npm:0.10.15"
     "@roamhq/wrtc": "npm:0.8.0"
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/react": "npm:16.0.1"


### PR DESCRIPTION
## Description
Downgrade [@mediapipe/tasks-vision](https://www.npmjs.com/package/@mediapipe/tasks-vision/v/0.10.16) to 0.10.15

The new release (0.10.16) does not contain wasm folder. Until we have new release we will prevent dependabot to update @mediapipe/tasks-vision.