### PR TITLE
fix: Misbehavior in call state handling [WPB-14246]

### DIFF
--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -2169,6 +2169,7 @@ export class CallingRepository {
     if (!call) {
       return;
     }
+
     const participant = call.getParticipant(userId, clientId);
     if (!participant) {
       return;
@@ -2199,10 +2200,6 @@ export class CallingRepository {
 
     if (state === VIDEO_STATE.SCREENSHARE) {
       call.analyticsScreenSharing = true;
-    }
-
-    if (call.state() !== CALL_STATE.MEDIA_ESTAB && isSameUser && !selfParticipant.sharesScreen()) {
-      selfParticipant.releaseVideoStream(true);
     }
 
     call

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -2216,10 +2216,6 @@ export class CallingRepository {
       call.analyticsScreenSharing = true;
     }
 
-    // if (call.state() === CALL_STATE.MEDIA_ESTAB && isSameUser && !selfParticipant.sharesScreen()) {
-    //   selfParticipant.releaseVideoStream(true);
-    // }
-
     call
       .participants()
       .filter(participant => participant.doesMatchIds(userId, clientId))

--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -2201,7 +2201,7 @@ export class CallingRepository {
       call.analyticsScreenSharing = true;
     }
 
-    if (call.state() === CALL_STATE.MEDIA_ESTAB && isSameUser && !selfParticipant.sharesScreen()) {
+    if (call.state() !== CALL_STATE.MEDIA_ESTAB && isSameUser && !selfParticipant.sharesScreen()) {
       selfParticipant.releaseVideoStream(true);
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14246" title="WPB-14246" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14246</a>  [Web] Local Video removed from GUI
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

We have observed that, in the web application, the local video is removed from the video HTML element when establishing a media connection. This is very unusual, as the local video should be displayed precisely when a media transmission is established. This is a fix for this bug.

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ