### PR TITLE
chore: Add debug button to manually reset MLS conversation [WPB-21541]

### DIFF
--- a/src/script/components/ConfigToolbar/ConfigToolbar.tsx
+++ b/src/script/components/ConfigToolbar/ConfigToolbar.tsx
@@ -32,6 +32,7 @@ import {wrapperStyles} from './ConfigToolbar.styles';
 
 export function ConfigToolbar() {
   const [showConfig, setShowConfig] = useState(false);
+  const [isResettingMLSConversation, setIsResettingMLSConversation] = useState(false);
   const [isGzipEnabled, setIsGzipEnabled] = useState(window.wire?.app.debug?.isGzippingEnabled() || false);
   const [configFeaturesState, setConfigFeaturesState] = useState<Configuration['FEATURE']>(Config.getConfig().FEATURE);
   const [isMessageSendingActive, setIsMessageSendingActive] = useState(false);
@@ -236,6 +237,17 @@ export function ConfigToolbar() {
     );
   };
 
+  const resetMLSConversation = async () => {
+    setIsResettingMLSConversation(true);
+    try {
+      await window.wire?.app?.debug?.resetMLSConversation();
+    } catch (error) {
+      console.error('Error resetting MLS conversation:', error);
+    } finally {
+      setIsResettingMLSConversation(false);
+    }
+  };
+
   if (!showConfig) {
     return null;
   }
@@ -252,9 +264,14 @@ export function ConfigToolbar() {
 
       <h3>Debug Functions</h3>
 
-      <Button onClick={() => window.wire?.app?.debug?.reconnectWebSocket()}>reconnectWebSocket</Button>
-      <Button onClick={() => window.wire?.app?.debug?.enablePressSpaceToUnmute()}>enablePressSpaceToUnmute</Button>
-      <Button onClick={() => window.wire?.app?.debug?.disablePressSpaceToUnmute()}>disablePressSpaceToUnmute</Button>
+      <Button onClick={() => window.wire?.app?.debug?.reconnectWebSocket()}>Reconnect WebSocket</Button>
+      <Button onClick={() => window.wire?.app?.debug?.enablePressSpaceToUnmute()}>Enable Press Space To Unmute</Button>
+      <Button onClick={() => window.wire?.app?.debug?.disablePressSpaceToUnmute()}>
+        Disable Press Space To Unmute
+      </Button>
+      <Button disabled={isResettingMLSConversation} onClick={resetMLSConversation}>
+        Reset MLS Conversation
+      </Button>
 
       <div>{renderAvsSwitch()}</div>
 

--- a/src/script/util/DebugUtil.ts
+++ b/src/script/util/DebugUtil.ts
@@ -271,6 +271,12 @@ export class DebugUtil {
     this.propertiesRepository.savePreference(PROPERTIES_TYPE.CALL.ENABLE_PRESS_SPACE_TO_UNMUTE, false);
   }
 
+  async resetMLSConversation() {
+    return (this.core.service?.conversation as any).resetMLSConversation(
+      this.conversationState.activeConversation()?.qualifiedId,
+    );
+  }
+
   setupAvsDebugger() {
     if (this.isEnabledAvsDebugger()) {
       this.enableAvsDebugger(true);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21541" title="WPB-21541" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21541</a>  [Web] Add debug button to trigger MLS group reset
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Will directly call core's reset method to trigger a manual reset of a MLS conversation
