### PR TITLE
fix(ConversationDetails): the block user button text [WPB-11005]

### DIFF
--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
@@ -263,6 +263,8 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
       }
     }, [firstParticipant]);
 
+    const {isBlocked: isParticipantBlocked} = useKoSubscribableChildren(firstParticipant!, ['isBlocked']);
+
     const conversationActions = getConversationActions(
       activeConversation,
       actionsViewModel,
@@ -270,6 +272,7 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
       teamRole,
       isServiceMode,
       isTeam,
+      isParticipantBlocked,
     );
 
     useEffect(() => {

--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
@@ -265,15 +265,15 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
 
     const {isBlocked: isParticipantBlocked} = useKoSubscribableChildren(firstParticipant!, ['isBlocked']);
 
-    const conversationActions = getConversationActions(
-      activeConversation,
+    const conversationActions = getConversationActions({
+      conversationEntity: activeConversation,
       actionsViewModel,
       conversationRepository,
       teamRole,
       isServiceMode,
       isTeam,
       isParticipantBlocked,
-    );
+    });
 
     useEffect(() => {
       conversationRepository.refreshUnavailableParticipants(activeConversation);

--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
@@ -224,7 +224,7 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
 
     const toggleMute = () => actionsViewModel.toggleMuteConversation(activeConversation);
 
-    const openParticipantDevices = () => togglePanel(PanelState.PARTICIPANT_DEVICES, firstParticipant, false, 'left');
+    const openParticipantDevices = () => togglePanel(PanelState.PARTICIPANT_DEVICES, firstParticipant!, false, 'left');
 
     const updateConversationName = (conversationName: string) =>
       conversationRepository.renameConversation(activeConversation, conversationName);
@@ -250,7 +250,7 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
 
     const isSingleUserMode = is1to1 || isRequest;
 
-    const isServiceMode = isSingleUserMode && firstParticipant.isService;
+    const isServiceMode = isSingleUserMode && firstParticipant!.isService;
 
     const getService = useCallback(async () => {
       if (firstParticipant) {
@@ -281,7 +281,7 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
 
     useEffect(() => {
       if (team.id && isSingleUserMode) {
-        teamRepository.updateTeamMembersByIds(team.id, [firstParticipant.id], true);
+        teamRepository.updateTeamMembersByIds(team.id, [firstParticipant!.id], true);
       }
     }, [firstParticipant, isSingleUserMode, team, teamRepository]);
 

--- a/src/script/page/RightSidebar/ConversationDetails/utils/getConversationActions.ts
+++ b/src/script/page/RightSidebar/ConversationDetails/utils/getConversationActions.ts
@@ -30,15 +30,25 @@ import {Conversation} from '../../../../entity/Conversation';
 import * as UserPermission from '../../../../user/UserPermission';
 import {ActionsViewModel} from '../../../../view_model/ActionsViewModel';
 
-const getConversationActions = (
-  conversationEntity: Conversation,
-  actionsViewModel: ActionsViewModel,
-  conversationRepository: ConversationRepository,
-  teamRole: UserPermission.ROLE,
-  isServiceMode: boolean = false,
-  isTeam: boolean = false,
-  isParticipantBlocked: boolean = false,
-): MenuItem[] => {
+interface GetConversationActionsParams {
+  conversationEntity: Conversation;
+  actionsViewModel: ActionsViewModel;
+  conversationRepository: ConversationRepository;
+  teamRole: UserPermission.ROLE;
+  isServiceMode?: boolean;
+  isTeam?: boolean;
+  isParticipantBlocked?: boolean;
+}
+
+const getConversationActions = ({
+  conversationEntity,
+  actionsViewModel,
+  conversationRepository,
+  teamRole,
+  isServiceMode = false,
+  isTeam = false,
+  isParticipantBlocked = false,
+}: GetConversationActionsParams): MenuItem[] => {
   if (!conversationEntity) {
     return [];
   }
@@ -83,7 +93,12 @@ const getConversationActions = (
     {
       condition: conversationEntity.isRequest(),
       item: {
-        click: async () => actionsViewModel.cancelConnectionRequest(userEntity, true, getNextConversation()),
+        click: async () => {
+          if (!userEntity) {
+            return;
+          }
+          void actionsViewModel.cancelConnectionRequest(userEntity, true, getNextConversation());
+        },
         Icon: Icon.CloseIcon,
         identifier: 'do-cancel-request',
         label: t('conversationDetailsActionCancelRequest'),
@@ -99,9 +114,14 @@ const getConversationActions = (
       },
     },
     {
-      condition: isSingleUser && (userEntity?.isConnected() || userEntity?.isRequest()) && !isParticipantBlocked,
+      condition: isSingleUser && Boolean(userEntity?.isConnected() || userEntity?.isRequest()),
       item: {
-        click: () => actionsViewModel.blockUser(userEntity),
+        click: () => {
+          if (!userEntity) {
+            return;
+          }
+          void actionsViewModel.blockUser(userEntity);
+        },
         Icon: Icon.BlockIcon,
         identifier: 'do-block',
         label: t('conversationDetailsActionBlock'),
@@ -110,7 +130,12 @@ const getConversationActions = (
     {
       condition: isSingleUser && isParticipantBlocked,
       item: {
-        click: () => actionsViewModel.unblockUser(userEntity),
+        click: () => {
+          if (!userEntity) {
+            return;
+          }
+          void actionsViewModel.unblockUser(userEntity);
+        },
         Icon: Icon.BlockIcon,
         identifier: 'do-unblock',
         label: t('conversationDetailsActionUnblock'),

--- a/src/script/page/RightSidebar/ConversationDetails/utils/getConversationActions.ts
+++ b/src/script/page/RightSidebar/ConversationDetails/utils/getConversationActions.ts
@@ -37,6 +37,7 @@ const getConversationActions = (
   teamRole: UserPermission.ROLE,
   isServiceMode: boolean = false,
   isTeam: boolean = false,
+  isParticipantBlocked: boolean = false,
 ): MenuItem[] => {
   if (!conversationEntity) {
     return [];
@@ -98,7 +99,7 @@ const getConversationActions = (
       },
     },
     {
-      condition: isSingleUser && (userEntity?.isConnected() || userEntity?.isRequest()),
+      condition: isSingleUser && (userEntity?.isConnected() || userEntity?.isRequest()) && !isParticipantBlocked,
       item: {
         click: () => actionsViewModel.blockUser(userEntity),
         Icon: Icon.BlockIcon,
@@ -107,7 +108,7 @@ const getConversationActions = (
       },
     },
     {
-      condition: isSingleUser && userEntity?.isBlocked(),
+      condition: isSingleUser && isParticipantBlocked,
       item: {
         click: () => actionsViewModel.unblockUser(userEntity),
         Icon: Icon.BlockIcon,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11005" title="WPB-11005" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11005</a>  [Web] block button state not updated when a user is blocked
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

- fixes the block button stale text, the ui didn't update dynamically after pressing the button

- refactores minor typescript/eslint errors/warnings
  - e.g. `firstParticipant` was `User | null` type, and it was passed to a function that requires `User` type only, I've marked it with typescript `!` operator (when it wasn't possible to use an if statement)

## Screenshots/Screencast (for UI changes)

Before:

https://github.com/user-attachments/assets/74cc9ced-82d2-4540-a245-3f420618aef9

After:

https://github.com/user-attachments/assets/5ac42b2e-c2c1-47ad-90f6-06d197d555b6

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ