### PR TITLE
feat: implement audit log in asset API [WPB-20666]

### DIFF
--- a/src/script/repositories/assets/AssetRepository.ts
+++ b/src/script/repositories/assets/AssetRepository.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {AssetOptions, AssetRetentionPolicy} from '@wireapp/api-client/lib/asset/';
+import {AssetAuditData, AssetOptions, AssetRetentionPolicy} from '@wireapp/api-client/lib/asset/';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import ko from 'knockout';
 import {container, singleton} from 'tsyringe';
@@ -46,6 +46,7 @@ interface CompressedImage {
 }
 
 export interface AssetUploadOptions extends AssetOptions {
+  auditData?: AssetAuditData;
   domain?: string;
   legalHoldStatus?: LegalHoldStatus;
 }

--- a/src/script/repositories/conversation/MessageRepository.ts
+++ b/src/script/repositories/conversation/MessageRepository.ts
@@ -723,7 +723,7 @@ export class MessageRepository {
       ...(isAuditLogEnabled && {auditData}),
     };
 
-    const asset = await this.assetRepository.uploadFile(file, messageId, options);
+    const asset = await this.assetRepository.uploadFile(file, messageId, options, isAuditLogEnabled);
 
     const metadata = asImage ? ((await buildMetadata(file)) as ImageMetadata) : undefined;
     const commonMessageData = {

--- a/src/script/repositories/conversation/MessageRepository.ts
+++ b/src/script/repositories/conversation/MessageRepository.ts
@@ -707,18 +707,20 @@ export class MessageRepository {
   ) {
     const isAuditLogEnabled = this.teamState.isAuditLogEnabled() && !getWebEnvironment().isProduction;
 
-    const auditData: AssetAuditData = {
-      conversationId: conversation.qualifiedId,
-      filename: meta.name,
-      filetype: meta.type,
-    };
+    const auditData: AssetAuditData | undefined = isAuditLogEnabled
+      ? {
+          conversationId: conversation.qualifiedId,
+          filename: meta.name,
+          filetype: meta.type,
+        }
+      : undefined;
 
     const retention = this.assetRepository.getAssetRetention(this.userState.self(), conversation);
     const options = {
       legalHoldStatus: conversation.legalHoldStatus(),
       public: true,
       retention,
-      auditData: isAuditLogEnabled ? auditData : undefined,
+      ...(isAuditLogEnabled && {auditData}),
     };
 
     const asset = await this.assetRepository.uploadFile(file, messageId, options);

--- a/src/script/repositories/conversation/MessageRepository.ts
+++ b/src/script/repositories/conversation/MessageRepository.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {AssetAuditData} from '@wireapp/api-client/lib/asset';
 import {ConversationProtocol, MessageSendingStatus, QualifiedUserClients} from '@wireapp/api-client/lib/conversation';
 import {BackendErrorLabel} from '@wireapp/api-client/lib/http/';
 import {QualifiedId, RequestCancellationError} from '@wireapp/api-client/lib/user';
@@ -78,6 +79,7 @@ import {Segmentation} from 'Repositories/tracking/Segmentation';
 import {protoFromType} from 'Repositories/user/AvailabilityMapper';
 import {UserRepository} from 'Repositories/user/UserRepository';
 import {UserState} from 'Repositories/user/UserState';
+import {getWebEnvironment} from 'Util/Environment';
 import {
   cancelSendingLinkPreview,
   clearLinkPreviewSendingState,
@@ -703,12 +705,22 @@ export class MessageRepository {
     asImage: boolean,
     meta: FileMetaDataContent,
   ) {
+    const isAuditLogEnabled = this.teamState.isAuditLogEnabled() && !getWebEnvironment().isProduction;
+
+    const auditData: AssetAuditData = {
+      conversationId: conversation.qualifiedId,
+      filename: meta.name,
+      filetype: meta.type,
+    };
+
     const retention = this.assetRepository.getAssetRetention(this.userState.self(), conversation);
     const options = {
       legalHoldStatus: conversation.legalHoldStatus(),
       public: true,
       retention,
+      auditData: isAuditLogEnabled ? auditData : undefined,
     };
+
     const asset = await this.assetRepository.uploadFile(file, messageId, options);
 
     const metadata = asImage ? ((await buildMetadata(file)) as ImageMetadata) : undefined;

--- a/src/script/repositories/team/TeamState.ts
+++ b/src/script/repositories/team/TeamState.ts
@@ -59,6 +59,7 @@ export class TeamState {
   readonly teamSize: ko.PureComputed<number>;
   readonly selfRole: ko.PureComputed<Role | undefined>;
   readonly isCellsEnabled: ko.PureComputed<boolean>;
+  readonly isAuditLogEnabled: ko.PureComputed<boolean>;
 
   constructor(private readonly userState = container.resolve(UserState)) {
     this.isTeam = ko.pureComputed(() => !!this.team()?.id);
@@ -136,6 +137,10 @@ export class TeamState {
 
     this.isCellsEnabled = ko.pureComputed(() => {
       return this.teamFeatures()?.cells?.status === FeatureStatus.ENABLED;
+    });
+
+    this.isAuditLogEnabled = ko.pureComputed(() => {
+      return this.teamFeatures()?.assetAuditLog?.status === FeatureStatus.ENABLED;
     });
   }
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20666" title="WPB-20666" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-20666</a>  [Web] [webapp] add metadata to fileUploads
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

Adds the option to log some asset metadata on some environments
- never log asset data on a production environment
- only log asset data if the backend feature flag is enabled
- do not upload file if the asset data is incomplete and the feature flag is enabled

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
