### PR TITLE
fix: icon for pop out calling view button in dark mode [WPB-16170]

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@wireapp/avs-debugger": "0.0.7",
     "@wireapp/commons": "5.4.1",
     "@wireapp/core": "46.19.3",
-    "@wireapp/react-ui-kit": "9.37.0",
+    "@wireapp/react-ui-kit": "9.38.0",
     "@wireapp/store-engine-dexie": "2.1.15",
     "@wireapp/telemetry": "0.3.1",
     "@wireapp/webapp-events": "0.28.0",

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -24,7 +24,14 @@ import {TabIndex} from '@wireapp/react-ui-kit/lib/types/enums';
 import cx from 'classnames';
 import {container} from 'tsyringe';
 
-import {Checkbox, CheckboxLabel, IconButton, IconButtonVariant, QUERY} from '@wireapp/react-ui-kit';
+import {
+  Checkbox,
+  CheckboxLabel,
+  IconButton,
+  IconButtonVariant,
+  OpenDetachedWindowIcon,
+  QUERY,
+} from '@wireapp/react-ui-kit';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {useAppNotification} from 'Components/AppNotification/AppNotification';
@@ -332,7 +339,7 @@ const FullscreenVideoCall = ({
                 data-uie-name="do-call-controls-video-maximize"
                 title={t('videoCallOverlayOpenPopupWindow')}
               >
-                <Icon.OpenDetachedWindowIcon />
+                <OpenDetachedWindowIcon />
               </IconButton>
             )}
           </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6390,9 +6390,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/react-ui-kit@npm:9.37.0":
-  version: 9.37.0
-  resolution: "@wireapp/react-ui-kit@npm:9.37.0"
+"@wireapp/react-ui-kit@npm:9.38.0":
+  version: 9.38.0
+  resolution: "@wireapp/react-ui-kit@npm:9.38.0"
   dependencies:
     "@types/color": "npm:3.0.6"
     color: "npm:4.2.3"
@@ -6407,7 +6407,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/b0232d671c3a60195111396be88abea7de54b4effeb7f264705a775be7d4a78bb31e0e70d8796a5e17bc897c49e61c6e8d2b5f708bc26ebf88dd4741578b5f29
+  checksum: 10/257bad9034c9ab4ec3a942853a3a7f1beafb62a44fa1e439465402d027819ee1754e7b6bcc150465cf6d7184484896111ab425a4c9cb620966f20bec8418226b
   languageName: node
   linkType: hard
 
@@ -19485,7 +19485,7 @@ __metadata:
     "@wireapp/core": "npm:46.19.3"
     "@wireapp/eslint-config": "npm:3.0.7"
     "@wireapp/prettier-config": "npm:0.6.4"
-    "@wireapp/react-ui-kit": "npm:9.37.0"
+    "@wireapp/react-ui-kit": "npm:9.38.0"
     "@wireapp/store-engine": "npm:5.1.11"
     "@wireapp/store-engine-dexie": "npm:2.1.15"
     "@wireapp/telemetry": "npm:0.3.1"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16170" title="WPB-16170" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16170</a>  [Web] Dark mode pop out calling view button is not colored right
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
Fixes the pop out calling view button icon in dark mode.

## Screenshots/Screencast (for UI changes)
### Before
![27917add-9730-4cd6-b591-420e5b434347](https://github.com/user-attachments/assets/3181e1c6-129d-4bc0-87ef-ddc504f9249b)

### After
<img width="297" alt="fix1-WPB-16170" src="https://github.com/user-attachments/assets/95eac8e9-8faa-4858-bcd2-bdd5faac64f9" />

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;
