### PR TITLE
chore(nx): fix the docker file [WPB-18162]

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -9,9 +9,13 @@ WORKDIR /app
 COPY package.json yarn.lock .yarnrc.yml .npmrc* ./
 COPY .yarn ./.yarn
 COPY apps/server/package.json ./apps/server/package.json
+COPY libraries/config/package.json ./libraries/config/package.json
 
 # Install only server production deps
 RUN yarn workspaces focus @wireapp/server --production
+
+# Copy built config library artifacts
+COPY libraries/config/lib ./libraries/config/lib
 
 # Copy built server artifacts and runtime files
 COPY apps/server/dist /dist


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18162" title="WPB-18162" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18162</a>  [Web] Monorepo - Phase 1 - Webapp setup
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Docker deployment failed since the docker file ran into a build issue

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
