### PR TITLE
runfix(CPB): add last edited time to CPB data [WPB-17986]

### DIFF
--- a/src/script/repositories/backup/CrossPlatformBackup/CPB.export.ts
+++ b/src/script/repositories/backup/CrossPlatformBackup/CPB.export.ts
@@ -149,7 +149,8 @@ export const exportCPBHistoryFromDatabase = async ({
     }
     const {success, data: eventData, error} = EventTableEntrySchema.safeParse(record);
     if (success) {
-      const {from, from_client_id, id, qualified_conversation, qualified_from, primary_key, time, type} = eventData;
+      const {edited_time, from, from_client_id, id, qualified_conversation, qualified_from, primary_key, time, type} =
+        eventData;
       if (!id) {
         // eslint-disable-next-line no-console
         CPBLogger.log('Event without id', eventData);
@@ -169,6 +170,7 @@ export const exportCPBHistoryFromDatabase = async ({
       );
       const senderClientId = from_client_id ?? '';
       const creationDate = new BackupDateTime(new Date(time));
+      const lastEditTime = edited_time ? new BackupDateTime(new Date(edited_time)) : null;
       // for debugging purposes
       const webPrimaryKey = primary_key;
 
@@ -199,14 +201,32 @@ export const exportCPBHistoryFromDatabase = async ({
         );
 
         backupExporter.addMessage(
-          new BackupMessage(id, conversationId, senderUserId, senderClientId, creationDate, asset, webPrimaryKey),
+          new BackupMessage(
+            id,
+            conversationId,
+            senderUserId,
+            senderClientId,
+            creationDate,
+            asset,
+            webPrimaryKey,
+            lastEditTime,
+          ),
         );
       }
 
       if (isMessageAddEvent(type) && eventData.data?.content) {
         const text = new BackupMessageContent.Text(eventData.data.content);
         backupExporter.addMessage(
-          new BackupMessage(id, conversationId, senderUserId, senderClientId, creationDate, text, webPrimaryKey),
+          new BackupMessage(
+            id,
+            conversationId,
+            senderUserId,
+            senderClientId,
+            creationDate,
+            text,
+            webPrimaryKey,
+            lastEditTime,
+          ),
         );
       }
 
@@ -227,7 +247,16 @@ export const exportCPBHistoryFromDatabase = async ({
           locationParseData.location.zoom,
         );
         backupExporter.addMessage(
-          new BackupMessage(id, conversationId, senderUserId, senderClientId, creationDate, location, webPrimaryKey),
+          new BackupMessage(
+            id,
+            conversationId,
+            senderUserId,
+            senderClientId,
+            creationDate,
+            location,
+            webPrimaryKey,
+            lastEditTime,
+          ),
         );
       }
     } else {

--- a/src/script/repositories/backup/CrossPlatformBackup/data.schema.ts
+++ b/src/script/repositories/backup/CrossPlatformBackup/data.schema.ts
@@ -42,6 +42,7 @@ export const EventTableEntrySchema = zod.object({
   category: zod.number().int().optional(),
   conversation: zod.string().min(1, 'Conversation is required'),
   data: zod.any(),
+  edited_time: zod.string().optional(),
   from: zod.string().optional().nullable(),
   from_client_id: zod.string().optional(),
   id: zod.string().optional(),

--- a/src/script/repositories/backup/CrossPlatformBackup/importMappers/mapEventRecord.ts
+++ b/src/script/repositories/backup/CrossPlatformBackup/importMappers/mapEventRecord.ts
@@ -44,6 +44,7 @@ const mapCommonMessageFields = ({
   senderClientId,
   senderUserId,
   webPrimaryKey,
+  lastEditTime,
 }: BackupMessage): CommonMessageFields => {
   const common = {
     conversation: conversationId.id.toString(),
@@ -60,6 +61,7 @@ const mapCommonMessageFields = ({
     },
     time: creationDate.date.toISOString(),
     primary_key: webPrimaryKey?.toString() ?? '',
+    edited_time: lastEditTime ? lastEditTime.date.toISOString() : undefined,
   };
   return common;
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17986" title="WPB-17986" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17986</a>  [Web] Edited message not showing edited timestamp after restoring
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

- export `edited_time` to the cross platform backup format
- import `lastEditTime` from the cross platform backup to the restored event data

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
