### PR TITLE
fix: rich text editor v2 [WPB-12089]

### DIFF
--- a/src/script/components/RichTextEditor/plugins/EditedMessagePlugin/EditedMessagePlugin.tsx
+++ b/src/script/components/RichTextEditor/plugins/EditedMessagePlugin/EditedMessagePlugin.tsx
@@ -51,7 +51,7 @@ export function EditedMessagePlugin({message}: Props): null {
 
           const mentionNodes = getMentionNodesFromMessage(message);
 
-          const allowedMentions = mentionNodes.map(node => node.getTextContent());
+          const allowedMentions = [...new Set(mentionNodes.map(node => node.getTextContent()))];
 
           const wrappedWithTags = wrapMentionsWithTags(messageContent, allowedMentions);
 

--- a/src/script/components/RichTextEditor/plugins/EditedMessagePlugin/wrapMentionsWithTags/wrapMentionsWithTags.ts
+++ b/src/script/components/RichTextEditor/plugins/EditedMessagePlugin/wrapMentionsWithTags/wrapMentionsWithTags.ts
@@ -27,7 +27,8 @@ export const wrapMentionsWithTags = (text: string, allMentions: string[]): strin
     return text;
   }
 
-  const mentionRegex = new RegExp(`(${allMentions.join('|')})`, 'g');
-
-  return text.replace(mentionRegex, '<mention>$1</mention>');
+  return allMentions.reduce(
+    (updatedText, mention) => updatedText.split(mention).join(`<mention>${mention}</mention>`),
+    text,
+  );
 };

--- a/src/style/content/conversation/input-bar.less
+++ b/src/style/content/conversation/input-bar.less
@@ -408,6 +408,7 @@
 
   display: grid;
   padding-left: var(--input-bar-avatar-spacing);
+  column-gap: 8px;
   grid-template-areas:
     'avatar input input'
     'avatar buttons buttons';

--- a/src/style/content/conversation/input-bar.less
+++ b/src/style/content/conversation/input-bar.less
@@ -411,7 +411,7 @@
   grid-template-areas:
     'avatar input input'
     'avatar buttons buttons';
-  grid-template-columns: calc(var(--input-bar-avatar-size) + var(--input-bar-avatar-spacing)) 1fr 1fr;
+  grid-template-columns: calc(var(--input-bar-avatar-size) + var(--input-bar-avatar-spacing)) 1fr min-content;
   row-gap: 8px;
 
   @media (min-width: 900px) {

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -325,7 +325,7 @@
       padding-left: 24px;
       margin-top: 0;
       margin-bottom: 0;
-      line-height: 0;
+      line-height: 0.85;
     }
 
     ol ol {

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -313,7 +313,7 @@
     display: inline;
     min-width: 0;
     line-height: var(--line-height-lg);
-    white-space: pre-wrap;
+    white-space: normal;
     word-wrap: break-word;
 
     li {
@@ -325,7 +325,7 @@
       padding-left: 24px;
       margin-top: 0;
       margin-bottom: 0;
-      line-height: 0.85;
+      line-height: 0;
     }
 
     ol ol {


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-12089" title="WPB-12089" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-12089</a>  [Web] Text formatting via UI in text input field
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->



## Description

Continuation of https://github.com/wireapp/wire-webapp/pull/18520 

**What's changed?**

- fix mentions (before it was breaking with the `|` character and multiple same mentions next to each other)
- remove unnecessary line spacing (`white-space: pre-wrap;`)
- fix edit message view (rich text turned off)

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
