### PR TITLE
fix: issue disabling public link expiration [WPB-22980]

### DIFF
--- a/apps/webapp/src/script/components/Cells/ShareModal/CellsShareExpirationFields.tsx
+++ b/apps/webapp/src/script/components/Cells/ShareModal/CellsShareExpirationFields.tsx
@@ -132,7 +132,7 @@ export const CellsShareExpirationFields = ({
       const label = formatTimeLabel(hour24, minutes);
       return {value: label, label};
     }
-    return timeOptions[timeOptions.length - 1];
+    return timeOptions[0];
   });
   const [selectedDate, setSelectedDate] = useState<DateValue | null>(() => {
     if (dateTime) {

--- a/apps/webapp/src/script/components/Cells/ShareModal/CellsShareExpirationFields.tsx
+++ b/apps/webapp/src/script/components/Cells/ShareModal/CellsShareExpirationFields.tsx
@@ -132,7 +132,7 @@ export const CellsShareExpirationFields = ({
       const label = formatTimeLabel(hour24, minutes);
       return {value: label, label};
     }
-    return timeOptions[0];
+    return timeOptions[timeOptions.length - 1];
   });
   const [selectedDate, setSelectedDate] = useState<DateValue | null>(() => {
     if (dateTime) {

--- a/apps/webapp/src/script/components/Cells/ShareModal/shareModalSerializer.test.ts
+++ b/apps/webapp/src/script/components/Cells/ShareModal/shareModalSerializer.test.ts
@@ -1,0 +1,184 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {serializeShareModalInput} from './shareModalSerializer';
+
+describe('serializeShareModalInput', () => {
+  describe('expiration handling', () => {
+    it('returns accessEnd as null when expiration is disabled', () => {
+      const result = serializeShareModalInput({
+        passwordEnabled: false,
+        passwordValue: '',
+        expirationEnabled: false,
+        expirationDateTime: null,
+        expirationInvalid: false,
+      });
+
+      expect(result.accessEnd).toBeNull();
+      expect(result.isValid).toBe(true);
+    });
+
+    it('returns accessEnd as timestamp string when expiration is enabled with valid date', () => {
+      const expirationDate = new Date('2025-12-31T23:59:59.000Z');
+      const expectedTimestamp = Math.floor(expirationDate.getTime() / 1000).toString();
+
+      const result = serializeShareModalInput({
+        passwordEnabled: false,
+        passwordValue: '',
+        expirationEnabled: true,
+        expirationDateTime: expirationDate,
+        expirationInvalid: false,
+      });
+
+      expect(result.accessEnd).toBe(expectedTimestamp);
+      expect(result.isValid).toBe(true);
+    });
+
+    it('returns accessEnd as undefined and isValid as false when expiration is enabled but date is null', () => {
+      const result = serializeShareModalInput({
+        passwordEnabled: false,
+        passwordValue: '',
+        expirationEnabled: true,
+        expirationDateTime: null,
+        expirationInvalid: false,
+      });
+
+      expect(result.accessEnd).toBeUndefined();
+      expect(result.isValid).toBe(false);
+    });
+
+    it('returns accessEnd as undefined and isValid as false when expiration is enabled but date is invalid', () => {
+      const result = serializeShareModalInput({
+        passwordEnabled: false,
+        passwordValue: '',
+        expirationEnabled: true,
+        expirationDateTime: new Date('2025-12-31T23:59:59.000Z'),
+        expirationInvalid: true,
+      });
+
+      expect(result.accessEnd).toBeUndefined();
+      expect(result.isValid).toBe(false);
+    });
+  });
+
+  describe('password handling', () => {
+    it('returns updatePassword when password is enabled with non-empty value', () => {
+      const result = serializeShareModalInput({
+        passwordEnabled: true,
+        passwordValue: 'secret123',
+        expirationEnabled: false,
+        expirationDateTime: null,
+        expirationInvalid: false,
+      });
+
+      expect(result.updatePassword).toBe('secret123');
+      expect(result.passwordEnabled).toBe(true);
+      expect(result.isValid).toBe(true);
+    });
+
+    it('trims password value and returns trimmed password', () => {
+      const result = serializeShareModalInput({
+        passwordEnabled: true,
+        passwordValue: '  secret123  ',
+        expirationEnabled: false,
+        expirationDateTime: null,
+        expirationInvalid: false,
+      });
+
+      expect(result.updatePassword).toBe('secret123');
+    });
+
+    it('returns isValid as false when password is enabled but value is empty', () => {
+      const result = serializeShareModalInput({
+        passwordEnabled: true,
+        passwordValue: '',
+        expirationEnabled: false,
+        expirationDateTime: null,
+        expirationInvalid: false,
+      });
+
+      expect(result.updatePassword).toBeUndefined();
+      expect(result.isValid).toBe(false);
+    });
+
+    it('returns isValid as false when password is enabled but value is only whitespace', () => {
+      const result = serializeShareModalInput({
+        passwordEnabled: true,
+        passwordValue: '   ',
+        expirationEnabled: false,
+        expirationDateTime: null,
+        expirationInvalid: false,
+      });
+
+      expect(result.updatePassword).toBeUndefined();
+      expect(result.isValid).toBe(false);
+    });
+
+    it('returns updatePassword as undefined when password is disabled', () => {
+      const result = serializeShareModalInput({
+        passwordEnabled: false,
+        passwordValue: 'ignored-password',
+        expirationEnabled: false,
+        expirationDateTime: null,
+        expirationInvalid: false,
+      });
+
+      expect(result.updatePassword).toBeUndefined();
+      expect(result.passwordEnabled).toBe(false);
+    });
+  });
+
+  describe('combined validation', () => {
+    it('returns isValid as true when both password and expiration are valid', () => {
+      const result = serializeShareModalInput({
+        passwordEnabled: true,
+        passwordValue: 'secret123',
+        expirationEnabled: true,
+        expirationDateTime: new Date('2025-12-31T23:59:59.000Z'),
+        expirationInvalid: false,
+      });
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it('returns isValid as false when password is invalid even if expiration is valid', () => {
+      const result = serializeShareModalInput({
+        passwordEnabled: true,
+        passwordValue: '',
+        expirationEnabled: true,
+        expirationDateTime: new Date('2025-12-31T23:59:59.000Z'),
+        expirationInvalid: false,
+      });
+
+      expect(result.isValid).toBe(false);
+    });
+
+    it('returns isValid as false when expiration is invalid even if password is valid', () => {
+      const result = serializeShareModalInput({
+        passwordEnabled: true,
+        passwordValue: 'secret123',
+        expirationEnabled: true,
+        expirationDateTime: null,
+        expirationInvalid: false,
+      });
+
+      expect(result.isValid).toBe(false);
+    });
+  });
+});

--- a/apps/webapp/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsShareModal/CellsShareModal.tsx
+++ b/apps/webapp/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsShareModal/CellsShareModal.tsx
@@ -149,7 +149,7 @@ const CellsShareModal = ({type, uuid, cellsRepository, modalId}: ShareModalParam
         await updatePublicLink({
           password: serialized.updatePassword,
           passwordEnabled: serialized.passwordEnabled,
-          ...(serialized.accessEnd ? {accessEnd: serialized.accessEnd} : {}),
+          accessEnd: serialized.accessEnd,
         });
       } catch {
         // Keep the modal open if the update fails.

--- a/apps/webapp/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsShareModal/useCellPublicLink.ts
+++ b/apps/webapp/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsShareModal/useCellPublicLink.ts
@@ -156,6 +156,18 @@ export const useCellPublicLink = ({uuid, cellsRepository}: UseCellPublicLinkPara
           passwordEnabled,
         });
 
+        // Update linkData with the new values so the UI doesn't reset
+        setLinkData(prevData => {
+          if (!prevData) {
+            return prevData;
+          }
+          return {
+            ...prevData,
+            PasswordRequired: passwordEnabled,
+            AccessEnd: accessEnd === null ? undefined : accessEnd !== undefined ? accessEnd : prevData.AccessEnd,
+          };
+        });
+
         setStatus('success');
       } catch (err) {
         setStatus('error');

--- a/apps/webapp/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsShareModal/useCellPublicLink.ts
+++ b/apps/webapp/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsShareModal/useCellPublicLink.ts
@@ -131,25 +131,20 @@ export const useCellPublicLink = ({uuid, cellsRepository}: UseCellPublicLinkPara
       try {
         setStatus('loading');
 
-        // Fetch the complete link object first
         const currentLink = await cellsRepository.getPublicLink({uuid: node.publicLink.uuid});
 
-        // Determine if we're creating a new password or updating an existing one
         const hasExistingPassword = currentLink.PasswordRequired === true;
         const isSettingPassword = passwordEnabled && password;
 
-        // Build the updated link, handling accessEnd removal
         const updatedLink: typeof currentLink = {
           ...currentLink,
           PasswordRequired: passwordEnabled,
         };
 
-        // Handle accessEnd: null means remove, string means set, undefined means don't change
         if (accessEnd === null) {
-          // User wants to clear expiration - delete the property
+          // Ensure that accessEnd is not present in JSON
           delete updatedLink.AccessEnd;
         } else if (accessEnd !== undefined) {
-          // User is setting a new expiration
           updatedLink.AccessEnd = accessEnd;
         }
 

--- a/apps/webapp/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsShareModal/useCellPublicLink.ts
+++ b/apps/webapp/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsShareModal/useCellPublicLink.ts
@@ -122,7 +122,7 @@ export const useCellPublicLink = ({uuid, cellsRepository}: UseCellPublicLinkPara
     }: {
       password?: string;
       passwordEnabled?: boolean;
-      accessEnd?: string;
+      accessEnd?: string | null;
     }) => {
       if (!node?.publicLink?.uuid) {
         throw new Error('No public link to update');
@@ -138,12 +138,20 @@ export const useCellPublicLink = ({uuid, cellsRepository}: UseCellPublicLinkPara
         const hasExistingPassword = currentLink.PasswordRequired === true;
         const isSettingPassword = passwordEnabled && password;
 
-        // Update only the properties we need to change
-        const updatedLink = {
+        // Build the updated link, handling accessEnd removal
+        const updatedLink: typeof currentLink = {
           ...currentLink,
           PasswordRequired: passwordEnabled,
-          ...(accessEnd ? {AccessEnd: accessEnd} : {}),
         };
+
+        // Handle accessEnd: null means remove, string means set, undefined means don't change
+        if (accessEnd === null) {
+          // User wants to clear expiration - delete the property
+          delete updatedLink.AccessEnd;
+        } else if (accessEnd !== undefined) {
+          // User is setting a new expiration
+          updatedLink.AccessEnd = accessEnd;
+        }
 
         await cellsRepository.updatePublicLink({
           linkUuid: node.publicLink.uuid,

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsNodeShareModal/CellsNodeShareModal.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsNodeShareModal/CellsNodeShareModal.tsx
@@ -167,7 +167,7 @@ const CellShareModalContent = ({
         await updatePublicLink({
           password: serialized.updatePassword,
           passwordEnabled: serialized.passwordEnabled,
-          ...(serialized.accessEnd ? {accessEnd: serialized.accessEnd} : {}),
+          accessEnd: serialized.accessEnd,
         });
       } catch {
         // Keep the modal open if the update fails.

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsNodeShareModal/useCellPublicLink.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsNodeShareModal/useCellPublicLink.ts
@@ -134,32 +134,26 @@ export const useCellPublicLink = ({uuid, conversationId, cellsRepository}: UseCe
       try {
         setStatus('loading');
 
-        // Fetch the complete link object first
         const currentLink = await cellsRepository.getPublicLink({uuid: node.publicLink.uuid});
 
-        // Determine if we're creating a new password or updating an existing one
         const hasExistingPassword = currentLink.PasswordRequired === true;
         const isSettingPassword = passwordEnabled && password;
 
-        // Build the updated link, handling accessEnd removal
         const updatedLink: typeof currentLink = {
           ...currentLink,
           PasswordRequired: passwordEnabled,
         };
 
-        // Handle accessEnd: null means remove, string means set, undefined means don't change
         if (accessEnd === null) {
-          // User wants to clear expiration - delete the property
+          // Ensure that accessEnd is not present in JSON
           delete updatedLink.AccessEnd;
         } else if (accessEnd !== undefined) {
-          // User is setting a new expiration
           updatedLink.AccessEnd = accessEnd;
         }
 
         await cellsRepository.updatePublicLink({
           linkUuid: node.publicLink.uuid,
           link: updatedLink,
-          // Use createPassword if no password exists, updatePassword if it does
           ...(isSettingPassword ? (hasExistingPassword ? {updatePassword: password} : {createPassword: password}) : {}),
           passwordEnabled,
         });

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsNodeShareModal/useCellPublicLink.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsNodeShareModal/useCellPublicLink.ts
@@ -158,6 +158,18 @@ export const useCellPublicLink = ({uuid, conversationId, cellsRepository}: UseCe
           passwordEnabled,
         });
 
+        // Update linkData with the new values so the UI doesn't reset
+        setLinkData(prevData => {
+          if (!prevData) {
+            return prevData;
+          }
+          return {
+            ...prevData,
+            PasswordRequired: passwordEnabled,
+            AccessEnd: accessEnd === null ? undefined : accessEnd !== undefined ? accessEnd : prevData.AccessEnd,
+          };
+        });
+
         setStatus('success');
       } catch (err) {
         setStatus('error');


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22980" title="WPB-22980" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22980</a>  [Web] Public Link - Expiration date cannot be disabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

https://wearezeta.atlassian.net/browse/WPB-22980

This commit adds tests and fixes the accessEnd property handling in public link updates.

Detailed Changes:
 - Implementation:
   - Added a new test for shareModalSerializer with tests for expiration and password handling.
   - Changed accessEnd property handling in useCellPublicLink hooks to support null values for removing expiration.
   - Removed conditional spreading of accessEnd in CellsShareModal and CellsNodeShareModal components.
 - Tests:
   - Added comprehensive test suite for serializeShareModalInput function covering expiration and password validation scenarios.

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

Uploading Screen Recording 2026-01-21 at 11.35.03.mov…

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
