### PR TITLE
fix: Automatically scroll to end of messages list [WPB-19255]

### DIFF
--- a/src/script/components/MessagesList/VirtualizedMessagesList/useScrollMessages.ts
+++ b/src/script/components/MessagesList/VirtualizedMessagesList/useScrollMessages.ts
@@ -133,22 +133,4 @@ export const useScrollMessages = (
       });
     }
   }, [conversation, userId, virtualizer, messages, conversationLastReadTimestamp]);
-
-  // If the scroll was at the top and new messages were loaded, scroll in a way that preserves the position.
-  useEffect(() => {
-    // Skip if there are no messages or a highlighted message is present
-    if (messages.length === 0 || highlightedMessage) {
-      return;
-    }
-
-    const virtualItems = virtualizer.getVirtualItems();
-    const lastIndex = messages.length - 1;
-    const isAtBottom = virtualItems.length > 0 && virtualItems[virtualItems.length - 1].index >= lastIndex - 1;
-
-    if (isAtBottom && !virtualizer.isScrolling) {
-      requestAnimationFrame(() => {
-        virtualizer.scrollToIndex(lastIndex, {align: 'end'});
-      });
-    }
-  }, [virtualizer, messages]);
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19255" title="WPB-19255" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19255</a>  [Web] When opening a conversation, the message list doesnt point to the start of unread messages 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Fixed issue with scrolling to the end of the messages list while we scrolling up a little bit from the bottom.

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
