### PR TITLE
fix: 1:1 conversations gives false unread after CPB import(WPB-20062)

### DIFF
--- a/src/script/repositories/backup/CrossPlatformBackup/importMappers/mapConversationRecord.ts
+++ b/src/script/repositories/backup/CrossPlatformBackup/importMappers/mapConversationRecord.ts
@@ -30,17 +30,18 @@ export const mapConversationRecord = ({
   name,
   lastModifiedTime,
 }: BackUpConversation): ConversationRecord | null => {
-  if (!qualifiedId || !name) {
+  if (!qualifiedId) {
     return null;
   }
 
   const lastEventTimestamp = lastModifiedTime ? new Date(lastModifiedTime.date.toString()).getTime() : 0;
+  const conversationName = name?.toString?.() ?? '';
 
   // We dont get all the "required" fields from the backup, so we need to outsmart the type system.
   // ToDO: Fix the backup to include all required fields or check if we can make them optional without breaking anything.
   const conversationRecord: ConversationRecord = {
     id: qualifiedId.id.toString(),
-    name: name.toString(),
+    name: conversationName,
     domain: qualifiedId.domain.toString(),
     last_read_timestamp: new Date().getTime(),
     last_event_timestamp: lastEventTimestamp,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20062" title="WPB-20062" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20062</a>  [All clients] 1:1 conversations should ignore MLS migration message when restoring backup
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description
mapConversationRecord currently returns null if the conversation name is falsy. Since 1:1 conversations are exported with an empty string as their name, they get filtered out during CPB import. This prevents their
last_event_timestamp from being restored, causing them to appear unread
after backup restore.

Fix:
Ensure that empty-string names for 1:1 conversations are preserved instead of filtered out.

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
