### PR TITLE
fix: make federated users on proteus selectable in certain situations [WPB-14458]

### DIFF
--- a/src/script/components/UserSearchableList/UserSearchableList.tsx
+++ b/src/script/components/UserSearchableList/UserSearchableList.tsx
@@ -94,7 +94,7 @@ export const UserSearchableList = ({
       // We shouldn't show any members that have the 'external' role and are not already locally known.
       const nonExternalMembers = await teamRepository.filterExternals(uniqueMembers);
       setRemoteTeamMembers(
-        filterRemoteTeamUsers ? teamRepository.filterRemoteDomainUsers(nonExternalMembers) : nonExternalMembers,
+        filterRemoteTeamUsers ? await teamRepository.filterRemoteDomainUsers(nonExternalMembers) : nonExternalMembers,
       );
     }, 300),
     [],
@@ -103,6 +103,10 @@ export const UserSearchableList = ({
   // Filter all list items if a filter is provided
 
   useEffect(() => {
+    const setUsers = async (users: User[]) => {
+      setFilteredUsers(filterRemoteTeamUsers ? await teamRepository.filterRemoteDomainUsers(users) : users);
+    };
+
     const {query: normalizedQuery} = searchRepository.normalizeQuery(filter);
     const results = searchRepository
       .searchUserInSet(filter, users)
@@ -119,7 +123,7 @@ export const UserSearchableList = ({
     }
 
     if (!selfFirst) {
-      setFilteredUsers(filterRemoteTeamUsers ? teamRepository.filterRemoteDomainUsers(results) : results);
+      void setUsers(results);
       return;
     }
 
@@ -127,7 +131,7 @@ export const UserSearchableList = ({
     const [selfUser, otherUsers] = partition(results, user => user.isMe);
 
     const concatUsers = selfUser.concat(otherUsers);
-    setFilteredUsers(filterRemoteTeamUsers ? teamRepository.filterRemoteDomainUsers(concatUsers) : concatUsers);
+    void setUsers(concatUsers);
   }, [filter, users.length]);
 
   const foundUserEntities = () => {

--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -241,7 +241,7 @@ export class TeamRepository extends TypedEventEmitter<Events> {
   public async filterRemoteDomainUsers(users: User[]): Promise<User[]> {
     const isMLS = this.teamState.teamFeatures()?.mls?.config.defaultProtocol === ConversationProtocol.MLS;
 
-    // If MLS is enabled, we return all users
+    // IF MLS is enabled, THEN return all users
     if (isMLS) {
       return users;
     }
@@ -254,11 +254,12 @@ export class TeamRepository extends TypedEventEmitter<Events> {
       this.backendSupportsMLS = await apiClient.supportsMLS();
     }
 
-    // If the backend does not support MLS and there are federated users, we return all users - Akamaya special case
+    // IF the backend does not support MLS, AND there are federated users, THEN return all users
     if (!this.backendSupportsMLS && hasFederatedUsers) {
       return users;
     }
 
+    // IF the backend supports MLS, AND we use the proteus protocol, THEN filter out federated users
     return users.filter(user => {
       if (user.domain !== domain) {
         this.logger.log(`Filtering out user ${user.id} because of domain mismatch, current protocol is not MLS`);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14458" title="WPB-14458" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-14458</a>  [Web] Still allow usage of federation for proteus in some cases
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The logic for filtering federated users got added:

- If there is no MLS removal key configured (from GET /mls/public-keys)
- AND If the client finds some federated users from search result (i.e. federation is enabled)
- then the user is allowed to search for federated users and add them to conversations even if they are using proteus