### PR TITLE
fix(messageRenderer): differentiate heading size by its level [WPB-11802]

### DIFF
--- a/src/script/util/messageRenderer.test.ts
+++ b/src/script/util/messageRenderer.test.ts
@@ -553,11 +553,11 @@ describe('Markdown for code snippets', () => {
 });
 
 describe('Markdown for headings', () => {
-  it('renders all headings the same', () => {
-    expect(renderMessage('# heading')).toBe('<div class="md-heading">heading</div>');
-    expect(renderMessage('## heading')).toBe('<div class="md-heading">heading</div>');
-    expect(renderMessage('### heading')).toBe('<div class="md-heading">heading</div>');
-    expect(renderMessage('#### heading')).toBe('<div class="md-heading">heading</div>');
+  it('differentiate heading size by its level', () => {
+    expect(renderMessage('# heading')).toBe('<div class="md-heading md-heading--1">heading</div>');
+    expect(renderMessage('## heading')).toBe('<div class="md-heading md-heading--2">heading</div>');
+    expect(renderMessage('### heading')).toBe('<div class="md-heading md-heading--3">heading</div>');
+    expect(renderMessage('#### heading')).toBe('<div class="md-heading md-heading--4">heading</div>');
   });
 });
 

--- a/src/script/util/messageRenderer.ts
+++ b/src/script/util/messageRenderer.ts
@@ -47,7 +47,10 @@ const markdownit = new MarkdownIt('zero', {
 
 const originalFenceRule = markdownit.renderer.rules.fence!;
 
-markdownit.renderer.rules.heading_open = () => '<div class="md-heading">';
+markdownit.renderer.rules.heading_open = (tokens, idx) => {
+  const headingLevel = tokens[idx].tag.slice(1);
+  return `<div class="md-heading md-heading--${headingLevel}">`;
+};
 markdownit.renderer.rules.heading_close = () => '</div>';
 const originalNormalizeLink = markdownit.normalizeLink!;
 

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -340,9 +340,21 @@
 
   .md-heading {
     margin: 4px 0 8px;
-    font-size: var(--font-size-large);
+    font-size: var(--font-size-base);
     font-weight: var(--font-weight-bold);
     line-height: var(--line-height-lg);
+
+    &--1 {
+      font-size: var(--font-size-xlarge);
+    }
+
+    &--2 {
+      font-size: var(--font-size-large);
+    }
+
+    &--3 {
+      font-size: var(--font-size-base);
+    }
 
     & + br {
       display: none;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11802" title="WPB-11802" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11802</a>  [Web] Differentiate heading size by its level
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Before:

![image](https://github.com/user-attachments/assets/a25236da-e01d-4083-a394-3924a377d0e7)

After:

![image](https://github.com/user-attachments/assets/6f733828-7d97-43a3-8f2d-f16f28abd2f1)

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
