### PR TITLE
feat: use recent emojis for in call reactions and move away hand raise button (WPB-16323)

### DIFF
--- a/src/script/components/calling/VideoControls/EmojisBar/EmojisBar.tsx
+++ b/src/script/components/calling/VideoControls/EmojisBar/EmojisBar.tsx
@@ -26,7 +26,7 @@ import {t} from 'Util/LocalizerUtil';
 
 import {styles} from './EmojisBar.styles';
 
-const EMOJIS_LIST = ['👍', '🎉', '❤️', '😂', '😮', '👏', '🤔', '😢'];
+const DEFAULT_EMOJI_LIST = ['👍', '🎉', '❤️', '😂', '😮', '👏', '🤔', '😢'];
 
 export interface EmojisBarProps {
   onEmojiClick: (emoji: string) => void;
@@ -68,6 +68,16 @@ export const EmojisBar = ({onEmojiClick, onPickerEmojiClick, targetWindow}: Emoj
     };
   }, [targetWindow, onPickerEmojiClick]);
 
+  const recentEmojis: {unified: string; original: string; count: number}[] = JSON.parse(
+    localStorage.getItem('epr_suggested') ?? '[]',
+  );
+
+  const recentTopEmojis = recentEmojis
+    .sort((emojiA, emojiB) => emojiB.count - emojiA.count)
+    .map(emoji => String.fromCodePoint(parseInt(emoji.unified, 16)))
+    .concat(DEFAULT_EMOJI_LIST)
+    .slice(0, 8);
+
   return (
     <div ref={emojisBarRef}>
       {showEmojiPicker ? (
@@ -86,7 +96,7 @@ export const EmojisBar = ({onEmojiClick, onPickerEmojiClick, targetWindow}: Emoj
           aria-label={t('callReactionButtonsAriaLabel')}
           css={styles.emojisBar}
         >
-          {EMOJIS_LIST.map(emoji => {
+          {recentTopEmojis.map(emoji => {
             const isDisabled = disabledEmojis.includes(emoji);
             return (
               <button

--- a/src/script/components/calling/VideoControls/VideoControls.tsx
+++ b/src/script/components/calling/VideoControls/VideoControls.tsx
@@ -678,6 +678,32 @@ export const VideoControls: React.FC<VideoControlsProps> = ({
 
         {isDesktop && (
           <>
+            {isInCallHandRaiseControlVisible && (
+              <li className="video-controls__item">
+                <button
+                  data-uie-value={isSelfHandRaised ? 'active' : 'inactive'}
+                  onClick={() => toggleIsHandRaised(isSelfHandRaised)}
+                  onKeyDown={event =>
+                    handleKeyDown({
+                      event,
+                      callback: () => toggleIsHandRaised(isSelfHandRaised),
+                      keys: [KEY.ENTER, KEY.SPACE],
+                    })
+                  }
+                  className={classNames('video-controls__button_primary', {active: isSelfHandRaised})}
+                  type="button"
+                  data-uie-name="do-toggle-hand-raise"
+                  role="switch"
+                  aria-checked={isSelfHandRaised}
+                  title={
+                    isSelfHandRaised ? t('videoCallParticipantLowerYourHand') : t('videoCallParticipantRaiseYourHand')
+                  }
+                >
+                  <RaiseHandIcon width={16} height={16} />
+                </button>
+              </li>
+            )}
+
             {participants.length > 2 && (
               <li className="video-controls__item">
                 <button
@@ -720,32 +746,6 @@ export const VideoControls: React.FC<VideoControlsProps> = ({
                     />
                   )}
                   <GridIcon width={16} height={16} />
-                </button>
-              </li>
-            )}
-
-            {isInCallHandRaiseControlVisible && (
-              <li className="video-controls__item">
-                <button
-                  data-uie-value={isSelfHandRaised ? 'active' : 'inactive'}
-                  onClick={() => toggleIsHandRaised(isSelfHandRaised)}
-                  onKeyDown={event =>
-                    handleKeyDown({
-                      event,
-                      callback: () => toggleIsHandRaised(isSelfHandRaised),
-                      keys: [KEY.ENTER, KEY.SPACE],
-                    })
-                  }
-                  className={classNames('video-controls__button_primary', {active: isSelfHandRaised})}
-                  type="button"
-                  data-uie-name="do-toggle-hand-raise"
-                  role="switch"
-                  aria-checked={isSelfHandRaised}
-                  title={
-                    isSelfHandRaised ? t('videoCallParticipantLowerYourHand') : t('videoCallParticipantRaiseYourHand')
-                  }
-                >
-                  <RaiseHandIcon width={16} height={16} />
                 </button>
               </li>
             )}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16323" title="WPB-16323" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16323</a>  [Web] Improvements for incall reaction (standard emojis) and positioning of hand raise
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

![image](https://github.com/user-attachments/assets/91e428c7-7c80-40f5-a6d5-a6de64822745)

