### PR TITLE
fix: private users cannot operate with notifications [WPB-15134]

### DIFF
--- a/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsOptions/ConversationDetailsOptions.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsOptions/ConversationDetailsOptions.tsx
@@ -114,8 +114,7 @@ const ConversationDetailsOptions = ({
   const isActiveGroupParticipant = isGroup && !isSelfUserRemoved;
 
   const showOptionGuests = isActiveGroupParticipant && !!teamId && roleRepository.canToggleGuests(activeConversation);
-  const hasAdvancedNotifications = isMutable && isTeam;
-  const showOptionNotificationsGroup = hasAdvancedNotifications && isGroup;
+  const showOptionNotificationsGroup = isMutable && isGroup;
   const showOptionTimedMessages =
     isActiveGroupParticipant && roleRepository.canToggleTimeout(activeConversation) && isSelfDeletingMessagesEnabled;
   const showOptionServices =
@@ -123,7 +122,7 @@ const ConversationDetailsOptions = ({
     !!teamId &&
     roleRepository.canToggleGuests(activeConversation) &&
     !isMLSConversation(activeConversation);
-  const showOptionNotifications1To1 = hasAdvancedNotifications && !isGroup;
+  const showOptionNotifications1To1 = isMutable && !isGroup;
   const showOptionReadReceipts = !!teamId && roleRepository.canToggleReadReceipts(activeConversation);
 
   const hasReceiptsEnabled = conversationRepository.expectReadReceipt(activeConversation);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15134" title="WPB-15134" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15134</a>  [Web] Private user can't operate with Notifications for group convo
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Fixes the issue where private users cannot operate with notifications in group conversations.

## Screenshots/Screencast (for UI changes)
### Before
![issue](https://github.com/user-attachments/assets/2d941a11-1e13-44ef-918d-9dc9b25d1b58)


### After
<img width="306" alt="fix" src="https://github.com/user-attachments/assets/a3caf025-94f2-40fe-87d0-b840ebfc8d1b" />



## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;