### PR TITLE
runfix: use correct key for asset conversation id [WPB-20666]  @V-Gira

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@wireapp/avs": "10.2.7",
     "@wireapp/avs-debugger": "0.0.7",
     "@wireapp/commons": "5.4.5",
-    "@wireapp/core": "46.39.7",
+    "@wireapp/core": "46.39.10",
     "@wireapp/kalium-backup": "0.0.4",
     "@wireapp/promise-queue": "2.4.5",
     "@wireapp/react-ui-kit": "9.68.0",

--- a/src/script/repositories/assets/AssetRepository.test.ts
+++ b/src/script/repositories/assets/AssetRepository.test.ts
@@ -145,7 +145,7 @@ describe('AssetRepository', () => {
   it('uploads assets with audit log enabled when specified if required metadata is present', async () => {
     isAuditLogEnabled = true;
     const assetAuditData = {
-      conversationId: {domain: 'domain', id: 'id'},
+      convId: {domain: 'domain', id: 'id'},
       filename: 'filename',
       filetype: 'filetype',
     };
@@ -167,7 +167,7 @@ describe('AssetRepository', () => {
   it('does not upload asset when audit log is enabled and required metadata is missing', async () => {
     isAuditLogEnabled = true;
     const assetAuditData = {
-      conversationId: {domain: 'domain', id: 'id'},
+      convId: {domain: 'domain', id: 'id'},
       filename: 'filename',
       filetype: '',
     };

--- a/src/script/repositories/assets/AssetRepository.ts
+++ b/src/script/repositories/assets/AssetRepository.ts
@@ -252,10 +252,7 @@ export class AssetRepository {
 
     if (isAuditLogEnabled) {
       const isIncompleteAuditData =
-        !options.auditData ||
-        !options.auditData.conversationId ||
-        !options.auditData.filename ||
-        !options.auditData.filetype;
+        !options.auditData || !options.auditData.convId || !options.auditData.filename || !options.auditData.filetype;
       if (isIncompleteAuditData) {
         this.removeFromUploadQueue(messageId);
         throw new Error('Audit data is incomplete, file cannot be uploaded');

--- a/src/script/repositories/conversation/MessageRepository.ts
+++ b/src/script/repositories/conversation/MessageRepository.ts
@@ -709,7 +709,7 @@ export class MessageRepository {
 
     const auditData: AssetAuditData | undefined = isAuditLogEnabled
       ? {
-          conversationId: conversation.qualifiedId,
+          convId: conversation.qualifiedId,
           filename: meta.name,
           filetype: meta.type,
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8510,9 +8510,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^27.79.1":
-  version: 27.79.1
-  resolution: "@wireapp/api-client@npm:27.79.1"
+"@wireapp/api-client@npm:^27.80.1":
+  version: 27.80.1
+  resolution: "@wireapp/api-client@npm:27.80.1"
   dependencies:
     "@aws-sdk/client-s3": "npm:3.908.0"
     "@aws-sdk/lib-storage": "npm:3.908.0"
@@ -8531,7 +8531,7 @@ __metadata:
     uuid: "npm:11.1.0"
     ws: "npm:8.18.1"
     zod: "npm:3.24.2"
-  checksum: 10/3dc09f0c036d270f5ae5dc4fcb1026930cb88f9e329bafa2150a5e29c8b543c5d16448580e6811697a2e420c34da03bcd7fe9654274c66a1c31b718286292180
+  checksum: 10/26257b3c0891c588007f205033c4d741d71b4173c752465df27cc3c7e90c1dcccd9ef2c23198ab1f4355e0618d0a7dc30f04e0039c87f231d0bd86ce8b75cd5b
   languageName: node
   linkType: hard
 
@@ -8596,11 +8596,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:46.39.7":
-  version: 46.39.7
-  resolution: "@wireapp/core@npm:46.39.7"
+"@wireapp/core@npm:46.39.10":
+  version: 46.39.10
+  resolution: "@wireapp/core@npm:46.39.10"
   dependencies:
-    "@wireapp/api-client": "npm:^27.79.1"
+    "@wireapp/api-client": "npm:^27.80.1"
     "@wireapp/commons": "npm:^5.4.5"
     "@wireapp/core-crypto": "npm:9.1.0"
     "@wireapp/cryptobox": "npm:12.8.0"
@@ -8618,7 +8618,7 @@ __metadata:
     long: "npm:^5.2.0"
     uuid: "npm:9.0.1"
     zod: "npm:3.24.2"
-  checksum: 10/1a3219376790a2123e4ae25b1c16dd0c056c7fa0eb77dbb67630c5286b527a6b7a307b6799382106fde8b4c697a3c35b5d4e67259f12f95097e8c18316bf4ad8
+  checksum: 10/d310f147cf0cfe28adadd36747189a4dc1755de6bb1c7342fd4af1878960c427686d2ca20f01c2eedb14d9d7da929559fe25e8d06e1be7bf9ce36d61704aa693
   languageName: node
   linkType: hard
 
@@ -22506,7 +22506,7 @@ __metadata:
     "@wireapp/avs-debugger": "npm:0.0.7"
     "@wireapp/commons": "npm:5.4.5"
     "@wireapp/copy-config": "npm:2.3.4"
-    "@wireapp/core": "npm:46.39.7"
+    "@wireapp/core": "npm:46.39.10"
     "@wireapp/eslint-config": "npm:3.0.7"
     "@wireapp/kalium-backup": "npm:0.0.4"
     "@wireapp/prettier-config": "npm:0.6.5"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20666" title="WPB-20666" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-20666</a>  [Web] [webapp] add metadata to fileUploads
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

use the correct convId key expected by the api, see https://staging-nginz-https.zinfra.io/v12/api/swagger-ui/#/default/assets-upload

- bump core to 46.39.10 see https://github.com/wireapp/wire-web-packages/pull/7462
- use `conId` instead on `conversationId` as the key passed to the assets API 

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
