### PR TITLE
feat: Avoid in call reactions transmitting to other calls (WPB-14330)

### DIFF
--- a/src/script/calling/CallingRepository.ts
+++ b/src/script/calling/CallingRepository.ts
@@ -752,12 +752,16 @@ export class CallingRepository {
       }
 
       case CALL_MESSAGE_TYPE.EMOJIS: {
-        const call = this.findCall(conversationId);
-        if (!call || !this.selfUser) {
+        const currentCall = this.callState.joinedCall();
+        if (
+          !currentCall ||
+          !matchQualifiedIds(currentCall.conversation.qualifiedId, conversationId) ||
+          !this.selfUser
+        ) {
           return;
         }
 
-        const senderParticipant = call
+        const senderParticipant = currentCall
           .participants()
           .find(participant => matchQualifiedIds(participant.user.qualifiedId, userId));
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14330" title="WPB-14330" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14330</a>  [Web] Reactions on a call transmit to other calls
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Description

We need to use current call instead of all calls to not show reactions when you're on a different call