### PR TITLE
fix(translation-setup): use default lang (en-US) as fallback

### DIFF
--- a/src/script/auth/localeConfig.ts
+++ b/src/script/auth/localeConfig.ts
@@ -25,7 +25,7 @@ import {QUERY_KEY} from './route';
 import {supportedLocales as Locales} from './supportedLocales';
 
 const DEFAULT_CURRENCY = SupportedCurrency.EUR;
-const DEFAULT_LANGUAGE = 'en-US';
+export const DEFAULT_LANGUAGE = 'en-US';
 
 function getLocale(): string {
   return mapLanguage(navigator.languages?.length ? navigator.languages[0] : navigator.language);

--- a/src/script/auth/page/Root.tsx
+++ b/src/script/auth/page/Root.tsx
@@ -51,7 +51,7 @@ import {VerifyEmailCode} from './VerifyEmailCode';
 import {VerifyEmailLink} from './VerifyEmailLink';
 
 import {Config} from '../../Config';
-import {mapLanguage, normalizeLanguage} from '../localeConfig';
+import {DEFAULT_LANGUAGE, mapLanguage, normalizeLanguage} from '../localeConfig';
 import {actionRoot as ROOT_ACTIONS} from '../module/action/';
 import {bindActionCreators, RootState} from '../module/reducer';
 import * as AuthSelector from '../module/selector/AuthSelector';
@@ -96,7 +96,9 @@ const RootComponent: FC<RootProps & ConnectedProps & DispatchProps> = ({
   }, []);
 
   const loadLanguage = (language: string) => {
-    return require(`I18n/${mapLanguage(language)}.json`);
+    const defaultLanguage = require(`I18n/${DEFAULT_LANGUAGE}.json`);
+    const userLanguage = require(`I18n/${mapLanguage(language)}.json`);
+    return {...defaultLanguage, ...userLanguage};
   };
 
   const navigate = (route: string): null => {


### PR DESCRIPTION
## Description

Make use of en-US language strings when translations are missing in other languages.

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ