### PR TITLE
chore: Do not allow empty block statements [WPB-22542]

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,6 +44,7 @@ module.exports = {
     '@typescript-eslint/no-floating-promises': 'warn',
     '@typescript-eslint/typedef': 'off',
     'no-dupe-class-members': 'off',
+    'no-empty': 'error',
     'no-unsanitized/property': 'off',
     'prefer-promise-reject-errors': 'off',
     'valid-jsdoc': 'off',

--- a/src/script/auth/main.tsx
+++ b/src/script/auth/main.tsx
@@ -55,7 +55,9 @@ const core = container.resolve(Core);
 let localStorage;
 try {
   localStorage = window.localStorage;
-} catch (error) {}
+} catch {
+  // ignore error
+}
 
 const store = configureStore({
   actions: actionRoot,

--- a/src/script/auth/page/ClientManager.tsx
+++ b/src/script/auth/page/ClientManager.tsx
@@ -68,7 +68,9 @@ const ClientManagerComponent = ({doGetAllClients, doLogout}: Props & ConnectedPr
   const logout = async () => {
     try {
       await doLogout();
-    } catch (error) {}
+    } catch (error) {
+      // ignore errors on logout
+    }
   };
 
   return (

--- a/src/script/components/panel/EnrichedFields.tsx
+++ b/src/script/components/panel/EnrichedFields.tsx
@@ -63,6 +63,7 @@ export const useEnrichedFields = (
         const richProfile = await richProfileRepository.getUserRichProfile(user.id);
         returnFields.push(...(richProfile?.fields ?? []));
       } catch {
+        // ignore errors
       } finally {
         if (!cancel) {
           onFieldsLoaded?.(returnFields);

--- a/src/script/repositories/conversation/ConversationRepository.ts
+++ b/src/script/repositories/conversation/ConversationRepository.ts
@@ -2078,7 +2078,9 @@ export class ConversationRepository {
 
     try {
       return await this.resolve1To1Conversation(otherUserId, {shouldRefreshUser}, conversation.qualifiedId);
-    } catch {}
+    } catch {
+      // ignore errors
+    }
 
     return conversation;
   };

--- a/src/script/repositories/conversation/MessageRepository.ts
+++ b/src/script/repositories/conversation/MessageRepository.ts
@@ -340,8 +340,6 @@ export class MessageRepository {
     },
   ): T {
     const quoteData = quote && {quotedMessageId: quote.messageId, quotedMessageSha256: new Uint8Array(quote.hash)};
-    if (quote) {
-    }
 
     return new TextContentBuilder(baseMessage)
       .withMentions(

--- a/src/script/repositories/team/TeamEntity.ts
+++ b/src/script/repositories/team/TeamEntity.ts
@@ -44,7 +44,9 @@ export class TeamEntity {
 
     try {
       hasIcon = !!this.icon && isValidAsset(this.icon);
-    } catch (error) {}
+    } catch (error) {
+      // ignore error
+    }
 
     if (hasIcon && teamDomain) {
       return new AssetRemoteData({assetKey: this.icon, assetDomain: teamDomain});


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22542" title="WPB-22542" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22542</a>  [Web] Do not allow empty block statements in the code
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- What did I change and why?
Added eslint rule to now allow empty block statements, we had an empty if statement with no linter errors.
- Risks and how to roll out / roll back (e.g. feature flags):
none.
---

## Security Checklist (required)

- [X] **External inputs are validated & sanitized** on client and/or server where applicable.
- [X] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [X] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [X] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [X] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [X] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

