### PR TITLE
feat: Grouping of messages by day (WPB-17297)

### DIFF
--- a/src/script/components/MessagesList/Message/Marker/Marker.tsx
+++ b/src/script/components/MessagesList/Message/Marker/Marker.tsx
@@ -59,11 +59,8 @@ function customDayTimestampCalculator(ts: number): string {
 }
 
 export function MarkerComponent({marker, scrollTo}: {marker: Marker; scrollTo: ScrollToElement}) {
-  const timeAgo = useRelativeTimestamp(
-    marker.timestamp,
-    marker.type === 'day',
-    marker.type === 'day' ? customDayTimestampCalculator : undefined,
-  );
+  const isDay = marker.type === 'day';
+  const timeAgo = useRelativeTimestamp(marker.timestamp, isDay, isDay ? customDayTimestampCalculator : undefined);
   const elementRef = useRef<HTMLDivElement>(null);
 
   const style = css`

--- a/src/script/components/MessagesList/Message/Marker/Marker.tsx
+++ b/src/script/components/MessagesList/Message/Marker/Marker.tsx
@@ -40,7 +40,7 @@ const markerStyles: Partial<Record<Marker['type'], SerializedStyles>> = {
   If yesterday: “Yesterday”
   Any other day: <Week day>, <date> (e.g. “Monday, April 12” or “Friday, January 6 2023”)
 */
-function getMessagesGroupLabelCallback(ts: number): string {
+function getMessagesGroupLabel(ts: number): string {
   const date = new Date(ts);
 
   if (isToday(date)) {
@@ -60,7 +60,7 @@ function getMessagesGroupLabelCallback(ts: number): string {
 
 export function MarkerComponent({marker, scrollTo}: {marker: Marker; scrollTo: ScrollToElement}) {
   const isDay = marker.type === 'day';
-  const timeAgo = useRelativeTimestamp(marker.timestamp, isDay, isDay ? getMessagesGroupLabelCallback : undefined);
+  const timeAgo = useRelativeTimestamp(marker.timestamp, isDay, isDay ? getMessagesGroupLabel : undefined);
   const elementRef = useRef<HTMLDivElement>(null);
 
   const style = css`

--- a/src/script/components/MessagesList/Message/Marker/Marker.tsx
+++ b/src/script/components/MessagesList/Message/Marker/Marker.tsx
@@ -42,10 +42,6 @@ const markerStyles: Partial<Record<Marker['type'], SerializedStyles>> = {
 */
 function getMessagesGroupLabelCallback(ts: number): string {
   const date = new Date(ts);
-  const today = new Date();
-
-  const isCurrentYear = date.getFullYear() === today.getFullYear();
-  const pattern = isCurrentYear ? 'EEEE, MMMM d' : 'EEEE, MMMM d yyyy';
 
   if (isToday(date)) {
     return t('conversationToday');
@@ -54,6 +50,10 @@ function getMessagesGroupLabelCallback(ts: number): string {
   if (isYesterday(date)) {
     return t('conversationYesterday');
   }
+
+  const today = new Date();
+  const isCurrentYear = date.getFullYear() === today.getFullYear();
+  const pattern = isCurrentYear ? 'EEEE, MMMM d' : 'EEEE, MMMM d yyyy';
 
   return formatLocale(date, pattern);
 }

--- a/src/script/components/MessagesList/Message/Marker/Marker.tsx
+++ b/src/script/components/MessagesList/Message/Marker/Marker.tsx
@@ -40,7 +40,7 @@ const markerStyles: Partial<Record<Marker['type'], SerializedStyles>> = {
   If yesterday: “Yesterday”
   Any other day: <Week day>, <date> (e.g. “Monday, April 12” or “Friday, January 6 2023”)
 */
-function customDayTimestampCalculator(ts: number): string {
+function getMessagesGroupLabelCallback(ts: number): string {
   const date = new Date(ts);
   const today = new Date();
 
@@ -60,7 +60,7 @@ function customDayTimestampCalculator(ts: number): string {
 
 export function MarkerComponent({marker, scrollTo}: {marker: Marker; scrollTo: ScrollToElement}) {
   const isDay = marker.type === 'day';
-  const timeAgo = useRelativeTimestamp(marker.timestamp, isDay, isDay ? customDayTimestampCalculator : undefined);
+  const timeAgo = useRelativeTimestamp(marker.timestamp, isDay, isDay ? getMessagesGroupLabelCallback : undefined);
   const elementRef = useRef<HTMLDivElement>(null);
 
   const style = css`

--- a/src/script/components/MessagesList/Message/Marker/Marker.tsx
+++ b/src/script/components/MessagesList/Message/Marker/Marker.tsx
@@ -22,6 +22,8 @@ import {useLayoutEffect, useRef} from 'react';
 import {SerializedStyles, css} from '@emotion/react';
 
 import {useRelativeTimestamp} from 'src/script/hooks/useRelativeTimestamp';
+import {t} from 'Util/LocalizerUtil';
+import {formatLocale, isToday, isYesterday} from 'Util/TimeUtil';
 
 import {dayMarkerStyle, baseMarkerStyle} from './Marker.styles';
 
@@ -33,8 +35,35 @@ const markerStyles: Partial<Record<Marker['type'], SerializedStyles>> = {
   day: dayMarkerStyle,
 };
 
+/**
+  If today: “Today”
+  If yesterday: “Yesterday”
+  Any other day: <Week day>, <date> (e.g. “Monday, April 12” or “Friday, January 6 2023”)
+*/
+function customDayTimestampCalculator(ts: number): string {
+  const date = new Date(ts);
+  const today = new Date();
+
+  const isCurrentYear = date.getFullYear() === today.getFullYear();
+  const pattern = isCurrentYear ? 'EEEE, MMMM d' : 'EEEE, MMMM d yyyy';
+
+  if (isToday(date)) {
+    return t('conversationToday');
+  }
+
+  if (isYesterday(date)) {
+    return t('conversationYesterday');
+  }
+
+  return formatLocale(date, pattern);
+}
+
 export function MarkerComponent({marker, scrollTo}: {marker: Marker; scrollTo: ScrollToElement}) {
-  const timeAgo = useRelativeTimestamp(marker.timestamp, marker.type === 'day');
+  const timeAgo = useRelativeTimestamp(
+    marker.timestamp,
+    marker.type === 'day',
+    marker.type === 'day' ? customDayTimestampCalculator : undefined,
+  );
   const elementRef = useRef<HTMLDivElement>(null);
 
   const style = css`

--- a/src/script/components/MessagesList/utils/messagesGroup.test.ts
+++ b/src/script/components/MessagesList/utils/messagesGroup.test.ts
@@ -89,30 +89,6 @@ describe('MessagesGroup', () => {
     expect(groupedMessages.findIndex(group => isMarker(group))).toBe(nbReadMessages);
   });
 
-  it('adds markers for messages sent on different hours', () => {
-    const nbPrevHourMessages = getRandomNumber(1, 10);
-    const nbNextHourMessages = getRandomNumber(1, 10);
-
-    const previousMessages = [...Array(nbPrevHourMessages)].map((_, index) =>
-      createMessageAddEvent({overrides: {time: new Date(index).toISOString()}}),
-    );
-    const nextMessages = [...Array(nbNextHourMessages)].map((_, index) =>
-      createMessageAddEvent({
-        overrides: {time: new Date(TimeInMillis.HOUR + 10 * TimeInMillis.MINUTE + index).toISOString()},
-      }),
-    );
-
-    const allMessages = [...previousMessages, ...nextMessages].map(
-      event => eventMapper.mapJsonEvent(event, conversation) as Message,
-    );
-
-    const groupedMessages = groupMessagesBySenderAndTime(allMessages, Infinity);
-    const firstMarkerIndex = groupedMessages.findIndex(group => isMarker(group));
-    const marker = groupedMessages[firstMarkerIndex] as any;
-    expect(firstMarkerIndex).toBe(nbPrevHourMessages);
-    expect(marker.type).toBe('hour');
-  });
-
   it('adds markers for messages sent on different days', () => {
     const nbPrevHourMessages = getRandomNumber(1, 10);
     const nbNextHourMessages = getRandomNumber(1, 10);

--- a/src/script/components/MessagesList/utils/messagesGroup.ts
+++ b/src/script/components/MessagesList/utils/messagesGroup.ts
@@ -18,7 +18,7 @@
  */
 
 import {Message} from 'src/script/entity/message/Message';
-import {differenceInMinutes, isSameDay, fromUnixTime, TIME_IN_MILLIS} from 'Util/TimeUtil';
+import {isSameDay, fromUnixTime, TIME_IN_MILLIS} from 'Util/TimeUtil';
 
 export type MessagesGroup = {
   sender: string;
@@ -28,7 +28,7 @@ export type MessagesGroup = {
 };
 
 export type Marker = {
-  type: 'unread' | 'day' | 'hour';
+  type: 'unread' | 'day';
   timestamp: number;
 };
 
@@ -60,10 +60,6 @@ function getMessageMarkerType(
 
   if (!isSameDay(previousMessageTimestamp, currentMessageTimestamp)) {
     return 'day';
-  }
-
-  if (differenceInMinutes(currentMessageTimestamp, previousMessageTimestamp) > 60) {
-    return 'hour';
   }
 
   return undefined;

--- a/src/script/hooks/useRelativeTimestamp.tsx
+++ b/src/script/hooks/useRelativeTimestamp.tsx
@@ -35,40 +35,42 @@ import {
   isYoungerThanMinute,
 } from 'Util/TimeUtil';
 
-export function useRelativeTimestamp(timestamp: number, asDay = false) {
-  const calculateTimestamp = (ts: number, isDay: boolean) => {
-    const date = fromUnixTime(ts / TIME_IN_MILLIS.SECOND);
-    if (isYoungerThanMinute(date)) {
-      return t('conversationJustNow');
-    }
+const calculateTimestamp = (ts: number, isDay: boolean) => {
+  const date = fromUnixTime(ts / TIME_IN_MILLIS.SECOND);
+  if (isYoungerThanMinute(date)) {
+    return t('conversationJustNow');
+  }
 
-    if (isYoungerThan1Hour(date)) {
-      return fromNowLocale(date);
-    }
+  if (isYoungerThan1Hour(date)) {
+    return fromNowLocale(date);
+  }
 
-    if (isToday(date)) {
-      const time = formatTimeShort(date);
-      return isDay ? `${t('conversationToday')} ${time}` : time;
-    }
-
-    if (isYesterday(date)) {
-      return `${t('conversationYesterday')} ${formatTimeShort(date)}`;
-    }
-    if (isYoungerThan7Days(date)) {
-      return formatLocale(date, 'EEEE p');
-    }
-
-    const weekDay = formatLocale(date, 'EEEE');
-    const dayMonth = formatDayMonth(date);
-    const year = isThisYear(date) ? '' : ` ${date.getFullYear()}`;
+  if (isToday(date)) {
     const time = formatTimeShort(date);
-    return isDay ? `${weekDay}, ${dayMonth}${year}, ${time}` : `${dayMonth}${year}, ${time}`;
-  };
-  const [timeago, setTimeago] = useState<string>(calculateTimestamp(timestamp, asDay));
+    return isDay ? `${t('conversationToday')} ${time}` : time;
+  }
+
+  if (isYesterday(date)) {
+    return `${t('conversationYesterday')} ${formatTimeShort(date)}`;
+  }
+
+  if (isYoungerThan7Days(date)) {
+    return formatLocale(date, 'EEEE p');
+  }
+
+  const weekDay = formatLocale(date, 'EEEE');
+  const dayMonth = formatDayMonth(date);
+  const year = isThisYear(date) ? '' : ` ${date.getFullYear()}`;
+  const time = formatTimeShort(date);
+  return isDay ? `${weekDay}, ${dayMonth}${year}, ${time}` : `${dayMonth}${year}, ${time}`;
+};
+
+export function useRelativeTimestamp(timestamp: number, asDay = false, calculateTimestampFn = calculateTimestamp) {
+  const [timeago, setTimeago] = useState<string>(calculateTimestampFn(timestamp, asDay));
 
   useEffect(() => {
     const interval = setInterval(() => {
-      setTimeago(calculateTimestamp(timestamp, asDay));
+      setTimeago(calculateTimestampFn(timestamp, asDay));
     }, TIME_IN_MILLIS.MINUTE);
     return () => clearInterval(interval);
   });

--- a/src/script/hooks/useRelativeTimestamp.tsx
+++ b/src/script/hooks/useRelativeTimestamp.tsx
@@ -65,12 +65,16 @@ const calculateTimestamp = (ts: number, isDay: boolean) => {
   return isDay ? `${weekDay}, ${dayMonth}${year}, ${time}` : `${dayMonth}${year}, ${time}`;
 };
 
-export function useRelativeTimestamp(timestamp: number, asDay = false, calculateTimestampFn = calculateTimestamp) {
-  const [timeago, setTimeago] = useState<string>(calculateTimestampFn(timestamp, asDay));
+export function useRelativeTimestamp(
+  timestamp: number,
+  asDay = false,
+  getMessagesGroupLabelCallBack = calculateTimestamp,
+) {
+  const [timeago, setTimeago] = useState<string>(getMessagesGroupLabelCallBack(timestamp, asDay));
 
   useEffect(() => {
     const interval = setInterval(() => {
-      setTimeago(calculateTimestampFn(timestamp, asDay));
+      setTimeago(getMessagesGroupLabelCallBack(timestamp, asDay));
     }, TIME_IN_MILLIS.MINUTE);
     return () => clearInterval(interval);
   });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17297" title="WPB-17297" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17297</a>  [Web] - Grouping of messages by day
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
- Only day divider are displayed – no gap dividers anymore
- Unread indicator is not to be changed
- Message timestamp is not to be changed
- Time divider only displays the date (no time)

Format:
If today: “Today”
If yesterday: “Yesterday”
Any other day: <Week day>, <date> (e.g. “Monday, April 12” or “Friday, January 6 2023”)

<img width="307" alt="image" src="https://github.com/user-attachments/assets/829f5b2b-d76d-421e-89bf-fbc97019abf9" />