### PR TITLE
fix: prevent empty team name submission [WPB-15274]

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/TeamCreation/TeamCreationModal.test.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/TeamCreation/TeamCreationModal.test.tsx
@@ -118,4 +118,24 @@ describe('TeamCreationModal', () => {
     fireEvent.click(getByTestId(testIdentifiers.doClose));
     expect(onCloseMock).toHaveBeenCalled();
   });
+
+  it('disables Continue button for empty or whitespace-only team names', () => {
+    const {getByTestId} = renderTeamCreationModal();
+
+    fireEvent.click(getByTestId(testIdentifiers.doContinue));
+
+    const continueButton = getByTestId(testIdentifiers.doContinue);
+    const teamNameInput = getByTestId(testIdentifiers.enterTeamName);
+
+    expect(continueButton).toBeDisabled();
+
+    fireEvent.change(teamNameInput, {target: {value: '   '}});
+    expect(continueButton).toBeDisabled();
+
+    fireEvent.change(teamNameInput, {target: {value: ''}});
+    expect(continueButton).toBeDisabled();
+
+    fireEvent.change(teamNameInput, {target: {value: 'Valid Team'}});
+    expect(continueButton).not.toBeDisabled();
+  });
 });

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/TeamCreation/TeamCreationSteps/Form.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/TeamCreation/TeamCreationSteps/Form.tsx
@@ -27,6 +27,13 @@ import {modalButtonsCss} from './TeamCreationSteps.styles';
 import {buttonCss} from '../TeamCreation.styles';
 
 export const Form = ({onNextStep, onPreviousStep, teamName, setTeamName}: StepProps) => {
+  const isValidTeamName = teamName.trim().length > 0;
+
+  function handleNextStep() {
+    setTeamName(teamName.trim());
+    onNextStep();
+  }
+
   return (
     <>
       <h2 className="heading-h2">{t('teamCreationFormTitle')}</h2>
@@ -47,7 +54,7 @@ export const Form = ({onNextStep, onPreviousStep, teamName, setTeamName}: StepPr
         <Button data-uie-name="do-go-back" onClick={onPreviousStep} variant={ButtonVariant.SECONDARY} css={buttonCss}>
           {t('teamCreationBack')}
         </Button>
-        <Button data-uie-name="do-continue" disabled={!teamName} onClick={onNextStep} css={buttonCss}>
+        <Button data-uie-name="do-continue" disabled={!isValidTeamName} onClick={handleNextStep} css={buttonCss}>
           {t('teamCreationContinue')}
         </Button>
       </div>

--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/TeamCreation/TeamCreationSteps/Form.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/TeamCreation/TeamCreationSteps/Form.tsx
@@ -27,10 +27,15 @@ import {modalButtonsCss} from './TeamCreationSteps.styles';
 import {buttonCss} from '../TeamCreation.styles';
 
 export const Form = ({onNextStep, onPreviousStep, teamName, setTeamName}: StepProps) => {
-  const isValidTeamName = teamName.trim().length > 0;
+  const trimmedTeamName = teamName.trim();
+  const isValidTeamName = trimmedTeamName.length > 0;
 
   function handleNextStep() {
-    setTeamName(teamName.trim());
+    if (!isValidTeamName) {
+      return;
+    }
+
+    setTeamName(trimmedTeamName);
     onNextStep();
   }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15274" title="WPB-15274" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15274</a>  [Web] Do not allow empty Team name from the UI
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Fixes the issue where user can type empty team name or white spaces in personal to team migration.

## Screenshots/Screencast (for UI changes)
### Before
<img width="776" alt="issue-WPB-15274" src="https://github.com/user-attachments/assets/1224668c-bd3b-4e16-be6f-367c7e4c38f9" />


### After
<img width="778" alt="fix-WPB-15274" src="https://github.com/user-attachments/assets/bebf3011-ec0b-4a92-b5e3-9f8901ddf735" />
<img width="768" alt="fix1-WPB-15274" src="https://github.com/user-attachments/assets/e3c545c2-85c7-41d2-8b3e-5b859b515c61" />


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;