### PR TITLE
runfix(cells): use team feature for cells sidebar tab condition [WPB-19356]

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/ConversationTabs.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationTabs/ConversationTabs.tsx
@@ -96,6 +96,7 @@ export const ConversationTabs = ({
   const teamState = container.resolve(TeamState);
   const totalUnreadConversations = unreadConversations.length;
   const {teamRole} = useKoSubscribableChildren(selfUser, ['teamRole']);
+  const {isCellsEnabled: isCellsEnabledForTeam} = useKoSubscribableChildren(teamState, ['isCellsEnabled']);
 
   const totalUnreadFavoriteConversations = favoriteConversations.filter(favoriteConversation =>
     favoriteConversation.hasUnread(),
@@ -175,6 +176,8 @@ export const ConversationTabs = ({
   const manageTeamUrl = getManageTeamUrl();
   const replaceWireLink = replaceLink('https://app.wire.com', '', '');
 
+  const showCellsTab = Config.getConfig().FEATURE.ENABLE_CELLS && isCellsEnabledForTeam;
+
   return (
     <>
       <div
@@ -231,7 +234,7 @@ export const ConversationTabs = ({
           isActive={currentTab === SidebarTabs.CONNECT}
         />
 
-        {Config.getConfig().FEATURE.ENABLE_CELLS && (
+        {showCellsTab && (
           <>
             <div className="conversations-sidebar-divider" />
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19356" title="WPB-19356" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19356</a>  [Web] Wire Cells available even by teams without Cells activation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

- only show the "all files" sidebar tab when cells is enabled at the team level

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
