### PR TITLE
fix: Revert former PR order of screen share in a call [WPB-15036]

### DIFF
--- a/src/script/calling/Call.ts
+++ b/src/script/calling/Call.ts
@@ -226,13 +226,10 @@ export class Call {
     const selfParticipant = this.getSelfParticipant();
     const remoteParticipants = this.getRemoteParticipants().sort((p1, p2) => sortUsersByPriority(p1.user, p2.user));
 
-    const [withVideoAndScreenShare, withoutVideo] = partition(remoteParticipants, participant =>
-      participant.isSendingVideo(),
-    );
-    const [withScreenShare, withVideo] = partition(withVideoAndScreenShare, participant => participant.sharesScreen());
+    const [withVideo, withoutVideo] = partition(remoteParticipants, participant => participant.isSendingVideo());
 
     const newPages = chunk<Participant>(
-      [selfParticipant, ...withScreenShare, ...withVideo, ...withoutVideo].filter(Boolean),
+      [selfParticipant, ...withVideo, ...withoutVideo].filter(Boolean),
       NUMBER_OF_PARTICIPANTS_IN_ONE_PAGE,
     );
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15036" title="WPB-15036" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15036</a>  [Web] User tiles in a call do not reshuffle according to priority (screenshare not bumped)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Reverts wireapp/wire-webapp#18490