### PR TITLE
feat: filter deleted users from our searchable user list [WPB-14259w]

### DIFF
--- a/src/script/components/UserList/UserList.tsx
+++ b/src/script/components/UserList/UserList.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {ChangeEvent, useCallback, useState} from 'react';
+import {ChangeEvent, useCallback, useMemo, useState} from 'react';
 
 import cx from 'classnames';
 import {container} from 'tsyringe';
@@ -96,9 +96,12 @@ export const UserList = ({
 }: UserListProps) => {
   const [maxShownUsers, setMaxShownUsers] = useState(USER_CHUNK_SIZE);
 
+  // filter out deleted users
+  const filteredUsers = useMemo(() => users.filter(user => !user.isDeleted), [users]);
+
   const [expandedFolders, setExpandedFolders] = useState<UserListSections[]>([UserListSections.CONTACTS]);
 
-  const hasMoreUsers = !truncate && users.length > maxShownUsers;
+  const hasMoreUsers = !truncate && filteredUsers.length > maxShownUsers;
 
   const highlightedUserIds = highlightedUsers.map(user => user.id);
   const {is_verified: isSelfVerified} = useKoSubscribableChildren(selfUser, ['is_verified']);
@@ -159,7 +162,7 @@ export const UserList = ({
     let adminCount = 0;
     let memberCount = 0;
 
-    users.forEach((userEntity: User) => {
+    filteredUsers.forEach((userEntity: User) => {
       if (userEntity.isService) {
         return;
       }
@@ -213,7 +216,7 @@ export const UserList = ({
       </>
     );
   } else {
-    const truncatedUsers = truncate ? users.slice(0, reducedUserCount) : users;
+    const truncatedUsers = truncate ? filteredUsers.slice(0, reducedUserCount) : filteredUsers;
     const isSelected = (userEntity: User): boolean =>
       isSelectable && !!selectedUsers?.some(user => user.id === userEntity.id);
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14259" title="WPB-14259" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14259</a>  [Web] Filter out deleted users during group creation / adding users to a group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Description

For production accounts and large organizations (teams), there are often many deleted users over time. 
They are labeled as "default", stick around in our database and show up for every rendered UserList (Group creation, Member invite, etc)

This is what it can look like:
![d4d7511f-f254-42d7-8c49-be63357d40ee](https://github.com/user-attachments/assets/dbed5d01-d992-4817-bbc3-def3089f77ee)

## Solution

This PR filters deleted users, based on our existing variable on the User-Entity.

## Result

![347f032c-94fb-4b20-a35b-c178cf6d4bab](https://github.com/user-attachments/assets/b2de06a8-77d7-4692-a175-956e37b5894b)

