### PR TITLE
fix: Remove extra id check in conversation mapper

### DIFF
--- a/src/script/repositories/conversation/ConversationMapper.ts
+++ b/src/script/repositories/conversation/ConversationMapper.ts
@@ -246,11 +246,6 @@ export class ConversationMapper {
       throw new ConversationError(BASE_ERROR_TYPE.INVALID_PARAMETER, BaseError.MESSAGE.INVALID_PARAMETER);
     }
 
-    // Ensure that conversationData has a qualified_id or id
-    if (!conversationData.qualified_id && !conversationData.id) {
-      throw new ConversationError(BASE_ERROR_TYPE.MISSING_PARAMETER, BaseError.MESSAGE.MISSING_QUALIFIED_ID);
-    }
-
     // since api V10 /get or /post conversation does not return id in conversation data
     const conversationIdFromQualifiedId = conversationData?.qualified_id?.id;
     if (conversationIdFromQualifiedId) {


### PR DESCRIPTION
Attempt to fix broken legacy backups