### PR TITLE
fix:  Login - New view is not announced for signup page correctly(WPB-21230)

### DIFF
--- a/src/script/auth/page/Root.tsx
+++ b/src/script/auth/page/Root.tsx
@@ -210,7 +210,7 @@ const RootComponent: FC<RootProps & ConnectedProps & DispatchProps> = ({
                 <Route
                   path=""
                   element={
-                    <Title title={`${t('authSSOLoginTitle')} . ${brandName}`}>
+                    <Title title={`${t('authLoginTitle')} . ${brandName}`}>
                       <SingleSignOn />
                     </Title>
                   }

--- a/src/script/auth/page/SingleSignOn.tsx
+++ b/src/script/auth/page/SingleSignOn.tsx
@@ -58,6 +58,7 @@ import {AppAlreadyOpen} from '../component/AppAlreadyOpen';
 import {BackButton} from '../component/BackButton';
 import {RootState, bindActionCreators} from '../module/reducer';
 import * as AuthSelector from '../module/selector/AuthSelector';
+import {srOnlyStyle} from '../util/a11y';
 import {getEnterpriseLoginV2FF} from '../util/helpers';
 
 type Props = React.HTMLAttributes<HTMLDivElement>;
@@ -260,13 +261,19 @@ const SingleSignOnComponent = ({hasDefaultSSOCode}: Props & ConnectedProps & Dis
                 {isEnterpriseLoginV2Enabled ? (
                   <>
                     <div
+                      aria-labelledby="sso-login-heading-label sso-login-heading-text"
                       css={{fontWeight: '500', fontSize: '1.5rem'}}
                       role="heading"
                       aria-level={1}
                       data-page-title
                       tabIndex={-1}
                     >
-                      {t('index.welcome', {brandName: Config.getConfig().BACKEND_NAME})}
+                      <span id="sso-login-heading-label" style={srOnlyStyle}>
+                        {t('authLoginTitle')}
+                      </span>
+                      <span id="sso-login-heading-text">
+                        {t('index.welcome', {brandName: Config.getConfig().BACKEND_NAME})}
+                      </span>
                     </div>
 
                     <Text block center data-uie-name="status-email-or-sso-code">

--- a/src/script/auth/util/a11y.ts
+++ b/src/script/auth/util/a11y.ts
@@ -1,0 +1,28 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import React from 'react';
+
+export const srOnlyStyle: React.CSSProperties = {
+  position: 'absolute',
+  left: -10000,
+  overflow: 'hidden',
+  width: 1,
+  height: 1,
+};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21230" title="WPB-21230" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21230</a>  [Web] Login - New view is not announced
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- For signup page we need to announce for Login
- When headline welcome to wire has keyboard focus for SR users only we need to also announce Login along with it.

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
