### PR TITLE
runfix: update the backgroundColor of the active speaker's name [WPB-21194]

### DIFF
--- a/src/script/components/calling/GroupVideoGridTile.styles.ts
+++ b/src/script/components/calling/GroupVideoGridTile.styles.ts
@@ -56,7 +56,7 @@ export const groupVideoActiveSpeakerTile = (isActivelySpeaking: boolean, partici
 });
 
 export const groupVideoActiveSpeaker = (isActivelySpeaking: boolean): CSSObject => ({
-  filter: isActivelySpeaking ? 'brightness(0.8)' : 'none',
+  backgroundColor: isActivelySpeaking ? 'var(--accent-color)' : 'var(--black)',
 });
 
 export const groupVideoParticipantNameWrapper = (


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21194" title="WPB-21194" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21194</a>  [Web] Calling - Own profile picture in the call incorrectly marked as a button
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
Fix the backgroundColor of the active speaker's name

- What did I change and why?
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
