### PR TITLE
fix: Close button for "Consent to share user data" needs accessible title(WPB-22174)

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -932,6 +932,7 @@
   "dataSharingModalDecline": "Decline",
   "dataSharingModalDescription": "Help to improve Wire by sharing your usage data via a pseudonymous ID. The data is neither linked to your personal information nor shared with third parties besides Wire Group. It includes, for example, when you use a feature, your app version, device type, or your operating system. This data will be deleted at the latest after 365 days. <br /> Find further details in our [link]Privacy Policy[/link]. You can revoke your consent at any time.",
   "dataSharingModalTitle": "Consent to share user data",
+  "dataSharingModalCloseBtnTitle": "Close window, Consent to share user data",
   "deletedUser": "Deleted User",
   "deletedUserBadge": "Deleted",
   "downloadLatestMLS": "Download the latest MLS Wire version",

--- a/src/script/repositories/properties/PropertiesRepository.ts
+++ b/src/script/repositories/properties/PropertiesRepository.ts
@@ -158,6 +158,7 @@ export class PropertiesRepository {
       text: {
         title: t('dataSharingModalTitle'),
         htmlMessage: t('dataSharingModalDescription', undefined, replaceLink(Config.getConfig().URL.PRIVACY_POLICY)),
+        closeBtnLabel: t('dataSharingModalCloseBtnTitle'),
       },
       primaryAction: {
         text: t('dataSharingModalAgree'),

--- a/src/types/i18n.d.ts
+++ b/src/types/i18n.d.ts
@@ -941,6 +941,7 @@ declare module 'I18n/en-US.json' {
     'dataSharingModalDecline': `Decline`;
     'dataSharingModalDescription': `Help to improve Wire by sharing your usage data via a pseudonymous ID. The data is neither linked to your personal information nor shared with third parties besides Wire Group. It includes, for example, when you use a feature, your app version, device type, or your operating system. This data will be deleted at the latest after 365 days. <br /> Find further details in our [link]Privacy Policy[/link]. You can revoke your consent at any time.`;
     'dataSharingModalTitle': `Consent to share user data`;
+    'dataSharingModalCloseBtnTitle': `Close window, Consent to share user data`;
     'deletedUser': `Deleted User`;
     'deletedUserBadge': `Deleted`;
     'downloadLatestMLS': `Download the latest MLS Wire version`;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22174" title="WPB-22174" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22174</a>  Close button for "Consent to share user data" just uses "image"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- Close button for "Consent to share user data" just uses "button" without any descriptive title

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
