### PR TITLE
fix: restore ability to add services to contact list [WPB-18602]

### DIFF
--- a/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
+++ b/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
@@ -19,6 +19,7 @@
 
 import React, {useEffect, useRef, useState} from 'react';
 
+import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 import cx from 'classnames';
 import {container} from 'tsyringe';
 
@@ -89,7 +90,7 @@ const StartUI: React.FC<StartUIProps> = ({
 
   const actions = mainViewModel.actions;
   const isTeam = teamState.isTeam();
-  const isMLSEnabled = teamState.isMLSEnabled();
+  const defaultProtocol = teamState.teamFeatures()?.mls?.config.defaultProtocol;
 
   const [searchQuery, setSearchQuery] = useState('');
   const [activeTab, setActiveTab] = useState(Tabs.PEOPLE);
@@ -149,7 +150,7 @@ const StartUI: React.FC<StartUIProps> = ({
           forceDark
         />
       </div>
-      {isTeam && canChatWithServices() && !isMLSEnabled && (
+      {isTeam && canChatWithServices() && defaultProtocol != ConversationProtocol.MLS && (
         <ul className="start-ui-list-tabs">
           <li className={`start-ui-list-tab ${activeTab === Tabs.PEOPLE ? 'active' : ''}`}>
             <button


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18602" title="WPB-18602" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18602</a>  [Web] Give users ability of adding a service to your contact list (that 1:1 with a bot would be Proteus)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

The service tabs that allows you to create 1:1 conv with bots is intended to be disabled when the default protocol is MLS see https://wearezeta.atlassian.net/browse/WPB-10781
It was however disabled when MLS is enabled at all for the team, which is currently the case for all production users.

<!-- Uncomment this section if your PR has UI changes -->
## Screenshots/Screencast (for UI changes)
Before:
<img width="383" height="316" alt="image" src="https://github.com/user-attachments/assets/5b11ef35-7759-4d4f-ac19-b7538c47f69f" />

After:
<img width="383" height="316" alt="image" src="https://github.com/user-attachments/assets/fd312433-fc0a-485a-93b5-3e72a6cdd020" />

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
