### PR TITLE
fix: Files that are in the bin should not be visible on the corresponding message [WPB-21586]

### DIFF
--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.test.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.test.tsx
@@ -168,8 +168,10 @@ describe('MultipartAssets', () => {
       );
 
       await waitFor(() => {
-        expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(1);
+        expect(mockCellsRepository.getNode).toHaveBeenCalled();
       });
+
+      const callsBeforeHashChange = mockCellsRepository.getNode.mock.calls.length;
 
       // Simulate hash change within the same conversation
       await act(async () => {
@@ -178,8 +180,7 @@ describe('MultipartAssets', () => {
       });
 
       await waitFor(() => {
-        expect(mockCellsRepository.getNode).toHaveBeenCalled();
-        expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(2);
+        expect(mockCellsRepository.getNode.mock.calls.length).toBeGreaterThan(callsBeforeHashChange);
       });
     });
 
@@ -354,8 +355,10 @@ describe('MultipartAssets', () => {
       );
 
       await waitFor(() => {
-        expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(1);
+        expect(mockCellsRepository.getNode).toHaveBeenCalled();
       });
+
+      const callsBeforeHashChange = mockCellsRepository.getNode.mock.calls.length;
 
       // Simulate hash change
       await act(async () => {
@@ -364,7 +367,7 @@ describe('MultipartAssets', () => {
       });
 
       await waitFor(() => {
-        expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(2);
+        expect(mockCellsRepository.getNode.mock.calls.length).toBeGreaterThan(callsBeforeHashChange);
       });
     });
 

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.test.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.test.tsx
@@ -1,0 +1,454 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render, screen, waitFor, act} from '@testing-library/react';
+import {RestNode} from 'cells-sdk-ts';
+
+import {ICellAsset} from '@wireapp/protocol-messaging';
+
+import {CellsRepository} from 'Repositories/cells/CellsRepository';
+import {withTheme} from 'src/script/auth/util/test/TestUtil';
+
+import {MultipartAssets} from './MultipartAssets';
+
+jest.mock('Hooks/useInView/useInView', () => ({
+  useInView: () => ({
+    elementRef: {current: null},
+    hasBeenInView: true,
+  }),
+}));
+
+const mockNode: RestNode = {
+  Path: '/path/to/test.pdf',
+  Uuid: 'test-uuid',
+  IsRecycled: false,
+  PreSignedGET: {
+    Url: 'https://example.com/file.pdf',
+  },
+  Previews: [],
+};
+
+const mockRecycledNode: RestNode = {
+  ...mockNode,
+  IsRecycled: true,
+};
+
+describe('MultipartAssets', () => {
+  let mockCellsRepository: jest.Mocked<CellsRepository>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCellsRepository = {
+      getNode: jest.fn(),
+    } as unknown as jest.Mocked<CellsRepository>;
+  });
+
+  const createMockAsset = (uuid: string, contentType: string, initialName: string): ICellAsset => ({
+    uuid,
+    initialName,
+    initialSize: 1024,
+    contentType,
+  });
+
+  describe('isRecycled state rendering', () => {
+    it('should display unavailable file message for recycled files', async () => {
+      mockCellsRepository.getNode.mockResolvedValue(mockRecycledNode);
+
+      const assets: ICellAsset[] = [createMockAsset('test-uuid', 'application/pdf', 'test.pdf')];
+
+      render(
+        withTheme(
+          <MultipartAssets
+            assets={assets}
+            conversationId="conv-123"
+            cellsRepository={mockCellsRepository}
+            senderName="John Doe"
+            timestamp={Date.now()}
+          />,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('cells.unavailableFile')).toBeInTheDocument();
+      });
+    });
+
+    it('should render normal file card for non-recycled files', async () => {
+      mockCellsRepository.getNode.mockResolvedValue(mockNode);
+
+      const assets: ICellAsset[] = [createMockAsset('test-uuid', 'application/pdf', 'test.pdf')];
+
+      render(
+        withTheme(
+          <MultipartAssets
+            assets={assets}
+            conversationId="conv-123"
+            cellsRepository={mockCellsRepository}
+            senderName="John Doe"
+            timestamp={Date.now()}
+          />,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(mockCellsRepository.getNode).toHaveBeenCalledWith({uuid: 'test-uuid'});
+      });
+
+      expect(screen.queryByText('cells.unavailableFile')).not.toBeInTheDocument();
+    });
+
+    it('should render multiple assets with mixed recycled state', async () => {
+      mockCellsRepository.getNode
+        .mockResolvedValueOnce(mockNode)
+        .mockResolvedValueOnce(mockRecycledNode)
+        .mockResolvedValueOnce(mockNode);
+
+      const assets: ICellAsset[] = [
+        createMockAsset('uuid-1', 'application/pdf', 'file1.pdf'),
+        createMockAsset('uuid-2', 'application/pdf', 'file2.pdf'),
+        createMockAsset('uuid-3', 'application/pdf', 'file3.pdf'),
+      ];
+
+      render(
+        withTheme(
+          <MultipartAssets
+            assets={assets}
+            conversationId="conv-123"
+            cellsRepository={mockCellsRepository}
+            senderName="John Doe"
+            timestamp={Date.now()}
+          />,
+        ),
+      );
+
+      await waitFor(() => {
+        const unavailableMessages = screen.getAllByText('cells.unavailableFile');
+        expect(unavailableMessages).toHaveLength(1);
+      });
+    });
+  });
+
+  describe('hash change listener', () => {
+    beforeEach(() => {
+      // Reset window.location.hash
+      window.location.hash = '';
+    });
+
+    it('should trigger refetch when hash changes within the same conversation', async () => {
+      mockCellsRepository.getNode.mockResolvedValue(mockNode);
+
+      const assets: ICellAsset[] = [createMockAsset('test-uuid', 'application/pdf', 'test.pdf')];
+
+      render(
+        withTheme(
+          <MultipartAssets
+            assets={assets}
+            conversationId="conv-123"
+            cellsRepository={mockCellsRepository}
+            senderName="John Doe"
+            timestamp={Date.now()}
+          />,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(1);
+      });
+
+      // Simulate hash change within the same conversation
+      await act(async () => {
+        window.location.hash = '#/conversation/conv-123/section';
+        window.dispatchEvent(new HashChangeEvent('hashchange'));
+      });
+
+      await waitFor(() => {
+        expect(mockCellsRepository.getNode).toHaveBeenCalled();
+        expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it('should NOT trigger refetch when navigating to /files view', async () => {
+      mockCellsRepository.getNode.mockResolvedValue(mockNode);
+
+      const assets: ICellAsset[] = [createMockAsset('test-uuid', 'application/pdf', 'test.pdf')];
+
+      render(
+        withTheme(
+          <MultipartAssets
+            assets={assets}
+            conversationId="conv-123"
+            cellsRepository={mockCellsRepository}
+            senderName="John Doe"
+            timestamp={Date.now()}
+          />,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(1);
+      });
+
+      // Simulate hash change to /files view
+      await act(async () => {
+        window.location.hash = '#/conversation/conv-123/files';
+        window.dispatchEvent(new HashChangeEvent('hashchange'));
+      });
+
+      // Wait a bit to ensure no additional calls are made
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT trigger refetch when navigating to different conversation', async () => {
+      mockCellsRepository.getNode.mockResolvedValue(mockNode);
+
+      const assets: ICellAsset[] = [createMockAsset('test-uuid', 'application/pdf', 'test.pdf')];
+
+      render(
+        withTheme(
+          <MultipartAssets
+            assets={assets}
+            conversationId="conv-123"
+            cellsRepository={mockCellsRepository}
+            senderName="John Doe"
+            timestamp={Date.now()}
+          />,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(1);
+      });
+
+      // Simulate hash change to different conversation
+      await act(async () => {
+        window.location.hash = '#/conversation/conv-456/section';
+        window.dispatchEvent(new HashChangeEvent('hashchange'));
+      });
+
+      // Wait a bit to ensure no additional calls are made
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle multiple hash changes within same conversation', async () => {
+      mockCellsRepository.getNode.mockResolvedValue(mockNode);
+
+      const assets: ICellAsset[] = [createMockAsset('test-uuid', 'application/pdf', 'test.pdf')];
+
+      render(
+        withTheme(
+          <MultipartAssets
+            assets={assets}
+            conversationId="conv-123"
+            cellsRepository={mockCellsRepository}
+            senderName="John Doe"
+            timestamp={Date.now()}
+          />,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(1);
+      });
+
+      const initialCalls = mockCellsRepository.getNode.mock.calls.length;
+
+      // First hash change
+      await act(async () => {
+        window.location.hash = '#/conversation/conv-123/section1';
+        window.dispatchEvent(new HashChangeEvent('hashchange'));
+      });
+
+      await waitFor(() => {
+        expect(mockCellsRepository.getNode.mock.calls.length).toBeGreaterThan(initialCalls);
+      });
+
+      const callsAfterFirst = mockCellsRepository.getNode.mock.calls.length;
+
+      // Second hash change
+      await act(async () => {
+        window.location.hash = '#/conversation/conv-123/section2';
+        window.dispatchEvent(new HashChangeEvent('hashchange'));
+      });
+
+      await waitFor(() => {
+        expect(mockCellsRepository.getNode.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+      });
+    });
+
+    it('should clean up hash change listener on unmount', async () => {
+      mockCellsRepository.getNode.mockResolvedValue(mockNode);
+
+      const assets: ICellAsset[] = [createMockAsset('test-uuid', 'application/pdf', 'test.pdf')];
+
+      const {unmount} = render(
+        withTheme(
+          <MultipartAssets
+            assets={assets}
+            conversationId="conv-123"
+            cellsRepository={mockCellsRepository}
+            senderName="John Doe"
+            timestamp={Date.now()}
+          />,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(1);
+      });
+
+      unmount();
+
+      // Simulate hash change after unmount
+      await act(async () => {
+        window.location.hash = '#/conversation/conv-123/section';
+        window.dispatchEvent(new HashChangeEvent('hashchange'));
+      });
+
+      // Wait a bit to ensure no additional calls are made
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      // Should not trigger additional fetch after unmount
+      expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('forceRefetch integration', () => {
+    it('should pass forceRefetch=true to fetchData when hash changes', async () => {
+      const initialNode = {...mockNode, Path: '/old/path/test.pdf'};
+      const updatedNode = {...mockNode, Path: '/new/path/test.pdf'};
+
+      mockCellsRepository.getNode.mockResolvedValueOnce(initialNode).mockResolvedValueOnce(updatedNode);
+
+      const assets: ICellAsset[] = [createMockAsset('test-uuid', 'application/pdf', 'test.pdf')];
+
+      render(
+        withTheme(
+          <MultipartAssets
+            assets={assets}
+            conversationId="conv-123"
+            cellsRepository={mockCellsRepository}
+            senderName="John Doe"
+            timestamp={Date.now()}
+          />,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(1);
+      });
+
+      // Simulate hash change
+      await act(async () => {
+        window.location.hash = '#/conversation/conv-123/section';
+        window.dispatchEvent(new HashChangeEvent('hashchange'));
+      });
+
+      await waitFor(() => {
+        expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it('should update from non-recycled to recycled state on hash change refetch', async () => {
+      mockCellsRepository.getNode.mockResolvedValueOnce(mockNode).mockResolvedValueOnce(mockRecycledNode);
+
+      const assets: ICellAsset[] = [createMockAsset('test-uuid', 'application/pdf', 'test.pdf')];
+
+      render(
+        withTheme(
+          <MultipartAssets
+            assets={assets}
+            conversationId="conv-123"
+            cellsRepository={mockCellsRepository}
+            senderName="John Doe"
+            timestamp={Date.now()}
+          />,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByText('cells.unavailableFile')).not.toBeInTheDocument();
+      });
+
+      // Simulate hash change
+      await act(async () => {
+        window.location.hash = '#/conversation/conv-123/section';
+        window.dispatchEvent(new HashChangeEvent('hashchange'));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('cells.unavailableFile')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('different asset types', () => {
+    it('should render unavailable message for recycled image assets', async () => {
+      mockCellsRepository.getNode.mockResolvedValue(mockRecycledNode);
+
+      const assets: ICellAsset[] = [
+        {
+          ...createMockAsset('test-uuid', 'image/png', 'test.png'),
+          image: {width: 100, height: 100},
+        },
+      ];
+
+      render(
+        withTheme(
+          <MultipartAssets
+            assets={assets}
+            conversationId="conv-123"
+            cellsRepository={mockCellsRepository}
+            senderName="John Doe"
+            timestamp={Date.now()}
+          />,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('cells.unavailableFile')).toBeInTheDocument();
+      });
+    });
+
+    it('should render unavailable message for recycled video assets', async () => {
+      mockCellsRepository.getNode.mockResolvedValue(mockRecycledNode);
+
+      const assets: ICellAsset[] = [createMockAsset('test-uuid', 'video/mp4', 'test.mp4')];
+
+      render(
+        withTheme(
+          <MultipartAssets
+            assets={assets}
+            conversationId="conv-123"
+            cellsRepository={mockCellsRepository}
+            senderName="John Doe"
+            timestamp={Date.now()}
+          />,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('cells.unavailableFile')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.tsx
@@ -131,7 +131,11 @@ const MultipartAsset = ({
   }, [fetchData, conversationId]);
 
   if (isRecycled) {
-    return <MediaFilePreviewCard isLoading={false} isError label={t('cells.unavailableFile')} />;
+    return (
+      <li ref={elementRef} css={fileCardStyles}>
+        <MediaFilePreviewCard isLoading={false} isError label={t('cells.unavailableFile')} />
+      </li>
+    );
   }
 
   if (isImage) {

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.tsx
@@ -114,8 +114,10 @@ const MultipartAsset = ({
   const name = path ? getName(path) : getName(initialName!);
 
   /**
-   * will listen to hash changes and fetch the data again
-   * in case changes were made to the file in the cell (file is moved to recycle bin, renamed, etc.)
+   * Listen to hash changes within the current conversation (excluding the `/files` view)
+   * and refetch the asset data. This keeps the asset state in sync after navigation,
+   * for example when returning from views where the file might have been moved,
+   * renamed, or otherwise modified.
    */
   useEffect(() => {
     const handleHashChange = () => {

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.tsx
@@ -17,14 +17,18 @@
  *
  */
 
+import {useEffect} from 'react';
+
 import {container} from 'tsyringe';
 
 import {ICellAsset} from '@wireapp/protocol-messaging';
 
 import {useInView} from 'Hooks/useInView/useInView';
 import {CellsRepository} from 'Repositories/cells/CellsRepository';
+import {t} from 'Util/LocalizerUtil';
 import {formatBytes, getFileExtension, trimFileExtension} from 'Util/util';
 
+import {MediaFilePreviewCard} from './common/MediaFilePreviewCard/MediaFilePreviewCard';
 import {FileAssetCard} from './FileAssetCard/FileAssetCard';
 import {ImageAssetCard} from './ImageAssetCard/ImageAssetCard';
 import {
@@ -41,11 +45,13 @@ interface MultipartAssetsProps {
   assets: ICellAsset[];
   cellsRepository?: CellsRepository;
   senderName: string;
+  conversationId: string;
   timestamp: number;
 }
 
 export const MultipartAssets = ({
   assets,
+  conversationId,
   cellsRepository = container.resolve(CellsRepository),
   senderName,
   timestamp,
@@ -54,6 +60,7 @@ export const MultipartAssets = ({
     <ul css={assets.length === 1 ? listSingleItemStyles : listStyles}>
       {assets.map(asset => (
         <MultipartAsset
+          conversationId={conversationId}
           key={asset.uuid}
           cellsRepository={cellsRepository}
           assetsCount={assets.length}
@@ -70,6 +77,7 @@ interface MultipartAssetProps extends ICellAsset {
   cellsRepository: CellsRepository;
   assetsCount: number;
   senderName: string;
+  conversationId: string;
   timestamp: number;
 }
 
@@ -78,6 +86,7 @@ const MultipartAsset = ({
   initialName,
   initialSize,
   contentType,
+  conversationId,
   cellsRepository,
   assetsCount,
   image: imageMetadata,
@@ -95,7 +104,7 @@ const MultipartAsset = ({
   const isSingleAsset = assetsCount === 1;
   const variant = isSingleAsset ? 'large' : 'small';
 
-  const {src, isLoading, isError, imagePreviewUrl, pdfPreviewUrl, path} = useGetMultipartAsset({
+  const {src, isLoading, isError, imagePreviewUrl, pdfPreviewUrl, path, isRecycled, fetchData} = useGetMultipartAsset({
     uuid,
     cellsRepository,
     isEnabled: hasBeenInView,
@@ -103,6 +112,25 @@ const MultipartAsset = ({
   });
 
   const name = path ? getName(path) : getName(initialName!);
+
+  /**
+   * will listen to hash changes and fetch the data again
+   * in case changes were made to the file in the cell (file is moved to recycle bin, renamed, etc.)
+   */
+  useEffect(() => {
+    const handleHashChange = () => {
+      const currentPath = window.location.hash;
+      if (currentPath.includes(conversationId) && !currentPath.endsWith('/files')) {
+        void fetchData(true);
+      }
+    };
+    window.addEventListener('hashchange', handleHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
+  }, [fetchData, conversationId]);
+
+  if (isRecycled) {
+    return <MediaFilePreviewCard isLoading={false} isError label={t('cells.unavailableFile')} />;
+  }
 
   if (isImage) {
     return (

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/common/MediaFilePreviewCard/MediaFilePreviewCard.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/common/MediaFilePreviewCard/MediaFilePreviewCard.styles.ts
@@ -34,6 +34,7 @@ export const wrapperStyles: CSSObject = {
 
 export const wrapperErrorStyles: CSSObject = {
   ...wrapperStyles,
+  width: 268,
   display: 'flex',
   alignItems: 'flex-start',
   justifyContent: 'space-between',

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/common/MediaFilePreviewCard/MediaFilePreviewCard.styles.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/common/MediaFilePreviewCard/MediaFilePreviewCard.styles.ts
@@ -34,7 +34,7 @@ export const wrapperStyles: CSSObject = {
 
 export const wrapperErrorStyles: CSSObject = {
   ...wrapperStyles,
-  width: 268,
+  width: '268px',
   display: 'flex',
   alignItems: 'flex-start',
   justifyContent: 'space-between',

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/common/MediaFilePreviewCard/MediaFilePreviewCard.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/common/MediaFilePreviewCard/MediaFilePreviewCard.tsx
@@ -36,7 +36,7 @@ interface MediaFilePreviewCardProps {
   label: string;
   isLoading: boolean;
   isError: boolean;
-  children: ReactNode;
+  children?: ReactNode;
 }
 
 export const MediaFilePreviewCard = ({label, isLoading, isError, children}: MediaFilePreviewCardProps) => {

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/useGetMultipartAsset/useGetMultipartAsset.test.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/useGetMultipartAsset/useGetMultipartAsset.test.ts
@@ -1,0 +1,405 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {act, renderHook, waitFor} from '@testing-library/react';
+import {RestNode} from 'cells-sdk-ts';
+
+import {CellsRepository} from 'Repositories/cells/CellsRepository';
+
+import {useGetMultipartAsset} from './useGetMultipartAsset';
+
+const mockNode: RestNode = {
+  Path: '/path/to/test.pdf',
+  Uuid: 'test-uuid',
+  IsRecycled: false,
+  PreSignedGET: {
+    Url: 'https://example.com/file.pdf',
+  },
+  Previews: [
+    {
+      ContentType: 'image/png',
+      PreSignedGET: {
+        Url: 'https://example.com/preview.png',
+      },
+      Processing: false,
+      Error: undefined,
+    },
+  ],
+};
+
+const mockRecycledNode: RestNode = {
+  ...mockNode,
+  IsRecycled: true,
+};
+
+describe('useGetMultipartAsset', () => {
+  let mockCellsRepository: jest.Mocked<CellsRepository>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockCellsRepository = {
+      getNode: jest.fn(),
+    } as unknown as jest.Mocked<CellsRepository>;
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  describe('isRecycled state handling', () => {
+    it('should set isRecycled to false for non-recycled files', async () => {
+      mockCellsRepository.getNode.mockResolvedValue(mockNode);
+
+      const {result} = renderHook(() =>
+        useGetMultipartAsset({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+          isEnabled: true,
+          retryPreviewUntilSuccess: false,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.isRecycled).toBe(false);
+      });
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isError).toBe(false);
+    });
+
+    it('should set isRecycled to true for recycled files', async () => {
+      mockCellsRepository.getNode.mockResolvedValue(mockRecycledNode);
+
+      const {result} = renderHook(() =>
+        useGetMultipartAsset({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+          isEnabled: true,
+          retryPreviewUntilSuccess: false,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.isRecycled).toBe(true);
+      });
+
+      expect(result.current.src).toBe('https://example.com/file.pdf');
+      expect(result.current.path).toBe('/path/to/test.pdf');
+    });
+
+    it('should update isRecycled state when refetched', async () => {
+      // Start with non-recycled node
+      mockCellsRepository.getNode.mockResolvedValueOnce(mockNode);
+
+      const {result} = renderHook(() =>
+        useGetMultipartAsset({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+          isEnabled: true,
+          retryPreviewUntilSuccess: false,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.isRecycled).toBe(false);
+      });
+
+      // Change to recycled node on refetch
+      mockCellsRepository.getNode.mockResolvedValueOnce(mockRecycledNode);
+
+      await act(async () => {
+        await result.current.fetchData(true);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isRecycled).toBe(true);
+      });
+    });
+  });
+
+  describe('forceRefetch parameter', () => {
+    it('should refetch data when forceRefetch is true even if already successful', async () => {
+      mockCellsRepository.getNode.mockResolvedValue(mockNode);
+
+      const {result} = renderHook(() =>
+        useGetMultipartAsset({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+          isEnabled: true,
+          retryPreviewUntilSuccess: false,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(1);
+
+      // Force refetch
+      await act(async () => {
+        await result.current.fetchData(true);
+      });
+
+      expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not refetch when forceRefetch is false and status is success', async () => {
+      mockCellsRepository.getNode.mockResolvedValue(mockNode);
+
+      const {result} = renderHook(() =>
+        useGetMultipartAsset({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+          isEnabled: true,
+          retryPreviewUntilSuccess: false,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(1);
+
+      // Try to fetch without force
+      await act(async () => {
+        await result.current.fetchData(false);
+      });
+
+      // Should not call getNode again
+      expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(1);
+    });
+
+    it('should update all state properties when forceRefetch is called', async () => {
+      const updatedNode: RestNode = {
+        ...mockNode,
+        Path: '/new/path/to/file.pdf',
+        PreSignedGET: {
+          Url: 'https://example.com/new-file.pdf',
+        },
+        Previews: [
+          {
+            ContentType: 'image/png',
+            PreSignedGET: {
+              Url: 'https://example.com/new-preview.png',
+            },
+            Processing: false,
+            Error: undefined,
+          },
+        ],
+      };
+
+      mockCellsRepository.getNode.mockResolvedValueOnce(mockNode);
+
+      const {result} = renderHook(() =>
+        useGetMultipartAsset({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+          isEnabled: true,
+          retryPreviewUntilSuccess: false,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.src).toBe('https://example.com/file.pdf');
+      });
+
+      // Update mock and force refetch
+      mockCellsRepository.getNode.mockResolvedValueOnce(updatedNode);
+
+      await act(async () => {
+        await result.current.fetchData(true);
+      });
+
+      await waitFor(() => {
+        expect(result.current.src).toBe('https://example.com/new-file.pdf');
+        expect(result.current.imagePreviewUrl).toBe('https://example.com/new-preview.png');
+        expect(result.current.path).toBe('/new/path/to/file.pdf');
+      });
+    });
+  });
+
+  describe('disabled state', () => {
+    it('should not fetch data when isEnabled is false', async () => {
+      mockCellsRepository.getNode.mockResolvedValue(mockNode);
+
+      renderHook(() =>
+        useGetMultipartAsset({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+          isEnabled: false,
+          retryPreviewUntilSuccess: false,
+        }),
+      );
+
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      expect(mockCellsRepository.getNode).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error handling', () => {
+    it('should set error state when fetch fails', async () => {
+      mockCellsRepository.getNode.mockRejectedValue(new Error('Network error'));
+
+      const {result} = renderHook(() =>
+        useGetMultipartAsset({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+          isEnabled: true,
+          retryPreviewUntilSuccess: false,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('should allow retry after error with forceRefetch', async () => {
+      mockCellsRepository.getNode.mockRejectedValueOnce(new Error('Network error'));
+
+      const {result} = renderHook(() =>
+        useGetMultipartAsset({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+          isEnabled: true,
+          retryPreviewUntilSuccess: false,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      // Retry with successful response
+      mockCellsRepository.getNode.mockResolvedValueOnce(mockNode);
+
+      await act(async () => {
+        await result.current.fetchData(true);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(false);
+        expect(result.current.src).toBe('https://example.com/file.pdf');
+      });
+    });
+  });
+
+  describe('preview retry logic', () => {
+    it('should return immediately when retryPreviewUntilSuccess is false', async () => {
+      const processingNode: RestNode = {
+        ...mockNode,
+        Previews: [
+          {
+            ContentType: 'image/png',
+            PreSignedGET: {
+              Url: 'https://example.com/preview.png',
+            },
+            Processing: true,
+            Error: undefined,
+          },
+        ],
+      };
+
+      mockCellsRepository.getNode.mockResolvedValue(processingNode);
+
+      const {result} = renderHook(() =>
+        useGetMultipartAsset({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+          isEnabled: true,
+          retryPreviewUntilSuccess: false,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Should only call once, no retries
+      expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(1);
+      expect(result.current.imagePreviewUrl).toBe('https://example.com/preview.png');
+    });
+
+    it('should retry when preview is processing and retryPreviewUntilSuccess is true', async () => {
+      const processingNode: RestNode = {
+        ...mockNode,
+        Previews: [
+          {
+            ContentType: 'image/png',
+            PreSignedGET: {
+              Url: 'https://example.com/preview.png',
+            },
+            Processing: true,
+            Error: undefined,
+          },
+        ],
+      };
+
+      const readyNode: RestNode = {
+        ...mockNode,
+        Previews: [
+          {
+            ContentType: 'image/png',
+            PreSignedGET: {
+              Url: 'https://example.com/preview.png',
+            },
+            Processing: false,
+            Error: undefined,
+          },
+        ],
+      };
+
+      mockCellsRepository.getNode.mockResolvedValueOnce(processingNode).mockResolvedValueOnce(readyNode);
+
+      const {result} = renderHook(() =>
+        useGetMultipartAsset({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+          isEnabled: true,
+          retryPreviewUntilSuccess: true,
+          retryDelay: 100,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(1);
+      });
+
+      // Wait for retry
+      await act(async () => {
+        jest.advanceTimersByTime(100);
+      });
+
+      await waitFor(() => {
+        expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(2);
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.imagePreviewUrl).toBe('https://example.com/preview.png');
+      });
+    });
+  });
+});

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/useGetMultipartAsset/useGetMultipartAsset.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/useGetMultipartAsset/useGetMultipartAsset.ts
@@ -61,6 +61,7 @@ export const useGetMultipartAsset = ({
   const [imagePreviewUrl, setImagePreviewUrl] = useState<string | undefined>(undefined);
   const [pdfPreviewUrl, setPdfPreviewUrl] = useState<string | undefined>(undefined);
   const [status, setStatus] = useState<Status>('idle');
+  const [isRecycled, setIsRecycled] = useState<boolean | undefined>(undefined);
 
   const timeoutRef = useRef<number>();
   const isMounted = useRef(true);
@@ -71,55 +72,58 @@ export const useGetMultipartAsset = ({
     uuidRef.current = uuid;
   }
 
-  const fetchData = useCallback(async () => {
-    if (!isMounted.current || status === 'success') {
-      return;
-    }
-
-    try {
-      setStatus('loading');
-      const asset = await cellsRepository.getNode({uuid});
-
-      if (!isMounted.current) {
+  const fetchData = useCallback(
+    async (forceRefetch = false) => {
+      if (!forceRefetch && (!isMounted.current || status === 'success')) {
         return;
       }
 
-      const imagePreview = asset.Previews?.find(preview => preview?.ContentType?.startsWith('image/'));
-      const pdfPreview = asset.Previews?.find(preview => preview?.ContentType?.startsWith('application/pdf'));
+      try {
+        setStatus('loading');
+        const asset = await cellsRepository.getNode({uuid});
+        if (!isMounted.current) {
+          return;
+        }
 
-      const shouldReturnImmediately =
-        !retryPreviewUntilSuccess || (!imagePreview && !pdfPreview) || (imagePreview?.Error && pdfPreview?.Error);
+        const imagePreview = asset.Previews?.find(preview => preview?.ContentType?.startsWith('image/'));
+        const pdfPreview = asset.Previews?.find(preview => preview?.ContentType?.startsWith('application/pdf'));
 
-      if (shouldReturnImmediately) {
+        const shouldReturnImmediately =
+          !retryPreviewUntilSuccess || (!imagePreview && !pdfPreview) || (imagePreview?.Error && pdfPreview?.Error);
+
+        if (shouldReturnImmediately) {
+          setSrc(asset.PreSignedGET?.Url);
+          setImagePreviewUrl(imagePreview?.PreSignedGET?.Url);
+          setPdfPreviewUrl(pdfPreview?.PreSignedGET?.Url);
+          setPath(asset.Path);
+          setIsRecycled(asset.IsRecycled);
+          setStatus('success');
+
+          return;
+        }
+
+        const shouldRetry = (imagePreview?.Processing || pdfPreview?.Processing) && attemptRef.current < maxRetries;
+
+        if (shouldRetry) {
+          attemptRef.current += 1;
+          setStatus('retrying');
+          return;
+        }
+
         setSrc(asset.PreSignedGET?.Url);
         setImagePreviewUrl(imagePreview?.PreSignedGET?.Url);
         setPdfPreviewUrl(pdfPreview?.PreSignedGET?.Url);
         setPath(asset.Path);
         setStatus('success');
-
-        return;
+      } catch (err) {
+        if (!isMounted.current) {
+          return;
+        }
+        setStatus('error');
       }
-
-      const shouldRetry = (imagePreview?.Processing || pdfPreview?.Processing) && attemptRef.current < maxRetries;
-
-      if (shouldRetry) {
-        attemptRef.current += 1;
-        setStatus('retrying');
-        return;
-      }
-
-      setSrc(asset.PreSignedGET?.Url);
-      setImagePreviewUrl(imagePreview?.PreSignedGET?.Url);
-      setPdfPreviewUrl(pdfPreview?.PreSignedGET?.Url);
-      setPath(asset.Path);
-      setStatus('success');
-    } catch (err) {
-      if (!isMounted.current) {
-        return;
-      }
-      setStatus('error');
-    }
-  }, [status, retryPreviewUntilSuccess, maxRetries, cellsRepository, uuid]);
+    },
+    [status, retryPreviewUntilSuccess, maxRetries, cellsRepository, uuid],
+  );
 
   useEffect(() => {
     isMounted.current = true;
@@ -160,6 +164,8 @@ export const useGetMultipartAsset = ({
   }, [status, fetchData, retryDelay]);
 
   return {
+    fetchData,
+    isRecycled,
     src,
     imagePreviewUrl,
     pdfPreviewUrl,

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/useGetMultipartAsset/useGetMultipartAsset.ts
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/useGetMultipartAsset/useGetMultipartAsset.ts
@@ -114,6 +114,7 @@ export const useGetMultipartAsset = ({
         setImagePreviewUrl(imagePreview?.PreSignedGET?.Url);
         setPdfPreviewUrl(pdfPreview?.PreSignedGET?.Url);
         setPath(asset.Path);
+        setIsRecycled(asset.IsRecycled);
         setStatus('success');
       } catch (err) {
         if (!isMounted.current) {

--- a/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
+++ b/src/script/components/MessagesList/Message/ContentMessage/asset/index.tsx
@@ -104,7 +104,12 @@ const ContentAsset = ({
             />
           )}
 
-          <MultipartAssets senderName={senderName} timestamp={timestamp} assets={filesMultipart} />
+          <MultipartAssets
+            conversationId={message.conversation_id}
+            senderName={senderName}
+            timestamp={timestamp}
+            assets={filesMultipart}
+          />
 
           {shouldRenderTextMultipart && (
             <ReadIndicator message={message} is1to1Conversation={is1to1Conversation} onClick={onClickDetails} />


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21586" title="WPB-21586" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21586</a>  [Web] Files that are in the bin shouldn't be visible in the conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- What did I change and why?
- Files that are in the bin should not be visible on the corresponding message, in order to achieve this I have implemented listening to the hash change event in the MultipartAsset component and triggering a force refetch of the information related to the file. this will also cover other changes to the file as well for example in case file is renamed.
- Risks and how to roll out / roll back (e.g. feature flags):
none.
---

## Security Checklist (required)

- [X] **External inputs are validated & sanitized** on client and/or server where applicable.
- [X] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [X] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [X] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

https://github.com/user-attachments/assets/f667c1ed-8775-4f68-903b-7c999ec00d0c

