### PR TITLE
fix: wrong error message on cancelling video or file download [WPB-15355]

### DIFF
--- a/src/script/assets/AssetError.ts
+++ b/src/script/assets/AssetError.ts
@@ -17,13 +17,6 @@
  *
  */
 
-export enum AssetTransferState {
-  CANCELED = 'cancelled',
-  DOWNLOADING = 'downloading',
-  UPLOAD_FAILED = 'upload-failed',
-  UPLOAD_PENDING = 'upload-pending',
-  UPLOADED = 'uploaded',
-  UPLOADING = 'uploading',
-  DOWNLOAD_FAILED_DECRPYT = 'download-failed-decrypt',
-  DOWNLOAD_FAILED_HASH = 'download-failed-hash',
+export enum AssetError {
+  CANCEL_ERROR = 'RequestCancellationError',
 }

--- a/src/script/assets/AssetRepository.ts
+++ b/src/script/assets/AssetRepository.ts
@@ -31,6 +31,7 @@ import {WebWorker} from 'Util/worker';
 import {AssetRemoteData} from './AssetRemoteData';
 import {AssetTransferState} from './AssetTransferState';
 import {getAssetUrl, setAssetUrl} from './AssetURLCache';
+import {AssetError} from './AssetError';
 
 import {Conversation} from '../entity/Conversation';
 import {FileAsset} from '../entity/message/FileAsset';
@@ -157,7 +158,9 @@ export class AssetRepository {
       return downloadBlob(blob, asset.file_name);
     } catch (error) {
       if (error instanceof Error) {
-        if (error.message.endsWith('Encrypted asset does not match its SHA-256 hash')) {
+        if (error.name === AssetError.CANCEL_ERROR) {
+          asset.status(AssetTransferState.CANCELED);
+        } else if (error.message.endsWith('Encrypted asset does not match its SHA-256 hash')) {
           asset.status(AssetTransferState.DOWNLOAD_FAILED_HASH);
         } else {
           asset.status(AssetTransferState.DOWNLOAD_FAILED_DECRPYT);

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/FileAssetComponent.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/FileAssetComponent.tsx
@@ -71,14 +71,15 @@ const FileAsset: React.FC<FileAssetProps> = ({
 
   const isPendingUpload = assetStatus === AssetTransferState.UPLOAD_PENDING;
   const isFailedUpload = assetStatus === AssetTransferState.UPLOAD_FAILED;
-  const isUploaded = assetStatus === AssetTransferState.UPLOADED || assetStatus === AssetTransferState.CANCELED;
+  const isUploadedOrCancelled =
+    assetStatus === AssetTransferState.UPLOADED || assetStatus === AssetTransferState.CANCELED;
   const isDownloading = assetStatus === AssetTransferState.DOWNLOADING;
   const isFailedDownloadingDecrypt = assetStatus === AssetTransferState.DOWNLOAD_FAILED_DECRPYT;
   const isFailedDownloadingHash = assetStatus === AssetTransferState.DOWNLOAD_FAILED_HASH;
   const isUploading = assetStatus === AssetTransferState.UPLOADING;
 
   const onDownloadAsset = async () => {
-    if (isUploaded) {
+    if (isUploadedOrCancelled) {
       downloadAsset(asset);
     }
   };
@@ -94,7 +95,7 @@ const FileAsset: React.FC<FileAssetProps> = ({
       {isFileSharingReceivingEnabled ? (
         <div
           className={cx('file', {
-            'cursor-pointer': isUploaded,
+            'cursor-pointer': isUploadedOrCancelled,
           })}
           data-uie-name="file"
           data-uie-value={asset.file_name}
@@ -108,7 +109,7 @@ const FileAsset: React.FC<FileAssetProps> = ({
             <div className="asset-placeholder loading-dots" />
           ) : (
             <>
-              {isUploaded && (
+              {isUploadedOrCancelled && (
                 <div className="file__icon icon-file" data-uie-name="file-icon">
                   <span className="file__icon__ext icon-view" />
                 </div>

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/FileAssetComponent.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/FileAssetComponent.tsx
@@ -71,7 +71,7 @@ const FileAsset: React.FC<FileAssetProps> = ({
 
   const isPendingUpload = assetStatus === AssetTransferState.UPLOAD_PENDING;
   const isFailedUpload = assetStatus === AssetTransferState.UPLOAD_FAILED;
-  const isUploaded = assetStatus === AssetTransferState.UPLOADED;
+  const isUploaded = assetStatus === AssetTransferState.UPLOADED || assetStatus === AssetTransferState.CANCELED;
   const isDownloading = assetStatus === AssetTransferState.DOWNLOADING;
   const isFailedDownloadingDecrypt = assetStatus === AssetTransferState.DOWNLOAD_FAILED_DECRPYT;
   const isFailedDownloadingHash = assetStatus === AssetTransferState.DOWNLOAD_FAILED_HASH;

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset.tsx
@@ -39,6 +39,7 @@ import {SeekBar} from './controls/SeekBar';
 import {FileAsset} from './FileAssetComponent';
 import {AssetUrl, useAssetTransfer} from './useAssetTransfer';
 
+import {AssetError} from '../../../../../assets/AssetError';
 import {AssetRepository} from '../../../../../assets/AssetRepository';
 import {AssetTransferState} from '../../../../../assets/AssetTransferState';
 import type {ContentMessage} from '../../../../../entity/message/ContentMessage';
@@ -147,7 +148,11 @@ const VideoAsset: React.FC<VideoAssetProps> = ({
           setIsVideoLoaded(true);
           amplify.publish(WebAppEvents.ANALYTICS.EVENT, EventName.MESSAGES.VIDEO.PLAY_SUCCESS);
         } catch (error) {
-          setVideoPlaybackError(true);
+          if (error instanceof Error) {
+            if (error.name !== AssetError.CANCEL_ERROR) {
+              setVideoPlaybackError(true);
+            }
+          }
           amplify.publish(WebAppEvents.ANALYTICS.EVENT, EventName.MESSAGES.VIDEO.PLAY_FAILED);
           console.error('Failed to load video asset ', error);
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15355" title="WPB-15355" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15355</a>  [Web] Wrong error message when canceling video download
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Fixes the issue where wrong error message was showing on canceling video or file download.

## Screenshots/Screencast (for UI changes)
### Before
In case of a video:
<img width="810" alt="issue_video" src="https://github.com/user-attachments/assets/c142f649-67f5-4f7e-a004-df2dc0dcafa6" />

In case of a file:

https://github.com/user-attachments/assets/0124ecc5-24ac-4326-8110-7ed3c7311d8e




### After

In case of a video:

https://github.com/user-attachments/assets/d3e8c5ff-910f-4642-8b9b-f52b6da6fa71

In case of a file:

https://github.com/user-attachments/assets/63c85dbf-0635-4625-8fd7-c1a3d0525160



## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;
