### PR TITLE
fix(ConversationSidebar): fix visual glitch when expanding the sidebar [WPB-10549]

### DIFF
--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -245,11 +245,6 @@
     gap: 12px;
   }
 
-  &--text {
-    .text-bold-small;
-    color: var(--gray-90);
-  }
-
   .button-states();
 
   &:focus-visible {
@@ -258,7 +253,11 @@
   }
 
   .conversations-sidebar-btn--text {
+    .text-bold-small;
+    overflow: hidden;
     color: var(--main-color);
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   &.active {


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10549" title="WPB-10549" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10549</a>  [web] Visual glitch when expanding the sidebar
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description


## Screenshots/Screencast (for UI changes)
![sidebar](https://github.com/user-attachments/assets/b2df643d-522f-4149-b39f-37011522c21d)


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
