### PR TITLE
feat(history-backup): add countly events for history backup [WPB-11693]

### DIFF
--- a/src/script/components/HistoryExport/HistoryExport.tsx
+++ b/src/script/components/HistoryExport/HistoryExport.tsx
@@ -19,15 +19,19 @@
 
 import {useContext, useEffect, useState} from 'react';
 
+import {amplify} from 'amplify';
 import {container} from 'tsyringe';
 
 import {Button, ButtonVariant, FlexBox} from '@wireapp/react-ui-kit';
+import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {LoadingBar} from 'Components/LoadingBar/LoadingBar';
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
 import {ClientState} from 'src/script/client/ClientState';
 import {User} from 'src/script/entity/User';
 import {ContentState} from 'src/script/page/useAppState';
+import {EventName} from 'src/script/tracking/EventName';
+import {Segmentation} from 'src/script/tracking/Segmentation';
 import {t} from 'Util/LocalizerUtil';
 import {getLogger} from 'Util/Logger';
 import {getCurrentDate} from 'Util/TimeUtil';
@@ -68,7 +72,7 @@ const HistoryExport = ({switchContent, user, clientState = container.resolve(Cli
   const mainViewModel = useContext(RootContext);
 
   useEffect(() => {
-    exportHistory();
+    showBackupModal();
   }, []);
 
   if (!mainViewModel) {
@@ -138,43 +142,48 @@ const HistoryExport = ({switchContent, user, clientState = container.resolve(Cli
     }
   };
 
-  const onCancel = () => backupRepository.cancelAction();
+  const onCancel = () => {
+    amplify.publish(WebAppEvents.ANALYTICS.EVENT, EventName.HISTORY.BACKUP_CANCELLED, {
+      [Segmentation.GENERAL.STEP]: Segmentation.BACKUP_CREATION.CANCELLATION_STEP.DURING_BACKUP,
+    });
+    backupRepository.cancelAction();
+  };
 
-  const getBackUpPassword = (): Promise<string> => {
-    return new Promise(resolve => {
-      PrimaryModal.show(PrimaryModal.type.PASSWORD_ADVANCED_SECURITY, {
-        primaryAction: {
-          action: async (password: string) => {
-            resolve(password);
-          },
-          text: t('backupEncryptionModalAction'),
+  const showBackupModal = () => {
+    PrimaryModal.show(PrimaryModal.type.PASSWORD_ADVANCED_SECURITY, {
+      primaryAction: {
+        action: async (password: string, hasMultipleAttempts: boolean) => {
+          exportHistory(password, hasMultipleAttempts);
         },
-        secondaryAction: [
-          {
-            action: () => {
-              resolve('');
-              dismissExport();
-            },
-            text: t('backupEncryptionModalCloseBtn'),
+        text: t('backupEncryptionModalAction'),
+      },
+      secondaryAction: [
+        {
+          action: () => {
+            amplify.publish(WebAppEvents.ANALYTICS.EVENT, EventName.HISTORY.BACKUP_CANCELLED, {
+              [Segmentation.GENERAL.STEP]: Segmentation.BACKUP_CREATION.CANCELLATION_STEP.BEFORE_BACKUP,
+            });
+            dismissExport();
           },
-        ],
-        passwordOptional: true,
-        text: {
-          closeBtnLabel: t('backupEncryptionModalCloseBtn'),
-          input: t('backupEncryptionModalPlaceholder'),
-          message: t('backupEncryptionModalMessage'),
-          title: t('backupEncryptionModalTitle'),
+          text: t('backupEncryptionModalCloseBtn'),
         },
-      });
+      ],
+      passwordOptional: true,
+      text: {
+        closeBtnLabel: t('backupEncryptionModalCloseBtn'),
+        input: t('backupEncryptionModalPlaceholder'),
+        message: t('backupEncryptionModalMessage'),
+        title: t('backupEncryptionModalTitle'),
+      },
     });
   };
 
-  const exportHistory = async () => {
-    const password = await getBackUpPassword();
+  const exportHistory = async (password: string, hasMultipleAttempts: boolean) => {
     setHistoryState(ExportState.PREPARING);
     setHasError(false);
 
     try {
+      const startTime = Date.now();
       const numberOfRecords = await backupRepository.getBackupInitData();
       logger.log(`Exporting '${numberOfRecords}' records from history`);
 
@@ -188,7 +197,14 @@ const HistoryExport = ({switchContent, user, clientState = container.resolve(Cli
           onProgress,
           password,
         );
-
+        amplify.publish(WebAppEvents.ANALYTICS.EVENT, EventName.HISTORY.BACKUP_CREATED, {
+          // converting to seconds
+          [Segmentation.BACKUP_CREATION.CREATION_DURATION]: Math.ceil((Date.now() - startTime) / 1000),
+          [Segmentation.BACKUP_CREATION.PASSWORD]: password ? Segmentation.GENERAL.YES : Segmentation.GENERAL.NO,
+          [Segmentation.BACKUP_CREATION.PASSWORD_MULTIPLE_ATTEMPTS]: hasMultipleAttempts
+            ? Segmentation.GENERAL.YES
+            : Segmentation.GENERAL.NO,
+        });
         onSuccess(archiveBlob);
         logger.log(`Completed export of '${numberOfRecords}' records from history`);
       } else {
@@ -258,7 +274,7 @@ const HistoryExport = ({switchContent, user, clientState = container.resolve(Cli
               {t('backupCancel')}
             </Button>
 
-            <Button onClick={exportHistory} data-uie-name="do-try-again-history-export-error">
+            <Button onClick={showBackupModal} data-uie-name="do-try-again-history-export-error">
               {t('backupTryAgain')}
             </Button>
           </FlexBox>

--- a/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
@@ -184,7 +184,7 @@ export const PrimaryModalComponent: FC = () => {
       [PrimaryModalType.PASSWORD]: () => action(passwordValue),
       [PrimaryModalType.GUEST_LINK_PASSWORD]: () => action(passwordValue, didCopyPassword),
       [PrimaryModalType.JOIN_GUEST_LINK_PASSWORD]: () => action(passwordValue),
-      [PrimaryModalType.PASSWORD_ADVANCED_SECURITY]: () => action(passwordInput),
+      [PrimaryModalType.PASSWORD_ADVANCED_SECURITY]: () => action(passwordInput, isFormSubmitted),
     };
 
     if (Object.keys(actions).includes(content?.currentType ?? '')) {

--- a/src/script/tracking/EventName.ts
+++ b/src/script/tracking/EventName.ts
@@ -48,4 +48,8 @@ export const EventName = {
       UNPLAYABLE_ERROR: 'messages.video.unplayable_error',
     },
   },
+  HISTORY: {
+    BACKUP_CREATED: 'history.backup_created',
+    BACKUP_CANCELLED: 'history.backup_cancelled',
+  },
 };

--- a/src/script/tracking/Segmentation.ts
+++ b/src/script/tracking/Segmentation.ts
@@ -59,4 +59,18 @@ export const Segmentation = {
     FROM: 'from',
     TO: 'to',
   },
+  BACKUP_CREATION: {
+    PASSWORD: 'password',
+    PASSWORD_MULTIPLE_ATTEMPTS: 'password_multiple_attempts',
+    CREATION_DURATION: 'creation_duration',
+    CANCELLATION_STEP: {
+      DURING_BACKUP: 'during_backup',
+      BEFORE_BACKUP: 'before_backup',
+    },
+  },
+  GENERAL: {
+    STEP: 'step',
+    YES: 'yes',
+    NO: 'no',
+  },
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11693" title="WPB-11693" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11693</a>  [Web] Create countly event for setting password on backup
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
Add countly events for backup history.

Note: There was a bug where if user cancel a modal, the backup still be created (in background) but inaccessible for the user. Fixed in this PR.

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ