### PR TITLE
runfix(backup): mark all restored conversations as read [WPB-18001]

### DIFF
--- a/src/script/backup/CrossPlatformBackup/importMappers/mapConversationRecord.ts
+++ b/src/script/backup/CrossPlatformBackup/importMappers/mapConversationRecord.ts
@@ -32,6 +32,7 @@ export const mapConversationRecord = ({id: qualifiedId, name}: BackUpConversatio
     id: qualifiedId.id.toString(),
     name: name.toString(),
     domain: qualifiedId.domain.toString(),
+    last_read_timestamp: new Date().getTime(),
   } as ConversationRecord;
   return conversationRecord;
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18001" title="WPB-18001" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18001</a>  [Web] All conversations should be marked as read after restoring backup
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

see ticket, all restored conversations should be marked as read (kalium-backup does not currently provide the last timestamp of a conversation)

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
