### PR TITLE
test(WPB-22129): wait for login to finish before continuing

### DIFF
--- a/test/e2e_tests/pageManager/webapp/pages/login.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/login.page.ts
@@ -21,6 +21,8 @@ import type {Page, Locator} from '@playwright/test';
 
 import type {User} from 'test/e2e_tests/data/user';
 
+import {webAppPath} from '../..';
+
 export class LoginPage {
   readonly page: Page;
 
@@ -44,5 +46,11 @@ export class LoginPage {
     await this.emailInput.fill(user.email);
     await this.passwordInput.fill(user.password);
     await this.signInButton.click();
+
+    /**
+     * Since the login may take up to 40s we manually wait for it to finish here instead of increasing the timeout on all actions / assertions after this util
+     * This is an exception to the general best practice of using playwrights web assertions. (See: https://playwright.dev/docs/best-practices#use-web-first-assertions)
+     */
+    await this.page.waitForURL(new RegExp(`^${webAppPath}$`), {timeout: 40_000, waitUntil: 'networkidle'});
   }
 }


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22129" title="WPB-22129" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22129</a>  [Web] Investigate and improve login e2e flow (its currently flaky)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

# Pull Request

## Summary

Stabilize test to avoid flake due to login taking so long. Normally this kind of waiting for a util to finished would be an antipattern. However considering the login sometimes taking a very long time and the fact that we can't easily improve it to be 3 times as fast this is a valid intermediate solution to avoid distractions due to flake. Ideally at some point the login would be fast enough this statement can be removed.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Since the assertion is done right after the login was triggered its timeout needs to be extended to account for the login taking up to 30s
