### PR TITLE
fix: show MLS device details for self client [WPB-15562]

### DIFF
--- a/src/script/hooks/useDeviceIdentities.ts
+++ b/src/script/hooks/useDeviceIdentities.ts
@@ -21,17 +21,20 @@ import {useCallback, useEffect, useState} from 'react';
 
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {stringifyQualifiedId} from '@wireapp/core/lib/util/qualifiedIdUtil';
+import {container} from 'tsyringe';
 
 import {E2EIHandler, getUsersIdentities, MLSStatuses, WireIdentity} from '../E2EIdentity';
+import {Core} from '../service/CoreSingleton';
 
 export const useUserIdentity = (userId: QualifiedId, groupId?: string, updateAfterEnrollment?: boolean) => {
+  const core = container.resolve(Core);
   const [deviceIdentities, setDeviceIdentities] = useState<WireIdentity[] | undefined>();
   const getDeviceIdentity = (deviceId: string) => {
     return deviceIdentities?.find(identity => identity.deviceId === deviceId);
   };
 
   const refreshDeviceIdentities = useCallback(async () => {
-    if (!groupId || !E2EIHandler.getInstance().isE2EIEnabled()) {
+    if (!groupId || !core.isMLSActiveForClient()) {
       return;
     }
 
@@ -41,7 +44,7 @@ export const useUserIdentity = (userId: QualifiedId, groupId?: string, updateAft
     /**
      * Dont check the userId directly, as it is a object that changes on every render, will cause infinite loop
      */
-  }, [userId.id, userId.domain, groupId]);
+  }, [groupId, userId.id, userId.domain]);
 
   useEffect(() => {
     void refreshDeviceIdentities();

--- a/src/script/page/MainContent/panels/preferences/DevicesPreferences/DevicesPreference.test.tsx
+++ b/src/script/page/MainContent/panels/preferences/DevicesPreferences/DevicesPreference.test.tsx
@@ -19,6 +19,7 @@
 
 import {render, waitFor} from '@testing-library/react';
 import {CONVERSATION_TYPE, ConversationProtocol} from '@wireapp/api-client/lib/conversation';
+import {container} from 'tsyringe';
 
 import {randomUUID} from 'crypto';
 
@@ -28,6 +29,7 @@ import {ClientState} from 'src/script/client/ClientState';
 import {ConversationState} from 'src/script/conversation/ConversationState';
 import {CryptographyRepository} from 'src/script/cryptography/CryptographyRepository';
 import {User} from 'src/script/entity/User';
+import {Core} from 'src/script/service/CoreSingleton';
 import {createUuid} from 'Util/uuid';
 
 import {DevicesPreferences} from './DevicesPreference';
@@ -57,6 +59,9 @@ describe('DevicesPreferences', () => {
   const selfProteusConversation = createConversation(ConversationProtocol.PROTEUS, CONVERSATION_TYPE.SELF);
   const selfMLSConversation = createConversation(ConversationProtocol.MLS, CONVERSATION_TYPE.SELF);
   const regularConversation = createConversation();
+
+  const coreMock = container.resolve(Core);
+  coreMock.isMLSActiveForClient = jest.fn().mockReturnValue(true);
 
   const selfUser = new User(createUuid());
   selfUser.devices([createDevice(), createDevice()]);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15562" title="WPB-15562" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15562</a>  [Web] Edge client does not show MLS thumbprint after team sets MLS as available protocol (not standard)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Fixes the bug where the MLS fingerprint was missing for users. 