### PR TITLE
feat: support special devices [WPB-22415]

### DIFF
--- a/src/script/repositories/media/MediaConstraintsHandler.test.ts
+++ b/src/script/repositories/media/MediaConstraintsHandler.test.ts
@@ -85,9 +85,10 @@ describe('MediaConstraintsHandler', () => {
       expect(constraints.video.deviceId).toBeUndefined();
       expect(constraints.video).toEqual(
         expect.objectContaining({
-          frameRate: expect.any(Number),
-          height: expect.any(Number),
-          width: expect.any(Number),
+          frameRate: {ideal: expect.any(Number)},
+          height: {ideal: expect.any(Number)},
+          width: {ideal: expect.any(Number)},
+          resizeMode: 'none',
         }),
       );
     });

--- a/src/script/repositories/media/MediaConstraintsHandler.ts
+++ b/src/script/repositories/media/MediaConstraintsHandler.ts
@@ -34,7 +34,7 @@ interface Config {
       DISPLAY_MEDIA: MediaTrackConstraints;
       USER_MEDIA: MediaTrackConstraints & {mediaSource: string};
     };
-    VIDEO: Record<VIDEO_QUALITY_MODE, MediaTrackConstraints> & {PREFERRED_FACING_MODE: string};
+    VIDEO: Record<VIDEO_QUALITY_MODE, MediaTrackConstraints & {resizeMode: string}> & {PREFERRED_FACING_MODE: string};
   };
   DEFAULT_DEVICE_ID: string;
 }
@@ -69,24 +69,28 @@ export class MediaConstraintsHandler {
         },
         VIDEO: {
           [VIDEO_QUALITY_MODE.FULL_HD]: {
-            frameRate: 15,
-            height: 1080,
-            width: 1920,
+            frameRate: {ideal: 15},
+            height: {ideal: 1080},
+            width: {ideal: 1920},
+            resizeMode: 'none',
           },
           [VIDEO_QUALITY_MODE.GROUP]: {
-            frameRate: 15,
-            height: 720,
-            width: 1280,
+            frameRate: {ideal: 15},
+            height: {ideal: 720},
+            width: {ideal: 1280},
+            resizeMode: 'none',
           },
           [VIDEO_QUALITY_MODE.HD]: {
-            frameRate: 15,
-            height: 720,
-            width: 1280,
+            frameRate: {ideal: 15},
+            height: {ideal: 720},
+            width: {ideal: 1280},
+            resizeMode: 'none',
           },
           [VIDEO_QUALITY_MODE.MOBILE]: {
-            frameRate: 15,
-            height: 720,
-            width: 1280,
+            frameRate: {ideal: 15},
+            height: {ideal: 720},
+            width: {ideal: 1280},
+            resizeMode: 'none',
           },
           PREFERRED_FACING_MODE: 'user',
         },


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22415" title="WPB-22415" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22415</a>  [Calling] Support special Devices
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


# Pull Request

## Summary

Improve robustness by preferring native camera resolutions while allowing flexible resolution selection

This change increases camera stability by 
- enforcing the use of native resolutions (**resizeMode: "none"**), 
- while switching to **ideal** constraints for width and height and frame rate less errors on select camera.

This approach provides greater flexibility in resolution selection across different devices, while still preventing implicit scaling or cropping. As a result, the video pipeline remains simpler and more robust, reducing the likelihood of decoder and GPU related issues, especially on Electron/Chromium based applications.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
