### PR TITLE
fix: Replace history when not finding conversation (WPB-15372)

### DIFF
--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -152,6 +152,7 @@ export class ContentViewModel {
 
   private handleMissingConversation(): void {
     this.closeRightSidebar();
+    setHistoryParam('/', history.state);
     return this.switchContent(ContentState.CONNECTION_REQUESTS);
   }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15372" title="WPB-15372" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15372</a>  [Web] Handling deleted team users that have a contact request open from when they were personal users
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

After deleting a no longer valid connection request to a user who was converted to team user we do also delete the corresponding conversation with them. problem is that after publishing an amplify event to switch to the next conversation sometimes the user might not have any more conversation than the recently deleted one. we do show a blank view but do not replace the url. this causes to show a conversation with name "name not available" next time the user reloads the app because ID of the old conversation is still in the url. with this fix we also replace the old id route with root route of / to avoid this behavior. 

![image](https://github.com/user-attachments/assets/99dcf1db-36d5-4225-8746-39786f4d07b9)

