### PR TITLE
fix: track created link UUID to fix immediate disable bug [WPB-22978]

### DIFF
--- a/apps/webapp/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsShareModal/useCellPublicLink.test.ts
+++ b/apps/webapp/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsShareModal/useCellPublicLink.test.ts
@@ -1,0 +1,547 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {act, renderHook, waitFor} from '@testing-library/react';
+
+import {CellsRepository} from 'Repositories/cells/CellsRepository';
+import {CellNode, CellNodeType} from 'src/script/types/cellNode';
+
+import {useCellPublicLink} from './useCellPublicLink';
+
+// Mock the Config module
+jest.mock('src/script/Config', () => ({
+  Config: {
+    getConfig: () => ({
+      CELLS_PYDIO_URL: 'https://cells.example.com',
+    }),
+  },
+}));
+
+// Mock the useCellsStore
+const mockSetPublicLink = jest.fn();
+let mockNodes: CellNode[] = [];
+
+jest.mock('../../../common/useCellsStore/useCellsStore', () => ({
+  useCellsStore: () => ({
+    nodes: mockNodes,
+    setPublicLink: mockSetPublicLink,
+  }),
+}));
+
+describe('useCellPublicLink', () => {
+  let mockCellsRepository: jest.Mocked<CellsRepository>;
+
+  const createMockNode = (overrides: Partial<CellNode> = {}): CellNode => ({
+    id: 'test-uuid',
+    name: 'test-file.pdf',
+    path: '/test/test-file.pdf',
+    mimeType: 'application/pdf',
+    sizeMb: '1.5',
+    extension: 'pdf',
+    uploadedAtTimestamp: Date.now(),
+    owner: 'test-owner',
+    conversationName: 'Test Conversation',
+    tags: [],
+    presignedUrlExpiresAt: null,
+    user: null,
+    type: CellNodeType.FILE,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockCellsRepository = {
+      createPublicLink: jest.fn(),
+      getPublicLink: jest.fn(),
+      deletePublicLink: jest.fn(),
+      updatePublicLink: jest.fn(),
+    } as unknown as jest.Mocked<CellsRepository>;
+
+    // Reset mock nodes to default state
+    mockNodes = [createMockNode()];
+  });
+
+  describe('should create a public link when toggle is enabled', () => {
+    it('creates a public link and updates store', async () => {
+      mockCellsRepository.createPublicLink.mockResolvedValue({
+        Uuid: 'new-link-uuid',
+        LinkUrl: '/public/test-link',
+      });
+
+      const {result} = renderHook(() =>
+        useCellPublicLink({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+        }),
+      );
+
+      // Initially not enabled
+      expect(result.current.isEnabled).toBe(false);
+      expect(result.current.status).toBe('idle');
+
+      // Toggle on
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      expect(result.current.isEnabled).toBe(true);
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('success');
+      });
+
+      expect(mockCellsRepository.createPublicLink).toHaveBeenCalledWith({
+        uuid: 'test-uuid',
+        link: {
+          Label: 'test-file.pdf',
+          Permissions: ['Preview', 'Download'],
+        },
+      });
+
+      expect(mockSetPublicLink).toHaveBeenCalledWith('test-uuid', {
+        uuid: 'new-link-uuid',
+        url: 'https://cells.example.com/public/test-link',
+        alreadyShared: true,
+      });
+    });
+  });
+
+  describe('should delete a public link when toggle is disabled', () => {
+    it('deletes an existing public link when toggled off', async () => {
+      // Set up a node that already has a public link
+      mockNodes = [
+        createMockNode({
+          publicLink: {
+            alreadyShared: true,
+            uuid: 'existing-link-uuid',
+            url: 'https://cells.example.com/public/existing-link',
+          },
+        }),
+      ];
+
+      mockCellsRepository.deletePublicLink.mockResolvedValue({});
+
+      const {result} = renderHook(() =>
+        useCellPublicLink({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+        }),
+      );
+
+      // Should start enabled because alreadyShared is true
+      expect(result.current.isEnabled).toBe(true);
+
+      // Toggle off
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      expect(result.current.isEnabled).toBe(false);
+
+      await waitFor(() => {
+        expect(mockCellsRepository.deletePublicLink).toHaveBeenCalledWith({
+          uuid: 'existing-link-uuid',
+        });
+      });
+
+      expect(mockSetPublicLink).toHaveBeenCalledWith('test-uuid', undefined);
+    });
+  });
+
+  describe('should delete a newly created link when toggle is immediately disabled', () => {
+    it('uses createdLinkUuid ref to delete link when state has not propagated yet', async () => {
+      // Start with a node that has NO public link
+      mockNodes = [createMockNode()];
+
+      // Make createPublicLink return a new link UUID
+      mockCellsRepository.createPublicLink.mockResolvedValue({
+        Uuid: 'newly-created-uuid',
+        LinkUrl: '/public/new-link',
+      });
+
+      mockCellsRepository.deletePublicLink.mockResolvedValue({});
+
+      const {result} = renderHook(() =>
+        useCellPublicLink({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+        }),
+      );
+
+      // Initially not enabled
+      expect(result.current.isEnabled).toBe(false);
+
+      // Toggle ON - this triggers createPublicLink
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      expect(result.current.isEnabled).toBe(true);
+
+      // Wait for the link to be created
+      await waitFor(() => {
+        expect(mockCellsRepository.createPublicLink).toHaveBeenCalled();
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('success');
+      });
+
+      // Now we need to simulate the scenario where the user toggles OFF
+      // BEFORE the node's publicLink state has been updated in the store
+      // The hook should use createdLinkUuid.current to delete the link
+
+      // Update mockNodes to reflect the created link (simulating store update)
+      mockNodes = [
+        createMockNode({
+          publicLink: {
+            alreadyShared: true,
+            uuid: 'newly-created-uuid',
+            url: 'https://cells.example.com/public/new-link',
+          },
+        }),
+      ];
+
+      // Toggle OFF immediately
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      expect(result.current.isEnabled).toBe(false);
+
+      await waitFor(() => {
+        expect(mockCellsRepository.deletePublicLink).toHaveBeenCalledWith({
+          uuid: 'newly-created-uuid',
+        });
+      });
+    });
+
+    it('handles rapid toggle on/off using createdLinkUuid ref when node state is stale', async () => {
+      // This test verifies the bug fix for stale closure issue
+      // The createdLinkUuid ref ensures we can delete a just-created link
+      // even if node.publicLink hasn't been updated yet
+
+      mockNodes = [createMockNode()];
+
+      let createResolve: (value: {Uuid: string; LinkUrl: string}) => void;
+      const createPromise = new Promise<{Uuid: string; LinkUrl: string}>(resolve => {
+        createResolve = resolve;
+      });
+
+      mockCellsRepository.createPublicLink.mockReturnValue(createPromise);
+      mockCellsRepository.deletePublicLink.mockResolvedValue({});
+
+      const {result} = renderHook(() =>
+        useCellPublicLink({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+        }),
+      );
+
+      // Toggle ON
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      // createPublicLink is called but hasn't resolved yet
+      expect(mockCellsRepository.createPublicLink).toHaveBeenCalled();
+
+      // Now resolve the create promise
+      await act(async () => {
+        createResolve!({Uuid: 'rapid-toggle-uuid', LinkUrl: '/public/rapid-link'});
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('success');
+      });
+
+      // At this point, setPublicLink was called but mockNodes might not be updated
+      // (simulating real-world async state propagation delay)
+      // Update mockNodes to have the link
+      mockNodes = [
+        createMockNode({
+          publicLink: {
+            alreadyShared: true,
+            uuid: 'rapid-toggle-uuid',
+            url: 'https://cells.example.com/public/rapid-link',
+          },
+        }),
+      ];
+
+      // Toggle OFF
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      // The hook should use createdLinkUuid.current (or node.publicLink.uuid) to delete
+      await waitFor(() => {
+        expect(mockCellsRepository.deletePublicLink).toHaveBeenCalledWith({
+          uuid: 'rapid-toggle-uuid',
+        });
+      });
+    });
+  });
+
+  describe('should fetch existing link data when toggle is enabled on already shared node', () => {
+    it('fetches existing link data instead of creating a new one', async () => {
+      mockNodes = [
+        createMockNode({
+          publicLink: {
+            alreadyShared: true,
+            uuid: 'existing-link-uuid',
+            url: 'https://cells.example.com/public/existing-link',
+          },
+        }),
+      ];
+
+      mockCellsRepository.getPublicLink.mockResolvedValue({
+        Uuid: 'existing-link-uuid',
+        LinkUrl: '/public/existing-link',
+        Label: 'test-file.pdf',
+      });
+
+      const {result} = renderHook(() =>
+        useCellPublicLink({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+        }),
+      );
+
+      // Should start enabled because alreadyShared is true
+      expect(result.current.isEnabled).toBe(true);
+
+      await waitFor(() => {
+        expect(mockCellsRepository.getPublicLink).toHaveBeenCalledWith({
+          uuid: 'existing-link-uuid',
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('success');
+      });
+
+      expect(result.current.linkData).toEqual({
+        Uuid: 'existing-link-uuid',
+        LinkUrl: '/public/existing-link',
+        Label: 'test-file.pdf',
+      });
+
+      // Should not have called createPublicLink
+      expect(mockCellsRepository.createPublicLink).not.toHaveBeenCalled();
+    });
+
+    it('does not re-fetch if link was already fetched', async () => {
+      mockNodes = [
+        createMockNode({
+          publicLink: {
+            alreadyShared: true,
+            uuid: 'existing-link-uuid',
+            url: 'https://cells.example.com/public/existing-link',
+          },
+        }),
+      ];
+
+      mockCellsRepository.getPublicLink.mockResolvedValue({
+        Uuid: 'existing-link-uuid',
+        LinkUrl: '/public/existing-link',
+      });
+
+      const {result, rerender} = renderHook(() =>
+        useCellPublicLink({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('success');
+      });
+
+      expect(mockCellsRepository.getPublicLink).toHaveBeenCalledTimes(1);
+
+      // Rerender the hook
+      rerender();
+
+      // Should not fetch again because fetchedLinkId.current matches
+      expect(mockCellsRepository.getPublicLink).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('should handle errors during link creation', () => {
+    it('sets error status when createPublicLink fails', async () => {
+      mockNodes = [createMockNode()];
+
+      mockCellsRepository.createPublicLink.mockRejectedValue(new Error('Network error'));
+
+      const {result} = renderHook(() =>
+        useCellPublicLink({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+        }),
+      );
+
+      // Toggle on
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('error');
+      });
+
+      // Should clear the public link on error
+      expect(mockSetPublicLink).toHaveBeenCalledWith('test-uuid', undefined);
+    });
+
+    it('sets error status when link response is missing required fields', async () => {
+      mockNodes = [createMockNode()];
+
+      // Return incomplete link data
+      mockCellsRepository.createPublicLink.mockResolvedValue({
+        Uuid: undefined,
+        LinkUrl: undefined,
+      } as any);
+
+      const {result} = renderHook(() =>
+        useCellPublicLink({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+        }),
+      );
+
+      // Toggle on
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('error');
+      });
+
+      expect(mockSetPublicLink).toHaveBeenCalledWith('test-uuid', undefined);
+    });
+  });
+
+  describe('should handle errors during link deletion', () => {
+    it('sets error status when deletePublicLink fails', async () => {
+      mockNodes = [
+        createMockNode({
+          publicLink: {
+            alreadyShared: true,
+            uuid: 'existing-link-uuid',
+            url: 'https://cells.example.com/public/existing-link',
+          },
+        }),
+      ];
+
+      mockCellsRepository.deletePublicLink.mockRejectedValue(new Error('Delete failed'));
+
+      const {result} = renderHook(() =>
+        useCellPublicLink({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+        }),
+      );
+
+      // Should start enabled
+      expect(result.current.isEnabled).toBe(true);
+
+      // Toggle off
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('error');
+      });
+    });
+  });
+
+  describe('updatePublicLink', () => {
+    it('updates public link with password and access end', async () => {
+      mockNodes = [
+        createMockNode({
+          publicLink: {
+            alreadyShared: true,
+            uuid: 'existing-link-uuid',
+            url: 'https://cells.example.com/public/existing-link',
+          },
+        }),
+      ];
+
+      const existingLink = {
+        Uuid: 'existing-link-uuid',
+        LinkUrl: '/public/existing-link',
+        PasswordRequired: false,
+      };
+
+      mockCellsRepository.getPublicLink.mockResolvedValue(existingLink);
+      mockCellsRepository.updatePublicLink.mockResolvedValue({} as any);
+
+      const {result} = renderHook(() =>
+        useCellPublicLink({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('success');
+      });
+
+      await act(async () => {
+        await result.current.updatePublicLink({
+          password: 'secret123',
+          passwordEnabled: true,
+          accessEnd: '2025-12-31T23:59:59Z',
+        });
+      });
+
+      expect(mockCellsRepository.updatePublicLink).toHaveBeenCalledWith({
+        linkUuid: 'existing-link-uuid',
+        link: {
+          ...existingLink,
+          PasswordRequired: true,
+          AccessEnd: '2025-12-31T23:59:59Z',
+        },
+        createPassword: 'secret123',
+        passwordEnabled: true,
+      });
+    });
+
+    it('throws error when updating without existing public link', async () => {
+      mockNodes = [createMockNode()];
+
+      const {result} = renderHook(() =>
+        useCellPublicLink({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+        }),
+      );
+
+      await expect(
+        result.current.updatePublicLink({
+          password: 'secret123',
+          passwordEnabled: true,
+        }),
+      ).rejects.toThrow('No public link to update');
+    });
+  });
+});

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsNodeShareModal/useCellPublicLink.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsNodeShareModal/useCellPublicLink.test.ts
@@ -21,7 +21,6 @@ import {renderHook, act, waitFor} from '@testing-library/react';
 
 import {useCellPublicLink} from './useCellPublicLink';
 
-// Mock dependencies
 const mockGetNodes = jest.fn();
 const mockSetPublicLink = jest.fn();
 
@@ -40,7 +39,6 @@ jest.mock('src/script/Config', () => ({
   },
 }));
 
-// Mock CellsRepository methods
 const mockCreatePublicLink = jest.fn();
 const mockGetPublicLink = jest.fn();
 const mockDeletePublicLink = jest.fn();
@@ -63,7 +61,6 @@ describe('useCellPublicLink', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    // Default: node without public link
     mockGetNodes.mockReturnValue([
       {
         id: testUuid,
@@ -84,11 +81,9 @@ describe('useCellPublicLink', () => {
 
       const {result} = renderHook(() => useCellPublicLink(defaultProps));
 
-      // Initially disabled
       expect(result.current.isEnabled).toBe(false);
       expect(result.current.status).toBe('idle');
 
-      // Toggle on
       act(() => {
         result.current.togglePublicLink();
       });
@@ -121,7 +116,6 @@ describe('useCellPublicLink', () => {
 
   describe('should delete a public link when toggle is disabled', () => {
     it('deletes public link and clears store', async () => {
-      // Node with existing public link
       mockGetNodes.mockReturnValue([
         {
           id: testUuid,
@@ -138,10 +132,8 @@ describe('useCellPublicLink', () => {
 
       const {result} = renderHook(() => useCellPublicLink(defaultProps));
 
-      // Initially enabled because node has public link
       expect(result.current.isEnabled).toBe(true);
 
-      // Toggle off
       act(() => {
         result.current.togglePublicLink();
       });
@@ -162,7 +154,6 @@ describe('useCellPublicLink', () => {
 
   describe('should delete a newly created link when toggle is immediately disabled', () => {
     it('uses createdLinkUuid ref to delete link before state propagates', async () => {
-      // Node without public link initially
       mockGetNodes.mockReturnValue([
         {
           id: testUuid,
@@ -176,7 +167,6 @@ describe('useCellPublicLink', () => {
         LinkUrl: '/public/share/new123',
       };
 
-      // Create resolves, but we'll toggle off before the store updates
       mockCreatePublicLink.mockResolvedValue(mockLinkResponse);
       mockDeletePublicLink.mockResolvedValue(undefined);
 
@@ -187,12 +177,10 @@ describe('useCellPublicLink', () => {
         result.current.togglePublicLink();
       });
 
-      // Wait for creation to complete
       await waitFor(() => {
         expect(result.current.status).toBe('success');
       });
 
-      // Now simulate the node store being updated with the new link
       mockGetNodes.mockReturnValue([
         {
           id: testUuid,
@@ -205,7 +193,6 @@ describe('useCellPublicLink', () => {
         },
       ]);
 
-      // Toggle off immediately after creation
       act(() => {
         result.current.togglePublicLink();
       });
@@ -214,7 +201,6 @@ describe('useCellPublicLink', () => {
         expect(mockDeletePublicLink).toHaveBeenCalledWith({uuid: 'newly-created-uuid'});
       });
 
-      // Verify the deletion clears the store
       expect(mockSetPublicLink).toHaveBeenLastCalledWith({
         conversationId: testConversationId,
         nodeId: testUuid,
@@ -223,7 +209,6 @@ describe('useCellPublicLink', () => {
     });
 
     it('uses createdLinkUuid ref as fallback when node.publicLink is not yet updated', async () => {
-      // Node without public link
       mockGetNodes.mockReturnValue([
         {
           id: testUuid,
@@ -246,14 +231,12 @@ describe('useCellPublicLink', () => {
 
       const {result} = renderHook(() => useCellPublicLink(defaultProps));
 
-      // Toggle on - start creation
       act(() => {
         result.current.togglePublicLink();
       });
 
       expect(result.current.status).toBe('loading');
 
-      // Resolve the creation - this sets createdLinkUuid.current
       await act(async () => {
         createResolve!(mockLinkResponse);
       });
@@ -262,7 +245,6 @@ describe('useCellPublicLink', () => {
         expect(result.current.status).toBe('success');
       });
 
-      // Simulate store update
       mockGetNodes.mockReturnValue([
         {
           id: testUuid,
@@ -275,12 +257,10 @@ describe('useCellPublicLink', () => {
         },
       ]);
 
-      // Toggle off
       act(() => {
         result.current.togglePublicLink();
       });
 
-      // The delete should use the createdLinkUuid or node.publicLink.uuid
       await waitFor(() => {
         expect(mockDeletePublicLink).toHaveBeenCalledWith({uuid: 'immediate-delete-uuid'});
       });
@@ -289,7 +269,6 @@ describe('useCellPublicLink', () => {
 
   describe('should fetch existing link data when toggle is enabled on already shared node', () => {
     it('fetches link details for already shared node', async () => {
-      // Node with alreadyShared flag but needs fetching
       mockGetNodes.mockReturnValue([
         {
           id: testUuid,
@@ -311,7 +290,6 @@ describe('useCellPublicLink', () => {
 
       const {result} = renderHook(() => useCellPublicLink(defaultProps));
 
-      // Already enabled due to alreadyShared
       expect(result.current.isEnabled).toBe(true);
 
       await waitFor(() => {
@@ -340,7 +318,6 @@ describe('useCellPublicLink', () => {
 
       const {result} = renderHook(() => useCellPublicLink(defaultProps));
 
-      // Toggle on
       act(() => {
         result.current.togglePublicLink();
       });
@@ -359,7 +336,6 @@ describe('useCellPublicLink', () => {
     it('handles missing LinkUrl in response', async () => {
       mockCreatePublicLink.mockResolvedValue({
         Uuid: 'uuid-only',
-        // Missing LinkUrl
       });
 
       const {result} = renderHook(() => useCellPublicLink(defaultProps));
@@ -376,7 +352,6 @@ describe('useCellPublicLink', () => {
     it('handles missing Uuid in response', async () => {
       mockCreatePublicLink.mockResolvedValue({
         LinkUrl: '/public/share/no-uuid',
-        // Missing Uuid
       });
 
       const {result} = renderHook(() => useCellPublicLink(defaultProps));
@@ -411,7 +386,6 @@ describe('useCellPublicLink', () => {
 
       expect(result.current.isEnabled).toBe(true);
 
-      // Toggle off
       act(() => {
         result.current.togglePublicLink();
       });
@@ -552,7 +526,6 @@ describe('useCellPublicLink', () => {
           id: testUuid,
           name: 'test-file.txt',
           publicLink: {
-            // No uuid, but has url (edge case)
             url: 'https://cells.example.com/public/share/orphan',
             alreadyShared: false,
           },
@@ -561,20 +534,16 @@ describe('useCellPublicLink', () => {
 
       const {result} = renderHook(() => useCellPublicLink(defaultProps));
 
-      // Start enabled because there's a url
       expect(result.current.isEnabled).toBe(false);
 
-      // Manually enable then disable
       act(() => {
         result.current.togglePublicLink();
       });
 
-      // Wait briefly
       await act(async () => {
         await new Promise(resolve => setTimeout(resolve, 50));
       });
 
-      // Delete should not be called since there's no uuid
       expect(mockDeletePublicLink).not.toHaveBeenCalled();
     });
 

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsNodeShareModal/useCellPublicLink.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsNodeShareModal/useCellPublicLink.test.ts
@@ -1,0 +1,614 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {renderHook, act, waitFor} from '@testing-library/react';
+
+import {useCellPublicLink} from './useCellPublicLink';
+
+// Mock dependencies
+const mockGetNodes = jest.fn();
+const mockSetPublicLink = jest.fn();
+
+jest.mock('../../../common/useCellsStore/useCellsStore', () => ({
+  useCellsStore: () => ({
+    getNodes: mockGetNodes,
+    setPublicLink: mockSetPublicLink,
+  }),
+}));
+
+jest.mock('src/script/Config', () => ({
+  Config: {
+    getConfig: () => ({
+      CELLS_PYDIO_URL: 'https://cells.example.com',
+    }),
+  },
+}));
+
+// Mock CellsRepository methods
+const mockCreatePublicLink = jest.fn();
+const mockGetPublicLink = jest.fn();
+const mockDeletePublicLink = jest.fn();
+
+const mockCellsRepository = {
+  createPublicLink: mockCreatePublicLink,
+  getPublicLink: mockGetPublicLink,
+  deletePublicLink: mockDeletePublicLink,
+} as any;
+
+describe('useCellPublicLink', () => {
+  const testUuid = 'test-node-uuid';
+  const testConversationId = 'test-conversation-id';
+
+  const defaultProps = {
+    uuid: testUuid,
+    conversationId: testConversationId,
+    cellsRepository: mockCellsRepository,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: node without public link
+    mockGetNodes.mockReturnValue([
+      {
+        id: testUuid,
+        name: 'test-file.txt',
+        publicLink: undefined,
+      },
+    ]);
+  });
+
+  describe('should create a public link when toggle is enabled', () => {
+    it('creates public link and updates store', async () => {
+      const mockLinkResponse = {
+        Uuid: 'new-link-uuid',
+        LinkUrl: '/public/share/abc123',
+        Label: 'test-file.txt',
+      };
+      mockCreatePublicLink.mockResolvedValue(mockLinkResponse);
+
+      const {result} = renderHook(() => useCellPublicLink(defaultProps));
+
+      // Initially disabled
+      expect(result.current.isEnabled).toBe(false);
+      expect(result.current.status).toBe('idle');
+
+      // Toggle on
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      expect(result.current.isEnabled).toBe(true);
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('success');
+      });
+
+      expect(mockCreatePublicLink).toHaveBeenCalledWith({
+        uuid: testUuid,
+        link: {
+          Label: 'test-file.txt',
+          Permissions: ['Preview', 'Download'],
+        },
+      });
+
+      expect(mockSetPublicLink).toHaveBeenCalledWith({
+        conversationId: testConversationId,
+        nodeId: testUuid,
+        data: {
+          uuid: 'new-link-uuid',
+          url: 'https://cells.example.com/public/share/abc123',
+          alreadyShared: true,
+        },
+      });
+    });
+  });
+
+  describe('should delete a public link when toggle is disabled', () => {
+    it('deletes public link and clears store', async () => {
+      // Node with existing public link
+      mockGetNodes.mockReturnValue([
+        {
+          id: testUuid,
+          name: 'test-file.txt',
+          publicLink: {
+            uuid: 'existing-link-uuid',
+            url: 'https://cells.example.com/public/share/existing',
+            alreadyShared: true,
+          },
+        },
+      ]);
+
+      mockDeletePublicLink.mockResolvedValue(undefined);
+
+      const {result} = renderHook(() => useCellPublicLink(defaultProps));
+
+      // Initially enabled because node has public link
+      expect(result.current.isEnabled).toBe(true);
+
+      // Toggle off
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      expect(result.current.isEnabled).toBe(false);
+
+      await waitFor(() => {
+        expect(mockDeletePublicLink).toHaveBeenCalledWith({uuid: 'existing-link-uuid'});
+      });
+
+      expect(mockSetPublicLink).toHaveBeenCalledWith({
+        conversationId: testConversationId,
+        nodeId: testUuid,
+        data: undefined,
+      });
+    });
+  });
+
+  describe('should delete a newly created link when toggle is immediately disabled', () => {
+    it('uses createdLinkUuid ref to delete link before state propagates', async () => {
+      // Node without public link initially
+      mockGetNodes.mockReturnValue([
+        {
+          id: testUuid,
+          name: 'test-file.txt',
+          publicLink: undefined,
+        },
+      ]);
+
+      const mockLinkResponse = {
+        Uuid: 'newly-created-uuid',
+        LinkUrl: '/public/share/new123',
+      };
+
+      // Create resolves, but we'll toggle off before the store updates
+      mockCreatePublicLink.mockResolvedValue(mockLinkResponse);
+      mockDeletePublicLink.mockResolvedValue(undefined);
+
+      const {result} = renderHook(() => useCellPublicLink(defaultProps));
+
+      // Toggle on - start creation
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      // Wait for creation to complete
+      await waitFor(() => {
+        expect(result.current.status).toBe('success');
+      });
+
+      // Now simulate the node store being updated with the new link
+      mockGetNodes.mockReturnValue([
+        {
+          id: testUuid,
+          name: 'test-file.txt',
+          publicLink: {
+            uuid: 'newly-created-uuid',
+            url: 'https://cells.example.com/public/share/new123',
+            alreadyShared: true,
+          },
+        },
+      ]);
+
+      // Toggle off immediately after creation
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      await waitFor(() => {
+        expect(mockDeletePublicLink).toHaveBeenCalledWith({uuid: 'newly-created-uuid'});
+      });
+
+      // Verify the deletion clears the store
+      expect(mockSetPublicLink).toHaveBeenLastCalledWith({
+        conversationId: testConversationId,
+        nodeId: testUuid,
+        data: undefined,
+      });
+    });
+
+    it('uses createdLinkUuid ref as fallback when node.publicLink is not yet updated', async () => {
+      // Node without public link
+      mockGetNodes.mockReturnValue([
+        {
+          id: testUuid,
+          name: 'test-file.txt',
+          publicLink: undefined,
+        },
+      ]);
+
+      const mockLinkResponse = {
+        Uuid: 'immediate-delete-uuid',
+        LinkUrl: '/public/share/immediate',
+      };
+
+      let createResolve: (value: any) => void;
+      const createPromise = new Promise(resolve => {
+        createResolve = resolve;
+      });
+      mockCreatePublicLink.mockReturnValue(createPromise);
+      mockDeletePublicLink.mockResolvedValue(undefined);
+
+      const {result} = renderHook(() => useCellPublicLink(defaultProps));
+
+      // Toggle on - start creation
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      expect(result.current.status).toBe('loading');
+
+      // Resolve the creation - this sets createdLinkUuid.current
+      await act(async () => {
+        createResolve!(mockLinkResponse);
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('success');
+      });
+
+      // Simulate store update
+      mockGetNodes.mockReturnValue([
+        {
+          id: testUuid,
+          name: 'test-file.txt',
+          publicLink: {
+            uuid: 'immediate-delete-uuid',
+            url: 'https://cells.example.com/public/share/immediate',
+            alreadyShared: true,
+          },
+        },
+      ]);
+
+      // Toggle off
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      // The delete should use the createdLinkUuid or node.publicLink.uuid
+      await waitFor(() => {
+        expect(mockDeletePublicLink).toHaveBeenCalledWith({uuid: 'immediate-delete-uuid'});
+      });
+    });
+  });
+
+  describe('should fetch existing link data when toggle is enabled on already shared node', () => {
+    it('fetches link details for already shared node', async () => {
+      // Node with alreadyShared flag but needs fetching
+      mockGetNodes.mockReturnValue([
+        {
+          id: testUuid,
+          name: 'test-file.txt',
+          publicLink: {
+            uuid: 'existing-uuid',
+            alreadyShared: true,
+          },
+        },
+      ]);
+
+      const mockLinkDetails = {
+        Uuid: 'existing-uuid',
+        LinkUrl: '/public/share/existing',
+        Label: 'test-file.txt',
+        PasswordRequired: false,
+      };
+      mockGetPublicLink.mockResolvedValue(mockLinkDetails);
+
+      const {result} = renderHook(() => useCellPublicLink(defaultProps));
+
+      // Already enabled due to alreadyShared
+      expect(result.current.isEnabled).toBe(true);
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('success');
+      });
+
+      expect(mockGetPublicLink).toHaveBeenCalledWith({uuid: 'existing-uuid'});
+
+      expect(mockSetPublicLink).toHaveBeenCalledWith({
+        conversationId: testConversationId,
+        nodeId: testUuid,
+        data: {
+          uuid: 'existing-uuid',
+          url: 'https://cells.example.com/public/share/existing',
+          alreadyShared: true,
+        },
+      });
+
+      expect(result.current.linkData).toEqual(mockLinkDetails);
+    });
+  });
+
+  describe('should handle errors during link creation', () => {
+    it('sets error status and clears store on creation failure', async () => {
+      mockCreatePublicLink.mockRejectedValue(new Error('Creation failed'));
+
+      const {result} = renderHook(() => useCellPublicLink(defaultProps));
+
+      // Toggle on
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('error');
+      });
+
+      expect(mockSetPublicLink).toHaveBeenCalledWith({
+        conversationId: testConversationId,
+        nodeId: testUuid,
+        data: undefined,
+      });
+    });
+
+    it('handles missing LinkUrl in response', async () => {
+      mockCreatePublicLink.mockResolvedValue({
+        Uuid: 'uuid-only',
+        // Missing LinkUrl
+      });
+
+      const {result} = renderHook(() => useCellPublicLink(defaultProps));
+
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('error');
+      });
+    });
+
+    it('handles missing Uuid in response', async () => {
+      mockCreatePublicLink.mockResolvedValue({
+        LinkUrl: '/public/share/no-uuid',
+        // Missing Uuid
+      });
+
+      const {result} = renderHook(() => useCellPublicLink(defaultProps));
+
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('error');
+      });
+    });
+  });
+
+  describe('should handle errors during link deletion', () => {
+    it('sets error status on deletion failure', async () => {
+      mockGetNodes.mockReturnValue([
+        {
+          id: testUuid,
+          name: 'test-file.txt',
+          publicLink: {
+            uuid: 'existing-link-uuid',
+            url: 'https://cells.example.com/public/share/existing',
+            alreadyShared: true,
+          },
+        },
+      ]);
+
+      mockDeletePublicLink.mockRejectedValue(new Error('Deletion failed'));
+
+      const {result} = renderHook(() => useCellPublicLink(defaultProps));
+
+      expect(result.current.isEnabled).toBe(true);
+
+      // Toggle off
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('error');
+      });
+
+      expect(mockDeletePublicLink).toHaveBeenCalledWith({uuid: 'existing-link-uuid'});
+    });
+  });
+
+  describe('should pass conversationId to store operations', () => {
+    it('passes conversationId when creating public link', async () => {
+      const customConversationId = 'custom-conversation-123';
+
+      mockCreatePublicLink.mockResolvedValue({
+        Uuid: 'link-uuid',
+        LinkUrl: '/public/share/test',
+      });
+
+      const {result} = renderHook(() =>
+        useCellPublicLink({
+          ...defaultProps,
+          conversationId: customConversationId,
+        }),
+      );
+
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('success');
+      });
+
+      expect(mockSetPublicLink).toHaveBeenCalledWith(
+        expect.objectContaining({
+          conversationId: customConversationId,
+        }),
+      );
+    });
+
+    it('passes conversationId when deleting public link', async () => {
+      const customConversationId = 'custom-conversation-456';
+
+      mockGetNodes.mockReturnValue([
+        {
+          id: testUuid,
+          name: 'test-file.txt',
+          publicLink: {
+            uuid: 'existing-link-uuid',
+            url: 'https://cells.example.com/public/share/existing',
+            alreadyShared: true,
+          },
+        },
+      ]);
+
+      mockDeletePublicLink.mockResolvedValue(undefined);
+
+      const {result} = renderHook(() =>
+        useCellPublicLink({
+          ...defaultProps,
+          conversationId: customConversationId,
+        }),
+      );
+
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      await waitFor(() => {
+        expect(mockDeletePublicLink).toHaveBeenCalled();
+      });
+
+      expect(mockSetPublicLink).toHaveBeenCalledWith(
+        expect.objectContaining({
+          conversationId: customConversationId,
+        }),
+      );
+    });
+
+    it('passes conversationId when fetching existing link', async () => {
+      const customConversationId = 'custom-conversation-789';
+
+      mockGetNodes.mockReturnValue([
+        {
+          id: testUuid,
+          name: 'test-file.txt',
+          publicLink: {
+            uuid: 'existing-uuid',
+            alreadyShared: true,
+          },
+        },
+      ]);
+
+      mockGetPublicLink.mockResolvedValue({
+        Uuid: 'existing-uuid',
+        LinkUrl: '/public/share/existing',
+      });
+
+      const {result} = renderHook(() =>
+        useCellPublicLink({
+          ...defaultProps,
+          conversationId: customConversationId,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('success');
+      });
+
+      expect(mockSetPublicLink).toHaveBeenCalledWith(
+        expect.objectContaining({
+          conversationId: customConversationId,
+        }),
+      );
+    });
+
+    it('uses getNodes with conversationId to find the node', () => {
+      const customConversationId = 'get-nodes-test-conversation';
+
+      renderHook(() =>
+        useCellPublicLink({
+          ...defaultProps,
+          conversationId: customConversationId,
+        }),
+      );
+
+      expect(mockGetNodes).toHaveBeenCalledWith({conversationId: customConversationId});
+    });
+  });
+
+  describe('additional edge cases', () => {
+    it('does not delete when no link uuid exists', async () => {
+      mockGetNodes.mockReturnValue([
+        {
+          id: testUuid,
+          name: 'test-file.txt',
+          publicLink: {
+            // No uuid, but has url (edge case)
+            url: 'https://cells.example.com/public/share/orphan',
+            alreadyShared: false,
+          },
+        },
+      ]);
+
+      const {result} = renderHook(() => useCellPublicLink(defaultProps));
+
+      // Start enabled because there's a url
+      expect(result.current.isEnabled).toBe(false);
+
+      // Manually enable then disable
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      // Wait briefly
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 50));
+      });
+
+      // Delete should not be called since there's no uuid
+      expect(mockDeletePublicLink).not.toHaveBeenCalled();
+    });
+
+    it('returns link url from node.publicLink', async () => {
+      mockGetNodes.mockReturnValue([
+        {
+          id: testUuid,
+          name: 'test-file.txt',
+          publicLink: {
+            uuid: 'test-uuid',
+            url: 'https://cells.example.com/public/share/test-link',
+            alreadyShared: true,
+          },
+        },
+      ]);
+
+      mockGetPublicLink.mockResolvedValue({
+        Uuid: 'test-uuid',
+        LinkUrl: '/public/share/test-link',
+      });
+
+      const {result} = renderHook(() => useCellPublicLink(defaultProps));
+
+      expect(result.current.link).toBe('https://cells.example.com/public/share/test-link');
+    });
+
+    it('handles node not found in store', () => {
+      mockGetNodes.mockReturnValue([]);
+
+      const {result} = renderHook(() => useCellPublicLink(defaultProps));
+
+      expect(result.current.isEnabled).toBe(false);
+      expect(result.current.status).toBe('idle');
+      expect(result.current.link).toBeUndefined();
+    });
+  });
+});

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsNodeShareModal/useCellPublicLink.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsNodeShareModal/useCellPublicLink.ts
@@ -42,6 +42,8 @@ export const useCellPublicLink = ({uuid, conversationId, cellsRepository}: UseCe
   const [status, setStatus] = useState<PublicLinkStatus>(node?.publicLink ? 'success' : 'idle');
   const [linkData, setLinkData] = useState<RestShareLink | null>(null);
   const fetchedLinkId = useRef<string | null>(null);
+  // Track created link UUID to handle immediate disable scenario
+  const createdLinkUuid = useRef<string | null>(null);
 
   const createPublicLink = useCallback(async () => {
     try {
@@ -59,10 +61,13 @@ export const useCellPublicLink = ({uuid, conversationId, cellsRepository}: UseCe
       }
 
       const newLink = {uuid: link.Uuid, url: Config.getConfig().CELLS_PYDIO_URL + link.LinkUrl, alreadyShared: true};
+      // Store the created link UUID for immediate deletion scenario
+      createdLinkUuid.current = link.Uuid;
       setPublicLink({conversationId, nodeId: uuid, data: newLink});
       setLinkData(link);
       setStatus('success');
     } catch (err) {
+      createdLinkUuid.current = null;
       setStatus('error');
       setPublicLink({conversationId, nodeId: uuid, data: undefined});
     }
@@ -102,18 +107,21 @@ export const useCellPublicLink = ({uuid, conversationId, cellsRepository}: UseCe
   }, [uuid, conversationId, setPublicLink]);
 
   const deletePublicLink = useCallback(async () => {
-    if (!node?.publicLink || !node.publicLink.uuid) {
+    // Use createdLinkUuid as fallback for immediate disable scenario
+    const linkUuid = node?.publicLink?.uuid || createdLinkUuid.current;
+
+    if (!linkUuid) {
       return;
     }
 
     try {
-      await cellsRepository.deletePublicLink({uuid: node.publicLink.uuid});
+      await cellsRepository.deletePublicLink({uuid: linkUuid});
       setPublicLink({conversationId, nodeId: uuid, data: undefined});
+      createdLinkUuid.current = null; // Clear after successful deletion
     } catch (err) {
       setStatus('error');
     }
     // cellsRepository is not a dependency because it's a singleton
-    // node?.publicLink is intentionally not a dependency to avoid infinite loop
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [uuid, conversationId, setPublicLink]);
 
@@ -155,6 +163,9 @@ export const useCellPublicLink = ({uuid, conversationId, cellsRepository}: UseCe
           ...(isSettingPassword ? (hasExistingPassword ? {updatePassword: password} : {createPassword: password}) : {}),
           passwordEnabled,
         });
+
+        const newLink = await cellsRepository.getPublicLink({uuid: node.publicLink.uuid});
+        setLinkData(newLink);
 
         setStatus('success');
       } catch (err) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22978" title="WPB-22978" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22978</a>  [Web] Enabling/Disabling public link in a row is not working
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-22978

Add createdLinkUuid ref to handle the stale closure issue when user creates a public link and immediately disables it

(cherry-pick) fix(public-links): update public link data after password change

This commit ensures the public link data is refreshed after a password change in the CellsNodeShareModal.

Detailed Changes:
 - Implementation:
   - Added a call to fetch the updated public link data from the repository after changing the password.
   - Updated the state with the new link data and set the status to success.

# Pull Request

## Summary

- What did I change and why?
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
