### PR TITLE
fix: remove call from the call state when a user is left the group [WPB-21813]

### DIFF
--- a/src/script/repositories/calling/CallingRepository.ts
+++ b/src/script/repositories/calling/CallingRepository.ts
@@ -35,16 +35,16 @@ import 'webrtc-adapter';
 
 import {
   AUDIO_STATE,
-  ENV as AVS_ENV,
-  STATE as CALL_STATE,
   CALL_TYPE,
   CONV_TYPE,
+  ENV as AVS_ENV,
   ERROR,
   getAvsInstance,
   LOG_LEVEL,
   QUALITY,
   REASON,
   RESOLUTION,
+  STATE as CALL_STATE,
   VIDEO_STATE,
   VSTREAMS,
   Wcall,
@@ -1666,6 +1666,12 @@ export class CallingRepository {
     }
   };
 
+  /**
+   * Leaves the call in the given conversation and on the basis of the given reason,
+   * Remove the call from the call state.
+   * @param conversationId
+   * @param reason
+   */
   readonly leaveCall = (conversationId: QualifiedId, reason: LEAVE_CALL_REASON): void => {
     const call = this.findCall(conversationId);
     if (call) {
@@ -1673,6 +1679,11 @@ export class CallingRepository {
       // Stop screen sharing if active
       if (call.getSelfParticipant().sharesScreen()) {
         this.stopScreenShare(call.getSelfParticipant(), call.conversation, call);
+      }
+
+      // If the user is not part of the conversation, the call must be removed from the state
+      if (reason === LEAVE_CALL_REASON.USER_IS_REMOVED_FROM_CONVERSATION) {
+        this.removeCall(call);
       }
     }
 

--- a/src/script/repositories/calling/enum/LeaveCallReason.ts
+++ b/src/script/repositories/calling/enum/LeaveCallReason.ts
@@ -25,7 +25,7 @@ export enum LEAVE_CALL_REASON {
   MANUAL_LEAVE_TO_JOIN_ANOTHER_CALL = 'manual_leave_to_join_another_call',
   MANUAL_LEAVE_BY_UI_CLICK = 'manual_leave_by_ui_click',
   USER_MANUALY_LEFT_CONVERSATION = 'user_manualy_left_conversation',
-  USER_IS_REMOVED_BY_AN_ADMIN_OR_LEFT_ON_ANOTHER_CLIENT = 'user_is_removed_by_an_admin_or_left_on_another_client',
+  USER_IS_REMOVED_FROM_CONVERSATION = 'user_is_removed_from_conversation',
   ABORTED_BECAUSE_FAILED_TO_UPDATE_MISSING_CLIENTS = 'abort_failed_to_update_missing_clients',
   ABORTED_BECAUSE_FAILED_TO_SEND_CALLING_MESSAGE = 'abort_failed_to_update_missing_clients',
   ABORTED_BECAUSE_USER_CANCELLED_MESSAGE_SENDING_BECAUSE_OF_A_DEGRADATION_WARNING = 'abort_failed_because_user_cancelled_message_sending_because_of_a_degradation_warning',

--- a/src/script/repositories/conversation/ConversationRepository.ts
+++ b/src/script/repositories/conversation/ConversationRepository.ts
@@ -18,38 +18,38 @@
  */
 
 import {
+  ADD_PERMISSION,
   Conversation as BackendConversation,
+  CONVERSATION_CELLS_STATE,
   CONVERSATION_TYPE,
   DefaultConversationRoleName as DefaultRole,
-  NewConversation,
   MessageSendingStatus,
+  NewConversation,
   RemoteConversations,
-  ADD_PERMISSION,
-  CONVERSATION_CELLS_STATE,
 } from '@wireapp/api-client/lib/conversation';
 import {
-  MemberLeaveReason,
   ConversationReceiptModeUpdateData,
+  MemberLeaveReason,
   RECEIPT_MODE,
 } from '@wireapp/api-client/lib/conversation/data';
 import {CONVERSATION_TYPING} from '@wireapp/api-client/lib/conversation/data/ConversationTypingData';
 import {
+  CONVERSATION_EVENT,
+  ConversationAddPermissionUpdateEvent,
   ConversationCreateEvent,
   ConversationEvent,
   ConversationMemberJoinEvent,
   ConversationMemberLeaveEvent,
   ConversationMemberUpdateEvent,
   ConversationMessageTimerUpdateEvent,
+  ConversationMLSResetEvent,
+  ConversationProtocolUpdateEvent,
   ConversationReceiptModeUpdateEvent,
   ConversationRenameEvent,
   ConversationTypingEvent,
-  CONVERSATION_EVENT,
-  ConversationProtocolUpdateEvent,
-  ConversationAddPermissionUpdateEvent,
-  ConversationMLSResetEvent,
 } from '@wireapp/api-client/lib/event';
-import {BackendErrorLabel} from '@wireapp/api-client/lib/http/';
 import type {BackendError} from '@wireapp/api-client/lib/http/';
+import {BackendErrorLabel} from '@wireapp/api-client/lib/http/';
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
 import type {QualifiedId} from '@wireapp/api-client/lib/user/';
 import {BaseCreateConversationResponse} from '@wireapp/core/lib/conversation';
@@ -118,16 +118,16 @@ import {ConversationLabelRepository} from './ConversationLabelRepository';
 import {ConversationDatabaseData, ConversationMapper} from './ConversationMapper';
 import {ConversationRoleRepository} from './ConversationRoleRepository';
 import {
+  isBackendProteus1to1Conversation,
+  isConnectionRequestConversation,
   isMixedConversation,
   isMLSCapableConversation,
   isMLSConversation,
+  isProteus1to1ConversationWithUser,
   isProteusConversation,
   MLSCapableConversation,
   MLSConversation,
-  isProteus1to1ConversationWithUser,
   ProteusConversation,
-  isConnectionRequestConversation,
-  isBackendProteus1to1Conversation,
 } from './ConversationSelectors';
 import {ConversationService} from './ConversationService';
 import {ConversationState} from './ConversationState';
@@ -160,7 +160,7 @@ import {MessageRepository} from './MessageRepository';
 import {NOTIFICATION_STATE} from './NotificationSetting';
 
 import {Config} from '../../Config';
-import {BaseError, BASE_ERROR_TYPE} from '../../error/BaseError';
+import {BASE_ERROR_TYPE, BaseError} from '../../error/BaseError';
 import {ConversationError} from '../../error/ConversationError';
 import {isMemberMessage} from '../../guards/Message';
 import * as LegalHoldEvaluator from '../../legal-hold/LegalHoldEvaluator';
@@ -4026,7 +4026,7 @@ export class ConversationRepository {
       conversationEntity.status(ConversationStatus.PAST_MEMBER);
       this.callingRepository.leaveCall(
         conversationEntity.qualifiedId,
-        LEAVE_CALL_REASON.USER_IS_REMOVED_BY_AN_ADMIN_OR_LEFT_ON_ANOTHER_CLIENT,
+        LEAVE_CALL_REASON.USER_IS_REMOVED_FROM_CONVERSATION,
       );
 
       if (this.userState.self().isTemporaryGuest()) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21813" title="WPB-21813" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21813</a>  [Web] Issues when leaving a group during an ongoing call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary
Call should be removed from the call state once the user left the group with ongoing call.

- What did I change and why?
-- I updated the method of leave call so that the user will not see CallingCell in the conversation list after leaving the group.
- Risks and how to roll out / roll back (e.g. feature flags): No risk in rolling this out.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
