### PR TITLE
fix: prevent closing on clicking outside e2ei modal [WPB-18604]

### DIFF
--- a/src/script/E2EIdentity/Modals/Modals.ts
+++ b/src/script/E2EIdentity/Modals/Modals.ts
@@ -224,6 +224,7 @@ export const getModalOptions = ({
           action: secondaryActionFn,
           text: t('acme.done.button.secondary'),
         },
+        ...hideCloseBtn,
       };
       modalType = PrimaryModal.type.ACKNOWLEDGE;
       break;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18604" title="WPB-18604" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18604</a>  [Web] Clicking outside E2EI confirmation modal (after successfully geting certificate) breaks the login
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

closing the modal on successful e2ei enrollment results in a stuck progress bar.

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
