### PR TITLE
fix: hide read receipts toggle for MLS groups [WPB-17937]

### DIFF
--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -99,6 +99,8 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
 
   const initialProtocol = protocolOptions.find(protocol => protocol.value === defaultProtocol)!;
 
+  const areReadReceiptsEnabled = defaultProtocol !== ConversationProtocol.MLS;
+
   const [isShown, setIsShown] = useState<boolean>(false);
   const [selectedContacts, setSelectedContacts] = useState<User[]>([]);
   const [enableReadReceipts, setEnableReadReceipts] = useState<boolean>(false);
@@ -501,15 +503,17 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
                     toggleId="services"
                   />
                 )}
-                <InfoToggle
-                  className="modal-style"
-                  dataUieName="read-receipts"
-                  info={t('readReceiptsToggleInfo')}
-                  isChecked={enableReadReceipts}
-                  setIsChecked={setEnableReadReceipts}
-                  isDisabled={false}
-                  name={t('readReceiptsToggleName')}
-                />
+                {areReadReceiptsEnabled && (
+                  <InfoToggle
+                    className="modal-style"
+                    dataUieName="read-receipts"
+                    info={t('readReceiptsToggleInfo')}
+                    isChecked={enableReadReceipts}
+                    setIsChecked={setEnableReadReceipts}
+                    isDisabled={false}
+                    name={t('readReceiptsToggleName')}
+                  />
+                )}
                 {enableMLSToggle && (
                   <>
                     <Select

--- a/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsOptions/ConversationDetailsOptions.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsOptions/ConversationDetailsOptions.tsx
@@ -119,7 +119,7 @@ const ConversationDetailsOptions = ({
   const showOptionTimedMessages = isActiveGroupParticipant && isSelfDeletingMessagesEnabled;
   const showOptionServices = isActiveGroupParticipant && isTeamConversation && !isMLSConversation(activeConversation);
   const showOptionNotifications1To1 = isMutable && !isGroup;
-  const showOptionReadReceipts = isTeamConversation;
+  const showOptionReadReceipts = isTeamConversation && !isMLSConversation(activeConversation);
 
   const hasReceiptsEnabled = conversationRepository.expectReadReceipt(activeConversation);
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17937" title="WPB-17937" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-17937</a>  [Web] Hide MLS Read Receipts in UI
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Read receipts being disabled in MLS conversations, we want to hide read receipts UI elements for regular MLS groups and from group creation if MLS is the default protocol

<!-- Uncomment this section if your PR has UI changes -->

## Screenshots/Screencast (for UI changes)
Proteus:
<img width="387" height="816" alt="image" src="https://github.com/user-attachments/assets/34387aac-c4c3-4cd0-ba9d-0e5b1423fee9" />
<img width="532" height="627" alt="image" src="https://github.com/user-attachments/assets/3d7590d0-254a-43d9-aadf-8a0802939815" />


MLS:
<img width="387" height="816" alt="image" src="https://github.com/user-attachments/assets/605f542c-271e-49fe-bcb9-924aec758e0d" />
<img width="535" height="491" alt="image" src="https://github.com/user-attachments/assets/7a6e054b-ece7-40fc-82c4-6fc56d9c6d3d" />



## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
