### PR TITLE
ci(dependabot): prevent dependabot from bumping major versions [WPB-16628]

### DIFF
--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -17,7 +17,15 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           PR_URL: ${{github.event.pull_request.html_url}}
 
+      - name: Fetch Dependabot metadata
+        if: ${{github.actor == 'dependabot[bot]'}}
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+
       - name: Enable auto-merge
+        if: ${{github.actor == 'otto-the-bot' || (github.actor == 'dependabot[bot]' && steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major')}}
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           GITHUB_TOKEN: ${{secrets.OTTO_THE_BOT_GH_TOKEN}}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16628" title="WPB-16628" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16628</a>  [Web] prevent depandabot from bumping major versions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Following this PR https://github.com/wireapp/wire-webapp/pull/16616, Dependabot has been able to bump major versions of packages.

This is unintended.

To stay in line with the previous workflow, this doesn't prevent Dependabot from *creating PRs* for major version bumps, but it no longer enable them to be merged automatically

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
