### PR TITLE
chore: bump avs to v10.2.19 [WPB-22020]

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@mediapipe/tasks-vision": "0.10.21",
     "@tanstack/react-table": "8.21.3",
     "@tanstack/react-virtual": "3.13.4",
-    "@wireapp/avs": "10.2.17",
+    "@wireapp/avs": "10.2.19",
     "@wireapp/avs-debugger": "0.0.7",
     "@wireapp/commons": "5.4.9",
     "@wireapp/core": "46.46.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6912,10 +6912,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/avs@npm:10.2.17":
-  version: 10.2.17
-  resolution: "@wireapp/avs@npm:10.2.17"
-  checksum: 10/ac68345f919e4a7f62f6ccdee7be903cb567306588f43d93883c321e4813e1f4698ac12f5ad428dc6afb87d12367a6ff3aa0375838f63aaf21a70e46caf8e7c7
+"@wireapp/avs@npm:10.2.19":
+  version: 10.2.19
+  resolution: "@wireapp/avs@npm:10.2.19"
+  checksum: 10/3f5a4a66e629307963a5e3382f3e4d4acbbbc8699f98203f5bca12249912112549b80d0c980af2c9b000c499a06d7282a46b4f2a5274ffd6991a6ff5f31466da
   languageName: node
   linkType: hard
 
@@ -20169,7 +20169,7 @@ __metadata:
     "@types/webpack-bundle-analyzer": "npm:^4"
     "@types/webpack-env": "npm:1.18.8"
     "@types/wicg-file-system-access": "npm:^2023.10.7"
-    "@wireapp/avs": "npm:10.2.17"
+    "@wireapp/avs": "npm:10.2.19"
     "@wireapp/avs-debugger": "npm:0.0.7"
     "@wireapp/commons": "npm:5.4.9"
     "@wireapp/copy-config": "npm:2.3.4"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22020" title="WPB-22020" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22020</a>  Bump AVS to v10.2.19 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Bump avs to v10.2.19

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
