### PR TITLE
runfix: address backward compatibility backup bug [WPB-15317]

### DIFF
--- a/src/script/components/HistoryImport/HistoryImport.tsx
+++ b/src/script/components/HistoryImport/HistoryImport.tsx
@@ -123,7 +123,11 @@ const HistoryImport = ({user, backupRepository, file, switchContent}: HistoryImp
       setErrorSecondary(t('backupImportAccountErrorSecondary'));
     } else if (error instanceof IncompatibleBackupError) {
       setErrorHeadline(t('backupImportVersionErrorHeadline'));
-      setErrorSecondary(t('backupImportVersionErrorSecondary', {brandName: Config.getConfig().BRAND_NAME}));
+      //@ts-expect-error
+      //the "brandname" should be provided
+      //the correct syntax is suspected to create issues with electron's console see https://wearezeta.atlassian.net/browse/WPB-15317
+      //TODO: figure out the issue with the electron console
+      setErrorSecondary(t('backupImportVersionErrorSecondary', Config.getConfig().BRAND_NAME));
     } else if (error instanceof IncompatibleBackupFormatError) {
       setErrorHeadline(t('backupImportFormatErrorHeadline'));
       setErrorSecondary(t('backupImportFormatErrorSecondary'));


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15317" title="WPB-15317" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15317</a>  [Web] Cannot restore prod backup to current edge webapp
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

A bug when restoring backup was introduced since the latest production release (2024-11-13)

This revert the only change to the relevant file `HistoryImport.tsx` since then.


<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
