### PR TITLE
chore(nx): fix eslint setup for monorepo, remove old eslint config in core [WPB-18162]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install JS dependencies
         run: yarn --immutable
 
+      - name: Build libraries
+        run: yarn nx run-many -t build --projects=tag:type:lib
+
       - name: Lint
         run: yarn nx run-many -t lint --all
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -51,12 +51,29 @@ const ignores = [
   'libraries/core/lib/',
   'libraries/core/.tmp/',
   'libraries/core/src/demo/',
+  'libraries/core/src/test/',
+  '**/jest.setup.ts',
 ];
 
 const base = compat.extends('@wireapp/eslint-config');
+// Remove 'project' from parserOptions in all base configs to avoid conflict with projectService
+const cleanedBase = base.map(cfg => {
+  if (cfg.languageOptions?.parserOptions) {
+    const parserOptions = cfg.languageOptions.parserOptions as Record<string, unknown>;
+    const {project, ...rest} = parserOptions;
+    return {
+      ...cfg,
+      languageOptions: {
+        ...cfg.languageOptions,
+        parserOptions: rest,
+      },
+    };
+  }
+  return cfg;
+});
 const config: Linter.Config[] = [
   {ignores},
-  ...base,
+  ...cleanedBase,
   {
     // Adjust legacy bits from extended config
     rules: {
@@ -70,12 +87,9 @@ const config: Linter.Config[] = [
     languageOptions: {
       parser: tsParser,
       parserOptions: {
-        // Enable type-aware linting for TypeScript sources
-        project: './tsconfig.eslint.json',
+        // Enable type-aware linting for TypeScript sources with project references support
+        projectService: true,
         tsconfigRootDir: __dirname,
-        EXPERIMENTAL_useProjectService: {
-          allowDefaultProjectForFiles: ['*.ts', '*.tsx'],
-        },
       },
       globals: {
         ...globals.browser,
@@ -151,7 +165,6 @@ const config: Linter.Config[] = [
       'import/resolver': {
         typescript: {
           alwaysTryTypes: true,
-          project: path.join(__dirname, 'tsconfig.eslint.json'),
         },
         node: {
           extensions: ['.js', '.jsx', '.ts', '.tsx'],

--- a/libraries/core/.eslintrc.json
+++ b/libraries/core/.eslintrc.json
@@ -1,7 +1,0 @@
-{
-  "extends": ["../../eslint.config.ts"],
-  "parserOptions": {
-    "project": "./tsconfig.eslint.json",
-    "tsconfigRootDir": "."
-  }
-}

--- a/libraries/core/src/demo/index.html
+++ b/libraries/core/src/demo/index.html
@@ -1,10 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <!-- Wire, Copyright (C) 2018 Wire Swiss GmbH -->
 <html>
   <head>
-    <meta charset="UTF-8"/>
+    <meta charset="UTF-8" />
     <title>Demo</title>
-    <link rel="shortcut icon" href="data:image/x-icon;" type="image/x-icon"/>
+    <link rel="shortcut icon" href="data:image/x-icon;" type="image/x-icon" />
     <script src="../../dist/core.bundle.js"></script>
   </head>
   <body>

--- a/libraries/core/tsconfig.eslint.json
+++ b/libraries/core/tsconfig.eslint.json
@@ -1,5 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src", "jest.setup.ts"],
-  "exclude": []
-}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -24,7 +24,8 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "apps/*": ["apps/*"]
+      "apps/*": ["apps/*"],
+      "@wireapp/core/lib/*": ["libraries/core/src/*"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18162" title="WPB-18162" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18162</a>  [Web] Monorepo - Phase 1 - Webapp setup
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


# Pull Request

## Summary

- There was still an old eslint config in the core package, which made issues.  Removed it. 
- Change eslint to use the new "projectService" config instead if "project"

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
