### PR TITLE
fix(mls-migration): align with other clients on which proteus converstaion to migrate (WPB-12162)

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -1620,8 +1620,10 @@ export class ConversationRepository {
       ),
     );
 
-    const mostRecentlyUsedProteusConversation = proteusConversations.sort(
-      (a, b) => b.last_event_timestamp() - a.last_event_timestamp(),
+    // In the event that multiple 1:1 Proteus conversations exist, we migrate the one with the lowest id
+    // See https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/1344602120/Use+case+multiple+1+1+conversation+in+teams+Proteus
+    const proteusConversationToBeKept = proteusConversations.sort((a, b) =>
+      a.qualifiedId.id.localeCompare(b.qualifiedId.id),
     )[0];
 
     // Before we delete the proteus 1:1 conversation, we need to make sure all the local properties are also migrated
@@ -1638,7 +1640,7 @@ export class ConversationRepository {
       mutedTimestamp,
       status,
       verification_state,
-    } = mostRecentlyUsedProteusConversation;
+    } = proteusConversationToBeKept;
 
     const updates: Partial<Record<keyof Conversation, any>> = {
       archivedState: archivedState(),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-12162" title="WPB-12162" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-12162</a>  [Web] Make sure the correct 1:1 convo is migrated to MLS
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Description

In the event of migrating 1:1 conversations to MLS, it is possible due to a race condition that multiple proteus conversation exist.
We previously relied on timestamps to find the latest active conversation to copy, the other clients are using the conversation qualified id in ascending order, see https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/1344602120/Use+case+multiple+1+1+conversation+in+teams+Proteus

This makes sure our migration strategy is aligned with other clients

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ