### PR TITLE
fix(PrimaryModal): allows no password for downloading backup [WPB-11590]

### DIFF
--- a/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
@@ -55,7 +55,7 @@ export const PrimaryModalComponent: FC = () => {
   const isModalVisible = currentId !== null;
   const passwordValueRef = useRef<HTMLInputElement>(null);
   const [isFormSubmitted, setIsFormSubmitted] = useState(false);
-  const isBackupPasswordValid = useMemo(() => passwordInput && isValidPassword(passwordInput), [passwordInput]);
+  const isBackupPasswordValid = useMemo(() => passwordInput === '' || isValidPassword(passwordInput), [passwordInput]);
 
   const {
     checkboxLabel,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11590" title="WPB-11590" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11590</a>  [Web] No checks for password complexity on setting a password for backups
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

After fixing the validation in [WPB-11590](https://wearezeta.atlassian.net/browse/WPB-11590), the backup password became mandatory, even though it is marked as optional. For now, we don't allow a password to download a backup. If the password is present, it's validated as it is now.

## Screenshots/Screencast (for UI changes)

Before:

https://github.com/user-attachments/assets/18fb4e31-091f-4cc9-8647-c35a7540ff44


After:


https://github.com/user-attachments/assets/9d66eaf2-95ea-47dd-9a7b-6537d034a678



## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-11590]: https://wearezeta.atlassian.net/browse/WPB-11590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ