### PR TITLE
chore(ci): add serialized precommit deploy and critical flow tests workflow

### DIFF
--- a/.github/workflows/playwright-crit-flow-tests.yml
+++ b/.github/workflows/playwright-crit-flow-tests.yml
@@ -1,9 +1,9 @@
 name: Playwright Critical Flow Tests
 
-on:
-  pull_request:
-    # we want to run the CI on every PR targetting those branches
-    branches: [dev]
+#on:
+#  pull_request:
+#    # we want to run the CI on every PR targetting those branches
+#    branches: [dev]
 
 jobs:
   smoke-tests:

--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -1,0 +1,190 @@
+name: precommit
+
+on:
+  pull_request:
+    branches: [dev]
+
+# One at a time lane for the shared precommit environment
+concurrency:
+  group: precommit-deploy
+  cancel-in-progress: false # queue newer runs
+
+jobs:
+  build:
+    runs-on: buildjet-8vcpu-ubuntu-2204
+    timeout-minutes: 20
+
+    outputs:
+      unit_tests_report: ${{ env.UNIT_TEST_REPORT_FILE }}
+      build_artifact: ${{ env.BUILD_ARTIFACT }}
+      total_additions: ${{ steps.check_additions.outputs.total_additions }}
+
+    env:
+      BUILD_DIR: server/dist/s3/
+      BUILD_ARTIFACT: ebs.zip
+      COMMIT_URL: ${{ github.event.head_commit.url }}
+      COMMITTER: ${{ github.event.head_commit.committer.name }}
+      CHANGELOG_FILE: ./changelog.md
+      UNIT_TEST_REPORT_FILE: ./unit-tests.log
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.16.x
+          cache: yarn
+
+      - run: yarn --immutable
+      - run: yarn configure
+      - run: yarn build:prod
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact
+          path: ${{ env.BUILD_DIR }}${{ env.BUILD_ARTIFACT }}
+
+      - name: Check total PR additions
+        id: check_additions
+        run: |
+          total_additions=$(gh api -H "Accept: application/vnd.github.v3+json" \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" \
+            | jq -r '.additions')
+          test -n "$total_additions" -a "$total_additions" != null
+          echo "Found total additions: $total_additions"
+          echo "total_additions=$total_additions" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy_to_aws:
+    name: Deploy to precommit
+    runs-on: ubuntu-latest
+    needs: [build]
+    timeout-minutes: 25
+
+    outputs:
+      precommit_url: ${{ steps.fetch_url.outputs.url }}
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-artifact
+
+      - name: Deploy to precommit environment
+        id: deploy
+        uses: einaregilsson/beanstalk-deploy@v22
+        with:
+          application_name: Webapp
+          aws_access_key: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
+          aws_secret_key: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
+          deployment_package: ${{ needs.build.outputs.build_artifact }}
+          environment_name: wire-webapp-precommit
+          region: eu-central-1
+          use_existing_version_if_available: true
+          version_description: ${{ github.sha }}
+          version_label: ${{ github.run_id }}
+          wait_for_deployment: true # ✅ wait until EB is green
+
+      - name: Fetch precommit URL
+        id: fetch_url
+        run: |
+          URL=$(aws elasticbeanstalk describe-environments \
+            --region eu-central-1 \
+            --environment-names wire-webapp-precommit \
+            --query "Environments[0].CNAME" --output text)
+          echo "url=https://$URL" >> "$GITHUB_OUTPUT"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: eu-central-1
+
+      - name: Deployment Status
+        if: ${{ always() }}
+        run: |
+          if [[ "${{ steps.deploy.outcome }}" == "success" ]]; then
+            echo "✅ Deployment completed successfully"
+          else
+            echo "❌ Deployment failed"; exit 1
+          fi
+
+  e2e_crit_flow:
+    name: Playwright Critical Flow (precommit)
+    runs-on: [self-hosted, Linux, X64, office]
+    needs: [deploy_to_aws]
+    timeout-minutes: 35
+    if: github.repository == 'wireapp/wire-webapp'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.16.x
+          cache: yarn
+
+      - run: yarn --immutable
+      - run: yarn playwright install --with-deps && yarn playwright install chrome
+      - uses: 1password/install-cli-action@v1
+
+      - name: Generate env file
+        run: op inject -i test/e2e_tests/.env.tpl -o test/e2e_tests/.env
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+      # Log which URL will be used for tests (deploy output vs fallback) and probe if env responds
+      - name: Show target URL + quick probe
+        env:
+          DEPLOY_URL: ${{ needs.deploy_to_aws.outputs.precommit_url }}
+          FALLBACK_URL: https://wire-webapp-precommit.zinfra.io/
+        run: |
+          if [ -n "$DEPLOY_URL" ]; then
+            echo "Using DEPLOY_URL from deploy job: $DEPLOY_URL"
+            TARGET="$DEPLOY_URL"
+          else
+            echo "Using FALLBACK_URL: $FALLBACK_URL"
+            TARGET="$FALLBACK_URL"
+          fi
+
+          # quick probe
+          curl -Is --max-time 10 "$TARGET" || true
+
+      - name: Run critical flow tests
+        env:
+          # TODO: remove hardcoded precommit env in the future when ephemeral PR envs will exist
+          # Overrides URL from 1Password
+          WEBAPP_URL: ${{ needs.deploy_to_aws.outputs.precommit_url || 'https://wire-webapp-precommit.zinfra.io/' }}
+        run: yarn e2e-test --grep "@crit-flow-web"
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+
+      - name: Generate PR comment
+        if: always()
+        id: generate_comment
+        run: |
+          node test/e2e_tests/scripts/create-playwright-report-summary.js
+          COMMENT=$(cat playwright-report-summary.txt)
+          echo "comment<<EOF" >> $GITHUB_OUTPUT
+          echo "$COMMENT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Comment on PR
+        if: always()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: playwright-summary
+          message: |
+            🔗 [Download Full Report Artifact](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+            ${{ steps.generate_comment.outputs.comment }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -138,26 +138,15 @@ jobs:
 
       # Log which URL will be used for tests (deploy output vs fallback) and probe if env responds
       - name: Show target URL + quick probe
-        env:
-          DEPLOY_URL: ${{ needs.deploy_to_aws.outputs.precommit_url }}
-          FALLBACK_URL: https://wire-webapp-precommit.zinfra.io/
         run: |
-          if [ -n "$DEPLOY_URL" ]; then
-            echo "Using DEPLOY_URL from deploy job: $DEPLOY_URL"
-            TARGET="$DEPLOY_URL"
-          else
-            echo "Using FALLBACK_URL: $FALLBACK_URL"
-            TARGET="$FALLBACK_URL"
-          fi
-
-          # quick probe
-          curl -Is --max-time 10 "$TARGET" || true
+          echo "Using precommit URL: https://wire-webapp-precommit.zinfra.io/"
+          curl -s -o /dev/null -w "HTTP %{http_code}\n" https://wire-webapp-precommit.zinfra.io/
 
       - name: Run critical flow tests
         env:
           # TODO: remove hardcoded precommit env in the future when ephemeral PR envs will exist
           # Overrides URL from 1Password
-          WEBAPP_URL: ${{ needs.deploy_to_aws.outputs.precommit_url || 'https://wire-webapp-precommit.zinfra.io/' }}
+          WEBAPP_URL: https://wire-webapp-precommit.zinfra.io/
         run: yarn e2e-test --grep "@crit-flow-web"
 
       - name: Upload test report

--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Deploy to precommit environment
         id: deploy
-        uses: einaregilsson/beanstalk-deploy@v22
+        uses: einaregilsson/beanstalk-deploy@27edd8a0ebe8656ac70654372c73f06f7e9a1027 # v22
         with:
           application_name: Webapp
           aws_access_key: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
@@ -129,7 +129,7 @@ jobs:
 
       - run: yarn --immutable
       - run: yarn playwright install --with-deps && yarn playwright install chrome
-      - uses: 1password/install-cli-action@v1
+      - uses: 1password/install-cli-action@143a85f84a90555d121cde2ff5872e393a47ab9f
 
       - name: Generate env file
         run: op inject -i test/e2e_tests/.env.tpl -o test/e2e_tests/.env
@@ -168,7 +168,7 @@ jobs:
 
       - name: Comment on PR
         if: always()
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405
         with:
           header: playwright-summary
           message: |

--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Run critical flow tests
         env:
           # TODO: remove hardcoded precommit env in the future when ephemeral PR envs will exist
-          # Overrides URL from 1Password
+          # Overrides URL from .env file
           WEBAPP_URL: https://wire-webapp-precommit.zinfra.io/
         run: yarn e2e-test --grep "@crit-flow-web"
 

--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -3,6 +3,8 @@ name: precommit
 on:
   pull_request:
     branches: [dev]
+    branches-ignore:
+      - 'dependabot/**' # skip all Dependabot PRs
 
 # One at a time lane for the shared precommit environment
 concurrency:

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -1,9 +1,9 @@
 name: precommit
 
-on:
-  pull_request:
-    # we want to run the CI on every PR targetting those branches
-    branches: [dev]
+#on:
+#  pull_request:
+#    # we want to run the CI on every PR targetting those branches
+#    branches: [dev]
 
 concurrency:
   group: precommit-deploy


### PR DESCRIPTION

## Description

This PR adds a new GitHub Actions workflow that:
- Builds the webapp on PRs targeting `dev`
- Deploys the build to the shared **precommit Elastic Beanstalk environment**
- Runs **Playwright critical flow tests** against precommit environment
- Uses `concurrency` to serialize precommit deployments (`cancel-in-progress: false`)
- Ensures tests always target the precommit env by overriding `WEBAPP_URL` with the EB deployment output (fallback: `https://wire-webapp-precommit.zinfra.io/`)
- **Disabled triggers for the old `precommit` and `Playwright Critical Flow Tests` workflows** (code kept but commented out)


### Notes
-  ! This is a temporary solution until **ephemeral PR environments** are introduced
