### PR TITLE
chore(deps): bump AVS to 10.0.7 [WPB-16177]

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@lexical/rich-text": "0.25.0",
     "@mediapipe/tasks-vision": "0.10.21",
     "@tanstack/react-virtual": "^3.13.0",
-    "@wireapp/avs": "10.0.5",
+    "@wireapp/avs": "10.0.7",
     "@wireapp/avs-debugger": "0.0.7",
     "@wireapp/commons": "5.4.1",
     "@wireapp/core": "46.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6204,10 +6204,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/avs@npm:10.0.5":
-  version: 10.0.5
-  resolution: "@wireapp/avs@npm:10.0.5"
-  checksum: 10/564b2de35d7ff2a57c78407f5317a02b4de887b091bb5df7a695111d59511763b970dd26971fd1233397f314f719cb9d0129bc88f924754949905b1ebcf78dd5
+"@wireapp/avs@npm:10.0.7":
+  version: 10.0.7
+  resolution: "@wireapp/avs@npm:10.0.7"
+  checksum: 10/622ecccac2fd3ebeec066b275775ac8e49a91523c9749155cbdf4aa5653a2a4268a29e612a966fc6f74900fd5bf64a73c303c6808f2ad2fe08bd8ef313ec9af8
   languageName: node
   linkType: hard
 
@@ -19478,7 +19478,7 @@ __metadata:
     "@types/uuid": "npm:^10.0.0"
     "@types/webpack-env": "npm:1.18.8"
     "@types/wicg-file-system-access": "npm:^2023.10.5"
-    "@wireapp/avs": "npm:10.0.5"
+    "@wireapp/avs": "npm:10.0.7"
     "@wireapp/avs-debugger": "npm:0.0.7"
     "@wireapp/commons": "npm:5.4.1"
     "@wireapp/copy-config": "npm:2.3.0"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16177" title="WPB-16177" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-16177</a>  |Web] Bump AVS to 10.0.7
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
see https://github.com/wireapp/wire-webapp/pull/18769 copying the description here:

In this PR, we are upgrading the AVS version to 10.0.7. Version 10.0.6 does not contain any features and was skipped for technical reasons.

The change is that AVS now includes a browser switch.

Firefox will always send the high resolution first, while Chrome will always send the lower resolution first. Additionally, Firefox will only send the high resolution during screen sharing. The reason for this is that Firefox has only properly supported simulcast for screen sharing since version 135 (as of January 2025). However, since it is not yet perfect, we are temporarily disabling it.

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
