### PR TITLE
chore: Bump @wireapp/core from 46.39.1 to 46.39.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@wireapp/avs": "10.0.46",
     "@wireapp/avs-debugger": "0.0.7",
     "@wireapp/commons": "5.4.5",
-    "@wireapp/core": "46.39.1",
+    "@wireapp/core": "46.39.2",
     "@wireapp/kalium-backup": "0.0.4",
     "@wireapp/promise-queue": "2.4.5",
     "@wireapp/react-ui-kit": "9.66.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8414,9 +8414,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:46.39.1":
-  version: 46.39.1
-  resolution: "@wireapp/core@npm:46.39.1"
+"@wireapp/core@npm:46.39.2":
+  version: 46.39.2
+  resolution: "@wireapp/core@npm:46.39.2"
   dependencies:
     "@wireapp/api-client": "npm:^27.77.2"
     "@wireapp/commons": "npm:^5.4.5"
@@ -8436,7 +8436,7 @@ __metadata:
     long: "npm:^5.2.0"
     uuid: "npm:9.0.1"
     zod: "npm:3.24.2"
-  checksum: 10/86a1f7dd39a147973c779974aab7d67dafd672bef2ed26856452f3dc698d4d5ee11bd661a959e75bc966401c7d012425e837e9ee34eb25ccdbd9e514bc867934
+  checksum: 10/50f35284f26415ef37464baffbc37fd107ddfe093a1e38c73571abcbf3ca8c64869052e7620eec1006b3aaabb6d45bd9f61ade8d18a2369387ec6f44df4f0188
   languageName: node
   linkType: hard
 
@@ -22312,7 +22312,7 @@ __metadata:
     "@wireapp/avs-debugger": "npm:0.0.7"
     "@wireapp/commons": "npm:5.4.5"
     "@wireapp/copy-config": "npm:2.3.4"
-    "@wireapp/core": "npm:46.39.1"
+    "@wireapp/core": "npm:46.39.2"
     "@wireapp/eslint-config": "npm:3.0.7"
     "@wireapp/kalium-backup": "npm:0.0.4"
     "@wireapp/prettier-config": "npm:0.6.5"


### PR DESCRIPTION
## Description

See https://github.com/wireapp/wire-web-packages/pull/7438
