### PR TITLE
chore: remove ticket number from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
 
 ## Checklist
 
-- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-423])
+- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
 - [ ] PR has been self reviewed by the author;
 - [ ] Hard-to-understand areas of the code have been commented;
 - [ ] If it is a core feature, unit tests have been added;


### PR DESCRIPTION
## Description

Using an actual ticket as an example in the PR template is creating issues with Echoes when the box is left unchecked

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
