### PR TITLE
fix: Pause notification processing before app is fully initialized [WPB-18813]

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@wireapp/avs": "10.0.46",
     "@wireapp/avs-debugger": "0.0.7",
     "@wireapp/commons": "5.4.4",
-    "@wireapp/core": "46.35.2",
+    "@wireapp/core": "46.35.3",
     "@wireapp/kalium-backup": "0.0.4",
     "@wireapp/promise-queue": "2.4.4",
     "@wireapp/react-ui-kit": "9.64.0",

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -573,6 +573,9 @@ export class App {
         },
       );
 
+      // Pause the notification queue until we've fully initialized
+      this.core.pauseNotificationQueue();
+
       eventLogger.log(AppInitializationStep.DecryptionCompleted, {count: totalNotifications});
 
       await conversationRepository.init1To1Conversations(connections, conversations);
@@ -636,6 +639,10 @@ export class App {
       this.logger.info(`App version ${Environment.version()} loaded in ${Date.now() - startTime}ms`);
 
       eventLogger.log(AppInitializationStep.AppInitCompleted);
+
+      // resume the notification queue now that we're fully initialized
+      this.core.resumeNotificationQueue();
+
       return selfUser;
     } catch (error) {
       if (error instanceof BaseError) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8619,9 +8619,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:46.35.2":
-  version: 46.35.2
-  resolution: "@wireapp/core@npm:46.35.2"
+"@wireapp/core@npm:46.35.3":
+  version: 46.35.3
+  resolution: "@wireapp/core@npm:46.35.3"
   dependencies:
     "@wireapp/api-client": "npm:^27.75.9"
     "@wireapp/commons": "npm:^5.4.5"
@@ -8641,7 +8641,7 @@ __metadata:
     long: "npm:^5.2.0"
     uuid: "npm:9.0.1"
     zod: "npm:3.24.2"
-  checksum: 10/fdc3aa4352ff09124b87df5ebe820a4435fa55e33009b79b5f335da77a1edf4f5eb5bd6e8374d82102c86298ee839bf66c9875c65023750f65b3fb8c9048615e
+  checksum: 10/a035c9fd50aa524e68dd240bdd1396ed7ce35f7e89271e6eef1d4d73b73cce409006ee20b5fbdb929882c86828d2f4b0601b5d7156b1630158291fd2d8582fad
   languageName: node
   linkType: hard
 
@@ -22466,7 +22466,7 @@ __metadata:
     "@wireapp/avs-debugger": "npm:0.0.7"
     "@wireapp/commons": "npm:5.4.4"
     "@wireapp/copy-config": "npm:2.3.3"
-    "@wireapp/core": "npm:46.35.2"
+    "@wireapp/core": "npm:46.35.3"
     "@wireapp/eslint-config": "npm:3.0.7"
     "@wireapp/kalium-backup": "npm:0.0.4"
     "@wireapp/prettier-config": "npm:0.6.4"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18813" title="WPB-18813" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18813</a>  [Web] During initial loading, incoming messages are displayed as a pop up notification
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

This PR is an effort to pause the notifications queue processing when the app is not fully initialized. it aims to fix native notifications showing up on the screen while the app is still in the loading screen.
