### PR TITLE
feat: Scroll to new messages while chat is open [WPB-19527]

### DIFF
--- a/src/script/components/MessagesList/VirtualizedMessagesList/VirtualizedMessagesList.tsx
+++ b/src/script/components/MessagesList/VirtualizedMessagesList/VirtualizedMessagesList.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {MutableRefObject, useEffect, useState} from 'react';
+import {MutableRefObject, useEffect, useMemo, useState} from 'react';
 
 import {useVirtualizer} from '@tanstack/react-virtual';
 import cx from 'classnames';
@@ -38,7 +38,7 @@ import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 
 import {VirtualizedJumpToLastMessageButton} from '../VirtualizedJumpToLastMessageButton';
 
-const ESTIMATED_ELEMENT_SIZE = 36;
+const ESTIMATED_ELEMENT_SIZE = 48;
 
 interface Props extends Omit<MessagesListParams, 'isRightSidebarOpen' | 'onLoading' | 'isConversationLoaded'> {
   parentElement: HTMLDivElement;
@@ -87,7 +87,10 @@ export const VirtualizedMessagesList = ({
   ]);
 
   const filteredMessages = filterMessages(allMessages);
-  const groupedMessages = groupMessagesBySenderAndTime(filteredMessages, conversationLastReadTimestamp.current);
+
+  const groupedMessages = useMemo(() => {
+    return groupMessagesBySenderAndTime(filteredMessages, conversationLastReadTimestamp.current);
+  }, [conversationLastReadTimestamp, filteredMessages]);
 
   const initialMessageId = conversation.initialMessage()?.id;
 
@@ -223,9 +226,9 @@ export const VirtualizedMessagesList = ({
 
           return (
             <div
+              key={virtualItem.key}
               data-index={virtualItem.index}
               ref={virtualizer.measureElement}
-              key={virtualItem.index}
               style={{
                 position: 'absolute',
                 width: '100%',

--- a/src/script/components/MessagesList/VirtualizedMessagesList/useLoadMessages.ts
+++ b/src/script/components/MessagesList/VirtualizedMessagesList/useLoadMessages.ts
@@ -26,7 +26,7 @@ import {Conversation} from 'Repositories/entity/Conversation';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {isLastReceivedMessage} from 'Util/conversationMessages';
 
-const SCROLL_THRESHOLD = 30;
+const SCROLL_THRESHOLD = 10;
 
 interface Props {
   conversation: Conversation;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19527" title="WPB-19527" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19527</a>  [Web] Message Virtualization - While chat is open, when new messages arrive it doesnt scroll down
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Fix for scrolling to new messages while chat is open.

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
