### PR TITLE
fix: hide read receipts toggle for MLS groups and channels [WPB-17937]

### DIFF
--- a/src/script/components/Modals/CreateConversation/CreateConversationSteps/Preference.tsx
+++ b/src/script/components/Modals/CreateConversation/CreateConversationSteps/Preference.tsx
@@ -17,6 +17,7 @@
  *
  */
 
+import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 import {container} from 'tsyringe';
 
 import {InfoToggle} from 'Components/toggle/InfoToggle';
@@ -43,9 +44,18 @@ export const Preference = () => {
 
   const teamState = container.resolve(TeamState);
 
-  const {isCellsEnabled: isCellsEnabledForTeam} = useKoSubscribableChildren(teamState, ['isCellsEnabled']);
+  const {isCellsEnabled: isCellsEnabledForTeam, isMLSEnabled} = useKoSubscribableChildren(teamState, [
+    'isCellsEnabled',
+    'isMLSEnabled',
+  ]);
   const isCellsEnabledForEnvironment = Config.getConfig().FEATURE.ENABLE_CELLS;
   const isCellsOptionEnabled = isCellsEnabledForEnvironment && isCellsEnabledForTeam;
+
+  const defaultProtocol = isMLSEnabled
+    ? teamState.teamFeatures()?.mls?.config.defaultProtocol
+    : ConversationProtocol.PROTEUS;
+
+  const areReadReceiptsEnabled = defaultProtocol !== ConversationProtocol.MLS;
 
   return (
     <>
@@ -70,18 +80,17 @@ export const Preference = () => {
           isChecked={isServicesEnabled}
         />
       )}
-
-      <InfoToggle
-        className="modal-style"
-        dataUieName="read-receipts"
-        info={t('readReceiptsToggleInfo')}
-        isChecked={isReadReceiptsEnabled}
-        setIsChecked={setIsReadReceiptsEnabled}
-        // Temporarily disabled read receipts toggle for channels
-        // until it is supported by MLS
-        isDisabled={conversationType === ConversationType.Channel}
-        name={t('readReceiptsToggleName')}
-      />
+      {areReadReceiptsEnabled && (
+        <InfoToggle
+          className="modal-style"
+          dataUieName="read-receipts"
+          info={t('readReceiptsToggleInfo')}
+          isChecked={isReadReceiptsEnabled}
+          setIsChecked={setIsReadReceiptsEnabled}
+          isDisabled={false}
+          name={t('readReceiptsToggleName')}
+        />
+      )}
 
       {isCellsOptionEnabled && (
         <InfoToggle

--- a/src/script/components/Modals/CreateConversation/CreateConversationSteps/Preference.tsx
+++ b/src/script/components/Modals/CreateConversation/CreateConversationSteps/Preference.tsx
@@ -55,6 +55,7 @@ export const Preference = () => {
     ? teamState.teamFeatures()?.mls?.config.defaultProtocol
     : ConversationProtocol.PROTEUS;
 
+  // Read receipts are temorarily disabled for MLS groups and channels until it is supported
   const areReadReceiptsEnabled = defaultProtocol !== ConversationProtocol.MLS;
 
   return (

--- a/src/script/components/Modals/CreateConversation/hooks/useCreateConversation.ts
+++ b/src/script/components/Modals/CreateConversation/hooks/useCreateConversation.ts
@@ -77,6 +77,9 @@ export const useCreateConversation = () => {
     ? teamState.teamFeatures()?.mls?.config.defaultProtocol
     : ConversationProtocol.PROTEUS;
 
+  // Read receipts are temorarily disabled for MLS groups and channels until it is supported
+  const isGroupWithReadReceiptsEnabled = defaultProtocol !== ConversationProtocol.MLS && isReadReceiptsEnabled;
+
   const getAccessState = () => {
     let access = ACCESS_STATE.TEAM.TEAM_ONLY;
     if (isGuestsEnabled) {
@@ -150,7 +153,7 @@ export const useCreateConversation = () => {
         {
           add_permission: moderator === ADD_PERMISSION.ADMINS ? ADD_PERMISSION.ADMINS : ADD_PERMISSION.EVERYONE,
           protocol: defaultProtocol,
-          receipt_mode: isReadReceiptsEnabled ? RECEIPT_MODE.ON : RECEIPT_MODE.OFF,
+          receipt_mode: isGroupWithReadReceiptsEnabled ? RECEIPT_MODE.ON : RECEIPT_MODE.OFF,
           cells: isCellsEnabled,
           group_conv_type:
             conversationType === ConversationType.Channel

--- a/src/script/components/Modals/CreateConversation/hooks/useCreateConversationModal.ts
+++ b/src/script/components/Modals/CreateConversation/hooks/useCreateConversationModal.ts
@@ -122,8 +122,7 @@ export const useCreateConversationModal = create<CreateConversationModalState>(s
     })),
   setModerator: (moderator: ADD_PERMISSION) => set({moderator}),
   setChatHistory: (history?: ChatHistory) => set({chatHistory: history || ChatHistory.Off}),
-  setConversationType: (conversationType: ConversationType) =>
-    set({conversationType, isReadReceiptsEnabled: conversationType === ConversationType.Group}),
+  setConversationType: (conversationType: ConversationType) => set({conversationType}),
   setConversationCreationStep: (step: ConversationCreationStep) => set({conversationCreationStep: step}),
   gotoNextStep: () => set(state => ({...state, conversationCreationStep: state.conversationCreationStep + 1})),
   gotoLastStep: () => set({conversationCreationStep: ConversationCreationStep.ParticipantsSelection}),

--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -104,6 +104,7 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
 
   const initialProtocol = protocolOptions.find(protocol => protocol.value === defaultProtocol)!;
 
+  // Read receipts are temorarily disabled for MLS groups and channels until it is supported
   const areReadReceiptsEnabled = defaultProtocol !== ConversationProtocol.MLS;
 
   //both environment feature flag and team feature flag must be enabled to create conversations with cells

--- a/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -104,6 +104,8 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
 
   const initialProtocol = protocolOptions.find(protocol => protocol.value === defaultProtocol)!;
 
+  const areReadReceiptsEnabled = defaultProtocol !== ConversationProtocol.MLS;
+
   //both environment feature flag and team feature flag must be enabled to create conversations with cells
   const isCellsEnabledForEnvironment = Config.getConfig().FEATURE.ENABLE_CELLS;
   const enableCellsToggle = isCellsEnabledForEnvironment && isCellsEnabledForTeam;
@@ -513,15 +515,17 @@ const GroupCreationModal: React.FC<GroupCreationModalProps> = ({
                     info={t('servicesRoomToggleInfo')}
                   />
                 )}
-                <InfoToggle
-                  className="modal-style"
-                  dataUieName="read-receipts"
-                  info={t('readReceiptsToggleInfo')}
-                  isChecked={enableReadReceipts}
-                  setIsChecked={setEnableReadReceipts}
-                  isDisabled={false}
-                  name={t('readReceiptsToggleName')}
-                />
+                {areReadReceiptsEnabled && (
+                  <InfoToggle
+                    className="modal-style"
+                    dataUieName="read-receipts"
+                    info={t('readReceiptsToggleInfo')}
+                    isChecked={enableReadReceipts}
+                    setIsChecked={setEnableReadReceipts}
+                    isDisabled={false}
+                    name={t('readReceiptsToggleName')}
+                  />
+                )}
                 {enableCellsToggle && (
                   <InfoToggle
                     className="modal-style"

--- a/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsOptions/ConversationDetailsOptions.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsOptions/ConversationDetailsOptions.tsx
@@ -29,7 +29,7 @@ import {PanelActions} from 'Components/panel/PanelActions';
 import {ReceiptModeToggle} from 'Components/toggle/ReceiptModeToggle';
 import {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
 import {ConversationRoleRepository} from 'Repositories/conversation/ConversationRoleRepository';
-import {isMLSConversation} from 'Repositories/conversation/ConversationSelectors';
+import {isGroupMLSConversation, isMLSConversation} from 'Repositories/conversation/ConversationSelectors';
 import {Conversation} from 'Repositories/entity/Conversation';
 import {User} from 'Repositories/entity/User';
 import {TeamState} from 'Repositories/team/TeamState';
@@ -123,13 +123,12 @@ const ConversationDetailsOptions = ({
   const isActiveGroupParticipant = isGroupOrChannel && !isSelfUserRemoved;
   const isTeamConversation = !!teamId;
   const isCellsConversation = !!cellsState && cellsState !== CONVERSATION_CELLS_STATE.DISABLED;
-
   const showOptionGuests = isActiveGroupParticipant && isTeamConversation;
   const showOptionNotificationsGroup = isMutable && isGroupOrChannel;
   const showOptionTimedMessages = isActiveGroupParticipant && isSelfDeletingMessagesEnabled;
   const showOptionServices = isActiveGroupParticipant && isTeamConversation && !isMLSConversation(activeConversation);
   const showOptionNotifications1To1 = isMutable && !isGroupOrChannel;
-  const showOptionReadReceipts = isTeamConversation;
+  const showOptionReadReceipts = isTeamConversation && !isGroupMLSConversation(activeConversation);
   const showChannelOptions = isChannel && isChannelsEnabled;
 
   const hasReceiptsEnabled = conversationRepository.expectReadReceipt(activeConversation);


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17937" title="WPB-17937" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-17937</a>  [Web] Hide MLS Read Receipts in UI
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->



## Description

Read receipts are not currently available for MLS conversations
The setting was only hidden for channels (that are always MLS) but still available for group conversations

See ticket for details, we decided to *remove* the option for MLS conversations, not just *disabling* the toggle

This PR:
- removes the read receipt toggle for channels and MLS groups entirely
- removes the toggle in the legacy group creation modal (in use when channels are not enabled)
- remove the toggle from the sidebar for group conversations

<!-- Uncomment this section if your PR has UI changes -->

## Screenshots/Screencast (for UI changes)
Before:
<img width="754" height="524" alt="image" src="https://github.com/user-attachments/assets/84e1569a-4c77-45c4-a85a-95eb47e10778" />
<img width="754" height="524" alt="image" src="https://github.com/user-attachments/assets/b1c4a57a-8334-43d6-9b5e-e26299321ea1" />
<img width="303" height="316" alt="image" src="https://github.com/user-attachments/assets/18c499d0-b05d-4da0-bc8b-981e8a5dd487" />

After:
<img width="747" height="516" alt="image" src="https://github.com/user-attachments/assets/a5eec67c-0ce1-4529-8cf1-6f9eb6dd1839" />
<img width="747" height="516" alt="image" src="https://github.com/user-attachments/assets/0e230bef-f725-45ac-a1ce-b10c0877277d" />
<img width="323" height="326" alt="image" src="https://github.com/user-attachments/assets/c808743f-d6c3-4bcb-94dc-5c0df4b251b2" />


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
