### PR TITLE
fix: clicking on pagination dots to switch pages [WPB-16183]

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -1750,5 +1750,8 @@
   "accountAlreadyExistsModal.content": "You can't log in with this email on the on-premises backend {backendName}.\nPlease change your email in the account settings or delete your account. Then, you can use this email again for your on-premises account.",
   "accountAlreadyExistsModal.changeEmailLink": "Change your email address",
   "accountAlreadyExistsModal.deletePersonalAccount": "Delete personal account",
-  "accountAlreadyExistsModal.removeTeamMember": "remove team member"
+  "accountAlreadyExistsModal.removeTeamMember": "remove team member",
+  "paginationLeftArrowAriaLabel": "Go to previous page",
+  "paginationRightArrowAriaLabel": "Go to next page",
+  "paginationDotAriaLabel": "Go to page {page}"
 }

--- a/src/script/components/calling/Pagination/Pagination.styles.ts
+++ b/src/script/components/calling/Pagination/Pagination.styles.ts
@@ -34,7 +34,7 @@ export const paginationDotsContainerStyles: CSSObject = {
   borderRadius: 12,
 };
 
-export const dotWrapperStyles = (isSmaller: boolean): CSSObject => {
+export const dotButtonStyles = (isSmaller: boolean): CSSObject => {
   return {
     display: 'flex',
     justifyContent: 'center',

--- a/src/script/components/calling/Pagination/Pagination.styles.ts
+++ b/src/script/components/calling/Pagination/Pagination.styles.ts
@@ -19,13 +19,13 @@
 
 import {CSSObject} from '@emotion/react';
 
-export const paginationWrapperStyles: CSSObject = {
+export const paginationContainerStyles: CSSObject = {
   display: 'flex',
   alignItems: 'center',
   gap: '4px',
 };
 
-export const paginationItemsStyles: CSSObject = {
+export const paginationDotsContainerStyles: CSSObject = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
@@ -34,7 +34,7 @@ export const paginationItemsStyles: CSSObject = {
   borderRadius: 12,
 };
 
-export const paginationItemWrapperStyles = (isSmaller: boolean): CSSObject => {
+export const dotWrapperStyles = (isSmaller: boolean): CSSObject => {
   return {
     display: 'flex',
     justifyContent: 'center',
@@ -48,15 +48,15 @@ export const paginationItemWrapperStyles = (isSmaller: boolean): CSSObject => {
   };
 };
 
-export const paginationItemStyles = (isCurrentPage: boolean, isSmaller: boolean): CSSObject => {
+export const dotStyles = (isActive: boolean, isSmaller: boolean): CSSObject => {
   return {
     borderRadius: '50%',
     '&:active': {
-      backgroundColor: isCurrentPage ? 'var(--accent-color)' : 'var(--toggle-button-unselected-bg)',
+      backgroundColor: isActive ? 'var(--accent-color)' : 'var(--toggle-button-unselected-bg)',
       border: '1px solid var(--accent-color)',
     },
-    backgroundColor: isCurrentPage ? 'var(--accent-color)' : 'transparent',
-    border: isCurrentPage ? 'solid 1px var(--accent-color)' : 'solid 1px var(--foreground)',
+    backgroundColor: isActive ? 'var(--accent-color)' : 'transparent',
+    border: isActive ? 'solid 1px var(--accent-color)' : 'solid 1px var(--foreground)',
     width: isSmaller ? '8px' : '12px',
     height: isSmaller ? '8px' : '12px',
   };

--- a/src/script/components/calling/Pagination/Pagination.test.tsx
+++ b/src/script/components/calling/Pagination/Pagination.test.tsx
@@ -1,0 +1,85 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render, fireEvent} from '@testing-library/react';
+
+import {withTheme} from 'src/script/auth/util/test/TestUtil';
+
+import {Pagination} from './Pagination';
+
+const testIdentifiers = {
+  paginationItem: 'pagination-item',
+  paginationPrevious: 'pagination-previous',
+  paginationNext: 'pagination-next',
+};
+
+describe('Pagination', () => {
+  const onChangePageMock = jest.fn();
+
+  const renderPagination = (props = {}) =>
+    render(withTheme(<Pagination totalPages={10} currentPage={0} onChangePage={onChangePageMock} {...props} />));
+
+  beforeEach(() => {
+    onChangePageMock.mockClear();
+  });
+
+  it('should render correct number of dots', () => {
+    const {getAllByTestId} = renderPagination();
+    expect(getAllByTestId(testIdentifiers.paginationItem)).toHaveLength(5);
+  });
+
+  it('should show correct active dot', () => {
+    const {getAllByTestId} = renderPagination({currentPage: 2});
+    const dots = getAllByTestId(testIdentifiers.paginationItem);
+    expect(dots[2]).toHaveAttribute('data-uie-status', 'active');
+  });
+
+  it('should disable previous button on first page', () => {
+    const {getByTestId} = renderPagination({currentPage: 0});
+    expect(getByTestId(testIdentifiers.paginationPrevious)).toBeDisabled();
+  });
+
+  it('should disable next button on last page', () => {
+    const {getByTestId} = renderPagination({currentPage: 9});
+    expect(getByTestId(testIdentifiers.paginationNext)).toBeDisabled();
+  });
+
+  it('should calls onChangePage when dot is clicked', () => {
+    const {getAllByTestId} = renderPagination();
+    fireEvent.click(getAllByTestId(testIdentifiers.paginationItem)[2]);
+    expect(onChangePageMock).toHaveBeenCalledWith(2);
+  });
+
+  it('should navigates to next page when clicking next button', () => {
+    const {getByTestId} = renderPagination({currentPage: 4});
+    fireEvent.click(getByTestId(testIdentifiers.paginationNext));
+    expect(onChangePageMock).toHaveBeenCalledWith(5);
+  });
+
+  it('should navigates to previous page when clicking previous button', () => {
+    const {getByTestId} = renderPagination({currentPage: 4});
+    fireEvent.click(getByTestId(testIdentifiers.paginationPrevious));
+    expect(onChangePageMock).toHaveBeenCalledWith(3);
+  });
+
+  it('should adjusts visible dots for smaller total pages', () => {
+    const {getAllByTestId} = renderPagination({totalPages: 3});
+    expect(getAllByTestId(testIdentifiers.paginationItem)).toHaveLength(3);
+  });
+});

--- a/src/script/components/calling/Pagination/PaginationArrow.tsx
+++ b/src/script/components/calling/Pagination/PaginationArrow.tsx
@@ -20,6 +20,7 @@
 import {ChevronIcon, IconButton, IconButtonVariant} from '@wireapp/react-ui-kit';
 
 import {handleKeyDown, KEY} from 'Util/KeyboardUtil';
+import {t} from 'Util/LocalizerUtil';
 
 import {chevronLeftStyles, chevronRightStyles, iconButtonStyles} from './Pagination.styles';
 
@@ -30,7 +31,9 @@ interface PaginationArrowProps {
   'data-uie-name': string;
 }
 
-export function PaginationArrow({onClick, disabled, direction, 'data-uie-name': uieName}: PaginationArrowProps) {
+export const PaginationArrow = ({onClick, disabled, direction, 'data-uie-name': uieName}: PaginationArrowProps) => {
+  const ariaLabel = direction === 'left' ? t('paginationLeftArrowAriaLabel') : t('paginationRightArrowAriaLabel');
+
   return (
     <IconButton
       variant={IconButtonVariant.SECONDARY}
@@ -46,8 +49,9 @@ export function PaginationArrow({onClick, disabled, direction, 'data-uie-name': 
       disabled={disabled}
       data-uie-name={uieName}
       type="button"
+      aria-label={ariaLabel}
     >
-      <ChevronIcon css={direction === 'left' ? chevronLeftStyles : chevronRightStyles} />
+      <ChevronIcon css={direction === 'left' ? chevronLeftStyles : chevronRightStyles} aria-hidden="true" />
     </IconButton>
   );
-}
+};

--- a/src/script/components/calling/Pagination/PaginationArrow.tsx
+++ b/src/script/components/calling/Pagination/PaginationArrow.tsx
@@ -1,0 +1,53 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {ChevronIcon, IconButton, IconButtonVariant} from '@wireapp/react-ui-kit';
+
+import {handleKeyDown, KEY} from 'Util/KeyboardUtil';
+
+import {chevronLeftStyles, chevronRightStyles, iconButtonStyles} from './Pagination.styles';
+
+interface PaginationArrowProps {
+  onClick: () => void;
+  disabled?: boolean;
+  direction: 'left' | 'right';
+  'data-uie-name': string;
+}
+
+export function PaginationArrow({onClick, disabled, direction, 'data-uie-name': uieName}: PaginationArrowProps) {
+  return (
+    <IconButton
+      variant={IconButtonVariant.SECONDARY}
+      css={iconButtonStyles}
+      onClick={onClick}
+      onKeyDown={event =>
+        handleKeyDown({
+          event,
+          callback: onClick,
+          keys: [KEY.ENTER, KEY.SPACE],
+        })
+      }
+      disabled={disabled}
+      data-uie-name={uieName}
+      type="button"
+    >
+      <ChevronIcon css={direction === 'left' ? chevronLeftStyles : chevronRightStyles} />
+    </IconButton>
+  );
+}

--- a/src/script/components/calling/Pagination/PaginationDot.tsx
+++ b/src/script/components/calling/Pagination/PaginationDot.tsx
@@ -1,0 +1,54 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {handleKeyDown, KEY} from 'Util/KeyboardUtil';
+
+import {dotStyles, dotWrapperStyles} from './Pagination.styles';
+
+interface PaginationDotProps {
+  page: number;
+  isCurrentPage: boolean;
+  isSmaller: boolean;
+  onClick: (page: number) => void;
+}
+
+export function PaginationDot({page, isCurrentPage, isSmaller, onClick}: PaginationDotProps) {
+  return (
+    <div
+      key={page}
+      css={dotWrapperStyles(isSmaller)}
+      onClick={() => onClick(page)}
+      onKeyDown={event =>
+        handleKeyDown({
+          event,
+          callback: () => onClick(page),
+          keys: [KEY.ENTER, KEY.SPACE],
+        })
+      }
+      role="button"
+      tabIndex={0}
+    >
+      <div
+        data-uie-name="pagination-item"
+        data-uie-status={isCurrentPage ? 'active' : 'inactive'}
+        css={dotStyles(isCurrentPage, isSmaller)}
+      />
+    </div>
+  );
+}

--- a/src/script/components/calling/Pagination/PaginationDot.tsx
+++ b/src/script/components/calling/Pagination/PaginationDot.tsx
@@ -18,8 +18,9 @@
  */
 
 import {handleKeyDown, KEY} from 'Util/KeyboardUtil';
+import {t} from 'Util/LocalizerUtil';
 
-import {dotStyles, dotWrapperStyles} from './Pagination.styles';
+import {dotStyles, dotButtonStyles} from './Pagination.styles';
 
 interface PaginationDotProps {
   page: number;
@@ -28,11 +29,11 @@ interface PaginationDotProps {
   onClick: (page: number) => void;
 }
 
-export function PaginationDot({page, isCurrentPage, isSmaller, onClick}: PaginationDotProps) {
+export const PaginationDot = ({page, isCurrentPage, isSmaller, onClick}: PaginationDotProps) => {
   return (
-    <div
-      key={page}
-      css={dotWrapperStyles(isSmaller)}
+    <button
+      className="icon-button"
+      css={dotButtonStyles(isSmaller)}
       onClick={() => onClick(page)}
       onKeyDown={event =>
         handleKeyDown({
@@ -41,14 +42,13 @@ export function PaginationDot({page, isCurrentPage, isSmaller, onClick}: Paginat
           keys: [KEY.ENTER, KEY.SPACE],
         })
       }
-      role="button"
-      tabIndex={0}
+      aria-label={t('paginationDotAriaLabel', {page: page + 1})}
     >
       <div
         data-uie-name="pagination-item"
         data-uie-status={isCurrentPage ? 'active' : 'inactive'}
         css={dotStyles(isCurrentPage, isSmaller)}
       />
-    </div>
+    </button>
   );
-}
+};

--- a/src/types/i18n.d.ts
+++ b/src/types/i18n.d.ts
@@ -1755,6 +1755,9 @@ declare module 'I18n/en-US.json' {
     'accountAlreadyExistsModal.changeEmailLink': `Change your email address`;
     'accountAlreadyExistsModal.deletePersonalAccount': `Delete personal account`;
     'accountAlreadyExistsModal.removeTeamMember': `remove team member`;
+    'paginationLeftArrowAriaLabel': `Go to previous page`;
+    'paginationRightArrowAriaLabel': `Go to next page`;
+    'paginationDotAriaLabel': `Go to page {page}`;
   };
   export default translations;
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16183" title="WPB-16183" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16183</a>  [Web] Popped out calling view when resized small, clicking on bubble to change page should not do anything
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
Fixes an issue where clicking on pagination dot buttons had no effect, preventing users from switching pages.

## Screenshots/Screencast (for UI changes)
### Before
https://github.com/user-attachments/assets/c44c1336-4e80-4c08-bfd5-8086d9afe2a7

### After
https://github.com/user-attachments/assets/74b72ecb-4a71-45f5-9f43-8e70fc26fd33

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;