### PR TITLE
ci(wire-builds): push q2-2025 tags to wire-builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on:
     branches: [master, dev, release/*, new-navigation]
     tags:
       - '*q1-2024*'
+      - '*q2-2025*'
       - '*staging*'
       - '*production*'
 
@@ -196,6 +197,9 @@ jobs:
               },
               "q1-2024": {
                 "targets": "[\"q1-2024\"]"
+              },
+              "q2-2025": {
+                "targets": "[\"q2-2025\"]"
               }
             }
           export_to: log,output
@@ -294,9 +298,6 @@ jobs:
               },
               "production": {
                 "targets": "[\"wire-webapp-prod\"]"
-              },
-              "release/q1-2024": {
-                "targets": "[\"wire-webapp-mls\"]"
               },
               "staging": {
                 "targets": "[\"wire-webapp-staging\"]"


### PR DESCRIPTION
## Description

This pushes commit containing `q2-2025` in their tag to the relevant `wire-builds` branch https://github.com/wireapp/wire-builds/tree/q2-2025

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
