### PR TITLE
fix: prevent microphone disabled dialog display when muted [WPB-9456]

### DIFF
--- a/src/script/repositories/calling/CallingRepository.ts
+++ b/src/script/repositories/calling/CallingRepository.ts
@@ -1703,7 +1703,7 @@ export class CallingRepository {
       call.muteState(shouldMute ? MuteState.SELF_MUTED : MuteState.NOT_MUTED);
       return;
     }
-    if (call.hasWorkingAudioInput === false && call.muteState() !== MuteState.NOT_MUTED) {
+    if (!shouldMute && call.hasWorkingAudioInput === false && call.muteState() !== MuteState.NOT_MUTED) {
       this.showNoAudioInputModal();
       return;
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9456" title="WPB-9456" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9456</a>  [web] Microphone disabled dialog shows up twice
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary
Do not show microphone disabled dialog twice when muted and browser doesn't have microphone permission.

---

## Security Checklist (required)

- [] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
