### PR TITLE
chore(e2e): Remove force refresh from cells e2e test [WPB-20746]

### DIFF
--- a/test/e2e_tests/specs/CriticalFlow/Cells/uploadingFileInGroupConversation.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/Cells/uploadingFileInGroupConversation.spec.ts
@@ -117,10 +117,6 @@ test(
 
     await test.step('User A opens group conversation files and sees the image file there', async () => {
       await userAPages.conversation().clickFilesTab();
-
-      // TODO: Refresh needed for the Files list to be displayed after the conversation is created [WPB-19978]
-      await userAPageManager.refreshPage({waitUntil: 'load'});
-
       await userAPages.cellsConversationFiles().clickFile(ImageQRCodeFileName);
 
       expect(await userAModals.cellsFileDetailView().isImageVisible()).toBeTruthy();


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20746" title="WPB-20746" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20746</a>  [QA] Remove force refresh from cells e2e test
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

https://wearezeta.atlassian.net/browse/WPB-20746

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

- Removed force refresh when opening files tab. It's no longer needed since [WPB-19978](https://wearezeta.atlassian.net/browse/WPB-19978) was fixed.

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-19978]: https://wearezeta.atlassian.net/browse/WPB-19978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ