### PR TITLE
fix(applock): prevent unintentional logout when applock is active [15545]

### DIFF
--- a/src/script/page/AppLock/AppLock.tsx
+++ b/src/script/page/AppLock/AppLock.tsx
@@ -84,6 +84,8 @@ const AppLock: React.FC<AppLockProps> = ({
     'isAppLockEnforced',
   ]);
 
+  // We log the user out if there is a style change on the app element
+  // i.e. if there is an attempt to remove the blur effect
   const {current: appObserver} = useRef(
     new MutationObserver(mutationRecords => {
       const [{attributeName}] = mutationRecords;
@@ -93,6 +95,7 @@ const AppLock: React.FC<AppLockProps> = ({
     }),
   );
 
+  // We log the user out if the modal is removed from the DOM
   const {current: modalObserver} = useRef(
     new MutationObserver(() => {
       const modalInDOM = document.querySelector('[data-uie-name="applock-modal"]');
@@ -156,11 +159,16 @@ const AppLock: React.FC<AppLockProps> = ({
     app?.style.setProperty('pointer-events', isVisible ? 'none' : 'auto', 'important');
 
     if (isVisible) {
-      modalObserver.observe(document.querySelector('#wire-main'), {
-        childList: true,
-        subtree: true,
-      });
-      appObserver.observe(document.querySelector('#app'), {attributes: true});
+      const wireMain = document.querySelector('#wire-main');
+      if (wireMain) {
+        modalObserver.observe(wireMain, {
+          childList: true,
+        });
+      }
+      const appElement = document.querySelector('#app');
+      if (appElement) {
+        appObserver.observe(appElement, {attributes: true});
+      }
     }
     return () => {
       modalObserver.disconnect();


### PR DESCRIPTION
## Description

The app would log out on app initialization for team users if app lock is active, without giving them the chance to disable app lock

There is an observer that makes sure the app or the modal is not tempered with to prevent people to simply removing the app lock from the DOM

It appears the observer is too aggressive, and would logout a user automatically

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
