### PR TITLE
fix(FailedToAddUsersMessage): fix styles for messageDetails [WPB-15334]

### DIFF
--- a/src/script/components/MessagesList/Message/FailedToAddUsersMessage.tsx
+++ b/src/script/components/MessagesList/Message/FailedToAddUsersMessage.tsx
@@ -149,11 +149,7 @@ const MessageDetails = ({failure, isMessageFocused, allUsers}: MessageDetailsPro
   const text = getText();
 
   return (
-    <p
-      data-uie-name="multi-user-not-added-details"
-      data-uie-value={domainStr}
-      style={{lineHeight: 'var(--line-height-sm)'}}
-    >
+    <p data-uie-name="multi-user-not-added-details" data-uie-value={domainStr}>
       {text && (
         <span
           css={warning}
@@ -251,7 +247,7 @@ const FailedToAddUsersMessage: React.FC<FailedToAddUsersMessageProps> = ({
           />
         </p>
       </div>
-      <div className="message-body" css={{flexDirection: 'column'}}>
+      <div className="message-details">
         {isOpen &&
           failures.map((failure, index) => (
             <MessageDetails allUsers={allUsers} isMessageFocused={isMessageFocused} key={index} failure={failure} />

--- a/src/style/content/conversation/message-list.less
+++ b/src/style/content/conversation/message-list.less
@@ -581,6 +581,11 @@
   margin-top: 24px;
 }
 
+.message-details {
+  margin-left: var(--conversation-message-sender-width);
+  font-size: var(--font-size-small);
+}
+
 .message-group-creation-header,
 .message-member-footer {
   padding-top: 16px;


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15334" title="WPB-15334" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15334</a>  [Web] Added participants description shifted when created a group after MLS migration
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Notes
I asked the designer about the spacings. I have her approval :)

## Screenshots/Screencast (for UI changes)
#### Please ignore the order of the messages in the screenshot (it's just a mock)
<img width="1155" alt="Screenshot 2025-01-24 at 22 14 40" src="https://github.com/user-attachments/assets/bee3189a-3f22-486f-a7e3-85cc7958a0e2" />

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
