### PR TITLE
runfix: update the size of group icon [WPB-16537]

### DIFF
--- a/src/style/list/conversations.less
+++ b/src/style/list/conversations.less
@@ -65,8 +65,8 @@
       }
 
       .conversations-sidebar-btn[data-uie-name='go-groups-view'] svg {
-        width: 20px;
-        height: 20px;
+        width: 22px;
+        height: 22px;
       }
 
       .conversations-sidebar-btn span {
@@ -315,14 +315,14 @@
 
 .conversations-sidebar-btn {
   svg {
-    width: 18px;
+    width: 20px;
     height: 14px;
     flex-shrink: 0;
   }
 
   &[data-uie-name='go-groups-view'] svg {
-    width: 18px;
-    height: 18px;
+    width: 20px;
+    height: 20px;
   }
 
   svg.folders-open-indicator {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16537" title="WPB-16537" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16537</a>  [Web] Adapt sidebar entry for groups filter avatar to the new group avatar
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
Updated the size of group icon suggested in design review

## Screenshots/Screencast (for UI changes)
![Screenshot 2025-03-17 at 16 43 18](https://github.com/user-attachments/assets/97e8c68e-ef92-4e48-8a71-0859cb2bee00) ![Screenshot 2025-03-17 at 16 43 30](https://github.com/user-attachments/assets/c2109ebc-f3de-40d7-9166-dd386f27f230)


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
