### PR TITLE
fix: refresh camera preview after call ends [WPB-15315]

### DIFF
--- a/src/script/page/MainContent/panels/preferences/AVPreferences.tsx
+++ b/src/script/page/MainContent/panels/preferences/AVPreferences.tsx
@@ -17,12 +17,6 @@
  *
  */
 
-import {useEffect, useState} from 'react';
-
-import {amplify} from 'amplify';
-
-import {WebAppEvents} from '@wireapp/webapp-events';
-
 import {MediaDeviceType} from 'src/script/media/MediaDeviceType';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
@@ -33,12 +27,12 @@ import {CameraPreferences} from './avPreferences/CameraPreferences';
 import {MicrophonePreferences} from './avPreferences/MicrophonePreferences';
 import {SaveCallLogs} from './avPreferences/SaveCallLogs';
 import {PreferencesPage} from './components/PreferencesPage';
+import {useCameraReloadOnCallEnd} from './useCameraReloadOnCallEnd';
 
 import type {CallingRepository} from '../../../../calling/CallingRepository';
 import {useInitializeMediaDevices} from '../../../../hooks/useInitializeMediaDevices';
 import type {MediaRepository} from '../../../../media/MediaRepository';
 import type {PropertiesRepository} from '../../../../properties/PropertiesRepository';
-import {EventName} from '../../../../tracking/EventName';
 
 interface AVPreferencesProps {
   callingRepository: CallingRepository;
@@ -51,27 +45,13 @@ const AVPreferences = ({
   propertiesRepository,
   callingRepository,
 }: AVPreferencesProps) => {
-  const [shouldReloadCamera, setShouldReloadCamera] = useState(false);
+  const {shouldReloadCamera} = useCameraReloadOnCallEnd(callingRepository);
   const deviceSupport = useKoSubscribableChildren(devicesHandler?.deviceSupport, [
     MediaDeviceType.AUDIO_INPUT,
     MediaDeviceType.AUDIO_OUTPUT,
     MediaDeviceType.VIDEO_INPUT,
   ]);
   const {isMediaDevicesAreInitialized} = useInitializeMediaDevices(devicesHandler, streamHandler);
-
-  // Reset camera component when call ends
-  useEffect(() => {
-    const handleCallEnd = (eventName: string, segmentations: any) => {
-      if (eventName === EventName.CALLING.ENDED_CALL && !callingRepository.hasActiveCall()) {
-        setShouldReloadCamera(prev => !prev);
-      }
-    };
-
-    amplify.subscribe(WebAppEvents.ANALYTICS.EVENT, handleCallEnd);
-    return () => {
-      amplify.unsubscribe(WebAppEvents.ANALYTICS.EVENT, handleCallEnd);
-    };
-  }, [callingRepository]);
 
   return (
     <PreferencesPage title={t('preferencesAV')}>

--- a/src/script/page/MainContent/panels/preferences/useCameraReloadOnCallEnd.test.ts
+++ b/src/script/page/MainContent/panels/preferences/useCameraReloadOnCallEnd.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {act, renderHook} from '@testing-library/react';
+import {amplify} from 'amplify';
+
+import {WebAppEvents} from '@wireapp/webapp-events';
+
+import {useCameraReloadOnCallEnd} from './useCameraReloadOnCallEnd';
+
+import {EventName} from '../../../../tracking/EventName';
+
+jest.mock('amplify');
+
+describe('useCameraReloadOnCallEnd', () => {
+  const mockCallingRepository = {
+    hasActiveCall: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should initialize with camera reload state set to false', () => {
+    const {result} = renderHook(() => useCameraReloadOnCallEnd(mockCallingRepository as any));
+
+    expect(result.current.shouldReloadCamera).toBe(false);
+    expect(amplify.subscribe).toHaveBeenCalledWith(WebAppEvents.ANALYTICS.EVENT, expect.any(Function));
+  });
+
+  it('should toggle camera reload state when call ends and no active call exists', () => {
+    mockCallingRepository.hasActiveCall.mockReturnValue(false);
+
+    const {result} = renderHook(() => useCameraReloadOnCallEnd(mockCallingRepository as any));
+
+    const subscribeCall = (amplify.subscribe as jest.Mock).mock.calls[0];
+    const eventHandler = subscribeCall[1];
+
+    expect(result.current.shouldReloadCamera).toBe(false);
+
+    act(() => {
+      eventHandler(EventName.CALLING.ENDED_CALL);
+    });
+
+    expect(result.current.shouldReloadCamera).toBe(true);
+    expect(mockCallingRepository.hasActiveCall).toHaveBeenCalled();
+  });
+
+  it('should not toggle camera reload state when event is not ENDED_CALL', () => {
+    mockCallingRepository.hasActiveCall.mockReturnValue(false);
+
+    const {result} = renderHook(() => useCameraReloadOnCallEnd(mockCallingRepository as any));
+
+    const subscribeCall = (amplify.subscribe as jest.Mock).mock.calls[0];
+    const eventHandler = subscribeCall[1];
+
+    act(() => {
+      eventHandler('SOME_OTHER_EVENT');
+    });
+
+    expect(result.current.shouldReloadCamera).toBe(false);
+    expect(mockCallingRepository.hasActiveCall).not.toHaveBeenCalled();
+  });
+
+  it('should not toggle camera reload state when there is an active call', () => {
+    mockCallingRepository.hasActiveCall.mockReturnValue(true);
+
+    const {result} = renderHook(() => useCameraReloadOnCallEnd(mockCallingRepository as any));
+
+    const subscribeCall = (amplify.subscribe as jest.Mock).mock.calls[0];
+    const eventHandler = subscribeCall[1];
+
+    act(() => {
+      eventHandler(EventName.CALLING.ENDED_CALL);
+    });
+
+    expect(result.current.shouldReloadCamera).toBe(false);
+    expect(mockCallingRepository.hasActiveCall).toHaveBeenCalled();
+  });
+
+  it('should unsubscribe from events on unmount', () => {
+    const {unmount} = renderHook(() => useCameraReloadOnCallEnd(mockCallingRepository as any));
+
+    unmount();
+
+    expect(amplify.unsubscribe).toHaveBeenCalledWith(WebAppEvents.ANALYTICS.EVENT, expect.any(Function));
+  });
+});

--- a/src/script/page/MainContent/panels/preferences/useCameraReloadOnCallEnd.ts
+++ b/src/script/page/MainContent/panels/preferences/useCameraReloadOnCallEnd.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {useEffect, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 
 import {amplify} from 'amplify';
 
@@ -29,18 +29,21 @@ import {EventName} from '../../../../tracking/EventName';
 export const useCameraReloadOnCallEnd = (callingRepository: CallingRepository) => {
   const [shouldReloadCamera, setShouldReloadCamera] = useState(false);
 
-  useEffect(() => {
-    const handleCallEnd = (eventName: string) => {
+  const handleCallEnd = useCallback(
+    (eventName: string) => {
       if (eventName === EventName.CALLING.ENDED_CALL && !callingRepository.hasActiveCall()) {
         setShouldReloadCamera(prev => !prev);
       }
-    };
+    },
+    [callingRepository],
+  );
 
+  useEffect(() => {
     amplify.subscribe(WebAppEvents.ANALYTICS.EVENT, handleCallEnd);
     return () => {
       amplify.unsubscribe(WebAppEvents.ANALYTICS.EVENT, handleCallEnd);
     };
-  }, [callingRepository]);
+  }, [handleCallEnd]);
 
   return {shouldReloadCamera};
 };

--- a/src/script/page/MainContent/panels/preferences/useCameraReloadOnCallEnd.ts
+++ b/src/script/page/MainContent/panels/preferences/useCameraReloadOnCallEnd.ts
@@ -1,0 +1,46 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {useEffect, useState} from 'react';
+
+import {amplify} from 'amplify';
+
+import {WebAppEvents} from '@wireapp/webapp-events';
+
+import type {CallingRepository} from '../../../../calling/CallingRepository';
+import {EventName} from '../../../../tracking/EventName';
+
+export const useCameraReloadOnCallEnd = (callingRepository: CallingRepository) => {
+  const [shouldReloadCamera, setShouldReloadCamera] = useState(false);
+
+  useEffect(() => {
+    const handleCallEnd = (eventName: string) => {
+      if (eventName === EventName.CALLING.ENDED_CALL && !callingRepository.hasActiveCall()) {
+        setShouldReloadCamera(prev => !prev);
+      }
+    };
+
+    amplify.subscribe(WebAppEvents.ANALYTICS.EVENT, handleCallEnd);
+    return () => {
+      amplify.unsubscribe(WebAppEvents.ANALYTICS.EVENT, handleCallEnd);
+    };
+  }, [callingRepository]);
+
+  return {shouldReloadCamera};
+};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15315" title="WPB-15315" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15315</a>  [Web] Settings React View is not updated if video ended
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
Fixes black screen issue in Audio Video preferences when returning from a call by properly refreshing the camera preview component.

## Screenshots/Screencast (for UI changes)
### Before

https://github.com/user-attachments/assets/13cfc1ad-48fb-4ecc-9526-5d2067ac5c12


### After

https://github.com/user-attachments/assets/c12d112b-95f2-4dcc-9313-f24519a22580


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;
