### PR TITLE
feat(AvatarImage): strips profile picture exif data [WPB-11172]

### DIFF
--- a/src/script/assets/AssetRepository.ts
+++ b/src/script/assets/AssetRepository.ts
@@ -37,6 +37,7 @@ import {FileAsset} from '../entity/message/FileAsset';
 import type {User} from '../entity/User';
 import {Core} from '../service/CoreSingleton';
 import {TeamState} from '../team/TeamState';
+import {stripImageExifData} from '../util/ImageUtil';
 
 interface CompressedImage {
   compressedBytes: Uint8Array;
@@ -160,9 +161,11 @@ export class AssetRepository {
     mediumImageKey: {domain?: string; key: string};
     previewImageKey: {domain?: string; key: string};
   }> {
+    const strippedImage = await stripImageExifData(image);
+
     const [{compressedBytes: previewImage}, {compressedBytes: mediumImage}] = await Promise.all([
-      this.compressImage(image),
-      this.compressImage(image, true),
+      this.compressImage(strippedImage),
+      this.compressImage(strippedImage, true),
     ]);
 
     const options: AssetUploadOptions = {

--- a/src/script/util/ImageUtil.test.ts
+++ b/src/script/util/ImageUtil.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {imageHasExifData, stripImageExifData} from './ImageUtil';
+
+const jpegWithExif = new Blob([new Uint8Array([0xff, 0xd8, 0xff, 0xe1, 0x00, 0x10, 0x45, 0x78, 0x69, 0x66])], {
+  type: 'image/jpeg',
+});
+
+const jpegWithoutExif = new Blob([new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x04, 0x4a, 0x46])], {
+  type: 'image/jpeg',
+});
+
+const nonJpeg = new Blob([new Uint8Array([0x00, 0x00, 0x00, 0x00])], {type: 'application/octet-stream'});
+
+URL.createObjectURL = jest.fn(() => 'mocked-url');
+URL.revokeObjectURL = jest.fn();
+
+describe('ImageUtil', () => {
+  let mockCanvas: HTMLCanvasElement;
+  let mockContext: CanvasRenderingContext2D;
+
+  beforeEach(() => {
+    global.Image = jest.fn(() => ({
+      onload: jest.fn(),
+      onerror: jest.fn(),
+      set src(value: string) {
+        if (value === 'mocked-url') {
+          setTimeout(() => this.onload(new Event('load')), 10);
+        }
+      },
+    })) as jest.Mock;
+
+    mockContext = {
+      drawImage: jest.fn(),
+    } as unknown as CanvasRenderingContext2D;
+
+    mockCanvas = {
+      width: 0,
+      height: 0,
+      getContext: jest.fn(() => mockContext),
+      toBlob: jest.fn((callback: (blob: Blob | null) => void) => {
+        callback(new Blob(['mocked-data'], {type: 'image/png'}));
+      }),
+    } as unknown as HTMLCanvasElement;
+
+    jest.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      if (tagName === 'canvas') {
+        return mockCanvas;
+      }
+      return null as unknown as HTMLElement;
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('imageHasExifData', () => {
+    it('returns true for JPEG with EXIF data', async () => {
+      const result = await imageHasExifData(jpegWithExif);
+      expect(result).toBe(true);
+    });
+
+    it('returns false for JPEG without EXIF data', async () => {
+      const result = await imageHasExifData(jpegWithoutExif);
+      expect(result).toBe(false);
+    });
+
+    it('returns false for non-JPEG files', async () => {
+      const result = await imageHasExifData(nonJpeg);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('stripImageExifData', () => {
+    it('successfully strips EXIF data and returns a new Blob', async () => {
+      const hasExifBefore = await imageHasExifData(jpegWithExif);
+      expect(hasExifBefore).toBe(true);
+
+      const result = await stripImageExifData(jpegWithExif);
+
+      const hasExifAfter = await imageHasExifData(result);
+      expect(hasExifAfter).toBe(false);
+    });
+
+    it('throws an error if the image fails to load', async () => {
+      global.Image = jest.fn(() => ({
+        onload: jest.fn(),
+        onerror: jest.fn(),
+        set src(value: string) {
+          if (value === 'mocked-url') {
+            setTimeout(() => this.onerror?.(new ErrorEvent('error')), 10);
+          }
+        },
+      })) as jest.Mock;
+
+      const inputBlob = new Blob(['dummy-image'], {type: 'image/png'});
+
+      await expect(stripImageExifData(inputBlob)).rejects.toThrow('Failed to load image');
+    });
+  });
+});

--- a/src/script/util/ImageUtil.ts
+++ b/src/script/util/ImageUtil.ts
@@ -1,0 +1,159 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export const stripImageExifData = async (image: Blob): Promise<Blob> => {
+  const url = URL.createObjectURL(image);
+  try {
+    const img = await createImageElement(url);
+    const canvas = drawImageOnCanvas(img);
+    const strippedBlob = await canvasToBlob(canvas, image.type);
+    return strippedBlob;
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(`Failed to strip EXIF data: ${error.message}`);
+    }
+    throw error;
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+};
+
+const createImageElement = (url: string): Promise<HTMLImageElement> => {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error(`Failed to load image from ${url}`));
+    img.src = url;
+  });
+};
+
+const drawImageOnCanvas = (img: HTMLImageElement): HTMLCanvasElement => {
+  const canvas = document.createElement('canvas');
+  canvas.width = img.width;
+  canvas.height = img.height;
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('Failed to get 2D context from canvas');
+  }
+
+  ctx.drawImage(img, 0, 0);
+  return canvas;
+};
+
+const canvasToBlob = (canvas: HTMLCanvasElement, type: string): Promise<Blob> => {
+  const validType = type || 'image/png';
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(blob => {
+      if (blob) {
+        resolve(blob);
+      } else {
+        reject(new Error('Failed to convert canvas to Blob'));
+      }
+    }, validType);
+  });
+};
+
+const EXIF_MARKER = 0xffe1;
+const EXIF_HEADER = 0x45786966; // "Exif" in ASCII
+const VALID_MARKER_MASK = 0xff00;
+const MIN_SEGMENT_LENGTH = 8;
+const INITIAL_OFFSET = 2;
+const EXIF_HEADER_OFFSET = 4;
+const MARKER_LENGTH = 2;
+const HEADER_LENGTH = 4;
+
+export const imageHasExifData = async (image: Blob): Promise<boolean> => {
+  try {
+    const arrayBuffer = await readFileAsArrayBuffer(image);
+    const view = new DataView(arrayBuffer);
+
+    if (!isJPEG(view)) {
+      return false;
+    }
+
+    return containsExifData(view);
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(`Failed to check for EXIF data: ${error.message}`);
+    }
+    throw error;
+  }
+};
+
+const readFileAsArrayBuffer = (blob: Blob): Promise<ArrayBuffer> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as ArrayBuffer);
+    reader.onerror = () => reject(new Error(`FileReader error`));
+    reader.readAsArrayBuffer(blob);
+  });
+};
+
+const isJPEG = (view: DataView): boolean => {
+  return view.getUint16(0, false) === 0xffd8;
+};
+
+const containsExifData = (view: DataView): boolean => {
+  let offset = INITIAL_OFFSET;
+
+  while (offset < view.byteLength) {
+    if (offset + MARKER_LENGTH > view.byteLength) {
+      break;
+    }
+
+    const marker = view.getUint16(offset, false);
+
+    if (marker === EXIF_MARKER) {
+      if (offset + EXIF_HEADER_OFFSET + HEADER_LENGTH > view.byteLength) {
+        break;
+      }
+      return isExifHeader(view, offset + EXIF_HEADER_OFFSET);
+    }
+
+    if (!isValidMarker(marker) || isInvalidSegmentLength(view, offset)) {
+      break;
+    }
+
+    const nextOffset = getNextOffset(view, offset);
+    if (offset + nextOffset > view.byteLength) {
+      break;
+    }
+
+    offset += nextOffset;
+  }
+
+  return false;
+};
+
+const isExifHeader = (view: DataView, offset: number): boolean => {
+  return view.getUint32(offset, false) === EXIF_HEADER;
+};
+
+const isValidMarker = (marker: number): boolean => {
+  return (marker & VALID_MARKER_MASK) === VALID_MARKER_MASK;
+};
+
+const isInvalidSegmentLength = (view: DataView, offset: number): boolean => {
+  return view.getUint16(offset + INITIAL_OFFSET, false) <= MIN_SEGMENT_LENGTH;
+};
+
+const getNextOffset = (view: DataView, offset: number): number => {
+  return INITIAL_OFFSET + view.getUint16(offset, false);
+};


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11172" title="WPB-11172" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11172</a>  [Web] Strip Exif data from profile pictures before upload
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

Introduce stripping images EXIF data in the `stripImageExifData` utility function. To properly check its behavior I had to create a util `imageHasExifData`, which also got its tests. Now it's used only for testing purposes, but nothing prevents it from being used in normal code.

## Manual testing

The app view (checking with `imageHasExifData`):

https://github.com/user-attachments/assets/a2c0c5c2-032d-4a78-9b38-fccb161ad3e2

---

I've downloaded an image with a large metadata (EXIF) set. Here's how it looks in the EXIF metadata viewer:


https://github.com/user-attachments/assets/04697f02-8f89-45ad-8df4-c1be069e1cab

And here is after stripping data (taken directly from the profile picture):

https://github.com/user-attachments/assets/0844296c-5c91-4108-a7ac-b86524ad1c32

---

It works also with geolocation data. Before stripping:

https://github.com/user-attachments/assets/ca8f75ad-ee10-4556-9a94-de8932521ec0

After:

https://github.com/user-attachments/assets/a2e09b48-e332-40b8-b360-a045208462f2

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ