### PR TITLE
feat: bump avs to 10.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@lexical/rich-text": "0.24.0",
     "@mediapipe/tasks-vision": "0.10.21",
     "@tanstack/react-virtual": "^3.13.0",
-    "@wireapp/avs": "10.0.4",
+    "@wireapp/avs": "10.0.5",
     "@wireapp/avs-debugger": "0.0.7",
     "@wireapp/commons": "5.4.1",
     "@wireapp/core": "46.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6162,10 +6162,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/avs@npm:10.0.4":
-  version: 10.0.4
-  resolution: "@wireapp/avs@npm:10.0.4"
-  checksum: 10/b584313806a95ffe732c9a4f62ea001f4871ee60e3a75830bd6dce176422c8eee43ae2be8ccff4642b1a3ed729508cc029f647219d04551523a77efe890370fe
+"@wireapp/avs@npm:10.0.5":
+  version: 10.0.5
+  resolution: "@wireapp/avs@npm:10.0.5"
+  checksum: 10/564b2de35d7ff2a57c78407f5317a02b4de887b091bb5df7a695111d59511763b970dd26971fd1233397f314f719cb9d0129bc88f924754949905b1ebcf78dd5
   languageName: node
   linkType: hard
 
@@ -19158,7 +19158,7 @@ __metadata:
     "@types/uuid": "npm:^10.0.0"
     "@types/webpack-env": "npm:1.18.8"
     "@types/wicg-file-system-access": "npm:^2023.10.5"
-    "@wireapp/avs": "npm:10.0.4"
+    "@wireapp/avs": "npm:10.0.5"
     "@wireapp/avs-debugger": "npm:0.0.7"
     "@wireapp/commons": "npm:5.4.1"
     "@wireapp/copy-config": "npm:2.3.0"


### PR DESCRIPTION
## Description

This PR bumps AVS to the latest simulcast version. 

It contains a fix for the IOS platform so that two call objects cannot be created. In addition, it brings the latest changes from AVS 9.x.x into the tree. This PR has no feature impact on Web.

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
