### PR TITLE
fix: proceed with 2fa flow after handling error [WPB-16948]

### DIFF
--- a/src/script/auth/module/action/AuthAction.ts
+++ b/src/script/auth/module/action/AuthAction.ts
@@ -28,7 +28,7 @@ import type {TeamData} from '@wireapp/api-client/lib/team/';
 import {LowDiskSpaceError} from '@wireapp/store-engine/lib/engine/error';
 import {StatusCodes as HTTP_STATUS, StatusCodes} from 'http-status-codes';
 
-import {isAxiosError, isBackendError} from 'Util/TypePredicateUtil';
+import {isBackendError} from 'Util/TypePredicateUtil';
 
 import {AuthActionCreator} from './creator/';
 import {LabeledError} from './LabeledError';
@@ -156,7 +156,7 @@ export class AuthAction {
          * We don't want to block the user from logging in if they have already received a code in the last few minutes.
          * Any other error should still be thrown.
          */
-        if (isAxiosError(error) && error.response?.status === StatusCodes.TOO_MANY_REQUESTS) {
+        if (isBackendError(error) && SyntheticErrorLabel.TOO_MANY_REQUESTS === error.label) {
           dispatch(AuthActionCreator.successfulSendTwoFactorCode());
           return;
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16948" title="WPB-16948" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16948</a>  [Web] 429 on login error blocks calling service
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

See https://github.com/wireapp/wire-webapp/pull/14974

The shape of the 429 error we received changed, so we were locking the login flow when we want to proceed to the 2fa login when we hit a rate limit in requesting emails.

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
