### PR TITLE
fix(BlockquotePlugin): block sending a message [WPB-12089]

### DIFF
--- a/src/script/components/InputBar/components/RichTextEditor/plugins/BlockquotePlugin/BlockquotePlugin.tsx
+++ b/src/script/components/InputBar/components/RichTextEditor/plugins/BlockquotePlugin/BlockquotePlugin.tsx
@@ -73,13 +73,15 @@ const registerBlockquoteEnterCommand = (editor: LexicalEditor) => {
         return false;
       }
 
+      if (!event.shiftKey) {
+        return false;
+      }
+
       event.preventDefault();
 
-      if (event.shiftKey) {
-        editor.update(() => {
-          editor.dispatchCommand(INSERT_LINE_BREAK_COMMAND, false);
-        });
-      }
+      editor.update(() => {
+        editor.dispatchCommand(INSERT_LINE_BREAK_COMMAND, false);
+      });
 
       return true;
     },


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-12089" title="WPB-12089" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-12089</a>  [Web] Text formatting via UI in text input field
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Fix BlockquotePlugin to not block sending a message, when user edits the blockquote

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
