### PR TITLE
fix: Allow personal users to create mls clients (WPB-17396)

### DIFF
--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -22,7 +22,7 @@
 
 import {Context} from '@wireapp/api-client/lib/auth';
 import {ClientClassification, ClientType} from '@wireapp/api-client/lib/client/';
-import {FeatureList} from '@wireapp/api-client/lib/team';
+import {FEATURE_KEY, FeatureList} from '@wireapp/api-client/lib/team';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {EVENTS as CoreEvents} from '@wireapp/core/lib/Account';
 import {MLSServiceEvents} from '@wireapp/core/lib/messagingProtocols/mls';
@@ -464,8 +464,8 @@ export class App {
         teamFeatures = features;
         teamMembers = members;
       } else {
-        const features = await this.apiClient.api.teams.feature.getAllFeatures();
-        teamFeatures = features;
+        const commonFeatures = (await this.core.service?.team.getCommonFeatureConfig()) ?? {};
+        teamFeatures = {mls: commonFeatures[FEATURE_KEY.MLS]};
       }
 
       try {

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -22,6 +22,8 @@
 
 import {Context} from '@wireapp/api-client/lib/auth';
 import {ClientClassification, ClientType} from '@wireapp/api-client/lib/client/';
+import {FeatureList} from '@wireapp/api-client/lib/team';
+import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {EVENTS as CoreEvents} from '@wireapp/core/lib/Account';
 import {MLSServiceEvents} from '@wireapp/core/lib/messagingProtocols/mls';
 import {amplify} from 'amplify';
@@ -453,7 +455,19 @@ export class App {
       if (!localClient) {
         throw new ClientError(CLIENT_ERROR_TYPE.NO_VALID_CLIENT, 'Client has been deleted on backend');
       }
-      const {features: teamFeatures, members: teamMembers} = await teamRepository.initTeam(selfUser.teamId);
+
+      let teamFeatures: FeatureList = {};
+      let teamMembers: QualifiedId[] = [];
+
+      if (selfUser.teamId) {
+        const {features, members} = await teamRepository.initTeam(selfUser.teamId);
+        teamFeatures = features;
+        teamMembers = members;
+      } else {
+        const features = await this.apiClient.api.teams.feature.getAllFeatures();
+        teamFeatures = features;
+      }
+
       try {
         await this.core.initClient(localClient, getClientMLSConfig(teamFeatures));
       } catch (error) {

--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -155,11 +155,14 @@ export class TeamRepository extends TypedEventEmitter<Events> {
     }
 
     if (!teamId) {
+      const mlsFeature = newFeatureList[FEATURE_KEY.MLS];
       return {
         team: undefined,
-        features: {
-          mls: newFeatureList[FEATURE_KEY.MLS],
-        },
+        features: mlsFeature
+          ? {
+              mls: newFeatureList[FEATURE_KEY.MLS],
+            }
+          : {},
         members: [],
       };
     }

--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -155,8 +155,15 @@ export class TeamRepository extends TypedEventEmitter<Events> {
     }
 
     if (!teamId) {
-      return {team: undefined, features: {}, members: []};
+      return {
+        team: undefined,
+        features: {
+          mls: newFeatureList[FEATURE_KEY.MLS],
+        },
+        members: [],
+      };
     }
+
     // Subscribe to team members change and update the user role and guest status
     this.teamState.teamMembers.subscribe(members => {
       this.userRepository.mapGuestStatus(members);

--- a/src/script/team/TeamRepository.ts
+++ b/src/script/team/TeamRepository.ts
@@ -155,18 +155,8 @@ export class TeamRepository extends TypedEventEmitter<Events> {
     }
 
     if (!teamId) {
-      const mlsFeature = newFeatureList[FEATURE_KEY.MLS];
-      return {
-        team: undefined,
-        features: mlsFeature
-          ? {
-              mls: newFeatureList[FEATURE_KEY.MLS],
-            }
-          : {},
-        members: [],
-      };
+      return {team: undefined, features: {}, members: []};
     }
-
     // Subscribe to team members change and update the user role and guest status
     this.teamState.teamMembers.subscribe(members => {
       this.userRepository.mapGuestStatus(members);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17396" title="WPB-17396" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17396</a>  [Web] Personal users can not exchange messages in MLS 1:1 conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Enable mls feature config for personal users to let them initialize a mls clients.