### PR TITLE
test(19944): implement clear conversation content tests [WPB-19944]

### DIFF
--- a/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -100,7 +100,9 @@ export class ConversationPage {
     this.conversationInfoButton = page.locator(selectByDataAttribute('do-open-info'));
     this.pingButton = page.locator(selectByDataAttribute('do-ping'));
     this.messageItems = page.locator(selectByDataAttribute('item-message'));
-    /** The attribute 'send-status' will be 1 while the message is being sent, since we only want to assert on sent messages these messages will be excluded. See: {@see StatusTypes} */
+    /** The attribute 'send-status' will be 1 while the message is being sent, since we only want to assert on sent messages these messages will be excluded. See: {@see StatusTypes}
+     * Status type -1 ensures that system messages do NOT count as sent messages
+     */
     this.messages = page.locator(
       `${selectByDataAttribute('item-message')}:not(${selectByDataAttribute('1', 'send-status')}):not(${selectByDataAttribute('-1', 'send-status')})`,
     );

--- a/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -102,7 +102,7 @@ export class ConversationPage {
     this.messageItems = page.locator(selectByDataAttribute('item-message'));
     /** The attribute 'send-status' will be 1 while the message is being sent, since we only want to assert on sent messages these messages will be excluded. See: {@see StatusTypes} */
     this.messages = page.locator(
-      `${selectByDataAttribute('item-message')}:not(${selectByDataAttribute('1', 'send-status')})`,
+      `${selectByDataAttribute('item-message')}:not(${selectByDataAttribute('1', 'send-status')}):not(${selectByDataAttribute('-1', 'send-status')})`,
     );
     this.messageDetails = page.locator('#message-details');
     this.filesTab = page.locator('#conversation-tab-files');
@@ -465,5 +465,12 @@ export class ConversationPage {
   async getCurrentFocusedToolTip(message: Locator) {
     await message.getByTestId('emoji-pill').first().hover();
     return this.page.locator('[data-testid="tooltip-content"]');
+  }
+
+  /**
+   * Returns the locator for the ping element within the message list.
+   */
+  getPing(): Locator {
+    return this.messageItems.locator(selectByDataAttribute('element-message-ping'));
   }
 }

--- a/test/e2e_tests/pageManager/webapp/pages/conversationDetails.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/conversationDetails.page.ts
@@ -30,6 +30,7 @@ export class ConversationDetailsPage {
   readonly selfDeletingMessageButton: Locator;
   readonly archiveButton: Locator;
   readonly blockConversationButton: Locator;
+  readonly clearConversationContentButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -40,6 +41,7 @@ export class ConversationDetailsPage {
     this.selfDeletingMessageButton = this.conversationDetails.getByRole('button', {name: 'Self-deleting messages'});
     this.archiveButton = this.conversationDetails.locator(selectByDataAttribute('do-archive'));
     this.blockConversationButton = this.conversationDetails.locator(selectByDataAttribute('do-block'));
+    this.clearConversationContentButton = this.conversationDetails.getByRole('button', {name: 'Clear Content'});
   }
 
   async waitForSidebar() {
@@ -167,5 +169,9 @@ export class ConversationDetailsPage {
 
   async clickBlockConversationButton() {
     await this.blockConversationButton.click();
+  }
+
+  async clickClearConversationContentButton() {
+    await this.clearConversationContentButton.click();
   }
 }

--- a/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -42,6 +42,7 @@ export class ConversationListPage {
   readonly createNewFolderButton: Locator;
   readonly conversationListHeaderTitle: Locator;
   readonly joinCallButton: Locator;
+  readonly clearContentButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -68,6 +69,7 @@ export class ConversationListPage {
     this.createNewFolderButton = this.moveToMenu.getByRole('button', {name: 'Create new folder'});
     this.conversationListHeaderTitle = page.locator('[data-uie-name="conversation-list-header-title"]');
     this.joinCallButton = page.getByRole('button', {name: 'Join'});
+    this.clearContentButton = page.getByRole('button', {name: 'Clear content'});
   }
 
   async isConversationItemVisible(conversationName: string) {

--- a/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
+++ b/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
@@ -40,7 +40,7 @@ test.describe('Clear Conversation Content', () => {
   [
     {tag: '@TC-152', type: 'clear'},
     {tag: '@TC-153', type: 'cancel clearing'},
-  ].forEach(({type, tag}) => {
+  ].forEach(({tag, type}) => {
     test(
       `I want to ${type} content of a group conversation via conversation list`,
       {tag: [tag, '@regression']},
@@ -92,72 +92,52 @@ test.describe('Clear Conversation Content', () => {
     );
   });
 
-  test(
-    'I want to clear content of 1:1 conversation via conversation list',
-    {tag: ['@TC-154', '@regression']},
-    async ({createPage}) => {
-      const [userAPageManager, userBPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
-        PageManager.from(createPage(withLogin(userB))),
-      ]);
+  [
+    {tag: '@TC-154', type: 'clear'},
+    {tag: '@TC-155', type: 'cancel clearing'},
+  ].forEach(({tag, type}) => {
+    test(
+      `I want to ${type} content of 1:1 conversation via conversation list`,
+      {tag: [tag, '@regression']},
+      async ({createPage}) => {
+        const [userAPageManager, userBPageManager] = await Promise.all([
+          PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
+          PageManager.from(createPage(withLogin(userB))),
+        ]);
 
-      const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
-      const userBPages = userBPageManager.webapp.pages;
+        const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
+        const userBPages = userBPageManager.webapp.pages;
 
-      // Step 1: Create a 1:1 conversation with User A and B
-      await userAPages.conversationList().openConversation(userB.fullName);
+        // Step 1: Create a 1:1 conversation with User A and B
+        await userAPages.conversationList().openConversation(userB.fullName);
 
-      // Step 2: Write messages in the conversation
-      await userAPages.conversation().sendMessage('Message from User A');
+        // Step 2: Write messages in the conversation
+        await userAPages.conversation().sendMessage('Message from User A');
 
-      await userBPages.conversationList().openConversation(userA.fullName);
-      await userBPages.conversation().sendMessage('Message from User B');
+        await userBPages.conversationList().openConversation(userA.fullName);
+        await userBPages.conversation().sendMessage('Message from User B');
 
-      // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
-      await userAPages.conversationList().openContextMenu(userB.fullName);
-      await userAPages.conversationList().clearContentButton.click();
-      // Step 4: Warning Popup should open
-      await expect(userAModals.confirm().modal).toBeVisible();
-      // Step 5: User A clicks 'Clear'
-      await userAModals.confirm().clickAction();
-      // Step 6: Verify that the conversation does not contain any past messages
-      await userAPages.conversationList().openConversation(userB.fullName);
-      await expect(userAPages.conversation().messages).toHaveCount(0);
-    },
-  );
+        // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
+        await userAPages.conversationList().openContextMenu(userB.fullName);
+        await userAPages.conversationList().clearContentButton.click();
+        // Step 4: Warning Popup should open
+        await expect(userAModals.confirm().modal).toBeVisible();
 
-  test(
-    'I want to cancel clearing content of 1:1 conversation via conversation list',
-    {tag: ['@TC-155', '@regression']},
-    async ({createPage}) => {
-      const [userAPageManager, userBPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
-        PageManager.from(createPage(withLogin(userB))),
-      ]);
-
-      const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
-      const userBPages = userBPageManager.webapp.pages;
-
-      // Step 1: Create a 1:1 conversation with User A and B
-      await userAPages.conversationList().openConversation(userB.fullName);
-
-      // Step 2: Write messages in the conversation
-      await userAPages.conversation().sendMessage('Message from User A');
-
-      await userBPages.conversationList().openConversation(userA.fullName);
-      await userBPages.conversation().sendMessage('Message from User B');
-
-      // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
-      await userAPages.conversationList().openContextMenu(userB.fullName);
-      await userAPages.conversationList().clearContentButton.click();
-      // Step 4: Warning Popup should open
-      await expect(userAModals.confirm().modal).toBeVisible();
-      // Step 5: User A clicks 'Cancel'
-      await userAModals.confirm().clickCancel();
-      // Step 6: Verify that the conversation does not contain any past messages
-      await expect(userAPages.conversation().messages).toHaveCount(2);
-    },
-  );
+        if (type === 'clear') {
+          // Step 5: User A clicks 'Clear'
+          await userAModals.confirm().clickAction();
+          // Step 6: Verify that the conversation does not contain any past messages
+          await userAPages.conversationList().openConversation(userB.fullName);
+          await expect(userAPages.conversation().messages).toHaveCount(0);
+        } else {
+          // Step 5: User A clicks 'Cancel'
+          await userAModals.confirm().clickCancel();
+          // Step 6: Verify that the conversation does not contain any past messages
+          await expect(userAPages.conversation().messages).toHaveCount(2);
+        }
+      },
+    );
+  });
 
   // TODO: Blocked [WPB-22442] - Group call feature requires Enterprise Account
   test.skip(
@@ -300,76 +280,63 @@ test.describe('Clear Conversation Content', () => {
     },
   );
 
-  test(
-    'I want to clear the group conversation content from conversation details options',
-    {tag: ['@TC-424', '@regression']},
-    async ({createPage}) => {
-      const [userAPageManager, userBPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
-        PageManager.from(createPage(withLogin(userB))),
-      ]);
+  [
+    {tag: '@TC-424', type: 'clear', conversationType: 'group'},
+    {tag: '@TC-425', type: 'clear', conversationType: '1:1'},
+  ].forEach(({tag, type, conversationType}) => {
+    test(
+      `I want to ${type} the ${conversationType} conversation content from conversation details options`,
+      {tag: [tag, '@regression']},
+      async ({createPage}) => {
+        const [userAPageManager, userBPageManager] = await Promise.all([
+          PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
+          PageManager.from(createPage(withLogin(userB))),
+        ]);
 
-      const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
-      const userBPages = userBPageManager.webapp.pages;
+        const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
+        const userBPages = userBPageManager.webapp.pages;
 
-      const conversationName = 'Group conversation';
-      await createGroup(userAPages, conversationName, [userB]);
+        const conversationName = 'Group conversation';
+        if (conversationType === 'group') {
+          await createGroup(userAPages, conversationName, [userB]);
+          // Step 1: User A and B write in group conversation
+          await userAPages.conversationList().openConversation(conversationName);
+          await userAPages.conversation().sendMessage('Message from User A');
 
-      // Step 1: User A and B write in group conversation
-      await userAPages.conversationList().openConversation(conversationName);
-      await userAPages.conversation().sendMessage('Message from User A');
+          await userBPages.conversationList().openConversation(conversationName);
+          await userBPages.conversation().sendMessage('Message from User B');
+        } else {
+          // Step 1: User A and B write in group conversation
+          await userAPages.conversationList().openConversation(userB.fullName);
+          await userAPages.conversation().sendMessage('Message from User A');
 
-      await userBPages.conversationList().openConversation(conversationName);
-      await userBPages.conversation().sendMessage('Message from User B');
+          await userBPages.conversationList().openConversation(userA.fullName);
+          await userBPages.conversation().sendMessage('Message from User B');
+        }
+        await expect(userAPages.conversation().messages).toHaveCount(2);
 
-      await expect(userAPages.conversation().messages).toHaveCount(2);
+        // Step 2: User A opens Conversation Details
+        await userAPages.conversation().clickConversationInfoButton();
+        // Step 3: User A clicks Clear Conversation Button
+        await userAPages.conversationDetails().clickClearConversationContentButton();
 
-      // Step 2: User A opens Conversation Details
-      await userAPages.conversation().clickConversationInfoButton();
-      // Step 3: User A clicks Clear Conversation Button
-      await userAPages.conversationDetails().clickClearConversationContentButton();
-      // Step 4: Clear Conversation Content Modal appears
-      await expect(userAModals.optionModal().modal).toBeVisible();
-      // Step 5: User A clicks 'Clear'
-      await userAModals.optionModal().clickAction();
-      // Step 6: Verify that the conversation does not contain any past messages
-      await userAPages.conversationList().openConversation(userB.fullName);
-      await expect(userAPages.conversation().messages).toHaveCount(0);
-    },
-  );
-
-  test(
-    'I want to clear the 1:1 conversation content from conversation details options',
-    {tag: ['@TC-425', '@regression']},
-    async ({createPage}) => {
-      const [userAPageManager, userBPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
-        PageManager.from(createPage(withLogin(userB))),
-      ]);
-
-      const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
-      const userBPages = userBPageManager.webapp.pages;
-
-      // Step 1: User A and B write in 1:1 conversation
-      await userAPages.conversationList().openConversation(userB.fullName);
-      await userAPages.conversation().sendMessage('Message from User A');
-
-      await userBPages.conversationList().openConversation(userA.fullName);
-      await userBPages.conversation().sendMessage('Message from User B');
-
-      await expect(userAPages.conversation().messages).toHaveCount(2);
-
-      // Step 2: User A opens Conversation Details
-      await userAPages.conversation().clickConversationInfoButton();
-      // Step 3: User A clicks Clear Conversation Button
-      await userAPages.conversationDetails().clickClearConversationContentButton();
-      // Step 4: Clear Conversation Content Modal appears
-      await expect(userAModals.confirm().modal).toBeVisible();
-      // Step 5: User A clicks 'Clear'
-      await userAModals.confirm().clickAction();
-      // Step 6: Verify that the conversation does not contain any past messages
-      await userAPages.conversationList().openConversation(userB.fullName);
-      await expect(userAPages.conversation().messages).toHaveCount(0);
-    },
-  );
+        if (conversationType === 'group') {
+          // Step 4: Clear Conversation Content Modal appears
+          await expect(userAModals.optionModal().modal).toBeVisible();
+          // Step 5: User A clicks 'Clear'
+          await userAModals.optionModal().clickAction();
+          // Step 6: Verify that the conversation does not contain any past messages
+          await userAPages.conversationList().openConversation(conversationName);
+        } else {
+          // Step 4: Clear Conversation Content Modal appears
+          await expect(userAModals.confirm().modal).toBeVisible();
+          // Step 5: User A clicks 'Clear'
+          await userAModals.confirm().clickAction();
+          // Step 6: Verify that the conversation does not contain any past messages
+          await userAPages.conversationList().openConversation(userB.fullName);
+        }
+        await expect(userAPages.conversation().messages).toHaveCount(0);
+      },
+    );
+  });
 });

--- a/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
+++ b/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
@@ -37,87 +37,60 @@ test.describe('Clear Conversation Content', () => {
     userC = team.members[1];
   });
 
-  test(
-    'I want to clear content of a group conversation via conversation list',
-    {tag: ['@TC-152', '@regression']},
-    async ({createPage}) => {
-      const [userAPageManager, userBPageManager, userCPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB), withConnectedUser(userC))),
-        PageManager.from(createPage(withLogin(userB))),
-        PageManager.from(createPage(withLogin(userC))),
-      ]);
+  [
+    {tag: '@TC-152', type: 'clear'},
+    {tag: '@TC-153', type: 'cancel clearing'},
+  ].forEach(({type, tag}) => {
+    test(
+      `I want to ${type} content of a group conversation via conversation list`,
+      {tag: [tag, '@regression']},
+      async ({createPage}) => {
+        const [userAPageManager, userBPageManager, userCPageManager] = await Promise.all([
+          PageManager.from(createPage(withLogin(userA), withConnectedUser(userB), withConnectedUser(userC))),
+          PageManager.from(createPage(withLogin(userB))),
+          PageManager.from(createPage(withLogin(userC))),
+        ]);
 
-      const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
-      const userBPages = userBPageManager.webapp.pages;
-      const userCPages = userCPageManager.webapp.pages;
+        const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
+        const userBPages = userBPageManager.webapp.pages;
+        const userCPages = userCPageManager.webapp.pages;
 
-      // Step 1: Create a group conversation with User A, B and C
-      const conversationName = 'Group conversation';
-      await createGroup(userAPages, conversationName, [userB, userC]);
+        // Step 1: Create a group conversation with User A, B and C
+        const conversationName = 'Group conversation';
+        await createGroup(userAPages, conversationName, [userB, userC]);
 
-      // Step 2: Write messages in the group conversation
-      await userAPages.conversationList().openConversation(conversationName);
-      await userAPages.conversation().sendMessage('Message from User A');
+        // Step 2: Write messages in the group conversation
+        await userAPages.conversationList().openConversation(conversationName);
+        await userAPages.conversation().sendMessage('Message from User A');
 
-      await userBPages.conversationList().openConversation(conversationName);
-      await userBPages.conversation().sendMessage('Message from User B');
+        await userBPages.conversationList().openConversation(conversationName);
+        await userBPages.conversation().sendMessage('Message from User B');
 
-      await userCPages.conversationList().openConversation(conversationName);
-      await userCPages.conversation().sendMessage('Message from User C');
+        await userCPages.conversationList().openConversation(conversationName);
+        await userCPages.conversation().sendMessage('Message from User C');
 
-      // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
-      await userAPages.conversationList().openContextMenu(conversationName);
-      await userAPages.conversationList().clearContentButton.click();
-      // Step 4: Warning Popup should open
-      await expect(userAModals.optionModal().modal).toBeVisible();
-      // Step 5: User A clicks 'Clear'
-      await userAModals.optionModal().clickAction();
-      // Step 6: Verify that the conversation does not contain any past messages
-      await userAPages.conversationList().openConversation(conversationName);
-      await expect(userAPages.conversation().messages).toHaveCount(0);
-    },
-  );
+        // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
+        await userAPages.conversationList().openContextMenu(conversationName);
+        await userAPages.conversationList().clearContentButton.click();
+        // Step 4: Warning Popup should open
+        await expect(userAModals.optionModal().modal).toBeVisible();
 
-  test(
-    'I want to cancel clearing content of a group conversation via conversation list',
-    {tag: ['@TC-153', '@regression']},
-    async ({createPage}) => {
-      const [userAPageManager, userBPageManager, userCPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB), withConnectedUser(userC))),
-        PageManager.from(createPage(withLogin(userB))),
-        PageManager.from(createPage(withLogin(userC))),
-      ]);
-
-      const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
-      const userBPages = userBPageManager.webapp.pages;
-      const userCPages = userCPageManager.webapp.pages;
-
-      // Step 1: Create a group conversation with User A, B and C
-      const conversationName = 'Group conversation';
-      await createGroup(userAPages, conversationName, [userB, userC]);
-
-      // Step 2: Write messages in the group conversation
-      await userAPages.conversationList().openConversation(conversationName);
-      await userAPages.conversation().sendMessage('Message from User A');
-
-      await userBPages.conversationList().openConversation(conversationName);
-      await userBPages.conversation().sendMessage('Message from User B');
-
-      await userCPages.conversationList().openConversation(conversationName);
-      await userCPages.conversation().sendMessage('Message from User C');
-
-      // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
-      await userAPages.conversationList().openContextMenu(conversationName);
-      await userAPages.conversationList().clearContentButton.click();
-      // Step 4: Warning Popup should open
-      await expect(userAModals.optionModal().modal).toBeVisible();
-      // Step 5: User A clicks 'Cancel'
-      await userAModals.optionModal().clickCancel();
-      // Step 6: Verify that the conversation does not contain any past messages
-      await userAPages.conversationList().openConversation(conversationName);
-      await expect(userAPages.conversation().messages).toHaveCount(3);
-    },
-  );
+        if (type === 'clear') {
+          // Step 5: User A clicks 'Clear'
+          await userAModals.optionModal().clickAction();
+          // Step 6: Verify that the conversation does not contain any past messages
+          await userAPages.conversationList().openConversation(conversationName);
+          await expect(userAPages.conversation().messages).toHaveCount(0);
+        } else {
+          // Step 5: User A clicks 'Cancel'
+          await userAModals.optionModal().clickCancel();
+          // Step 6: Verify that the conversation does not contain any past messages
+          await userAPages.conversationList().openConversation(conversationName);
+          await expect(userAPages.conversation().messages).toHaveCount(3);
+        }
+      },
+    );
+  });
 
   test(
     'I want to clear content of 1:1 conversation via conversation list',
@@ -237,20 +210,15 @@ test.describe('Clear Conversation Content', () => {
       await expect(userAPages.conversation().getPing()).toBeVisible();
 
       // Step 6.3: Verify you can receive incoming pictures
-      const {page} = userAPages.conversation();
+      const {page} = userBPages.conversation();
       await shareAssetHelper(getImageFilePath(), page, page.getByRole('button', {name: 'Add picture'}));
-      await shareAssetHelper(
-        getImageFilePath(),
-        userBPageManager.page,
-        userBPageManager.page.getByRole('button', {name: 'Add picture'}),
-      );
       const messageWithImage = userAPages.conversation().getMessage({sender: userB});
       await expect(messageWithImage).toBeVisible();
 
       // Step 6.4: Verify you can receive incoming files
       await userAPages.conversationList().openConversation(conversationName);
       await shareAssetHelper(getTextFilePath(), page, page.getByRole('button', {name: 'Add file'}));
-      const messageWithFile = userAPages.conversation().getMessage({sender: userA});
+      const messageWithFile = userAPages.conversation().getMessage({sender: userB});
       await expect(messageWithFile).toBeVisible();
 
       // Step 6.5: Verify you can receive incoming calls
@@ -265,7 +233,6 @@ test.describe('Clear Conversation Content', () => {
     'I want to see incoming picture, ping and call after I clear content of a 1:1 conversation via conversation list',
     {tag: ['@TC-8779', '@regression']},
     async ({createPage}) => {
-      test.slow();
       const [userAPageManager, userBPageManager] = await Promise.all([
         PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
         PageManager.from(createPage(withLogin(userB))),
@@ -281,6 +248,7 @@ test.describe('Clear Conversation Content', () => {
       await userAPages.conversation().sendMessage('Message from User A');
       await userBPages.conversationList().openConversation(userA.fullName);
       await userBPages.conversation().sendMessage('Message from User B');
+      await expect(userAPages.conversation().messages).toHaveCount(2);
 
       // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
       await userAPages.conversationList().openContextMenu(userB.fullName);
@@ -305,20 +273,23 @@ test.describe('Clear Conversation Content', () => {
       await expect(userAPages.conversation().getPing()).toBeVisible();
 
       // Step 6.3: Verify you can receive incoming pictures
-      const {page} = userAPages.conversation();
+      const {page} = userBPages.conversation();
       await shareAssetHelper(getImageFilePath(), page, page.getByRole('button', {name: 'Add picture'}));
-      await shareAssetHelper(
-        getImageFilePath(),
-        userBPageManager.page,
-        userBPageManager.page.getByRole('button', {name: 'Add picture'}),
-      );
-      const messageWithImage = userAPages.conversation().getMessage({sender: userB}).last();
+      const messageWithImage = userAPages
+        .conversation()
+        .getMessage({sender: userB})
+        .filter({has: userAPages.conversation().page.locator('img[data-uie-name="image-asset-img"]')});
       await expect(messageWithImage).toBeVisible();
 
       // Step 6.4: Verify you can receive incoming files
       await userAPages.conversationList().openConversation(userB.fullName);
       await shareAssetHelper(getTextFilePath(), page, page.getByRole('button', {name: 'Add file'}));
-      const messageWithFile = userAPages.conversation().getMessage({sender: userB}).last();
+      const messageWithFile = userAPages
+        .conversation()
+        .getMessage({sender: userB})
+        .filter({
+          has: userAPages.conversation().page.locator('[data-uie-name="file-asset"]'),
+        });
       await expect(messageWithFile).toBeVisible();
 
       // Step 6.5: Verify you can receive incoming calls
@@ -350,6 +321,8 @@ test.describe('Clear Conversation Content', () => {
 
       await userBPages.conversationList().openConversation(conversationName);
       await userBPages.conversation().sendMessage('Message from User B');
+
+      await expect(userAPages.conversation().messages).toHaveCount(2);
 
       // Step 2: User A opens Conversation Details
       await userAPages.conversation().clickConversationInfoButton();
@@ -383,6 +356,8 @@ test.describe('Clear Conversation Content', () => {
 
       await userBPages.conversationList().openConversation(userA.fullName);
       await userBPages.conversation().sendMessage('Message from User B');
+
+      await expect(userAPages.conversation().messages).toHaveCount(2);
 
       // Step 2: User A opens Conversation Details
       await userAPages.conversation().clickConversationInfoButton();

--- a/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
+++ b/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
@@ -86,7 +86,7 @@ test.describe('Clear Conversation Content', () => {
         } else {
           // Step 5: User A clicks 'Cancel'
           await userAModals.optionModal().clickCancel();
-          // Step 6: Verify that the conversation does not contain any past messages
+          // Step 6: Verify that the conversation still contains any past messages
           await userAPages.conversationList().openConversation(conversationName);
           await expect(userAPages.conversation().messages).toHaveCount(3);
         }
@@ -136,7 +136,7 @@ test.describe('Clear Conversation Content', () => {
         } else {
           // Step 5: User A clicks 'Cancel'
           await userAModals.confirm().clickCancel();
-          // Step 6: Verify that the conversation does not contain any past messages
+          // Step 6: Verify that the conversation still contains any past messages
           await expect(userAPages.conversation().messages).toHaveCount(2);
         }
       },
@@ -271,7 +271,7 @@ test.describe('Clear Conversation Content', () => {
           await userBPages.conversationList().openConversation(conversationName);
           await userBPages.conversation().sendMessage('Message from User B');
         } else {
-          // Step 1: User A and B write in group conversation
+          // Step 1: User A and B write in conversation
           await userAPages.conversationList().openConversation(userB.fullName);
           await userAPages.conversation().sendMessage('Message from User A');
 

--- a/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
+++ b/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
@@ -53,7 +53,7 @@ test.describe('Clear Conversation Content', () => {
       const conversationName = 'Group conversation';
       await createGroup(userAPages, conversationName, [userB, userC]);
 
-      // Step 2: Write messages in the  group conversation
+      // Step 2: Write messages in the group conversation
       await userAPages.conversationList().openConversation(conversationName);
       await userAPages.conversation().sendMessage('Message from User A');
 
@@ -94,7 +94,7 @@ test.describe('Clear Conversation Content', () => {
       const conversationName = 'Group conversation';
       await createGroup(userAPages, conversationName, [userB, userC]);
 
-      // Step 2: Write messages in the  group conversation
+      // Step 2: Write messages in the group conversation
       await userAPages.conversationList().openConversation(conversationName);
       await userAPages.conversation().sendMessage('Message from User A');
 
@@ -114,6 +114,40 @@ test.describe('Clear Conversation Content', () => {
       // Step 6: Verify that the conversation does not contain any past messages
       await userAPages.conversationList().openConversation(conversationName);
       await expect(userAPages.conversation().messages).toHaveCount(3);
+    },
+  );
+
+  test(
+    'I want to clear content of 1on1 conversation via conversation list',
+    {tag: ['@TC-154', '@regression']},
+    async ({createPage}) => {
+      const [userAPageManager, userBPageManager] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB), withConnectedUser(userC))),
+        PageManager.from(createPage(withLogin(userB))),
+      ]);
+
+      const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
+      const userBPages = userBPageManager.webapp.pages;
+
+      // Step 1: Create a 1:1 conversation with User A and B
+      await userAPages.conversationList().openConversation(userB.fullName);
+
+      // Step 2: Write messages in the conversation
+      await userAPages.conversation().sendMessage('Message from User A');
+
+      await userBPages.conversationList().openConversation(userA.fullName);
+      await userBPages.conversation().sendMessage('Message from User B');
+
+      // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
+      await userAPages.conversationList().openContextMenu(userB.fullName);
+      await userAPages.conversationList().clearContentButton.click();
+      // Step 4: Warning Popup should open
+      await expect(userAModals.confirm().modal).toBeVisible();
+      // Step 5: User A clicks 'Clear'
+      await userAModals.confirm().clickAction();
+      // Step 6: Verify that the conversation does not contain any past messages
+      await userAPages.conversationList().openConversation(userB.fullName);
+      await expect(userAPages.conversation().messages).toHaveCount(0);
     },
   );
 });

--- a/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
+++ b/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
@@ -46,7 +46,7 @@ test.describe('Clear Conversation Content', () => {
       {tag: [tag, '@regression']},
       async ({createPage}) => {
         const [userAPageManager, userBPageManager, userCPageManager] = await Promise.all([
-          PageManager.from(createPage(withLogin(userA), withConnectedUser(userB), withConnectedUser(userC))),
+          PageManager.from(createPage(withLogin(userA))),
           PageManager.from(createPage(withLogin(userB))),
           PageManager.from(createPage(withLogin(userC))),
         ]);
@@ -68,6 +68,8 @@ test.describe('Clear Conversation Content', () => {
 
         await userCPages.conversationList().openConversation(conversationName);
         await userCPages.conversation().sendMessage('Message from User C');
+
+        await expect(userAPages.conversation().messages).toHaveCount(3);
 
         // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
         await userAPages.conversationList().openContextMenu(conversationName);
@@ -116,6 +118,8 @@ test.describe('Clear Conversation Content', () => {
 
         await userBPages.conversationList().openConversation(userA.fullName);
         await userBPages.conversation().sendMessage('Message from User B');
+
+        await expect(userAPages.conversation().messages).toHaveCount(2);
 
         // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
         await userAPages.conversationList().openContextMenu(userB.fullName);
@@ -180,8 +184,9 @@ test.describe('Clear Conversation Content', () => {
         if (conversationType === 'group') {
           await userCPages.conversationList().openConversation(conversationName);
           await userCPages.conversation().sendMessage('Message from User C');
+          await expect(userAPages.conversation().messages).toHaveCount(3);
         } else {
-          return;
+          await expect(userAPages.conversation().messages).toHaveCount(2);
         }
 
         // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
@@ -196,6 +201,8 @@ test.describe('Clear Conversation Content', () => {
           await expect(userAModals.confirm().modal).toBeVisible();
           await userAModals.confirm().clickAction();
         }
+
+        await expect(userAPages.conversation().messages).toHaveCount(0);
 
         // Step 5: Verify you can receive incoming new messages, pings, calls, pictures, and files
         // 5.1 Messages
@@ -217,7 +224,7 @@ test.describe('Clear Conversation Content', () => {
         const messageWithImage = userAPages
           .conversation()
           .getMessage({sender: userB})
-          .filter({has: userAPages.conversation().page.locator('img[data-uie-name="image-asset-img"]')});
+          .filter({has: userAPages.conversation().page.getByRole('img')});
         await expect(messageWithImage).toBeVisible();
 
         // 5.4 Files
@@ -239,11 +246,11 @@ test.describe('Clear Conversation Content', () => {
   });
 
   [
-    {tag: '@TC-424', type: 'clear', conversationType: 'group'},
-    {tag: '@TC-425', type: 'clear', conversationType: '1:1'},
-  ].forEach(({tag, type, conversationType}) => {
+    {tag: '@TC-424', conversationType: 'group'},
+    {tag: '@TC-425', conversationType: '1:1'},
+  ].forEach(({tag, conversationType}) => {
     test(
-      `I want to ${type} the ${conversationType} conversation content from conversation details options`,
+      `I want to clear the ${conversationType} conversation content from conversation details options`,
       {tag: [tag, '@regression']},
       async ({createPage}) => {
         const [userAPageManager, userBPageManager] = await Promise.all([

--- a/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
+++ b/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
@@ -19,55 +19,60 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, withLogin, withConnectedUser} from 'test/e2e_tests/test.fixtures';
+import {test, withLogin, withConnectedUser, expect} from 'test/e2e_tests/test.fixtures';
 
 import {createGroup} from '../../utils/userActions';
 
-test.describe('User Blocking', () => {
-  test.describe('Block: User A and User B are NOT in the same team', () => {
-    let userA: User;
-    let userB: User;
-    let userC: User;
+test.describe('Clear Conversation Content', () => {
+  let userA: User;
+  let userB: User;
+  let userC: User;
 
-    test.beforeEach(async ({createTeam}) => {
-      const team = await createTeam('Test Team', {withMembers: 2});
-      userA = team.owner;
-      userB = team.members[0];
-      userC = team.members[1];
-    });
-
-    test(
-      'I want to clear content of a group conversation via conversation list',
-      {tag: ['@TC-152', '@regression']},
-      async ({createPage}) => {
-        const userAPageManager = (
-          await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB), withConnectedUser(userC)))
-        ).webapp;
-        const {pages: userAPages} = userAPageManager;
-        const userBPages = (await PageManager.from(createPage(withLogin(userB)))).webapp.pages;
-        const userCPages = (await PageManager.from(createPage(withLogin(userC)))).webapp.pages;
-
-        // Step 1: Create a group conversation with User A, B and C
-        const conversationName = 'Group conversation';
-        await createGroup(userAPages, conversationName, [userB, userC]);
-
-        // Step 2: Write messages in the  group conversation
-        await userAPages.conversationList().openConversation(conversationName);
-        await userAPages.conversation().sendMessage('Message from User A');
-
-        await userBPages.conversationList().openConversation(conversationName);
-        await userBPages.conversation().sendMessage('Message from User B');
-
-        await userCPages.conversationList().openConversation(conversationName);
-        await userCPages.conversation().sendMessage('Message from User C');
-
-        // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
-        await userAPages.conversationList().openContextMenu(conversationName);
-
-        // Step 4: Warning Popup should open
-        // Step 5: Confirm the Popup
-        // Step 6: Verify that the conversation does not contain any past messages
-      },
-    );
+  test.beforeEach(async ({createTeam}) => {
+    const team = await createTeam('Test Team', {withMembers: 2});
+    userA = team.owner;
+    userB = team.members[0];
+    userC = team.members[1];
   });
+
+  test(
+    'I want to clear content of a group conversation via conversation list',
+    {tag: ['@TC-152', '@regression']},
+    async ({createPage}) => {
+      const [userAPageManager, userBPageManager, userCPageManager] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB), withConnectedUser(userC))),
+        PageManager.from(createPage(withLogin(userB))),
+        PageManager.from(createPage(withLogin(userC))),
+      ]);
+
+      const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
+      const userBPages = userBPageManager.webapp.pages;
+      const userCPages = userCPageManager.webapp.pages;
+
+      // Step 1: Create a group conversation with User A, B and C
+      const conversationName = 'Group conversation';
+      await createGroup(userAPages, conversationName, [userB, userC]);
+
+      // Step 2: Write messages in the  group conversation
+      await userAPages.conversationList().openConversation(conversationName);
+      await userAPages.conversation().sendMessage('Message from User A');
+
+      await userBPages.conversationList().openConversation(conversationName);
+      await userBPages.conversation().sendMessage('Message from User B');
+
+      await userCPages.conversationList().openConversation(conversationName);
+      await userCPages.conversation().sendMessage('Message from User C');
+
+      // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
+      await userAPages.conversationList().openContextMenu(conversationName);
+      await userAPages.conversationList().clearContentButton.click();
+      // Step 4: Warning Popup should open
+      await expect(userAModals.optionModal().modal).toBeVisible();
+      // Step 5: Confirm the Popup
+      await userAModals.optionModal().clickAction();
+      // Step 6: Verify that the conversation does not contain any past messages
+      await userAPages.conversationList().openConversation(conversationName);
+      await expect(userAPages.conversation().messages).toHaveCount(0);
+    },
+  );
 });

--- a/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
+++ b/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
@@ -68,11 +68,52 @@ test.describe('Clear Conversation Content', () => {
       await userAPages.conversationList().clearContentButton.click();
       // Step 4: Warning Popup should open
       await expect(userAModals.optionModal().modal).toBeVisible();
-      // Step 5: Confirm the Popup
+      // Step 5: User A clicks 'Clear'
       await userAModals.optionModal().clickAction();
       // Step 6: Verify that the conversation does not contain any past messages
       await userAPages.conversationList().openConversation(conversationName);
       await expect(userAPages.conversation().messages).toHaveCount(0);
+    },
+  );
+
+  test(
+    'I want to cancel clearing content of a group conversation via conversation list',
+    {tag: ['@TC-153', '@regression']},
+    async ({createPage}) => {
+      const [userAPageManager, userBPageManager, userCPageManager] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB), withConnectedUser(userC))),
+        PageManager.from(createPage(withLogin(userB))),
+        PageManager.from(createPage(withLogin(userC))),
+      ]);
+
+      const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
+      const userBPages = userBPageManager.webapp.pages;
+      const userCPages = userCPageManager.webapp.pages;
+
+      // Step 1: Create a group conversation with User A, B and C
+      const conversationName = 'Group conversation';
+      await createGroup(userAPages, conversationName, [userB, userC]);
+
+      // Step 2: Write messages in the  group conversation
+      await userAPages.conversationList().openConversation(conversationName);
+      await userAPages.conversation().sendMessage('Message from User A');
+
+      await userBPages.conversationList().openConversation(conversationName);
+      await userBPages.conversation().sendMessage('Message from User B');
+
+      await userCPages.conversationList().openConversation(conversationName);
+      await userCPages.conversation().sendMessage('Message from User C');
+
+      // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
+      await userAPages.conversationList().openContextMenu(conversationName);
+      await userAPages.conversationList().clearContentButton.click();
+      // Step 4: Warning Popup should open
+      await expect(userAModals.optionModal().modal).toBeVisible();
+      // Step 5: User A clicks 'Cancel'
+      await userAModals.optionModal().clickCancel();
+      // Step 6: Verify that the conversation does not contain any past messages
+      await userAPages.conversationList().openConversation(conversationName);
+      await expect(userAPages.conversation().messages).toHaveCount(3);
     },
   );
 });

--- a/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
+++ b/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
@@ -1,0 +1,64 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {User} from 'test/e2e_tests/data/user';
+import {PageManager} from 'test/e2e_tests/pageManager';
+import {test, expect, withLogin, withConnectionRequest} from 'test/e2e_tests/test.fixtures';
+
+test.describe('User Blocking', () => {
+  test.describe('Block: User A and User B are NOT in the same team', () => {
+    let userA: User;
+    let userB: User;
+    //let userC: User;
+
+    test.beforeEach(async ({createTeam}) => {
+      const [teamA, teamB] = await Promise.all([createTeam('Team A', {withMembers: 1}), createTeam('Team B')]);
+      userA = teamA.owner;
+      userB = teamB.owner;
+      //userC = teamA.members[0];
+    });
+
+    test(
+      'I want to cancel blocking a 1:1 conversation from conversation list',
+      {tag: ['@TC-137', '@regression']},
+      async ({createPage}) => {
+        const userAPageManager = (await PageManager.from(createPage(withLogin(userA), withConnectionRequest(userB))))
+          .webapp;
+        const {pages: userAPages, modals: userAModals} = userAPageManager;
+
+        // Preconditions: User B accepts the connection request
+        const userBPages = (await PageManager.from(createPage(withLogin(userB)))).webapp.pages;
+        await userBPages.connectRequest().clickConnectButton();
+
+        // Step 1: User A opens conversation with User B
+        await userAPages.conversationList().openConversation(userB.fullName);
+        // Step 2: User A opens the options menu for user B
+        await userAPages.conversationList().clickConversationOptions(userB.fullName);
+        // Step 3: User A opens modal and clicks 'Block' button
+        await userAPages.conversationList().clickBlockConversation();
+        // Step 4: User A clicks 'Cancel' button
+        await userAModals.blockWarning().clickCancel();
+        // Step 5: Conversation is still present, and User A can open it
+        await userAPages.conversationList().openConversation(userB.fullName);
+        // Step 6: User A still can send message to User B
+        await expect(userAPages.conversation().messageInput).toBeVisible();
+      },
+    );
+  });
+});


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19944" title="WPB-19944" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19944</a>  [Web/QA] Write the clear conversation regression tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request
[WPB-19944](https://wearezeta.atlassian.net/browse/WPB-19944) [Web/QA] Write the clear conversation regression tests in Playwright

## Summary

- Add clear conversation content regression tests
- TC-156 is skipped due to testing group calls requires an enterprise team which we currently can't create to use within the tests

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).



[WPB-19944]: https://wearezeta.atlassian.net/browse/WPB-19944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ