### PR TITLE
fix: order of screen share in a call [WPB-15036]

### DIFF
--- a/src/script/calling/Call.ts
+++ b/src/script/calling/Call.ts
@@ -226,10 +226,13 @@ export class Call {
     const selfParticipant = this.getSelfParticipant();
     const remoteParticipants = this.getRemoteParticipants().sort((p1, p2) => sortUsersByPriority(p1.user, p2.user));
 
-    const [withVideo, withoutVideo] = partition(remoteParticipants, participant => participant.isSendingVideo());
+    const [withVideoAndScreenShare, withoutVideo] = partition(remoteParticipants, participant =>
+      participant.isSendingVideo(),
+    );
+    const [withScreenShare, withVideo] = partition(withVideoAndScreenShare, participant => participant.sharesScreen());
 
     const newPages = chunk<Participant>(
-      [selfParticipant, ...withVideo, ...withoutVideo].filter(Boolean),
+      [selfParticipant, ...withScreenShare, ...withVideo, ...withoutVideo].filter(Boolean),
       NUMBER_OF_PARTICIPANTS_IN_ONE_PAGE,
     );
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15036" title="WPB-15036" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15036</a>  [Web] User tiles in a call do not reshuffle according to priority (screenshare not bumped)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

This PR fix thats user tiles in a call do not reshuffle according to priority (screenshare not bumped)

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
