### PR TITLE
build: Add ingress to helm chart (ported from nginx-ingress-services) [WPB-22715]

### DIFF
--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Wire webapp in Kubernetes
 name: webapp
-version: 0.4.0
+version: 0.5.0

--- a/charts/webapp/templates/_helpers.tpl
+++ b/charts/webapp/templates/_helpers.tpl
@@ -33,6 +33,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   {{- if and .Values.tls.enabled (not .Values.ingress.enabled) }}
     {{- fail "ingress.enabled must be true when tls.enabled is true" }}
   {{- end }}
+  {{- if and .Values.tls.enabled (not .Values.tls.useCertManager) (empty .Values.tls.existingSecretName) }}
+    {{- fail "When tls.enabled is true, either tls.useCertManager must be true or tls.existingSecretName must be set" }}
+  {{- end }}
 {{- end -}}
 
 {{/* Get Ingress API Version */}}
@@ -63,6 +66,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{- define "webapp.certificateSecretName" -}}
 {{- printf "%s-managed-tls-certificate" (include "webapp.fullname" .) -}}
+{{- end -}}
+
+{{- define "webapp.tlsSecretName" -}}
+{{- if .Values.tls.existingSecretName -}}
+{{- .Values.tls.existingSecretName -}}
+{{- else -}}
+{{- include "webapp.certificateSecretName" . -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "webapp.issuerName" -}}

--- a/charts/webapp/templates/_helpers.tpl
+++ b/charts/webapp/templates/_helpers.tpl
@@ -38,32 +38,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   {{- end }}
 {{- end -}}
 
-{{/* Get Ingress API Version */}}
-{{- define "ingress.apiVersion" -}}
-  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19-0" (include "kubeVersion" .)) -}}
-      {{- print "networking.k8s.io/v1" -}}
-  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
-    {{- print "networking.k8s.io/v1beta1" -}}
-  {{- else -}}
-    {{- print "extensions/v1beta1" -}}
-  {{- end -}}
-{{- end -}}
-
-{{/* Check Ingress stability */}}
-{{- define "ingress.isStable" -}}
-  {{- eq (include "ingress.apiVersion" .) "networking.k8s.io/v1" -}}
-{{- end -}}
-
-{{/* Check Ingress supports pathType */}}
-{{/* pathType was added to networking.k8s.io/v1beta1 in Kubernetes 1.18 */}}
-{{- define "ingress.supportsPathType" -}}
-  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" (include "kubeVersion" .))) -}}
-{{- end -}}
-
-{{- define "ingress.FieldNotAnnotation" -}}
-  {{- (semverCompare ">= 1.27-0" (include "kubeVersion" .)) -}}
-{{- end -}}
-
 {{- define "webapp.certificateSecretName" -}}
 {{- printf "%s-managed-tls-certificate" (include "webapp.fullname" .) -}}
 {{- end -}}

--- a/charts/webapp/templates/_helpers.tpl
+++ b/charts/webapp/templates/_helpers.tpl
@@ -23,3 +23,58 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "includeSecurityContext" -}}
   {{- (semverCompare ">= 1.24-0" (include "kubeVersion" .)) -}}
 {{- end -}}
+
+{{- define "webapp.validateDomainConfig" -}}
+  {{- if or .Values.ingress.enabled .Values.tls.enabled }}
+    {{- if not .Values.webappDomain }}
+      {{- fail "webappDomain must be set when enabling ingress or tls" }}
+    {{- end }}
+  {{- end }}
+  {{- if and .Values.tls.enabled (not .Values.ingress.enabled) }}
+    {{- fail "ingress.enabled must be true when tls.enabled is true" }}
+  {{- end }}
+{{- end -}}
+
+{{/* Get Ingress API Version */}}
+{{- define "ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19-0" (include "kubeVersion" .)) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/* Check Ingress stability */}}
+{{- define "ingress.isStable" -}}
+  {{- eq (include "ingress.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- end -}}
+
+{{/* Check Ingress supports pathType */}}
+{{/* pathType was added to networking.k8s.io/v1beta1 in Kubernetes 1.18 */}}
+{{- define "ingress.supportsPathType" -}}
+  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" (include "kubeVersion" .))) -}}
+{{- end -}}
+
+{{- define "ingress.FieldNotAnnotation" -}}
+  {{- (semverCompare ">= 1.27-0" (include "kubeVersion" .)) -}}
+{{- end -}}
+
+{{- define "webapp.certificateSecretName" -}}
+{{- printf "%s-managed-tls-certificate" (include "webapp.fullname" .) -}}
+{{- end -}}
+
+{{- define "webapp.issuerName" -}}
+{{- printf "%s-%s" (include "webapp.fullname" .) .Values.tls.issuer.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Returns the Letsencrypt API server URL based on whether testMode is enabled or disabled */}}
+{{- define "webapp.certManager.apiServerURL" -}}
+{{- $hostnameParts := list "acme" -}}
+{{- if .Values.certManager.inTestMode -}}
+    {{- $hostnameParts = append $hostnameParts "staging" -}}
+{{- end -}}
+{{- $hostnameParts = append $hostnameParts "v02" -}}
+{{- join "-" $hostnameParts | printf "https://%s.api.letsencrypt.org/directory" -}}
+{{- end -}}

--- a/charts/webapp/templates/certificate.yaml
+++ b/charts/webapp/templates/certificate.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.tls.enabled .Values.tls.useCertManager .Values.ingress.enabled }}
+{{- if and .Values.tls.enabled .Values.tls.useCertManager .Values.ingress.enabled (empty .Values.tls.existingSecretName) }}
 {{- include "webapp.validateDomainConfig" . }}
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/charts/webapp/templates/certificate.yaml
+++ b/charts/webapp/templates/certificate.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.tls.enabled .Values.tls.useCertManager .Values.ingress.enabled }}
+{{- include "webapp.validateDomainConfig" . }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: "{{ include "webapp.fullname" . }}-csr"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  issuerRef:
+    name: {{ include "webapp.issuerName" . | quote }}
+    {{- if or (eq .Values.tls.issuer.kind "Issuer") (eq .Values.tls.issuer.kind "ClusterIssuer") }}
+    kind: {{ .Values.tls.issuer.kind }}
+    {{- else }}
+    {{- fail (cat ".tls.issuer.kind can only be one of Issuer or ClusterIssuer, got: " .Values.tls.issuer.kind )}}
+    {{- end }}
+  usages:
+    - server auth
+  duration: 2160h
+  renewBefore: 360h
+  isCA: false
+  secretName: {{ include "webapp.certificateSecretName" . | quote }}
+
+  privateKey:
+    algorithm: ECDSA
+    size: 384
+    encoding: PKCS1
+    rotationPolicy: Always
+
+  dnsNames:
+    - {{ .Values.webappDomain }}
+{{- end -}}

--- a/charts/webapp/templates/ingress.yaml
+++ b/charts/webapp/templates/ingress.yaml
@@ -1,0 +1,86 @@
+{{- if .Values.ingress.enabled }}
+{{- include "webapp.validateDomainConfig" . }}
+{{- $apiIsStable := eq (include "ingress.isStable" .) "true" -}}
+{{- $ingressFieldNotAnnotation := eq (include "ingress.FieldNotAnnotation" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
+{{- $ingressClass := default "nginx" .Values.ingress.className -}}
+{{- $backendDomain := "" -}}
+{{- $backendRest := "" -}}
+{{- if .Values.ingress.renderCSPInIngress }}
+  {{- $backendDomain = required "Need a 'config.externalUrls.backendDomain' for CSP headers." .Values.config.externalUrls.backendDomain -}}
+  {{- $backendRest = required "Need a 'config.externalUrls.backendRest' for CSP headers." .Values.config.externalUrls.backendRest -}}
+{{- end }}
+apiVersion: {{ include "ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: webapp
+  labels:
+    app: webapp
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- if not $ingressFieldNotAnnotation }}
+    kubernetes.io/ingress.class: {{ $ingressClass | quote }}
+    {{- end }}
+    {{- range $key, $val := .Values.ingress.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+    {{- if .Values.ingress.renderCSPInIngress }}
+    {{- if not (contains $ingressClass "nginx") }}
+        {{- fail "In ingress CSP header setting only works with a 'nginx' controller. (Rename it to 'nginx-*' if it is one.)" }}
+    {{- end }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($uri !~ "(^/sso/finalize-login(/[a-zA-Z0-9-]*)?$)|(^/sso/initiate-login(/[a-zA-Z0-9-]*)?$)|(^/favicon.ico$)") {
+        set $CSP "connect-src 'self' blob: data: https://*.giphy.com https://{{ $backendRest }}";
+        {{- if .Values.config.externalUrls.backendWebsocket }}
+        set $CSP "${CSP} wss://{{ .Values.config.externalUrls.backendWebsocket }}";
+        {{- end }}
+        set $CSP "${CSP} https://*.{{ $backendDomain }};";
+        set $CSP "${CSP} default-src 'self';";
+        set $CSP "${CSP} font-src 'self' data:;";
+        set $CSP "${CSP} frame-src https://*.soundcloud.com https://*.spotify.com https://*.vimeo.com https://*.youtube-nocookie.com;";
+        set $CSP "${CSP} img-src 'self' blob: data: https://*.giphy.com https://*.{{ $backendDomain }};";
+        set $CSP "${CSP} manifest-src 'self';";
+        set $CSP "${CSP} media-src 'self' blob: data:;";
+        set $CSP "${CSP} object-src 'none';";
+        set $CSP "${CSP} script-src 'self' 'unsafe-eval' https://*.{{ $backendDomain }}; ";
+        set $CSP "${CSP} style-src 'self' 'unsafe-inline';";
+        set $CSP "${CSP} worker-src 'self' blob:;";
+        set $CSP "${CSP} base-uri 'self';";
+        set $CSP "${CSP} form-action 'self';";
+        set $CSP "${CSP} frame-ancestors 'self';";
+        set $CSP "${CSP} script-src-attr 'none';";
+        set $CSP "${CSP} upgrade-insecure-requests";
+        more_set_headers "content-security-policy: $CSP";
+      }
+    {{- end }}
+spec:
+  {{- if $ingressFieldNotAnnotation }}
+  ingressClassName: {{ $ingressClass | quote }}
+  {{- end }}
+  {{- if .Values.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.webappDomain }}
+      secretName: {{ include "webapp.certificateSecretName" . | quote }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.webappDomain }}
+      http:
+        paths:
+          - path: /
+            {{- if $ingressSupportsPathType }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if $apiIsStable }}
+              service:
+                name: webapp-http
+                port:
+                  number: {{ .Values.service.http.port | default .Values.service.http.internalPort }}
+              {{- else }}
+              serviceName: webapp-http
+              servicePort: {{ .Values.service.http.port | default .Values.service.http.internalPort }}
+              {{- end }}
+{{- end }}

--- a/charts/webapp/templates/ingress.yaml
+++ b/charts/webapp/templates/ingress.yaml
@@ -63,7 +63,7 @@ spec:
   tls:
     - hosts:
         - {{ .Values.webappDomain }}
-      secretName: {{ include "webapp.certificateSecretName" . | quote }}
+      secretName: {{ include "webapp.tlsSecretName" . | quote }}
   {{- end }}
   rules:
     - host: {{ .Values.webappDomain }}

--- a/charts/webapp/templates/ingress.yaml
+++ b/charts/webapp/templates/ingress.yaml
@@ -1,8 +1,5 @@
 {{- if .Values.ingress.enabled }}
 {{- include "webapp.validateDomainConfig" . }}
-{{- $apiIsStable := eq (include "ingress.isStable" .) "true" -}}
-{{- $ingressFieldNotAnnotation := eq (include "ingress.FieldNotAnnotation" .) "true" -}}
-{{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
 {{- $ingressClass := default "nginx" .Values.ingress.className -}}
 {{- $backendDomain := "" -}}
 {{- $backendRest := "" -}}
@@ -10,7 +7,7 @@
   {{- $backendDomain = required "Need a 'config.externalUrls.backendDomain' for CSP headers." .Values.config.externalUrls.backendDomain -}}
   {{- $backendRest = required "Need a 'config.externalUrls.backendRest' for CSP headers." .Values.config.externalUrls.backendRest -}}
 {{- end }}
-apiVersion: {{ include "ingress.apiVersion" . }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: webapp
@@ -20,9 +17,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    {{- if not $ingressFieldNotAnnotation }}
-    kubernetes.io/ingress.class: {{ $ingressClass | quote }}
-    {{- end }}
     {{- range $key, $val := .Values.ingress.annotations }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
@@ -56,9 +50,7 @@ metadata:
       }
     {{- end }}
 spec:
-  {{- if $ingressFieldNotAnnotation }}
   ingressClassName: {{ $ingressClass | quote }}
-  {{- end }}
   {{- if .Values.tls.enabled }}
   tls:
     - hosts:
@@ -70,17 +62,10 @@ spec:
       http:
         paths:
           - path: /
-            {{- if $ingressSupportsPathType }}
             pathType: Prefix
-            {{- end }}
             backend:
-              {{- if $apiIsStable }}
               service:
                 name: webapp-http
                 port:
                   number: {{ .Values.service.http.port | default .Values.service.http.internalPort }}
-              {{- else }}
-              serviceName: webapp-http
-              servicePort: {{ .Values.service.http.port | default .Values.service.http.internalPort }}
-              {{- end }}
 {{- end }}

--- a/charts/webapp/templates/issuer.yaml
+++ b/charts/webapp/templates/issuer.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.tls.enabled .Values.tls.useCertManager .Values.tls.createIssuer .Values.ingress.enabled }}
+{{- if and .Values.tls.enabled .Values.tls.useCertManager .Values.tls.createIssuer .Values.ingress.enabled (empty .Values.tls.existingSecretName) }}
 {{- include "webapp.validateDomainConfig" . }}
 apiVersion: cert-manager.io/v1
 {{- if or (eq .Values.tls.issuer.kind "Issuer") (eq .Values.tls.issuer.kind "ClusterIssuer") }}

--- a/charts/webapp/templates/issuer.yaml
+++ b/charts/webapp/templates/issuer.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.tls.enabled .Values.tls.useCertManager .Values.tls.createIssuer .Values.ingress.enabled }}
+{{- include "webapp.validateDomainConfig" . }}
+apiVersion: cert-manager.io/v1
+{{- if or (eq .Values.tls.issuer.kind "Issuer") (eq .Values.tls.issuer.kind "ClusterIssuer") }}
+kind: "{{ .Values.tls.issuer.kind }}"
+{{- else }}
+{{- fail (cat ".tls.issuer.kind can only be one of Issuer or ClusterIssuer, got: " .Values.tls.issuer.kind )}}
+{{- end }}
+metadata:
+  name: {{ include "webapp.issuerName" . | quote }}
+  {{- if eq .Values.tls.issuer.kind "Issuer" }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  acme:
+    server: {{ include "webapp.certManager.apiServerURL" . | quote }}
+    email: {{ required "Missing value: certManager.certmasterEmail" .Values.certManager.certmasterEmail | quote }}
+    privateKeySecretRef:
+      name: {{ include "webapp.issuerName" . -}}-account-key
+    solvers:
+{{- if .Values.certManager.customSolvers }}
+{{ toYaml .Values.certManager.customSolvers | indent 6 }}
+{{- else }}
+      - http01:
+          ingress:
+            class: {{ default "nginx" .Values.ingress.className }}
+{{- end }}
+{{- end -}}

--- a/charts/webapp/templates/service.yaml
+++ b/charts/webapp/templates/service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: webapp-http
+  labels:
+    app: webapp
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.service.http.port | default .Values.service.http.internalPort }}
+      targetPort: {{ .Values.service.http.internalPort }}
+  selector:
+    app: webapp
+{{- end }}

--- a/charts/webapp/templates/validation.yaml
+++ b/charts/webapp/templates/validation.yaml
@@ -1,0 +1,4 @@
+{{- /*
+This template triggers validation logic without rendering a Kubernetes resource.
+*/ -}}
+{{- include "webapp.validateDomainConfig" . -}}

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -10,6 +10,28 @@ resources:
 image:
   repository: quay.io/wire/webapp
   # tag: override version defined in Chart.appVersion
+
+# webappDomain: webapp.example.com
+
+ingress:
+  enabled: false
+  className: nginx
+  annotations: {}
+  renderCSPInIngress: false
+
+tls:
+  enabled: false
+  useCertManager: true
+  createIssuer: true
+  issuer:
+    name: letsencrypt-http01
+    kind: Issuer
+
+certManager:
+  inTestMode: false
+  certmasterEmail:
+  customSolvers:
+
 service:
   https:
     externalPort: 443

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -22,10 +22,10 @@ ingress:
 tls:
   enabled: false
   useCertManager: true
-  createIssuer: true
+  createIssuer: false
   issuer:
-    name: letsencrypt-http01
-    kind: Issuer
+    name: letsencrypt
+    kind: ClusterIssuer
 
 certManager:
   inTestMode: false

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -21,8 +21,9 @@ ingress:
 
 tls:
   enabled: false
-  useCertManager: true
+  useCertManager: false
   createIssuer: false
+  # existingSecretName: "" # set this if you created e.g. a wildcard cert outside this chart
   issuer:
     name: letsencrypt
     kind: ClusterIssuer


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22715" title="WPB-22715" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22715</a>  Create PoC webapp deployment using argocd
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

To be able to deploy a webapp standalone, it needs an ingress and options to configure DNS and TLS.

- feat: add optional ingress and tls for webapp helm chart
- allow using an existing wildcard cert


This PR using this helm chart currently gets (successfully) deployed under https://webapp-branch-helm-ingress.apps-staging.wire.link using argocd to test that these helm chart changes actually work (deployment manifests here: https://github.com/wireapp/argocd-apps/blob/main/applications/webapp-branch.yaml )

The code is mostly ported over from https://github.com/wireapp/wire-server/blob/develop/charts/nginx-ingress-services/templates/ingress.yaml
The "nginx-ingress-services" is a helm chart that works but assumes everything wire-server gets deployed together, which isn't necessarily the case. A better abstraction is to locate the ingress resources next to the services and pods that need it (like the webapp).
