### PR TITLE
runfix(backup-repo): do not pass files to debug logs after validating metadata [WPB-15317]

### DIFF
--- a/src/script/backup/BackupRepository.ts
+++ b/src/script/backup/BackupRepository.ts
@@ -486,7 +486,7 @@ export class BackupRepository {
     const metaData = new TextDecoder().decode(rawData);
     const parsedMetaData = JSON.parse(metaData);
     const archiveVersion = this._verifyMetadata(user, parsedMetaData);
-    this.logger.debug('Validated metadata during history import', files);
+    this.logger.debug('Validated metadata during history import');
     return archiveVersion;
   }
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15317" title="WPB-15317" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15317</a>  [Web] Cannot restore prod backup to current edge webapp
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

Electron appears to be running into heap size issues because of JSON.stringify of the entire passed files with this debug logs.

We want to pinpoint the issue by removing the passed files from the logs

### Note

This file has been refactored in the dev branch, this is a specific fix for the release candidate, and will need to be reverted before merging back dev on next release

see the PR on dev here https://github.com/wireapp/wire-webapp/pull/18580

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
