### PR TITLE
fix: allow personal users to select mentions and replies notification setting [WPB-16650]

### DIFF
--- a/src/script/entity/Conversation.test.ts
+++ b/src/script/entity/Conversation.test.ts
@@ -948,58 +948,29 @@ describe('Conversation', () => {
     it('returns expected values', () => {
       const NOTIFICATION_STATES = NOTIFICATION_STATE;
       const conversationEntity = new Conversation(createUuid());
-      const selfUserEntity = new User(createUuid(), null);
+      const selfUserEntity = new User(createUuid(), undefined);
 
       expect(conversationEntity.notificationState()).toBe(NOTIFICATION_STATES.NOTHING);
+
       conversationEntity.selfUser(selfUserEntity);
-      conversationEntity.mutedState(undefined);
-
+      conversationEntity.mutedState(NOTIFICATION_STATES.EVERYTHING);
       expect(conversationEntity.notificationState()).toBe(NOTIFICATION_STATES.EVERYTHING);
-      //@ts-expect-error
-      conversationEntity.mutedState('true');
 
-      expect(conversationEntity.notificationState()).toBe(NOTIFICATION_STATES.EVERYTHING);
       //@ts-expect-error
       conversationEntity.mutedState(true);
+      expect(conversationEntity.notificationState()).toBe(NOTIFICATION_STATES.MENTIONS_AND_REPLIES);
 
-      expect(conversationEntity.notificationState()).toBe(NOTIFICATION_STATES.NOTHING);
       //@ts-expect-error
       conversationEntity.mutedState(false);
-
       expect(conversationEntity.notificationState()).toBe(NOTIFICATION_STATES.EVERYTHING);
+
       conversationEntity.mutedState(NOTIFICATION_STATES.NOTHING);
-
       expect(conversationEntity.notificationState()).toBe(NOTIFICATION_STATES.NOTHING);
+
       conversationEntity.mutedState(NOTIFICATION_STATES.MENTIONS_AND_REPLIES);
-
-      expect(conversationEntity.notificationState()).toBe(NOTIFICATION_STATES.NOTHING);
-      conversationEntity.mutedState(NOTIFICATION_STATES.EVERYTHING);
-
-      expect(conversationEntity.notificationState()).toBe(NOTIFICATION_STATES.EVERYTHING);
-      selfUserEntity.teamId = createUuid();
-      conversationEntity.mutedState(undefined);
-
-      expect(conversationEntity.notificationState()).toBe(NOTIFICATION_STATES.EVERYTHING);
-      //@ts-expect-error
-      conversationEntity.mutedState('true');
-
-      expect(conversationEntity.notificationState()).toBe(NOTIFICATION_STATES.EVERYTHING);
-      //@ts-expect-error
-      conversationEntity.mutedState(true);
-
       expect(conversationEntity.notificationState()).toBe(NOTIFICATION_STATES.MENTIONS_AND_REPLIES);
-      //@ts-expect-error
-      conversationEntity.mutedState(false);
 
-      expect(conversationEntity.notificationState()).toBe(NOTIFICATION_STATES.EVERYTHING);
-      conversationEntity.mutedState(NOTIFICATION_STATES.NOTHING);
-
-      expect(conversationEntity.notificationState()).toBe(NOTIFICATION_STATES.NOTHING);
-      conversationEntity.mutedState(NOTIFICATION_STATES.MENTIONS_AND_REPLIES);
-
-      expect(conversationEntity.notificationState()).toBe(NOTIFICATION_STATES.MENTIONS_AND_REPLIES);
       conversationEntity.mutedState(NOTIFICATION_STATES.EVERYTHING);
-
       expect(conversationEntity.notificationState()).toBe(NOTIFICATION_STATES.EVERYTHING);
     });
   });

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -315,22 +315,11 @@ export class Conversation {
       }
       const mutedState = this.mutedState();
 
-      const knownNotificationStates = Object.values(NOTIFICATION_STATE);
-      if (knownNotificationStates.includes(mutedState)) {
-        const isStateMentionsAndReplies = mutedState === NOTIFICATION_STATE.MENTIONS_AND_REPLIES;
-        const isInvalidState = isStateMentionsAndReplies && !this.selfUser()?.teamId;
-
-        return isInvalidState ? NOTIFICATION_STATE.NOTHING : mutedState;
-      }
-
       if (typeof mutedState === 'boolean') {
-        const migratedMutedState = !!this.selfUser()?.teamId
-          ? NOTIFICATION_STATE.MENTIONS_AND_REPLIES
-          : NOTIFICATION_STATE.NOTHING;
-        return this.mutedState() ? migratedMutedState : NOTIFICATION_STATE.EVERYTHING;
+        return mutedState ? NOTIFICATION_STATE.MENTIONS_AND_REPLIES : NOTIFICATION_STATE.EVERYTHING;
       }
 
-      return NOTIFICATION_STATE.EVERYTHING;
+      return mutedState;
     });
 
     this.is_archived = this.archivedState;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16650" title="WPB-16650" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16650</a>  [Web] cannot select "Mentions and replies" as notification setting for group as personal user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
Fixes the issue where personal users cannot select "Mentions and Replies" notification setting in group conversations. When attempting to select this option, it defaults to "Nothing". This was previously a deliberate restriction in the codebase that limited this feature to team users only.

## Screenshots/Screencast (for UI changes)
### Before

https://github.com/user-attachments/assets/ac323c18-8d30-4493-967d-fe8b00683104


### After

https://github.com/user-attachments/assets/b904082d-8a9a-41c9-aed5-28aa34f54db1


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;