### PR TITLE
fix: sign out other instance when logged in with new instance [WPB-15071]

### DIFF
--- a/src/script/auth/page/Index.tsx
+++ b/src/script/auth/page/Index.tsx
@@ -29,6 +29,7 @@ import {UrlUtil} from '@wireapp/commons';
 import {Button, ButtonVariant, ContainerXS, ErrorMessage, Text} from '@wireapp/react-ui-kit';
 
 import {LogoFullIcon} from 'Components/Icon';
+import {useSingleInstance} from 'Hooks/useSingleInstance';
 import {Core} from 'src/script/service/CoreSingleton';
 import {isDataDogEnabled} from 'Util/DataDog';
 import {getWebEnvironment} from 'Util/Environment';
@@ -49,6 +50,7 @@ type Props = React.HTMLProps<HTMLDivElement>;
 
 const IndexComponent = ({defaultSSOCode, doInit}: Props & ConnectedProps & DispatchProps) => {
   const navigate = useNavigate();
+  const {hasOtherInstance} = useSingleInstance();
   const core = container.resolve(Core);
   const [logoutReason, setLogoutReason] = useState<string>();
 
@@ -62,10 +64,10 @@ const IndexComponent = ({defaultSSOCode, doInit}: Props & ConnectedProps & Dispa
   const immediateLogin = useCallback(async () => {
     await doInit({isImmediateLogin: true, shouldValidateLocalClient: true});
     // Check if the user is already logged in
-    if (core.getLocalClient()) {
+    if (!hasOtherInstance && core.getLocalClient()) {
       navigate(ROUTE.HISTORY_INFO);
     }
-  }, [core, doInit, navigate]);
+  }, [core, doInit, navigate, hasOtherInstance]);
 
   useEffect(() => {
     if (Config.getConfig().FEATURE.ENABLE_AUTO_LOGIN) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15071" title="WPB-15071" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15071</a>  [Web] Redirection of Netnod production
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Previously we navigated user to the app if the user has active session, https://github.com/wireapp/wire-webapp/pull/18655.
That changed caused some issue if the user is logged into another tab and try to login on another. The user stuck on the loop where one tab try to end the session and another auto login with existing session. Now, I added check to logout if the user want to start a new session from another tab.

Note: The changes are still behind feature flag `FEATURE.ENABLE_AUTO_LOGIN`


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
