### PR TITLE
test: add new fixtures to create users and pages

### DIFF
--- a/test/e2e_tests/backend/apiManager.e2e.ts
+++ b/test/e2e_tests/backend/apiManager.e2e.ts
@@ -27,6 +27,7 @@ import {ConnectionRepositoryE2E} from './connectionRepository.e2e';
 import {ConversationRepositoryE2E} from './ConversationRepository';
 import {FeatureConfigRepositoryE2E} from './featureConfigRepository.e2e';
 import {InbucketClientE2E} from './inbucketClient.e2e';
+import {PropertiesRepositoryE2E} from './propertiesRepostitory.e2e';
 import {TeamRepositoryE2E} from './teamRepository.e2e';
 import {TestServiceClientE2E} from './testServiceClient.e2e';
 import {UserRepositoryE2E} from './userRepository.e2e';
@@ -44,6 +45,7 @@ export class ApiManagerE2E {
   inbucket: InbucketClientE2E;
   connection: ConnectionRepositoryE2E;
   callingService: CallingServiceClientE2E;
+  properties: PropertiesRepositoryE2E;
 
   constructor() {
     this.user = new UserRepositoryE2E();
@@ -56,6 +58,7 @@ export class ApiManagerE2E {
     this.inbucket = new InbucketClientE2E();
     this.connection = new ConnectionRepositoryE2E();
     this.callingService = new CallingServiceClientE2E();
+    this.properties = new PropertiesRepositoryE2E();
   }
 
   async addDevicesToUser(user: User, numberOfDevices: number) {

--- a/test/e2e_tests/backend/apiManager.e2e.ts
+++ b/test/e2e_tests/backend/apiManager.e2e.ts
@@ -97,6 +97,10 @@ export class ApiManagerE2E {
     await this.user.setUniqueUsername(user.username, user.token);
   }
 
+  async deletePersonalUser(user: User) {
+    await this.user.deleteUser(user.password, user.token);
+  }
+
   /**
    * Long polling to see if a conference calling feature is available for a given team.
    * This is to wait until stripe/ibis has set free account restrictions after team creation.

--- a/test/e2e_tests/backend/propertiesRepostitory.e2e.ts
+++ b/test/e2e_tests/backend/propertiesRepostitory.e2e.ts
@@ -1,0 +1,36 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {WebappProperties} from '@wireapp/api-client/lib/user/data/';
+
+import {TypeUtil} from '@wireapp/commons';
+
+import {BackendClientE2E} from './backendClient.e2e';
+
+export class PropertiesRepositoryE2E extends BackendClientE2E {
+  /** Update a property of a user, e.g. to decline sharing telemetry */
+  async putProperty(data: TypeUtil.RecursivePartial<WebappProperties>, token: string) {
+    await this.axiosInstance.put('properties/webapp', data, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+}

--- a/test/e2e_tests/pageManager/index.ts
+++ b/test/e2e_tests/pageManager/index.ts
@@ -108,6 +108,10 @@ export class PageManager {
     return this.page.goto(webAppPath, {waitUntil: 'networkidle'});
   };
 
+  openLoginPage = async () => {
+    await this.page.goto(`${webAppPath}auth/#/login`);
+  };
+
   openUrl = (url: string) => {
     return this.page.goto(url, {waitUntil: 'networkidle'});
   };

--- a/test/e2e_tests/pageManager/index.ts
+++ b/test/e2e_tests/pageManager/index.ts
@@ -87,9 +87,11 @@ export class PageManager {
 
   constructor(private readonly page: Page) {}
 
-  static from = (page: Page): PageManager => {
-    return new PageManager(page);
-  };
+  static from(page: Page): PageManager;
+  static from(page: Promise<Page>): Promise<PageManager>;
+  static from(page: Page | Promise<Page>): PageManager | Promise<PageManager> {
+    return 'then' in page ? page.then(p => new PageManager(p)) : new PageManager(page);
+  }
 
   openNewTab = async <T>(url?: string, handler?: (tab: PageManager) => Promise<T>): Promise<T> => {
     const newPage = await this.page.context().newPage();

--- a/test/e2e_tests/pageManager/webapp/components/conversationSidebar.component.ts
+++ b/test/e2e_tests/pageManager/webapp/components/conversationSidebar.component.ts
@@ -48,14 +48,6 @@ export class ConversationSidebar {
     this.sidebar = page.locator(`.conversations-sidebar-items`);
   }
 
-  async getPersonalStatusName() {
-    return (await this.personalStatusName.textContent()) ?? '';
-  }
-
-  async getPersonalUserName() {
-    return (await this.personalUserName.textContent()) ?? '';
-  }
-
   async clickPreferencesButton() {
     await this.preferencesButton.click();
   }

--- a/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -145,10 +145,6 @@ export class ConversationPage {
     await this.cancelRequest.click();
   }
 
-  async isWatermarkVisible() {
-    return await this.watermark.isVisible();
-  }
-
   async sendMessage(message: string) {
     await this.messageInput.fill(message);
     await this.sendMessageButton.click();

--- a/test/e2e_tests/pageManager/webapp/pages/login.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/login.page.ts
@@ -17,14 +17,14 @@
  *
  */
 
-import {Page, Locator} from '@playwright/test';
+import type {Page, Locator} from '@playwright/test';
+
+import type {User} from 'test/e2e_tests/data/user';
 
 export class LoginPage {
   readonly page: Page;
 
-  readonly backButton: Locator;
   readonly signInButton: Locator;
-  readonly loginForm: Locator;
   readonly emailInput: Locator;
   readonly passwordInput: Locator;
   readonly loginErrorText: Locator;
@@ -32,31 +32,15 @@ export class LoginPage {
   constructor(page: Page) {
     this.page = page;
 
-    this.backButton = page.locator('[data-uie-name="go-index"]');
     this.signInButton = page.locator('[data-uie-name="do-sign-in"]');
-    this.loginForm = page.locator('[data-uie-name="login"]');
     this.emailInput = page.locator('[data-uie-name="enter-email"]');
     this.passwordInput = page.locator('[data-uie-name="enter-password"]');
     this.loginErrorText = page.locator('[data-uie-name="error-message"]');
   }
 
-  async isEmailFieldVisible() {
-    return await this.emailInput.isVisible();
-  }
-
-  async inputEmail(email: string) {
-    await this.emailInput.fill(email);
-  }
-
-  async inputPassword(password: string) {
-    await this.passwordInput.fill(password);
-  }
-
-  async clickSignInButton() {
+  async login(user: Pick<User, 'email' | 'password'>) {
+    await this.emailInput.fill(user.email);
+    await this.passwordInput.fill(user.password);
     await this.signInButton.click();
-  }
-
-  async getErrorMessage() {
-    return (await this.loginErrorText.textContent()) ?? '';
   }
 }

--- a/test/e2e_tests/specs/Authentication/authentication.spec.ts
+++ b/test/e2e_tests/specs/Authentication/authentication.spec.ts
@@ -1,0 +1,36 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {test, expect} from 'test/e2e_tests/test.fixtures';
+
+test.describe('Authentication', () => {
+  test(
+    'I want to be asked to share telemetry data when I log in',
+    {tag: ['@TC-8780', '@regression']},
+    async ({pageManager, createUser}) => {
+      const {pages, modals} = pageManager.webapp;
+      const user = await createUser({disableTelemetry: false});
+
+      await pageManager.openLoginPage();
+      await pages.login().login(user);
+
+      await expect(modals.dataShareConsent().modalTitle).toBeVisible();
+    },
+  );
+});

--- a/test/e2e_tests/specs/CriticalFlow/personalAccountLifecycle-TC-8638.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/personalAccountLifecycle-TC-8638.spec.ts
@@ -85,9 +85,11 @@ test('Personal Account Lifecycle', {tag: ['@TC-8638', '@crit-flow-web']}, async 
   });
 
   await test.step('Personal user A checks that username was set correctly', async () => {
-    expect(await components.conversationSidebar().getPersonalStatusName()).toBe(`${userA.firstName} ${userA.lastName}`);
-    expect(await components.conversationSidebar().getPersonalUserName()).toContain(userA.username);
-    expect(await pages.conversation().isWatermarkVisible());
+    await expect(components.conversationSidebar().personalStatusName).toHaveText(
+      `${userA.firstName} ${userA.lastName}`,
+    );
+    await expect(components.conversationSidebar().personalUserName).toContainText(userA.username);
+    await expect(pages.conversation().watermark).toBeVisible();
   });
 
   await test.step('Personal user A searches for other personal user B', async () => {

--- a/test/e2e_tests/specs/Edit/edit.spec.ts
+++ b/test/e2e_tests/specs/Edit/edit.spec.ts
@@ -195,11 +195,14 @@ test.describe('Edit', () => {
     {tag: ['@TC-692', '@regression']},
     async ({createPage, userA, userB}) => {
       const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConversation(userB)),
-        createPage(withLogin(userB), withConversation(userA)),
+        PageManager.from(createPage(withLogin(userA), withConversation(userB))),
+        PageManager.from(createPage(withLogin(userB), withConversation(userA))),
       ]);
-      const userAPages = PageManager.from(userAPage).webapp.pages;
-      const userBPages = PageManager.from(userBPage).webapp.pages;
+
+      // ToDo: Can this boiler plate be abstracted? E.g. overload Pagemanager.from to accept a promise?
+      // Maybe it would be best to split the PageManager a bit, since the .webapp.pages often prevents optimization?
+      const userAPages = userAPage.webapp.pages;
+      const userBPages = userBPage.webapp.pages;
 
       await userAPages.conversation().sendMessage('Test');
       const sentMessage = userAPages.conversation().getMessage({sender: userA});

--- a/test/e2e_tests/specs/Edit/edit.spec.ts
+++ b/test/e2e_tests/specs/Edit/edit.spec.ts
@@ -37,8 +37,7 @@ test.describe('Edit', () => {
   });
 
   test('I can edit my message in 1:1', {tag: ['@TC-679', '@regression']}, async ({createPage, userA, userB}) => {
-    const page = await createPage(withLogin(userA), withConversation(userB));
-    const {pages} = PageManager.from(page).webapp;
+    const pages = (await PageManager.from(createPage(withLogin(userA), withConversation(userB)))).webapp.pages;
 
     await pages.conversation().sendMessage('Test Message');
 
@@ -57,8 +56,7 @@ test.describe('Edit', () => {
     'I can edit my message in a group conversation',
     {tag: ['@TC-680', '@regression']},
     async ({createPage, userA, userB}) => {
-      const page = await createPage(withLogin(userA));
-      const {pages} = PageManager.from(page).webapp;
+      const pages = (await PageManager.from(createPage(withLogin(userA)))).webapp.pages;
 
       await createGroup(pages, 'Test Group', [userB]);
       await pages.conversationList().openConversation('Test Group');
@@ -80,11 +78,9 @@ test.describe('Edit', () => {
     'I see changed message if message was edited from another device',
     {tag: ['@TC-682', '@regression']},
     async ({createPage, userA, userB}) => {
-      const deviceAPage = await createPage(withLogin(userA), withConversation(userB));
-      const deviceA = PageManager.from(deviceAPage).webapp.pages;
+      const deviceA = (await PageManager.from(createPage(withLogin(userA), withConversation(userB)))).webapp.pages;
       // Device 2 is intentionally created after device 1 to ensure the history info warning is confirmed
-      const deviceBPage = await createPage(withLogin(userA));
-      const deviceB = PageManager.from(deviceBPage).webapp.pages;
+      const deviceB = (await PageManager.from(createPage(withLogin(userA)))).webapp.pages;
 
       await deviceB.historyInfo().clickConfirmButton();
       await deviceB.conversationList().openConversation(userB.fullName);
@@ -106,12 +102,10 @@ test.describe('Edit', () => {
   );
 
   test('I cannot edit another users message', {tag: ['@TC-683', '@regression']}, async ({createPage, userA, userB}) => {
-    const [userAPage, userBPage] = await Promise.all([
-      createPage(withLogin(userA), withConversation(userB)),
-      createPage(withLogin(userB), withConversation(userA)),
+    const [userAPages, userBPages] = await Promise.all([
+      PageManager.from(createPage(withLogin(userA), withConversation(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB), withConversation(userA))).then(pm => pm.webapp.pages),
     ]);
-    const userAPages = PageManager.from(userAPage).webapp.pages;
-    const userBPages = PageManager.from(userBPage).webapp.pages;
 
     await userAPages.conversation().sendMessage('Test Message');
 
@@ -126,8 +120,7 @@ test.describe('Edit', () => {
     'I can edit my last message by pressing the up arrow key',
     {tag: ['@TC-686', '@regression']},
     async ({createPage, userA, userB}) => {
-      const page = await createPage(withLogin(userA), withConversation(userB));
-      const pages = PageManager.from(page).webapp.pages;
+      const pages = (await PageManager.from(createPage(withLogin(userA), withConversation(userB)))).webapp.pages;
 
       await pages.conversation().sendMessage('Test Message');
       await expect(pages.conversation().getMessage({content: 'Test Message'})).toBeVisible();
@@ -141,12 +134,10 @@ test.describe('Edit', () => {
     'Editing a message does not create unread dot on receiver side',
     {tag: ['@TC-690', '@regression']},
     async ({createPage, userA, userB}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConversation(userB)),
-        createPage(withLogin(userB), withConversation(userA)),
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConversation(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConversation(userA))).then(pm => pm.webapp.pages),
       ]);
-      const userAPages = PageManager.from(userAPage).webapp.pages;
-      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await test.step('Create group as second conversation', async () => {
         // We need to create a second conversation in order to switch to it to ensure the unread marker can be shown on the not open conversation
@@ -194,15 +185,10 @@ test.describe('Edit', () => {
     'I can see the changed message was edited from another user',
     {tag: ['@TC-692', '@regression']},
     async ({createPage, userA, userB}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConversation(userB))),
-        PageManager.from(createPage(withLogin(userB), withConversation(userA))),
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConversation(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConversation(userA))).then(pm => pm.webapp.pages),
       ]);
-
-      // ToDo: Can this boiler plate be abstracted? E.g. overload Pagemanager.from to accept a promise?
-      // Maybe it would be best to split the PageManager a bit, since the .webapp.pages often prevents optimization?
-      const userAPages = userAPage.webapp.pages;
-      const userBPages = userBPage.webapp.pages;
 
       await userAPages.conversation().sendMessage('Test');
       const sentMessage = userAPages.conversation().getMessage({sender: userA});
@@ -223,8 +209,7 @@ test.describe('Edit', () => {
     'I want to see the last edited text including a timestamp in message detail view if the message has been edited',
     {tag: ['@TC-3563', '@regression']},
     async ({createPage, userA, userB}) => {
-      const page = await createPage(withLogin(userA));
-      const pages = PageManager.from(page).webapp.pages;
+      const pages = await PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages);
       await createGroup(pages, 'Test Group', [userB]); // The message detail view is only available for group conversations
 
       await pages.conversationList().openConversation('Test Group');

--- a/test/e2e_tests/specs/Edit/edit.spec.ts
+++ b/test/e2e_tests/specs/Edit/edit.spec.ts
@@ -17,67 +17,29 @@
  *
  */
 
-import {Browser} from '@playwright/test';
-
-import {getUser, User} from 'test/e2e_tests/data/user';
+import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test as baseTest, expect} from 'test/e2e_tests/test.fixtures';
-import {removeCreatedUser} from 'test/e2e_tests/utils/tearDown.util';
-import {createGroup, loginUser} from 'test/e2e_tests/utils/userActions';
+import {test as baseTest, expect, withConversation, withLogin} from 'test/e2e_tests/test.fixtures';
+import {createGroup} from 'test/e2e_tests/utils/userActions';
 
 const test = baseTest.extend<{userA: User; userB: User}>({
-  userA: async ({api}, use) => {
-    const userA = getUser();
-    await api.createPersonalUser(userA);
-    await use(userA);
-    await removeCreatedUser(api, userA);
+  userA: async ({createUser}, use) => {
+    await use(await createUser());
   },
-  userB: async ({api}, use) => {
-    const userB = getUser();
-    await api.createPersonalUser(userB);
-    await use(userB);
-    await removeCreatedUser(api, userB);
+  userB: async ({createUser}, use) => {
+    await use(await createUser());
   },
 });
-
-const createPagesForUser = async (
-  browser: Browser,
-  user: User,
-  options?: {confirmHistoryWarning?: boolean; declineDataShareConsent?: boolean; openConversationWith?: User},
-) => {
-  const context = await browser.newContext();
-  const page = await context.newPage();
-  const pageManager = PageManager.from(page);
-
-  await pageManager.openMainPage();
-  await loginUser(user, pageManager);
-  const {pages, modals} = pageManager.webapp;
-
-  if (options?.confirmHistoryWarning) {
-    await pages.historyInfo().clickConfirmButton();
-  }
-
-  if (options?.declineDataShareConsent) {
-    await modals.dataShareConsent().clickDecline();
-  }
-
-  if (options?.openConversationWith) {
-    await pages.conversationList().openConversation(options.openConversationWith.fullName);
-  }
-
-  return pages;
-};
 
 test.describe('Edit', () => {
   test.beforeEach(async ({api, userA, userB}) => {
     await api.connectUsers(userA, userB);
   });
 
-  test('I can edit my message in 1:1', {tag: ['@TC-679', '@regression']}, async ({browser, userA, userB}) => {
-    const pages = await createPagesForUser(browser, userA, {
-      declineDataShareConsent: true,
-      openConversationWith: userB,
-    });
+  test('I can edit my message in 1:1', {tag: ['@TC-679', '@regression']}, async ({createPage, userA, userB}) => {
+    const page = await createPage(withLogin(userA), withConversation(userB));
+    const {pages} = PageManager.from(page).webapp;
+
     await pages.conversation().sendMessage('Test Message');
 
     const message = pages.conversation().getMessage({sender: userA});
@@ -94,8 +56,10 @@ test.describe('Edit', () => {
   test(
     'I can edit my message in a group conversation',
     {tag: ['@TC-680', '@regression']},
-    async ({browser, userA, userB}) => {
-      const pages = await createPagesForUser(browser, userA, {declineDataShareConsent: true});
+    async ({createPage, userA, userB}) => {
+      const page = await createPage(withLogin(userA));
+      const {pages} = PageManager.from(page).webapp;
+
       await createGroup(pages, 'Test Group', [userB]);
       await pages.conversationList().openConversation('Test Group');
       await pages.conversation().sendMessage('Test Message');
@@ -115,39 +79,40 @@ test.describe('Edit', () => {
   test(
     'I see changed message if message was edited from another device',
     {tag: ['@TC-682', '@regression']},
-    async ({browser, userA, userB}) => {
-      const device1 = await createPagesForUser(browser, userA, {
-        declineDataShareConsent: true,
-        openConversationWith: userB,
-      });
-
+    async ({createPage, userA, userB}) => {
+      const deviceAPage = await createPage(withLogin(userA), withConversation(userB));
+      const deviceA = PageManager.from(deviceAPage).webapp.pages;
       // Device 2 is intentionally created after device 1 to ensure the history info warning is confirmed
-      const device2 = await createPagesForUser(browser, userA, {
-        confirmHistoryWarning: true,
-        openConversationWith: userB,
-      });
+      const deviceBPage = await createPage(withLogin(userA));
+      const deviceB = PageManager.from(deviceBPage).webapp.pages;
 
-      await device1.conversation().sendMessage('Message from device 1');
+      await deviceB.historyInfo().clickConfirmButton();
+      await deviceB.conversationList().openConversation(userB.fullName);
 
-      const messageOnDevice1 = device1.conversation().getMessage({sender: userA});
-      const messageOnDevice2 = device2.conversation().getMessage({sender: userA});
-      await expect(messageOnDevice1).toContainText('Message from device 1');
-      await expect(messageOnDevice2).toContainText('Message from device 1');
+      await deviceA.conversation().sendMessage('Message from device 1');
 
-      await device1.conversation().editMessage(messageOnDevice1);
-      await expect(device1.conversation().messageInput).toContainText('Message from device 1');
-      await device1.conversation().sendMessage('Updated message from device 1');
+      const messageOnDeviceA = deviceA.conversation().getMessage({sender: userA});
+      const messageOnDeviceB = deviceB.conversation().getMessage({sender: userA});
+      await expect(messageOnDeviceA).toContainText('Message from device 1');
+      await expect(messageOnDeviceB).toContainText('Message from device 1');
 
-      await expect(messageOnDevice1).toContainText('Updated message from device 1');
-      await expect(messageOnDevice2).toContainText('Updated message from device 1');
+      await deviceA.conversation().editMessage(messageOnDeviceA);
+      await expect(deviceA.conversation().messageInput).toContainText('Message from device 1');
+      await deviceA.conversation().sendMessage('Updated message from device 1');
+
+      await expect(messageOnDeviceA).toContainText('Updated message from device 1');
+      await expect(messageOnDeviceB).toContainText('Updated message from device 1');
     },
   );
 
-  test('I cannot edit another users message', {tag: ['@TC-683', '@regression']}, async ({browser, userA, userB}) => {
-    const [userAPages, userBPages] = await Promise.all([
-      createPagesForUser(browser, userA, {declineDataShareConsent: true, openConversationWith: userB}),
-      createPagesForUser(browser, userB, {declineDataShareConsent: true, openConversationWith: userA}),
+  test('I cannot edit another users message', {tag: ['@TC-683', '@regression']}, async ({createPage, userA, userB}) => {
+    const [userAPage, userBPage] = await Promise.all([
+      createPage(withLogin(userA), withConversation(userB)),
+      createPage(withLogin(userB), withConversation(userA)),
     ]);
+    const userAPages = PageManager.from(userAPage).webapp.pages;
+    const userBPages = PageManager.from(userBPage).webapp.pages;
+
     await userAPages.conversation().sendMessage('Test Message');
 
     const message = userBPages.conversation().getMessage({sender: userA});
@@ -160,11 +125,10 @@ test.describe('Edit', () => {
   test(
     'I can edit my last message by pressing the up arrow key',
     {tag: ['@TC-686', '@regression']},
-    async ({browser, userA, userB}) => {
-      const pages = await createPagesForUser(browser, userA, {
-        declineDataShareConsent: true,
-        openConversationWith: userB,
-      });
+    async ({createPage, userA, userB}) => {
+      const page = await createPage(withLogin(userA), withConversation(userB));
+      const pages = PageManager.from(page).webapp.pages;
+
       await pages.conversation().sendMessage('Test Message');
       await expect(pages.conversation().getMessage({content: 'Test Message'})).toBeVisible();
 
@@ -176,11 +140,13 @@ test.describe('Edit', () => {
   test(
     'Editing a message does not create unread dot on receiver side',
     {tag: ['@TC-690', '@regression']},
-    async ({browser, userA, userB}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        createPagesForUser(browser, userA, {declineDataShareConsent: true}),
-        createPagesForUser(browser, userB, {declineDataShareConsent: true}),
+    async ({createPage, userA, userB}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConversation(userB)),
+        createPage(withLogin(userB), withConversation(userA)),
       ]);
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await test.step('Create group as second conversation', async () => {
         // We need to create a second conversation in order to switch to it to ensure the unread marker can be shown on the not open conversation
@@ -227,11 +193,13 @@ test.describe('Edit', () => {
   test(
     'I can see the changed message was edited from another user',
     {tag: ['@TC-692', '@regression']},
-    async ({browser, userA, userB}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        createPagesForUser(browser, userA, {declineDataShareConsent: true, openConversationWith: userB}),
-        createPagesForUser(browser, userB, {declineDataShareConsent: true, openConversationWith: userA}),
+    async ({createPage, userA, userB}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConversation(userB)),
+        createPage(withLogin(userB), withConversation(userA)),
       ]);
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await userAPages.conversation().sendMessage('Test');
       const sentMessage = userAPages.conversation().getMessage({sender: userA});
@@ -251,8 +219,9 @@ test.describe('Edit', () => {
   test(
     'I want to see the last edited text including a timestamp in message detail view if the message has been edited',
     {tag: ['@TC-3563', '@regression']},
-    async ({browser, userA, userB}) => {
-      const pages = await createPagesForUser(browser, userA, {declineDataShareConsent: true});
+    async ({createPage, userA, userB}) => {
+      const page = await createPage(withLogin(userA));
+      const pages = PageManager.from(page).webapp.pages;
       await createGroup(pages, 'Test Group', [userB]); // The message detail view is only available for group conversations
 
       await pages.conversationList().openConversation('Test Group');

--- a/test/e2e_tests/specs/LoginSpecs/login.spec.ts
+++ b/test/e2e_tests/specs/LoginSpecs/login.spec.ts
@@ -49,13 +49,3 @@ test('Verify you can sign in by email', {tag: ['@TC-3461', '@regression']}, asyn
   await expect(components.conversationSidebar().personalStatusName).toHaveText(`${user.firstName} ${user.lastName}`);
   await expect(components.conversationSidebar().personalUserName).toContainText(user.username);
 });
-
-test('I want to be asked to share telemetry data when I log in', async ({pageManager, createUser}) => {
-  const {pages, modals} = pageManager.webapp;
-  const user = await createUser({disableTelemetry: false});
-
-  await pageManager.openLoginPage();
-  await pages.login().login(user);
-
-  await expect(modals.dataShareConsent().modalTitle).toBeVisible();
-});

--- a/test/e2e_tests/specs/LoginSpecs/login.spec.ts
+++ b/test/e2e_tests/specs/LoginSpecs/login.spec.ts
@@ -17,49 +17,33 @@
  *
  */
 
-import {getUser} from '../../data/user';
 import {test, expect} from '../../test.fixtures';
-import {addCreatedUser, removeCreatedUser} from '../../utils/tearDown.util';
-import {loginUser} from '../../utils/userActions';
-import {generateSecurePassword} from '../../utils/userDataGenerator';
-
-const user = getUser();
 
 test(
   'Verify sign in error appearance in case of wrong credentials',
   {tag: ['@TC-3465', '@smoke']},
   async ({pageManager}) => {
-    const incorrectEmail = 'blablabla@wire.engineering';
-    const incorrectPassword = generateSecurePassword();
+    const {pages} = pageManager.webapp;
 
-    const pages = pageManager.webapp.pages;
+    await pageManager.openLoginPage();
+    await pages.login().login({email: 'incorrect-email@wire.engineering', password: 'incorrectPassword'});
 
-    await pageManager.openMainPage();
-    await pages.singleSignOn().enterEmailOnSSOPage(incorrectEmail);
-    await pages.login().inputPassword(incorrectPassword);
-    await pages.login().clickSignInButton();
-
-    const errorMessage = await pages.login().getErrorMessage();
-
-    expect(errorMessage).toBe('Please verify your details and try again');
+    const errorMessage = pages.login().loginErrorText;
+    await expect(errorMessage).toHaveText('Please verify your details and try again');
   },
 );
 
-test('Verify you can sign in by email', {tag: ['@TC-3461', '@regression']}, async ({pageManager, api}) => {
-  const {modals, components} = pageManager.webapp;
-
-  // Create user with random password, email, username, lastName, firstName
-  await api.createPersonalUser(user);
-
-  // Adding created user to the list for later cleanup
-  addCreatedUser(user);
+test('Verify you can sign in by email', {tag: ['@TC-3461', '@regression']}, async ({pageManager, createUser}) => {
+  const {components, pages} = pageManager.webapp;
+  const user = await createUser();
 
   await pageManager.openMainPage();
-  await loginUser(user, pageManager);
-  await modals.dataShareConsent().clickDecline();
+  await pages.singleSignOn().enterEmailOnSSOPage(user.email);
+  await expect(pages.login().emailInput).toHaveValue(user.email);
 
-  expect(await components.conversationSidebar().getPersonalStatusName()).toBe(`${user.firstName} ${user.lastName}`);
-  expect(await components.conversationSidebar().getPersonalUserName()).toContain(user.username);
+  await pages.login().passwordInput.fill(user.password);
+  await pages.login().signInButton.click();
 
-  await removeCreatedUser(api, user);
+  await expect(components.conversationSidebar().personalStatusName).toHaveText(`${user.firstName} ${user.lastName}`);
+  await expect(components.conversationSidebar().personalUserName).toContainText(user.username);
 });

--- a/test/e2e_tests/specs/LoginSpecs/login.spec.ts
+++ b/test/e2e_tests/specs/LoginSpecs/login.spec.ts
@@ -47,3 +47,13 @@ test('Verify you can sign in by email', {tag: ['@TC-3461', '@regression']}, asyn
   await expect(components.conversationSidebar().personalStatusName).toHaveText(`${user.firstName} ${user.lastName}`);
   await expect(components.conversationSidebar().personalUserName).toContainText(user.username);
 });
+
+test('I want to be asked to share telemetry data when I log in', async ({pageManager, createUser}) => {
+  const {pages, modals} = pageManager.webapp;
+  const user = await createUser({disableTelemetry: false});
+
+  await pageManager.openLoginPage();
+  await pages.login().login(user);
+
+  await expect(modals.dataShareConsent().modalTitle).toBeVisible();
+});

--- a/test/e2e_tests/specs/LoginSpecs/login.spec.ts
+++ b/test/e2e_tests/specs/LoginSpecs/login.spec.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import {generateRandomPassword} from 'Util/StringUtil';
+
 import {test, expect} from '../../test.fixtures';
 
 test(
@@ -26,7 +28,7 @@ test(
     const {pages} = pageManager.webapp;
 
     await pageManager.openLoginPage();
-    await pages.login().login({email: 'incorrect-email@wire.engineering', password: 'incorrectPassword'});
+    await pages.login().login({email: 'incorrect-email@wire.engineering', password: generateRandomPassword()});
 
     const errorMessage = pages.login().loginErrorText;
     await expect(errorMessage).toHaveText('Please verify your details and try again');

--- a/test/e2e_tests/test.fixtures.ts
+++ b/test/e2e_tests/test.fixtures.ts
@@ -28,7 +28,7 @@ type Fixtures = {
   api: ApiManagerE2E;
   pageManager: PageManager;
   createPage: () => Promise<Page>;
-  createUser: () => Promise<User>;
+  createUser: (options?: {disableTelemetry?: boolean}) => Promise<User>;
 };
 
 export const test = baseTest.extend<Fixtures>({
@@ -56,9 +56,16 @@ export const test = baseTest.extend<Fixtures>({
   createUser: async ({api}, use) => {
     const users: User[] = [];
 
-    await use(async () => {
+    await use(async options => {
+      const {disableTelemetry = true} = options ?? {};
+
       const user = getUser();
       await api.createPersonalUser(user);
+
+      if (disableTelemetry) {
+        await api.properties.putProperty({settings: {privacy: {telemetry_data_sharing: false}}}, user.token);
+      }
+
       users.push(user);
       return user;
     });

--- a/test/e2e_tests/test.fixtures.ts
+++ b/test/e2e_tests/test.fixtures.ts
@@ -23,11 +23,17 @@ import {ApiManagerE2E} from './backend/apiManager.e2e';
 import {getUser, User} from './data/user';
 import {PageManager} from './pageManager';
 
+type PagePlugin = (page: Page) => void | Promise<void>;
+
 // Define custom test type with axios fixture
 type Fixtures = {
   api: ApiManagerE2E;
   pageManager: PageManager;
-  createPage: () => Promise<Page>;
+  /**
+   * Create a new page within a new browser context - The context and it's pages will be removed after the test automatically
+   * @param setup Array of PagePlugins, effectively functions which will be applied to the page in the given order
+   */
+  createPage: (...setup: PagePlugin[]) => Promise<Page>;
   createUser: (options?: {disableTelemetry?: boolean}) => Promise<User>;
 };
 
@@ -43,10 +49,15 @@ export const test = baseTest.extend<Fixtures>({
   createPage: async ({browser}, use) => {
     const contexts: BrowserContext[] = [];
 
-    await use(async () => {
+    await use(async (...setup) => {
       const context = await browser.newContext();
       const page = await context.newPage();
       contexts.push(context);
+
+      for (const setupFn of setup) {
+        await setupFn(page);
+      }
+
       return page;
     });
 
@@ -73,5 +84,21 @@ export const test = baseTest.extend<Fixtures>({
     await Promise.all(users.map(user => api.deletePersonalUser(user)));
   },
 });
+
+/** PagePlugin to log in as the given user */
+export const withLogin =
+  (user: User): PagePlugin =>
+  async page => {
+    const pageManager = PageManager.from(page);
+    await pageManager.openLoginPage();
+    await pageManager.webapp.pages.login().login(user);
+  };
+
+/** PagePlugin to open a conversation with the given user */
+export const withConversation =
+  (user: Pick<User, 'fullName'>): PagePlugin =>
+  async page => {
+    await PageManager.from(page).webapp.pages.conversationList().openConversation(user.fullName);
+  };
 
 export {expect} from '@playwright/test';

--- a/test/e2e_tests/test.fixtures.ts
+++ b/test/e2e_tests/test.fixtures.ts
@@ -17,15 +17,18 @@
  *
  */
 
-import {test as baseTest} from '@playwright/test';
+import {test as baseTest, type BrowserContext, type Page} from '@playwright/test';
 
 import {ApiManagerE2E} from './backend/apiManager.e2e';
+import {getUser, User} from './data/user';
 import {PageManager} from './pageManager';
 
 // Define custom test type with axios fixture
 type Fixtures = {
   api: ApiManagerE2E;
   pageManager: PageManager;
+  createPage: () => Promise<Page>;
+  createUser: () => Promise<User>;
 };
 
 export const test = baseTest.extend<Fixtures>({
@@ -36,6 +39,31 @@ export const test = baseTest.extend<Fixtures>({
   pageManager: async ({page}, use) => {
     // Create a new instance of PageManager for each test
     await use(new PageManager(page));
+  },
+  createPage: async ({browser}, use) => {
+    const contexts: BrowserContext[] = [];
+
+    await use(async () => {
+      const context = await browser.newContext();
+      const page = await context.newPage();
+      contexts.push(context);
+      return page;
+    });
+
+    // Close all contexts created throughout the tests (will automatically close all pages associated with each context)
+    await Promise.all(contexts.map(ctx => ctx.close()));
+  },
+  createUser: async ({api}, use) => {
+    const users: User[] = [];
+
+    await use(async () => {
+      const user = getUser();
+      await api.createPersonalUser(user);
+      users.push(user);
+      return user;
+    });
+
+    await Promise.all(users.map(user => api.deletePersonalUser(user)));
   },
 });
 

--- a/test/e2e_tests/test.fixtures.ts
+++ b/test/e2e_tests/test.fixtures.ts
@@ -87,11 +87,11 @@ export const test = baseTest.extend<Fixtures>({
 
 /** PagePlugin to log in as the given user */
 export const withLogin =
-  (user: User): PagePlugin =>
+  (user: User | Promise<User>): PagePlugin =>
   async page => {
     const pageManager = PageManager.from(page);
     await pageManager.openLoginPage();
-    await pageManager.webapp.pages.login().login(user);
+    await pageManager.webapp.pages.login().login(await user);
   };
 
 /** PagePlugin to open a conversation with the given user */

--- a/test/e2e_tests/utils/userActions.ts
+++ b/test/e2e_tests/utils/userActions.ts
@@ -27,8 +27,8 @@ export const loginUser = async (user: User, pageManager: PageManager) => {
   const {pages} = pageManager.webapp;
   await pages.singleSignOn().isSSOPageVisible();
   await pages.singleSignOn().enterEmailOnSSOPage(user.email);
-  await pages.login().inputPassword(user.password);
-  await pages.login().clickSignInButton();
+  await pages.login().passwordInput.fill(user.password);
+  await pages.login().signInButton.click();
 };
 
 export const sendTextMessageToUser = async (pageManager: PageManager, recipient: User, text: string) => {


### PR DESCRIPTION
## Description

In a lot of cases we need to create multiple pages to simulate multiple devices / users within one test. The two new added fixtures `createPage()` and `createUser()` allow us to do that in a save way, ensuring tests are isolated and created contexts / users are correctly cleaned up. (Even if the test fails in the middle)
The fixtures also allow us to generalize some more advanced use cases through the API. For example preventing the Telemetry modal from appearing after every login, reducing the time a test takes by ~5s per login. The design of the fixtures is extensible and more options may be added in the future if they really provide benefit to a lot of tests.
I started by refactoring the login tests, using them as a POC. The ultimate goal would be to refactor all tests creating a uniform codebase but I'd like to avoid doing so within one PR, so please see this as the first step of an incremental refactoring.

> **Note:** Since the Telemetry modal is now skipped by default I added a new test to ensure it still works. Please let me know if you think it should be moved to a different category or expanded somehow.

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

## Notes for reviewers
- I also refactored some of the POM/COMs I encountered while refactoring the login tests. I removed the "getter functions" in favor of using the locators in assertions directly and removed some unused or only used once functions.