### PR TITLE
test(WPB-19964): add regression tests for message reactions

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -89,7 +89,7 @@ export class ConversationPage {
     this.removeUserButton = page.locator(selectByDataAttribute('do-remove-item-text'));
     this.addMemberButton = page.locator(selectByDataAttribute('go-add-people'));
     this.systemMessages = page.locator(
-      `${selectByDataAttribute('item-message')}${selectByClass('system-message')}${selectByDataAttribute('-1', 'send-status')}`,
+      `${selectByDataAttribute('item-message')}${selectByClass('system-message')}:not(${selectByDataAttribute('1', 'send-status')})`,
     );
     this.callButton = page.locator(selectByDataAttribute('do-call'));
     this.conversationInfoButton = page.locator(selectByDataAttribute('do-open-info'));
@@ -99,7 +99,7 @@ export class ConversationPage {
      * Status type -1 ensures that system messages do NOT count as sent messages
      */
     this.messages = page.locator(
-      `${selectByDataAttribute('item-message')}:not(${selectByDataAttribute('1', 'send-status')}):not(${selectByDataAttribute('-1', 'send-status')})`,
+      `${selectByDataAttribute('item-message')}:not(${selectByDataAttribute('1', 'send-status')}):not(${selectByDataAttribute('-1', 'send-status')}):not(${selectByClass('system-message')})`,
     );
     this.messageDetails = page.locator('#message-details');
     this.filesTab = page.locator('#conversation-tab-files');

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -60,6 +60,7 @@ export class ConversationPage {
   readonly itemPendingRequest: Locator;
   readonly ignoreButton: Locator;
   readonly cancelRequest: Locator;
+  readonly reactionWithHeartEmoji: Locator;
 
   readonly getImageAltText = (user: User) => `Image from ${user.fullName}`;
 
@@ -107,6 +108,7 @@ export class ConversationPage {
     this.itemPendingRequest = page.locator(selectByDataAttribute('item-pending-requests'));
     this.ignoreButton = page.getByTestId('do-ignore');
     this.cancelRequest = page.getByTestId('do-cancel-request');
+    this.reactionWithHeartEmoji = page.getByRole('button', {name: /react with heart emoji/i});
   }
 
   protected getImageLocator(user: User): Locator {
@@ -264,12 +266,10 @@ export class ConversationPage {
 
   async reactOnMessage(message: Locator, emojiType: EmojiReaction) {
     await message.hover();
-    const reactionButton = message.getByRole('group').getByRole('button').first();
-    await reactionButton.click();
 
     switch (emojiType) {
       case 'plus-one':
-        // The first quick reaction button is +1 (thumbs up), so we just clicked it
+        await message.getByRole('group').getByRole('button').first().click();
         break;
       case 'heart':
         await this.page.getByTestId('reactwith-love-message').click();

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -88,7 +88,9 @@ export class ConversationPage {
     this.makeAdminToggle = page.locator(selectByDataAttribute('do-allow-admin'));
     this.removeUserButton = page.locator(selectByDataAttribute('do-remove-item-text'));
     this.addMemberButton = page.locator(selectByDataAttribute('go-add-people'));
-    this.systemMessages = page.locator(`${selectByDataAttribute('item-message')}${selectByClass('system-message')}`);
+    this.systemMessages = page.locator(
+      `${selectByDataAttribute('item-message')}${selectByClass('system-message')}${selectByDataAttribute('-1', 'send-status')}`,
+    );
     this.callButton = page.locator(selectByDataAttribute('do-call'));
     this.conversationInfoButton = page.locator(selectByDataAttribute('do-open-info'));
     this.pingButton = page.locator(selectByDataAttribute('do-ping'));

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -60,7 +60,6 @@ export class ConversationPage {
   readonly itemPendingRequest: Locator;
   readonly ignoreButton: Locator;
   readonly cancelRequest: Locator;
-  readonly reactionWithHeartEmoji: Locator;
 
   readonly getImageAltText = (user: User) => `Image from ${user.fullName}`;
 
@@ -89,9 +88,7 @@ export class ConversationPage {
     this.makeAdminToggle = page.locator(selectByDataAttribute('do-allow-admin'));
     this.removeUserButton = page.locator(selectByDataAttribute('do-remove-item-text'));
     this.addMemberButton = page.locator(selectByDataAttribute('go-add-people'));
-    this.systemMessages = page.locator(
-      `${selectByDataAttribute('item-message')}${selectByClass('system-message')} ${selectByClass('message-header')}`,
-    );
+    this.systemMessages = page.locator(`${selectByDataAttribute('item-message')}${selectByClass('system-message')}`);
     this.callButton = page.locator(selectByDataAttribute('do-call'));
     this.conversationInfoButton = page.locator(selectByDataAttribute('do-open-info'));
     this.pingButton = page.locator(selectByDataAttribute('do-ping'));
@@ -108,7 +105,6 @@ export class ConversationPage {
     this.itemPendingRequest = page.locator(selectByDataAttribute('item-pending-requests'));
     this.ignoreButton = page.getByTestId('do-ignore');
     this.cancelRequest = page.getByTestId('do-cancel-request');
-    this.reactionWithHeartEmoji = page.getByRole('button', {name: /react with heart emoji/i});
   }
 
   protected getImageLocator(user: User): Locator {

--- a/apps/webapp/test/e2e_tests/specs/Reactions/reactions.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reactions/reactions.spec.ts
@@ -1,0 +1,279 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {User} from 'test/e2e_tests/data/user';
+import {PageManager} from 'test/e2e_tests/pageManager';
+import {test, expect, withLogin, withConnectedUser} from 'test/e2e_tests/test.fixtures';
+import {getAudioFilePath, getTextFilePath, getVideoFilePath, shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
+import {getImageFilePath} from 'test/e2e_tests/utils/sendImage.util';
+import {selectByDataAttribute} from '../../utils/selector.util';
+
+type PM = Awaited<ReturnType<typeof PageManager.from>>;
+type Pages = PM['webapp']['pages'];
+
+type LikeCase = {
+  tc: '@TC-1527' | '@TC-1528' | '@TC-1529' | '@TC-1530' | '@TC-1532' | '@TC-1536';
+  title: string;
+  sendFromUserB: (userBPages: Pages) => Promise<void>;
+};
+
+test.describe('Reactions', () => {
+  let userA: User;
+  let userB: User;
+
+  test.beforeEach(async ({createTeam}) => {
+    const team = await createTeam('Test Team', {withMembers: 1});
+    userA = team.owner;
+    userB = team.members[0];
+  });
+
+  const likeCases: LikeCase[] = [
+    {
+      tc: '@TC-1527',
+      title: 'link preview in 1:1',
+      sendFromUserB: async (userBPages: Pages) => {
+        const link = 'https://www.kaufland.de/';
+        await userBPages.conversation().sendMessage(link);
+      },
+    },
+    {
+      tc: '@TC-1528',
+      title: 'picture',
+      sendFromUserB: async (userBPages: Pages) => {
+        const {page} = userBPages.conversation();
+        await shareAssetHelper(getImageFilePath(), page, page.getByRole('button', {name: 'Add picture'}));
+      },
+    },
+    {
+      tc: '@TC-1529',
+      title: 'audio message',
+      sendFromUserB: async (userBPages: Pages) => {
+        const {page} = userBPages.conversation();
+        await shareAssetHelper(getAudioFilePath(), page, page.getByRole('button', {name: 'Add file'}));
+      },
+    },
+    {
+      tc: '@TC-1530',
+      title: 'video message',
+      sendFromUserB: async (userBPages: Pages) => {
+        const {page} = userBPages.conversation();
+        await shareAssetHelper(getVideoFilePath(), page, page.getByRole('button', {name: 'Add file'}));
+      },
+    },
+    {
+      tc: '@TC-1532',
+      title: 'shared file',
+      sendFromUserB: async (userBPages: Pages) => {
+        const {page} = userBPages.conversation();
+        await shareAssetHelper(getTextFilePath(), page, page.getByRole('button', {name: 'Add file'}));
+      },
+    },
+    {
+      tc: '@TC-1536',
+      title: 'message in 1:1',
+      sendFromUserB: async (userBPages: Pages) => {
+        await userBPages.conversation().sendMessage('Message from User B');
+      },
+    },
+  ];
+
+  for (const c of likeCases) {
+    test(`Verify liking someone's ${c.title}`, {tag: [c.tc, '@regression']}, async ({createPage}) => {
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      ]);
+
+      await c.sendFromUserB(userBPages);
+
+      const messageFromUserB = userAPages.conversation().getMessage({sender: userB});
+      await expect(messageFromUserB).toBeVisible();
+
+      await userAPages.conversation().reactOnMessage(messageFromUserB, 'heart');
+
+      await expect(userAPages.conversation().reactionWithHeartEmoji).toBeVisible();
+    });
+  }
+
+  test("Verify liking someone's location", {tag: ['@TC-1533', '@regression']}, async ({createPage, api}) => {
+    const userAPages = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(
+      pm => pm.webapp.pages,
+    );
+
+    await test.step('Prerequisite: Send location via TestService', async () => {
+      const {instanceId} = await api.testService.createInstance(
+        userB.password,
+        userB.email,
+        'Test Service Device',
+        false,
+      );
+      const conversationId = await api.conversation.getConversationWithUser(userB.token, userA.id!);
+      await api.testService.sendLocation(instanceId, conversationId, {
+        locationName: 'Test Location',
+        latitude: 52.5170365,
+        longitude: 13.404954,
+        zoom: 42,
+      });
+    });
+
+    const messageWithLink = userAPages.conversation().getMessage({sender: userB});
+    await userAPages.conversation().reactOnMessage(messageWithLink, 'heart');
+
+    await expect(userAPages.conversation().reactionWithHeartEmoji).toBeVisible();
+  });
+
+  test('Verify liking an own text message', {tag: ['@TC-1534', '@regression']}, async ({createPage}) => {
+    const userAPages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
+
+    await userAPages.conversation().sendMessage('Message from User A');
+    const messageUserA = userAPages.conversation().getMessage({sender: userA});
+    await userAPages.conversation().reactOnMessage(messageUserA, 'heart');
+
+    await expect(userAPages.conversation().reactionWithHeartEmoji).toBeVisible();
+  });
+
+  test('Verify you cannot like a system message', {tag: ['@TC-1535', '@regression']}, async ({createPage}) => {
+    const userAPages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
+
+    const systemMessage = userAPages
+      .conversation()
+      .page.locator(`${selectByDataAttribute('item-message')}${selectByDataAttribute('-1', 'send-status')}`)
+      .last();
+    await systemMessage.hover();
+
+    const reactionButtons = systemMessage.getByRole('group').getByRole('button').first();
+    await expect(reactionButtons).not.toBeVisible();
+  });
+
+  test('Verify likes are reset if you edited message', {tag: ['@TC-1538', '@regression']}, async ({createPage}) => {
+    const [userAPages, userBPages] = await Promise.all([
+      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+    ]);
+
+    await userBPages.conversation().sendMessage('Message from User B');
+
+    const messageUserB = userAPages.conversation().getMessage({sender: userB});
+    await userAPages.conversation().reactOnMessage(messageUserB, 'heart');
+
+    const reaction = userAPages.conversation().reactionWithHeartEmoji;
+    await expect(reaction).toBeVisible();
+
+    await userBPages.conversation().editMessage(userBPages.conversation().getMessage({sender: userB}));
+    await userBPages.conversation().sendMessage('Edited Message');
+    const editedMessage = userAPages.conversation().getMessage({content: 'Edited Message'});
+    await expect(editedMessage).toBeVisible();
+
+    await expect(reaction).not.toBeVisible();
+  });
+
+  test(
+    'Verify I can open like list by hovering the link in the tooltip of a reaction pill',
+    {tag: ['@TC-1540', '@regression']},
+    async ({createPage}) => {
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      ]);
+
+      await userBPages.conversation().sendMessage('Message from User B');
+
+      const messageUserB = userAPages.conversation().getMessage({sender: userB});
+      await userAPages.conversation().reactOnMessage(messageUserB, 'heart');
+
+      const message = userBPages.conversation().getMessage({sender: userB});
+      await userBPages.conversation().reactOnMessage(message, 'heart');
+
+      const reaction = userAPages.conversation().reactionWithHeartEmoji;
+      await reaction.hover();
+
+      const tooltip = userAPages
+        .conversation()
+        .page.locator('[data-testid="tooltip-content"] div')
+        .filter({hasText: `${userA.fullName} reacted with`});
+      await expect(tooltip).toBeVisible();
+    },
+  );
+
+  test(
+    'I want to add/remove a reaction by clicking a reaction pill',
+    {tag: ['@TC-1548', '@regression']},
+    async ({createPage}) => {
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      ]);
+
+      await userBPages.conversation().sendMessage('Message to react to');
+      const messageInUserA = userAPages.conversation().getMessage({sender: userB});
+
+      await userAPages.conversation().reactOnMessage(messageInUserA, 'heart');
+
+      const messageInUserB = userBPages.conversation().getMessage({sender: userB});
+      await userBPages.conversation().reactOnMessage(messageInUserB, 'heart');
+
+      const reactionPill = userAPages.conversation().reactionWithHeartEmoji;
+
+      await expect(reactionPill).toBeVisible();
+      await expect(reactionPill).toHaveAttribute('aria-label', '2 reactions, react with heart emoji');
+      await expect(reactionPill).toHaveAttribute('aria-pressed', 'true');
+
+      await reactionPill.click();
+      await expect(reactionPill).toHaveAttribute('aria-label', '1 reaction, react with heart emoji');
+      await expect(reactionPill).toHaveAttribute('aria-pressed', 'false');
+
+      await reactionPill.click();
+      await expect(reactionPill).toHaveAttribute('aria-label', '2 reactions, react with heart emoji');
+      await expect(reactionPill).toHaveAttribute('aria-pressed', 'true');
+    },
+  );
+
+  test(
+    'I want to add/remove a reaction using emoji picker',
+    {tag: ['@TC-1549', '@regression']},
+    async ({createPage}) => {
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      ]);
+
+      await userBPages.conversation().sendMessage('Message for emoji picker test');
+      const message = userAPages.conversation().getMessage({sender: userB});
+
+      await message.hover();
+
+      const thumbsUpButton = message.getByRole('button', {name: 'React with thumbs up'});
+
+      await expect(thumbsUpButton).toBeVisible();
+      await expect(thumbsUpButton).toHaveAttribute('aria-pressed', 'false');
+
+      await thumbsUpButton.click();
+      await expect(thumbsUpButton).toHaveAttribute('aria-pressed', 'true');
+
+      const reactionPill = userAPages.conversation().page.getByRole('button', {name: /react with \+1/i});
+      await expect(reactionPill).toBeVisible();
+
+      await message.hover();
+      await thumbsUpButton.click();
+
+      await expect(thumbsUpButton).toHaveAttribute('aria-pressed', 'false');
+      await expect(reactionPill).not.toBeVisible();
+    },
+  );
+});


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19964" title="WPB-19964" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19964</a>  [Web/QA] Write the Reactions regression tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

https://wearezeta.atlassian.net/browse/WPB-19964
# Pull Request

## Summary
Add regression tests for reactions on messages and assets

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

## Note for reviewers
Code duplication cannot be reduced any further because it only refers to signing in users.