### PR TITLE
fix: delete REMOVE_TEAM_MEMBER link from acc already exists modal

### DIFF
--- a/src/script/auth/component/AccountAlreadyExistsModal.tsx
+++ b/src/script/auth/component/AccountAlreadyExistsModal.tsx
@@ -29,11 +29,8 @@ export interface AccountAlreadyExistsModalProps {
 }
 
 export const AccountAlreadyExistsModal = ({onClose}: AccountAlreadyExistsModalProps) => {
-  const {
-    CHANGE_EMAIL_ADDRESS: changeEmailAddressUrl,
-    DELETE_PERSONAL_ACCOUNT: deletePersonalAccountUrl,
-    REMOVE_TEAM_MEMBER: removeTeamMemberUrl,
-  } = Config.getConfig().URL.SUPPORT;
+  const {CHANGE_EMAIL_ADDRESS: changeEmailAddressUrl, DELETE_PERSONAL_ACCOUNT: deletePersonalAccountUrl} =
+    Config.getConfig().URL.SUPPORT;
 
   return (
     <Modal onClose={onClose}>
@@ -52,10 +49,6 @@ export const AccountAlreadyExistsModal = ({onClose}: AccountAlreadyExistsModalPr
           👉{' '}
           <Link href={deletePersonalAccountUrl} target="_blank" css={linkCss}>
             {t('accountAlreadyExistsModal.deletePersonalAccount')}
-          </Link>{' '}
-          {t('index.or')}{' '}
-          <Link href={removeTeamMemberUrl} target="_blank" css={linkCss}>
-            {t('accountAlreadyExistsModal.removeTeamMember')}
           </Link>
         </Text>
         <Button css={buttonCss} block type="button" onClick={onClose} data-uie-name="guest-link-join-submit-button">


### PR DESCRIPTION
## Description

Deleted REMOVE_TEAM_MEMBER link from acc already exists modal.

## Screenshots/Screencast (for UI changes)

<img width="706" alt="Screenshot 2025-03-04 at 10 53 53" src="https://github.com/user-attachments/assets/6c487768-33ec-4682-9f09-fde8b00355c2" />
## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
