### PR TITLE
feat(RightSidebar): Hide delete group for removed admin from group

### DIFF
--- a/src/script/page/RightSidebar/ConversationDetails/utils/getConversationActions.ts
+++ b/src/script/page/RightSidebar/ConversationDetails/utils/getConversationActions.ts
@@ -151,7 +151,11 @@ const getConversationActions = ({
       },
     },
     {
-      condition: !isSingleUser && isTeam && roleRepository.canDeleteGroup(conversationEntity),
+      condition:
+        !isSingleUser &&
+        isTeam &&
+        roleRepository.canDeleteGroup(conversationEntity) &&
+        !conversationEntity.isSelfUserRemoved(),
       item: {
         click: () => actionsViewModel.deleteConversation(conversationEntity),
         Icon: Icon.DeleteIcon,

--- a/src/style/panel/panel.less
+++ b/src/style/panel/panel.less
@@ -302,6 +302,10 @@
       color: var(--gray-70);
       justify-self: flex-end;
 
+      .panel__action-item__summary & {
+        justify-self: flex-start;
+      }
+
       &-title {
         margin-bottom: 4px;
         font-size: 0.875rem;


### PR DESCRIPTION
## Description

Removed 'Delete group' for removed admin group.

Before:
![image](https://github.com/user-attachments/assets/e176cbc9-a09e-4cc5-aa34-6198d5f466c5)

After:
![image](https://github.com/user-attachments/assets/3196e67a-a5bd-4e5b-9737-47df9fc59c1b)

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ