### PR TITLE
feat: bump to AVS 9.10.25 [WPB-16289]

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@lexical/rich-text": "0.25.0",
     "@mediapipe/tasks-vision": "0.10.21",
     "@tanstack/react-virtual": "^3.13.0",
-    "@wireapp/avs": "9.10.16",
+    "@wireapp/avs": "9.10.25",
     "@wireapp/avs-debugger": "0.0.7",
     "@wireapp/commons": "5.4.1",
     "@wireapp/core": "46.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6204,10 +6204,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/avs@npm:9.10.16":
-  version: 9.10.16
-  resolution: "@wireapp/avs@npm:9.10.16"
-  checksum: 10/2ed7b43e5be5bfadfb8eb870cdfc2a758f835e87304e7c445114580831b63e720c6a96e12db7addd90b8581c2ffc424b1e65987ea4c34d9e19bb45aa5ba3701f
+"@wireapp/avs@npm:9.10.25":
+  version: 9.10.25
+  resolution: "@wireapp/avs@npm:9.10.25"
+  checksum: 10/9c8ac87aa6a5cac5443f0723fdd1ae660d10c07f663ae9c5d2529c5882a0f80b5226533a23a463527aa73a468a21e7deb81acb6e2a254fefc57cef94e5612508
   languageName: node
   linkType: hard
 
@@ -19478,7 +19478,7 @@ __metadata:
     "@types/uuid": "npm:^10.0.0"
     "@types/webpack-env": "npm:1.18.8"
     "@types/wicg-file-system-access": "npm:^2023.10.5"
-    "@wireapp/avs": "npm:9.10.16"
+    "@wireapp/avs": "npm:9.10.25"
     "@wireapp/avs-debugger": "npm:0.0.7"
     "@wireapp/commons": "npm:5.4.1"
     "@wireapp/copy-config": "npm:2.3.0"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16289" title="WPB-16289" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-16289</a>  [AVS-WEB] AVS warnings after WebApp cleaned dev branch from simulcast features
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Remove warnings in stats logs

## Description

In AVS, all remote sources of tracks are checked for audio level without filtering. This leads to a lot of warnings if the remote tracks are not assigned to a participant. The bump fixes the problem.

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
