### PR TITLE
fix: Handle null active conversation for file dropzone

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -471,7 +471,7 @@ export const Conversation = ({
   const {getRootProps, getInputProps, open, isDragAccept} = useFilesUploadDropzone({
     isTeam: inTeam,
     cellsRepository: repositories.cells,
-    conversation: activeConversation!,
+    conversation: activeConversation,
   });
 
   const isCellsEnabled = Config.getConfig().FEATURE.ENABLE_CELLS;

--- a/src/script/components/Conversation/useFilesUploadDropzone/useFilesUploadDropzone.ts
+++ b/src/script/components/Conversation/useFilesUploadDropzone/useFilesUploadDropzone.ts
@@ -41,10 +41,14 @@ const logger = getLogger('FileDropzone');
 interface UseFilesUploadDropzoneParams {
   isTeam: boolean;
   cellsRepository: CellsRepository;
-  conversation: Pick<Conversation, 'id' | 'qualifiedId'>;
+  conversation?: Pick<Conversation, 'id' | 'qualifiedId'>;
 }
 
-export const useFilesUploadDropzone = ({isTeam, cellsRepository, conversation}: UseFilesUploadDropzoneParams) => {
+export const useFilesUploadDropzone = ({
+  isTeam,
+  cellsRepository,
+  conversation = {id: '', qualifiedId: {id: '', domain: ''}},
+}: UseFilesUploadDropzoneParams) => {
   const {addFiles, getFiles, updateFile} = useFileUploadState();
   const files = getFiles({conversationId: conversation.id});
 


### PR DESCRIPTION
## Description

Handle empty active conversation for files dropzone when opening settings page