### PR TITLE
fix: dont show headline if we dont have a thumbprint or details

### DIFF
--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/MLSDeviceDetails/MLSDeviceDetails.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/MLSDeviceDetails/MLSDeviceDetails.tsx
@@ -40,8 +40,14 @@ export const MLSDeviceDetails = ({isCurrentDevice, identity, isSelfUser = false}
 
   const certificateState = identity?.status ?? MLSStatuses.NOT_ACTIVATED;
   const isE2EIEnabled = E2EIHandler.getInstance().isE2EIEnabled();
+  const showE2EICertificateDetails =
+    isE2EIEnabled && (isSelfUser || (!isSelfUser && certificateState !== MLSStatuses.NOT_ACTIVATED));
 
   if (!isSelfUser && certificateState === MLSStatuses.NOT_ACTIVATED) {
+    return null;
+  }
+
+  if (!showE2EICertificateDetails && !identity?.thumbprint) {
     return null;
   }
 
@@ -59,9 +65,7 @@ export const MLSDeviceDetails = ({isCurrentDevice, identity, isSelfUser = false}
         </>
       )}
 
-      {isE2EIEnabled && (isSelfUser || (!isSelfUser && certificateState !== MLSStatuses.NOT_ACTIVATED)) && (
-        <E2EICertificateDetails identity={identity} isCurrentDevice={isCurrentDevice} />
-      )}
+      {showE2EICertificateDetails && <E2EICertificateDetails identity={identity} isCurrentDevice={isCurrentDevice} />}
     </div>
   );
 };


### PR DESCRIPTION
There was an issue with the MLS Details headline being shown in certain situations