### PR TITLE
fix: update grid when participant change between video and screen share. [WPB-15036]

### DIFF
--- a/src/script/calling/Call.test.ts
+++ b/src/script/calling/Call.test.ts
@@ -1,0 +1,228 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import ko from 'knockout';
+
+import {CALL_TYPE, CONV_TYPE, Wcall} from '@wireapp/avs';
+
+import {generateConversation} from 'test/helper/ConversationGenerator';
+
+import {Call} from './Call';
+import {CallingRepository} from './CallingRepository';
+import {Participant} from './Participant';
+
+import {TestFactory} from '../../../test/helper/TestFactory';
+import {Conversation} from '../entity/Conversation';
+import {User} from '../entity/User';
+import {MediaDevicesHandler} from '../media/MediaDevicesHandler';
+
+const createSelfParticipant = () => {
+  const selfUser = new User();
+  selfUser.isMe = true;
+  return new Participant(selfUser, 'client1');
+};
+
+const createParticipant = (name: string) => {
+  const user = new User();
+  user.name(name);
+  return new Participant(user, `client-${name}`);
+};
+
+const mediaDevices = {
+  audioinput: ko.pureComputed(() => 'test'),
+  audiooutput: ko.pureComputed(() => 'test'),
+  screeninput: ko.pureComputed(() => 'test'),
+  videoinput: ko.pureComputed(() => 'test'),
+};
+
+const buildMediaDevicesHandler = () => {
+  return {
+    currentAvailableDeviceId: mediaDevices,
+    setOnMediaDevicesRefreshHandler: jest.fn(),
+  } as unknown as MediaDevicesHandler;
+};
+
+describe('Call', () => {
+  const testFactory = new TestFactory();
+  let call: Call;
+  let callingRepository: CallingRepository;
+  let selfParticipant: Participant;
+  let firstParticipant: Participant;
+  let secondParticipant: Participant;
+  let thirdParticipant: Participant;
+  let fourthParticipant: Participant;
+  let fifthParticipant: Participant;
+  let conv: Conversation;
+  let wCall: Wcall;
+  let wUser: number;
+
+  beforeAll(() => {
+    return testFactory.exposeCallingActors().then(injectedCallingRepository => {
+      callingRepository = injectedCallingRepository;
+      // return callingRepository.initAvs(selfUser, clientId).then(avsApi => {
+      //   wCall = avsApi.wCall;
+      //   wUser = avsApi.wUser;
+      // });
+    });
+  });
+
+  beforeEach(() => {
+    selfParticipant = createSelfParticipant();
+
+    firstParticipant = createParticipant('A-first');
+    secondParticipant = createParticipant('B-second');
+    thirdParticipant = createParticipant('C-third');
+    fourthParticipant = createParticipant('D-fourth');
+    fifthParticipant = createParticipant('E-fifth');
+
+    conv = generateConversation();
+    call = new Call(
+      {domain: '', id: ''},
+      conv,
+      CONV_TYPE.CONFERENCE,
+      selfParticipant,
+      CALL_TYPE.NORMAL,
+      buildMediaDevicesHandler(),
+    );
+
+    // Add participant in not alphabetic order
+    call.addParticipant(fourthParticipant);
+    call.addParticipant(fifthParticipant);
+    call.addParticipant(secondParticipant);
+    call.addParticipant(firstParticipant);
+    call.addParticipant(thirdParticipant);
+  });
+
+  afterEach(() => {
+    callingRepository['callState'].calls([]);
+    callingRepository['conversationState'].conversations([]);
+    callingRepository.destroy();
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    return wCall && wCall.destroy(wUser);
+  });
+
+  describe('update pages', () => {
+    it('everyone is muted then sort alphabetically', async () => {
+      call.updatePages();
+      const pages = call.pages.pop();
+      expect(pages.map(p => p.user.name())).toEqual([
+        selfParticipant.user.name(),
+        firstParticipant.user.name(),
+        secondParticipant.user.name(),
+        thirdParticipant.user.name(),
+        fourthParticipant.user.name(),
+        fifthParticipant.user.name(),
+      ]);
+    });
+
+    it('participants who send videos are sorted to the front', async () => {
+      thirdParticipant.videoState(4);
+      fourthParticipant.videoState(4);
+      call.updatePages();
+      const pages = call.pages.pop();
+      expect(pages.map(p => p.user.name())).toEqual([
+        selfParticipant.user.name(),
+        thirdParticipant.user.name(),
+        fourthParticipant.user.name(),
+        firstParticipant.user.name(),
+        secondParticipant.user.name(),
+        fifthParticipant.user.name(),
+      ]);
+    });
+
+    it('participants who send screen share are sorted to the front', async () => {
+      secondParticipant.videoState(1);
+      thirdParticipant.videoState(1);
+      call.updatePages();
+      const pages = call.pages.pop();
+      expect(pages.map(p => p.user.name())).toEqual([
+        selfParticipant.user.name(),
+        secondParticipant.user.name(),
+        thirdParticipant.user.name(),
+        firstParticipant.user.name(),
+        fourthParticipant.user.name(),
+        fifthParticipant.user.name(),
+      ]);
+    });
+
+    it('sort the participant with screen share first then videos then muted', async () => {
+      fourthParticipant.videoState(4);
+      thirdParticipant.videoState(1);
+      fifthParticipant.videoState(1);
+
+      call.updatePages();
+      const pages = call.pages.pop();
+      expect(pages.map(p => p.user.name())).toEqual([
+        selfParticipant.user.name(),
+        fourthParticipant.user.name(),
+        thirdParticipant.user.name(),
+        fifthParticipant.user.name(),
+        firstParticipant.user.name(),
+        secondParticipant.user.name(),
+      ]);
+    });
+
+    it('adjust sorting when participant is changed from screen share to video', async () => {
+      fourthParticipant.videoState(4);
+      thirdParticipant.videoState(1);
+      fifthParticipant.videoState(1);
+
+      call.updatePages();
+
+      fourthParticipant.videoState(1);
+
+      call.updatePages();
+
+      const pages = call.pages.pop();
+      expect(pages.map(p => p.user.name())).toEqual([
+        selfParticipant.user.name(),
+        thirdParticipant.user.name(),
+        fourthParticipant.user.name(),
+        fifthParticipant.user.name(),
+        firstParticipant.user.name(),
+        secondParticipant.user.name(),
+      ]);
+    });
+
+    it('adjust sorting when participant is changed from video to screen share', async () => {
+      fourthParticipant.videoState(4);
+      thirdParticipant.videoState(1);
+      fifthParticipant.videoState(1);
+
+      call.updatePages();
+
+      fifthParticipant.videoState(4);
+
+      call.updatePages();
+
+      const pages = call.pages.pop();
+      expect(pages.map(p => p.user.name())).toEqual([
+        selfParticipant.user.name(),
+        fourthParticipant.user.name(),
+        fifthParticipant.user.name(),
+        thirdParticipant.user.name(),
+        firstParticipant.user.name(),
+        secondParticipant.user.name(),
+      ]);
+    });
+  });
+});

--- a/src/script/calling/videoGridHandler.ts
+++ b/src/script/calling/videoGridHandler.ts
@@ -58,9 +58,11 @@ export const useVideoGrid = (call: Call): Grid => {
     updateGrid();
     const nameSubscriptions = participants?.map(p => p.user.name.subscribe(updateGrid));
     const videoSubscriptions = participants?.map(p => p.isSendingVideo.subscribe(updateGrid));
+    const screenShareSubscriptions = participants?.map(p => p.sharesScreen.subscribe(updateGrid));
     return () => {
       nameSubscriptions?.forEach(s => s.dispose());
       videoSubscriptions?.forEach(s => s.dispose());
+      screenShareSubscriptions?.forEach(s => s.dispose());
     };
   }, [participants, participants?.length, call, currentPage, pages?.length]);
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15036" title="WPB-15036" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15036</a>  [Web] User tiles in a call do not reshuffle according to priority (screenshare not bumped)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

When a participant switched from video to screen share or from screen share to video, no grid update occurred. This PR fixes this issue.
  
  - add tests for sort method

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
