### PR TITLE
fix: Wire deeplink with custom passed url [WPB-17649]

### DIFF
--- a/src/script/util/messageRenderer.test.ts
+++ b/src/script/util/messageRenderer.test.ts
@@ -197,6 +197,18 @@ describe('renderMessage', () => {
     );
   });
 
+  it('renders a wire deeplink with config url', () => {
+    expect(renderMessage('wire://access/?config=https://test.com/deeplink.json')).toBe(
+      '<a href="wire://access/?config=https://test.com/deeplink.json" target="_blank" rel="nofollow noopener noreferrer" data-uie-name="wire-deep-link">wire://access/?config=https://test.com/deeplink.json</a>',
+    );
+  });
+
+  it('renders a wire deeplink with config url with alias', () => {
+    expect(renderMessage('[deeplink](wire://access/?config=https://test.com/deeplink.json)')).toBe(
+      '<a href="wire://access/?config=https://test.com/deeplink.json" target="_blank" rel="nofollow noopener noreferrer" data-uie-name="wire-deep-link">deeplink</a>',
+    );
+  });
+
   it('renders a link from markdown notation with formatting', () => {
     expect(renderMessage('[**doop**](http://www.example.com)')).toBe(
       '<a href="http://www.example.com" target="_blank" rel="nofollow noopener noreferrer" data-md-link="true" data-uie-name="markdown-link"><strong>doop</strong></a>',

--- a/src/script/util/messageRenderer.ts
+++ b/src/script/util/messageRenderer.ts
@@ -72,7 +72,7 @@ markdownit.linkify.add('wire:', {
     return 0;
   },
   normalize: match => {
-    // match.url has the form ‘wire:...’; replace it with ‘wire://...’ if needed
+    // match.url has the form ‘wire:/...’; replace it with ‘wire://...’ if needed
     if (match.url.startsWith('wire:/') && !match.url.startsWith('wire://')) {
       match.url = match.url.replace('wire:/', 'wire://');
     }

--- a/src/script/util/messageRenderer.ts
+++ b/src/script/util/messageRenderer.ts
@@ -59,6 +59,26 @@ const markdownit = new MarkdownIt('zero', {
   'blockquote',
 ]);
 
+markdownit.linkify.add('wire:', {
+  validate: (text, pos) => {
+    // Typical linkify schema: valid url chars to first whitespace or control char
+    const tail = text.slice(pos);
+
+    // A simple matcher: up to the first space, <, or a parenthesis.
+    const match = /^[^\s<>()]+/.exec(tail);
+    if (match) {
+      return match[0].length;
+    }
+    return 0;
+  },
+  normalize: match => {
+    // match.url has the form ‘wire:...’; replace it with ‘wire://...’ if needed
+    if (match.url.startsWith('wire:/') && !match.url.startsWith('wire://')) {
+      match.url = match.url.replace('wire:/', 'wire://');
+    }
+  },
+});
+
 const originalFenceRule = markdownit.renderer.rules.fence!;
 
 markdownit.renderer.rules.heading_open = (tokens, idx) => {


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17649" title="WPB-17649" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17649</a>  [Web] Web Client Converts Plain URLs to Markdown Links, Breaking Deep Links
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->



## Description
This pull request enhances the `messageRenderer` utility to support rendering "wire" protocol deep links. It includes updates to both the link validation logic and the test suite to ensure proper handling of these links.

### Enhancements to link rendering:

* Added support for "wire:" protocol links by extending the `linkify` functionality in `MarkdownIt`. This includes a custom validation function to identify valid "wire:" links and a normalization step to ensure the URLs use the correct `wire://` format. [[1]](diffhunk://#diff-a3227964955e953ea33ba329eea0eb4b423b17aefcdeb96e95c93f8404f0a7b7R62-R81)

### Updates to test cases:

* Added new test cases to verify the rendering of "wire" protocol deep links, both with direct URLs and markdown aliases. These tests ensure the links are correctly formatted and include attributes for security and UI tracking. [[2]](diffhunk://#diff-9eb891e25d09ee32673db1601fbf4d6ca28b9c4f927277789b3dfd1f480d7c11R200-R211)

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
