### PR TITLE
runfix(cells): fetch conversation to refresh cells state [WPB-19978]

### DIFF
--- a/src/script/components/Conversation/ConversationCells/useRefreshCellsState/useRefreshCellsState.ts
+++ b/src/script/components/Conversation/ConversationCells/useRefreshCellsState/useRefreshCellsState.ts
@@ -45,8 +45,8 @@ export const useRefreshCellsState = ({
   const fetchCountRef = useRef(0);
 
   const refreshCellsState = useCallback(async () => {
-    const conversation = await conversationRepository.getConversationById(conversationQualifiedId);
-    setCellsState(conversation.cellsState());
+    const conversation = await conversationRepository.fetchBackendConversationEntityById(conversationQualifiedId);
+    setCellsState(conversation.cells_state);
     fetchCountRef.current += 1;
   }, [conversationRepository, conversationQualifiedId]);
 

--- a/src/script/repositories/conversation/ConversationRepository.test.ts
+++ b/src/script/repositories/conversation/ConversationRepository.test.ts
@@ -3314,6 +3314,34 @@ describe('ConversationRepository', () => {
       });
     });
   });
+
+  describe('fetchBackendConversationEntityById', () => {
+    it('returns backend conversation entity on success', async () => {
+      const conversationRepository = await testFactory.exposeConversationActors();
+      const qualifiedId = {id: 'test-id', domain: 'test-domain'};
+      const backendConversation = generateAPIConversation({id: qualifiedId});
+
+      jest
+        .spyOn(conversationRepository['conversationService'], 'getConversationById')
+        .mockResolvedValueOnce(backendConversation);
+
+      const result = await conversationRepository.fetchBackendConversationEntityById(qualifiedId);
+      expect(result).toBe(backendConversation);
+    });
+
+    it('throws and logs error when backend call fails', async () => {
+      const conversationRepository = await testFactory.exposeConversationActors();
+      const qualifiedId = {id: 'test-id', domain: 'test-domain'};
+      const error = new Error('Backend error');
+
+      jest.spyOn(conversationRepository['conversationService'], 'getConversationById').mockRejectedValueOnce(error);
+
+      const loggerSpy = jest.spyOn(conversationRepository['logger'], 'error').mockImplementation(() => {});
+
+      await expect(conversationRepository.fetchBackendConversationEntityById(qualifiedId)).rejects.toThrow(error);
+      expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to get conversation from backend'));
+    });
+  });
 });
 
 describe('leaveConversation', () => {

--- a/src/script/repositories/conversation/ConversationRepository.ts
+++ b/src/script/repositories/conversation/ConversationRepository.ts
@@ -593,7 +593,7 @@ export class ConversationRepository {
   /**
    * Get a conversation from the backend.
    */
-  public async fetchConversationById({id: conversationId, domain}: QualifiedId): Promise<Conversation> {
+  private async fetchConversationById({id: conversationId, domain}: QualifiedId): Promise<Conversation> {
     const qualifiedId = {domain, id: conversationId};
     const fetching_conversations: Record<string, FetchPromise[]> = {};
     if (fetching_conversations.hasOwnProperty(conversationId)) {
@@ -628,6 +628,19 @@ export class ConversationRepository {
       throw error;
     }
   }
+
+  /**
+   * Get a conversation from the backend without updating local storage
+   * @param qualifiedId qualified id of the conversation to fetch
+   * @returns the fetched backend conversation entity
+   */
+  public fetchBackendConversationEntityById = async (qualifiedId: QualifiedId): Promise<BackendConversation> => {
+    const backendConversationEntity = await this.conversationService.getConversationById(qualifiedId).catch(error => {
+      this.logger.error(`Failed to get conversation from backend: ${error.message}`);
+      throw error;
+    });
+    return backendConversationEntity;
+  };
 
   /**
    * Will load all the conversations in memory


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19978" title="WPB-19978" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19978</a>  [Web] Refresh needed for the Files list to be displayed after the conversation is created
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Fetching a conversation from the backend is necessary to refresh it's `cells_state`

It what replaced by getting the local sate of the conversation here https://github.com/wireapp/wire-webapp/pull/19303

This was done to fix a rendering issue, this can be done by creating a new method in the conversation repository that doesn't add database manipulation instead

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
