### PR TITLE
fix(UserRepository): ensure local user has a name before returning user object [WPB-11166]

### DIFF
--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -583,7 +583,7 @@ export class UserRepository extends TypedEventEmitter<Events> {
 
       const localUser = dbUsers.find(dbUser => dbUser.id === user.id);
 
-      if (localUser) {
+      if (localUser && localUser.name) {
         return {
           ...user,
           name: localUser.name,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11166" title="WPB-11166" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11166</a>  [web] Maintain user name when they are removed from the backend.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Minor adjustment for https://github.com/wireapp/wire-webapp/pull/18304

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ