### PR TITLE
fix: hide channel creation modal for private user [WPB-20178]

### DIFF
--- a/src/script/page/LeftSidebar/panels/Conversations/ConversationHeader/ConversationHeader.tsx
+++ b/src/script/page/LeftSidebar/panels/Conversations/ConversationHeader/ConversationHeader.tsx
@@ -105,7 +105,7 @@ export const ConversationHeaderComponent = ({
   }, [searchInputRef, jumpToRecentSearch]);
 
   const showCreateConversationModal = () => {
-    if (isChannelsEnabled && (canCreateChannels || !selfUser.teamId)) {
+    if (isChannelsEnabled && canCreateChannels) {
       showModal();
     } else {
       amplify.publish(WebAppEvents.CONVERSATION.CREATE_GROUP, 'conversation_details');


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20178" title="WPB-20178" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20178</a>  [Web] Hide Channels modal for Private users
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

We don't need channels modal for private users. There is a case where a private user can see the channels option but after creating a team the option gets hidden due to feature config

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
