### PR TITLE
fix(VideoAsset): dark mode error message color [WPB-11667]

### DIFF
--- a/src/style/components/asset/video-asset.less
+++ b/src/style/components/asset/video-asset.less
@@ -77,7 +77,7 @@
 
     flex-direction: column;
     background-color: var(--background-fade-8);
-    color: #000;
+    color: var(--main-color);
     gap: 16px;
   }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11667" title="WPB-11667" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11667</a>  [Web] Display unsupported video as file + countly event
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Screenshots/Screencast (for UI changes)

Before:
![image](https://github.com/user-attachments/assets/8fed639a-efaa-476f-b012-6d1a18126373)

After:
![image](https://github.com/user-attachments/assets/0c04d894-0769-4e53-bd2f-45b555f45831)

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ