### PR TITLE
fix: Conversation tab name localised cells(WPB-23086)

### DIFF
--- a/apps/webapp/src/script/components/Conversation/ConversationTabs/ConversationTabs.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationTabs/ConversationTabs.tsx
@@ -83,7 +83,7 @@ export const ConversationTabs = ({activeTabIndex, onIndexChange, conversationQua
       <div className="conversation-tabs__list" role="tablist" aria-label={t('conversationTabs')}>
         <ConversationTab
           id="conversation"
-          label="Conversation"
+          label={t('cells.tableRow.conversationName')}
           isActive={activeTabIndex === 0}
           onClick={event => {
             createNavigate(messagesUrl)(event);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23086" title="WPB-23086" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23086</a>  [web] Conversation as the tab name in the German version (Drive)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Issue: Conversation as the tab name in the German version (Drive)
Solution: Make Conversation tab name localised
---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
