### PR TITLE
fix: Add missing imports in callstate

### DIFF
--- a/src/script/calling/CallState.ts
+++ b/src/script/calling/CallState.ts
@@ -18,10 +18,12 @@
  */
 
 import {QualifiedId} from '@wireapp/api-client/lib/user';
+import {amplify} from 'amplify';
 import ko from 'knockout';
 import {singleton} from 'tsyringe';
 
 import {REASON as CALL_REASON, STATE as CALL_STATE} from '@wireapp/avs';
+import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {matchQualifiedIds} from 'Util/QualifiedId';
 


### PR DESCRIPTION
some imports were missed in https://github.com/wireapp/wire-webapp/commit/3a6630b8f8224ba60e15115454d92810c8680a0c#diff-fe34e87445607172d8a5ec309f990baf1ca9ed996a3741061d2e258aeabbb9c3L80