### PR TITLE
test: increase default test timeout

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,6 +34,8 @@ module.exports = defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
+  /* Due to the tests usually requiring registration and login of a new user the default 30s timeout isn't sufficient */
+  timeout: 90_000,
   /* Retry on CI only */
   retries: process.env.CI ? numberOfRetriesOnCI : 0,
   /* Opt out of parallel tests on CI. */

--- a/test/e2e_tests/specs/2FA-for-TeamsSpecs/2fa-for-teams.spec.ts
+++ b/test/e2e_tests/specs/2FA-for-TeamsSpecs/2fa-for-teams.spec.ts
@@ -25,7 +25,6 @@ import {loginUser} from 'test/e2e_tests/utils/userActions';
 import {test, expect} from '../../test.fixtures';
 
 test.describe('f2a for teams', () => {
-  test.slow();
   const teamName = 'Critical';
   let owner: User = getUser();
   const member1 = getUser();

--- a/test/e2e_tests/specs/Accessibility/Accessibility.spec.ts
+++ b/test/e2e_tests/specs/Accessibility/Accessibility.spec.ts
@@ -26,8 +26,6 @@ import {createGroup, loginUser} from 'test/e2e_tests/utils/userActions';
 import {test, expect} from '../../test.fixtures';
 
 test.describe('Accessibility', () => {
-  test.slow();
-
   let owner = getUser();
   const members = Array.from({length: 2}, () => getUser());
   const [memberA, memberB] = members;

--- a/test/e2e_tests/specs/AccountSettingsSpecs/accountSettings.spec.ts
+++ b/test/e2e_tests/specs/AccountSettingsSpecs/accountSettings.spec.ts
@@ -29,7 +29,6 @@ test.describe('account settings', () => {
   let owner = getUser();
   const members = Array.from({length: 2}, () => getUser());
   const [memberA, memberB] = members;
-  test.slow();
 
   test.beforeAll(async ({api}) => {
     const user = await bootstrapTeamForTesting(api, members, owner, 'test');

--- a/test/e2e_tests/specs/AppLock/AppLock.spec.ts
+++ b/test/e2e_tests/specs/AppLock/AppLock.spec.ts
@@ -26,8 +26,6 @@ import {handleAppLockState} from 'test/e2e_tests/utils/userActions';
 import {test, expect} from '../../test.fixtures';
 
 test.describe('AppLock', () => {
-  test.slow();
-
   let owner = getUser();
   const members = Array.from({length: 2}, () => getUser());
   const [memberA] = members;

--- a/test/e2e_tests/specs/ArchiveSpecs/archive.spec.ts
+++ b/test/e2e_tests/specs/ArchiveSpecs/archive.spec.ts
@@ -26,8 +26,6 @@ import {createGroup} from 'test/e2e_tests/utils/userActions';
 import {test, expect} from '../../test.fixtures';
 
 test.describe('Accessibility', () => {
-  test.slow();
-
   let owner = getUser();
   const members = Array.from({length: 2}, () => getUser());
   const [memberA, memberB] = members;

--- a/test/e2e_tests/specs/Block/block.spec.ts
+++ b/test/e2e_tests/specs/Block/block.spec.ts
@@ -303,7 +303,6 @@ test.describe('Block', () => {
     'Verify you can unblock someone from search list',
     {tag: ['@TC-148', '@regression']},
     async ({pageManager: userAPageManager}) => {
-      test.slow();
       const {pages: userAPages, modals: userAModals, components: userAComponents} = userAPageManager.webapp;
 
       await test.step('User A blocks User B', async () => {

--- a/test/e2e_tests/specs/Connections/Connections.spec.ts
+++ b/test/e2e_tests/specs/Connections/Connections.spec.ts
@@ -25,8 +25,6 @@ import {tearDownAll} from 'test/e2e_tests/utils/tearDown.util';
 import {test, expect} from '../../test.fixtures';
 
 test.describe('Connections', () => {
-  test.slow();
-
   const members = Array.from({length: 2}, () => getUser());
   const [memberA, memberB] = members;
 

--- a/test/e2e_tests/specs/CriticalFlow/Cells/uploadingFileInGroupConversation.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/Cells/uploadingFileInGroupConversation.spec.ts
@@ -42,8 +42,6 @@ test(
   'Uploading an file in a group conversation',
   {tag: ['@crit-flow-cells']},
   async ({pageManager: userAPageManager, browser, api}) => {
-    test.slow(); // This test involves file upload and download, which can be slow
-
     const {pages: userAPages, modals: userAModals, components: userAComponents} = userAPageManager.webapp;
 
     const userBContext = await browser.newContext();

--- a/test/e2e_tests/specs/CriticalFlow/accountManagement-TC-8639.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/accountManagement-TC-8639.spec.ts
@@ -35,8 +35,6 @@ const conversationName = 'Tracking';
 const appLockPassphrase = generateSecurePassword();
 
 test('Account Management', {tag: ['@TC-8639', '@crit-flow-web']}, async ({pageManager, api}) => {
-  test.slow(); // Increasing test timeout to 90 seconds to accommodate the full flow
-
   // Add fake video devices to the browser context
   await addMockCamerasToContext(pageManager.getContext());
 

--- a/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
@@ -44,8 +44,6 @@ test(
   'Team owner adds whole team to an all team chat',
   {tag: ['@TC-8631', '@crit-flow-web']},
   async ({pageManager, api, browser}) => {
-    test.slow(); // Increasing test timeout to 90 seconds to accommodate the full flow
-
     const {pages, modals} = pageManager.webapp;
 
     // Create page managers for members that will be reused across steps

--- a/test/e2e_tests/specs/CriticalFlow/backupRestoration-TC-8634.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/backupRestoration-TC-8634.spec.ts
@@ -33,8 +33,6 @@ let backupName: string;
 let passwordProtectedBackupName: string;
 
 test('Setting up new device with a backup', {tag: ['@TC-8634', '@crit-flow-web']}, async ({pageManager, api}) => {
-  test.slow(); // Increasing test timeout to 90 seconds to accommodate the full flow
-
   const {pages, modals, components} = pageManager.webapp;
 
   const createAndSaveBackup = async (password?: string, filenamePrefix?: string): Promise<string> => {

--- a/test/e2e_tests/specs/CriticalFlow/channelsManagement-TC-8752.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/channelsManagement-TC-8752.spec.ts
@@ -37,8 +37,6 @@ let memberPages: PageManager;
 test('Channels Management', {tag: ['@TC-8752', '@crit-flow-web']}, async ({pageManager, api, browser}) => {
   const {pages, modals} = pageManager.webapp;
 
-  test.slow(); // Increasing test timeout to 90 seconds to accommodate the full flow
-
   await test.step('Preconditions: Team owner create a channels enabled team', async () => {
     const user = await api.createTeamOwner(owner, teamName);
     owner = {...owner, ...user};

--- a/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
@@ -34,7 +34,6 @@ const conversationName = 'Test Conversation';
 test('Conversation Management', {tag: ['@TC-8636', '@crit-flow-web']}, async ({pageManager, api, browser}) => {
   test.setTimeout(150_000);
   const {pages, modals, components} = pageManager.webapp;
-  test.slow(); // Increasing test timeout to 90 seconds to accommodate the full flow
 
   await test.step('Preconditions: Team owner created a team with 5 members', async () => {
     const user = await api.createTeamOwner(owner, teamName);

--- a/test/e2e_tests/specs/CriticalFlow/joinTeam-TC-8635.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/joinTeam-TC-8635.spec.ts
@@ -39,8 +39,6 @@ test(
   'New person joins team and setups up device',
   {tag: ['@TC-8635', '@crit-flow-web']},
   async ({pageManager, api, browser}) => {
-    test.slow(); // Increasing test timeout to 90 seconds to accommodate the full flow
-
     const {pages, components, modals} = pageManager.webapp;
 
     await test.step('Preconditions: Creating preconditions for the test via API', async () => {

--- a/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
@@ -45,8 +45,6 @@ let memberBPM: PageManager;
 const selfDestructMessageText = 'This message will self-destruct in 10 seconds.';
 
 test('Messages in 1:1', {tag: ['@TC-8750', '@crit-flow-web']}, async ({pageManager, api, browser}) => {
-  test.slow(); // Increasing test timeout to 90 seconds to accommodate the full flow
-
   const {pages, modals, components} = pageManager.webapp;
 
   // Step 0: Preconditions

--- a/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
@@ -45,8 +45,6 @@ test(
   'Messages in Channels',
   {tag: ['@TC-8753', '@crit-flow-web']},
   async ({pageManager: userAPageManager, browser, api}) => {
-    test.slow(); // Increasing test timeout to 90 seconds to accommodate the full flow
-
     const {pages: userAPages, modals: userAModals, components: userAComponents} = userAPageManager.webapp;
 
     const userBContext = await browser.newContext();

--- a/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
@@ -43,8 +43,6 @@ test(
   'Messages in Groups',
   {tag: ['@TC-8751', '@crit-flow-web']},
   async ({pageManager: userAPageManager, api, browser}) => {
-    test.slow(); // Increasing test timeout to 90 seconds to accommodate the full flow
-
     const {pages: userAPages, modals: userAModals, components: userAComponents} = userAPageManager.webapp;
 
     const userBContext = await browser.newContext();

--- a/test/e2e_tests/specs/CriticalFlow/personalAccountLifecycle-TC-8638.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/personalAccountLifecycle-TC-8638.spec.ts
@@ -40,7 +40,6 @@ test('Personal Account Lifecycle', {tag: ['@TC-8638', '@crit-flow-web']}, async 
   const [pageManagerB, pageManagerC] = pageManagers;
 
   const {pages, modals, components} = pageManager.webapp;
-  test.slow(); // Increasing test timeout to 90 seconds to accommodate the full flow
 
   await test.step('Preconditions: Creating preconditions for the test via API', async () => {
     await Promise.all(

--- a/test/e2e_tests/specs/RegisterSpecs/register.spec.ts
+++ b/test/e2e_tests/specs/RegisterSpecs/register.spec.ts
@@ -24,9 +24,6 @@ import {addCreatedUser, removeCreatedUser} from 'test/e2e_tests/utils/tearDown.u
 import {test, expect} from '../../test.fixtures';
 
 test.describe('registration personal account', () => {
-  // Helper function to handle common registration steps
-  test.slow();
-
   test.describe('email registration used', () => {
     const userA = getUser();
 

--- a/test/e2e_tests/specs/RegressionSpecs/block-messages.spec.ts
+++ b/test/e2e_tests/specs/RegressionSpecs/block-messages.spec.ts
@@ -30,8 +30,6 @@ const userB = getUser();
 const userA = getUser();
 
 test('Block specs', {tag: ['@TC-141', '@regression']}, async ({pageManager: userAPageManager, api, browser}) => {
-  test.slow(); // Increasing test timeout to 90 seconds to accommodate the full flow
-
   const {pages: userAPages, modals: userAModals, components: userAComponents} = userAPageManager.webapp;
   const userBContext = await browser.newContext();
   const userBPage = await userBContext.newPage();

--- a/test/e2e_tests/specs/RegressionSpecs/block-search.spec.ts
+++ b/test/e2e_tests/specs/RegressionSpecs/block-search.spec.ts
@@ -29,55 +29,49 @@ import {test, expect} from '../../test.fixtures';
 const userB = getUser();
 const userA = getUser();
 
-test(
-  'Block from search specs',
-  {tag: ['@TC-144', '@regression']},
-  async ({pageManager: userAPageManager, api, browser}) => {
-    test.slow(); // Increasing test timeout to 90 seconds to accommodate the full flow
+test('Block from search specs', {tag: ['@TC-144', '@regression']}, async ({api, browser}) => {
+  const userBContext = await browser.newContext();
+  const userBPage = await userBContext.newPage();
+  const userBPageManager = PageManager.from(userBPage);
+  const {pages: userBPages, modals: userBModals, components: userBComponents} = userBPageManager.webapp;
 
-    const userBContext = await browser.newContext();
-    const userBPage = await userBContext.newPage();
-    const userBPageManager = PageManager.from(userBPage);
-    const {pages: userBPages, modals: userBModals, components: userBComponents} = userBPageManager.webapp;
+  await test.step('Preconditions: Creating preconditions for the test via API', async () => {
+    await api.createPersonalUser(userA);
+    addCreatedUser(userA);
 
-    await test.step('Preconditions: Creating preconditions for the test via API', async () => {
-      await api.createPersonalUser(userA);
-      addCreatedUser(userA);
+    await api.createPersonalUser(userB);
+    addCreatedUser(userB);
+  });
 
-      await api.createPersonalUser(userB);
-      addCreatedUser(userB);
-    });
+  await test.step('Precondition: Users A and B are signed in to the application', async () => {
+    await Promise.all([
+      (async () => {
+        await userBPageManager.openMainPage();
+        await loginUser(userB, userBPageManager);
+        await userBModals.dataShareConsent().clickDecline();
+        await userBComponents.conversationSidebar().isPageLoaded();
+      })(),
+    ]);
+  });
 
-    await test.step('Precondition: Users A and B are signed in to the application', async () => {
-      await Promise.all([
-        (async () => {
-          await userBPageManager.openMainPage();
-          await loginUser(userB, userBPageManager);
-          await userBModals.dataShareConsent().clickDecline();
-          await userBComponents.conversationSidebar().isPageLoaded();
-        })(),
-      ]);
-    });
+  // Test steps
+  await test.step('User B sends User A a connection request', async () => {
+    await userBComponents.conversationSidebar().clickConnectButton();
+    await userBPages.startUI().selectUser(userA.username);
+    expect(await userBModals.userProfile().isVisible());
+    await userBModals.userProfile().clickConnectButton();
+  });
 
-    // Test steps
-    await test.step('User B sends User A a connection request', async () => {
-      await userBComponents.conversationSidebar().clickConnectButton();
-      await userBPages.startUI().selectUser(userA.username);
-      expect(await userBModals.userProfile().isVisible());
-      await userBModals.userProfile().clickConnectButton();
-    });
+  await test.step('User B blocks User A from connection request', async () => {
+    await userBPages.conversationList().openContextMenu(userA.fullName);
+    await userBPages.conversationList().clickBlockConversation();
+    await userBModals.blockWarning().clickBlock();
+  });
 
-    await test.step('User B blocks User A from connection request', async () => {
-      await userBPages.conversationList().openContextMenu(userA.fullName);
-      await userBPages.conversationList().clickBlockConversation();
-      await userBModals.blockWarning().clickBlock();
-    });
-
-    await test.step('User B sees User A as blocked', async () => {
-      await expect(userBPages.conversationList().isConversationBlocked(userA.fullName)).toBeTruthy();
-    });
-  },
-);
+  await test.step('User B sees User A as blocked', async () => {
+    await expect(userBPages.conversationList().isConversationBlocked(userA.fullName)).toBeTruthy();
+  });
+});
 
 test.afterAll(async ({api}) => {
   await removeCreatedUser(api, userA);

--- a/test/e2e_tests/specs/teamManagement.spec.ts
+++ b/test/e2e_tests/specs/teamManagement.spec.ts
@@ -73,7 +73,6 @@ test(
     tag: ['@crit-flow-tm', '@TC-2166', '@TC-2173', '@TC-2176', '@TC-2177', '@teamManagement-regression'],
   },
   async ({api, pageManager}) => {
-    test.slow();
     const {pages, modals} = pageManager.tm;
 
     // Creating test data


### PR DESCRIPTION
## Description

As aligned with the team this PR increases the default test timeout from 30s to 90s. Since pretty much all our tests require a user registration and login to happen first we had to put `test.slow()` into almost every test. By setting the test timeout to 90s by default those can be removed since they had the same effect (tripling the default test timeout).

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

## Important Details for the Reviewers
- The changes within `test/e2e_tests/specs/RegressionSpecs/block-search.spec.ts` look like a lot but removing the `test.slow()` simply allowed formatting to shrink quiet a lot.