### PR TITLE
fix: add vertical spacing to show more button for replies [WPB-11935]

### DIFF
--- a/src/style/content/conversation/message-quote.less
+++ b/src/style/content/conversation/message-quote.less
@@ -11,6 +11,7 @@
       .focus-outline;
       .focus-border-radius;
       .focus-offset;
+      margin: 0.75rem 0;
     }
   }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11935" title="WPB-11935" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11935</a>  [Web] Fix "Show more" button spacing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Fixes the spacing issue for the "Show More" button when focused with keyboard.

## Screenshots/Screencast (for UI changes)
### Before
![image-20241030-092743](https://github.com/user-attachments/assets/1fdc75e6-594b-405d-b948-a12600650c6b)


### After
<img width="821" alt="Screenshot 2025-01-13 at 13 20 26" src="https://github.com/user-attachments/assets/b5723595-0c9c-4480-b047-5653052f0e11" />


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;