### PR TITLE
fix: calling pop out window buttons allignment [WPB-10675]

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@wireapp/avs": "9.9.3",
     "@wireapp/commons": "5.2.10",
     "@wireapp/core": "46.4.0",
-    "@wireapp/react-ui-kit": "9.23.4",
+    "@wireapp/react-ui-kit": "9.23.5",
     "@wireapp/store-engine-dexie": "2.1.12",
     "@wireapp/webapp-events": "0.24.0",
     "amplify": "https://github.com/wireapp/amplify#head=master",

--- a/src/script/components/calling/DetachedCallingCell/DetachedCallingCell.tsx
+++ b/src/script/components/calling/DetachedCallingCell/DetachedCallingCell.tsx
@@ -28,6 +28,7 @@ import {UserState} from 'src/script/user/UserState';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 
 import {CallingContainer} from '../CallingOverlayContainer';
+import {WindowContextProvider} from '../useWindow';
 
 interface DetachedCallingCellProps {
   callingRepository: CallingRepository;
@@ -44,7 +45,11 @@ export const DetachedCallingCell = ({
   callState = container.resolve(CallState),
   userState = container.resolve(UserState),
 }: DetachedCallingCellProps) => {
-  const {joinedCall: activeCall, viewMode} = useKoSubscribableChildren(callState, ['joinedCall', 'viewMode']);
+  const {
+    joinedCall: activeCall,
+    viewMode,
+    detachedWindow,
+  } = useKoSubscribableChildren(callState, ['joinedCall', 'viewMode', 'detachedWindow']);
   const {self: selfUser} = useKoSubscribableChildren(userState, ['self']);
 
   const isDetachedWindow = viewMode === CallingViewMode.DETACHED_WINDOW;
@@ -55,11 +60,13 @@ export const DetachedCallingCell = ({
 
   return (
     <DetachedWindow callState={callState}>
-      <CallingContainer
-        callingRepository={callingRepository}
-        mediaRepository={mediaRepository}
-        toggleScreenshare={toggleScreenshare}
-      />
+      <WindowContextProvider value={detachedWindow || window}>
+        <CallingContainer
+          callingRepository={callingRepository}
+          mediaRepository={mediaRepository}
+          toggleScreenshare={toggleScreenshare}
+        />
+      </WindowContextProvider>
     </DetachedWindow>
   );
 };

--- a/src/script/components/calling/useWindow.ts
+++ b/src/script/components/calling/useWindow.ts
@@ -17,12 +17,13 @@
  *
  */
 
-import {useMatchMedia} from '@wireapp/react-ui-kit';
+import React, {useContext} from 'react';
 
-import {useWindow} from 'Components/calling/useWindow';
+const WindowContext = React.createContext<Window>(window);
 
-export const useActiveWindowMatchMedia = (mediaQuery: string) => {
-  const activeWindow = useWindow();
+export const WindowContextProvider = WindowContext.Provider;
 
-  return useMatchMedia(mediaQuery, activeWindow);
+export const useWindow = () => {
+  const currentWindow = useContext(WindowContext);
+  return currentWindow;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6047,9 +6047,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/react-ui-kit@npm:9.23.4":
-  version: 9.23.4
-  resolution: "@wireapp/react-ui-kit@npm:9.23.4"
+"@wireapp/react-ui-kit@npm:9.23.5":
+  version: 9.23.5
+  resolution: "@wireapp/react-ui-kit@npm:9.23.5"
   dependencies:
     "@types/color": "npm:3.0.6"
     color: "npm:4.2.3"
@@ -6064,7 +6064,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/4d196d887e165810ae010dc213713b0b41a5d2f38e2a2eef01398c2099e9b14154615e66c872b17b6e3960c71cab8c205fa646b1fc137b61e97aaaef99968dfe
+  checksum: 10/d5ca64c81371eb9623959e25b6c9ff84863b26a378f8f9af317f5a2607f4ee7327042966f08c98c9b4f3deadb848de728b8f7ede3c05f15f5e2972cdf21ba70e
   languageName: node
   linkType: hard
 
@@ -18498,7 +18498,7 @@ __metadata:
     "@wireapp/core": "npm:46.4.0"
     "@wireapp/eslint-config": "npm:3.0.7"
     "@wireapp/prettier-config": "npm:0.6.4"
-    "@wireapp/react-ui-kit": "npm:9.23.4"
+    "@wireapp/react-ui-kit": "npm:9.23.5"
     "@wireapp/store-engine": "npm:5.1.8"
     "@wireapp/store-engine-dexie": "npm:2.1.12"
     "@wireapp/webapp-events": "npm:0.24.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -534,20 +534,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-transforms@npm:^7.25.7":
-  version: 7.25.7
-  resolution: "@babel/helper-module-transforms@npm:7.25.7"
-  dependencies:
-    "@babel/helper-module-imports": "npm:^7.25.7"
-    "@babel/helper-simple-access": "npm:^7.25.7"
-    "@babel/helper-validator-identifier": "npm:^7.25.7"
-    "@babel/traverse": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: 10/480309b1272ceaa985de1393f0e4c41aede0d5921ca644cec5aeaf43c8e4192b6dd56a58ef6d7e9acd02a43184ab45d3b241fc8c3a0a00f9dbb30235fd8a1181
-  languageName: node
-  linkType: hard
-
 "@babel/helper-optimise-call-expression@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-optimise-call-expression@npm:7.24.7"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10675" title="WPB-10675" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10675</a>  [Web] Call popup layout is broken sometimes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
We have `CallingContainer` component used by 2 windows (main window and detached window). To get the parent window object we were using `useActiveWindow` which is incorrect because `useActiveWindow` returns the window in focus (not parent window). I introduced store to keep the window object and use it in `useActiveWindowMatchMedia` to check `matchMedia`.

<img width="633" alt="Screenshot 2024-10-07 at 17 54 34" src="https://github.com/user-attachments/assets/fca2370f-5ac4-4d0c-a5f1-940d3a7e4a7d">


## Screenshots/Screencast (for UI changes)
Issue:

https://github.com/user-attachments/assets/79b6de42-96cc-4d4f-a0af-b1b5fce74dd2

Fixed:

https://github.com/user-attachments/assets/f13e2d7c-1107-450b-9057-d0d55aec7a6f

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ