### PR TITLE
runfix(pipeline): Let pre-commit pipeline wait until smoke tests are done

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,13 +99,13 @@ pipeline {
                   final List workflowRuns = jsonData['workflow_runs']
                   echo("Looking for hash ${commit_hash}")
 
-                  return workflowRuns.any { run -> 
+                  return workflowRuns.any { run ->
                     def result = checkWorkflowRun(run, commit_hash)
                     if (run['conclusion'] == 'cancelled') {
                       echo("GitHub Action was cancelled. Ending Jenkins pipeline.")
                       return true
                     }
-                    
+
                     return result
                   }
                 }
@@ -155,7 +155,7 @@ pipeline {
 
         stage('Trigger smoke test') {
           steps {
-            build job: 'Webapp_Smoke_Chrome', parameters: [string(name: 'TAGS', value: '@smoke'), string(name: 'GIT_BRANCH', value: 'web-dev'), string(name: 'webappApplicationPath', value: "$webappApplicationPath")], wait: false
+            build job: 'Webapp_Smoke_Chrome', parameters: [string(name: 'TAGS', value: '@smoke'), string(name: 'GIT_BRANCH', value: 'web-dev'), string(name: 'webappApplicationPath', value: "$webappApplicationPath")]
           }
         }
     }


### PR DESCRIPTION
## Description
The pre-commit pipeline is starting smoke tests before a PR is merged. But the pipeline does not wait for the results of the smoke tests and always reports a success.
<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
