### PR TITLE
test: remove util `isMessageVisible()` in favor of web first assertions

### DIFF
--- a/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -202,17 +202,26 @@ export class ConversationPage {
   }
 
   /**
-   * Util to get a message in the conversation sent by a given user
-   * @param user Optional parameter to specify user who sent the message. If undefined the last message matching the content will be returned.
+   * Util to get a message in the conversation
+   * @param options.content Only match messages containing this text
+   * @param options.sender Only match messages send by this user
+   * @returns a Locator to the matching message(s)
    */
-  getMessage(messageContent: string, user?: User) {
-    const message = this.messageItems.filter({hasText: messageContent});
+  getMessage(options?: {content?: string | RegExp; sender?: User}): Locator {
+    let message = this.messageItems;
 
-    if (user !== undefined) {
-      return message.filter({has: this.page.getByTestId('sender-name').getByText(user.fullName)});
+    if (options?.content) {
+      message = message.filter({hasText: options.content});
     }
 
-    return message.last();
+    if (options?.sender?.fullName) {
+      message = message.filter({
+        // Using getByLabel doesn't work here as the aria label is just placed on a div with no input inside which could be located
+        has: this.page.locator(`.content-message-wrapper[aria-label*="${options.sender.fullName}"]`),
+      });
+    }
+
+    return message;
   }
 
   /**

--- a/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -152,9 +152,7 @@ export class ConversationPage {
   async sendMessage(message: string) {
     await this.messageInput.fill(message);
     await this.sendMessageButton.click();
-    // Wait for the specific message to appear in the conversation
-    const messageLocator = this.messages.filter({hasText: message}).last();
-    await messageLocator.waitFor({state: 'visible', timeout: 20_000});
+    await this.isMessageVisible(message); // isMessageVisible not only checks for visibility but ensures the optimistic update was persisted
   }
 
   async typeMessage(message: string) {

--- a/test/e2e_tests/specs/AccountSettingsSpecs/accountSettings.spec.ts
+++ b/test/e2e_tests/specs/AccountSettingsSpecs/accountSettings.spec.ts
@@ -241,7 +241,7 @@ test.describe('account settings', () => {
       // check that the chat is open
       expect(await pages.conversationList().isConversationItemVisible(groupName)).toBeTruthy();
       await pages.conversation().sendMessage('test');
-      const message = pages.conversation().getMessage('test');
+      const message = pages.conversation().getMessage({content: 'test', sender: memberA});
 
       await expect(message.getByTestId('sender-name')).toHaveText(memberA.fullName);
 

--- a/test/e2e_tests/specs/AccountSettingsSpecs/accountSettings.spec.ts
+++ b/test/e2e_tests/specs/AccountSettingsSpecs/accountSettings.spec.ts
@@ -241,7 +241,7 @@ test.describe('account settings', () => {
       // check that the chat is open
       expect(await pages.conversationList().isConversationItemVisible(groupName)).toBeTruthy();
       await pages.conversation().sendMessage('test');
-      const message = await pages.conversation().messageItems.nth(1); // skip the system messages
+      const message = pages.conversation().getMessage('test');
 
       await expect(message.getByTestId('sender-name')).toHaveText(memberA.fullName);
 

--- a/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
@@ -122,49 +122,49 @@ test(
       // Now all members can send and receive encrypted messages
       // Team owner sends a message
       await pages.conversation().sendMessage(`Hello from ${owner.firstName}!`);
-      expect(await pages.conversation().isMessageVisible(`Hello from ${owner.firstName}!`)).toBeTruthy();
+      await expect(pages.conversation().getMessage(`Hello from ${owner.firstName}!`)).toBeVisible();
 
       // Member1 sends a message
       await member1PageManager.webapp.pages.conversation().sendMessage(`Hello from ${member1.firstName}!`);
-      expect(
-        await member1PageManager.webapp.pages.conversation().isMessageVisible(`Hello from ${member1.firstName}!`),
-      ).toBeTruthy();
+      await expect(
+        member1PageManager.webapp.pages.conversation().getMessage(`Hello from ${member1.firstName}!`),
+      ).toBeVisible();
 
       // Member2 sends a message
       await member2PageManager.webapp.pages.conversation().sendMessage(`Hello from ${member2.firstName}!`);
-      expect(
-        await member2PageManager.webapp.pages.conversation().isMessageVisible(`Hello from ${member2.firstName}!`),
-      ).toBeTruthy();
+      await expect(
+        member2PageManager.webapp.pages.conversation().getMessage(`Hello from ${member2.firstName}!`),
+      ).toBeVisible();
 
       // Owner verifies all messages are visible
       await pages.conversationList().openConversation(conversationName);
-      expect(await pages.conversation().isMessageVisible(`Hello from ${member1.firstName}!`)).toBeTruthy();
-      expect(await pages.conversation().isMessageVisible(`Hello from ${member2.firstName}!`)).toBeTruthy();
+      await expect(pages.conversation().getMessage(`Hello from ${member1.firstName}!`)).toBeVisible();
+      await expect(pages.conversation().getMessage(`Hello from ${member2.firstName}!`)).toBeVisible();
     });
 
     await test.step('Team owner and group members react on received messages with reactions', async () => {
       // Owner reacts to member1's message with +1 (thumbs up)
       await pages.conversationList().openConversation(conversationName);
-      const member1MessageForOwner = pages.conversation().getMessageByText(`Hello from ${member1.firstName}!`).first();
+      const member1MessageForOwner = pages.conversation().getMessage(`Hello from ${member1.firstName}!`).first();
       await member1MessageForOwner.waitFor({state: 'visible'}); // Wait for message to be ready
       await pages.conversation().reactOnMessage(member1MessageForOwner, 'plus-one');
 
       // Owner reacts to member2's message with +1 (thumbs up)
-      const member2MessageForOwner = pages.conversation().getMessageByText(`Hello from ${member2.firstName}!`).first();
+      const member2MessageForOwner = pages.conversation().getMessage(`Hello from ${member2.firstName}!`).first();
       await pages.conversation().reactOnMessage(member2MessageForOwner, 'plus-one');
 
       // Member1 reacts to owner's message with heart (❤️)
       await member1PageManager.webapp.pages.conversationList().openConversation(conversationName);
       const ownerMessageForMember1 = member1PageManager.webapp.pages
         .conversation()
-        .getMessageByText(`Hello from ${owner.firstName}!`)
+        .getMessage(`Hello from ${owner.firstName}!`)
         .first();
       await member1PageManager.webapp.pages.conversation().reactOnMessage(ownerMessageForMember1, 'heart');
 
       // Member1 reacts to member2's message with heart (❤️)
       const member2MessageForMember1 = member1PageManager.webapp.pages
         .conversation()
-        .getMessageByText(`Hello from ${member2.firstName}!`)
+        .getMessage(`Hello from ${member2.firstName}!`)
         .first();
       await member1PageManager.webapp.pages.conversation().reactOnMessage(member2MessageForMember1, 'heart');
 
@@ -172,14 +172,14 @@ test(
       await member2PageManager.webapp.pages.conversationList().openConversation(conversationName);
       const ownerMessageForMember2 = member2PageManager.webapp.pages
         .conversation()
-        .getMessageByText(`Hello from ${owner.firstName}!`)
+        .getMessage(`Hello from ${owner.firstName}!`)
         .first();
       await member2PageManager.webapp.pages.conversation().reactOnMessage(ownerMessageForMember2, 'joy');
 
       // Member2 reacts to member1's message with joy (😂)
       const member1MessageForMember2 = member2PageManager.webapp.pages
         .conversation()
-        .getMessageByText(`Hello from ${member1.firstName}!`)
+        .getMessage(`Hello from ${member1.firstName}!`)
         .first();
       await member2PageManager.webapp.pages.conversation().reactOnMessage(member1MessageForMember2, 'joy');
     });
@@ -187,7 +187,7 @@ test(
     await test.step('All group participants make sure they see reactions from other group participants', async () => {
       // Owner verifies they can see heart (❤️) and joy (😂) reactions on their message from member1 and member2
       await pages.conversationList().openConversation(conversationName);
-      const ownerMessage = pages.conversation().getMessageByText(`Hello from ${owner.firstName}!`);
+      const ownerMessage = pages.conversation().getMessage(`Hello from ${owner.firstName}!`);
       await expect(pages.conversation().getReactionOnMessage(ownerMessage, 'heart')).toBeVisible();
       await expect(pages.conversation().getReactionOnMessage(ownerMessage, 'joy')).toBeVisible();
 
@@ -195,7 +195,7 @@ test(
       await member1PageManager.webapp.pages.conversationList().openConversation(conversationName);
       const member1Message = member1PageManager.webapp.pages
         .conversation()
-        .getMessageByText(`Hello from ${member1.firstName}!`);
+        .getMessage(`Hello from ${member1.firstName}!`);
       await expect(
         member1PageManager.webapp.pages.conversation().getReactionOnMessage(member1Message, 'plus-one'),
       ).toBeVisible();
@@ -207,7 +207,7 @@ test(
       await member2PageManager.webapp.pages.conversationList().openConversation(conversationName);
       const member2Message = member2PageManager.webapp.pages
         .conversation()
-        .getMessageByText(`Hello from ${member2.firstName}!`);
+        .getMessage(`Hello from ${member2.firstName}!`);
       await expect(
         member2PageManager.webapp.pages.conversation().getReactionOnMessage(member2Message, 'plus-one'),
       ).toBeVisible();

--- a/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
@@ -122,72 +122,68 @@ test(
       // Now all members can send and receive encrypted messages
       // Team owner sends a message
       await pages.conversation().sendMessage(`Hello from ${owner.firstName}!`);
-      await expect(pages.conversation().getMessage(`Hello from ${owner.firstName}!`)).toBeVisible();
+      await expect(pages.conversation().getMessage({content: `Hello from ${owner.firstName}!`})).toBeVisible();
 
       // Member1 sends a message
       await member1PageManager.webapp.pages.conversation().sendMessage(`Hello from ${member1.firstName}!`);
       await expect(
-        member1PageManager.webapp.pages.conversation().getMessage(`Hello from ${member1.firstName}!`),
+        member1PageManager.webapp.pages.conversation().getMessage({content: `Hello from ${member1.firstName}!`}),
       ).toBeVisible();
 
       // Member2 sends a message
       await member2PageManager.webapp.pages.conversation().sendMessage(`Hello from ${member2.firstName}!`);
       await expect(
-        member2PageManager.webapp.pages.conversation().getMessage(`Hello from ${member2.firstName}!`),
+        member2PageManager.webapp.pages.conversation().getMessage({content: `Hello from ${member2.firstName}!`}),
       ).toBeVisible();
 
       // Owner verifies all messages are visible
       await pages.conversationList().openConversation(conversationName);
-      await expect(pages.conversation().getMessage(`Hello from ${member1.firstName}!`)).toBeVisible();
-      await expect(pages.conversation().getMessage(`Hello from ${member2.firstName}!`)).toBeVisible();
+      await expect(pages.conversation().getMessage({content: `Hello from ${member1.firstName}!`})).toBeVisible();
+      await expect(pages.conversation().getMessage({content: `Hello from ${member2.firstName}!`})).toBeVisible();
     });
 
     await test.step('Team owner and group members react on received messages with reactions', async () => {
       // Owner reacts to member1's message with +1 (thumbs up)
       await pages.conversationList().openConversation(conversationName);
-      const member1MessageForOwner = pages.conversation().getMessage(`Hello from ${member1.firstName}!`).first();
+      const member1MessageForOwner = pages.conversation().getMessage({content: `Hello from ${member1.firstName}!`});
       await member1MessageForOwner.waitFor({state: 'visible'}); // Wait for message to be ready
       await pages.conversation().reactOnMessage(member1MessageForOwner, 'plus-one');
 
       // Owner reacts to member2's message with +1 (thumbs up)
-      const member2MessageForOwner = pages.conversation().getMessage(`Hello from ${member2.firstName}!`).first();
+      const member2MessageForOwner = pages.conversation().getMessage({content: `Hello from ${member2.firstName}!`});
       await pages.conversation().reactOnMessage(member2MessageForOwner, 'plus-one');
 
       // Member1 reacts to owner's message with heart (❤️)
       await member1PageManager.webapp.pages.conversationList().openConversation(conversationName);
       const ownerMessageForMember1 = member1PageManager.webapp.pages
         .conversation()
-        .getMessage(`Hello from ${owner.firstName}!`)
-        .first();
+        .getMessage({content: `Hello from ${owner.firstName}!`});
       await member1PageManager.webapp.pages.conversation().reactOnMessage(ownerMessageForMember1, 'heart');
 
       // Member1 reacts to member2's message with heart (❤️)
       const member2MessageForMember1 = member1PageManager.webapp.pages
         .conversation()
-        .getMessage(`Hello from ${member2.firstName}!`)
-        .first();
+        .getMessage({content: `Hello from ${member2.firstName}!`});
       await member1PageManager.webapp.pages.conversation().reactOnMessage(member2MessageForMember1, 'heart');
 
       // Member2 reacts to owner's message with joy (😂)
       await member2PageManager.webapp.pages.conversationList().openConversation(conversationName);
       const ownerMessageForMember2 = member2PageManager.webapp.pages
         .conversation()
-        .getMessage(`Hello from ${owner.firstName}!`)
-        .first();
+        .getMessage({content: `Hello from ${owner.firstName}!`});
       await member2PageManager.webapp.pages.conversation().reactOnMessage(ownerMessageForMember2, 'joy');
 
       // Member2 reacts to member1's message with joy (😂)
       const member1MessageForMember2 = member2PageManager.webapp.pages
         .conversation()
-        .getMessage(`Hello from ${member1.firstName}!`)
-        .first();
+        .getMessage({content: `Hello from ${member1.firstName}!`});
       await member2PageManager.webapp.pages.conversation().reactOnMessage(member1MessageForMember2, 'joy');
     });
 
     await test.step('All group participants make sure they see reactions from other group participants', async () => {
       // Owner verifies they can see heart (❤️) and joy (😂) reactions on their message from member1 and member2
       await pages.conversationList().openConversation(conversationName);
-      const ownerMessage = pages.conversation().getMessage(`Hello from ${owner.firstName}!`);
+      const ownerMessage = pages.conversation().getMessage({content: `Hello from ${owner.firstName}!`});
       await expect(pages.conversation().getReactionOnMessage(ownerMessage, 'heart')).toBeVisible();
       await expect(pages.conversation().getReactionOnMessage(ownerMessage, 'joy')).toBeVisible();
 
@@ -195,7 +191,7 @@ test(
       await member1PageManager.webapp.pages.conversationList().openConversation(conversationName);
       const member1Message = member1PageManager.webapp.pages
         .conversation()
-        .getMessage(`Hello from ${member1.firstName}!`);
+        .getMessage({content: `Hello from ${member1.firstName}!`});
       await expect(
         member1PageManager.webapp.pages.conversation().getReactionOnMessage(member1Message, 'plus-one'),
       ).toBeVisible();
@@ -207,7 +203,7 @@ test(
       await member2PageManager.webapp.pages.conversationList().openConversation(conversationName);
       const member2Message = member2PageManager.webapp.pages
         .conversation()
-        .getMessage(`Hello from ${member2.firstName}!`);
+        .getMessage({content: `Hello from ${member2.firstName}!`});
       await expect(
         member2PageManager.webapp.pages.conversation().getReactionOnMessage(member2Message, 'plus-one'),
       ).toBeVisible();

--- a/test/e2e_tests/specs/CriticalFlow/backupRestoration-TC-8634.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/backupRestoration-TC-8634.spec.ts
@@ -70,8 +70,7 @@ test('Setting up new device with a backup', {tag: ['@TC-8634', '@crit-flow-web']
   await test.step('User generates data', async () => {
     await pages.conversationList().openConversation(userB.fullName);
     await pages.conversation().sendMessage(personalMessage);
-
-    expect(pages.conversation().isMessageVisible(personalMessage)).toBeTruthy();
+    await expect(pages.conversation().getMessage(personalMessage)).toBeVisible();
 
     await pages.conversationList().clickCreateGroup();
     await pages.groupCreation().setGroupName(groupName);
@@ -80,7 +79,7 @@ test('Setting up new device with a backup', {tag: ['@TC-8634', '@crit-flow-web']
     await pages.conversationList().openConversation(groupName);
     await pages.conversation().sendMessage(groupMessage);
 
-    expect(pages.conversation().isMessageVisible(groupMessage)).toBeTruthy();
+    await expect(pages.conversation().getMessage(groupMessage)).toBeVisible();
   });
 
   await test.step('User creates and saves a backup', async () => {
@@ -103,10 +102,10 @@ test('Setting up new device with a backup', {tag: ['@TC-8634', '@crit-flow-web']
 
   await test.step('User doesnt see previous data (messages)', async () => {
     await pages.conversationList().openConversation(userB.fullName);
-    expect(await pages.conversation().isMessageVisible(personalMessage, false)).toBeFalsy();
+    await expect(pages.conversation().getMessage(personalMessage)).not.toBeVisible();
 
     await pages.conversationList().openConversation(groupName);
-    expect(await pages.conversation().isMessageVisible(groupMessage, false)).toBeFalsy();
+    await expect(pages.conversation().getMessage(groupMessage)).not.toBeVisible();
   });
 
   await test.step('User restores the previously created backup', async () => {
@@ -128,10 +127,10 @@ test('Setting up new device with a backup', {tag: ['@TC-8634', '@crit-flow-web']
   await test.step('All data (chat history, contacts) are restored', async () => {
     await components.conversationSidebar().clickAllConversationsButton();
     await pages.conversationList().openConversation(groupName);
-    expect(pages.conversation().isMessageVisible(groupMessage)).toBeTruthy();
+    await expect(pages.conversation().getMessage(groupMessage)).toBeVisible();
 
     await pages.conversationList().openConversation(userB.fullName);
-    expect(pages.conversation().isMessageVisible(personalMessage)).toBeTruthy();
+    await expect(pages.conversation().getMessage(personalMessage)).toBeVisible();
   });
 });
 

--- a/test/e2e_tests/specs/CriticalFlow/backupRestoration-TC-8634.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/backupRestoration-TC-8634.spec.ts
@@ -70,7 +70,7 @@ test('Setting up new device with a backup', {tag: ['@TC-8634', '@crit-flow-web']
   await test.step('User generates data', async () => {
     await pages.conversationList().openConversation(userB.fullName);
     await pages.conversation().sendMessage(personalMessage);
-    await expect(pages.conversation().getMessage(personalMessage)).toBeVisible();
+    await expect(pages.conversation().getMessage({content: personalMessage})).toBeVisible();
 
     await pages.conversationList().clickCreateGroup();
     await pages.groupCreation().setGroupName(groupName);
@@ -79,7 +79,7 @@ test('Setting up new device with a backup', {tag: ['@TC-8634', '@crit-flow-web']
     await pages.conversationList().openConversation(groupName);
     await pages.conversation().sendMessage(groupMessage);
 
-    await expect(pages.conversation().getMessage(groupMessage)).toBeVisible();
+    await expect(pages.conversation().getMessage({content: groupMessage})).toBeVisible();
   });
 
   await test.step('User creates and saves a backup', async () => {
@@ -102,10 +102,10 @@ test('Setting up new device with a backup', {tag: ['@TC-8634', '@crit-flow-web']
 
   await test.step('User doesnt see previous data (messages)', async () => {
     await pages.conversationList().openConversation(userB.fullName);
-    await expect(pages.conversation().getMessage(personalMessage)).not.toBeVisible();
+    await expect(pages.conversation().getMessage({content: personalMessage})).not.toBeVisible();
 
     await pages.conversationList().openConversation(groupName);
-    await expect(pages.conversation().getMessage(groupMessage)).not.toBeVisible();
+    await expect(pages.conversation().getMessage({content: groupMessage})).not.toBeVisible();
   });
 
   await test.step('User restores the previously created backup', async () => {
@@ -127,10 +127,10 @@ test('Setting up new device with a backup', {tag: ['@TC-8634', '@crit-flow-web']
   await test.step('All data (chat history, contacts) are restored', async () => {
     await components.conversationSidebar().clickAllConversationsButton();
     await pages.conversationList().openConversation(groupName);
-    await expect(pages.conversation().getMessage(groupMessage)).toBeVisible();
+    await expect(pages.conversation().getMessage({content: groupMessage})).toBeVisible();
 
     await pages.conversationList().openConversation(userB.fullName);
-    await expect(pages.conversation().getMessage(personalMessage)).toBeVisible();
+    await expect(pages.conversation().getMessage({content: personalMessage})).toBeVisible();
   });
 });
 

--- a/test/e2e_tests/specs/CriticalFlow/channelsManagement-TC-8752.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/channelsManagement-TC-8752.spec.ts
@@ -151,7 +151,9 @@ test('Channels Management', {tag: ['@TC-8752', '@crit-flow-web']}, async ({pageM
   });
 
   await test.step('Team member sees the message', async () => {
-    await expect(memberPages.webapp.pages.conversation().getMessage('Hello team! Admin here.')).toBeVisible();
+    await expect(
+      memberPages.webapp.pages.conversation().getMessage({content: 'Hello team! Admin here.'}),
+    ).toBeVisible();
   });
 });
 

--- a/test/e2e_tests/specs/CriticalFlow/channelsManagement-TC-8752.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/channelsManagement-TC-8752.spec.ts
@@ -151,7 +151,7 @@ test('Channels Management', {tag: ['@TC-8752', '@crit-flow-web']}, async ({pageM
   });
 
   await test.step('Team member sees the message', async () => {
-    expect(await memberPages.webapp.pages.conversation().isMessageVisible('Hello team! Admin here.')).toBeTruthy();
+    await expect(memberPages.webapp.pages.conversation().getMessage('Hello team! Admin here.')).toBeVisible();
   });
 });
 

--- a/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
@@ -74,7 +74,7 @@ test('Conversation Management', {tag: ['@TC-8636', '@crit-flow-web']}, async ({p
     await pages.conversationList().openConversation(conversationName);
     await Promise.all(
       members.map(async member => {
-        const message = pages.conversation().getMessage(`Hello team! ${member.firstName} here.`);
+        const message = pages.conversation().getMessage({content: `Hello team! ${member.firstName} here.`});
         await expect(message).toBeVisible();
       }),
     );
@@ -85,11 +85,11 @@ test('Conversation Management', {tag: ['@TC-8636', '@crit-flow-web']}, async ({p
     await components.inputBarControls().setEphemeralTimerTo('10 seconds');
     await pages.conversation().sendMessage(textMessage);
 
-    await expect(pages.conversation().getMessage(textMessage)).toBeVisible();
+    await expect(pages.conversation().getMessage({content: textMessage})).toBeVisible();
     // Wait for more than 10 seconds to ensure the message is deleted
     await pages.conversation().page.waitForTimeout(11000);
 
-    await expect(pages.conversation().getMessage(textMessage)).not.toBeVisible();
+    await expect(pages.conversation().getMessage({content: textMessage})).not.toBeVisible();
     await components.inputBarControls().setEphemeralTimerTo('Off');
   });
 

--- a/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
@@ -72,9 +72,12 @@ test('Conversation Management', {tag: ['@TC-8636', '@crit-flow-web']}, async ({p
 
   await test.step('Team owner signed in to the application and verify messages', async () => {
     await pages.conversationList().openConversation(conversationName);
-    for (const member of members) {
-      expect(await pages.conversation().isMessageVisible(`Hello team! ${member.firstName} here.`)).toBeTruthy();
-    }
+    await Promise.all(
+      members.map(async member => {
+        const message = pages.conversation().getMessage(`Hello team! ${member.firstName} here.`);
+        await expect(message).toBeVisible();
+      }),
+    );
   });
 
   await test.step('Team owner send self-destructing messages', async () => {
@@ -82,11 +85,11 @@ test('Conversation Management', {tag: ['@TC-8636', '@crit-flow-web']}, async ({p
     await components.inputBarControls().setEphemeralTimerTo('10 seconds');
     await pages.conversation().sendMessage(textMessage);
 
-    expect(await pages.conversation().isMessageVisible(textMessage)).toBeTruthy();
+    await expect(pages.conversation().getMessage(textMessage)).toBeVisible();
     // Wait for more than 10 seconds to ensure the message is deleted
     await pages.conversation().page.waitForTimeout(11000);
 
-    expect(await pages.conversation().isMessageVisible(textMessage, false)).toBeFalsy();
+    await expect(pages.conversation().getMessage(textMessage)).not.toBeVisible();
     await components.inputBarControls().setEphemeralTimerTo('Off');
   });
 

--- a/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
@@ -176,11 +176,11 @@ test('Messages in 1:1', {tag: ['@TC-8750', '@crit-flow-web']}, async ({pageManag
   await test.step('User A sends a quick (10 sec) self deleting message', async () => {
     await components.inputBarControls().setEphemeralTimerTo('10 seconds');
     await pages.conversation().sendMessage(selfDestructMessageText);
-    await expect(pages.conversation().getMessage(selfDestructMessageText)).toBeVisible();
+    await expect(pages.conversation().getMessage({content: selfDestructMessageText})).toBeVisible();
   });
 
   await test.step('User B sees the message', async () => {
-    await expect(memberBPM.webapp.pages.conversation().getMessage(selfDestructMessageText)).toBeVisible();
+    await expect(memberBPM.webapp.pages.conversation().getMessage({content: selfDestructMessageText})).toBeVisible();
   });
 
   // Step 7: Message removal
@@ -188,8 +188,10 @@ test('Messages in 1:1', {tag: ['@TC-8750', '@crit-flow-web']}, async ({pageManag
     await memberBPM.webapp.pages.conversation().page.waitForTimeout(11_000);
   });
   await test.step('Both users see the message as removed', async () => {
-    await expect(memberBPM.webapp.pages.conversation().getMessage(selfDestructMessageText)).not.toBeVisible();
-    await expect(pages.conversation().getMessage(selfDestructMessageText)).not.toBeVisible();
+    await expect(
+      memberBPM.webapp.pages.conversation().getMessage({content: selfDestructMessageText}),
+    ).not.toBeVisible();
+    await expect(pages.conversation().getMessage({content: selfDestructMessageText})).not.toBeVisible();
 
     // Reset ephemeral timer to 'Off'
     await components.inputBarControls().setEphemeralTimerTo('Off');

--- a/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
@@ -176,10 +176,11 @@ test('Messages in 1:1', {tag: ['@TC-8750', '@crit-flow-web']}, async ({pageManag
   await test.step('User A sends a quick (10 sec) self deleting message', async () => {
     await components.inputBarControls().setEphemeralTimerTo('10 seconds');
     await pages.conversation().sendMessage(selfDestructMessageText);
-    expect(await pages.conversation().isMessageVisible(selfDestructMessageText)).toBeTruthy();
+    await expect(pages.conversation().getMessage(selfDestructMessageText)).toBeVisible();
   });
+
   await test.step('User B sees the message', async () => {
-    expect(await memberBPM.webapp.pages.conversation().isMessageVisible(selfDestructMessageText)).toBeTruthy();
+    await expect(memberBPM.webapp.pages.conversation().getMessage(selfDestructMessageText)).toBeVisible();
   });
 
   // Step 7: Message removal
@@ -187,8 +188,8 @@ test('Messages in 1:1', {tag: ['@TC-8750', '@crit-flow-web']}, async ({pageManag
     await memberBPM.webapp.pages.conversation().page.waitForTimeout(11_000);
   });
   await test.step('Both users see the message as removed', async () => {
-    expect(await memberBPM.webapp.pages.conversation().isMessageVisible(selfDestructMessageText, false)).toBeFalsy();
-    expect(await pages.conversation().isMessageVisible(selfDestructMessageText, false)).toBeFalsy();
+    await expect(memberBPM.webapp.pages.conversation().getMessage(selfDestructMessageText)).not.toBeVisible();
+    await expect(pages.conversation().getMessage(selfDestructMessageText)).not.toBeVisible();
 
     // Reset ephemeral timer to 'Off'
     await components.inputBarControls().setEphemeralTimerTo('Off');

--- a/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
@@ -101,7 +101,7 @@ test(
       await userBPageManager.refreshPage({waitUntil: 'load'});
 
       await userBPages.conversationList().openConversation(channelName);
-      await expect(userBPages.conversation().getMessage(`@${userB.fullName} ${messageText}`)).toBeVisible();
+      await expect(userBPages.conversation().getMessage({content: `@${userB.fullName} ${messageText}`})).toBeVisible();
     });
 
     await test.step('User A sends image', async () => {
@@ -165,11 +165,11 @@ test(
     await test.step('User A sends a quick (10 sec) self deleting message', async () => {
       await userAComponents.inputBarControls().setEphemeralTimerTo('10 seconds');
       await userAPages.conversation().sendMessage(selfDestructMessageText);
-      await expect(userAPages.conversation().getMessage(selfDestructMessageText)).toBeVisible();
+      await expect(userAPages.conversation().getMessage({content: selfDestructMessageText})).toBeVisible();
     });
 
     await test.step('User B sees the message', async () => {
-      await expect(userBPages.conversation().getMessage(selfDestructMessageText)).toBeVisible();
+      await expect(userBPages.conversation().getMessage({content: selfDestructMessageText})).toBeVisible();
     });
 
     await test.step('User B waits 10 seconds', async () => {
@@ -177,8 +177,8 @@ test(
     });
 
     await test.step('Both users see the message as removed', async () => {
-      await expect(userBPages.conversation().getMessage(selfDestructMessageText)).not.toBeVisible();
-      await expect(userAPages.conversation().getMessage(selfDestructMessageText)).not.toBeVisible();
+      await expect(userBPages.conversation().getMessage({content: selfDestructMessageText})).not.toBeVisible();
+      await expect(userAPages.conversation().getMessage({content: selfDestructMessageText})).not.toBeVisible();
 
       // Reset ephemeral timer to 'Off'
       await userAComponents.inputBarControls().setEphemeralTimerTo('Off');

--- a/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
@@ -101,7 +101,7 @@ test(
       await userBPageManager.refreshPage({waitUntil: 'load'});
 
       await userBPages.conversationList().openConversation(channelName);
-      expect(await userBPages.conversation().isMessageVisible(`@${userB.fullName} ${messageText}`)).toBeTruthy();
+      await expect(userBPages.conversation().getMessage(`@${userB.fullName} ${messageText}`)).toBeVisible();
     });
 
     await test.step('User A sends image', async () => {
@@ -165,11 +165,11 @@ test(
     await test.step('User A sends a quick (10 sec) self deleting message', async () => {
       await userAComponents.inputBarControls().setEphemeralTimerTo('10 seconds');
       await userAPages.conversation().sendMessage(selfDestructMessageText);
-      expect(await userAPages.conversation().isMessageVisible(selfDestructMessageText)).toBeTruthy();
+      await expect(userAPages.conversation().getMessage(selfDestructMessageText)).toBeVisible();
     });
 
     await test.step('User B sees the message', async () => {
-      expect(await userBPages.conversation().isMessageVisible(selfDestructMessageText)).toBeTruthy();
+      await expect(userBPages.conversation().getMessage(selfDestructMessageText)).toBeVisible();
     });
 
     await test.step('User B waits 10 seconds', async () => {
@@ -177,8 +177,8 @@ test(
     });
 
     await test.step('Both users see the message as removed', async () => {
-      expect(await userBPages.conversation().isMessageVisible(selfDestructMessageText, false)).toBeFalsy();
-      expect(await userAPages.conversation().isMessageVisible(selfDestructMessageText, false)).toBeFalsy();
+      await expect(userBPages.conversation().getMessage(selfDestructMessageText)).not.toBeVisible();
+      await expect(userAPages.conversation().getMessage(selfDestructMessageText)).not.toBeVisible();
 
       // Reset ephemeral timer to 'Off'
       await userAComponents.inputBarControls().setEphemeralTimerTo('Off');

--- a/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
@@ -90,7 +90,7 @@ test(
       await userBPageManager.refreshPage({waitUntil: 'load'});
 
       await userBPages.conversationList().openConversation(conversationName);
-      expect(await userBPages.conversation().isMessageVisible(`@${userB.fullName} ${messageText}`)).toBeTruthy();
+      await expect(userBPages.conversation().getMessage(`@${userB.fullName} ${messageText}`)).toBeVisible();
     });
 
     await test.step('User A sends image', async () => {
@@ -154,11 +154,11 @@ test(
     await test.step('User A sends a quick (10 sec) self deleting message', async () => {
       await userAComponents.inputBarControls().setEphemeralTimerTo('10 seconds');
       await userAPages.conversation().sendMessage(selfDestructMessageText);
-      expect(await userAPages.conversation().isMessageVisible(selfDestructMessageText)).toBeTruthy();
+      await expect(userAPages.conversation().getMessage(selfDestructMessageText)).toBeVisible();
     });
 
     await test.step('User B sees the message', async () => {
-      expect(await userBPages.conversation().isMessageVisible(selfDestructMessageText)).toBeTruthy();
+      await expect(userBPages.conversation().getMessage(selfDestructMessageText)).toBeVisible();
     });
 
     await test.step('User B waits 10 seconds', async () => {
@@ -166,8 +166,8 @@ test(
     });
 
     await test.step('Both users see the message as removed', async () => {
-      expect(await userBPages.conversation().isMessageVisible(selfDestructMessageText, false)).toBeFalsy();
-      expect(await userAPages.conversation().isMessageVisible(selfDestructMessageText, false)).toBeFalsy();
+      await expect(userBPages.conversation().getMessage(selfDestructMessageText)).not.toBeVisible();
+      await expect(userAPages.conversation().getMessage(selfDestructMessageText)).not.toBeVisible();
 
       // Reset ephemeral timer to 'Off'
       await userAComponents.inputBarControls().setEphemeralTimerTo('Off');

--- a/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
@@ -90,7 +90,7 @@ test(
       await userBPageManager.refreshPage({waitUntil: 'load'});
 
       await userBPages.conversationList().openConversation(conversationName);
-      await expect(userBPages.conversation().getMessage(`@${userB.fullName} ${messageText}`)).toBeVisible();
+      await expect(userBPages.conversation().getMessage({content: `@${userB.fullName} ${messageText}`})).toBeVisible();
     });
 
     await test.step('User A sends image', async () => {
@@ -154,11 +154,11 @@ test(
     await test.step('User A sends a quick (10 sec) self deleting message', async () => {
       await userAComponents.inputBarControls().setEphemeralTimerTo('10 seconds');
       await userAPages.conversation().sendMessage(selfDestructMessageText);
-      await expect(userAPages.conversation().getMessage(selfDestructMessageText)).toBeVisible();
+      await expect(userAPages.conversation().getMessage({content: selfDestructMessageText})).toBeVisible();
     });
 
     await test.step('User B sees the message', async () => {
-      await expect(userBPages.conversation().getMessage(selfDestructMessageText)).toBeVisible();
+      await expect(userBPages.conversation().getMessage({content: selfDestructMessageText})).toBeVisible();
     });
 
     await test.step('User B waits 10 seconds', async () => {
@@ -166,8 +166,8 @@ test(
     });
 
     await test.step('Both users see the message as removed', async () => {
-      await expect(userBPages.conversation().getMessage(selfDestructMessageText)).not.toBeVisible();
-      await expect(userAPages.conversation().getMessage(selfDestructMessageText)).not.toBeVisible();
+      await expect(userBPages.conversation().getMessage({content: selfDestructMessageText})).not.toBeVisible();
+      await expect(userAPages.conversation().getMessage({content: selfDestructMessageText})).not.toBeVisible();
 
       // Reset ephemeral timer to 'Off'
       await userAComponents.inputBarControls().setEphemeralTimerTo('Off');

--- a/test/e2e_tests/specs/CriticalFlow/personalAccountLifecycle-TC-8638.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/personalAccountLifecycle-TC-8638.spec.ts
@@ -116,7 +116,9 @@ test('Personal Account Lifecycle', {tag: ['@TC-8638', '@crit-flow-web']}, async 
   await test.step('Personal user B can see the message from user A', async () => {
     await pageManagerB.refreshPage({waitUntil: 'domcontentloaded'});
     await pageManagerB.webapp.pages.conversationList().openConversation(userA.fullName);
-    await expect(pageManagerB.webapp.pages.conversation().getMessage(`Hello! ${userA.firstName} here.`)).toBeVisible();
+    await expect(
+      pageManagerB.webapp.pages.conversation().getMessage({content: `Hello! ${userA.firstName} here.`}),
+    ).toBeVisible();
   });
 
   await test.step('Personal user A blocks personal user B', async () => {
@@ -155,7 +157,9 @@ test('Personal Account Lifecycle', {tag: ['@TC-8638', '@crit-flow-web']}, async 
 
   await test.step('Personal user C can see the message from user A', async () => {
     await pageManagerC.webapp.pages.conversationList().openConversation(userA.fullName);
-    await expect(pageManagerC.webapp.pages.conversation().getMessage(`Hello! ${userA.firstName} here.`)).toBeVisible();
+    await expect(
+      pageManagerC.webapp.pages.conversation().getMessage({content: `Hello! ${userA.firstName} here.`}),
+    ).toBeVisible();
   });
 
   await test.step('Personal User A deletes their account', async () => {

--- a/test/e2e_tests/specs/CriticalFlow/personalAccountLifecycle-TC-8638.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/personalAccountLifecycle-TC-8638.spec.ts
@@ -116,9 +116,7 @@ test('Personal Account Lifecycle', {tag: ['@TC-8638', '@crit-flow-web']}, async 
   await test.step('Personal user B can see the message from user A', async () => {
     await pageManagerB.refreshPage({waitUntil: 'domcontentloaded'});
     await pageManagerB.webapp.pages.conversationList().openConversation(userA.fullName);
-    expect(
-      await pageManagerB.webapp.pages.conversation().isMessageVisible(`Hello! ${userA.firstName} here.`),
-    ).toBeTruthy();
+    await expect(pageManagerB.webapp.pages.conversation().getMessage(`Hello! ${userA.firstName} here.`)).toBeVisible();
   });
 
   await test.step('Personal user A blocks personal user B', async () => {
@@ -157,9 +155,7 @@ test('Personal Account Lifecycle', {tag: ['@TC-8638', '@crit-flow-web']}, async 
 
   await test.step('Personal user C can see the message from user A', async () => {
     await pageManagerC.webapp.pages.conversationList().openConversation(userA.fullName);
-    expect(
-      await pageManagerC.webapp.pages.conversation().isMessageVisible(`Hello! ${userA.firstName} here.`),
-    ).toBeTruthy();
+    await expect(pageManagerC.webapp.pages.conversation().getMessage(`Hello! ${userA.firstName} here.`)).toBeVisible();
   });
 
   await test.step('Personal User A deletes their account', async () => {

--- a/test/e2e_tests/specs/Edit/edit.spec.ts
+++ b/test/e2e_tests/specs/Edit/edit.spec.ts
@@ -80,7 +80,7 @@ test.describe('Edit', () => {
     });
     await pages.conversation().sendMessage('Test Message');
 
-    const message = pages.conversation().getMessageFromUser(userA);
+    const message = pages.conversation().getMessage('', userA);
     await expect(message).toContainText('Test Message');
 
     await pages.conversation().editMessage(message);
@@ -100,7 +100,7 @@ test.describe('Edit', () => {
       await pages.conversationList().openConversation('Test Group');
       await pages.conversation().sendMessage('Test Message');
 
-      const message = pages.conversation().getMessageFromUser(userA);
+      const message = pages.conversation().getMessage('', userA);
       await expect(message).toContainText('Test Message');
 
       await pages.conversation().editMessage(message);
@@ -129,8 +129,8 @@ test.describe('Edit', () => {
 
       await device1.conversation().sendMessage('Message from device 1');
 
-      const messageOnDevice1 = device1.conversation().getMessageFromUser(userA);
-      const messageOnDevice2 = device2.conversation().getMessageFromUser(userA);
+      const messageOnDevice1 = device1.conversation().getMessage('', userA);
+      const messageOnDevice2 = device2.conversation().getMessage('', userA);
       await expect(messageOnDevice1).toContainText('Message from device 1');
       await expect(messageOnDevice2).toContainText('Message from device 1');
 
@@ -150,7 +150,7 @@ test.describe('Edit', () => {
     ]);
     await userAPages.conversation().sendMessage('Test Message');
 
-    const message = userBPages.conversation().getMessageFromUser(userA);
+    const message = userBPages.conversation().getMessage('', userA);
     await expect(message).toContainText('Test Message');
 
     const messageOptions = await userBPages.conversation().openMessageOptions(message);
@@ -207,7 +207,7 @@ test.describe('Edit', () => {
       });
 
       await test.step('Change message sent by A', async () => {
-        const message = userAPages.conversation().getMessageFromUser(userA);
+        const message = userAPages.conversation().getMessage('', userA);
         await userAPages.conversation().editMessage(message);
         await expect(userAPages.conversation().messageInput).toContainText('Test Message');
         await userAPages.conversation().sendMessage('Edited Message');
@@ -218,7 +218,7 @@ test.describe('Edit', () => {
         await expect(conversation.getByTestId('status-unread')).not.toBeVisible();
 
         await userBPages.conversationList().openConversation(userA.fullName);
-        await expect(userBPages.conversation().getMessageFromUser(userA)).toContainText('Edited Message');
+        await expect(userBPages.conversation().getMessage('', userA)).toContainText('Edited Message');
       });
     },
   );
@@ -233,9 +233,9 @@ test.describe('Edit', () => {
       ]);
 
       await userAPages.conversation().sendMessage('Test');
-      const sentMessage = userAPages.conversation().getMessageFromUser(userA);
+      const sentMessage = userAPages.conversation().getMessage('', userA);
 
-      const receivedMessage = userBPages.conversation().getMessageFromUser(userA);
+      const receivedMessage = userBPages.conversation().getMessage('', userA);
       await expect(receivedMessage).toContainText('Test');
 
       await userAPages.conversation().editMessage(sentMessage);
@@ -256,7 +256,7 @@ test.describe('Edit', () => {
       await pages.conversationList().openConversation('Test Group');
       await pages.conversation().sendMessage('Test message');
 
-      const message = pages.conversation().getMessageFromUser(userA);
+      const message = pages.conversation().getMessage('', userA);
       await pages.conversation().openMessageDetails(message);
 
       const timeEdited = pages.messageDetails().timeEdited;

--- a/test/e2e_tests/specs/Edit/edit.spec.ts
+++ b/test/e2e_tests/specs/Edit/edit.spec.ts
@@ -80,7 +80,7 @@ test.describe('Edit', () => {
     });
     await pages.conversation().sendMessage('Test Message');
 
-    const message = pages.conversation().getMessage('', userA);
+    const message = pages.conversation().getMessage({sender: userA});
     await expect(message).toContainText('Test Message');
 
     await pages.conversation().editMessage(message);
@@ -100,7 +100,7 @@ test.describe('Edit', () => {
       await pages.conversationList().openConversation('Test Group');
       await pages.conversation().sendMessage('Test Message');
 
-      const message = pages.conversation().getMessage('', userA);
+      const message = pages.conversation().getMessage({sender: userA});
       await expect(message).toContainText('Test Message');
 
       await pages.conversation().editMessage(message);
@@ -129,8 +129,8 @@ test.describe('Edit', () => {
 
       await device1.conversation().sendMessage('Message from device 1');
 
-      const messageOnDevice1 = device1.conversation().getMessage('', userA);
-      const messageOnDevice2 = device2.conversation().getMessage('', userA);
+      const messageOnDevice1 = device1.conversation().getMessage({sender: userA});
+      const messageOnDevice2 = device2.conversation().getMessage({sender: userA});
       await expect(messageOnDevice1).toContainText('Message from device 1');
       await expect(messageOnDevice2).toContainText('Message from device 1');
 
@@ -150,7 +150,7 @@ test.describe('Edit', () => {
     ]);
     await userAPages.conversation().sendMessage('Test Message');
 
-    const message = userBPages.conversation().getMessage('', userA);
+    const message = userBPages.conversation().getMessage({sender: userA});
     await expect(message).toContainText('Test Message');
 
     const messageOptions = await userBPages.conversation().openMessageOptions(message);
@@ -166,6 +166,7 @@ test.describe('Edit', () => {
         openConversationWith: userB,
       });
       await pages.conversation().sendMessage('Test Message');
+      await expect(pages.conversation().getMessage({content: 'Test Message'})).toBeVisible();
 
       await pages.conversation().messageInput.press('ArrowUp');
       await expect(pages.conversation().messageInput).toContainText('Test Message');
@@ -207,7 +208,7 @@ test.describe('Edit', () => {
       });
 
       await test.step('Change message sent by A', async () => {
-        const message = userAPages.conversation().getMessage('', userA);
+        const message = userAPages.conversation().getMessage({sender: userA});
         await userAPages.conversation().editMessage(message);
         await expect(userAPages.conversation().messageInput).toContainText('Test Message');
         await userAPages.conversation().sendMessage('Edited Message');
@@ -218,7 +219,7 @@ test.describe('Edit', () => {
         await expect(conversation.getByTestId('status-unread')).not.toBeVisible();
 
         await userBPages.conversationList().openConversation(userA.fullName);
-        await expect(userBPages.conversation().getMessage('', userA)).toContainText('Edited Message');
+        await expect(userBPages.conversation().getMessage({sender: userA})).toContainText('Edited Message');
       });
     },
   );
@@ -233,9 +234,10 @@ test.describe('Edit', () => {
       ]);
 
       await userAPages.conversation().sendMessage('Test');
-      const sentMessage = userAPages.conversation().getMessage('', userA);
+      const sentMessage = userAPages.conversation().getMessage({sender: userA});
+      await expect(sentMessage).toBeVisible();
 
-      const receivedMessage = userBPages.conversation().getMessage('', userA);
+      const receivedMessage = userBPages.conversation().getMessage({sender: userA});
       await expect(receivedMessage).toContainText('Test');
 
       await userAPages.conversation().editMessage(sentMessage);
@@ -256,7 +258,7 @@ test.describe('Edit', () => {
       await pages.conversationList().openConversation('Test Group');
       await pages.conversation().sendMessage('Test message');
 
-      const message = pages.conversation().getMessage('', userA);
+      const message = pages.conversation().getMessage({sender: userA});
       await pages.conversation().openMessageDetails(message);
 
       const timeEdited = pages.messageDetails().timeEdited;

--- a/test/e2e_tests/utils/userActions.ts
+++ b/test/e2e_tests/utils/userActions.ts
@@ -77,13 +77,6 @@ export const sendTextMessageToConversation = async (
   const {pages} = pageManager.webapp;
   await pages.conversationList().openConversation(conversation);
   await pages.conversation().sendMessage(message);
-
-  // TODO: Bug [WPB-18226] Message is not visible in the conversation after sending it
-  await pages.conversation().page.waitForTimeout(500); // Wait for the message to be sent
-  // await pageManager.refreshPage({waitUntil: 'domcontentloaded'}); // does not check if the page is loaded and time out!
-  // End of TODO: Bug [WPB-18226]
-
-  expect(await pages.conversation().isMessageVisible(message)).toBeTruthy();
 };
 
 type UserPages = PageManager['webapp']['pages'];


### PR DESCRIPTION
## Description

This is a performance and stability optimization for our tests. I noticed that sending a message takes a lot of time. Turns out the util always waits 5s after sending the message to ensure it was sent.
Since this util was creating a manual assertion I removed it in favor of a new `getMessage()` util which integrates nicely with playwrights web first assertions aligning with best practices: https://playwright.dev/docs/best-practices#dont-use-manual-assertions
Using web first assertions not only makes the tests more stable but also speeds them up a lot since the test no longer waits a fixed time after sending the message but can continue as soon as the assertion is fulfilled.

> **Note:** I manually compared the results of the last nightly CI run with a local test run to ensure only tests which also failed in CI fail locally to avoid breaking any of the already working tests with this change.

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;