### PR TITLE
fix(mls): Join guest room by external commit (WPB-16379)

### DIFF
--- a/src/script/conversation/ConversationRepository.test.ts
+++ b/src/script/conversation/ConversationRepository.test.ts
@@ -1956,6 +1956,10 @@ describe('ConversationRepository', () => {
           });
 
           jest.spyOn(container.resolve(Core).service!.mls!, 'conversationExists').mockResolvedValueOnce(true);
+
+          const conversationRepo = testFactory.conversation_repository!;
+          jest.spyOn(conversationRepo['conversationService'], 'mlsGroupExistsLocally').mockResolvedValue(false);
+
           return testFactory.conversation_repository['handleConversationEvent'](memberJoinEvent).then(() => {
             expect(testFactory.conversation_repository['onMemberJoin']).toHaveBeenCalled();
             expect(testFactory.conversation_repository.updateParticipatingUserEntities).toHaveBeenCalled();
@@ -1982,6 +1986,10 @@ describe('ConversationRepository', () => {
             Object.defineProperty(container.resolve(Core), 'clientId', {value: mockSelfClientId});
 
             jest.spyOn(container.resolve(Core).service!.mls!, 'conversationExists').mockResolvedValueOnce(true);
+
+            const conversationRepo = testFactory.conversation_repository!;
+            jest.spyOn(conversationRepo['conversationService'], 'mlsGroupExistsLocally').mockResolvedValue(false);
+
             return testFactory.conversation_repository['handleConversationEvent'](memberJoinEvent).then(() => {
               expect(testFactory.conversation_repository['onMemberJoin']).toHaveBeenCalled();
               expect(testFactory.conversation_repository.updateParticipatingUserEntities).toHaveBeenCalled();

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -3737,13 +3737,15 @@ export class ConversationRepository {
 
     const doesMLSGroupExistLocally = await this.conversationService.mlsGroupExistsLocally(groupId);
 
-    if (!doesMLSGroupExistLocally) {
+    if (doesMLSGroupExistLocally) {
       return;
     }
 
     if (isSelfJoin) {
       // if user has joined and was also event creator (eg. joined via guest link) we need to add its other clients to mls group
+      // we also need to join the conversation with the current self client
       try {
+        await this.core.service?.conversation.joinByExternalCommit(conversation.qualifiedId);
         await addOtherSelfClientsToMLSConversation(
           conversation,
           this.userState.self().qualifiedId,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16379" title="WPB-16379" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16379</a>  [Web] Joining a MLS group from a guest link is not working properly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

If user has joined and was also event creator (eg. joined via guest link) we need to add its other clients to mls group and we also need to join the conversation with the current self client. 

The previous version of the code used to exit out of `handleMLSConversationMemberJoin` function if a group did not exist locally exactly the opposite behavior was needed, if a group does not exist locally instead of exiting the function we should try to join by an external commit and also add our other clients to the conversation as well.