### PR TITLE
chore: Revert "chore: Serialize object arguments in desktop runtime (#18359)"

### DIFF
--- a/src/script/util/Logger.ts
+++ b/src/script/util/Logger.ts
@@ -17,42 +17,15 @@
  *
  */
 
-import {LogFactory, Logger, Runtime} from '@wireapp/commons';
+import {LogFactory, Logger} from '@wireapp/commons';
 
 const LOGGER_NAMESPACE = '@wireapp/webapp';
 
-function serializeArgs(args: any[]): any[] {
-  return args.map(arg => (typeof arg === 'object' && arg !== null ? JSON.stringify(arg) : arg));
-}
-
 function getLogger(name: string): Logger {
-  const logger = LogFactory.getLogger(name, {
+  return LogFactory.getLogger(name, {
     namespace: LOGGER_NAMESPACE,
     separator: '/',
   });
-
-  if (Runtime.isDesktopApp()) {
-    return {
-      ...logger,
-      debug: (...args: any[]): void => {
-        logger.debug(...serializeArgs(args));
-      },
-      error: (...args: any[]): void => {
-        logger.error(...serializeArgs(args));
-      },
-      info: (...args: any[]): void => {
-        logger.info(...serializeArgs(args));
-      },
-      log: (...args: any[]): void => {
-        logger.log(...serializeArgs(args));
-      },
-      warn: (...args: any[]): void => {
-        logger.warn(...serializeArgs(args));
-      },
-    };
-  }
-
-  return logger;
 }
 
 export {getLogger, LOGGER_NAMESPACE, Logger};


### PR DESCRIPTION
This reverts commit c93b3d0c7d233e48ef09f8bc5eaf349148cbb7d1.

We now have the logic included in the commons package it self, see: https://github.com/wireapp/wire-web-packages/pull/6696/files#diff-ad6a94dc3c89ce1621f2eb61ea0048c4e42ea4295bbe326d7461c22e852f376fR122-R141
