### PR TITLE
chore: update copilot instructions to link relevant docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,10 +7,17 @@
 - Use severities: **[Blocker]**, **[Important]**, **[Suggestion]**.
 - Do **not** nitpick items handled by automation (formatting, lint rules).
 
-Related docs:
+Related docs (important):
 
-- **Coding Standards:** https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md
-- **Tech Radar:** https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md
+- **Coding Standards:** docs/coding-standards.md
+- **Tech Radar:** docs/tech-radar.md
+
+**Additional rules (open when relevant)**
+
+- Security: `.github/instructions/security.instructions.md`
+- Accessibility: `.github/instructions/accessibility.instructions.md`
+- React/UX: `.github/instructions/react.instructions.md`
+- TypeScript: `.github/instructions/typescript.instructions.md`
 
 ---
 
@@ -50,12 +57,12 @@ Related docs:
 
 ### Everything else
 
-- For imports/TS/React/testing/naming/readability: **refer to** the [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md).
+- For imports/TS/React/testing/naming/readability: **refer to** the [Coding Standards](docs/coding-standards.md).
   - If a standard is violated, link the relevant section and suggest a minimal change.
 
 ### Technology choices
 
-- Compare any new dependencies in `package.json`/lockfiles to the [Tech Radar](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).
+- Compare any new dependencies in `package.json`/lockfiles to the [Tech Radar](docs/tech-radar.md).
   - If not **Adopt**/**Trial**, mark **[Blocker]** and request an RFC/approval link.
   - For **Trial**, ensure usage is narrowly scoped and success criteria exist.
 


### PR DESCRIPTION
# Pull Request

## Summary

The additional rules need to be linked in the main copilot instructions file. 
This has not been the case and is fixed in this PR. 

Additionally copilot can work with relative links, I removed the static ones

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
