### PR TITLE
fix: improve visibility of connection requests [WPB-14764]

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -200,7 +200,7 @@ export const Conversations: React.FC<ConversationsProps> = ({
     ![SidebarTabs.DIRECTS, SidebarTabs.GROUPS, SidebarTabs.FAVORITES].includes(currentTab) &&
     groupParticipantsConversations.length > 0;
 
-  const showConnectionrequests = [SidebarTabs.RECENT, SidebarTabs.DIRECTS].includes(currentTab);
+  const showConnectionRequests = [SidebarTabs.RECENT, SidebarTabs.DIRECTS].includes(currentTab);
   const hasVisibleConnectionRequests = connectRequests.length > 0 && showConnectionrequests;
   const hasVisibleConversations = currentTabConversations.length > 0;
   const hasNoVisbleConversations = !hasVisibleConversations && !hasVisibleConnectionRequests;

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -200,11 +200,15 @@ export const Conversations: React.FC<ConversationsProps> = ({
     ![SidebarTabs.DIRECTS, SidebarTabs.GROUPS, SidebarTabs.FAVORITES].includes(currentTab) &&
     groupParticipantsConversations.length > 0;
 
-  const hasNoConversations = conversations.length + connectRequests.length === 0;
+  const showConnectionrequests = [SidebarTabs.RECENT, SidebarTabs.DIRECTS].includes(currentTab);
+  const hasVisibleConnectionRequests = connectRequests.length > 0 && showConnectionrequests;
+  const hasVisibleConversations = currentTabConversations.length > 0;
+  const hasNoVisbleConversations = !hasVisibleConversations && !hasVisibleConnectionRequests;
+
   const hasEmptyConversationsList =
     !isGroupParticipantsVisible &&
-    ((showSearchInput && currentTabConversations.length === 0) ||
-      (hasNoConversations && currentTab !== SidebarTabs.ARCHIVES));
+    ((showSearchInput && hasNoVisbleConversations) ||
+      (hasNoVisbleConversations && currentTab !== SidebarTabs.ARCHIVES));
 
   const toggleSidebar = useCallback(() => {
     if (isFoldersTabOpen) {
@@ -339,7 +343,7 @@ export const Conversations: React.FC<ConversationsProps> = ({
             currentFolder={currentFolder}
             currentTab={currentTab}
             selfUser={selfUser}
-            showSearchInput={(showSearchInput && currentTabConversations.length !== 0) || !!conversationsFilter}
+            showSearchInput={(showSearchInput && hasVisibleConversations) || !!conversationsFilter}
             searchValue={conversationsFilter}
             setSearchValue={onSearch}
             searchInputPlaceholder={searchInputPlaceholder}
@@ -424,7 +428,7 @@ export const Conversations: React.FC<ConversationsProps> = ({
                 callState={callState}
                 currentFocus={currentFocus}
                 listViewModel={listViewModel}
-                connectRequests={connectRequests}
+                connectRequests={showConnectionrequests ? connectRequests : []}
                 handleArrowKeyDown={handleKeyDown}
                 conversationState={conversationState}
                 conversations={currentTabConversations}

--- a/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/Conversations.tsx
@@ -201,7 +201,7 @@ export const Conversations: React.FC<ConversationsProps> = ({
     groupParticipantsConversations.length > 0;
 
   const showConnectionRequests = [SidebarTabs.RECENT, SidebarTabs.DIRECTS].includes(currentTab);
-  const hasVisibleConnectionRequests = connectRequests.length > 0 && showConnectionrequests;
+  const hasVisibleConnectionRequests = connectRequests.length > 0 && showConnectionRequests;
   const hasVisibleConversations = currentTabConversations.length > 0;
   const hasNoVisbleConversations = !hasVisibleConversations && !hasVisibleConnectionRequests;
 
@@ -428,7 +428,7 @@ export const Conversations: React.FC<ConversationsProps> = ({
                 callState={callState}
                 currentFocus={currentFocus}
                 listViewModel={listViewModel}
-                connectRequests={showConnectionrequests ? connectRequests : []}
+                connectRequests={showConnectionRequests ? connectRequests : []}
                 handleArrowKeyDown={handleKeyDown}
                 conversationState={conversationState}
                 conversations={currentTabConversations}


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14764" title="WPB-14764" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14764</a>  [Web] Contact request is shown at the bottom of conversations list 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

- only show pending connection requests in All and 1:1 tabs
- do not show the empty conversations status if there are pending connection requests

this only fixes the very visible bug, it also should make it a bit easier to implement the redesign coming later https://www.figma.com/design/jnygr7PEOk1yHgjBF18udc/Desktop

<!-- Uncomment this section if your PR has UI changes -->

## Screenshots/Screencast (for UI changes)
#### Before
![image](https://github.com/user-attachments/assets/50b8d95a-5cae-4ef1-a40f-eb33b33e3b76)

#### After
![image](https://github.com/user-attachments/assets/f8e794ca-1d34-47e6-a68a-a059820247a8)


## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
