### PR TITLE
fix: Add support for custom document in useClickOutside (WPB-14862)

### DIFF
--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -160,8 +160,6 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
   const emojiBarRef = useRef(null);
   const emojiBarToggleButtonRef = useRef(null);
 
-  useClickOutside(emojiBarRef, () => setShowEmojisBar(false), emojiBarToggleButtonRef);
-
   const {blurredVideoStream} = useKoSubscribableChildren(selfParticipant, ['blurredVideoStream']);
   const hasBlurredBackground = !!blurredVideoStream;
 
@@ -206,11 +204,12 @@ const FullscreenVideoCall: React.FC<FullscreenVideoCallProps> = ({
   ]);
 
   const {selfUser, roles} = useKoSubscribableChildren(conversation, ['selfUser', 'roles']);
-  const {emojis, viewMode, isScreenSharingSourceFromDetachedWindow} = useKoSubscribableChildren(callState, [
-    'emojis',
-    'viewMode',
-    'isScreenSharingSourceFromDetachedWindow',
-  ]);
+  const {emojis, viewMode, detachedWindow, isScreenSharingSourceFromDetachedWindow} = useKoSubscribableChildren(
+    callState,
+    ['emojis', 'viewMode', 'detachedWindow', 'isScreenSharingSourceFromDetachedWindow'],
+  );
+
+  useClickOutside(emojiBarRef, () => setShowEmojisBar(false), emojiBarToggleButtonRef, detachedWindow?.document);
 
   const [audioOptionsOpen, setAudioOptionsOpen] = useState(false);
   const [videoOptionsOpen, setVideoOptionsOpen] = useState(false);

--- a/src/script/hooks/useClickOutside.tsx
+++ b/src/script/hooks/useClickOutside.tsx
@@ -23,6 +23,7 @@ export const useClickOutside = (
   ref: RefObject<Element>,
   onClick: (e: MouseEvent) => void,
   exclude?: RefObject<Element>,
+  windowDocument = window.document,
 ) => {
   useEffect(() => {
     const handleClick = (event: MouseEvent) => {
@@ -34,8 +35,8 @@ export const useClickOutside = (
         }
       }
     };
-    document.addEventListener('click', handleClick);
+    windowDocument.addEventListener('click', handleClick);
 
-    return () => document.removeEventListener('click', handleClick);
-  }, [onClick]);
+    return () => windowDocument.removeEventListener('click', handleClick);
+  }, [exclude, onClick, ref, windowDocument]);
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14862" title="WPB-14862" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14862</a>  [Web] Clicking outside of the in call reaction tooltip should exit it (also in detached window)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Calling detached window has it's own window object that's why if you are in detached window, the "click out of the in call reaction to untoggle the thing" doesnt work