### PR TITLE
runfix(cells): use two lines for attachments names [WPB-20813]

### DIFF
--- a/src/script/components/FileCard/FileCardName/FileCardName.styles.ts
+++ b/src/script/components/FileCard/FileCardName/FileCardName.styles.ts
@@ -28,7 +28,6 @@ export const textStyles: CSSObject = {
   WebkitBoxOrient: 'vertical',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
   marginTop: '4px',
 
   '[data-file-card="header"] &': {

--- a/src/script/components/FileCard/FileCardName/FileCardName.tsx
+++ b/src/script/components/FileCard/FileCardName/FileCardName.tsx
@@ -32,7 +32,7 @@ interface FileCardNameProps {
   variant?: 'primary' | 'secondary';
 }
 
-export const FileCardName = ({truncateAfterLines = 1, variant = 'primary'}: FileCardNameProps) => {
+export const FileCardName = ({truncateAfterLines = 2, variant = 'primary'}: FileCardNameProps) => {
   const {name} = useFileCardContext();
 
   return (


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20813" title="WPB-20813" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20813</a>  [Web] Attachment texts can overlap in case of long names.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Use 2 lines instead of 1 for attachments with a long name
- wrap if the name is more than 1 line
- use an ellipsis after the 2nd line

<!-- Uncomment this section if your PR has UI changes -->

## Screenshots/Screencast (for UI changes)
Before
<img width="575" height="265" alt="image" src="https://github.com/user-attachments/assets/3f08c083-34b7-4bb7-a185-62017e1d1737" />
<img width="575" height="265" alt="image" src="https://github.com/user-attachments/assets/845c7904-5e3c-421e-8a49-63eb5cc671c0" />

After
<img width="575" height="265" alt="Screenshot From 2025-10-27 15-04-31" src="https://github.com/user-attachments/assets/33ad5cd8-37db-4467-a8e2-a3d2d188316c" />
<img width="575" height="265" alt="image" src="https://github.com/user-attachments/assets/4775cb61-e1d5-4072-b31b-94c48128b8c6" />


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
