### PR TITLE
ci(dependabot): ignore lexical minor version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,9 @@ updates:
           - '0.10.16'
       - dependency-name: '@types/node'
       - dependency-name: 'typescript'
+      # ignore lexical group minor version bumps, as they include breaking changes
+      - group: lexical
+        update-types: ['version-update:semver-major', 'version-update:semver-minor']
 
   # Server dependencies
   - package-ecosystem: npm


### PR DESCRIPTION
## Description

latest lexical minor version bumps included a whole array of breaking changes https://github.com/wireapp/wire-webapp/pull/18890

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
