### PR TITLE
feat: Redirect to unsupported page when desktop is enforced (WPB-17261)

### DIFF
--- a/src/script/auth/main.tsx
+++ b/src/script/auth/main.tsx
@@ -28,6 +28,8 @@ import {createRoot} from 'react-dom/client';
 import {Provider} from 'react-redux';
 import {container} from 'tsyringe';
 
+import {Runtime} from '@wireapp/commons';
+
 import {initializeDataDog} from 'Util/DataDog';
 import {enableLogging} from 'Util/LoggerUtil';
 import {exposeWrapperGlobals} from 'Util/wrapper';
@@ -91,4 +93,12 @@ async function runApp() {
 }
 
 enableLogging(config);
+
+const enforceDesktopApplication = config.FEATURE.ENABLE_ENFORCE_DESKTOP_APPLICATION_ONLY && !Runtime.isDesktopApp();
+
+if (enforceDesktopApplication) {
+  const unSupportedPageUrl = `${window.location.origin}/unsupported`;
+  window.location.replace(unSupportedPageUrl);
+}
+
 runApp();

--- a/src/script/main/index.tsx
+++ b/src/script/main/index.tsx
@@ -52,7 +52,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   const enforceDesktopApplication = config.FEATURE.ENABLE_ENFORCE_DESKTOP_APPLICATION_ONLY && !Runtime.isDesktopApp();
 
   if (enforceDesktopApplication) {
-    doRedirect(SIGN_OUT_REASON.APP_INIT);
+    const unSupportedPageUrl = `${window.location.origin}/unsupported`;
+    window.location.replace(unSupportedPageUrl);
+    return;
   }
 
   const shouldPersist = loadValue<boolean>(StorageKey.AUTH.PERSIST);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17261" title="WPB-17261" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17261</a>  [Web] Only desktop supported flag does not redirect user to the correct page when using browser
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
