### PR TITLE
chore: Bump @wireapp/core from 46.31.0 to 46.31.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@wireapp/avs": "10.0.46",
     "@wireapp/avs-debugger": "0.0.7",
     "@wireapp/commons": "5.4.2",
-    "@wireapp/core": "46.31.0",
+    "@wireapp/core": "46.31.2",
     "@wireapp/kalium-backup": "0.0.3",
     "@wireapp/react-ui-kit": "9.62.0",
     "@wireapp/store-engine-dexie": "2.1.15",

--- a/src/script/util/DebugUtil.ts
+++ b/src/script/util/DebugUtil.ts
@@ -243,7 +243,6 @@ export class DebugUtil {
   }
 
   async reconnectWebSocketWithLastNotificationIdFromBackend({dryRun} = {dryRun: false}) {
-    await this.core.service?.notification.initializeNotificationStream(this.clientState.currentClient!.id);
     return this.reconnectWebSocket({dryRun});
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8396,9 +8396,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:46.31.0":
-  version: 46.31.0
-  resolution: "@wireapp/core@npm:46.31.0"
+"@wireapp/core@npm:46.31.2":
+  version: 46.31.2
+  resolution: "@wireapp/core@npm:46.31.2"
   dependencies:
     "@wireapp/api-client": "npm:^27.68.0"
     "@wireapp/commons": "npm:^5.4.2"
@@ -8418,7 +8418,7 @@ __metadata:
     long: "npm:^5.2.0"
     uuid: "npm:9.0.1"
     zod: "npm:3.24.2"
-  checksum: 10/b3cb77620d8d2eb0996fb9454df5dbe4efb6bed8b143b85f166cfbe841d90bda5bebb703bbcc4ad92cc0beebfd75bb93739e4048eabe41d84b76c2a5f1254362
+  checksum: 10/a5742306e0c15cd7831b9d81e72f001aad1d0d6f33ef641ca6d3b7be9a803dd80721c3089a8684e3a4c6c46294c073652c02a4ef7cb6a16dcc9a6bea77b4f3f2
   languageName: node
   linkType: hard
 
@@ -21998,7 +21998,7 @@ __metadata:
     "@wireapp/avs-debugger": "npm:0.0.7"
     "@wireapp/commons": "npm:5.4.2"
     "@wireapp/copy-config": "npm:2.3.0"
-    "@wireapp/core": "npm:46.31.0"
+    "@wireapp/core": "npm:46.31.2"
     "@wireapp/eslint-config": "npm:3.0.7"
     "@wireapp/kalium-backup": "npm:0.0.3"
     "@wireapp/prettier-config": "npm:0.6.4"


### PR DESCRIPTION
https://github.com/wireapp/wire-web-packages/pull/7099 & https://github.com/wireapp/wire-web-packages/pull/7097