### PR TITLE
chore: Do not log profile image data url

### DIFF
--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -343,7 +343,7 @@ export class TeamRepository extends TypedEventEmitter<Events> {
         accountInfo.availability = this.userState.self().availability();
       }
 
-      this.logger.log('Publishing account info', accountInfo);
+      this.logger.log('Publishing account info', {...accountInfo, picture: null});
       amplify.publish(WebAppEvents.TEAM.INFO, accountInfo);
       return accountInfo;
     }


### PR DESCRIPTION
## Description:
Updated the logging of accountInfo to omit the large picture field, making the log more readable and preventing unnecessarily large log files.

## Changes:
Replaced this.logger.log('Publishing account info', accountInfo) with this.logger.log('Publishing account info', {...accountInfo, picture: null}).

The picture field was too large and not readable, making the log files unnecessarily heavy.