### PR TITLE
fix(CellDescription): Change Draft Message icon color

### DIFF
--- a/src/script/components/ConversationListCell/components/CellDescription/CellDescription.style.ts
+++ b/src/script/components/ConversationListCell/components/CellDescription/CellDescription.style.ts
@@ -22,4 +22,8 @@ import {CSSObject} from '@emotion/react';
 export const iconStyle: CSSObject = {
   verticalAlign: 'middle',
   marginRight: '8px',
+
+  path: {
+    fill: 'var(--background)',
+  },
 };


### PR DESCRIPTION
## Description

Changed Draft Message icon color for dark mode.

## Screenshots/Screencast (for UI changes)

Before:
<img width="283" alt="image" src="https://github.com/user-attachments/assets/66130f43-eeac-40ff-830d-8897b7accc6a" />

After:
![image](https://github.com/user-attachments/assets/216e6298-c5be-4b77-b42e-2b820fb531ce)


## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
