### PR TITLE
test(WPB-22129): fix login test util

### DIFF
--- a/test/e2e_tests/pageManager/webapp/pages/login.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/login.page.ts
@@ -21,8 +21,6 @@ import type {Page, Locator} from '@playwright/test';
 
 import type {User} from 'test/e2e_tests/data/user';
 
-import {webAppPath} from '../..';
-
 export class LoginPage {
   readonly page: Page;
 
@@ -46,11 +44,5 @@ export class LoginPage {
     await this.emailInput.fill(user.email);
     await this.passwordInput.fill(user.password);
     await this.signInButton.click();
-
-    /**
-     * Since the login may take up to 40s we manually wait for it to finish here instead of increasing the timeout on all actions / assertions after this util
-     * This is an exception to the general best practice of using playwrights web assertions. (See: https://playwright.dev/docs/best-practices#use-web-first-assertions)
-     */
-    await this.page.waitForURL(new RegExp(`^${webAppPath}$`), {timeout: 40_000, waitUntil: 'networkidle'});
   }
 }

--- a/test/e2e_tests/specs/Edit/edit.spec.ts
+++ b/test/e2e_tests/specs/Edit/edit.spec.ts
@@ -72,8 +72,7 @@ test.describe('Edit', () => {
       const deviceA = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
 
       // Device 2 is intentionally created after device 1 to ensure the history info warning is confirmed
-      const deviceB = (await PageManager.from(createPage(withLogin(userA)))).webapp.pages;
-      await deviceB.historyInfo().clickConfirmButton();
+      const deviceB = (await PageManager.from(createPage(withLogin(userA, {confirmNewHistory: true})))).webapp.pages;
       await deviceB.conversationList().openConversation(userB.fullName);
 
       await deviceA.conversation().sendMessage('Message from device 1');


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22129" title="WPB-22129" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22129</a>  [Web] Investigate and improve login e2e flow (its currently flaky)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


# Pull Request

## Summary

Waiting for the navigation to the app on login caused issues in cases where the history info was shown in between, causing the test to timeout without interaction. So the stand alone util will no longer wait for it, only the page plugin will ensure the login finished, optionally also confirming the history info.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).

---

## Notes for reviewers

- The authentication tests manually add the timeout extension since they can't use the page plugin as they're testing the login itself
