### PR TITLE
fix(VideoAsset): blank videos playability [WPB-11667]

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset.tsx
@@ -109,7 +109,15 @@ const VideoAsset: React.FC<VideoAssetProps> = ({
   const isVideoPlayable = async (url: string): Promise<boolean> => {
     const video = document.createElement('video');
     return new Promise<boolean>(resolve => {
-      video.onloadedmetadata = () => resolve(true);
+      video.onloadedmetadata = () => {
+        // Detects is the video track is properly available.
+        // If these dimensions are 0, typically the video track can't be properly decoded/rendered.
+        if (video.videoWidth === 0 || video.videoHeight === 0) {
+          resolve(false);
+          return;
+        }
+        resolve(true);
+      };
       video.onerror = () => resolve(false);
       video.src = url;
     });


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11667" title="WPB-11667" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11667</a>  [Web] Display unsupported video as file + countly event
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->




## Description

After merging https://github.com/wireapp/wire-webapp/pull/18200, we noticed that our logic inside `isVideoPlayable` doesn't catch every unplayable video. We've found a video where sound plays well, the video "image" is only blank, black background.

This PR fixes that issue by checking for video "dimensions". I've tested it locally (Web & Desktop App), and it works fine now.


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ