### PR TITLE
feat: make screen selection modal accessible [WPB-21192]

### DIFF
--- a/apps/webapp/src/script/components/calling/ChooseScreen.tsx
+++ b/apps/webapp/src/script/components/calling/ChooseScreen.tsx
@@ -128,7 +128,7 @@ function ChooseScreen({choose, callState = container.resolve(CallState)}: Choose
       focusContext.targetDocument.removeEventListener('keydown', handleKeyDown);
       dialog.removeEventListener('focusout', handleFocusOut);
     };
-  }, [selectableScreens, selectableWindows, cancel, callState]);
+  }, [selectableScreens, selectableWindows, cancel, callState, restoreFocusRef]);
 
   const renderPreviews = (list: ElectronDesktopCapturerSource[], uieName: string) =>
     list.map(({id, name, thumbnail}) => (

--- a/apps/webapp/src/script/components/calling/ChooseScreen.tsx
+++ b/apps/webapp/src/script/components/calling/ChooseScreen.tsx
@@ -17,14 +17,16 @@
  *
  */
 
-import {Fragment, useCallback, useEffect} from 'react';
+import {Fragment, useCallback, useEffect, useRef} from 'react';
 
 import {container} from 'tsyringe';
 
-import {CallState} from 'Repositories/calling/CallState';
+import {CallingViewMode, CallState} from 'Repositories/calling/CallState';
 import {ElectronDesktopCapturerSource} from 'Repositories/media/MediaDevicesHandler';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
+import {KEY} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
+import {captureModalFocusContext} from 'Util/ModalFocusUtil';
 
 interface ChooseScreenProps {
   choose: (screenId: string) => void;
@@ -37,40 +39,123 @@ function ChooseScreen({choose, callState = container.resolve(CallState)}: Choose
     'selectableWindows',
   ]);
 
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const restoreFocusRef = useRef<(() => void) | null>(null);
+
   const cancel = useCallback(() => {
+    requestAnimationFrame(() => {
+      restoreFocusRef.current?.();
+    });
     callState.selectableScreens([]);
     callState.selectableWindows([]);
-  }, [callState]);
+  }, [callState, restoreFocusRef]);
+
+  const handleChoose = useCallback(
+    (screenId: string) => {
+      requestAnimationFrame(() => {
+        restoreFocusRef.current?.();
+      });
+      choose(screenId);
+    },
+    [choose, restoreFocusRef],
+  );
 
   useEffect(() => {
-    const closeOnEsc = ({key}: KeyboardEvent): void => {
-      if (key === 'Escape') {
+    const dialog = dialogRef.current;
+    if (!dialog) {
+      return undefined;
+    }
+
+    const detachedWindow = callState.detachedWindow();
+    const isDetachedWindow = callState.viewMode() === CallingViewMode.DETACHED_WINDOW;
+
+    const focusContext = captureModalFocusContext({
+      targetDocument: isDetachedWindow && detachedWindow ? detachedWindow.document : undefined,
+      container: isDetachedWindow && detachedWindow ? detachedWindow.document.body : undefined,
+    });
+
+    restoreFocusRef.current = focusContext.createFocusRestorationCallback();
+
+    // Get all focusable elements
+    const getFocusableElements = () => Array.from(dialog.querySelectorAll<HTMLElement>('button:not([disabled])'));
+
+    // Focus first screen when dialog appears
+    const firstFocusableElement = getFocusableElements().at(0);
+    firstFocusableElement?.focus();
+
+    // Keydown handler for ESC and Tab
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === KEY.ESC) {
         cancel();
+        return;
+      }
+
+      if (event.key === KEY.TAB) {
+        const elements = getFocusableElements();
+        if (elements.length === 0) {
+          return;
+        }
+
+        const firstElement = elements.at(0);
+        const lastElement = elements.at(-1);
+        const activeElement = focusContext.targetDocument.activeElement;
+
+        // Shift+Tab on first elem move the focus to the last
+        if (event.shiftKey && activeElement === firstElement) {
+          event.preventDefault();
+          lastElement?.focus();
+        } else if (!event.shiftKey && activeElement === lastElement) {
+          event.preventDefault();
+          firstElement?.focus();
+        }
       }
     };
 
-    document.addEventListener('keydown', closeOnEsc);
-    return () => {
-      document.removeEventListener('keydown', closeOnEsc);
+    // Prevent focus from getting out of the dialog
+    const handleFocusOut = (event: FocusEvent) => {
+      const relatedTarget = event.relatedTarget as HTMLElement | null;
+      if (!relatedTarget || !dialog.contains(relatedTarget)) {
+        event.preventDefault();
+        const elements = getFocusableElements();
+        elements.at(0)?.focus();
+      }
     };
-  }, [cancel]);
+
+    focusContext.targetDocument.addEventListener('keydown', handleKeyDown);
+    dialog.addEventListener('focusout', handleFocusOut);
+
+    return () => {
+      focusContext.targetDocument.removeEventListener('keydown', handleKeyDown);
+      dialog.removeEventListener('focusout', handleFocusOut);
+    };
+  }, [selectableScreens, selectableWindows, cancel, callState]);
 
   const renderPreviews = (list: ElectronDesktopCapturerSource[], uieName: string) =>
-    list.map(({id, thumbnail}) => (
+    list.map(({id, name, thumbnail}) => (
       <button
         type="button"
         key={id}
         className="choose-screen-list-item"
         data-uie-name={uieName}
-        onClick={() => choose(id)}
+        onClick={() => handleChoose(id)}
+        aria-label={name}
+        title={name}
       >
         <img className="choose-screen-list-image" src={thumbnail.toDataURL()} role="presentation" alt="" />
       </button>
     ));
 
   return (
-    <div className="choose-screen">
-      <div className="label-xs text-white">{t('callChooseSharedScreen')}</div>
+    <div
+      ref={dialogRef}
+      className="choose-screen"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="choose-screen-title"
+    >
+      <div id="choose-screen-title" className="label-xs text-white">
+        {t('callChooseSharedScreen')}
+      </div>
       <div className="choose-screen-list">{renderPreviews(selectableScreens, 'item-screen')}</div>
       {selectableWindows.length > 0 && (
         <Fragment>

--- a/apps/webapp/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/apps/webapp/src/script/components/calling/FullscreenVideoCall.tsx
@@ -239,6 +239,15 @@ const FullscreenVideoCall = ({
         return;
       }
 
+      // Allow focus to move into the ChooseScreen dialog if it's open
+      const chooseScreenDialog = targetDocument.querySelector('.choose-screen[role="dialog"]');
+      if (chooseScreenDialog) {
+        if (chooseScreenDialog.contains(target)) {
+          return;
+        }
+        return;
+      }
+
       event.preventDefault();
       event.stopPropagation();
 

--- a/apps/webapp/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/apps/webapp/src/script/components/calling/FullscreenVideoCall.tsx
@@ -242,9 +242,6 @@ const FullscreenVideoCall = ({
       // Allow focus to move into the ChooseScreen dialog if it's open
       const chooseScreenDialog = targetDocument.querySelector('.choose-screen[role="dialog"]');
       if (chooseScreenDialog) {
-        if (chooseScreenDialog.contains(target)) {
-          return;
-        }
         return;
       }
 

--- a/apps/webapp/src/script/components/calling/GroupVideoGrid.tsx
+++ b/apps/webapp/src/script/components/calling/GroupVideoGrid.tsx
@@ -113,6 +113,7 @@ const GroupVideoThumbnailWrapper = ({children, minimized}: {children?: ReactNode
         : undefined
     }
     data-uie-name="self-video-thumbnail-wrapper"
+    aria-hidden="true"
   >
     {children}
   </div>

--- a/apps/webapp/src/script/components/calling/chooseScreen.test.tsx
+++ b/apps/webapp/src/script/components/calling/chooseScreen.test.tsx
@@ -26,12 +26,12 @@ import {ChooseScreen} from './ChooseScreen';
 
 describe('ChooseScreen', () => {
   const screens = [
-    {id: 'screen:first', thumbnail: {toDataURL: () => 'first screen'} as HTMLCanvasElement},
-    {id: 'screen:second', thumbnail: {toDataURL: () => 'second screen'} as HTMLCanvasElement},
+    {id: 'screen:first', name: 'Screen 1', thumbnail: {toDataURL: () => 'first screen'} as HTMLCanvasElement},
+    {id: 'screen:second', name: 'Screen 2', thumbnail: {toDataURL: () => 'second screen'} as HTMLCanvasElement},
   ];
   const windows = [
-    {id: 'window:first', thumbnail: {toDataURL: () => 'first window'} as HTMLCanvasElement},
-    {id: 'window:second', thumbnail: {toDataURL: () => 'second window'} as HTMLCanvasElement},
+    {id: 'window:first', name: 'Window 1', thumbnail: {toDataURL: () => 'first window'} as HTMLCanvasElement},
+    {id: 'window:second', name: 'Window 2', thumbnail: {toDataURL: () => 'second window'} as HTMLCanvasElement},
   ];
 
   const props = {

--- a/apps/webapp/src/script/components/calling/chooseScreen.test.tsx
+++ b/apps/webapp/src/script/components/calling/chooseScreen.test.tsx
@@ -108,7 +108,7 @@ describe('ChooseScreen', () => {
   it('calls cancel on escape', () => {
     setup();
 
-    fireEvent.keyDown(document, {code: 'Enter', key: 'Escape'});
+    fireEvent.keyDown(document, {code: 'Escape', key: 'Escape'});
     expect(callState.selectableScreens()).toEqual([]);
     expect(callState.selectableWindows()).toEqual([]);
   });

--- a/apps/webapp/src/script/components/calling/chooseScreen.test.tsx
+++ b/apps/webapp/src/script/components/calling/chooseScreen.test.tsx
@@ -21,32 +21,83 @@ import {render, fireEvent} from '@testing-library/react';
 import {container} from 'tsyringe';
 
 import {CallState} from 'Repositories/calling/CallState';
+import {captureModalFocusContext} from 'Util/ModalFocusUtil';
 
 import {ChooseScreen} from './ChooseScreen';
 
+jest.mock('Util/ModalFocusUtil', () => ({
+  captureModalFocusContext: jest.fn(),
+}));
+
 describe('ChooseScreen', () => {
   const screens = [
-    {id: 'screen:first', name: 'Screen 1', thumbnail: {toDataURL: () => 'first screen'} as HTMLCanvasElement},
-    {id: 'screen:second', name: 'Screen 2', thumbnail: {toDataURL: () => 'second screen'} as HTMLCanvasElement},
+    {
+      id: 'screen:first',
+      name: 'Screen 1',
+      thumbnail: {toDataURL: () => 'first screen'} as HTMLCanvasElement,
+      display_id: '',
+    },
+    {
+      id: 'screen:second',
+      name: 'Screen 2',
+      thumbnail: {toDataURL: () => 'second screen'} as HTMLCanvasElement,
+      display_id: '',
+    },
   ];
   const windows = [
-    {id: 'window:first', name: 'Window 1', thumbnail: {toDataURL: () => 'first window'} as HTMLCanvasElement},
-    {id: 'window:second', name: 'Window 2', thumbnail: {toDataURL: () => 'second window'} as HTMLCanvasElement},
+    {
+      id: 'window:first',
+      name: 'Window 1',
+      thumbnail: {toDataURL: () => 'first window'} as HTMLCanvasElement,
+      display_id: '',
+    },
+    {
+      id: 'window:second',
+      name: 'Window 2',
+      thumbnail: {toDataURL: () => 'second window'} as HTMLCanvasElement,
+      display_id: '',
+    },
   ];
-
-  const props = {
-    choose: jest.fn(),
-  };
 
   const callState = container.resolve(CallState);
 
+  const createFocusContext = () => {
+    const restore = jest.fn();
+    return {
+      targetDocument: document,
+      createFocusRestorationCallback: () => restore,
+      restoreMock: restore,
+    };
+  };
+
+  const setup = () => {
+    callState.selectableScreens(screens);
+    callState.selectableWindows(windows);
+
+    const focusContext = createFocusContext();
+    (captureModalFocusContext as jest.Mock).mockReturnValue(focusContext);
+
+    const props = {choose: jest.fn()};
+    const renderedComponent = render(<ChooseScreen {...props} />);
+
+    return {props, focusContext, ...renderedComponent};
+  };
+
   beforeEach(() => {
-    callState.selectableScreens(screens as any);
-    callState.selectableWindows(windows as any);
+    jest.clearAllMocks();
+
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    (window.requestAnimationFrame as jest.Mock | undefined)?.mockRestore?.();
   });
 
   it('shows the available screens', () => {
-    const {container} = render(<ChooseScreen {...props} />);
+    const {container} = setup();
     const screenItems = container.querySelectorAll('[data-uie-name="item-screen"]');
     const windowItems = container.querySelectorAll('[data-uie-name="item-window"]');
 
@@ -55,7 +106,7 @@ describe('ChooseScreen', () => {
   });
 
   it('calls cancel on escape', () => {
-    render(<ChooseScreen {...props} />);
+    setup();
 
     fireEvent.keyDown(document, {code: 'Enter', key: 'Escape'});
     expect(callState.selectableScreens()).toEqual([]);
@@ -63,7 +114,7 @@ describe('ChooseScreen', () => {
   });
 
   it('calls cancel on cancel button click', () => {
-    const {container} = render(<ChooseScreen {...props} />);
+    const {container} = setup();
 
     const cancelButton = container.querySelector('[data-uie-name="do-choose-screen-cancel"]');
     expect(cancelButton).not.toBeNull();
@@ -74,7 +125,7 @@ describe('ChooseScreen', () => {
   });
 
   it('chooses the correct screens on click', () => {
-    const {container} = render(<ChooseScreen {...props} />);
+    const {container, props} = setup();
 
     const ids = [...screens, ...windows].map(({id}) => id);
 
@@ -87,5 +138,109 @@ describe('ChooseScreen', () => {
       fireEvent.click(listItem);
       expect(props.choose).toHaveBeenCalledWith(ids[index]);
     });
+  });
+
+  it('renders as an aria-modal dialog with labelled title', () => {
+    const {container} = setup();
+    const dialog = container.querySelector('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'choose-screen-title');
+    expect(container.querySelector('#choose-screen-title')).not.toBeNull();
+  });
+
+  it('focuses the first focusable element (first preview button) on mount', () => {
+    const {container} = setup();
+    const firstItem = container.querySelector<HTMLButtonElement>('[data-uie-name="item-screen"]');
+    expect(firstItem).not.toBeNull();
+    expect(document.activeElement).toBe(firstItem);
+  });
+
+  it('traps focus: Tab on last element cycles to first', () => {
+    const {container} = setup();
+
+    const buttons = Array.from(container.querySelectorAll<HTMLButtonElement>('button:not([disabled])'));
+    expect(buttons.length).toBeGreaterThan(1);
+
+    const first = buttons.at(0);
+    const last = buttons.at(-1);
+
+    last?.focus();
+    expect(document.activeElement).toBe(last);
+
+    fireEvent.keyDown(document, {key: 'Tab'});
+
+    expect(document.activeElement).toBe(first);
+  });
+
+  it('traps focus: Shift+Tab on first element cycles to last', () => {
+    const {container} = setup();
+
+    const buttons = Array.from(container.querySelectorAll<HTMLButtonElement>('button:not([disabled])'));
+    expect(buttons.length).toBeGreaterThan(1);
+
+    const first = buttons[0];
+    const last = buttons[buttons.length - 1];
+
+    first.focus();
+    expect(document.activeElement).toBe(first);
+
+    fireEvent.keyDown(document, {key: 'Tab', shiftKey: true});
+
+    expect(document.activeElement).toBe(last);
+  });
+
+  it('keeps focus in dialog on focusout (redirects to first focusable)', () => {
+    const {container} = setup();
+
+    const buttons = Array.from(container.querySelectorAll<HTMLButtonElement>('button:not([disabled])'));
+    const first = buttons[0];
+
+    // simulate focus leaving the dialog
+    const dialog = container.querySelector<HTMLDivElement>('.choose-screen');
+    expect(dialog).not.toBeNull();
+
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+
+    fireEvent.focusOut(dialog!, {relatedTarget: outside});
+
+    expect(document.activeElement).toBe(first);
+
+    document.body.removeChild(outside);
+  });
+
+  it('calls focus restoration callback on cancel (Escape)', () => {
+    const {focusContext} = setup();
+
+    fireEvent.keyDown(document, {key: 'Escape'});
+    expect(focusContext.restoreMock).toHaveBeenCalled();
+  });
+
+  it('calls focus restoration callback on cancel button click', () => {
+    const {container, focusContext} = setup();
+
+    const cancelButton = container.querySelector('[data-uie-name="do-choose-screen-cancel"]')!;
+    fireEvent.click(cancelButton);
+
+    expect(focusContext.restoreMock).toHaveBeenCalled();
+  });
+
+  it('calls choose and restores focus when selecting a screen/window', () => {
+    const {container, props, focusContext} = setup();
+
+    const firstScreen = container.querySelector('[data-uie-name="item-screen"]')!;
+    fireEvent.click(firstScreen);
+
+    expect(props.choose).toHaveBeenCalledWith('screen:first');
+    expect(focusContext.restoreMock).toHaveBeenCalled();
+  });
+
+  it('does not cancel when key is not Escape or Tab', () => {
+    setup();
+
+    fireEvent.keyDown(document, {key: 'Enter'});
+    expect(callState.selectableScreens()).toHaveLength(screens.length);
+    expect(callState.selectableWindows()).toHaveLength(windows.length);
   });
 });

--- a/apps/webapp/src/style/components/calling/choose-screen.less
+++ b/apps/webapp/src/style/components/calling/choose-screen.less
@@ -84,6 +84,18 @@
       left: 32px;
     }
   }
+
+  &:focus,
+  &:focus-visible {
+    outline: none;
+  }
+
+  &:focus img,
+  &:focus-within img,
+  &:hover img {
+    border: 1px solid var(--accent-color);
+    box-shadow: 0 0 0 2px var(--accent-color-100);
+  }
 }
 
 .choose-screen-list-image {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21192" title="WPB-21192" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21192</a>  [Web] Calling - Screen cannot be selected with the keyboard
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary
Make Screen selection modal accessible.

- What did I change and why?
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
