### PR TITLE
runfix(cells): update file name in conversation list after renaming [WPB-19828]

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.tsx
@@ -84,7 +84,6 @@ const MultipartAsset = ({
   senderName,
   timestamp,
 }: MultipartAssetProps) => {
-  const name = getName(initialName!);
   const extension = getFileExtension(initialName!);
   const size = formatBytes(Number(initialSize));
 
@@ -96,12 +95,14 @@ const MultipartAsset = ({
   const isSingleAsset = assetsCount === 1;
   const variant = isSingleAsset ? 'large' : 'small';
 
-  const {src, isLoading, isError, imagePreviewUrl, pdfPreviewUrl} = useGetMultipartAsset({
+  const {src, isLoading, isError, imagePreviewUrl, pdfPreviewUrl, path} = useGetMultipartAsset({
     uuid,
     cellsRepository,
     isEnabled: hasBeenInView,
     retryPreviewUntilSuccess: isSingleAsset && !isImage && !isVideo,
   });
+
+  const name = path ? getName(path) : getName(initialName!);
 
   if (isImage) {
     return (

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/useGetMultipartAsset/useGetMultipartAsset.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/useGetMultipartAsset/useGetMultipartAsset.ts
@@ -56,6 +56,7 @@ export const useGetMultipartAsset = ({
   retryDelay = DEFAULT_RETRY_DELAY,
 }: UseGetMultipartAssetPreviewProps) => {
   const uuidRef = useRef(uuid);
+  const [path, setPath] = useState<string | undefined>(undefined);
   const [src, setSrc] = useState<string | undefined>(undefined);
   const [imagePreviewUrl, setImagePreviewUrl] = useState<string | undefined>(undefined);
   const [pdfPreviewUrl, setPdfPreviewUrl] = useState<string | undefined>(undefined);
@@ -93,6 +94,7 @@ export const useGetMultipartAsset = ({
         setSrc(asset.PreSignedGET?.Url);
         setImagePreviewUrl(imagePreview?.PreSignedGET?.Url);
         setPdfPreviewUrl(pdfPreview?.PreSignedGET?.Url);
+        setPath(asset.Path);
         setStatus('success');
 
         return;
@@ -109,6 +111,7 @@ export const useGetMultipartAsset = ({
       setSrc(asset.PreSignedGET?.Url);
       setImagePreviewUrl(imagePreview?.PreSignedGET?.Url);
       setPdfPreviewUrl(pdfPreview?.PreSignedGET?.Url);
+      setPath(asset.Path);
       setStatus('success');
     } catch (err) {
       if (!isMounted.current) {
@@ -162,5 +165,6 @@ export const useGetMultipartAsset = ({
     pdfPreviewUrl,
     isLoading: ['loading', 'retrying', 'idle'].includes(status),
     isError: status === 'error',
+    path,
   };
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19828" title="WPB-19828" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19828</a>  [Web] When file is renamed in the list view, it still shows the old name in the conversation view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

The names of multipart assets — the component Cells use to display assets in a conversation — was only set once when created, meaning it would not update after the file is renamed

This updates the name of an asset anytime it's path changes — when the asset is renamed

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
