### PR TITLE
fix(cells): multipart message name [WPB-17930]

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.tsx
@@ -84,7 +84,7 @@ const MultipartAsset = ({
   senderName,
   timestamp,
 }: MultipartAssetProps) => {
-  const name = trimFileExtension(initialName!);
+  const name = getName(initialName!);
   const extension = getFileExtension(initialName!);
   const size = formatBytes(Number(initialSize));
 
@@ -154,4 +154,10 @@ const MultipartAsset = ({
       />
     </li>
   );
+};
+
+const getName = (name: string): string => {
+  const parts = name.split('/');
+  const lastPart = parts[parts.length - 1];
+  return trimFileExtension(lastPart);
 };


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17930" title="WPB-17930" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17930</a>  [Web] Sanitize cells file title from Android
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

Messages' file names from Android are sent with their full path (folders). Because of this, we need to trim the "path" from the name and display only the file name, without the extension.

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
