### PR TITLE
fix: add new css var for transparent images bg [WPB-18503]

### DIFF
--- a/src/script/components/InputBar/FilePreviews/ImagePreviewCard/ImagePreviewCard.styles.ts
+++ b/src/script/components/InputBar/FilePreviews/ImagePreviewCard/ImagePreviewCard.styles.ts
@@ -24,4 +24,5 @@ export const imageStyles: CSSObject = {
   height: '100%',
   objectFit: 'cover',
   borderRadius: '10px',
+  backgroundColor: 'var(--transparent-img-bg)',
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetLarge/ImageAssetLarge.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetLarge/ImageAssetLarge.styles.ts
@@ -69,7 +69,7 @@ export const imageStyle: CSSObject = {
   objectFit: 'contain',
   objectPosition: 'left center',
   opacity: 'var(--opacity)',
-  backgroundColor: 'var(--input-bar-bg)',
+  backgroundColor: 'var(--transparent-img-bg)',
 };
 
 export const errorIconStyles: CSSObject = {

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetSmall/ImageAssetSmall.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetSmall/ImageAssetSmall.styles.ts
@@ -35,5 +35,5 @@ export const imageStyles: CSSObject = {
   height: '100%',
   objectFit: 'cover',
   borderRadius: '10px',
-  backgroundColor: 'var(--input-bar-bg)',
+  backgroundColor: 'var(--transparent-img-bg)',
 };

--- a/src/style/common/mixins.less
+++ b/src/style/common/mixins.less
@@ -41,7 +41,7 @@
   .setVariables(foreground background);
   .setColorFade(foreground, @foreground);
   .setColorFade(background, @background);
-  .setVariables(app-bg sidebar-bg input-bar-bg sidebar-border-color sidebar-folder-selected-bg main-color border-color app-bg-secondary conversation-list-bg-opacity group-icon-bg);
+  .setVariables(app-bg sidebar-bg input-bar-bg transparent-img-bg sidebar-border-color sidebar-folder-selected-bg main-color border-color app-bg-secondary conversation-list-bg-opacity group-icon-bg);
   .setVariables(group-video-bg group-video-tile-bg participant-audio-connecting-color inactive-call-button-bg inactive-call-button-border inactive-call-button-hover-bg inactive-call-button-hover-border disabled-call-button-bg disabled-call-button-border disabled-call-button-svg button-group-left-hover button-group-right-hover toggle-button-unselected-hover-border toggle-button-unselected-hover-bg);
   .setVariables(modal-bg modal-border-color);
   .setVariables(preference-account-input-bg);

--- a/src/style/foundation/themes.less
+++ b/src/style/foundation/themes.less
@@ -36,7 +36,8 @@ body.theme-default {
   @main-color: var(--black);
   @app-bg-secondary: var(--white);
   @conversation-list-bg-opacity: fade(#000, 64%);
-  @input-bar-bg: var(--gray-20);
+  @input-bar-bg: var(--white);
+  @transparent-img-bg: var(--gray-20);
   @group-icon-bg: var(--white);
 
   // ----------------------------------------------------------------------------
@@ -139,7 +140,8 @@ body.theme-dark {
   @border-color: var(--gray-90);
   @app-bg-secondary: var(--black);
   @conversation-list-bg-opacity: fade(#000, 78%);
-  @input-bar-bg: var(--gray-90);
+  @input-bar-bg: var(--gray-100);
+  @transparent-img-bg: var(--gray-90);
   @group-icon-bg: var(--gray-95);
 
   // ----------------------------------------------------------------------------


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18503" title="WPB-18503" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18503</a>  [Web] Cells unify transparent images thumbnails
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

This pull request introduces a new CSS variable, `--transparent-img-bg`, to improve styling consistency for image backgrounds across components. 

<img width="264" height="466" alt="Screenshot 2025-07-31 at 12 54 02" src="https://github.com/user-attachments/assets/f0b14ec7-a8d9-41bc-8cbb-ca6a4e5e155c" />
<img width="264" height="466" alt="Screenshot 2025-07-31 at 12 53 54" src="https://github.com/user-attachments/assets/d09278f3-4655-4e27-bc93-b751f52d2de1" />


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
