### PR TITLE
fix: dont call the E2EI service when the feature is not on [WPB-15356]

### DIFF
--- a/src/script/hooks/useDeviceIdentities.ts
+++ b/src/script/hooks/useDeviceIdentities.ts
@@ -31,7 +31,7 @@ export const useUserIdentity = (userId: QualifiedId, groupId?: string, updateAft
   };
 
   const refreshDeviceIdentities = useCallback(async () => {
-    if (!groupId) {
+    if (!groupId || !E2EIHandler.getInstance().isE2EIEnabled()) {
       return;
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15356" title="WPB-15356" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15356</a>  [Web] E2EI log error when logging in with old permanent test users
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
