### PR TITLE
chore: align AVS version with mobile platforms [WPB-11653]

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@emotion/react": "11.11.3",
     "@lexical/history": "0.12.5",
     "@lexical/react": "0.12.5",
-    "@wireapp/avs": "9.6.18",
+    "@wireapp/avs": "9.10.16",
     "@wireapp/commons": "5.2.7",
     "@wireapp/core": "46.1.0-hotfix-1.7",
     "@wireapp/react-ui-kit": "9.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4714,10 +4714,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/avs@npm:9.6.18":
-  version: 9.6.18
-  resolution: "@wireapp/avs@npm:9.6.18"
-  checksum: d7a72b37006fd30710ebae4e795b39f0159f301dbd80fe3838f34ea3e053c88d778191700b4c6d9ae57d0bff5d2856cae1f30b11074922e714acb832672beed5
+"@wireapp/avs@npm:9.10.16":
+  version: 9.10.16
+  resolution: "@wireapp/avs@npm:9.10.16"
+  checksum: 2bcbc35075f358a5f3f2de93a6f8b5779578862e95660d40412b8eeaf632f9c16a507f22ba84e2f7d16cc236b75a6d338a37356f10fec79ecd726ae7531407b3
   languageName: node
   linkType: hard
 
@@ -17505,7 +17505,7 @@ __metadata:
     "@types/speakingurl": 13.0.6
     "@types/underscore": 1.11.15
     "@types/webpack-env": 1.18.4
-    "@wireapp/avs": 9.6.18
+    "@wireapp/avs": 9.10.16
     "@wireapp/commons": 5.2.7
     "@wireapp/copy-config": 2.1.14
     "@wireapp/core": 46.1.0-hotfix-1.7


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11653" title="WPB-11653" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11653</a>  [Web] Include new AVS version in webapp
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

A new version of AVS has been released for the mobile platforms to make use the latest version of webrtc.
This align the AVS version with the mobile cliemts

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ