### PR TITLE
feat(countly): remove performance plugin

### DIFF
--- a/src/page/auth.ejs
+++ b/src/page/auth.ejs
@@ -22,9 +22,7 @@
     <script src="../min/basicBrowserFeatureCheck.js?v=<%= VERSION %>"></script>
     <script src="../min/checkBrowser.js?v=<%= VERSION %>"></script>
 
-    <script src='../libs/countly/boomerang.min.js?v=<%= VERSION %>' type='text/javascript'></script>
     <script src='../libs/countly/countly.min.js?v=<%= VERSION %>' type='text/javascript'></script>
-    <script src='../min/countlyBoomerangCustom.js?v=<%= VERSION %>' type='text/javascript'></script>
     <script type='text/javascript' nonce="<%= COUNTLY_NONCE %>">
       var Countly = Countly || {};
       Countly.q = Countly.q || [];
@@ -39,7 +37,6 @@
 
       Countly.q.push(['track_sessions']);
       Countly.q.push(['track_pageview']);
-      Countly.q.push(['track_performance']);
       
       Countly.init();
     </script>

--- a/src/page/index.ejs
+++ b/src/page/index.ejs
@@ -22,9 +22,7 @@
     <script src="./min/basicBrowserFeatureCheck.js?v=<%= VERSION %>"></script>
     <script src="./min/checkBrowser.js?v=<%= VERSION %>"></script>
 
-    <script src='./libs/countly/boomerang.min.js?v=<%= VERSION %>' type='text/javascript'></script>
     <script src='./libs/countly/countly.min.js?v=<%= VERSION %>' type='text/javascript'></script>
-    <script src='./min/countlyBoomerangCustom.js?v=<%= VERSION %>' type='text/javascript'></script>
     <script type='text/javascript' nonce="<%= COUNTLY_NONCE %>">
       var Countly = Countly || {};
       Countly.q = Countly.q || [];
@@ -39,7 +37,6 @@
 
       Countly.q.push(['track_sessions']);
       Countly.q.push(['track_pageview']);
-      Countly.q.push(['track_performance']);
 
       Countly.init();
     </script>

--- a/src/script/tracking/EventTrackingRepository.ts
+++ b/src/script/tracking/EventTrackingRepository.ts
@@ -296,8 +296,6 @@ export class EventTrackingRepository {
 
     if (this.isProductReportingActivated === true || getForcedErrorReportingStatus()) {
       window.Countly.q.push(['begin_session']);
-      // enable APM
-      window.Countly.q.push(['track_performance']);
       if (this.sendAppOpenEvent) {
         this.sendAppOpenEvent = false;
         this.trackProductReportingEvent(EventName.APP_OPEN);


### PR DESCRIPTION
## Description

Boomerang causes a lot of stack size limit errors while chaining all of our api calls trough its code. 
This is an issue and we need to remove the code before we find a solution for it. 