### PR TITLE
feat: add full emoji selection for In-call reactions [WPB-15113]

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -332,6 +332,8 @@
   "callReactionButtonsAriaLabel": "Emoji selection bar",
   "callReactions": "Reactions",
   "callReactionsAriaLabel": "Emoji {emoji} from {from}",
+  "callReactionEmojiPickerButtonAriaLabel": "Open emoji picker",
+  "callReactionEmojiPickerAriaLabel": "Emoji picker",
   "callStateCbr": "Constant Bit Rate",
   "callStateConnecting": "Connecting…",
   "callStateIncoming": "Calling…",

--- a/src/script/components/calling/VideoControls/EmojisBar/EmojisBar.styles.ts
+++ b/src/script/components/calling/VideoControls/EmojisBar/EmojisBar.styles.ts
@@ -21,58 +21,133 @@ import {CSSObject} from '@emotion/react';
 
 import {media} from '@wireapp/react-ui-kit';
 
-export const emojisBarWrapperStyles: CSSObject = {
-  position: 'absolute',
-  bottom: '130%',
-  left: '50%',
-  display: 'grid',
-  padding: '0.4rem',
-  borderRadius: '12px',
-  backgroundColor: 'var(--inactive-call-button-bg)',
-  boxShadow: '0px 7px 15px 0 #0000004d',
-  gap: '0.5rem',
-  gridTemplateColumns: 'repeat(3, 1fr)',
-  transform: 'translateX(-50%)',
-
-  [media.tablet]: {
-    transform: 'none',
-    left: 'auto',
-    right: 0,
-  },
-
-  '&::after': {
+export const styles: {
+  emojisBar: CSSObject;
+  button: CSSObject;
+  picker: CSSObject;
+} = {
+  emojisBar: {
     position: 'absolute',
-    bottom: '-0.5rem',
+    bottom: '130%',
     left: '50%',
-    width: 0,
-    height: 0,
-    borderTop: '0.5rem solid var(--inactive-call-button-bg)',
-    borderRight: '0.5rem solid transparent',
-    borderLeft: '0.5rem solid transparent',
-    content: '""',
     transform: 'translateX(-50%)',
+    display: 'grid',
+    gap: '0.5rem',
+    gridTemplateColumns: 'repeat(3, 1fr)',
+    borderRadius: '12px',
+    backgroundColor: 'var(--inactive-call-button-bg)',
+    boxShadow: '0px 7px 15px 0 #0000004d',
+    padding: '0.5rem',
 
     [media.tablet]: {
       transform: 'none',
       left: 'auto',
-      right: '0.625rem',
+      right: 0,
+    },
+
+    '&::after': {
+      position: 'absolute',
+      bottom: '-0.5rem',
+      left: '50%',
+      width: 0,
+      height: 0,
+      borderTop: '0.5rem solid var(--inactive-call-button-bg)',
+      borderRight: '0.5rem solid transparent',
+      borderLeft: '0.5rem solid transparent',
+      content: '""',
+      transform: 'translateX(-50%)',
+
+      [media.tablet]: {
+        transform: 'none',
+        left: 'auto',
+        right: '0.625rem',
+      },
     },
   },
-};
+  button: {
+    backgroundColor: 'transparent',
+    border: 0,
+    padding: '0.5rem',
+    borderRadius: '1rem',
+    fontSize: '1.5rem',
 
-export const emojisBarButtonStyles: CSSObject = {
-  backgroundColor: 'transparent',
-  border: 0,
-  padding: '0.5rem',
-  borderRadius: '1rem',
-  fontSize: '1.5rem',
+    '&:disabled': {
+      cursor: 'not-allowed',
+      opacity: 0.5,
+    },
 
-  '&:disabled': {
-    cursor: 'not-allowed',
-    opacity: 0.5,
+    '&:hover': {
+      backgroundColor: 'var(--inactive-call-button-hover-bg)',
+    },
   },
+  picker: {
+    position: 'absolute',
+    bottom: '130%',
+    right: 0,
+    transform: 'translateX(15%)',
+    borderRadius: '12px',
+    backgroundColor: 'var(--inactive-call-button-bg)',
+    boxShadow: '0px 7px 15px 0 #0000004d',
+    padding: '0.5rem',
 
-  '&:hover': {
-    backgroundColor: 'var(--inactive-call-button-hover-bg)',
+    [media.tablet]: {
+      transform: 'none',
+    },
+
+    [media.mobile]: {
+      transform: 'translateX(26%)',
+    },
+
+    '&::after': {
+      position: 'absolute',
+      bottom: '-0.5rem',
+      right: '18%',
+      width: 0,
+      height: 0,
+      borderTop: '0.5rem solid var(--inactive-call-button-bg)',
+      borderRight: '0.5rem solid transparent',
+      borderLeft: '0.5rem solid transparent',
+      content: '""',
+
+      [media.tablet]: {
+        right: '0.625rem',
+      },
+
+      [media.mobile]: {
+        right: '30%',
+      },
+    },
+
+    '& .EmojiPickerReact': {
+      borderStyle: 'none !important',
+      backgroundColor: 'var(--message-actions-background) !important',
+      boxShadow: 'none',
+
+      'body.theme-dark &': {
+        boxShadow: 'none',
+      },
+    },
+
+    '& .EmojiPickerReact .epr-preview': {
+      borderTop: '1px solid var(--message-actions-border-hover)',
+    },
+
+    '& .EmojiPickerReact li.epr-emoji-category > .epr-emoji-category-label': {
+      backgroundColor: 'var(--message-actions-background)',
+    },
+
+    '& .EmojiPickerReact .epr-search-container input': {
+      'body.theme-dark &': {
+        border: '1px solid var(--gray-70)',
+        borderRadius: '12px',
+        background: 'var(--gray-100)',
+      },
+    },
+
+    '& .EmojiPickerReact button.epr-emoji': {
+      '&:hover > *, &:focus > *, &:focus-visible > *': {
+        backgroundColor: 'var(--message-actions-background-hover)',
+      },
+    },
   },
 };

--- a/src/script/components/calling/VideoControls/VideoControls.tsx
+++ b/src/script/components/calling/VideoControls/VideoControls.tsx
@@ -17,19 +17,18 @@
  *
  */
 
-import React, {useRef, useState} from 'react';
+import React, {useState} from 'react';
 
 import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 import classNames from 'classnames';
 import {container} from 'tsyringe';
 
 import {CALL_TYPE} from '@wireapp/avs';
-import {EmojiIcon, GridIcon, QUERY, RaiseHandIcon, MoreIcon} from '@wireapp/react-ui-kit';
+import {EmojiIcon, GridIcon, MoreIcon, QUERY, RaiseHandIcon} from '@wireapp/react-ui-kit';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import * as Icon from 'Components/Icon';
 import {useActiveWindowMatchMedia} from 'Hooks/useActiveWindowMatchMedia';
-import {useClickOutside} from 'Hooks/useClickOutside';
 import {useUserPropertyValue} from 'Hooks/useUserProperty';
 import {Call} from 'src/script/calling/Call';
 import {CallingViewMode, CallState} from 'src/script/calling/CallState';
@@ -135,9 +134,6 @@ export const VideoControls: React.FC<VideoControlsProps> = ({
 
   const {is1to1: is1to1Conversation} = useKoSubscribableChildren(conversation, ['is1to1']);
 
-  const emojiBarRef = useRef<HTMLDivElement | null>(null);
-  const emojiBarToggleButtonRef = useRef<HTMLButtonElement | null>(null);
-
   const {blurredVideoStream} = useKoSubscribableChildren(selfParticipant, ['blurredVideoStream']);
   const hasBlurredBackground = !!blurredVideoStream;
 
@@ -146,8 +142,6 @@ export const VideoControls: React.FC<VideoControlsProps> = ({
   const [showEmojisBar, setShowEmojisBar] = useState(false);
 
   const {viewMode, detachedWindow} = useKoSubscribableChildren(callState, ['viewMode', 'detachedWindow']);
-
-  useClickOutside(emojiBarRef, () => setShowEmojisBar(false), emojiBarToggleButtonRef, detachedWindow?.document);
 
   const {isVideoCallingEnabled} = useKoSubscribableChildren(teamState, ['isVideoCallingEnabled']);
 
@@ -648,7 +642,13 @@ export const VideoControls: React.FC<VideoControlsProps> = ({
       <div css={moreControlsWrapperStyles}>
         {!isDesktop && (
           <li className="video-controls__item">
-            {showEmojisBar && <EmojisBar onEmojiClick={handleEmojiClick} ref={emojiBarRef} />}
+            {showEmojisBar && (
+              <EmojisBar
+                onEmojiClick={handleEmojiClick}
+                onPickerEmojiClick={() => setShowEmojisBar(false)}
+                detachedWindow={detachedWindow}
+              />
+            )}
             <button
               title={t('callMenuMoreInteractions')}
               className={classNames(
@@ -750,9 +750,14 @@ export const VideoControls: React.FC<VideoControlsProps> = ({
 
             {isInCallReactionsEnable && (
               <li className="video-controls__item">
-                {showEmojisBar && <EmojisBar onEmojiClick={handleEmojiClick} ref={emojiBarRef} />}
+                {showEmojisBar && (
+                  <EmojisBar
+                    onEmojiClick={handleEmojiClick}
+                    onPickerEmojiClick={() => setShowEmojisBar(false)}
+                    detachedWindow={detachedWindow}
+                  />
+                )}
                 <button
-                  ref={emojiBarToggleButtonRef}
                   title={t('callReactions')}
                   className={classNames('video-controls__button_primary', {active: showEmojisBar})}
                   onClick={() => setShowEmojisBar(prev => !prev)}

--- a/src/types/i18n.d.ts
+++ b/src/types/i18n.d.ts
@@ -336,6 +336,8 @@ declare module 'I18n/en-US.json' {
     'callReactionButtonsAriaLabel': `Emoji selection bar`;
     'callReactions': `Reactions`;
     'callReactionsAriaLabel': `Emoji {emoji} from {from}`;
+    'callReactionEmojiPickerButtonAriaLabel': `Open emoji picker`;
+    'callReactionEmojiPickerAriaLabel': `Emoji picker`;
     'callStateCbr': `Constant Bit Rate`;
     'callStateConnecting': `Connecting…`;
     'callStateIncoming': `Calling…`;
@@ -402,12 +404,12 @@ declare module 'I18n/en-US.json' {
     'conversationAssetUploadCancel': `Cancel`;
     'conversationAssetUploadFailed': `Upload Failed`;
     'conversationAssetUploading': `Uploading…`;
-    'conversationAudioAssetRestricted': `Receiving audio messages is prohibited`;
-    'conversationAudioAssetUploading': `Uploading: {name}`;
-    'conversationAudioAssetUploadFailed': `Upload failed: {name}`;
-    'conversationAudioAssetPlay': `Play`;
-    'conversationAudioAssetPause': `Pause`;
     'conversationAudioAssetCancel': `Cancel`;
+    'conversationAudioAssetPause': `Pause`;
+    'conversationAudioAssetPlay': `Play`;
+    'conversationAudioAssetRestricted': `Receiving audio messages is prohibited`;
+    'conversationAudioAssetUploadFailed': `Upload failed: {name}`;
+    'conversationAudioAssetUploading': `Uploading: {name}`;
     'conversationButtonSeparator': `or`;
     'conversationClassified': `Security level: VS-NfD`;
     'conversationConnectWithNewUsers': `Connect with People`;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15113" title="WPB-15113" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15113</a>  Allow for full selection of emojis in in-call reactions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

This feat enhances in-call reactions by allowing users to select from the full range of emojis, rather than being limited to a predefined set.

## Screenshots/Screencast (for UI changes)

https://github.com/user-attachments/assets/f94eb59d-3f70-433a-b509-69b903042e33


https://github.com/user-attachments/assets/7f1b1d76-cfca-4bd0-ab6a-93bc30781bfc


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;
