### PR TITLE
fix: display empty state for folders on collapsed state [WPB-10547]

### DIFF
--- a/src/script/components/InputBar/components/MessageTimerButton/MessageTimerButton.tsx
+++ b/src/script/components/InputBar/components/MessageTimerButton/MessageTimerButton.tsx
@@ -74,7 +74,7 @@ const MessageTimerButton: React.FC<MessageTimerButtonProps> = ({
   // Click on ephemeral button
   const onClick = (event: React.MouseEvent<HTMLSpanElement>): void => {
     const entries = setEntries();
-    showContextMenu(event, entries, 'message-timer-menu');
+    showContextMenu({event, entries, identifier: 'message-timer-menu'});
   };
 
   if (!isSelfDeletingMessagesEnabled) {
@@ -85,7 +85,7 @@ const MessageTimerButton: React.FC<MessageTimerButtonProps> = ({
     if (isSpaceOrEnterKey(event.key)) {
       const newEvent = setContextMenuPosition(event);
       const entries = setEntries();
-      showContextMenu(newEvent, entries, 'message-timer-menu');
+      showContextMenu({event: newEvent, entries, identifier: 'message-timer-menu'});
     }
   };
 

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageActions.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageActions.tsx
@@ -102,7 +102,7 @@ const MessageActionsMenu: FC<MessageActionsMenuProps> = ({
           setCurrentMsgAction(selectedMsgActionName);
           handleMenuOpen(true);
           const newEvent = setContextMenuPosition(event);
-          showContextMenu(newEvent, menuEntries, 'message-options-menu');
+          showContextMenu({event: newEvent, entries: menuEntries, identifier: 'message-options-menu'});
         }
       } else if (!event.shiftKey && isTabKey(event) && !reactionsTotalCount) {
         // if there's no reaction then on tab from context menu hide the message actions menu
@@ -127,7 +127,12 @@ const MessageActionsMenu: FC<MessageActionsMenuProps> = ({
       } else if (selectedMsgActionName) {
         setCurrentMsgAction(selectedMsgActionName);
         handleMenuOpen(true);
-        showContextMenu(event, menuEntries, 'message-options-menu', resetActionMenuStates);
+        showContextMenu({
+          event,
+          entries: menuEntries,
+          identifier: 'message-options-menu',
+          resetMenuStates: resetActionMenuStates,
+        });
       }
     },
     [currentMsgActionName, handleMenuOpen, menuEntries],

--- a/src/script/components/calling/CallingCell/CallIngParticipantList/CallingParticipantList.tsx
+++ b/src/script/components/calling/CallingCell/CallIngParticipantList/CallingParticipantList.tsx
@@ -75,7 +75,7 @@ export const CallingParticipantList = ({
     };
 
     const entries: ContextMenuEntry[] = [muteOthers].concat(!participant.user.isMe ? muteParticipant : []);
-    showContextMenu(event, entries, 'participant-moderator-menu');
+    showContextMenu({event, entries, identifier: 'participant-moderator-menu'});
   };
 
   return (

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab.tsx
@@ -17,6 +17,8 @@
  *
  */
 
+import {useMemo} from 'react';
+
 import cx from 'classnames';
 
 import * as Icons from 'Components/Icon';
@@ -58,7 +60,7 @@ export const ConversationFolderTab = ({
   unreadConversations = [],
   dataUieName,
 }: ConversationFolderTabProps) => {
-  const {status: sidebarStatus, setStatus: setSidebarStatus} = useSidebarStore();
+  const {status: sidebarStatus} = useSidebarStore();
   const {openFolder, isFoldersTabOpen, toggleFoldersTab, expandedFolder} = useFolderStore();
   const {conversationLabelRepository} = conversationRepository;
   const isSideBarOpen = sidebarStatus === SidebarStatus.OPEN;
@@ -75,6 +77,18 @@ export const ConversationFolderTab = ({
     .map(label => createLabel(label.name, conversationLabelRepository.getLabelConversations(label), label.id))
     .filter(({conversations, name}) => !!conversations().length && !!name);
 
+  const placeholder = useMemo(
+    () => (
+      <div className="conversations-sidebar-folders--empty">
+        {t('conversationFoldersEmptyText')}
+        <a href={Config.getConfig().URL.SUPPORT.FOLDERS} target="_blank" rel="noreferrer">
+          {t('conversationFoldersEmptyTextLearnMore')}
+        </a>
+      </div>
+    ),
+    [],
+  );
+
   function openFoldersContextMenu(event: React.MouseEvent<HTMLButtonElement>) {
     const entries: ContextMenuEntry[] = folders.map(folder => ({
       click: () => {
@@ -90,7 +104,7 @@ export const ConversationFolderTab = ({
     event.clientX = boundingRect.right + 4;
     event.clientY = boundingRect.top;
 
-    showContextMenu(event, entries, 'navigation-folders-menu');
+    showContextMenu({event, entries, identifier: 'navigation-folders-menu', placeholder});
   }
 
   function handleToggleFoldersTab(event: React.MouseEvent<HTMLButtonElement>) {
@@ -99,14 +113,7 @@ export const ConversationFolderTab = ({
       return;
     }
 
-    if (folders.length === 0) {
-      setSidebarStatus(SidebarStatus.OPEN);
-      return;
-    }
-
-    if (folders.length !== 0) {
-      openFoldersContextMenu(event);
-    }
+    openFoldersContextMenu(event);
   }
 
   function getTotalUnreadConversationMessages(conversations: Conversation[]) {
@@ -132,6 +139,7 @@ export const ConversationFolderTab = ({
         onClick={handleToggleFoldersTab}
         title={title}
         data-uie-name={dataUieName}
+        css={{...(!isSideBarOpen && {padding: '8px 2px 8px 6px'})}}
       >
         <span className="conversations-sidebar-btn--text-wrapper">
           {Icon}
@@ -141,14 +149,7 @@ export const ConversationFolderTab = ({
       </button>
       <div className={cx('conversations-sidebar-folders', {active: isFoldersTabOpen})}>
         <div className="conversations-sidebar-folders--inner-wrapper" data-uie-name="folder-list">
-          {folders.length === 0 && (
-            <div className="conversations-sidebar-folders--empty">
-              {t('conversationFoldersEmptyText')}
-              <a href={Config.getConfig().URL.SUPPORT.FOLDERS} target="_blank" rel="noreferrer">
-                {t('conversationFoldersEmptyTextLearnMore')}
-              </a>
-            </div>
-          )}
+          {folders.length === 0 && placeholder}
           {folders.map(folder => {
             const unreadCount = getTotalUnreadConversationMessages(folder.conversations());
             const isActive = folder.id === expandedFolder;

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/ConversationTabs.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/ConversationTabs.tsx
@@ -33,6 +33,7 @@ import {
   footerDisclaimerTooltip,
   iconStyle,
 } from './ConversationTabs.styles';
+import {FolderIcon} from './FolderIcon';
 
 import {Config} from '../../../../../Config';
 import {Conversation} from '../../../../../entity/Conversation';
@@ -111,7 +112,7 @@ export const ConversationTabs = ({
       type: SidebarTabs.FOLDER,
       title: t('folderViewTooltip'),
       dataUieName: 'go-folders-view',
-      Icon: <Icon.FoldersOutline />,
+      Icon: <FolderIcon />,
       unreadConversations: totalUnreadConversations,
     },
     {

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/FolderIcon.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/FolderIcon.tsx
@@ -1,0 +1,34 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import * as Icon from 'Components/Icon';
+
+import {SidebarStatus, useSidebarStore} from '../useSidebarStore';
+
+export const FolderIcon = () => {
+  const {status} = useSidebarStore();
+  const isSideBarOpen = status === SidebarStatus.OPEN;
+
+  return (
+    <span className="folder-icon">
+      <Icon.FoldersOutline />
+      {!isSideBarOpen && <Icon.ChevronIcon />}
+    </span>
+  );
+};

--- a/src/script/ui/AvailabilityContextMenu.ts
+++ b/src/script/ui/AvailabilityContextMenu.ts
@@ -47,6 +47,6 @@ export const AvailabilityContextMenu = {
       },
     ];
 
-    showContextMenu(event, entries, elementName);
+    showContextMenu({event, entries, identifier: elementName});
   },
 };

--- a/src/script/ui/LabelContextMenu.ts
+++ b/src/script/ui/LabelContextMenu.ts
@@ -53,5 +53,5 @@ export const showLabelContextMenu = (
     : [noLabels];
 
   const entries: ContextMenuEntry[] = [newLabel, separator, ...namedLabels];
-  showContextMenu(event, entries, 'conversation-label-context-menu');
+  showContextMenu({event, entries, identifier: 'conversation-label-context-menu'});
 };

--- a/src/script/view_model/ListViewModel.ts
+++ b/src/script/view_model/ListViewModel.ts
@@ -444,7 +444,7 @@ export class ListViewModel {
       });
     }
 
-    showContextMenu(event, entries, 'conversation-list-options-menu');
+    showContextMenu({event, entries, identifier: 'conversation-list-options-menu'});
   };
 
   readonly clickToArchive = (conversationEntity = this.conversationState.activeConversation()): void => {

--- a/src/style/common/context.less
+++ b/src/style/common/context.less
@@ -97,4 +97,14 @@
   &__icon {
     margin-right: 8px;
   }
+  &__placeholder {
+    position: fixed;
+    width: 8.75rem;
+    padding: 1rem 1.25rem;
+    border-radius: 0.75rem;
+    background-color: var(--modal-bg);
+    box-shadow:
+      0 0 1px 0 fade(#000, 8%),
+      0 8px 24px 0 fade(#000, 16%);
+  }
 }

--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -60,6 +60,18 @@
         height: 16px;
       }
 
+      .conversations-sidebar-btn .folder-icon {
+        display: flex;
+        align-items: center;
+
+        svg:last-child {
+          width: 7px;
+          height: 7px;
+          margin-left: 2px;
+          transform: rotate(-90deg);
+        }
+      }
+
       .folders-open-indicator,
       .external-link-icon {
         display: none;
@@ -142,15 +154,16 @@
   transition: grid-template-rows 0.3s ease-in-out;
 
   &.active {
-    padding: 0.5rem 0;
+    padding-bottom: 0.5rem;
     grid-template-rows: 1fr;
   }
 
   &--empty {
     display: flex;
     flex-direction: column;
-    font-size: 14px;
+    font-size: 0.75rem;
     font-weight: 400;
+    line-height: 0.875rem;
   }
 
   &--inner-wrapper {
@@ -159,7 +172,7 @@
     flex-direction: column;
     align-items: start;
     justify-content: center;
-    padding: 0 0.5rem;
+    padding: 0 0.5rem 0 2rem;
     gap: 4px;
   }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10547" title="WPB-10547" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10547</a>  [Web] New sidebar uncollapses if folders are selected and there are no folders
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Displayed empty folder state when the sidebar is close.
Additionally, fixed the position of empty state content in expanded mode and added chevron to match the design.

https://www.figma.com/design/jnygr7PEOk1yHgjBF18udc/Desktop?node-id=3456-10237&node-type=frame&t=Zk6iwCRzQGtAtfJy-0

## Screenshot/Recordings

https://github.com/user-attachments/assets/78d3e368-9d78-4f94-9899-6384b4e8172d

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ