### PR TITLE
feat: Allow selecting mics and speakers configured in the OS  [WPB-11571,WPB-11329]

### DIFF
--- a/src/script/media/MediaDevicesHandler.test.ts
+++ b/src/script/media/MediaDevicesHandler.test.ts
@@ -35,6 +35,10 @@ describe('MediaDevicesHandler', () => {
    * - 2 cameras
    * - 3 microphones
    * - 4 speakers
+   *
+   * However the devices which look like duplicates in fact refer to different
+   * settings a user can make in the operation system, so we shouldn't filter
+   * them.
    */
   const realWorldTestSetup = {
     microphones: [
@@ -150,7 +154,7 @@ describe('MediaDevicesHandler', () => {
     enumerateDevicesSpy = spyOn(window.navigator.mediaDevices, 'enumerateDevices');
   });
   describe('refreshMediaDevices', () => {
-    it('filters duplicate microphones and keeps the ones marked with "communications"', done => {
+    it('does not filter duplicate microphones', done => {
       enumerateDevicesSpy.and.returnValue(
         Promise.resolve([
           {
@@ -178,12 +182,12 @@ describe('MediaDevicesHandler', () => {
       devicesHandler.initializeMediaDevices(true);
 
       setTimeout(() => {
-        expect(devicesHandler.availableDevices.audioinput().length).toEqual(1);
+        expect(devicesHandler.availableDevices.audioinput().length).toEqual(3);
         done();
       });
     });
 
-    it('filters duplicate speakers', done => {
+    it('does not filter duplicate speakers', done => {
       enumerateDevicesSpy.and.returnValue(
         Promise.resolve([
           ...realWorldTestSetup.cameras,
@@ -201,8 +205,8 @@ describe('MediaDevicesHandler', () => {
 
       setTimeout(() => {
         expect(devicesHandler.availableDevices.videoinput().length).toEqual(2);
-        expect(devicesHandler.availableDevices.audioinput().length).toEqual(3);
-        expect(devicesHandler.availableDevices.audiooutput().length).toEqual(4);
+        expect(devicesHandler.availableDevices.audioinput().length).toEqual(5);
+        expect(devicesHandler.availableDevices.audiooutput().length).toEqual(7);
         done();
       });
     });

--- a/src/script/media/MediaDevicesHandler.ts
+++ b/src/script/media/MediaDevicesHandler.ts
@@ -234,30 +234,12 @@ export class MediaDevicesHandler {
       device => device.kind === MediaDeviceType.VIDEO_INPUT,
     );
 
-    /*
-     * On Windows the same device can be listed multiple times with different group ids ("default", "communications", etc.).
-     * In such a scenario, the device listed as "communications" device is preferred for conferencing calls, so we filter its duplicates.
-     */
     const microphones = mediaDevices.filter(device => device.kind === MediaDeviceType.AUDIO_INPUT);
-    const dedupedMicrophones = microphones.reduce<Record<string, MediaDeviceInfo>>((microphoneList, microphone) => {
-      if (!microphoneList.hasOwnProperty(microphone.deviceId) || microphone.deviceId === 'communications') {
-        microphoneList[microphone.groupId] = microphone;
-      }
-      return microphoneList;
-    }, {});
-
     const speakers = mediaDevices.filter(device => device.kind === MediaDeviceType.AUDIO_OUTPUT);
-    const dedupedSpeakers = speakers.reduce<Record<string, MediaDeviceInfo>>((speakerList, speaker) => {
-      if (!speakerList.hasOwnProperty(speaker.deviceId) || speaker.deviceId === 'communications') {
-        speakerList[speaker.groupId] = speaker;
-      }
-      return speakerList;
-    }, {});
-
     return {
       cameras: videoInputDevices,
-      microphones: Object.values(dedupedMicrophones),
-      speakers: Object.values(dedupedSpeakers),
+      microphones: microphones,
+      speakers: speakers,
     };
   }
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11571" title="WPB-11571" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11571</a>  [Web] Display same Device multiple times in Linux FF
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


https://wearezeta.atlassian.net/browse/WPB-11329

## Description

In addition this will also fix the problem where in Firefox on Linux "Monitor of \<device-name\>" is shown instead of the microphone. 

## Checklist

- [x] mentions the JIRA issue in the PR name
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

## Important Details for the Reviewers

- please look at listed mics and speakers on all supported browsers in Windows, Linux and MacOS
