### PR TITLE
runfix(cells): filter out drafts from cells queries [WPB-19862]

### DIFF
--- a/src/script/components/CellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.ts
+++ b/src/script/components/CellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.ts
@@ -81,8 +81,11 @@ export const useSearchCellsNodes = ({
           conversationRepository,
         });
 
+        // filter out draft nodes from results
+        const filteredNodes = result.Nodes?.filter(node => !node.IsDraft);
+
         const transformedNodes = transformCellsNodes({
-          nodes: result.Nodes || [],
+          nodes: filteredNodes || [],
           users,
           conversations,
         });

--- a/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/useGetAllCellsNodes.ts
+++ b/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/useGetAllCellsNodes.ts
@@ -69,7 +69,10 @@ export const useGetAllCellsNodes = ({
 
       const users = await getUsersFromNodes({nodes: result.Nodes, userRepository});
 
-      const transformedNodes = transformDataToCellsNodes({nodes: result.Nodes, users});
+      // filter out draft nodes from results
+      const filteredNodes = result.Nodes.filter(node => !node.IsDraft);
+
+      const transformedNodes = transformDataToCellsNodes({nodes: filteredNodes, users});
       setNodes({conversationId: id, nodes: transformedNodes});
 
       const pagination = result.Pagination ? transformToCellPagination(result.Pagination) : null;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19862" title="WPB-19862" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19862</a>  [Web] Draft Assets Management - MVP
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Draft were displayed on the conversation files tab and all files tab before being sent.

Draft nodes in cells are nodes that are in the process of being of being uploaded or uploaded but the user hasn;t pressed "send" yet

<!-- Uncomment this section if your PR has UI changes -->

## Screenshots/Screencast (for UI changes)
Before:
<img width="924" height="929" alt="image" src="https://github.com/user-attachments/assets/2027e879-15f1-468c-ad8d-46e70fc11e9b" />
<img width="924" height="929" alt="image" src="https://github.com/user-attachments/assets/884cc590-6389-4b1c-9204-31fa5026c43e" />

After:
<img width="924" height="929" alt="image" src="https://github.com/user-attachments/assets/d01c92e2-0ab0-4952-93aa-1a27950a443d" />


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
