### PR TITLE
chore(e2e): Update brig api client for the latest changes to cells feature flag [WPB-22503]

### DIFF
--- a/test/e2e_tests/backend/brigRepository.e2e.ts
+++ b/test/e2e_tests/backend/brigRepository.e2e.ts
@@ -190,7 +190,52 @@ export class BrigRepositoryE2E {
     await this.axiosInstance.put(
       `i/teams/${teamId}/features/cells`,
       {
+        config: {
+          channels: {
+            default: 'enabled',
+            enabled: true,
+          },
+          collabora: {
+            enabled: true,
+          },
+          groups: {
+            default: 'enabled',
+            enabled: true,
+          },
+          metadata: {
+            namespaces: {
+              usermetaTags: {
+                allowFreeValues: true,
+                defaultValues: [],
+              },
+            },
+          },
+          one2one: {
+            default: 'enabled',
+            enabled: true,
+          },
+          publicLinks: {
+            enableFiles: true,
+            enableFolders: true,
+            enforceExpirationDefault: 0,
+            enforceExpirationMax: 0,
+            enforcePassword: false,
+          },
+          storage: {
+            perFileQuotaBytes: '104857600',
+            recycle: {
+              allowSkip: false,
+              autoPurgeDays: 30,
+              disable: false,
+            },
+          },
+          users: {
+            externals: true,
+            guests: true,
+          },
+        },
         status: 'enabled',
+        ttl: 'unlimited',
       },
       {
         headers: {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22503" title="WPB-22503" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22503</a>  [Web] Update brig api client for the latest changes to cells feature flag
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

https://wearezeta.atlassian.net/browse/WPB-22503

## Summary

- The expected payload has been changed and e2e needed to be updated.

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
