### PR TITLE
fix: Debounce on conversation click to avoid maximum update depth exceeded error (WPB-11955)

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationsList.tsx
@@ -28,6 +28,8 @@ import React, {
 } from 'react';
 
 import {useVirtualizer} from '@tanstack/react-virtual';
+import {TimeInMillis} from '@wireapp/commons/lib/util/TimeUtil';
+import {useDebouncedCallback} from 'use-debounce';
 
 import {WIDTH} from '@wireapp/react-ui-kit';
 
@@ -142,27 +144,38 @@ export const ConversationsList = ({
     estimateSize: () => 56,
   });
 
+  const debouncedOnConversationClick = useDebouncedCallback(
+    (
+      conversation: Conversation,
+      event: ReactMouseEvent<HTMLDivElement, MouseEvent> | ReactKeyBoardEvent<HTMLDivElement>,
+    ) => {
+      if (isActiveConversation(conversation)) {
+        if (window.innerWidth > WIDTH.TABLET_SM_MAX || document.documentElement.clientWidth > WIDTH.TABLET_SM_MAX) {
+          clearSearchFilter();
+          setClickedFilteredConversationId(conversation.id);
+          return;
+        }
+      }
+
+      if (isKeyboardEvent(event)) {
+        createNavigateKeyboard(generateConversationUrl(conversation.qualifiedId), true)(event);
+      } else {
+        createNavigate(generateConversationUrl(conversation.qualifiedId))(event);
+      }
+
+      clearSearchFilter();
+      setClickedFilteredConversationId(conversation.id);
+    },
+    TimeInMillis.SECOND / 2, // Adjust debounce delay as needed
+    {leading: true},
+  );
+
   const onConversationClick = useCallback(
     (conversation: Conversation) =>
       (event: ReactMouseEvent<HTMLDivElement, MouseEvent> | ReactKeyBoardEvent<HTMLDivElement>) => {
-        if (isActiveConversation(conversation)) {
-          if (window.innerWidth > WIDTH.TABLET_SM_MAX || document.documentElement.clientWidth > WIDTH.TABLET_SM_MAX) {
-            clearSearchFilter();
-            setClickedFilteredConversationId(conversation.id);
-            return;
-          }
-        }
-
-        if (isKeyboardEvent(event)) {
-          createNavigateKeyboard(generateConversationUrl(conversation.qualifiedId), true)(event);
-        } else {
-          createNavigate(generateConversationUrl(conversation.qualifiedId))(event);
-        }
-
-        clearSearchFilter();
-        setClickedFilteredConversationId(conversation.id);
+        debouncedOnConversationClick(conversation, event);
       },
-    [clearSearchFilter, isActiveConversation],
+    [debouncedOnConversationClick],
   );
 
   const getCommonConversationCellProps = (conversation: Conversation, index: number) => ({


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11955" title="WPB-11955" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11955</a>  [Web] Webapp crashes when quickly switching conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

when clicking too fast to switch conversations we update the state of the react too many times we end up with a Maximum update depth exceeded react error. 

https://react.dev/errors/185

To avoid this a debounce mechanism is added to the conversation onClick handler.