### PR TITLE
fix(backup): abort backup export when cliking outside modal [WPB-18421]

### DIFF
--- a/src/script/components/HistoryExport/HistoryExport.tsx
+++ b/src/script/components/HistoryExport/HistoryExport.tsx
@@ -155,8 +155,16 @@ const HistoryExport = ({switchContent, user, clientState = container.resolve(Cli
     backupRepository.cancelAction();
   };
 
+  const onClose = () => {
+    amplify.publish(WebAppEvents.ANALYTICS.EVENT, EventName.HISTORY.BACKUP_CANCELLED, {
+      [Segmentation.GENERAL.STEP]: Segmentation.BACKUP_CREATION.CANCELLATION_STEP.BEFORE_BACKUP,
+    });
+    dismissExport();
+  };
+
   const showBackupModal = () => {
     PrimaryModal.show(PrimaryModal.type.PASSWORD_ADVANCED_SECURITY, {
+      close: () => onClose(),
       primaryAction: {
         action: async (password: string, hasMultipleAttempts: boolean) => {
           exportHistory(password, hasMultipleAttempts);
@@ -165,12 +173,7 @@ const HistoryExport = ({switchContent, user, clientState = container.resolve(Cli
       },
       secondaryAction: [
         {
-          action: () => {
-            amplify.publish(WebAppEvents.ANALYTICS.EVENT, EventName.HISTORY.BACKUP_CANCELLED, {
-              [Segmentation.GENERAL.STEP]: Segmentation.BACKUP_CREATION.CANCELLATION_STEP.BEFORE_BACKUP,
-            });
-            dismissExport();
-          },
+          action: () => onClose(),
           text: t('backupEncryptionModalCloseBtn'),
         },
       ],


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18421" title="WPB-18421" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18421</a>  Clicking outside the box while creating backups makes the client get stuck
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

We need to call `dismissExport()' when closing the export backup modal in order to not get stuck with an export progressing bar and no option to go back

```
  const dismissExport = () => {
    switchContent(ContentState.PREFERENCES_ACCOUNT);
  };
  ```
  This was missing from the action that triggers when clicking outside the modal to dismiss it

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
