### PR TITLE
fix: spacing after list in rich text editor [WPB-15685]

### DIFF
--- a/src/script/util/messageRenderer.test.ts
+++ b/src/script/util/messageRenderer.test.ts
@@ -164,7 +164,7 @@ describe('renderMessage', () => {
   });
 
   it('renders text with more than one newline in between', () => {
-    expect(renderMessage('Hello,\n\n\n\n\n\n\nworld!')).toBe('Hello,<br><br><br><br><br><br>world!');
+    expect(renderMessage('Hello,\n\n\n\n\n\n\nworld!')).toBe('Hello,<br><br><br><br><br><br><br>world!');
   });
 
   it('does not render URLs within <code> tags', () => {

--- a/src/script/util/messageRenderer.test.ts
+++ b/src/script/util/messageRenderer.test.ts
@@ -164,7 +164,7 @@ describe('renderMessage', () => {
   });
 
   it('renders text with more than one newline in between', () => {
-    expect(renderMessage('Hello,\n\n\n\n\n\n\nworld!')).toBe('Hello,<br><br><br><br><br><br><br>world!');
+    expect(renderMessage('Hello,\n\n\n\n\n\n\nworld!')).toBe('Hello,<br><br><br><br><br><br>world!');
   });
 
   it('does not render URLs within <code> tags', () => {

--- a/src/script/util/messageRenderer.ts
+++ b/src/script/util/messageRenderer.ts
@@ -100,7 +100,6 @@ markdownit.renderer.rules.paragraph_open = (tokens, idx) => {
   const previousPosition = previousWithMap ? (previousWithMap.map || [0, 0])[1] - 1 : 0;
   const count = position - previousPosition;
 
-  // Check if the previous token was a list (either bullet or ordered)
   const previousToken = tokens[idx - 1];
   const isPreviousTokenList =
     previousToken && (previousToken.type === 'bullet_list_close' || previousToken.type === 'ordered_list_close');

--- a/src/script/util/messageRenderer.ts
+++ b/src/script/util/messageRenderer.ts
@@ -99,9 +99,9 @@ markdownit.renderer.rules.paragraph_open = (tokens, idx) => {
     .find(({map}) => map?.length);
   const previousPosition = previousWithMap ? (previousWithMap.map || [0, 0])[1] - 1 : 0;
   const count = position - previousPosition;
-  return '<br>'.repeat(Math.max(count, 0));
+  return count > 1 ? `${'<br>'.repeat(count - 1)}<p>` : '<p>';
 };
-markdownit.renderer.rules.paragraph_close = () => '';
+markdownit.renderer.rules.paragraph_close = () => '</p>';
 
 const renderMention = (mentionData: MentionText) => {
   const elementClasses = mentionData.isSelfMentioned ? ' self-mention' : '';

--- a/src/script/util/messageRenderer.ts
+++ b/src/script/util/messageRenderer.ts
@@ -27,7 +27,7 @@ import {replaceInRange} from './StringUtil';
 import type {MentionEntity} from '../message/MentionEntity';
 
 interface MentionText {
-  domain: string | null;
+  domain: string | null | undefined;
   isSelfMentioned: boolean;
   text: string;
   userId: string;

--- a/src/script/util/messageRenderer.ts
+++ b/src/script/util/messageRenderer.ts
@@ -99,9 +99,9 @@ markdownit.renderer.rules.paragraph_open = (tokens, idx) => {
     .find(({map}) => map?.length);
   const previousPosition = previousWithMap ? (previousWithMap.map || [0, 0])[1] - 1 : 0;
   const count = position - previousPosition;
-  return count > 1 ? `${'<br>'.repeat(count - 1)}<p>` : '<p>';
+  return count > 1 ? `${'<br>'.repeat(count - 1)}` : '';
 };
-markdownit.renderer.rules.paragraph_close = () => '</p>';
+markdownit.renderer.rules.paragraph_close = () => '';
 
 const renderMention = (mentionData: MentionText) => {
   const elementClasses = mentionData.isSelfMentioned ? ' self-mention' : '';

--- a/src/script/util/messageRenderer.ts
+++ b/src/script/util/messageRenderer.ts
@@ -99,7 +99,16 @@ markdownit.renderer.rules.paragraph_open = (tokens, idx) => {
     .find(({map}) => map?.length);
   const previousPosition = previousWithMap ? (previousWithMap.map || [0, 0])[1] - 1 : 0;
   const count = position - previousPosition;
-  return count > 1 ? `${'<br>'.repeat(count - 1)}` : '';
+
+  // Check if the previous token was a list (either bullet or ordered)
+  const previousToken = tokens[idx - 1];
+  const isPreviousTokenList =
+    previousToken && (previousToken.type === 'bullet_list_close' || previousToken.type === 'ordered_list_close');
+
+  if (isPreviousTokenList) {
+    return count > 1 ? `${'<br>'.repeat(count - 1)}` : '';
+  }
+  return '<br>'.repeat(Math.max(count, 0));
 };
 markdownit.renderer.rules.paragraph_close = () => '';
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15685" title="WPB-15685" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15685</a>  [Web] Fix spacing after list in the rich text editor
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Description

This PR addresses two issues:

1. Correct handling of empty lines in markdown rendering.
2. TypeScript error related to the `domain` property in the `MentionText` interface.

**Changes:**

1. Adjusted `paragraph_open` and `paragraph_close` rules in `messageRenderer.ts` to handle empty lines correctly only for lists.
2. Ensured proper addition of `<br>` tags for empty lines between paragraphs.
3. Updated the `MentionText` interface to allow `domain` to be of type `string | null | undefined`.

## Screenshots/Screencast (for UI changes)
### Before
<img width="785" alt="issue" src="https://github.com/user-attachments/assets/ca099f10-5f0d-439b-973a-2d707176d76c" />

### After
<img width="795" alt="fix" src="https://github.com/user-attachments/assets/8d5cac7e-551f-4e37-8e8b-7f9c44dc9d96" />

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;
