### PR TITLE
fix: restrict delete group option to admins in the creator's team [WPB-15293]

### DIFF
--- a/src/script/page/RightSidebar/ConversationDetails/utils/getConversationActions.ts
+++ b/src/script/page/RightSidebar/ConversationDetails/utils/getConversationActions.ts
@@ -156,7 +156,8 @@ const getConversationActions = ({
         !isSingleUser &&
         isTeam &&
         roleRepository.canDeleteGroup(conversationEntity) &&
-        !conversationEntity.isSelfUserRemoved(),
+        !conversationEntity.isSelfUserRemoved() &&
+        conversationEntity.inTeam(),
       item: {
         click: () => actionsViewModel.deleteConversation(conversationEntity),
         Icon: Icon.DeleteIcon,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15293" title="WPB-15293" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15293</a>  [Web] Only group admins, that are in the same team as the group creator, should see the delete group option
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Fixes the issue where the "Delete group" option is visible to group admins who are not part of the same team as the group creator.

## Screenshots/Screencast (for UI changes)
### Before
<img width="203" alt="issue" src="https://github.com/user-attachments/assets/eea960a7-675a-4bec-b3e9-0bbaa1b6155c" />

### After
<img width="202" alt="fix" src="https://github.com/user-attachments/assets/99bbc55a-bfbe-44c9-ae97-aa0ba485524f" />

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;
