### PR TITLE
fix: Warning container overlapping fullscreen calling UI

### DIFF
--- a/src/style/foundation/video-calling.less
+++ b/src/style/foundation/video-calling.less
@@ -31,6 +31,14 @@
   width: 100vw;
   height: 100vh;
   background-color: var(--app-bg-secondary);
+
+  &.app--small-offset {
+    height: calc(100vh - 32px);
+  }
+
+  &.app--large-offset {
+    height: calc(100vh - 64px);
+  }
 }
 
 .video-calling {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14331" title="WPB-14331" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14331</a>  [Desktop] Update banner in calls is blocking the pagination & pop-out button
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Fixed overlapping Warning/Update container in full width call.

Before:
![image](https://github.com/user-attachments/assets/cb479864-b413-42a9-8c0f-0dbb31ec96b5)

After:
![image](https://github.com/user-attachments/assets/09e82e88-efc9-45c5-9784-d78a2301302d)


<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ