### PR TITLE
ci(WPB-21987): use prebuilt testservice in CI

### DIFF
--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -124,73 +124,35 @@ jobs:
             echo "❌ Deployment failed"; exit 1
           fi
 
-  build_testservice:
-    name: Build Kalium Test Service
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          repository: wireapp/kalium
-          ref: main
-
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Gradle Cache
-        uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # SHA of tag v5.0.0
-
-      - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # SHA of tag v5.0.0
-
-      - name: Build the testservice
-        run: ./gradlew :testservice:shadowJar
-
-      - name: Upload jar
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: kalium-testservice
-          path: |
-            testservice/build/libs/
-            testservice/config.yml
-          retention-days: 1
-
   e2e_crit_flow:
     name: Playwright Critical Flow (precommit)
     if: ${{ !cancelled() && github.repository == 'wireapp/wire-webapp' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot' }}
     runs-on: ubuntu-latest
-    needs: [deploy_to_aws, build_testservice]
+    needs: [deploy_to_aws]
     timeout-minutes: 35
+
     strategy:
       fail-fast: false
       matrix:
         # prettier-ignore
         shard: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]
 
+    services:
+      # Run the kalium testservice as service container of the current job
+      testservice:
+        image: quay.io/wire/testservice:latest
+        ports:
+          - 8080:8080
+
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: yarn
-
-      - name: Download Testservice Jar
-        uses: actions/download-artifact@v5
-        with:
-          name: kalium-testservice
-          path: testservice
 
       - run: yarn --immutable
       - run: yarn playwright install --with-deps chrome
@@ -207,12 +169,6 @@ jobs:
           echo "Using precommit URL: https://wire-webapp-precommit.zinfra.io/"
           curl -s -o /dev/null -w "HTTP %{http_code}\n" https://wire-webapp-precommit.zinfra.io/
 
-      - name: Start Testservice in background
-        id: start-testservice
-        run: |
-          java -jar testservice/build/libs/testservice-*-all.jar server testservice/config.yml &
-          echo TESTSERVICE_PID=$! >> "$GITHUB_OUTPUT"
-
       - name: Run critical flow tests
         env:
           # TODO: remove hardcoded precommit env in the future when ephemeral PR envs will exist
@@ -228,11 +184,6 @@ jobs:
           name: blob-report-${{ matrix.shard }}
           path: blob-report
           retention-days: 1
-
-      - name: Stop Testservice
-        run: kill -SIGKILL $TESTSERVICE_PID
-        env:
-          TESTSERVICE_PID: ${{ steps.start-testservice.outputs.TESTSERVICE_PID }}
 
   e2e-report:
     runs-on: ubuntu-latest

--- a/test/e2e_tests/README.md
+++ b/test/e2e_tests/README.md
@@ -1,6 +1,6 @@
 ## Please refer to [Playwright doc](https://playwright.dev/docs/intro) for detailed overview of the framework, troubleshooting, and best practices.
 
-# Requirements beyond the base project
+## Requirements beyond the base project
 
 Have 1Password's cli installed (op)
 
@@ -12,13 +12,22 @@ op inject -i test/e2e_tests/.env.staging.tpl -o test/e2e_tests/.env
 
 It will generate .env file with variables from 1Password
 
-# Tests
+### Running the Testservice
+
+Some of the E2E tests require a connection to a running [Testservice](https://github.com/wireapp/kalium/tree/develop/tools/testservice). The default address stored in 1Password is for an instance running on prem. If you're within the Wire VPN you can just use it.
+
+If you're not in the Wire VPN you can run it locally as a docker container:
+
+1. Start it by running `docker run -d --platform linux/amd64 -p 8080:8080 -p 8081:8081 quay.io/wire/testservice`
+2. Update the env var `TEST_SERVICE_URL` in `test/e2e_tests/.env` to point to it: `TEST_SERVICE_URL=http://localhost:8080``
+
+## Tests
 
 E2E tests can be found inside [test folder](/test/e2e_tests/). The folder contains [page objects](/test/e2e_tests/pages), [backend classes](/test/e2e_tests/backend), and [credentialsReader.ts](/test//e2e_tests/utils/credentialsReader.ts) for access 1Password credentials.
 
 [Playwright config can be found in the root folder of the repo](/playwright.config.ts)
 
-## Running the tests
+### Running the tests
 
 E2E tests can be run via
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21987" title="WPB-21987" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21987</a>  [WEB/QA] POC - Use sharding to run e2e tests in parallel in CI
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

# Pull Request

## Summary

- Instead of building the kalium testservice in every CI run, use the now available prebuilt image of it

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).

---

## Notes for reviewers

- I checked the test case `@TC-3009` to verify the testservice works as it requires it. The test run where it was successfully executed can be seen [here](https://github.com/wireapp/wire-webapp/actions/runs/20106057782/job/57690720867)
