### PR TITLE
fix: deactivate camera if toggle of and [WPB-15506]

### DIFF
--- a/src/script/calling/CallingRepository.test.ts
+++ b/src/script/calling/CallingRepository.test.ts
@@ -27,7 +27,7 @@ import 'jsdom-worker';
 import ko, {Subscription} from 'knockout';
 import {container} from 'tsyringe';
 
-import {CONV_TYPE, CALL_TYPE, STATE as CALL_STATE, REASON, Wcall} from '@wireapp/avs';
+import {CONV_TYPE, CALL_TYPE, STATE as CALL_STATE, REASON, Wcall, VIDEO_STATE} from '@wireapp/avs';
 import {Runtime} from '@wireapp/commons';
 
 import {Call} from 'src/script/calling/Call';
@@ -515,6 +515,114 @@ describe('CallingRepository', () => {
 
       expect(selfParticipant.releaseAudioStream).toHaveBeenCalledTimes(1);
       expect(selfParticipant.releaseVideoStream).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('camera', () => {
+    let selfParticipant: Participant;
+    let conv: Conversation;
+    let call: Call;
+    beforeEach(() => {
+      selfParticipant = createSelfParticipant();
+      conv = createConversation();
+      call = new Call(
+        {domain: '', id: ''},
+        conv,
+        CONV_TYPE.CONFERENCE,
+        selfParticipant,
+        CALL_TYPE.NORMAL,
+        buildMediaDevicesHandler(),
+      );
+    });
+
+    describe('on incoming call', () => {
+      it('toggle on', async () => {
+        selfParticipant.videoState(VIDEO_STATE.STOPPED);
+        spyOn(selfParticipant, 'releaseVideoStream');
+        spyOn(wCall, 'setVideoSendState');
+        call.state(CALL_STATE.INCOMING);
+        callingRepository.toggleCamera(call);
+        expect(selfParticipant.releaseVideoStream).toHaveBeenCalledTimes(0);
+        expect(wCall.setVideoSendState).toHaveBeenCalledWith(wUser, conv.id, VIDEO_STATE.STARTED);
+      });
+
+      it('toggle off', async () => {
+        selfParticipant.videoState(VIDEO_STATE.STARTED);
+        spyOn(selfParticipant, 'releaseVideoStream');
+        spyOn(wCall, 'setVideoSendState');
+        call.state(CALL_STATE.INCOMING);
+        callingRepository.toggleCamera(call);
+
+        expect(selfParticipant.releaseVideoStream).toHaveBeenCalledTimes(1);
+        expect(wCall.setVideoSendState).toHaveBeenCalledWith(wUser, conv.id, VIDEO_STATE.STOPPED);
+      });
+    });
+
+    describe('on running call', () => {
+      it('toggle on', async () => {
+        selfParticipant.videoState(VIDEO_STATE.STOPPED);
+        spyOn(selfParticipant, 'releaseVideoStream');
+        spyOn(wCall, 'setVideoSendState');
+        call.state(CALL_STATE.MEDIA_ESTAB);
+        callingRepository.toggleCamera(call);
+        expect(selfParticipant.releaseVideoStream).toHaveBeenCalledTimes(0);
+        expect(wCall.setVideoSendState).toHaveBeenCalledWith(wUser, conv.id, VIDEO_STATE.STARTED);
+      });
+
+      it('toggle off', async () => {
+        selfParticipant.videoState(VIDEO_STATE.STARTED);
+        spyOn(selfParticipant, 'releaseVideoStream');
+        spyOn(wCall, 'setVideoSendState');
+        call.state(CALL_STATE.MEDIA_ESTAB);
+        callingRepository.toggleCamera(call);
+
+        expect(selfParticipant.releaseVideoStream).toHaveBeenCalledTimes(1);
+        expect(wCall.setVideoSendState).toHaveBeenCalledWith(wUser, conv.id, VIDEO_STATE.STOPPED);
+      });
+
+      // This is an edge case. You can toggleCamera on when you have screen share enabled!
+      it('toggle on when screen shared', async () => {
+        selfParticipant.videoState(VIDEO_STATE.SCREENSHARE);
+        spyOn(selfParticipant, 'releaseVideoStream');
+        spyOn(wCall, 'setVideoSendState');
+        call.state(CALL_STATE.MEDIA_ESTAB);
+        callingRepository.toggleCamera(call);
+        expect(selfParticipant.releaseVideoStream).toHaveBeenCalledTimes(0);
+        expect(wCall.setVideoSendState).toHaveBeenCalledWith(wUser, conv.id, VIDEO_STATE.STARTED);
+      });
+    });
+
+    describe.skip('on not supported call state', () => {
+      it('ANSWERED, toggle will be failing', async () => {
+        selfParticipant.videoState(VIDEO_STATE.STOPPED);
+        call.state(CALL_STATE.ANSWERED);
+        expect(() => callingRepository.toggleCamera(call)).toThrow('invalid call state in `toggleCamera`');
+      });
+      it('NONE, toggle will be failing', async () => {
+        selfParticipant.videoState(VIDEO_STATE.STOPPED);
+        call.state(CALL_STATE.NONE);
+        expect(() => callingRepository.toggleCamera(call)).toThrow('invalid call state in `toggleCamera`');
+      });
+      it('UNKNOWN, toggle will be failing', async () => {
+        selfParticipant.videoState(VIDEO_STATE.STOPPED);
+        call.state(CALL_STATE.UNKNOWN);
+        expect(() => callingRepository.toggleCamera(call)).toThrow('invalid call state in `toggleCamera`');
+      });
+      it('OUTGOING, toggle will be failing', async () => {
+        selfParticipant.videoState(VIDEO_STATE.STOPPED);
+        call.state(CALL_STATE.OUTGOING);
+        expect(() => callingRepository.toggleCamera(call)).toThrow('invalid call state in `toggleCamera`');
+      });
+      it('TERM_LOCAL, toggle will be failing', async () => {
+        selfParticipant.videoState(VIDEO_STATE.STOPPED);
+        call.state(CALL_STATE.TERM_LOCAL);
+        expect(() => callingRepository.toggleCamera(call)).toThrow('invalid call state in `toggleCamera`');
+      });
+      it('TERM_REMOTE, toggle will be failing', async () => {
+        selfParticipant.videoState(VIDEO_STATE.STOPPED);
+        call.state(CALL_STATE.TERM_REMOTE);
+        expect(() => callingRepository.toggleCamera(call)).toThrow('invalid call state in `toggleCamera`');
+      });
     });
   });
 });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15506" title="WPB-15506" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15506</a>  [Web] Camera light stays on even when the 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
 
 Deactivate camera instantly if click mute button and not wait for event
 
 - remove instantly track when camera mutes
 - add unit test to cover this imported changes and extend the implementation.

## Description

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
