### PR TITLE
feat: enable Rust SFT support by debugging config [WPB-20702]

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@mediapipe/tasks-vision": "0.10.21",
     "@tanstack/react-table": "8.21.3",
     "@tanstack/react-virtual": "3.13.4",
-    "@wireapp/avs": "10.0.46",
+    "@wireapp/avs": "10.2.2",
     "@wireapp/avs-debugger": "0.0.7",
     "@wireapp/commons": "5.4.4",
     "@wireapp/core": "46.34.11",

--- a/src/script/components/ConfigToolbar/ConfigToolbar.tsx
+++ b/src/script/components/ConfigToolbar/ConfigToolbar.tsx
@@ -38,6 +38,7 @@ export function ConfigToolbar() {
   const [prefix, setPrefix] = useState('Message -'); // Prefix input
   const wrapperRef = useRef(null);
   const [avsDebuggerEnabled, setAvsDebuggerEnabled] = useState(!!window.wire?.app?.debug?.isEnabledAvsDebugger()); //
+  const [avsRustSftEnabled, setAvsRustSftEnabled] = useState(!!window.wire?.app?.debug?.isEnabledAvsRustSFT()); //
 
   // Toggle config tool on 'cmd/ctrl + shift + 2'
   useEffect(() => {
@@ -180,6 +181,24 @@ export function ConfigToolbar() {
     );
   };
 
+  const handleAvsRustSftEnable = (isChecked: boolean) => {
+    setAvsRustSftEnabled(!!window.wire?.app?.debug?.enableAvsRustSFT(isChecked));
+  };
+  const renderAvsRustSftSwitch = (value: boolean) => {
+    return (
+      <div style={{marginBottom: '10px'}}>
+        <label htmlFor="avs-rust-sft-checkbox" style={{display: 'block', fontWeight: 'bold'}}>
+          ENABLE AVS RUST SFT
+        </label>
+        <Switch
+          id="avs-rust-sft-checkbox"
+          checked={avsRustSftEnabled}
+          onToggle={isChecked => handleAvsRustSftEnable(isChecked)}
+        />
+      </div>
+    );
+  };
+
   if (!showConfig) {
     return null;
   }
@@ -202,6 +221,10 @@ export function ConfigToolbar() {
       <Button onClick={() => window.wire?.app?.debug?.disablePressSpaceToUnmute()}>disablePressSpaceToUnmute</Button>
 
       <div>{renderAvsSwitch(avsDebuggerEnabled)}</div>
+
+      <hr />
+
+      <div>{renderAvsRustSftSwitch(avsRustSftEnabled)}</div>
 
       <hr />
 

--- a/src/script/repositories/calling/Call.ts
+++ b/src/script/repositories/calling/Call.ts
@@ -246,4 +246,12 @@ export class Call {
     this.currentPage(Math.min(this.currentPage(), newPages.length - 1));
     this.pages(newPages);
   }
+
+  public useAvsRustSFT(): boolean {
+    const conversationName = this.conversation.display_name();
+    if (!conversationName.includes('Sync - Calling')) {
+      return false;
+    }
+    return !!window.wire?.app?.debug?.isEnabledAvsRustSFT();
+  }
 }

--- a/src/script/util/DebugUtil.ts
+++ b/src/script/util/DebugUtil.ts
@@ -299,6 +299,27 @@ export class DebugUtil {
     return isEnabled === 'true';
   }
 
+  isEnabledAvsRustSFT(): boolean {
+    const storage = getStorage();
+
+    if (storage === undefined) {
+      return false;
+    }
+
+    const isEnabled = storage.getItem('avs-rust-sft-enabled');
+    return isEnabled === 'true';
+  }
+
+  enableAvsRustSFT(enable: boolean): boolean {
+    const storage = getStorage();
+
+    if (storage === undefined) {
+      return false;
+    }
+    storage.setItem('avs-rust-sft-enabled', `${enable}`);
+    return enable;
+  }
+
   /** Used by QA test automation. */
   blockAllConnections(): Promise<void[]> {
     const blockUsers = this.userState.users().map(userEntity => this.connectionRepository.blockUser(userEntity));

--- a/yarn.lock
+++ b/yarn.lock
@@ -8557,10 +8557,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/avs@npm:10.0.46":
-  version: 10.0.46
-  resolution: "@wireapp/avs@npm:10.0.46"
-  checksum: 10/cd688f92cac64c6d0aa1492fab26f715015f926965eb61532a61d29c7c2f6bbbc22ff0ef7abe119fc8583896fc96bfc48cf7c883c888843123c3453e5d7603a2
+"@wireapp/avs@npm:10.2.2":
+  version: 10.2.2
+  resolution: "@wireapp/avs@npm:10.2.2"
+  checksum: 10/9e506d3590137a3a812ab87b6e20d09865cd23c895b8011ceb918e54529f67c49f1d7e34809793526d2d10ea196d369a4073ef4bcc8d3cc100dcf217ecf8b453
   languageName: node
   linkType: hard
 
@@ -22436,7 +22436,7 @@ __metadata:
     "@types/webpack-bundle-analyzer": "npm:^4"
     "@types/webpack-env": "npm:1.18.8"
     "@types/wicg-file-system-access": "npm:^2023.10.5"
-    "@wireapp/avs": "npm:10.0.46"
+    "@wireapp/avs": "npm:10.2.2"
     "@wireapp/avs-debugger": "npm:0.0.7"
     "@wireapp/commons": "npm:5.4.4"
     "@wireapp/copy-config": "npm:2.3.2"


### PR DESCRIPTION
## What's new in this PR?

- AVS bump to 10.2.3
- Debugging feature switch for new rust SFT
- The new Calling Meeting AVS interfaces (but still disabled on your side) that comes with the AVS bump automatically.

## Description

To be able to test the SFT intensively, we want to integrate it into our daily routine. Therefore, we have integrated an SFT switch into the web app that operates according to two rules:

1. SFT Rut must be enabled.
2. A specific channel name must be specified.

Then the new SFT is automatically used in the Stars Cluster.


## Screenshots/Screencast (for UI changes)

<img width="1087" height="668" alt="Bildschirmfoto 2025-09-24 um 12 17 34" src="https://github.com/user-attachments/assets/310d08a4-87a4-4251-bd34-99b4317fa46e" />


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
