### PR TITLE
fix: unify transparent image bg in input bar and message content [WPB-18503]

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetLarge/ImageAssetLarge.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetLarge/ImageAssetLarge.styles.ts
@@ -69,6 +69,7 @@ export const imageStyle: CSSObject = {
   objectFit: 'contain',
   objectPosition: 'left center',
   opacity: 'var(--opacity)',
+  backgroundColor: 'var(--input-bar-bg)',
 };
 
 export const errorIconStyles: CSSObject = {

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetSmall/ImageAssetSmall.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetSmall/ImageAssetSmall.styles.ts
@@ -35,4 +35,5 @@ export const imageStyles: CSSObject = {
   height: '100%',
   objectFit: 'cover',
   borderRadius: '10px',
+  backgroundColor: 'var(--input-bar-bg)',
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18503" title="WPB-18503" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18503</a>  [Web] Cells unify transparent images thumbnails
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
This pull request introduces a small visual update to the `ImageAssetLarge` component. Specifically, it adds a background color to the image style for better visual consistency.

Old:
<img width="258" height="464" alt="Screenshot 2025-07-29 at 18 20 00" src="https://github.com/user-attachments/assets/c843e529-83c2-4a76-b4a6-070d7b4c8008" />
<img width="258" height="464" alt="Screenshot 2025-07-29 at 18 19 29" src="https://github.com/user-attachments/assets/27de53ec-7656-4d3f-8901-b03d9ed76e0a" />

New:
<img width="258" height="464" alt="Screenshot 2025-07-29 at 18 19 05" src="https://github.com/user-attachments/assets/11917af2-6e1c-45f6-9ff7-4d86eae51c5a" />
<img width="258" height="464" alt="Screenshot 2025-07-29 at 18 18 47" src="https://github.com/user-attachments/assets/3d491275-26f3-4bd4-9384-cd04cf734257" />


## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
