### PR TITLE
fix(mls): Establish MLS group conversation when joining with deeplink (WPB-18084)

### DIFF
--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -3682,7 +3682,7 @@ export class ConversationRepository {
 
       // If the group is not established yet, we need to establish it
       if (!isAlreadyEstablished) {
-        await initMLSGroupConversation(conversationEntity, selfUser?.qualifiedId, {core: this.core});
+        await initMLSGroupConversation(conversationEntity, selfUser.qualifiedId, {core: this.core});
       }
     }
 

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -153,6 +153,7 @@ import {isMemberMessage} from '../guards/Message';
 import * as LegalHoldEvaluator from '../legal-hold/LegalHoldEvaluator';
 import {MessageCategory} from '../message/MessageCategory';
 import {SystemMessageType} from '../message/SystemMessageType';
+import {initMLSGroupConversation} from '../mls';
 import {PropertiesRepository} from '../properties/PropertiesRepository';
 import {SelfRepository} from '../self/SelfRepository';
 import {Core} from '../service/CoreSingleton';
@@ -3659,6 +3660,30 @@ export class ConversationRepository {
     const updatedMessageEntity = await this.updateMessageUserEntities(messageEntity);
     if (conversationEntity && updatedMessageEntity) {
       conversationEntity.addMessage(updatedMessageEntity);
+    }
+
+    /**
+     * if user joins a mls conversation using a guest link they do not receive a welcome message
+     * and we only receive the group creation event instead
+     * In this case we need to establish the mls group conversation
+     */
+    const isMLSConversation = isMLSCapableConversation(conversationEntity);
+
+    if (isMLSConversation) {
+      const isAlreadyEstablished = await this.conversationService.isMLSGroupEstablishedLocally(
+        conversationEntity.groupId,
+      );
+
+      const selfUser = this.userState.self();
+
+      if (!selfUser?.qualifiedId) {
+        throw new Error('Self user qualified ID is not defined');
+      }
+
+      // If the group is not established yet, we need to establish it
+      if (!isAlreadyEstablished) {
+        await initMLSGroupConversation(conversationEntity, selfUser?.qualifiedId, {core: this.core});
+      }
     }
 
     return {conversationEntity, messageEntity: updatedMessageEntity};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18084" title="WPB-18084" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18084</a>  [Web] When joining or being added during creation to a MLS group or channel with Web edge, no messages can be sent
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
if user joins a mls conversation using a guest link they do not receive a welcome message and we only receive the group creation event instead In this case we need to establish the mls group conversation.