### PR TITLE
test(WPB-19968): add tests for self deleting messages

### DIFF
--- a/src/script/components/InputBar/InputBarControls/MessageTimerButton/MessageTimerButton.tsx
+++ b/src/script/components/InputBar/InputBarControls/MessageTimerButton/MessageTimerButton.tsx
@@ -93,6 +93,7 @@ const MessageTimerButton = ({conversation, teamState = container.resolve(TeamSta
       onClick={isTimerDisabled ? undefined : onClick}
       onKeyDown={handleContextKeyDown}
       title={t('tooltipConversationEphemeral')}
+      disabled={isTimerDisabled}
       data-uie-value={isTimerDisabled ? 'disabled' : 'enabled'}
       data-uie-name="do-set-ephemeral-timer"
       type="button"

--- a/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -53,7 +53,8 @@ export class ConversationPage {
   readonly callButton: Locator;
   readonly conversationInfoButton: Locator;
   readonly pingButton: Locator;
-  readonly messages: Locator; // Only contains message items which have been sent successfully
+  /** Messages in conversation, only contains message items which have been sent successfully */
+  readonly messages: Locator;
   readonly messageDetails: Locator;
   readonly messageItems: Locator;
   readonly filesTab: Locator;

--- a/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -53,7 +53,7 @@ export class ConversationPage {
   readonly callButton: Locator;
   readonly conversationInfoButton: Locator;
   readonly pingButton: Locator;
-  readonly messages: Locator;
+  readonly messages: Locator; // Only contains message items which have been sent successfully
   readonly messageDetails: Locator;
   readonly messageItems: Locator;
   readonly filesTab: Locator;
@@ -100,7 +100,8 @@ export class ConversationPage {
     this.pingButton = page.locator(selectByDataAttribute('do-ping'));
     this.messageItems = page.locator(selectByDataAttribute('item-message'));
     this.messages = page.locator(
-      `${selectByDataAttribute('item-message')} ${selectByClass('message-body')}:not(:has(p${selectByClass('text-foreground')})):has(${selectByClass('text')})`,
+      // The attribute 'send-status' indicates whether the optimistic update for sending the message was successful
+      `${selectByDataAttribute('item-message')}${selectByDataAttribute('2', 'send-status')}`,
     );
     this.messageDetails = page.locator('#message-details');
     this.filesTab = page.locator('#conversation-tab-files');
@@ -225,7 +226,7 @@ export class ConversationPage {
    * @returns a Locator to the matching message(s)
    */
   getMessage(options?: {content?: string | RegExp; sender?: User}): Locator {
-    let message = this.messageItems;
+    let message = this.messages;
 
     if (options?.content) {
       message = message.filter({hasText: options.content});

--- a/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -21,7 +21,7 @@ import {Locator, Page} from '@playwright/test';
 
 import {User} from 'test/e2e_tests/data/user';
 import {downloadAssetAndGetFilePath} from 'test/e2e_tests/utils/asset.util';
-import {selectById, selectByClass, selectByDataAttribute} from 'test/e2e_tests/utils/selector.util';
+import {selectByClass, selectByDataAttribute} from 'test/e2e_tests/utils/selector.util';
 
 import {ConfirmModal} from '../modals/confirm.modal';
 
@@ -40,6 +40,7 @@ export class ConversationPage {
   readonly conversationTitle: Locator;
   readonly watermark: Locator;
   readonly timerMessageButton: Locator;
+  readonly timerOffButton: Locator;
   readonly timerTenSecondsButton: Locator;
   readonly openGroupInformationViaName: Locator;
   readonly membersList: Locator;
@@ -83,7 +84,8 @@ export class ConversationPage {
     this.conversationTitle = page.locator('[data-uie-name="status-conversation-title-bar-label"]');
     this.openGroupInformationViaName = page.locator(selectByDataAttribute('status-conversation-title-bar-label'));
     this.timerMessageButton = page.locator(selectByDataAttribute('do-set-ephemeral-timer'));
-    this.timerTenSecondsButton = page.locator(selectById('btn-10-seconds'));
+    this.timerOffButton = page.getByRole('button', {name: 'Off'});
+    this.timerTenSecondsButton = page.getByRole('button', {name: '10 seconds'});
     this.membersList = page.locator(selectByDataAttribute('list-members'));
     this.adminsList = page.locator(selectByDataAttribute('list-admins'));
     this.leaveConversationButton = page.locator(selectByDataAttribute('do-leave-item-text'));
@@ -171,10 +173,14 @@ export class ConversationPage {
     await message.getByRole('group').getByTestId('do-reply-message').click();
   }
 
-  async sendTimedMessage(message: string) {
+  async enableSelfDeletingMessages() {
     await this.timerMessageButton.click();
     await this.timerTenSecondsButton.click();
-    await this.sendMessage(message);
+  }
+
+  async disableSelfDeletingMessages() {
+    await this.timerMessageButton.click();
+    await this.timerOffButton.click();
   }
 
   async sendMessageWithUserMention(userFullName: string, messageText?: string) {

--- a/test/e2e_tests/pageManager/webapp/pages/conversationDetails.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/conversationDetails.page.ts
@@ -108,7 +108,7 @@ export class ConversationDetailsPage {
   async setSelfDeletingMessages(value: 'Off' | '10 seconds') {
     await this.selfDeletingMessageButton.click();
     const selfDeletingMessagesPanel = this.page.locator('#timed-messages');
-    // I tried to use accessible locators but the radio options are currently not accessible
+    // The radio options are currently not accessible so accessible locators can't be used
     await selfDeletingMessagesPanel.getByRole('radiogroup').locator('label', {hasText: value}).click();
     await selfDeletingMessagesPanel.getByRole('button', {name: 'Go back'}).click();
   }

--- a/test/e2e_tests/pageManager/webapp/pages/conversationDetails.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/conversationDetails.page.ts
@@ -27,6 +27,7 @@ export class ConversationDetailsPage {
   readonly addPeopleButton: Locator;
   readonly conversationDetails: Locator;
   readonly guestOptionsButton: Locator;
+  readonly selfDeletingMessageButton: Locator;
   readonly archiveButton: Locator;
 
   constructor(page: Page) {
@@ -35,6 +36,7 @@ export class ConversationDetailsPage {
     this.addPeopleButton = page.locator(`${selectByDataAttribute('go-add-people')}`);
     this.conversationDetails = page.locator('#conversation-details');
     this.guestOptionsButton = this.conversationDetails.locator('[data-uie-name="go-guest-options"]');
+    this.selfDeletingMessageButton = this.conversationDetails.getByRole('button', {name: 'Self-deleting messages'});
     this.archiveButton = this.conversationDetails.locator(selectByDataAttribute('do-archive'));
   }
 
@@ -100,6 +102,15 @@ export class ConversationDetailsPage {
 
   async clickArchiveButton() {
     await this.archiveButton.click();
+  }
+
+  /** Opens the self deleting messages panel, selects the given value and closes it again */
+  async setSelfDeletingMessages(value: 'Off' | '10 seconds') {
+    await this.selfDeletingMessageButton.click();
+    const selfDeletingMessagesPanel = this.page.locator('#timed-messages');
+    // I tried to use accessible locators but the radio options are currently not accessible
+    await selfDeletingMessagesPanel.getByRole('radiogroup').locator('label', {hasText: value}).click();
+    await selfDeletingMessagesPanel.getByRole('button', {name: 'Go back'}).click();
   }
 
   async addServiceToConversation(serviceName: string) {

--- a/test/e2e_tests/specs/Reply/reply.spec.ts
+++ b/test/e2e_tests/specs/Reply/reply.spec.ts
@@ -29,7 +29,7 @@ test.describe('Reply', () => {
   let userA: User;
   let userB: User;
 
-  test.beforeEach(async ({createTeam, createUser}) => {
+  test.beforeEach(async ({createTeam}) => {
     const team = await createTeam('Test Team', {withMembers: 1});
     userA = team.owner;
     userB = team.members[0];

--- a/test/e2e_tests/specs/Reply/reply.spec.ts
+++ b/test/e2e_tests/specs/Reply/reply.spec.ts
@@ -49,7 +49,8 @@ test.describe('Reply', () => {
   test('I should not be able to reply to timed messages', {tag: ['@TC-8039', '@regression']}, async ({createPage}) => {
     const pages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
 
-    await pages.conversation().sendTimedMessage('Gone in 10s');
+    await pages.conversation().enableSelfDeletingMessages();
+    await pages.conversation().sendMessage('Gone in 10s');
     const message = pages.conversation().getMessage({content: 'Gone in 10s'});
     await message.hover();
 
@@ -251,7 +252,8 @@ test.describe('Reply', () => {
 
       const message = pages.conversation().getMessage({sender: userA});
       await pages.conversation().replyToMessage(message);
-      await pages.conversation().sendTimedMessage('Timed Reply');
+      await pages.conversation().enableSelfDeletingMessages();
+      await pages.conversation().sendMessage('Timed Reply');
 
       const reply = pages.conversation().getMessage({content: 'Timed Reply'});
       await expect(reply.getByTestId('quote-item')).toContainText('Message');

--- a/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
+++ b/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
@@ -205,4 +205,26 @@ test.describe('Self Deleting Messages', () => {
       await expect(pages.conversation().timerMessageButton).toContainText('s10');
     },
   );
+
+  test(
+    'I want to see a system message that a global timer was set or changed or removed in conversation options',
+    {tag: ['@TC-3720', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      const [userAPages, userBPages] = [userAPage, userBPage].map(page => PageManager.from(page).webapp.pages);
+      await createGroup(userAPages, 'Test Group', [userB]);
+
+      await userAPages.conversationList().openConversation('Test Group');
+      await userAPages.conversation().toggleGroupInformation();
+      await userAPages.conversationDetails().setSelfDeletingMessages('10 seconds');
+
+      await userBPages.conversationList().openConversation('Test Group');
+      await expect(
+        userBPages.conversation().systemMessages.getByText('set the message timer to 10 seconds'),
+      ).toBeAttached();
+
+      await userAPages.conversationDetails().setSelfDeletingMessages('Off');
+      await expect(userBPages.conversation().systemMessages.getByText('turned off the message timer')).toBeAttached();
+    },
+  );
 });

--- a/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
+++ b/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
@@ -105,9 +105,8 @@ test.describe('Self Deleting Messages', () => {
   test(
     'Verify that message with previous timer are deleted on start-up when the timeout passed in 1:1',
     {tag: ['@TC-664', '@regression']},
-    async ({createPage, userA, userB}) => {
-      let page = await createPage(withLogin(userA), withConversation(userB));
-      const ctx = page.context();
+    async ({context, createPage, userA, userB}) => {
+      let page = await createPage(context, withLogin(userA), withConversation(userB));
       let pages = PageManager.from(page).webapp.pages;
 
       await pages.conversation().enableSelfDeletingMessages();
@@ -118,9 +117,8 @@ test.describe('Self Deleting Messages', () => {
       await new Promise(res => setTimeout(res, 10_000)); // Wait 10s before logging in again to ensure the message has should be deleted by now
 
       // Re-open page reusing the same context so the login is not happening on a new device
-      page = await ctx.newPage();
+      page = await createPage(context, withLogin(userA), withConversation(userB));
       pages = PageManager.from(page).webapp.pages;
-      await withLogin(userA)(page);
 
       const selfDeletingMessage = pages.conversation().getMessage({sender: userA});
       await expect(selfDeletingMessage).toBeVisible();

--- a/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
+++ b/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
@@ -232,7 +232,7 @@ test.describe('Self Deleting Messages', () => {
       await expect(searchResults).toContainText('Test');
     });
 
-    // Currently the message isn't removed from the search results after its specified lifetime
+    // WPB-21980 - Currently the message isn't removed from the search results after its specified lifetime
     test.skip(
       'I want to to see ephemeral messages disappear from search results when their timer runs out',
       {tag: ['@TC-3731', '@regression']},

--- a/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
+++ b/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
@@ -1,0 +1,54 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {User} from 'test/e2e_tests/data/user';
+import {PageManager} from 'test/e2e_tests/pageManager';
+import {test as baseTest, expect, withConversation, withLogin} from 'test/e2e_tests/test.fixtures';
+
+const test = baseTest.extend<{userA: User; userB: User}>({
+  userA: async ({createUser}, use) => use(await createUser()),
+  userB: async ({createUser}, use) => use(await createUser()),
+});
+
+test.describe('Self Deleting Messages', () => {
+  test.beforeEach(async ({api, userA, userB}) => {
+    await api.connectUsers(userA, userB);
+  });
+
+  test(
+    'Verify sending ephemeral text message in 1:1',
+    {tag: ['@TC-657', '@regression']},
+    async ({createPage, userA, userB}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConversation(userB)),
+        createPage(withLogin(userB), withConversation(userA)),
+      ]);
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
+
+      await userAPages.conversation().sendTimedMessage('Gone in 10s');
+      await expect(userAPages.conversation().getMessage({content: 'Gone in 10s'})).toBeVisible();
+      await expect(userBPages.conversation().getMessage({content: 'Gone in 10s'})).toBeVisible();
+
+      await userBPage.waitForTimeout(10_000); // Wait for 10s so the message is deleted
+      await expect(userAPages.conversation().getMessage({content: 'Gone in 10s'})).not.toBeVisible();
+      await expect(userBPages.conversation().getMessage({content: 'Gone in 10s'})).not.toBeVisible();
+    },
+  );
+});

--- a/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
+++ b/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
@@ -190,4 +190,19 @@ test.describe('Self Deleting Messages', () => {
       await expect(pages.conversation().timerMessageButton).toBeDisabled();
     },
   );
+
+  test(
+    'I want to see the ephemeral indicator is updated in the input field if someone sets a global timer in conversation options',
+    {tag: ['@TC-3719', '@regression']},
+    async ({createPage}) => {
+      const pages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
+      await createGroup(pages, 'Test Group', [userB]);
+
+      await pages.conversationList().openConversation('Test Group');
+      await pages.conversation().toggleGroupInformation();
+      await pages.conversationDetails().setSelfDeletingMessages('10 seconds');
+
+      await expect(pages.conversation().timerMessageButton).toContainText('s10');
+    },
+  );
 });

--- a/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
+++ b/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
@@ -175,4 +175,19 @@ test.describe('Self Deleting Messages', () => {
       await expect(pages.conversationDetails().selfDeletingMessageButton).toContainText('10 seconds');
     },
   );
+
+  test(
+    'I want to see timed message disable in an input bar when global settings conversation options are set',
+    {tag: ['@TC-3718', '@regression']},
+    async ({createPage}) => {
+      const pages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
+      await createGroup(pages, 'Test Group', [userB]);
+
+      await pages.conversationList().openConversation('Test Group');
+      await pages.conversation().toggleGroupInformation();
+      await pages.conversationDetails().setSelfDeletingMessages('10 seconds');
+
+      await expect(pages.conversation().timerMessageButton).toBeDisabled();
+    },
+  );
 });

--- a/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
+++ b/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
@@ -144,6 +144,7 @@ test.describe('Self Deleting Messages', () => {
     },
   );
 
+  // ToDo: Put all the tests for global setting into describe with same beforeEach
   test('I want to set a global group conversation timer', {tag: ['@TC-3715', '@regression']}, async ({createPage}) => {
     const page = await createPage(withLogin(userA));
     const pages = PageManager.from(page).webapp.pages;
@@ -225,6 +226,25 @@ test.describe('Self Deleting Messages', () => {
 
       await userAPages.conversationDetails().setSelfDeletingMessages('Off');
       await expect(userBPages.conversation().systemMessages.getByText('turned off the message timer')).toBeAttached();
+    },
+  );
+
+  test(
+    'I want to see ephemeral messages in the search results',
+    {tag: ['@TC-3717', '@regression']},
+    async ({createPage}) => {
+      const page = await createPage(withLogin(userA), withConnectedUser(userB));
+      const pages = PageManager.from(page).webapp.pages;
+
+      await pages.conversation().enableSelfDeletingMessages();
+      await pages.conversation().sendMessage('Test');
+
+      await pages.conversation().searchButton.click();
+      await pages.collection().searchForMessages('Test');
+
+      const searchResults = pages.collection().searchItems;
+      await expect(searchResults).toHaveCount(1);
+      await expect(searchResults).toContainText('Test');
     },
   );
 });

--- a/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
+++ b/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
@@ -43,8 +43,8 @@ test.describe('Self Deleting Messages', () => {
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
-      await userAPages.conversation().sendTimedMessage('Gone in 10s');
-      await expect(userAPages.conversation().getMessage({content: 'Gone in 10s'})).toBeVisible();
+      await userAPages.conversation().enableSelfDeletingMessages();
+      await userAPages.conversation().sendMessage('Gone in 10s');
       await expect(userBPages.conversation().getMessage({content: 'Gone in 10s'})).toBeVisible();
 
       await userBPage.waitForTimeout(10_000); // Wait for 10s so the message is deleted
@@ -64,8 +64,8 @@ test.describe('Self Deleting Messages', () => {
       await createGroup(userAPages, 'Test Group', [userB]);
       await userBPages.conversationList().openConversation('Test Group');
 
-      await userAPages.conversation().sendTimedMessage('Gone in 10s');
-      await expect(userAPages.conversation().getMessage({content: 'Gone in 10s'})).toBeVisible();
+      await userAPages.conversation().enableSelfDeletingMessages();
+      await userAPages.conversation().sendMessage('Gone in 10s');
       await expect(userBPages.conversation().getMessage({content: 'Gone in 10s'})).toBeVisible();
 
       await userBPage.waitForTimeout(10_000); // Wait for 10s so the message is deleted

--- a/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
+++ b/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
@@ -143,4 +143,21 @@ test.describe('Self Deleting Messages', () => {
       await expect(userBPages.conversation().getMessage({content: 'Test Message'})).toBeVisible();
     },
   );
+
+  test('I want to set a global group conversation timer', {tag: ['@TC-3715', '@regression']}, async ({createPage}) => {
+    const page = await createPage(withLogin(userA));
+    const pages = PageManager.from(page).webapp.pages;
+    await createGroup(pages, 'Test Group', [userB]);
+
+    await pages.conversationList().openConversation('Test Group');
+    await pages.conversation().toggleGroupInformation();
+    await pages.conversationDetails().setSelfDeletingMessages('10 seconds');
+
+    await pages.conversation().sendMessage('Message');
+    const message = pages.conversation().getMessage({content: 'Message'});
+    await expect(message).toBeAttached();
+
+    await page.waitForTimeout(10_000);
+    await expect(message).not.toBeAttached();
+  });
 });

--- a/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
+++ b/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
@@ -247,4 +247,28 @@ test.describe('Self Deleting Messages', () => {
       await expect(searchResults).toContainText('Test');
     },
   );
+
+  // Currently the message isn't removed from the search results after its specified lifetime
+  test.skip(
+    'I want to to see ephemeral messages disappear from search results when their timer runs out',
+    {tag: ['@TC-3731', '@regression']},
+    async ({createPage}) => {
+      const page = await createPage(withLogin(userA), withConnectedUser(userB));
+      const pages = PageManager.from(page).webapp.pages;
+
+      await pages.conversation().enableSelfDeletingMessages();
+      await pages.conversation().sendMessage('Test');
+      await expect(pages.conversation().getMessage({content: 'Test'})).toBeVisible();
+
+      await pages.conversation().searchButton.click();
+      await pages.collection().searchForMessages('Test');
+
+      const searchResults = pages.collection().searchItems;
+      await expect(searchResults).toHaveCount(1);
+
+      await page.waitForTimeout(10_000);
+
+      await expect(searchResults).toHaveCount(0);
+    },
+  );
 });

--- a/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
+++ b/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
@@ -160,4 +160,19 @@ test.describe('Self Deleting Messages', () => {
     await page.waitForTimeout(10_000);
     await expect(message).not.toBeAttached();
   });
+
+  test(
+    'I want to see the current timer in conversation details',
+    {tag: ['@TC-3716', '@regression']},
+    async ({createPage}) => {
+      const pages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
+      await createGroup(pages, 'Test Group', [userB]);
+
+      await pages.conversationList().openConversation('Test Group');
+      await pages.conversation().toggleGroupInformation();
+      await pages.conversationDetails().setSelfDeletingMessages('10 seconds');
+
+      await expect(pages.conversationDetails().selfDeletingMessageButton).toContainText('10 seconds');
+    },
+  );
 });


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19968" title="WPB-19968" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19968</a>  [Web/QA] Write the Self Deleting Messages regression tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


# Pull Request

## Summary

- Add regression tests for self deleting messages

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- I noticed that the timed message button is not really disabled but only ignores the click event, so I fixed the accessibility there
- For now I kept all test cases separate like they are defined in Testiny, however we might want to merge some of them since they are very similar
