### PR TITLE
runfix: correct group icon dark mode background color [WPB-15794]

### DIFF
--- a/src/script/components/Avatar/GroupAvatar.tsx
+++ b/src/script/components/Avatar/GroupAvatar.tsx
@@ -40,7 +40,7 @@ export const GroupAvatar: React.FC<GroupAvatarProps> = ({className}) => {
       <div
         css={{
           ...CSS_SQUARE(28),
-          backgroundColor: 'var(--app-bg-secondary)',
+          backgroundColor: 'var(--group-icon-bg)',
           borderRadius: 5,
           display: 'flex',
           flexWrap: 'wrap',

--- a/src/style/common/mixins.less
+++ b/src/style/common/mixins.less
@@ -41,7 +41,7 @@
   .setVariables(foreground background);
   .setColorFade(foreground, @foreground);
   .setColorFade(background, @background);
-  .setVariables(app-bg sidebar-bg input-bar-bg sidebar-border-color sidebar-folder-selected-bg main-color border-color app-bg-secondary conversation-list-bg-opacity);
+  .setVariables(app-bg sidebar-bg input-bar-bg sidebar-border-color sidebar-folder-selected-bg main-color border-color app-bg-secondary conversation-list-bg-opacity group-icon-bg);
   .setVariables(group-video-bg group-video-tile-bg participant-audio-connecting-color inactive-call-button-bg inactive-call-button-border inactive-call-button-hover-bg inactive-call-button-hover-border disabled-call-button-bg disabled-call-button-border disabled-call-button-svg button-group-left-hover button-group-right-hover toggle-button-unselected-hover-border toggle-button-unselected-hover-bg);
   .setVariables(modal-bg modal-border-color);
   .setVariables(preference-account-input-bg);

--- a/src/style/foundation/themes.less
+++ b/src/style/foundation/themes.less
@@ -29,16 +29,21 @@ body.theme-default {
   // Framework
   // ----------------------------------------------------------------------------
   @app-bg: var(--gray-10);
-  @sidebar-bg: var(--gray-20);
-  @sidebar-border-color: var(--gray-50);
-  @sidebar-folder-selected-bg: var(--gray-30);
   @border-color: var(--gray-40);
   @main-color: var(--black);
   @app-bg-secondary: var(--white);
+  @input-bar-bg: var(--white);
+
+  // ----------------------------------------------------------------------------
+  // Coversation Sidebar
+  // ----------------------------------------------------------------------------
+  @sidebar-bg: var(--gray-20);
+  @sidebar-border-color: var(--gray-50);
+  @sidebar-folder-selected-bg: var(--gray-30);
   @conversation-list-bg-opacity: fade(#000, 64%);
   @sidebar-box-shadow: #eee;
   @sidebar-box-shadow-lg: rgba(0, 0, 0, 0.12);
-  @input-bar-bg: var(--white);
+  @group-icon-bg: var(--white);
 
   // ----------------------------------------------------------------------------
   // Calling
@@ -133,14 +138,19 @@ body.theme-dark {
   // Framework
   // ----------------------------------------------------------------------------
   @app-bg: var(--gray-95);
-  @sidebar-bg: var(--gray-100);
-  @sidebar-border-color: var(--gray-95);
-  @sidebar-folder-selected-bg: var(--gray-95);
   @main-color: var(--white);
   @border-color: var(--gray-90);
   @app-bg-secondary: var(--black);
-  @conversation-list-bg-opacity: fade(#000, 78%);
   @input-bar-bg: var(--gray-100);
+
+  // ----------------------------------------------------------------------------
+  // Coversation Sidebar
+  // ----------------------------------------------------------------------------
+  @sidebar-bg: var(--gray-100);
+  @sidebar-border-color: var(--gray-95);
+  @sidebar-folder-selected-bg: var(--gray-95);
+  @conversation-list-bg-opacity: fade(#000, 78%);
+  @group-icon-bg: var(--gray-95);
 
   // ----------------------------------------------------------------------------
   // Calling

--- a/src/style/foundation/themes.less
+++ b/src/style/foundation/themes.less
@@ -144,7 +144,7 @@ body.theme-dark {
   @input-bar-bg: var(--gray-100);
 
   // ----------------------------------------------------------------------------
-  // Coversation Sidebar
+  // Conversation Sidebar
   // ----------------------------------------------------------------------------
   @sidebar-bg: var(--gray-100);
   @sidebar-border-color: var(--gray-95);

--- a/src/style/foundation/themes.less
+++ b/src/style/foundation/themes.less
@@ -41,8 +41,6 @@ body.theme-default {
   @sidebar-border-color: var(--gray-50);
   @sidebar-folder-selected-bg: var(--gray-30);
   @conversation-list-bg-opacity: fade(#000, 64%);
-  @sidebar-box-shadow: #eee;
-  @sidebar-box-shadow-lg: rgba(0, 0, 0, 0.12);
   @group-icon-bg: var(--white);
 
   // ----------------------------------------------------------------------------

--- a/src/style/foundation/themes.less
+++ b/src/style/foundation/themes.less
@@ -35,7 +35,7 @@ body.theme-default {
   @input-bar-bg: var(--white);
 
   // ----------------------------------------------------------------------------
-  // Coversation Sidebar
+  // Conversation Sidebar
   // ----------------------------------------------------------------------------
   @sidebar-bg: var(--gray-20);
   @sidebar-border-color: var(--gray-50);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15794" title="WPB-15794" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-15794</a>  [Web] Adjust group avatars (not channels) to be in line with channel mocks
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

correct group icon dark mode background color


<!-- Uncomment this section if your PR has UI changes -->
## Screenshots/Screencast (for UI changes)

Before:
![image](https://github.com/user-attachments/assets/89a72b6c-4f94-4ec3-953d-7c582c5355d0)

After:
![image](https://github.com/user-attachments/assets/eeb95ed8-0d76-41f2-a79a-84a69b846238)


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
