### PR TITLE
feat: Save draft message reply

### DIFF
--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -19,9 +19,10 @@
 
 import {useCallback, useEffect, useRef, useState} from 'react';
 
+import {$convertToMarkdownString} from '@lexical/markdown';
 import {amplify} from 'amplify';
 import cx from 'classnames';
-import {CLEAR_EDITOR_COMMAND, LexicalEditor, $createTextNode, $insertNodes} from 'lexical';
+import {LexicalEditor, $createTextNode, $insertNodes} from 'lexical';
 import {container} from 'tsyringe';
 
 import {WebAppEvents} from '@wireapp/webapp-events';
@@ -30,6 +31,8 @@ import {Avatar, AVATAR_SIZE} from 'Components/Avatar';
 import {ConversationClassifiedBar} from 'Components/ClassifiedBar/ClassifiedBar';
 import {checkFileSharingPermission} from 'Components/Conversation/utils/checkFileSharingPermission';
 import {EmojiPicker} from 'Components/EmojiPicker/EmojiPicker';
+import {markdownTransformers} from 'Components/InputBar/components/RichTextEditor/utils/markdownTransformers';
+import {transformMessage} from 'Components/InputBar/components/RichTextEditor/utils/transformMessage';
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
 import {showWarningModal} from 'Components/Modals/utils/showWarningModal';
 import {ConversationRepository} from 'src/script/conversation/ConversationRepository';
@@ -214,9 +217,27 @@ export const InputBar = ({
     ),
   });
 
+  const handleSaveEditorDraft = (replyId?: string) => {
+    const editor = editorRef.current;
+
+    if (!editor) {
+      return;
+    }
+
+    editor.getEditorState().read(() => {
+      const markdown = $convertToMarkdownString(markdownTransformers, undefined, true);
+      void saveDraft(
+        JSON.stringify(editor.getEditorState().toJSON()),
+        transformMessage({replaceEmojis: shouldReplaceEmoji, markdown}),
+        replyId,
+      );
+    });
+  };
+
   const resetDraftState = () => {
     setReplyMessageEntity(null);
-    editorRef.current?.dispatchCommand(CLEAR_EDITOR_COMMAND, undefined);
+
+    handleSaveEditorDraft();
   };
 
   const clearPastedFile = () => setPastedFile(null);
@@ -255,10 +276,6 @@ export const InputBar = ({
     }
   };
 
-  const handleCancelReply = () => {
-    cancelMessageReply(false);
-  };
-
   const editMessage = (messageEntity?: ContentMessage) => {
     if (messageEntity?.isEditable() && messageEntity !== editedMessage) {
       cancelMessageReply();
@@ -279,6 +296,7 @@ export const InputBar = ({
       cancelMessageReply(false);
       cancelMessageEditing(!!editedMessage);
       setReplyMessageEntity(messageEntity);
+      handleSaveEditorDraft(messageEntity.id);
 
       editorRef.current?.focus();
     }
@@ -460,13 +478,13 @@ export const InputBar = ({
     };
   }, []);
 
-  const saveDraft = async (editorState: string, plainMessage: string) => {
+  const saveDraft = async (editorState: string, plainMessage: string, replyId?: string) => {
     await saveDraftState({
       storageRepository,
       conversation,
       editorState,
       plainMessage: sanitizeMarkdown(plainMessage),
-      replyId: replyMessageEntity?.id,
+      replyId: replyId ?? replyMessageEntity?.id,
       editedMessageId: editedMessage?.id,
     });
   };
@@ -592,7 +610,9 @@ export const InputBar = ({
           <ConversationClassifiedBar conversation={conversation} classifiedDomains={classifiedDomains} />
         )}
 
-        {isReplying && !isEditing && <ReplyBar replyMessageEntity={replyMessageEntity} onCancel={handleCancelReply} />}
+        {isReplying && !isEditing && (
+          <ReplyBar replyMessageEntity={replyMessageEntity} onCancel={() => cancelMessageReply(true)} />
+        )}
 
         <div
           className={cx(`${conversationInputBarClassName}__input input-bar-container`, {

--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -217,7 +217,7 @@ export const InputBar = ({
     ),
   });
 
-  const handleSaveEditorDraft = (replyId?: string) => {
+  const handleSaveEditorDraft = (replyId = '') => {
     const editor = editorRef.current;
 
     if (!editor) {
@@ -611,7 +611,7 @@ export const InputBar = ({
         )}
 
         {isReplying && !isEditing && (
-          <ReplyBar replyMessageEntity={replyMessageEntity} onCancel={() => cancelMessageReply()} />
+          <ReplyBar replyMessageEntity={replyMessageEntity} onCancel={() => cancelMessageReply(false)} />
         )}
 
         <div

--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -22,7 +22,7 @@ import {useCallback, useEffect, useRef, useState} from 'react';
 import {$convertToMarkdownString} from '@lexical/markdown';
 import {amplify} from 'amplify';
 import cx from 'classnames';
-import {LexicalEditor, $createTextNode, $insertNodes} from 'lexical';
+import {LexicalEditor, $createTextNode, $insertNodes, CLEAR_EDITOR_COMMAND} from 'lexical';
 import {container} from 'tsyringe';
 
 import {WebAppEvents} from '@wireapp/webapp-events';
@@ -236,8 +236,7 @@ export const InputBar = ({
 
   const resetDraftState = () => {
     setReplyMessageEntity(null);
-
-    handleSaveEditorDraft();
+    editorRef.current?.dispatchCommand(CLEAR_EDITOR_COMMAND, undefined);
   };
 
   const clearPastedFile = () => setPastedFile(null);
@@ -251,6 +250,7 @@ export const InputBar = ({
 
   const cancelMessageReply = (resetDraft = true) => {
     setReplyMessageEntity(null);
+    handleSaveEditorDraft();
 
     if (resetDraft) {
       resetDraftState();
@@ -611,7 +611,7 @@ export const InputBar = ({
         )}
 
         {isReplying && !isEditing && (
-          <ReplyBar replyMessageEntity={replyMessageEntity} onCancel={() => cancelMessageReply(true)} />
+          <ReplyBar replyMessageEntity={replyMessageEntity} onCancel={() => cancelMessageReply()} />
         )}
 
         <div

--- a/src/script/components/InputBar/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/script/components/InputBar/components/RichTextEditor/RichTextEditor.tsx
@@ -76,7 +76,7 @@ interface RichTextEditorProps {
   showFormatToolbar: boolean;
   showMarkdownPreview: boolean;
   getMentionCandidates: (search?: string | null) => User[];
-  saveDraftState: (editor: string, plainMessage: string) => void;
+  saveDraftState: (editor: string, plainMessage: string, replyId?: string) => void;
   loadDraftState: () => Promise<DraftState>;
   onUpdate: (content: RichTextContent) => void;
   onArrowUp: () => void;

--- a/src/script/components/InputBar/components/RichTextEditor/utils/useEditorDraftState.ts
+++ b/src/script/components/InputBar/components/RichTextEditor/utils/useEditorDraftState.ts
@@ -30,7 +30,7 @@ const DRAFT_SAVE_DELAY = 800;
 
 interface UseEditorDraftStateProps {
   editorRef: RefObject<LexicalEditor | null>;
-  saveDraftState: (editorState: string, plainMessage: string) => void;
+  saveDraftState: (editorState: string, plainMessage: string, replyId?: string) => void;
   replaceEmojis: boolean;
 }
 
@@ -43,7 +43,11 @@ export const useEditorDraftState = ({editorRef, saveDraftState, replaceEmojis}: 
 
     editor.getEditorState().read(() => {
       const markdown = $convertToMarkdownString(markdownTransformers, undefined, true);
-      saveDraftState(JSON.stringify(editor.getEditorState().toJSON()), transformMessage({replaceEmojis, markdown}));
+      saveDraftState(
+        JSON.stringify(editor.getEditorState().toJSON()),
+        transformMessage({replaceEmojis, markdown}),
+        undefined,
+      );
     });
   }, [editorRef, saveDraftState, replaceEmojis]);
 


### PR DESCRIPTION
## Description

While user click on reply message (without writing text) and change tab, reply draft message is not properly saved.
Also while user want to remove reply message box, and change tab then reply draft message is present after change conversation.

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
