### PR TITLE
runfix: achieve WYSIWYG with lists and blockquotes markdown rendering [WPB-16228]

### DIFF
--- a/src/script/components/InputBar/InputBarEditor/RichTextEditor/plugins/BlockquotePlugin/BlockquotePlugin.tsx
+++ b/src/script/components/InputBar/InputBarEditor/RichTextEditor/plugins/BlockquotePlugin/BlockquotePlugin.tsx
@@ -129,6 +129,7 @@ const registerBlockquoteBackspaceCommand = (editor: LexicalEditor) => {
       editor.update(() => {
         lastChild.remove();
         editor.dispatchCommand(INSERT_PARAGRAPH_COMMAND, undefined);
+        editor.dispatchCommand(INSERT_PARAGRAPH_COMMAND, undefined);
       });
 
       return true;

--- a/src/script/util/messageRenderer.ts
+++ b/src/script/util/messageRenderer.ts
@@ -102,7 +102,10 @@ markdownit.renderer.rules.paragraph_open = (tokens, idx) => {
 
   const previousToken = tokens[idx - 1];
   const isPreviousTokenList =
-    previousToken && (previousToken.type === 'bullet_list_close' || previousToken.type === 'ordered_list_close');
+    previousToken &&
+    (previousToken.type === 'bullet_list_close' ||
+      previousToken.type === 'ordered_list_close' ||
+      previousToken.type === 'blockquote_close');
 
   if (isPreviousTokenList) {
     return count > 1 ? `${'<br>'.repeat(count - 1)}` : '';

--- a/src/style/components/lexical-input.less
+++ b/src/style/components/lexical-input.less
@@ -214,6 +214,9 @@
 
   &__item {
     margin: 0 24px;
+    & .rtl {
+      margin: 24px 0;
+    }
 
     &--nested {
       list-style-type: none;
@@ -247,6 +250,19 @@
       list-style-position: outside;
       list-style-type: lower-roman;
     }
+  }
+
+  // keep the list indentation for the next paragraph after the list
+  & + .editor-paragraph,
+  // and for every paragraph with text with a parent with text
+  // the ltr class is present for a paragraph with left-to-right text
+  & ~ .ltr + .ltr {
+    margin-left: 24px;
+  }
+  // mirror for right-to-left languages
+  & + .rtl,
+  & ~ .rtl + .rtl {
+    margin-right: 24px;
   }
 }
 

--- a/src/style/components/lexical-input.less
+++ b/src/style/components/lexical-input.less
@@ -252,14 +252,14 @@
     }
   }
 
-  // keep the list indentation for the next paragraph after the list
+  /*  keep the list indentation for the next paragraph after the list 
+      and for every paragraph with text with a parent with text
+      the ltr class is present for a paragraph with left-to-right text  */
   & + .editor-paragraph,
-  // and for every paragraph with text with a parent with text
-  // the ltr class is present for a paragraph with left-to-right text
   & ~ .ltr + .ltr {
     margin-left: 24px;
   }
-  // mirror for right-to-left languages
+  /* mirror for right-to-left languages */
   & + .rtl,
   & ~ .rtl + .rtl {
     margin-right: 24px;


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16228" title="WPB-16228" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16228</a>  [Web] Fix quotes formatting
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16129" title="WPB-16129" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16229</a> [Web] Adding a line after list in richt text editor adds a tabulator when it should not
  </td></table>
  <br />

## Description

There's a couple of discrepancies between markdown rendering in the input bar and the message list:
- blockquotes are not correctly escaped in the input bar and appear in the message list
- lists need an extra new line to be escaped, which is not represented in the input bar

<!-- Uncomment this section if your PR has UI changes -->
## Screenshots/Screencast (for UI changes)
### before
![Kooha-2025-03-10-14-40-23](https://github.com/user-attachments/assets/ecf535bd-c005-4230-b142-fb79076eed89)
![Kooha-2025-03-10-14-42-20](https://github.com/user-attachments/assets/4bb567cc-4c12-4a0b-b4f6-4ce4e3a98437)

#### after
![Kooha-2025-03-10-14-33-23](https://github.com/user-attachments/assets/ed6ce62e-376d-450a-81f7-8370d5ab27b2)
![Kooha-2025-03-10-14-38-04](https://github.com/user-attachments/assets/83075d5c-1ff3-49ef-9f4f-9daf4daa3daa)


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
