### PR TITLE
test(WPB-19939): add authentication regression tests

### DIFF
--- a/test/e2e_tests/pageManager/index.ts
+++ b/test/e2e_tests/pageManager/index.ts
@@ -48,6 +48,7 @@ import {ErrorModal} from './webapp/modals/error.modal';
 import {ExportBackupModal} from './webapp/modals/exportBackup.modal';
 import {importBackupModal} from './webapp/modals/importBackup.modal';
 import {LeaveConversationModal} from './webapp/modals/leaveConversation.modal';
+import {PasswordModal} from './webapp/modals/password.modal';
 import {RemoveMemberModal} from './webapp/modals/removeMember.modal';
 import {UnableToOpenConversationModal} from './webapp/modals/unableToOpenConversation.modal';
 import {UserProfileModal} from './webapp/modals/userProfile.modal';
@@ -226,6 +227,7 @@ export class PageManager {
         this.getOrCreate('webapp.modals.marketingConsent', () => new MarketingConsentModal(this.page)),
       acknowledge: () => this.getOrCreate('webapp.modals.marketingConsent', () => new AcknowledgeModal(this.page)),
       confirm: () => this.getOrCreate('webapp.modals.confirm', () => new ConfirmModal(this.page)),
+      password: () => this.getOrCreate('webapp.modals.password', () => new PasswordModal(this.page)),
       cellsFileDetailView: () =>
         this.getOrCreate('webapp.modals.cellsFileDetailView', () => new CellsFileDetailViewModal(this.page)),
       cancelRequest: () =>

--- a/test/e2e_tests/pageManager/index.ts
+++ b/test/e2e_tests/pageManager/index.ts
@@ -61,6 +61,7 @@ import {ConversationPage} from './webapp/pages/conversation.page';
 import {ConversationDetailsPage} from './webapp/pages/conversationDetails.page';
 import {ConversationListPage} from './webapp/pages/conversationList.page';
 import {DeleteAccountPage} from './webapp/pages/deleteAccount.page';
+import {DevicesPage} from './webapp/pages/devices.page';
 import {EmailVerificationPage} from './webapp/pages/emailVerification.page';
 import {GroupCreationPage} from './webapp/pages/groupCreation.page';
 import {GuestOptionsPage} from './webapp/pages/guestOptions.page';
@@ -175,6 +176,7 @@ export class PageManager {
       connectRequest: () => this.getOrCreate('webapp.pages.connectRequest', () => new ConnectRequestPage(this.page)),
       calling: () => this.getOrCreate('webapp.pages.calling', () => new CallingPage(this.page)),
       settings: () => this.getOrCreate('webapp.pages.settings', () => new SettingsPage(this.page)),
+      devices: () => this.getOrCreate('webapp.pages.devices', () => new DevicesPage(this.page)),
       options: () => this.getOrCreate('webapp.pages.options', () => new OptionsPage(this.page)),
       audioVideoSettings: () =>
         this.getOrCreate('webapp.pages.audioVideoSettings', () => new AudioVideoSettingsPage(this.page)),

--- a/test/e2e_tests/pageManager/webapp/modals/password.modal.ts
+++ b/test/e2e_tests/pageManager/webapp/modals/password.modal.ts
@@ -1,0 +1,33 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {BaseModal} from './base.modal';
+
+export class PasswordModal extends BaseModal {
+  readonly passwordInput: Locator;
+
+  constructor(page: Page) {
+    // For some reason the password modal is rendered using the `modal-template-option` attribute
+    super(page, 'modal-template-option');
+
+    this.passwordInput = this.modal.getByLabel('Password');
+  }
+}

--- a/test/e2e_tests/pageManager/webapp/pages/devices.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/devices.page.ts
@@ -17,33 +17,19 @@
  *
  */
 
-import {Page, Locator} from '@playwright/test';
+import {Locator, Page} from '@playwright/test';
 
-export class SettingsPage {
+export class DevicesPage {
   readonly page: Page;
 
-  readonly accountButton: Locator;
-  readonly devicesButton: Locator;
-  readonly optionsButton: Locator;
-  readonly audioVideoButton: Locator;
+  readonly proteusId: Locator;
+  readonly activeDevices: Locator;
 
   constructor(page: Page) {
     this.page = page;
-    this.accountButton = page.getByRole('button', {name: 'Account'});
-    this.devicesButton = page.getByRole('button', {name: 'Devices'});
-    this.optionsButton = page.getByRole('button', {name: 'Options'});
-    this.audioVideoButton = page.getByRole('button', {name: 'Audio / Video'});
-  }
 
-  async clickAudioVideoSettingsButton() {
-    await this.audioVideoButton.click();
-  }
-
-  async clickAccountButton() {
-    await this.accountButton.click();
-  }
-
-  async clickOptionsButton() {
-    await this.optionsButton.click();
+    // The id is not using any label or similar but just multiple paragraphs beneath each other
+    this.proteusId = page.locator("p:text('Proteus ID') + p");
+    this.activeDevices = page.getByRole('group', {name: 'Active'}).getByRole('button', {name: /device details/});
   }
 }

--- a/test/e2e_tests/pageManager/webapp/pages/login.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/login.page.ts
@@ -28,6 +28,7 @@ export class LoginPage {
   readonly emailInput: Locator;
   readonly passwordInput: Locator;
   readonly loginErrorText: Locator;
+  readonly publicComputerCheckbox: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -36,6 +37,7 @@ export class LoginPage {
     this.emailInput = page.locator('[data-uie-name="enter-email"]');
     this.passwordInput = page.locator('[data-uie-name="enter-password"]');
     this.loginErrorText = page.locator('[data-uie-name="error-message"]');
+    this.publicComputerCheckbox = page.getByText('This is a public computer');
   }
 
   async login(user: Pick<User, 'email' | 'password'>) {

--- a/test/e2e_tests/specs/Authentication/authentication.spec.ts
+++ b/test/e2e_tests/specs/Authentication/authentication.spec.ts
@@ -21,6 +21,25 @@ import {test, expect} from 'test/e2e_tests/test.fixtures';
 
 test.describe('Authentication', () => {
   test(
+    'Verify sign in button is disabled in case of empty credentials',
+    {tag: ['@TC-3457', '@regression']},
+    async ({pageManager}) => {
+      const {pages} = pageManager.webapp;
+      const {emailInput, passwordInput, signInButton} = pages.login();
+      await pageManager.openLoginPage();
+
+      await expect(signInButton).toBeDisabled();
+
+      await emailInput.fill('invalid@email');
+      await passwordInput.fill('invalidPassword');
+      await expect(signInButton).not.toBeDisabled();
+
+      await passwordInput.clear();
+      await expect(signInButton).toBeDisabled();
+    },
+  );
+
+  test(
     'I want to be asked to share telemetry data when I log in',
     {tag: ['@TC-8780', '@regression']},
     async ({pageManager, createUser}) => {

--- a/test/e2e_tests/specs/Authentication/authentication.spec.ts
+++ b/test/e2e_tests/specs/Authentication/authentication.spec.ts
@@ -109,4 +109,17 @@ test.describe('Authentication', () => {
       });
     },
   );
+
+  test(
+    'Verify sign in error appearance in case of wrong credentials',
+    {tag: ['@TC-3465', '@regression']},
+    async ({pageManager}) => {
+      const {pages} = pageManager.webapp;
+      await pageManager.openLoginPage();
+
+      await pages.login().login({email: 'invalid@wire.com', password: 'invalid'});
+
+      await expect(pages.login().loginErrorText).toHaveText('Please verify your details and try again');
+    },
+  );
 });

--- a/test/e2e_tests/specs/Authentication/authentication.spec.ts
+++ b/test/e2e_tests/specs/Authentication/authentication.spec.ts
@@ -124,35 +124,48 @@ test.describe('Authentication', () => {
     },
   );
 
-  test(
-    'I want to keep my history after refreshing the page on permanent device',
-    {tag: ['@TC-3472', '@regression']},
-    async ({pageManager, createTeam}) => {
-      const {pages} = pageManager.webapp;
-      const team = await createTeam('Test Team', {withMembers: 1});
-      const userA = team.owner;
-      const userB = team.members[0];
+  [
+    {tag: '@TC-3472', deviceType: 'permanent'},
+    {tag: '@TC-3473', deviceType: 'temporary'},
+  ].forEach(({deviceType, tag}) => {
+    test(
+      `I want to keep my history after refreshing the page on ${deviceType} device`,
+      {tag: [tag, '@regression']},
+      async ({pageManager, createTeam}) => {
+        const {pages} = pageManager.webapp;
+        const team = await createTeam('Test Team', {withMembers: 1});
+        const userA = team.owner;
+        const userB = team.members[0];
 
-      await test.step('Log in and connect with user B', async () => {
-        await pageManager.openLoginPage();
-        await pages.login().login(userA);
-        await connectWithUser(pageManager, userB);
-      });
+        await test.step('Log in and connect with user B', async () => {
+          await pageManager.openLoginPage();
 
-      await test.step('Send a message', async () => {
-        await pages.conversationList().openConversation(userB.fullName);
-        await pages.conversation().sendMessage('Before refresh');
-      });
+          if (deviceType === 'temporary') {
+            await pages.login().publicComputerCheckbox.click();
+            await pages.login().login(userA);
+            await pages.historyInfo().clickConfirmButton();
+          } else {
+            await pages.login().login(userA);
+          }
 
-      await test.step('Ensure message is still visible after page refresh', async () => {
-        const message = pages.conversation().getMessage({content: 'Before refresh'});
-        await expect(message).toBeVisible();
+          await connectWithUser(pageManager, userB);
+        });
 
-        await pageManager.refreshPage();
+        await test.step('Send a message', async () => {
+          await pages.conversationList().openConversation(userB.fullName);
+          await pages.conversation().sendMessage('Before refresh');
+        });
 
-        await pages.conversationList().openConversation(userB.fullName);
-        await expect(message).toBeVisible();
-      });
-    },
-  );
+        await test.step('Ensure message is still visible after page refresh', async () => {
+          const message = pages.conversation().getMessage({content: 'Before refresh'});
+          await expect(message).toBeVisible();
+
+          await pageManager.refreshPage();
+
+          await pages.conversationList().openConversation(userB.fullName);
+          await expect(message).toBeVisible();
+        });
+      },
+    );
+  });
 });

--- a/test/e2e_tests/specs/Authentication/authentication.spec.ts
+++ b/test/e2e_tests/specs/Authentication/authentication.spec.ts
@@ -52,4 +52,18 @@ test.describe('Authentication', () => {
       await expect(modals.dataShareConsent().modalTitle).toBeVisible();
     },
   );
+
+  test(
+    'Verify sign in error appearance in case of suspended team account',
+    {tag: ['@TC-3468', '@regression']},
+    async ({pageManager}) => {
+      const {pages} = pageManager.webapp;
+      await pageManager.openLoginPage();
+
+      const userOfSuspendedTeam = {email: 'sven+team6@wire.com', password: '12345678'};
+      await pages.login().login(userOfSuspendedTeam);
+
+      await expect(pages.login().loginErrorText).toHaveText('This account is no longer authorized to log in');
+    },
+  );
 });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19939" title="WPB-19939" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19939</a>  [Web/QA] Write the authentication regression tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- Adds the regression tests for authentication

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).

---

## Notes for reviewers

- The test case for only allowing TLS v1.3 and higher was skipped for now as currently only v1.2 seems to be enforced. A bug story will be linked or the test updated once it's clarified which minimum version to test for.
