### PR TITLE
fix: pagination active dot visibility [WPB-16183]

### DIFF
--- a/src/script/components/calling/Pagination/PaginationDot.tsx
+++ b/src/script/components/calling/Pagination/PaginationDot.tsx
@@ -43,12 +43,12 @@ export const PaginationDot = ({page, isCurrentPage, isSmaller, onClick}: Paginat
         })
       }
       aria-label={t('paginationDotAriaLabel', {page: page + 1})}
+      aria-current={isCurrentPage ? 'page' : undefined}
+      data-page={page}
+      data-uie-name="pagination-item"
+      data-uie-status={isCurrentPage ? 'active' : 'inactive'}
     >
-      <div
-        data-uie-name="pagination-item"
-        data-uie-status={isCurrentPage ? 'active' : 'inactive'}
-        css={dotStyles(isCurrentPage, isSmaller)}
-      />
+      <div css={dotStyles(isCurrentPage, isSmaller)} />
     </button>
   );
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16183" title="WPB-16183" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16183</a>  [Web] Popped out calling view when resized small, clicking on bubble to change page should not do anything
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
Fixes the issue where use can navigate through pagination dot buttons but active dot was not rendering properly and user cannot see the exact active page.

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;
