### PR TITLE
fix: show group settings to group members in read-only mode [WPB-15796]

### DIFF
--- a/src/script/components/toggle/ReceiptModeToggle.tsx
+++ b/src/script/components/toggle/ReceiptModeToggle.tsx
@@ -28,12 +28,15 @@ import * as Icon from '../Icon';
 export interface ReceiptModeToggleProps {
   onReceiptModeChanged: (receiptMode: RECEIPT_MODE) => void;
   receiptMode: RECEIPT_MODE;
+  disabled?: boolean;
 }
 
-const ReceiptModeToggle = ({receiptMode, onReceiptModeChanged}: ReceiptModeToggleProps) => {
+const ReceiptModeToggle = ({receiptMode, onReceiptModeChanged, disabled = false}: ReceiptModeToggleProps) => {
   const updateValue = () => {
-    const newReceiptMode = receiptMode !== RECEIPT_MODE.ON ? RECEIPT_MODE.ON : RECEIPT_MODE.OFF;
-    onReceiptModeChanged(newReceiptMode);
+    if (!disabled) {
+      const newReceiptMode = receiptMode !== RECEIPT_MODE.ON ? RECEIPT_MODE.ON : RECEIPT_MODE.OFF;
+      onReceiptModeChanged(newReceiptMode);
+    }
   };
 
   const inputRef = React.useRef<HTMLInputElement>(null);
@@ -41,7 +44,9 @@ const ReceiptModeToggle = ({receiptMode, onReceiptModeChanged}: ReceiptModeToggl
 
   return (
     <>
-      <div className="panel__action-item panel__action-item--toggle">
+      <div
+        className={`panel__action-item panel__action-item--toggle${disabled ? ' panel__action-item--disabled' : ''}`}
+      >
         <label
           htmlFor="receipt-toggle-input"
           data-uie-name="do-toggle-receipt-mode"
@@ -66,13 +71,16 @@ const ReceiptModeToggle = ({receiptMode, onReceiptModeChanged}: ReceiptModeToggl
           name="preferences_device_verification_toggle"
           onChange={() => updateValue()}
           type="checkbox"
+          disabled={disabled}
         />
 
         <button
-          className="button-label"
+          className={`button-label${disabled ? ' disabled' : ''}`}
           aria-pressed={receiptMode !== RECEIPT_MODE.OFF}
+          aria-disabled={disabled}
           type="button"
           onClick={() => updateValue()}
+          disabled={disabled}
         >
           <span className="button-label__switch" />
           <span className="visually-hidden">{t('receiptToggleLabel')}</span>

--- a/src/script/components/toggle/ReceiptModeToggle.tsx
+++ b/src/script/components/toggle/ReceiptModeToggle.tsx
@@ -20,6 +20,7 @@
 import React from 'react';
 
 import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data';
+import cx from 'classnames';
 
 import {t} from 'Util/LocalizerUtil';
 
@@ -45,7 +46,9 @@ const ReceiptModeToggle = ({receiptMode, onReceiptModeChanged, disabled = false}
   return (
     <>
       <div
-        className={`panel__action-item panel__action-item--toggle${disabled ? ' panel__action-item--disabled' : ''}`}
+        className={cx('panel__action-item', 'panel__action-item--toggle', {
+          'panel__action-item--disabled': disabled,
+        })}
       >
         <label
           htmlFor="receipt-toggle-input"
@@ -77,7 +80,6 @@ const ReceiptModeToggle = ({receiptMode, onReceiptModeChanged, disabled = false}
         <button
           className={`button-label${disabled ? ' disabled' : ''}`}
           aria-pressed={receiptMode !== RECEIPT_MODE.OFF}
-          aria-disabled={disabled}
           type="button"
           onClick={() => updateValue()}
           disabled={disabled}

--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.test.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.test.tsx
@@ -75,6 +75,8 @@ const getDefaultParams = () => {
     canLeaveGroup: () => true,
     canRenameGroup: () => true,
     canToggleTimeout: () => true,
+    canToggleGuests: () => true,
+    canToggleReadReceipts: () => true,
     isUserGroupAdmin: () => true,
   };
 

--- a/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsOptions/ConversationDetailsOption.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsOptions/ConversationDetailsOption.tsx
@@ -23,13 +23,14 @@ import * as Icon from 'Components/Icon';
 
 interface ConversationDetailsOptionProps {
   className: string;
-  onClick: () => void;
+  onClick?: () => void;
   title: string;
   icon: ReactElement;
   statusText: string;
   dataUieName: string;
   statusUieName: string;
   iconClassName?: string;
+  disabled?: boolean;
 }
 
 const ConversationDetailsOption: FC<ConversationDetailsOptionProps> = ({
@@ -40,9 +41,16 @@ const ConversationDetailsOption: FC<ConversationDetailsOptionProps> = ({
   statusText,
   dataUieName,
   statusUieName,
+  disabled = false,
 }) => (
   <li className={className}>
-    <button className="panel__action-item" onClick={onClick} data-uie-name={dataUieName} type="button">
+    <button
+      className="panel__action-item"
+      onClick={onClick}
+      data-uie-name={dataUieName}
+      type="button"
+      disabled={disabled}
+    >
       <span className="panel__action-item__icon">{icon}</span>
 
       <span className="panel__action-item__summary">
@@ -55,7 +63,7 @@ const ConversationDetailsOption: FC<ConversationDetailsOptionProps> = ({
         </p>
       </span>
 
-      <Icon.ChevronRight className="chevron-right-icon" />
+      {!disabled && <Icon.ChevronRight className="chevron-right-icon" />}
     </button>
   </li>
 );

--- a/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsOptions/ConversationDetailsOptions.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsOptions/ConversationDetailsOptions.tsx
@@ -112,20 +112,20 @@ const ConversationDetailsOptions = ({
   });
 
   const isActiveGroupParticipant = isGroup && !isSelfUserRemoved;
+  const isTeamConversation = !!teamId;
 
-  const showOptionGuests = isActiveGroupParticipant && !!teamId && roleRepository.canToggleGuests(activeConversation);
+  const showOptionGuests = isActiveGroupParticipant && isTeamConversation;
   const showOptionNotificationsGroup = isMutable && isGroup;
-  const showOptionTimedMessages =
-    isActiveGroupParticipant && roleRepository.canToggleTimeout(activeConversation) && isSelfDeletingMessagesEnabled;
-  const showOptionServices =
-    isActiveGroupParticipant &&
-    !!teamId &&
-    roleRepository.canToggleGuests(activeConversation) &&
-    !isMLSConversation(activeConversation);
+  const showOptionTimedMessages = isActiveGroupParticipant && isSelfDeletingMessagesEnabled;
+  const showOptionServices = isActiveGroupParticipant && isTeamConversation && !isMLSConversation(activeConversation);
   const showOptionNotifications1To1 = isMutable && !isGroup;
-  const showOptionReadReceipts = !!teamId && roleRepository.canToggleReadReceipts(activeConversation);
+  const showOptionReadReceipts = isTeamConversation;
 
   const hasReceiptsEnabled = conversationRepository.expectReadReceipt(activeConversation);
+
+  const canEditGuests = roleRepository.canToggleGuests(activeConversation);
+  const canEditTimeout = roleRepository.canToggleTimeout(activeConversation);
+  const canEditReadReceipts = roleRepository.canToggleReadReceipts(activeConversation);
 
   const openNotificationsPanel = () => togglePanel(PanelState.NOTIFICATIONS, activeConversation);
 
@@ -159,42 +159,49 @@ const ConversationDetailsOptions = ({
         {showOptionTimedMessages && (
           <ConversationDetailsOption
             className="conversation-details__timed-messages"
-            onClick={openTimedMessagePanel}
+            onClick={canEditTimeout ? openTimedMessagePanel : undefined}
             dataUieName="go-timed-messages"
             icon={<Icon.TimerIcon />}
             title={t('conversationDetailsActionTimedMessages')}
             statusUieName="status-timed-messages"
             statusText={timedMessagesText}
+            disabled={!canEditTimeout}
           />
         )}
 
         {showOptionGuests && (
           <ConversationDetailsOption
             className="conversation-details__guest-options"
-            onClick={openGuestPanel}
+            onClick={canEditGuests ? openGuestPanel : undefined}
             dataUieName="go-guest-options"
             icon={<Icon.GuestIcon />}
             title={t('conversationDetailsActionGuestOptions')}
             statusUieName="status-allow-guests"
             statusText={guestOptionsText}
+            disabled={!canEditGuests}
           />
         )}
 
         {showOptionServices && (
           <ConversationDetailsOption
             className="conversation-details__services-options"
-            onClick={openServicePanel}
+            onClick={canEditGuests ? openServicePanel : undefined}
             dataUieName="go-services-options"
             icon={<Icon.ServiceIcon className="service-icon" />}
             title={t('conversationDetailsActionServicesOptions')}
             statusUieName="status-allow-services"
             statusText={servicesOptionsText}
+            disabled={!canEditGuests}
           />
         )}
 
         {showOptionReadReceipts && (
           <li className="conversation-details__read-receipts">
-            <ReceiptModeToggle receiptMode={receiptMode} onReceiptModeChanged={updateConversationReceiptMode} />
+            <ReceiptModeToggle
+              receiptMode={receiptMode}
+              onReceiptModeChanged={updateConversationReceiptMode}
+              disabled={!canEditReadReceipts}
+            />
           </li>
         )}
 

--- a/src/style/panel/panel.less
+++ b/src/style/panel/panel.less
@@ -452,6 +452,10 @@ button.panel__action-item,
 .panel__action-button {
   .button-states();
   .text-medium;
+
+  &:disabled {
+    cursor: not-allowed;
+  }
 }
 
 button.panel__action-item:focus-visible {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15796" title="WPB-15796" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15796</a>  [Web] Make group options settings visible for regular users (not admins)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
This change makes group settings visible to all group members while maintaining admin-only edit permissions. Non-admin members can now view settings but cannot modify them.

- Modified `ConversationDetailsOptions` to show settings to all members
- Added `disabled` state to settings options for non-admin members
- Updated UI to indicate read-only state with visual cues
- Added proper cursor handling for disabled elements

## Screenshots/Screencast (for UI changes)
### Before
<img width="226" alt="issue-WPB-15796" src="https://github.com/user-attachments/assets/9d658faa-7841-4684-809b-25fd6c814bf8" />

### After
<img width="227" alt="fix-WPB-15796" src="https://github.com/user-attachments/assets/79e6615a-9937-4df0-9684-652a865f8fea" />

https://github.com/user-attachments/assets/2154b9f6-8048-471e-b2b6-bfc77640678f


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;
