### PR TITLE
fix(JumpToLastMessageButton): reposition JumpToLastMessageButton [WPB-10711] [WPB-12092]

### DIFF
--- a/src/script/components/MessagesList/MessageList.styles.ts
+++ b/src/script/components/MessagesList/MessageList.styles.ts
@@ -20,17 +20,15 @@
 import {CSSObject} from '@emotion/react';
 
 export const jumpToLastMessageButtonStyles: CSSObject = {
-  position: 'absolute',
+  position: 'sticky',
   right: '10px',
   height: '40px',
   borderRadius: '100%',
-  bottom: '56px',
-  marginBottom: '10px',
+  bottom: '10px',
+  marginLeft: 'auto',
+  marginTop: '-40px',
+  marginBottom: 0,
   zIndex: 1,
-
-  '@media (max-width: 768px)': {
-    bottom: '100px',
-  },
 };
 
 export const jumpToLastMessageChevronStyles: CSSObject = {

--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -359,8 +359,8 @@ export const MessagesList: FC<MessagesListParams> = ({
             });
           })}
         </div>
+        <JumpToLastMessageButton onGoToLastMessage={jumpToLastMessage} conversation={conversation} />
       </FadingScrollbar>
-      <JumpToLastMessageButton onGoToLastMessage={jumpToLastMessage} conversation={conversation} />
     </>
   );
 };

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -19,6 +19,7 @@
 
 // MEMBER LIST
 .message-list {
+  position: relative;
   overflow: auto;
   flex: 1 1;
 }


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10711" title="WPB-10711" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10711</a>  [Web] input bar overlaps the "jump to bottom" button
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->




## Description
This PR contains the fix for two tickets: 
https://wearezeta.atlassian.net/browse/WPB-10711 (the jump to bottom button should move up with the input bar)
https://wearezeta.atlassian.net/browse/WPB-12092 (the jump to bottom should be visible if the group information panel is open)

I tested it on three browsers (Chrome, Firefox, Safari) with mobile, tablet, and desktop resolution.


## Screenshots/Screencast (for UI changes)
#### with a long message and without the group information side panel
![Screenshot 2024-11-15 at 10 42 31](https://github.com/user-attachments/assets/c5b57dba-ee6c-4fde-894d-c93b380f1ff2)
![Screenshot 2024-11-15 at 17 24 55](https://github.com/user-attachments/assets/15c2b3de-52b3-4a53-a00d-0572124f1ac9)

#### without a long message and the group information side panel
![Screenshot 2024-11-15 at 10 43 01](https://github.com/user-attachments/assets/47a6d98d-7ef7-4ff2-8662-81d945a005de)
![Screenshot 2024-11-15 at 17 24 39](https://github.com/user-attachments/assets/e3968f7d-8df2-4cde-80c2-b01f1e0b03b5)

#### with a long message and the group information side panel
![Screenshot 2024-11-15 at 10 42 40](https://github.com/user-attachments/assets/e0998701-a53f-49a1-91e1-45f336f1521d)
![Screenshot 2024-11-15 at 17 26 05](https://github.com/user-attachments/assets/84b25869-4d68-4b89-9678-8d4487d64686)

#### without a long message and with the group information side panel
![Screenshot 2024-11-15 at 10 42 51](https://github.com/user-attachments/assets/ac5dd9fd-9546-4d01-acc4-460f8dbd71ab)

#### without the jump to bottom button
![Screenshot 2024-11-15 at 10 43 13](https://github.com/user-attachments/assets/8ee60df5-cc95-42a0-af95-07914c1931fc)


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->

[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ