### PR TITLE
test(WPB-19943): Add e2e regression tests for calling

### DIFF
--- a/src/script/components/AppContainer/AppContainer.tsx
+++ b/src/script/components/AppContainer/AppContainer.tsx
@@ -120,6 +120,9 @@ export const AppContainer = ({config, clientType}: AppProps) => {
           toggleScreenshare={mainView.calling.callActions.toggleScreenshare}
         />
       )}
+
+      {/* Wrapper which will hold the audio elements for playing e.g. the ringtone. The elements are created within AudioRepository.ts */}
+      <div id="audio-elements" />
     </>
   );
 };

--- a/src/script/repositories/audio/AudioRepository.ts
+++ b/src/script/repositories/audio/AudioRepository.ts
@@ -92,8 +92,10 @@ export class AudioRepository {
   }
 
   private initSounds(): void {
+    const audioElementsWrapper = document.getElementById('audio-elements');
     Object.values(AudioType).forEach(audioId => {
       this.audioElements[audioId] = this.createAudioElement(`./audio/${audioId}.mp3`);
+      audioElementsWrapper?.appendChild(this.audioElements[audioId]);
     });
   }
 

--- a/test/e2e_tests/pageManager/index.ts
+++ b/test/e2e_tests/pageManager/index.ts
@@ -64,6 +64,7 @@ import {ConversationListPage} from './webapp/pages/conversationList.page';
 import {DeleteAccountPage} from './webapp/pages/deleteAccount.page';
 import {DevicesPage} from './webapp/pages/devices.page';
 import {EmailVerificationPage} from './webapp/pages/emailVerification.page';
+import {FullScreenCallPage} from './webapp/pages/fullScreenCall.page';
 import {GroupCreationPage} from './webapp/pages/groupCreation.page';
 import {GuestOptionsPage} from './webapp/pages/guestOptions.page';
 import {HistoryExportPage} from './webapp/pages/historyExport.page';
@@ -172,6 +173,7 @@ export class PageManager {
         this.getOrCreate('webapp.pages.cellsConversationFiles', () => new CellsConversationFilesPage(this.page)),
       connectRequest: () => this.getOrCreate('webapp.pages.connectRequest', () => new ConnectRequestPage(this.page)),
       calling: () => this.getOrCreate('webapp.pages.calling', () => new CallingPage(this.page)),
+      fullScreenCall: () => this.getOrCreate('webapp.pages.fullScreenCall', () => FullScreenCallPage(this.page)),
       settings: () => this.getOrCreate('webapp.pages.settings', () => new SettingsPage(this.page)),
       devices: () => this.getOrCreate('webapp.pages.devices', () => new DevicesPage(this.page)),
       options: () => this.getOrCreate('webapp.pages.options', () => new OptionsPage(this.page)),

--- a/test/e2e_tests/pageManager/webapp/pages/calling.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/calling.page.ts
@@ -21,6 +21,8 @@ import {Page, Locator} from '@playwright/test';
 
 import {selectByDataAttribute} from 'test/e2e_tests/utils/selector.util';
 
+import {FullScreenCallPage} from './fullScreenCall.page';
+
 export class CallingPage {
   readonly page: Page;
 
@@ -110,6 +112,7 @@ export class CallingPage {
 
   async maximizeCell() {
     await this.goFullScreen.click();
+    return FullScreenCallPage(this.page);
   }
 
   // ─── Mute Controls ──────────────────────────────────────────────────────

--- a/test/e2e_tests/pageManager/webapp/pages/calling.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/calling.page.ts
@@ -50,8 +50,8 @@ export class CallingPage {
     this.callCell = page.locator('[data-uie-name="item-call"]');
     this.fullScreen = page.locator('.video-calling-wrapper');
     this.goFullScreen = page.locator('[data-uie-name="do-maximize-call"]');
-    this.acceptCallButton = this.callCell.locator('[data-uie-name="do-call-controls-call-accept"]');
-    this.leaveCallButton = this.callCell.locator('[data-uie-name="do-call-controls-call-leave"]');
+    this.acceptCallButton = this.callCell.getByRole('button', {name: 'Accept'});
+    this.leaveCallButton = this.callCell.getByRole('button', {name: 'Hang Up'});
 
     // Mute / Unmute control
     this.fullScreenMuteButton = page.locator('[data-uie-name="do-call-controls-video-call-mute"]');

--- a/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -41,6 +41,7 @@ export class ConversationListPage {
   readonly moveToMenu: Locator;
   readonly createNewFolderButton: Locator;
   readonly conversationListHeaderTitle: Locator;
+  readonly joinCallButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -66,6 +67,7 @@ export class ConversationListPage {
     this.moveToMenu = page.getByRole('menu');
     this.createNewFolderButton = this.moveToMenu.getByRole('button', {name: 'Create new folder'});
     this.conversationListHeaderTitle = page.locator('[data-uie-name="conversation-list-header-title"]');
+    this.joinCallButton = page.getByRole('button', {name: 'Join'});
   }
 
   async isConversationItemVisible(conversationName: string) {

--- a/test/e2e_tests/pageManager/webapp/pages/fullScreenCall.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/fullScreenCall.page.ts
@@ -1,0 +1,52 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Page} from '@playwright/test';
+
+import {User} from 'test/e2e_tests/data/user';
+
+export const FullScreenCallPage = (page: Page) => {
+  const component = page.locator('.video-calling-wrapper');
+
+  const reactButton = component.getByTitle('Reactions');
+
+  /* Press the react button and click the given emoji within the opened toolbar */
+  const sendReaction = async (emoji: '👍') => {
+    await reactButton.click();
+    const emojiPicker = component.getByRole('toolbar').and(component.getByLabel('Reactions'));
+
+    await emojiPicker.getByRole('button', {name: emoji}).click();
+  };
+
+  /**
+   * Get the locator for a sent reaction
+   * @param options.emoji Optional emoji to filter for
+   * @param options.sender Optional filter for the user who sent the emoji
+   */
+  const getReaction = (options?: {emoji?: '👍'; sender?: Pick<User, 'fullName'>}) => {
+    return component.getByRole('img', {
+      name: new RegExp(`Emoji ${options?.emoji ?? '.*'} from ${options?.sender?.fullName ?? '.*'}`),
+    });
+  };
+
+  return {
+    sendReaction,
+    getReaction,
+  };
+};

--- a/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -1,0 +1,65 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {User} from 'test/e2e_tests/data/user';
+import {PageManager} from 'test/e2e_tests/pageManager';
+import {test, withConnectedUser, withLogin, expect} from 'test/e2e_tests/test.fixtures';
+
+test.describe('Calling', () => {
+  let userA: User;
+  let userB: User;
+  let userC: User;
+
+  test.beforeEach(async ({createTeam}) => {
+    const team = await createTeam('Team Call Team', {withMembers: 2});
+    userA = team.owner;
+    userB = team.members[0];
+    userC = team.members[1];
+  });
+
+  test(
+    'Verify that current call is terminated if you want to call someone else (as caller)',
+    {tag: ['@TC-2802', '@regression']},
+    async ({createPage}) => {
+      const [{pages: userAPages, modals: userAModals}, {pages: userBPages}] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB), withConnectedUser(userC))).then(
+          pm => pm.webapp,
+        ),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp),
+      ]);
+
+      // User A has a call with user B
+      await userAPages.conversationList().openConversation(userB.fullName);
+      await userAPages.conversation().clickCallButton();
+      await userBPages.calling().clickAcceptCallButton();
+      await expect(userBPages.calling().callCell).toBeVisible();
+
+      // User A starts a call with user C while in a call with user B
+      await userAPages.conversationList().openConversation(userC.fullName);
+      await userAPages.conversation().clickCallButton();
+
+      // A modal is shown prompting him to confirm before cancelling the ongoing call
+      await expect(userAModals.confirm().modalTitle).toContainText('Hang up current call?');
+      await userAModals.confirm().clickAction();
+
+      // The call with user B should be terminated
+      await expect(userBPages.calling().callCell).not.toBeVisible();
+    },
+  );
+});

--- a/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -82,4 +82,24 @@ test.describe('Calling', () => {
     await userACall.sendReaction('👍');
     await reactionAssertion;
   });
+
+  test(
+    'I want to answer incoming call with Join button in conversation view',
+    {tag: ['@TC-2826', '@regression']},
+    async ({createPage}) => {
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+      ]);
+
+      await userAPages.conversationList().openConversation(userB.fullName);
+      await userAPages.conversation().clickCallButton();
+
+      await expect(userBPages.conversationList().joinCallButton).toBeVisible();
+      await expect(userBPages.calling().acceptCallButton).toBeVisible();
+
+      await userBPages.conversationList().joinCallButton.click();
+      await expect(userBPages.calling().acceptCallButton).not.toBeVisible();
+    },
+  );
 });

--- a/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -62,4 +62,24 @@ test.describe('Calling', () => {
       await expect(userBPages.calling().callCell).not.toBeVisible();
     },
   );
+
+  test('Verify in call reactions', {tag: ['@TC-8774', '@regression']}, async ({createPage}) => {
+    const [userAPages, userBPages] = await Promise.all([
+      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+    ]);
+
+    await userAPages.conversationList().openConversation(userB.fullName);
+    await userAPages.conversation().clickCallButton();
+    await userBPages.calling().clickAcceptCallButton();
+
+    const [userACall, userBCall] = await Promise.all([
+      userAPages.calling().maximizeCell(),
+      userBPages.calling().maximizeCell(),
+    ]);
+
+    const reactionAssertion = expect(userBCall.getReaction({emoji: '👍', sender: userA})).toBeVisible();
+    await userACall.sendReaction('👍');
+    await reactionAssertion;
+  });
 });

--- a/test/e2e_tests/utils/audio.util.ts
+++ b/test/e2e_tests/utils/audio.util.ts
@@ -1,0 +1,32 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Page} from '@playwright/test';
+
+import {AudioType} from 'Repositories/audio/AudioType';
+
+/**
+ * Detect if the given sound is currently being played. The sounds played are managed by `AudioRepository.ts`
+ * @param page the page to check if audio is playing on
+ * @param type the sound which is currently playing
+ */
+export const isPlayingAudio = async (page: Page, type: AudioType) => {
+  const audioTag = page.locator(`#audio-elements>audio[src*="${type}"]`);
+  return await audioTag.evaluate((el: HTMLAudioElement) => !el.paused);
+};


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19943" title="WPB-19943" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19943</a>  [Web/QA] Write the calling regression tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->



# Pull Request

## Summary

- Add regression tests for calling where no group is involved
  - Testing group calls requires an enterprise team which we currently can't create to use within the tests

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).

---

## Notes for reviewers

- In order to test the ringing sound I had to actually attach the created Audio Elements to the DOM, otherwise it's not possible to detect if audio is playing or not.