### PR TITLE
runfix(a11y): address accessibility of self deleting message indicator [WPB-22727]

### DIFF
--- a/apps/webapp/src/i18n/en-US.json
+++ b/apps/webapp/src/i18n/en-US.json
@@ -159,6 +159,7 @@
   "accessibility.rightPanel.GoBack": "Go back",
   "accessibility.rightPanel.close": "Close conversation info",
   "accessibility.searchInput.cancel": "Delete entry",
+  "accessibility.selfDeletingMessage.timer": "Self-deleting message, timer is counting down.",
   "accessibility.userProfileDeleteEntry": "Delete entry",
   "accountAlreadyExistsModal.changeEmailLink": "Change your email address",
   "accountAlreadyExistsModal.content": "This email's domain belongs to an on-premises backend. Please change your email in the account settings or delete your account. If you are part of a team please contact your team admin.",

--- a/apps/webapp/src/script/components/MessagesList/Message/EphemeralTimer.styles.ts
+++ b/apps/webapp/src/script/components/MessagesList/Message/EphemeralTimer.styles.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2018 Wire Swiss GmbH
+ * Copyright (C) 2026 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,22 +17,21 @@
  *
  */
 
-@strokewidth: 4px;
-@strokelength: @strokewidth * pi();
+import {CSSObject} from '@emotion/react';
 
-.ephemeral-timer {
-  &__background {
-    fill: var(--foreground-fade-16);
-    stroke: var(--foreground);
-    stroke-width: 1px;
-  }
+const strokewidth = 4;
+const strokelength = strokewidth * Math.PI;
 
-  &__dial {
-    --offset: 1;
-    fill: none;
-    stroke: var(--foreground);
-    stroke-dasharray: @strokelength;
-    stroke-dashoffset: calc(@strokelength * (1 + var(--offset)));
-    stroke-width: @strokewidth;
-  }
-}
+export const ephemeralTimerBackgroundStyle: CSSObject = {
+  fill: 'var(--app-bg-secondary)',
+  stroke: 'var(--foreground)',
+  strokeWidth: '1px',
+};
+
+export const ephemeralTimerDialStyle: (offset: number) => CSSObject = (offset = 1) => ({
+  fill: 'none',
+  stroke: 'var(--foreground)',
+  strokeDasharray: strokelength,
+  strokeDashoffset: `${strokelength * (1 + offset)}`,
+  strokeWidth: strokewidth,
+});

--- a/apps/webapp/src/script/components/MessagesList/Message/EphemeralTimer.test.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/EphemeralTimer.test.tsx
@@ -36,7 +36,12 @@ describe('EphemeralTimer', () => {
 
     const circle = getByTestId('ephemeral-timer-circle');
 
-    expect(window.getComputedStyle(circle).getPropertyValue('--offset')).toBe('1');
+    const offset = 1;
+    const strokewidth = 4;
+    const strokelength = strokewidth * Math.PI;
+    const expected = strokelength * (1 + offset); // offset === 1 => (1 + offset)
+
+    expect(parseFloat(window.getComputedStyle(circle).getPropertyValue('stroke-dashoffset'))).toBeCloseTo(expected, 5);
   });
 
   it('hides the icon when no ephemeral timer was started', () => {
@@ -46,6 +51,11 @@ describe('EphemeralTimer', () => {
 
     const circle = getByTestId('ephemeral-timer-circle');
 
-    expect(window.getComputedStyle(circle).getPropertyValue('--offset')).toBe('0');
+    const offset = 0;
+    const strokewidth = 4;
+    const strokelength = strokewidth * Math.PI;
+    const expected = strokelength * (1 + offset);
+
+    expect(parseFloat(window.getComputedStyle(circle).getPropertyValue('stroke-dashoffset'))).toBeCloseTo(expected, 5);
   });
 });

--- a/apps/webapp/src/script/components/MessagesList/Message/EphemeralTimer.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/EphemeralTimer.tsx
@@ -17,10 +17,13 @@
  *
  */
 
-import {CSSProperties} from 'react';
+import {TabIndex} from '@wireapp/react-ui-kit';
 
 import type {Message} from 'Repositories/entity/message/Message';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
+import {t} from 'Util/LocalizerUtil';
+
+import {ephemeralTimerBackgroundStyle, ephemeralTimerDialStyle} from './EphemeralTimer.styles';
 
 interface EphemeralTimerProps {
   message: Message;
@@ -36,15 +39,21 @@ const EphemeralTimer = ({message}: EphemeralTimerProps) => {
   const duration = Number(expires) - started;
 
   return (
-    <svg aria-hidden="true" className="ephemeral-timer" viewBox="0 0 8 8" width={8} height={8}>
-      <circle className="ephemeral-timer__background" cx={4} cy={4} r={3.5} />
+    <svg
+      aria-label={t('accessibility.selfDeletingMessage.timer')}
+      className="ephemeral-timer"
+      tabIndex={TabIndex.FOCUSABLE}
+      viewBox="0 0 8 8"
+      width={8}
+      height={8}
+    >
+      <circle css={ephemeralTimerBackgroundStyle} cx={4} cy={4} r={3.5} />
       <circle
+        css={ephemeralTimerDialStyle(remaining / duration || 0)}
         data-uie-name="ephemeral-timer-circle"
-        className="ephemeral-timer__dial"
         cx={4}
         cy={4}
         r={2}
-        style={{'--offset': remaining / duration || 0} as CSSProperties}
         transform="rotate(-90 4 4)"
       />
     </svg>

--- a/apps/webapp/src/style/foundation/main.less
+++ b/apps/webapp/src/style/foundation/main.less
@@ -62,7 +62,6 @@
 @import '../components/image';
 @import '../components/classified-bar';
 @import '../components/device-card';
-@import '../components/ephemeral-timer';
 @import '../components/message-timer-button';
 @import '../components/full-search';
 @import '../components/input-level';

--- a/apps/webapp/src/types/i18n.d.ts
+++ b/apps/webapp/src/types/i18n.d.ts
@@ -163,6 +163,7 @@ declare module 'I18n/en-US.json' {
     'accessibility.rightPanel.GoBack': `Go back`;
     'accessibility.rightPanel.close': `Close conversation info`;
     'accessibility.searchInput.cancel': `Delete entry`;
+    'accessibility.selfDeletingMessage.timer': `Self-deleting message, timer is counting down.`;
     'accessibility.userProfileDeleteEntry': `Delete entry`;
     'accountAlreadyExistsModal.changeEmailLink': `Change your email address`;
     'accountAlreadyExistsModal.content': `This email\'s domain belongs to an on-premises backend. Please change your email in the account settings or delete your account. If you are part of a team please contact your team admin.`;
@@ -478,7 +479,7 @@ declare module 'I18n/en-US.json' {
     'cells.search.closeButton': `Close`;
     'cells.search.failed': `Something went wrong, please try again later.`;
     'cells.search.placeholder': `Search files and folders`;
-    "cells.breadcrumb.files": "{conversationName} files",
+    'cells.breadcrumb.files': `{conversationName} files`;
     'cells.selfDeletingMessage.info': `The feature is not available for conversations with a shared Drive.`;
     'cells.shareModal.changePassword': `Change Password`;
     'cells.shareModal.copyLink': `Copy Link`;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22727" title="WPB-22727" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22727</a>  [Web] Colored circles of self-deleting messages need alt text for screenreader
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- Refactor less style of the ephemeral timer into CSS object components
- add aria-label to the self deleting message timer
- make the self deleting message timer keyboard focussable
- improve contrast of dial background

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)
Contrast before:
<img width="30" height="26" alt="image" src="https://github.com/user-attachments/assets/5e324731-1a30-40cf-a843-716e6bc4b5a5" />

Contrast after:
<img width="37" height="31" alt="image" src="https://github.com/user-attachments/assets/66c80433-41c0-45a4-ae86-5e40763fbc4b" />


## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
