### PR TITLE
runfix(api-client/core): use v7 endpoint for setting member conversation roles [WPB-15024]

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@wireapp/avs": "10.0.4",
     "@wireapp/avs-debugger": "0.0.7",
     "@wireapp/commons": "5.4.0",
-    "@wireapp/core": "46.15.1",
+    "@wireapp/core": "46.15.3",
     "@wireapp/react-ui-kit": "9.28.0",
     "@wireapp/store-engine-dexie": "2.1.15",
     "@wireapp/telemetry": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@wireapp/avs": "10.0.4",
     "@wireapp/avs-debugger": "0.0.7",
     "@wireapp/commons": "5.4.0",
-    "@wireapp/core": "46.15.0",
+    "@wireapp/core": "46.15.1",
     "@wireapp/react-ui-kit": "9.28.0",
     "@wireapp/store-engine-dexie": "2.1.15",
     "@wireapp/telemetry": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@wireapp/avs": "10.0.4",
     "@wireapp/avs-debugger": "0.0.7",
     "@wireapp/commons": "5.4.0",
-    "@wireapp/core": "46.14.1",
+    "@wireapp/core": "46.15.0",
     "@wireapp/react-ui-kit": "9.28.0",
     "@wireapp/store-engine-dexie": "2.1.15",
     "@wireapp/telemetry": "0.1.4",

--- a/src/script/conversation/ConversationRoleRepository.ts
+++ b/src/script/conversation/ConversationRoleRepository.ts
@@ -112,7 +112,7 @@ export class ConversationRoleRepository {
     userId: QualifiedId,
     conversationRole: string,
   ): Promise<void> => {
-    return this.conversationService.putMembers(conversation.id, userId, {
+    return this.conversationService.putMembers(conversation.qualifiedId, userId, {
       conversation_role: conversationRole,
     });
   };

--- a/src/script/conversation/ConversationRoleRepository.ts
+++ b/src/script/conversation/ConversationRoleRepository.ts
@@ -18,6 +18,7 @@
  */
 
 import {DefaultConversationRoleName as DefaultRole, ConversationRole} from '@wireapp/api-client/lib/conversation/';
+import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {container} from 'tsyringe';
 
 import {Logger, getLogger} from 'Util/Logger';
@@ -108,7 +109,7 @@ export class ConversationRoleRepository {
 
   readonly setMemberConversationRole = (
     conversation: Conversation,
-    userId: string,
+    userId: QualifiedId,
     conversationRole: string,
   ): Promise<void> => {
     return this.conversationService.putMembers(conversation.id, userId, {

--- a/src/script/conversation/ConversationService.ts
+++ b/src/script/conversation/ConversationService.ts
@@ -303,7 +303,7 @@ export class ConversationService {
     return this.apiClient.api.conversation.deleteMember(conversationId, userId);
   }
 
-  putMembers(conversationId: string, userId: QualifiedId, data: ConversationOtherMemberUpdateData): Promise<void> {
+  putMembers(conversationId: QualifiedId, userId: QualifiedId, data: ConversationOtherMemberUpdateData): Promise<void> {
     return this.apiClient.api.conversation.putOtherMember(userId, conversationId, data);
   }
 

--- a/src/script/conversation/ConversationService.ts
+++ b/src/script/conversation/ConversationService.ts
@@ -303,7 +303,7 @@ export class ConversationService {
     return this.apiClient.api.conversation.deleteMember(conversationId, userId);
   }
 
-  putMembers(conversationId: string, userId: string, data: ConversationOtherMemberUpdateData): Promise<void> {
+  putMembers(conversationId: string, userId: QualifiedId, data: ConversationOtherMemberUpdateData): Promise<void> {
     return this.apiClient.api.conversation.putOtherMember(userId, conversationId, data);
   }
 

--- a/src/script/page/RightSidebar/GroupParticipantUser/GroupParticipantUser.tsx
+++ b/src/script/page/RightSidebar/GroupParticipantUser/GroupParticipantUser.tsx
@@ -95,7 +95,7 @@ const GroupParticipantUser: FC<GroupParticipantUserProps> = ({
     }
 
     const newRole = isAdmin ? DefaultRole.WIRE_MEMBER : DefaultRole.WIRE_ADMIN;
-    await conversationRoleRepository.setMemberConversationRole(activeConversation, currentUser.id, newRole);
+    await conversationRoleRepository.setMemberConversationRole(activeConversation, currentUser.qualifiedId, newRole);
 
     roles[currentUser.id] = newRole;
     activeConversation.roles(roles);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5948,9 +5948,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^27.14.0":
-  version: 27.14.0
-  resolution: "@wireapp/api-client@npm:27.14.0"
+"@wireapp/api-client@npm:^27.15.0":
+  version: 27.15.0
+  resolution: "@wireapp/api-client@npm:27.15.0"
   dependencies:
     "@wireapp/commons": "npm:^5.4.0"
     "@wireapp/priority-queue": "npm:^2.1.11"
@@ -5965,7 +5965,7 @@ __metadata:
     tough-cookie: "npm:4.1.4"
     ws: "npm:8.18.0"
     zod: "npm:3.23.8"
-  checksum: 10/8f03bc24e21b8a1b2c78e4aa663115eb910d2cb5acbf3e4603e25ed860b72a1c2342db4cf02d2f853413386b3d6b91128d0baf72cb4c6f3237dc75f49b4a4151
+  checksum: 10/1c84a237ff83411bd2f66777a478969ca797c7b5c42aa862c1b63e24425b4884f264ceb8d92b9382453e9c263c785bb5d387ff4ee9dd79926c0bcd2926e69947
   languageName: node
   linkType: hard
 
@@ -6030,11 +6030,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:46.14.1":
-  version: 46.14.1
-  resolution: "@wireapp/core@npm:46.14.1"
+"@wireapp/core@npm:46.15.0":
+  version: 46.15.0
+  resolution: "@wireapp/core@npm:46.15.0"
   dependencies:
-    "@wireapp/api-client": "npm:^27.14.0"
+    "@wireapp/api-client": "npm:^27.15.0"
     "@wireapp/commons": "npm:^5.4.0"
     "@wireapp/core-crypto": "npm:3.0.0"
     "@wireapp/cryptobox": "npm:12.8.0"
@@ -6052,7 +6052,7 @@ __metadata:
     long: "npm:^5.2.0"
     uuid: "npm:9.0.1"
     zod: "npm:3.23.8"
-  checksum: 10/11a5fbedddc1c5be8218935f4b1f1ec9c7824c4261e6d189ad3708f8edcdcfaea143fd121fd57c05a790c0392e9e5757c5a82742c1c8a85fb3ff9f8360a4c650
+  checksum: 10/dd38b8836d8a0d25374471927b286099d6bfd3a06be5a8aae3a47c537ff6b5d265f9a522e100f40efeae1f1ec993456f66c2e167d9dd96d7646c689a90cafdb1
   languageName: node
   linkType: hard
 
@@ -18785,7 +18785,7 @@ __metadata:
     "@wireapp/avs-debugger": "npm:0.0.7"
     "@wireapp/commons": "npm:5.4.0"
     "@wireapp/copy-config": "npm:2.2.10"
-    "@wireapp/core": "npm:46.14.1"
+    "@wireapp/core": "npm:46.15.0"
     "@wireapp/eslint-config": "npm:3.0.7"
     "@wireapp/prettier-config": "npm:0.6.4"
     "@wireapp/react-ui-kit": "npm:9.28.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5948,9 +5948,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^27.15.1":
-  version: 27.16.0
-  resolution: "@wireapp/api-client@npm:27.16.0"
+"@wireapp/api-client@npm:^27.16.1":
+  version: 27.16.1
+  resolution: "@wireapp/api-client@npm:27.16.1"
   dependencies:
     "@wireapp/commons": "npm:^5.4.0"
     "@wireapp/priority-queue": "npm:^2.1.11"
@@ -5965,7 +5965,7 @@ __metadata:
     tough-cookie: "npm:4.1.4"
     ws: "npm:8.18.0"
     zod: "npm:3.23.8"
-  checksum: 10/5e1c6cfdbd0adf77722294a3a8db093e56714e2839a747dad0a852843fcff87a2938cba5b4311b1bc0877b1cdf79d8636740e48a536f56e869b42e63b123d952
+  checksum: 10/d9965829f8264dbc0317cbf2addca0eb3ef08f958ebf2422be60985de8254d777b24edbe89e98112dbe0a7096bea3b41b9cc246602404aa72b8e4b07ffabd57e
   languageName: node
   linkType: hard
 
@@ -6030,11 +6030,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:46.15.1":
-  version: 46.15.1
-  resolution: "@wireapp/core@npm:46.15.1"
+"@wireapp/core@npm:46.15.3":
+  version: 46.15.3
+  resolution: "@wireapp/core@npm:46.15.3"
   dependencies:
-    "@wireapp/api-client": "npm:^27.15.1"
+    "@wireapp/api-client": "npm:^27.16.1"
     "@wireapp/commons": "npm:^5.4.0"
     "@wireapp/core-crypto": "npm:3.0.0"
     "@wireapp/cryptobox": "npm:12.8.0"
@@ -6052,7 +6052,7 @@ __metadata:
     long: "npm:^5.2.0"
     uuid: "npm:9.0.1"
     zod: "npm:3.23.8"
-  checksum: 10/a9ddeb21934e0bf3c7811b6243bc911f62e4dd36b276befd53fa6f8ebe9c375e31a2515873161994b37e68d6d6905180562669bb8b468f8cd1d0a8a0ff356593
+  checksum: 10/ec2f4f32606367e6a8d94341b8f528a0cf90c4b0cb05f40b0e972605557a9d97ae5891cfd8338cdecb615515240dfcfbbe2b4c1faf7d3f79ee2d37b1ad248e07
   languageName: node
   linkType: hard
 
@@ -18785,7 +18785,7 @@ __metadata:
     "@wireapp/avs-debugger": "npm:0.0.7"
     "@wireapp/commons": "npm:5.4.0"
     "@wireapp/copy-config": "npm:2.2.10"
-    "@wireapp/core": "npm:46.15.1"
+    "@wireapp/core": "npm:46.15.3"
     "@wireapp/eslint-config": "npm:3.0.7"
     "@wireapp/prettier-config": "npm:0.6.4"
     "@wireapp/react-ui-kit": "npm:9.28.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5948,9 +5948,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^27.15.0":
-  version: 27.15.0
-  resolution: "@wireapp/api-client@npm:27.15.0"
+"@wireapp/api-client@npm:^27.15.1":
+  version: 27.16.0
+  resolution: "@wireapp/api-client@npm:27.16.0"
   dependencies:
     "@wireapp/commons": "npm:^5.4.0"
     "@wireapp/priority-queue": "npm:^2.1.11"
@@ -5965,7 +5965,7 @@ __metadata:
     tough-cookie: "npm:4.1.4"
     ws: "npm:8.18.0"
     zod: "npm:3.23.8"
-  checksum: 10/1c84a237ff83411bd2f66777a478969ca797c7b5c42aa862c1b63e24425b4884f264ceb8d92b9382453e9c263c785bb5d387ff4ee9dd79926c0bcd2926e69947
+  checksum: 10/5e1c6cfdbd0adf77722294a3a8db093e56714e2839a747dad0a852843fcff87a2938cba5b4311b1bc0877b1cdf79d8636740e48a536f56e869b42e63b123d952
   languageName: node
   linkType: hard
 
@@ -6030,11 +6030,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:46.15.0":
-  version: 46.15.0
-  resolution: "@wireapp/core@npm:46.15.0"
+"@wireapp/core@npm:46.15.1":
+  version: 46.15.1
+  resolution: "@wireapp/core@npm:46.15.1"
   dependencies:
-    "@wireapp/api-client": "npm:^27.15.0"
+    "@wireapp/api-client": "npm:^27.15.1"
     "@wireapp/commons": "npm:^5.4.0"
     "@wireapp/core-crypto": "npm:3.0.0"
     "@wireapp/cryptobox": "npm:12.8.0"
@@ -6052,7 +6052,7 @@ __metadata:
     long: "npm:^5.2.0"
     uuid: "npm:9.0.1"
     zod: "npm:3.23.8"
-  checksum: 10/dd38b8836d8a0d25374471927b286099d6bfd3a06be5a8aae3a47c537ff6b5d265f9a522e100f40efeae1f1ec993456f66c2e167d9dd96d7646c689a90cafdb1
+  checksum: 10/a9ddeb21934e0bf3c7811b6243bc911f62e4dd36b276befd53fa6f8ebe9c375e31a2515873161994b37e68d6d6905180562669bb8b468f8cd1d0a8a0ff356593
   languageName: node
   linkType: hard
 
@@ -18785,7 +18785,7 @@ __metadata:
     "@wireapp/avs-debugger": "npm:0.0.7"
     "@wireapp/commons": "npm:5.4.0"
     "@wireapp/copy-config": "npm:2.2.10"
-    "@wireapp/core": "npm:46.15.0"
+    "@wireapp/core": "npm:46.15.1"
     "@wireapp/eslint-config": "npm:3.0.7"
     "@wireapp/prettier-config": "npm:0.6.4"
     "@wireapp/react-ui-kit": "npm:9.28.0"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15024" title="WPB-15024" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15024</a>  [Web] Use proper v7 endpoint for making someone group admin
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

The endpoint using a string as user id is deprecated in v7 and replaced by an endpoint that accepts QualifiedId only, see https://staging-nginz-https.zinfra.io/v4/api/swagger-ui/#/default/update-other-member

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
