### PR TITLE
fix(E2EI): add condition to disable the conversation check [WPB-15964]

### DIFF
--- a/src/__mocks__/@wireapp/core.ts
+++ b/src/__mocks__/@wireapp/core.ts
@@ -36,6 +36,7 @@ export class Account extends EventEmitter {
   }
   configureMLSCallbacks = jest.fn();
   enrollE2EI = jest.fn();
+  isMLSActiveForClient = jest.fn();
   service = {
     e2eIdentity: {
       isE2EIEnabled: jest.fn(),

--- a/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
+++ b/src/script/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.ts
@@ -23,6 +23,7 @@ import {E2eiConversationState} from '@wireapp/core/lib/messagingProtocols/mls';
 import {StringifiedQualifiedId, stringifyQualifiedId} from '@wireapp/core/lib/util/qualifiedIdUtil';
 
 import {
+  E2EIHandler,
   getActiveWireIdentity,
   getAllGroupUsersIdentities,
   getConversationVerificationState,
@@ -197,8 +198,12 @@ export class MLSConversationVerificationStateHandler {
   };
 
   public checkConversationVerificationState = async (conversation: Conversation): Promise<void> => {
-    const isSelfConversation = conversation.type() === CONVERSATION_TYPE.SELF;
-    if (!isMLSConversation(conversation) || isSelfConversation) {
+    // Is the feature supported and enabled?
+    const isMLSAndE2EIEnabled = (await this.core.isMLSActiveForClient()) && E2EIHandler.getInstance().isE2EIEnabled();
+    // We only want to check MLS conversations that are not self conversations
+    const isMLSAndNotSelfConversation =
+      isMLSConversation(conversation) && conversation.type() !== CONVERSATION_TYPE.SELF;
+    if (!isMLSAndE2EIEnabled || !isMLSAndNotSelfConversation) {
       return;
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15964" title="WPB-15964" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15964</a>  [Web] MLS conversations show E2EI related error messages in log even if E2EI is disabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

The check for this feature used to be implicit by not getting any conversation data from CoreCrypto. 
This changed, and I added an explicit check for the MLS and E2EI feature flags.