### PR TITLE
feat: Add error screen when Collabora cannot be opened, fix dark mode style issues(WPB-22818)

### DIFF
--- a/apps/webapp/src/i18n/en-US.json
+++ b/apps/webapp/src/i18n/en-US.json
@@ -1014,6 +1014,8 @@
   "federationDelete": "[bold]Your backend[/bold] stopped federating with [bold]{backendUrl}.[/bold]",
   "fileCardDefaultCloseButtonLabel": "Close",
   "fileFullscreenModal.editor.error": "Failed to load edit preview",
+  "fileFullscreenModal.editor.errorTitle": "Unable to open file edit mode",
+  "fileFullscreenModal.editor.errorDescription": "There was a problem connecting to the server. Please try again.",
   "fileFullscreenModal.editor.iframeTitle": "Document editor",
   "fileFullscreenModal.noPreviewAvailable.callToAction": "Download File",
   "fileFullscreenModal.noPreviewAvailable.description": "There is no preview available for this file. Download the file instead.",

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.styles.ts
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.styles.ts
@@ -108,18 +108,26 @@ export const editModeButtonStyles: CSSObject = {
   padding: '4px',
   borderRadius: '12px',
 
+  'body.theme-dark &': {
+    backgroundColor: 'var(--gray-90)',
+  },
+
   button: {
     padding: '4px 18px',
     borderRadius: '8px',
     backgroundColor: 'transparent',
     border: 'none',
+    color: 'var(--base-secondary-text)',
     transition: 'background-color 0.3s ease-in-out, color 0.3s ease-in-out',
 
     '&.active': {
-      backgroundColor: COLOR_V2.WHITE,
+      backgroundColor: 'var(--app-bg-secondary)',
+      color: 'var(--main-color)',
     },
     svg: {
       marginRight: '8px',
+      color: 'currentColor',
+      fill: 'currentColor',
       transition: 'color 0.3s ease-in-out',
     },
   },

--- a/apps/webapp/src/script/components/FileFullscreenModal/PdfViewer/PdfControls/PdfControls.styles.ts
+++ b/apps/webapp/src/script/components/FileFullscreenModal/PdfViewer/PdfControls/PdfControls.styles.ts
@@ -25,6 +25,7 @@ export const wrapperStyles: CSSObject = {
   left: '50%',
   transform: 'translateX(-50%)',
   backgroundColor: 'var(--gray-20)',
+  color: 'var(--main-color)',
   zIndex: 1000,
   display: 'flex',
   alignItems: 'center',
@@ -32,10 +33,16 @@ export const wrapperStyles: CSSObject = {
   gap: '16px',
   padding: '4px',
   borderRadius: '12px',
+
+  'body.theme-dark &': {
+    backgroundColor: 'var(--gray-90)',
+    color: 'var(--main-color)',
+  },
 };
 
 export const buttonStyles: CSSObject = {
   marginBottom: '0px',
+  color: 'inherit',
 };
 
 export const pageNumberStyles: CSSObject = {

--- a/apps/webapp/src/script/components/Modals/ModalComponent/ModalComponent.styles.tsx
+++ b/apps/webapp/src/script/components/Modals/ModalComponent/ModalComponent.styles.tsx
@@ -46,7 +46,7 @@ export const ModalContentStyles: CSSObject = {
   animation: 'scaleIn 0.35s cubic-bezier(0.165, 0.84, 0.44, 1)',
   backgroundColor: 'var(--modal-bg)',
   border: 'var(--modal-border-color)',
-  borderRadius: 4,
+  borderRadius: 10,
   cursor: 'default',
   display: 'flex',
   flexDirection: 'column',

--- a/apps/webapp/src/types/i18n.d.ts
+++ b/apps/webapp/src/types/i18n.d.ts
@@ -1018,6 +1018,8 @@ declare module 'I18n/en-US.json' {
     'federationDelete': `[bold]Your backend[/bold] stopped federating with [bold]{backendUrl}.[/bold]`;
     'fileCardDefaultCloseButtonLabel': `Close`;
     'fileFullscreenModal.editor.error': `Failed to load edit preview`;
+    'fileFullscreenModal.editor.errorTitle': `Unable to open file edit mode`;
+    'fileFullscreenModal.editor.errorDescription': `There was a problem connecting to the server. Please try again.`;
     'fileFullscreenModal.editor.iframeTitle': `Document editor`;
     'fileFullscreenModal.noPreviewAvailable.callToAction': `Download File`;
     'fileFullscreenModal.noPreviewAvailable.description': `There is no preview available for this file. Download the file instead.`;

--- a/apps/webapp/src/types/i18n.d.ts
+++ b/apps/webapp/src/types/i18n.d.ts
@@ -478,7 +478,7 @@ declare module 'I18n/en-US.json' {
     'cells.search.closeButton': `Close`;
     'cells.search.failed': `Something went wrong, please try again later.`;
     'cells.search.placeholder': `Search files and folders`;
-    "cells.breadcrumb.files": "{conversationName} files",
+    'cells.breadcrumb.files': `{conversationName} files`;
     'cells.selfDeletingMessage.info': `The feature is not available for conversations with a shared Drive.`;
     'cells.shareModal.changePassword': `Change Password`;
     'cells.shareModal.copyLink': `Copy Link`;


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22818" title="WPB-22818" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22818</a>  [Web] Update error screen copy when Collabora cannot be opened
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

# Pull Request

## Summary

As a Wire Drive user,
- When Collabora can’t be opened,
- I want to see a clear and up-to-date error message

Acceptance Criteria

- Error screen displays the exact copy from the mock
- Fix dark UI collabora viewing, editing, pagination style issues

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)
<img width="507" height="62" alt="Screenshot 2026-01-29 at 11 31 11" src="https://github.com/user-attachments/assets/e08b2d54-bd31-4982-8dfc-5a3f7a12406b" />
<img width="467" height="75" alt="Screenshot 2026-01-29 at 12 00 49" src="https://github.com/user-attachments/assets/a2c22489-b1c8-44bc-8090-127e1229f9ae" />
<img width="625" height="407" alt="Screenshot 2026-01-29 at 14 44 49" src="https://github.com/user-attachments/assets/8acbeca4-76e1-4a29-9892-33035c5dba4b" />
<img width="1512" height="982" alt="Screenshot 2026-01-29 at 14 44 57" src="https://github.com/user-attachments/assets/485e0f3b-6a24-413f-8336-3dce665a2108" />


## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
