### PR TITLE
fix: provide access rights to only team conversation owner

### DIFF
--- a/src/script/components/MessagesList/Message/E2eEncryptionMessage/E2eEncryptionMessage.styles.ts
+++ b/src/script/components/MessagesList/Message/E2eEncryptionMessage/E2eEncryptionMessage.styles.ts
@@ -20,6 +20,8 @@
 import {CSSObject} from '@emotion/react';
 
 export const e2eMessageContainerCss: CSSObject = {
+  width: '100%',
+  marginTop: '1rem',
   background: 'var(--green-background)',
   padding: '12px 0',
   display: 'flex',

--- a/src/script/conversation/ConversationRoleRepository.ts
+++ b/src/script/conversation/ConversationRoleRepository.ts
@@ -145,8 +145,8 @@ export class ConversationRoleRepository {
   };
 
   readonly hasPermission = (conversation: Conversation, user: User, permissionName: Permissions): boolean => {
-    // Bypass permission check for admin or owner and when conversation is a channel
-    if (user.isAdminOrOwner() && conversation.isChannel()) {
+    // Bypass permission check for admin or owner and when conversation is a channel and teamId matches
+    if (user.isAdminOrOwner() && conversation.teamId === user.teamId && conversation.isChannel()) {
       return true;
     }
 


### PR DESCRIPTION
## Description
Provide access rights to only team conversation owner.
Fixed e2ee message ui for 1-1 conversation.

## Screenshot
![Screenshot 2025-04-09 at 16 34 37](https://github.com/user-attachments/assets/369a71de-e588-4dbc-ae4b-82c760384110)

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
