### PR TITLE
revert: bump @types/node from 22.9.0 to 22.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@types/libsodium-wrappers": "0",
     "@types/linkify-it": "5.0.0",
     "@types/markdown-it": "14.1.1",
-    "@types/node": "22.9.3",
+    "@types/node": "22.9.0",
     "@types/open-graph": "0.2.5",
     "@types/platform": "1.3.6",
     "@types/react": "18.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5365,12 +5365,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:22.9.3":
-  version: 22.9.3
-  resolution: "@types/node@npm:22.9.3"
+"@types/node@npm:22.9.0":
+  version: 22.9.0
+  resolution: "@types/node@npm:22.9.0"
   dependencies:
     undici-types: "npm:~6.19.8"
-  checksum: 10/c32a03ff998b8c6cf7d653216508a92b1e6569dd5031ea6cfc2aaa8c75ebbf4172bf1602f0e1f673086e210787dc96667b99ba4d919bc151f9a1f88aeac42822
+  checksum: 10/a7df3426891868b0f5fb03e46aeddd8446178233521c624a44531c92a040cf08a82d8235f7e1e02af731fd16984665d4d71f3418caf9c2788313b10f040d615d
   languageName: node
   linkType: hard
 
@@ -18708,7 +18708,7 @@ __metadata:
     "@types/libsodium-wrappers": "npm:0"
     "@types/linkify-it": "npm:5.0.0"
     "@types/markdown-it": "npm:14.1.1"
-    "@types/node": "npm:22.9.3"
+    "@types/node": "npm:22.9.0"
     "@types/open-graph": "npm:0.2.5"
     "@types/platform": "npm:1.3.6"
     "@types/react": "npm:18.3.3"


### PR DESCRIPTION
Reverts wireapp/wire-webapp#18366