### PR TITLE
revert: Revert "chore: Revert "runfix: Search result is scrolledTo in Virtual List" [WPB-20674]

### DIFF
--- a/src/script/components/MessagesList/MessageList.tsx
+++ b/src/script/components/MessagesList/MessageList.tsx
@@ -307,7 +307,6 @@ export const MessagesList: FC<MessagesListParams> = ({
                 : undefined;
 
               const key = `${message.id || 'message'}-${message.timestamp()}`;
-
               const isHighlighted = !!highlightedMessage && highlightedMessage === message.id;
               const isFocused = !!focusedId && focusedId === message.id;
 

--- a/src/script/components/MessagesList/VirtualizedMessagesList/VirtualizedMessagesList.tsx
+++ b/src/script/components/MessagesList/VirtualizedMessagesList/VirtualizedMessagesList.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {MutableRefObject, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
+import {MutableRefObject, useCallback, useEffect, useLayoutEffect, useMemo, useState} from 'react';
 
 import {useVirtualizer} from '@tanstack/react-virtual';
 import cx from 'classnames';
@@ -180,15 +180,11 @@ export const VirtualizedMessagesList = ({
     }
   }, []);
 
-  const scrolledToHighlightedMessage = useRef(false);
-
   const onTimestampClick = async (messageId: string) => {
-    scrolledToHighlightedMessage.current = false;
     setHighlightedMessage(messageId);
 
     const clearHighlightedMessage = setTimeout(() => {
       setHighlightedMessage(undefined);
-      scrolledToHighlightedMessage.current = false;
       clearTimeout(clearHighlightedMessage);
     }, 5000);
 
@@ -201,21 +197,27 @@ export const VirtualizedMessagesList = ({
     }
   };
 
-  useLayoutEffect(() => {
-    if (highlightedMessage && !scrolledToHighlightedMessage.current) {
-      const highlightedMessageIndex = groupedMessages.findIndex(
-        msg => !isMarker(msg) && msg.message.id === highlightedMessage,
-      );
+  useEffect(() => {
+    // setTimeout is a workaround for smoother scrolling in virtualizer
+    // also without, creates race condition with scrolledToHighlightedMessage
+    // https://github.com/TanStack/virtual/issues/216
+    const setScrolledToHighlightedMessageTimeout = setTimeout(() => {
+      // When we have a highlighted message, that is not visible yet, find the index
+      if (highlightedMessage) {
+        const highlightedMessageIndex = groupedMessages.findIndex(
+          msg => !isMarker(msg) && msg.message.id === highlightedMessage,
+        );
 
-      if (highlightedMessageIndex !== -1) {
-        virtualizer.scrollToIndex(highlightedMessageIndex, {align: 'center'});
-        scrolledToHighlightedMessage.current = true;
-
-        const setScrolledToHighlightedMessageTimeout = setTimeout(() => {
-          clearTimeout(setScrolledToHighlightedMessageTimeout);
-        }, 100);
+        // scroll the index if the message is there and not a timestamp
+        if (highlightedMessageIndex !== -1) {
+          virtualizer.scrollToIndex(highlightedMessageIndex, {align: 'start'});
+        }
+        clearTimeout(setScrolledToHighlightedMessageTimeout);
+        setTimeout(() => {
+          setHighlightedMessage(undefined);
+        }, 1000); // set to time of animation of highlightedMessage - @todo create const for animation time
       }
-    }
+    }, 100);
   }, [groupedMessages, highlightedMessage]);
 
   const onJumpToLastMessageClick = async () => {

--- a/test/e2e_tests/specs/RegressionSpecs/scroll-to-highlighted-message.spec.ts
+++ b/test/e2e_tests/specs/RegressionSpecs/scroll-to-highlighted-message.spec.ts
@@ -1,0 +1,192 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {PageManager} from 'test/e2e_tests/pageManager';
+import {addCreatedUser, removeCreatedUser} from 'test/e2e_tests/utils/tearDown.util';
+import {loginUser} from 'test/e2e_tests/utils/userActions';
+
+import {getUser} from '../../data/user';
+import {test, expect} from '../../test.fixtures';
+
+// Generating test data
+const userA = getUser();
+const userB = getUser();
+
+test(
+  'Scroll to highlighted message',
+  {tag: ['@regression']},
+  async ({pageManager: userAPageManager, api, browser, page: userAPage}) => {
+    test.slow(); // Increasing test timeout to 90 seconds to accommodate the full flow
+
+    const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
+    const userBContext = await browser.newContext();
+    const userBPage = await userBContext.newPage();
+    const userBPageManager = PageManager.from(userBPage);
+    const {pages: userBPages, modals: userBModals} = userBPageManager.webapp;
+
+    const messages = [
+      'First message in conversation',
+      'Second message',
+      'Third message',
+      'Fourth message',
+      'Fifth message',
+      'Message to be highlighted',
+      'Seventh message',
+      'Eighth message',
+      'Ninth message',
+      'Tenth message',
+    ];
+
+    await test.step('Preconditions: Creating users via API', async () => {
+      await api.createPersonalUser(userA);
+      addCreatedUser(userA);
+
+      await api.createPersonalUser(userB);
+      addCreatedUser(userB);
+
+      await api.connectUsers(userA, userB);
+    });
+
+    await test.step('Users A and B are signed in to the application', async () => {
+      await Promise.all([
+        (async () => {
+          await userAPageManager.openMainPage();
+          await loginUser(userA, userAPageManager);
+          await userAModals.dataShareConsent().clickDecline();
+        })(),
+
+        (async () => {
+          await userBPageManager.openMainPage();
+          await loginUser(userB, userBPageManager);
+          await userBModals.dataShareConsent().clickDecline();
+        })(),
+      ]);
+    });
+
+    await test.step('User A sends multiple messages to create a scrollable conversation', async () => {
+      await userAPages.conversationList().openConversation(userB.fullName);
+
+      // Send messages to create a long conversation
+      for (const message of messages) {
+        await userAPages.conversation().sendMessage(message);
+      }
+    });
+
+    await test.step('User B receives the messages', async () => {
+      await userBPages.conversationList().openConversation(userA.fullName);
+
+      // Verify the last message is visible
+      expect(await userBPages.conversation().isMessageVisible(messages[messages.length - 1])).toBeTruthy();
+    });
+
+    await test.step('User B clicks on message timestamp to highlight and scroll to a specific message', async () => {
+      // Get the message to be highlighted (6th message in the list)
+      const messageToHighlight = messages[5]; // "Message to be highlighted"
+      const messageLocator = userBPage.locator(`[data-uie-name="item-message"]`, {
+        has: userBPage.locator('.text', {hasText: messageToHighlight}),
+      });
+
+      // Click on the message timestamp
+      const timestampLocator = messageLocator.locator('[data-uie-name="message-timestamp"]');
+      await timestampLocator.click();
+
+      // Wait for scroll animation (100ms initial timeout + time for scroll)
+      await userBPage.waitForTimeout(200);
+
+      // Verify the message is now visible and highlighted
+      const highlightedMessage = userBPage.locator('[data-uie-name="item-message"].message-highlighted', {
+        has: userBPage.locator('.text', {hasText: messageToHighlight}),
+      });
+
+      expect(await highlightedMessage.isVisible()).toBeTruthy();
+    });
+
+    await test.step('Highlighted state is removed after animation completes', async () => {
+      const messageToHighlight = messages[5];
+
+      // Wait for the highlight to be cleared (1000ms timeout)
+      await userBPage.waitForTimeout(1100);
+
+      // Verify the message is no longer highlighted
+      const highlightedMessage = userBPage.locator('[data-uie-name="item-message"].message-highlighted', {
+        has: userBPage.locator('.text', {hasText: messageToHighlight}),
+      });
+
+      expect(await highlightedMessage.count()).toBe(0);
+    });
+
+    await test.step('Scroll to different message via timestamp click', async () => {
+      // Scroll to bottom first
+      await userBPages.conversation().sendMessage('New bottom message');
+      await userBPage.waitForTimeout(500);
+
+      // Click on a different message timestamp (3rd message)
+      const messageToHighlight = messages[2]; // "Third message"
+      const messageLocator = userBPage.locator(`[data-uie-name="item-message"]`, {
+        has: userBPage.locator('.text', {hasText: messageToHighlight}),
+      });
+
+      const timestampLocator = messageLocator.locator('[data-uie-name="message-timestamp"]');
+      await timestampLocator.click();
+
+      // Wait for scroll animation
+      await userBPage.waitForTimeout(200);
+
+      // Verify the message is now visible and highlighted
+      const highlightedMessage = userBPage.locator('[data-uie-name="item-message"].message-highlighted', {
+        has: userBPage.locator('.text', {hasText: messageToHighlight}),
+      });
+
+      expect(await highlightedMessage.isVisible()).toBeTruthy();
+    });
+
+    await test.step('User A can also scroll to highlighted message', async () => {
+      // Scroll to bottom
+      const lastMessage = 'A new message from A';
+      await userAPages.conversation().sendMessage(lastMessage);
+      await userAPage.waitForTimeout(500);
+
+      // Click on timestamp of earlier message
+      const messageToHighlight = messages[4]; // "Fifth message"
+      const messageLocator = userAPage.locator(`[data-uie-name="item-message"]`, {
+        has: userAPage.locator('.text', {hasText: messageToHighlight}),
+      });
+
+      const timestampLocator = messageLocator.locator('[data-uie-name="message-timestamp"]');
+      await timestampLocator.click();
+
+      // Wait for scroll animation
+      await userAPage.waitForTimeout(200);
+
+      // Verify the message is highlighted
+      const highlightedMessage = userAPage.locator('[data-uie-name="item-message"].message-highlighted', {
+        has: userAPage.locator('.text', {hasText: messageToHighlight}),
+      });
+
+      expect(await highlightedMessage.isVisible()).toBeTruthy();
+    });
+
+    await userBContext.close();
+  },
+);
+
+test.afterAll(async ({api}) => {
+  await removeCreatedUser(api, userA);
+  await removeCreatedUser(api, userB);
+});

--- a/test/unit_tests/components/MessagesList/useScrollToHighlightedMessage.test.ts
+++ b/test/unit_tests/components/MessagesList/useScrollToHighlightedMessage.test.ts
@@ -1,0 +1,221 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {useEffect} from 'react';
+
+import {renderHook} from '@testing-library/react';
+
+import {isMarker} from 'Components/MessagesList/utils/virtualizedMessagesGroup';
+
+// Mock the isMarker function
+jest.mock('Components/MessagesList/utils/virtualizedMessagesGroup', () => ({
+  isMarker: jest.fn(),
+}));
+
+describe('useScrollToHighlightedMessage', () => {
+  // Mock virtualizer
+  const mockScrollToIndex = jest.fn();
+  const mockVirtualizer = {
+    scrollToIndex: mockScrollToIndex,
+  };
+
+  // Mock messages
+  const mockMessage1 = {message: {id: 'msg-1'}};
+  const mockMessage2 = {message: {id: 'msg-2'}};
+  const mockMessage3 = {message: {id: 'msg-3'}};
+  const mockMarker = {type: 'timestamp'};
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(isMarker).mockImplementation((item: any) => item.type === 'timestamp');
+  });
+
+  // Helper to simulate the useEffect hook
+  const useScrollToHighlightedMessage = (
+    groupedMessages: any[],
+    highlightedMessage: string | undefined,
+    setHighlightedMessage: (value: string | undefined) => void,
+  ) => {
+    useEffect(() => {
+      // setTimeout is a workaround for smoother scrolling in virtualizer
+      // also without, creates race condition with scrolledToHighlightedMessage
+      // https://github.com/TanStack/virtual/issues/216
+      const setScrolledToHighlightedMessageTimeout = setTimeout(() => {
+        // When we have a highlighted message, that is not visible yet, find the index
+        if (highlightedMessage) {
+          const highlightedMessageIndex = groupedMessages.findIndex(
+            msg => !isMarker(msg) && msg.message.id === highlightedMessage,
+          );
+
+          // scroll the index if the message is there and not a timestamp
+          if (highlightedMessageIndex !== -1) {
+            mockVirtualizer.scrollToIndex(highlightedMessageIndex, {align: 'start'});
+          }
+          clearTimeout(setScrolledToHighlightedMessageTimeout);
+          setTimeout(() => {
+            setHighlightedMessage(undefined);
+          }, 1000); // set to time of animation of highlightedMessage - @todo create const for animation time
+        }
+      }, 100);
+    }, [groupedMessages, highlightedMessage]);
+  };
+
+  it('should not scroll when highlightedMessage is undefined', () => {
+    const setHighlightedMessage = jest.fn();
+    const groupedMessages = [mockMessage1, mockMessage2, mockMessage3];
+
+    renderHook(() => useScrollToHighlightedMessage(groupedMessages, undefined, setHighlightedMessage));
+
+    jest.advanceTimersByTime(100);
+
+    expect(mockScrollToIndex).not.toHaveBeenCalled();
+    expect(setHighlightedMessage).not.toHaveBeenCalled();
+  });
+
+  it('should scroll to the highlighted message index when found', () => {
+    const setHighlightedMessage = jest.fn();
+    const groupedMessages = [mockMessage1, mockMessage2, mockMessage3];
+
+    renderHook(() => useScrollToHighlightedMessage(groupedMessages, 'msg-2', setHighlightedMessage));
+
+    jest.advanceTimersByTime(100);
+
+    expect(mockScrollToIndex).toHaveBeenCalledWith(1, {align: 'start'});
+  });
+
+  it('should clear highlighted message after 1000ms', () => {
+    const setHighlightedMessage = jest.fn();
+    const groupedMessages = [mockMessage1, mockMessage2, mockMessage3];
+
+    renderHook(() => useScrollToHighlightedMessage(groupedMessages, 'msg-2', setHighlightedMessage));
+
+    // Advance past the initial scroll timeout
+    jest.advanceTimersByTime(100);
+
+    expect(setHighlightedMessage).not.toHaveBeenCalled();
+
+    // Advance to clear highlighted message
+    jest.advanceTimersByTime(1000);
+
+    expect(setHighlightedMessage).toHaveBeenCalledWith(undefined);
+  });
+
+  it('should not scroll when highlighted message is not found in groupedMessages', () => {
+    const setHighlightedMessage = jest.fn();
+    const groupedMessages = [mockMessage1, mockMessage2, mockMessage3];
+
+    renderHook(() => useScrollToHighlightedMessage(groupedMessages, 'msg-nonexistent', setHighlightedMessage));
+
+    jest.advanceTimersByTime(100);
+
+    expect(mockScrollToIndex).not.toHaveBeenCalled();
+    // Should still clear the highlighted message
+    jest.advanceTimersByTime(1000);
+    expect(setHighlightedMessage).toHaveBeenCalledWith(undefined);
+  });
+
+  it('should skip marker items when finding the message index', () => {
+    const setHighlightedMessage = jest.fn();
+    const groupedMessages = [mockMarker, mockMessage1, mockMessage2, mockMessage3];
+
+    renderHook(() => useScrollToHighlightedMessage(groupedMessages, 'msg-2', setHighlightedMessage));
+
+    jest.advanceTimersByTime(100);
+
+    // Should find message at index 2 (skipping marker at index 0)
+    expect(mockScrollToIndex).toHaveBeenCalledWith(2, {align: 'start'});
+  });
+
+  it('should re-execute when highlightedMessage changes', () => {
+    const setHighlightedMessage = jest.fn();
+    const groupedMessages = [mockMessage1, mockMessage2, mockMessage3];
+
+    const {rerender} = renderHook(
+      ({highlightedMsg}) => useScrollToHighlightedMessage(groupedMessages, highlightedMsg, setHighlightedMessage),
+      {initialProps: {highlightedMsg: 'msg-1'}},
+    );
+
+    jest.advanceTimersByTime(100);
+    expect(mockScrollToIndex).toHaveBeenCalledWith(0, {align: 'start'});
+
+    // Change highlighted message
+    rerender({highlightedMsg: 'msg-3'});
+    jest.advanceTimersByTime(100);
+
+    expect(mockScrollToIndex).toHaveBeenCalledWith(2, {align: 'start'});
+    expect(mockScrollToIndex).toHaveBeenCalledTimes(2);
+  });
+
+  it('should re-execute when groupedMessages changes', () => {
+    const setHighlightedMessage = jest.fn();
+    const initialMessages = [mockMessage1, mockMessage2];
+
+    const {rerender} = renderHook(
+      ({messages}) => useScrollToHighlightedMessage(messages, 'msg-3', setHighlightedMessage),
+      {initialProps: {messages: initialMessages}},
+    );
+
+    jest.advanceTimersByTime(100);
+    // Message not found initially
+    expect(mockScrollToIndex).not.toHaveBeenCalled();
+
+    // Add message to the list
+    const updatedMessages = [...initialMessages, mockMessage3];
+    rerender({messages: updatedMessages});
+    jest.advanceTimersByTime(100);
+
+    // Now message should be found and scrolled to
+    expect(mockScrollToIndex).toHaveBeenCalledWith(2, {align: 'start'});
+  });
+
+  it('should wait 100ms before scrolling (timeout workaround)', () => {
+    const setHighlightedMessage = jest.fn();
+    const groupedMessages = [mockMessage1, mockMessage2, mockMessage3];
+
+    renderHook(() => useScrollToHighlightedMessage(groupedMessages, 'msg-2', setHighlightedMessage));
+
+    // Before timeout
+    jest.advanceTimersByTime(99);
+    expect(mockScrollToIndex).not.toHaveBeenCalled();
+
+    // After timeout
+    jest.advanceTimersByTime(1);
+    expect(mockScrollToIndex).toHaveBeenCalledWith(1, {align: 'start'});
+  });
+
+  it('should handle marker at the position of highlighted message', () => {
+    const setHighlightedMessage = jest.fn();
+    const groupedMessages = [mockMessage1, mockMarker, mockMessage2];
+
+    renderHook(() => useScrollToHighlightedMessage(groupedMessages, 'msg-2', setHighlightedMessage));
+
+    jest.advanceTimersByTime(100);
+
+    // Should find message at index 2, not confused by marker
+    expect(mockScrollToIndex).toHaveBeenCalledWith(2, {align: 'start'});
+  });
+});


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20674" title="WPB-20674" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20674</a>  [Web] Searching for a past message in channel no longer goes to selected message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Revert "chore: Revert "runfix: Search result is scrolledTo in Virtual List (#19643)" (#19697)"

This reverts commit 444c41b183d97a01bf815bf1efa8f10791077993.

Original PR: https://github.com/wireapp/wire-webapp/pull/19643 
Jira: https://wearezeta.atlassian.net/browse/WPB-20674 