### PR TITLE
fix: change import of useWarnings hook

### DIFF
--- a/src/script/page/AppMain.tsx
+++ b/src/script/page/AppMain.tsx
@@ -95,8 +95,6 @@ export const AppMain: FC<AppMainProps> = ({
 
   useInitializeRootFontSize();
 
-  const {showSmallOffset, showLargeOffset} = useWarnings();
-
   if (!apiContext) {
     throw new Error('API Context has not been set');
   }
@@ -113,6 +111,8 @@ export const AppMain: FC<AppMainProps> = ({
     'desktopScreenShareMenu',
     'viewMode',
   ]);
+
+  const {showSmallOffset, showLargeOffset} = useWarnings();
 
   const teamState = container.resolve(TeamState);
   const userState = container.resolve(UserState);


### PR DESCRIPTION
## Description

Probably will fix automations, because of useWarnings hook is used before apiContext.

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
