### PR TITLE
runfix: emojis picker click outside and search clear button background [WPB-16145]

### DIFF
--- a/src/script/components/calling/VideoControls/EmojisBar/EmojisBar.styles.ts
+++ b/src/script/components/calling/VideoControls/EmojisBar/EmojisBar.styles.ts
@@ -136,11 +136,19 @@ export const styles: {
       backgroundColor: 'var(--message-actions-background)',
     },
 
-    '& .EmojiPickerReact .epr-search-container input': {
-      'body.theme-dark &': {
-        border: '1px solid var(--gray-70)',
-        borderRadius: '12px',
-        background: 'var(--gray-100)',
+    '& .EmojiPickerReact .epr-search-container': {
+      input: {
+        'body.theme-dark &': {
+          border: '1px solid var(--gray-70)',
+          borderRadius: '12px',
+          background: 'var(--gray-100)',
+        },
+      },
+
+      'button.epr-btn:hover': {
+        'body.theme-dark &': {
+          background: 'none',
+        },
       },
     },
 

--- a/src/script/components/calling/VideoControls/EmojisBar/EmojisBar.tsx
+++ b/src/script/components/calling/VideoControls/EmojisBar/EmojisBar.tsx
@@ -31,10 +31,10 @@ const EMOJIS_LIST = ['👍', '🎉', '❤️', '😂', '😮', '👏', '🤔', '
 export interface EmojisBarProps {
   onEmojiClick: (emoji: string) => void;
   onPickerEmojiClick: () => void;
-  detachedWindow?: Window | null;
+  targetWindow: Window;
 }
 
-export const EmojisBar = ({onEmojiClick, onPickerEmojiClick, detachedWindow}: EmojisBarProps) => {
+export const EmojisBar = ({onEmojiClick, onPickerEmojiClick, targetWindow}: EmojisBarProps) => {
   const emojisBarRef = useRef<HTMLDivElement>(null);
 
   const [disabledEmojis, setDisabledEmojis] = useState<string[]>([]);
@@ -62,15 +62,11 @@ export const EmojisBar = ({onEmojiClick, onPickerEmojiClick, detachedWindow}: Em
   };
 
   useEffect(() => {
-    if (detachedWindow) {
-      detachedWindow.document.addEventListener('mousedown', handleClickOutside);
-      return () => {
-        detachedWindow.document.removeEventListener('mousedown', handleClickOutside);
-      };
-    }
-
-    return () => {};
-  }, [detachedWindow]);
+    targetWindow.document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      targetWindow.document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [targetWindow, onPickerEmojiClick]);
 
   return (
     <div ref={emojisBarRef}>

--- a/src/script/components/calling/VideoControls/VideoControls.tsx
+++ b/src/script/components/calling/VideoControls/VideoControls.tsx
@@ -377,6 +377,8 @@ export const VideoControls: React.FC<VideoControlsProps> = ({
 
   const isInCallHandRaiseControlVisible = isInCallHandRaiseEnable && !is1to1Conversation;
 
+  const emojisBarTargetWindow = viewMode === CallingViewMode.DETACHED_WINDOW ? detachedWindow! : window;
+
   return (
     <ul id="video-controls" className="video-controls" css={videoControlsWrapperStyles}>
       <div
@@ -646,7 +648,7 @@ export const VideoControls: React.FC<VideoControlsProps> = ({
               <EmojisBar
                 onEmojiClick={handleEmojiClick}
                 onPickerEmojiClick={() => setShowEmojisBar(false)}
-                targetWindow={viewMode === CallingViewMode.DETACHED_WINDOW ? detachedWindow! : window}
+                targetWindow={emojisBarTargetWindow}
               />
             )}
             <button
@@ -754,7 +756,7 @@ export const VideoControls: React.FC<VideoControlsProps> = ({
                   <EmojisBar
                     onEmojiClick={handleEmojiClick}
                     onPickerEmojiClick={() => setShowEmojisBar(false)}
-                    targetWindow={viewMode === CallingViewMode.DETACHED_WINDOW ? detachedWindow! : window}
+                    targetWindow={emojisBarTargetWindow}
                   />
                 )}
                 <button

--- a/src/script/components/calling/VideoControls/VideoControls.tsx
+++ b/src/script/components/calling/VideoControls/VideoControls.tsx
@@ -646,7 +646,7 @@ export const VideoControls: React.FC<VideoControlsProps> = ({
               <EmojisBar
                 onEmojiClick={handleEmojiClick}
                 onPickerEmojiClick={() => setShowEmojisBar(false)}
-                detachedWindow={detachedWindow}
+                targetWindow={viewMode === CallingViewMode.DETACHED_WINDOW ? detachedWindow! : window}
               />
             )}
             <button
@@ -754,7 +754,7 @@ export const VideoControls: React.FC<VideoControlsProps> = ({
                   <EmojisBar
                     onEmojiClick={handleEmojiClick}
                     onPickerEmojiClick={() => setShowEmojisBar(false)}
-                    detachedWindow={detachedWindow}
+                    targetWindow={viewMode === CallingViewMode.DETACHED_WINDOW ? detachedWindow! : window}
                   />
                 )}
                 <button


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16145" title="WPB-16145" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16145</a>  [Web] Fix emojis picker click-outside and search input clear button background in call reactions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Fixes the click outside handling for emojis picker in full screen view and hover background from emoji picker search clear button in dark mode.

## Screenshots/Screencast (for UI changes)

https://github.com/user-attachments/assets/1bdec44a-697f-4549-99f3-11ee391b643f



## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;