### PR TITLE
runfix: inject support url in enrollment modal string [WPB-18339]

### DIFF
--- a/src/script/E2EIdentity/Modals/Modals.ts
+++ b/src/script/E2EIdentity/Modals/Modals.ts
@@ -81,14 +81,25 @@ export const getModalOptions = ({
   </div>
   `;
 
-  const gracePeriodOverParagraph = t('acme.settingsChanged.gracePeriodOver.paragraph', undefined, {
-    br: '<br>',
-    ...replaceLearnMore,
-  });
-
-  const settingsChangedParagraph = t('acme.settingsChanged.paragraph', undefined, {br: '<br>', ...replaceLearnMore});
-
   const supportUrl = Config.getConfig().URL.SUPPORT.E2EI_VERIFICATION_CERTIFICATE;
+
+  const gracePeriodOverParagraph = t(
+    'acme.settingsChanged.gracePeriodOver.paragraph',
+    {url: supportUrl},
+    {
+      br: '<br>',
+      ...replaceLearnMore,
+    },
+  );
+
+  const settingsChangedParagraph = t(
+    'acme.settingsChanged.paragraph',
+    {url: supportUrl},
+    {
+      br: '<br>',
+      ...replaceLearnMore,
+    },
+  );
 
   switch (type) {
     case ModalType.ENROLL:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18339" title="WPB-18339" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18339</a>  [Web] Implement E2EI Learn More link and have it be configurable via env variable
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

A url parameter was missing from the localisation string for the e2ei enrollment modal

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
