### PR TITLE
fix: rely on remote conversation for read receipt settings [WPB-11212]

### DIFF
--- a/src/script/conversation/ConversationMapper.test.ts
+++ b/src/script/conversation/ConversationMapper.test.ts
@@ -694,15 +694,16 @@ describe('ConversationMapper', () => {
       expect(merged_conversation.last_server_timestamp).toBe(localData.last_event_timestamp);
     });
 
-    it('prefers local data over remote data when mapping the read receipts value', () => {
+    it('prefers remote data over remote data when mapping the read receipts value', () => {
       const localReceiptMode = 0;
-      const [localData, remoteData] = getDataWithReadReceiptMode(localReceiptMode, 1);
+      const remoteReceiptMode = 1;
+      const [localData, remoteData] = getDataWithReadReceiptMode(localReceiptMode, remoteReceiptMode);
       const [mergedConversation] = ConversationMapper.mergeConversations(
         [localData] as ConversationDatabaseData[],
         {found: [remoteData]} as RemoteConversations,
       );
 
-      expect(mergedConversation.receipt_mode).toBe(localReceiptMode);
+      expect(mergedConversation.receipt_mode).toBe(remoteReceiptMode);
     });
 
     it('uses the remote receipt mode when there is no local receipt mode', () => {

--- a/src/script/conversation/ConversationMapper.ts
+++ b/src/script/conversation/ConversationMapper.ts
@@ -429,10 +429,6 @@ export class ConversationMapper {
       }
     });
 
-    if (typeof localConversationData.receipt_mode === 'number') {
-      updates.receipt_mode = localConversationData.receipt_mode;
-    }
-
     const mergedConversation: ConversationDatabaseData = {...localConversationData, ...updates};
 
     const isGroup = type === CONVERSATION_TYPE.REGULAR;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11212" title="WPB-11212" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11212</a>  [Web] Conversation shows read receipts as enabled on Web, but there are no visible read receipts
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

The read receipt status of conversation can get off out sync with back-end on web only.
The local status would be displayed as OFF while read receipt would be active in the conversation.

It turns out favoring the local state was an intentional behavior implemented here: https://github.com/wireapp/wire-webapp/pull/5443
The conversation read receipt  property is currently intended to apply to all users, regardless of individual settings, so the use case mentioned in the PR is no longer relevant, reverting it makes sure the local state is in sync with the remote state on app initialization.

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ