### PR TITLE
runfix(cells): change no files error to the empty message [WPB-15679]

### DIFF
--- a/src/script/components/CellsGlobalView/useGetAllCellsFiles/useGetAllCellsFiles.ts
+++ b/src/script/components/CellsGlobalView/useGetAllCellsFiles/useGetAllCellsFiles.ts
@@ -38,8 +38,9 @@ export const useGetAllCellsFiles = ({cellsRepository}: UseGetAllCellsFilesProps)
 
       const result = await cellsRepository.searchFiles({query: '*'});
 
-      if (!result.Nodes) {
-        throw new Error('No files found');
+      if (!result.Nodes?.length) {
+        setStatus('success');
+        return;
       }
 
       const transformedFiles = transformNodesToCellsFiles(result.Nodes);

--- a/src/script/components/Conversation/ConversationCells/useGetAllCellsFiles/useGetAllCellsFiles.ts
+++ b/src/script/components/Conversation/ConversationCells/useGetAllCellsFiles/useGetAllCellsFiles.ts
@@ -50,8 +50,9 @@ export const useGetAllCellsFiles = ({cellsRepository, conversationQualifiedId}: 
         path: `${id}@${domainPerEnv}`,
       });
 
-      if (!result.Nodes) {
-        throw new Error('No files found');
+      if (!result.Nodes?.length) {
+        setStatus('success');
+        return;
       }
 
       const transformedFiles = transformNodesToCellsFiles(result.Nodes);


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15679" title="WPB-15679" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15679</a>  [Web] Conversation “files” tab view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

When no files were available for a conversation, an error message was displayed instead of an actual message about an empty file list. This will no longer be the case — now we mark responses as successful and display the empty list info instead.

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
