### PR TITLE
feat(VideoAsset): new file card

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,6 +48,7 @@ module.exports = {
     'prefer-promise-reject-errors': 'off',
     'valid-jsdoc': 'off',
     'jest/no-jasmine-globals': 'off',
+    'jsx-a11y/media-has-caption': 'off',
   },
   settings: {
     'import/resolver': {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@wireapp/avs-debugger": "0.0.7",
     "@wireapp/commons": "5.4.1",
     "@wireapp/core": "46.17.0",
-    "@wireapp/react-ui-kit": "9.35.0",
+    "@wireapp/react-ui-kit": "9.36.0",
     "@wireapp/store-engine-dexie": "2.1.15",
     "@wireapp/telemetry": "0.3.1",
     "@wireapp/webapp-events": "0.28.0",

--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -583,6 +583,7 @@
   "conversationUpdatedTimerYou": " set the message timer to {time}",
   "conversationVideoAssetRestricted": "Receiving videos is prohibited",
   "conversationViewAllConversations": "All conversations",
+  "conversationVideoAssetError": "Couldn’t generate preview",
   "conversationViewTooltip": "All",
   "conversationVoiceChannelDeactivate": " called",
   "conversationVoiceChannelDeactivateYou": " called",

--- a/src/script/components/MessagesList/Message/ContentMessage/MessageQuote.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/MessageQuote.tsx
@@ -37,7 +37,7 @@ import {AudioAsset} from './asset/AudioAsset/AudioAsset';
 import {FileAsset} from './asset/FileAssetComponent';
 import {LocationAsset} from './asset/LocationAsset';
 import {TextMessageRenderer} from './asset/TextMessageRenderer';
-import {VideoAsset} from './asset/VideoAsset';
+import {VideoAsset} from './asset/VideoAsset/VideoAsset';
 
 import {MessageActions} from '..';
 import type {Conversation} from '../../../../entity/Conversation';

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/AudioAsset/AudioAssetCard/AudioAssetCard.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/AudioAsset/AudioAssetCard/AudioAssetCard.tsx
@@ -60,7 +60,6 @@ export const AudioAssetCard = ({
       </FileCard.Header>
       <FileCard.Name />
       <FileCard.Content>
-        {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
         <audio ref={getAudioElementRef} src={src} onTimeUpdate={onTimeUpdate} />
         <div css={contentStyles}>{children}</div>
       </FileCard.Content>

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAsset.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAsset.tsx
@@ -34,17 +34,16 @@ import {t} from 'Util/LocalizerUtil';
 import {formatSeconds} from 'Util/TimeUtil';
 import {useEffectRef} from 'Util/useEffectRef';
 
-import {MediaButton} from './controls/MediaButton';
-import {SeekBar} from './controls/SeekBar';
-import {FileAsset} from './FileAssetComponent';
-import {AssetUrl, useAssetTransfer} from './useAssetTransfer';
-
-import {AssetError} from '../../../../../assets/AssetError';
-import {AssetRepository} from '../../../../../assets/AssetRepository';
-import {AssetTransferState} from '../../../../../assets/AssetTransferState';
-import type {ContentMessage} from '../../../../../entity/message/ContentMessage';
-import type {FileAsset as FileAssetType} from '../../../../../entity/message/FileAsset';
-import {TeamState} from '../../../../../team/TeamState';
+import {AssetError} from '../../../../../../assets/AssetError';
+import {AssetRepository} from '../../../../../../assets/AssetRepository';
+import {AssetTransferState} from '../../../../../../assets/AssetTransferState';
+import type {ContentMessage} from '../../../../../../entity/message/ContentMessage';
+import type {FileAsset as FileAssetType} from '../../../../../../entity/message/FileAsset';
+import {TeamState} from '../../../../../../team/TeamState';
+import {MediaButton} from '../controls/MediaButton';
+import {SeekBar} from '../controls/SeekBar';
+import {FileAsset} from '../FileAssetComponent';
+import {AssetUrl, useAssetTransfer} from '../useAssetTransfer';
 
 interface VideoAssetProps {
   assetRepository?: AssetRepository;

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAsset.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAsset.tsx
@@ -28,18 +28,18 @@ import {Button, ButtonVariant, useTimeout} from '@wireapp/react-ui-kit';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {RestrictedVideo} from 'Components/asset/RestrictedVideo';
+import {AssetError} from 'src/script/assets/AssetError';
+import {AssetRepository} from 'src/script/assets/AssetRepository';
+import {AssetTransferState} from 'src/script/assets/AssetTransferState';
+import type {ContentMessage} from 'src/script/entity/message/ContentMessage';
+import type {FileAsset as FileAssetType} from 'src/script/entity/message/FileAsset';
+import {TeamState} from 'src/script/team/TeamState';
 import {EventName} from 'src/script/tracking/EventName';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 import {formatSeconds} from 'Util/TimeUtil';
 import {useEffectRef} from 'Util/useEffectRef';
 
-import {AssetError} from '../../../../../../assets/AssetError';
-import {AssetRepository} from '../../../../../../assets/AssetRepository';
-import {AssetTransferState} from '../../../../../../assets/AssetTransferState';
-import type {ContentMessage} from '../../../../../../entity/message/ContentMessage';
-import type {FileAsset as FileAssetType} from '../../../../../../entity/message/FileAsset';
-import {TeamState} from '../../../../../../team/TeamState';
 import {MediaButton} from '../controls/MediaButton';
 import {SeekBar} from '../controls/SeekBar';
 import {FileAsset} from '../FileAssetComponent';

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAssetCard/VideoAssetCard.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAssetCard/VideoAssetCard.styles.ts
@@ -19,21 +19,12 @@
 
 import {CSSObject} from '@emotion/react';
 
-export const wrapperStyles: CSSObject = {
-  display: 'flex',
-  alignItems: 'center',
-  height: '32px',
-  width: '32px',
-};
+export const contentWrapperStyles: CSSObject = {
+  position: 'relative',
+  aspectRatio: '16/9',
 
-export const playButtonStyles: CSSObject = {
-  width: '32px',
-  height: '32px',
-  borderRadius: '50%',
-  backgroundColor: 'var(--icon-button-primary-enabled-bg)',
-  border: '1px solid var(--icon-button-primary-border)',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  flexShrink: 0,
+  // Fallback for the above  aspect-ratio
+  '@supports not (aspect-ratio: 16/9)': {
+    paddingBottom: '56.25%',
+  },
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAssetCard/VideoAssetCard.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAssetCard/VideoAssetCard.tsx
@@ -1,0 +1,57 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {forwardRef, ReactNode} from 'react';
+
+import {FileCard} from 'Components/FileCard/FileCard';
+
+import {contentWrapperStyles} from './VideoAssetCard.styles';
+
+interface VideoAssetCardProps {
+  extension: string;
+  name: string;
+  size: string;
+  isError?: boolean;
+  isLoading?: boolean;
+  loadingProgress?: number;
+  children: ReactNode;
+}
+
+export const VideoAssetCard = forwardRef<HTMLDivElement, VideoAssetCardProps>(
+  ({extension, name, size, isError, isLoading, loadingProgress, children}, ref) => {
+    return (
+      <FileCard.Root variant="large" extension={extension} name={name} size={size}>
+        <FileCard.Header>
+          <FileCard.Icon />
+          <FileCard.Type />
+          <FileCard.Name />
+        </FileCard.Header>
+        <FileCard.Content>
+          <div ref={ref} css={contentWrapperStyles}>
+            {children}
+          </div>
+        </FileCard.Content>
+        {isError && <FileCard.Error />}
+        {isLoading && <FileCard.Loading progress={loadingProgress} />}
+      </FileCard.Root>
+    );
+  },
+);
+
+VideoAssetCard.displayName = 'VideoAssetCard';

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAssetError/VideoAssetError.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAssetError/VideoAssetError.styles.ts
@@ -22,18 +22,15 @@ import {CSSObject} from '@emotion/react';
 export const wrapperStyles: CSSObject = {
   display: 'flex',
   alignItems: 'center',
-  height: '32px',
-  width: '32px',
+  gap: '16px',
 };
 
-export const playButtonStyles: CSSObject = {
-  width: '32px',
-  height: '32px',
-  borderRadius: '50%',
-  backgroundColor: 'var(--icon-button-primary-enabled-bg)',
-  border: '1px solid var(--icon-button-primary-border)',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  flexShrink: 0,
+export const iconStyles: CSSObject = {
+  fill: 'var(--gray-70)',
+};
+
+export const textStyles: CSSObject = {
+  color: 'var(--main-color)',
+  fontSize: 'var(--font-size-medium)',
+  fontWeight: 'var(--font-weight-regular)',
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAssetError/VideoAssetError.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAssetError/VideoAssetError.tsx
@@ -19,6 +19,8 @@
 
 import {AlertIcon} from '@wireapp/react-ui-kit';
 
+import {t} from 'Util/LocalizerUtil';
+
 import {wrapperStyles, iconStyles, textStyles} from './VideoAssetError.styles';
 
 import {VideoAssetPlaceholder} from '../common/VideoAssetPlaceholder/VideoAssetPlaceholder';
@@ -28,7 +30,7 @@ export const VideoAssetError = () => {
     <VideoAssetPlaceholder>
       <div css={wrapperStyles}>
         <AlertIcon css={iconStyles} />
-        <p css={textStyles}>Couldn’t generate preview</p>
+        <p css={textStyles}>{t('conversationVideoAssetError')}</p>
       </div>
     </VideoAssetPlaceholder>
   );

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAssetError/VideoAssetError.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAssetError/VideoAssetError.tsx
@@ -17,23 +17,19 @@
  *
  */
 
-import {CSSObject} from '@emotion/react';
+import {AlertIcon} from '@wireapp/react-ui-kit';
 
-export const wrapperStyles: CSSObject = {
-  display: 'flex',
-  alignItems: 'center',
-  height: '32px',
-  width: '32px',
-};
+import {wrapperStyles, iconStyles, textStyles} from './VideoAssetError.styles';
 
-export const playButtonStyles: CSSObject = {
-  width: '32px',
-  height: '32px',
-  borderRadius: '50%',
-  backgroundColor: 'var(--icon-button-primary-enabled-bg)',
-  border: '1px solid var(--icon-button-primary-border)',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  flexShrink: 0,
+import {VideoAssetPlaceholder} from '../common/VideoAssetPlaceholder/VideoAssetPlaceholder';
+
+export const VideoAssetError = () => {
+  return (
+    <VideoAssetPlaceholder>
+      <div css={wrapperStyles}>
+        <AlertIcon css={iconStyles} />
+        <p css={textStyles}>Couldn’t generate preview</p>
+      </div>
+    </VideoAssetPlaceholder>
+  );
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAssetLoading/VideoAssetLoading.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAssetLoading/VideoAssetLoading.tsx
@@ -17,23 +17,12 @@
  *
  */
 
-import {CSSObject} from '@emotion/react';
+import {VideoAssetPlaceholder} from '../common/VideoAssetPlaceholder/VideoAssetPlaceholder';
 
-export const wrapperStyles: CSSObject = {
-  display: 'flex',
-  alignItems: 'center',
-  height: '32px',
-  width: '32px',
-};
-
-export const playButtonStyles: CSSObject = {
-  width: '32px',
-  height: '32px',
-  borderRadius: '50%',
-  backgroundColor: 'var(--icon-button-primary-enabled-bg)',
-  border: '1px solid var(--icon-button-primary-border)',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  flexShrink: 0,
+export const VideoAssetLoading = () => {
+  return (
+    <VideoAssetPlaceholder>
+      <div className="loading-dots" />
+    </VideoAssetPlaceholder>
+  );
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAssetV2.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAssetV2.styles.ts
@@ -19,22 +19,22 @@
 
 import {CSSObject} from '@emotion/react';
 
-export const wrapperStyles: CSSObject = {
+const overlayStyles: CSSObject = {
   position: 'absolute',
   top: 0,
   left: 0,
   right: 0,
   bottom: 0,
+};
+
+export const wrapperStyles: CSSObject = {
+  ...overlayStyles,
   borderRadius: '10px',
   overflow: 'hidden',
 };
 
 export const controlsWrapperStyles: CSSObject = {
-  position: 'absolute',
-  top: 0,
-  left: 0,
-  right: 0,
-  bottom: 0,
+  ...overlayStyles,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAssetV2.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAssetV2.styles.ts
@@ -20,20 +20,28 @@
 import {CSSObject} from '@emotion/react';
 
 export const wrapperStyles: CSSObject = {
-  display: 'flex',
-  alignItems: 'center',
-  height: '32px',
-  width: '32px',
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  borderRadius: '10px',
+  overflow: 'hidden',
 };
 
-export const playButtonStyles: CSSObject = {
-  width: '32px',
-  height: '32px',
-  borderRadius: '50%',
-  backgroundColor: 'var(--icon-button-primary-enabled-bg)',
-  border: '1px solid var(--icon-button-primary-border)',
+export const controlsWrapperStyles: CSSObject = {
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  flexShrink: 0,
+};
+
+export const videoStyles: CSSObject = {
+  backgroundColor: 'var(--black)',
+  width: '100%',
+  height: '100%',
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAssetV2.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAssetV2.tsx
@@ -118,6 +118,7 @@ export const VideoAssetV2 = ({message, isFocusable = true, isFileShareRestricted
         <video
           ref={setVideoElement}
           src={url}
+          preload="metadata"
           css={videoStyles}
           playsInline
           onError={handleError}

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAssetV2.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAssetV2.tsx
@@ -1,0 +1,138 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
+
+import type {ContentMessage} from 'src/script/entity/message/ContentMessage';
+import type {FileAsset as FileAssetType} from 'src/script/entity/message/FileAsset';
+import {useInView} from 'src/script/hooks/useInView/useInView';
+import {useEffectRef} from 'Util/useEffectRef';
+
+import {isVideoMimeTypeSupported} from './isVideoMimeTypeSupported/isVideoMimeTypeSupported';
+import {useVideoMetadata} from './useVideoMetadata/useVideoMetadata';
+import {useVideoPlayback} from './useVideoPlayback/useVideoPlayback';
+import {VideoAssetCard} from './VideoAssetCard/VideoAssetCard';
+import {VideoAssetError} from './VideoAssetError/VideoAssetError';
+import {VideoAssetLoading} from './VideoAssetLoading/VideoAssetLoading';
+import {wrapperStyles, videoStyles, controlsWrapperStyles} from './VideoAssetV2.styles';
+import {VideoControls} from './VideoControls/VideoControls';
+import {VideoPlayOverlay} from './VideoPlayOverlay/VideoPlayOverlay';
+
+import {FileAsset} from '../FileAssetComponent';
+import {useAssetTransfer} from '../useAssetTransfer';
+
+interface VideoAssetProps {
+  message: ContentMessage;
+  isFocusable?: boolean;
+  isFileShareRestricted: boolean;
+}
+
+/**
+ * Root margin for viewport visibility detection.
+ * Controls when the video element is loaded based on viewport visibility.
+ */
+const VIDEO_ROOT_MARGIN = '0px';
+
+export const VideoAssetV2 = ({message, isFocusable = true, isFileShareRestricted}: VideoAssetProps) => {
+  const asset = message.getFirstAsset() as FileAssetType;
+
+  const [videoElement, setVideoElement] = useEffectRef<HTMLVideoElement>();
+
+  const {elementRef, isInView} = useInView({
+    rootMargin: VIDEO_ROOT_MARGIN,
+  });
+
+  const {transferState, isPendingUpload, uploadProgress, cancelUpload, getAssetUrl} = useAssetTransfer(message);
+
+  const {src, isError, isLoaded, isPlayedRef, handlePlay, handlePause, handleError, handleTimeUpdate} =
+    useVideoPlayback({
+      asset,
+      videoElement,
+      enabled: !isFileShareRestricted && isInView,
+      getAssetUrl,
+    });
+
+  const {name, extension, size, type} = useVideoMetadata({asset});
+
+  if (!isVideoMimeTypeSupported(type)) {
+    return <FileAsset message={message} isFocusable={isFocusable} />;
+  }
+
+  if (isPendingUpload || !isLoaded) {
+    return (
+      <VideoAssetCard
+        ref={elementRef}
+        extension={extension}
+        name={name}
+        size={size}
+        isLoading
+        loadingProgress={uploadProgress}
+      >
+        <VideoAssetLoading />
+      </VideoAssetCard>
+    );
+  }
+
+  if (isError) {
+    return (
+      <VideoAssetCard ref={elementRef} extension={extension} name={name} size={size} isError>
+        <VideoAssetError />
+      </VideoAssetCard>
+    );
+  }
+
+  return (
+    <VideoAssetCard ref={elementRef} extension={extension} name={name} size={size}>
+      <div css={wrapperStyles}>
+        <video
+          ref={setVideoElement}
+          src={src?.url}
+          css={videoStyles}
+          playsInline
+          onError={handleError}
+          onTimeUpdate={handleTimeUpdate}
+          onLoadedMetadata={handleTimeUpdate}
+          tabIndex={TabIndex.UNFOCUSABLE}
+        />
+        <div css={controlsWrapperStyles}>
+          {!isPlayedRef.current && (
+            <VideoPlayOverlay
+              videoElement={videoElement}
+              handlePlay={handlePlay}
+              handlePause={handlePause}
+              handleCancelUpload={cancelUpload}
+              handleCancelDownload={asset.cancelDownload}
+              transferState={transferState}
+              isFocusable={isFocusable}
+            />
+          )}
+          {videoElement && isPlayedRef.current && (
+            <VideoControls
+              videoElement={videoElement}
+              handlePlay={handlePlay}
+              handlePause={handlePause}
+              transferState={transferState}
+              isFocusable={isFocusable}
+            />
+          )}
+        </div>
+      </div>
+    </VideoAssetCard>
+  );
+};

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAssetV2.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAssetV2.tsx
@@ -61,11 +61,9 @@ export const VideoAssetV2 = ({message, isFocusable = true, isFileShareRestricted
 
   const {transferState, isPendingUpload, uploadProgress, cancelUpload, getAssetUrl} = useAssetTransfer(message);
 
-  const {
-    url,
-    isError: isApiError,
-    isLoaded,
-  } = useGetVideoAsset({asset, enabled: !isFileShareRestricted && isInView, getAssetUrl});
+  const isEnabled = !isFileShareRestricted && isInView;
+
+  const {url, isError: isApiError, isLoaded} = useGetVideoAsset({asset, isEnabled, getAssetUrl});
 
   const {
     isPlaying,
@@ -78,7 +76,7 @@ export const VideoAssetV2 = ({message, isFocusable = true, isFileShareRestricted
   } = useVideoPlayback({
     url,
     videoElement,
-    enabled: !isFileShareRestricted && isInView,
+    isEnabled,
   });
 
   const {name, extension, size, type} = getVideoMetadata({asset});

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoControls/VideoControls.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoControls/VideoControls.styles.ts
@@ -20,20 +20,41 @@
 import {CSSObject} from '@emotion/react';
 
 export const wrapperStyles: CSSObject = {
+  position: 'absolute',
+  bottom: 0,
   display: 'flex',
+  width: '100%',
+  height: '56px',
   alignItems: 'center',
-  height: '32px',
-  width: '32px',
+  padding: '0 8px',
+  color: 'var(--white)',
+
+  '&::before': {
+    content: "''",
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    zIndex: 0,
+    pointerEvents: 'none',
+    background: 'linear-gradient(to bottom, rgba(255,255,255,0), rgba(0,0,0,0.4))',
+  },
 };
 
-export const playButtonStyles: CSSObject = {
-  width: '32px',
-  height: '32px',
-  borderRadius: '50%',
-  backgroundColor: 'var(--icon-button-primary-enabled-bg)',
-  border: '1px solid var(--icon-button-primary-border)',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  flexShrink: 0,
+export const timeStyles: CSSObject = {
+  fontSize: 'var(--font-size-xsmall)',
+  fontWeight: 'var(--font-weight-regular)',
+  textAlign: 'center',
+  zIndex: 1,
+};
+
+export const seekbarStyles: CSSObject = {
+  margin: '0 8px',
+  zIndex: 1,
+};
+
+export const playButtonWrapperStyles: CSSObject = {
+  marginRight: '8px',
+  zIndex: 1,
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoControls/VideoControls.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoControls/VideoControls.tsx
@@ -1,0 +1,71 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {AssetTransferState} from 'src/script/assets/AssetTransferState';
+import {formatSeconds} from 'Util/TimeUtil';
+
+import {wrapperStyles, playButtonWrapperStyles, seekbarStyles, timeStyles} from './VideoControls.styles';
+
+import {SeekBar} from '../../controls/SeekBar';
+import {VideoPlayButton} from '../common/VideoPlayButton/VideoPlayButton';
+
+interface VideoControlsProps {
+  videoElement: HTMLVideoElement;
+  isFocusable: boolean;
+  handlePlay: () => void;
+  handlePause: () => void;
+  transferState: AssetTransferState;
+}
+
+export const VideoControls = ({
+  videoElement,
+  isFocusable,
+  handlePlay,
+  handlePause,
+  transferState,
+}: VideoControlsProps) => {
+  const currentTime = formatSeconds(videoElement.currentTime);
+  const duration = formatSeconds(videoElement.duration);
+
+  return (
+    <div css={wrapperStyles}>
+      <div css={playButtonWrapperStyles}>
+        <VideoPlayButton
+          mediaElement={videoElement}
+          onPlay={handlePlay}
+          onPause={handlePause}
+          transferState={transferState}
+          isFocusable={isFocusable}
+        />
+      </div>
+      <span css={timeStyles} data-uie-name="status-video-time">
+        {currentTime}
+      </span>
+      <SeekBar
+        css={seekbarStyles}
+        data-uie-name="status-video-seekbar"
+        mediaElement={videoElement}
+        isFocusable={isFocusable}
+      />
+      <span css={timeStyles} data-uie-name="status-video-time">
+        {duration}
+      </span>
+    </div>
+  );
+};

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoControls/VideoControls.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoControls/VideoControls.tsx
@@ -27,6 +27,7 @@ import {VideoPlayButton} from '../common/VideoPlayButton/VideoPlayButton';
 
 interface VideoControlsProps {
   videoElement: HTMLVideoElement;
+  isPlaying: boolean;
   isFocusable: boolean;
   handlePlay: () => void;
   handlePause: () => void;
@@ -35,6 +36,7 @@ interface VideoControlsProps {
 
 export const VideoControls = ({
   videoElement,
+  isPlaying,
   isFocusable,
   handlePlay,
   handlePause,
@@ -48,6 +50,7 @@ export const VideoControls = ({
       <div css={playButtonWrapperStyles}>
         <VideoPlayButton
           mediaElement={videoElement}
+          isPlaying={isPlaying}
           onPlay={handlePlay}
           onPause={handlePause}
           transferState={transferState}

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoPlayOverlay/VideoPlayOverlay.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoPlayOverlay/VideoPlayOverlay.styles.ts
@@ -22,18 +22,7 @@ import {CSSObject} from '@emotion/react';
 export const wrapperStyles: CSSObject = {
   display: 'flex',
   alignItems: 'center',
-  height: '32px',
-  width: '32px',
-};
-
-export const playButtonStyles: CSSObject = {
-  width: '32px',
-  height: '32px',
-  borderRadius: '50%',
-  backgroundColor: 'var(--icon-button-primary-enabled-bg)',
-  border: '1px solid var(--icon-button-primary-border)',
-  display: 'flex',
-  alignItems: 'center',
   justifyContent: 'center',
-  flexShrink: 0,
+  width: '100%',
+  height: '100%',
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoPlayOverlay/VideoPlayOverlay.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoPlayOverlay/VideoPlayOverlay.tsx
@@ -24,21 +24,21 @@ import {wrapperStyles} from './VideoPlayOverlay.styles';
 import {VideoPlayButton} from '../common/VideoPlayButton/VideoPlayButton';
 
 interface VideoPlayOverlayProps {
+  isPlaying: boolean;
   videoElement?: HTMLVideoElement;
   handlePlay: () => void;
   handlePause: () => void;
   handleCancelUpload: () => void;
   handleCancelDownload: () => void;
   transferState: AssetTransferState;
-  isUploading: boolean;
   isFocusable: boolean;
 }
 
 export const VideoPlayOverlay = ({
+  isPlaying,
   videoElement,
   handlePlay,
   handlePause,
-  isUploading,
   handleCancelUpload,
   handleCancelDownload,
   transferState,
@@ -47,10 +47,11 @@ export const VideoPlayOverlay = ({
   return (
     <div css={wrapperStyles}>
       <VideoPlayButton
+        isPlaying={isPlaying}
         mediaElement={videoElement}
         onPlay={handlePlay}
         onPause={handlePause}
-        onCancel={isUploading ? handleCancelUpload : handleCancelDownload}
+        onCancel={transferState === AssetTransferState.UPLOADING ? handleCancelUpload : handleCancelDownload}
         transferState={transferState}
         isFocusable={isFocusable}
         isFullscreen

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoPlayOverlay/VideoPlayOverlay.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoPlayOverlay/VideoPlayOverlay.tsx
@@ -1,0 +1,60 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {AssetTransferState} from 'src/script/assets/AssetTransferState';
+
+import {wrapperStyles} from './VideoPlayOverlay.styles';
+
+import {VideoPlayButton} from '../common/VideoPlayButton/VideoPlayButton';
+
+interface VideoPlayOverlayProps {
+  videoElement?: HTMLVideoElement;
+  handlePlay: () => void;
+  handlePause: () => void;
+  handleCancelUpload: () => void;
+  handleCancelDownload: () => void;
+  transferState: AssetTransferState;
+  isUploading: boolean;
+  isFocusable: boolean;
+}
+
+export const VideoPlayOverlay = ({
+  videoElement,
+  handlePlay,
+  handlePause,
+  isUploading,
+  handleCancelUpload,
+  handleCancelDownload,
+  transferState,
+  isFocusable,
+}: VideoPlayOverlayProps) => {
+  return (
+    <div css={wrapperStyles}>
+      <VideoPlayButton
+        mediaElement={videoElement}
+        onPlay={handlePlay}
+        onPause={handlePause}
+        onCancel={isUploading ? handleCancelUpload : handleCancelDownload}
+        transferState={transferState}
+        isFocusable={isFocusable}
+        isFullscreen
+      />
+    </div>
+  );
+};

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/common/VideoAssetPlaceholder/VideoAssetPlaceholder.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/common/VideoAssetPlaceholder/VideoAssetPlaceholder.styles.ts
@@ -21,19 +21,17 @@ import {CSSObject} from '@emotion/react';
 
 export const wrapperStyles: CSSObject = {
   display: 'flex',
-  alignItems: 'center',
-  height: '32px',
-  width: '32px',
-};
-
-export const playButtonStyles: CSSObject = {
-  width: '32px',
-  height: '32px',
-  borderRadius: '50%',
-  backgroundColor: 'var(--icon-button-primary-enabled-bg)',
-  border: '1px solid var(--icon-button-primary-border)',
-  display: 'flex',
-  alignItems: 'center',
   justifyContent: 'center',
-  flexShrink: 0,
+  alignItems: 'center',
+  width: '100%',
+  backgroundColor: 'var(--foreground-fade-8)',
+  border: '1px solid var(--border-color)',
+  borderRadius: '10px',
+  color: 'var(--gray-70)',
+  aspectRatio: '16/9',
+
+  // Fallback for the above  aspect-ratio
+  '@supports not (aspect-ratio: 16/9)': {
+    paddingBottom: '56.25%',
+  },
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/common/VideoAssetPlaceholder/VideoAssetPlaceholder.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/common/VideoAssetPlaceholder/VideoAssetPlaceholder.tsx
@@ -17,23 +17,14 @@
  *
  */
 
-import {CSSObject} from '@emotion/react';
+import {ReactNode} from 'react';
 
-export const wrapperStyles: CSSObject = {
-  display: 'flex',
-  alignItems: 'center',
-  height: '32px',
-  width: '32px',
-};
+import {wrapperStyles} from './VideoAssetPlaceholder.styles';
 
-export const playButtonStyles: CSSObject = {
-  width: '32px',
-  height: '32px',
-  borderRadius: '50%',
-  backgroundColor: 'var(--icon-button-primary-enabled-bg)',
-  border: '1px solid var(--icon-button-primary-border)',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  flexShrink: 0,
+interface VideoAssetPlaceholderProps {
+  children: ReactNode;
+}
+
+export const VideoAssetPlaceholder = ({children}: VideoAssetPlaceholderProps) => {
+  return <div css={wrapperStyles}>{children}</div>;
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/common/VideoPlayButton/VideoPlayButton.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/common/VideoPlayButton/VideoPlayButton.styles.ts
@@ -22,13 +22,26 @@ import {CSSObject} from '@emotion/react';
 export const wrapperStyles: CSSObject = {
   display: 'flex',
   alignItems: 'center',
-  height: '32px',
-  width: '32px',
+  justifyContent: 'center',
+  height: '24px',
+  width: '24px',
+  background: 'none',
+  border: 'none',
+  padding: 0,
+  margin: 0,
+  cursor: 'pointer',
+  outline: 'none',
+};
+
+export const wrapperStylesFullscreen: CSSObject = {
+  ...wrapperStyles,
+  height: '100%',
+  width: '100%',
 };
 
 export const playButtonStyles: CSSObject = {
-  width: '32px',
-  height: '32px',
+  width: '24px',
+  height: '24px',
   borderRadius: '50%',
   backgroundColor: 'var(--icon-button-primary-enabled-bg)',
   border: '1px solid var(--icon-button-primary-border)',

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/common/VideoPlayButton/VideoPlayButton.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/common/VideoPlayButton/VideoPlayButton.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {ReactNode, useEffect, useState} from 'react';
+import {ReactNode, useEffect} from 'react';
 
 import {CloseIcon, PauseIcon, PlayIcon} from '@wireapp/react-ui-kit';
 
@@ -33,6 +33,7 @@ export interface VideoPlayButtonProps {
   onPlay: () => void;
   onCancel?: () => void;
   transferState: AssetTransferState;
+  isPlaying: boolean;
   isFocusable?: boolean;
   isDisabled?: boolean;
   isFullscreen?: boolean;
@@ -44,14 +45,11 @@ export const VideoPlayButton = ({
   onPlay,
   onPause,
   onCancel,
+  isPlaying,
   isFocusable = true,
   isFullscreen = false,
   isDisabled = false,
 }: VideoPlayButtonProps) => {
-  const [isPlaying, setIsPlaying] = useState<boolean>(false);
-  const handlePlay = () => setIsPlaying(true);
-  const handlePause = () => setIsPlaying(false);
-
   const messageFocusedTabIndex = useMessageFocusedTabIndex(isFocusable);
 
   const isUploaded = transferState === AssetTransferState.UPLOADED;
@@ -63,14 +61,14 @@ export const VideoPlayButton = ({
       return undefined;
     }
 
-    mediaElement.addEventListener('playing', handlePlay);
-    mediaElement.addEventListener('pause', handlePause);
+    mediaElement.addEventListener('playing', onPlay);
+    mediaElement.addEventListener('pause', onPause);
 
     return () => {
-      mediaElement.removeEventListener('playing', handlePlay);
-      mediaElement.removeEventListener('pause', handlePause);
+      mediaElement.removeEventListener('playing', onPlay);
+      mediaElement.removeEventListener('pause', onPause);
     };
-  }, [mediaElement]);
+  }, [mediaElement, onPlay, onPause]);
 
   if (isUploading || isDownloading) {
     return (

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/common/VideoPlayButton/VideoPlayButton.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/common/VideoPlayButton/VideoPlayButton.tsx
@@ -1,0 +1,136 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {ReactNode, useEffect, useState} from 'react';
+
+import {CloseIcon, PauseIcon, PlayIcon} from '@wireapp/react-ui-kit';
+
+import {useMessageFocusedTabIndex} from 'Components/MessagesList/Message/util';
+import {AssetTransferState} from 'src/script/assets/AssetTransferState';
+import {t} from 'Util/LocalizerUtil';
+
+import {wrapperStyles, playButtonStyles, wrapperStylesFullscreen} from './VideoPlayButton.styles';
+
+export interface VideoPlayButtonProps {
+  mediaElement?: HTMLMediaElement;
+  onPause: () => void;
+  onPlay: () => void;
+  onCancel?: () => void;
+  transferState: AssetTransferState;
+  isFocusable?: boolean;
+  isDisabled?: boolean;
+  isFullscreen?: boolean;
+}
+
+export const VideoPlayButton = ({
+  mediaElement,
+  transferState,
+  onPlay,
+  onPause,
+  onCancel,
+  isFocusable = true,
+  isFullscreen = false,
+  isDisabled = false,
+}: VideoPlayButtonProps) => {
+  const [isPlaying, setIsPlaying] = useState<boolean>(false);
+  const handlePlay = () => setIsPlaying(true);
+  const handlePause = () => setIsPlaying(false);
+
+  const messageFocusedTabIndex = useMessageFocusedTabIndex(isFocusable);
+
+  const isUploaded = transferState === AssetTransferState.UPLOADED;
+  const isDownloading = transferState === AssetTransferState.DOWNLOADING;
+  const isUploading = transferState === AssetTransferState.UPLOADING;
+
+  useEffect(() => {
+    if (!mediaElement) {
+      return undefined;
+    }
+
+    mediaElement.addEventListener('playing', handlePlay);
+    mediaElement.addEventListener('pause', handlePause);
+
+    return () => {
+      mediaElement.removeEventListener('playing', handlePlay);
+      mediaElement.removeEventListener('pause', handlePause);
+    };
+  }, [mediaElement]);
+
+  if (isUploading || isDownloading) {
+    return (
+      <VideoButton
+        label={t('conversationAudioAssetCancel')}
+        onClick={onCancel}
+        tabIndex={messageFocusedTabIndex}
+        isDisabled
+        isFullscreen={isFullscreen}
+      >
+        <CloseIcon width={10} height={10} />
+      </VideoButton>
+    );
+  }
+
+  if (isUploaded) {
+    return (
+      <VideoButton
+        label={isPlaying ? t('conversationAudioAssetPause') : t('conversationAudioAssetPlay')}
+        onClick={isPlaying ? onPause : onPlay}
+        tabIndex={messageFocusedTabIndex}
+        isDisabled={isDisabled}
+        isFullscreen={isFullscreen}
+      >
+        {isPlaying ? <PauseIcon width={10} height={10} /> : <PlayIcon width={10} height={10} />}
+      </VideoButton>
+    );
+  }
+
+  return null;
+};
+
+interface VideoButtonProps {
+  label: string;
+  isDisabled?: boolean;
+  isFullscreen?: boolean;
+  onClick?: () => void;
+  children: ReactNode;
+  tabIndex: number;
+}
+
+const VideoButton = ({
+  label,
+  isDisabled = false,
+  isFullscreen = false,
+  onClick,
+  children,
+  tabIndex,
+}: VideoButtonProps) => {
+  return (
+    <button
+      type="button"
+      css={isFullscreen ? wrapperStylesFullscreen : wrapperStyles}
+      onClick={onClick}
+      disabled={isDisabled}
+      data-uie-name="do-play-media"
+      aria-label={label}
+      tabIndex={tabIndex}
+    >
+      <div css={playButtonStyles}>{children}</div>
+    </button>
+  );
+};

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/getVideoMetadata/getVideoMetadata.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/getVideoMetadata/getVideoMetadata.ts
@@ -20,11 +20,11 @@
 import type {FileAsset as FileAssetType} from 'src/script/entity/message/FileAsset';
 import {formatBytes, getFileExtension, trimFileExtension} from 'Util/util';
 
-interface UseVideoMetadataParams {
+interface GetVideoMetadataParams {
   asset: FileAssetType;
 }
 
-export const useVideoMetadata = ({asset}: UseVideoMetadataParams) => {
+export const getVideoMetadata = ({asset}: GetVideoMetadataParams) => {
   const name = trimFileExtension(asset.file_name);
   const extension = getFileExtension(asset.file_name!);
   const size = formatBytes(asset.file_size);

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/isVideoMimeTypeSupported/isVideoMimeTypeSupported.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/isVideoMimeTypeSupported/isVideoMimeTypeSupported.ts
@@ -17,23 +17,20 @@
  *
  */
 
-import {CSSObject} from '@emotion/react';
+import {amplify} from 'amplify';
 
-export const wrapperStyles: CSSObject = {
-  display: 'flex',
-  alignItems: 'center',
-  height: '32px',
-  width: '32px',
-};
+import {WebAppEvents} from '@wireapp/webapp-events';
 
-export const playButtonStyles: CSSObject = {
-  width: '32px',
-  height: '32px',
-  borderRadius: '50%',
-  backgroundColor: 'var(--icon-button-primary-enabled-bg)',
-  border: '1px solid var(--icon-button-primary-border)',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  flexShrink: 0,
+import {EventName} from 'src/script/tracking/EventName';
+
+export const isVideoMimeTypeSupported = (mimeType: string): boolean => {
+  const video = document.createElement('video');
+  const canPlay = video.canPlayType(mimeType) !== '';
+
+  if (!canPlay) {
+    amplify.publish(WebAppEvents.ANALYTICS.EVENT, EventName.MESSAGES.VIDEO.PLAY_FAILED);
+    amplify.publish(WebAppEvents.ANALYTICS.EVENT, EventName.MESSAGES.VIDEO.UNSUPPORTED_MIME_TYPE);
+  }
+
+  return canPlay;
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/useGetVideoAsset/useGetVideoAsset.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/useGetVideoAsset/useGetVideoAsset.ts
@@ -32,17 +32,17 @@ import {AssetUrl} from '../../useAssetTransfer';
 
 interface UseGetVideoAssetProps {
   asset: FileAsset;
-  enabled: boolean;
+  isEnabled: boolean;
   getAssetUrl: (resource: any) => Promise<AssetUrl>;
 }
 
-export const useGetVideoAsset = ({asset, enabled, getAssetUrl}: UseGetVideoAssetProps) => {
+export const useGetVideoAsset = ({asset, isEnabled, getAssetUrl}: UseGetVideoAssetProps) => {
   const [url, setUrl] = useState('');
   const [isError, setIsError] = useState(false);
   const [isLoaded, setIsLoaded] = useState(false);
 
   const fetchAssetUrl = useCallback(async () => {
-    if (url || !enabled) {
+    if (url || !isEnabled) {
       return;
     }
 
@@ -64,7 +64,7 @@ export const useGetVideoAsset = ({asset, enabled, getAssetUrl}: UseGetVideoAsset
     }
 
     asset.status(AssetTransferState.UPLOADED);
-  }, [asset, enabled, getAssetUrl, url]);
+  }, [asset, isEnabled, getAssetUrl, url]);
 
   useEffect(() => {
     void fetchAssetUrl();

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/useGetVideoAsset/useGetVideoAsset.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/useGetVideoAsset/useGetVideoAsset.ts
@@ -1,0 +1,78 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {useState, useCallback, useEffect} from 'react';
+
+import {amplify} from 'amplify';
+
+import {WebAppEvents} from '@wireapp/webapp-events';
+
+import {AssetError} from 'src/script/assets/AssetError';
+import {AssetTransferState} from 'src/script/assets/AssetTransferState';
+import type {FileAsset} from 'src/script/entity/message/FileAsset';
+import {EventName} from 'src/script/tracking/EventName';
+
+import {AssetUrl} from '../../useAssetTransfer';
+
+interface UseGetVideoAssetProps {
+  asset: FileAsset;
+  enabled: boolean;
+  getAssetUrl: (resource: any) => Promise<AssetUrl>;
+}
+
+export const useGetVideoAsset = ({asset, enabled, getAssetUrl}: UseGetVideoAssetProps) => {
+  const [url, setUrl] = useState('');
+  const [isError, setIsError] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  const fetchAssetUrl = useCallback(async () => {
+    if (url || !enabled) {
+      return;
+    }
+
+    asset.status(AssetTransferState.DOWNLOADING);
+
+    try {
+      const assetUrl = await getAssetUrl(asset.original_resource());
+
+      setUrl(assetUrl.url);
+      setIsLoaded(true);
+
+      amplify.publish(WebAppEvents.ANALYTICS.EVENT, EventName.MESSAGES.VIDEO.PLAY_SUCCESS);
+    } catch (error) {
+      if (error instanceof Error && error.name !== AssetError.CANCEL_ERROR) {
+        setIsError(true);
+      }
+      amplify.publish(WebAppEvents.ANALYTICS.EVENT, EventName.MESSAGES.VIDEO.PLAY_FAILED);
+      console.error('Failed to load video asset ', error);
+    }
+
+    asset.status(AssetTransferState.UPLOADED);
+  }, [asset, enabled, getAssetUrl, url]);
+
+  useEffect(() => {
+    void fetchAssetUrl();
+  }, [fetchAssetUrl]);
+
+  return {
+    url,
+    isError,
+    isLoaded,
+  };
+};

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/useVideoMetadata/useVideoMetadata.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/useVideoMetadata/useVideoMetadata.ts
@@ -17,23 +17,25 @@
  *
  */
 
-import {CSSObject} from '@emotion/react';
+import type {FileAsset as FileAssetType} from 'src/script/entity/message/FileAsset';
+import {formatBytes, getFileExtension, trimFileExtension} from 'Util/util';
 
-export const wrapperStyles: CSSObject = {
-  display: 'flex',
-  alignItems: 'center',
-  height: '32px',
-  width: '32px',
-};
+interface UseVideoMetadataParams {
+  asset: FileAssetType;
+}
 
-export const playButtonStyles: CSSObject = {
-  width: '32px',
-  height: '32px',
-  borderRadius: '50%',
-  backgroundColor: 'var(--icon-button-primary-enabled-bg)',
-  border: '1px solid var(--icon-button-primary-border)',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  flexShrink: 0,
+export const useVideoMetadata = ({asset}: UseVideoMetadataParams) => {
+  const name = trimFileExtension(asset.file_name);
+  const extension = getFileExtension(asset.file_name!);
+  const size = formatBytes(asset.file_size);
+  const type = asset.file_type || '';
+  const duration = asset?.meta?.duration ?? 0;
+
+  return {
+    name,
+    extension,
+    size,
+    type,
+    duration,
+  };
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/useVideoPlayback/isVideoPlayable/isVideoPlayable.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/useVideoPlayback/isVideoPlayable/isVideoPlayable.ts
@@ -17,23 +17,17 @@
  *
  */
 
-import {CSSObject} from '@emotion/react';
-
-export const wrapperStyles: CSSObject = {
-  display: 'flex',
-  alignItems: 'center',
-  height: '32px',
-  width: '32px',
-};
-
-export const playButtonStyles: CSSObject = {
-  width: '32px',
-  height: '32px',
-  borderRadius: '50%',
-  backgroundColor: 'var(--icon-button-primary-enabled-bg)',
-  border: '1px solid var(--icon-button-primary-border)',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  flexShrink: 0,
+export const isVideoPlayable = async (url: string): Promise<boolean> => {
+  const video = document.createElement('video');
+  return new Promise<boolean>(resolve => {
+    video.onloadedmetadata = () => {
+      if (video.videoWidth === 0 || video.videoHeight === 0) {
+        resolve(false);
+        return;
+      }
+      resolve(true);
+    };
+    video.onerror = () => resolve(false);
+    video.src = url;
+  });
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/useVideoPlayback/useVideoPlayback.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/useVideoPlayback/useVideoPlayback.ts
@@ -32,12 +32,12 @@ import {AssetUrl} from '../../useAssetTransfer';
 interface UseVideoPlaybackProps {
   url: string;
   videoElement: HTMLVideoElement | undefined;
-  enabled: boolean;
+  isEnabled: boolean;
 }
 
 type PlayabilityStatus = 'not-checked' | 'playable' | 'unplayable';
 
-export const useVideoPlayback = ({url, videoElement, enabled}: UseVideoPlaybackProps) => {
+export const useVideoPlayback = ({url, videoElement, isEnabled}: UseVideoPlaybackProps) => {
   const [isPlaying, setIsPlaying] = useState<boolean>(false);
   const [isError, setIsError] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
@@ -71,7 +71,7 @@ export const useVideoPlayback = ({url, videoElement, enabled}: UseVideoPlaybackP
   };
 
   const handlePlay = async (src?: AssetUrl): Promise<void> => {
-    if (!enabled || !src || !videoElement) {
+    if (!isEnabled || !src || !videoElement) {
       return;
     }
 

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/useVideoPlayback/useVideoPlayback.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/useVideoPlayback/useVideoPlayback.ts
@@ -1,0 +1,125 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {useState, useCallback, useEffect, SyntheticEvent, useRef} from 'react';
+
+import {amplify} from 'amplify';
+
+import {WebAppEvents} from '@wireapp/webapp-events';
+
+import {AssetError} from 'src/script/assets/AssetError';
+import {AssetTransferState} from 'src/script/assets/AssetTransferState';
+import type {FileAsset} from 'src/script/entity/message/FileAsset';
+import {EventName} from 'src/script/tracking/EventName';
+
+import {isVideoPlayable} from './isVideoPlayable/isVideoPlayable';
+
+import {AssetUrl} from '../../useAssetTransfer';
+
+interface UseVideoPlaybackProps {
+  asset: FileAsset;
+  videoElement: HTMLVideoElement | undefined;
+  enabled: boolean;
+  getAssetUrl: (resource: any) => Promise<AssetUrl>;
+}
+
+export const useVideoPlayback = ({asset, videoElement, enabled, getAssetUrl}: UseVideoPlaybackProps) => {
+  const [src, setSrc] = useState<AssetUrl>();
+  const [isError, setIsError] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const isPlayedRef = useRef(false);
+
+  const fetchAssetUrl = useCallback(async () => {
+    if (src || !enabled) {
+      return;
+    }
+
+    asset.status(AssetTransferState.DOWNLOADING);
+
+    try {
+      const assetUrl = await getAssetUrl(asset.original_resource());
+      const playable = await isVideoPlayable(assetUrl.url);
+
+      if (!playable) {
+        amplify.publish(WebAppEvents.ANALYTICS.EVENT, EventName.MESSAGES.VIDEO.PLAY_FAILED);
+        amplify.publish(WebAppEvents.ANALYTICS.EVENT, EventName.MESSAGES.VIDEO.UNPLAYABLE_ERROR);
+        setIsError(true);
+        return;
+      }
+
+      setSrc(assetUrl);
+      setIsLoaded(true);
+      amplify.publish(WebAppEvents.ANALYTICS.EVENT, EventName.MESSAGES.VIDEO.PLAY_SUCCESS);
+    } catch (error) {
+      if (error instanceof Error && error.name !== AssetError.CANCEL_ERROR) {
+        setIsError(true);
+      }
+      amplify.publish(WebAppEvents.ANALYTICS.EVENT, EventName.MESSAGES.VIDEO.PLAY_FAILED);
+      console.error('Failed to load video asset ', error);
+    }
+
+    asset.status(AssetTransferState.UPLOADED);
+  }, [asset, enabled, getAssetUrl, src]);
+
+  useEffect(() => {
+    void fetchAssetUrl();
+  }, [fetchAssetUrl]);
+
+  const handleTimeUpdate = useCallback(() => {
+    if (!videoElement) {
+      return;
+    }
+    setCurrentTime(videoElement.currentTime);
+  }, [videoElement]);
+
+  const handlePlay = async (src?: AssetUrl): Promise<void> => {
+    if (!enabled) {
+      return;
+    }
+
+    if (src && videoElement) {
+      void videoElement.play();
+    }
+
+    isPlayedRef.current = true;
+  };
+
+  const handlePause = useCallback((): void => {
+    videoElement?.pause();
+  }, [videoElement]);
+
+  const handleError = useCallback((event: SyntheticEvent<HTMLVideoElement>) => {
+    setIsError(true);
+    amplify.publish(WebAppEvents.ANALYTICS.EVENT, EventName.MESSAGES.VIDEO.PLAY_FAILED);
+    console.error('Video cannot be played', event);
+  }, []);
+
+  return {
+    src,
+    currentTime,
+    isError,
+    isLoaded,
+    isPlayedRef,
+    handleTimeUpdate,
+    handlePlay,
+    handlePause,
+    handleError,
+  };
+};

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
@@ -36,7 +36,7 @@ import {LinkPreviewAsset} from './LinkPreviewAssetComponent';
 import {LocationAsset} from './LocationAsset';
 import {MessageButton} from './MessageButton';
 import {TextMessageRenderer} from './TextMessageRenderer';
-import {VideoAsset} from './VideoAsset';
+import {VideoAssetV2} from './VideoAsset/VideoAssetV2';
 
 import {MessageActions} from '../..';
 import {AssetType} from '../../../../../assets/AssetType';
@@ -68,6 +68,7 @@ const ContentAsset = ({
   isMessageFocused,
   is1to1Conversation,
   onClickDetails,
+  isFileShareRestricted,
 }: ContentAssetProps) => {
   const {isObfuscated, status} = useKoSubscribableChildren(message, ['isObfuscated', 'status']);
   const {previews} = useKoSubscribableChildren(asset as Text, ['previews']);
@@ -119,7 +120,13 @@ const ContentAsset = ({
       }
 
       if ((asset as FileAssetType).isVideo()) {
-        return <VideoAsset message={message} isFocusable={isMessageFocused} />;
+        return (
+          <VideoAssetV2
+            message={message}
+            isFocusable={isMessageFocused}
+            isFileShareRestricted={isFileShareRestricted}
+          />
+        );
       }
 
     case AssetType.IMAGE:

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
@@ -36,7 +36,7 @@ import {LinkPreviewAsset} from './LinkPreviewAssetComponent';
 import {LocationAsset} from './LocationAsset';
 import {MessageButton} from './MessageButton';
 import {TextMessageRenderer} from './TextMessageRenderer';
-import {VideoAssetV2} from './VideoAsset/VideoAssetV2';
+import {VideoAsset} from './VideoAsset/VideoAsset';
 
 import {MessageActions} from '../..';
 import {AssetType} from '../../../../../assets/AssetType';
@@ -68,7 +68,6 @@ const ContentAsset = ({
   isMessageFocused,
   is1to1Conversation,
   onClickDetails,
-  isFileShareRestricted,
 }: ContentAssetProps) => {
   const {isObfuscated, status} = useKoSubscribableChildren(message, ['isObfuscated', 'status']);
   const {previews} = useKoSubscribableChildren(asset as Text, ['previews']);
@@ -120,13 +119,7 @@ const ContentAsset = ({
       }
 
       if ((asset as FileAssetType).isVideo()) {
-        return (
-          <VideoAssetV2
-            message={message}
-            isFocusable={isMessageFocused}
-            isFileShareRestricted={isFileShareRestricted}
-          />
-        );
+        return <VideoAsset message={message} isFocusable={isMessageFocused} />;
       }
 
     case AssetType.IMAGE:

--- a/src/script/hooks/useInView/useInView.test.ts
+++ b/src/script/hooks/useInView/useInView.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {act, renderHook} from '@testing-library/react';
+
+import {useInView} from './useInView';
+
+describe('useInView', () => {
+  const mockIntersectionObserver = jest.fn();
+  let observerCallback: (entries: IntersectionObserverEntry[]) => void;
+
+  beforeEach(() => {
+    mockIntersectionObserver.mockImplementation((callback: (entries: IntersectionObserverEntry[]) => void) => {
+      observerCallback = callback;
+      return {
+        observe: jest.fn(),
+        disconnect: jest.fn(),
+      };
+    });
+
+    window.IntersectionObserver = mockIntersectionObserver;
+  });
+
+  it('initializes with element not in view', () => {
+    const {result} = renderHook(() => useInView());
+    const {isInView} = result.current;
+
+    expect(isInView).toBe(false);
+  });
+
+  it('updates isInView state when intersection changes', () => {
+    const {result} = renderHook(() => useInView());
+
+    act(() => {
+      observerCallback([{isIntersecting: true} as IntersectionObserverEntry]);
+    });
+
+    const {isInView} = result.current;
+    expect(isInView).toBe(true);
+  });
+
+  it('creates IntersectionObserver with provided options', () => {
+    const options = {
+      root: document.createElement('div'),
+      rootMargin: '10px',
+      threshold: 0.5,
+    };
+
+    renderHook(() => useInView(options));
+
+    expect(mockIntersectionObserver).toHaveBeenCalledWith(expect.any(Function), options);
+  });
+
+  it('disconnects observer on unmount', () => {
+    const disconnect = jest.fn();
+    mockIntersectionObserver.mockImplementation(() => ({
+      observe: jest.fn(),
+      disconnect,
+    }));
+
+    const {unmount} = renderHook(() => useInView());
+    unmount();
+
+    expect(disconnect).toHaveBeenCalled();
+  });
+
+  it('respects rootMargin option when determining visibility', () => {
+    const {result} = renderHook(() =>
+      useInView({
+        rootMargin: '50px',
+      }),
+    );
+
+    act(() => {
+      // Simulate an element that would be just outside the viewport
+      // but within the rootMargin area
+      observerCallback([
+        {
+          isIntersecting: true,
+          boundingClientRect: {
+            top: -45, // element is 45px above viewport
+            bottom: 0,
+            left: 0,
+            right: 0,
+          },
+        } as IntersectionObserverEntry,
+      ]);
+    });
+
+    const {isInView} = result.current;
+    expect(isInView).toBe(true);
+  });
+});

--- a/src/script/hooks/useInView/useInView.ts
+++ b/src/script/hooks/useInView/useInView.ts
@@ -35,7 +35,7 @@ export const useInView = <Element extends HTMLElement = HTMLDivElement>(options:
   useEffect(() => {
     const element = elementRef.current;
     if (!element) {
-      return;
+      return undefined;
     }
 
     const observer = new IntersectionObserver(([entry]) => {

--- a/src/script/hooks/useInView/useInView.ts
+++ b/src/script/hooks/useInView/useInView.ts
@@ -1,0 +1,53 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {useEffect, useRef, useState} from 'react';
+
+interface UseInViewOptions {
+  /** The root element to use as the viewport, defaults to browser viewport */
+  root?: Element | null;
+  /** Margin around the root element */
+  rootMargin?: string;
+  /** Percentage of element that needs to be visible to trigger */
+  threshold?: number | number[];
+}
+
+export const useInView = <Element extends HTMLElement = HTMLDivElement>(options: UseInViewOptions = {}) => {
+  const [isInView, setIsInView] = useState(false);
+  const elementRef = useRef<Element | null>(null);
+
+  useEffect(() => {
+    const element = elementRef.current;
+    if (!element) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(([entry]) => {
+      setIsInView(entry.isIntersecting);
+    }, options);
+
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [options, options.root, options.rootMargin, options.threshold]);
+
+  return {elementRef, isInView};
+};

--- a/src/types/i18n.d.ts
+++ b/src/types/i18n.d.ts
@@ -587,6 +587,7 @@ declare module 'I18n/en-US.json' {
     'conversationUpdatedTimerYou': ` set the message timer to {time}`;
     'conversationVideoAssetRestricted': `Receiving videos is prohibited`;
     'conversationViewAllConversations': `All conversations`;
+    'conversationVideoAssetError': `Couldn’t generate preview`;
     'conversationViewTooltip': `All`;
     'conversationVoiceChannelDeactivate': ` called`;
     'conversationVoiceChannelDeactivateYou': ` called`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6312,9 +6312,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/react-ui-kit@npm:9.35.0":
-  version: 9.35.0
-  resolution: "@wireapp/react-ui-kit@npm:9.35.0"
+"@wireapp/react-ui-kit@npm:9.36.0":
+  version: 9.36.0
+  resolution: "@wireapp/react-ui-kit@npm:9.36.0"
   dependencies:
     "@types/color": "npm:3.0.6"
     color: "npm:4.2.3"
@@ -6329,7 +6329,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/4854bec9b1a7ce55a727bb8a9b99d397fea9b678cf506de4bf602934de2174c2215a8ccb18d193b4c1b52a55419f1e89e729778f3ac801dce20b3e29a83b4929
+  checksum: 10/41233d8605d9e2f9ebf774cf62788960ef648eddd4c2148250b7e52e5e16ab09c7aff1aca859857b5272242aa7f9b239af23a8e22fc4857c3831ef3a91818b95
   languageName: node
   linkType: hard
 
@@ -19073,7 +19073,7 @@ __metadata:
     "@wireapp/core": "npm:46.17.0"
     "@wireapp/eslint-config": "npm:3.0.7"
     "@wireapp/prettier-config": "npm:0.6.4"
-    "@wireapp/react-ui-kit": "npm:9.35.0"
+    "@wireapp/react-ui-kit": "npm:9.36.0"
     "@wireapp/store-engine": "npm:5.1.11"
     "@wireapp/store-engine-dexie": "npm:2.1.15"
     "@wireapp/telemetry": "npm:0.3.1"


### PR DESCRIPTION
## Description

**What's changed:**
- new file card from https://github.com/wireapp/wire-webapp/pull/18692
- new loading strategy (details below)
- refactor (a little bit)

**Important:**

The whole thing (almost) was built with an existing logic, in some places refactored, simplified or moved to a new hook/function/file. When reviewing, please take this into account.

**Loading logic:**

Currently, we load a video after pressing the play button. It's a good way performance-wise, but we don't display previews/posters, which is kinda poor UX.

The new approach changes that. How it works:
- if a video is off-screen, don't load it at all
- if it is in the viewport, load only the "metadata" (by specifying `preload="metadata"` on the video tag, browser decides how much should be fetched, [more info](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#preload)), by doing it we'll be able to display a preview and duration
- after clicking the play button, additional data is going to be fetched

**Detailed comparison below:**

<details>
<summary>Data usage & performance analysis</summary>

The transfer may vary slightly, but this demo should be a good view of how it works. 

**The current implementation:**

We don't load anything until a user clicks on the play button.

https://github.com/user-attachments/assets/abd855cc-01ba-4fd6-9b0e-853dc71cb06d

**The new one with `preload="metadata"`:**

We fetch some data when the video is on screen, the rest is loaded after playing the video.

https://github.com/user-attachments/assets/7da0d422-48e6-403a-955b-21bc09f41907


**The new one with `preload="auto"`:**

We load everything at once, right after the video shows in the viewport.

https://github.com/user-attachments/assets/a04b27bb-f3b2-4373-ade3-a13868c91c3f


</details>

## Demo

**Playing:**

https://github.com/user-attachments/assets/27aa8c91-118b-46be-83e6-1a8d142bdd05

**Loading:**
<img width="519" alt="Screenshot 2025-02-10 at 13 46 09" src="https://github.com/user-attachments/assets/4a0ebefa-a335-4459-aba3-55b0d9325ad7" />

**Loading only in the viewport:**


https://github.com/user-attachments/assets/5a427cbc-31c6-4565-9314-6d87daab1265


**Error:**
<img width="519" alt="Screenshot 2025-02-10 at 13 46 35" src="https://github.com/user-attachments/assets/3cc05c2b-8cb8-4257-9309-3fe3cee569ee" />


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
