### PR TITLE
fix(conversation): add retry attempts for conversationNotFound Error [WPB-18227]

### DIFF
--- a/src/script/repositories/conversation/ConversationRepository.ts
+++ b/src/script/repositories/conversation/ConversationRepository.ts
@@ -611,7 +611,9 @@ export class ConversationRepository {
       await this.updateParticipatingUserEntities(conversationEntity);
       await this.saveConversation(conversationEntity);
 
-      fetching_conversations[conversationId].forEach(({resolveFn}) => resolveFn(conversationEntity));
+      for (const {resolveFn} of fetching_conversations[conversationId]) {
+        resolveFn(conversationEntity);
+      }
       delete fetching_conversations[conversationId];
 
       return conversationEntity;
@@ -628,11 +630,15 @@ export class ConversationRepository {
           ConversationError.MESSAGE.CONVERSATION_NOT_FOUND,
           originalError,
         );
-        fetching_conversations[conversationId].forEach(({rejectFn}) => rejectFn(error));
-        delete fetching_conversations[conversationId];
 
+        for (const {rejectFn} of fetching_conversations[conversationId]) {
+          rejectFn(error);
+        }
+
+        delete fetching_conversations[conversationId];
         throw error;
       }
+      throw new Error('unkown error encountered', {cause: originalError});
     }
   }
 

--- a/src/script/view_model/ContentViewModel.ts
+++ b/src/script/view_model/ContentViewModel.ts
@@ -294,7 +294,10 @@ export class ContentViewModel {
     } catch (error: unknown) {
       if (this.isConversationNotFoundError(error)) {
         // Retry fetching the conversation to handle race conditions
-        const fetchSucceeded = await this.retryFetchConversationWithBackoff(conversation, 5);
+        const fetchSucceeded = await this.retryFetchConversationWithBackoff({
+          id: conversation.domain,
+          domain: conversation.domain,
+        });
 
         if (fetchSucceeded) {
           // Conversation was found after retry, attempt to show it again


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18227" title="WPB-18227" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18227</a>  [Web] Can't open this conversation - modal is shown after login
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Description

We show this error when an conversation we try to load from backend is not available anymore (Backend returns a not found error).
This could be triggered in rare cases for fresh users due to race conditions. 

![Wire 2025-11-13 at 4_47 PM](https://github.com/user-attachments/assets/6eef53a6-b061-498b-8cd5-6ad3fe0e789e)

## Fix

Added a retry mechanism for fetching the conversation, before accepting the error and continuing to handle the error state. 

## Result

- The retry mechanism handles edge case
- Every other case that causes the backend to deliver us the "not found" - error is handled as before
