### PR TITLE
fix: update background color for focus-visible on inactive buttons [WPB-21269]

### DIFF
--- a/apps/webapp/src/script/components/calling/VideoControls/VideoControls.styles.ts
+++ b/apps/webapp/src/script/components/calling/VideoControls/VideoControls.styles.ts
@@ -55,6 +55,7 @@ export const videoControlActiveStyles = css`
     background-color: var(--background);
   }
   &:focus-visible {
+    background-color: var(--background);
     outline: 2px solid var(--accent-color-focus);
   }
   &:active:not(:disabled) {
@@ -85,6 +86,7 @@ export const videoControlInActiveStyles = css`
     background-color: var(--inactive-call-button-hover-bg);
   }
   &:focus-visible {
+    background-color: var(--inactive-call-button-hover-bg);
     outline: 2px solid var(--accent-color-focus);
   }
   &:active:not(:disabled) {

--- a/apps/webapp/src/style/foundation/video-calling.less
+++ b/apps/webapp/src/style/foundation/video-calling.less
@@ -227,33 +227,42 @@
     &--red {
       border: 1px solid var(--red-500);
       background-color: var(--red-500);
+
       svg > path {
         fill: var(--app-bg-secondary);
       }
+
       &:focus-visible {
+        background-color: @red-600;
         outline: 2px solid @red-300;
         outline-offset: 1px;
 
         body.theme-dark & {
+          background-color: @red-dark-400;
           outline: 2px solid @red-dark-300;
         }
       }
+
       &:hover:not(:disabled) {
         border-color: @red-600;
         background-color: @red-600;
+
         body.theme-dark & {
           border-color: @red-dark-400;
           background-color: @red-dark-400;
         }
       }
+
       &:active:not(:disabled) {
         border-color: @red-700;
         background-color: @red-700;
+
         body.theme-dark & {
           border-color: @red-dark-500;
           background-color: var(--red-500);
         }
       }
+
       &:disabled {
         cursor: not-allowed;
         opacity: 0.5;
@@ -270,16 +279,14 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    animation:
-      flyUp 2.5s linear forwards,
-      fadeIn 1s;
+    animation: flyUp 2.5s linear forwards,
+    fadeIn 1s;
     font-size: 2rem;
     gap: 0.1rem;
 
     @media (min-height: 1070) {
-      animation:
-        flyUp 3.5s linear forwards,
-        fadeIn 1s;
+      animation: flyUp 3.5s linear forwards,
+      fadeIn 1s;
     }
   }
 
@@ -339,6 +346,7 @@
   background-color: var(--inactive-call-button-bg);
   cursor: pointer;
   line-height: 0;
+
   > svg {
     fill: var(--main-color);
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21269" title="WPB-21269" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21269</a>  [Web] Calling - Contrast of the focus border is difficult to see when buttons are activated
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary
update background color for focus-visible on inactive buttons

- What did I change and why?
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
