### PR TITLE
fix: prevent overlap of warning container in call [WPB-14331]

### DIFF
--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -22,6 +22,7 @@ import React, {useEffect, useRef, useState} from 'react';
 import {DefaultConversationRoleName} from '@wireapp/api-client/lib/conversation/';
 import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 import classNames from 'classnames';
+import cx from 'classnames';
 import {container} from 'tsyringe';
 
 import {CALL_TYPE} from '@wireapp/avs';
@@ -73,6 +74,7 @@ import {CallingViewMode, CallState, MuteState} from '../../calling/CallState';
 import {Participant} from '../../calling/Participant';
 import type {Grid} from '../../calling/videoGridHandler';
 import type {Conversation} from '../../entity/Conversation';
+import {useWarnings} from '../../guards/useWarnings';
 import {ElectronDesktopCapturerSource, MediaDevicesHandler} from '../../media/MediaDevicesHandler';
 import {TeamState} from '../../team/TeamState';
 import {CallViewTab} from '../../view_model/CallingViewModel';
@@ -144,6 +146,9 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
   const [isConfirmCloseModalOpen, setIsConfirmCloseModalOpen] = useState<boolean>(false);
   const [showEmojisBar, setShowEmojisBar] = useState<boolean>(false);
   const [disabledEmojis, setDisabledEmojis] = useState<string[]>([]);
+
+  const {showSmallOffset, showLargeOffset} = useWarnings();
+
   const selfParticipant = call.getSelfParticipant();
   const {sharesScreen: selfSharesScreen, sharesCamera: selfSharesCamera} = useKoSubscribableChildren(selfParticipant, [
     'sharesScreen',
@@ -406,7 +411,12 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
   const isModerator = selfUser && roles[selfUser.id] === DefaultConversationRoleName.WIRE_ADMIN;
 
   return (
-    <div className="video-calling-wrapper">
+    <div
+      className={cx('video-calling-wrapper', {
+        'app--small-offset': showSmallOffset,
+        'app--large-offset': showLargeOffset,
+      })}
+    >
       <div id="video-calling" className="video-calling">
         <div css={videoTopBarStyles}>
           <div id="video-title" className="video-title">

--- a/src/script/guards/useWarnings.ts
+++ b/src/script/guards/useWarnings.ts
@@ -1,0 +1,34 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {useWarningsState} from '../view_model/WarningsContainer/WarningsState';
+import {CONFIG, TYPE as type} from '../view_model/WarningsContainer/WarningsTypes';
+
+export const useWarnings = () => {
+  const warnings = useWarningsState(state => state.warnings);
+  const visibleWarning = warnings[warnings.length - 1];
+  const isConnectivityRecovery = visibleWarning === type.CONNECTIVITY_RECOVERY;
+  const hasOffset = warnings.length > 0 && !isConnectivityRecovery;
+  const isMiniMode = CONFIG.MINI_MODES.includes(visibleWarning);
+
+  return {
+    showSmallOffset: hasOffset && isMiniMode,
+    showLargeOffset: hasOffset && !isMiniMode,
+  };
+};

--- a/src/script/page/AppMain.tsx
+++ b/src/script/page/AppMain.tsx
@@ -20,6 +20,7 @@
 import {FC, useEffect, useLayoutEffect} from 'react';
 
 import {amplify} from 'amplify';
+import cx from 'classnames';
 import {ErrorBoundary} from 'react-error-boundary';
 import {container} from 'tsyringe';
 
@@ -51,6 +52,7 @@ import {useAppState, ContentState} from './useAppState';
 import {CallingViewMode, CallState, DesktopScreenShareMenu} from '../calling/CallState';
 import {ConversationState} from '../conversation/ConversationState';
 import {User} from '../entity/User';
+import {useWarnings} from '../guards/useWarnings';
 import {useActiveWindow} from '../hooks/useActiveWindow';
 import {useInitializeRootFontSize} from '../hooks/useRootFontSize';
 import {App} from '../main/app';
@@ -92,6 +94,8 @@ export const AppMain: FC<AppMainProps> = ({
   useActiveWindow(window);
 
   useInitializeRootFontSize();
+
+  const {showSmallOffset, showLargeOffset} = useWarnings();
 
   if (!apiContext) {
     throw new Error('API Context has not been set');
@@ -249,7 +253,13 @@ export const AppMain: FC<AppMainProps> = ({
         <ErrorBoundary FallbackComponent={ErrorFallback}>
           {Config.getConfig().FEATURE.ENABLE_DEBUG && <ConfigToolbar />}
           {!locked && (
-            <div id="app" className="app">
+            <div
+              id="app"
+              className={cx('app', {
+                'app--small-offset': showSmallOffset,
+                'app--large-offset': showLargeOffset,
+              })}
+            >
               {showLeftSidebar && (
                 <LeftSidebar
                   listViewModel={mainView.list}

--- a/src/script/view_model/WarningsContainer/WarningsContainer.tsx
+++ b/src/script/view_model/WarningsContainer/WarningsContainer.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import React, {useEffect} from 'react';
+import {useEffect} from 'react';
 
 import cx from 'classnames';
 
@@ -28,7 +28,7 @@ import {t} from 'Util/LocalizerUtil';
 import {afterRender} from 'Util/util';
 
 import {closeWarning, useWarningsState} from './WarningsState';
-import {CONFIG, TYPE} from './WarningsTypes';
+import {CONFIG, TYPE as type} from './WarningsTypes';
 
 import {Config} from '../../Config';
 
@@ -36,30 +36,39 @@ interface WarningProps {
   onRefresh: () => void;
 }
 
-const WarningsContainer: React.FC<WarningProps> = ({onRefresh}) => {
+export const WarningsContainer = ({onRefresh}: WarningProps) => {
   const name = useWarningsState(state => state.name);
   const warnings = useWarningsState(state => state.warnings);
-  const type = TYPE;
   const visibleWarning = warnings[warnings.length - 1];
-  const warningDimmed = warnings.some(warning => CONFIG.DIMMED_MODES.includes(warning));
 
   useEffect(() => {
-    const visibleWarning = warnings[warnings.length - 1];
-    const isConnectivityRecovery = visibleWarning === TYPE.CONNECTIVITY_RECOVERY;
+    const isConnectivityRecovery = visibleWarning === type.CONNECTIVITY_RECOVERY;
     const hasOffset = warnings.length > 0 && !isConnectivityRecovery;
     const isMiniMode = CONFIG.MINI_MODES.includes(visibleWarning);
 
     const app = document.querySelector('#app');
+    const callingWrapper = document.querySelector('.video-calling-wrapper');
+
     if (app) {
       app.classList.toggle('app--small-offset', hasOffset && isMiniMode);
       app.classList.toggle('app--large-offset', hasOffset && !isMiniMode);
     }
 
-    afterRender(() => window.dispatchEvent(new Event('resize')));
-  }, [warnings]);
+    if (callingWrapper) {
+      callingWrapper.classList.toggle('app--small-offset', hasOffset && isMiniMode);
+      callingWrapper.classList.toggle('app--large-offset', hasOffset && !isMiniMode);
+    }
 
-  const brandName = Config.getConfig().BRAND_NAME;
-  const URL = Config.getConfig().URL;
+    afterRender(() => window.dispatchEvent(new Event('resize')));
+  }, [visibleWarning, warnings.length]);
+
+  if (warnings.length === 0) {
+    return null;
+  }
+
+  const warningDimmed = warnings.some(warning => CONFIG.DIMMED_MODES.includes(warning));
+
+  const {BRAND_NAME: brandName, URL} = Config.getConfig();
 
   const closeButton = (
     <button
@@ -69,10 +78,6 @@ const WarningsContainer: React.FC<WarningProps> = ({onRefresh}) => {
       onClick={closeWarning}
     />
   );
-
-  if (warnings.length === 0) {
-    return null;
-  }
 
   return (
     <div className={cx('warning', {'warning-dimmed': warningDimmed})}>
@@ -328,5 +333,3 @@ const WarningsContainer: React.FC<WarningProps> = ({onRefresh}) => {
     </div>
   );
 };
-
-export {WarningsContainer};

--- a/src/script/view_model/WarningsContainer/WarningsContainer.tsx
+++ b/src/script/view_model/WarningsContainer/WarningsContainer.tsx
@@ -17,15 +17,12 @@
  *
  */
 
-import {useEffect} from 'react';
-
 import cx from 'classnames';
 
 import {Runtime} from '@wireapp/commons';
 
 import * as Icon from 'Components/Icon';
 import {t} from 'Util/LocalizerUtil';
-import {afterRender} from 'Util/util';
 
 import {closeWarning, useWarningsState} from './WarningsState';
 import {CONFIG, TYPE as type} from './WarningsTypes';
@@ -40,27 +37,6 @@ export const WarningsContainer = ({onRefresh}: WarningProps) => {
   const name = useWarningsState(state => state.name);
   const warnings = useWarningsState(state => state.warnings);
   const visibleWarning = warnings[warnings.length - 1];
-
-  useEffect(() => {
-    const isConnectivityRecovery = visibleWarning === type.CONNECTIVITY_RECOVERY;
-    const hasOffset = warnings.length > 0 && !isConnectivityRecovery;
-    const isMiniMode = CONFIG.MINI_MODES.includes(visibleWarning);
-
-    const app = document.querySelector('#app');
-    const callingWrapper = document.querySelector('.video-calling-wrapper');
-
-    if (app) {
-      app.classList.toggle('app--small-offset', hasOffset && isMiniMode);
-      app.classList.toggle('app--large-offset', hasOffset && !isMiniMode);
-    }
-
-    if (callingWrapper) {
-      callingWrapper.classList.toggle('app--small-offset', hasOffset && isMiniMode);
-      callingWrapper.classList.toggle('app--large-offset', hasOffset && !isMiniMode);
-    }
-
-    afterRender(() => window.dispatchEvent(new Event('resize')));
-  }, [visibleWarning, warnings.length]);
 
   if (warnings.length === 0) {
     return null;

--- a/src/style/foundation/video-calling.less
+++ b/src/style/foundation/video-calling.less
@@ -31,6 +31,14 @@
   width: 100vw;
   height: 100vh;
   background-color: var(--app-bg-secondary);
+
+  &.app--small-offset {
+    height: calc(100vh - 32px);
+  }
+
+  &.app--large-offset {
+    height: calc(100vh - 64px);
+  }
 }
 
 .video-calling {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14331" title="WPB-14331" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14331</a>  [Desktop] Update banner in calls is blocking the pagination & pop-out button
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Fixed overlapping Warning/Update container in full width call.

Before:
![image](https://github.com/user-attachments/assets/cb479864-b413-42a9-8c0f-0dbb31ec96b5)

After:
![image](https://github.com/user-attachments/assets/09e82e88-efc9-45c5-9784-d78a2301302d)


<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ