### PR TITLE
chore: update @wireapp/core [WPB-18371]

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@wireapp/avs": "10.0.46",
     "@wireapp/avs-debugger": "0.0.7",
     "@wireapp/commons": "5.4.2",
-    "@wireapp/core": "46.29.3",
+    "@wireapp/core": "46.29.4",
     "@wireapp/kalium-backup": "0.0.3",
     "@wireapp/react-ui-kit": "9.59.3",
     "@wireapp/store-engine-dexie": "2.1.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8502,9 +8502,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:46.29.3":
-  version: 46.29.3
-  resolution: "@wireapp/core@npm:46.29.3"
+"@wireapp/core@npm:46.29.4":
+  version: 46.29.4
+  resolution: "@wireapp/core@npm:46.29.4"
   dependencies:
     "@wireapp/api-client": "npm:^27.66.0"
     "@wireapp/commons": "npm:^5.4.2"
@@ -8524,7 +8524,7 @@ __metadata:
     long: "npm:^5.2.0"
     uuid: "npm:9.0.1"
     zod: "npm:3.24.2"
-  checksum: 10/a38b4754970eab90a8b2dbed0bd1912415a2527cf08b0de4509ed5aff08e03a82dd7506e3198f2fc265f03b25f91cd14f966e17b21a57b6a9b57f53b6ab15798
+  checksum: 10/efcd61522f2cf005b09fd9dc4e913f1365f837fd49c695ef4d98007c734b6a8a024e6d32198529f9de2eaa68994f09a79100ec1bc42bbfc37433a8b2cdbab79a
   languageName: node
   linkType: hard
 
@@ -22128,7 +22128,7 @@ __metadata:
     "@wireapp/avs-debugger": "npm:0.0.7"
     "@wireapp/commons": "npm:5.4.2"
     "@wireapp/copy-config": "npm:2.3.0"
-    "@wireapp/core": "npm:46.29.3"
+    "@wireapp/core": "npm:46.29.4"
     "@wireapp/eslint-config": "npm:3.0.7"
     "@wireapp/kalium-backup": "npm:0.0.3"
     "@wireapp/prettier-config": "npm:0.6.4"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18371" title="WPB-18371" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18371</a>  [Web] (MLS) Emit epoch change event after joining by external commit
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This pull request includes a version update for the `@wireapp/core` dependency in the `package.json` file. The version was incremented from `46.29.3` to `46.29.4` to include the latest changes or fixes.