### PR TITLE
fix: Do not fetch backend to update MLS conversation properties upon reset event arrival [WPB-21618]

### DIFF
--- a/src/script/repositories/conversation/ConversationRepository.test.ts
+++ b/src/script/repositories/conversation/ConversationRepository.test.ts
@@ -37,6 +37,7 @@ import {
   ConversationMemberJoinEvent,
   CONVERSATION_EVENT,
   ConversationMLSWelcomeEvent,
+  ConversationMLSResetEvent,
 } from '@wireapp/api-client/lib/event/';
 import {BackendError, BackendErrorLabel} from '@wireapp/api-client/lib/http';
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
@@ -110,6 +111,7 @@ function buildConversationRepository() {
     wipeMLSCapableConversation: () => {},
     postBots: () => {},
     saveConversationStateInDb: () => {},
+    wipeMLSConversation: () => {},
   } as ConversationService;
   const messageRepository = {setClientMismatchHandler: () => {}} as unknown as MessageRepository;
   // @ts-ignore
@@ -3418,5 +3420,75 @@ describe('deleteConversation', () => {
     expect(conversationState.conversations()).toEqual([]);
     expect(deleteConversationFromDbSpy).toHaveBeenCalledWith(conversation.id);
     expect(wipeMLSCapableConversationSpy).toHaveBeenCalledWith(conversation);
+  });
+});
+
+describe('onMLSResetMessage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should handle MLS reset message by updating groupId & epoch of the conversation and deleting the old groupId from core crypto', async () => {
+    const [conversationRepository, {conversationState, conversationService, core}] = buildConversationRepository();
+
+    const conversation = _generateConversation({protocol: CONVERSATION_PROTOCOL.MLS, groupId: 'old-group-id'});
+
+    conversationState.conversations([conversation]);
+
+    const mlsResetEvent: ConversationMLSResetEvent = {
+      type: CONVERSATION_EVENT.MLS_RESET,
+      time: new Date().toISOString(),
+      from: 'user-id',
+      conversation: conversation.id,
+      qualified_conversation: conversation.qualifiedId,
+      data: {
+        new_group_id: 'new-group-id',
+        group_id: 'old-group-id',
+      },
+    };
+
+    spyOn(core.service!.conversation, 'wipeMLSConversation').and.returnValue(Promise.resolve(undefined));
+    spyOn(core.service!.conversation, 'mlsGroupExistsLocally').and.returnValue(Promise.resolve(false));
+    const updatePropertiesSpy = jest.spyOn(ConversationMapper, 'updateProperties');
+    const saveConversationStateInDbSpy = jest.spyOn(conversationService, 'saveConversationStateInDb');
+
+    await (conversationRepository as any).onMLSResetMessage(conversation, mlsResetEvent);
+
+    expect(updatePropertiesSpy).toHaveBeenCalledWith(conversation, {
+      groupId: 'new-group-id',
+      epoch: 0,
+    });
+    expect(saveConversationStateInDbSpy).toHaveBeenCalledWith(conversation);
+  });
+
+  it('Should skip updating conversation if new groupId already exists locally', async () => {
+    const [conversationRepository, {conversationState, conversationService, core}] = buildConversationRepository();
+
+    const conversation = _generateConversation({protocol: CONVERSATION_PROTOCOL.MLS, groupId: 'old-group-id'});
+
+    conversationState.conversations([conversation]);
+
+    const mlsResetEvent: ConversationMLSResetEvent = {
+      type: CONVERSATION_EVENT.MLS_RESET,
+      time: new Date().toISOString(),
+      from: 'user-id',
+      conversation: conversation.id,
+      qualified_conversation: conversation.qualifiedId,
+      data: {
+        new_group_id: 'new-group-id',
+        group_id: 'old-group-id',
+      },
+    };
+
+    spyOn(core.service!.conversation, 'wipeMLSConversation').and.returnValue(Promise.resolve(undefined));
+    spyOn(core.service!.conversation, 'mlsGroupExistsLocally').and.returnValue(Promise.resolve(true));
+
+    const updatePropertiesSpy = jest.spyOn(ConversationMapper, 'updateProperties');
+    const saveConversationStateInDbSpy = jest.spyOn(conversationService, 'saveConversationStateInDb');
+
+    await (conversationRepository as any).onMLSResetMessage(conversation, mlsResetEvent);
+
+    expect(updatePropertiesSpy).not.toHaveBeenCalled();
+    expect(saveConversationStateInDbSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/script/repositories/conversation/ConversationRepository.ts
+++ b/src/script/repositories/conversation/ConversationRepository.ts
@@ -4369,8 +4369,14 @@ export class ConversationRepository {
 
       const {new_group_id: newGroupId, group_id: oldGroupId} = eventJson.data;
 
-      await this.core.service?.conversation.wipeMLSConversation(oldGroupId);
-      const existingConversation = this.core.service?.conversation.mlsGroupExistsLocally(newGroupId);
+      const conversationService = this.core.service?.conversation;
+
+      if (!conversationService) {
+        throw new Error('Conversation service is not available!');
+      }
+
+      await conversationService.wipeMLSConversation(oldGroupId);
+      const existingConversation = await conversationService.mlsGroupExistsLocally(newGroupId);
 
       if (existingConversation) {
         this.logger.info(

--- a/src/script/repositories/conversation/ConversationRepository.ts
+++ b/src/script/repositories/conversation/ConversationRepository.ts
@@ -4370,9 +4370,9 @@ export class ConversationRepository {
       const {new_group_id: newGroupId, group_id: oldGroupId} = eventJson.data;
 
       await this.core.service?.conversation.wipeMLSConversation(oldGroupId);
-      const exisitingConversation = this.core.service?.conversation.mlsGroupExistsLocally(newGroupId);
+      const existingConversation = this.core.service?.conversation.mlsGroupExistsLocally(newGroupId);
 
-      if (exisitingConversation) {
+      if (existingConversation) {
         this.logger.info(
           'An MLS conversation with the new group ID already exists on core crypto. no need to update epoch',
         );

--- a/src/script/repositories/conversation/ConversationRepository.ts
+++ b/src/script/repositories/conversation/ConversationRepository.ts
@@ -4359,13 +4359,36 @@ export class ConversationRepository {
    */
   private async onMLSResetMessage(conversationEntity: Conversation, eventJson: ConversationMLSResetEvent) {
     try {
+      this.logger.info(`Handling MLS reset event for conversation ${conversationEntity.id}`, {eventJson});
       if (!isMLSConversation(conversationEntity)) {
+        this.logger.warn(
+          `Received MLS reset event for a conversation that is not MLS capable: ${conversationEntity.id}`,
+        );
         return;
       }
 
-      await this.core.service?.conversation.wipeMLSConversation(eventJson.data.group_id);
+      const {new_group_id: newGroupId, group_id: oldGroupId} = eventJson.data;
 
-      await this.refreshConversationProtocolProperties(conversationEntity);
+      await this.core.service?.conversation.wipeMLSConversation(oldGroupId);
+      const exisitingConversation = this.core.service?.conversation.mlsGroupExistsLocally(newGroupId);
+
+      if (exisitingConversation) {
+        this.logger.info(
+          'An MLS conversation with the new group ID already exists on core crypto. no need to update epoch',
+        );
+        return;
+      }
+
+      const updatedConversation = ConversationMapper.updateProperties(conversationEntity, {
+        epoch: 0,
+        groupId: newGroupId,
+      });
+
+      await this.saveConversationStateInDb(updatedConversation);
+
+      this.logger.info(
+        `Updated conversation group ID from ${oldGroupId} to ${newGroupId} for conversation ${conversationEntity.id} and set epoch to 0`,
+      );
     } catch (error) {
       this.logger.error(`Failed to reset MLS conversation ${conversationEntity.id}`, error);
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21618" title="WPB-21618" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21618</a>  [Web] Recover from MlsErrorWrongEpoch when decrypting messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

When a reset event arrives from the backend there is a possibility that the new welcome for the conversation that was reset has already arrived before and with that conversation epoch is now 1 not 0.

previously when a reset event arrived we fetched the backend to update the epoch which introduced a race condition. with this PR first we check if the new group_id exists on core crypto (meaning welcome has already arrived) and if so we skip updating the conversation epoch otherwise we set it to 0.
