### PR TITLE
fix(files): check for sharing permission on pasting files only [WPB-18723]

### DIFF
--- a/src/script/components/InputBar/useFileHandling/useFilePaste/useFilePaste.test.ts
+++ b/src/script/components/InputBar/useFileHandling/useFilePaste/useFilePaste.test.ts
@@ -67,6 +67,7 @@ describe('useFilePaste', () => {
     const calledWithFile = mockOnFilePasted.mock.calls[0][0];
     expect(calledWithFile instanceof File).toBe(true);
     expect(calledWithFile.name).toBe(`Pasted file from ${mockFormattedDate}.txt`);
+    expect(checkFileSharingPermissionModule.checkFileSharingPermission).toHaveBeenCalled();
   });
 
   it('ignores paste events with text/plain content', () => {
@@ -79,6 +80,7 @@ describe('useFilePaste', () => {
     });
 
     expect(mockOnFilePasted).not.toHaveBeenCalled();
+    expect(checkFileSharingPermissionModule.checkFileSharingPermission).not.toHaveBeenCalled();
   });
 
   it('does nothing when no files are pasted', () => {
@@ -91,12 +93,6 @@ describe('useFilePaste', () => {
     });
 
     expect(mockOnFilePasted).not.toHaveBeenCalled();
-  });
-
-  it('uses checkFileSharingPermission wrapper', () => {
-    renderHook(() => useFilePaste({onFilePasted: mockOnFilePasted}));
-
-    expect(checkFileSharingPermissionModule.checkFileSharingPermission).toHaveBeenCalled();
   });
 });
 

--- a/src/script/components/InputBar/useFileHandling/useFilePaste/useFilePaste.ts
+++ b/src/script/components/InputBar/useFileHandling/useFilePaste/useFilePaste.ts
@@ -60,14 +60,15 @@ export const useFilePaste = ({onFilePasted}: UseFilePasteParams) => {
       const files = event.clipboardData?.files;
 
       if (files) {
-        processClipboardFiles(files);
+        const permissionHandler = checkFileSharingPermission(processClipboardFiles);
+        permissionHandler(files);
       }
     },
     [processClipboardFiles],
   );
 
   useEffect(() => {
-    document.addEventListener('paste', checkFileSharingPermission(handlePasteEvent));
-    return () => document.removeEventListener('paste', checkFileSharingPermission(handlePasteEvent));
+    document.addEventListener('paste', handlePasteEvent);
+    return () => document.removeEventListener('paste', handlePasteEvent);
   }, [handlePasteEvent]);
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18723" title="WPB-18723" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18723</a>  [Web] When Team does not allow file transfer, pasting text from clip board triggers mutliple warnings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Every paste event in the input bar currently performs a check to whether or not file sharing is permitted for the team.

This triggers the check (and prevent pasting for files if the setting is enabled) only when the clipboard contains a file

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
