### PR TITLE
runfix(cells): use file id as uuid for upload [WPB-15706]

### DIFF
--- a/src/script/cells/CellsRepository.ts
+++ b/src/script/cells/CellsRepository.ts
@@ -53,10 +53,17 @@ export class CellsRepository {
     this.isInitialized = true;
   }
 
-  async uploadFile({file, path}: {file: File; path: string}): Promise<{uuid: string; versionId: string}> {
+  async uploadFile({
+    uuid,
+    file,
+    path,
+  }: {
+    uuid: string;
+    file: File;
+    path: string;
+  }): Promise<{uuid: string; versionId: string}> {
     const filePath = `${path || this.basePath}/${encodeURIComponent(file.name)}`;
 
-    const uuid = createUuid();
     const versionId = createUuid();
 
     await this.apiClient.api.cells.uploadFileDraft({

--- a/src/script/components/Conversation/useFilesUploadDropzone/useFilesUploadDropzone.ts
+++ b/src/script/components/Conversation/useFilesUploadDropzone/useFilesUploadDropzone.ts
@@ -60,6 +60,7 @@ export const useFilesUploadDropzone = ({isTeam, cellsRepository, conversation}: 
 
     try {
       const {uuid, versionId} = await cellsRepository.uploadFile({
+        uuid: file.id,
         file,
         path,
       });

--- a/src/script/components/InputBar/FilePreviews/useFilePreview/useFilePreview.ts
+++ b/src/script/components/InputBar/FilePreviews/useFilePreview/useFilePreview.ts
@@ -61,6 +61,7 @@ export const useFilePreview = ({file, cellsRepository, conversationQualifiedId}:
           : `${conversationQualifiedId.id}@${conversationQualifiedId.domain}`;
 
       const {uuid, versionId} = await cellsRepository.uploadFile({
+        uuid: file.id,
         file,
         path,
       });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15706" title="WPB-15706" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15706</a>  [Web] Receive message with multiple files 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Use file id as uuid for cells upload

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
