### PR TITLE
fix(JoinGuestLinkPasswordModal): heading copy [WPB-11041]

### DIFF
--- a/src/script/auth/component/JoinGuestLinkPasswordModal.tsx
+++ b/src/script/auth/component/JoinGuestLinkPasswordModal.tsx
@@ -24,6 +24,8 @@ import {useIntl} from 'react-intl';
 
 import {Button, COLOR, Container, ErrorMessage, Form, H2, Input, Link, Modal, Text} from '@wireapp/react-ui-kit';
 
+import {t} from 'Util/LocalizerUtil';
+
 import {Config} from '../../Config';
 import {joinGuestLinkPasswordModalStrings} from '../../strings';
 
@@ -62,8 +64,8 @@ const JoinGuestLinkPasswordModal: React.FC<JoinGuestLinkPasswordModalProps> = ({
       <Container style={{maxWidth: '400px'}}>
         <H2 style={{whiteSpace: 'break-spaces', fontWeight: 500, marginTop: '10px', textAlign: 'center'}}>
           {conversationName
-            ? _(joinGuestLinkPasswordModalStrings.headline, {conversationName})
-            : _(joinGuestLinkPasswordModalStrings.headlineDefault)}
+            ? t('guestLinkPasswordModal.headline', {conversationName})
+            : t('guestLinkPasswordModal.headlineDefault')}
         </H2>
         <Text block fontSize="var(--font-size-base)" style={{marginBottom: 24}}>
           {_(joinGuestLinkPasswordModalStrings.description)}

--- a/src/script/strings.ts
+++ b/src/script/strings.ts
@@ -350,14 +350,6 @@ export const acceptNewsModalStrings = defineMessages({
 });
 
 export const joinGuestLinkPasswordModalStrings = defineMessages({
-  headline: {
-    defaultMessage: '{conversationName} \n Enter password',
-    id: 'guestLinkPasswordModal.headline',
-  },
-  headlineDefault: {
-    defaultMessage: 'Enter password',
-    id: 'guestLinkPasswordModal.headlineDefault',
-  },
   description: {
     defaultMessage: 'Please enter the password you have received with the access link for this conversation.',
     id: 'guestLinkPasswordModal.description',


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11041" title="WPB-11041" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11041</a>  [web] Guest link password copy is broken.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Fix the guest link password heading copy.

![image](https://github.com/user-attachments/assets/3c64c9d2-40ed-444d-8c55-c54ec1fcfd3d)


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ