### PR TITLE
fix(preferences): direct landing on Preferences related routes [WPB-20397]

### DIFF
--- a/src/script/view_model/ListViewModel.ts
+++ b/src/script/view_model/ListViewModel.ts
@@ -242,36 +242,39 @@ export class ListViewModel {
     }
   };
 
+  private switchListAndSetTab = (listState: ListState, tab: SidebarTabs) => {
+    useSidebarStore.getState().setCurrentTab(tab);
+    this.switchList(listState);
+  };
+
   openPreferencesAccount = async (): Promise<void> => {
     await this.teamRepository.getTeam();
 
-    const {setCurrentTab} = useSidebarStore.getState();
-    setCurrentTab(SidebarTabs.PREFERENCES);
+    this.switchListAndSetTab(ListState.PREFERENCES, SidebarTabs.PREFERENCES);
 
-    this.switchList(ListState.PREFERENCES);
     this.contentViewModel.switchContent(ContentState.PREFERENCES_ACCOUNT);
   };
 
   readonly openPreferencesDevices = (): void => {
-    this.switchList(ListState.PREFERENCES);
+    this.switchListAndSetTab(ListState.PREFERENCES, SidebarTabs.PREFERENCES);
 
     return this.contentViewModel.switchContent(ContentState.PREFERENCES_DEVICES);
   };
 
   readonly openPreferencesAbout = (): void => {
-    this.switchList(ListState.PREFERENCES);
+    this.switchListAndSetTab(ListState.PREFERENCES, SidebarTabs.PREFERENCES);
 
     return this.contentViewModel.switchContent(ContentState.PREFERENCES_ABOUT);
   };
 
   readonly openPreferencesAudioVideo = (): void => {
-    this.switchList(ListState.PREFERENCES);
+    this.switchListAndSetTab(ListState.PREFERENCES, SidebarTabs.PREFERENCES);
 
     return this.contentViewModel.switchContent(ContentState.PREFERENCES_AV);
   };
 
   readonly openPreferencesOptions = (): void => {
-    this.switchList(ListState.PREFERENCES);
+    this.switchListAndSetTab(ListState.PREFERENCES, SidebarTabs.PREFERENCES);
 
     return this.contentViewModel.switchContent(ContentState.PREFERENCES_OPTIONS);
   };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20397" title="WPB-20397" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20397</a>  Landing directly to App routes is showing wrong sidebar content
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
Landing on preference related urls directly from web browser is showing correct sidebar content.

https://github.com/user-attachments/assets/47abad89-c5a8-4578-bb00-bd8a3652b5b7

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
