### PR TITLE
refactor(WPB-21957): create fixture for creating teams + refactor edit tests with it

### DIFF
--- a/test/e2e_tests/backend/authRepository.e2e.ts
+++ b/test/e2e_tests/backend/authRepository.e2e.ts
@@ -63,6 +63,23 @@ export class AuthRepositoryE2E extends BackendClientE2E {
     });
   }
 
+  async upgradeUserToTeamOwner(user: User, teamName: string) {
+    const res = this.axiosInstance.post(
+      'upgrade-personal-to-team',
+      {
+        name: teamName,
+        icon: 'default',
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${user.token}`,
+        },
+      },
+    );
+    const data = (await res).data;
+    return {teamId: data.team_id, teamName: data.team_name};
+  }
+
   public async activateAccount(email: string, code: string) {
     await this.axiosInstance.post('activate', {
       code,

--- a/test/e2e_tests/backend/backendClient.e2e.ts
+++ b/test/e2e_tests/backend/backendClient.e2e.ts
@@ -17,10 +17,9 @@
  *
  */
 
-import {MINIMUM_API_VERSION} from '@wireapp/api-client/lib/Config';
 import axios, {AxiosInstance} from 'axios';
 
-const TEST_API_VERSION = `v${MINIMUM_API_VERSION}`;
+const TEST_API_VERSION = `v13`;
 export class BackendClientE2E {
   readonly axiosInstance: AxiosInstance;
 

--- a/test/e2e_tests/backend/backendClient.e2e.ts
+++ b/test/e2e_tests/backend/backendClient.e2e.ts
@@ -19,6 +19,7 @@
 
 import axios, {AxiosInstance} from 'axios';
 
+// ToDo: Fix via export from api-client
 const TEST_API_VERSION = `v13`;
 export class BackendClientE2E {
   readonly axiosInstance: AxiosInstance;

--- a/test/e2e_tests/backend/teamRepository.e2e.ts
+++ b/test/e2e_tests/backend/teamRepository.e2e.ts
@@ -42,6 +42,22 @@ export class TeamRepositoryE2E extends BackendClientE2E {
     return (await response).data.id;
   }
 
+  async acceptTeamInvitation(teamInvitationCode: string, user: Pick<User, 'password' | 'token'>) {
+    await this.axiosInstance.post(
+      'teams/invitations/accept',
+      {
+        code: teamInvitationCode,
+        password: user.password,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${user.token}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+  }
+
   async addServiceToTeamWhitelist(teamId: string, service: Service, token: string) {
     await this.axiosInstance.post(
       `teams/${teamId}/services/whitelist`,

--- a/test/e2e_tests/specs/Edit/edit.spec.ts
+++ b/test/e2e_tests/specs/Edit/edit.spec.ts
@@ -26,9 +26,10 @@ test.describe('Edit', () => {
   let userA: User;
   let userB: User;
 
-  test.beforeEach(async ({createTeamOwner, createUser}) => {
-    userB = await createUser();
-    userA = await createTeamOwner('Test Team', {addMembers: [userB]});
+  test.beforeEach(async ({createTeam}) => {
+    const team = await createTeam('Test Team', {withMembers: 1});
+    userA = team.owner;
+    userB = team.members[0];
   });
 
   test('I can edit my message in 1:1', {tag: ['@TC-679', '@regression']}, async ({createPage}) => {

--- a/test/e2e_tests/specs/Edit/edit.spec.ts
+++ b/test/e2e_tests/specs/Edit/edit.spec.ts
@@ -17,48 +17,45 @@
  *
  */
 
-import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test as baseTest, expect, withConversation, withLogin} from 'test/e2e_tests/test.fixtures';
+import {test, expect, withConnectedUser, withLogin} from 'test/e2e_tests/test.fixtures';
 import {createGroup} from 'test/e2e_tests/utils/userActions';
 
-const test = baseTest.extend<{userA: User; userB: User}>({
-  userA: async ({createUser}, use) => {
-    await use(await createUser());
-  },
-  userB: async ({createUser}, use) => {
-    await use(await createUser());
-  },
-});
-
 test.describe('Edit', () => {
-  test.beforeEach(async ({api, userA, userB}) => {
-    await api.connectUsers(userA, userB);
-  });
+  test(
+    'I can edit my message in 1:1',
+    {tag: ['@TC-679', '@regression']},
+    async ({createPage, createUser, createTeamOwner}) => {
+      const userB = await createUser();
+      const userA = await createTeamOwner('Test Team 3', {addMembers: [userB]});
 
-  test('I can edit my message in 1:1', {tag: ['@TC-679', '@regression']}, async ({createPage, userA, userB}) => {
-    const pages = (await PageManager.from(createPage(withLogin(userA), withConversation(userB)))).webapp.pages;
+      const userAPageManager = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)));
+      const {pages: userAPages} = userAPageManager.webapp;
 
-    await pages.conversation().sendMessage('Test Message');
+      await userAPages.conversation().sendMessage('Test Message');
 
-    const message = pages.conversation().getMessage({sender: userA});
-    await expect(message).toContainText('Test Message');
+      const message = userAPages.conversation().getMessage({sender: userA});
+      await expect(message).toContainText('Test Message');
 
-    await pages.conversation().editMessage(message);
-    await expect(pages.conversation().messageInput).toContainText('Test Message');
+      await userAPages.conversation().editMessage(message);
+      await expect(userAPages.conversation().messageInput).toContainText('Test Message');
 
-    // Overwrite the text in the message input and send it
-    await pages.conversation().sendMessage('Edited Message');
-    await expect(message).toContainText('Edited Message');
-  });
+      // Overwrite the text in the message input and send it
+      await userAPages.conversation().sendMessage('Edited Message');
+      await expect(message).toContainText('Edited Message');
+    },
+  );
 
   test(
     'I can edit my message in a group conversation',
     {tag: ['@TC-680', '@regression']},
-    async ({createPage, userA, userB}) => {
-      const pages = (await PageManager.from(createPage(withLogin(userA)))).webapp.pages;
+    async ({createUser, createTeamOwner, createPage}) => {
+      const userB = await createUser();
+      const userA = await createTeamOwner('Test Team', {addMembers: [userB]});
 
+      const pages = (await PageManager.from(createPage(withLogin(userA)))).webapp.pages;
       await createGroup(pages, 'Test Group', [userB]);
+
       await pages.conversationList().openConversation('Test Group');
       await pages.conversation().sendMessage('Test Message');
 
@@ -77,11 +74,14 @@ test.describe('Edit', () => {
   test(
     'I see changed message if message was edited from another device',
     {tag: ['@TC-682', '@regression']},
-    async ({createPage, userA, userB}) => {
-      const deviceA = (await PageManager.from(createPage(withLogin(userA), withConversation(userB)))).webapp.pages;
+    async ({createTeamOwner, createUser, createPage}) => {
+      const userB = await createUser();
+      const userA = await createTeamOwner('Test Team', {addMembers: [userB]});
+
+      const deviceA = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
+
       // Device 2 is intentionally created after device 1 to ensure the history info warning is confirmed
       const deviceB = (await PageManager.from(createPage(withLogin(userA)))).webapp.pages;
-
       await deviceB.historyInfo().clickConfirmButton();
       await deviceB.conversationList().openConversation(userB.fullName);
 
@@ -101,26 +101,35 @@ test.describe('Edit', () => {
     },
   );
 
-  test('I cannot edit another users message', {tag: ['@TC-683', '@regression']}, async ({createPage, userA, userB}) => {
-    const [userAPages, userBPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConversation(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB), withConversation(userA))).then(pm => pm.webapp.pages),
-    ]);
+  test(
+    'I cannot edit another users message',
+    {tag: ['@TC-683', '@regression']},
+    async ({createTeamOwner, createUser, createPage}) => {
+      const userB = await createUser();
+      const userA = await createTeamOwner('Test Team', {addMembers: [userB]});
 
-    await userAPages.conversation().sendMessage('Test Message');
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      ]);
 
-    const message = userBPages.conversation().getMessage({sender: userA});
-    await expect(message).toContainText('Test Message');
+      await userAPages.conversation().sendMessage('Test Message');
 
-    const messageOptions = await userBPages.conversation().openMessageOptions(message);
-    await expect(messageOptions).not.toContainText('Edit');
-  });
+      const message = userBPages.conversation().getMessage({sender: userA});
+      await expect(message).toContainText('Test Message');
+
+      const messageOptions = await userBPages.conversation().openMessageOptions(message);
+      await expect(messageOptions).not.toContainText('Edit');
+    },
+  );
 
   test(
     'I can edit my last message by pressing the up arrow key',
     {tag: ['@TC-686', '@regression']},
-    async ({createPage, userA, userB}) => {
-      const pages = (await PageManager.from(createPage(withLogin(userA), withConversation(userB)))).webapp.pages;
+    async ({createTeamOwner, createUser, createPage}) => {
+      const userB = await createUser();
+      const userA = await createTeamOwner('Test Team', {addMembers: [userB]});
+      const pages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
 
       await pages.conversation().sendMessage('Test Message');
       await expect(pages.conversation().getMessage({content: 'Test Message'})).toBeVisible();
@@ -133,10 +142,12 @@ test.describe('Edit', () => {
   test(
     'Editing a message does not create unread dot on receiver side',
     {tag: ['@TC-690', '@regression']},
-    async ({createPage, userA, userB}) => {
+    async ({createTeamOwner, createUser, createPage}) => {
+      const userB = await createUser();
+      const userA = await createTeamOwner('Test Team', {addMembers: [userB]});
       const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConversation(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB), withConversation(userA))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
       ]);
 
       await test.step('Create group as second conversation', async () => {
@@ -184,10 +195,12 @@ test.describe('Edit', () => {
   test(
     'I can see the changed message was edited from another user',
     {tag: ['@TC-692', '@regression']},
-    async ({createPage, userA, userB}) => {
+    async ({createTeamOwner, createUser, createPage}) => {
+      const userB = await createUser();
+      const userA = await createTeamOwner('Test Team', {addMembers: [userB]});
       const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConversation(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB), withConversation(userA))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
       ]);
 
       await userAPages.conversation().sendMessage('Test');
@@ -208,7 +221,10 @@ test.describe('Edit', () => {
   test(
     'I want to see the last edited text including a timestamp in message detail view if the message has been edited',
     {tag: ['@TC-3563', '@regression']},
-    async ({createPage, userA, userB}) => {
+    async ({createTeamOwner, createUser, createPage}) => {
+      const userB = await createUser();
+      const userA = await createTeamOwner('Test Team', {addMembers: [userB]});
+
       const pages = await PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages);
       await createGroup(pages, 'Test Group', [userB]); // The message detail view is only available for group conversations
 

--- a/test/e2e_tests/test.fixtures.ts
+++ b/test/e2e_tests/test.fixtures.ts
@@ -43,6 +43,7 @@ type Fixtures = {
   createUser: (options?: Parameters<typeof createUser>[1]) => Promise<User>;
   /**
    * Creates a team and the associated owner, optionally adding members to it
+   * Note: The team and owner are automatically deleted when the test completes.
    * @param options.withMembers Can either be the number of team members to create or an array of existing members to add to the team
    * @returns an object containing the teams owner and an array of members. The size of the members array matches the number or array length passed to `withMembers`
    */

--- a/test/e2e_tests/utils/userActions.ts
+++ b/test/e2e_tests/utils/userActions.ts
@@ -114,7 +114,7 @@ export const handleAppLockState = async (pageManager: PageManager, appLockPassCo
 export async function loginAndSetup(user: User, pageManager: PageManager) {
   const {modals, components} = pageManager.webapp;
   await pageManager.openMainPage();
-  await loginUser(user, pageManager); // Verwendet die bestehende loginUser-Funktion
+  await loginUser(user, pageManager);
   await modals.dataShareConsent().clickDecline();
   await components.conversationSidebar().isPageLoaded();
 }
@@ -141,6 +141,18 @@ export async function connectUsersManually(
 
   await userBPages.conversationList().openPendingConnectionRequest();
   await userBPages.connectRequest().clickConnectButton();
+}
+
+/**
+ * Opens the connections tab, searches for the given user and starts a conversation with him
+ * Note: This util only works if both users are part of the same team.
+ */
+export async function connectWithUser(senderPageManager: PageManager, receiver: Pick<User, 'username'>) {
+  const {pages, modals, components} = senderPageManager.webapp;
+  await components.conversationSidebar().clickConnectButton();
+  await pages.startUI().searchInput.fill(receiver.username);
+  await pages.startUI().selectUser(receiver.username);
+  await modals.userProfile().clickStartConversation();
 }
 
 /**


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21957" title="WPB-21957" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21957</a>  [Web/QA] Add fixture for creating teams
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

This PR adds a new fixture to create a team owner with a team and the option to add members to it. This was mainly done to avoid the race condition which can occur when connecting users via the api. Using a team eliminates the need to send a connection request first.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).

---

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues): 
- Linked PRs (e.g. web-packages): #19760
