### PR TITLE
test(WPB-19968): use a unique test message to avoid strict mode violation

### DIFF
--- a/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
+++ b/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
@@ -166,8 +166,8 @@ test.describe('Self Deleting Messages', () => {
     });
 
     test('I want to set a global group conversation timer', {tag: ['@TC-3715', '@regression']}, async () => {
-      await userAPages.conversation().sendMessage('Message');
-      const message = userBPages.conversation().getMessage({content: 'Message'});
+      await userAPages.conversation().sendMessage('Test Message');
+      const message = userBPages.conversation().getMessage({content: 'Test Message'});
       await expect(message).toBeAttached();
 
       await new Promise(res => setTimeout(res, 10_000));


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19968" title="WPB-19968" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19968</a>  [Web/QA] Write the Self Deleting Messages regression tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

The test asserted based on the message with text "Message" however the system message might contain the same text causing a strict mode violation.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers


