### PR TITLE
fix: pdf worker build [WPB-15678]

### DIFF
--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -121,7 +121,8 @@ import {UserService} from '../user/UserService';
 import {ViewModelRepositories} from '../view_model/MainViewModel';
 import {Warnings} from '../view_model/WarningsContainer';
 
-pdfjs.GlobalWorkerOptions.workerSrc = new URL('pdfjs-dist/build/pdf.worker.min.mjs', import.meta.url).toString();
+// Initialize PDF.js worker for react-pdf package
+pdfjs.GlobalWorkerOptions.workerSrc = '/min/pdf.worker.mjs';
 
 export function doRedirect(signOutReason: SIGN_OUT_REASON) {
   let url = `/auth/${location.search}`;

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -175,6 +175,13 @@ module.exports = {
         {from: `assets`, to: `${dist}/assets`},
         {from: 'src/page/basicBrowserFeatureCheck.js', to: `${dist}/min/`},
         {from: 'src/page/loader.js', to: `${dist}/min/`},
+        // Copy PDF worker for react-pdf package
+        {
+          from: path.dirname(require.resolve('pdfjs-dist/package.json')) + '/build/pdf.worker.mjs',
+          to: `${dist}/min/pdf.worker.mjs`,
+          // Prevents content hashing
+          info: {minimized: true},
+        },
       ],
     }),
     new webpack.IgnorePlugin({resourceRegExp: /.*\.wasm/}),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15678" title="WPB-15678" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15678</a>  [Web] Cells fullscreen pdf
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

There's a problem with the prod build (on the IMAI env) with loading the PDF worker. It's probably caused by not finding the proper path. 

As the [docs suggest](https://github.com/wojtekmaj/react-pdf?tab=readme-ov-file#copy-worker-to-public-directory), we could initiate the PDF worker from our own copied file - this PR introduces that approach. 

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
