### PR TITLE
runfix(cells): ignore 401 error when no cells conversations exist [WPB-20957]

### DIFF
--- a/src/script/components/CellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.ts
+++ b/src/script/components/CellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.ts
@@ -104,7 +104,14 @@ export const useSearchCellsNodes = ({
 
         setStatus('success');
       } catch (error) {
-        setStatus('error');
+        // If the user isn't part of any cells-enabled conversations, the user will not exist in Cells database
+        // the search will return a 401 error
+        const hasCellsConversations = conversationRepository.getAllCellEnabledGroupConversations().length > 0;
+        if (!hasCellsConversations) {
+          setStatus('success');
+        } else {
+          setStatus('error');
+        }
         setNodes([]);
         setPagination(null);
       }

--- a/src/script/repositories/conversation/ConversationRepository.ts
+++ b/src/script/repositories/conversation/ConversationRepository.ts
@@ -26,6 +26,7 @@ import {
   MessageSendingStatus,
   RemoteConversations,
   ADD_PERMISSION,
+  CONVERSATION_CELLS_STATE,
 } from '@wireapp/api-client/lib/conversation';
 import {
   MemberLeaveReason,
@@ -1283,6 +1284,19 @@ export class ConversationRepository {
    */
   public readonly getAllGroupConversations = (): Conversation[] => {
     return this.conversationState.conversations().filter(conversation => conversation.isGroupOrChannel());
+  };
+
+  /**
+   * Get all the group conversations with Cells enabled.
+   */
+  public readonly getAllCellEnabledGroupConversations = (): Conversation[] => {
+    return this.conversationState
+      .conversations()
+      .filter(
+        conversation =>
+          conversation.cellsState() === CONVERSATION_CELLS_STATE.READY ||
+          conversation.cellsState() === CONVERSATION_CELLS_STATE.PENDING,
+      );
   };
 
   /**


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20957" title="WPB-20957" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20957</a>  [Web] Empty state screen for all files
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

A user only exists on the Cells backend if they are part of an existing conversation
It has the unintended consequence of throwing a `401 unauthorized` error when attempting to query the Cells api witout being part of a conversation with cells enabled.

We can ignore the error if a user is trying to query the API without existing Cells conversation and return an empty state instead

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
