### PR TITLE
ci(publish): Fix wire-server deployment logic [WPB-22538]

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,9 +48,15 @@ jobs:
           cache: 'yarn'
 
       - name: Set environment variables
+        shell: bash
         run: |
-          echo "BRANCH_NAME=$(git branch --show-current)" >> $GITHUB_ENV
-          echo "TAG=$(git tag --points-at ${{github.sha}})" >> $GITHUB_ENV
+          echo "BRANCH_NAME=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
+
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            echo "TAG=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
+          else
+            echo "TAG=" >> "$GITHUB_ENV"
+          fi
 
       - name: Print environment variables
         run: |


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22538" title="WPB-22538" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22538</a>  [Web] Fix wire-server deployment logic 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary

Workflow publish.yml can be triggered by:
a branch (dev, master, release/foo)
a tag (YYYY-MM-DD-staging.X, YYYY-MM-DD-production.X)

Current workflow will deploy to wire-server every time there is branch or tag push, which causes workflow to fail in case there is both YYYY-MM-DD-staging.X and YYYY-MM-DD-production.X tag pointing to same commit. This will be the case when we create RC with staging tag and release to production with production tag. Same commit will have 2 tags pointing at it. If master branch has a hotfix commit which wasnt merged to dev before 2 tags were created (app was released to prod), when attempting to align branches by merging master → dev, publish.yml workflow will fail.

Solution:
If the workflow was triggered by a branch push:
TAG is explicitly set to empty → This prevents accidental reuse of a production/staging tag just because the commit happens to have tags pointing at it

If the workflow was triggered by a tag push:
TAG is set to the tag name → This is what we need for staging/production deploys or release artifacts

