### PR TITLE
fix: icon for pop in calling view button in dark mode [WPB-16170]

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@wireapp/avs-debugger": "0.0.7",
     "@wireapp/commons": "5.4.2",
     "@wireapp/core": "46.19.5",
-    "@wireapp/react-ui-kit": "9.38.0",
+    "@wireapp/react-ui-kit": "9.39.0",
     "@wireapp/store-engine-dexie": "2.1.15",
     "@wireapp/telemetry": "0.3.1",
     "@wireapp/webapp-events": "0.28.0",

--- a/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/src/script/components/calling/FullscreenVideoCall.tsx
@@ -27,6 +27,7 @@ import {container} from 'tsyringe';
 import {
   Checkbox,
   CheckboxLabel,
+  CloseDetachedWindowIcon,
   IconButton,
   IconButtonVariant,
   OpenDetachedWindowIcon,
@@ -319,7 +320,7 @@ const FullscreenVideoCall = ({
                 data-uie-name="do-call-controls-video-minimize"
                 title={t('videoCallOverlayCloseFullScreen')}
               >
-                {viewMode === CallingViewMode.DETACHED_WINDOW ? <Icon.CloseDetachedWindowIcon /> : <Icon.MessageIcon />}
+                {viewMode === CallingViewMode.DETACHED_WINDOW ? <CloseDetachedWindowIcon /> : <Icon.MessageIcon />}
               </IconButton>
             )}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7619,9 +7619,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/react-ui-kit@npm:9.38.0":
-  version: 9.38.0
-  resolution: "@wireapp/react-ui-kit@npm:9.38.0"
+"@wireapp/react-ui-kit@npm:9.39.0":
+  version: 9.39.0
+  resolution: "@wireapp/react-ui-kit@npm:9.39.0"
   dependencies:
     "@types/color": "npm:3.0.6"
     color: "npm:4.2.3"
@@ -7636,7 +7636,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/257bad9034c9ab4ec3a942853a3a7f1beafb62a44fa1e439465402d027819ee1754e7b6bcc150465cf6d7184484896111ab425a4c9cb620966f20bec8418226b
+  checksum: 10/93f7bdf45fdfb8c4921abd0de3c15863eea8acba6ae2b92abf7bf99f31082e0dd78584fe569c7f71b30031c8685937b319cc7e6c8cc5f8f20765415255a312f6
   languageName: node
   linkType: hard
 
@@ -20680,7 +20680,7 @@ __metadata:
     "@wireapp/core": "npm:46.19.5"
     "@wireapp/eslint-config": "npm:3.0.7"
     "@wireapp/prettier-config": "npm:0.6.4"
-    "@wireapp/react-ui-kit": "npm:9.38.0"
+    "@wireapp/react-ui-kit": "npm:9.39.0"
     "@wireapp/store-engine": "npm:5.1.11"
     "@wireapp/store-engine-dexie": "npm:2.1.15"
     "@wireapp/telemetry": "npm:0.3.1"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16170" title="WPB-16170" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16170</a>  [Web] Dark mode pop out calling view button is not colored right
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
Fixes the pop in calling view button icon in dark mode.

## Screenshots/Screencast (for UI changes)
### Before
<img width="358" alt="issue2-WPB-16170" src="https://github.com/user-attachments/assets/f6dd5142-f46c-4f7a-80f0-92dbd1fa7828" />

### After
<img width="358" alt="fix2-WPB-16170" src="https://github.com/user-attachments/assets/e42afd43-c2cb-4caf-8e6e-935d996ae3e8" />

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;
