### PR TITLE
runfix(backup): prevent exporting undefined self user id [WPB-17558]

### DIFF
--- a/src/script/backup/CrossPlatformBackup/CPB.export.ts
+++ b/src/script/backup/CrossPlatformBackup/CPB.export.ts
@@ -156,7 +156,10 @@ export const exportCPBHistoryFromDatabase = async ({
       }
 
       const conversationId = new BackupQualifiedId(qualified_conversation.id, qualified_conversation.domain ?? '');
-      const senderUserId = new BackupQualifiedId(qualified_from?.id ?? from ?? '', qualified_from?.domain ?? '');
+      const senderUserId = new BackupQualifiedId(
+        qualified_from?.id ?? from ?? user.id,
+        qualified_from?.domain ?? user.domain,
+      );
       const senderClientId = from_client_id ?? '';
       const creationDate = new BackupDateTime(new Date(time));
       // for debugging purposes
@@ -178,7 +181,7 @@ export const exportCPBHistoryFromDatabase = async ({
         const asset = new BackupMessageContent.Asset(
           assetParseData.content_type,
           Number.parseInt(`${assetParseData.content_length}`),
-          assetParseData.info.name,
+          assetParseData.info?.name ?? '',
           transformObjectToArray(assetParseData.otr_key),
           transformObjectToArray(assetParseData.sha256),
           assetParseData.key,

--- a/src/script/backup/CrossPlatformBackup/data.schema.ts
+++ b/src/script/backup/CrossPlatformBackup/data.schema.ts
@@ -32,7 +32,7 @@ export type ConversationTableEntry = zod.infer<typeof ConversationTableEntrySche
 export const UserTableEntrySchema = zod.object({
   handle: zod.string().optional(),
   id: zod.string(),
-  name: zod.string().optional(),
+  name: zod.string().optional().nullable(),
   qualified_id: QualifiedIdSchema.optional(),
 });
 export type UserTableEntry = zod.infer<typeof UserTableEntrySchema>;
@@ -41,7 +41,7 @@ export const EventTableEntrySchema = zod.object({
   category: zod.number().int().optional(),
   conversation: zod.string().min(1, 'Conversation is required'),
   data: zod.any(),
-  from: zod.string().optional(),
+  from: zod.string().optional().nullable(),
   from_client_id: zod.string().optional(),
   id: zod.string().optional(),
   primary_key: zod.number().int().positive('Primary key must be a positive integer'),

--- a/src/script/conversation/ConversationMapper.ts
+++ b/src/script/conversation/ConversationMapper.ts
@@ -30,6 +30,7 @@ import {
   ADD_PERMISSION,
   CONVERSATION_CELLS_STATE,
 } from '@wireapp/api-client/lib/conversation';
+import {QualifiedId} from '@wireapp/api-client/lib/user';
 import ko from 'knockout';
 import {isObject} from 'underscore';
 
@@ -292,17 +293,25 @@ export class ConversationMapper {
     }
 
     // Active participants from database or backend payload
-    const participatingUserIds =
-      qualified_others ??
-      (members?.others?.length
-        ? members.others.map(other => ({
-            domain: other.qualified_id?.domain ?? '',
-            id: other.id,
-          }))
-        : others?.map(userId => ({
-            domain: '',
-            id: userId,
-          })) ?? []);
+    let participatingUserIds: QualifiedId[] = [];
+
+    if (qualified_others) {
+      participatingUserIds = qualified_others;
+    }
+
+    if (!qualified_others && members?.others?.length) {
+      participatingUserIds = members.others.map(other => ({
+        domain: other.qualified_id?.domain ?? '',
+        id: other.id,
+      }));
+    }
+
+    if (!qualified_others && !members?.others?.length && others) {
+      participatingUserIds = others.map(userId => ({
+        domain: '',
+        id: userId,
+      }));
+    }
 
     conversationEntity.participating_user_ids(participatingUserIds);
 

--- a/src/script/conversation/ConversationMapper.ts
+++ b/src/script/conversation/ConversationMapper.ts
@@ -293,10 +293,16 @@ export class ConversationMapper {
 
     // Active participants from database or backend payload
     const participatingUserIds =
-      qualified_others ||
-      (members?.others
-        ? members.others.map(other => ({domain: other.qualified_id?.domain || '', id: other.id}))
-        : others.map(userId => ({domain: '', id: userId})));
+      qualified_others ??
+      (members?.others?.length
+        ? members.others.map(other => ({
+            domain: other.qualified_id?.domain ?? '',
+            id: other.id,
+          }))
+        : others?.map(userId => ({
+            domain: '',
+            id: userId,
+          })) ?? []);
 
     conversationEntity.participating_user_ids(participatingUserIds);
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17558" title="WPB-17558" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17558</a>  [Web] Backup - Messages from self user have an undefined sender ID
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Description

When creating a group conversation the `selfUser` can possibly be `undefined` https://github.com/wireapp/wire-webapp/blob/dev/src/script/entity/Conversation.ts#L173.

It can create a situation where the sender fields of a message sent `from` and `qualified_from` are `undefined`.
This is handle gracefully on web, but it can cause situation where the self user appears as an unknown user when restoring a backup from web on android.

<!-- Uncomment this section if your PR has UI changes -->

## Screenshots/Screencast (for UI changes)
#### Before
![image](https://github.com/user-attachments/assets/5d3c9fd6-5d5f-4f79-b63b-e9cc6229a25e)
#### After
![image](https://github.com/user-attachments/assets/28b1c3f1-cec2-4280-bb0b-ec8f4e8c5a56)

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
