### PR TITLE
runfix(cells): use team feature for cells group creation condition [WPB-19356]

### DIFF
--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -117,7 +117,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
   const [groupCreationState, setGroupCreationState] = useState<GroupCreationModalState>(
     GroupCreationModalState.DEFAULT,
   );
-  const [isCellsOptionEnabled, setIsCellsOptionEnabled] = useState(isCellsEnabledForTeam);
+  const [isCellsOptionEnabled, setIsCellsOptionEnabled] = useState(enableCellsToggle);
 
   const mainViewModel = useContext(RootContext);
 

--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -77,7 +77,13 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
     isTeam,
     isMLSEnabled: isMLSEnabledForTeam,
     isProtocolToggleEnabledForUser,
-  } = useKoSubscribableChildren(teamState, ['isTeam', 'isMLSEnabled', 'isProtocolToggleEnabledForUser']);
+    isCellsEnabled: isCellsEnabledForTeam,
+  } = useKoSubscribableChildren(teamState, [
+    'isTeam',
+    'isMLSEnabled',
+    'isProtocolToggleEnabledForUser',
+    'isCellsEnabled',
+  ]);
   const {self: selfUser} = useKoSubscribableChildren(userState, ['self']);
 
   const enableMLSToggle = isMLSEnabledForTeam && isProtocolToggleEnabledForUser;
@@ -111,7 +117,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
   const [groupCreationState, setGroupCreationState] = useState<GroupCreationModalState>(
     GroupCreationModalState.DEFAULT,
   );
-  const [isCellsOptionEnabled, setIsCellsOptionEnabled] = useState(true);
+  const [isCellsOptionEnabled, setIsCellsOptionEnabled] = useState(isCellsEnabledForTeam);
 
   const mainViewModel = useContext(RootContext);
 
@@ -141,7 +147,11 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
   const isGuestEnabled = isGuestRoom || isGuestAndServicesRoom;
   const isServicesEnabled = isServicesRoom || isGuestAndServicesRoom;
 
-  const isCellsEnabled = Config.getConfig().FEATURE.ENABLE_CELLS && isCellsOptionEnabled;
+  const isCellsEnabledForEnvironment = Config.getConfig().FEATURE.ENABLE_CELLS;
+
+  const isCellsEnabledForGroup = isCellsEnabledForEnvironment && isCellsOptionEnabled;
+
+  const enableCellsToggle = isCellsEnabledForEnvironment && isCellsEnabledForTeam;
 
   const {setCurrentTab: setCurrentSidebarTab} = useSidebarStore();
 
@@ -223,7 +233,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
           {
             protocol: enableMLSToggle ? selectedProtocol.value : defaultProtocol,
             receipt_mode: enableReadReceipts ? RECEIPT_MODE.ON : RECEIPT_MODE.OFF,
-            cells: isCellsEnabled,
+            cells: isCellsEnabledForGroup,
           },
         );
 
@@ -513,7 +523,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
                   isDisabled={false}
                   name={t('readReceiptsToggleName')}
                 />
-                {Config.getConfig().FEATURE.ENABLE_CELLS && (
+                {enableCellsToggle && (
                   <InfoToggle
                     className="modal-style"
                     dataUieName="cells"

--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -104,6 +104,12 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
 
   const initialProtocol = protocolOptions.find(protocol => protocol.value === defaultProtocol)!;
 
+  //both environment feature flag and team feature flag must be enabled to create conversations with cells
+  const isCellsEnabledForEnvironment = Config.getConfig().FEATURE.ENABLE_CELLS;
+  const enableCellsToggle = isCellsEnabledForEnvironment && isCellsEnabledForTeam;
+  const [isCellsOptionEnabled, setIsCellsOptionEnabled] = useState(enableCellsToggle);
+  const isCellsEnabledForGroup = isCellsEnabledForEnvironment && isCellsOptionEnabled;
+
   const [isShown, setIsShown] = useState<boolean>(false);
   const [selectedContacts, setSelectedContacts] = useState<User[]>([]);
   const [enableReadReceipts, setEnableReadReceipts] = useState<boolean>(false);
@@ -117,7 +123,6 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
   const [groupCreationState, setGroupCreationState] = useState<GroupCreationModalState>(
     GroupCreationModalState.DEFAULT,
   );
-  const [isCellsOptionEnabled, setIsCellsOptionEnabled] = useState(enableCellsToggle);
 
   const mainViewModel = useContext(RootContext);
 
@@ -146,12 +151,6 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
   const isGuestRoom = accessState === ACCESS_STATE.TEAM.GUEST_ROOM;
   const isGuestEnabled = isGuestRoom || isGuestAndServicesRoom;
   const isServicesEnabled = isServicesRoom || isGuestAndServicesRoom;
-
-  const isCellsEnabledForEnvironment = Config.getConfig().FEATURE.ENABLE_CELLS;
-
-  const isCellsEnabledForGroup = isCellsEnabledForEnvironment && isCellsOptionEnabled;
-
-  const enableCellsToggle = isCellsEnabledForEnvironment && isCellsEnabledForTeam;
 
   const {setCurrentTab: setCurrentSidebarTab} = useSidebarStore();
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19356" title="WPB-19356" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19356</a>  [Web] Wire Cells available even by teams without Cells activation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

- set the "files" initial toggle state to `on` if cells is enabled for the team and `off` otherwise
- do not show the toggle if cells isn't enabled for the team

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
