### PR TITLE
fix: Exclude emoji search input when disabling typing in full screen calls (WPB-16133)

### DIFF
--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -205,7 +205,12 @@ const FullscreenVideoCall = ({
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent): void => {
-      if (viewMode !== CallingViewMode.FULL_SCREEN) {
+      const target = event.target as HTMLElement;
+
+      if (
+        viewMode !== CallingViewMode.FULL_SCREEN ||
+        target?.getAttribute('aria-controls') === 'epr-search-id' // Exclude emoji search input
+      ) {
         return;
       }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16133" title="WPB-16133" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16133</a>  [Web] In-Call reactions search for any emoji does not accept typing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

in full screen calls we prevent keyboard events to avoid accidentally typing into the input bar and possibly sending a message. this is also preventing the user to type into the new full reactions search in the full screen call which we need to make an exemption.