### PR TITLE
fix: Use production url instead of environment variable to enable asset logging [WPB-22566] (#19971)

### DIFF
--- a/src/script/repositories/conversation/MessageRepository.ts
+++ b/src/script/repositories/conversation/MessageRepository.ts
@@ -80,7 +80,6 @@ import {Segmentation} from 'Repositories/tracking/Segmentation';
 import {protoFromType} from 'Repositories/user/AvailabilityMapper';
 import {UserRepository} from 'Repositories/user/UserRepository';
 import {UserState} from 'Repositories/user/UserState';
-import {getWebEnvironment} from 'Util/Environment';
 import {
   cancelSendingLinkPreview,
   clearLinkPreviewSendingState,
@@ -730,7 +729,7 @@ export class MessageRepository {
     asImage: boolean,
     meta: FileMetaDataContent,
   ) {
-    const isAuditLogEnabled = this.teamState.isAuditLogEnabled() && !getWebEnvironment().isProduction;
+    const isAuditLogEnabled = this.teamState.isAuditLogEnabled() && TeamState.isAuditLogEnabledForBackend();
 
     const auditData: AssetAuditData | undefined = isAuditLogEnabled
       ? {

--- a/src/script/repositories/team/TeamState.ts
+++ b/src/script/repositories/team/TeamState.ts
@@ -26,6 +26,7 @@ import {Conversation} from 'Repositories/entity/Conversation';
 import {User} from 'Repositories/entity/User';
 import {ROLE, roleMap} from 'Repositories/user/UserPermission';
 import {UserState} from 'Repositories/user/UserState';
+import {Config} from 'src/script/Config';
 import {sortUsersByPriority} from 'Util/StringUtil';
 
 import {TeamEntity} from './TeamEntity';
@@ -144,6 +145,15 @@ export class TeamState {
     this.isAuditLogEnabled = ko.pureComputed(() => {
       return this.teamFeatures()?.assetAuditLog?.status === FEATURE_STATUS.ENABLED;
     });
+  }
+
+  /**
+   * Check if audit logging is enabled for the current backend.
+   * Audit logging is explicitly disabled for the production cloud backend.
+   */
+  static isAuditLogEnabledForBackend(): boolean {
+    const {BACKEND_REST} = Config.getConfig();
+    return BACKEND_REST !== 'https://prod-nginz-https.wire.com';
   }
 
   isInTeam(entity: User | Conversation): boolean {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22566" title="WPB-22566" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22566</a>  [Web] Schwarz - Asset Audit logs not enabled in production 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- What did I change and why?
Cherry pick of https://github.com/wireapp/wire-webapp/pull/19971
- Risks and how to roll out / roll back (e.g. feature flags):
none.
---

## Security Checklist (required)

- [X] **External inputs are validated & sanitized** on client and/or server where applicable.
- [X] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [X] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [X] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [X] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [X] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).
