### PR TITLE
feat(cells): use team feature for cells file sharing condition [WPB-19293]

### DIFF
--- a/src/script/components/InputBar/InputBar.tsx
+++ b/src/script/components/InputBar/InputBar.tsx
@@ -111,10 +111,13 @@ export const InputBar = ({
   onCellImageUpload,
   onCellAssetUpload,
 }: InputBarProps) => {
-  const {classifiedDomains, isSelfDeletingMessagesEnabled, isFileSharingSendingEnabled} = useKoSubscribableChildren(
-    teamState,
-    ['classifiedDomains', 'isSelfDeletingMessagesEnabled', 'isFileSharingSendingEnabled'],
-  );
+  const {classifiedDomains, isSelfDeletingMessagesEnabled, isFileSharingSendingEnabled, isCellsEnabled} =
+    useKoSubscribableChildren(teamState, [
+      'classifiedDomains',
+      'isSelfDeletingMessagesEnabled',
+      'isFileSharingSendingEnabled',
+      'isCellsEnabled',
+    ]);
   const {connection, localMessageTimer, messageTimer, hasGlobalMessageTimer, isSelfUserRemoved, is1to1} =
     useKoSubscribableChildren(conversation, [
       'connection',
@@ -315,6 +318,7 @@ export const InputBar = ({
                   {!!files.length && <FilePreviews files={files} conversationQualifiedId={conversation.qualifiedId} />}
                   <InputBarControls
                     conversation={conversation}
+                    isCellsFeatureEnabled={isCellsEnabled}
                     isFileSharingSendingEnabled={isFileSharingSendingEnabled}
                     pingDisabled={ping.isPingDisabled}
                     messageContent={messageContent}

--- a/src/script/components/InputBar/InputBarControls/ControlButtons.tsx
+++ b/src/script/components/InputBar/InputBarControls/ControlButtons.tsx
@@ -19,6 +19,8 @@
 
 import {MouseEvent} from 'react';
 
+import {CONVERSATION_CELLS_STATE} from '@wireapp/api-client/lib/conversation/';
+
 import {FormatSeparator} from 'Components/InputBar/common/FormatSeparator/FormatSeparator';
 import {Conversation} from 'Repositories/entity/Conversation';
 import {Config} from 'src/script/Config';
@@ -80,6 +82,7 @@ const ControlButtons = ({
   onCellAssetUpload,
 }: ControlButtonsProps) => {
   const isCellsEnabled = Config.getConfig().FEATURE.ENABLE_CELLS && isCellsFeatureEnabled;
+  const isCellsConversation = isCellsEnabled && conversation.cellsState() !== CONVERSATION_CELLS_STATE.DISABLED;
 
   if (isEditing) {
     return (
@@ -124,7 +127,7 @@ const ControlButtons = ({
         {!disableFilesharing && (
           <>
             <li>
-              {isCellsEnabled ? (
+              {isCellsConversation ? (
                 <CellImageUploadButton onClick={onCellImageUpload} />
               ) : (
                 <ImageUploadButton
@@ -135,7 +138,7 @@ const ControlButtons = ({
             </li>
 
             <li>
-              {isCellsEnabled ? (
+              {isCellsConversation ? (
                 <CellAssetUploadButton onClick={onCellAssetUpload} />
               ) : (
                 <AssetUploadButton
@@ -152,7 +155,7 @@ const ControlButtons = ({
         <li>
           <PingButton isDisabled={!!disablePing} onClick={onClickPing} />
         </li>
-        {!isCellsEnabled && (
+        {!isCellsConversation && (
           <li>
             <MessageTimerButton conversation={conversation} />
           </li>

--- a/src/script/components/InputBar/InputBarControls/ControlButtons.tsx
+++ b/src/script/components/InputBar/InputBarControls/ControlButtons.tsx
@@ -39,6 +39,7 @@ export type ControlButtonsProps = {
   conversation: Conversation;
   disablePing?: boolean;
   disableFilesharing?: boolean;
+  isCellsFeatureEnabled?: boolean;
   isEditing?: boolean;
   isFormatActive: boolean;
   isEmojiActive: boolean;
@@ -61,6 +62,7 @@ const ControlButtons = ({
   disablePing,
   disableFilesharing,
   input,
+  isCellsFeatureEnabled,
   isEditing,
   isFormatActive,
   isEmojiActive,
@@ -77,7 +79,7 @@ const ControlButtons = ({
   onCellImageUpload,
   onCellAssetUpload,
 }: ControlButtonsProps) => {
-  const isCellsEnabled = Config.getConfig().FEATURE.ENABLE_CELLS;
+  const isCellsEnabled = Config.getConfig().FEATURE.ENABLE_CELLS && isCellsFeatureEnabled;
 
   if (isEditing) {
     return (

--- a/src/script/components/InputBar/InputBarControls/InputBarControls.tsx
+++ b/src/script/components/InputBar/InputBarControls/InputBarControls.tsx
@@ -36,6 +36,7 @@ interface InputBarControlsProps {
   isFileSharingSendingEnabled: boolean;
   pingDisabled: boolean;
   messageContent: MessageContent;
+  isCellsFeatureEnabled: boolean;
   isEditing: boolean;
   isSendingDisabled: boolean;
   showMarkdownPreview: boolean;
@@ -64,6 +65,7 @@ export const InputBarControls = ({
   isFileSharingSendingEnabled,
   pingDisabled,
   messageContent,
+  isCellsFeatureEnabled: isCellsFeatureEnabled,
   isEditing,
   isSendingDisabled,
   showMarkdownPreview,
@@ -98,6 +100,7 @@ export const InputBarControls = ({
           disableFilesharing={!isFileSharingSendingEnabled}
           disablePing={pingDisabled}
           input={messageContent.text}
+          isCellsFeatureEnabled={isCellsFeatureEnabled}
           isEditing={isEditing}
           onCancelEditing={onEscape}
           onClickPing={onClickPing}

--- a/src/script/repositories/team/TeamState.ts
+++ b/src/script/repositories/team/TeamState.ts
@@ -58,6 +58,7 @@ export class TeamState {
   readonly teamDomain: ko.PureComputed<string>;
   readonly teamSize: ko.PureComputed<number>;
   readonly selfRole: ko.PureComputed<Role | undefined>;
+  readonly isCellsEnabled: ko.PureComputed<boolean>;
 
   constructor(private readonly userState = container.resolve(UserState)) {
     this.isTeam = ko.pureComputed(() => !!this.team()?.id);
@@ -131,6 +132,10 @@ export class TeamState {
       const roles = this.memberRoles();
       const userId = this.userState.self()?.id;
       return roles && userId ? roleMap[roles[userId]] : undefined;
+    });
+
+    this.isCellsEnabled = ko.pureComputed(() => {
+      return this.teamFeatures()?.cells?.status === FeatureStatus.ENABLED;
     });
   }
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19293" title="WPB-19293" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19293</a>  [Web] Cannot send files when cells is enabled in the environment but not the team
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

Add flags for using the cells api to share files in a conversation:
- (was already implementd) Cells is enabled on the environment
- Cells is enabled as a team feature for the user
- Cells is enabled at the conversation level

Without the added flags, we would attempt to use the cells api to share files in conversation that do not have cells enabled

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
