### PR TITLE
fix(RichTextEditor): pasting mentions, links, and code [WPB-12089]

### DIFF
--- a/src/script/components/InputBar/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/script/components/InputBar/components/RichTextEditor/RichTextEditor.tsx
@@ -50,6 +50,7 @@ import {ReplaceEmojiPlugin} from './plugins/InlineEmojiReplacementPlugin';
 import {ListItemTabIndentationPlugin} from './plugins/ListIndentationPlugin/ListIndentationPlugin';
 import {ListMaxIndentLevelPlugin} from './plugins/ListMaxIndentLevelPlugin/ListMaxIndentLevelPlugin';
 import {MentionsPlugin} from './plugins/MentionsPlugin';
+import {PastePlugin} from './plugins/PastePlugin/PastePlugin';
 import {ReplaceCarriageReturnPlugin} from './plugins/ReplaceCarriageReturnPlugin/ReplaceCarriageReturnPlugin';
 import {SendPlugin} from './plugins/SendPlugin/SendPlugin';
 import {markdownTransformers} from './utils/markdownTransformers';
@@ -181,6 +182,7 @@ export const RichTextEditor = ({
               }
             }}
           />
+          <PastePlugin getMentionCandidates={getMentionCandidates} />
         </div>
       </div>
       {showFormatToolbar && showMarkdownPreview && (

--- a/src/script/components/InputBar/components/RichTextEditor/plugins/PastePlugin/PastePlugin.tsx
+++ b/src/script/components/InputBar/components/RichTextEditor/plugins/PastePlugin/PastePlugin.tsx
@@ -1,0 +1,186 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {useEffect} from 'react';
+
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {$getSelection, $createTextNode, PASTE_COMMAND, COMMAND_PRIORITY_LOW} from 'lexical';
+
+import {User} from 'src/script/entity/User';
+
+import {$createMentionNode} from '../../nodes/MentionNode';
+
+interface PastePluginProps {
+  getMentionCandidates: () => User[];
+}
+
+interface Segment {
+  /** Type of the segment - either plain text or a mention */
+  type: 'text' | 'mention';
+  /** Content of the segment - for mentions this is the username without @ */
+  content: string;
+}
+
+/**
+ * Plugin that handles pasting text with mentions into the editor.
+ * It preserves mentions for users that exist in the current context and
+ * converts mentions of non-existent users to plain text.
+ */
+export const PastePlugin = ({getMentionCandidates}: PastePluginProps) => {
+  const [editor] = useLexicalComposerContext();
+
+  /**
+   * Processes a mention element from pasted HTML content.
+   * Creates a mention node if the user exists in the current context,
+   * otherwise converts it to plain text.
+   */
+  const handleMentionFromHtml = (mentionElem: Element, availableUsers: User[]) => {
+    const value = mentionElem.getAttribute('data-lexical-mention-value');
+    if (!value) {
+      return;
+    }
+
+    const username = value.startsWith('@') ? value.substring(1) : value;
+    const selection = $getSelection();
+
+    if (!selection) {
+      return;
+    }
+
+    const userExists = availableUsers.some(user => user.name() === username);
+
+    if (!userExists) {
+      selection.insertText(`@${username}`);
+      return;
+    }
+
+    const mentionNode = $createMentionNode('@', username);
+
+    selection.insertNodes([mentionNode, $createTextNode(' ')]);
+  };
+
+  /**
+   * Creates a segment object with the specified type and content.
+   * Used to standardize segment creation throughout the plugin.
+   */
+  const createSegment = (type: 'text' | 'mention', content: string): Segment => ({
+    type,
+    content,
+  });
+
+  /**
+   * Processes plain text content and splits it into segments.
+   * Each segment is either a mention (if the user exists) or plain text.
+   * Preserves the original text structure including spaces and formatting.
+   */
+  const processPlainTextSegments = (text: string, availableUsers: User[]): Segment[] => {
+    const mentions = text.match(/@[\w]+/g) || [];
+
+    if (mentions.length === 0) {
+      return [createSegment('text', text)];
+    }
+
+    return mentions.reduce<{segments: Segment[]; lastIndex: number}>(
+      (acc, mention) => {
+        const mentionIndex = text.indexOf(mention, acc.lastIndex);
+        const segments = [...acc.segments];
+
+        if (mentionIndex > acc.lastIndex) {
+          segments.push(createSegment('text', text.slice(acc.lastIndex, mentionIndex)));
+        }
+
+        const username = mention.substring(1);
+        const userExists = availableUsers.some(user => user.name() === username);
+        segments.push(createSegment(userExists ? 'mention' : 'text', userExists ? username : mention));
+
+        return {
+          segments,
+          lastIndex: mentionIndex + mention.length,
+        };
+      },
+      {segments: [], lastIndex: 0},
+    ).segments;
+  };
+
+  /**
+   * Inserts a list of segments into the editor at the current selection.
+   * Handles both text and mention segments appropriately.
+   */
+  const insertSegments = (segments: Segment[]) => {
+    const selection = $getSelection();
+    if (!selection) {
+      return;
+    }
+
+    segments.forEach(segment => {
+      if (segment.type === 'text') {
+        selection.insertText(segment.content);
+        return;
+      }
+
+      const mentionNode = $createMentionNode('@', segment.content);
+      selection.insertNodes([mentionNode, $createTextNode(' ')]);
+    });
+  };
+
+  /**
+   * Handles the paste event by processing both HTML and plain text content.
+   * Attempts to preserve rich text structure when possible, falling back to
+   * plain text processing when needed.
+   */
+  const handlePaste = (event: ClipboardEvent) => {
+    const clipboardData = event.clipboardData;
+    if (!clipboardData) {
+      return false;
+    }
+
+    const htmlContent = clipboardData.getData('text/html');
+    const plainText = clipboardData.getData('text/plain');
+    const availableUsers = getMentionCandidates();
+
+    editor.update(() => {
+      try {
+        if (htmlContent) {
+          const parser = new DOMParser();
+          const mentions = parser.parseFromString(htmlContent, 'text/html').querySelectorAll('[data-lexical-mention]');
+
+          if (mentions.length > 0) {
+            mentions.forEach(mention => handleMentionFromHtml(mention, availableUsers));
+            return true;
+          }
+        }
+
+        const segments = processPlainTextSegments(plainText, availableUsers);
+        insertSegments(segments);
+      } catch (error) {
+        console.error('Error handling paste:', error);
+        const selection = $getSelection();
+        selection?.insertText(plainText);
+      }
+    });
+
+    return true;
+  };
+
+  useEffect(() => {
+    return editor.registerCommand(PASTE_COMMAND, handlePaste, COMMAND_PRIORITY_LOW);
+  }, [editor, getMentionCandidates]);
+
+  return null;
+};

--- a/src/script/components/InputBar/components/RichTextEditor/plugins/PastePlugin/PastePlugin.tsx
+++ b/src/script/components/InputBar/components/RichTextEditor/plugins/PastePlugin/PastePlugin.tsx
@@ -28,6 +28,7 @@ import {
   COMMAND_PRIORITY_LOW,
   $isRangeSelection,
   $isTextNode,
+  BaseSelection,
 } from 'lexical';
 
 import {User} from 'src/script/entity/User';
@@ -38,6 +39,8 @@ interface PastePluginProps {
   /** Function that returns list of users that can be mentioned in the current context */
   getMentionCandidates: () => User[];
 }
+
+type RangeSelection = BaseSelection | null;
 
 /**
  * PastePlugin handles pasting content into the editor while preserving formatting and special nodes.
@@ -87,7 +90,7 @@ export const PastePlugin = ({getMentionCandidates}: PastePluginProps): JSX.Eleme
    * @returns boolean - True if mentions were handled successfully
    */
   const handleLexicalMentions = useCallback(
-    (doc: Document, selection: ReturnType<typeof $getSelection> | null, availableUsers: User[]): boolean => {
+    (doc: Document, selection: RangeSelection | null, availableUsers: User[]): boolean => {
       if (!selection) {
         return false;
       }
@@ -133,7 +136,7 @@ export const PastePlugin = ({getMentionCandidates}: PastePluginProps): JSX.Eleme
    * @returns boolean - True if formatted content was handled successfully
    */
   const handleFormattedContent = useCallback(
-    (doc: Document, selection: ReturnType<typeof $getSelection> | null): boolean => {
+    (doc: Document, selection: RangeSelection | null): boolean => {
       if (!selection) {
         return false;
       }
@@ -178,7 +181,7 @@ export const PastePlugin = ({getMentionCandidates}: PastePluginProps): JSX.Eleme
    * @param availableUsers - List of users that can be mentioned in current context
    */
   const processMentions = useCallback(
-    (selection: ReturnType<typeof $getSelection> | null, mentions: NodeListOf<Element>, availableUsers: User[]) => {
+    (selection: RangeSelection | null, mentions: NodeListOf<Element>, availableUsers: User[]) => {
       if (!selection) {
         return;
       }

--- a/src/script/components/InputBar/components/RichTextEditor/plugins/PastePlugin/PastePlugin.tsx
+++ b/src/script/components/InputBar/components/RichTextEditor/plugins/PastePlugin/PastePlugin.tsx
@@ -40,7 +40,7 @@ interface PastePluginProps {
   getMentionCandidates: () => User[];
 }
 
-type RangeSelection = BaseSelection | null;
+type Selection = BaseSelection | null;
 
 /**
  * PastePlugin handles pasting content into the editor while preserving formatting and special nodes.
@@ -90,7 +90,7 @@ export const PastePlugin = ({getMentionCandidates}: PastePluginProps): JSX.Eleme
    * @returns boolean - True if mentions were handled successfully
    */
   const handleLexicalMentions = useCallback(
-    (doc: Document, selection: RangeSelection | null, availableUsers: User[]): boolean => {
+    (doc: Document, selection: Selection, availableUsers: User[]): boolean => {
       if (!selection) {
         return false;
       }
@@ -135,7 +135,7 @@ export const PastePlugin = ({getMentionCandidates}: PastePluginProps): JSX.Eleme
    * @returns boolean - True if formatted content was handled successfully
    */
   const handleFormattedContent = useCallback(
-    (doc: Document, selection: RangeSelection | null): boolean => {
+    (doc: Document, selection: Selection): boolean => {
       if (!selection) {
         return false;
       }
@@ -180,7 +180,7 @@ export const PastePlugin = ({getMentionCandidates}: PastePluginProps): JSX.Eleme
    * @param availableUsers - List of users that can be mentioned in current context
    */
   const processMentions = useCallback(
-    (selection: RangeSelection | null, mentions: NodeListOf<Element>, availableUsers: User[]) => {
+    (selection: Selection, mentions: NodeListOf<Element>, availableUsers: User[]) => {
       if (!selection) {
         return;
       }

--- a/src/script/components/InputBar/components/RichTextEditor/plugins/PastePlugin/PastePlugin.tsx
+++ b/src/script/components/InputBar/components/RichTextEditor/plugins/PastePlugin/PastePlugin.tsx
@@ -122,7 +122,7 @@ export const PastePlugin = ({getMentionCandidates}: PastePluginProps): JSX.Eleme
       selection.insertNodes(nodes);
       return true;
     },
-    [editor],
+    [editor, validateMention],
   );
 
   /**
@@ -203,7 +203,7 @@ export const PastePlugin = ({getMentionCandidates}: PastePluginProps): JSX.Eleme
         }
       });
     },
-    [],
+    [validateMention],
   );
 
   /**

--- a/src/script/components/InputBar/components/RichTextEditor/plugins/PastePlugin/PastePlugin.tsx
+++ b/src/script/components/InputBar/components/RichTextEditor/plugins/PastePlugin/PastePlugin.tsx
@@ -31,10 +31,12 @@ interface PastePluginProps {
 }
 
 interface Segment {
-  /** Type of the segment - either plain text or a mention */
-  type: 'text' | 'mention';
-  /** Content of the segment - for mentions this is the username without @ */
+  /** Type of the segment - either plain text, mention, or link */
+  type: 'text' | 'mention' | 'link';
+  /** Content of the segment */
   content: string;
+  /** URL for link segments */
+  url?: string;
 }
 
 /**
@@ -79,19 +81,54 @@ export const PastePlugin = ({getMentionCandidates}: PastePluginProps) => {
    * Creates a segment object with the specified type and content.
    * Used to standardize segment creation throughout the plugin.
    */
-  const createSegment = (type: 'text' | 'mention', content: string): Segment => ({
+  const createSegment = (type: Segment['type'], content: string, url?: string): Segment => ({
     type,
     content,
+    ...(url && {url}),
   });
 
   /**
    * Processes plain text content and splits it into segments.
-   * Each segment is either a mention (if the user exists) or plain text.
+   * Each segment is either a mention, link, or plain text.
    * Preserves the original text structure including spaces and formatting.
    */
   const processPlainTextSegments = (text: string, availableUsers: User[]): Segment[] => {
-    const mentions = text.match(/@[\w]+/g) || [];
+    const segments: Segment[] = [];
+    let lastIndex = 0;
 
+    // First, find all URLs and create segments
+    const urlMatches = Array.from(text.matchAll(URL_REGEX));
+    urlMatches.forEach(match => {
+      const url = match[0];
+      const urlIndex = match.index!;
+
+      // Add text before URL if exists
+      if (urlIndex > lastIndex) {
+        const textBefore = text.slice(lastIndex, urlIndex);
+        const mentionSegments = processMentionSegments(textBefore, availableUsers);
+        segments.push(...mentionSegments);
+      }
+
+      // Add URL segment
+      segments.push(createSegment('link', url, url));
+      lastIndex = urlIndex + url.length;
+    });
+
+    // Process remaining text for mentions
+    if (lastIndex < text.length) {
+      const remainingText = text.slice(lastIndex);
+      const mentionSegments = processMentionSegments(remainingText, availableUsers);
+      segments.push(...mentionSegments);
+    }
+
+    return segments;
+  };
+
+  /**
+   * Processes text for mentions and returns segments
+   */
+  const processMentionSegments = (text: string, availableUsers: User[]): Segment[] => {
+    const mentions = text.match(/@[\w]+/g) || [];
     if (mentions.length === 0) {
       return [createSegment('text', text)];
     }
@@ -129,14 +166,47 @@ export const PastePlugin = ({getMentionCandidates}: PastePluginProps) => {
     }
 
     segments.forEach(segment => {
-      if (segment.type === 'text') {
-        selection.insertText(segment.content);
-        return;
+      switch (segment.type) {
+        case 'text':
+          selection.insertText(segment.content);
+          break;
+        case 'mention':
+          const mentionNode = $createMentionNode('@', segment.content);
+          selection.insertNodes([mentionNode, $createTextNode(' ')]);
+          break;
+        case 'link':
+          selection.insertText(createMarkdownLink(segment.url!, segment.content));
+          break;
       }
-
-      const mentionNode = $createMentionNode('@', segment.content);
-      selection.insertNodes([mentionNode, $createTextNode(' ')]);
     });
+  };
+
+  /**
+   * Processes HTML links from pasted content.
+   * Creates markdown links preserving both href and text content.
+   */
+  const handleLinksFromHtml = (doc: Document): boolean => {
+    const links = doc.querySelectorAll('a');
+    if (links.length === 0) {
+      return false;
+    }
+
+    const selection = $getSelection();
+    if (!selection) {
+      return false;
+    }
+
+    links.forEach(link => {
+      const href = link.getAttribute('href');
+      const text = link.textContent?.trim();
+
+      if (href && text) {
+        selection.insertText(createMarkdownLink(href, text));
+        selection.insertText(' ');
+      }
+    });
+
+    return true;
   };
 
   /**
@@ -158,9 +228,13 @@ export const PastePlugin = ({getMentionCandidates}: PastePluginProps) => {
       try {
         if (htmlContent) {
           const parser = new DOMParser();
-          const mentions = parser.parseFromString(htmlContent, 'text/html').querySelectorAll('[data-lexical-mention]');
+          const doc = parser.parseFromString(htmlContent, 'text/html');
 
-          if (mentions.length > 0) {
+          const mentions = doc.querySelectorAll('[data-lexical-mention]');
+          const handledMentions = mentions.length > 0;
+          const handledLinks = handleLinksFromHtml(doc);
+
+          if (handledMentions || handledLinks) {
             mentions.forEach(mention => handleMentionFromHtml(mention, availableUsers));
             return true;
           }
@@ -183,4 +257,15 @@ export const PastePlugin = ({getMentionCandidates}: PastePluginProps) => {
   }, [editor, getMentionCandidates]);
 
   return null;
+};
+
+// URL regex that matches most common URL formats
+const URL_REGEX =
+  /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/gi;
+
+/**
+ * Creates a markdown link from a URL and optional text
+ */
+const createMarkdownLink = (url: string, text?: string): string => {
+  return `[${text || url}](${url})`;
 };

--- a/src/script/components/InputBar/components/RichTextEditor/plugins/PastePlugin/PastePlugin.tsx
+++ b/src/script/components/InputBar/components/RichTextEditor/plugins/PastePlugin/PastePlugin.tsx
@@ -136,16 +136,17 @@ export const PastePlugin = ({getMentionCandidates}: PastePluginProps): JSX.Eleme
    * @returns string - Processed text with markdown links
    */
   const processLinks = (text: string, links: NodeListOf<Element>): string => {
-    let processedText = text;
-    links.forEach(link => {
+    return Array.from(links).reduce((processedText, link) => {
       const href = link.getAttribute('href');
       const linkText = link.textContent?.trim();
-      if (href && linkText) {
-        const linkMarkdown = `[${linkText}](${href})`;
-        processedText = processedText.replace(new RegExp(`\\b${linkText}\\b`), linkMarkdown);
+
+      if (!href || !linkText) {
+        return processedText;
       }
-    });
-    return processedText;
+
+      const linkMarkdown = `[${linkText}](${href})`;
+      return processedText.replace(new RegExp(`\\b${linkText}\\b`), linkMarkdown);
+    }, text);
   };
 
   /**

--- a/src/script/components/InputBar/components/RichTextEditor/plugins/PastePlugin/PastePlugin.tsx
+++ b/src/script/components/InputBar/components/RichTextEditor/plugins/PastePlugin/PastePlugin.tsx
@@ -103,18 +103,17 @@ export const PastePlugin = ({getMentionCandidates}: PastePluginProps): JSX.Eleme
       // Process mentions in the DOM before generating nodes
       lexicalMentions.forEach(mention => {
         const {isValid, username} = validateMention(mention, availableUsers);
-        if (!username) {
+        if (!username || isValid) {
           return;
         }
 
-        if (!isValid) {
-          const textNode = doc.createTextNode(`@${username}`);
-          const parent = mention.parentNode;
-          if (!parent) {
-            return;
-          }
-          parent.replaceChild(textNode, mention);
+        const parent = mention.parentNode;
+        if (!parent) {
+          return;
         }
+
+        const textNode = doc.createTextNode(`@${username}`);
+        parent.replaceChild(textNode, mention);
       });
 
       const nodes = $generateNodesFromDOM(editor, doc);

--- a/src/script/components/InputBar/components/RichTextEditor/utils/markdownTransformers.ts
+++ b/src/script/components/InputBar/components/RichTextEditor/utils/markdownTransformers.ts
@@ -28,6 +28,7 @@ import {
   STRIKETHROUGH,
   UNORDERED_LIST,
   QUOTE,
+  LINK,
 } from '@lexical/markdown';
 
 export const markdownTransformers = [
@@ -41,4 +42,5 @@ export const markdownTransformers = [
   ITALIC_STAR,
   STRIKETHROUGH,
   QUOTE,
+  LINK,
 ];

--- a/src/script/components/InputBar/components/RichTextEditor/utils/markdownTransformers.ts
+++ b/src/script/components/InputBar/components/RichTextEditor/utils/markdownTransformers.ts
@@ -28,7 +28,6 @@ import {
   STRIKETHROUGH,
   UNORDERED_LIST,
   QUOTE,
-  LINK,
 } from '@lexical/markdown';
 
 export const markdownTransformers = [
@@ -42,5 +41,4 @@ export const markdownTransformers = [
   ITALIC_STAR,
   STRIKETHROUGH,
   QUOTE,
-  LINK,
 ];

--- a/src/style/components/lexical-input.less
+++ b/src/style/components/lexical-input.less
@@ -190,11 +190,12 @@
 }
 
 .editor-code {
-  display: inline-block;
+  display: block;
   overflow: auto;
-  max-width: var(--conversation-message-asset-width);
+  max-width: max-content;
   padding: 12px;
   border-radius: 12px;
+  margin: 4px 0;
   background: var(--foreground-fade-8);
   font-size: var(--font-size-small);
   text-overflow: unset;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-12089" title="WPB-12089" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-12089</a>  [Web] Text formatting via UI in text input field
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

**Fixed pasting links** - instead of pasting a link that can't be edited (we don't have the format link button yet), we paste copied links as markdown, syntax `[text](href)`.

It's a **temporary** solution, we're gonna change that when we introduce a link button for formatting.

**Before:**

https://github.com/user-attachments/assets/1267d1d9-c977-4a5f-9305-a8873155968a

**After:**

https://github.com/user-attachments/assets/667a5f14-b455-4904-9100-de305d15223a

---

**Fixed pasting mentions** - we had a problem when you copied a mention of user `@John` from conversation A, and pasted this mention to conversation B, it will be presented (only visually, `@John` wouldn't be mentioned actually) as a mention, even if the `@John` isn't there. 

The fix provides a way to distinguish if the mentioned person is in the conversation or not, if they are, we create a fully valid mention, otherwise, it's presented as plain text.

**Before:**

https://github.com/user-attachments/assets/ee80b7ca-8d43-480c-b6b9-0117cf9c0e58


**After:**

https://github.com/user-attachments/assets/954a57c3-70c5-46cf-af06-78069798c568

---

**Fixed pasting code blocks** - sometimes, after pasting, multiple code blocks were presented horizontally instead of vertically (one under the other), now it's corrected. 

Before:
<img width="980" alt="Screenshot 2025-01-14 at 14 52 58" src="https://github.com/user-attachments/assets/be8f9d8a-bafc-4c8b-91d7-a62b26a7d870" />

After:
<img width="803" alt="Screenshot 2025-01-14 at 14 53 11" src="https://github.com/user-attachments/assets/d031a421-35af-4420-a546-f0edaad5a6f0" />

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
