### PR TITLE
fix: add "wire-" prefix for sso code [WPB-11927]

### DIFF
--- a/src/script/auth/page/Index.test.tsx
+++ b/src/script/auth/page/Index.test.tsx
@@ -28,6 +28,7 @@ import {initialAuthState} from '../module/reducer/authReducer';
 import {ROUTE} from '../route';
 import {mockStoreFactory} from '../util/test/mockStoreFactory';
 import {mountComponent} from '../util/test/TestUtil';
+import {getPrefixedSSOCode} from '../util/urlUtil';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -71,7 +72,7 @@ describe('when visiting the index page', () => {
       }),
     );
 
-    expect(Navigate).toHaveBeenCalledWith({to: `${ROUTE.SSO}/wire-${defaultSSOCode}`}, {});
+    expect(Navigate).toHaveBeenCalledWith({to: `${ROUTE.SSO}/${getPrefixedSSOCode(defaultSSOCode)}`}, {});
   });
 
   it('shows the welcome text with default backend name', () => {

--- a/src/script/auth/page/Index.tsx
+++ b/src/script/auth/page/Index.tsx
@@ -40,6 +40,7 @@ import {bindActionCreators, RootState} from '../module/reducer';
 import * as AuthSelector from '../module/selector/AuthSelector';
 import {QUERY_KEY, ROUTE} from '../route';
 import {logoutReasonStrings} from '../util/logoutUtil';
+import {getPrefixedSSOCode} from '../util/urlUtil';
 
 type Props = React.HTMLProps<HTMLDivElement>;
 
@@ -56,7 +57,7 @@ const IndexComponent = ({defaultSSOCode}: Props & ConnectedProps & DispatchProps
 
   if (defaultSSOCode) {
     // Redirect to prefilled SSO login if default SSO code is set on backend
-    return <Navigate to={`${ROUTE.SSO}/wire-${defaultSSOCode}`} />;
+    return <Navigate to={`${ROUTE.SSO}/${getPrefixedSSOCode(defaultSSOCode)}`} />;
   }
 
   const features = Config.getConfig().FEATURE;

--- a/src/script/auth/page/Login.tsx
+++ b/src/script/auth/page/Login.tsx
@@ -77,6 +77,7 @@ import * as ConversationSelector from '../module/selector/ConversationSelector';
 import {QUERY_KEY, ROUTE} from '../route';
 import {parseError, parseValidationErrors} from '../util/errorUtil';
 import {getOAuthQueryString} from '../util/oauthUtil';
+import {getPrefixedSSOCode} from '../util/urlUtil';
 type Props = React.HTMLProps<HTMLDivElement> & {
   embedded?: boolean;
 };
@@ -156,7 +157,7 @@ const LoginComponent = ({
   useEffect(() => {
     // Redirect to prefilled SSO login if default SSO code is set on backend unless we're following the guest link flow
     if (defaultSSOCode && !embedded) {
-      navigate(`${ROUTE.SSO}/${defaultSSOCode}`);
+      navigate(`${ROUTE.SSO}/${getPrefixedSSOCode(defaultSSOCode)}`);
     }
   }, [defaultSSOCode, embedded, navigate]);
 
@@ -474,7 +475,7 @@ const LoginComponent = ({
                       <Button
                         type="button"
                         variant={ButtonVariant.SECONDARY}
-                        onClick={() => navigate(`${ROUTE.SSO}/${defaultSSOCode ?? ''}`)}
+                        onClick={() => navigate(`${ROUTE.SSO}/${getPrefixedSSOCode(defaultSSOCode)}`)}
                         style={{marginTop: '16px'}}
                         data-uie-name="go-sso-login"
                       >

--- a/src/script/auth/page/SingleSignOnForm.tsx
+++ b/src/script/auth/page/SingleSignOnForm.tsx
@@ -55,14 +55,13 @@ import * as ConversationSelector from '../module/selector/ConversationSelector';
 import {QUERY_KEY, ROUTE} from '../route';
 import {parseError, parseValidationErrors} from '../util/errorUtil';
 import {logoutReasonStrings} from '../util/logoutUtil';
-import {getSearchParams} from '../util/urlUtil';
+import {getSearchParams, SSO_CODE_PREFIX} from '../util/urlUtil';
 
 export interface SingleSignOnFormProps extends React.HTMLAttributes<HTMLDivElement> {
   doLogin: (code: string) => Promise<void>;
   initialCode?: string;
 }
 
-const SSO_CODE_PREFIX = 'wire-';
 const SSO_CODE_PREFIX_REGEX = '[wW][iI][rR][eE]-';
 const SingleSignOnFormComponent = ({
   initialCode,

--- a/src/script/auth/util/urlUtil.ts
+++ b/src/script/auth/util/urlUtil.ts
@@ -61,3 +61,9 @@ export function openTab(url: string): Window {
   }
   return newWindow;
 }
+
+export const SSO_CODE_PREFIX = 'wire-';
+
+export function getPrefixedSSOCode(code?: string) {
+  return code ? `${SSO_CODE_PREFIX}${code}` : '';
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11927" title="WPB-11927" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11927</a>  [On-prem] SSO code not populating correctly for existing users on join link
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Added 'wire-' prefix for sso code.

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
