### PR TITLE
runfix: block mobile browsers

### DIFF
--- a/src/script/browser/CheckBrowser.ts
+++ b/src/script/browser/CheckBrowser.ts
@@ -96,6 +96,7 @@ const checkBrowser = (): void => {
     console.error("This browser doesn't support cookies to run the Wire app!");
     return;
   }
+  // Skip the mobile browser check for OAuth
   if (isOauth()) {
     return;
   }

--- a/src/script/browser/CheckBrowser.ts
+++ b/src/script/browser/CheckBrowser.ts
@@ -99,12 +99,13 @@ const checkBrowser = (): void => {
   if (isOauth()) {
     return;
   }
-  if (!('RTCPeerConnection' in window)) {
+  const isMobile = window.matchMedia('(any-pointer:coarse)').matches;
+  if (!('RTCPeerConnection' in window) || isMobile) {
     location.href = '/unsupported/';
     console.error("This browser doesn't support RTC to run the Wire app!");
     return;
   }
-  supportsIndexDB()
+  void supportsIndexDB()
     .catch(() => false)
     .then(res => {
       if (!res) {

--- a/src/script/browser/CheckBrowser.ts
+++ b/src/script/browser/CheckBrowser.ts
@@ -39,6 +39,16 @@ const isOauth = (): boolean => location?.hash?.includes(QUERY_KEY.SCOPE) ?? fals
 
 const cookieName = 'cookie_supported_test_wire_cookie_name';
 
+const isMobileBrowser = (): boolean => {
+  const isTouchScreen = window.matchMedia('(any-pointer:coarse)').matches;
+  const isSmallScreen = window.matchMedia('(max-width: 768px)').matches;
+  return (
+    isTouchScreen &&
+    isSmallScreen &&
+    /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
+  );
+};
+
 const supportsCookies = (): boolean => {
   switch (navigator.cookieEnabled) {
     case true:
@@ -53,6 +63,11 @@ const supportsCookies = (): boolean => {
       }
       return false;
   }
+};
+
+const redirectUnsupportedBrowser = (error: string): void => {
+  location.href = '/unsupported/';
+  console.error(error);
 };
 
 const supportsIndexDB = (): Promise<boolean> =>
@@ -92,26 +107,28 @@ const supportsIndexDB = (): Promise<boolean> =>
 
 const checkBrowser = (): void => {
   if (!supportsCookies()) {
-    location.href = '/unsupported/';
-    console.error("This browser doesn't support cookies to run the Wire app!");
+    redirectUnsupportedBrowser("This browser doesn't support cookies to run the Wire app!");
     return;
   }
   // Skip the mobile browser check for OAuth
   if (isOauth()) {
     return;
   }
-  const isMobile = window.matchMedia('(any-pointer:coarse)').matches;
-  if (!('RTCPeerConnection' in window) || isMobile) {
-    location.href = '/unsupported/';
-    console.error("This browser doesn't support RTC to run the Wire app!");
+
+  if (isMobileBrowser()) {
+    redirectUnsupportedBrowser("This browser doesn't support the Wire app on mobile devices!");
+    return;
+  }
+
+  if (!('RTCPeerConnection' in window)) {
+    redirectUnsupportedBrowser("This browser doesn't support RTC to run the Wire app!");
     return;
   }
   void supportsIndexDB()
     .catch(() => false)
     .then(res => {
       if (!res) {
-        location.href = '/unsupported/';
-        console.error("This browser doesn't support IndexDB to run the Wire app!");
+        redirectUnsupportedBrowser("This browser doesn't support IndexDB to run the Wire app!");
       }
     });
 };


### PR DESCRIPTION
## Description

The PR from a while ago which reworked our way of detecting browsers [#17325](https://github.com/wireapp/wire-webapp/pull/17325) had the side effect that our mobile detection has been removed as well.

This PR adds the mobile detection back in and blocks mobile devices.
