### PR TITLE
feat: Support multipart message replies [WPB-15705]

### DIFF
--- a/src/script/message/MessageHasher.ts
+++ b/src/script/message/MessageHasher.ts
@@ -61,6 +61,8 @@ const getTimestampBytes = (event: any): number[] => {
 
 const getTextBytes = (event: any): number[] => utf8ToUtf16BE(event.data.content);
 
+const getMultipartTextBytes = (event: any): number[] => utf8ToUtf16BE(event.data.text.content);
+
 /**
  * Creates a hash of the given event.
  *
@@ -72,6 +74,10 @@ const hashEvent = (event: any): Promise<ArrayBuffer> => {
   switch (event.type) {
     case ClientEvent.CONVERSATION.MESSAGE_ADD: {
       specificBytes = getTextBytes(event);
+      break;
+    }
+    case ClientEvent.CONVERSATION.MULTIPART_MESSAGE_ADD: {
+      specificBytes = getMultipartTextBytes(event);
       break;
     }
     case ClientEvent.CONVERSATION.LOCATION: {

--- a/src/script/repositories/conversation/EventBuilder/EventBuilder.ts
+++ b/src/script/repositories/conversation/EventBuilder/EventBuilder.ts
@@ -163,9 +163,29 @@ export type MultipartMessageAddEvent = ConversationEvent<
   CONVERSATION.MULTIPART_MESSAGE_ADD,
   {
     attachments: MultiPartContent['attachments'];
-    text: MultiPartContent['text'] & {mentions?: string[]; previews?: string[]};
+    text: MultiPartContent['text'] & {
+      mentions?: string[];
+      previews?: string[];
+      quote?:
+        | string
+        | {
+            message_id: string;
+            user_id: string;
+            hash: Uint8Array;
+          }
+        | {error: {type: string}};
+    };
+    replacing_message_id?: string;
   }
->;
+> & {
+  /** who have received/read the event */
+  read_receipts?: ReadReceipt[];
+  /** who reacted to the event */
+  reactions?: UserReactionMap | ReactionMap;
+  edited_time?: string;
+  status: StatusType;
+  version?: number;
+};
 export type MissedEvent = BaseEvent & {id: string; type: CONVERSATION.MISSED_MESSAGES};
 export type JoinedAfterMLSMigrationFinalisationEvent = BaseEvent & {
   type: CONVERSATION.JOINED_AFTER_MLS_MIGRATION;

--- a/src/script/repositories/event/EventService.ts
+++ b/src/script/repositories/event/EventService.ts
@@ -203,7 +203,20 @@ export class EventService {
         .table(StorageSchemata.OBJECT_STORE.EVENTS)
         .where(['conversation', 'time'])
         .between([conversationId, quotedMessageTime], [conversationId, new Date().toISOString()], true, true)
-        .filter(event => event.data && event.data.quote && event.data.quote.message_id === quotedMessageId)
+        .filter(event => {
+          if (!event.data) {
+            return false;
+          }
+          // Check normal message quote
+          if (event.data.quote && event.data.quote.message_id === quotedMessageId) {
+            return true;
+          }
+          // Check multipart message quote
+          if (event.data.text?.quote && event.data.text.quote.message_id === quotedMessageId) {
+            return true;
+          }
+          return false;
+        })
         .toArray();
       return events;
     }
@@ -217,7 +230,20 @@ export class EventService {
           record.time <= new Date().toISOString()
         );
       })
-      .filter(event => !!event.data && !!event.data.quote && event.data.quote.message_id === quotedMessageId)
+      .filter(event => {
+        if (!event.data) {
+          return false;
+        }
+        // Check normal message quote
+        if (event.data.quote && event.data.quote.message_id === quotedMessageId) {
+          return true;
+        }
+        // Check multipart message quote
+        if (event.data.text?.quote && event.data.text.quote.message_id === quotedMessageId) {
+          return true;
+        }
+        return false;
+      })
       .sort(compareEventsByConversation);
   }
 

--- a/src/script/repositories/event/preprocessor/QuoteDecoderMiddleware.ts
+++ b/src/script/repositories/event/preprocessor/QuoteDecoderMiddleware.ts
@@ -19,7 +19,7 @@
 
 import {Quote} from '@wireapp/protocol-messaging';
 
-import {MessageAddEvent} from 'Repositories/conversation/EventBuilder';
+import {MessageAddEvent, MultipartMessageAddEvent} from 'Repositories/conversation/EventBuilder';
 import {StoredEvent} from 'Repositories/storage/record/EventRecord';
 import {getLogger, Logger} from 'Util/Logger';
 import {base64ToArray} from 'Util/util';
@@ -48,6 +48,12 @@ export class QuotedMessageMiddleware implements EventMiddleware {
       case ClientEvent.CONVERSATION.MESSAGE_ADD: {
         const originalMessageId = event.data.replacing_message_id;
         return originalMessageId ? this.handleEditEvent(event, originalMessageId) : this.handleAddEvent(event);
+      }
+      case ClientEvent.CONVERSATION.MULTIPART_MESSAGE_ADD: {
+        const originalMessageId = event.data.replacing_message_id;
+        return originalMessageId
+          ? this.handleMultipartEditEvent(event, originalMessageId)
+          : this.handleMultipartAddEvent(event);
       }
     }
     return event;
@@ -98,6 +104,62 @@ export class QuotedMessageMiddleware implements EventMiddleware {
     };
 
     const decoratedData = {...event.data, quote: quoteData};
+    return {...event, data: decoratedData};
+  }
+
+  private async handleMultipartEditEvent(
+    event: MultipartMessageAddEvent,
+    originalMessageId: string,
+  ): Promise<MultipartMessageAddEvent> {
+    const originalEvent = (await this.eventService.loadEvent(event.conversation, originalMessageId)) as StoredEvent<
+      MessageAddEvent | MultipartMessageAddEvent | undefined
+    >;
+    if (!originalEvent) {
+      return event;
+    }
+
+    const originalQuote =
+      originalEvent.type === ClientEvent.CONVERSATION.MULTIPART_MESSAGE_ADD
+        ? originalEvent.data.text.quote
+        : originalEvent.data.quote;
+
+    const decoratedData = {...event.data, text: {...event.data.text, quote: originalQuote} as any};
+    return {...event, data: decoratedData};
+  }
+
+  private async handleMultipartAddEvent(event: MultipartMessageAddEvent): Promise<MultipartMessageAddEvent> {
+    const rawQuote = event.data.text.quote;
+
+    if (!rawQuote || typeof rawQuote !== 'string') {
+      return event;
+    }
+
+    const encodedQuote = base64ToArray(rawQuote);
+    const quote = Quote.decode(encodedQuote);
+    this.logger.info(`Found quoted message in multipart: ${quote.quotedMessageId}`);
+
+    const messageId = quote.quotedMessageId;
+
+    const quotedMessage = await this.eventService.loadEvent(event.conversation, messageId);
+    if (!quotedMessage) {
+      this.logger.warn(`Quoted message with ID "${messageId}" not found.`);
+      const quoteData = {
+        error: {
+          type: QuoteEntity.ERROR.MESSAGE_NOT_FOUND,
+        },
+      };
+
+      const decoratedData = {...event.data, text: {...event.data.text, quote: quoteData} as any};
+      return {...event, data: decoratedData};
+    }
+
+    const quoteData = {
+      message_id: messageId,
+      user_id: quotedMessage.from,
+      hash: quote.quotedMessageSha256,
+    };
+
+    const decoratedData = {...event.data, text: {...event.data.text, quote: quoteData} as any};
     return {...event, data: decoratedData};
   }
 }

--- a/src/script/repositories/event/preprocessor/RepliesUpdaterMiddleware.ts
+++ b/src/script/repositories/event/preprocessor/RepliesUpdaterMiddleware.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {DeleteEvent, MessageAddEvent} from 'Repositories/conversation/EventBuilder';
+import {DeleteEvent, MessageAddEvent, MultipartMessageAddEvent} from 'Repositories/conversation/EventBuilder';
 import {StoredEvent} from 'Repositories/storage/record/EventRecord';
 import {getLogger, Logger} from 'Util/Logger';
 
@@ -45,6 +45,11 @@ export class RepliesUpdaterMiddleware implements EventMiddleware {
         return originalMessageId ? this.handleEditEvent(event, originalMessageId) : event;
       }
 
+      case ClientEvent.CONVERSATION.MULTIPART_MESSAGE_ADD: {
+        const originalMessageId = event.data.replacing_message_id;
+        return originalMessageId ? this.handleMultipartEditEvent(event, originalMessageId) : event;
+      }
+
       case ClientEvent.CONVERSATION.MESSAGE_DELETE: {
         return this.handleDeleteEvent(event);
       }
@@ -60,7 +65,11 @@ export class RepliesUpdaterMiddleware implements EventMiddleware {
     const {replies} = await this.findRepliesToMessage(event.conversation, originalMessageId);
     this.logger.info(`Invalidating '${replies.length}' replies to deleted message '${originalMessageId}'`);
     replies.forEach(async reply => {
-      reply.data.quote = {error: {type: QuoteEntity.ERROR.MESSAGE_NOT_FOUND}};
+      if (reply.type === ClientEvent.CONVERSATION.MESSAGE_ADD) {
+        reply.data.quote = {error: {type: QuoteEntity.ERROR.MESSAGE_NOT_FOUND}};
+      } else if (reply.type === ClientEvent.CONVERSATION.MULTIPART_MESSAGE_ADD && reply.data.text) {
+        reply.data.text.quote = {error: {type: QuoteEntity.ERROR.MESSAGE_NOT_FOUND}} as any;
+      }
       await this.eventService.replaceEvent(reply);
     });
     return event;
@@ -77,9 +86,43 @@ export class RepliesUpdaterMiddleware implements EventMiddleware {
 
     this.logger.info(`Updating '${replies.length}' replies to updated message '${originalMessageId}'`);
     replies.forEach(async reply => {
-      const quote = reply.data.quote;
-      if (quote && typeof quote !== 'string' && 'message_id' in quote && 'id' in event) {
-        quote.message_id = event.id as string;
+      if (reply.type === ClientEvent.CONVERSATION.MESSAGE_ADD) {
+        const quote = reply.data.quote;
+        if (quote && typeof quote !== 'string' && 'message_id' in quote && 'id' in event) {
+          quote.message_id = event.id as string;
+        }
+      } else if (reply.type === ClientEvent.CONVERSATION.MULTIPART_MESSAGE_ADD && reply.data.text?.quote) {
+        const quote = reply.data.text.quote;
+        if (quote && typeof quote !== 'string' && 'message_id' in quote && 'id' in event) {
+          quote.message_id = event.id as string;
+        }
+      }
+      await this.eventService.replaceEvent(reply);
+    });
+    return event;
+  }
+
+  /**
+   * will update the message ID of all the replies to an edited multipart message
+   */
+  private async handleMultipartEditEvent(event: MultipartMessageAddEvent, originalMessageId: string) {
+    const {originalEvent, replies} = await this.findRepliesToMessage(event.conversation, originalMessageId, event.id);
+    if (!originalEvent) {
+      return event;
+    }
+
+    this.logger.info(`Updating '${replies.length}' replies to updated multipart message '${originalMessageId}'`);
+    replies.forEach(async reply => {
+      if (reply.type === ClientEvent.CONVERSATION.MESSAGE_ADD) {
+        const quote = reply.data.quote;
+        if (quote && typeof quote !== 'string' && 'message_id' in quote && 'id' in event) {
+          quote.message_id = event.id as string;
+        }
+      } else if (reply.type === ClientEvent.CONVERSATION.MULTIPART_MESSAGE_ADD && reply.data.text?.quote) {
+        const quote = reply.data.text.quote;
+        if (quote && typeof quote !== 'string' && 'message_id' in quote && 'id' in event) {
+          quote.message_id = event.id as string;
+        }
       }
       await this.eventService.replaceEvent(reply);
     });
@@ -91,10 +134,17 @@ export class RepliesUpdaterMiddleware implements EventMiddleware {
     messageId: string,
     /** in case the message was edited, we need to query the DB using the old event ID */
     previousMessageId?: string,
-  ): Promise<{originalEvent?: MessageAddEvent; replies: StoredEvent<MessageAddEvent>[]}> {
+  ): Promise<{
+    originalEvent?: MessageAddEvent | MultipartMessageAddEvent;
+    replies: StoredEvent<MessageAddEvent | MultipartMessageAddEvent>[];
+  }> {
     const originalEvent = await this.eventService.loadEvent(conversationId, previousMessageId ?? messageId);
 
-    if (!originalEvent || originalEvent.type !== ClientEvent.CONVERSATION.MESSAGE_ADD) {
+    if (
+      !originalEvent ||
+      (originalEvent.type !== ClientEvent.CONVERSATION.MESSAGE_ADD &&
+        originalEvent.type !== ClientEvent.CONVERSATION.MULTIPART_MESSAGE_ADD)
+    ) {
       return {
         replies: [],
       };

--- a/test/e2e_tests/pageManager/webapp/cells/cellsConversation.page.ts
+++ b/test/e2e_tests/pageManager/webapp/cells/cellsConversation.page.ts
@@ -29,6 +29,16 @@ export class CellsConversationPage extends ConversationPage {
     super(page);
   }
 
+  async isMultipartMessageVisible(user: User, messageText: string): Promise<boolean> {
+    const messageLocator = this.getMessage({sender: user});
+    const textLocator = messageLocator.locator(`p`, {hasText: messageText});
+    const imageLocator = messageLocator.locator(`[aria-label^="Image from ${user.fullName}"]`);
+    await textLocator.waitFor({state: 'visible', timeout: 5000});
+    await imageLocator.waitFor({state: 'visible', timeout: 5000});
+
+    return (await textLocator.isVisible()) && (await imageLocator.isVisible());
+  }
+
   override getImageLocator(user: User): Locator {
     return this.page.locator(`${selectByDataAttribute('item-message')} [aria-label^="Image from ${user.fullName}"]`);
   }

--- a/test/e2e_tests/pageManager/webapp/components/inputBarControls.component.ts
+++ b/test/e2e_tests/pageManager/webapp/components/inputBarControls.component.ts
@@ -32,6 +32,7 @@ export class InputBarControls {
   readonly ping: Locator;
   readonly setEphemeralTimer: Locator;
   readonly sendMessage: Locator;
+  readonly messageInput: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -41,6 +42,7 @@ export class InputBarControls {
     this.ping = page.locator(`${selectByDataAttribute('do-ping')}`);
     this.setEphemeralTimer = page.locator(`${selectByDataAttribute('do-set-ephemeral-timer')}`);
     this.sendMessage = page.locator(`${selectByDataAttribute('do-send-message')}`);
+    this.messageInput = page.locator(`${selectByDataAttribute('input-message')}`);
   }
 
   async clickShareImage(imageFilePath: string) {
@@ -72,6 +74,10 @@ export class InputBarControls {
         return;
       }
     }
+  }
+
+  async setMessageInput(message: string) {
+    await this.messageInput.fill(message);
   }
 
   async clickSendMessage() {

--- a/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -385,6 +385,20 @@ export class ConversationPage {
     return await fileMessageLocator.isVisible();
   }
 
+  async isReplyMessageVisible(replyText: string) {
+    const replyMessageLocator = this.page.locator(
+      `${selectByDataAttribute('item-message')} ${selectByClass('message-body')}${selectByClass('message-quoted')} ${selectByClass(
+        'text',
+      )}`,
+      {hasText: replyText},
+    );
+
+    // Wait for at least one matching element to appear (optional timeout can be set)
+    await replyMessageLocator.first().waitFor({state: 'visible'});
+
+    return await replyMessageLocator.isVisible();
+  }
+
   async downloadFile() {
     const downloadButton = this.page.locator(
       `${selectByDataAttribute('item-message')} ${selectByDataAttribute('file-asset')}`,

--- a/test/e2e_tests/specs/CriticalFlow/Cells/replyingToMultipartMessage-TC-8787.spec.ts
+++ b/test/e2e_tests/specs/CriticalFlow/Cells/replyingToMultipartMessage-TC-8787.spec.ts
@@ -1,0 +1,120 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {getUser} from 'test/e2e_tests/data/user';
+import {PageManager} from 'test/e2e_tests/pageManager';
+import {getImageFilePath} from 'test/e2e_tests/utils/sendImage.util';
+import {addCreatedTeam, removeCreatedTeam} from 'test/e2e_tests/utils/tearDown.util';
+import {inviteMembers, loginUser} from 'test/e2e_tests/utils/userActions';
+
+import {test, expect} from '../../../test.fixtures';
+
+// User A is a team owner, User B is a team member
+let userA = getUser();
+userA.firstName = 'integrationtest';
+userA.lastName = 'integrationtest';
+userA.fullName = 'integrationtest';
+
+const userB = getUser();
+
+const teamName = 'Cells Critical Team';
+const conversationName = 'Cells Critical Conversation';
+const initialMessageText = 'Here is an image for you';
+const replyMessageText = 'Nice image, thanks!';
+
+const imageFilePath = getImageFilePath();
+
+test(
+  'Replying to multipart message in a group conversation',
+  {tag: ['@crit-flow-cells', '@regression', '@TC-8787']},
+  async ({pageManager: userAPageManager, browser, api}) => {
+    const {pages: userAPages, modals: userAModals, components: userAComponents} = userAPageManager.webapp;
+
+    const userBContext = await browser.newContext();
+    const userBPage = await userBContext.newPage();
+    const userBPageManager = new PageManager(userBPage);
+
+    const {pages: userBPages, modals: userBModals, components: userBComponents} = userBPageManager.webapp;
+
+    await test.step('Preconditions: Creating preconditions for the test via API', async () => {
+      await api.createTeamOwner(userA, teamName).then(user => {
+        userA = {...userA, ...user};
+      });
+      addCreatedTeam(userA, userA.teamId);
+      await inviteMembers([userB], userA, api);
+
+      await api.brig.unlockCellsFeature(userA.teamId);
+      await api.brig.enableCells(userA.teamId);
+    });
+
+    await test.step('Preconditions: Both users log in and open the group', async () => {
+      const loginOwner = async () => {
+        await userAPageManager.openMainPage();
+        await loginUser(userA, userAPageManager);
+        if (process.env.ENV_NAME === 'staging') {
+          await userAModals.dataShareConsent().clickDecline();
+        }
+        await userAPages.conversationList().clickCreateGroup();
+        // Files should be disabled by default
+        expect(await userAPages.groupCreation().isFilesCheckboxChecked()).toBeFalsy();
+
+        await userAPages.groupCreation().enableFilesCheckbox();
+        await userAPages.groupCreation().setGroupName(conversationName);
+        await userAPages.startUI().selectUsers([userB.username]);
+        await userAPages.groupCreation().clickCreateGroupButton();
+      };
+
+      const loginMember = async () => {
+        await userBPageManager.openMainPage();
+        await loginUser(userB, userBPageManager);
+        if (process.env.ENV_NAME === 'staging') {
+          await userBModals.dataShareConsent().clickDecline();
+        }
+      };
+
+      await Promise.all([loginOwner(), loginMember()]);
+      await userBPages.conversationList().openConversation(conversationName);
+
+      // Wait for some time before uploading the file to make sure the cell is ready
+      await new Promise(resolve => setTimeout(resolve, 5000));
+    });
+
+    await test.step('User A sends a multipart message to User B in a group conversation', async () => {
+      await userAPages.conversationList().openConversation(conversationName);
+      await userAComponents.inputBarControls().clickShareFile(imageFilePath);
+      await userAComponents.inputBarControls().setMessageInput(initialMessageText);
+      await userAComponents.inputBarControls().clickSendMessage();
+
+      expect(await userBPages.cellsConversation().isMultipartMessageVisible(userA, initialMessageText)).toBeTruthy();
+    });
+
+    await test.step('User B replies to a multipart message', async () => {
+      const message = userBPages.cellsConversation().getMessage({sender: userA});
+      await userBPages.cellsConversation().replyToMessage(message);
+      await userBComponents.inputBarControls().setMessageInput(replyMessageText);
+      await userBComponents.inputBarControls().clickSendMessage();
+
+      expect(await userAPages.cellsConversation().isReplyMessageVisible(replyMessageText)).toBeTruthy();
+    });
+  },
+);
+
+test.afterAll(async ({api}) => {
+  await removeCreatedTeam(api, userA);
+});


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15705" title="WPB-15705" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15705</a>  [Web] Messages replies
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


# Pull Request

## Summary

- What did I change and why?
This PR adds support for multipart message replies, extending the existing quote/reply functionality to handle multipart messages (messages with text and attachments). The implementation mirrors the existing single-part message reply handling by adding parallel code paths for multipart messages throughout the quote processing pipeline.

- Adds quote support to MultipartMessageAddEvent type definition
- Extends reply/quote middleware to handle multipart messages alongside regular messages
- Updates event service filters to find replies in both message types
- Added e2e test for replying to multipart message TC-8787

- Risks and how to roll out / roll back (e.g. feature flags):
none.
---

## Security Checklist (required)

- [X] **External inputs are validated & sanitized** on client and/or server where applicable.
- [X] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [X] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [X] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [X] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [X] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).
