### PR TITLE
refactor(PrimaryModal): split into components [WPB-10932]

### DIFF
--- a/src/script/components/Modals/PrimaryModal/CheckboxOption/CheckboxOption.tsx
+++ b/src/script/components/Modals/PrimaryModal/CheckboxOption/CheckboxOption.tsx
@@ -1,0 +1,40 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {ChangeEvent} from 'react';
+
+import {Checkbox, CheckboxLabel} from '@wireapp/react-ui-kit';
+
+interface CheckboxOptionProps {
+  isChecked: boolean;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  label: string;
+}
+
+export const CheckboxOption = ({label, isChecked, onChange}: CheckboxOptionProps) => {
+  return (
+    <div className="modal-option">
+      <Checkbox checked={isChecked} data-uie-name="modal-option-checkbox" id="clear-data-checkbox" onChange={onChange}>
+        <CheckboxLabel className="label-xs" htmlFor="clear-data-checkbox">
+          {label}
+        </CheckboxLabel>
+      </Checkbox>
+    </div>
+  );
+};

--- a/src/script/components/Modals/PrimaryModal/GuestLinkPasswordForm/GuestLinkPasswordForm.styles.ts
+++ b/src/script/components/Modals/PrimaryModal/GuestLinkPasswordForm/GuestLinkPasswordForm.styles.ts
@@ -19,6 +19,6 @@
 
 import {CSSObject} from '@emotion/react';
 
-export const errorMessage: CSSObject = {
+export const errorMessageStyles: CSSObject = {
   marginBottom: 18,
 };

--- a/src/script/components/Modals/PrimaryModal/GuestLinkPasswordForm/GuestLinkPasswordForm.styles.ts
+++ b/src/script/components/Modals/PrimaryModal/GuestLinkPasswordForm/GuestLinkPasswordForm.styles.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2023 Wire Swiss GmbH
+ * Copyright (C) 2024 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,6 +19,6 @@
 
 import {CSSObject} from '@emotion/react';
 
-export const guestLinkPasswordErrorMessageStyles: CSSObject = {
+export const errorMessage: CSSObject = {
   marginBottom: 18,
 };

--- a/src/script/components/Modals/PrimaryModal/GuestLinkPasswordForm/GuestLinkPasswordForm.tsx
+++ b/src/script/components/Modals/PrimaryModal/GuestLinkPasswordForm/GuestLinkPasswordForm.tsx
@@ -17,6 +17,8 @@
  *
  */
 
+import type {FormEvent} from 'react';
+
 import {ValidationUtil} from '@wireapp/commons';
 import {Form, Input, ErrorMessage} from '@wireapp/react-ui-kit';
 
@@ -27,7 +29,7 @@ import {t} from 'Util/LocalizerUtil';
 import {errorMessage} from './GuestLinkPasswordForm.styles';
 
 interface GuestLinkPasswordFormProps {
-  onSubmit: () => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   onGeneratePassword: (password: string) => void;
   passwordValue: string;
   passwordValueRef: React.RefObject<HTMLInputElement>;

--- a/src/script/components/Modals/PrimaryModal/GuestLinkPasswordForm/GuestLinkPasswordForm.tsx
+++ b/src/script/components/Modals/PrimaryModal/GuestLinkPasswordForm/GuestLinkPasswordForm.tsx
@@ -24,7 +24,7 @@ import {PasswordGeneratorButton} from 'Components/PasswordGeneratorButton';
 import {Config} from 'src/script/Config';
 import {t} from 'Util/LocalizerUtil';
 
-import {guestLinkPasswordErrorMessageStyles} from '../PrimaryModal.styles';
+import {errorMessage} from './GuestLinkPasswordForm.styles';
 
 interface GuestLinkPasswordFormProps {
   onSubmit: () => void;
@@ -102,7 +102,7 @@ export const GuestLinkPasswordForm = ({
 
 const GuestLinkPasswordModalErrorMessage = () => {
   return (
-    <ErrorMessage data-uie-name="primary-modals-error-message" css={guestLinkPasswordErrorMessageStyles}>
+    <ErrorMessage data-uie-name="primary-modals-error-message" css={errorMessage}>
       {t('modalGuestLinkJoinHelperText', {
         minPasswordLength: Config.getConfig().MINIMUM_PASSWORD_LENGTH.toString(),
       })}

--- a/src/script/components/Modals/PrimaryModal/GuestLinkPasswordForm/GuestLinkPasswordForm.tsx
+++ b/src/script/components/Modals/PrimaryModal/GuestLinkPasswordForm/GuestLinkPasswordForm.tsx
@@ -26,7 +26,7 @@ import {PasswordGeneratorButton} from 'Components/PasswordGeneratorButton';
 import {Config} from 'src/script/Config';
 import {t} from 'Util/LocalizerUtil';
 
-import {errorMessage} from './GuestLinkPasswordForm.styles';
+import {errorMessageStyles} from './GuestLinkPasswordForm.styles';
 
 interface GuestLinkPasswordFormProps {
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
@@ -104,7 +104,7 @@ export const GuestLinkPasswordForm = ({
 
 const GuestLinkPasswordModalErrorMessage = () => {
   return (
-    <ErrorMessage data-uie-name="primary-modals-error-message" css={errorMessage}>
+    <ErrorMessage data-uie-name="primary-modals-error-message" css={errorMessageStyles}>
       {t('modalGuestLinkJoinHelperText', {
         minPasswordLength: Config.getConfig().MINIMUM_PASSWORD_LENGTH.toString(),
       })}

--- a/src/script/components/Modals/PrimaryModal/GuestLinkPasswordForm/GuestLinkPasswordForm.tsx
+++ b/src/script/components/Modals/PrimaryModal/GuestLinkPasswordForm/GuestLinkPasswordForm.tsx
@@ -1,0 +1,111 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {ValidationUtil} from '@wireapp/commons';
+import {Form, Input, ErrorMessage} from '@wireapp/react-ui-kit';
+
+import {PasswordGeneratorButton} from 'Components/PasswordGeneratorButton';
+import {Config} from 'src/script/Config';
+import {t} from 'Util/LocalizerUtil';
+
+import {guestLinkPasswordErrorMessageStyles} from '../PrimaryModal.styles';
+
+interface GuestLinkPasswordFormProps {
+  onSubmit: () => void;
+  onGeneratePassword: (password: string) => void;
+  passwordValue: string;
+  passwordValueRef: React.RefObject<HTMLInputElement>;
+  onPasswordValueChange: (value: string) => void;
+  isPasswordInputMarkInvalid: boolean;
+  passwordConfirmationValue: string;
+  onPasswordConfirmationChange: (value: string) => void;
+  isPasswordConfirmationMarkInvalid: boolean;
+}
+
+export const GuestLinkPasswordForm = ({
+  onSubmit,
+  onGeneratePassword,
+  passwordValue,
+  passwordValueRef,
+  onPasswordValueChange,
+  isPasswordInputMarkInvalid,
+  passwordConfirmationValue,
+  onPasswordConfirmationChange,
+  isPasswordConfirmationMarkInvalid,
+}: GuestLinkPasswordFormProps) => {
+  return (
+    <>
+      <PasswordGeneratorButton
+        passwordLength={Config.getConfig().MINIMUM_PASSWORD_LENGTH}
+        onGeneratePassword={onGeneratePassword}
+      />
+      <Form
+        name="guest-password-link-form"
+        data-uie-name="guest-password-link-form"
+        onSubmit={onSubmit}
+        autoComplete="off"
+      >
+        <Input
+          name="guest-link-password"
+          data-uie-name="guest-link-password"
+          required
+          placeholder={t('modalGuestLinkJoinPlaceholder')}
+          label={t('modalGuestLinkJoinLabel')}
+          helperText={t('modalGuestLinkJoinHelperText', {
+            minPasswordLength: Config.getConfig().MINIMUM_PASSWORD_LENGTH.toString(),
+          })}
+          id="modal_pswd"
+          className="modal__input"
+          type="password"
+          autoComplete="off"
+          value={passwordValue}
+          ref={passwordValueRef}
+          onChange={event => onPasswordValueChange(event.currentTarget.value)}
+          pattern={ValidationUtil.getNewPasswordPattern(Config.getConfig().NEW_PASSWORD_MINIMUM_LENGTH)}
+          markInvalid={isPasswordInputMarkInvalid}
+          error={isPasswordInputMarkInvalid ? <GuestLinkPasswordModalErrorMessage /> : undefined}
+        />
+        <Input
+          name="guest-link-password-confirm"
+          data-uie-name="guest-link-password-confirm"
+          required
+          placeholder={t('modalGuestLinkJoinConfirmPlaceholder')}
+          label={t('modalGuestLinkJoinConfirmLabel')}
+          className="modal__input"
+          type="password"
+          id="modal_pswd_confirmation"
+          autoComplete="off"
+          value={passwordConfirmationValue}
+          onChange={event => onPasswordConfirmationChange(event.currentTarget.value)}
+          markInvalid={isPasswordConfirmationMarkInvalid}
+        />
+      </Form>
+    </>
+  );
+};
+
+const GuestLinkPasswordModalErrorMessage = () => {
+  return (
+    <ErrorMessage data-uie-name="primary-modals-error-message" css={guestLinkPasswordErrorMessageStyles}>
+      {t('modalGuestLinkJoinHelperText', {
+        minPasswordLength: Config.getConfig().MINIMUM_PASSWORD_LENGTH.toString(),
+      })}
+    </ErrorMessage>
+  );
+};

--- a/src/script/components/Modals/PrimaryModal/InputForm/InputForm.tsx
+++ b/src/script/components/Modals/PrimaryModal/InputForm/InputForm.tsx
@@ -1,0 +1,45 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+interface InputFormProps {
+  onSubmit: () => void;
+  inputValue: string;
+  inputPlaceholder: string;
+  onInputChange: (value: string) => void;
+}
+
+export const InputForm = ({onSubmit, inputValue, inputPlaceholder, onInputChange}: InputFormProps) => {
+  return (
+    <form onSubmit={onSubmit}>
+      <label htmlFor="modal-input" className="visually-hidden">
+        {inputPlaceholder}
+      </label>
+
+      <input
+        ref={ref => ref?.focus()}
+        maxLength={64}
+        className="modal__input"
+        id="modal-input"
+        value={inputValue}
+        placeholder={inputPlaceholder}
+        onChange={event => onInputChange(event.target.value)}
+      />
+    </form>
+  );
+};

--- a/src/script/components/Modals/PrimaryModal/InputForm/InputForm.tsx
+++ b/src/script/components/Modals/PrimaryModal/InputForm/InputForm.tsx
@@ -17,8 +17,10 @@
  *
  */
 
+import type {FormEvent} from 'react';
+
 interface InputFormProps {
-  onSubmit: () => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   inputValue: string;
   inputPlaceholder: string;
   onInputChange: (value: string) => void;

--- a/src/script/components/Modals/PrimaryModal/JoinGuesLinkPasswordForm/JoinGuesLinkPasswordForm.tsx
+++ b/src/script/components/Modals/PrimaryModal/JoinGuesLinkPasswordForm/JoinGuesLinkPasswordForm.tsx
@@ -1,0 +1,73 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {COLOR, Form, Link, Text} from '@wireapp/react-ui-kit';
+
+import {Config} from 'src/script/Config';
+import {t} from 'Util/LocalizerUtil';
+
+interface JoinGuesLinkPasswordFormProps {
+  onFormSubmit: () => void;
+  inputValue: string;
+  onInputChange: (value: string) => void;
+}
+
+export const JoinGuesLinkPasswordForm = ({onFormSubmit, inputValue, onInputChange}: JoinGuesLinkPasswordFormProps) => {
+  return (
+    <Form
+      name="guest-password-join-form"
+      data-uie-name="guest-password-join-form"
+      onSubmit={onFormSubmit}
+      autoComplete="off"
+    >
+      <label
+        style={{
+          fontSize: '0.875rem',
+          fontWeight: 400,
+          lineHeight: '1rem',
+          color: 'var(--text-input-label)',
+          marginBottom: 2,
+        }}
+        htmlFor="modal_pswd"
+      >
+        {t('guestLinkPasswordModal.passwordInputLabel')}
+      </label>
+
+      <input
+        style={{
+          boxShadow: '0 0 0 1px var(--text-input-border)',
+          borderRadius: 12,
+          margin: 0,
+        }}
+        id="modal_pswd"
+        className="modal__input"
+        type="password"
+        value={inputValue}
+        placeholder={t('guestLinkPasswordModal.passwordInputPlaceholder')}
+        onChange={event => onInputChange(event.target.value)}
+      />
+
+      <Link style={{marginTop: 24}} href={Config.getConfig().URL.SUPPORT.LEARN_MORE_ABOUT_GUEST_LINKS} target="_blank">
+        <Text block color={COLOR.BLUE} style={{textDecoration: 'underline', marginBottom: 24}}>
+          {t('guestLinkPasswordModal.learnMoreLink')}
+        </Text>
+      </Link>
+    </Form>
+  );
+};

--- a/src/script/components/Modals/PrimaryModal/JoinGuestLinkPasswordForm/JoinGuestLinkPasswordForm.styles.ts
+++ b/src/script/components/Modals/PrimaryModal/JoinGuestLinkPasswordForm/JoinGuestLinkPasswordForm.styles.ts
@@ -20,9 +20,9 @@
 import {CSSObject} from '@emotion/react';
 
 export const label: CSSObject = {
-  fontSize: '0.875rem',
-  fontWeight: 400,
-  lineHeight: '1rem',
+  fontSize: 'var(--font-size-medium)',
+  fontWeight: 'var(--font-weight-regular)',
+  lineHeight: 'var(--line-height-sm)',
   color: 'var(--text-input-label)',
   marginBottom: 2,
 };

--- a/src/script/components/Modals/PrimaryModal/JoinGuestLinkPasswordForm/JoinGuestLinkPasswordForm.styles.ts
+++ b/src/script/components/Modals/PrimaryModal/JoinGuestLinkPasswordForm/JoinGuestLinkPasswordForm.styles.ts
@@ -1,0 +1,43 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {CSSObject} from '@emotion/react';
+
+export const label: CSSObject = {
+  fontSize: '0.875rem',
+  fontWeight: 400,
+  lineHeight: '1rem',
+  color: 'var(--text-input-label)',
+  marginBottom: 2,
+};
+
+export const input: CSSObject = {
+  boxShadow: '0 0 0 1px var(--text-input-border)',
+  borderRadius: 12,
+  margin: 0,
+};
+
+export const link: CSSObject = {
+  marginTop: 24,
+};
+
+export const linkText: CSSObject = {
+  textDecoration: 'underline',
+  marginBottom: 24,
+};

--- a/src/script/components/Modals/PrimaryModal/JoinGuestLinkPasswordForm/JoinGuestLinkPasswordForm.styles.ts
+++ b/src/script/components/Modals/PrimaryModal/JoinGuestLinkPasswordForm/JoinGuestLinkPasswordForm.styles.ts
@@ -19,7 +19,7 @@
 
 import {CSSObject} from '@emotion/react';
 
-export const label: CSSObject = {
+export const labelStyles: CSSObject = {
   fontSize: 'var(--font-size-medium)',
   fontWeight: 'var(--font-weight-regular)',
   lineHeight: 'var(--line-height-sm)',
@@ -27,17 +27,17 @@ export const label: CSSObject = {
   marginBottom: 2,
 };
 
-export const input: CSSObject = {
+export const inputStyles: CSSObject = {
   boxShadow: '0 0 0 1px var(--text-input-border)',
   borderRadius: 12,
   margin: 0,
 };
 
-export const link: CSSObject = {
+export const linkStyles: CSSObject = {
   marginTop: 24,
 };
 
-export const linkText: CSSObject = {
+export const linkTextStyles: CSSObject = {
   textDecoration: 'underline',
   marginBottom: 24,
 };

--- a/src/script/components/Modals/PrimaryModal/JoinGuestLinkPasswordForm/JoinGuestLinkPasswordForm.tsx
+++ b/src/script/components/Modals/PrimaryModal/JoinGuestLinkPasswordForm/JoinGuestLinkPasswordForm.tsx
@@ -17,6 +17,8 @@
  *
  */
 
+import type {FormEvent} from 'react';
+
 import {COLOR, Form, Link, Text} from '@wireapp/react-ui-kit';
 
 import {Config} from 'src/script/Config';
@@ -25,7 +27,7 @@ import {t} from 'Util/LocalizerUtil';
 import {label, input, link, linkText} from './JoinGuestLinkPasswordForm.styles';
 
 interface JoinGuestLinkPasswordFormProps {
-  onSubmit: () => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   inputValue: string;
   onInputChange: (value: string) => void;
 }

--- a/src/script/components/Modals/PrimaryModal/JoinGuestLinkPasswordForm/JoinGuestLinkPasswordForm.tsx
+++ b/src/script/components/Modals/PrimaryModal/JoinGuestLinkPasswordForm/JoinGuestLinkPasswordForm.tsx
@@ -24,7 +24,7 @@ import {COLOR, Form, Link, Text} from '@wireapp/react-ui-kit';
 import {Config} from 'src/script/Config';
 import {t} from 'Util/LocalizerUtil';
 
-import {label, input, link, linkText} from './JoinGuestLinkPasswordForm.styles';
+import {labelStyles, inputStyles, linkStyles, linkTextStyles} from './JoinGuestLinkPasswordForm.styles';
 
 interface JoinGuestLinkPasswordFormProps {
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
@@ -40,12 +40,12 @@ export const JoinGuestLinkPasswordForm = ({onSubmit, inputValue, onInputChange}:
       onSubmit={onSubmit}
       autoComplete="off"
     >
-      <label css={label} htmlFor="modal_pswd">
+      <label css={labelStyles} htmlFor="modal_pswd">
         {t('guestLinkPasswordModal.passwordInputLabel')}
       </label>
 
       <input
-        css={input}
+        css={inputStyles}
         id="modal_pswd"
         className="modal__input"
         type="password"
@@ -54,8 +54,8 @@ export const JoinGuestLinkPasswordForm = ({onSubmit, inputValue, onInputChange}:
         onChange={event => onInputChange(event.target.value)}
       />
 
-      <Link css={link} href={Config.getConfig().URL.SUPPORT.LEARN_MORE_ABOUT_GUEST_LINKS} target="_blank">
-        <Text block color={COLOR.BLUE} css={linkText}>
+      <Link css={linkStyles} href={Config.getConfig().URL.SUPPORT.LEARN_MORE_ABOUT_GUEST_LINKS} target="_blank">
+        <Text block color={COLOR.BLUE} css={linkTextStyles}>
           {t('guestLinkPasswordModal.learnMoreLink')}
         </Text>
       </Link>

--- a/src/script/components/Modals/PrimaryModal/JoinGuestLinkPasswordForm/JoinGuestLinkPasswordForm.tsx
+++ b/src/script/components/Modals/PrimaryModal/JoinGuestLinkPasswordForm/JoinGuestLinkPasswordForm.tsx
@@ -25,21 +25,17 @@ import {t} from 'Util/LocalizerUtil';
 import {label, input, link, linkText} from './JoinGuestLinkPasswordForm.styles';
 
 interface JoinGuestLinkPasswordFormProps {
-  onFormSubmit: () => void;
+  onSubmit: () => void;
   inputValue: string;
   onInputChange: (value: string) => void;
 }
 
-export const JoinGuestLinkPasswordForm = ({
-  onFormSubmit,
-  inputValue,
-  onInputChange,
-}: JoinGuestLinkPasswordFormProps) => {
+export const JoinGuestLinkPasswordForm = ({onSubmit, inputValue, onInputChange}: JoinGuestLinkPasswordFormProps) => {
   return (
     <Form
       name="guest-password-join-form"
       data-uie-name="guest-password-join-form"
-      onSubmit={onFormSubmit}
+      onSubmit={onSubmit}
       autoComplete="off"
     >
       <label css={label} htmlFor="modal_pswd">

--- a/src/script/components/Modals/PrimaryModal/JoinGuestLinkPasswordForm/JoinGuestLinkPasswordForm.tsx
+++ b/src/script/components/Modals/PrimaryModal/JoinGuestLinkPasswordForm/JoinGuestLinkPasswordForm.tsx
@@ -22,13 +22,19 @@ import {COLOR, Form, Link, Text} from '@wireapp/react-ui-kit';
 import {Config} from 'src/script/Config';
 import {t} from 'Util/LocalizerUtil';
 
-interface JoinGuesLinkPasswordFormProps {
+import {label, input, link, linkText} from './JoinGuestLinkPasswordForm.styles';
+
+interface JoinGuestLinkPasswordFormProps {
   onFormSubmit: () => void;
   inputValue: string;
   onInputChange: (value: string) => void;
 }
 
-export const JoinGuesLinkPasswordForm = ({onFormSubmit, inputValue, onInputChange}: JoinGuesLinkPasswordFormProps) => {
+export const JoinGuestLinkPasswordForm = ({
+  onFormSubmit,
+  inputValue,
+  onInputChange,
+}: JoinGuestLinkPasswordFormProps) => {
   return (
     <Form
       name="guest-password-join-form"
@@ -36,25 +42,12 @@ export const JoinGuesLinkPasswordForm = ({onFormSubmit, inputValue, onInputChang
       onSubmit={onFormSubmit}
       autoComplete="off"
     >
-      <label
-        style={{
-          fontSize: '0.875rem',
-          fontWeight: 400,
-          lineHeight: '1rem',
-          color: 'var(--text-input-label)',
-          marginBottom: 2,
-        }}
-        htmlFor="modal_pswd"
-      >
+      <label css={label} htmlFor="modal_pswd">
         {t('guestLinkPasswordModal.passwordInputLabel')}
       </label>
 
       <input
-        style={{
-          boxShadow: '0 0 0 1px var(--text-input-border)',
-          borderRadius: 12,
-          margin: 0,
-        }}
+        css={input}
         id="modal_pswd"
         className="modal__input"
         type="password"
@@ -63,8 +56,8 @@ export const JoinGuesLinkPasswordForm = ({onFormSubmit, inputValue, onInputChang
         onChange={event => onInputChange(event.target.value)}
       />
 
-      <Link style={{marginTop: 24}} href={Config.getConfig().URL.SUPPORT.LEARN_MORE_ABOUT_GUEST_LINKS} target="_blank">
-        <Text block color={COLOR.BLUE} style={{textDecoration: 'underline', marginBottom: 24}}>
+      <Link css={link} href={Config.getConfig().URL.SUPPORT.LEARN_MORE_ABOUT_GUEST_LINKS} target="_blank">
+        <Text block color={COLOR.BLUE} css={linkText}>
           {t('guestLinkPasswordModal.learnMoreLink')}
         </Text>
       </Link>

--- a/src/script/components/Modals/PrimaryModal/PasswordAdvancedSecurityForm/PasswordAdvancedSecurityForm.tsx
+++ b/src/script/components/Modals/PrimaryModal/PasswordAdvancedSecurityForm/PasswordAdvancedSecurityForm.tsx
@@ -1,0 +1,63 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {ReactElement, ChangeEvent} from 'react';
+
+import {Input} from '@wireapp/react-ui-kit';
+
+interface PasswordAdvancedSecurityFormProps {
+  onSubmit: () => void;
+  inputValue: string;
+  inputPlaceholder: string;
+  isInputInvalid: boolean;
+  onInputChange: (value: string) => void;
+  inputHelperText: string;
+  error?: ReactElement;
+}
+
+export const PasswordAdvancedSecurityForm = ({
+  onSubmit,
+  inputValue,
+  inputPlaceholder,
+  isInputInvalid,
+  onInputChange,
+  inputHelperText,
+  error,
+}: PasswordAdvancedSecurityFormProps) => {
+  return (
+    <form onSubmit={onSubmit}>
+      <Input
+        id="modal_pswd_with_rules"
+        type="password"
+        value={inputValue}
+        placeholder={inputPlaceholder}
+        required
+        data-uie-name="backup-password"
+        markInvalid={isInputInvalid}
+        onChange={(event: ChangeEvent<HTMLInputElement>) => {
+          onInputChange(event.target.value);
+        }}
+        autoComplete="password"
+        pattern=".{2,64}"
+        helperText={inputHelperText}
+        error={error}
+      />
+    </form>
+  );
+};

--- a/src/script/components/Modals/PrimaryModal/PasswordAdvancedSecurityForm/PasswordAdvancedSecurityForm.tsx
+++ b/src/script/components/Modals/PrimaryModal/PasswordAdvancedSecurityForm/PasswordAdvancedSecurityForm.tsx
@@ -17,12 +17,12 @@
  *
  */
 
-import type {ReactElement, ChangeEvent} from 'react';
+import type {ReactElement, ChangeEvent, FormEvent} from 'react';
 
 import {Input} from '@wireapp/react-ui-kit';
 
 interface PasswordAdvancedSecurityFormProps {
-  onSubmit: () => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   inputValue: string;
   inputPlaceholder: string;
   isInputInvalid: boolean;

--- a/src/script/components/Modals/PrimaryModal/PasswordForm/PasswordForm.tsx
+++ b/src/script/components/Modals/PrimaryModal/PasswordForm/PasswordForm.tsx
@@ -1,0 +1,44 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+interface PasswordFormProps {
+  onFormSubmit: () => void;
+  inputPlaceholder: string;
+  inputValue: string;
+  onInputChange: (value: string) => void;
+}
+
+export const PasswordForm = ({onFormSubmit, inputPlaceholder, inputValue, onInputChange}: PasswordFormProps) => {
+  return (
+    <form onSubmit={onFormSubmit}>
+      <label htmlFor="modal_pswd" className="visually-hidden">
+        {inputPlaceholder}
+      </label>
+
+      <input
+        id="modal_pswd"
+        className="modal__input"
+        type="password"
+        value={inputValue}
+        placeholder={inputPlaceholder}
+        onChange={event => onInputChange(event.target.value)}
+      />
+    </form>
+  );
+};

--- a/src/script/components/Modals/PrimaryModal/PasswordForm/PasswordForm.tsx
+++ b/src/script/components/Modals/PrimaryModal/PasswordForm/PasswordForm.tsx
@@ -18,15 +18,15 @@
  */
 
 interface PasswordFormProps {
-  onFormSubmit: () => void;
+  onSubmit: () => void;
   inputPlaceholder: string;
   inputValue: string;
   onInputChange: (value: string) => void;
 }
 
-export const PasswordForm = ({onFormSubmit, inputPlaceholder, inputValue, onInputChange}: PasswordFormProps) => {
+export const PasswordForm = ({onSubmit, inputPlaceholder, inputValue, onInputChange}: PasswordFormProps) => {
   return (
-    <form onSubmit={onFormSubmit}>
+    <form onSubmit={onSubmit}>
       <label htmlFor="modal_pswd" className="visually-hidden">
         {inputPlaceholder}
       </label>

--- a/src/script/components/Modals/PrimaryModal/PasswordForm/PasswordForm.tsx
+++ b/src/script/components/Modals/PrimaryModal/PasswordForm/PasswordForm.tsx
@@ -17,8 +17,10 @@
  *
  */
 
+import type {FormEvent} from 'react';
+
 interface PasswordFormProps {
-  onSubmit: () => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   inputPlaceholder: string;
   inputValue: string;
   onInputChange: (value: string) => void;

--- a/src/script/components/Modals/PrimaryModal/PrimaryButton/PrimaryButton.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryButton/PrimaryButton.tsx
@@ -17,12 +17,12 @@
  *
  */
 
-import {forwardRef, ReactNode} from 'react';
+import {forwardRef, ReactNode, MouseEvent} from 'react';
 
 import cx from 'classnames';
 
 interface PrimaryButtonProps {
-  onClick: () => void;
+  onClick: (event: MouseEvent<HTMLButtonElement>) => void;
   disabled: boolean;
   fullWidth: boolean;
   children: ReactNode;

--- a/src/script/components/Modals/PrimaryModal/PrimaryButton/PrimaryButton.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryButton/PrimaryButton.tsx
@@ -1,0 +1,51 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {forwardRef, ReactNode} from 'react';
+
+import cx from 'classnames';
+
+interface PrimaryButtonProps {
+  onClick: () => void;
+  disabled: boolean;
+  fullWidth: boolean;
+  children: ReactNode;
+}
+
+export const PrimaryButton = forwardRef<HTMLButtonElement, PrimaryButtonProps>(
+  ({onClick, disabled, fullWidth, children}, ref) => {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        onClick={onClick}
+        disabled={disabled}
+        className={cx('modal__button modal__button--primary', {
+          'modal__button--full': fullWidth,
+        })}
+        data-uie-name="do-action"
+        key={`modal-primary-button`}
+      >
+        {children}
+      </button>
+    );
+  },
+);
+
+PrimaryButton.displayName = 'PrimaryButton';

--- a/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
@@ -243,7 +243,7 @@ export const PrimaryModalComponent: FC = () => {
 
   const primaryButton = !!primaryAction?.text && (
     <PrimaryButton
-      key={`modal-primary-button`}
+      key="modal-primary-button"
       ref={primaryActionButtonRef}
       onClick={performAction(confirm, !!closeOnConfirm)}
       disabled={isPrimaryActionDisabled(primaryAction.disabled)}

--- a/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
@@ -33,7 +33,7 @@ import {CheckboxOption} from './CheckboxOption/CheckboxOption';
 import {MessageContent} from './Content/MessageContent';
 import {GuestLinkPasswordForm} from './GuestLinkPasswordForm/GuestLinkPasswordForm';
 import {InputForm} from './InputForm/InputForm';
-import {JoinGuesLinkPasswordForm} from './JoinGuesLinkPasswordForm/JoinGuesLinkPasswordForm';
+import {JoinGuestLinkPasswordFormProps} from './JoinGuestLinkPasswordForm/JoinGuestLinkPasswordForm';
 import {PasswordAdvancedSecurityForm} from './PasswordAdvancedSecurityForm/PasswordAdvancedSecurityForm';
 import {PasswordForm} from './PasswordForm/PasswordForm';
 import {PrimaryButton} from './PrimaryButton/PrimaryButton';
@@ -316,7 +316,7 @@ export const PrimaryModalComponent: FC = () => {
         )}
 
         {isJoinGuestLinkPassword && (
-          <JoinGuesLinkPasswordForm
+          <JoinGuestLinkPasswordFormProps
             onFormSubmit={() => doAction(confirm, !!closeOnConfirm)}
             inputValue={passwordValue}
             onInputChange={setPasswordValue}

--- a/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
@@ -230,16 +230,15 @@ export const PrimaryModalComponent: FC = () => {
   const secondaryButtons = secondaryActions
     .filter((action): action is ButtonAction => action !== null && !!action.text)
     .map(action => (
-      <>
-        <SecondaryButton
-          onClick={() => doAction(action.action, !!closeOnSecondaryAction, true)}
-          disabled={action.disabled}
-          fullWidth={hasMultipleSecondary || allButtonsFullWidth}
-          uieName={action.uieName}
-        >
-          {action.text}
-        </SecondaryButton>
-      </>
+      <SecondaryButton
+        key={`${action.text}-${action.uieName}`}
+        onClick={() => doAction(action.action, !!closeOnSecondaryAction, true)}
+        disabled={action.disabled}
+        fullWidth={hasMultipleSecondary || allButtonsFullWidth}
+        uieName={action.uieName}
+      >
+        {action.text}
+      </SecondaryButton>
     ));
 
   const primaryButton = !!primaryAction?.text && (

--- a/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
@@ -19,25 +19,31 @@
 
 import {FC, FormEvent, MouseEvent, useState, useRef, ChangeEvent, useEffect, useMemo} from 'react';
 
-import cx from 'classnames';
-
 import {ValidationUtil} from '@wireapp/commons';
-import {Checkbox, CheckboxLabel, COLOR, Form, Link, Text, Input, Loading, ErrorMessage} from '@wireapp/react-ui-kit';
+import {ErrorMessage} from '@wireapp/react-ui-kit';
 
 import {CopyToClipboardButton} from 'Components/CopyToClipboardButton';
 import {FadingScrollbar} from 'Components/FadingScrollbar';
-import * as Icon from 'Components/Icon';
-import {ModalComponent} from 'Components/ModalComponent';
-import {PasswordGeneratorButton} from 'Components/PasswordGeneratorButton';
 import {Config} from 'src/script/Config';
 import {isEnterKey, isEscapeKey} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
 import {isValidPassword} from 'Util/StringUtil';
 
+import {CheckboxOption} from './CheckboxOption/CheckboxOption';
 import {MessageContent} from './Content/MessageContent';
-import {guestLinkPasswordErrorMessageStyles} from './PrimaryModal.styles';
+import {GuestLinkPasswordForm} from './GuestLinkPasswordForm/GuestLinkPasswordForm';
+import {InputForm} from './InputForm/InputForm';
+import {JoinGuesLinkPasswordForm} from './JoinGuesLinkPasswordForm/JoinGuesLinkPasswordForm';
+import {PasswordAdvancedSecurityForm} from './PasswordAdvancedSecurityForm/PasswordAdvancedSecurityForm';
+import {PasswordForm} from './PasswordForm/PasswordForm';
+import {PrimaryButton} from './PrimaryButton/PrimaryButton';
+import {PrimaryModalButtons} from './PrimaryModalButtons/PrimaryModalButtons';
+import {PrimaryModalHeader} from './PrimaryModalHeader/PrimaryModalHeader';
+import {PrimaryModalLoading} from './PrimaryModalLoading/PrimaryModalLoading';
+import {PrimaryModalShell} from './PrimaryModalShell/PrimaryModalShell';
 import {usePrimaryModalState, showNextModalInQueue, defaultContent, removeCurrentModal} from './PrimaryModalState';
 import {ButtonAction, PrimaryModalType} from './PrimaryModalTypes';
+import {SecondaryButton} from './SecondaryButton/SecondaryButton';
 
 export const PrimaryModalComponent: FC = () => {
   const [inputValue, updateInputValue] = useState<string>('');
@@ -110,6 +116,7 @@ export const PrimaryModalComponent: FC = () => {
     }
     return passwordRegex.test(passwordInput);
   };
+
   const checkGuestLinkPassword = (password: string, passwordConfirm: string): boolean => {
     if (password !== passwordConfirm) {
       return false;
@@ -196,13 +203,14 @@ export const PrimaryModalComponent: FC = () => {
 
   const secondaryActions = Array.isArray(secondaryAction) ? secondaryAction : [secondaryAction];
 
-  const modalRef = useRef<HTMLDivElement>(null);
+  const closeAction = () => {
+    if (hasPasswordWithRules) {
+      const [closeAction] = secondaryActions;
+      closeAction?.action?.();
+    }
+  };
 
   useEffect(() => {
-    if (isModalVisible) {
-      modalRef.current?.focus();
-    }
-
     const onKeyPress = (event: KeyboardEvent) => {
       if (isEscapeKey(event) && isModalVisible) {
         removeCurrentModal();
@@ -217,310 +225,136 @@ export const PrimaryModalComponent: FC = () => {
 
     document.addEventListener('keypress', onKeyPress);
     return () => document.removeEventListener('keypress', onKeyPress);
-  }, [isModalVisible, primaryAction]);
-
-  const closeAction = () => {
-    if (hasPasswordWithRules) {
-      const [closeAction] = secondaryActions;
-      closeAction?.action?.();
-    }
-  };
+  }, [primaryAction, isModalVisible]);
 
   const secondaryButtons = secondaryActions
     .filter((action): action is ButtonAction => action !== null && !!action.text)
     .map(action => (
-      <button
-        key={`${action.text}-${action.uieName}`}
-        type="button"
-        onClick={doAction(action.action, !!closeOnSecondaryAction, true)}
-        data-uie-name={action.uieName}
-        className={cx('modal__button modal__button--secondary', {
-          'modal__button--full': hasMultipleSecondary || allButtonsFullWidth,
-        })}
-        disabled={action.disabled || false}
-      >
-        {action.text}
-      </button>
+      <>
+        <SecondaryButton
+          onClick={() => doAction(action.action, !!closeOnSecondaryAction, true)}
+          disabled={action.disabled}
+          fullWidth={hasMultipleSecondary || allButtonsFullWidth}
+          uieName={action.uieName}
+        >
+          {action.text}
+        </SecondaryButton>
+      </>
     ));
 
   const primaryButton = !!primaryAction?.text && (
-    <button
-      ref={primaryActionButtonRef}
-      type="button"
-      onClick={doAction(confirm, !!closeOnConfirm)}
-      disabled={isPrimaryActionDisabled(primaryAction.disabled)}
-      className={cx('modal__button modal__button--primary', {
-        'modal__button--full': hasMultipleSecondary || allButtonsFullWidth,
-      })}
-      data-uie-name="do-action"
+    <PrimaryButton
       key={`modal-primary-button`}
+      ref={primaryActionButtonRef}
+      onClick={() => doAction(confirm, !!closeOnConfirm)}
+      disabled={isPrimaryActionDisabled(primaryAction.disabled)}
+      fullWidth={hasMultipleSecondary || allButtonsFullWidth}
     >
       {primaryAction.text}
-    </button>
+    </PrimaryButton>
   );
 
   const buttons = primaryBtnFirst ? [primaryButton, ...secondaryButtons] : [...secondaryButtons, primaryButton];
   const isPasswordFieldValid = isFormSubmitted && !passwordValueRef.current?.validity.valid;
-
-  const guestLinkPasswordErrorMessage = isPasswordFieldValid ? (
-    <ErrorMessage data-uie-name="primary-modals-error-message" css={guestLinkPasswordErrorMessageStyles}>
-      {t('modalGuestLinkJoinHelperText', {
-        minPasswordLength: Config.getConfig().MINIMUM_PASSWORD_LENGTH.toString(),
-      })}
-    </ErrorMessage>
-  ) : undefined;
 
   const backupPasswordHint = t('backupPasswordHint', {
     minPasswordLength: Config.getConfig().NEW_PASSWORD_MINIMUM_LENGTH.toString(),
   });
 
   return (
-    <div
-      id="modals"
-      data-uie-name="primary-modals-container"
-      role="dialog"
-      aria-modal="true"
-      aria-label={titleText}
-      tabIndex={-1}
-      ref={modalRef}
+    <PrimaryModalShell
+      title={titleText}
+      isShown={isModalVisible}
+      onClose={onModalHidden}
+      onBgClick={onBgClick}
+      modalUie={modalUie}
     >
-      <ModalComponent isShown={isModalVisible} onClosed={onModalHidden} onBgClick={onBgClick} data-uie-name={modalUie}>
-        {isModalVisible && (
-          <>
-            <div className="modal__header" data-uie-name="status-modal-title">
-              {titleText && (
-                <h2 className="modal__header__title" id="modal-title">
-                  {titleText}
-                </h2>
-              )}
-              {!hideCloseBtn && (
-                <button
-                  type="button"
-                  className="modal__header__button"
-                  onClick={() => {
-                    removeCurrentModal();
-                    closeAction();
-                  }}
-                  aria-label={closeBtnTitle}
-                  data-uie-name="do-close"
-                >
-                  <Icon.CloseIcon className="modal__header__icon" aria-hidden="true" />
-                </button>
-              )}
-            </div>
+      <PrimaryModalHeader
+        titleText={titleText}
+        closeBtnTitle={closeBtnTitle}
+        hideCloseBtn={hideCloseBtn}
+        closeAction={closeAction}
+      />
+      <FadingScrollbar className="modal__body">
+        <MessageContent message={message} messageHtml={messageHtml} />
 
-            <FadingScrollbar className="modal__body">
-              <MessageContent message={message} messageHtml={messageHtml} />
-
-              {isGuestLinkPassword && (
-                <PasswordGeneratorButton
-                  passwordLength={Config.getConfig().MINIMUM_PASSWORD_LENGTH}
-                  onGeneratePassword={password => {
-                    setPasswordValue(password);
-                    setPasswordConfirmationValue(password);
-                    setIsFormSubmitted(false);
-                  }}
-                />
-              )}
-
-              {isGuestLinkPassword && (
-                <Form
-                  name="guest-password-link-form"
-                  data-uie-name="guest-password-link-form"
-                  onSubmit={doAction(confirm, !!closeOnConfirm)}
-                  autoComplete="off"
-                >
-                  <Input
-                    name="guest-link-password"
-                    data-uie-name="guest-link-password"
-                    required
-                    placeholder={t('modalGuestLinkJoinPlaceholder')}
-                    label={t('modalGuestLinkJoinLabel')}
-                    helperText={t('modalGuestLinkJoinHelperText', {
-                      minPasswordLength: Config.getConfig().MINIMUM_PASSWORD_LENGTH.toString(),
-                    })}
-                    id="modal_pswd"
-                    className="modal__input"
-                    type="password"
-                    autoComplete="off"
-                    value={passwordValue}
-                    ref={passwordValueRef}
-                    onChange={event => setPasswordValue(event.currentTarget.value)}
-                    pattern={ValidationUtil.getNewPasswordPattern(Config.getConfig().NEW_PASSWORD_MINIMUM_LENGTH)}
-                    markInvalid={isPasswordFieldValid}
-                    error={guestLinkPasswordErrorMessage}
-                  />
-                  <Input
-                    name="guest-link-password-confirm"
-                    data-uie-name="guest-link-password-confirm"
-                    required
-                    placeholder={t('modalGuestLinkJoinConfirmPlaceholder')}
-                    label={t('modalGuestLinkJoinConfirmLabel')}
-                    className="modal__input"
-                    type="password"
-                    id="modal_pswd_confirmation"
-                    autoComplete="off"
-                    value={passwordConfirmationValue}
-                    onChange={event => setPasswordConfirmationValue(event.currentTarget.value)}
-                    markInvalid={isFormSubmitted && !areGuestLinkPasswordsValid}
-                  />
-                </Form>
-              )}
-
-              {copyPassword && (
-                <CopyToClipboardButton
-                  disabled={!passwordGuestLinkActionEnabled}
-                  textToCopy={passwordValue}
-                  displayText={t('guestOptionsPasswordCopyToClipboard')}
-                  copySuccessText={t('guestOptionsPasswordCopyToClipboardSuccess')}
-                  onCopySuccess={() => setDidCopyPassword(true)}
-                />
-              )}
-
-              {isPassword && (
-                <form onSubmit={doAction(confirm, !!closeOnConfirm)}>
-                  <label htmlFor="modal_pswd" className="visually-hidden">
-                    {inputPlaceholder}
-                  </label>
-
-                  <input
-                    id="modal_pswd"
-                    className="modal__input"
-                    type="password"
-                    value={passwordValue}
-                    placeholder={inputPlaceholder}
-                    onChange={event => setPasswordValue(event.target.value)}
-                  />
-                </form>
-              )}
-
-              {isJoinGuestLinkPassword && (
-                <Form
-                  name="guest-password-join-form"
-                  data-uie-name="guest-password-join-form"
-                  onSubmit={doAction(confirm, !!closeOnConfirm)}
-                  autoComplete="off"
-                >
-                  <label
-                    style={{
-                      fontSize: '0.875rem',
-                      fontWeight: 400,
-                      lineHeight: '1rem',
-                      color: 'var(--text-input-label)',
-                      marginBottom: 2,
-                    }}
-                    htmlFor="modal_pswd"
-                  >
-                    {t('guestLinkPasswordModal.passwordInputLabel')}
-                  </label>
-
-                  <input
-                    style={{
-                      boxShadow: '0 0 0 1px var(--text-input-border)',
-                      borderRadius: 12,
-                      margin: 0,
-                    }}
-                    id="modal_pswd"
-                    className="modal__input"
-                    type="password"
-                    value={passwordValue}
-                    placeholder={t('guestLinkPasswordModal.passwordInputPlaceholder')}
-                    onChange={event => setPasswordValue(event.target.value)}
-                  />
-
-                  <Link
-                    style={{marginTop: 24}}
-                    href={Config.getConfig().URL.SUPPORT.LEARN_MORE_ABOUT_GUEST_LINKS}
-                    target="_blank"
-                  >
-                    <Text block color={COLOR.BLUE} style={{textDecoration: 'underline', marginBottom: 24}}>
-                      {t('guestLinkPasswordModal.learnMoreLink')}
-                    </Text>
-                  </Link>
-                </Form>
-              )}
-
-              {hasPasswordWithRules && (
-                <form onSubmit={doAction(confirm, !!closeOnConfirm)}>
-                  <Input
-                    id="modal_pswd_with_rules"
-                    type="password"
-                    value={passwordInput}
-                    placeholder={inputPlaceholder}
-                    required
-                    data-uie-name="backup-password"
-                    markInvalid={isFormSubmitted && !isBackupPasswordValid}
-                    onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                      updatePasswordWithRules(event.target.value);
-                    }}
-                    autoComplete="password"
-                    pattern=".{2,64}"
-                    helperText={backupPasswordHint}
-                    {...(isFormSubmitted &&
-                      !isBackupPasswordValid && {error: <ErrorMessage>{backupPasswordHint}</ErrorMessage>})}
-                  />
-                </form>
-              )}
-
-              {isInput && (
-                <form onSubmit={doAction(confirm, !!closeOnConfirm)}>
-                  <label htmlFor="modal-input" className="visually-hidden">
-                    {inputPlaceholder}
-                  </label>
-
-                  <input
-                    ref={ref => ref?.focus()}
-                    maxLength={64}
-                    className="modal__input"
-                    id="modal-input"
-                    value={inputValue}
-                    placeholder={inputPlaceholder}
-                    onChange={event => updateInputValue(event.target.value)}
-                  />
-                </form>
-              )}
-
-              {errorMessage && <div className="modal__input__error">{errorMessage}</div>}
-
-              {isOption && (
-                <div className="modal-option">
-                  <Checkbox
-                    checked={optionChecked}
-                    data-uie-name="modal-option-checkbox"
-                    id="clear-data-checkbox"
-                    onChange={onOptionChange}
-                  >
-                    <CheckboxLabel className="label-xs" htmlFor="clear-data-checkbox">
-                      {checkboxLabel}
-                    </CheckboxLabel>
-                  </Checkbox>
-                </div>
-              )}
-
-              {showLoadingIndicator ? (
-                <div
-                  style={{
-                    display: 'flex',
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                    margin: '1.5rem 0 2rem 0',
-                  }}
-                >
-                  <Loading />
-                </div>
-              ) : (
-                <div
-                  className={cx('modal__buttons', {
-                    'modal__buttons--column': hasMultipleSecondary || allButtonsFullWidth,
-                  })}
-                >
-                  {buttons}
-                </div>
-              )}
-            </FadingScrollbar>
-          </>
+        {isGuestLinkPassword && (
+          <GuestLinkPasswordForm
+            onSubmit={() => doAction(confirm, !!closeOnConfirm)}
+            onGeneratePassword={password => {
+              setPasswordValue(password);
+              setPasswordConfirmationValue(password);
+              setIsFormSubmitted(false);
+            }}
+            passwordValue={passwordValue}
+            passwordValueRef={passwordValueRef}
+            onPasswordValueChange={setPasswordValue}
+            isPasswordInputMarkInvalid={isPasswordFieldValid}
+            passwordConfirmationValue={passwordConfirmationValue}
+            onPasswordConfirmationChange={setPasswordConfirmationValue}
+            isPasswordConfirmationMarkInvalid={isFormSubmitted && !areGuestLinkPasswordsValid}
+          />
         )}
-      </ModalComponent>
-    </div>
+
+        {copyPassword && (
+          <CopyToClipboardButton
+            disabled={!passwordGuestLinkActionEnabled}
+            textToCopy={passwordValue}
+            displayText={t('guestOptionsPasswordCopyToClipboard')}
+            copySuccessText={t('guestOptionsPasswordCopyToClipboardSuccess')}
+            onCopySuccess={() => setDidCopyPassword(true)}
+          />
+        )}
+
+        {isPassword && (
+          <PasswordForm
+            onFormSubmit={() => doAction(confirm, !!closeOnConfirm)}
+            inputPlaceholder={inputPlaceholder}
+            inputValue={passwordValue}
+            onInputChange={setPasswordValue}
+          />
+        )}
+
+        {isJoinGuestLinkPassword && (
+          <JoinGuesLinkPasswordForm
+            onFormSubmit={() => doAction(confirm, !!closeOnConfirm)}
+            inputValue={passwordValue}
+            onInputChange={setPasswordValue}
+          />
+        )}
+
+        {hasPasswordWithRules && (
+          <PasswordAdvancedSecurityForm
+            onSubmit={() => doAction(confirm, !!closeOnConfirm)}
+            inputValue={passwordInput}
+            inputPlaceholder={inputPlaceholder}
+            isInputInvalid={isFormSubmitted && !isBackupPasswordValid}
+            onInputChange={updatePasswordWithRules}
+            inputHelperText={backupPasswordHint}
+            {...(isFormSubmitted &&
+              !isBackupPasswordValid && {error: <ErrorMessage>{backupPasswordHint}</ErrorMessage>})}
+          />
+        )}
+
+        {isInput && (
+          <InputForm
+            onSubmit={() => doAction(confirm, !!closeOnConfirm)}
+            inputValue={inputValue}
+            inputPlaceholder={inputPlaceholder}
+            onInputChange={updateInputValue}
+          />
+        )}
+
+        {errorMessage && <div className="modal__input__error">{errorMessage}</div>}
+
+        {isOption && <CheckboxOption isChecked={optionChecked} onChange={onOptionChange} label={checkboxLabel} />}
+
+        {showLoadingIndicator ? (
+          <PrimaryModalLoading />
+        ) : (
+          <PrimaryModalButtons isColumn={hasMultipleSecondary || allButtonsFullWidth}>{buttons}</PrimaryModalButtons>
+        )}
+      </FadingScrollbar>
+    </PrimaryModalShell>
   );
 };

--- a/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
@@ -145,7 +145,7 @@ export const PrimaryModalComponent: FC = () => {
     return !inputActionEnabled && !actionEnabled;
   };
 
-  const doAction =
+  const performAction =
     (action?: Function, closeAfter = true, skipValidation = false) =>
     (event: FormEvent<HTMLFormElement> | MouseEvent<HTMLButtonElement>) => {
       event.preventDefault();
@@ -203,13 +203,6 @@ export const PrimaryModalComponent: FC = () => {
 
   const secondaryActions = Array.isArray(secondaryAction) ? secondaryAction : [secondaryAction];
 
-  const closeAction = () => {
-    if (hasPasswordWithRules) {
-      const [closeAction] = secondaryActions;
-      closeAction?.action?.();
-    }
-  };
-
   useEffect(() => {
     const onKeyPress = (event: KeyboardEvent) => {
       if (isEscapeKey(event) && isModalVisible) {
@@ -227,12 +220,19 @@ export const PrimaryModalComponent: FC = () => {
     return () => document.removeEventListener('keypress', onKeyPress);
   }, [primaryAction, isModalVisible]);
 
+  const closeAction = () => {
+    if (hasPasswordWithRules) {
+      const [closeAction] = secondaryActions;
+      closeAction?.action?.();
+    }
+  };
+
   const secondaryButtons = secondaryActions
     .filter((action): action is ButtonAction => action !== null && !!action.text)
     .map(action => (
       <SecondaryButton
         key={`${action.text}-${action.uieName}`}
-        onClick={() => doAction(action.action, !!closeOnSecondaryAction, true)}
+        onClick={performAction(action.action, !!closeOnSecondaryAction, true)}
         disabled={action.disabled}
         fullWidth={hasMultipleSecondary || allButtonsFullWidth}
         uieName={action.uieName}
@@ -245,7 +245,7 @@ export const PrimaryModalComponent: FC = () => {
     <PrimaryButton
       key={`modal-primary-button`}
       ref={primaryActionButtonRef}
-      onClick={() => doAction(confirm, !!closeOnConfirm)}
+      onClick={performAction(confirm, !!closeOnConfirm)}
       disabled={isPrimaryActionDisabled(primaryAction.disabled)}
       fullWidth={hasMultipleSecondary || allButtonsFullWidth}
     >
@@ -279,7 +279,7 @@ export const PrimaryModalComponent: FC = () => {
 
         {isGuestLinkPassword && (
           <GuestLinkPasswordForm
-            onSubmit={() => doAction(confirm, !!closeOnConfirm)}
+            onSubmit={performAction(confirm, !!closeOnConfirm)}
             onGeneratePassword={password => {
               setPasswordValue(password);
               setPasswordConfirmationValue(password);
@@ -307,7 +307,7 @@ export const PrimaryModalComponent: FC = () => {
 
         {isPassword && (
           <PasswordForm
-            onSubmit={() => doAction(confirm, !!closeOnConfirm)}
+            onSubmit={performAction(confirm, !!closeOnConfirm)}
             inputPlaceholder={inputPlaceholder}
             inputValue={passwordValue}
             onInputChange={setPasswordValue}
@@ -316,7 +316,7 @@ export const PrimaryModalComponent: FC = () => {
 
         {isJoinGuestLinkPassword && (
           <JoinGuestLinkPasswordForm
-            onSubmit={() => doAction(confirm, !!closeOnConfirm)}
+            onSubmit={performAction(confirm, !!closeOnConfirm)}
             inputValue={passwordValue}
             onInputChange={setPasswordValue}
           />
@@ -324,7 +324,7 @@ export const PrimaryModalComponent: FC = () => {
 
         {hasPasswordWithRules && (
           <PasswordAdvancedSecurityForm
-            onSubmit={() => doAction(confirm, !!closeOnConfirm)}
+            onSubmit={performAction(confirm, !!closeOnConfirm)}
             inputValue={passwordInput}
             inputPlaceholder={inputPlaceholder}
             isInputInvalid={isFormSubmitted && !isBackupPasswordValid}
@@ -337,7 +337,7 @@ export const PrimaryModalComponent: FC = () => {
 
         {isInput && (
           <InputForm
-            onSubmit={() => doAction(confirm, !!closeOnConfirm)}
+            onSubmit={performAction(confirm, !!closeOnConfirm)}
             inputValue={inputValue}
             inputPlaceholder={inputPlaceholder}
             onInputChange={updateInputValue}

--- a/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
@@ -266,7 +266,7 @@ export const PrimaryModalComponent: FC = () => {
       isShown={isModalVisible}
       onClose={onModalHidden}
       onBgClick={onBgClick}
-      modalUie={modalUie}
+      dataUieName={modalUie}
     >
       <PrimaryModalHeader
         titleText={titleText}

--- a/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
@@ -308,7 +308,7 @@ export const PrimaryModalComponent: FC = () => {
 
         {isPassword && (
           <PasswordForm
-            onFormSubmit={() => doAction(confirm, !!closeOnConfirm)}
+            onSubmit={() => doAction(confirm, !!closeOnConfirm)}
             inputPlaceholder={inputPlaceholder}
             inputValue={passwordValue}
             onInputChange={setPasswordValue}

--- a/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
@@ -33,7 +33,7 @@ import {CheckboxOption} from './CheckboxOption/CheckboxOption';
 import {MessageContent} from './Content/MessageContent';
 import {GuestLinkPasswordForm} from './GuestLinkPasswordForm/GuestLinkPasswordForm';
 import {InputForm} from './InputForm/InputForm';
-import {JoinGuestLinkPasswordFormProps} from './JoinGuestLinkPasswordForm/JoinGuestLinkPasswordForm';
+import {JoinGuestLinkPasswordForm} from './JoinGuestLinkPasswordForm/JoinGuestLinkPasswordForm';
 import {PasswordAdvancedSecurityForm} from './PasswordAdvancedSecurityForm/PasswordAdvancedSecurityForm';
 import {PasswordForm} from './PasswordForm/PasswordForm';
 import {PrimaryButton} from './PrimaryButton/PrimaryButton';
@@ -316,8 +316,8 @@ export const PrimaryModalComponent: FC = () => {
         )}
 
         {isJoinGuestLinkPassword && (
-          <JoinGuestLinkPasswordFormProps
-            onFormSubmit={() => doAction(confirm, !!closeOnConfirm)}
+          <JoinGuestLinkPasswordForm
+            onSubmit={() => doAction(confirm, !!closeOnConfirm)}
             inputValue={passwordValue}
             onInputChange={setPasswordValue}
           />

--- a/src/script/components/Modals/PrimaryModal/PrimaryModalButtons/PrimaryModalButtons.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModalButtons/PrimaryModalButtons.tsx
@@ -1,0 +1,39 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {ReactNode} from 'react';
+
+import cx from 'classnames';
+
+interface PrimaryModalButtonsProps {
+  isColumn: boolean;
+  children: ReactNode;
+}
+
+export const PrimaryModalButtons = ({isColumn, children}: PrimaryModalButtonsProps) => {
+  return (
+    <div
+      className={cx('modal__buttons', {
+        'modal__buttons--column': isColumn,
+      })}
+    >
+      {children}
+    </div>
+  );
+};

--- a/src/script/components/Modals/PrimaryModal/PrimaryModalHeader/PrimaryModalHeader.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModalHeader/PrimaryModalHeader.tsx
@@ -1,0 +1,55 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import * as Icon from 'Components/Icon';
+
+import {removeCurrentModal} from '../PrimaryModalState';
+
+interface ModalHeaderProps {
+  titleText: string;
+  closeBtnTitle?: string;
+  hideCloseBtn?: boolean;
+  closeAction: () => void;
+}
+
+export const PrimaryModalHeader = ({titleText, closeAction, closeBtnTitle, hideCloseBtn}: ModalHeaderProps) => {
+  return (
+    <div className="modal__header" data-uie-name="status-modal-title">
+      {titleText && (
+        <h2 className="modal__header__title" id="modal-title">
+          {titleText}
+        </h2>
+      )}
+      {!hideCloseBtn && (
+        <button
+          type="button"
+          className="modal__header__button"
+          onClick={() => {
+            removeCurrentModal();
+            closeAction();
+          }}
+          aria-label={closeBtnTitle}
+          data-uie-name="do-close"
+        >
+          <Icon.CloseIcon className="modal__header__icon" aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  );
+};

--- a/src/script/components/Modals/PrimaryModal/PrimaryModalHeader/PrimaryModalHeader.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModalHeader/PrimaryModalHeader.tsx
@@ -31,11 +31,9 @@ interface ModalHeaderProps {
 export const PrimaryModalHeader = ({titleText, closeAction, closeBtnTitle, hideCloseBtn}: ModalHeaderProps) => {
   return (
     <div className="modal__header" data-uie-name="status-modal-title">
-      {titleText && (
-        <h2 className="modal__header__title" id="modal-title">
-          {titleText}
-        </h2>
-      )}
+      <h2 className="modal__header__title" id="modal-title">
+        {titleText}
+      </h2>
       {!hideCloseBtn && (
         <button
           type="button"

--- a/src/script/components/Modals/PrimaryModal/PrimaryModalLoading/PrimaryModalLoading.styles.ts
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModalLoading/PrimaryModalLoading.styles.ts
@@ -19,7 +19,7 @@
 
 import {CSSObject} from '@emotion/react';
 
-export const wrapper: CSSObject = {
+export const wrapperStyles: CSSObject = {
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',

--- a/src/script/components/Modals/PrimaryModal/PrimaryModalLoading/PrimaryModalLoading.styles.ts
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModalLoading/PrimaryModalLoading.styles.ts
@@ -17,14 +17,11 @@
  *
  */
 
-import {Loading} from '@wireapp/react-ui-kit';
+import {CSSObject} from '@emotion/react';
 
-import {wrapper} from './PrimaryModalLoading.styles';
-
-export const PrimaryModalLoading = () => {
-  return (
-    <div css={wrapper}>
-      <Loading />
-    </div>
-  );
+export const wrapper: CSSObject = {
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  margin: '1.5rem 0 2rem 0',
 };

--- a/src/script/components/Modals/PrimaryModal/PrimaryModalLoading/PrimaryModalLoading.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModalLoading/PrimaryModalLoading.tsx
@@ -1,0 +1,35 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Loading} from '@wireapp/react-ui-kit';
+
+export const PrimaryModalLoading = () => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        margin: '1.5rem 0 2rem 0',
+      }}
+    >
+      <Loading />
+    </div>
+  );
+};

--- a/src/script/components/Modals/PrimaryModal/PrimaryModalLoading/PrimaryModalLoading.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModalLoading/PrimaryModalLoading.tsx
@@ -19,11 +19,11 @@
 
 import {Loading} from '@wireapp/react-ui-kit';
 
-import {wrapper} from './PrimaryModalLoading.styles';
+import {wrapperStyles} from './PrimaryModalLoading.styles';
 
 export const PrimaryModalLoading = () => {
   return (
-    <div css={wrapper}>
+    <div css={wrapperStyles}>
       <Loading />
     </div>
   );

--- a/src/script/components/Modals/PrimaryModal/PrimaryModalShell/PrimaryModalShell.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModalShell/PrimaryModalShell.tsx
@@ -1,0 +1,57 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {useRef, useEffect, ReactNode} from 'react';
+
+import {ModalComponent} from 'Components/ModalComponent';
+
+interface PrimaryModalShellProps {
+  title: string;
+  isShown: boolean;
+  children: ReactNode;
+  modalUie: string;
+  onClose: () => void;
+  onBgClick: () => void;
+}
+
+export const PrimaryModalShell = ({isShown, title, modalUie, children, onClose, onBgClick}: PrimaryModalShellProps) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isShown) {
+      modalRef.current?.focus();
+    }
+  }, [isShown]);
+
+  return (
+    <div
+      id="modals"
+      data-uie-name="primary-modals-container"
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      tabIndex={-1}
+      ref={modalRef}
+    >
+      <ModalComponent isShown={isShown} onClosed={onClose} onBgClick={onBgClick} data-uie-name={modalUie}>
+        {isShown ? children : undefined}
+      </ModalComponent>
+    </div>
+  );
+};

--- a/src/script/components/Modals/PrimaryModal/PrimaryModalShell/PrimaryModalShell.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModalShell/PrimaryModalShell.tsx
@@ -50,7 +50,7 @@ export const PrimaryModalShell = ({isShown, title, modalUie, children, onClose, 
       ref={modalRef}
     >
       <ModalComponent isShown={isShown} onClosed={onClose} onBgClick={onBgClick} data-uie-name={modalUie}>
-        {isShown ? children : undefined}
+        {isShown && children}
       </ModalComponent>
     </div>
   );

--- a/src/script/components/Modals/PrimaryModal/PrimaryModalShell/PrimaryModalShell.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModalShell/PrimaryModalShell.tsx
@@ -25,12 +25,19 @@ interface PrimaryModalShellProps {
   title: string;
   isShown: boolean;
   children: ReactNode;
-  modalUie: string;
+  dataUieName: string;
   onClose: () => void;
   onBgClick: () => void;
 }
 
-export const PrimaryModalShell = ({isShown, title, modalUie, children, onClose, onBgClick}: PrimaryModalShellProps) => {
+export const PrimaryModalShell = ({
+  isShown,
+  title,
+  dataUieName,
+  children,
+  onClose,
+  onBgClick,
+}: PrimaryModalShellProps) => {
   const modalRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -49,7 +56,7 @@ export const PrimaryModalShell = ({isShown, title, modalUie, children, onClose, 
       tabIndex={-1}
       ref={modalRef}
     >
-      <ModalComponent isShown={isShown} onClosed={onClose} onBgClick={onBgClick} data-uie-name={modalUie}>
+      <ModalComponent isShown={isShown} onClosed={onClose} onBgClick={onBgClick} data-uie-name={dataUieName}>
         {isShown && children}
       </ModalComponent>
     </div>

--- a/src/script/components/Modals/PrimaryModal/PrimaryModalShell/PrimaryModalShell.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModalShell/PrimaryModalShell.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {useRef, useEffect, ReactNode} from 'react';
+import {ReactNode} from 'react';
 
 import {ModalComponent} from 'Components/ModalComponent';
 
@@ -38,14 +38,6 @@ export const PrimaryModalShell = ({
   onClose,
   onBgClick,
 }: PrimaryModalShellProps) => {
-  const modalRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (isShown) {
-      modalRef.current?.focus();
-    }
-  }, [isShown]);
-
   return (
     <div
       id="modals"
@@ -54,7 +46,7 @@ export const PrimaryModalShell = ({
       aria-modal="true"
       aria-label={title}
       tabIndex={-1}
-      ref={modalRef}
+      ref={ref => isShown && ref?.focus()}
     >
       <ModalComponent isShown={isShown} onClosed={onClose} onBgClick={onBgClick} data-uie-name={dataUieName}>
         {isShown && children}

--- a/src/script/components/Modals/PrimaryModal/SecondaryButton/SecondaryButton.tsx
+++ b/src/script/components/Modals/PrimaryModal/SecondaryButton/SecondaryButton.tsx
@@ -17,12 +17,12 @@
  *
  */
 
-import type {ReactNode} from 'react';
+import type {ReactNode, MouseEvent} from 'react';
 
 import cx from 'classnames';
 
 interface SecondaryButtonProps {
-  onClick: () => void;
+  onClick: (event: MouseEvent<HTMLButtonElement>) => void;
   disabled?: boolean;
   children: ReactNode;
   fullWidth: boolean;

--- a/src/script/components/Modals/PrimaryModal/SecondaryButton/SecondaryButton.tsx
+++ b/src/script/components/Modals/PrimaryModal/SecondaryButton/SecondaryButton.tsx
@@ -1,0 +1,46 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {ReactNode} from 'react';
+
+import cx from 'classnames';
+
+interface SecondaryButtonProps {
+  onClick: () => void;
+  disabled?: boolean;
+  children: ReactNode;
+  fullWidth: boolean;
+  uieName?: string;
+}
+
+export const SecondaryButton = ({onClick, disabled = false, fullWidth, uieName, children}: SecondaryButtonProps) => {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-uie-name={uieName}
+      className={cx('modal__button modal__button--secondary', {
+        'modal__button--full': fullWidth,
+      })}
+      disabled={disabled}
+    >
+      {children}
+    </button>
+  );
+};


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10932" title="WPB-10932" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10932</a>  [Web] Split PrimaryModal component into more readable form
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->




## Description

I've refactored part of the PrimaryModal component. I decided to start with JSX chunks and move them into new components - that was the main goal. 

I left the logic as it was, the overall "look" of the component is untouched. Further refactoring (e.g. creating multiple modals, not sharing logic in one file, etc.) requires adding more tests, which we currently lack. I'll hold off on that for now.

No additional code was added in this PR, just moving files around, creating components/styles files, renaming stuff, etc.

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ