### PR TITLE
fix: Avoid maximum update depth exceeded error by ref comparison (WPB-11955)

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -348,6 +348,7 @@ export const Conversations: React.FC<ConversationsProps> = ({
             searchInputRef={searchInputRef}
           />
         }
+        conversationListRef={conversationListRef}
         setConversationListRef={setConversationListRef}
         hasHeader={!isPreferences}
         sidebar={

--- a/src/script/page/LeftSidebar/panels/ListWrapper.tsx
+++ b/src/script/page/LeftSidebar/panels/ListWrapper.tsx
@@ -57,6 +57,7 @@ interface LeftListWrapperProps {
   onClose?: () => void;
   hasHeader?: boolean;
   conversationsFilter?: string;
+  conversationListRef?: HTMLElement | null;
   setConversationListRef?: (element: HTMLElement) => void;
 }
 
@@ -72,6 +73,7 @@ const ListWrapper = memo(
     footer,
     before,
     headerUieName,
+    conversationListRef,
     setConversationListRef,
   }: LeftListWrapperProps) => {
     const calculateBorders = throttle((element: HTMLElement) => {
@@ -91,7 +93,9 @@ const ListWrapper = memo(
         return;
       }
 
-      setConversationListRef?.(element);
+      if (element !== conversationListRef) {
+        setConversationListRef?.(element);
+      }
 
       calculateBorders(element);
       element.addEventListener('scroll', () => calculateBorders(element));


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11955" title="WPB-11955" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11955</a>  [Web] Webapp crashes when quickly switching conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Problem:
We were encountering a "Maximum update depth exceeded" error when switching conversations quickly. Investigation revealed that the ref callback in ListWrapper was calling setConversationListRef on every render—even when the element hadn’t changed. This caused the parent component to re-render repeatedly, leading to an infinite update loop.

Solution:
I modified the ref callback to update the state only when the element reference has actually changed. By comparing the new element with the current state before calling setConversationListRef, we prevent unnecessary state updates and break the infinite loop.
