### PR TITLE
fix: add guard on join/call buttons [WPB-21715].

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Prerequisites:
 ## 1. Fetching dependencies and configurations
 
 1. Run `yarn`
-
    - This will install all dependencies and fetch a [configuration](https://github.com/wireapp/wire-web-config-wire/) for the application.
 
 ## 2. Build & run

--- a/src/script/components/calling/CallingCell/CallingControls/CallingControls.tsx
+++ b/src/script/components/calling/CallingCell/CallingControls/CallingControls.tsx
@@ -54,6 +54,7 @@ interface CallingControlsProps {
   disableScreenButton: boolean;
   teamState: TeamState;
   supportsVideoCall: boolean;
+  isAnswerButtonDisabled?: boolean;
 }
 
 export const CallingControls = ({
@@ -75,6 +76,7 @@ export const CallingControls = ({
   selfParticipant,
   teamState = container.resolve(TeamState),
   supportsVideoCall,
+  isAnswerButtonDisabled = false,
 }: CallingControlsProps) => {
   const {isVideoCallingEnabled} = useKoSubscribableChildren(teamState, ['isVideoCallingEnabled']);
   const {sharesScreen: selfSharesScreen, sharesCamera: selfSharesCamera} = useKoSubscribableChildren(selfParticipant, [
@@ -190,6 +192,7 @@ export const CallingControls = ({
                 onClick={answerCall}
                 type="button"
                 data-uie-name="do-call-controls-call-join"
+                disabled={isAnswerButtonDisabled}
               >
                 {t('callJoin')}
               </button>
@@ -201,6 +204,7 @@ export const CallingControls = ({
                 title={t('callAccept')}
                 aria-label={t('callAccept')}
                 data-uie-name="do-call-controls-call-accept"
+                disabled={isAnswerButtonDisabled}
               >
                 <Icon.PickupIcon className="small-icon" />
               </button>

--- a/src/script/hooks/useConversationCall.ts
+++ b/src/script/hooks/useConversationCall.ts
@@ -1,0 +1,77 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {useEffect, useMemo, useState} from 'react';
+
+import {container} from 'tsyringe';
+
+import {STATE as CALL_STATE} from '@wireapp/avs';
+
+import {CallState} from 'Repositories/calling/CallState';
+import type {Conversation} from 'Repositories/entity/Conversation';
+import {useKoSubscribableChildren} from 'Util/ComponentUtil';
+import {matchQualifiedIds} from 'Util/QualifiedId';
+
+interface ConversationCallState {
+  /** connecting/joining */
+  isCallConnecting: boolean;
+  /** active/joined */
+  isCallActive: boolean;
+}
+
+/**
+ * Hook to get the call state for a specific conversation
+ * @param conversation - The conversation to check for calls
+ * @returns Call state information
+ */
+export const useConversationCall = (conversation: Conversation): ConversationCallState => {
+  const callState = container.resolve(CallState);
+  const {calls} = useKoSubscribableChildren(callState, ['calls']);
+
+  const call = useMemo(
+    () => calls.find(call => matchQualifiedIds(call.conversation.qualifiedId, conversation.qualifiedId)),
+    [calls, conversation.qualifiedId],
+  );
+
+  const [currentCallState, setCurrentCallState] = useState<CALL_STATE | null>(() => call?.state() ?? null);
+
+  // Subscribe to the call's state changes
+  useEffect(() => {
+    if (!call) {
+      setCurrentCallState(null);
+      return;
+    }
+
+    setCurrentCallState(call.state());
+
+    // Subscribe to state changes
+    const subscription = call.state.subscribe(newState => {
+      setCurrentCallState(newState);
+    });
+
+    return () => {
+      subscription.dispose();
+    };
+  }, [call]);
+
+  return {
+    isCallConnecting: currentCallState === CALL_STATE.ANSWERED,
+    isCallActive: currentCallState === CALL_STATE.MEDIA_ESTAB,
+  };
+};

--- a/src/script/hooks/useConversationCall.ts
+++ b/src/script/hooks/useConversationCall.ts
@@ -55,7 +55,7 @@ export const useConversationCall = (conversation: Conversation): ConversationCal
   useEffect(() => {
     if (!call) {
       setCurrentCallState(null);
-      return;
+      return () => {};
     }
 
     setCurrentCallState(call.state());

--- a/src/script/view_model/ListViewModel.ts
+++ b/src/script/view_model/ListViewModel.ts
@@ -148,7 +148,7 @@ export class ListViewModel {
     amplify.subscribe(WebAppEvents.SHORTCUT.SILENCE, this.changeNotificationSetting); // todo: deprecated - remove when user base of wrappers version >= 3.4 is large enough
   };
 
-  readonly answerCall = (conversationEntity: Conversation): void => {
+  readonly answerCall = async (conversationEntity: Conversation): Promise<void> => {
     const call = this.callingRepository.findCall(conversationEntity.qualifiedId);
 
     if (!call) {
@@ -156,15 +156,15 @@ export class ListViewModel {
     }
 
     if (call.isConference && !this.callingRepository.supportsConferenceCalling) {
-      PrimaryModal.show(PrimaryModal.type.ACKNOWLEDGE, {
+      return PrimaryModal.show(PrimaryModal.type.ACKNOWLEDGE, {
         text: {
           message: `${t('modalConferenceCallNotSupportedMessage')} ${t('modalConferenceCallNotSupportedJoinMessage')}`,
           title: t('modalConferenceCallNotSupportedHeadline'),
         },
       });
-    } else {
-      this.callingViewModel.callActions.answer(call);
     }
+
+    return this.callingViewModel.callActions.answer(call);
   };
 
   readonly changeNotificationSetting = () => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21715" title="WPB-21715" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21715</a>  Tapping call join button repeatedly leads to incorrect state
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
Add guard on join/call buttons on `CallingCell.tsx`, `TitleBar.tsx` and `ConversationList.tsx`.
Clicking on join/call button multiple times will not try to connect call multiple times.

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).