### PR TITLE
fix: Only use /await on staging server

### DIFF
--- a/libraries/api-client/src/tcp/WebSocketClient.ts
+++ b/libraries/api-client/src/tcp/WebSocketClient.ts
@@ -235,6 +235,18 @@ export class WebSocketClient extends EventEmitter {
     return this.isSocketLocked;
   }
 
+  /**
+   * this is a temporary hack method to check if app is running on
+   * wire.com domain in order to use a different temporary websocket
+   * endpoint on wire production server
+   * delete this method as soon as /websocket no longer exists on prod backend
+   * (possibly with next release of web), and change line 284 to use /await only
+   * @returns true if app is connected to wire.com backend
+   */
+  private _temporaryIsProdBackend() {
+    return window.location.hostname.includes('wire.com');
+  }
+
   public buildWebSocketUrl(): string {
     const {
       accessTokenStore: {getAccessToken, getNextMarkerToken},
@@ -269,7 +281,7 @@ export class WebSocketClient extends EventEmitter {
     const queryString = queryParams.toString();
 
     const websocketAddress = this.useLegacySocket
-      ? `${this.baseUrl}/await?${queryString}`
+      ? `${this.baseUrl}/${this._temporaryIsProdBackend() ? 'websocket' : 'await'}?${queryString}`
       : `${this.baseUrl}${this.versionPrefix}/events?${queryString}`;
 
     this.logger.info(`WebSocket URL: ${websocketAddress}`);

--- a/libraries/api-client/src/tcp/WebSocketClient.ts
+++ b/libraries/api-client/src/tcp/WebSocketClient.ts
@@ -244,6 +244,9 @@ export class WebSocketClient extends EventEmitter {
    * @returns true if app is connected to wire.com backend
    */
   private _temporaryIsProdBackend() {
+    if (typeof window === 'undefined') {
+      return false;
+    }
     return window.location.hostname.includes('wire.com');
   }
 


### PR DESCRIPTION
# Pull Request

## Summary

- What did I change and why?
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
