### PR TITLE
fix(countly): initialize countly inside the app again

### DIFF
--- a/server/Server.ts
+++ b/server/Server.ts
@@ -214,7 +214,6 @@ class Server {
       OPEN_GRAPH: this.config.OPEN_GRAPH,
       VERSION: this.config.VERSION,
       COUNTLY_API_KEY: this.config.COUNTLY_API_KEY,
-      COUNTLY_ENABLE_LOGGING: this.config.COUNTLY_ENABLE_LOGGING,
       COUNTLY_NONCE: this.config.COUNTLY_NONCE,
     };
   }

--- a/server/config/server.config.ts
+++ b/server/config/server.config.ts
@@ -126,7 +126,6 @@ export function generateConfig(params: ConfigGeneratorParams, env: Env) {
       DISALLOW: readFile(ROBOTS_DISALLOW_FILE, 'User-agent: *\r\nDisallow: /'),
     },
     COUNTLY_API_KEY: env.COUNTLY_API_KEY || '',
-    COUNTLY_ENABLE_LOGGING: env.COUNTLY_ENABLE_LOGGING == 'true',
     COUNTLY_NONCE: COUNTLY_NONCE.value,
     SSL_CERTIFICATE_KEY_PATH:
       env.SSL_CERTIFICATE_KEY_PATH || path.join(__dirname, '../certificate/development-key.pem'),

--- a/src/page/auth.ejs
+++ b/src/page/auth.ejs
@@ -32,13 +32,10 @@
       Countly.offline_mode = true;
       Countly.use_session_cookie = false;
       Countly.storage = 'localstorage';
-      Countly.debug = "<%= COUNTLY_ENABLE_LOGGING %>" === "true";
       Countly.require_consent = true;
 
       Countly.q.push(['track_sessions']);
       Countly.q.push(['track_pageview']);
-      
-      Countly.init();
     </script>
   </head>
 

--- a/src/page/index.ejs
+++ b/src/page/index.ejs
@@ -32,13 +32,10 @@
       Countly.offline_mode = true;
       Countly.use_session_cookie = false;
       Countly.storage = 'localstorage';
-      Countly.debug = "<%= COUNTLY_ENABLE_LOGGING %>" === "true";
       Countly.require_consent = true;
 
       Countly.q.push(['track_sessions']);
       Countly.q.push(['track_pageview']);
-
-      Countly.init();
     </script>
   </head>
 

--- a/src/script/tracking/EventTrackingRepository.ts
+++ b/src/script/tracking/EventTrackingRepository.ts
@@ -75,6 +75,7 @@ export class EventTrackingRepository {
   private countlyDeviceId: string;
   private readonly logger: Logger;
   private readonly countlyLogger: Logger;
+  private countlyInitialized: boolean;
   isErrorReportingActivated: boolean;
 
   static get CONFIG() {
@@ -97,6 +98,7 @@ export class EventTrackingRepository {
   ) {
     this.logger = getLogger('EventTrackingRepository');
     this.countlyLogger = getLogger('Countly');
+    this.countlyInitialized = false;
 
     this.isErrorReportingActivated = false;
     this.isProductReportingActivated = false;
@@ -253,8 +255,19 @@ export class EventTrackingRepository {
 
     const {COUNTLY_ENABLE_LOGGING, VERSION} = Config.getConfig();
 
-    window.Countly.app_version = VERSION;
-    window.Countly.debug = COUNTLY_ENABLE_LOGGING;
+    // Initialize Countly if it is not initialized yet
+    if (!this.countlyInitialized) {
+      window.Countly.app_version = VERSION;
+      window.Countly.debug = COUNTLY_ENABLE_LOGGING;
+      window.Countly.init();
+      this.countlyInitialized = true;
+      this.countlyLogger.info(
+        'Countly has been initialized with version',
+        VERSION,
+        'and logging',
+        COUNTLY_ENABLE_LOGGING,
+      );
+    }
 
     const device_id = trackingId || this.countlyDeviceId;
     window.Countly.q.push(['change_id', device_id]);


### PR DESCRIPTION
## Description

We dont need to rely on the server anymore to initialize countly. Since the performance plugin is gone.
We initialize countly now from inside the app again, which makes environment variable changes more reliable and removes code that is not needed.