### PR TITLE
fix(RichTextEditor): prevent double paste in Firefox [WPB-15264]

### DIFF
--- a/src/script/components/InputBar/components/RichTextEditor/plugins/PastePlugin/PastePlugin.tsx
+++ b/src/script/components/InputBar/components/RichTextEditor/plugins/PastePlugin/PastePlugin.tsx
@@ -274,6 +274,8 @@ export const PastePlugin = ({getMentionCandidates}: PastePluginProps): JSX.Eleme
         }
       });
 
+      // Prevent the default paste behavior
+      event.preventDefault();
       return true;
     },
     [editor, getMentionCandidates, handleLexicalMentions, handleFormattedContent, processMentions],

--- a/src/script/components/InputBar/components/RichTextEditor/plugins/PastePlugin/PastePlugin.tsx
+++ b/src/script/components/InputBar/components/RichTextEditor/plugins/PastePlugin/PastePlugin.tsx
@@ -274,7 +274,6 @@ export const PastePlugin = ({getMentionCandidates}: PastePluginProps): JSX.Eleme
         }
       });
 
-      // Prevent the default paste behavior
       event.preventDefault();
       return true;
     },


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15264" title="WPB-15264" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15264</a>  Enhance Rich Text Editor - PRD + Bugs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

This fixes Firefox's pasting behavior. The text was pasted twice because of the missing `event.preventDefault` and the Firefox handling events behavior. It also prevents the browser from performing its default paste action after we've already handled the paste event ourselves. 

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
