### PR TITLE
chore(config): bump wire-web-config-wire to 0.34.2

### DIFF
--- a/app-config/package.json
+++ b/app-config/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "wire-web-config-default-master": "https://github.com/wireapp/wire-web-config-wire#v0.34.1",
+    "wire-web-config-default-master": "https://github.com/wireapp/wire-web-config-wire#v0.34.2",
     "wire-web-config-default-staging": "https://github.com/wireapp/wire-web-config-default#v0.34.1"
   }
 }


### PR DESCRIPTION
## Description

the tag [0.34.1](https://github.com/wireapp/wire-web-config-wire/tree/v0.34.1) of https://github.com/wireapp/wire-web-config-wire points to the [wrong environment variables](https://github.com/wireapp/wire-web-config-wire/blob/v0.34.1/wire-webapp/.env.defaults#L30) for production

the new tag [0.34.2](https://github.com/wireapp/wire-web-config-wire/tree/v0.34.2) [corrects the issue](https://github.com/wireapp/wire-web-config-wire/blob/v0.34.2/wire-webapp/.env.defaults#L30)

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
