### PR TITLE
fix: handle long file name in file preview modal [WPB-18625]

### DIFF
--- a/src/script/components/FileFullscreenModal/FileHeader/FileHeader.styles.ts
+++ b/src/script/components/FileFullscreenModal/FileHeader/FileHeader.styles.ts
@@ -62,6 +62,10 @@ export const metadataStyles: CSSObject = {
 export const nameStyles: CSSObject = {
   fontSize: 'var(--font-size-medium)',
   fontWeight: 'var(--font-weight-semibold)',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  width: 'calc(100vw - 320px)',
 };
 
 export const textStyles: CSSObject = {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18625" title="WPB-18625" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18625</a>  [Web] Long file names are not truncated
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Handled long file name in file preview modal 

## Screenshots/Screencast (for UI changes)

https://github.com/user-attachments/assets/8e5362e5-4ad8-4db2-bb1e-a8a6475ce05a

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
