### PR TITLE
fix: set default add_permission value to ADMINS

### DIFF
--- a/src/script/conversation/ConversationMapper.ts
+++ b/src/script/conversation/ConversationMapper.ts
@@ -275,7 +275,7 @@ export class ConversationMapper {
     conversationEntity.type(type);
     conversationEntity.name(name || '');
     conversationEntity.groupConversationType(group_conv_type || GROUP_CONVERSATION_TYPE.GROUP_CONVERSATION);
-    conversationEntity.conversationModerator(add_permission || ADD_PERMISSION.EVERYONE);
+    conversationEntity.conversationModerator(add_permission || ADD_PERMISSION.ADMINS);
 
     const selfState = members?.self || conversationData;
     conversationEntity = ConversationMapper.updateSelfStatus(conversationEntity, selfState as any);


### PR DESCRIPTION
## Description

Set default add_permission value to ADMINS to prevent team admins acting as group admin

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
