### PR TITLE
runfix: display name of deleted conversations when restored [WPB-19758]

### DIFF
--- a/src/script/repositories/backup/CrossPlatformBackup/importMappers/mapConversationRecord.ts
+++ b/src/script/repositories/backup/CrossPlatformBackup/importMappers/mapConversationRecord.ts
@@ -23,6 +23,8 @@ import {ConversationRecord} from 'Repositories/storage';
 
 import {BackUpConversation} from '../CPB.library';
 
+const isGroupConversation = (name: string) => name.length > 0;
+
 export const mapConversationRecord = ({
   id: qualifiedId,
   name,
@@ -45,7 +47,7 @@ export const mapConversationRecord = ({
     // In the case of recovered conversations that a user has since left, the type will not be possible to obtain from the back-end.
     // Not having a type would prevent those to sisplay correctly in the UI.
     // 1 to 1 conversations do not have a name, so we can use that to determine the type.
-    type: name.length > 0 ? CONVERSATION_TYPE.REGULAR : CONVERSATION_TYPE.ONE_TO_ONE,
+    type: isGroupConversation(name) ? CONVERSATION_TYPE.REGULAR : CONVERSATION_TYPE.ONE_TO_ONE,
   } as ConversationRecord;
   return conversationRecord;
 };

--- a/src/script/repositories/backup/CrossPlatformBackup/importMappers/mapConversationRecord.ts
+++ b/src/script/repositories/backup/CrossPlatformBackup/importMappers/mapConversationRecord.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import {CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation/';
+
 import {ConversationRecord} from 'Repositories/storage';
 
 import {BackUpConversation} from '../CPB.library';
@@ -40,6 +42,10 @@ export const mapConversationRecord = ({
     domain: qualifiedId.domain.toString(),
     last_read_timestamp: new Date().getTime(),
     last_event_timestamp: lastEventTimestamp,
+    // In the case of recovered conversations that a user has since left, the type will not be possible to obtain from the back-end.
+    // Not having a type would prevent those to sisplay correctly in the UI.
+    // 1 to 1 conversations do not have a name, so we can use that to determine the type.
+    type: name.length > 0 ? CONVERSATION_TYPE.REGULAR : CONVERSATION_TYPE.ONE_TO_ONE,
   } as ConversationRecord;
   return conversationRecord;
 };

--- a/src/script/repositories/entity/Conversation.ts
+++ b/src/script/repositories/entity/Conversation.ts
@@ -277,7 +277,8 @@ export class Conversation {
       () =>
         this.isConversationWithBlockedUser() ||
         this.is1to1ConversationWithDeletedUser() ||
-        this.readOnlyState() !== null,
+        this.readOnlyState() !== null ||
+        this.accessState() === undefined,
     );
 
     this.isGroup = ko.pureComputed(() => {


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19758" title="WPB-19758" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19758</a>  [Web] Conversations missing name after restoring backup
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Description

Restored conversations from a cross platform backup can be displayed without a name if the user left of deleted them between saving and restoring.

#### Issue
- since the user is not part of the conversation, some information cannot be fetched from the backend
- the cross platform backup is missing information to display the conversation to the ui
- users can attempt to send messages in conversations they're no longer a part of

#### Solution
- assume the `type` of a conversation when restoring it, this is normally fetched from the backend, the value from the backup will only be used if the conversation cannot be fetched (user removed from conversation)
- prevent users from sending messages in a conversation if its access state is `undefined`

<!-- Uncomment this section if your PR has UI changes -->
## Screenshots/Screencast (for UI changes)
Before:
<img width="336" height="661" alt="image" src="https://github.com/user-attachments/assets/3fce6cf5-2273-4774-830e-797f5c51b305" />
After:
<img width="336" height="661" alt="image" src="https://github.com/user-attachments/assets/473ac651-d6c9-4c81-81a9-33c08fc72c60" />


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
