### PR TITLE
fix(search-conv): fix search input focus out [WPB-14253]

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationHeader/ConversationHeader.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationHeader/ConversationHeader.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {forwardRef, KeyboardEvent, useEffect, useRef} from 'react';
+import {forwardRef, KeyboardEvent, MutableRefObject, useEffect} from 'react';
 
 import {amplify} from 'amplify';
 
@@ -53,6 +53,7 @@ interface ConversationHeaderProps {
   currentFolder?: ConversationLabel;
   onSearchEnterClick: (event: KeyboardEvent<HTMLInputElement>) => void;
   jumpToRecentSearch: () => void;
+  searchInputRef: MutableRefObject<HTMLInputElement | null>;
 }
 
 export const ConversationHeaderComponent = ({
@@ -65,9 +66,8 @@ export const ConversationHeaderComponent = ({
   searchInputPlaceholder,
   onSearchEnterClick,
   jumpToRecentSearch,
+  searchInputRef,
 }: ConversationHeaderProps) => {
-  const inputRef = useRef<HTMLInputElement | null>(null);
-
   const {canCreateGroupConversation} = generatePermissionHelpers(selfUser.teamRole());
   const isFolderView = currentTab === SidebarTabs.FOLDER;
 
@@ -89,7 +89,7 @@ export const ConversationHeaderComponent = ({
   useEffect(() => {
     const onSearchShortcut = () => {
       jumpToRecentSearch();
-      inputRef.current?.focus();
+      searchInputRef?.current?.focus();
     };
 
     amplify.subscribe(WebAppEvents.SHORTCUT.SEARCH, onSearchShortcut);
@@ -97,7 +97,7 @@ export const ConversationHeaderComponent = ({
     return () => {
       amplify.unsubscribe(WebAppEvents.SHORTCUT.SEARCH, onSearchShortcut);
     };
-  }, [jumpToRecentSearch]);
+  }, [searchInputRef, jumpToRecentSearch]);
 
   return (
     <>
@@ -121,7 +121,7 @@ export const ConversationHeaderComponent = ({
       {showSearchInput && (
         <Input
           onKeyDown={onKeyDown}
-          ref={inputRef}
+          ref={searchInputRef}
           className="label-1"
           value={searchValue}
           onChange={event => setSearchValue(event.currentTarget.value)}

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React, {KeyboardEvent as ReactKeyBoardEvent, useEffect, useState} from 'react';
+import React, {KeyboardEvent as ReactKeyBoardEvent, useEffect, useRef, useState} from 'react';
 
 import {amplify} from 'amplify';
 import {container} from 'tsyringe';
@@ -96,6 +96,7 @@ const Conversations: React.FC<ConversationsProps> = ({
   selfUser,
 }) => {
   const [conversationListRef, setConversationListRef] = useState<HTMLElement | null>(null);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
 
   const {currentTab, status: sidebarStatus, setStatus: setSidebarStatus, setCurrentTab} = useSidebarStore();
   const [conversationsFilter, setConversationsFilter] = useState<string>('');
@@ -319,6 +320,7 @@ const Conversations: React.FC<ConversationsProps> = ({
             searchInputPlaceholder={searchInputPlaceholder}
             onSearchEnterClick={handleEnterSearchClick}
             jumpToRecentSearch={jumpToRecentSearch}
+            searchInputRef={searchInputRef}
           />
         }
         setConversationListRef={setConversationListRef}
@@ -405,6 +407,7 @@ const Conversations: React.FC<ConversationsProps> = ({
                 isEmpty={hasEmptyConversationsList}
                 groupParticipantsConversations={groupParticipantsConversations}
                 isGroupParticipantsVisible={isGroupParticipantsVisible}
+                searchInputRef={searchInputRef}
               />
             )}
           </>

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.test.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.test.tsx
@@ -17,6 +17,8 @@
  *
  */
 
+import {createRef} from 'react';
+
 import {render} from '@testing-library/react';
 import {ConversationProtocol, CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation';
 import ko from 'knockout';
@@ -82,6 +84,7 @@ describe('ConversationsList', () => {
         groupParticipantsConversations={[]}
         isGroupParticipantsVisible={false}
         isEmpty={false}
+        searchInputRef={createRef()}
       />,
     );
 

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
@@ -17,7 +17,13 @@
  *
  */
 
-import React, {MouseEvent as ReactMouseEvent, KeyboardEvent as ReactKeyBoardEvent, useEffect, useState} from 'react';
+import React, {
+  MouseEvent as ReactMouseEvent,
+  KeyboardEvent as ReactKeyBoardEvent,
+  useEffect,
+  useState,
+  MutableRefObject,
+} from 'react';
 
 import {ConversationListCell} from 'Components/ConversationListCell';
 import {Call} from 'src/script/calling/Call';
@@ -58,6 +64,7 @@ interface ConversationsListProps {
   groupParticipantsConversations: Conversation[];
   isGroupParticipantsVisible: boolean;
   isEmpty: boolean;
+  searchInputRef: MutableRefObject<HTMLInputElement | null>;
 }
 
 export const ConversationsList = ({
@@ -75,6 +82,7 @@ export const ConversationsList = ({
   groupParticipantsConversations,
   isGroupParticipantsVisible,
   isEmpty,
+  searchInputRef,
 }: ConversationsListProps) => {
   const {setCurrentView} = useAppMainState(state => state.responsiveView);
   const {currentTab} = useSidebarStore();
@@ -104,7 +112,8 @@ export const ConversationsList = ({
   };
 
   const getCommonConversationCellProps = (conversation: Conversation, index: number) => ({
-    isFocused: !conversationsFilter && currentFocus === conversation.id,
+    isFocused:
+      document.activeElement !== searchInputRef.current && !conversationsFilter && currentFocus === conversation.id,
     handleArrowKeyDown: handleArrowKeyDown(index),
     resetConversationFocus: resetConversationFocus,
     dataUieName: 'item-conversation',


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14253" title="WPB-14253" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14253</a>  "Search for conversation" searchfiled should not automatically de-select
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
Fix search conversation input focus out on last character removal.

## Screenshots/Screencast (for UI changes)

### Before:

https://github.com/user-attachments/assets/478c9726-77d0-4d65-b365-8c8979cc18da

### After: 

https://github.com/user-attachments/assets/a7e55870-22b0-4bdb-8ccb-d8fcef4574e8

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ