### PR TITLE
fix(cells): avoid double conversations cell state issue [WPB-18933]

### DIFF
--- a/src/script/components/Conversation/ConversationCells/useRefreshCellsState/useRefreshCellsState.ts
+++ b/src/script/components/Conversation/ConversationCells/useRefreshCellsState/useRefreshCellsState.ts
@@ -45,7 +45,7 @@ export const useRefreshCellsState = ({
   const fetchCountRef = useRef(0);
 
   const refreshCellsState = useCallback(async () => {
-    const conversation = await conversationRepository.fetchConversationById(conversationQualifiedId);
+    const conversation = await conversationRepository.getConversationById(conversationQualifiedId);
     setCellsState(conversation.cellsState());
     fetchCountRef.current += 1;
   }, [conversationRepository, conversationQualifiedId]);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18933" title="WPB-18933" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18933</a>  [Web] Double conversation appearing when clicking on the Files tab
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Clicking on the file tab in a Cells conversation would create a duplicated conversation at the top of the list

<!-- Uncomment this section if your PR has UI changes -->

## Screenshots/Screencast (for UI changes)
Before
![Kooha-2025-07-30-14-34-33](https://github.com/user-attachments/assets/92908d8a-d679-4e2f-84aa-4ae2f56bbea7)

After
![Kooha-2025-07-30-14-33-37](https://github.com/user-attachments/assets/9af5aaad-a460-42b1-bd8b-0d37a7175a76)

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
