### PR TITLE
fix: handle user.delete event [WPB-18869]

### DIFF
--- a/src/i18n/de-DE.json
+++ b/src/i18n/de-DE.json
@@ -740,6 +740,7 @@
   "conversationLikesCaptionSingular": "[bold]{userName}[/bold]",
   "conversationLocationLink": "Standort anzeigen",
   "conversationMLSMigrationFinalisationOngoingCall": "Aufgrund der Umstellung auf MLS haben Sie möglicherweise Probleme mit Ihrem aktuellen Anruf. Wenn das der Fall ist, legen Sie auf und rufen Sie erneut an.",
+  "converstationMemberDeleted": "Dieser Benutzer ist nicht mehr verfügbar",
   "conversationMemberJoined": "[bold]{name}[/bold] hat {users} hinzugefügt",
   "conversationMemberJoinedMore": "[bold]{name}[/bold] hat {users} und [showmore]{count} andere[/showmore] hinzugefügt",
   "conversationMemberJoinedSelf": "[bold]{name}[/bold] ist beigetreten",

--- a/src/i18n/de-DE.json
+++ b/src/i18n/de-DE.json
@@ -740,7 +740,6 @@
   "conversationLikesCaptionSingular": "[bold]{userName}[/bold]",
   "conversationLocationLink": "Standort anzeigen",
   "conversationMLSMigrationFinalisationOngoingCall": "Aufgrund der Umstellung auf MLS haben Sie möglicherweise Probleme mit Ihrem aktuellen Anruf. Wenn das der Fall ist, legen Sie auf und rufen Sie erneut an.",
-  "converstationMemberDeleted": "Dieser Benutzer ist nicht mehr verfügbar",
   "conversationMemberJoined": "[bold]{name}[/bold] hat {users} hinzugefügt",
   "conversationMemberJoinedMore": "[bold]{name}[/bold] hat {users} und [showmore]{count} andere[/showmore] hinzugefügt",
   "conversationMemberJoinedSelf": "[bold]{name}[/bold] ist beigetreten",

--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -740,6 +740,7 @@
   "conversationLikesCaptionSingular": "[bold]{userName}[/bold]",
   "conversationLocationLink": "Open Map",
   "conversationMLSMigrationFinalisationOngoingCall": "Due to migration to MLS, you might have issues with your current call. If that's the case, hang up and call again.",
+  "converstationMemberDeleted": "This user is no longer available",
   "conversationMemberJoined": "[bold]{name}[/bold] added {users} to the conversation",
   "conversationMemberJoinedMore": "[bold]{name}[/bold] added {users}, and [showmore]{count} more[/showmore] to the conversation",
   "conversationMemberJoinedSelf": "[bold]{name}[/bold] joined",

--- a/src/script/components/MessagesList/Message/MemberMessage/MessageContent.tsx
+++ b/src/script/components/MessagesList/Message/MemberMessage/MessageContent.tsx
@@ -143,6 +143,9 @@ function getContent(message: MemberMessageEntity) {
     }
 
     case CONVERSATION_EVENT.MEMBER_LEAVE: {
+      if (message.reason === MemberLeaveReason.USER_DELETED) {
+        return t('converstationMemberDeleted');
+      }
       if (message.reason === MemberLeaveReason.LEGAL_HOLD_POLICY_CONFLICT) {
         const replaceLinkLegalHold = replaceLink(
           Config.getConfig().URL.SUPPORT.LEGAL_HOLD_BLOCK,

--- a/src/script/components/MessagesList/Message/MemberMessage/MessageContent.tsx
+++ b/src/script/components/MessagesList/Message/MemberMessage/MessageContent.tsx
@@ -143,9 +143,6 @@ function getContent(message: MemberMessageEntity) {
     }
 
     case CONVERSATION_EVENT.MEMBER_LEAVE: {
-      if (message.reason === MemberLeaveReason.USER_DELETED) {
-        return t('converstationMemberDeleted');
-      }
       if (message.reason === MemberLeaveReason.LEGAL_HOLD_POLICY_CONFLICT) {
         const replaceLinkLegalHold = replaceLink(
           Config.getConfig().URL.SUPPORT.LEGAL_HOLD_BLOCK,
@@ -187,6 +184,11 @@ function getContent(message: MemberMessageEntity) {
       if (!actor.id) {
         return t('conversationMemberWereRemoved', {users: allUsers}, {}, true);
       }
+
+      if (message.reason === MemberLeaveReason.USER_DELETED) {
+        return t('converstationMemberDeleted');
+      }
+
       return actor.isMe
         ? t('conversationMemberRemovedYou', {users: allUsers}, {}, true)
         : t('conversationMemberRemoved', {name, users: allUsers}, {}, true);

--- a/src/script/repositories/conversation/ConversationRepository.ts
+++ b/src/script/repositories/conversation/ConversationRepository.ts
@@ -386,6 +386,7 @@ export class ConversationRepository {
 
     this.selfRepository.on('selfSupportedProtocolsUpdated', this.initAllLocal1To1Conversations);
     this.userRepository.on('supportedProtocolsUpdated', this.onUserSupportedProtocolsUpdated);
+    this.userRepository.on('userDeleted', this.onUserDeleted);
   }
 
   public initMLSConversationRecoveredListener() {
@@ -2455,6 +2456,27 @@ export class ConversationRepository {
     const event = EventBuilder.buildMemberJoin(conversationEntity, sender, users, timestamp);
     return this.eventRepository.injectEvent(event, EventRepository.SOURCE.INJECTED);
   }
+
+  /**
+   * Will inject a member deleted event in 1:1 conversations with that user.
+   * This will be used to notify the other user that the user was deleted.
+   *
+   * @param userId User ID of the user that was deleted
+   */
+
+  private readonly onUserDeleted = async (userId: QualifiedId) => {
+    const found1to1Conversation = this.conversationState.get1to1ConversationWithUser(userId);
+    if (!found1to1Conversation) {
+      return;
+    }
+
+    const deletedEvent = EventBuilder.buildMemberDeleted(
+      found1to1Conversation,
+      userId,
+      this.serverTimeHandler.toServerTimestamp(),
+    );
+    await this.eventRepository.injectEvent(deletedEvent, EventRepository.SOURCE.INJECTED);
+  };
 
   /**
    * Add service to conversation.

--- a/src/script/repositories/conversation/ConversationRepository.ts
+++ b/src/script/repositories/conversation/ConversationRepository.ts
@@ -2470,10 +2470,12 @@ export class ConversationRepository {
       return;
     }
 
-    const deletedEvent = EventBuilder.buildMemberDeleted(
+    const deletedEvent = EventBuilder.buildMemberLeave(
       found1to1Conversation,
-      userId,
+      [userId],
+      '',
       this.serverTimeHandler.toServerTimestamp(),
+      MemberLeaveReason.USER_DELETED,
     );
     await this.eventRepository.injectEvent(deletedEvent, EventRepository.SOURCE.INJECTED);
   };

--- a/src/script/repositories/conversation/ConversationState.ts
+++ b/src/script/repositories/conversation/ConversationState.ts
@@ -246,6 +246,23 @@ export class ConversationState {
     return mlsConversation || null;
   }
 
+  /**
+   * Get a 1:1 conversation with a user.
+   * @param userId User ID
+   * @returns Conversation with the user or undefined if not found
+   */
+  get1to1ConversationWithUser(userId: QualifiedId): Conversation | undefined {
+    const foundMLSConversation = this.findMLS1to1Conversation(userId);
+    if (foundMLSConversation) {
+      return foundMLSConversation;
+    }
+    const foundProteusConversations = this.findProteus1to1Conversations(userId);
+    if (foundProteusConversations && foundProteusConversations.length > 0) {
+      return foundProteusConversations[0];
+    }
+    return undefined;
+  }
+
   has1to1ConversationWithUser(userId: QualifiedId): boolean {
     const foundMLSConversation = this.findMLS1to1Conversation(userId);
     if (foundMLSConversation) {

--- a/src/script/repositories/conversation/EventBuilder.ts
+++ b/src/script/repositories/conversation/EventBuilder.ts
@@ -662,6 +662,24 @@ export const EventBuilder = {
     };
   },
 
+  buildMemberDeleted(
+    conversationEntity: Conversation,
+    userId: QualifiedId,
+    currentTimestamp: number,
+  ): MemberLeaveEvent {
+    return {
+      ...buildQualifiedId(conversationEntity),
+      data: {
+        qualified_user_ids: [userId],
+        user_ids: [userId.id],
+        reason: MemberLeaveReason.USER_DELETED,
+      },
+      from: userId.id,
+      time: conversationEntity.getNextIsoDate(currentTimestamp),
+      type: CONVERSATION_EVENT.MEMBER_LEAVE,
+    };
+  },
+
   buildUnableToDecrypt(
     event: ConversationOtrMessageAddEvent | ConversationMLSMessageAddEvent,
     decryptionError: DecryptionError,

--- a/src/script/repositories/conversation/EventBuilder.ts
+++ b/src/script/repositories/conversation/EventBuilder.ts
@@ -542,12 +542,14 @@ export const EventBuilder = {
     userIds: QualifiedId[],
     from: string,
     currentTimestamp: number,
+    reason?: MemberLeaveReason,
   ): MemberLeaveEvent {
     return {
       ...buildQualifiedId(conversationEntity),
       data: {
         qualified_user_ids: userIds,
         user_ids: userIds.map(({id}) => id),
+        reason,
       },
       from: from,
       time: conversationEntity.getNextIsoDate(currentTimestamp),
@@ -659,24 +661,6 @@ export const EventBuilder = {
       id: createUuid(),
       time: new Date(isoDate).toISOString(),
       type: ClientEvent.CONVERSATION.TEAM_MEMBER_LEAVE,
-    };
-  },
-
-  buildMemberDeleted(
-    conversationEntity: Conversation,
-    userId: QualifiedId,
-    currentTimestamp: number,
-  ): MemberLeaveEvent {
-    return {
-      ...buildQualifiedId(conversationEntity),
-      data: {
-        qualified_user_ids: [userId],
-        user_ids: [userId.id],
-        reason: MemberLeaveReason.USER_DELETED,
-      },
-      from: userId.id,
-      time: conversationEntity.getNextIsoDate(currentTimestamp),
-      type: CONVERSATION_EVENT.MEMBER_LEAVE,
     };
   },
 

--- a/src/types/i18n.d.ts
+++ b/src/types/i18n.d.ts
@@ -739,6 +739,7 @@ declare module 'I18n/en-US.json' {
     'conversationLikesCaptionSingular': `[bold]{userName}[/bold]`;
     'conversationLocationLink': `Open Map`;
     'conversationMLSMigrationFinalisationOngoingCall': `Due to migration to MLS, you might have issues with your current call. If that\'s the case, hang up and call again.`;
+    'converstationMemberDeleted': `This user is no longer available`;
     'conversationMemberJoined': `[bold]{name}[/bold] added {users} to the conversation`;
     'conversationMemberJoinedMore': `[bold]{name}[/bold] added {users}, and [showmore]{count} more[/showmore] to the conversation`;
     'conversationMemberJoinedSelf': `[bold]{name}[/bold] joined`;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18869" title="WPB-18869" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18869</a>  [Web] Conversation remains and acts as usual if federated contact is deleted
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

`user.delete` backend event are not being handled with 1:1 conversations with federated users

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
