### PR TITLE
feat: add team management link for sidebar [WPB-17720]

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/ConversationTabs.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/ConversationTabs.tsx
@@ -28,15 +28,19 @@ import {
   SupportIcon,
   ChannelIcon,
   CollectionIcon,
+  TeamIcon,
 } from '@wireapp/react-ui-kit';
 
 import * as Icon from 'Components/Icon';
 import {ConversationRepository} from 'src/script/conversation/ConversationRepository';
 import {User} from 'src/script/entity/User';
+import {getManageTeamUrl} from 'src/script/externalRoute';
 import {ConversationFolderTab} from 'src/script/page/LeftSidebar/panels/Conversations/ConversationTab/ConversationFolderTab';
 import {SidebarTabs} from 'src/script/page/LeftSidebar/panels/Conversations/useSidebarStore';
 import {Core} from 'src/script/service/CoreSingleton';
 import {TeamState} from 'src/script/team/TeamState';
+import {FEATURES, hasAccessToFeature} from 'src/script/user/UserPermission';
+import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {isDataDogEnabled} from 'Util/DataDog';
 import {getWebEnvironment} from 'Util/Environment';
 import {replaceLink, t} from 'Util/LocalizerUtil';
@@ -89,6 +93,7 @@ export const ConversationTabs = ({
   const core = container.resolve(Core);
   const teamState = container.resolve(TeamState);
   const totalUnreadConversations = unreadConversations.length;
+  const {teamRole} = useKoSubscribableChildren(selfUser, ['teamRole']);
 
   const totalUnreadFavoriteConversations = favoriteConversations.filter(favoriteConversation =>
     favoriteConversation.hasUnread(),
@@ -165,7 +170,7 @@ export const ConversationTabs = ({
       unreadConversations: channelConversationsLength,
     });
   }
-
+  const manageTeamUrl = getManageTeamUrl();
   const replaceWireLink = replaceLink('https://app.wire.com', '', '');
 
   return (
@@ -293,6 +298,24 @@ export const ConversationTabs = ({
           showNotificationsBadge={showNotificationsBadge}
           isActive={currentTab === SidebarTabs.PREFERENCES}
         />
+
+        {hasAccessToFeature(FEATURES.MANAGE_TEAM, teamRole) && (
+          <a
+            rel="nofollow noopener noreferrer"
+            target="_blank"
+            href={manageTeamUrl}
+            type="button"
+            className="conversations-sidebar-btn"
+            title={t('preferencesAccountManageTeam')}
+            data-uie-name="go-team-management"
+          >
+            <span className="conversations-sidebar-btn--text-wrapper">
+              <TeamIcon />
+              <span className="conversations-sidebar-btn--text"> {t('preferencesAccountManageTeam')}</span>
+              <ExternalLinkIcon className="external-link-icon" />
+            </span>
+          </a>
+        )}
 
         <a
           rel="nofollow noopener noreferrer"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17720" title="WPB-17720" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-17720</a>  [Web] Add link to Team Management (TM) in sidebar for admins and team owners
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Added team management link for sidebar

## Screenshots/Screencast (for UI changes)
![Screenshot 2025-06-26 at 16 59 54](https://github.com/user-attachments/assets/692ac4e3-bd0c-4eca-b537-e89b878961e0)

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
