### PR TITLE
feat(user-migration): added banner to start migration flow [WPB-11265]

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -1586,5 +1586,8 @@
   "wireLinux": "{{brandName}} for Linux",
   "wireMacos": "{{brandName}} for macOS",
   "wireWindows": "{{brandName}} for Windows",
-  "wire_for_web": "{{brandName}} for Web"
+  "wire_for_web": "{{brandName}} for Web",
+  "teamUpgradeBannerHeader": "Enjoy benefits of a team",
+  "teamUpgradeBannerContent": "Explore extra features for free with the same level of security.",
+  "teamUpgradeBannerButtonText": "Create Wire Team"
 }

--- a/src/script/components/BannerPortal/BannerPortal.styles.ts
+++ b/src/script/components/BannerPortal/BannerPortal.styles.ts
@@ -1,0 +1,27 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {CSSObject} from '@emotion/react';
+
+export const portalContainerCss: CSSObject = {
+  zIndex: 1000,
+  position: 'fixed',
+  boxShadow: '0px 0px 12px 0px var(--background-fade-32)',
+  borderRadius: '0.5rem',
+};

--- a/src/script/components/BannerPortal/BannerPortal.tsx
+++ b/src/script/components/BannerPortal/BannerPortal.tsx
@@ -39,8 +39,8 @@ export const BannerPortal = ({
 
   const {activeWindow} = useActiveWindowState.getState();
 
-  const handleClickOutside = (event: any) => {
-    if (bannerRef && !bannerRef.contains(event.target)) {
+  const handleClickOutside = (event: MouseEvent) => {
+    if (bannerRef && !bannerRef.contains(event.target as Node)) {
       onClose();
     }
   };

--- a/src/script/components/BannerPortal/BannerPortal.tsx
+++ b/src/script/components/BannerPortal/BannerPortal.tsx
@@ -1,0 +1,71 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {ReactNode, useEffect, useState} from 'react';
+
+import {CSSObject} from '@emotion/react';
+import {createPortal} from 'react-dom';
+
+import {useActiveWindowState} from 'src/script/hooks/useActiveWindow';
+
+export const BannerPortal = ({
+  onClose,
+  positionX = 0,
+  positionY = 0,
+  children,
+}: {
+  onClose: () => void;
+  positionX?: number;
+  positionY?: number;
+  children: ReactNode;
+}) => {
+  const [bannerRef, setBannerRef] = useState<HTMLDivElement | null>();
+
+  const {activeWindow} = useActiveWindowState.getState();
+
+  const handleClickOutside = (event: any) => {
+    if (bannerRef && !bannerRef.contains(event.target)) {
+      onClose();
+    }
+  };
+
+  useEffect(() => {
+    activeWindow.document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      activeWindow.document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [handleClickOutside]);
+
+  const top = positionY - (bannerRef?.clientHeight || 0);
+  const left = positionX;
+
+  return createPortal(
+    <div ref={setBannerRef} css={{...portalContainerCss, top, left}}>
+      {children}
+    </div>,
+    activeWindow.document.body,
+  );
+};
+
+const portalContainerCss: CSSObject = {
+  zIndex: 1000,
+  position: 'fixed',
+  boxShadow: '0px 0px 12px 0px var(--background-fade-32)',
+  borderRadius: '0.5rem',
+};

--- a/src/script/components/BannerPortal/BannerPortal.tsx
+++ b/src/script/components/BannerPortal/BannerPortal.tsx
@@ -19,22 +19,20 @@
 
 import {ReactNode, useEffect, useRef} from 'react';
 
-import {CSSObject} from '@emotion/react';
 import {createPortal} from 'react-dom';
 
 import {useActiveWindowState} from 'src/script/hooks/useActiveWindow';
 
-export const BannerPortal = ({
-  onClose,
-  positionX = 0,
-  positionY = 0,
-  children,
-}: {
+import {portalContainerCss} from './BannerPortal.styles';
+
+interface Props {
   onClose: () => void;
   positionX?: number;
   positionY?: number;
   children: ReactNode;
-}) => {
+}
+
+export const BannerPortal = ({onClose, positionX = 0, positionY = 0, children}: Props) => {
   const bannerRef = useRef<HTMLDivElement | null>(null);
 
   const {activeWindow} = useActiveWindowState.getState();
@@ -68,11 +66,4 @@ export const BannerPortal = ({
     </div>,
     activeWindow.document.body,
   );
-};
-
-const portalContainerCss: CSSObject = {
-  zIndex: 1000,
-  position: 'fixed',
-  boxShadow: '0px 0px 12px 0px var(--background-fade-32)',
-  borderRadius: '0.5rem',
 };

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationSidebar/ConversationSidebar.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationSidebar/ConversationSidebar.tsx
@@ -93,6 +93,7 @@ export const ConversationSidebar = ({
           conversationRepository={conversationRepository}
           onClickPreferences={onClickPreferences}
           showNotificationsBadge={showNotificationsBadge}
+          selfUser={selfUser}
         />
       </FadingScrollbar>
 

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/ConversationTabs.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/ConversationTabs.tsx
@@ -38,7 +38,7 @@ import {
   iconStyle,
 } from './ConversationTabs.styles';
 import {FolderIcon} from './FolderIcon';
-import {TeamUpgradeBanner} from './TeamUpgradeBanner';
+import {TeamCreationBanner} from './TeamCreation/TeamCreationBanner';
 
 import {Config} from '../../../../../Config';
 import {Conversation} from '../../../../../entity/Conversation';
@@ -193,7 +193,7 @@ export const ConversationTabs = ({
         aria-owns="tab-1 tab-2"
         className="conversations-sidebar-list-footer"
       >
-        {!teamState.isInTeam(selfUser) && <TeamUpgradeBanner />}
+        {!teamState.isInTeam(selfUser) && <TeamCreationBanner />}
 
         {!getWebEnvironment().isProduction && isDataDogEnabled() && (
           <div css={footerDisclaimer}>

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/ConversationTabs.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/ConversationTabs.tsx
@@ -17,12 +17,16 @@
  *
  */
 
+import {container} from 'tsyringe';
+
 import {GroupIcon, MessageIcon, StarIcon, ExternalLinkIcon, Tooltip, SupportIcon} from '@wireapp/react-ui-kit';
 
 import * as Icon from 'Components/Icon';
 import {ConversationRepository} from 'src/script/conversation/ConversationRepository';
+import {User} from 'src/script/entity/User';
 import {ConversationFolderTab} from 'src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab';
 import {SidebarTabs} from 'src/script/page/LeftSidebar/panels/Conversations/useSidebarStore';
+import {TeamState} from 'src/script/team/TeamState';
 import {isDataDogEnabled} from 'Util/DataDog';
 import {getWebEnvironment} from 'Util/Environment';
 import {replaceLink, t} from 'Util/LocalizerUtil';
@@ -34,6 +38,7 @@ import {
   iconStyle,
 } from './ConversationTabs.styles';
 import {FolderIcon} from './FolderIcon';
+import {TeamUpgradeBanner} from './TeamUpgradeBanner';
 
 import {Config} from '../../../../../Config';
 import {Conversation} from '../../../../../entity/Conversation';
@@ -52,6 +57,7 @@ interface ConversationTabsProps {
   currentTab: SidebarTabs;
   onClickPreferences: () => void;
   showNotificationsBadge?: boolean;
+  selfUser: User;
 }
 
 export const ConversationTabs = ({
@@ -65,7 +71,9 @@ export const ConversationTabs = ({
   currentTab,
   onClickPreferences,
   showNotificationsBadge = false,
+  selfUser,
 }: ConversationTabsProps) => {
+  const teamState = container.resolve(TeamState);
   const totalUnreadConversations = unreadConversations.length;
 
   const totalUnreadFavoriteConversations = favoriteConversations.filter(favoriteConversation =>
@@ -185,6 +193,8 @@ export const ConversationTabs = ({
         aria-owns="tab-1 tab-2"
         className="conversations-sidebar-list-footer"
       >
+        {!teamState.isInTeam(selfUser) && <TeamUpgradeBanner />}
+
         {!getWebEnvironment().isProduction && isDataDogEnabled() && (
           <div css={footerDisclaimer}>
             <Tooltip

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/TeamCreation/TeamCreation.styles.ts
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/TeamCreation/TeamCreation.styles.ts
@@ -1,0 +1,57 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {CSSObject} from '@emotion/react';
+
+export const teamUpgradeBannerContainerCss: CSSObject = {
+  border: '1px solid var(--accent-color-500)',
+  padding: '0.5rem',
+  borderRadius: '0.5rem',
+  // fixed with the width of collapsable sidebar
+  width: '203px',
+  fill: 'var(--main-color)',
+  background: 'var(--accent-color-50)',
+  '.theme-dark &': {
+    background: 'var(--accent-color-800)',
+  },
+};
+
+export const teamUpgradeBannerHeaderCss: CSSObject = {
+  lineHeight: 'var(--line-height-sm)',
+  marginLeft: '0.5rem',
+  verticalAlign: 'text-top',
+};
+
+export const teamUpgradeBannerContentCss: CSSObject = {
+  lineHeight: '.875rem',
+  marginBottom: '0.5rem',
+};
+
+export const teamUpgradeBannerButtonCss: CSSObject = {
+  margin: 0,
+  height: '2.1rem',
+  fontSize: 'var(--font-size-medium)',
+  padding: '0.25rem 0.5rem',
+  borderRadius: '12px',
+};
+
+export const iconButtonCss: CSSObject = {
+  width: '2rem',
+  marginBottom: '0.5rem',
+};

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/TeamCreation/TeamCreationBanner.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/TeamCreation/TeamCreationBanner.tsx
@@ -57,7 +57,7 @@ const PADDING_Y = 34;
 
 export const TeamCreationBanner = () => {
   const [isBannerVisible, setIsBannerVisible] = useState(false);
-  const [position, setPosition] = useState<{x?: number; y?: number}>({});
+  const [position, setPosition] = useState<{x: number; y: number}>({x: 0, y: 0});
   const {status: sidebarStatus} = useSidebarStore();
   const clickHandler = (event: React.MouseEvent<HTMLButtonElement>) => {
     setIsBannerVisible(true);
@@ -77,8 +77,8 @@ export const TeamCreationBanner = () => {
       {isBannerVisible && (
         <BannerPortal
           // Position + padding
-          positionX={(position.x || 0) + PADDING_X}
-          positionY={(position.y || 0) + PADDING_Y}
+          positionX={position.x + PADDING_X}
+          positionY={position.y + PADDING_Y}
           onClose={() => setIsBannerVisible(false)}
         >
           <Banner />

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/TeamCreation/TeamCreationBanner.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/TeamCreation/TeamCreationBanner.tsx
@@ -33,7 +33,7 @@ import {
   teamUpgradeBannerHeaderCss,
 } from './TeamCreation.styles';
 
-import {useSidebarStore} from '../../useSidebarStore';
+import {SidebarStatus, useSidebarStore} from '../../useSidebarStore';
 
 const Banner = () => {
   return (
@@ -52,6 +52,9 @@ const Banner = () => {
   );
 };
 
+const PADDING_X = 40;
+const PADDING_Y = 34;
+
 export const TeamCreationBanner = () => {
   const [isBannerVisible, setIsBannerVisible] = useState(false);
   const [position, setPosition] = useState<{x?: number; y?: number}>({});
@@ -62,7 +65,7 @@ export const TeamCreationBanner = () => {
     setPosition({x: rect.x, y: rect.y});
   };
 
-  if (sidebarStatus === 'OPEN') {
+  if (sidebarStatus === SidebarStatus.OPEN) {
     return <Banner />;
   }
 
@@ -74,8 +77,8 @@ export const TeamCreationBanner = () => {
       {isBannerVisible && (
         <BannerPortal
           // Position + padding
-          positionX={(position.x || 0) + 40}
-          positionY={(position.y || 0) + 34}
+          positionX={(position.x || 0) + PADDING_X}
+          positionY={(position.y || 0) + PADDING_Y}
           onClose={() => setIsBannerVisible(false)}
         >
           <Banner />

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/TeamCreation/TeamCreationBanner.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/TeamCreation/TeamCreationBanner.tsx
@@ -19,22 +19,32 @@
 
 import {useState} from 'react';
 
-import {CSSObject} from '@emotion/react';
-
 import {Button, ButtonVariant, IconButton} from '@wireapp/react-ui-kit';
 
 import {BannerPortal} from 'Components/BannerPortal/BannerPortal';
 import * as Icon from 'Components/Icon';
 import {t} from 'Util/LocalizerUtil';
 
-import {useSidebarStore} from '../useSidebarStore';
+import {
+  iconButtonCss,
+  teamUpgradeBannerButtonCss,
+  teamUpgradeBannerContainerCss,
+  teamUpgradeBannerContentCss,
+  teamUpgradeBannerHeaderCss,
+} from './TeamCreation.styles';
+
+import {useSidebarStore} from '../../useSidebarStore';
 
 const Banner = () => {
   return (
     <div css={teamUpgradeBannerContainerCss}>
       <Icon.InfoIcon />
-      <span css={teamUpgradeBannerHeaderCss}>{t('teamUpgradeBannerHeader')}</span>
-      <div css={teamUpgradeBannerContentCss}>{t('teamUpgradeBannerContent')}</div>
+      <span className="heading-h4" css={teamUpgradeBannerHeaderCss}>
+        {t('teamUpgradeBannerHeader')}
+      </span>
+      <div className="subline" css={teamUpgradeBannerContentCss}>
+        {t('teamUpgradeBannerContent')}
+      </div>
       <Button css={teamUpgradeBannerButtonCss} variant={ButtonVariant.SECONDARY}>
         {t('teamUpgradeBannerButtonText')}
       </Button>
@@ -42,7 +52,7 @@ const Banner = () => {
   );
 };
 
-export const TeamUpgradeBanner = () => {
+export const TeamCreationBanner = () => {
   const [isBannerVisible, setIsBannerVisible] = useState(false);
   const [position, setPosition] = useState<{x?: number; y?: number}>({});
   const {status: sidebarStatus} = useSidebarStore();
@@ -73,40 +83,4 @@ export const TeamUpgradeBanner = () => {
       )}
     </>
   );
-};
-
-const teamUpgradeBannerContainerCss: CSSObject = {
-  border: '1px solid var(--accent-color-500)',
-  padding: '0.5rem',
-  background: 'var(--accent-color-50)',
-  borderRadius: '0.5rem',
-  maxWidth: '13rem',
-  minWidth: '12.5rem',
-};
-
-const teamUpgradeBannerHeaderCss: CSSObject = {
-  fontSize: '.75rem',
-  lineHeight: '.875rem',
-  fontWeight: 'bold',
-  marginLeft: '0.5rem',
-  verticalAlign: 'text-top',
-};
-
-const teamUpgradeBannerContentCss: CSSObject = {
-  fontSize: '.75rem',
-  lineHeight: '.875rem',
-  marginBottom: '0.5rem',
-};
-
-const teamUpgradeBannerButtonCss: CSSObject = {
-  margin: 0,
-  height: '2.1rem',
-  fontSize: '0.875rem',
-  padding: '0.25rem 0.5rem',
-  borderRadius: '12px',
-};
-
-const iconButtonCss: CSSObject = {
-  width: '2rem',
-  marginBottom: '0.5rem',
 };

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/TeamUpgradeBanner.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/TeamUpgradeBanner.tsx
@@ -1,0 +1,112 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {useState} from 'react';
+
+import {CSSObject} from '@emotion/react';
+
+import {Button, ButtonVariant, IconButton} from '@wireapp/react-ui-kit';
+
+import {BannerPortal} from 'Components/BannerPortal/BannerPortal';
+import * as Icon from 'Components/Icon';
+import {t} from 'Util/LocalizerUtil';
+
+import {useSidebarStore} from '../useSidebarStore';
+
+const Banner = () => {
+  return (
+    <div css={teamUpgradeBannerContainerCss}>
+      <Icon.InfoIcon />
+      <span css={teamUpgradeBannerHeaderCss}>{t('teamUpgradeBannerHeader')}</span>
+      <div css={teamUpgradeBannerContentCss}>{t('teamUpgradeBannerContent')}</div>
+      <Button css={teamUpgradeBannerButtonCss} variant={ButtonVariant.SECONDARY}>
+        {t('teamUpgradeBannerButtonText')}
+      </Button>
+    </div>
+  );
+};
+
+export const TeamUpgradeBanner = () => {
+  const [isBannerVisible, setIsBannerVisible] = useState(false);
+  const [position, setPosition] = useState<{x?: number; y?: number}>({});
+  const {status: sidebarStatus} = useSidebarStore();
+  const clickHandler = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setIsBannerVisible(true);
+    const rect = event.currentTarget.getBoundingClientRect();
+    setPosition({x: rect.x, y: rect.y});
+  };
+
+  if (sidebarStatus === 'OPEN') {
+    return <Banner />;
+  }
+
+  return (
+    <>
+      <IconButton css={iconButtonCss} onClick={clickHandler}>
+        <Icon.InfoIcon />
+      </IconButton>
+      {isBannerVisible && (
+        <BannerPortal
+          // Position + padding
+          positionX={(position.x || 0) + 40}
+          positionY={(position.y || 0) + 34}
+          onClose={() => setIsBannerVisible(false)}
+        >
+          <Banner />
+        </BannerPortal>
+      )}
+    </>
+  );
+};
+
+const teamUpgradeBannerContainerCss: CSSObject = {
+  border: '1px solid var(--accent-color-500)',
+  padding: '0.5rem',
+  background: 'var(--accent-color-50)',
+  borderRadius: '0.5rem',
+  maxWidth: '13rem',
+  minWidth: '12.5rem',
+};
+
+const teamUpgradeBannerHeaderCss: CSSObject = {
+  fontSize: '.75rem',
+  lineHeight: '.875rem',
+  fontWeight: 'bold',
+  marginLeft: '0.5rem',
+  verticalAlign: 'text-top',
+};
+
+const teamUpgradeBannerContentCss: CSSObject = {
+  fontSize: '.75rem',
+  lineHeight: '.875rem',
+  marginBottom: '0.5rem',
+};
+
+const teamUpgradeBannerButtonCss: CSSObject = {
+  margin: 0,
+  height: '2.1rem',
+  fontSize: '0.875rem',
+  padding: '0.25rem 0.5rem',
+  borderRadius: '12px',
+};
+
+const iconButtonCss: CSSObject = {
+  width: '2rem',
+  marginBottom: '0.5rem',
+};


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11265" title="WPB-11265" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11265</a>  [Web] Create Call-To-Action within the app for personal users to be able to start a team
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

Added call-to-action banner to start migration flow from private user to team user

## Screen Recording

https://github.com/user-attachments/assets/48c14c8a-7111-4cde-a857-4bd8e7d60374

#### Dark mode:
<img width="266" alt="Screenshot 2024-10-28 at 11 31 20" src="https://github.com/user-attachments/assets/aace8431-ea38-4316-9b08-b2e0ca0879ed">

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ