### PR TITLE
fix: newsletter check [WPB-11942]

### DIFF
--- a/src/script/auth/page/SetHandle.tsx
+++ b/src/script/auth/page/SetHandle.tsx
@@ -38,7 +38,9 @@ import {
   Text,
 } from '@wireapp/react-ui-kit';
 
+import {StorageKey} from 'src/script/storage';
 import {t} from 'Util/LocalizerUtil';
+import {storeValue} from 'Util/StorageUtil';
 import {isBackendError} from 'Util/TypePredicateUtil';
 
 import {Page} from './Page';
@@ -105,6 +107,16 @@ const SetHandleComponent = ({
     setHandle(event.target.value);
   };
 
+  const handleAcceptNewletterConsent = () => {
+    void updateConsent(ConsentType.MARKETING, 1);
+    storeValue(StorageKey.INITIAL_MAKRETING_CONSENT_ACCEPTED, true);
+  };
+
+  const handleDeclineNewletterConsent = () => {
+    void updateConsent(ConsentType.MARKETING, 0);
+    storeValue(StorageKey.INITIAL_MAKRETING_CONSENT_ACCEPTED, false);
+  };
+
   if (hasSelfHandle) {
     return null;
   }
@@ -143,10 +155,7 @@ const SetHandleComponent = ({
         {error && parseError(error)}
       </ContainerXS>
       {!isFetching && hasUnsetMarketingConsent && (
-        <AcceptNewsModal
-          onConfirm={() => updateConsent(ConsentType.MARKETING, 1)}
-          onDecline={() => updateConsent(ConsentType.MARKETING, 0)}
-        />
+        <AcceptNewsModal onConfirm={handleAcceptNewletterConsent} onDecline={handleDeclineNewletterConsent} />
       )}
     </Page>
   );

--- a/src/script/properties/PropertiesRepository.ts
+++ b/src/script/properties/PropertiesRepository.ts
@@ -100,7 +100,7 @@ export class PropertiesRepository {
         privacy: {
           telemetry_data_sharing: undefined,
           marketing_consent:
-            loadValue(StorageKey.INITIAL_MAKRETING_CONSENT_ACCEPTED) ||
+            loadValue(StorageKey.INITIAL_MAKRETING_CONSENT_ACCEPTED) ??
             PropertiesRepository.CONFIG.WIRE_MARKETING_CONSENT.defaultValue,
         },
         sound: {

--- a/src/script/properties/PropertiesRepository.ts
+++ b/src/script/properties/PropertiesRepository.ts
@@ -32,12 +32,14 @@ import {deepMerge} from 'Util/deepMerge';
 import {Environment} from 'Util/Environment';
 import {replaceLink, t} from 'Util/LocalizerUtil';
 import {getLogger, Logger} from 'Util/Logger';
+import {loadValue} from 'Util/StorageUtil';
 
 import type {PropertiesService} from './PropertiesService';
 import {PROPERTIES_TYPE, UserConsentStatus} from './PropertiesType';
 
 import type {User} from '../entity/User';
 import type {SelfService} from '../self/SelfService';
+import {StorageKey} from '../storage';
 import {isTelemetryEnabledAtCurrentEnvironment} from '../tracking/Telemetry.helpers';
 import {ConsentValue} from '../user/ConsentValue';
 import {CONVERSATION_TYPING_INDICATOR_MODE} from '../user/TypingIndicatorMode';
@@ -97,7 +99,9 @@ export class PropertiesRepository {
         },
         privacy: {
           telemetry_data_sharing: undefined,
-          marketing_consent: PropertiesRepository.CONFIG.WIRE_MARKETING_CONSENT.defaultValue,
+          marketing_consent:
+            loadValue(StorageKey.INITIAL_MAKRETING_CONSENT_ACCEPTED) ||
+            PropertiesRepository.CONFIG.WIRE_MARKETING_CONSENT.defaultValue,
         },
         sound: {
           alerts: AudioPreference.ALL,

--- a/src/script/storage/StorageKey.ts
+++ b/src/script/storage/StorageKey.ts
@@ -42,6 +42,7 @@ export const StorageKey = {
   INPUT: {
     SHOW_FORMATTING: 'z.storage.StorageKey.INPUT.SHOW_FORMATTING',
   },
+  INITIAL_MAKRETING_CONSENT_ACCEPTED: 'z.storage.StorageKey.INITIAL_MAKRETING_CONSENT_ACCEPTED',
 };
 
 export const ROOT_FONT_SIZE_KEY = 'root-font-size';


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11942" title="WPB-11942" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11942</a>  [Web] Accepting to receive newsletters during personal account creation is not synced to account settings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

As a user, as I'm registering, I can choose whether to accept the newsletter consent. Currently, it doesn't matter what option I choose, after registering, in the settings, I'm gonna see the checkbox unchecked. This change fixes it and store user's choice, and base on that it shows the state.


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
