### PR TITLE
chore(dependabot): ignore @types/node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,7 @@ updates:
       - dependency-name: '@mediapipe/tasks-vision'
         versions:
           - '0.10.16'
+      - dependency-name: '@types/node'
 
   # Server dependencies
   - package-ecosystem: npm
@@ -56,8 +57,6 @@ updates:
         versions:
           - '>= 2.a'
       - dependency-name: '@types/node'
-        versions:
-          - '>= 13.a'
 
   # Github actions
   - package-ecosystem: 'github-actions'


### PR DESCRIPTION
## Description

Ignore auto bumping `@types/node` after it has broken our dev server

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ