### PR TITLE
feat: add role and aria attributes for screen sharing toggle accessibility [WPB-21195]

### DIFF
--- a/src/script/components/calling/CallingCell/CallingControls/CallingControls.tsx
+++ b/src/script/components/calling/CallingCell/CallingControls/CallingControls.tsx
@@ -148,6 +148,8 @@ export const CallingControls = ({
                   data-uie-value={selfSharesScreen ? 'active' : 'inactive'}
                   data-uie-enabled={disableScreenButton ? 'false' : 'true'}
                   title={t('videoCallOverlayShareScreen')}
+                  role="switch"
+                  aria-checked={selfSharesScreen}
                   disabled={disableScreenButton}
                 >
                   {selfSharesScreen ? (

--- a/src/script/components/calling/VideoControls/VideoControls.tsx
+++ b/src/script/components/calling/VideoControls/VideoControls.tsx
@@ -659,6 +659,8 @@ export const VideoControls = ({
             data-uie-value={selfSharesScreen ? 'active' : 'inactive'}
             data-uie-enabled={canShareScreen ? 'true' : 'false'}
             data-uie-name="do-toggle-screen"
+            role="switch"
+            aria-checked={selfSharesScreen}
             title={t('videoCallOverlayShareScreen')}
           >
             {selfSharesScreen ? (


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21195" title="WPB-21195" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21195</a>  [Web] Calling - "Share screen" button without value
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary
Add role and aria attributes for screen sharing toggle accessibility

- What did I change and why?
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
