### PR TITLE
chore(e2e): Fixing cells e2e test to have files disabled by default [WPB-21542]

### DIFF
--- a/test/e2e_tests/pageManager/webapp/pages/groupCreation.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/groupCreation.page.ts
@@ -57,8 +57,13 @@ export class GroupCreationPage {
     await this.addMembersButton.click();
   }
 
+  async enableFilesCheckbox() {
+    await this.filesCheckbox.click();
+  }
+
   async isFilesCheckboxChecked() {
-    return this.filesCheckbox.isEnabled();
+    const value = await this.filesCheckbox.getAttribute('data-uie-value');
+    return value === 'checked';
   }
 
   async waitForModalClose() {

--- a/test/e2e_tests/specs/CriticalFlow/Cells/uploadingFileInGroupConversation.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/Cells/uploadingFileInGroupConversation.spec.ts
@@ -71,10 +71,11 @@ test(
           await userAModals.dataShareConsent().clickDecline();
         }
         await userAPages.conversationList().clickCreateGroup();
-        // Files should be enabled by default
-        expect(await userAPages.groupCreation().isFilesCheckboxChecked()).toBeTruthy();
-        await userAPages.groupCreation().setGroupName(conversationName);
+        // Files should be disabled by default
+        expect(await userAPages.groupCreation().isFilesCheckboxChecked()).toBeFalsy();
 
+        await userAPages.groupCreation().enableFilesCheckbox();
+        await userAPages.groupCreation().setGroupName(conversationName);
         await userAPages.startUI().selectUsers([userB.username]);
         await userAPages.groupCreation().clickCreateGroupButton();
       };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21542" title="WPB-21542" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21542</a>  [Web] Update cells e2e test so that Files are disabled by default when creating a group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

https://wearezeta.atlassian.net/browse/WPB-21542

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

Changed the check so that Files option is expected to be disabled by default when creating a new group in cells-enabled team.

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
