### PR TITLE
test(WPB-19934): fix and refactor Accessibility tests

### DIFF
--- a/apps/webapp/src/script/components/TitleBar/TitleBar.tsx
+++ b/apps/webapp/src/script/components/TitleBar/TitleBar.tsx
@@ -263,6 +263,7 @@ export const TitleBar = ({
             className="conversation-title-bar-icon icon-back"
             css={{marginBottom: 0}}
             onClick={setLeftSidebar}
+            aria-label={t('index.goBack')}
           />
         )}
 

--- a/apps/webapp/test/e2e_tests/pageManager/index.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/index.ts
@@ -152,6 +152,7 @@ export class PageManager {
       singleSignOn: () => this.getOrCreate('webapp.pages.singleSignOn', () => new SingleSignOnPage(this.page)),
       welcome: () => this.getOrCreate('webapp.pages.welcome', () => new WelcomePage(this.page)),
       registration: () => this.getOrCreate('webapp.pages.registration', () => new RegistrationPage(this.page)),
+      sidebar: () => this.getOrCreate('webapp.pages.sidebar', () => new ConversationSidebar(this.page)),
       startUI: () => this.getOrCreate('webapp.pages.startUI', () => new StartUIPage(this.page)),
       account: () => this.getOrCreate('webapp.pages.account', () => new AccountPage(this.page)),
       conversationList: () =>

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -30,10 +30,8 @@ type EmojiReaction = 'plus-one' | 'heart' | 'joy';
 export class ConversationPage {
   readonly page: Page;
 
-  readonly createGroupModal: Locator;
-  readonly createGroupButton: Locator;
-  readonly createGroupNameInput: Locator;
-  readonly createGroupSubmitButton: Locator;
+  /** The back button is shown on narrow screens e.g. phones to navigate back to the conversation list */
+  readonly backButton: Locator;
   readonly messageInput: Locator;
   readonly sendMessageButton: Locator;
   readonly searchButton: Locator;
@@ -58,7 +56,7 @@ export class ConversationPage {
   readonly messageDetails: Locator;
   readonly messageItems: Locator;
   readonly filesTab: Locator;
-  readonly isTypingIndicator: Locator;
+  readonly typingIndicator: Locator;
   readonly itemPendingRequest: Locator;
   readonly ignoreButton: Locator;
   readonly cancelRequest: Locator;
@@ -74,10 +72,7 @@ export class ConversationPage {
   constructor(page: Page) {
     this.page = page;
 
-    this.createGroupButton = page.locator(selectByDataAttribute('go-create-group'));
-    this.createGroupModal = page.locator(selectByDataAttribute('group-creation-label'));
-    this.createGroupNameInput = this.createGroupModal.locator(selectByDataAttribute('enter-group-name'));
-    this.createGroupSubmitButton = this.createGroupModal.locator(selectByDataAttribute('submit'));
+    this.backButton = page.getByRole('button', {name: 'Go Back'});
     this.messageInput = page.locator(selectByDataAttribute('input-message'));
     this.watermark = page.locator(`${selectByDataAttribute('no-conversation')} svg`);
     this.sendMessageButton = page.locator(selectByDataAttribute('do-send-message'));
@@ -108,7 +103,7 @@ export class ConversationPage {
     );
     this.messageDetails = page.locator('#message-details');
     this.filesTab = page.locator('#conversation-tab-files');
-    this.isTypingIndicator = page.locator(selectByDataAttribute('typing-indicator-title'));
+    this.typingIndicator = page.locator(selectByDataAttribute('typing-indicator-title'));
     this.itemPendingRequest = page.locator(selectByDataAttribute('item-pending-requests'));
     this.ignoreButton = page.getByTestId('do-ignore');
     this.cancelRequest = page.getByTestId('do-cancel-request');
@@ -164,12 +159,6 @@ export class ConversationPage {
     await this.messageInput.click();
     // Use pressSequentially which simulates realistic typing with built-in delays
     await this.messageInput.pressSequentially(message, {delay: 100});
-  }
-
-  async createGroup(groupName: string) {
-    await this.createGroupButton.click();
-    await this.createGroupNameInput.fill(groupName);
-    await this.createGroupSubmitButton.click();
   }
 
   async replyToMessage(message: Locator) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19934" title="WPB-19934" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19934</a>  [Web/QA] Write the "accessibility" regression tests to playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- Refactor Accessibility tests to the latest test setup
- Fix existing tests to test the intended behavior and pass
- Improve accessibility on narrow screens by adding a label to back icon button
- Remove some unused locators

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Notes for reviewers

- The sidebar was intentionally exposed on the pages object. This is an attempt to declutter our current PageManager setup where the "pages" already contain almost all components like the ConversationList as page. The end goal is to only have one flat object instead of differentiating between pages, modals and components as separate objects.
