### PR TITLE
fix: default notification state for newly created conversations [WPB-16859]

### DIFF
--- a/src/script/conversation/ConversationMapper.ts
+++ b/src/script/conversation/ConversationMapper.ts
@@ -37,6 +37,7 @@ import {LegalHoldStatus} from '@wireapp/protocol-messaging';
 import {ACCESS_STATE} from './AccessState';
 import {ConversationStatus} from './ConversationStatus';
 import {ConversationVerificationState} from './ConversationVerificationState';
+import {NOTIFICATION_STATE} from './NotificationSetting';
 
 import {Conversation} from '../entity/Conversation';
 import {BaseError, BASE_ERROR_TYPE} from '../error/BaseError';
@@ -282,6 +283,10 @@ export class ConversationMapper {
     if (!conversationEntity.last_event_timestamp() && initialTimestamp) {
       conversationEntity.last_event_timestamp(initialTimestamp);
       conversationEntity.last_server_timestamp(initialTimestamp);
+    }
+
+    if (conversationEntity.mutedState() === null) {
+      conversationEntity.mutedState(NOTIFICATION_STATE.EVERYTHING);
     }
 
     // Active participants from database or backend payload

--- a/src/script/entity/Conversation.test.ts
+++ b/src/script/entity/Conversation.test.ts
@@ -956,14 +956,6 @@ describe('Conversation', () => {
       conversationEntity.mutedState(NOTIFICATION_STATES.EVERYTHING);
       expect(conversationEntity.notificationState()).toBe(NOTIFICATION_STATES.EVERYTHING);
 
-      //@ts-expect-error
-      conversationEntity.mutedState(true);
-      expect(conversationEntity.notificationState()).toBe(NOTIFICATION_STATES.MENTIONS_AND_REPLIES);
-
-      //@ts-expect-error
-      conversationEntity.mutedState(false);
-      expect(conversationEntity.notificationState()).toBe(NOTIFICATION_STATES.EVERYTHING);
-
       conversationEntity.mutedState(NOTIFICATION_STATES.NOTHING);
       expect(conversationEntity.notificationState()).toBe(NOTIFICATION_STATES.NOTHING);
 

--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -332,13 +332,7 @@ export class Conversation {
       if (!this.selfUser()) {
         return NOTIFICATION_STATE.NOTHING;
       }
-      const mutedState = this.mutedState();
-
-      if (typeof mutedState === 'boolean') {
-        return mutedState ? NOTIFICATION_STATE.MENTIONS_AND_REPLIES : NOTIFICATION_STATE.EVERYTHING;
-      }
-
-      return mutedState;
+      return this.mutedState();
     });
 
     this.is_archived = this.archivedState;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16859" title="WPB-16859" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16859</a>  [Web] Newly created group has muted notifications by default
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
Fixes issue where newly created group and 1:1 conversations have muted notifications by default.

## Screenshots/Screencast (for UI changes)
### Private Users

https://github.com/user-attachments/assets/0c4f49c9-7c34-45c1-9669-51a8ef70251c


### Team Users

https://github.com/user-attachments/assets/961fbdf8-3962-477d-90de-39bab9094b37


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author
- [ ] Hard-to-understand areas of the code have been commented
- [x] If it is a core feature, unit tests have been added
