### PR TITLE
runfix(backup): prevent quitting when cliking outside export modal [WPB-18421]

### DIFF
--- a/src/script/components/HistoryExport/HistoryExport.tsx
+++ b/src/script/components/HistoryExport/HistoryExport.tsx
@@ -164,7 +164,7 @@ const HistoryExport = ({switchContent, user, clientState = container.resolve(Cli
 
   const showBackupModal = () => {
     PrimaryModal.show(PrimaryModal.type.PASSWORD_ADVANCED_SECURITY, {
-      close: () => onClose(),
+      preventClose: true,
       primaryAction: {
         action: async (password: string, hasMultipleAttempts: boolean) => {
           exportHistory(password, hasMultipleAttempts);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18421" title="WPB-18421" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18421</a>  Clicking outside the box while creating backups makes the client get stuck
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

see https://github.com/wireapp/wire-webapp/pull/19189
Primary Modals trigger the `close()` function on confirm, which prevents exporting a backup because of the linked PR, which added changing the view to the previous step to the close action.

This prevents closing the modal altogether when clicking outside of it by setting the `preventClose: true` prop instead.

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
