### PR TITLE
feat: add ChannelAvatar support in CallingHeader component [WPB-19261]

### DIFF
--- a/src/script/components/Avatar/index.ts
+++ b/src/script/components/Avatar/index.ts
@@ -18,4 +18,5 @@
  */
 
 export * from './Avatar';
+export * from './ChannelAvatar';
 export * from './GroupAvatar';

--- a/src/script/components/calling/CallingCell/CallingCell.tsx
+++ b/src/script/components/calling/CallingCell/CallingCell.tsx
@@ -103,11 +103,13 @@ export const CallingCell = ({
 
   const {
     isGroupOrChannel,
+    isChannel,
     participating_user_ets: userEts,
     selfUser,
     display_name: conversationName,
   } = useKoSubscribableChildren(conversation, [
     'isGroupOrChannel',
+    'isChannel',
     'participating_user_ets',
     'selfUser',
     'display_name',
@@ -350,6 +352,7 @@ export const CallingCell = ({
 
           <CallingHeader
             isGroup={isGroupOrChannel}
+            isChannel={isChannel}
             isOngoing={isOngoing}
             showAlert={showAlert}
             isVideoCall={isVideoCall}

--- a/src/script/components/calling/CallingCell/CallingHeader/CallingHeader.tsx
+++ b/src/script/components/calling/CallingCell/CallingHeader/CallingHeader.tsx
@@ -19,7 +19,7 @@
 
 import {TabIndex, IconButton, IconButtonVariant} from '@wireapp/react-ui-kit';
 
-import {Avatar, AVATAR_SIZE, GroupAvatar} from 'Components/Avatar';
+import {Avatar, AVATAR_SIZE, ChannelAvatar, GroupAvatar} from 'Components/Avatar';
 import {Duration} from 'Components/calling/Duration';
 import * as Icon from 'Components/Icon';
 import {User} from 'Repositories/entity/User';
@@ -42,6 +42,7 @@ import {createNavigate, createNavigateKeyboard} from '../../../../router/routerB
 interface CallingHeaderProps {
   isOngoing: boolean;
   isGroup: boolean;
+  isChannel: boolean;
   showAlert: boolean;
   isVideoCall: boolean;
   clearShowAlert: () => void;
@@ -61,6 +62,7 @@ interface CallingHeaderProps {
 
 export const CallingHeader = ({
   isGroup,
+  isChannel,
   isOngoing,
   showAlert,
   isVideoCall,
@@ -104,9 +106,14 @@ export const CallingHeader = ({
       >
         {isDetachedWindow && !isTemporaryUser && (
           <div css={callAvatar}>
-            {isGroup && <GroupAvatar conversationID={conversationID} />}
-            {!isGroup && !!conversationParticipants.length && (
-              <Avatar participant={conversationParticipants[0]} avatarSize={AVATAR_SIZE.SMALL} />
+            {isChannel ? (
+              <ChannelAvatar conversationID={conversationID} />
+            ) : isGroup ? (
+              <GroupAvatar conversationID={conversationID} />
+            ) : (
+              conversationParticipants.length > 0 && (
+                <Avatar participant={conversationParticipants[0]} avatarSize={AVATAR_SIZE.SMALL} />
+              )
             )}
           </div>
         )}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19261" title="WPB-19261" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19261</a>  A call in a channel has the wrong icon
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary
Show correct icon of channel on detached calling view.

- What did I change and why?
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
