### PR TITLE
feat(EnrichedFields): don't show the "status" field when the availability is "none" [WPB-12116]

### DIFF
--- a/src/script/components/panel/EnrichedFields.tsx
+++ b/src/script/components/panel/EnrichedFields.tsx
@@ -100,7 +100,8 @@ const EnrichedFields = ({
     return null;
   }
 
-  const shouldShowAvailability = showAvailability && ![undefined, Availability.Type.NONE].includes(availability);
+  const shouldShowAvailability =
+    showAvailability && availability !== undefined && availability !== Availability.Type.NONE;
 
   return (
     <div className="enriched-fields">

--- a/src/script/components/panel/EnrichedFields.tsx
+++ b/src/script/components/panel/EnrichedFields.tsx
@@ -22,6 +22,8 @@ import {useEffect, useState} from 'react';
 import type {RichInfoField} from '@wireapp/api-client/lib/user/RichInfo';
 import {container} from 'tsyringe';
 
+import {Availability} from '@wireapp/protocol-messaging';
+
 import {availabilityStatus, availabilityTranslationKeys} from 'Util/AvailabilityStatus';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
@@ -98,9 +100,11 @@ const EnrichedFields = ({
     return null;
   }
 
+  const shouldShowAvailability = showAvailability && ![undefined, Availability.Type.NONE].includes(availability);
+
   return (
     <div className="enriched-fields">
-      {showAvailability && availability !== undefined && (
+      {shouldShowAvailability && (
         <div className="enriched-fields__entry">
           <p className="enriched-fields__entry__key" data-uie-name="item-enriched-key">
             {t('availability.status')}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-12116" title="WPB-12116" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-12116</a>  [Web] Do not show status field in user profile (via deeplink) if no status is set
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Don't display "Status" when the availability is "none"

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ