### PR TITLE
core: Ignore libsodium-wrappers v0.7.16 in Dependabot [WPB-22420]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,10 @@ updates:
       - dependency-name: '@lexical/markdown'
       - dependency-name: '@lexical/react'
       - dependency-name: '@lexical/rich-text'
+      # Wait until libsodium-wrappers:0.7.17 because: https://github.com/jedisct1/libsodium.js/issues/357
+      - dependency-name: 'libsodium-wrappers'
+        versions:
+          - '0.7.16'
 
   # Server dependencies
   - package-ecosystem: npm

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "keyboardjs": "2.7.0",
     "knockout": "3.5.1",
     "lexical": "0.27.2",
-    "libsodium-wrappers": "0.7.16",
+    "libsodium-wrappers": "0.7.15",
     "linkify-it": "5.0.0",
     "long": "5.3.2",
     "markdown-it": "14.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14247,12 +14247,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"libsodium-wrappers@npm:0.7.16":
-  version: 0.7.16
-  resolution: "libsodium-wrappers@npm:0.7.16"
+"libsodium-wrappers@npm:0.7.15":
+  version: 0.7.15
+  resolution: "libsodium-wrappers@npm:0.7.15"
   dependencies:
-    libsodium: "npm:^0.7.16"
-  checksum: 10/4f6fdec0ee3ee960bb13bbbafde6f119ed16534c9afb8a2e96b0e9d3ca44937ca6e3ac24ea1822fc9c938031c8b2d42a26c797b0b7673de01b3ff29d73df4218
+    libsodium: "npm:^0.7.15"
+  checksum: 10/a97e72da2de9b9294df35aaa053c7943b7eab0e805e5c4cbdc37bd7190221875b57d485f41595b217e80cbe44f96033a756ea12bc6214d3710b2be3d16ac1f9b
   languageName: node
   linkType: hard
 
@@ -20724,7 +20724,7 @@ __metadata:
     less: "npm:4.5.1"
     less-loader: "npm:12.3.0"
     lexical: "npm:0.27.2"
-    libsodium-wrappers: "npm:0.7.16"
+    libsodium-wrappers: "npm:0.7.15"
     linkify-it: "npm:5.0.0"
     lint-staged: "npm:15.5.0"
     long: "npm:5.3.2"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

This change updates the Dependabot configuration to explicitly ignore
libsodium-wrappers version 0.7.16. Because of: https://github.com/jedisct1/libsodium.js/issues/357

The update will be picked up automatically once a newer version is released.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
