### PR TITLE
fix(cells): conversation files state [WPB-15706]

### DIFF
--- a/src/script/components/Conversation/ConversationCells/CellsTable/CellsFileShareModal/CellsFileShareModal.tsx
+++ b/src/script/components/Conversation/ConversationCells/CellsTable/CellsFileShareModal/CellsFileShareModal.tsx
@@ -40,21 +40,24 @@ import {CellsTableLoader} from '../../common/CellsTableLoader/CellsTableLoader';
 
 interface ShareFileModalParams {
   uuid: string;
+  conversationId: string;
   cellsRepository: CellsRepository;
 }
 
-export const showShareFileModal = ({uuid, cellsRepository}: ShareFileModalParams) => {
+export const showShareFileModal = ({uuid, conversationId, cellsRepository}: ShareFileModalParams) => {
   PrimaryModal.show(PrimaryModal.type.CONFIRM, {
     primaryAction: {action: () => {}, text: t('cellsGlobalView.shareFileModalPrimaryAction')},
     text: {
-      message: <CellsShareFileModalContent uuid={uuid} cellsRepository={cellsRepository} />,
+      message: (
+        <CellsShareFileModalContent uuid={uuid} conversationId={conversationId} cellsRepository={cellsRepository} />
+      ),
       title: t('cellsGlobalView.shareFileModalHeading'),
     },
   });
 };
 
-const CellsShareFileModalContent = ({uuid, cellsRepository}: ShareFileModalParams) => {
-  const {status, link, isEnabled, togglePublicLink} = useCellPublicLink({uuid, cellsRepository});
+const CellsShareFileModalContent = ({uuid, conversationId, cellsRepository}: ShareFileModalParams) => {
+  const {status, link, isEnabled, togglePublicLink} = useCellPublicLink({uuid, conversationId, cellsRepository});
 
   const isInputDisabled = ['loading', 'error'].includes(status);
 

--- a/src/script/components/Conversation/ConversationCells/CellsTable/CellsTable.tsx
+++ b/src/script/components/Conversation/ConversationCells/CellsTable/CellsTable.tsx
@@ -46,12 +46,13 @@ import {CellFile} from '../common/cellFile/cellFile';
 interface CellsTableProps {
   files: CellFile[];
   cellsRepository: CellsRepository;
+  conversationId: string;
   onDeleteFile: (uuid: string) => void;
 }
 
 const columnHelper = createColumnHelper<CellFile>();
 
-export const CellsTable = ({files, cellsRepository, onDeleteFile}: CellsTableProps) => {
+export const CellsTable = ({files, cellsRepository, conversationId, onDeleteFile}: CellsTableProps) => {
   const showDeleteFileModal = useCallback(
     ({uuid, name}: {uuid: string; name: string}) => {
       PrimaryModal.show(PrimaryModal.type.CONFIRM, {
@@ -107,7 +108,7 @@ export const CellsTable = ({files, cellsRepository, onDeleteFile}: CellsTablePro
                     }
                   : undefined
               }
-              onShare={() => showShareFileModal({uuid, cellsRepository})}
+              onShare={() => showShareFileModal({uuid, conversationId, cellsRepository})}
               onDownload={fileUrl ? () => forcedDownloadFile({url: fileUrl, name: info.row.original.name}) : undefined}
               onDelete={() => showDeleteFileModal({uuid, name: info.row.original.name})}
             />

--- a/src/script/components/Conversation/ConversationCells/ConversationCells.tsx
+++ b/src/script/components/Conversation/ConversationCells/ConversationCells.tsx
@@ -44,7 +44,10 @@ export const ConversationCells = ({
   conversationQualifiedId,
 }: ConversationCellsProps) => {
   const {getFiles, status: filesStatus, clearAll, removeFile} = useCellsStore();
-  const files = getFiles({conversationId: conversationQualifiedId.id});
+
+  const conversationId = conversationQualifiedId.id;
+
+  const files = getFiles({conversationId});
   const {refresh} = useGetAllCellsFiles({cellsRepository, conversationQualifiedId});
 
   const isLoading = filesStatus === 'loading';
@@ -59,20 +62,22 @@ export const ConversationCells = ({
   const handleDeleteFile = useCallback(
     async (uuid: string) => {
       try {
-        removeFile({conversationId: conversationQualifiedId.id, fileId: uuid});
+        removeFile({conversationId, fileId: uuid});
         await cellsRepository.deleteFile({uuid});
       } catch (error) {
         deleteFileFailedNotification.show();
         console.error(error);
       }
     },
-    [conversationQualifiedId.id, removeFile, deleteFileFailedNotification],
+    // cellsRepository is not a dependency because it's a singleton
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [conversationId, removeFile, deleteFileFailedNotification],
   );
 
   const handleRefresh = useCallback(async () => {
-    clearAll({conversationId: conversationQualifiedId.id});
+    clearAll({conversationId});
     await refresh();
-  }, [refresh, clearAll, conversationQualifiedId.id]);
+  }, [refresh, clearAll, conversationId]);
 
   return (
     <div css={wrapperStyles}>
@@ -81,7 +86,7 @@ export const ConversationCells = ({
         <CellsTable
           files={files}
           cellsRepository={cellsRepository}
-          conversationId={conversationQualifiedId.id}
+          conversationId={conversationId}
           onDeleteFile={handleDeleteFile}
         />
       )}

--- a/src/script/components/Conversation/ConversationCells/useGetAllCellsFiles/useGetAllCellsFiles.ts
+++ b/src/script/components/Conversation/ConversationCells/useGetAllCellsFiles/useGetAllCellsFiles.ts
@@ -56,7 +56,7 @@ export const useGetAllCellsFiles = ({cellsRepository, conversationQualifiedId}: 
       }
 
       const transformedFiles = transformNodesToCellsFiles(result.Nodes);
-      setFiles(transformedFiles);
+      setFiles({conversationId: id, files: transformedFiles});
       setStatus('success');
     } catch (error) {
       setError(error instanceof Error ? error : new Error('Failed to fetch files', {cause: error}));


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15706" title="WPB-15706" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15706</a>  [Web] Receive message with multiple files 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Fix `useCellsStore` to update files per conversation id. By that, we avoid the stale view between conversations, since there's only one store instance per `Conversation.tsx`.

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
