### PR TITLE
fix: Resolve virtual rendering focus issues (WPB-15154)

### DIFF
--- a/src/script/components/ConversationListCell/ConversationListCell.tsx
+++ b/src/script/components/ConversationListCell/ConversationListCell.tsx
@@ -17,13 +17,7 @@
  *
  */
 
-import React, {
-  useEffect,
-  useRef,
-  useState,
-  MouseEvent as ReactMouseEvent,
-  KeyboardEvent as ReactKeyBoardEvent,
-} from 'react';
+import React, {useRef, useState, MouseEvent as ReactMouseEvent, KeyboardEvent as ReactKeyBoardEvent} from 'react';
 
 import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 import cx from 'classnames';
@@ -143,13 +137,6 @@ export const ConversationListCell = ({
       handleArrowKeyDown(event);
     }
   };
-
-  // always focus on the selected conversation when the folder tab loaded
-  useEffect(() => {
-    if (isFocused) {
-      conversationRef.current?.focus();
-    }
-  }, [isFocused]);
 
   return (
     <li

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
@@ -182,12 +182,10 @@ export const ConversationsList = ({
   useEffect(() => {
     if (!conversationsFilter && clickedFilteredConversationId) {
       const conversationIndex = conversationsToDisplay.findIndex(conv => conv.id === clickedFilteredConversationId);
-
       if (conversationIndex !== -1) {
-        rowVirtualizer.scrollToIndex(conversationIndex, {align: 'center'});
+        rowVirtualizer.scrollToIndex(conversationIndex, {align: 'auto'});
       }
 
-      // scrollToConversation(clickedFilteredConversationId);
       setClickedFilteredConversationId(null);
     }
   }, [conversationsFilter, clickedFilteredConversationId, conversationsToDisplay]);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15154" title="WPB-15154" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15154</a>  [Web] Improve loading of conversation list by only loading what is visible in viewport
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

- changed align behavior of scrollToIndex of rowVirtualizer to auto to avoid always bringing the conversation in center even in cases they are already visible
- removed useEffect for focusing as it was causing unexpected focus jumping behavior and it had no use case when opening a folder
