### PR TITLE
chore(e2e): Update id for a parent element of an image in detailed image view [WPB-22205]

### DIFF
--- a/test/e2e_tests/pageManager/webapp/cells/cellsFileDetailView.modal.ts
+++ b/test/e2e_tests/pageManager/webapp/cells/cellsFileDetailView.modal.ts
@@ -31,7 +31,7 @@ export class CellsFileDetailViewModal {
     this.page = page;
     this.closeButton = page.locator("[aria-label='Close']");
     this.downloadButton = page.locator("[aria-label='Download']");
-    this.image = page.locator("[role='dialog'][aria-modal='true'][id^=':'][id$=':'] img");
+    this.image = page.locator("[role='dialog'][aria-modal='true'] img");
   }
 
   async isImageVisible() {

--- a/test/e2e_tests/specs/CriticalFlow/Cells/uploadingFileInGroupConversation.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/Cells/uploadingFileInGroupConversation.spec.ts
@@ -40,7 +40,7 @@ const imageFilePath = getImageFilePath();
 
 test(
   'Uploading an file in a group conversation',
-  {tag: ['@crit-flow-cells']},
+  {tag: ['@crit-flow-cells', '@regression']},
   async ({pageManager: userAPageManager, browser, api}) => {
     const {pages: userAPages, modals: userAModals, components: userAComponents} = userAPageManager.webapp;
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22205" title="WPB-22205" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22205</a>  [Web] Update id for a parent element of an image in detailed image view.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request
https://wearezeta.atlassian.net/browse/WPB-22205

## Summary

- Changed the id for the parent element of an image in detailed view for cells-enabled conversation
- Added @regression tag so that the test is also running with the regression suite

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
