### PR TITLE
runfix(cells): disable or hide downloads if the cells url is not given [WPB-19230]

### DIFF
--- a/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsTableRowOptions/CellsTableRowOptions.tsx
+++ b/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsTableRowOptions/CellsTableRowOptions.tsx
@@ -59,7 +59,7 @@ export const CellsTableRowOptions = ({node, cellsRepository}: CellsTableRowOptio
         <DropdownMenu.Item onClick={() => showShareModal({type: node.type, uuid: node.id, cellsRepository})}>
           {t('cells.options.share')}
         </DropdownMenu.Item>
-        {url && (
+        {!!url && (
           <DropdownMenu.Item
             onClick={() =>
               forcedDownloadFile({

--- a/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableRowOptions/CellsTableRowOptions.tsx
+++ b/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableRowOptions/CellsTableRowOptions.tsx
@@ -180,7 +180,7 @@ const CellsTableRowOptionsContent = ({
           {t('cells.options.share')}
         </DropdownMenu.Item>
 
-        {url && (
+        {!!url && (
           <DropdownMenu.Item onClick={() => forcedDownloadFile({url, name})}>
             {t('cells.options.download')}
           </DropdownMenu.Item>

--- a/src/script/components/FileFullscreenModal/FileHeader/FileHeader.tsx
+++ b/src/script/components/FileFullscreenModal/FileHeader/FileHeader.tsx
@@ -84,6 +84,7 @@ export const FileHeader = ({
           variant={ButtonVariant.TERTIARY}
           css={downloadButtonStyles}
           onClick={() => forcedDownloadFile({url: fileUrl || '', name: fileNameWithExtension})}
+          disabled={!fileUrl}
           aria-label={t('cells.imageFullScreenModal.downloadButton')}
         >
           <DownloadIcon />

--- a/src/script/components/FileFullscreenModal/NoPreviewAvailable/NoPreviewAvailable.tsx
+++ b/src/script/components/FileFullscreenModal/NoPreviewAvailable/NoPreviewAvailable.tsx
@@ -38,7 +38,10 @@ export const NoPreviewAvailable = ({fileUrl, fileName, fileExtension}: NoPreview
       title={t('fileFullscreenModal.noPreviewAvailable.title')}
       description={t('fileFullscreenModal.noPreviewAvailable.description')}
       callToAction={
-        <Button onClick={() => forcedDownloadFile({url: fileUrl || '', name: fileNameWithExtension})}>
+        <Button
+          onClick={() => forcedDownloadFile({url: fileUrl || '', name: fileNameWithExtension})}
+          disabled={!fileUrl}
+        >
           {t('fileFullscreenModal.noPreviewAvailable.callToAction')}
         </Button>
       }

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/FileAssetCard/FileAssetWithPreview/FileAssetWithPreview.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/FileAssetCard/FileAssetWithPreview/FileAssetWithPreview.tsx
@@ -76,7 +76,7 @@ export const FileAssetWithPreview = ({
         <FileCard.Icon type={isError ? 'unavailable' : 'file'} />
         {!isError && <FileCard.Type />}
         <FileCard.Name variant={isError ? 'secondary' : 'primary'} />
-        <FileAssetOptions src={src} name={name} extension={extension} onOpen={() => setIsOpen(true)} />
+        {!isError && <FileAssetOptions src={src} name={name} extension={extension} onOpen={() => setIsOpen(true)} />}
       </FileCard.Header>
       <FileCard.Content>
         <button
@@ -86,6 +86,7 @@ export const FileAssetWithPreview = ({
           aria-controls={id}
           aria-haspopup="dialog"
           aria-expanded={isOpen}
+          disabled={isError}
         >
           <img
             src={imagePreviewUrl}
@@ -101,7 +102,9 @@ export const FileAssetWithPreview = ({
               {shouldDisplayPreviewError && (
                 <>
                   <AlertIcon css={errorIconStyles} width={14} height={14} />
-                  <p css={errorTextStyles}>{t('cells.unavailableFilePreview')}</p>
+                  <p css={errorTextStyles}>
+                    {isError ? t('cells.unavailableFile') : t('cells.unavailableFilePreview')}
+                  </p>
                 </>
               )}
             </div>

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/FileAssetCard/common/FileAssetOptions/FileAssetOptions.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/FileAssetCard/common/FileAssetOptions/FileAssetOptions.tsx
@@ -43,12 +43,11 @@ export const FileAssetOptions = ({onOpen, src, name, extension}: FileAssetOption
       </DropdownMenu.Trigger>
       <DropdownMenu.Content>
         <DropdownMenu.Item onClick={onOpen}>{t('cells.options.open')}</DropdownMenu.Item>
-        <DropdownMenu.Item
-          onClick={() => forcedDownloadFile({url: src || '', name: fileNameWithExtension})}
-          aria-label={t('cells.options.download')}
-        >
-          {t('cells.options.download')}
-        </DropdownMenu.Item>
+        {!!src && (
+          <DropdownMenu.Item onClick={() => forcedDownloadFile({url: src, name: fileNameWithExtension})}>
+            {t('cells.options.download')}
+          </DropdownMenu.Item>
+        )}
       </DropdownMenu.Content>
     </DropdownMenu>
   );

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetLarge/ImageAssetLarge.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetLarge/ImageAssetLarge.tsx
@@ -75,6 +75,7 @@ export const ImageAssetLarge = ({
         aria-haspopup="dialog"
         aria-expanded={isOpen}
         aria-controls={id}
+        disabled={isError}
         style={
           {
             '--aspect-ratio': aspectRatio,

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetSmall/ImageAssetSmall.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetSmall/ImageAssetSmall.tsx
@@ -61,6 +61,7 @@ export const ImageAssetSmall = ({
         aria-haspopup="dialog"
         aria-expanded={isOpen}
         aria-controls={id}
+        disabled={isError}
       >
         <MediaFilePreviewCard
           label={src ? t('conversationFileImagePreviewLabel', {src}) : ''}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19230" title="WPB-19230" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19230</a>  [Web] Detail view can be opened for deleted file
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Users were given the option to download a file even when no valid url for the file was given — in case of errors or if the file was permanently deleted

<!-- Uncomment this section if your PR has UI changes -->

## Screenshots/Screencast (for UI changes)
#### Before:
<img width="525" height="338" alt="image" src="https://github.com/user-attachments/assets/d4b46069-cad1-4b3b-87c9-db0a7b9b1196" />
<img width="583" height="336" alt="image" src="https://github.com/user-attachments/assets/64bca22f-a1e0-4f50-8483-5418831ef2e9" />
<img width="500" height="444" alt="image" src="https://github.com/user-attachments/assets/f6ff59fe-7678-44b4-80ab-8feb5f2c066f" />
<img width="573" height="323" alt="image" src="https://github.com/user-attachments/assets/3fb2d67e-96a1-4f4b-b32a-b3ba11b49ab8" />

#### After:

<img width="520" height="342" alt="image" src="https://github.com/user-attachments/assets/54443f6b-ecf6-460a-ae38-50d0bfd7d659" />
<img width="710" height="388" alt="image" src="https://github.com/user-attachments/assets/ed2d0a9c-49dd-40e4-ab55-b8d7b3d6c7e7" />

Shown as demonstration, this preview is not actually reachable:
<img width="499" height="439" alt="image" src="https://github.com/user-attachments/assets/fda2f7f0-dc06-4880-966e-06b72df841e6" />



## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
