### PR TITLE
runfix(backup): map different asset types [WPB-17781]

### DIFF
--- a/src/script/backup/CrossPlatformBackup/AssetMetadata.ts
+++ b/src/script/backup/CrossPlatformBackup/AssetMetadata.ts
@@ -20,7 +20,7 @@
 import {isObject} from 'src/script/guards/common';
 
 import {AssetMetaData, BackupMessageContent} from './CPB.library';
-import {ImageAsset} from './CPB.types';
+import {AudioAsset, ImageAsset} from './CPB.types';
 
 const AssetContentType = {
   Image: ['image/jpg', 'image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/'],
@@ -53,6 +53,11 @@ const AssetContentType = {
 
 const hasNameProperty = (infoObject: unknown): infoObject is {name: string} =>
   isObject(infoObject) && 'name' in infoObject;
+const isAudioAsset = (contentType: string, metaObject: unknown): metaObject is AudioAsset =>
+  AssetContentType.isAudio(contentType) &&
+  isObject(metaObject) &&
+  'normalization' in metaObject &&
+  'duration' in metaObject;
 const isImageAsset = (contentType: string, infoObject: unknown): infoObject is ImageAsset =>
   AssetContentType.isImage(contentType) &&
   isObject(infoObject) &&
@@ -60,31 +65,18 @@ const isImageAsset = (contentType: string, infoObject: unknown): infoObject is I
   'width' in infoObject &&
   'tag' in infoObject;
 
-// These can be used in the future if we have to pass more data for these kind of file types
-
-// const isFileAsset = (contentType: string, infoObject: unknown): infoObject is FileAsset =>
-//   AssetContentType.isData(contentType) && hasNameProperty(infoObject);
-//const isVideoAsset = (contentType: string, infoObject: unknown): infoObject is VideoAsset =>
-//  AssetContentType.isVideo(contentType) && isObject(infoObject) && infoObject !== null && 'name' in infoObject;
-//const isAudioAsset = (contentType: string, infoObject: unknown): infoObject is AudioAsset =>
-//  AssetContentType.isAudio(contentType) && isObject(infoObject) && infoObject !== null && 'name' in infoObject;
-//const isTextAsset = (contentType: string, infoObject: unknown): infoObject is TexttAsset =>
-//  AssetContentType.isText(contentType) && isObject(infoObject) && infoObject !== null && 'name' in infoObject;
-//const isOtherAsset = (contentType: string, infoObject: unknown): infoObject is OtherAsset =>
-//  AssetContentType.isOther(contentType) && isObject(infoObject) && infoObject !== null && 'name' in infoObject;
-// const isUndefinedAsset = (contentType: string, infoObject: unknown): infoObject is UndefinedAsset =>
-//   AssetContentType.isUndefined(contentType) && hasNameProperty(infoObject);
-
 /**
  * Build metadata for an asset backup
  * @param contentType
  * @param infoObject
  * @returns metadata for the asset
  */
-export const buildMetaData = (contentType: string, infoObject: unknown) => {
+export const buildMetaData = (contentType: string, infoObject: unknown, metaObject: unknown) => {
   let metaData: AssetMetaData | null;
 
-  if (isImageAsset(contentType, infoObject)) {
+  if (isAudioAsset(contentType, metaObject)) {
+    metaData = new BackupMessageContent.Asset.AssetMetadata.Audio(metaObject.normalization, metaObject.duration);
+  } else if (isImageAsset(contentType, infoObject)) {
     metaData = new BackupMessageContent.Asset.AssetMetadata.Image(infoObject.width, infoObject.height, infoObject.tag);
   } else if (hasNameProperty(infoObject)) {
     metaData = new BackupMessageContent.Asset.AssetMetadata.Generic(infoObject.name);

--- a/src/script/backup/CrossPlatformBackup/CPB.export.ts
+++ b/src/script/backup/CrossPlatformBackup/CPB.export.ts
@@ -181,7 +181,7 @@ export const exportCPBHistoryFromDatabase = async ({
           return;
         }
 
-        const metaData = buildMetaData(assetParseData.content_type, assetParseData.info);
+        const metaData = buildMetaData(assetParseData.content_type, assetParseData.info, assetParseData.meta);
 
         const asset = new BackupMessageContent.Asset(
           assetParseData.content_type,

--- a/src/script/backup/CrossPlatformBackup/CPB.types.ts
+++ b/src/script/backup/CrossPlatformBackup/CPB.types.ts
@@ -46,8 +46,11 @@ export type ImageAsset = commonAsset & {
   width: number;
   tag: string;
 };
+export type AudioAsset = commonAsset & {
+  normalization: Int8Array | null;
+  duration: any;
+};
 export type FileAsset = commonAsset;
-export type AudioAsset = commonAsset;
 export type VideoAsset = commonAsset;
 export type TextAsset = commonAsset;
 export type UndefinedAsset = commonAsset;

--- a/src/script/backup/CrossPlatformBackup/data.schema.ts
+++ b/src/script/backup/CrossPlatformBackup/data.schema.ts
@@ -67,6 +67,7 @@ export const AssetContentSchema = zod.object({
   domain: zod.string().optional(),
   info: zod.any(),
   key: zod.string(),
+  meta: zod.any(),
   otr_key: zod.record(zod.string(), zod.number()),
   sha256: zod.record(zod.string(), zod.number()),
   token: zod.string().optional(),

--- a/src/script/backup/CrossPlatformBackup/importMappers/mapEventRecord.ts
+++ b/src/script/backup/CrossPlatformBackup/importMappers/mapEventRecord.ts
@@ -105,8 +105,12 @@ const mapMessageContentToCategory = (message: BackupMessage): MessageCategory =>
     return MessageCategory.LOCATION;
   }
   if (isAssetContent(message.content)) {
+    const name = message.content.name;
     const metadata = message.content.metaData;
     if (!metadata) {
+      if (name) {
+        return MessageCategory.FILE;
+      }
       return MessageCategory.UNDEFINED;
     }
     if (isImageContent(metadata)) {
@@ -147,7 +151,7 @@ const mapAssetMessageToEventRecord = (message: AssetBackupMessage): EventRecord 
   data: {
     content_length: message.content.size.toString(),
     content_type: message.content.mimeType.toString(),
-    info: message.content.metaData,
+    info: {...message.content.metaData, name: message.content.name?.toString() ?? null},
     domain: message.content.assetDomain?.toString(),
     key: message.content.assetId?.toString(),
     otr_key: transformArrayToObject(message.content.otrKey),

--- a/src/script/backup/CrossPlatformBackup/importMappers/mapEventRecord.ts
+++ b/src/script/backup/CrossPlatformBackup/importMappers/mapEventRecord.ts
@@ -18,6 +18,7 @@
  */
 
 import {ClientEvent} from 'src/script/event/Client';
+import {MessageCategory} from 'src/script/message/MessageCategory';
 import {EventRecord} from 'src/script/storage';
 
 import {CPBLogger} from '..';
@@ -79,6 +80,54 @@ const isAssetContent = (content: BackupMessageContent): content is BackupMessage
   content instanceof BackupMessageContent.Asset;
 const isLocationContent = (content: BackupMessageContent): content is BackupMessageContent.Location =>
   content instanceof BackupMessageContent.Location;
+const isImageContent = (
+  metadata: BackupMessageContent.Asset.AssetMetadata,
+): metadata is BackupMessageContent.Asset.AssetMetadata.Image =>
+  metadata instanceof BackupMessageContent.Asset.AssetMetadata.Image;
+const isVideoContent = (
+  metadata: BackupMessageContent.Asset.AssetMetadata,
+): metadata is BackupMessageContent.Asset.AssetMetadata.Video =>
+  metadata instanceof BackupMessageContent.Asset.AssetMetadata.Video;
+const isAudioContent = (
+  metadata: BackupMessageContent.Asset.AssetMetadata,
+): metadata is BackupMessageContent.Asset.AssetMetadata.Audio =>
+  metadata instanceof BackupMessageContent.Asset.AssetMetadata.Audio;
+const isFileContent = (
+  metadata: BackupMessageContent.Asset.AssetMetadata,
+): metadata is BackupMessageContent.Asset.AssetMetadata.Generic =>
+  metadata instanceof BackupMessageContent.Asset.AssetMetadata.Generic;
+
+const mapMessageContentToCategory = (message: BackupMessage): MessageCategory => {
+  if (isTextContent(message.content)) {
+    return MessageCategory.TEXT;
+  }
+  if (isLocationContent(message.content)) {
+    return MessageCategory.LOCATION;
+  }
+  if (isAssetContent(message.content)) {
+    const metadata = message.content.metaData;
+    if (!metadata) {
+      return MessageCategory.UNDEFINED;
+    }
+    if (isImageContent(metadata)) {
+      const mimeType = message.content.mimeType;
+      if (mimeType === 'image/gif') {
+        return MessageCategory.GIF;
+      }
+      return MessageCategory.IMAGE;
+    }
+    if (isVideoContent(metadata)) {
+      return MessageCategory.VIDEO;
+    }
+    if (isAudioContent(metadata)) {
+      return MessageCategory.AUDIO;
+    }
+    if (isFileContent(metadata)) {
+      return MessageCategory.FILE;
+    }
+  }
+  return MessageCategory.UNDEFINED;
+};
 
 type TextBackupMessage = BackupMessage & {content: BackupMessageContent.Text};
 const mapTextMessageToEventRecord = (message: TextBackupMessage): EventRecord => ({
@@ -88,7 +137,7 @@ const mapTextMessageToEventRecord = (message: TextBackupMessage): EventRecord =>
   },
   // there is a type mismatch here, but it is not relevant for the import
   type: ClientEvent.CONVERSATION.MESSAGE_ADD as any,
-  category: 16,
+  category: mapMessageContentToCategory(message),
 });
 
 type AssetBackupMessage = BackupMessage & {content: BackupMessageContent.Asset};
@@ -108,7 +157,7 @@ const mapAssetMessageToEventRecord = (message: AssetBackupMessage): EventRecord 
   },
   // there is a type mismatch here, but it is not relevant for the import
   type: ClientEvent.CONVERSATION.ASSET_ADD as any,
-  category: 128,
+  category: mapMessageContentToCategory(message),
 });
 
 type LocationBackupMessage = BackupMessage & {content: BackupMessageContent.Location};
@@ -124,7 +173,7 @@ const mapLocationMessageToEventRecord = (message: LocationBackupMessage): EventR
     },
   },
   type: ClientEvent.CONVERSATION.LOCATION as any,
-  category: 4096,
+  category: mapMessageContentToCategory(message),
 });
 
 /**

--- a/src/script/conversation/EventMapper.ts
+++ b/src/script/conversation/EventMapper.ts
@@ -866,9 +866,11 @@ export class EventMapper {
 
   _mapAsset(event: LegacyEventRecord) {
     const eventData = event.data;
-    const assetInfo = eventData.info;
-    const isMediumImage = assetInfo && assetInfo.tag === 'medium';
-    return isMediumImage ? this._mapAssetImage(event) : this._mapAssetFile(event);
+    const category = event.category;
+    const isFile = category === 512;
+    const mimeType = eventData.content_type;
+    const isImage = mimeType && mimeType.startsWith('image/');
+    return isImage && !isFile ? this._mapAssetImage(event) : this._mapAssetFile(event);
   }
 
   /**

--- a/src/script/conversation/EventMapper.ts
+++ b/src/script/conversation/EventMapper.ts
@@ -83,6 +83,7 @@ import {ClientEvent} from '../event/Client';
 import {isContentMessage} from '../guards/Message';
 import {CALL_MESSAGE_TYPE} from '../message/CallMessageType';
 import {MentionEntity} from '../message/MentionEntity';
+import {MessageCategory} from '../message/MessageCategory';
 import {QuoteEntity} from '../message/QuoteEntity';
 import {StatusType} from '../message/StatusType';
 import {SystemMessageType} from '../message/SystemMessageType';
@@ -867,7 +868,7 @@ export class EventMapper {
   _mapAsset(event: LegacyEventRecord) {
     const eventData = event.data;
     const category = event.category;
-    const isFile = category === 512;
+    const isFile = category === MessageCategory.FILE;
     const mimeType = eventData.content_type;
     const isImage = mimeType && mimeType.startsWith('image/');
     return isImage && !isFile ? this._mapAssetImage(event) : this._mapAssetFile(event);


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17781" title="WPB-17781" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17781</a>  [Web] Address CPB playtest findings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

correctly map different asset types to their category
- assign the correct web asset category to asset coming from cross platform backups
- map assets from the web database to the correct CPB type on export

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
