### PR TITLE
fix: Recover from having a local unestablished MLS group [WPB-21122]

### DIFF
--- a/src/script/repositories/conversation/ConversationRepository.ts
+++ b/src/script/repositories/conversation/ConversationRepository.ts
@@ -2198,7 +2198,7 @@ export class ConversationRepository {
           this.logger.error('Epoch is 0, but retry is false, not retrying again', {conversationId, groupId, epoch});
           return;
         }
-        return this.recoverFromLocalUnestblishedMLSConversations({conversationId, groupId, epoch, core});
+        return this.recoverFromLocalUnestablishedMLSConversations({conversationId, groupId, epoch, core});
       }
       return;
     }
@@ -2262,7 +2262,7 @@ export class ConversationRepository {
    * indicating that the conversation has not been properly established.
    * throws error in case both local and remote MLS group are at epoch 0 or remote epoch is not available
    */
-  private recoverFromLocalUnestblishedMLSConversations = async ({
+  private recoverFromLocalUnestablishedMLSConversations = async ({
     conversationId,
     groupId,
     epoch,

--- a/src/script/repositories/conversation/ConversationRepository.ts
+++ b/src/script/repositories/conversation/ConversationRepository.ts
@@ -2260,6 +2260,7 @@ export class ConversationRepository {
    * Recovers from local unestablished MLS conversations by refetching metadata and re-establishing the conversation.
    * This is typically needed when the local epoch is 0 but the epoch on backend is greater than 0
    * indicating that the conversation has not been properly established.
+   * throws error in case both local and remote MLS group are at epoch 0 or remote epoch is not available
    */
   private recoverFromLocalUnestblishedMLSConversations = async ({
     conversationId,

--- a/src/script/repositories/conversation/ConversationRepository.ts
+++ b/src/script/repositories/conversation/ConversationRepository.ts
@@ -2282,7 +2282,7 @@ export class ConversationRepository {
       const remoteConversation = await this.conversationService.getConversationById(conversationId);
       const remoteEpoch = remoteConversation.epoch;
       if (!remoteEpoch) {
-        this.logger.error('Remote epoch is not available!', {remoteEpoch});
+        this.logger.error('Remote epoch is not available!', {remoteConversation});
         throw new Error('Remote epoch is not available!');
       }
       if (remoteEpoch === epoch) {

--- a/src/script/repositories/conversation/ConversationRepository.ts
+++ b/src/script/repositories/conversation/ConversationRepository.ts
@@ -2286,8 +2286,10 @@ export class ConversationRepository {
         throw new Error('Remote epoch is not available!');
       }
       if (remoteEpoch === epoch) {
-        this.logger.error('Remote epoch is the same as local epoch, something is wrong!', {remoteEpoch, epoch});
-        throw new Error('Remote epoch is the same as local epoch, something is wrong!');
+        const errorMessage =
+          'Cannot recover: both local and remote MLS group are at epoch 0, the conversation was never established on the backend';
+        this.logger.error(errorMessage, {remoteEpoch, epoch});
+        throw new Error(errorMessage);
       }
 
       return this.ensureConversationExists({conversationId, groupId, epoch: remoteEpoch, core, retry: false});


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21122" title="WPB-21122" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21122</a>  [Web] Recover from having a local unestablished MLS group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

### Problem scenario
If a client fails to establish a MLS conversation it might be left with a local MLS group in core crypto. Since this MLS group was never established it will be stuck epoch 0.

Since conversationExists()will return true clients will consider this conversation to be established even though it’s not. 

### Recovery 
When trying to send a message in a conversation with a local MLS group stuck at epoch 0, delete the local MLS group and re-join the group / establish the group.