### PR TITLE
fix(externalUrls): avoid appending locale to urls in custom envs [WB18474]

### DIFF
--- a/src/script/externalRoute.ts
+++ b/src/script/externalRoute.ts
@@ -22,6 +22,8 @@ import {Config} from './Config';
 
 const URL = Config.getConfig().URL;
 
+const isProductionWebsite = URL.WEBSITE_BASE && URL.WEBSITE_BASE === 'https://wire.com';
+
 const getTeamSettingsUrl = (path: string = '', utmSource?: string): string | undefined => {
   const query = utmSource ? `?utm_source=${utmSource}&utm_term=desktop` : '';
   const teamSettingsUrl = `${URL.TEAMS_BASE}${path}${query}`;
@@ -71,6 +73,9 @@ const getCreateTeamUrl = (): string | undefined =>
 export const addLocaleToUrl = (url?: string): string | undefined => {
   if (!url) {
     return undefined;
+  }
+  if (!isProductionWebsite) {
+    return url;
   }
   const language = currentLanguage().slice(0, 2);
   const websiteLanguage = language == 'de' ? language : 'en';


### PR DESCRIPTION
## Description

We have logic to append the locale directly to the website url for German users
This is only intended to work with `https://wire.com` and can create issues with custom deployment where locales are handled differently or not at all.

This PR includes a check to only append the website url with locale for the production website. 

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
