### PR TITLE
feat: filter remote domain users in conversation creation list [WPB-10792]

### DIFF
--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -440,6 +440,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
               conversationRepository={conversationRepository}
               noUnderline
               allowRemoteSearch
+              filterRemoteTeamUsers={true}
             />
           </FadingScrollbar>
         )}

--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -440,7 +440,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
               conversationRepository={conversationRepository}
               noUnderline
               allowRemoteSearch
-              filterRemoteTeamUsers={true}
+              filterRemoteTeamUsers
             />
           </FadingScrollbar>
         )}

--- a/src/script/components/UserSearchableList.tsx
+++ b/src/script/components/UserSearchableList.tsx
@@ -92,7 +92,8 @@ export const UserSearchableList: React.FC<UserListProps> = ({
 
       // We shouldn't show any members that have the 'external' role and are not already locally known.
       const nonExternalMembers = await teamRepository.filterExternals(uniqueMembers);
-      setRemoteTeamMembers(nonExternalMembers);
+      const nonRemoteDomainMembers = teamRepository.filterRemoteDomainUsers(nonExternalMembers);
+      setRemoteTeamMembers(nonRemoteDomainMembers);
     }, 300),
     [],
   );
@@ -116,13 +117,13 @@ export const UserSearchableList: React.FC<UserListProps> = ({
     }
 
     if (!selfFirst) {
-      setFilteredUsers(results);
+      setFilteredUsers(teamRepository.filterRemoteDomainUsers(results));
       return;
     }
 
     // make sure the self user is the first one in the list
     const [selfUser, otherUsers] = partition(results, user => user.isMe);
-    setFilteredUsers(selfUser.concat(otherUsers));
+    setFilteredUsers(teamRepository.filterRemoteDomainUsers(selfUser.concat(otherUsers)));
   }, [filter, users.length]);
 
   const foundUserEntities = () => {

--- a/src/script/components/UserSearchableList.tsx
+++ b/src/script/components/UserSearchableList.tsx
@@ -94,11 +94,9 @@ export const UserSearchableList: React.FC<UserListProps> = ({
 
       // We shouldn't show any members that have the 'external' role and are not already locally known.
       const nonExternalMembers = await teamRepository.filterExternals(uniqueMembers);
-      if (!filterRemoteTeamUsers) {
-        setRemoteTeamMembers(nonExternalMembers);
-        return;
-      }
-      setRemoteTeamMembers(teamRepository.filterRemoteDomainUsers(nonExternalMembers));
+      setRemoteTeamMembers(
+        filterRemoteTeamUsers ? teamRepository.filterRemoteDomainUsers(nonExternalMembers) : nonExternalMembers,
+      );
     }, 300),
     [],
   );

--- a/src/script/page/RightSidebar/AddParticipants/AddParticipants.tsx
+++ b/src/script/page/RightSidebar/AddParticipants/AddParticipants.tsx
@@ -248,6 +248,7 @@ const AddParticipants: FC<AddParticipantsProps> = ({
               selfUser={selfUser}
               isSelectable
               allowRemoteSearch
+              filterRemoteTeamUsers={true}
             />
           )}
 

--- a/src/script/page/RightSidebar/AddParticipants/AddParticipants.tsx
+++ b/src/script/page/RightSidebar/AddParticipants/AddParticipants.tsx
@@ -248,7 +248,7 @@ const AddParticipants: FC<AddParticipantsProps> = ({
               selfUser={selfUser}
               isSelectable
               allowRemoteSearch
-              filterRemoteTeamUsers={true}
+              filterRemoteTeamUsers
             />
           )}
 

--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -236,6 +236,21 @@ export class TeamRepository extends TypedEventEmitter<Events> {
     await this.updateTeamMembersByIds(selfTeamId, newTeamMemberIds, true);
   };
 
+  filterRemoteDomainUsers(users: User[]): User[] {
+    const isMLS = this.getTeamSupportedProtocols().includes(ConversationProtocol.MLS);
+    if (isMLS) {
+      return users;
+    }
+    const domain = this.userState.self()?.domain ?? this.teamState.teamDomain();
+    return users.filter(user => {
+      if (user.domain !== domain) {
+        this.logger.log(`Filtering out user ${user.id} because of domain mismatch, current protocol is not MLS`);
+        return false;
+      }
+      return true;
+    });
+  }
+
   async filterExternals(users: User[]): Promise<User[]> {
     const teamId = this.teamState.team()?.id;
     if (!teamId) {

--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -237,7 +237,8 @@ export class TeamRepository extends TypedEventEmitter<Events> {
   };
 
   filterRemoteDomainUsers(users: User[]): User[] {
-    const isMLS = this.getTeamSupportedProtocols().includes(ConversationProtocol.MLS);
+    const isMLS = this.teamState.teamFeatures()?.mls?.config.defaultProtocol === ConversationProtocol.MLS;
+
     if (isMLS) {
       return users;
     }


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10792" title="WPB-10792" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10792</a>  [Web] Do not display remote domain users when Proteus is default protocol of the team
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

When the conversation type is not MLS, we should not show federated team users in the conversation creation list.
For Proteus and Mixed, both the Proteus protocol is used, therefore the filter applies to these conversation protocol types.

This PR also takes care of the ticket [WPB-10790](https://wearezeta.atlassian.net/browse/WPB-10790)

[WPB-10790]: https://wearezeta.atlassian.net/browse/WPB-10790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ