### PR TITLE
feat(backup): perform user check before importing backup [WPB-17781]

### DIFF
--- a/src/script/backup/CrossPlatformBackup/CPB.import.ts
+++ b/src/script/backup/CrossPlatformBackup/CPB.import.ts
@@ -17,14 +17,14 @@
  *
  */
 
-import {CPBackupImporter, BackupImportResult} from './CPB.library';
+import {CPBackupImporter, BackupImportResult, BackupQualifiedId} from './CPB.library';
 import {ImportHistoryToDatabaseParams} from './CPB.types';
 import {mapConversationRecord, mapUserRecord} from './importMappers';
 import {mapEventRecord} from './importMappers/mapEventRecord';
 
 import {ConversationRecord, EventRecord, UserRecord} from '../../storage';
 import {FileDescriptor, Filename} from '../Backup.types';
-import {IncompatibleBackupError} from '../Error';
+import {DifferentAccountError, IncompatibleBackupError} from '../Error';
 
 import {CPBLogger, peekCrossPlatformData} from '.';
 
@@ -34,14 +34,20 @@ import {CPBLogger, peekCrossPlatformData} from '.';
 export const importCPBHistoryToDatabase = async ({
   fileBytes,
   password,
+  user,
 }: ImportHistoryToDatabaseParams): Promise<{
   archiveVersion: number;
   fileDescriptors: FileDescriptor[];
 }> => {
   const backupImporter = new CPBackupImporter();
   const backupData = new Uint8Array(fileBytes);
-  const peekedData = await peekCrossPlatformData(fileBytes);
+  const peekedData = await peekCrossPlatformData(fileBytes, new BackupQualifiedId(user.id, user.domain));
   const FileDescriptor: FileDescriptor[] = [];
+
+  if (!peekedData.isUserBackup) {
+    CPBLogger.log('Backup is not created by the same user');
+    throw new DifferentAccountError('Backup is not created by the same user');
+  }
 
   // Import the backup
 

--- a/src/script/backup/CrossPlatformBackup/CPB.import.ts
+++ b/src/script/backup/CrossPlatformBackup/CPB.import.ts
@@ -44,6 +44,7 @@ export const importCPBHistoryToDatabase = async ({
   const peekedData = await peekCrossPlatformData(fileBytes, new BackupQualifiedId(user.id, user.domain));
   const FileDescriptor: FileDescriptor[] = [];
 
+  // Check if the backup was created by the same user
   if (!peekedData.isUserBackup) {
     CPBLogger.log('Backup is not created by the same user');
     throw new DifferentAccountError('Backup is not created by the same user');

--- a/src/script/backup/CrossPlatformBackup/CPB.library.ts
+++ b/src/script/backup/CrossPlatformBackup/CPB.library.ts
@@ -34,6 +34,9 @@ import BackupMessageContent = com.wire.backup.data.BackupMessageContent;
 import BackupDateTime = com.wire.backup.data.BackupDateTime;
 import EncryptionAlgorithm = BackupMessageContent.Asset.EncryptionAlgorithm;
 import AssetMetaData = com.wire.backup.data.BackupMessageContent.Asset.AssetMetadata;
+
+// Importing functions from the Java library
+import isCreatedBySameUser = com.wire.backup.ingest.isCreatedBySameUser;
 /* eslint-enable */
 
 export {
@@ -50,4 +53,5 @@ export {
   BackupDateTime,
   EncryptionAlgorithm,
   AssetMetaData,
+  isCreatedBySameUser,
 };


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17781" title="WPB-17781" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17781</a>  [Web] Implement backup User ownership check
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

Perform a User ownership check before importing backup

<!-- Uncomment this section if your PR has UI changes -->
## Screenshots/Screencast (for UI changes)
![image](https://github.com/user-attachments/assets/5f3aed78-b61d-465b-8cb4-cb823aa460ca)


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
