### PR TITLE
runfix: reopen currently selected conversation in collapsed view [WPB-15351]

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
@@ -26,6 +26,8 @@ import React, {
   useCallback,
 } from 'react';
 
+import {WIDTH} from '@wireapp/react-ui-kit';
+
 import {ConversationListCell} from 'Components/ConversationListCell';
 import {Call} from 'src/script/calling/Call';
 import {ConversationLabel, ConversationLabelRepository} from 'src/script/conversation/ConversationLabelRepository';
@@ -128,9 +130,11 @@ export const ConversationsList = ({
     (conversation: Conversation) =>
       (event: ReactMouseEvent<HTMLDivElement, MouseEvent> | ReactKeyBoardEvent<HTMLDivElement>) => {
         if (isActiveConversation(conversation)) {
-          clearSearchFilter();
-          setClickedFilteredConversationId(conversation.id);
-          return;
+          if (window.innerWidth > WIDTH.TABLET_SM_MAX || document.documentElement.clientWidth > WIDTH.TABLET_SM_MAX) {
+            clearSearchFilter();
+            setClickedFilteredConversationId(conversation.id);
+            return;
+          }
         }
 
         if (isKeyboardEvent(event)) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15351" title="WPB-15351" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15351</a>  [Web] Can't re-open currently selected conversation in collapsed view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Fixes an issue where the user cannot re-open the currently selected conversation in collapsed view (e.g., when the window width is less than 720px).

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;
