### PR TITLE
runfix: fix QA pipeline by adding missing connect sources

### DIFF
--- a/server/config/server.config.ts
+++ b/server/config/server.config.ts
@@ -71,11 +71,14 @@ function parseCommaSeparatedList(list: string = ''): string[] {
 function mergedCSP({urls}: ConfigGeneratorParams, env: Record<string, string>): Record<string, Iterable<string>> {
   const objectSrc = parseCommaSeparatedList(env.CSP_EXTRA_OBJECT_SRC);
   const csp = {
-    connectSrc:
-      env.FEATURE_ENABLE_DEBUG === 'true'
-        ? // Allow all connections in debug mode
-          ['*']
-        : [...defaultCSP.connectSrc, urls.api, urls.ws, ...parseCommaSeparatedList(env.CSP_EXTRA_CONNECT_SRC)],
+    connectSrc: [
+      ...defaultCSP.connectSrc,
+      urls.api,
+      urls.ws,
+      ...parseCommaSeparatedList(env.CSP_EXTRA_CONNECT_SRC),
+      // Allow all other connections in debug mode
+      env.FEATURE_ENABLE_DEBUG == 'true' ? '*' : '',
+    ].filter(Boolean),
     defaultSrc: [...defaultCSP.defaultSrc, ...parseCommaSeparatedList(env.CSP_EXTRA_DEFAULT_SRC)],
     fontSrc: [...defaultCSP.fontSrc, ...parseCommaSeparatedList(env.CSP_EXTRA_FONT_SRC)],
     frameSrc: [...defaultCSP.frameSrc, ...parseCommaSeparatedList(env.CSP_EXTRA_FRAME_SRC)],


### PR DESCRIPTION
## Description

This PR is an addition to https://github.com/wireapp/wire-webapp/pull/18796
The QA pipeline is failing and expecting all the other sources to be there in `connectSrc` array.

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
