### PR TITLE
fix: prevent session-expired redirect after logout(WPB-20547)

### DIFF
--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -376,7 +376,7 @@ export class App {
    * @param config
    * @param onProgress
    */
-  async initApp(clientType: ClientType, onProgress: (message?: string) => void) {
+  async initApp(clientType: ClientType, onProgress: (message?: string) => void): Promise<User | undefined> {
     // add body information
     const startTime = Date.now();
     await updateApiVersion();
@@ -415,7 +415,8 @@ export class App {
 
         if (!hasAuthenticatedSession) {
           this.logger.info('User flagged as logged out without an authenticated session. Redirecting to login.');
-          return this.repository.lifeCycle.redirectToLogin(SIGN_OUT_REASON.NOT_SIGNED_IN);
+          this.repository.lifeCycle.redirectToLogin(SIGN_OUT_REASON.NOT_SIGNED_IN);
+          return undefined;
         }
       }
 

--- a/src/script/main/app.ts
+++ b/src/script/main/app.ts
@@ -80,7 +80,7 @@ import {PropertiesService} from 'Repositories/properties/PropertiesService';
 import {SearchRepository} from 'Repositories/search/SearchRepository';
 import {SelfRepository} from 'Repositories/self/SelfRepository';
 import {SelfService} from 'Repositories/self/SelfService';
-import {StorageRepository, StorageService} from 'Repositories/storage';
+import {StorageKey, StorageRepository, StorageService} from 'Repositories/storage';
 import {TeamRepository} from 'Repositories/team/TeamRepository';
 import {TeamService} from 'Repositories/team/TeamService';
 import {EventTrackingRepository} from 'Repositories/tracking/EventTrackingRepository';
@@ -91,6 +91,7 @@ import {DebugUtil} from 'Util/DebugUtil';
 import {Environment} from 'Util/Environment';
 import {t} from 'Util/LocalizerUtil';
 import {getLogger, Logger} from 'Util/Logger';
+import {loadValue, resetStoreValue} from 'Util/StorageUtil';
 import {durationFrom, formatCoarseDuration, TIME_IN_MILLIS} from 'Util/TimeUtil';
 import {AppInitializationStep, checkIndexedDb, InitializationEventLogger} from 'Util/util';
 
@@ -405,6 +406,18 @@ export class App {
       await checkIndexedDb();
 
       telemetry.timeStep(AppInitTimingsStep.RECEIVED_ACCESS_TOKEN);
+
+      const showLoginAfterLogout = Boolean(loadValue<boolean>(StorageKey.AUTH.SHOW_LOGIN));
+      resetStoreValue(StorageKey.AUTH.SHOW_LOGIN);
+
+      if (showLoginAfterLogout) {
+        const hasAuthenticatedSession = this.apiClient.transport?.http?.hasValidAccessToken?.() ?? false;
+
+        if (!hasAuthenticatedSession) {
+          this.logger.info('User flagged as logged out without an authenticated session. Redirecting to login.');
+          return this.repository.lifeCycle.redirectToLogin(SIGN_OUT_REASON.NOT_SIGNED_IN);
+        }
+      }
 
       let selfUser: User;
 

--- a/src/script/repositories/LifeCycleRepository/LifeCycleRepository.ts
+++ b/src/script/repositories/LifeCycleRepository/LifeCycleRepository.ts
@@ -30,6 +30,7 @@ import {StorageKey} from 'Repositories/storage/StorageKey';
 import type {StorageRepository} from 'Repositories/storage/StorageRepository';
 import type {UserRepository} from 'Repositories/user/UserRepository';
 import {getLogger, Logger} from 'Util/Logger';
+import {resetStoreValue, storeValue} from 'Util/StorageUtil';
 import {includesString} from 'Util/StringUtil';
 import {appendParameter} from 'Util/UrlUtil';
 
@@ -128,6 +129,13 @@ export class LifeCycleRepository {
       return;
     }
     this.isCurrentlyLoggingOut = true;
+
+    const isUserRequestedLogout = signOutReason === SIGN_OUT_REASON.USER_REQUESTED;
+    if (isUserRequestedLogout) {
+      storeValue(StorageKey.AUTH.SHOW_LOGIN, true);
+    } else {
+      resetStoreValue(StorageKey.AUTH.SHOW_LOGIN);
+    }
 
     // Helper function to notify about logout completion and redirect
     const completeLogoutAndRedirect = (): void => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20547" title="WPB-20547" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20547</a>  [Web] After logout, going to webapp gets redirected to session expired
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
- initApp now checks flag + token validity before hitting /self
- Redirects to plain login when flagged logged out with no valid session
- Added unit tests for SHOW_LOGIN store/reset behaviour

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
