### PR TITLE
fix: prevent showing user twice in 1:1 call [WPB-20192]

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@wireapp/avs": "9.10.25",
     "@wireapp/avs-debugger": "0.0.7",
     "@wireapp/commons": "5.4.2",
-    "@wireapp/core": "46.23.7-hotfix-1.2.0",
+    "@wireapp/core": "46.23.7-hotfix-1.2.1",
     "@wireapp/react-ui-kit": "9.44.1",
     "@wireapp/store-engine-dexie": "2.1.15",
     "@wireapp/telemetry": "0.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7713,9 +7713,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:46.23.7-hotfix-1.2.0":
-  version: 46.23.7-hotfix-1.2.0
-  resolution: "@wireapp/core@npm:46.23.7-hotfix-1.2.0"
+"@wireapp/core@npm:46.23.7-hotfix-1.2.1":
+  version: 46.23.7-hotfix-1.2.1
+  resolution: "@wireapp/core@npm:46.23.7-hotfix-1.2.1"
   dependencies:
     "@wireapp/api-client": "npm:27.51.0-hotfix-1.1"
     "@wireapp/commons": "npm:^5.4.2"
@@ -7735,7 +7735,7 @@ __metadata:
     long: "npm:^5.2.0"
     uuid: "npm:9.0.1"
     zod: "npm:3.24.2"
-  checksum: 10/17d4589098620b6afa2c46735cc7695ab764f524ee9783bf8c6879bbd8948cb6a72a639468473334efa7e4cd92f5e4c3f0cf667a3584c220c516babec3201f71
+  checksum: 10/a94b5c4926afcce4c0650da08fae3c33aace65b5e1de7c60932494fb0483682f5a9e3d8266eb75c7c687baf2b8fc94a5a691e6ffedfe60ffadbdf6c344bef248
   languageName: node
   linkType: hard
 
@@ -20934,7 +20934,7 @@ __metadata:
     "@wireapp/avs-debugger": "npm:0.0.7"
     "@wireapp/commons": "npm:5.4.2"
     "@wireapp/copy-config": "npm:2.3.0"
-    "@wireapp/core": "npm:46.23.7-hotfix-1.2.0"
+    "@wireapp/core": "npm:46.23.7-hotfix-1.2.1"
     "@wireapp/eslint-config": "npm:3.0.7"
     "@wireapp/prettier-config": "npm:0.6.4"
     "@wireapp/react-ui-kit": "npm:9.44.1"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20192" title="WPB-20192" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20192</a>  [Web] User shows twice in a call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Bump core to `46.23.7-hotfix-1.2.1`

See Core PR here https://github.com/wireapp/wire-web-packages/pull/7328

Related with thit ticket about external commit handling https://wearezeta.atlassian.net/browse/WPB-20079
Since 1:1 are treated as group call in the relese branch, they re also affected by this issue

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
