### PR TITLE
chore: Do not use api version 10

### DIFF
--- a/src/script/Config.ts
+++ b/src/script/Config.ts
@@ -17,8 +17,6 @@
  *
  */
 
-import {MINIMUM_API_VERSION} from '@wireapp/api-client/lib/Config';
-
 import {Runtime} from '@wireapp/commons';
 
 import {createUuid} from 'Util/uuid';
@@ -86,9 +84,9 @@ const config = {
   ALLOWED_IMAGE_TYPES: ['image/bmp', 'image/gif', 'image/jpeg', 'image/jpg', 'image/png', 'image/webp'],
 
   /** Which min and max version of the backend api do we support */
-  SUPPORTED_API_RANGE: [MINIMUM_API_VERSION, env.ENABLE_DEV_BACKEND_API ? Infinity : MINIMUM_API_VERSION],
+  SUPPORTED_API_RANGE: [8, env.ENABLE_DEV_BACKEND_API ? Infinity : 9],
 
-  /** DataDog client api keys acces */
+  /** DataDog client api keys access */
   dataDog: {
     clientToken: env.DATADOG_CLIENT_TOKEN,
     applicationId: env.DATADOG_APPLICATION_ID,


### PR DESCRIPTION
api version 10 has breaking changes so as long as they are not adopted we shouldn't be using it.