### PR TITLE
fix: Disable Password & Expiration toggles unless Public Link is enabled(WPB-22952)

### DIFF
--- a/apps/webapp/src/script/components/Cells/ShareModal/CellsShareExpirationFields.tsx
+++ b/apps/webapp/src/script/components/Cells/ShareModal/CellsShareExpirationFields.tsx
@@ -60,7 +60,6 @@ import {
   expirationLabelStyles,
   timeSelectLabelVisuallyHiddenStyles,
   timeSelectMenuStyles,
-  timeSelectMenuPortalStyles,
   timeSelectStyles,
   timeSelectWrapperStyles,
   expirationErrorBorderStyles,
@@ -276,7 +275,6 @@ export const CellsShareExpirationFields = ({
             value={selectedTime}
             selectContainerCSS={timeControlStyles}
             selectControlCSS={timeControlStyles}
-            selectMenuPortalCSS={timeSelectMenuPortalStyles}
             menuCSS={timeSelectMenuStyles}
             menuPlacement="top"
             maxMenuHeight={menuMaxHeight}

--- a/apps/webapp/src/script/components/Cells/ShareModal/CellsShareExpirationFields.tsx
+++ b/apps/webapp/src/script/components/Cells/ShareModal/CellsShareExpirationFields.tsx
@@ -65,6 +65,7 @@ import {
   expirationErrorBorderStyles,
   expirationErrorLabelStyles,
   expirationErrorTextStyles,
+  timeSelectMenuPortalStyles,
 } from './CellsShareExpirationStyles';
 
 interface CellsShareExpirationFieldsLabels {
@@ -285,6 +286,7 @@ export const CellsShareExpirationFields = ({
               }
             }}
             markInvalid={isExpirationInvalid}
+            selectMenuPortalCSS={timeSelectMenuPortalStyles}
           />
         </div>
       </div>

--- a/apps/webapp/src/script/components/Cells/ShareModal/CellsShareModalContent.tsx
+++ b/apps/webapp/src/script/components/Cells/ShareModal/CellsShareModalContent.tsx
@@ -171,6 +171,7 @@ export const CellsShareModalContent = ({
 }: CellsShareModalContentProps) => {
   const resolvedLabels = {...DEFAULT_LABELS, ...labels};
   const shouldShowLink = publicLink.isEnabled && publicLink.status === 'success' && publicLink.link;
+  const areDependentTogglesDisabled = !publicLink.isEnabled;
   const publicLinkColors = switchColors?.publicLink ?? DEFAULT_SWITCH_COLORS;
   const passwordColors = switchColors?.password ?? DEFAULT_SWITCH_COLORS;
   const expirationColors = switchColors?.expiration ?? DEFAULT_SWITCH_COLORS;
@@ -211,8 +212,9 @@ export const CellsShareModalContent = ({
           <Switch
             id="switch-password"
             aria-describedby="switch-password-description"
-            checked={password.isEnabled}
+            checked={publicLink.isEnabled && password.isEnabled}
             onToggle={password.onToggle}
+            disabled={areDependentTogglesDisabled}
             {...passwordColors}
           />
         </div>
@@ -269,8 +271,9 @@ export const CellsShareModalContent = ({
           <Switch
             id="switch-expiration"
             aria-describedby="switch-expiration-description"
-            checked={expiration.isEnabled}
+            checked={publicLink.isEnabled && expiration.isEnabled}
             onToggle={expiration.onToggle}
+            disabled={areDependentTogglesDisabled}
             {...expirationColors}
           />
         </div>

--- a/apps/webapp/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsShareModal/CellsShareModal.styles.ts
+++ b/apps/webapp/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsShareModal/CellsShareModal.styles.ts
@@ -19,8 +19,6 @@
 
 import {CSSObject} from '@emotion/react';
 
-import {COLOR_V2} from '@wireapp/react-ui-kit';
-
 export const wrapperStyles: CSSObject = {
   paddingTop: '8px',
   width: '100%',
@@ -40,12 +38,12 @@ export const publicLinkDescriptionStyles: CSSObject = {
 
 export const passwordDescriptionStyles: CSSObject = {
   fontSize: 'var(--font-size-small)',
-  color: COLOR_V2.GRAY_90,
+  color: 'var(--base-secondary-text)',
 };
 
 export const expirationDescriptionStyles: CSSObject = {
   fontSize: 'var(--font-size-small)',
-  color: COLOR_V2.GRAY_90,
+  color: 'var(--base-secondary-text)',
 };
 
 export const dividerStyles: CSSObject = {

--- a/apps/webapp/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsShareModal/CellsShareModal.tsx
+++ b/apps/webapp/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsShareModal/CellsShareModal.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 
 import {CellsShareModalContent} from 'Components/Cells/ShareModal/CellsShareModalContent';
 import {serializeShareModalInput} from 'Components/Cells/ShareModal/shareModalSerializer';
@@ -105,10 +105,16 @@ const CellsShareModal = ({type, uuid, cellsRepository, modalId}: ShareModalParam
   const [passwordValue, setPasswordValue] = useState('');
   const [expirationDateTime, setExpirationDateTime] = useState<Date | null>(null);
   const [isExpirationInvalid, setIsExpirationInvalid] = useState(false);
+  const initializedLinkIdRef = useRef<string | null>(null);
 
   // Initialize toggles and values based on existing link data
   useEffect(() => {
-    if (linkData && status === 'success') {
+    if (!isEnabled) {
+      initializedLinkIdRef.current = null;
+      return;
+    }
+
+    if (linkData && status === 'success' && initializedLinkIdRef.current !== linkData.Uuid) {
       // Always sync password toggle with linkData state
       setIsPasswordEnabled(!!linkData.PasswordRequired);
 
@@ -122,10 +128,36 @@ const CellsShareModal = ({type, uuid, cellsRepository, modalId}: ShareModalParam
         setIsExpirationEnabled(false);
         setExpirationDateTime(null);
       }
+      if (linkData?.Uuid) {
+        initializedLinkIdRef.current = linkData.Uuid;
+      }
     }
-  }, [linkData, status, setIsPasswordEnabled, setIsExpirationEnabled]);
+  }, [isEnabled, linkData, status, setIsPasswordEnabled, setIsExpirationEnabled]);
 
   const isInputDisabled = ['loading', 'error'].includes(status);
+
+  useEffect(() => {
+    if (!isEnabled) {
+      setIsPasswordEnabled(false);
+      setIsExpirationEnabled(false);
+      setPasswordValue('');
+      setExpirationDateTime(null);
+      setIsExpirationInvalid(false);
+    }
+  }, [isEnabled, setIsPasswordEnabled, setIsExpirationEnabled]);
+
+  useEffect(() => {
+    if (!isExpirationEnabled) {
+      setExpirationDateTime(null);
+      setIsExpirationInvalid(false);
+    }
+  }, [isExpirationEnabled]);
+
+  useEffect(() => {
+    if (!isPasswordEnabled) {
+      setPasswordValue('');
+    }
+  }, [isPasswordEnabled]);
 
   useEffect(() => {
     submitHandlers.set(modalId, async () => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22952" title="WPB-22952" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22952</a>  [Web] Disable Password & Expiration toggles unless Public Link is enabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

### **Current Behavior**

In the Share via Link screen, users see three toggles:

- Create public link
- Password
- Expiration

Currently, Password and Expiration can be toggled even when “Create public link” is OFF.

This creates an inconsistent and confusing state, since password and expiration only make sense for an active public link.

 

### **Expected Behavior**

1. Password and Expiration toggles should be disabled by default
3. They should become enabled only after “Create public link” is toggled ON

**If “Create public link” is toggled OFF again:**

Password and Expiration are automatically disabled (and so the additional options panels for password and expiration are hidden along the way).

### **Acceptance Criteria**

1. When Create public link = OFF, Password toggle is disabled
3. When Create public link = OFF, Expiration toggle is disabled
5. When Create public link = ON, Password & Expiration toggles can be enabled
7. Toggling Create public link OFF resets or deactivates Password & Expiration

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
