### PR TITLE
feat: Move app notification to top of the content

### DIFF
--- a/src/script/components/AppNotification/AppNotification.styles.ts
+++ b/src/script/components/AppNotification/AppNotification.styles.ts
@@ -33,7 +33,7 @@ export const wrapper: CSSObject = {
   left: '50%',
   translate: '-50% 0',
   transition: 'top 0.3s, opacity 0.3s',
-  zIndex: '99',
+  zIndex: '99999',
 
   'body.theme-dark &': {
     backgroundColor: 'var(--gray-80)',

--- a/src/script/util/DebugUtil.ts
+++ b/src/script/util/DebugUtil.ts
@@ -37,6 +37,7 @@ import keyboardjs from 'keyboardjs';
 import {$createTextNode, $getRoot, LexicalEditor} from 'lexical';
 import {container} from 'tsyringe';
 
+import {showAppNotification} from 'Components/AppNotification';
 import {getLogger, Logger} from 'Util/Logger';
 
 import {KEY} from './KeyboardUtil';
@@ -580,5 +581,9 @@ export class DebugUtil {
   // Used by QA test automation, allows to disable or enable the forced error reporting
   disableForcedErrorReporting() {
     return disableForcedErrorReporting();
+  }
+
+  renderAppNotification(message?: string) {
+    showAppNotification(message ?? 'Test notification');
   }
 }

--- a/src/script/util/DebugUtil.ts
+++ b/src/script/util/DebugUtil.ts
@@ -584,6 +584,6 @@ export class DebugUtil {
   }
 
   renderAppNotification(message?: string) {
-    showAppNotification(message ?? 'Test notification');
+    showAppNotification(message || 'Test notification');
   }
 }


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-10379

## Description

- Updated z-index of app notification.
- Added showAppNotification method to DebugUtil.

Before:
App notification was displayed under the "services available".

Now:
App notification is displaying on the top of the content.

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ