### PR TITLE
fix: wrong grammar in German system message [WPB-14795]

### DIFF
--- a/src/script/conversation/EventMapper.ts
+++ b/src/script/conversation/EventMapper.ts
@@ -715,8 +715,8 @@ export class EventMapper {
    * @param eventData Message data
    * @returns Rename message entity
    */
-  private _mapEventRename({data: eventData}: LegacyEventRecord) {
-    return new RenameMessage(eventData.name);
+  private _mapEventRename({data: eventData, from, qualified_from}: LegacyEventRecord) {
+    return new RenameMessage(eventData.name, from, qualified_from?.domain);
   }
 
   /**


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14795" title="WPB-14795" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14795</a>  [Web] Wrong grammar in German System message ("Sie hat die Unterhaltung umbenannt")
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Fixes the incorrect grammar in the German system message ("Sie hat die Unterhaltung umbenannt")

## Screenshots/Screencast (for UI changes)
### Before
<img width="931" alt="issue-WPB-14795" src="https://github.com/user-attachments/assets/fd4f676d-0668-4029-bdb2-6784faa11b6c" />


### After
<img width="928" alt="fix-WPB-14795" src="https://github.com/user-attachments/assets/2f304296-8a0e-4867-8dc7-3e0c19228992" />


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;
