### PR TITLE
fix(WPB-19951): Disable primary action of input modal if empty

### DIFF
--- a/src/script/components/Modals/PrimaryModal/InputForm/InputForm.tsx
+++ b/src/script/components/Modals/PrimaryModal/InputForm/InputForm.tsx
@@ -37,6 +37,7 @@ export const InputForm = ({onSubmit, inputValue, inputPlaceholder, onInputChange
         ref={ref => ref?.focus()}
         maxLength={64}
         className="modal__input"
+        data-uie-name="modal-input"
         id="modal-input"
         value={inputValue}
         placeholder={inputPlaceholder}

--- a/src/script/components/Modals/PrimaryModal/InputForm/InputForm.tsx
+++ b/src/script/components/Modals/PrimaryModal/InputForm/InputForm.tsx
@@ -37,7 +37,6 @@ export const InputForm = ({onSubmit, inputValue, inputPlaceholder, onInputChange
         ref={ref => ref?.focus()}
         maxLength={64}
         className="modal__input"
-        data-uie-name="modal-input"
         id="modal-input"
         value={inputValue}
         placeholder={inputPlaceholder}

--- a/src/script/components/Modals/PrimaryModal/PrimaryModal.test.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModal.test.tsx
@@ -144,7 +144,7 @@ const renderPrimaryModal = (
   secondaryAction = () => {},
   hideCloseBtn = false,
 ) => {
-  const {getByTestId, queryByTestId} = render(withTheme(<PrimaryModalComponent />));
+  const {getByTestId, queryByTestId, getByLabelText} = render(withTheme(<PrimaryModalComponent />));
   act(() => {
     PrimaryModal.show(type, {
       primaryAction: {
@@ -158,6 +158,7 @@ const renderPrimaryModal = (
       text: {
         message: 'test-message',
         title: 'test-title',
+        input: 'test-input',
       },
       hideCloseBtn,
       copyPassword: true,
@@ -172,7 +173,7 @@ const renderPrimaryModal = (
     getCloseButton: () => queryByTestId('do-close'),
     getErrorMessage: () => getByTestId('primary-modals-error-message'),
     getPasswordInput: () => getByTestId('guest-link-password'),
-    getInput: () => getByTestId('modal-input'),
+    getInput: () => getByLabelText('test-input'),
     getGeneratePasswordButton: () => getByTestId('do-generate-password'),
     getConfirmPasswordInput: () => getByTestId('guest-link-password-confirm'),
   };

--- a/src/script/components/Modals/PrimaryModal/PrimaryModal.test.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModal.test.tsx
@@ -74,6 +74,16 @@ describe('PrimaryModal', () => {
     });
   });
 
+  describe('Input', () => {
+    it('should disable the primary button while the input is empty', async () => {
+      const {getPrimaryActionButton, getInput} = renderPrimaryModal(PrimaryModalType.INPUT);
+      expect(getPrimaryActionButton()).toHaveProperty('disabled', true);
+
+      fireEvent.change(getInput(), {target: {value: 'Test'}});
+      expect(getPrimaryActionButton()).toHaveProperty('disabled', false);
+    });
+  });
+
   describe('GuestLinkPassword', () => {
     const action = jest.fn().mockImplementation();
 
@@ -162,6 +172,7 @@ const renderPrimaryModal = (
     getCloseButton: () => queryByTestId('do-close'),
     getErrorMessage: () => getByTestId('primary-modals-error-message'),
     getPasswordInput: () => getByTestId('guest-link-password'),
+    getInput: () => getByTestId('modal-input'),
     getGeneratePasswordButton: () => getByTestId('do-generate-password'),
     getConfirmPasswordInput: () => getByTestId('guest-link-password-confirm'),
   };

--- a/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
+++ b/src/script/components/Modals/PrimaryModal/PrimaryModal.tsx
@@ -143,6 +143,9 @@ export const PrimaryModalComponent: FC = () => {
     if (isConfirm) {
       return false;
     }
+    if (isInput) {
+      return !inputActionEnabled;
+    }
     return !inputActionEnabled && !actionEnabled;
   };
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19951" title="WPB-19951" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19951</a>  [Web/QA] Write the Folders regression tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

This is to improve the accessability of the application, instead of just doing nothing upon clicking the button.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).

---

## Notes for reviewers

- 
