### PR TITLE
test(WPB-19967): Add regression tests for user search functionality

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/startUI.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/startUI.page.ts
@@ -66,4 +66,8 @@ export class StartUIPage {
     }
     throw new Error(`User ${username} not found in search results`);
   }
+
+  getSearchResultForSpecificUser(username: String) {
+    return this.page.getByRole('button', {name: `Open profile of ${username}`});
+  }
 }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/startUI.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/startUI.page.ts
@@ -67,7 +67,7 @@ export class StartUIPage {
     throw new Error(`User ${username} not found in search results`);
   }
 
-  getSearchResultForSpecificUser(username: String) {
+  getSearchResultForSpecificUser(username: string) {
     return this.page.getByRole('button', {name: `Open profile of ${username}`});
   }
 }

--- a/apps/webapp/test/e2e_tests/specs/Search/search.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Search/search.spec.ts
@@ -1,0 +1,93 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {PageManager} from 'test/e2e_tests/pageManager';
+import {test, expect, withLogin} from 'test/e2e_tests/test.fixtures';
+import {createGroup} from '../../utils/userActions';
+
+test.describe('Search', () => {
+  test(
+    'Verify you can search by partial username of unconnected user',
+    {tag: ['@TC-1657', '@regression']},
+    async ({createUser, createPage}) => {
+      const [userA, userB] = await Promise.all([createUser(), createUser()]);
+      const userAPageManager = await PageManager.from(createPage(withLogin(userA)));
+      const {pages: userAPages, components: userAComponents} = userAPageManager.webapp;
+      const partialUsername = userB.username.slice(0, -1);
+
+      await userAComponents.conversationSidebar().clickConnectButton();
+      await userAPages.startUI().searchInput.fill(partialUsername);
+      const searchResult = userAPages.startUI().getSearchResultForSpecificUser(userB.fullName);
+      await expect(searchResult).toBeVisible();
+      await expect(searchResult).toContainText(userB.fullName);
+    },
+  );
+
+  // TODO: blocked by [WPB-222687] - search result remains empty
+  test.skip(
+    'Verify search by username with at (@) symbol',
+    {tag: ['@TC-1658', '@regression']},
+    async ({createUser, createPage}) => {
+      const [userA, userB] = await Promise.all([createUser(), createUser()]);
+      const userAPageManager = await PageManager.from(createPage(withLogin(userA)));
+      const userAPages = userAPageManager.webapp.pages;
+
+      const conversationName = 'Group conversation';
+      await createGroup(userAPages, conversationName, [userB]);
+      await userAPages.conversationList().openConversation(conversationName);
+      await userAPages.conversation().sendMessage('@' + userB.username + 'Group message with mention of User B');
+      await userAPages.conversationList().searchConversation('@' + userB.username);
+
+      await expect(userAPages.conversationList().getConversationLocator(conversationName)).toBeVisible();
+      await expect(userAPages.conversationList().getConversationLocator(userB.fullName)).toBeVisible();
+    },
+  );
+
+  test(
+    'Verify result for direct hit is shown on top when searching for unique username',
+    {tag: ['@TC-1662', '@regression']},
+    async ({createUser, createPage}) => {
+      const [userA, userB] = await Promise.all([createUser(), createUser()]);
+      const userAPageManager = await PageManager.from(createPage(withLogin(userA)));
+      const {pages: userAPages, components: userAComponents} = userAPageManager.webapp;
+
+      await userAComponents.conversationSidebar().clickConnectButton();
+      await userAPages.startUI().searchInput.fill('@' + userB.username);
+      const searchResult = userAPages.startUI().getSearchResultForSpecificUser(userB.fullName);
+      await expect(searchResult).toBeVisible();
+      await expect(userAPages.startUI().searchResults).toHaveCount(1);
+    },
+  );
+
+  test(
+    'I want to see search result when searching for unique username without @ in the beginning',
+    {tag: ['@TC-1665', '@regression']},
+    async ({createUser, createPage}) => {
+      const [userA, userB] = await Promise.all([createUser(), createUser()]);
+      const userAPageManager = await PageManager.from(createPage(withLogin(userA)));
+      const {pages: userAPages, components: userAComponents} = userAPageManager.webapp;
+
+      await userAComponents.conversationSidebar().clickConnectButton();
+      await userAPages.startUI().searchInput.fill(userB.username);
+      const searchResult = userAPages.startUI().getSearchResultForSpecificUser(userB.fullName);
+      await expect(searchResult).toBeVisible();
+      await expect(searchResult).toContainText(userB.fullName);
+    },
+  );
+});

--- a/apps/webapp/test/e2e_tests/specs/Search/search.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Search/search.spec.ts
@@ -51,8 +51,8 @@ test.describe('Search', () => {
       const conversationName = 'Group conversation';
       await createGroup(userAPages, conversationName, [userB]);
       await userAPages.conversationList().openConversation(conversationName);
-      await userAPages.conversation().sendMessage('@' + userB.username + 'Group message with mention of User B');
-      await userAPages.conversationList().searchConversation('@' + userB.username);
+      await userAPages.conversation().sendMessage(`@${userB.username} Group message with mention of User B`);
+      await userAPages.conversationList().searchConversation(`@${userB.username}`);
 
       await expect(userAPages.conversationList().getConversationLocator(conversationName)).toBeVisible();
       await expect(userAPages.conversationList().getConversationLocator(userB.fullName)).toBeVisible();


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19967" title="WPB-19967" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19967</a>  [Web/QA] Write the Search regression tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Add search regression tests.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Notes for reviewers
The test case TC-1658 regarding search by username with '@' symbol
(mentions context) is currently skipped due to bug [WPB-222687].
