### PR TITLE
fix: Do not use detached window for camera source

### DIFF
--- a/src/script/media/MediaStreamHandler.ts
+++ b/src/script/media/MediaStreamHandler.ts
@@ -166,7 +166,8 @@ export class MediaStreamHandler {
 
     const detachedWindow = callState.detachedWindow();
     const isInDetachedMode = callState.viewMode() === CallingViewMode.DETACHED_WINDOW;
-    const useDetachedWindowForScreenSharingSource = isInDetachedMode && detachedWindow !== null;
+    const useDetachedWindowForScreenSharingSource =
+      screen === true && video === false && isInDetachedMode && detachedWindow !== null;
 
     if (useDetachedWindowForScreenSharingSource) {
       callState.isScreenSharingSourceFromDetachedWindow(true);

--- a/src/script/media/MediaStreamHandler.ts
+++ b/src/script/media/MediaStreamHandler.ts
@@ -167,7 +167,7 @@ export class MediaStreamHandler {
     const detachedWindow = callState.detachedWindow();
     const isInDetachedMode = callState.viewMode() === CallingViewMode.DETACHED_WINDOW;
     const useDetachedWindowForScreenSharingSource =
-      screen === true && video === false && isInDetachedMode && detachedWindow !== null;
+      screen && !video && isInDetachedMode && detachedWindow !== null;
 
     if (useDetachedWindowForScreenSharingSource) {
       callState.isScreenSharingSourceFromDetachedWindow(true);

--- a/src/script/media/MediaStreamHandler.ts
+++ b/src/script/media/MediaStreamHandler.ts
@@ -166,8 +166,7 @@ export class MediaStreamHandler {
 
     const detachedWindow = callState.detachedWindow();
     const isInDetachedMode = callState.viewMode() === CallingViewMode.DETACHED_WINDOW;
-    const useDetachedWindowForScreenSharingSource =
-      screen && !video && isInDetachedMode && detachedWindow !== null;
+    const useDetachedWindowForScreenSharingSource = screen && !video && isInDetachedMode && detachedWindow !== null;
 
     if (useDetachedWindowForScreenSharingSource) {
       callState.isScreenSharingSourceFromDetachedWindow(true);


### PR DESCRIPTION
we should explicitly check that requested media stream is screen and then use detached window for it's source if we have a detached window, otherwise if we also request video from the detached window when user closes it the video ends up blank black.