### PR TITLE
fix: adjust background color for in call reactions tooltip [WPB-14328]

### DIFF
--- a/src/style/foundation/video-calling.less
+++ b/src/style/foundation/video-calling.less
@@ -142,7 +142,7 @@
     display: grid;
     padding: 0.4rem;
     border-radius: 1rem;
-    background-color: #fff;
+    background-color: var(--app-bg-secondary);
     box-shadow: 0px 7px 15px 0 #0000004d;
     gap: 0.5rem;
     grid-template-columns: repeat(3, 1fr);
@@ -154,7 +154,7 @@
       left: 50%;
       width: 0;
       height: 0;
-      border-top: 0.5rem solid #fff;
+      border-top: 0.5rem solid var(--app-bg-secondary);
       border-right: 0.5rem solid transparent;
       border-left: 0.5rem solid transparent;
       content: '';
@@ -167,7 +167,7 @@
       border-radius: 1rem;
       font-size: 1.5rem;
       &:hover {
-        background-color: var(--inactive-call-button-border);
+        background-color: var(--inactive-call-button-hover-bg);
       }
 
       &.disabled {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14328" title="WPB-14328" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14328</a>  [Web] Tooltip for incall reactions not darkmode friendly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

assign css variable for tooltip's background compatible with dark mode

<!-- Uncomment this section if your PR has UI changes -->
## Screenshots/Screencast (for UI changes)
Before:
![image](https://github.com/user-attachments/assets/57e843ed-8def-4422-827d-48d426ee5679)
After:
![image](https://github.com/user-attachments/assets/8ec35867-ad2d-4803-be33-19a93462fe38)

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ