### PR TITLE
fix: show participants list on small screens [WPB-16184]

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -1675,6 +1675,7 @@
   "videoCallOverlayMicrophone": "Microphone",
   "videoCallOverlayOpenFullScreen": "Open the call in full screen",
   "videoCallOverlayOpenPopupWindow": "Open in a new window",
+  "videoCallOverlayParticipantsListCloseButton": "Hide participants",
   "videoCallOverlayParticipantsListLabel": "Participants ({count})",
   "videoCallOverlayParticipantsRaisedHandListLabel": "Raised hands ({count})",
   "videoCallOverlayShareScreen": "Share Screen",

--- a/src/script/components/calling/CallingCell/CallIngParticipantList/CallingParticipantList.styles.ts
+++ b/src/script/components/calling/CallingCell/CallIngParticipantList/CallingParticipantList.styles.ts
@@ -29,3 +29,26 @@ export const labelWithIconStyles: CSSObject = {
   display: 'flex',
   justifyContent: 'space-between',
 };
+
+export const participantListWrapperStyles = (isMobile: boolean): CSSObject => ({
+  position: isMobile ? 'absolute' : 'relative',
+  inset: isMobile ? 0 : 'auto',
+  width: isMobile ? '100%' : 'auto',
+  height: isMobile ? '100%' : 'auto',
+  zIndex: isMobile ? 2 : 'auto',
+  backgroundColor: 'var(--app-bg-secondary)',
+  border: isMobile ? '2px solid var(--accent-color)' : 'none',
+  borderRadius: isMobile ? 10 : 0,
+});
+
+export const headerStyles: CSSObject = {
+  display: 'flex',
+  justifyContent: 'flex-end',
+  alignItems: 'center',
+  padding: '12px 10px',
+  borderBottom: '1px solid var(--border-color)',
+  '& button': {
+    minWidth: 'auto',
+    minHeight: 'auto',
+  },
+};

--- a/src/script/components/calling/CallingCell/CallIngParticipantList/CallingParticipantList.styles.ts
+++ b/src/script/components/calling/CallingCell/CallIngParticipantList/CallingParticipantList.styles.ts
@@ -19,6 +19,8 @@
 
 import {CSSObject} from '@emotion/react';
 
+import {media} from '@wireapp/react-ui-kit';
+
 export const labelStyles: CSSObject = {
   padding: '12px 10px',
   fontWeight: 'var(--font-weight-semibold)',
@@ -30,23 +32,28 @@ export const labelWithIconStyles: CSSObject = {
   justifyContent: 'space-between',
 };
 
-export const participantListWrapperStyles = (isMobile: boolean): CSSObject => ({
-  position: isMobile ? 'absolute' : 'relative',
-  inset: isMobile ? 0 : 'auto',
-  width: isMobile ? '100%' : 'auto',
-  height: isMobile ? '100%' : 'auto',
-  zIndex: isMobile ? 2 : 'auto',
-  backgroundColor: 'var(--app-bg-secondary)',
-  border: isMobile ? '2px solid var(--accent-color)' : 'none',
-  borderRadius: isMobile ? 10 : 0,
-});
+export const participantListWrapperStyles: CSSObject = {
+  [media.mobile]: {
+    position: 'absolute',
+    inset: 0,
+    width: '100%',
+    height: '100%',
+    zIndex: 2,
+    backgroundColor: 'var(--app-bg-secondary)',
+    border: '2px solid var(--accent-color)',
+    borderRadius: 10,
+  },
+};
 
 export const headerStyles: CSSObject = {
-  display: 'flex',
-  justifyContent: 'flex-end',
-  alignItems: 'center',
-  padding: '12px 10px',
-  borderBottom: '1px solid var(--border-color)',
+  display: 'none',
+  [media.mobile]: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    padding: '12px 10px',
+    borderBottom: '1px solid var(--border-color)',
+  },
   '& button': {
     minWidth: 'auto',
     minHeight: 'auto',

--- a/src/script/components/calling/CallingCell/CallIngParticipantList/CallingParticipantList.tsx
+++ b/src/script/components/calling/CallingCell/CallIngParticipantList/CallingParticipantList.tsx
@@ -21,12 +21,11 @@ import React, {useMemo} from 'react';
 
 import cx from 'classnames';
 
-import {QUERY, Tooltip} from '@wireapp/react-ui-kit';
+import {Tooltip} from '@wireapp/react-ui-kit';
 
 import {CallParticipantsListItem} from 'Components/calling/CallParticipantsListItem';
 import {FadingScrollbar} from 'Components/FadingScrollbar';
 import * as Icon from 'Components/Icon';
-import {useActiveWindowMatchMedia} from 'Hooks/useActiveWindowMatchMedia';
 import {t} from 'Util/LocalizerUtil';
 import {sortUsersByPriority} from 'Util/StringUtil';
 
@@ -96,28 +95,24 @@ export const CallingParticipantList = ({
       .sort((participantA, participantB) => sortUsersByPriority(participantA.user, participantB.user));
   }, [participants]);
 
-  const isMobile = useActiveWindowMatchMedia(QUERY.mobile);
-
   return (
     <div
       className={cx('call-ui__participant-list__wrapper', {
         'call-ui__participant-list__wrapper--active': showParticipants,
       })}
-      css={participantListWrapperStyles(isMobile)}
+      css={participantListWrapperStyles}
     >
       <FadingScrollbar className="call-ui__participant-list__container">
-        {isMobile && (
-          <div css={headerStyles}>
-            <button
-              type="button"
-              className="icon-button"
-              onClick={onClose}
-              title={t('videoCallOverlayParticipantsListCloseButton')}
-            >
-              <Icon.CloseIcon />
-            </button>
-          </div>
-        )}
+        <div css={headerStyles}>
+          <button
+            type="button"
+            className="icon-button"
+            onClick={onClose}
+            title={t('videoCallOverlayParticipantsListCloseButton')}
+          >
+            <Icon.CloseIcon />
+          </button>
+        </div>
         {handRaisedParticipants.length > 0 && (
           <>
             <p css={labelWithIconStyles}>

--- a/src/script/components/calling/CallingCell/CallIngParticipantList/CallingParticipantList.tsx
+++ b/src/script/components/calling/CallingCell/CallIngParticipantList/CallingParticipantList.tsx
@@ -21,15 +21,21 @@ import React, {useMemo} from 'react';
 
 import cx from 'classnames';
 
-import {Tooltip} from '@wireapp/react-ui-kit';
+import {QUERY, Tooltip} from '@wireapp/react-ui-kit';
 
 import {CallParticipantsListItem} from 'Components/calling/CallParticipantsListItem';
 import {FadingScrollbar} from 'Components/FadingScrollbar';
 import * as Icon from 'Components/Icon';
+import {useActiveWindowMatchMedia} from 'Hooks/useActiveWindowMatchMedia';
 import {t} from 'Util/LocalizerUtil';
 import {sortUsersByPriority} from 'Util/StringUtil';
 
-import {labelStyles, labelWithIconStyles} from './CallingParticipantList.styles';
+import {
+  headerStyles,
+  labelStyles,
+  labelWithIconStyles,
+  participantListWrapperStyles,
+} from './CallingParticipantList.styles';
 
 import {CallingRepository} from '../../../../calling/CallingRepository';
 import {Participant} from '../../../../calling/Participant';
@@ -44,6 +50,7 @@ interface CallingParticipantListProps {
   participants: Participant[];
   handRaisedParticipants: Participant[];
   showParticipants?: boolean;
+  onClose: () => void;
 }
 
 export const CallingParticipantList = ({
@@ -54,6 +61,7 @@ export const CallingParticipantList = ({
   participants,
   handRaisedParticipants,
   showParticipants,
+  onClose,
 }: CallingParticipantListProps) => {
   const getParticipantContext = (event: React.MouseEvent<HTMLDivElement>, participant: Participant) => {
     event.preventDefault();
@@ -88,13 +96,28 @@ export const CallingParticipantList = ({
       .sort((participantA, participantB) => sortUsersByPriority(participantA.user, participantB.user));
   }, [participants]);
 
+  const isMobile = useActiveWindowMatchMedia(QUERY.mobile);
+
   return (
     <div
       className={cx('call-ui__participant-list__wrapper', {
         'call-ui__participant-list__wrapper--active': showParticipants,
       })}
+      css={participantListWrapperStyles(isMobile)}
     >
       <FadingScrollbar className="call-ui__participant-list__container">
+        {isMobile && (
+          <div css={headerStyles}>
+            <button
+              type="button"
+              className="icon-button"
+              onClick={onClose}
+              title={t('videoCallOverlayParticipantsListCloseButton')}
+            >
+              <Icon.CloseIcon />
+            </button>
+          </div>
+        )}
         {handRaisedParticipants.length > 0 && (
           <>
             <p css={labelWithIconStyles}>

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -362,6 +362,19 @@ const FullscreenVideoCall = ({
               }}
             />
           )}
+
+          {isMobile && isParticipantsListOpen && (
+            <CallingParticipantList
+              handRaisedParticipants={handRaisedParticipants}
+              callingRepository={callingRepository}
+              conversation={conversation}
+              participants={participants}
+              isModerator={isModerator}
+              isSelfVerified={selfUser?.is_verified()}
+              showParticipants={true}
+              onClose={toggleParticipantsList}
+            />
+          )}
         </div>
 
         {isMobile && isPaginationVisible && (
@@ -421,7 +434,7 @@ const FullscreenVideoCall = ({
           </>
         )}
       </div>
-      {isParticipantsListOpen && (
+      {!isMobile && isParticipantsListOpen && (
         <CallingParticipantList
           handRaisedParticipants={handRaisedParticipants}
           callingRepository={callingRepository}
@@ -430,6 +443,7 @@ const FullscreenVideoCall = ({
           isModerator={isModerator}
           isSelfVerified={selfUser?.is_verified()}
           showParticipants={true}
+          onClose={toggleParticipantsList}
         />
       )}
       <ModalComponent

--- a/src/style/foundation/video-calling.less
+++ b/src/style/foundation/video-calling.less
@@ -60,6 +60,7 @@
 }
 
 .video-element-remote {
+  position: relative;
   display: flex;
   flex: 1;
   flex-direction: column;

--- a/src/types/i18n.d.ts
+++ b/src/types/i18n.d.ts
@@ -333,9 +333,9 @@ declare module 'I18n/en-US.json' {
     'callNoOneJoined': `no other participant joined.`;
     'callParticipants': `{number} on call`;
     'callReactionButtonAriaLabel': `Select emoji {emoji}`;
-    'callReactionButtonsAriaLabel': `Emoji selection bar`;
-    'callReactionEmojiPickerAriaLabel': `Emoji picker`;
-    'callReactionEmojiPickerButtonAriaLabel': `Open emoji picker`;
+    'callReactionButtonsAriaLabel': `Reactions`;
+    'callReactionEmojiPickerAriaLabel': `Emoji collection`;
+    'callReactionEmojiPickerButtonAriaLabel': `View all reactions`;
     'callReactions': `Reactions`;
     'callReactionsAriaLabel': `Emoji {emoji} from {from}`;
     'callStateCbr': `Constant Bit Rate`;
@@ -1679,6 +1679,7 @@ declare module 'I18n/en-US.json' {
     'videoCallOverlayMicrophone': `Microphone`;
     'videoCallOverlayOpenFullScreen': `Open the call in full screen`;
     'videoCallOverlayOpenPopupWindow': `Open in a new window`;
+    'videoCallOverlayParticipantsListCloseButton': `Hide participants`;
     'videoCallOverlayParticipantsListLabel': `Participants ({count})`;
     'videoCallOverlayParticipantsRaisedHandListLabel': `Raised hands ({count})`;
     'videoCallOverlayShareScreen': `Share Screen`;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16184" title="WPB-16184" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16184</a>  [Web] Minimize popped out calling view to slim, select participant list, it is not shown
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
Fixes the issue where participants list was not visible in popped out calling view for small screens. With this change participants list will be shown over the video feed on small screens.

## Screenshots/Screencast (for UI changes)
### Before
<img width="469" alt="issue-WPB-16184" src="https://github.com/user-attachments/assets/4c28bbe8-5578-4755-93f1-812f550e4704" />

### After
<img width="381" alt="fix-WPB-16184" src="https://github.com/user-attachments/assets/999acbd3-2765-474f-8b35-6df032fc1728" />
<img width="378" alt="fix2-WPB-16184" src="https://github.com/user-attachments/assets/684680fb-7959-439f-88a3-3a7a452dc590" />

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;
