### PR TITLE
fix: Resolve issue with accidentally using proteus as conversation protocol [WPB-21675]

### DIFF
--- a/src/script/repositories/team/TeamState.ts
+++ b/src/script/repositories/team/TeamState.ts
@@ -114,8 +114,9 @@ export class TeamState {
       () => true || this.teamFeatures()?.videoCalling?.status === FEATURE_STATUS.ENABLED,
     );
 
-    const isMLSEnabled = this.teamFeatures()?.mls?.status === FEATURE_STATUS.ENABLED;
-    this.isMLSEnabled = ko.pureComputed(() => isMLSEnabled ?? false);
+    this.isMLSEnabled = ko.pureComputed(() => {
+      return this.teamFeatures()?.mls?.status === FEATURE_STATUS.ENABLED;
+    });
 
     this.isProtocolToggleEnabledForUser = ko.pureComputed(
       () => this.teamFeatures()?.mls?.config.protocolToggleUsers.includes(this.userState.self().id) ?? false,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21675" title="WPB-21675" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21675</a>  [Web] Dev / edge client creates Proteus groups even with MLS as default protocol
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

This was caused by https://github.com/wireapp/wire-webapp/pull/19631/files#diff-dcfcb465eb3efd98f1fe5992d1097003f4d6949d12ec1a8a5fe5dbad0112d764R116-R118

Because the variable isMLSEnabled was defined outside ko.pureComputed this.isMLSEnabled was not updating automatically upon arrival of team features
