### PR TITLE
ci(WPB-19585): Add workflow to run e2e tests across different environments

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -100,6 +100,12 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     needs: [test]
+
+    # It's necessary to define the outputs of the job so the calling workflow can access them
+    outputs:
+      reportArtifactId: ${{ steps.generate-outputs.outputs.reportArtifactId }}
+      reportUrl: ${{ steps.generate-outputs.outputs.reportUrl }}
+
     steps:
       - uses: actions/checkout@v6
 
@@ -132,6 +138,7 @@ jobs:
           path: apps/webapp/playwright-report/
 
       - name: Generate outputs
+        id: generate-outputs
         run: |
           echo "reportUrl=${{ steps.upload_playwright_report.outputs.artifact-url }}" >> $GITHUB_OUTPUT
           echo "reportArtifactId=${{ steps.upload_playwright_report.outputs.artifact-id }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,6 +1,28 @@
 name: E2E Tests
 
 on:
+  # Options for the workflow when it's manually triggered
+  workflow_dispatch:
+    inputs:
+      webappUrl:
+        type: choice
+        description: Define which stage to run the tests against
+        required: true
+        options:
+          - https://wire-webapp-dev.zinfra.io/
+          - https://wire-webapp-master.zinfra.io/
+          - https://wire-webapp-edge.wire.com/
+          - https://wire-webapp-staging.wire.com/
+      backendUrl:
+        type: string
+        description: Define which backend should be used (make sure this matches the one used by the stage set for webappUrl)
+        options:
+          - https://staging-nginz-https.zinfra.io/
+          - https://prod-nginz-https.wire.com/
+      grep:
+        type: string
+        description: Define which tests to run, the given value will be passed to the `--grep` flag of playwright
+  # Options for calling the workflow within an other workflow
   workflow_call:
     inputs:
       webappUrl:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -85,7 +85,8 @@ jobs:
           WEBAPP_URL: ${{ inputs.webappUrl }}
           BACKEND_URL: ${{ inputs.backendUrl }}
           TEST_SERVICE_URL: http://localhost:8080 # Run tests against locally running test service
-        run: yarn nx run webapp:e2e --shard=${{ matrix.shard }}/${{ strategy.job-total }} ${{ inputs.grep && format('--grep "{0}"', inputs.grep) }}
+          GREP: ${{ inputs.grep }}
+        run: yarn nx run webapp:e2e --shard=${{ matrix.shard }}/${{ strategy.job-total }} --grep="${GREP}"
 
       - name: Upload blob report
         if: ${{ !cancelled() }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,114 @@
+name: E2E Tests
+
+on:
+  workflow_call:
+    inputs:
+      webappUrl:
+        type: string
+        required: true
+      backendUrl:
+        type: string
+        required: true
+      grep:
+        type: string
+        description: Define which tests to run, the given value will be passed to the `--grep` flag of playwright
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN:
+        required: true
+    outputs:
+      reportArtifactId:
+        description: ID of the playwright report artifact
+        value: ${{ jobs.e2e-report.outputs.reportArtifactId }}
+      reportUrl:
+        description: URL to the playwright report artifact
+        value: ${{ jobs.e2e-report.outputs.reportUrl }}
+
+jobs:
+  test:
+    name: Run E2E Tests
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # prettier-ignore
+        shard: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]
+
+    services:
+      # Run the kalium testservice as service container of the current job
+      testservice:
+        image: quay.io/wire/testservice:latest
+        ports:
+          - 8080:8080
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - run: yarn --immutable
+      - run: yarn playwright install --with-deps chrome
+      - uses: 1password/install-cli-action@143a85f84a90555d121cde2ff5872e393a47ab9f
+
+      - name: Generate env file
+        run: op inject -i apps/webapp/test/e2e_tests/.env.staging.tpl -o apps/webapp/test/e2e_tests/.env
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+      - name: Run tests
+        env:
+          WEBAPP_URL: ${{ inputs.webappUrl }}
+          BACKEND_URL: ${{ inputs.backendUrl }}
+          TEST_SERVICE_URL: http://localhost:8080 # Run tests against locally running test service
+        run: yarn nx run webapp:e2e --shard=${{ matrix.shard }}/${{ strategy.job-total }} ${{ inputs.grep && format('--grep "{0}"', inputs.grep) }}
+
+      - name: Upload blob report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v5
+        with:
+          name: blob-report-${{ matrix.shard }}
+          path: apps/webapp/blob-report
+          retention-days: 1
+
+  e2e-report:
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - run: yarn --immutable
+
+      - name: Download blob reports
+        uses: actions/download-artifact@v5
+        with:
+          path: all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+
+      - name: Merge playwright reports
+        run: |
+          ls -la all-blob-reports/ || echo "No blob reports found"
+          cd apps/webapp
+          yarn playwright merge-reports --config ./playwright.config.ts ../../all-blob-reports
+          cd ../..
+
+      - name: Upload test report
+        id: upload_playwright_report
+        uses: actions/upload-artifact@v5
+        with:
+          name: playwright-report
+          path: apps/webapp/playwright-report/
+
+      - name: Generate outputs
+        run: |
+          echo "reportUrl=${{ steps.upload_playwright_report.outputs.artifact-url }}" >> $GITHUB_OUTPUT
+          echo "reportArtifactId=${{ steps.upload_playwright_report.outputs.artifact-id }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -124,71 +124,23 @@ jobs:
             echo "❌ Deployment failed"; exit 1
           fi
 
-  e2e_crit_flow:
+  run_e2e_tests:
     name: Playwright Critical Flow (precommit)
     if: ${{ !cancelled() && github.repository == 'wireapp/wire-webapp' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot' }}
-    runs-on: ubuntu-latest
-    needs: [deploy_to_aws]
-    timeout-minutes: 35
-
-    strategy:
-      fail-fast: false
-      matrix:
-        # prettier-ignore
-        shard: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]
-
-    services:
-      # Run the kalium testservice as service container of the current job
-      testservice:
-        image: quay.io/wire/testservice:latest
-        ports:
-          - 8080:8080
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
-
-      - run: yarn --immutable
-      - run: yarn playwright install --with-deps chrome
-      - uses: 1password/install-cli-action@143a85f84a90555d121cde2ff5872e393a47ab9f
-
-      - name: Generate env file
-        run: op inject -i apps/webapp/test/e2e_tests/.env.staging.tpl -o apps/webapp/test/e2e_tests/.env
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-
-      # Log which URL will be used for tests (deploy output vs fallback) and probe if env responds
-      - name: Show target URL + quick probe
-        run: |
-          echo "Using precommit URL: https://wire-webapp-precommit.zinfra.io/"
-          curl -s -o /dev/null -w "HTTP %{http_code}\n" https://wire-webapp-precommit.zinfra.io/
-
-      - name: Run critical flow tests
-        env:
-          # TODO: remove hardcoded precommit env in the future when ephemeral PR envs will exist
-          # Overrides URL from .env file
-          WEBAPP_URL: https://wire-webapp-precommit.zinfra.io/
-          TEST_SERVICE_URL: http://localhost:8080 # Run tests against locally running test service
-        run: yarn nx run webapp:e2e --shard=${{ matrix.shard }}/${{ strategy.job-total }} --grep "@crit-flow-web|@regression"
-
-      - name: Upload blob report
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v5
-        with:
-          name: blob-report-${{ matrix.shard }}
-          path: apps/webapp/blob-report
-          retention-days: 1
+    needs: deploy_to_aws
+    uses: ./.github/workflows/e2e-tests.yml
+    with:
+      webappUrl: https://wire-webapp-precommit.zinfra.io/
+      backendUrl: https://staging-nginz-https.zinfra.io/
+      grep: '@crit-flow-web|@regression'
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
   e2e-report:
-    runs-on: ubuntu-latest
+    name: Generate test report
+    needs: run_e2e_tests
     if: ${{ !cancelled() }}
-    needs: [e2e_crit_flow]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
@@ -199,29 +151,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
 
-      - run: yarn --immutable
-
-      - name: Download blob reports
+      - name: Download report
         uses: actions/download-artifact@v5
         with:
-          path: all-blob-reports
-          pattern: blob-report-*
-          merge-multiple: true
-
-      - name: Merge playwright reports
-        run: |
-          ls -la all-blob-reports/ || echo "No blob reports found"
-          cd apps/webapp
-          yarn playwright merge-reports --config ./playwright.config.ts ../../all-blob-reports
-          cd ../..
-
-      - name: Upload test report
-        id: upload_playwright_report
-        if: always()
-        uses: actions/upload-artifact@v5
-        with:
-          name: playwright-report
-          path: apps/webapp/playwright-report/
+          artifact-ids: ${{ needs.run_e2e_tests.outputs.reportArtifactId }}
+          path: apps/webapp/playwright-report
 
       - name: Generate PR comment
         if: always()
@@ -253,7 +187,7 @@ jobs:
         with:
           header: playwright-summary
           message: |
-            🔗 [Download Full Report Artifact](${{ steps.upload_playwright_report.outputs.artifact-url }})
+            🔗 [Download Full Report Artifact](${{ needs.run_e2e_tests.outputs.reportUrl }})
 
             ${{ steps.generate_comment.outputs.comment }}
         env:

--- a/apps/webapp/test/e2e_tests/.env.fulu.tpl
+++ b/apps/webapp/test/e2e_tests/.env.fulu.tpl
@@ -32,6 +32,5 @@ INBUCKET_PASSWORD="{{ op://Test Automation/BackendConnection fulu/inbucketPasswo
 INBUCKET_URL=op://Test Automation/BackendConnection fulu/inbucketUrl
 BACKEND_URL=op://Test Automation/BackendConnection fulu/backendUrl
 WEBAPP_URL=op://Test Automation/BackendConnection fulu/webappUrl
-TEAM_MANAGEMENT_URL=op://Test Automation/BackendConnection fulu/teamManagementUrl
 DOMAIN=op://Test Automation/BackendConnection fulu/domain
 BASIC_AUTH=op://Test Automation/BackendConnection fulu/basicAuth

--- a/apps/webapp/test/e2e_tests/.env.imai.tpl
+++ b/apps/webapp/test/e2e_tests/.env.imai.tpl
@@ -32,6 +32,5 @@ INBUCKET_PASSWORD="{{ op://Test Automation/BackendConnection imai/inbucketPasswo
 INBUCKET_URL=op://Test Automation/BackendConnection imai/inbucketUrl
 BACKEND_URL=op://Test Automation/BackendConnection imai/backendUrl
 WEBAPP_URL=op://Test Automation/BackendConnection imai/webappUrl
-TEAM_MANAGEMENT_URL=op://Test Automation/BackendConnection imai/teamManagementUrl
 DOMAIN=op://Test Automation/BackendConnection imai/domain
 BASIC_AUTH=op://Test Automation/BackendConnection imai/basicAuth

--- a/apps/webapp/test/e2e_tests/.env.staging.tpl
+++ b/apps/webapp/test/e2e_tests/.env.staging.tpl
@@ -38,6 +38,5 @@ INBUCKET_PASSWORD="{{ op://Test Automation/BackendConnection staging/inbucketPas
 INBUCKET_URL=op://Test Automation/BackendConnection staging/inbucketUrl
 BACKEND_URL=op://Test Automation/BackendConnection staging/backendUrl
 WEBAPP_URL=op://Test Automation/BackendConnection staging/webappUrl
-TEAM_MANAGEMENT_URL=op://Test Automation/BackendConnection staging/teamManagementUrl
 DOMAIN=op://Test Automation/BackendConnection staging/domain
 BASIC_AUTH=op://Test Automation/BackendConnection staging/basicAuth

--- a/apps/webapp/test/e2e_tests/pageManager/index.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/index.ts
@@ -74,7 +74,6 @@ import {StartUIPage} from './webapp/pages/startUI.page';
 import {WelcomePage} from './webapp/pages/welcome.page';
 
 export const webAppPath = process.env.WEBAPP_URL ?? '';
-const teamManagementPath = process.env.TEAM_MANAGEMENT_URL ?? '';
 
 export class PageManager {
   private readonly cache = new Map<string, any>();
@@ -110,10 +109,6 @@ export class PageManager {
 
   openUrl = (url: string) => {
     return this.page.goto(url, {waitUntil: 'networkidle'});
-  };
-
-  openTeamManagementPage = () => {
-    return this.page.goto(teamManagementPath, {waitUntil: 'networkidle'});
   };
 
   refreshPage = (options: {waitUntil?: 'load' | 'domcontentloaded' | 'networkidle'} = {waitUntil: 'networkidle'}) => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19585" title="WPB-19585" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19585</a>  [Web/QA] Github action to run regression and crit flows on various envs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- Remove no longer used env var for team management url
- Add reusable workflow for executing the e2e tests in CI
- Refactor existing precommit-crit-flows workflow to use it
- Allow e2e tests workflow to be triggered manually for different environments

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- 
