### PR TITLE
runfix: pass file name with extension to cells api [WPB-20155]

### DIFF
--- a/src/script/components/FileFullscreenModal/FileHeader/FileHeader.tsx
+++ b/src/script/components/FileFullscreenModal/FileHeader/FileHeader.tsx
@@ -23,7 +23,7 @@ import {FileTypeIcon} from 'Components/Conversation/common/FileTypeIcon/FileType
 import {MessageTime} from 'Components/MessagesList/Message/MessageTime';
 import {useRelativeTimestamp} from 'Hooks/useRelativeTimestamp';
 import {t} from 'Util/LocalizerUtil';
-import {forcedDownloadFile} from 'Util/util';
+import {forcedDownloadFile, getFileNameWithExtension} from 'Util/util';
 
 import {
   headerStyles,
@@ -56,6 +56,7 @@ export const FileHeader = ({
   badges,
 }: FileHeaderProps) => {
   const timeAgo = useRelativeTimestamp(timestamp);
+  const fileNameWithExtension = getFileNameWithExtension(fileName, fileExtension);
 
   return (
     <header css={headerStyles}>
@@ -82,7 +83,7 @@ export const FileHeader = ({
         <Button
           variant={ButtonVariant.TERTIARY}
           css={downloadButtonStyles}
-          onClick={() => forcedDownloadFile({url: fileUrl || '', name: fileName})}
+          onClick={() => forcedDownloadFile({url: fileUrl || '', name: fileNameWithExtension})}
           aria-label={t('cells.imageFullScreenModal.downloadButton')}
         >
           <DownloadIcon />

--- a/src/script/components/FileFullscreenModal/NoPreviewAvailable/NoPreviewAvailable.tsx
+++ b/src/script/components/FileFullscreenModal/NoPreviewAvailable/NoPreviewAvailable.tsx
@@ -20,7 +20,7 @@
 import {Button} from '@wireapp/react-ui-kit';
 
 import {t} from 'Util/LocalizerUtil';
-import {forcedDownloadFile} from 'Util/util';
+import {forcedDownloadFile, getFileNameWithExtension} from 'Util/util';
 
 import {FilePlaceholder} from '../common/FilePlaceholder/FilePlaceholder';
 
@@ -31,12 +31,14 @@ interface NoPreviewAvailableProps {
 }
 
 export const NoPreviewAvailable = ({fileUrl, fileName, fileExtension}: NoPreviewAvailableProps) => {
+  const fileNameWithExtension = getFileNameWithExtension(fileName, fileExtension);
+
   return (
     <FilePlaceholder
       title={t('fileFullscreenModal.noPreviewAvailable.title')}
       description={t('fileFullscreenModal.noPreviewAvailable.description')}
       callToAction={
-        <Button onClick={() => forcedDownloadFile({url: fileUrl || '', name: fileName})}>
+        <Button onClick={() => forcedDownloadFile({url: fileUrl || '', name: fileNameWithExtension})}>
           {t('fileFullscreenModal.noPreviewAvailable.callToAction')}
         </Button>
       }

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/FileAssetCard/common/FileAssetOptions/FileAssetOptions.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/FileAssetCard/common/FileAssetOptions/FileAssetOptions.tsx
@@ -20,7 +20,7 @@
 import {DropdownMenu, MoreIcon} from '@wireapp/react-ui-kit';
 
 import {t} from 'Util/LocalizerUtil';
-import {forcedDownloadFile} from 'Util/util';
+import {forcedDownloadFile, getFileNameWithExtension} from 'Util/util';
 
 import {buttonStyles, iconStyles} from './FileAssetOptions.styles';
 
@@ -32,6 +32,8 @@ interface FileAssetOptionsProps {
 }
 
 export const FileAssetOptions = ({onOpen, src, name, extension}: FileAssetOptionsProps) => {
+  const fileNameWithExtension = getFileNameWithExtension(name, extension);
+
   return (
     <DropdownMenu>
       <DropdownMenu.Trigger asChild>
@@ -42,7 +44,7 @@ export const FileAssetOptions = ({onOpen, src, name, extension}: FileAssetOption
       <DropdownMenu.Content>
         <DropdownMenu.Item onClick={onOpen}>{t('cells.options.open')}</DropdownMenu.Item>
         <DropdownMenu.Item
-          onClick={() => forcedDownloadFile({url: src || '', name: `${name}.${extension}`})}
+          onClick={() => forcedDownloadFile({url: src || '', name: fileNameWithExtension})}
           aria-label={t('cells.options.download')}
         >
           {t('cells.options.download')}

--- a/src/script/util/util.test.ts
+++ b/src/script/util/util.test.ts
@@ -30,6 +30,7 @@ import {
   stripUrlWrapper,
   trimFileExtension,
   zeroPadding,
+  getFileNameWithExtension,
 } from 'Util/util';
 
 import {createUuid} from './uuid';
@@ -264,5 +265,15 @@ describe('zeroPadding', () => {
 
   it('can transform 666 to a string', () => {
     expect(zeroPadding(666)).toEqual('666');
+  });
+});
+
+describe('getFileNameWithExtension', () => {
+  it('adds the extension if not present', () => {
+    expect(getFileNameWithExtension('file', 'jpg')).toBe('file.jpg');
+  });
+
+  it('does not add the extension if already present', () => {
+    expect(getFileNameWithExtension('file.jpg', 'jpg')).toBe('file.jpg');
   });
 });

--- a/src/script/util/util.ts
+++ b/src/script/util/util.ts
@@ -237,6 +237,17 @@ export const downloadFile = (url: string, fileName: string, mimeType?: string): 
 };
 
 /**
+ * Get the file name with the extension. If the file name already has the extension, it won't be added again.
+ * @param name The file name
+ * @param extension The file extension
+ * @returns The file name with the extension
+ */
+export const getFileNameWithExtension = (name: string, extension: string): string => {
+  const hasExtension = name.toLowerCase().endsWith(`.${extension.toLowerCase()}`);
+  return hasExtension ? name : `${name}.${extension}`;
+};
+
+/**
  * Forces file download instead of browser "preview".
  * We use fetch + blob because native <a download> doesn't work reliably across browsers and file types (especially PDFs and images).
  */


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20155" title="WPB-20155" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20155</a>  [Web] Inconsistent behavior when downloading a shared file from different locations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

hardens the dowload of files with the cell API by making sure:
- we provide a file extension
- we don't provide a file extension twice

Making it an util ensure the download is correct regardless of whether the `fileName` passed to a particular component contains an extension or not

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
