### PR TITLE
test(WPB-22420): allow conversation locator to only locate conversations with a given protocol

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -20,7 +20,6 @@
 import {Locator, Page} from '@playwright/test';
 
 import {selectById, selectByDataAttribute} from 'test/e2e_tests/utils/selector.util';
-import {escapeHtml} from 'test/e2e_tests/utils/userDataProcessor';
 
 import {User} from '../../../data/user';
 
@@ -90,8 +89,8 @@ export class ConversationListPage {
     return await mentionIndicator.isVisible();
   }
 
-  async openConversation(conversationName: string) {
-    await this.getConversationLocator(conversationName).first().click();
+  async openConversation(conversationName: string, options?: Parameters<typeof this.getConversationLocator>[1]) {
+    await this.getConversationLocator(conversationName, options).click();
   }
 
   async openPendingConnectionRequest() {
@@ -118,10 +117,19 @@ export class ConversationListPage {
     await this.createGroupButton.click();
   }
 
-  getConversationLocator(conversationName: string) {
-    return this.page.locator(
-      `${selectByDataAttribute('item-conversation')}${selectByDataAttribute(escapeHtml(conversationName), 'value')}`,
-    );
+  /**
+   * Get a locator for a specific conversation in the list
+   * @param conversationName Name of the conversation to search for
+   * @param options.protocol Only locate conversations matching this protocol (mls only works for 1on1 conversations as groups still use proteus) - Default: "mls"
+   */
+  getConversationLocator(conversationName: string, options?: {protocol?: 'mls' | 'proteus'}) {
+    const conversation = this.page.getByTestId('item-conversation').filter({hasText: conversationName});
+
+    if (options?.protocol) {
+      return conversation.and(this.page.locator(`[data-protocol="${options.protocol}"]`));
+    }
+
+    return conversation;
   }
 
   async openContextMenu(conversationName: string) {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -29,7 +29,6 @@ export class ConversationListPage {
 
   readonly blockConversationMenuButton: Locator;
   readonly createGroupButton: Locator;
-  readonly connectWithPeopleButton: Locator;
   readonly pendingConnectionRequest: Locator;
   readonly leaveConversationButton: Locator;
   readonly searchConversationsInput: Locator;
@@ -51,7 +50,6 @@ export class ConversationListPage {
       `${selectById('btn-block')}${selectByDataAttribute('conversation-list-options-menu')}`,
     );
 
-    this.connectWithPeopleButton = page.locator('[data-uie-name="connect-with-new-users"]');
     this.pendingConnectionRequest = page.locator('[data-uie-name="connection-request"]');
     this.createGroupButton = page.locator(
       `${selectByDataAttribute('conversation-list-header')} ${selectByDataAttribute('go-create-group')}`,
@@ -102,10 +100,6 @@ export class ConversationListPage {
 
   async clickConversationOptions(conversationName: string) {
     await this.getConversationLocator(conversationName).locator(selectByDataAttribute('go-options')).first().click();
-  }
-
-  async clickConnectWithPeople() {
-    await this.connectWithPeopleButton.click();
   }
 
   async clickBlockConversation() {

--- a/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
@@ -43,9 +43,8 @@ export async function blockUserFromConversationList(pageManager: PageManager, us
  * @param pageManager PageManager of the blocking user
  * @param userToBlock User object of the user to be blocked
  */
-export async function blockUserFromProfileView(pageManager: PageManager, userToBlock: User) {
+export async function blockUserFromProfileView(pageManager: PageManager) {
   const {pages, modals} = pageManager.webapp;
-  await pages.conversationList().openConversation(userToBlock.fullName);
   await pages.conversation().clickConversationInfoButton();
   await pages.participantDetails().blockUser();
   await modals.blockWarning().clickBlock();
@@ -158,6 +157,7 @@ test.describe('User Blocking', () => {
         // Preconditions: User B accepts the connection request
         const userBPages = (await PageManager.from(createPage(withLogin(userB)))).webapp.pages;
         await userBPages.connectRequest().clickConnectButton();
+        await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
         await createGroup(userAPages, conversationName, [userB]);
 
         await test.step('Step 1: User B sends message to group chat with User A', async () => {
@@ -201,7 +201,7 @@ test.describe('User Blocking', () => {
         // Step 1: User A and B have a 1:1 conversation
         await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
         // Step 2: User A blocks User B
-        await blockUserFromProfileView(userAPageManagerInstance, userB);
+        await blockUserFromProfileView(userAPageManagerInstance);
         await expect(userAPages.conversation().messageInput).toBeHidden();
         // Step 3: User A unblocks User B from Conversation Details Options
         await userAPages.conversationList().clickConversationOptions(userB.fullName);

--- a/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
@@ -93,7 +93,7 @@ test.describe('User Blocking', () => {
         await userBPages.connectRequest().clickConnectButton();
 
         // Step 1: User A opens conversation with User B
-        await userAPages.conversationList().openConversation(userB.fullName);
+        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
         // Step 2: User A opens the options menu for user B
         await userAPages.conversationList().clickConversationOptions(userB.fullName);
         // Step 3: User A opens modal and clicks 'Block' button
@@ -101,7 +101,7 @@ test.describe('User Blocking', () => {
         // Step 4: User A clicks 'Cancel' button
         await userAModals.blockWarning().clickCancel();
         // Step 5: Conversation is still present, and User A can open it
-        await userAPages.conversationList().openConversation(userB.fullName);
+        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
         // Step 6: User A still can send message to User B
         await expect(userAPages.conversation().messageInput).toBeVisible();
       },
@@ -120,7 +120,7 @@ test.describe('User Blocking', () => {
         await userBPages.connectRequest().clickConnectButton();
 
         // Step 1: User A and B have a 1:1 conversation
-        await userAPages.conversationList().openConversation(userB.fullName);
+        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
         // Step 2: User A opens conversation info
         await userAPages.conversation().clickConversationInfoButton();
         // Step 3: User A clicks 'Block conversation' button
@@ -128,10 +128,10 @@ test.describe('User Blocking', () => {
         // Step 4: User A clicks 'Confirm' button
         await userAModals.blockWarning().clickBlock();
         // Step 5: User A cannot send message to User B
-        await userAPages.conversationList().openConversation(userB.fullName);
+        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
         await expect(userAPages.conversation().messageInput).not.toBeVisible();
         // Step 6: User B cannot send message to User A
-        await userBPages.conversationList().openConversation(userA.fullName);
+        await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
         await userBPages.conversation().sendMessage('Message after block');
         const message = userAPages.conversation().getMessage({sender: userB});
         await expect(message).not.toBeVisible();
@@ -199,7 +199,7 @@ test.describe('User Blocking', () => {
         await userBPages.connectRequest().clickConnectButton();
 
         // Step 1: User A and B have a 1:1 conversation
-        await userAPages.conversationList().openConversation(userB.fullName);
+        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
         // Step 2: User A blocks User B
         await blockUserFromProfileView(userAPageManagerInstance, userB);
         await expect(userAPages.conversation().messageInput).toBeHidden();
@@ -208,15 +208,15 @@ test.describe('User Blocking', () => {
         await userAPages.conversationList().clickUnblockConversation();
         await userAModals.confirm().clickAction();
         // Step 4: User A send message to User B
-        await userAPages.conversationList().openConversation(userB.fullName);
+        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
         await userAPages.conversation().sendMessage('Message after unblock');
         // Step 5: User B receives message from User A
-        await userBPages.conversationList().openConversation(userA.fullName);
+        await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
         await expect(userBPages.conversation().messages).toHaveCount(1);
         // Step 6: User B writes message to User A
         await userBPages.conversation().sendMessage('Message after being unblocked');
         // Step 7: User A receives message from User B
-        await userAPages.conversationList().openConversation(userB.fullName);
+        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
         const message = userAPages.conversation().getMessage({sender: userB});
         await expect(message).toContainText('Message after being unblocked');
       },
@@ -308,16 +308,16 @@ test.describe('User Blocking', () => {
         });
 
         await test.step('User B receives message sent by User A', async () => {
-          await userAPages.conversationList().openConversation(userB.fullName);
+          await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
           await userAPages.conversation().sendMessage('Message after unblocking');
-          await userBPages.conversationList().openConversation(userA.fullName);
+          await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
           await expect(userBPages.conversation().messages).toHaveCount(1);
         });
 
         await test.step('User A receives message sent by User B', async () => {
-          await userBPages.conversationList().openConversation(userA.fullName);
+          await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
           await userBPages.conversation().sendMessage('Message after being unblocked');
-          await userAPages.conversationList().openConversation(userB.fullName);
+          await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
           const message = userAPages.conversation().getMessage({sender: userB});
           await expect(message).toContainText('Message after being unblocked');
         });

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
@@ -66,14 +66,14 @@ test('Messages in 1:1', {tag: ['@TC-8750', '@crit-flow-web']}, async ({createTea
   await test.step('User A sends image', async () => {
     const {pages, components} = memberAPageManager.webapp;
 
-    // Wait for connection to be fully established, MLS migration is still ongoing
-    await memberAPageManager.waitForTimeout(5_000);
-    await pages.conversationList().openConversation(memberB.fullName);
+    // When a conversation between two non team members is created proteus will be used by default and later upgrade to mls.
+    // To avoid loosing messages during the fast execution with playwright we wait for the upgrade is finished to open the MLS conversation.
+    await pages.conversationList().openConversation(memberB.fullName, {protocol: 'mls'});
     await components.inputBarControls().clickShareImage(imageFilePath);
     expect(await pages.conversation().isImageFromUserVisible(memberA)).toBeTruthy();
   });
   await test.step('User B can see the image in the conversation', async () => {
-    await memberBPageManager.webapp.pages.conversationList().openConversation(memberA.fullName);
+    await memberBPageManager.webapp.pages.conversationList().openConversation(memberA.fullName, {protocol: 'mls'});
 
     // Verify that the image is visible in the conversation
     expect(await memberBPageManager.webapp.pages.conversation().isImageFromUserVisible(memberA)).toBeTruthy();

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
@@ -89,8 +89,8 @@ test('Messages in 1:1', {tag: ['@TC-8750', '@crit-flow-web']}, async ({createTea
     await memberBPageManager.webapp.pages.conversation().clickImage(memberA);
 
     // Verify that the detail view modal is visible
-    expect(await memberBPageManager.webapp.modals.detailViewModal().isVisible()).toBeTruthy();
-    expect(await memberBPageManager.webapp.modals.detailViewModal().isImageVisible()).toBeTruthy();
+    await expect(memberBPageManager.webapp.modals.detailViewModal().mainWindow).toBeVisible();
+    await expect(memberBPageManager.webapp.modals.detailViewModal().image).toBeVisible();
   });
   await test.step('User B can download the image', async () => {
     // Click on the download button to download the image

--- a/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
@@ -307,7 +307,9 @@ test.describe('Reply', () => {
       await userAPages.conversation().clickConversationInfoButton();
       await userAPages.conversation().removeMemberFromGroup(userB.fullName);
       await new ConfirmModal(userAPages.conversation().page).clickAction();
-      await expect(userBPages.conversation().getMessage({content: `${userA.fullName} removed you`})).toBeVisible();
+      await expect(
+        userBPages.conversation().systemMessages.filter({hasText: `${userA.fullName} removed you`}),
+      ).toBeVisible();
 
       await message.hover();
       await expect(message.getByTestId('do-reply-message')).not.toBeAttached();


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

This PR adds the option to only locate conversations which use a given protocol. This is due to the issue we sometimes encounter when two users which are not part of the same team connect and send messages to each other. Playwright is so fast that it might send a message before / while the migration from proteus to mls is ongoing, resulting in the message being lost. For now this problem can't be solved since proteus needs to be the initial default for new conversations until it is fully removed from wire.
So far we worked around this issue by using members of the same team for the tests, but for some test cases this isn't possible. This new optional flag in the api allows us to still test these cases without having to rely on flaky workarounds like timeouts.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Notes for reviewers

- Since our existing workaround using Teams contains additional benefits like the users already being connected I kept it in place for most of the tests.
- I also noticed an unused locator along the way and removed it.