### PR TITLE
chore: Bump @wireapp/commons from 5.4.2 to 5.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@tanstack/react-virtual": "3.13.4",
     "@wireapp/avs": "10.0.46",
     "@wireapp/avs-debugger": "0.0.7",
-    "@wireapp/commons": "5.4.2",
+    "@wireapp/commons": "5.4.3",
     "@wireapp/core": "46.31.3",
     "@wireapp/kalium-backup": "0.0.3",
     "@wireapp/react-ui-kit": "9.62.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8360,7 +8360,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/commons@npm:5.4.2, @wireapp/commons@npm:^5.4.2":
+"@wireapp/commons@npm:5.4.3":
+  version: 5.4.3
+  resolution: "@wireapp/commons@npm:5.4.3"
+  dependencies:
+    ansi-regex: "npm:5.0.1"
+    fs-extra: "npm:11.3.0"
+    logdown: "npm:3.3.1"
+    platform: "npm:1.3.6"
+  checksum: 10/81e2b260f17f0010b9ef34958c2641fe4eaa42673d31451e79d373534a6c119febe2ef47f8b591a8e8e0f2ea3fa7fd3b495bf560ae2786f718befa73bca1cc08
+  languageName: node
+  linkType: hard
+
+"@wireapp/commons@npm:^5.4.2":
   version: 5.4.2
   resolution: "@wireapp/commons@npm:5.4.2"
   dependencies:
@@ -21996,7 +22008,7 @@ __metadata:
     "@types/wicg-file-system-access": "npm:^2023.10.5"
     "@wireapp/avs": "npm:10.0.46"
     "@wireapp/avs-debugger": "npm:0.0.7"
-    "@wireapp/commons": "npm:5.4.2"
+    "@wireapp/commons": "npm:5.4.3"
     "@wireapp/copy-config": "npm:2.3.0"
     "@wireapp/core": "npm:46.31.3"
     "@wireapp/eslint-config": "npm:3.0.7"


### PR DESCRIPTION
https://github.com/wireapp/wire-web-packages/pull/7101