### PR TITLE
chore: Bump @wireapp/core to 46.46.11 [WPB-22504]

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@wireapp/avs": "10.2.21",
     "@wireapp/avs-debugger": "0.0.7",
     "@wireapp/commons": "5.4.10",
-    "@wireapp/core": "46.46.9",
+    "@wireapp/core": "46.46.11",
     "@wireapp/kalium-backup": "0.0.4",
     "@wireapp/promise-queue": "2.4.10",
     "@wireapp/react-ui-kit": "9.72.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6928,9 +6928,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:^27.94.0":
-  version: 27.94.0
-  resolution: "@wireapp/api-client@npm:27.94.0"
+"@wireapp/api-client@npm:^27.94.1":
+  version: 27.94.1
+  resolution: "@wireapp/api-client@npm:27.94.1"
   dependencies:
     "@aws-sdk/client-s3": "npm:3.940.0"
     "@aws-sdk/lib-storage": "npm:3.940.0"
@@ -6939,7 +6939,7 @@ __metadata:
     "@wireapp/protocol-messaging": "npm:1.53.0"
     axios: "npm:1.13.2"
     axios-retry: "npm:4.5.0"
-    cells-sdk-ts: "npm:0.1.1-alpha17"
+    cells-sdk-ts: "npm:0.1.1-alpha18"
     http-status-codes: "npm:2.3.0"
     logdown: "npm:3.3.1"
     pako: "npm:2.1.0"
@@ -6949,7 +6949,7 @@ __metadata:
     uuid: "npm:11.1.0"
     ws: "npm:8.18.1"
     zod: "npm:3.24.2"
-  checksum: 10/df9b3aba04a392086f4bba64c33723ec881febb6cd05271ab1ace48a544c073ab4b2966ab6b975e91a0c11a8c6dbf732816059c3f3cc3300aa277814a4d8a283
+  checksum: 10/d13f308fee1e323d3531b1e3a59fbbeeb975d7a6d38702c830126f7719f19f6ca289c8e5510b287e7a991a4429dd2b6e6e9d9e05c3308da6b55ebcc4a6281f2b
   languageName: node
   linkType: hard
 
@@ -7014,11 +7014,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core@npm:46.46.9":
-  version: 46.46.9
-  resolution: "@wireapp/core@npm:46.46.9"
+"@wireapp/core@npm:46.46.11":
+  version: 46.46.11
+  resolution: "@wireapp/core@npm:46.46.11"
   dependencies:
-    "@wireapp/api-client": "npm:^27.94.0"
+    "@wireapp/api-client": "npm:^27.94.1"
     "@wireapp/commons": "npm:^5.4.10"
     "@wireapp/core-crypto": "npm:9.1.2"
     "@wireapp/cryptobox": "npm:12.8.0"
@@ -7036,7 +7036,7 @@ __metadata:
     long: "npm:^5.2.0"
     uuid: "npm:9.0.1"
     zod: "npm:3.24.2"
-  checksum: 10/ee1134775d4ba837bb06b2b2faf6469fad880f3e82812ac54cb4be07afcc537a47a2675e41aae19174e83eea06255b0e0232a3fefb13b41715e22b4fb597a666
+  checksum: 10/8f123a3204e905ec124e4bc65da6fd4922bca59fd77f47c287b1610fbfb3d1fe46f6749bc29a8ee0eaf17a0f9c0b85785a21a339116b550aab62eb3846d21515
   languageName: node
   linkType: hard
 
@@ -8466,12 +8466,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cells-sdk-ts@npm:0.1.1-alpha17":
-  version: 0.1.1-alpha17
-  resolution: "cells-sdk-ts@npm:0.1.1-alpha17"
+"cells-sdk-ts@npm:0.1.1-alpha18":
+  version: 0.1.1-alpha18
+  resolution: "cells-sdk-ts@npm:0.1.1-alpha18"
   dependencies:
     axios: "npm:^1.9.0"
-  checksum: 10/6dcea3f86f1d391c1a9367152c542b4c299f533d16a6ba5af0e840a6eaa3703152b62dc0efa38104f69bb0a130f168573d783c35f6b9c9b6a880cacb48240339
+  checksum: 10/9e17db9d905c6d7ab4fe602b29f8ecd74b10015a0d33e8f4fc512f3fec5db3f055fce1616d5ec46ba5c94d1f941d1bad7c7f1be3dd31a851056ce38460b5d754
   languageName: node
   linkType: hard
 
@@ -20273,7 +20273,7 @@ __metadata:
     "@wireapp/avs-debugger": "npm:0.0.7"
     "@wireapp/commons": "npm:5.4.10"
     "@wireapp/copy-config": "npm:2.3.4"
-    "@wireapp/core": "npm:46.46.9"
+    "@wireapp/core": "npm:46.46.11"
     "@wireapp/eslint-config": "npm:3.0.7"
     "@wireapp/kalium-backup": "npm:0.0.4"
     "@wireapp/prettier-config": "npm:0.6.9"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22504" title="WPB-22504" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22504</a>  [Web] Remove extra logs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- What did I change and why?
Bump core!
- Risks and how to roll out / roll back (e.g. feature flags):
none
---

## Security Checklist (required)

- [X] **External inputs are validated & sanitized** on client and/or server where applicable.
- [X] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [X] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [X] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [X] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [X] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).
