### PR TITLE
runfix: replace wire with pydio message protocol [WPB-16433]

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@wireapp/avs": "9.10.25",
     "@wireapp/avs-debugger": "0.0.7",
     "@wireapp/commons": "5.4.2",
-    "@wireapp/core": "46.19.11",
+    "@wireapp/core": "46.20.1",
     "@wireapp/react-ui-kit": "9.43.0",
     "@wireapp/store-engine-dexie": "2.1.15",
     "@wireapp/telemetry": "0.3.1",

--- a/src/script/assets/AssetRepository.ts
+++ b/src/script/assets/AssetRepository.ts
@@ -22,7 +22,7 @@ import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import ko from 'knockout';
 import {container, singleton} from 'tsyringe';
 
-import {GenericMessage, LegalHoldStatus} from '@wireapp/protocol-messaging';
+import {GenericMessage, LegalHoldStatus} from '@pydio/protocol-messaging';
 
 import {getLogger, Logger} from 'Util/Logger';
 import {downloadBlob, loadFileBuffer, loadImage} from 'Util/util';

--- a/src/script/cells/CellsRepository.ts
+++ b/src/script/cells/CellsRepository.ts
@@ -59,10 +59,9 @@ export class CellsRepository {
   }
 
   async getPublicLink({uuid, label}: {uuid: string; label: string}) {
-    return this.apiClient.api.cells.getFilePublicLink({
+    return this.apiClient.api.cells.createFilePublicLink({
       uuid,
       label,
-      alreadyShared: false,
     });
   }
 

--- a/src/script/components/AvailabilityIcon/Availability.styles.tsx
+++ b/src/script/components/AvailabilityIcon/Availability.styles.tsx
@@ -18,8 +18,7 @@
  */
 
 import {CSSObject} from '@emotion/react';
-
-import {Availability as AvailabilityProp} from '@wireapp/protocol-messaging';
+import {Availability as AvailabilityProp} from '@pydio/protocol-messaging';
 
 import {AVATAR_SIZE} from 'Components/Avatar';
 import {CSS_SQUARE} from 'Util/CSSMixin';

--- a/src/script/components/AvailabilityIcon/Availability.tsx
+++ b/src/script/components/AvailabilityIcon/Availability.tsx
@@ -19,7 +19,7 @@
 
 import {ReactNode} from 'react';
 
-import {Availability as AvailabilityProp} from '@wireapp/protocol-messaging';
+import {Availability as AvailabilityProp} from '@pydio/protocol-messaging';
 
 import {AVATAR_SIZE} from 'Components/Avatar';
 

--- a/src/script/components/Avatar/UserAvatar/UserAvatar.test.tsx
+++ b/src/script/components/Avatar/UserAvatar/UserAvatar.test.tsx
@@ -17,9 +17,8 @@
  *
  */
 
+import {Availability} from '@pydio/protocol-messaging';
 import {render} from '@testing-library/react';
-
-import {Availability} from '@wireapp/protocol-messaging';
 
 import {User} from 'src/script/entity/User';
 import {TeamState} from 'src/script/team/TeamState';

--- a/src/script/components/Avatar/UserAvatar/UserAvatar.tsx
+++ b/src/script/components/Avatar/UserAvatar/UserAvatar.tsx
@@ -19,9 +19,9 @@
 
 import React, {MouseEvent as ReactMouseEvent, KeyboardEvent as ReactKeyBoardEvent} from 'react';
 
+import {Availability as AvailabilityType} from '@pydio/protocol-messaging';
 import {container} from 'tsyringe';
 
-import {Availability as AvailabilityType} from '@wireapp/protocol-messaging';
 import {COLOR} from '@wireapp/react-ui-kit';
 
 import {AvailabilityIcon} from 'Components/AvailabilityIcon';

--- a/src/script/components/MessagesList/Message/VerificationMessage.test.tsx
+++ b/src/script/components/MessagesList/Message/VerificationMessage.test.tsx
@@ -17,10 +17,9 @@
  *
  */
 
+import {QualifiedUserId} from '@pydio/protocol-messaging';
 import {render} from '@testing-library/react';
 import ko from 'knockout';
-
-import {QualifiedUserId} from '@wireapp/protocol-messaging';
 
 import {VerificationMessage as VerificationMessageEntity} from 'src/script/entity/message/VerificationMessage';
 import {VerificationMessageType} from 'src/script/message/VerificationMessageType';

--- a/src/script/components/MessagesList/UploadAssets/components/UploadAssetItem/UploadAssetItem.tsx
+++ b/src/script/components/MessagesList/UploadAssets/components/UploadAssetItem/UploadAssetItem.tsx
@@ -19,7 +19,7 @@
 
 import {useEffect, useState} from 'react';
 
-import {GenericMessage} from '@wireapp/protocol-messaging';
+import {GenericMessage} from '@pydio/protocol-messaging';
 
 import {LoadingBar} from 'Components/LoadingBar';
 import {t} from 'Util/LocalizerUtil';

--- a/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.test.tsx
+++ b/src/script/components/calling/CallParticipantsListItem/CallParticipantsListItem.test.tsx
@@ -17,9 +17,8 @@
  *
  */
 
+import {Availability} from '@pydio/protocol-messaging';
 import {render} from '@testing-library/react';
-
-import {Availability} from '@wireapp/protocol-messaging';
 
 import {Participant} from 'src/script/calling/Participant';
 import {User} from 'src/script/entity/User';

--- a/src/script/components/panel/EnrichedFields.tsx
+++ b/src/script/components/panel/EnrichedFields.tsx
@@ -19,10 +19,9 @@
 
 import {useEffect, useState} from 'react';
 
+import {Availability} from '@pydio/protocol-messaging';
 import type {RichInfoField} from '@wireapp/api-client/lib/user/RichInfo';
 import {container} from 'tsyringe';
-
-import {Availability} from '@wireapp/protocol-messaging';
 
 import {availabilityStatus, availabilityTranslationKeys} from 'Util/AvailabilityStatus';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';

--- a/src/script/conversation/ConversationEphemeralHandler.ts
+++ b/src/script/conversation/ConversationEphemeralHandler.ts
@@ -17,10 +17,9 @@
  *
  */
 
+import {Article, LinkPreview} from '@pydio/protocol-messaging';
 import {ConversationMessageTimerUpdateEvent, CONVERSATION_EVENT} from '@wireapp/api-client/lib/event/';
 import ko from 'knockout';
-
-import {Article, LinkPreview} from '@wireapp/protocol-messaging';
 
 import {getLogger, Logger} from 'Util/Logger';
 import {clamp} from 'Util/NumberUtil';

--- a/src/script/conversation/ConversationMapper.ts
+++ b/src/script/conversation/ConversationMapper.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {LegalHoldStatus} from '@pydio/protocol-messaging';
 import {
   CONVERSATION_ACCESS_ROLE,
   Conversation as ConversationBackendData,
@@ -29,8 +30,6 @@ import {
 } from '@wireapp/api-client/lib/conversation';
 import ko from 'knockout';
 import {isObject} from 'underscore';
-
-import {LegalHoldStatus} from '@wireapp/protocol-messaging';
 
 import {ACCESS_STATE} from './AccessState';
 import {ConversationStatus} from './ConversationStatus';

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {Asset as ProtobufAsset, Confirmation, LegalHoldStatus} from '@pydio/protocol-messaging';
 import {
   Conversation as BackendConversation,
   ConversationProtocol,
@@ -55,7 +56,6 @@ import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import {container} from 'tsyringe';
 import {flatten} from 'underscore';
 
-import {Asset as ProtobufAsset, Confirmation, LegalHoldStatus} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {TYPING_TIMEOUT, useTypingIndicatorState} from 'Components/InputBar/TypingIndicator';

--- a/src/script/conversation/EventBuilder.ts
+++ b/src/script/conversation/EventBuilder.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import type {Asset, LegalHoldStatus} from '@pydio/protocol-messaging';
 import {MemberLeaveReason} from '@wireapp/api-client/lib/conversation/data';
 import {
   CONVERSATION_EVENT,
@@ -29,7 +30,6 @@ import {ReactionType} from '@wireapp/core/lib/conversation/ReactionType';
 import {DecryptionError} from '@wireapp/core/lib/errors/DecryptionError';
 
 import type {REASON as AVS_REASON} from '@wireapp/avs';
-import type {Asset, LegalHoldStatus} from '@wireapp/protocol-messaging';
 
 import {createUuid} from 'Util/uuid';
 

--- a/src/script/conversation/EventMapper.test.ts
+++ b/src/script/conversation/EventMapper.test.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {Article, LinkPreview, Mention} from '@wireapp/protocol-messaging';
+import {Article, LinkPreview, Mention} from '@pydio/protocol-messaging';
 
 import {AssetType} from 'src/script/assets/AssetType';
 import {Conversation} from 'src/script/entity/Conversation';

--- a/src/script/conversation/EventMapper.ts
+++ b/src/script/conversation/EventMapper.ts
@@ -17,10 +17,9 @@
  *
  */
 
+import {LinkPreview, Mention} from '@pydio/protocol-messaging';
 import {CONVERSATION_EVENT, ConversationEvent, ConversationProtocolUpdateEvent} from '@wireapp/api-client/lib/event/';
 import {container} from 'tsyringe';
-
-import {LinkPreview, Mention} from '@wireapp/protocol-messaging';
 
 import {t} from 'Util/LocalizerUtil';
 import {getLogger, Logger} from 'Util/Logger';

--- a/src/script/conversation/MessageRepository.test.ts
+++ b/src/script/conversation/MessageRepository.test.ts
@@ -17,13 +17,13 @@
  *
  */
 
+import {LegalHoldStatus} from '@pydio/protocol-messaging';
 import {ConnectionStatus} from '@wireapp/api-client/lib/connection/';
 import {CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation/';
 import {ConversationProtocol} from '@wireapp/api-client/lib/conversation/NewConversation';
 import {MessageSendingState} from '@wireapp/core/lib/conversation';
 
 import {Account} from '@wireapp/core';
-import {LegalHoldStatus} from '@wireapp/protocol-messaging';
 
 import {ConnectionEntity} from 'src/script/connection/ConnectionEntity';
 import {MessageRepository} from 'src/script/conversation/MessageRepository';

--- a/src/script/conversation/MessageRepository.ts
+++ b/src/script/conversation/MessageRepository.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {Asset, Availability, Confirmation, GenericMessage} from '@pydio/protocol-messaging';
 import {ConversationProtocol, MessageSendingStatus, QualifiedUserClients} from '@wireapp/api-client/lib/conversation';
 import {BackendErrorLabel} from '@wireapp/api-client/lib/http/';
 import {QualifiedId, RequestCancellationError} from '@wireapp/api-client/lib/user';
@@ -44,7 +45,6 @@ import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import {container} from 'tsyringe';
 import {partition} from 'underscore';
 
-import {Asset, Availability, Confirmation, GenericMessage} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {

--- a/src/script/cryptography/CryptographyMapper.test.ts
+++ b/src/script/cryptography/CryptographyMapper.test.ts
@@ -17,10 +17,6 @@
  *
  */
 
-import {CONVERSATION_EVENT} from '@wireapp/api-client/lib/event/';
-import {GenericMessageType} from '@wireapp/core/lib/conversation';
-import {isObject} from 'underscore';
-
 import {
   Asset,
   Availability,
@@ -36,7 +32,10 @@ import {
   MessageHide,
   Reaction,
   Text,
-} from '@wireapp/protocol-messaging';
+} from '@pydio/protocol-messaging';
+import {CONVERSATION_EVENT} from '@wireapp/api-client/lib/event/';
+import {GenericMessageType} from '@wireapp/core/lib/conversation';
+import {isObject} from 'underscore';
 
 import {PROTO_MESSAGE_TYPE} from 'src/script/cryptography/ProtoMessageType';
 import {CryptographyError} from 'src/script/error/CryptographyError';

--- a/src/script/cryptography/CryptographyMapper.ts
+++ b/src/script/cryptography/CryptographyMapper.ts
@@ -18,14 +18,6 @@
  */
 
 import {
-  ConversationOtrMessageAddEvent,
-  ConversationMLSMessageAddEvent,
-  CONVERSATION_EVENT,
-} from '@wireapp/api-client/lib/event';
-import {GenericMessageType} from '@wireapp/core/lib/conversation';
-import {container} from 'tsyringe';
-
-import {
   Asset,
   Availability,
   ButtonActionConfirmation,
@@ -51,7 +43,14 @@ import {
   Text,
   InCallEmoji,
   InCallHandRaise,
-} from '@wireapp/protocol-messaging';
+} from '@pydio/protocol-messaging';
+import {
+  ConversationOtrMessageAddEvent,
+  ConversationMLSMessageAddEvent,
+  CONVERSATION_EVENT,
+} from '@wireapp/api-client/lib/event';
+import {GenericMessageType} from '@wireapp/core/lib/conversation';
+import {container} from 'tsyringe';
 
 import {CALL_MESSAGE_TYPE} from 'src/script/calling/enum/CallMessageType';
 import {getLogger, Logger} from 'Util/Logger';

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {LegalHoldStatus} from '@pydio/protocol-messaging';
 import {
   CONVERSATION_ACCESS_ROLE,
   CONVERSATION_ACCESS,
@@ -32,7 +33,6 @@ import ko from 'knockout';
 import {container} from 'tsyringe';
 import {Cancelable, debounce} from 'underscore';
 
-import {LegalHoldStatus} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {useLegalHoldModalState} from 'Components/Modals/LegalHoldModal/LegalHoldModal.state';

--- a/src/script/entity/User/User.ts
+++ b/src/script/entity/User/User.ts
@@ -17,13 +17,13 @@
  *
  */
 
+import {Availability} from '@pydio/protocol-messaging';
 import {ConnectionStatus} from '@wireapp/api-client/lib/connection/';
 import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {amplify} from 'amplify';
 import ko from 'knockout';
 
-import {Availability} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {t} from 'Util/LocalizerUtil';

--- a/src/script/entity/message/FileAsset.ts
+++ b/src/script/entity/message/FileAsset.ts
@@ -17,9 +17,8 @@
  *
  */
 
+import type {Asset as ProtobufAsset} from '@pydio/protocol-messaging';
 import ko from 'knockout';
-
-import type {Asset as ProtobufAsset} from '@wireapp/protocol-messaging';
 
 import {Logger, getLogger} from 'Util/Logger';
 

--- a/src/script/entity/message/LegalHoldMessage.ts
+++ b/src/script/entity/message/LegalHoldMessage.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {LegalHoldStatus} from '@wireapp/protocol-messaging';
+import {LegalHoldStatus} from '@pydio/protocol-messaging';
 
 import {Message} from './Message';
 

--- a/src/script/entity/message/LinkPreview.ts
+++ b/src/script/entity/message/LinkPreview.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import type {ITweet} from '@wireapp/protocol-messaging';
+import type {ITweet} from '@pydio/protocol-messaging';
 
 import {obfuscate} from 'Util/StringUtil';
 

--- a/src/script/entity/message/Message.ts
+++ b/src/script/entity/message/Message.ts
@@ -17,10 +17,9 @@
  *
  */
 
+import type {LegalHoldStatus} from '@pydio/protocol-messaging';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import ko from 'knockout';
-
-import type {LegalHoldStatus} from '@wireapp/protocol-messaging';
 
 import {t, getUserName} from 'Util/LocalizerUtil';
 import {formatDateNumeral, formatDurationCaption, formatTimeShort, fromUnixTime, TIME_IN_MILLIS} from 'Util/TimeUtil';

--- a/src/script/entity/message/VerificationMessage.ts
+++ b/src/script/entity/message/VerificationMessage.ts
@@ -17,9 +17,8 @@
  *
  */
 
+import {QualifiedUserId} from '@pydio/protocol-messaging';
 import ko from 'knockout';
-
-import {QualifiedUserId} from '@wireapp/protocol-messaging';
 
 import {matchQualifiedIds} from 'Util/QualifiedId';
 

--- a/src/script/event/EventService.ts
+++ b/src/script/event/EventService.ts
@@ -17,12 +17,11 @@
  *
  */
 
+import {Asset as ProtobufAsset} from '@pydio/protocol-messaging';
 import {CONVERSATION_EVENT} from '@wireapp/api-client/lib/event/';
 import {QualifiedId} from '@wireapp/api-client/lib/user/';
 import type {Dexie} from 'dexie';
 import {container} from 'tsyringe';
-
-import {Asset as ProtobufAsset} from '@wireapp/protocol-messaging';
 
 import {getLogger, Logger} from 'Util/Logger';
 

--- a/src/script/event/preprocessor/EventStorageMiddleware/EventStorageMiddleware.test.ts
+++ b/src/script/event/preprocessor/EventStorageMiddleware/EventStorageMiddleware.test.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {Asset as ProtobufAsset} from '@wireapp/protocol-messaging';
+import {Asset as ProtobufAsset} from '@pydio/protocol-messaging';
 
 import {AssetTransferState} from 'src/script/assets/AssetTransferState';
 import {ConversationState} from 'src/script/conversation/ConversationState';

--- a/src/script/event/preprocessor/EventStorageMiddleware/eventHandlers/assetEventHandler.ts
+++ b/src/script/event/preprocessor/EventStorageMiddleware/eventHandlers/assetEventHandler.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {Asset as ProtobufAsset} from '@wireapp/protocol-messaging';
+import {Asset as ProtobufAsset} from '@pydio/protocol-messaging';
 
 import {AssetTransferState} from 'src/script/assets/AssetTransferState';
 import {AssetAddEvent} from 'src/script/conversation/EventBuilder';

--- a/src/script/event/preprocessor/QuoteDecoderMiddleware.test.ts
+++ b/src/script/event/preprocessor/QuoteDecoderMiddleware.test.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {Quote} from '@wireapp/protocol-messaging';
+import {Quote} from '@pydio/protocol-messaging';
 
 import {Conversation} from 'src/script/entity/Conversation';
 import {User} from 'src/script/entity/User';

--- a/src/script/event/preprocessor/QuoteDecoderMiddleware.ts
+++ b/src/script/event/preprocessor/QuoteDecoderMiddleware.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {Quote} from '@wireapp/protocol-messaging';
+import {Quote} from '@pydio/protocol-messaging';
 
 import {MessageAddEvent} from 'src/script/conversation/EventBuilder';
 import {getLogger, Logger} from 'Util/Logger';

--- a/src/script/legal-hold/LegalHoldEvaluator.test.ts
+++ b/src/script/legal-hold/LegalHoldEvaluator.test.ts
@@ -17,9 +17,8 @@
  *
  */
 
+import {GenericMessage, LegalHoldStatus, Text} from '@pydio/protocol-messaging';
 import {GenericMessageType} from '@wireapp/core/lib/conversation';
-
-import {GenericMessage, LegalHoldStatus, Text} from '@wireapp/protocol-messaging';
 
 import {createMessageAddEvent} from 'test/helper/EventGenerator';
 import {createUuid} from 'Util/uuid';

--- a/src/script/legal-hold/LegalHoldEvaluator.ts
+++ b/src/script/legal-hold/LegalHoldEvaluator.ts
@@ -17,9 +17,8 @@
  *
  */
 
+import {LegalHoldStatus} from '@pydio/protocol-messaging';
 import {CONVERSATION_EVENT} from '@wireapp/api-client/lib/event';
-
-import {LegalHoldStatus} from '@wireapp/protocol-messaging';
 
 import type {Conversation} from '../entity/Conversation';
 import type {User} from '../entity/User';

--- a/src/script/message/MentionEntity.ts
+++ b/src/script/message/MentionEntity.ts
@@ -17,9 +17,8 @@
  *
  */
 
+import {IMention, Mention} from '@pydio/protocol-messaging';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
-
-import {IMention, Mention} from '@wireapp/protocol-messaging';
 
 import {matchQualifiedIds} from 'Util/QualifiedId';
 import {isUUID} from 'Util/ValidationUtil';

--- a/src/script/message/QuoteEntity.ts
+++ b/src/script/message/QuoteEntity.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {Quote} from '@wireapp/protocol-messaging';
+import {Quote} from '@pydio/protocol-messaging';
 
 export interface QuoteEntityOptions {
   error?: Error;

--- a/src/script/notification/NotificationRepository.test.ts
+++ b/src/script/notification/NotificationRepository.test.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {Availability} from '@pydio/protocol-messaging';
 import {ConnectionStatus} from '@wireapp/api-client/lib/connection';
 import {CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation';
 import {CONVERSATION_EVENT} from '@wireapp/api-client/lib/event';
@@ -25,7 +26,6 @@ import {amplify} from 'amplify';
 import {container} from 'tsyringe';
 
 import {Runtime} from '@wireapp/commons';
-import {Availability} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {CallingRepository} from 'src/script/calling/CallingRepository';

--- a/src/script/notification/NotificationRepository.ts
+++ b/src/script/notification/NotificationRepository.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {Availability} from '@pydio/protocol-messaging';
 import type {QualifiedId} from '@wireapp/api-client/lib/user/';
 import {NotificationPreference, WebappProperties} from '@wireapp/api-client/lib/user/data/';
 import {amplify} from 'amplify';
@@ -24,7 +25,6 @@ import ko from 'knockout';
 import {container} from 'tsyringe';
 
 import {Runtime} from '@wireapp/commons';
-import {Availability} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {CallingRepository} from 'src/script/calling/CallingRepository';

--- a/src/script/page/MainContent/panels/preferences/accountPreferences/AvailabilityButtons.tsx
+++ b/src/script/page/MainContent/panels/preferences/accountPreferences/AvailabilityButtons.tsx
@@ -20,10 +20,10 @@
 import React from 'react';
 
 import {CSSObject} from '@emotion/serialize';
+import {Availability} from '@pydio/protocol-messaging';
 import {amplify} from 'amplify';
 import cx from 'classnames';
 
-import {Availability} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {availabilityStatus} from 'Util/AvailabilityStatus';

--- a/src/script/storage/record/ConversationRecord.ts
+++ b/src/script/storage/record/ConversationRecord.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {LegalHoldStatus} from '@pydio/protocol-messaging';
 import {
   CONVERSATION_ACCESS_ROLE,
   CONVERSATION_ACCESS,
@@ -27,8 +28,6 @@ import {
 import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data';
 import {ConversationProtocol} from '@wireapp/api-client/lib/conversation/NewConversation';
 import type {QualifiedId} from '@wireapp/api-client/lib/user/';
-
-import {LegalHoldStatus} from '@wireapp/protocol-messaging';
 
 import {CONVERSATION_READONLY_STATE} from 'src/script/conversation/ConversationRepository';
 

--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {Availability} from '@pydio/protocol-messaging';
 import {ConversationProtocol, ConversationRolesList} from '@wireapp/api-client/lib/conversation';
 import type {
   TeamConversationDeleteEvent,
@@ -34,7 +35,6 @@ import {amplify} from 'amplify';
 import {container} from 'tsyringe';
 
 import {Runtime, TypedEventEmitter} from '@wireapp/commons';
-import {Availability} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';

--- a/src/script/ui/AvailabilityContextMenu.ts
+++ b/src/script/ui/AvailabilityContextMenu.ts
@@ -17,9 +17,9 @@
  *
  */
 
+import {Availability} from '@pydio/protocol-messaging';
 import {amplify} from 'amplify';
 
-import {Availability} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {t} from 'Util/LocalizerUtil';

--- a/src/script/ui/ContextMenu.tsx
+++ b/src/script/ui/ContextMenu.tsx
@@ -19,10 +19,10 @@
 
 import React, {ReactNode, useEffect, useMemo, useRef, useState} from 'react';
 
+import {Availability} from '@pydio/protocol-messaging';
 import cx from 'classnames';
 import {createRoot, Root} from 'react-dom/client';
 
-import {Availability} from '@wireapp/protocol-messaging';
 import {StyledApp, THEME_ID} from '@wireapp/react-ui-kit';
 
 import * as Icon from 'Components/Icon';

--- a/src/script/user/AvailabilityMapper.ts
+++ b/src/script/user/AvailabilityMapper.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {Availability} from '@wireapp/protocol-messaging';
+import {Availability} from '@pydio/protocol-messaging';
 
 import {BaseError} from '../error/BaseError';
 import {UserError} from '../error/UserError';

--- a/src/script/user/AvailabilityModal.ts
+++ b/src/script/user/AvailabilityModal.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {Availability} from '@wireapp/protocol-messaging';
+import {Availability} from '@pydio/protocol-messaging';
 
 import {t} from 'Util/LocalizerUtil';
 import {loadValue, storeValue} from 'Util/StorageUtil';

--- a/src/script/user/UserMapper.test.ts
+++ b/src/script/user/UserMapper.test.ts
@@ -17,9 +17,8 @@
  *
  */
 
+import {Availability} from '@pydio/protocol-messaging';
 import {UserAsset, UserAssetType} from '@wireapp/api-client/lib/user';
-
-import {Availability} from '@wireapp/protocol-messaging';
 
 import {ACCENT_ID} from 'src/script/Config';
 import {User} from 'src/script/entity/User';

--- a/src/script/user/UserRepository.test.ts
+++ b/src/script/user/UserRepository.test.ts
@@ -18,6 +18,7 @@
  */
 
 import {generateUUID} from '@datadog/browser-core';
+import {Availability} from '@pydio/protocol-messaging';
 import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data';
 import {USER_EVENT, UserUpdateEvent} from '@wireapp/api-client/lib/event';
@@ -25,7 +26,6 @@ import type {User as APIClientUser} from '@wireapp/api-client/lib/user';
 import {amplify} from 'amplify';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 
-import {Availability} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {entities} from 'test/api/payloads';

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {Availability} from '@pydio/protocol-messaging';
 import type {AddedClient, PublicClient} from '@wireapp/api-client/lib/client';
 import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 import {
@@ -41,7 +42,6 @@ import {container} from 'tsyringe';
 import {flatten, uniq} from 'underscore';
 
 import {TypedEventEmitter, type AccentColor} from '@wireapp/commons';
-import {Availability} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {useLegalHoldModalState} from 'Components/Modals/LegalHoldModal/LegalHoldModal.state';

--- a/src/script/util/AvailabilityStatus.tsx
+++ b/src/script/util/AvailabilityStatus.tsx
@@ -18,8 +18,7 @@
  */
 
 import {CSSObject} from '@emotion/serialize';
-
-import {Availability} from '@wireapp/protocol-messaging';
+import {Availability} from '@pydio/protocol-messaging';
 
 import * as Icon from 'Components/Icon';
 import {CSS_SQUARE} from 'Util/CSSMixin';

--- a/src/script/view_model/CallingViewModel.ts
+++ b/src/script/view_model/CallingViewModel.ts
@@ -17,13 +17,13 @@
  *
  */
 
+import {Availability} from '@pydio/protocol-messaging';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {amplify} from 'amplify';
 import ko from 'knockout';
 import {container} from 'tsyringe';
 
 import {CALL_TYPE, REASON as CALL_REASON, STATE as CALL_STATE} from '@wireapp/avs';
-import {Availability} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {ButtonGroupTab} from 'Components/calling/ButtonGroup';

--- a/test/unit_tests/message/MentionEntitySpec.js
+++ b/test/unit_tests/message/MentionEntitySpec.js
@@ -17,7 +17,7 @@
  *
  */
 
-import {Mention} from '@wireapp/protocol-messaging';
+import {Mention} from '@pydio/protocol-messaging';
 
 import {MentionEntity} from 'src/script/message/MentionEntity';
 import {base64ToArray} from 'Util/util';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5491,7 +5491,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pydio/protocol-messaging@npm:1.51.0":
+"@pydio/protocol-messaging@npm:1.51.0, @pydio/protocol-messaging@npm:^1.51.0":
   version: 1.51.0
   resolution: "@pydio/protocol-messaging@npm:1.51.0"
   dependencies:
@@ -7450,9 +7450,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^27.24.0":
-  version: 27.26.0
-  resolution: "@wireapp/api-client@npm:27.26.0"
+"@wireapp/api-client@npm:^27.27.0":
+  version: 27.27.0
+  resolution: "@wireapp/api-client@npm:27.27.0"
   dependencies:
     "@aws-sdk/client-s3": "npm:3.750.0"
     "@pydio/protocol-messaging": "npm:1.51.0"
@@ -7470,7 +7470,7 @@ __metadata:
     uuid: "npm:11.1.0"
     ws: "npm:8.18.1"
     zod: "npm:3.24.2"
-  checksum: 10/4d2cc9336305306bb3412da9cdc7bc49b8def448662567bc737fb116bfae3e62dbb539e78dd95a31d6f76f1b24e284beb9079358066e65093f1dbf37a7276cc2
+  checksum: 10/5d60eb8f6b45df4ec9db9b2408881b42f70d2948346070994a5ef929f18d82ae7c55a748a59a528249306fd78179b77e80ba9da035881bc8f451bf64e3c125d3
   languageName: node
   linkType: hard
 
@@ -7535,17 +7535,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:46.19.11":
-  version: 46.19.11
-  resolution: "@wireapp/core@npm:46.19.11"
+"@wireapp/core@npm:46.20.1":
+  version: 46.20.1
+  resolution: "@wireapp/core@npm:46.20.1"
   dependencies:
-    "@wireapp/api-client": "npm:^27.24.0"
+    "@pydio/protocol-messaging": "npm:^1.51.0"
+    "@wireapp/api-client": "npm:^27.27.0"
     "@wireapp/commons": "npm:^5.4.2"
     "@wireapp/core-crypto": "npm:3.1.0"
     "@wireapp/cryptobox": "npm:12.8.0"
     "@wireapp/priority-queue": "npm:^2.1.11"
     "@wireapp/promise-queue": "npm:^2.3.12"
-    "@wireapp/protocol-messaging": "npm:1.51.0"
     "@wireapp/store-engine": "npm:5.1.11"
     axios: "npm:1.7.9"
     bazinga64: "npm:^6.3.11"
@@ -7557,7 +7557,7 @@ __metadata:
     long: "npm:^5.2.0"
     uuid: "npm:9.0.1"
     zod: "npm:3.24.2"
-  checksum: 10/ed8cbaff01304b9cb1b075e05fcffa3fd92a1e7a36bb4657f485dcdf2cb48c07bac960d9540c454a9fd2f36d130a96837bd58ad319fdc4d154a5cb485a8b113d
+  checksum: 10/8eab667fe93c676e59cffc6f4055bb3078f91bca3c95474c50a3829a04c465bc3d5f4020e68d4ddc90346827da1770c8170f7c897075506bcc40506824a95d54
   languageName: node
   linkType: hard
 
@@ -7656,18 +7656,6 @@ __metadata:
     "@wireapp/cbor": "npm:4.7.3"
     libsodium-wrappers-sumo: "npm:0.7.9"
   checksum: 10/94bb7c599df64146cf7d4d6e03d11bb293152f7eff21ce26164fd8cfec9a134e3b5c48ec4555c4d93a1a203c735ad3ea5bc21c8cac7acc42458d6adbccf655f8
-  languageName: node
-  linkType: hard
-
-"@wireapp/protocol-messaging@npm:1.51.0":
-  version: 1.51.0
-  resolution: "@wireapp/protocol-messaging@npm:1.51.0"
-  dependencies:
-    long: "npm:5.2.0"
-    protobufjs: "npm:7.2.5"
-    protobufjs-cli: "npm:1.1.2"
-    typescript: "npm:4.8.4"
-  checksum: 10/8403a24dd8f58176993d30c40285a30ee0d03f146f8ef8813422338c92d745f18d19e856a0f42b5da095f091c284b9becd98e51428dd4bb636a22e5161af4f50
   languageName: node
   linkType: hard
 
@@ -20744,7 +20732,7 @@ __metadata:
     "@wireapp/avs-debugger": "npm:0.0.7"
     "@wireapp/commons": "npm:5.4.2"
     "@wireapp/copy-config": "npm:2.3.0"
-    "@wireapp/core": "npm:46.19.11"
+    "@wireapp/core": "npm:46.20.1"
     "@wireapp/eslint-config": "npm:3.0.7"
     "@wireapp/prettier-config": "npm:0.6.4"
     "@wireapp/react-ui-kit": "npm:9.43.0"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16433" title="WPB-16433" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16433</a>  [Web] Implement Cells message protocol changes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Continuation of https://github.com/wireapp/wire-web-packages/pull/6978 - replaces `@wireapp/protocol-messaging` with `@pydio/protocol-messaging` for the sake of using new protocol changes.

The change is temporary, and we'll be back to the original package in the future.

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
