### PR TITLE
fix: Allow personal users to create mls clients [WPB-20129]

### DIFF
--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -22,6 +22,8 @@
 
 import {Context} from '@wireapp/api-client/lib/auth';
 import {ClientClassification, ClientType} from '@wireapp/api-client/lib/client/';
+import {FEATURE_KEY, FeatureList} from '@wireapp/api-client/lib/team';
+import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {EVENTS as CoreEvents} from '@wireapp/core/lib/Account';
 import {MLSServiceEvents} from '@wireapp/core/lib/messagingProtocols/mls';
 import {amplify} from 'amplify';
@@ -427,7 +429,19 @@ export class App {
       if (!localClient) {
         throw new ClientError(CLIENT_ERROR_TYPE.NO_VALID_CLIENT, 'Client has been deleted on backend');
       }
-      const {features: teamFeatures, members: teamMembers} = await teamRepository.initTeam(selfUser.teamId);
+
+      let teamFeatures: FeatureList = {};
+      let teamMembers: QualifiedId[] = [];
+
+      if (selfUser.teamId) {
+        const {features, members} = await teamRepository.initTeam(selfUser.teamId);
+        teamFeatures = features;
+        teamMembers = members;
+      } else {
+        const commonFeatures = (await this.core.service?.team.getCommonFeatureConfig()) ?? {};
+        teamFeatures = {mls: commonFeatures[FEATURE_KEY.MLS]};
+      }
+
       try {
         await this.core.initClient(localClient, getClientMLSConfig(teamFeatures));
       } catch (error) {


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20129" title="WPB-20129" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20129</a>  [Web] Temporary guests do not create MLS client, thus cannot send messages in a MLS group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

cherry-pick of https://github.com/wireapp/wire-webapp/commit/c67e441693a42e4a4dc0e0da9cfa6908b0b0be57 to the `q2-2025` branch
See PR here https://github.com/wireapp/wire-webapp/pull/19054


<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
