### PR TITLE
feat(backup): map location events to backup [WPB-17311]

### DIFF
--- a/src/script/backup/CrossPlatformBackup/CPB.helper.ts
+++ b/src/script/backup/CrossPlatformBackup/CPB.helper.ts
@@ -78,8 +78,10 @@ export const isMessageAddEvent = (eventType: unknown): boolean =>
   eventType === ClientEvent.CONVERSATION.MESSAGE_ADD.toString();
 export const isAssetAddEvent = (eventType: unknown): boolean =>
   eventType === ClientEvent.CONVERSATION.ASSET_ADD.toString();
+export const isLocationAddEvent = (eventType: unknown): boolean =>
+  eventType === ClientEvent.CONVERSATION.LOCATION.toString();
 export const isSupportedEventType = (eventType: string): boolean =>
-  isMessageAddEvent(eventType) || isAssetAddEvent(eventType);
+  isMessageAddEvent(eventType) || isAssetAddEvent(eventType) || isLocationAddEvent(eventType);
 
 interface ExportTableParams<T> {
   backupService: BackupService;

--- a/src/script/backup/CrossPlatformBackup/data.schema.ts
+++ b/src/script/backup/CrossPlatformBackup/data.schema.ts
@@ -102,3 +102,12 @@ export const AssetContentSchema = zod.object({
   // status: zod.string().optional(),
   // legal_hold_status: zod.number(),
 });
+
+export const LocationContentSchema = zod.object({
+  location: zod.object({
+    latitude: zod.number(),
+    longitude: zod.number(),
+    name: zod.string().optional().nullable(),
+    zoom: zod.number().optional().nullable(),
+  }),
+});

--- a/src/script/backup/CrossPlatformBackup/importMappers/mapEventRecord.ts
+++ b/src/script/backup/CrossPlatformBackup/importMappers/mapEventRecord.ts
@@ -77,6 +77,8 @@ const isTextContent = (content: BackupMessageContent): content is BackupMessageC
   content instanceof BackupMessageContent.Text;
 const isAssetContent = (content: BackupMessageContent): content is BackupMessageContent.Asset =>
   content instanceof BackupMessageContent.Asset;
+const isLocationContent = (content: BackupMessageContent): content is BackupMessageContent.Location =>
+  content instanceof BackupMessageContent.Location;
 
 type TextBackupMessage = BackupMessage & {content: BackupMessageContent.Text};
 const mapTextMessageToEventRecord = (message: TextBackupMessage): EventRecord => ({
@@ -115,6 +117,22 @@ const mapAssetMessageToEventRecord = (message: AssetBackupMessage): EventRecord 
   category: 128,
 });
 
+type LocationBackupMessage = BackupMessage & {content: BackupMessageContent.Location};
+// Maps a LocationBackupMessage to an EventRecord
+const mapLocationMessageToEventRecord = (message: LocationBackupMessage): EventRecord => ({
+  ...mapCommonMessageFields(message),
+  data: {
+    location: {
+      latitude: message.content.latitude,
+      longitude: message.content.longitude,
+      name: message.content.name,
+      zoom: message.content.zoom,
+    },
+  },
+  type: ClientEvent.CONVERSATION.LOCATION as any,
+  category: 4096,
+});
+
 /**
  * Maps a BackupMessage to an EventRecord
  * @param message
@@ -123,6 +141,10 @@ const mapAssetMessageToEventRecord = (message: AssetBackupMessage): EventRecord 
 export const mapEventRecord = (message: BackupMessage): EventRecord | undefined => {
   if (isAssetContent(message.content)) {
     return mapAssetMessageToEventRecord(message as AssetBackupMessage);
+  }
+
+  if (isLocationContent(message.content)) {
+    return mapLocationMessageToEventRecord(message as LocationBackupMessage);
   }
 
   if (isTextContent(message.content)) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17311" title="WPB-17311" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17311</a>  [Web] Implement import of Cross Platform Backups
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Map the location event (message type from mobile) to the imported and exported backups

From the `kalium-backup` library:
```typescript
        class Location extends com.wire.backup.data.BackupMessageContent {
            constructor(longitude: number, latitude: number, name: Nullable<string>, zoom: Nullable<number>);
            get longitude(): number;
            get latitude(): number;
            get name(): Nullable<string>;
            get zoom(): Nullable<number>;
            copy(longitude?: number, latitude?: number, name?: Nullable<string>, zoom?: Nullable<number>): com.wire.backup.data.BackupMessageContent.Location;
            toString(): string;
            hashCode(): number;
            equals(other: Nullable<any>): boolean;
        }
```

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
