### PR TITLE
runfix(cells): address multipart file preview issues [WPB-19357]

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/FileAssetCard/FileAssetSmall/FileAssetSmall.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/FileAssetCard/FileAssetSmall/FileAssetSmall.tsx
@@ -64,7 +64,7 @@ export const FileAssetSmall = ({
         onClick={showModal}
         css={hollowWrapperButtonStyles}
         aria-label={t('cells.filePreviewButton.ariaLabel', {name})}
-      ></button>
+      />
       <FileCard.Header>
         <FileCard.Icon type={isError ? 'unavailable' : 'file'} />
         {!isError && <FileCard.Type />}

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/FileAssetCard/FileAssetSmall/FileAssetSmall.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/FileAssetCard/FileAssetSmall/FileAssetSmall.tsx
@@ -59,33 +59,32 @@ export const FileAssetSmall = ({
   };
 
   return (
-    <button
-      onClick={showModal}
-      css={hollowWrapperButtonStyles}
-      aria-label={t('cells.filePreviewButton.ariaLabel', {name})}
-    >
-      <FileCard.Root extension={extension} name={name} size={size}>
-        <FileCard.Header>
-          <FileCard.Icon type={isError ? 'unavailable' : 'file'} />
-          {!isError && <FileCard.Type />}
-          <FileAssetOptions src={src} name={name} extension={extension} onOpen={showModal} />
-        </FileCard.Header>
-        <FileCard.Name variant={isError ? 'secondary' : 'primary'} truncateAfterLines={2} />
-        <FilePreviewModal
-          id={id}
-          fileUrl={src}
-          filePdfPreviewUrl={pdfPreviewUrl}
-          fileImagePreviewUrl={imagePreviewUrl}
-          fileName={name}
-          fileExtension={extension}
-          senderName={senderName}
-          timestamp={timestamp}
-          isOpen={isOpen}
-          onClose={() => setIsOpen(false)}
-          isError={isError}
-          isLoading={isLoading}
-        />
-      </FileCard.Root>
-    </button>
+    <FileCard.Root extension={extension} name={name} size={size}>
+      <button
+        onClick={showModal}
+        css={hollowWrapperButtonStyles}
+        aria-label={t('cells.filePreviewButton.ariaLabel', {name})}
+      ></button>
+      <FileCard.Header>
+        <FileCard.Icon type={isError ? 'unavailable' : 'file'} />
+        {!isError && <FileCard.Type />}
+        <FileAssetOptions src={src} name={name} extension={extension} onOpen={showModal} />
+      </FileCard.Header>
+      <FileCard.Name variant={isError ? 'secondary' : 'primary'} truncateAfterLines={2} />
+      <FilePreviewModal
+        id={id}
+        fileUrl={src}
+        filePdfPreviewUrl={pdfPreviewUrl}
+        fileImagePreviewUrl={imagePreviewUrl}
+        fileName={name}
+        fileExtension={extension}
+        senderName={senderName}
+        timestamp={timestamp}
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        isError={isError}
+        isLoading={isLoading}
+      />
+    </FileCard.Root>
   );
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.styles.ts
@@ -63,8 +63,14 @@ export const fileCardStyles = {
 
 export const hollowWrapperButtonStyles: CSSObject = {
   padding: '0',
+  position: 'absolute',
+  top: '0',
+  left: '0',
+  width: '100%',
+  height: '100%',
   border: 'none',
   background: 'none',
   textAlign: 'unset',
   cursor: 'pointer',
+  zIndex: '1',
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.styles.ts
@@ -64,13 +64,10 @@ export const fileCardStyles = {
 export const hollowWrapperButtonStyles: CSSObject = {
   padding: '0',
   position: 'absolute',
-  top: '0',
   left: '0',
   width: '100%',
   height: '100%',
   border: 'none',
   background: 'none',
-  textAlign: 'unset',
   cursor: 'pointer',
-  zIndex: '1',
 };

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/VideoAssetCard/VideoAssetSmall/VideoAssetSmall.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/VideoAssetCard/VideoAssetSmall/VideoAssetSmall.tsx
@@ -52,21 +52,21 @@ export const VideoAssetSmall = ({
 
   return (
     <>
-      <button
-        css={hollowWrapperButtonStyles}
-        onClick={() => setIsOpen(true)}
-        aria-label={t('accessibility.conversationAssetImageAlt', {
-          username: senderName,
-          messageDate: timestamp,
-        })}
-        aria-haspopup="dialog"
-        aria-expanded={isOpen}
-        aria-controls={id}
+      <MediaFilePreviewCard
+        label={src ? t('conversationFileVideoPreviewLabel', {src}) : ''}
+        isLoading={isLoading}
+        isError={isError}
       >
-        <MediaFilePreviewCard
-          label={src ? t('conversationFileVideoPreviewLabel', {src}) : ''}
-          isLoading={isLoading}
-          isError={isError}
+        <button
+          css={hollowWrapperButtonStyles}
+          onClick={() => setIsOpen(true)}
+          aria-label={t('accessibility.conversationAssetImageAlt', {
+            username: senderName,
+            messageDate: timestamp,
+          })}
+          aria-haspopup="dialog"
+          aria-expanded={isOpen}
+          aria-controls={id}
         >
           {!isLoading && !isError && (
             <>
@@ -76,8 +76,8 @@ export const VideoAssetSmall = ({
               </div>
             </>
           )}
-        </MediaFilePreviewCard>
-      </button>
+        </button>
+      </MediaFilePreviewCard>
       <FileFullscreenModal
         id={id}
         isOpen={isOpen}


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19357" title="WPB-19357" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19357</a>  [Web] Close (X) button unresponsive after opening a file preview
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19358" title="WPB-19358" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19358</a>  [Web] Clicking on 3-dot menu on file thumbnail opens file preview instead of showing options
  </td></table>
## Description

Adresses 2 issues:
- unable to close file preview for multipart assets
- clicking the context menu dropdown opens the file preview

<!-- Uncomment this section if your PR has UI changes -->

## Screenshots/Screencast (for UI changes)
 After:
 
![Kooha-2025-08-21-17-31-04](https://github.com/user-attachments/assets/ac06c330-f269-4a58-bb9c-6694a663c100)


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
