### PR TITLE
feat: Allow users to pause gifs

### DIFF
--- a/src/script/repositories/entity/message/FileAsset.ts
+++ b/src/script/repositories/entity/message/FileAsset.ts
@@ -40,6 +40,7 @@ export class FileAsset extends Asset {
   public readonly downloadProgress: ko.PureComputed<number | undefined>;
   public readonly cancelDownload: () => void;
   public file_size: number;
+  public readonly file_type: string;
   public meta: Partial<AssetMetaData>;
   public readonly status: ko.Observable<AssetTransferState>;
   public readonly upload_failed_reason: ko.Observable<ProtobufAsset.NotUploaded>;

--- a/src/style/components/image.less
+++ b/src/style/components/image.less
@@ -43,3 +43,58 @@
     line-height: 1.3em;
   }
 }
+
+.image-asset--animated-wrapper {
+  position: relative;
+  display: inline-block;
+
+  summary {
+    position: absolute;
+    z-index: 2;
+    top: 0.5rem;
+    right: 0.5rem;
+    width: 0;
+    height: 2em;
+    border-width: 1em 0 1em 2em;
+    border-style: solid;
+
+    border-color: transparent transparent transparent #202020;
+    background: transparent;
+    cursor: pointer;
+    opacity: 0.1;
+    transition: 100ms all ease;
+
+    &:focus,
+    &:focus-visible {
+      opacity: 1;
+      outline: 2px solid var(--accent-color, #ffffff);
+      outline-offset: 2px;
+    }
+  }
+
+  &:hover summary {
+    opacity: 1;
+  }
+
+  [open] summary {
+    border-width: 0 0 0 2em;
+    border-style: double;
+  }
+
+  /* for blink/webkit */
+  details summary::-webkit-details-marker {
+    display: none;
+  }
+  /* for firefox */
+  details > summary:first-of-type {
+    list-style: none;
+  }
+
+  .image-asset--animated img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    display: inline-block;
+    overflow: visible;
+  }
+}


### PR DESCRIPTION
# Pull Request

Its very jarring when a gif keeps looping while writing messages, so I thought I'll implement a play/pause button.

Somethings to note:
* The pause button, actually shows the first frame of the gif, so its more of a stop button.
* I tried to make the buttons only appear on hover, but I suck at CSS, so please help.
* There are no tests, I can try to add them (after my vacation).
* Further enahancement: extend the feature to support animated PNG and animated webp images.

Inspired by: 
- https://css-tricks.com/pause-gif-details-summary/
- https://css-tricks.com/making-pure-css-playpause-button/

## Summary

- What did I change and why?
The `FileAsset` type now exposes `file_type` which is then thread through various types to decide whether to show gif logic.

- Risks and how to roll out / roll back (e.g. feature flags):

I haven't tested this with large GIFs, there rendering could be slower

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/tree/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
