### PR TITLE
runfix(cells): delete cells node when deleting a message permanently [WPB-16851]

### DIFF
--- a/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.test.tsx
+++ b/src/script/page/RightSidebar/ConversationDetails/ConversationDetails.test.tsx
@@ -20,6 +20,7 @@
 import {act, render} from '@testing-library/react';
 import {CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation';
 
+import {CellsRepository} from 'Repositories/cells/CellsRepository';
 import {ConnectionRepository} from 'Repositories/connection/ConnectionRepository';
 import {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
 import {ConversationRoleRepository} from 'Repositories/conversation/ConversationRoleRepository';
@@ -85,6 +86,7 @@ const getDefaultParams = () => {
   return {
     actionsViewModel: new ActionsViewModel(
       {} as SelfRepository,
+      {} as CellsRepository,
       {} as ConnectionRepository,
       conversationRepository,
       {} as IntegrationRepository,

--- a/src/script/repositories/cells/CellsRepository.ts
+++ b/src/script/repositories/cells/CellsRepository.ts
@@ -113,6 +113,12 @@ export class CellsRepository {
     return this.apiClient.api.cells.deleteNode({uuid, permanently});
   }
 
+  async deleteNodes({uuids, permanently = false}: {uuids: string[]; permanently?: boolean}) {
+    uuids.forEach(async uuid => {
+      await this.deleteNode({uuid, permanently});
+    });
+  }
+
   async moveNode({currentPath, targetPath}: {currentPath: string; targetPath: string}) {
     return this.apiClient.api.cells.moveNode({currentPath, targetPath});
   }

--- a/src/script/repositories/conversation/MessageRepository.ts
+++ b/src/script/repositories/conversation/MessageRepository.ts
@@ -666,6 +666,30 @@ export class MessageRepository {
   }
 
   /**
+   * Get Cells assets' attachments ids from a message.
+   *
+   * @param messageEntity Message to get attachments from
+   * @returns Array of attachment ids
+   */
+  public getCellsAssetAttachmentIds(messageEntity: Message): string[] {
+    if (!messageEntity.hasMultipartAsset || !messageEntity.isContent()) {
+      return [];
+    }
+
+    const multipartAsset = messageEntity.getFirstAsset();
+    if (!multipartAsset || !multipartAsset.isMultipart()) {
+      return [];
+    }
+
+    const attachments = multipartAsset.attachments?.() ?? [];
+    const cellsAttachmentsIds = attachments.flatMap(attachment =>
+      attachment.cellAsset?.uuid ? [attachment.cellAsset.uuid] : [],
+    );
+
+    return cellsAttachmentsIds;
+  }
+
+  /**
    * Create asset metadata message to specified conversation.
    */
   private async createAssetMetadata(

--- a/src/script/repositories/entity/message/Message.ts
+++ b/src/script/repositories/entity/message/Message.ts
@@ -195,6 +195,10 @@ export class Message {
     return this.isContent() ? this.assets().some(assetEntity => assetEntity.isText()) : false;
   }
 
+  hasMultipartAsset(): boolean {
+    return this.isContent() ? this.assets().some(assetEntity => assetEntity.type === AssetType.MULTIPART) : false;
+  }
+
   /**
    * Check if message is a call message.
    * @returns Is message of type call

--- a/src/script/view_model/ActionsViewModel.ts
+++ b/src/script/view_model/ActionsViewModel.ts
@@ -251,11 +251,20 @@ export class ActionsViewModel {
 
   readonly deleteMessageEveryone = (conversationEntity: Conversation, messageEntity: Message): Promise<void> => {
     if (conversationEntity && messageEntity) {
+      const cellsAssets = this.messageRepository.getCellsAssetAttachmentIds(messageEntity);
+
+      const deleteMessage = async () => {
+        if (cellsAssets.length > 0) {
+          await this.cellsRepository.deleteNodes({uuids: cellsAssets, permanently: true});
+        }
+        await this.messageRepository.deleteMessageForEveryone(conversationEntity, messageEntity);
+      };
+
       return new Promise(resolve => {
         PrimaryModal.show(PrimaryModal.type.CONFIRM, {
           primaryAction: {
             action: async () => {
-              await this.messageRepository.deleteMessageForEveryone(conversationEntity, messageEntity);
+              await deleteMessage();
               resolve();
             },
             text: t('modalConversationDeleteMessageEveryoneAction'),

--- a/src/script/view_model/ActionsViewModel.ts
+++ b/src/script/view_model/ActionsViewModel.ts
@@ -26,6 +26,7 @@ import {container} from 'tsyringe';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {PrimaryModal, removeCurrentModal, usePrimaryModalState} from 'Components/Modals/PrimaryModal';
+import {CellsRepository} from 'Repositories/cells/CellsRepository';
 import type {ClientEntity} from 'Repositories/client';
 import type {ConnectionRepository} from 'Repositories/connection/ConnectionRepository';
 import type {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
@@ -46,6 +47,7 @@ import type {MainViewModel} from './MainViewModel';
 export class ActionsViewModel {
   constructor(
     private readonly selfRepository: SelfRepository,
+    private readonly cellsRepository: CellsRepository,
     private readonly connectionRepository: ConnectionRepository,
     private readonly conversationRepository: ConversationRepository,
     private readonly integrationRepository: IntegrationRepository,

--- a/src/script/view_model/MainViewModel.ts
+++ b/src/script/view_model/MainViewModel.ts
@@ -108,6 +108,7 @@ export class MainViewModel {
 
     this.actions = new ActionsViewModel(
       repositories.self,
+      repositories.cells,
       repositories.connection,
       repositories.conversation,
       repositories.integration,


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16851" title="WPB-16851" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16851</a>  [Web] Deleting a multipart message deletes files on the server (pydio)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

When deleting a message for everyone in the conversation list, the assets contained in the message would stay uploaded to cells and available in the files tab.

This deletes permamnently Cells assets included in the message when deleting the message from the list

<!-- Uncomment this section if your PR has UI changes -->

## Screenshots/Screencast (for UI changes)
After
![Kooha-2025-10-20-13-47-47](https://github.com/user-attachments/assets/5e440a0a-6d0e-4058-b7e6-724fef76febb)


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
