### PR TITLE
fix: conversation removal from custom folder [WPB-15352]

### DIFF
--- a/src/script/conversation/ConversationLabelRepository.ts
+++ b/src/script/conversation/ConversationLabelRepository.ts
@@ -244,9 +244,18 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
       .sort(({name: nameA}, {name: nameB}) => nameA.localeCompare(nameB, undefined, {sensitivity: 'base'}));
 
   readonly removeConversationFromLabel = (label: ConversationLabel, removeConversation: Conversation): void => {
-    label.conversations(label.conversations().filter(conversation => conversation !== removeConversation));
-
     const {setCurrentTab} = useSidebarStore.getState();
+
+    // Remove conversation from folder and update folder in labels
+    const folderIndex = this.labels.indexOf(label);
+    const updatedFolder = createLabel(
+      label.name,
+      label.conversations().filter(conversation => conversation !== removeConversation),
+      label.id,
+      label.type,
+    );
+
+    this.labels.splice(folderIndex, 1, updatedFolder);
 
     // Delete folder if it no longer contains any conversation
     if (!label.conversations().length) {

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -133,6 +133,7 @@ export const Conversations: React.FC<ConversationsProps> = ({
   const {activeCalls} = useKoSubscribableChildren(callState, ['activeCalls']);
 
   const {conversationLabelRepository} = conversationRepository;
+  const {labels} = useKoSubscribableChildren(conversationLabelRepository, ['labels']);
   const favoriteConversations = useMemo(
     () => conversationLabelRepository.getFavorites(conversations),
     [conversationLabelRepository, conversations],
@@ -177,8 +178,7 @@ export const Conversations: React.FC<ConversationsProps> = ({
     favoriteConversations,
   });
 
-  const currentFolder = conversationLabelRepository
-    .getLabels()
+  const currentFolder = labels
     .map(label => createLabel(label.name, conversationLabelRepository.getLabelConversations(label), label.id))
     .find(folder => folder.id === expandedFolder);
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15352" title="WPB-15352" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15352</a>  [Web] Removing conversation from custom folder does not update the view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Fixed UI re-rendering on conversation removal from custom folder.


## Screenshots/Screencast (for UI changes)

https://github.com/user-attachments/assets/dae450bd-be3b-4301-8c5f-9df4fd842b04

https://github.com/user-attachments/assets/c74e0297-1379-4eb8-a53d-82d88a28e13c

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
