### PR TITLE
runfix(cells): display profile name of cell owner [WPB-18624]

### DIFF
--- a/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsOwnerColumn/CellsOwnerColumn.tsx
+++ b/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsOwnerColumn/CellsOwnerColumn.tsx
@@ -38,7 +38,7 @@ export const CellsTableOwnerColumn = ({owner, user}: CellsTableOwnerColumnProps)
       <div css={avatarWrapperStyles}>
         <Avatar participant={user} avatarSize={AVATAR_SIZE.XXX_SMALL} />
       </div>
-      <span css={textStyles}>{owner}</span>
+      <span css={textStyles}>{user.name()}</span>
     </button>
   );
 };

--- a/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableOwnerColumn/CellsTableOwnerColumn.tsx
+++ b/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableOwnerColumn/CellsTableOwnerColumn.tsx
@@ -38,7 +38,7 @@ export const CellsTableOwnerColumn = ({owner, user}: CellsTableOwnerColumnProps)
       <div css={avatarWrapperStyles}>
         <Avatar participant={user} avatarSize={AVATAR_SIZE.XXX_SMALL} />
       </div>
-      <span css={textStyles}>{owner}</span>
+      <span css={textStyles}>{user.name()}</span>
     </button>
   );
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18624" title="WPB-18624" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18624</a>  [Web] Owner avatar - display name instead of login
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Display the wire user profile name for the owner of a node in both tables instead of the `owner` field from the cell node

<!-- Uncomment this section if your PR has UI changes -->

## Screenshots/Screencast (for UI changes)
After:
<img width="555" height="85" alt="image" src="https://github.com/user-attachments/assets/d0707cf0-c210-46e8-8776-10ca1883ae17" />

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
