### PR TITLE
runfix(cells): disable self-deleting messages in cells conversations [WPB-19753]

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -466,6 +466,7 @@
   "cells.search.closeButton": "Close",
   "cells.search.failed": "Something went wrong, please try again later.",
   "cells.search.placeholder": "Search files and folders",
+  "cells.selfDeletingMessage.info": "Self-deleting messages are currently not available for conversations with Cells.",
   "cells.shareModal.copyLink": "Copy Link",
   "cells.shareModal.disablePublicLink": "Disable public link",
   "cells.shareModal.disablePublicLink.description": "Disable public link",

--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.tsx
@@ -158,14 +158,14 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
 
     const notificationStatusText = getNotificationText(notificationState);
     function getTimedMessagesText(): string {
+      if (isCellsConversation) {
+        return t('cells.selfDeletingMessage.info');
+      }
       if (isSelfDeletingMessagesEnforced) {
         return formatDuration(getEnforcedSelfDeletingMessagesTimeout).text;
       }
       if (hasTimer && globalMessageTimer) {
         return formatDuration(globalMessageTimer).text;
-      }
-      if (isCellsConversation) {
-        return t('cells.selfDeletingMessage.info');
       }
       return t('ephemeralUnitsNone');
     }

--- a/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsOptions/ConversationDetailsOptions.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsOptions/ConversationDetailsOptions.tsx
@@ -126,7 +126,7 @@ const ConversationDetailsOptions = ({
 
   const showOptionGuests = isActiveGroupParticipant && isTeamConversation;
   const showOptionNotificationsGroup = isMutable && isGroupOrChannel;
-  const showOptionTimedMessages = isActiveGroupParticipant && isSelfDeletingMessagesEnabled && !isCellsConversation;
+  const showOptionTimedMessages = isActiveGroupParticipant && isSelfDeletingMessagesEnabled;
   const showOptionServices = isActiveGroupParticipant && isTeamConversation && !isMLSConversation(activeConversation);
   const showOptionNotifications1To1 = isMutable && !isGroupOrChannel;
   const showOptionReadReceipts = isTeamConversation;
@@ -135,7 +135,7 @@ const ConversationDetailsOptions = ({
   const hasReceiptsEnabled = conversationRepository.expectReadReceipt(activeConversation);
 
   const canEditGuests = roleRepository.canToggleGuests(activeConversation);
-  const canEditTimeout = roleRepository.canToggleTimeout(activeConversation);
+  const canEditTimeout = roleRepository.canToggleTimeout(activeConversation) && !isCellsConversation;
   const canEditReadReceipts = roleRepository.canToggleReadReceipts(activeConversation);
 
   const openNotificationsPanel = () => togglePanel(PanelState.NOTIFICATIONS, activeConversation);

--- a/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsOptions/ConversationDetailsOptions.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/components/ConversationDetailsOptions/ConversationDetailsOptions.tsx
@@ -17,6 +17,7 @@
  *
  */
 
+import {CONVERSATION_CELLS_STATE} from '@wireapp/api-client/lib/conversation';
 import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data/';
 import {amplify} from 'amplify';
 
@@ -84,6 +85,7 @@ const ConversationDetailsOptions = ({
     firstUserEntity: firstParticipant,
     isChannel,
     isGroupOrChannel,
+    cellsState,
   } = useKoSubscribableChildren(activeConversation, [
     'isMutable',
     'receiptMode',
@@ -93,6 +95,7 @@ const ConversationDetailsOptions = ({
     'firstUserEntity',
     'isChannel',
     'isGroupOrChannel',
+    'cellsState',
   ]);
   const {isSelfDeletingMessagesEnabled, isTeam} = useKoSubscribableChildren(teamState, [
     'isSelfDeletingMessagesEnabled',
@@ -119,10 +122,11 @@ const ConversationDetailsOptions = ({
 
   const isActiveGroupParticipant = isGroupOrChannel && !isSelfUserRemoved;
   const isTeamConversation = !!teamId;
+  const isCellsConversation = !!cellsState && cellsState !== CONVERSATION_CELLS_STATE.DISABLED;
 
   const showOptionGuests = isActiveGroupParticipant && isTeamConversation;
   const showOptionNotificationsGroup = isMutable && isGroupOrChannel;
-  const showOptionTimedMessages = isActiveGroupParticipant && isSelfDeletingMessagesEnabled;
+  const showOptionTimedMessages = isActiveGroupParticipant && isSelfDeletingMessagesEnabled && !isCellsConversation;
   const showOptionServices = isActiveGroupParticipant && isTeamConversation && !isMLSConversation(activeConversation);
   const showOptionNotifications1To1 = isMutable && !isGroupOrChannel;
   const showOptionReadReceipts = isTeamConversation;

--- a/src/script/repositories/entity/Conversation.ts
+++ b/src/script/repositories/entity/Conversation.ts
@@ -420,7 +420,9 @@ export class Conversation {
 
     this.receiptMode = ko.observable(RECEIPT_MODE.OFF);
 
-    // The team configuration for self-deleting messages has
+    // Self-deleting messages are not available for conversations
+    // with Cells enabled.
+    // Otherwise the team configuration for self-deleting messages has
     // always precedence over conversation or local settings.
     // https://wearezeta.atlassian.net/wiki/spaces/SER/pages/474873953/Tech+spec+Self-deleting+messages+feature+config
     //

--- a/src/types/i18n.d.ts
+++ b/src/types/i18n.d.ts
@@ -465,6 +465,7 @@ declare module 'I18n/en-US.json' {
     'cells.search.closeButton': `Close`;
     'cells.search.failed': `Something went wrong, please try again later.`;
     'cells.search.placeholder': `Search files and folders`;
+    'cells.selfDeletingMessage.info': `Self-deleting messages are currently not available for conversations with Cells.`;
     'cells.shareModal.copyLink': `Copy Link`;
     'cells.shareModal.disablePublicLink': `Disable public link`;
     'cells.shareModal.disablePublicLink.description': `Disable public link`;


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19753" title="WPB-19753" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19753</a>  [Web] Disable self-deleting messages in conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

- never enable self-deleting messages in cells conversations
- disable the self-deleting messages option in the side panel for cells conversations

<!-- Uncomment this section if your PR has UI changes -->

## Screenshots/Screencast (for UI changes)
<img width="329" height="123" alt="Screenshot From 2025-09-15 16-08-30" src="https://github.com/user-attachments/assets/787bbe9b-d800-48da-9b7f-fdf80fbcc327" />


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
