### PR TITLE
fix: Filter dead connection conversations (WPB-15377)

### DIFF
--- a/src/script/components/ConfigToolbar/ConfigToolbar.tsx
+++ b/src/script/components/ConfigToolbar/ConfigToolbar.tsx
@@ -186,7 +186,7 @@ export function ConfigToolbar() {
 
   return (
     <div ref={wrapperRef} css={wrapperStyles}>
-      <h3>Configuration Tool</h3>
+      <h3>Developer Menu</h3>
       <h4 style={{color: 'red', fontWeight: 'bold'}}>
         Caution: Modifying these settings can affect the behavior of the application. Ensure you understand the
         implications of each change before proceeding. Changes may cause unexpected behavior.

--- a/src/script/connection/ConnectionRepository.ts
+++ b/src/script/connection/ConnectionRepository.ts
@@ -301,6 +301,7 @@ export class ConnectionRepository {
     const deadConnectionEntities = ConnectionMapper.mapConnectionsFromJson(deadConnections);
 
     this.connectionState.connections(connections);
+    this.connectionState.deadConnections(deadConnectionEntities);
     return {connections, deadConnections: deadConnectionEntities};
   }
 

--- a/src/script/connection/ConnectionState.ts
+++ b/src/script/connection/ConnectionState.ts
@@ -25,8 +25,10 @@ import {ConnectionEntity} from './ConnectionEntity';
 @singleton()
 export class ConnectionState {
   public readonly connections: ko.ObservableArray<ConnectionEntity>;
+  public readonly deadConnections: ko.ObservableArray<ConnectionEntity>;
 
   constructor() {
     this.connections = ko.observableArray();
+    this.deadConnections = ko.observableArray();
   }
 }

--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -2549,7 +2549,7 @@ describe('ConversationRepository', () => {
         .mockResolvedValue(localConversations as unknown as ConversationDatabaseData[]);
       jest.spyOn(conversationService, 'saveConversationsInDb').mockImplementation(data => Promise.resolve(data));
 
-      const conversations = await conversationRepository.loadConversations([]);
+      const conversations = await conversationRepository.loadConversations([], []);
 
       expect(conversations).toHaveLength(remoteConversations.found.length);
     });
@@ -2594,7 +2594,7 @@ describe('ConversationRepository', () => {
         .mockResolvedValue(localConversations as unknown as ConversationDatabaseData[]);
       jest.spyOn(conversationService, 'saveConversationsInDb').mockImplementation(data => Promise.resolve(data));
 
-      const conversations = await conversationRepository.loadConversations([]);
+      const conversations = await conversationRepository.loadConversations([], []);
 
       expect(conversations).toHaveLength(1);
     });
@@ -2639,7 +2639,7 @@ describe('ConversationRepository', () => {
         .mockResolvedValue(localConversations as unknown as ConversationDatabaseData[]);
       jest.spyOn(conversationService, 'saveConversationsInDb').mockImplementation(data => Promise.resolve(data));
 
-      const conversations = await conversationRepository.loadConversations([]);
+      const conversations = await conversationRepository.loadConversations([], []);
 
       expect(conversations).toHaveLength(remoteConversations.found.length);
     });
@@ -2675,7 +2675,7 @@ describe('ConversationRepository', () => {
         .mockResolvedValue(localConversations as unknown as ConversationDatabaseData[]);
       jest.spyOn(conversationService, 'saveConversationsInDb').mockImplementation(data => Promise.resolve(data));
 
-      const conversations = await conversationRepository.loadConversations([]);
+      const conversations = await conversationRepository.loadConversations([], []);
 
       expect(conversations).toHaveLength(0);
       expect(conversationService.deleteConversationFromDb).toHaveBeenCalledWith(connectionReq.qualified_id.id);
@@ -2719,7 +2719,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationService, 'getAllConversations')
         .mockResolvedValue(remoteConversations as unknown as RemoteConversations);
 
-      await conversationRepository.loadConversations([]);
+      await conversationRepository.loadConversations([], []);
 
       expect(conversationState.missingConversations).toHaveLength(remoteConversations.failed.length);
     });

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -760,14 +760,15 @@ export class ConversationRepository {
       );
     });
 
-    await this.deleteAndBlockConversations(
-      deletedConnectionRequests.map(
-        deletedConnection =>
-          deletedConnection.qualified_id || {id: deletedConnection.id, domain: deletedConnection.domain ?? ''},
-      ),
+const deletedConnectionIds = deletedConnectionRequests.map(
+      deletedConnection =>
+        deletedConnection.qualified_id || {id: deletedConnection.id, domain: deletedConnection.domain ?? ''},
     );
 
-    await this.deleteAndBlockConversations(deadConnections.map(deadConnection => deadConnection.conversationId));
+    const deadConnectionIds = deadConnections.map(deadConnection => deadConnection.conversationId);
+
+    await this.deleteAndBlockConversations(deletedConnectionIds);
+    await this.deleteAndBlockConversations(deadConnectionIds);
 
     return {
       localConversations: filteredLocalConversations,

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -748,20 +748,19 @@ export class ConversationRepository {
       }
     }
 
-    let filteredRemoteConversations = remoteConversations.found?.filter(
-      remoteConversation =>
-        !deletedConnectionRequests.find(({qualified_id, id, domain}) =>
-          matchQualifiedIds(qualified_id || {id, domain}, remoteConversation.qualified_id),
-        ),
-    );
-
-    filteredRemoteConversations = filteredRemoteConversations?.filter(backendConversation => {
-      return !deadConnections.some(deadConnection =>
-        matchQualifiedIds(backendConversation.qualified_id, deadConnection.conversationId),
+    const filteredRemoteConversations = remoteConversations.found?.filter(remoteConversation => {
+      const isNotDeletedConnection = !deletedConnectionRequests.find(({qualified_id, id, domain}) =>
+        matchQualifiedIds(qualified_id || {id, domain}, remoteConversation.qualified_id),
       );
+
+      const isNotDeadConnection = !deadConnections.some(deadConnection =>
+        matchQualifiedIds(remoteConversation.qualified_id, deadConnection.conversationId),
+      );
+
+      return isNotDeletedConnection && isNotDeadConnection;
     });
 
-const deletedConnectionIds = deletedConnectionRequests.map(
+    const deletedConnectionIds = deletedConnectionRequests.map(
       deletedConnection =>
         deletedConnection.qualified_id || {id: deletedConnection.id, domain: deletedConnection.domain ?? ''},
     );

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -643,7 +643,8 @@ export class ConversationRepository {
       });
 
     const connections = this.connectionState.connections();
-    return this.loadRemoteConversations(remoteConversations, connections);
+    const deadConnections = this.connectionState.deadConnections();
+    return this.loadRemoteConversations(remoteConversations, connections, deadConnections);
   }
 
   /**
@@ -725,7 +726,7 @@ export class ConversationRepository {
     localConversations: ConversationDatabaseData[],
     remoteConversations: RemoteConversations,
     connections: ConnectionEntity[],
-    deadConnections: ConnectionEntity[],
+    deadConnections: ConnectionEntity[] = [],
   ): Promise<{localConversations: ConversationDatabaseData[]; remoteConversations: RemoteConversations}> {
     //If there's any local conversation of type 3 (CONNECT), but the connection doesn't exist anymore (user was deleted),
     // we delete the conversation and blacklist it so it's never refetched from the backend
@@ -811,7 +812,7 @@ export class ConversationRepository {
   private async loadRemoteConversations(
     remoteConversations: RemoteConversations,
     connections: ConnectionEntity[],
-    deadConnections: ConnectionEntity[],
+    deadConnections: ConnectionEntity[] = [],
   ): Promise<Conversation[]> {
     const localConversations = await this.conversationService.loadConversationStatesFromDb<ConversationDatabaseData>();
 

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -466,13 +466,13 @@ export class App {
       onProgress(10);
       telemetry.timeStep(AppInitTimingsStep.INITIALIZED_CRYPTOGRAPHY);
 
-      const connections = await connectionRepository.getConnections(teamMembers);
+      const {connections, deadConnections} = await connectionRepository.getConnections(teamMembers);
 
       telemetry.timeStep(AppInitTimingsStep.RECEIVED_USER_DATA);
 
       telemetry.addStatistic(AppInitStatisticsValue.CONNECTIONS, connections.length, 50);
 
-      const conversations = await conversationRepository.loadConversations(connections);
+      const conversations = await conversationRepository.loadConversations(connections, deadConnections);
       eventLogger.log(AppInitializationStep.ConversationsLoaded);
       // We load all the users the self user is connected with
       await userRepository.loadUsers(selfUser, connections, conversations, teamMembers);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15377" title="WPB-15377" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15377</a>  [Web] Name not available conversations appear for "dead" contact requests on fresh client
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

When a connection request is sent from user A to user B or vice verse a conversation is created for this connection.
If the connection request is in the not accepted state and user B joins user A's team we have to ignore this conversation.
 
Backend persists that conversation which was initially created when user B wasn't part of user A's team and they had a pending connection request.

This PR aims to filter and block that dead conversation.