### PR TITLE
runfix(cells): account for tags in files header [WPB-20732]

### DIFF
--- a/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsTableTagsColumn/CellsTableTagsColumn.styles.ts
+++ b/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsTableTagsColumn/CellsTableTagsColumn.styles.ts
@@ -24,6 +24,10 @@ import {styleBreakpoint} from 'Components/Conversation/ConversationCells/common/
 export const wrapperStyles: CSSObject = {
   display: 'inline-flex',
 
+  '& > *': {
+    overflow: 'hidden',
+  },
+
   [`@media (min-width: ${styleBreakpoint}px)`]: {
     display: 'flex',
   },

--- a/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTagsColumn/CellsTagsColumn.styles.ts
+++ b/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTagsColumn/CellsTagsColumn.styles.ts
@@ -24,6 +24,10 @@ import {styleBreakpoint} from 'Components/Conversation/ConversationCells/common/
 export const wrapperStyles: CSSObject = {
   display: 'inline-flex',
 
+  '& > *': {
+    overflow: 'hidden',
+  },
+
   [`@media (min-width: ${styleBreakpoint}px)`]: {
     display: 'flex',
   },

--- a/src/script/components/FileFullscreenModal/FileHeader/FileHeader.styles.ts
+++ b/src/script/components/FileFullscreenModal/FileHeader/FileHeader.styles.ts
@@ -50,6 +50,7 @@ export const closeButtonStyles: CSSObject = {
 export const leftColumnStyles: CSSObject = {
   display: 'flex',
   alignItems: 'center',
+  flex: '1 1 auto',
 };
 
 export const metadataStyles: CSSObject = {
@@ -57,6 +58,7 @@ export const metadataStyles: CSSObject = {
   alignItems: 'center',
   gap: '16px',
   fontSize: 'var(--font-size-small)',
+  flex: '1 1 auto',
 };
 
 export const nameStyles: CSSObject = {
@@ -65,7 +67,7 @@ export const nameStyles: CSSObject = {
   whiteSpace: 'nowrap',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
-  width: 'calc(100vw - 320px)',
+  flex: '1 1 auto',
 };
 
 export const textStyles: CSSObject = {
@@ -82,7 +84,7 @@ export const actionButtonsStyles: CSSObject = {
   alignItems: 'center',
   justifyContent: 'center',
   flexShrink: '0',
-  marginRight: '8px',
+  marginInline: '8px',
 };
 
 export const downloadButtonStyles: CSSObject = {

--- a/src/style/content/conversation/title-bar.less
+++ b/src/style/content/conversation/title-bar.less
@@ -65,7 +65,7 @@ body.theme-dark {
 
   position: absolute;
   z-index: @z-index-badge;
-  top: 56px;
+  top: 50px;
   padding: 5px 16px;
   border-radius: 6px;
   background-color: var(--accent-color);


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20732" title="WPB-20732" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20732</a>  [Web] Tags break the layout of file preview header
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

Tags would break the layout of preview headers
- replace baked in calc adjusting file name size with flex grow

Bonus ticket https://wearezeta.atlassian.net/browse/WPB-18665:
- fix overflow of tags in the list views
- adjust position of guest badge

<!-- Uncomment this section if your PR has UI changes -->

## Screenshots/Screencast (for UI changes)
Before
<img width="1229" height="51" alt="Screenshot From 2025-10-16 16-25-55" src="https://github.com/user-attachments/assets/a3a51ec5-bae6-4e7e-a4a2-41887653cb42" />
<img width="796" height="47" alt="Screenshot From 2025-10-16 16-40-14" src="https://github.com/user-attachments/assets/e32926b7-dbc1-403f-b36f-31584e6affe0" />
<img width="242" height="86" alt="image" src="https://github.com/user-attachments/assets/f525d7d9-4eb8-4d34-a4d7-67497ca17353" />

After
<img width="1229" height="51" alt="Screenshot From 2025-10-16 16-25-00" src="https://github.com/user-attachments/assets/ce8dc04d-b7b3-4e36-9562-0bfaba8bea49" />
<img width="796" height="47" alt="Screenshot From 2025-10-16 16-39-51" src="https://github.com/user-attachments/assets/30c7f052-cd90-415c-b217-7f5df74d9d71" />
<img width="242" height="86" alt="image" src="https://github.com/user-attachments/assets/3dc66b54-3940-45d8-8e58-a1a88fffdd2c" />



## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
