### PR TITLE
fix(cells): file upload window [WPB-15706]

### DIFF
--- a/src/script/components/Conversation/Conversation.tsx
+++ b/src/script/components/Conversation/Conversation.tsx
@@ -468,7 +468,12 @@ export const Conversation = ({
     [addReadReceiptToBatch, repositories.conversation, repositories.integration, updateConversationLastRead],
   );
 
-  const {getRootProps, getInputProps, open, isDragAccept} = useFilesUploadDropzone({
+  const {
+    getRootProps,
+    getInputProps,
+    open: openCellsUploadWindow,
+    isDragAccept,
+  } = useFilesUploadDropzone({
     isTeam: inTeam,
     cellsRepository: repositories.cells,
     conversation: activeConversation,
@@ -575,8 +580,10 @@ export const Conversation = ({
                   selfUser={selfUser}
                   onShiftTab={() => setMsgElementsFocusable(false)}
                   uploadDroppedFiles={uploadDroppedFiles}
-                  uploadImages={isCellsEnabled ? () => open() : uploadImages}
-                  uploadFiles={isCellsEnabled ? () => open() : uploadFiles}
+                  uploadImages={uploadImages}
+                  uploadFiles={uploadFiles}
+                  onCellImageUpload={openCellsUploadWindow}
+                  onCellAssetUpload={openCellsUploadWindow}
                 />
               ))}
 

--- a/src/script/components/InputBar/InputBar.test.tsx
+++ b/src/script/components/InputBar/InputBar.test.tsx
@@ -92,6 +92,8 @@ describe('InputBar', () => {
     uploadDroppedFiles: jest.fn(),
     uploadImages: jest.fn(),
     uploadFiles: jest.fn(),
+    onCellImageUpload: jest.fn(),
+    onCellAssetUpload: jest.fn(),
   });
 
   beforeEach(() => {

--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -88,6 +88,8 @@ interface InputBarProps {
   uploadDroppedFiles: (droppedFiles: File[]) => void;
   uploadImages: (images: File[]) => void;
   uploadFiles: (files: File[]) => void;
+  onCellImageUpload: () => void;
+  onCellAssetUpload: () => void;
 }
 
 export const InputBar = ({
@@ -106,6 +108,8 @@ export const InputBar = ({
   uploadDroppedFiles,
   uploadImages,
   uploadFiles,
+  onCellImageUpload,
+  onCellAssetUpload,
 }: InputBarProps) => {
   const {classifiedDomains, isSelfDeletingMessagesEnabled, isFileSharingSendingEnabled} = useKoSubscribableChildren(
     teamState,
@@ -326,6 +330,8 @@ export const InputBar = ({
                     onSelectImages={uploadImages}
                     onSend={handleSendMessage}
                     isSending={isSending}
+                    onCellImageUpload={onCellImageUpload}
+                    onCellAssetUpload={onCellAssetUpload}
                   />
                 </InputBarEditor>
               )}

--- a/src/script/components/InputBar/InputBarControls/CellAssetUploadButton/CellAssetUploadButton.tsx
+++ b/src/script/components/InputBar/InputBarControls/CellAssetUploadButton/CellAssetUploadButton.tsx
@@ -1,0 +1,40 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import * as Icon from 'Components/Icon';
+import {t} from 'Util/LocalizerUtil';
+
+interface CellAssetUploadButtonProps {
+  onClick: () => void;
+}
+
+export const CellAssetUploadButton = ({onClick}: CellAssetUploadButtonProps) => {
+  return (
+    <button
+      type="button"
+      aria-label={t('tooltipConversationFile')}
+      title={t('tooltipConversationFile')}
+      className="input-bar-control file-button"
+      onClick={onClick}
+      data-uie-name="do-share-file"
+    >
+      <Icon.AttachmentIcon />
+    </button>
+  );
+};

--- a/src/script/components/InputBar/InputBarControls/CellImageUploadButton/CellImageUploadButton.tsx
+++ b/src/script/components/InputBar/InputBarControls/CellImageUploadButton/CellImageUploadButton.tsx
@@ -1,0 +1,40 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import * as Icon from 'Components/Icon';
+import {t} from 'Util/LocalizerUtil';
+
+interface CellImageUploadButtonProps {
+  onClick: () => void;
+}
+
+export const CellImageUploadButton = ({onClick}: CellImageUploadButtonProps) => {
+  return (
+    <button
+      type="button"
+      aria-label={t('tooltipConversationAddImage')}
+      title={t('tooltipConversationAddImage')}
+      className="input-bar-control file-button"
+      onClick={onClick}
+      data-uie-name="do-share-image"
+    >
+      <Icon.ImageIcon />
+    </button>
+  );
+};

--- a/src/script/components/InputBar/InputBarControls/ControlButtons.test.tsx
+++ b/src/script/components/InputBar/InputBarControls/ControlButtons.test.tsx
@@ -40,6 +40,8 @@ const defaultParams: PropsType = {
   isEmojiActive: true,
   onFormatClick: jest.fn(),
   onEmojiClick: jest.fn(),
+  onCellImageUpload: jest.fn(),
+  onCellAssetUpload: jest.fn(),
 };
 
 const allButtonTitles = [

--- a/src/script/components/InputBar/InputBarControls/ControlButtons.tsx
+++ b/src/script/components/InputBar/InputBarControls/ControlButtons.tsx
@@ -25,6 +25,8 @@ import {Conversation} from 'src/script/entity/Conversation';
 
 import {AssetUploadButton} from './AssetUploadButton/AssetUploadButton';
 import {CancelEditButton} from './CancelEditButton/CancelEditButton';
+import {CellAssetUploadButton} from './CellAssetUploadButton/CellAssetUploadButton';
+import {CellImageUploadButton} from './CellImageUploadButton/CellImageUploadButton';
 import {EmojiButton} from './EmojiButton/EmojiButton';
 import {FormatTextButton} from './FormatTextButton/FormatTextButton';
 import {GiphyButton} from './GiphyButton/GiphyButton';
@@ -50,6 +52,8 @@ export type ControlButtonsProps = {
   onGifClick: () => void;
   onFormatClick: () => void;
   onEmojiClick: (event: MouseEvent<HTMLButtonElement>) => void;
+  onCellAssetUpload: () => void;
+  onCellImageUpload: () => void;
 };
 
 const ControlButtons = ({
@@ -70,6 +74,8 @@ const ControlButtons = ({
   onGifClick,
   onFormatClick,
   onEmojiClick,
+  onCellImageUpload,
+  onCellAssetUpload,
 }: ControlButtonsProps) => {
   const isCellsEnabled = Config.getConfig().FEATURE.ENABLE_CELLS;
 
@@ -116,17 +122,25 @@ const ControlButtons = ({
         {!disableFilesharing && (
           <>
             <li>
-              <ImageUploadButton
-                onSelectImages={onSelectImages}
-                acceptedImageTypes={Config.getConfig().ALLOWED_IMAGE_TYPES}
-              />
+              {isCellsEnabled ? (
+                <CellImageUploadButton onClick={onCellImageUpload} />
+              ) : (
+                <ImageUploadButton
+                  onSelectImages={onSelectImages}
+                  acceptedImageTypes={Config.getConfig().ALLOWED_IMAGE_TYPES}
+                />
+              )}
             </li>
 
             <li>
-              <AssetUploadButton
-                onSelectFiles={onSelectFiles}
-                acceptedFileTypes={Config.getConfig().FEATURE.ALLOWED_FILE_UPLOAD_EXTENSIONS}
-              />
+              {isCellsEnabled ? (
+                <CellAssetUploadButton onClick={onCellAssetUpload} />
+              ) : (
+                <AssetUploadButton
+                  onSelectFiles={onSelectFiles}
+                  acceptedFileTypes={Config.getConfig().FEATURE.ALLOWED_FILE_UPLOAD_EXTENSIONS}
+                />
+              )}
             </li>
           </>
         )}
@@ -157,6 +171,16 @@ const ControlButtons = ({
           {showEmojiButton && (
             <li>
               <EmojiButton isActive={isEmojiActive} onClick={onEmojiClick} />
+            </li>
+          )}
+          {!disableFilesharing && isCellsEnabled && (
+            <li>
+              <CellImageUploadButton onClick={onCellImageUpload} />
+            </li>
+          )}
+          {!disableFilesharing && isCellsEnabled && (
+            <li>
+              <CellAssetUploadButton onClick={onCellAssetUpload} />
             </li>
           )}
           <li aria-hidden="true">

--- a/src/script/components/InputBar/InputBarControls/InputBarControls.tsx
+++ b/src/script/components/InputBar/InputBarControls/InputBarControls.tsx
@@ -53,6 +53,8 @@ interface InputBarControlsProps {
   onGifClick: () => void;
   onSelectFiles: (files: File[]) => void;
   onSelectImages: (files: File[]) => void;
+  onCellImageUpload: () => void;
+  onCellAssetUpload: () => void;
   onSend: () => void;
   isSending: boolean;
 }
@@ -73,6 +75,8 @@ export const InputBarControls = ({
   onGifClick,
   onSelectFiles,
   onSelectImages,
+  onCellImageUpload,
+  onCellAssetUpload,
   onSend,
   isSending,
 }: InputBarControlsProps) => {
@@ -107,6 +111,8 @@ export const InputBarControls = ({
           isEmojiActive={emojiPicker.open}
           onFormatClick={formatToolbar.handleClick}
           onEmojiClick={emojiPicker.handleToggle}
+          onCellImageUpload={onCellImageUpload}
+          onCellAssetUpload={onCellAssetUpload}
         />
       </ul>
       <SendMessageButton


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15706" title="WPB-15706" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15706</a>  [Web] Receive message with multiple files 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

- fix double opening on upload button click (cells only), created a separate component based on the original button, but without the internal logic (input element)
- show upload buttons when user types a message (cells only)

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
