### PR TITLE
chore(release): use git branch --format for clean contains check

### DIFF
--- a/bin/release_tag.ts
+++ b/bin/release_tag.ts
@@ -80,9 +80,10 @@ if (commitId) {
 
   if (stage === DeploymentStage.PRODUCTION || stage === DeploymentStage.STAGING) {
     // If we're releasing to production, we need to ensure the commitId is part of the master branch.
-    const commitBranch = exec(`git branch --contains ${commitId}`)
+    const commitBranch = exec(`git branch --contains ${commitId} --format="%(refname:short)"`)
       .split('\n')
       .map(branch => branch.trim());
+    console.info(commitBranch);
     if (!commitBranch.includes(branch)) {
       logger.error(`Commit ID "${commitId}" is not part of the ${branch} branch. Aborting.`);
       process.exit(1);


### PR DESCRIPTION
## Description

it wrongly rejected valid commits because git branch --contains outputs a “*” on the current branch; now we use the formatted branch list (git branch --contains <sha> --format="%(refname:short)") so the containment check is clean and tagging no longer fails on commits that are actually on the branch.
