### PR TITLE
feat: Adjust in call reactions styles (WPB-10241)

### DIFF
--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -743,7 +743,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                     marginRight: 10,
                   }}
                 >
-                  {(participants.length > 2 || true) && (
+                  {participants.length > 2 && (
                     <li className="video-controls__item">
                       <button
                         onBlur={event => {

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -739,9 +739,11 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                     ...(!horizontalSmBreakpoint && {minWidth: '157px'}),
                     display: 'flex',
                     justifyContent: 'flex-end',
+                    gap: 10,
+                    marginRight: 10,
                   }}
                 >
-                  {participants.length > 2 && (
+                  {(participants.length > 2 || true) && (
                     <li className="video-controls__item">
                       <button
                         onBlur={event => {
@@ -749,10 +751,9 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                             toggleCallView();
                           }
                         }}
-                        className="video-controls__button video-controls__button--small video-controls__view-mode"
+                        className={classNames('video-controls__button_primary', {active: isCallViewOpen})}
                         onClick={toggleCallView}
                         onKeyDown={event => handleKeyDown(event, toggleCallView)}
-                        css={isCallViewOpen ? videoControlActiveStyles : videoControlInActiveStyles}
                         type="button"
                         data-uie-name="do-call-controls-video-call-view"
                         role="switch"
@@ -818,8 +819,7 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                       )}
                       <button
                         title={t('callReactions')}
-                        css={showEmojisBar ? videoControlActiveStyles : videoControlInActiveStyles}
-                        className="video-controls__button video-controls__button--small"
+                        className={classNames('video-controls__button_primary', {active: showEmojisBar})}
                         onClick={() => setShowEmojisBar(prev => !prev)}
                         type="button"
                         aria-labelledby="show-emoji-bar"
@@ -831,11 +831,10 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
                   )}
                   <li className="video-controls__item">
                     <button
-                      className="video-controls__button video-controls__button--small"
                       data-uie-value={isParticipantsListOpen ? 'active' : 'inactive'}
                       onClick={toggleParticipantsList}
                       onKeyDown={event => handleKeyDown(event, toggleParticipantsList)}
-                      css={isParticipantsListOpen ? videoControlActiveStyles : videoControlInActiveStyles}
+                      className={classNames('video-controls__button_primary', {active: isParticipantsListOpen})}
                       type="button"
                       data-uie-name="do-toggle-call-participants-list"
                       role="switch"

--- a/src/style/foundation/video-calling.less
+++ b/src/style/foundation/video-calling.less
@@ -199,6 +199,10 @@
     display: none;
   }
 
+  &__button_primary {
+    .button-icon-primary;
+  }
+
   &__button {
     .button-reset-default;
     position: relative;
@@ -272,16 +276,16 @@
     animation:
       flyUp 4s linear forwards,
       fadeIn 1s;
-    font-size: 2rem;
+    font-size: 1.75rem;
     gap: 0.1rem;
   }
 
   .emoji-text {
-    padding: 0.4rem;
-    border-radius: 0.3rem;
+    padding: 0.4rem 0.6rem;
+    border-radius: 0.5rem;
     background-color: rgba(0, 0, 0, 0.804);
     color: white;
-    font-size: 1rem;
+    font-size: 0.875rem;
     font-size: bold;
     font-weight: bold;
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10241" title="WPB-10241" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10241</a>  [Web] Adjust in-call reaction design for use within pop out calling view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Before:
<img width="117" alt="image" src="https://github.com/user-attachments/assets/10f36e92-0873-46e5-b8c2-1243279d6f9c">
<img width="122" alt="image" src="https://github.com/user-attachments/assets/d9d1e1d9-3701-460f-9eed-dd9336b5b921">

After:
<img width="104" alt="image" src="https://github.com/user-attachments/assets/53e936a0-45bd-4dcd-87fc-8be1da6061c7">
<img width="137" alt="image" src="https://github.com/user-attachments/assets/d85eac35-00a6-4b6d-90c8-b6691759f8e1">
