### PR TITLE
fix(Conversation): cells files path & use qualifiedId [WPB-15679]

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -504,7 +504,7 @@ export const Conversation = ({
             <>
               <ConversationTabs activeTabIndex={activeTabIndex} onIndexChange={setActiveTabIndex} />
               <ConversationTabPanel id="files" isActive={activeTabIndex === 1}>
-                {activeTabIndex === 1 && <ConversationCells conversationId={activeConversation.id} />}
+                {activeTabIndex === 1 && <ConversationCells conversationQualifiedId={activeConversation.qualifiedId} />}
               </ConversationTabPanel>
             </>
           )}

--- a/src/script/components/Conversation/ConversationCells/ConversationCells.tsx
+++ b/src/script/components/Conversation/ConversationCells/ConversationCells.tsx
@@ -19,6 +19,7 @@
 
 import {useCallback} from 'react';
 
+import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {container} from 'tsyringe';
 
 import {useAppNotification} from 'Components/AppNotification/AppNotification';
@@ -35,15 +36,15 @@ import {useGetAllCellsFiles} from './useGetAllCellsFiles/useGetAllCellsFiles';
 
 interface ConversationCellsProps {
   cellsRepository?: CellsRepository;
-  conversationId: string;
+  conversationQualifiedId: QualifiedId;
 }
 
 export const ConversationCells = ({
   cellsRepository = container.resolve(CellsRepository),
-  conversationId,
+  conversationQualifiedId,
 }: ConversationCellsProps) => {
   const {files, status: filesStatus, clearAll, removeFile} = useCellsStore();
-  const {refresh} = useGetAllCellsFiles({cellsRepository, conversationId});
+  const {refresh} = useGetAllCellsFiles({cellsRepository, conversationQualifiedId});
 
   const isLoading = filesStatus === 'loading';
   const isError = filesStatus === 'error';

--- a/src/script/components/Conversation/ConversationCells/useGetAllCellsFiles/useGetAllCellsFiles.ts
+++ b/src/script/components/Conversation/ConversationCells/useGetAllCellsFiles/useGetAllCellsFiles.ts
@@ -19,6 +19,8 @@
 
 import {useEffect, useCallback} from 'react';
 
+import {QualifiedId} from '@wireapp/api-client/lib/user/';
+
 import {CellsRepository} from 'src/script/cells/CellsRepository';
 import {Config} from 'src/script/Config';
 
@@ -28,18 +30,24 @@ import {useCellsStore} from '../common/useCellsStore/useCellsStore';
 
 interface UseGetAllCellsFilesProps {
   cellsRepository: CellsRepository;
-  conversationId: string;
+  conversationQualifiedId: QualifiedId;
 }
 
-export const useGetAllCellsFiles = ({cellsRepository, conversationId}: UseGetAllCellsFilesProps) => {
+export const useGetAllCellsFiles = ({cellsRepository, conversationQualifiedId}: UseGetAllCellsFilesProps) => {
   const {setFiles, setStatus, setError} = useCellsStore();
 
   const fetchFiles = useCallback(async () => {
     try {
       setStatus('loading');
 
+      const {domain, id} = conversationQualifiedId;
+
+      // Temporary solution to handle the local development
+      // TODO: remove this once we have a proper way to handle the domain per env
+      const domainPerEnv = process.env.NODE_ENV === 'development' ? Config.getConfig().CELLS_WIRE_DOMAIN : domain;
+
       const result = await cellsRepository.getAllFiles({
-        path: `${conversationId}@${Config.getConfig().CELLS_WIRE_DOMAIN}`,
+        path: `${id}@${domainPerEnv}`,
       });
 
       if (!result.Nodes) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15679" title="WPB-15679" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15679</a>  [Web] Conversation “files” tab view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Fix the path for getting the conversation's cell files by changing it to the qualifiedId.

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
