### PR TITLE
runfix: provide url for image asset download [WPB-20155]

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetLarge/ImageAssetLarge.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetLarge/ImageAssetLarge.tsx
@@ -113,6 +113,7 @@ export const ImageAssetLarge = ({
         onClose={() => setIsOpen(false)}
         filePreviewUrl={src}
         fileExtension={extension}
+        fileUrl={src}
         fileName={name}
         senderName={senderName}
         timestamp={timestamp}

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetSmall/ImageAssetSmall.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetSmall/ImageAssetSmall.tsx
@@ -77,6 +77,7 @@ export const ImageAssetSmall = ({
         filePreviewUrl={src}
         fileExtension={extension}
         fileName={name}
+        fileUrl={src}
         senderName={senderName}
         timestamp={timestamp}
       />

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/VideoAssetCard/VideoAssetSmall/VideoAssetSmall.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/VideoAssetCard/VideoAssetSmall/VideoAssetSmall.tsx
@@ -85,6 +85,7 @@ export const VideoAssetSmall = ({
         filePreviewUrl={src}
         fileExtension={extension}
         fileName={fileName}
+        fileUrl={src}
         senderName={senderName}
         timestamp={timestamp}
       />


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20155" title="WPB-20155" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20155</a>  [Web] Inconsistent behavior when downloading a shared file from different locations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

A `fileUrl` prop needs to be passed to the `FileFullscreenModal` component for the download to proceed
It was missing from Images and Videos asset cards

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
