### PR TITLE
runfix(cells): correctly truncate lines for attachment names [WPB-20813]

### DIFF
--- a/src/script/components/FileCard/FileCardName/FileCardName.tsx
+++ b/src/script/components/FileCard/FileCardName/FileCardName.tsx
@@ -32,7 +32,7 @@ interface FileCardNameProps {
   variant?: 'primary' | 'secondary';
 }
 
-export const FileCardName = ({truncateAfterLines = 2, variant = 'primary'}: FileCardNameProps) => {
+export const FileCardName = ({truncateAfterLines = 1, variant = 'primary'}: FileCardNameProps) => {
   const {name} = useFileCardContext();
 
   return (


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20813" title="WPB-20813" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20813</a>  [Web] Attachment texts can overlap in case of long names.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Mistake in this PR https://github.com/wireapp/wire-webapp/pull/19710

the `truncateAfterLines` prop didn't need to be set to 2 by default as it's correctly set by the component.
The fix in the previous PR was to remove `whiteSpace: 'nowrap'`, changing  `truncateAfterLines` is a mistake.

See component where the prop is correctly set to 2  [here](https://github.com/wireapp/wire-webapp/blob/dev/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/FileAssetCard/FileAssetSmall/FileAssetSmall.tsx#L73)
```ts
 <FileCard.Name variant={isError ? 'secondary' : 'primary'} truncateAfterLines={2} />
 ```

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
