### PR TITLE
fix(CallingHeader): popout button styles [WPB-9780]

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -1539,7 +1539,7 @@
   "videoCallOverlayHideParticipantsList": "Hide participants list",
   "videoCallOverlayMicrophone": "Microphone",
   "videoCallOverlayOpenFullScreen": "Open the call in full screen",
-  "videoCallOverlayOpenPopupWindow": "Open in new window",
+  "videoCallOverlayOpenPopupWindow": "Open in a new window",
   "videoCallOverlayParticipantsListLabel": "Participants ({{count}})",
   "videoCallOverlayShareScreen": "Share Screen",
   "videoCallOverlayShowParticipantsList": "Show participants list",

--- a/src/script/components/calling/CallingCell/CallingHeader/CallingHeader.tsx
+++ b/src/script/components/calling/CallingCell/CallingHeader/CallingHeader.tsx
@@ -19,6 +19,8 @@
 
 import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 
+import {IconButton, IconButtonVariant} from '@wireapp/react-ui-kit';
+
 import {Avatar, AVATAR_SIZE, GroupAvatar} from 'Components/Avatar';
 import {Duration} from 'Components/calling/Duration';
 import * as Icon from 'Components/Icon';
@@ -148,9 +150,14 @@ export const CallingHeader = ({
 
       {isDetachedCallingFeatureEnabled() && isOngoing && (
         <div>
-          <button css={detachedWindowButton} onClick={toggleDetachedWindow}>
+          <IconButton
+            variant={IconButtonVariant.SECONDARY}
+            title={t('videoCallOverlayOpenPopupWindow')}
+            css={detachedWindowButton}
+            onClick={toggleDetachedWindow}
+          >
             {isDetachedWindow ? <Icon.CloseDetachedWindowIcon /> : <Icon.OpenDetachedWindowIcon />}
-          </button>
+          </IconButton>
         </div>
       )}
     </div>


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9780" title="WPB-9780" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9780</a>  [Web] Calling pop out window (same as maximized calling view) v1
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

There's a problem with the open popout button, the button doesn't have appropriate styles for states like focus, hove, etc. This change fixes it by replacing the button with the `IconButton` component.

## Screenshots/Screencast (for UI changes)

Before:

https://github.com/user-attachments/assets/a8540a88-d317-4bb9-a331-6e11f661fe61


After:

https://github.com/user-attachments/assets/9e2eb751-e2f0-436a-9d89-474d3530fb78


## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ