### PR TITLE
feat: Allow sending webp images

### DIFF
--- a/src/script/Config.ts
+++ b/src/script/Config.ts
@@ -78,7 +78,7 @@ const config = {
   MIN_TEAM_CREATION_SUPPORTED_API_VERSION: 7,
 
   /** Image MIME types */
-  ALLOWED_IMAGE_TYPES: ['image/bmp', 'image/gif', 'image/jpeg', 'image/jpg', 'image/png'],
+  ALLOWED_IMAGE_TYPES: ['image/bmp', 'image/gif', 'image/jpeg', 'image/jpg', 'image/png', 'image/webp'],
 
   /** Which min and max version of the backend api do we support */
   SUPPORTED_API_RANGE: [1, env.ENABLE_DEV_BACKEND_API ? Infinity : 7],


### PR DESCRIPTION
## Description

They can already be sent by selecting "All Files" in the image picker, at least in KDE plasma. Allowing them just saves a step and also doesn't make it look like wire doesn't support webp images. Viewing these looks fine on the Android.
 
I also wanted to add `image/apng` and `image/avif`, while these work just fine in web (apngs are even shown animated!), they are not shown as images on android and offered as downloads, so I didn't add them here.

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
