### PR TITLE
runfix: address design review for call reactions [WPB-14328]

### DIFF
--- a/src/style/foundation/video-calling.less
+++ b/src/style/foundation/video-calling.less
@@ -141,8 +141,8 @@
     left: 50%;
     display: grid;
     padding: 0.4rem;
-    border-radius: 1rem;
-    background-color: var(--app-bg-secondary);
+    border-radius: 12px;
+    background-color: var(--inactive-call-button-bg);
     box-shadow: 0px 7px 15px 0 #0000004d;
     gap: 0.5rem;
     grid-template-columns: repeat(3, 1fr);
@@ -154,7 +154,7 @@
       left: 50%;
       width: 0;
       height: 0;
-      border-top: 0.5rem solid var(--app-bg-secondary);
+      border-top: 0.5rem solid var(--inactive-call-button-bg);
       border-right: 0.5rem solid transparent;
       border-left: 0.5rem solid transparent;
       content: '';


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14328" title="WPB-14328" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14328</a>  [Web] Tooltip for incall reactions not darkmode friendly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

- Use a different color for the call reaction background in dark mode, from black to fray-90
- Change corner radius from 1rem to 12px (rem border radius can be unpredictable because of different system font scaling)

<!-- Uncomment this section if your PR has UI changes -->

## Screenshots/Screencast (for UI changes)
Before:
![image](https://github.com/user-attachments/assets/fd7c1c68-7361-4ef5-8cc7-d133f4dc1eb3)

After:
![image](https://github.com/user-attachments/assets/05046121-819f-4fc9-8d17-43b3267fe633)


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ