### PR TITLE
fix: handle user.delete event [WPB-18869]

### DIFF
--- a/src/i18n/de-DE.json
+++ b/src/i18n/de-DE.json
@@ -548,6 +548,7 @@
   "conversationLikesCaptionSingular": "[bold]{userName}[/bold]",
   "conversationLocationLink": "Standort anzeigen",
   "conversationMLSMigrationFinalisationOngoingCall": "Aufgrund der Umstellung auf MLS haben Sie möglicherweise Probleme mit Ihrem aktuellen Anruf. Wenn das der Fall ist, legen Sie auf und rufen Sie erneut an.",
+  "conversationMemberDeleted": "Dieser Benutzer ist nicht mehr verfügbar",
   "conversationMemberJoined": "[bold]{name}[/bold] hat {users} hinzugefügt",
   "conversationMemberJoinedMore": "[bold]{name}[/bold] hat {users} und [showmore]{count} andere[/showmore] hinzugefügt",
   "conversationMemberJoinedSelf": "[bold]{name}[/bold] ist beigetreten",

--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -551,7 +551,7 @@
   "conversationLikesCaptionSingular": "[bold]{userName}[/bold]",
   "conversationLocationLink": "Open Map",
   "conversationMLSMigrationFinalisationOngoingCall": "Due to migration to MLS, you might have issues with your current call. If that's the case, hang up and call again.",
-  "converstationMemberDeleted": "This user is no longer available",
+  "conversationMemberDeleted": "This user is no longer available",
   "conversationMemberJoined": "[bold]{name}[/bold] added {users} to the conversation",
   "conversationMemberJoinedMore": "[bold]{name}[/bold] added {users}, and [showmore]{count} more[/showmore] to the conversation",
   "conversationMemberJoinedSelf": "[bold]{name}[/bold] joined",

--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -551,6 +551,7 @@
   "conversationLikesCaptionSingular": "[bold]{userName}[/bold]",
   "conversationLocationLink": "Open Map",
   "conversationMLSMigrationFinalisationOngoingCall": "Due to migration to MLS, you might have issues with your current call. If that's the case, hang up and call again.",
+  "converstationMemberDeleted": "This user is no longer available",
   "conversationMemberJoined": "[bold]{name}[/bold] added {users} to the conversation",
   "conversationMemberJoinedMore": "[bold]{name}[/bold] added {users}, and [showmore]{count} more[/showmore] to the conversation",
   "conversationMemberJoinedSelf": "[bold]{name}[/bold] joined",

--- a/src/script/components/MessagesList/Message/MemberMessage/MessageContent.tsx
+++ b/src/script/components/MessagesList/Message/MemberMessage/MessageContent.tsx
@@ -184,6 +184,11 @@ function getContent(message: MemberMessageEntity) {
       if (!actor.id) {
         return t('conversationMemberWereRemoved', {users: allUsers}, {}, true);
       }
+
+      if (message.reason === MemberLeaveReason.USER_DELETED) {
+        return t('converstationMemberDeleted');
+      }
+
       return actor.isMe
         ? t('conversationMemberRemovedYou', {users: allUsers}, {}, true)
         : t('conversationMemberRemoved', {name, users: allUsers}, {}, true);

--- a/src/script/components/MessagesList/Message/MemberMessage/MessageContent.tsx
+++ b/src/script/components/MessagesList/Message/MemberMessage/MessageContent.tsx
@@ -186,7 +186,7 @@ function getContent(message: MemberMessageEntity) {
       }
 
       if (message.reason === MemberLeaveReason.USER_DELETED) {
-        return t('converstationMemberDeleted');
+        return t('conversationMemberDeleted');
       }
 
       return actor.isMe

--- a/src/script/conversation/ConversationRepository.ts
+++ b/src/script/conversation/ConversationRepository.ts
@@ -383,6 +383,7 @@ export class ConversationRepository {
 
     this.selfRepository.on('selfSupportedProtocolsUpdated', this.initAllLocal1To1Conversations);
     this.userRepository.on('supportedProtocolsUpdated', this.onUserSupportedProtocolsUpdated);
+    this.userRepository.on('userDeleted', this.onUserDeleted);
   }
 
   public initMLSConversationRecoveredListener() {
@@ -2438,6 +2439,29 @@ export class ConversationRepository {
     const event = EventBuilder.buildMemberJoin(conversationEntity, sender, users, timestamp);
     return this.eventRepository.injectEvent(event, EventRepository.SOURCE.INJECTED);
   }
+
+  /**
+   * Will inject a member deleted event in 1:1 conversations with that user.
+   * This will be used to notify the other user that the user was deleted.
+   *
+   * @param userId User ID of the user that was deleted
+   */
+
+  private readonly onUserDeleted = async (userId: QualifiedId) => {
+    const found1to1Conversation = this.conversationState.get1to1ConversationWithUser(userId);
+    if (!found1to1Conversation) {
+      return;
+    }
+
+    const deletedEvent = EventBuilder.buildMemberLeave(
+      found1to1Conversation,
+      [userId],
+      '',
+      this.serverTimeHandler.toServerTimestamp(),
+      MemberLeaveReason.USER_DELETED,
+    );
+    await this.eventRepository.injectEvent(deletedEvent, EventRepository.SOURCE.INJECTED);
+  };
 
   /**
    * Add service to conversation.

--- a/src/script/conversation/ConversationState.ts
+++ b/src/script/conversation/ConversationState.ts
@@ -227,6 +227,23 @@ export class ConversationState {
     return mlsConversation || null;
   }
 
+  /**
+   * Get a 1:1 conversation with a user.
+   * @param userId User ID
+   * @returns Conversation with the user or undefined if not found
+   */
+  get1to1ConversationWithUser(userId: QualifiedId): Conversation | undefined {
+    const foundMLSConversation = this.findMLS1to1Conversation(userId);
+    if (foundMLSConversation) {
+      return foundMLSConversation;
+    }
+    const foundProteusConversations = this.findProteus1to1Conversations(userId);
+    if (foundProteusConversations && foundProteusConversations.length > 0) {
+      return foundProteusConversations[0];
+    }
+    return undefined;
+  }
+
   has1to1ConversationWithUser(userId: QualifiedId): boolean {
     const foundMLSConversation = this.findMLS1to1Conversation(userId);
     if (foundMLSConversation) {

--- a/src/script/conversation/EventBuilder.ts
+++ b/src/script/conversation/EventBuilder.ts
@@ -533,12 +533,14 @@ export const EventBuilder = {
     userIds: QualifiedId[],
     from: string,
     currentTimestamp: number,
+    reason?: MemberLeaveReason,
   ): MemberLeaveEvent {
     return {
       ...buildQualifiedId(conversationEntity),
       data: {
         qualified_user_ids: userIds,
         user_ids: userIds.map(({id}) => id),
+        reason,
       },
       from: from,
       time: conversationEntity.getNextIsoDate(currentTimestamp),

--- a/src/script/user/UserRepository.ts
+++ b/src/script/user/UserRepository.ts
@@ -109,6 +109,12 @@ type Events = {
   supportedProtocolsUpdated: {user: User; supportedProtocols: ConversationProtocol[]};
   userDeleted: QualifiedId;
 };
+
+type UserDeleteEventWithQualifiedId = {
+  id: string;
+  qualified_id: QualifiedId;
+  type: USER_EVENT.DELETE;
+};
 export class UserRepository extends TypedEventEmitter<Events> {
   private readonly logger: Logger;
   public readonly userMapper: UserMapper;
@@ -158,7 +164,8 @@ export class UserRepository extends TypedEventEmitter<Events> {
 
     switch (eventJson.type) {
       case USER_EVENT.DELETE:
-        this.userDelete(eventJson);
+        const userDeleteEvent = eventJson as UserDeleteEventWithQualifiedId;
+        this.userDelete(userDeleteEvent);
         break;
       case USER_EVENT.UPDATE:
         await this.onUserUpdate(eventJson, source);

--- a/src/types/i18n.d.ts
+++ b/src/types/i18n.d.ts
@@ -555,6 +555,7 @@ declare module 'I18n/en-US.json' {
     'conversationLikesCaptionSingular': `[bold]{userName}[/bold]`;
     'conversationLocationLink': `Open Map`;
     'conversationMLSMigrationFinalisationOngoingCall': `Due to migration to MLS, you might have issues with your current call. If that\'s the case, hang up and call again.`;
+    'converstationMemberDeleted': `This user is no longer available`;
     'conversationMemberJoined': `[bold]{name}[/bold] added {users} to the conversation`;
     'conversationMemberJoinedMore': `[bold]{name}[/bold] added {users}, and [showmore]{count} more[/showmore] to the conversation`;
     'conversationMemberJoinedSelf': `[bold]{name}[/bold] joined`;

--- a/src/types/i18n.d.ts
+++ b/src/types/i18n.d.ts
@@ -555,7 +555,7 @@ declare module 'I18n/en-US.json' {
     'conversationLikesCaptionSingular': `[bold]{userName}[/bold]`;
     'conversationLocationLink': `Open Map`;
     'conversationMLSMigrationFinalisationOngoingCall': `Due to migration to MLS, you might have issues with your current call. If that\'s the case, hang up and call again.`;
-    'converstationMemberDeleted': `This user is no longer available`;
+    'conversationMemberDeleted': `This user is no longer available`;
     'conversationMemberJoined': `[bold]{name}[/bold] added {users} to the conversation`;
     'conversationMemberJoinedMore': `[bold]{name}[/bold] added {users}, and [showmore]{count} more[/showmore] to the conversation`;
     'conversationMemberJoinedSelf': `[bold]{name}[/bold] joined`;


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18869" title="WPB-18869" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18869</a>  [Web] Conversation remains and acts as usual if federated contact is deleted
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Description

`user.delete` backend event are not being handled with 1:1 conversations with federated users

see PR targeting dev (reverted) here https://github.com/wireapp/wire-webapp/pull/19440

additional workaround specific to merging to the release branch 3e843cf285fb6f6b7d844633b6633bbae8c0bb09

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
