### PR TITLE
ci(dependabot): ignore all lexical deps update [WPB-16921]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,12 @@ updates:
           - '0.10.16'
       - dependency-name: '@types/node'
       - dependency-name: 'typescript'
+      - dependency-name: 'lexical-@lexical/code'
+      - dependency-name: 'lexical-@lexical/history'
+      - dependency-name: 'lexical-@lexical/list'
+      - dependency-name: 'lexical-@lexical/markdown'
+      - dependency-name: 'lexical-@lexical/react'
+      - dependency-name: 'lexical-@lexical/rich-text'
 
   # Server dependencies
   - package-ecosystem: npm


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16921" title="WPB-16921" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16921</a>  [Web] Markdown characters are auto escaped
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

A lexical Minor update introduced a breaking change that escapes common characters used in Markdown for formatting like \* and \_ making it impossible to format without formatting preview disabled

This prevent dependabot future updates

https://github.com/wireapp/wire-webapp/pull/18932

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
