### PR TITLE
test(WPB-20613): fix critical flow test for 1 on 1 calls TC-8754

### DIFF
--- a/apps/webapp/playwright.config.ts
+++ b/apps/webapp/playwright.config.ts
@@ -69,7 +69,11 @@ module.exports = defineConfig({
         channel: 'chrome',
         headless: process.env.HEADLESS !== 'false',
         launchOptions: {
-          args: ['--use-fake-device-for-media-stream', '--use-fake-ui-for-media-stream'],
+          args: [
+            '--use-fake-device-for-media-stream', // Provide fake devices for audio & video device input
+            '--use-fake-ui-for-media-stream', // Bypasses the popup to grant permission and select video / audio input device by automatically selecting the default one
+            '--mute-audio', // Mute all audio output from the test browser because e.g. the ringtone of a call can be annoying during testing
+          ],
         },
       }, // or 'chrome-beta'
     },

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/audioVideoSettings.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/audioVideoSettings.page.ts
@@ -22,52 +22,51 @@ import {Locator, Page} from '@playwright/test';
 export class AudioVideoSettingsPage {
   readonly page: Page;
 
-  readonly microphoneDrowdown: Locator;
-  readonly speakerDrowdown: Locator;
-
-  readonly cameraDrowdown: Locator;
+  readonly microphoneDropdown: Locator;
+  readonly speakerDropdown: Locator;
+  readonly cameraDropdown: Locator;
 
   constructor(page: Page) {
     this.page = page;
 
-    this.microphoneDrowdown = page.locator('[data-uie-name="enter-microphone"]');
-    this.speakerDrowdown = page.locator('[data-uie-name="enter-speaker"]');
-    this.cameraDrowdown = page.locator('[data-uie-name="enter-camera"]');
+    this.microphoneDropdown = page.locator('[data-uie-name="enter-microphone"]');
+    this.speakerDropdown = page.locator('[data-uie-name="enter-speaker"]');
+    this.cameraDropdown = page.locator('[data-uie-name="enter-camera"]');
   }
 
   async selectMicrophone(microphoneName: string) {
     // The Select component doesn't implement the disabled state correctly so we need to use this workaround
-    await this.microphoneDrowdown.getByRole('combobox', {name: 'Microphone'}).isEditable();
-    await this.microphoneDrowdown.click();
+    await this.microphoneDropdown.getByRole('combobox', {name: 'Microphone'}).isEditable();
+    await this.microphoneDropdown.click();
     await this.page.getByRole('listbox').getByRole('option', {name: microphoneName}).click();
   }
 
   async isMicrophoneSetTo(expectedMicrophoneName: string) {
-    const selectedMicrophone = await this.microphoneDrowdown.getByText(expectedMicrophoneName, {exact: true});
+    const selectedMicrophone = await this.microphoneDropdown.getByText(expectedMicrophoneName, {exact: true});
     return selectedMicrophone.isVisible();
   }
 
   async selectSpeaker(speakerName: string) {
     // The Select component doesn't implement the disabled state correctly so we need to use this workaround
-    await this.speakerDrowdown.getByRole('combobox', {name: 'Speakers'}).isEditable();
-    await this.speakerDrowdown.click();
+    await this.speakerDropdown.getByRole('combobox', {name: 'Speakers'}).isEditable();
+    await this.speakerDropdown.click();
     await this.page.getByRole('listbox').getByRole('option', {name: speakerName}).click();
   }
 
   async isSpeakerSetTo(expectedSpeakerName: string) {
-    const selectedSpeaker = await this.speakerDrowdown.getByText(expectedSpeakerName, {exact: true});
+    const selectedSpeaker = await this.speakerDropdown.getByText(expectedSpeakerName, {exact: true});
     return selectedSpeaker.isVisible();
   }
 
   async selectCamera(cameraName: string) {
     // The Select component doesn't implement the disabled state correctly so we need to use this workaround
-    await this.cameraDrowdown.getByRole('combobox', {name: 'Camera'}).isEditable();
-    await this.cameraDrowdown.click();
+    await this.cameraDropdown.getByRole('combobox', {name: 'Camera'}).isEditable();
+    await this.cameraDropdown.click();
     await this.page.getByRole('listbox').getByRole('option', {name: cameraName}).click();
   }
 
   async isCameraSetTo(expectedCameraName: string) {
-    const selectedCamera = await this.cameraDrowdown.getByText(expectedCameraName, {exact: true});
+    const selectedCamera = await this.cameraDropdown.getByText(expectedCameraName, {exact: true});
     return selectedCamera.isVisible();
   }
 }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/audioVideoSettings.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/audioVideoSettings.page.ts
@@ -36,8 +36,10 @@ export class AudioVideoSettingsPage {
   }
 
   async selectMicrophone(microphoneName: string) {
+    // The Select component doesn't implement the disabled state correctly so we need to use this workaround
+    await this.microphoneDrowdown.getByRole('combobox', {name: 'Microphone'}).isEditable();
     await this.microphoneDrowdown.click();
-    await this.page.locator(`[data-uie-name="option-enter-microphone"]`).filter({hasText: microphoneName}).click();
+    await this.page.getByRole('listbox').getByRole('option', {name: microphoneName}).click();
   }
 
   async isMicrophoneSetTo(expectedMicrophoneName: string) {
@@ -46,8 +48,10 @@ export class AudioVideoSettingsPage {
   }
 
   async selectSpeaker(speakerName: string) {
+    // The Select component doesn't implement the disabled state correctly so we need to use this workaround
+    await this.speakerDrowdown.getByRole('combobox', {name: 'Speakers'}).isEditable();
     await this.speakerDrowdown.click();
-    await this.page.locator(`[data-uie-name="option-enter-speaker"]`).filter({hasText: speakerName}).click();
+    await this.page.getByRole('listbox').getByRole('option', {name: speakerName}).click();
   }
 
   async isSpeakerSetTo(expectedSpeakerName: string) {
@@ -56,8 +60,10 @@ export class AudioVideoSettingsPage {
   }
 
   async selectCamera(cameraName: string) {
+    // The Select component doesn't implement the disabled state correctly so we need to use this workaround
+    await this.cameraDrowdown.getByRole('combobox', {name: 'Camera'}).isEditable();
     await this.cameraDrowdown.click();
-    await this.page.locator(`[data-uie-name="option-enter-camera"]`).filter({hasText: cameraName}).click();
+    await this.page.getByRole('listbox').getByRole('option', {name: cameraName}).click();
   }
 
   async isCameraSetTo(expectedCameraName: string) {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/audioVideoSettings.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/audioVideoSettings.page.ts
@@ -37,7 +37,7 @@ export class AudioVideoSettingsPage {
 
   async selectMicrophone(microphoneName: string) {
     await this.microphoneDrowdown.click();
-    await this.getMicrophoneOptions().locator(`text=${microphoneName}`).click();
+    await this.page.locator(`[data-uie-name="option-enter-microphone"]`).filter({hasText: microphoneName}).click();
   }
 
   async isMicrophoneSetTo(expectedMicrophoneName: string) {
@@ -47,7 +47,7 @@ export class AudioVideoSettingsPage {
 
   async selectSpeaker(speakerName: string) {
     await this.speakerDrowdown.click();
-    await this.getSpeakerOptions().locator(`text=${speakerName}`).click();
+    await this.page.locator(`[data-uie-name="option-enter-speaker"]`).filter({hasText: speakerName}).click();
   }
 
   async isSpeakerSetTo(expectedSpeakerName: string) {
@@ -57,23 +57,11 @@ export class AudioVideoSettingsPage {
 
   async selectCamera(cameraName: string) {
     await this.cameraDrowdown.click();
-    await this.getCameraOptions().locator(`text=${cameraName}`).click();
+    await this.page.locator(`[data-uie-name="option-enter-camera"]`).filter({hasText: cameraName}).click();
   }
 
   async isCameraSetTo(expectedCameraName: string) {
     const selectedCamera = await this.cameraDrowdown.getByText(expectedCameraName, {exact: true});
     return selectedCamera.isVisible();
-  }
-
-  private getMicrophoneOptions(): Locator {
-    return this.page.locator(`[data-uie-name="option-enter-microphone"]`);
-  }
-
-  private getSpeakerOptions(): Locator {
-    return this.page.locator(`[data-uie-name="option-enter-speaker"]`);
-  }
-
-  private getCameraOptions(): Locator {
-    return this.page.locator(`[data-uie-name="option-enter-camera"]`);
   }
 }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/audioVideoSettings.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/audioVideoSettings.page.ts
@@ -42,7 +42,7 @@ export class AudioVideoSettingsPage {
   }
 
   async isMicrophoneSetTo(expectedMicrophoneName: string) {
-    const selectedMicrophone = await this.microphoneDropdown.getByText(expectedMicrophoneName, {exact: true});
+    const selectedMicrophone = this.microphoneDropdown.getByText(expectedMicrophoneName, {exact: true});
     return selectedMicrophone.isVisible();
   }
 
@@ -54,7 +54,7 @@ export class AudioVideoSettingsPage {
   }
 
   async isSpeakerSetTo(expectedSpeakerName: string) {
-    const selectedSpeaker = await this.speakerDropdown.getByText(expectedSpeakerName, {exact: true});
+    const selectedSpeaker = this.speakerDropdown.getByText(expectedSpeakerName, {exact: true});
     return selectedSpeaker.isVisible();
   }
 
@@ -66,7 +66,7 @@ export class AudioVideoSettingsPage {
   }
 
   async isCameraSetTo(expectedCameraName: string) {
-    const selectedCamera = await this.cameraDropdown.getByText(expectedCameraName, {exact: true});
+    const selectedCamera = this.cameraDropdown.getByText(expectedCameraName, {exact: true});
     return selectedCamera.isVisible();
   }
 }

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/accountManagement-TC-8639.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/accountManagement-TC-8639.spec.ts
@@ -18,7 +18,6 @@
  */
 
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {addMockCamerasToContext} from 'test/e2e_tests/utils/mockVideoDevice.util';
 
 import {expect, test, withLogin} from '../../test.fixtures';
 import {generateSecurePassword, generateWireEmail} from '../../utils/userDataGenerator';
@@ -26,11 +25,9 @@ import {loginUser} from 'test/e2e_tests/utils/userActions';
 
 const appLockPassphrase = generateSecurePassword();
 
-test('Account Management', {tag: ['@TC-8639', '@crit-flow-web']}, async ({context, createUser, createPage, api}) => {
-  await addMockCamerasToContext(context);
-
+test('Account Management', {tag: ['@TC-8639', '@crit-flow-web']}, async ({createUser, createPage, api}) => {
   const user = await createUser();
-  const pageManager = PageManager.from(await createPage(context, withLogin(user)));
+  const pageManager = PageManager.from(await createPage(withLogin(user)));
   const {pages, modals, components} = pageManager.webapp;
 
   await test.step('Member opens settings', async () => {

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsCall-TC-8755.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsCall-TC-8755.spec.ts
@@ -19,7 +19,6 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {addMockCamerasToContext} from 'test/e2e_tests/utils/mockVideoDevice.util';
 
 import {test, expect, withLogin} from '../../test.fixtures';
 import {createGroup} from 'test/e2e_tests/utils/userActions';
@@ -50,11 +49,8 @@ test.fixme(
 
       // Create page managers for both owner and member
       // Member page manager is needed for the channel/calling service to work properly
-      await Promise.all([
-        PageManager.from(createPage(withLogin(owner))).then(async pm => {
-          ownerPageManager = pm;
-          await addMockCamerasToContext(ownerPageManager.getContext());
-        }),
+      [ownerPageManager] = await Promise.all([
+        PageManager.from(createPage(withLogin(owner))),
         // Member logs in but calling service handles call participation
         createPage(withLogin(member)),
       ]);

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupVideoCall-TC-8637.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupVideoCall-TC-8637.spec.ts
@@ -19,7 +19,6 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {addMockCamerasToContext} from 'test/e2e_tests/utils/mockVideoDevice.util';
 
 import {test, expect, withLogin, withConnectionRequest} from '../../test.fixtures';
 import {createGroup} from 'test/e2e_tests/utils/userActions';
@@ -50,10 +49,7 @@ test.fixme(
       guestUser = await createUser();
 
       const [pmOwner, pmGuest] = await Promise.all([
-        PageManager.from(createPage(withLogin(teamOwner), withConnectionRequest(guestUser))).then(async pm => {
-          await addMockCamerasToContext(pm.getContext());
-          return pm;
-        }),
+        PageManager.from(createPage(withLogin(teamOwner), withConnectionRequest(guestUser))),
         PageManager.from(createPage(withLogin(guestUser))),
       ]);
       ownerPageManager = pmOwner;

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/oneOnOneCall-TC-8754.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/oneOnOneCall-TC-8754.spec.ts
@@ -19,14 +19,13 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {addMockCamerasToContext} from 'test/e2e_tests/utils/mockVideoDevice.util';
 
 import {test, expect, withLogin, withConnectionRequest} from '../../test.fixtures';
 
 test(
   '1:1 Video call with device switch and screenshare',
   {tag: ['@TC-8754', '@crit-flow-web']},
-  async ({createTeam, createPage, browser, api}) => {
+  async ({createTeam, createPage, api}) => {
     test.setTimeout(150_000);
 
     let ownerA: User;
@@ -40,10 +39,8 @@ test(
       ownerA = teamA.owner;
       ownerB = teamB.owner;
 
-      const userAContext = await browser.newContext();
-      await addMockCamerasToContext(userAContext);
       const [pmA, pmB] = await Promise.all([
-        PageManager.from(createPage(userAContext, withLogin(ownerA), withConnectionRequest(ownerB))),
+        PageManager.from(createPage(withLogin(ownerA), withConnectionRequest(ownerB))),
         PageManager.from(createPage(withLogin(ownerB))),
       ]);
       ownerAPageManager = pmA;

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/oneOnOneCall-TC-8754.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/oneOnOneCall-TC-8754.spec.ts
@@ -28,11 +28,11 @@ test(
     test.setTimeout(150_000);
 
     const [{owner: userA}, {owner: userB}] = await Promise.all([createTeam('User A Team'), createTeam('User B Team')]);
-    const [userAPageManager, userBPageManager, callingServiceInstanceId] = await Promise.all([
+    const [userAPageManager, userBPageManager] = await Promise.all([
       PageManager.from(createPage(withLogin(userA), withConnectionRequest(userB))),
       PageManager.from(createPage(withLogin(userB))),
-      api.callingService.createInstance(userB.password, userB.email).then(res => res.id),
     ]);
+    const {id: callingServiceInstanceId} = await api.callingService.createInstance(userB.password, userB.email);
 
     await test.step('User B accepts connection request from User A', async () => {
       const {pages} = userBPageManager.webapp;

--- a/apps/webapp/test/e2e_tests/specs/noInternetCallGuard.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/noInternetCallGuard.spec.ts
@@ -19,12 +19,12 @@
 
 import {getUser} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {addMockCamerasToContext} from 'test/e2e_tests/utils/mockVideoDevice.util';
 import {addCreatedTeam, removeCreatedTeam} from 'test/e2e_tests/utils/tearDown.util';
 import {loginUser} from 'test/e2e_tests/utils/userActions';
 
 import {expect, test} from '../test.fixtures';
 import {makeNetworkOffline, makeNetworkOnline} from '../utils/network.util';
+import {mockAudioAndVideoDevices} from '../utils/mockVideoDevice.util';
 
 let ownerA = getUser();
 let ownerB = getUser();
@@ -37,7 +37,7 @@ test('Starting call 1:1 call without internet', async ({browser, pageManager: ow
 
   const {pages: ownerAPages, modals: ownerAModals, components: ownerAComponents} = ownerAPageManager.webapp;
 
-  await addMockCamerasToContext(ownerAPageManager.getContext());
+  await ownerAPageManager.getContext().addInitScript(mockAudioAndVideoDevices);
 
   const ownerBContext = await browser.newContext();
   const ownerBPage = await ownerBContext.newPage();

--- a/apps/webapp/test/e2e_tests/test.fixtures.ts
+++ b/apps/webapp/test/e2e_tests/test.fixtures.ts
@@ -23,6 +23,7 @@ import {ApiManagerE2E} from './backend/apiManager.e2e';
 import {getUser, User} from './data/user';
 import {PageManager} from './pageManager';
 import {connectWithUser, sendConnectionRequest} from './utils/userActions';
+import {mockAudioAndVideoDevices} from './utils/mockVideoDevice.util';
 
 type PagePlugin = (page: Page) => void | Promise<void>;
 
@@ -90,6 +91,9 @@ export const test = baseTest.extend<Fixtures>({
         context = firstParam;
         setupFns = plugins;
       }
+
+      // Add mocked Audio and Video devices (Hardware is treated as part of the test setup)
+      await context.addInitScript(mockAudioAndVideoDevices);
 
       const page = await context.newPage();
       for (const setupFn of setupFns) {

--- a/apps/webapp/test/e2e_tests/utils/mockVideoDevice.util.ts
+++ b/apps/webapp/test/e2e_tests/utils/mockVideoDevice.util.ts
@@ -26,8 +26,11 @@
  * No matter which of the devices is selected the default input is returned. (The default input is mocked via launchArgs in the playwright config)
  */
 export const mockAudioAndVideoDevices = () => {
+  // If media devices aren't defined on the current device there's nothing to mock
+  if (!navigator.mediaDevices) return;
+
   // Keep a copy of the original function so it can be used within its own stub
-  const originalGetUserMedia = navigator.mediaDevices?.getUserMedia.bind(navigator.mediaDevices);
+  const originalGetUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
 
   // Mock the devices the browser sees, 3 for each device type
   navigator.mediaDevices.enumerateDevices = async () => [

--- a/apps/webapp/test/e2e_tests/utils/mockVideoDevice.util.ts
+++ b/apps/webapp/test/e2e_tests/utils/mockVideoDevice.util.ts
@@ -24,88 +24,37 @@ export async function addMockCamerasToContext(context: BrowserContext): Promise<
   await context.addInitScript(() => {
     const originalGetUserMedia = navigator.mediaDevices?.getUserMedia.bind(navigator.mediaDevices);
 
-    navigator.mediaDevices.enumerateDevices = async () => {
-      return [
-        {
-          deviceId: 'default',
-          kind: 'videoinput',
-          label: 'Fake Camera 1',
-          groupId: 'video-group-1',
-          toJSON: () => '{}',
-          __proto__: MediaDeviceInfo.prototype,
-        },
-        {
-          deviceId: 'video-2',
-          kind: 'videoinput',
-          label: 'Fake Camera 2',
-          groupId: 'video-group-2',
-          toJSON: () => '{}',
-          __proto__: MediaDeviceInfo.prototype,
-        },
-        {
-          deviceId: 'video-3',
-          kind: 'videoinput',
-          label: 'Fake Camera 3',
-          groupId: 'video-group-3',
-          toJSON: () => '{}',
-          __proto__: MediaDeviceInfo.prototype,
-        },
+    navigator.mediaDevices.enumerateDevices = async () => [
+      // Create 3 fake cameras
+      ...Array.from<unknown, MediaDeviceInfo>({length: 3}, (_, i) => ({
+        deviceId: `video-camera-${i + 1}`,
+        kind: 'videoinput',
+        label: `Fake Camera ${i + 1}`,
+        groupId: `video-group-${i + 1}`,
+        toJSON: () => `{ "deviceId": "video-camera-${i + 1}" }`,
+      })),
 
-        {
-          deviceId: 'default',
-          kind: 'audioinput',
-          label: 'Fake Audio Input 1',
-          groupId: 'audio-input-group-1',
-          toJSON: () => '{}',
-          __proto__: MediaDeviceInfo.prototype,
-        },
-        {
-          deviceId: 'audio-input-2',
-          kind: 'audioinput',
-          label: 'Fake Audio Input 2',
-          groupId: 'audio-input-group-2',
-          toJSON: () => '{}',
-          __proto__: MediaDeviceInfo.prototype,
-        },
-        {
-          deviceId: 'audio-input-3',
-          kind: 'audioinput',
-          label: 'Fake Audio Input 3',
-          groupId: 'audio-input-group-3',
-          toJSON: () => '{}',
-          __proto__: MediaDeviceInfo.prototype,
-        },
+      // Create 3 fake audio inputs
+      ...Array.from<unknown, MediaDeviceInfo>({length: 3}, (_, i) => ({
+        deviceId: `audio-input-${i + 1}`,
+        kind: 'audioinput',
+        label: `Fake Audio Input ${i + 1}`,
+        groupId: `audio-input-group-${i + 1}`,
+        toJSON: () => `{ "deviceId": "audio-input-${i + 1}" }`,
+      })),
 
-        {
-          deviceId: 'default',
-          kind: 'audiooutput',
-          label: 'Fake Audio Output 1',
-          groupId: 'audio-output-group-1',
-          toJSON: () => '{}',
-          __proto__: MediaDeviceInfo.prototype,
-        },
-        {
-          deviceId: 'audio-output-2',
-          kind: 'audiooutput',
-          label: 'Fake Audio Output 2',
-          groupId: 'audio-output-group-2',
-          toJSON: () => '{}',
-          __proto__: MediaDeviceInfo.prototype,
-        },
-        {
-          deviceId: 'audio-output-3',
-          kind: 'audiooutput',
-          label: 'Fake Audio Output 3',
-          groupId: 'audio-output-group-3',
-          toJSON: () => '{}',
-          __proto__: MediaDeviceInfo.prototype,
-        },
-      ];
-    };
+      // Create 3 fake audio outputs
+      ...Array.from<unknown, MediaDeviceInfo>({length: 3}, (_, i) => ({
+        deviceId: `audio-output-${i + 1}`,
+        kind: 'audiooutput',
+        label: `Fake Audio Output ${i + 1}`,
+        groupId: `audio-output-group-${i + 1}`,
+        toJSON: () => `{ "deviceId": "audio-output-${i + 1}" }`,
+      })),
+    ];
 
     navigator.mediaDevices.getUserMedia = async () => {
-      const stream = await originalGetUserMedia({audio: {deviceId: 'default'}, video: {deviceId: 'default'}});
-      return stream;
+      return await originalGetUserMedia({audio: {deviceId: 'default'}, video: {deviceId: 'default'}});
     };
   });
 }

--- a/apps/webapp/test/e2e_tests/utils/mockVideoDevice.util.ts
+++ b/apps/webapp/test/e2e_tests/utils/mockVideoDevice.util.ts
@@ -40,7 +40,7 @@ export const mockAudioAndVideoDevices = () => {
       kind: 'videoinput',
       label: `Fake Camera ${i + 1}`,
       groupId: `video-group-${i + 1}`,
-      toJSON: () => `{ "deviceId": "video-camera-${i + 1}" }`,
+      toJSON: () => ({deviceId: `video-camera-${i + 1}`}),
     })),
 
     // Create 3 fake audio inputs
@@ -49,7 +49,7 @@ export const mockAudioAndVideoDevices = () => {
       kind: 'audioinput',
       label: `Fake Audio Input ${i + 1}`,
       groupId: `audio-input-group-${i + 1}`,
-      toJSON: () => `{ "deviceId": "audio-input-${i + 1}" }`,
+      toJSON: () => ({deviceId: `audio-input-${i + 1}`}),
     })),
 
     // Create 3 fake audio outputs
@@ -58,7 +58,7 @@ export const mockAudioAndVideoDevices = () => {
       kind: 'audiooutput',
       label: `Fake Audio Output ${i + 1}`,
       groupId: `audio-output-group-${i + 1}`,
-      toJSON: () => `{ "deviceId": "audio-output-${i + 1}" }`,
+      toJSON: () => ({deviceId: `audio-output-${i + 1}`}),
     })),
   ];
 

--- a/apps/webapp/test/e2e_tests/utils/mockVideoDevice.util.ts
+++ b/apps/webapp/test/e2e_tests/utils/mockVideoDevice.util.ts
@@ -33,34 +33,30 @@ export const mockAudioAndVideoDevices = () => {
   const originalGetUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
 
   // Mock the devices the browser sees, 3 for each device type
-  navigator.mediaDevices.enumerateDevices = async () => [
-    // Create 3 fake cameras
-    ...Array.from<unknown, MediaDeviceInfo>({length: 3}, (_, i) => ({
-      deviceId: `video-camera-${i + 1}`,
-      kind: 'videoinput',
-      label: `Fake Camera ${i + 1}`,
-      groupId: `video-group-${i + 1}`,
-      toJSON: () => ({deviceId: `video-camera-${i + 1}`}),
-    })),
-
-    // Create 3 fake audio inputs
-    ...Array.from<unknown, MediaDeviceInfo>({length: 3}, (_, i) => ({
-      deviceId: `audio-input-${i + 1}`,
-      kind: 'audioinput',
-      label: `Fake Audio Input ${i + 1}`,
-      groupId: `audio-input-group-${i + 1}`,
-      toJSON: () => ({deviceId: `audio-input-${i + 1}`}),
-    })),
-
-    // Create 3 fake audio outputs
-    ...Array.from<unknown, MediaDeviceInfo>({length: 3}, (_, i) => ({
-      deviceId: `audio-output-${i + 1}`,
-      kind: 'audiooutput',
-      label: `Fake Audio Output ${i + 1}`,
-      groupId: `audio-output-group-${i + 1}`,
-      toJSON: () => ({deviceId: `audio-output-${i + 1}`}),
-    })),
-  ];
+  navigator.mediaDevices.enumerateDevices = async () =>
+    Array.from<never, MediaDeviceInfo[]>({length: 3}, (_, i) => [
+      {
+        deviceId: `video-camera-${i + 1}`,
+        kind: 'videoinput',
+        label: `Fake Camera ${i + 1}`,
+        groupId: `video-group-${i + 1}`,
+        toJSON: () => ({deviceId: `video-camera-${i + 1}`}),
+      },
+      {
+        deviceId: `audio-input-${i + 1}`,
+        kind: 'audioinput',
+        label: `Fake Audio Input ${i + 1}`,
+        groupId: `audio-input-group-${i + 1}`,
+        toJSON: () => ({deviceId: `audio-input-${i + 1}`}),
+      },
+      {
+        deviceId: `audio-output-${i + 1}`,
+        kind: 'audiooutput',
+        label: `Fake Audio Output ${i + 1}`,
+        groupId: `audio-output-group-${i + 1}`,
+        toJSON: () => ({deviceId: `audio-output-${i + 1}`}),
+      },
+    ]).flat();
 
   /**
    * Stub the function to always return the default audio / video stream no matter which device was requested.

--- a/apps/webapp/test/e2e_tests/utils/mockVideoDevice.util.ts
+++ b/apps/webapp/test/e2e_tests/utils/mockVideoDevice.util.ts
@@ -17,44 +17,39 @@
  *
  */
 
-import {BrowserContext} from '@playwright/test';
+export const mockAudioAndVideoDevices = () => {
+  const originalGetUserMedia = navigator.mediaDevices?.getUserMedia.bind(navigator.mediaDevices);
 
-export async function addMockCamerasToContext(context: BrowserContext): Promise<void> {
-  // Add init script to existing context
-  await context.addInitScript(() => {
-    const originalGetUserMedia = navigator.mediaDevices?.getUserMedia.bind(navigator.mediaDevices);
+  navigator.mediaDevices.enumerateDevices = async () => [
+    // Create 3 fake cameras
+    ...Array.from<unknown, MediaDeviceInfo>({length: 3}, (_, i) => ({
+      deviceId: `video-camera-${i + 1}`,
+      kind: 'videoinput',
+      label: `Fake Camera ${i + 1}`,
+      groupId: `video-group-${i + 1}`,
+      toJSON: () => `{ "deviceId": "video-camera-${i + 1}" }`,
+    })),
 
-    navigator.mediaDevices.enumerateDevices = async () => [
-      // Create 3 fake cameras
-      ...Array.from<unknown, MediaDeviceInfo>({length: 3}, (_, i) => ({
-        deviceId: `video-camera-${i + 1}`,
-        kind: 'videoinput',
-        label: `Fake Camera ${i + 1}`,
-        groupId: `video-group-${i + 1}`,
-        toJSON: () => `{ "deviceId": "video-camera-${i + 1}" }`,
-      })),
+    // Create 3 fake audio inputs
+    ...Array.from<unknown, MediaDeviceInfo>({length: 3}, (_, i) => ({
+      deviceId: `audio-input-${i + 1}`,
+      kind: 'audioinput',
+      label: `Fake Audio Input ${i + 1}`,
+      groupId: `audio-input-group-${i + 1}`,
+      toJSON: () => `{ "deviceId": "audio-input-${i + 1}" }`,
+    })),
 
-      // Create 3 fake audio inputs
-      ...Array.from<unknown, MediaDeviceInfo>({length: 3}, (_, i) => ({
-        deviceId: `audio-input-${i + 1}`,
-        kind: 'audioinput',
-        label: `Fake Audio Input ${i + 1}`,
-        groupId: `audio-input-group-${i + 1}`,
-        toJSON: () => `{ "deviceId": "audio-input-${i + 1}" }`,
-      })),
+    // Create 3 fake audio outputs
+    ...Array.from<unknown, MediaDeviceInfo>({length: 3}, (_, i) => ({
+      deviceId: `audio-output-${i + 1}`,
+      kind: 'audiooutput',
+      label: `Fake Audio Output ${i + 1}`,
+      groupId: `audio-output-group-${i + 1}`,
+      toJSON: () => `{ "deviceId": "audio-output-${i + 1}" }`,
+    })),
+  ];
 
-      // Create 3 fake audio outputs
-      ...Array.from<unknown, MediaDeviceInfo>({length: 3}, (_, i) => ({
-        deviceId: `audio-output-${i + 1}`,
-        kind: 'audiooutput',
-        label: `Fake Audio Output ${i + 1}`,
-        groupId: `audio-output-group-${i + 1}`,
-        toJSON: () => `{ "deviceId": "audio-output-${i + 1}" }`,
-      })),
-    ];
-
-    navigator.mediaDevices.getUserMedia = async () => {
-      return await originalGetUserMedia({audio: {deviceId: 'default'}, video: {deviceId: 'default'}});
-    };
-  });
-}
+  navigator.mediaDevices.getUserMedia = async () => {
+    return await originalGetUserMedia({audio: {deviceId: 'default'}, video: {deviceId: 'default'}});
+  };
+};

--- a/apps/webapp/test/e2e_tests/utils/mockVideoDevice.util.ts
+++ b/apps/webapp/test/e2e_tests/utils/mockVideoDevice.util.ts
@@ -17,9 +17,19 @@
  *
  */
 
+/**
+ * Init script to mock the available audio and video devices the browser sees.
+ *
+ * Usage: `context.addInitScript(mockAudioAndVideoDevices);`
+ *
+ * This will add 3 devices for audio in- and output as well as 3 cameras.
+ * No matter which of the devices is selected the default input is returned. (The default input is mocked via launchArgs in the playwright config)
+ */
 export const mockAudioAndVideoDevices = () => {
+  // Keep a copy of the original function so it can be used within its own stub
   const originalGetUserMedia = navigator.mediaDevices?.getUserMedia.bind(navigator.mediaDevices);
 
+  // Mock the devices the browser sees, 3 for each device type
   navigator.mediaDevices.enumerateDevices = async () => [
     // Create 3 fake cameras
     ...Array.from<unknown, MediaDeviceInfo>({length: 3}, (_, i) => ({
@@ -49,6 +59,11 @@ export const mockAudioAndVideoDevices = () => {
     })),
   ];
 
+  /**
+   * Stub the function to always return the default audio / video stream no matter which device was requested.
+   * This is necessary as only the default device gets mocked by the chrome launch args,
+   * otherwise the dummy devices defined above would show up as inputs but wouldn't work once selected.
+   */
   navigator.mediaDevices.getUserMedia = async () => {
     return await originalGetUserMedia({audio: {deviceId: 'default'}, video: {deviceId: 'default'}});
   };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20613" title="WPB-20613" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20613</a>  [Web] Find a solution of failing critical tests due to timeout.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- Refactor mocks for audio and video devices -> The fake devices now work and don't just show up in the dropdown
- Fix test for 1 on 1 calls by fixing the video mock and improving the locators for the device dropdowns
- Mute audio of the test browser so e.g. ringtones within a test don't make you think you're being called...

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Notes for reviewers

- I noticed that the `Select` component used for the audio / video in- and outputs doesn't reflect the disabled state correctly. This is heavily related to the input tag within it not really being linked to the actual value and options. I had to use a few workarounds but this should be improved at the source.