### PR TITLE
runfix(CPB): keep conversation order after restoring backup [WPB-18298]

### DIFF
--- a/src/script/repositories/backup/CrossPlatformBackup/CPB.export.ts
+++ b/src/script/repositories/backup/CrossPlatformBackup/CPB.export.ts
@@ -92,9 +92,11 @@ export const exportCPBHistoryFromDatabase = async ({
     const {success, data, error} = ConversationTableEntrySchema.safeParse(record);
 
     if (success) {
-      backupExporter.addConversation(
-        new BackUpConversation(new BackupQualifiedId(data.id, data.domain), data.name ?? ''),
-      );
+      const qualifiedId = new BackupQualifiedId(data.id, data.domain);
+      const name = data.name ?? '';
+      const lastModifiedTime = new BackupDateTime(new Date(data.last_event_timestamp));
+
+      backupExporter.addConversation(new BackUpConversation(qualifiedId, name, lastModifiedTime));
     } else {
       CPBLogger.error('Conversation data schema validation failed', error);
     }

--- a/src/script/repositories/backup/CrossPlatformBackup/data.schema.ts
+++ b/src/script/repositories/backup/CrossPlatformBackup/data.schema.ts
@@ -26,6 +26,7 @@ export const QualifiedIdSchema = zod.object({
 
 export const ConversationTableEntrySchema = QualifiedIdSchema.extend({
   name: zod.string().nullable().optional(),
+  last_event_timestamp: zod.number(),
 });
 export type ConversationTableEntry = zod.infer<typeof ConversationTableEntrySchema>;
 

--- a/src/script/repositories/backup/CrossPlatformBackup/importMappers/mapConversationRecord.ts
+++ b/src/script/repositories/backup/CrossPlatformBackup/importMappers/mapConversationRecord.ts
@@ -21,10 +21,16 @@ import {ConversationRecord} from 'Repositories/storage';
 
 import {BackUpConversation} from '../CPB.library';
 
-export const mapConversationRecord = ({id: qualifiedId, name}: BackUpConversation): ConversationRecord | null => {
+export const mapConversationRecord = ({
+  id: qualifiedId,
+  name,
+  lastModifiedTime,
+}: BackUpConversation): ConversationRecord | null => {
   if (!qualifiedId || !name) {
     return null;
   }
+
+  const lastEventTimestamp = lastModifiedTime ? new Date(lastModifiedTime.date.toString()).getTime() : 0;
 
   // We dont get all the "required" fields from the backup, so we need to outsmart the type system.
   // ToDO: Fix the backup to include all required fields or check if we can make them optional without breaking anything.
@@ -33,6 +39,7 @@ export const mapConversationRecord = ({id: qualifiedId, name}: BackUpConversatio
     name: name.toString(),
     domain: qualifiedId.domain.toString(),
     last_read_timestamp: new Date().getTime(),
+    last_event_timestamp: lastEventTimestamp,
   } as ConversationRecord;
   return conversationRecord;
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18298" title="WPB-18298" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18298</a>  [Web] Keep conversations order after restoring backup
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Export the timestamp of the last event in a conversation to the cross-platform backup format.
Supported by `@wireapp/kalium-backup` > v0.0.4
This allow restoring the conversations in the corret order ­— last modified at the top

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
