### PR TITLE
test(WPB-19966): fix getMessage locator to account for different message states

### DIFF
--- a/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -100,9 +100,9 @@ export class ConversationPage {
     this.conversationInfoButton = page.locator(selectByDataAttribute('do-open-info'));
     this.pingButton = page.locator(selectByDataAttribute('do-ping'));
     this.messageItems = page.locator(selectByDataAttribute('item-message'));
+    /** The attribute 'send-status' will be 1 while the message is being sent, since we only want to assert on sent messages these messages will be excluded. See: {@see StatusTypes} */
     this.messages = page.locator(
-      // The attribute 'send-status' indicates whether the optimistic update for sending the message was successful
-      `${selectByDataAttribute('item-message')}${selectByDataAttribute('2', 'send-status')}`,
+      `${selectByDataAttribute('item-message')}:not(${selectByDataAttribute('1', 'send-status')})`,
     );
     this.messageDetails = page.locator('#message-details');
     this.filesTab = page.locator('#conversation-tab-files');


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19966" title="WPB-19966" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19966</a>  [Web/QA] Write the Reply regression tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

This PR fixes the `getMessage()` util in the conversation POM. It is supposed to only locate already sent messages, however the specified locator was to strict only locating messages with status "SENT" but ignoring other states like "DELIVERED". Now only messages in the sending state are ignored and all other states (including "UNSPECIFIED") are located correctly.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).

---

## Notes for reviewers

