### PR TITLE
fix: Do not send mls message to self mls conversations when mls is not enabled on the team (WPB-16202)

### DIFF
--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -1144,7 +1144,9 @@ export class MessageRepository {
   }
 
   private async sendToSelfConversations(payload: GenericMessage) {
-    const selfConversations = this.conversationState.getSelfConversations(supportsMLS());
+    const selfConversations = this.conversationState.getSelfConversations(
+      supportsMLS() && this.teamState.isMLSEnabled(),
+    );
     await Promise.all(
       selfConversations.map(selfConversation =>
         this.sendAndInjectMessage(payload, selfConversation, {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16202" title="WPB-16202" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16202</a>  [Web] MLS Error with self conversation when MLS is not enabled for the team
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

```typescript
const selfConversations = this.conversationState.getSelfConversations(supportsMLS());
```

problem was this line.
when trying to send a message to self we get all the self conversations
if mls is enabled we also include self mls conversations
the condition for checking if mls is enabled was to only check if we support cryptography apis, no check to see if MLS is also enabled in the team as well or not!

changing the above line to this fixes it:

```typescript
const selfConversations = this.conversationState.getSelfConversations(
  supportsMLS() && this.teamState.isMLSEnabled(),
);
```