### PR TITLE
runfix(cells): prevent overflow of files names [WPB-20813]

### DIFF
--- a/src/script/components/FileCard/FileCardName/FileCardName.styles.ts
+++ b/src/script/components/FileCard/FileCardName/FileCardName.styles.ts
@@ -27,6 +27,8 @@ export const textStyles: CSSObject = {
   WebkitLineClamp: 'var(--truncate-after-lines)',
   WebkitBoxOrient: 'vertical',
   overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
   marginTop: '4px',
 
   '[data-file-card="header"] &': {

--- a/src/script/components/FileCard/FileCardRoot/FileCardRoot.styles.ts
+++ b/src/script/components/FileCard/FileCardRoot/FileCardRoot.styles.ts
@@ -46,7 +46,6 @@ export const wrapperStylesLarge: CSSObject = {
 };
 
 export const contentStyles: CSSObject = {
-  alignItems: 'flex-start',
   display: 'flex',
   flexDirection: 'column',
   minHeight: '60px',


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20813" title="WPB-20813" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20813</a>  [Web] Attachment texts can overlap in case of long names.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Files names were overflowing the tiles instead of being truncated

<!-- Uncomment this section if your PR has UI changes -->

## Screenshots/Screencast (for UI changes)
Before:
<img width="696" height="313" alt="Screenshot From 2025-10-16 14-32-56" src="https://github.com/user-attachments/assets/bbb0b01c-a8d9-462f-a502-396a9b1842c1" />
After:
<img width="696" height="313" alt="Screenshot From 2025-10-16 14-32-10" src="https://github.com/user-attachments/assets/faa66269-f3c2-4330-a868-07ff789a6204" />

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
