### PR TITLE
fix: display MLS device details when MLS is active [WPB-14833]

### DIFF
--- a/src/script/hooks/useDeviceIdentities.ts
+++ b/src/script/hooks/useDeviceIdentities.ts
@@ -26,9 +26,12 @@ import {E2EIHandler, getUsersIdentities, MLSStatuses, WireIdentity} from '../E2E
 
 export const useUserIdentity = (userId: QualifiedId, groupId?: string, updateAfterEnrollment?: boolean) => {
   const [deviceIdentities, setDeviceIdentities] = useState<WireIdentity[] | undefined>();
+  const getDeviceIdentity = (deviceId: string) => {
+    return deviceIdentities?.find(identity => identity.deviceId === deviceId);
+  };
 
   const refreshDeviceIdentities = useCallback(async () => {
-    if (!E2EIHandler.getInstance().isE2EIEnabled() || !groupId) {
+    if (!groupId) {
       return;
     }
 
@@ -63,11 +66,6 @@ export const useUserIdentity = (userId: QualifiedId, groupId?: string, updateAft
         ? MLSStatuses.VALID
         : MLSStatuses.NOT_ACTIVATED,
 
-    getDeviceIdentity:
-      deviceIdentities !== undefined
-        ? (deviceId: string) => {
-            return deviceIdentities.find(identity => identity.deviceId === deviceId);
-          }
-        : undefined,
+    getDeviceIdentity,
   };
 };

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DetailedDevice.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DetailedDevice.tsx
@@ -41,7 +41,7 @@ export const DetailedDevice: React.FC<DeviceProps> = ({
   getDeviceIdentity,
   isProteusVerified,
 }) => {
-  const getIdentity = getDeviceIdentity ? () => getDeviceIdentity(device.id) : undefined;
+  const getIdentity = () => getDeviceIdentity?.(device.id);
 
   return (
     <>

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/MLSDeviceDetails/MLSDeviceDetails.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/MLSDeviceDetails/MLSDeviceDetails.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {MLSStatuses, WireIdentity} from 'src/script/E2EIdentity';
+import {E2EIHandler, MLSStatuses, WireIdentity} from 'src/script/E2EIdentity';
 import {t} from 'Util/LocalizerUtil';
 import {splitFingerprint} from 'Util/StringUtil';
 
@@ -39,6 +39,7 @@ export const MLSDeviceDetails = ({isCurrentDevice, identity, isSelfUser = false}
   }
 
   const certificateState = identity?.status ?? MLSStatuses.NOT_ACTIVATED;
+  const isE2EIEnabled = E2EIHandler.getInstance().isE2EIEnabled();
 
   if (!isSelfUser && certificateState === MLSStatuses.NOT_ACTIVATED) {
     return null;
@@ -58,7 +59,7 @@ export const MLSDeviceDetails = ({isCurrentDevice, identity, isSelfUser = false}
         </>
       )}
 
-      {(isSelfUser || (!isSelfUser && certificateState !== MLSStatuses.NOT_ACTIVATED)) && (
+      {isE2EIEnabled && (isSelfUser || (!isSelfUser && certificateState !== MLSStatuses.NOT_ACTIVATED)) && (
         <E2EICertificateDetails identity={identity} isCurrentDevice={isCurrentDevice} />
       )}
     </div>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14833" title="WPB-14833" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14833</a>  [Web] Show MLS thumbprint even if there is no E2EI enabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

There was a bug which caused the MLS thumbprint only to be displayed when E2EI was active.
This PR fixes this behaviour, and the MLS Thumbprint always gets displayed.

<img width="1110" alt="Screenshot 2024-12-05 at 15 25 36" src="https://github.com/user-attachments/assets/654d0d17-91df-463f-87df-35e37c0e53aa">
