### PR TITLE
fix(lexical-input): input flickering after adding an inline code [WPB-12089]

### DIFF
--- a/src/style/components/lexical-input.less
+++ b/src/style/components/lexical-input.less
@@ -64,7 +64,7 @@
 
   // Inline code should have a smaller, custom line height
   // It prevents input from flickering when inserting an inline code
-  code:not(editor-code) {
+  code:not(.editor-code) {
     line-height: 17px;
   }
 }

--- a/src/style/components/lexical-input.less
+++ b/src/style/components/lexical-input.less
@@ -61,6 +61,12 @@
 .editor-paragraph {
   //margin: 0 0 15px 0;
   position: relative;
+
+  // Inline code should have a smaller, custom line height
+  // It prevents input from flickering when inserting an inline code
+  code:not(editor-code) {
+    line-height: 17px;
+  }
 }
 
 .dropdown .item .icon {
@@ -183,10 +189,11 @@
 }
 
 .editor-inline-code {
-  display: inline-block;
-  padding: 2px 4px;
+  display: inline;
+  padding: 2px 3px;
   border-radius: 4px;
   background: var(--foreground-fade-8);
+  font-size: var(--font-size-medium);
 }
 
 .editor-code {
@@ -438,4 +445,9 @@ body.theme-dark {
 }
 .editor-tokenVariable {
   color: var(--token-variable);
+}
+
+.conversation-input-bar-text {
+  min-height: var(--conversation-input-line-height);
+  line-height: var(--conversation-input-line-height);
 }

--- a/src/style/components/lexical-input.less
+++ b/src/style/components/lexical-input.less
@@ -446,8 +446,3 @@ body.theme-dark {
 .editor-tokenVariable {
   color: var(--token-variable);
 }
-
-.conversation-input-bar-text {
-  min-height: var(--conversation-input-line-height);
-  line-height: var(--conversation-input-line-height);
-}

--- a/src/style/components/lexical-input.less
+++ b/src/style/components/lexical-input.less
@@ -190,7 +190,7 @@
 
 .editor-inline-code {
   display: inline;
-  padding: 2px 3px;
+  padding: 2px 4px;
   border-radius: 4px;
   background: var(--foreground-fade-8);
   font-size: var(--font-size-medium);


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-12089" title="WPB-12089" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-12089</a>  [Web] Text formatting via UI in text input field
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

**Before:**

https://github.com/user-attachments/assets/675878ac-732c-4875-b6a0-244b500f385b

**After:**

https://github.com/user-attachments/assets/0c1735d6-28d0-4218-8336-ec8f93256ff6


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
