### PR TITLE
refactor(WPB-19943): remove async getPage from PageManager

### DIFF
--- a/test/e2e_tests/pageManager/index.ts
+++ b/test/e2e_tests/pageManager/index.ts
@@ -88,7 +88,7 @@ const teamManagementPath = process.env.TEAM_MANAGEMENT_URL ?? '';
 export class PageManager {
   private readonly cache = new Map<string, any>();
 
-  constructor(private readonly page: Page) {}
+  constructor(readonly page: Page) {}
 
   static from(page: Page): PageManager;
   static from(page: Promise<Page>): Promise<PageManager>;
@@ -135,10 +135,6 @@ export class PageManager {
 
   getContext = () => {
     return this.page.context();
-  };
-
-  getPage = async () => {
-    return await this.page;
   };
 
   waitForRequest = (url: string) => {

--- a/test/e2e_tests/specs/Accessibility/Accessibility.spec.ts
+++ b/test/e2e_tests/specs/Accessibility/Accessibility.spec.ts
@@ -125,23 +125,27 @@ test.describe('Accessibility', () => {
     },
   );
 
-  test('I want to see collapsed view when app is narrow', {tag: ['@TC-48', '@regression']}, async ({pageManager}) => {
-    await (await pageManager.getPage()).setViewportSize(narrowViewport);
+  test(
+    'I want to see collapsed view when app is narrow',
+    {tag: ['@TC-48', '@regression']},
+    async ({page, pageManager}) => {
+      await page.setViewportSize(narrowViewport);
 
-    await pageManager.openMainPage();
-    await loginUser(memberA, pageManager);
-    const {components, pages} = pageManager.webapp;
+      await pageManager.openMainPage();
+      await loginUser(memberA, pageManager);
+      const {components, pages} = pageManager.webapp;
 
-    await pages.historyInfo().clickConfirmButton();
-    await components.conversationSidebar().sidebar.waitFor({state: 'visible', timeout: loginTimeOut});
+      await pages.historyInfo().clickConfirmButton();
+      await components.conversationSidebar().sidebar.waitFor({state: 'visible', timeout: loginTimeOut});
 
-    await expect(components.conversationSidebar().sidebar).toHaveAttribute('data-is-collapsed', 'true');
-  });
+      await expect(components.conversationSidebar().sidebar).toHaveAttribute('data-is-collapsed', 'true');
+    },
+  );
 
   test(
     'I should not lose a drafted message when switching between conversations in collapsed view',
     {tag: ['@TC-51', '@regression']},
-    async ({pageManager}) => {
+    async ({page, pageManager}) => {
       const message = 'test';
       const {components, modals, pages} = pageManager.webapp;
       await pageManager.openMainPage();
@@ -153,7 +157,6 @@ test.describe('Accessibility', () => {
       await createGroup(pages, conversationName, [memberB]);
 
       await pages.conversation().typeMessage(message);
-      const page = await pageManager.getPage();
 
       await components.conversationSidebar().clickConnectButton();
 

--- a/test/e2e_tests/specs/AccountSettingsSpecs/accountSettings.spec.ts
+++ b/test/e2e_tests/specs/AccountSettingsSpecs/accountSettings.spec.ts
@@ -185,15 +185,13 @@ test.describe('account settings', () => {
   test(
     'Verify I can retrieve calling logs',
     {tag: ['@TC-1725', '@regression']},
-    async ({pageManager: memberPageManagerA, browser, api}) => {
+    async ({page, pageManager: memberPageManagerA, browser}) => {
       const consoleMessages: string[] = [];
 
       const memberContext = await browser.newContext();
       const memberPage = await memberContext.newPage();
       const memberPageManagerB = new PageManager(memberPage);
       const {pages, components, modals} = memberPageManagerA.webapp;
-
-      const page = await memberPageManagerA.getPage();
 
       page.on('console', msg => {
         consoleMessages.push(msg.text());
@@ -229,7 +227,7 @@ test.describe('account settings', () => {
   test(
     'I want to see the Full Name wherever my name gets displayed',
     {tag: ['@TC-1948', '@regression']},
-    async ({pageManager, api}) => {
+    async ({page, pageManager, api}) => {
       const groupName = 'test group';
       const {components, pages} = pageManager.webapp;
 
@@ -258,7 +256,7 @@ test.describe('account settings', () => {
       await api.brig.unlockChannelFeature(owner.teamId);
       await api.brig.enableChannelsFeature(owner.teamId);
 
-      await (await pageManager.getPage()).reload();
+      await page.reload();
 
       await createChannel(pages, 'test', [memberB]);
 

--- a/test/e2e_tests/specs/AppLock/AppLock.spec.ts
+++ b/test/e2e_tests/specs/AppLock/AppLock.spec.ts
@@ -41,7 +41,7 @@ test.describe('AppLock', () => {
   test(
     'I want to see app lock setup modal on login after app lock has been enforced for the team',
     {tag: ['@TC-2744', '@TC-2740', '@regression']},
-    async ({pageManager}) => {
+    async ({page, pageManager}) => {
       const {modals} = pageManager.webapp;
 
       await completeLogin(pageManager, memberA);
@@ -49,7 +49,6 @@ test.describe('AppLock', () => {
 
       await test.step('Web: I should not be able to close app lock setup modal if app lock is enforced', async () => {
         // click outside the modal
-        const page = await pageManager.getPage();
         await page.mouse.click(200, 350);
         // check if the modal still there
         expect(await modals.appLock().isVisible()).toBeTruthy();
@@ -60,9 +59,8 @@ test.describe('AppLock', () => {
   test(
     'Web: App should not lock if I switch back to webapp tab in time (during inactivity timeout)',
     {tag: ['@TC-2752', '@TC-2753', '@regression']},
-    async ({pageManager, browser}) => {
+    async ({page: webappPageA, pageManager, browser}) => {
       const {modals} = pageManager.webapp;
-      const webappPageA = await pageManager.getPage();
 
       await completeLogin(pageManager, memberA);
       await handleAppLockState(pageManager, appLockPassCode);
@@ -87,7 +85,7 @@ test.describe('AppLock', () => {
   test(
     'Web: I want to unlock the app with passphrase after login',
     {tag: ['@TC-2754', '@TC-2755', '@TC-2758', '@TC-2763', '@regression']},
-    async ({pageManager}) => {
+    async ({page, pageManager}) => {
       const {modals, pages} = pageManager.webapp;
 
       await completeLogin(pageManager, memberA);
@@ -110,14 +108,14 @@ test.describe('AppLock', () => {
         await modals.appLock().clickReset();
         await modals.appLock().inputUserPassword('wrong password');
 
-        expect(await checkAnyIndexedDBExists(await pageManager.getPage())).toBeTruthy();
+        expect(await checkAnyIndexedDBExists(page)).toBeTruthy();
       });
 
       await test.step('I want to wipe database when I forgot my app lock passphrase', async () => {
         await modals.appLock().inputUserPassword(memberA.password);
 
         await expect(pages.singleSignOn().ssoCodeEmailInput).toBeVisible();
-        expect(await checkAnyIndexedDBExists(await pageManager.getPage())).toBeFalsy();
+        expect(await checkAnyIndexedDBExists(page)).toBeFalsy();
       });
     },
   );
@@ -125,12 +123,11 @@ test.describe('AppLock', () => {
   test(
     'I should not be able to switch off app lock if it is enforced for the team',
     {tag: ['@TC-2770', '@TC-2767', '@regression']},
-    async ({pageManager}) => {
+    async ({page, pageManager}) => {
       const {components, pages} = pageManager.webapp;
       await completeLogin(pageManager, memberA);
       await handleAppLockState(pageManager, appLockPassCode);
       await components.conversationSidebar().clickPreferencesButton();
-      const page = await pageManager.getPage();
 
       await expect(pages.account().appLockCheckbox).toBeDisabled();
       // check here string

--- a/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
@@ -43,7 +43,7 @@ let member2Context: BrowserContext | undefined;
 test(
   'Team owner adds whole team to an all team chat',
   {tag: ['@TC-8631', '@crit-flow-web']},
-  async ({pageManager, api, browser}) => {
+  async ({page, pageManager, api, browser}) => {
     const {pages, modals} = pageManager.webapp;
 
     // Create page managers for members that will be reused across steps
@@ -92,7 +92,6 @@ test(
       await pages.conversationDetails().clickAddPeopleButton();
       await pages.conversationDetails().addServiceToConversation('Poll');
       // Verify service was added by checking for system message
-      const page = await pageManager.getPage();
       await expect(page.getByText('You added Poll Bot to the')).toBeVisible();
     });
 

--- a/test/e2e_tests/specs/CriticalFlow/groupVideoCall-TC-8637.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/groupVideoCall-TC-8637.spec.ts
@@ -114,7 +114,7 @@ test(
       await ownerPages.startUI().selectUser(guestUser.username);
       await ownerModals.userProfile().clickConnectButton();
       expect(await ownerPages.conversationList().isConversationItemVisible(guestUser.fullName));
-      await expect(await guestPageManager.getPage()).toHaveTitle('(1) Wire');
+      await expect(guestPage).toHaveTitle('(1) Wire');
 
       await guestPages.conversationList().openPendingConnectionRequest();
       await guestPages.connectRequest().clickConnectButton();

--- a/test/e2e_tests/specs/CriticalFlow/oneOnOneCall-TC-8754.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/oneOnOneCall-TC-8754.spec.ts
@@ -72,7 +72,7 @@ test(
       await ownerAModals.userProfile().clickConnectButton();
 
       expect(await ownerAPages.conversationList().isConversationItemVisible(ownerB.fullName));
-      await expect(await ownerBPageManager.getPage()).toHaveTitle('(1) Wire');
+      await expect(ownerBPage).toHaveTitle('(1) Wire');
 
       await ownerBPages.conversationList().openPendingConnectionRequest();
       await ownerBPages.connectRequest().clickConnectButton();

--- a/test/e2e_tests/specs/noInternetCallGuard.spec.ts
+++ b/test/e2e_tests/specs/noInternetCallGuard.spec.ts
@@ -81,7 +81,7 @@ test('Starting call 1:1 call without internet', async ({browser, pageManager: ow
     await ownerAModals.userProfile().clickConnectButton();
 
     expect(await ownerAPages.conversationList().isConversationItemVisible(ownerB.fullName));
-    await expect(await ownerBPageManager.getPage()).toHaveTitle('(1) Wire');
+    await expect(ownerBPage).toHaveTitle('(1) Wire');
 
     await ownerBPages.conversationList().openPendingConnectionRequest();
     await ownerBPages.connectRequest().clickConnectButton();

--- a/test/e2e_tests/utils/network.util.ts
+++ b/test/e2e_tests/utils/network.util.ts
@@ -25,7 +25,7 @@ import {PageManager} from '../pageManager';
  * @param pageManager
  */
 export const makeNetworkOffline = async (pageManager: PageManager) => {
-  const cdpSession = await pageManager.getContext().newCDPSession(await pageManager.getPage());
+  const cdpSession = await pageManager.getContext().newCDPSession(pageManager.page);
   await cdpSession.send('Network.emulateNetworkConditions', {
     offline: true,
     latency: 0,
@@ -40,7 +40,7 @@ export const makeNetworkOffline = async (pageManager: PageManager) => {
  * @param pageManager
  */
 export const makeNetworkOnline = async (pageManager: PageManager) => {
-  const cdpSession = await pageManager.getContext().newCDPSession(await pageManager.getPage());
+  const cdpSession = await pageManager.getContext().newCDPSession(pageManager.page);
   await cdpSession.send('Network.emulateNetworkConditions', {
     offline: false,
     latency: 0,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19943" title="WPB-19943" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19943</a>  [Web/QA] Write the calling regression tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

The PageManager had an async getter just to access a constructor parameter. This was unnecessary and wrong.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).

---

## Notes for reviewers

-
