### PR TITLE
fix: Do not mark conversation as read with self user system messages (WPB-17209)

### DIFF
--- a/src/script/entity/Conversation.ts
+++ b/src/script/entity/Conversation.ts
@@ -455,7 +455,10 @@ export class Conversation {
       for (let index = messages.length - 1; index >= 0; index--) {
         const messageEntity = messages[index];
         if (messageEntity.visible()) {
-          const isReadMessage = messageEntity.timestamp() <= this.last_read_timestamp() || messageEntity.user().isMe;
+          const isReadMessage =
+            messageEntity.timestamp() <= this.last_read_timestamp() ||
+            (messageEntity.user().isMe && !messageEntity.isSystem());
+
           if (isReadMessage) {
             break;
           }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17209" title="WPB-17209" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17209</a>  [Web] - After migrating the team to MLS number of unread msgs from 1-1 conversations disappears
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
After migrating the team to MLS number of unread msgs from 1-1 conversations disappears because of the inserted system message