### PR TITLE
runfix(a11y): change alt text for conversation title [WPB-22737]

### DIFF
--- a/apps/webapp/src/i18n/en-US.json
+++ b/apps/webapp/src/i18n/en-US.json
@@ -1962,7 +1962,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/script/components/TitleBar/TitleBar.tsx
+++ b/apps/webapp/src/script/components/TitleBar/TitleBar.tsx
@@ -47,8 +47,6 @@ import {TIME_IN_MILLIS} from 'Util/TimeUtil';
 
 import {RightSidebarParams} from '../../page/AppMain';
 import {PanelState} from '../../page/RightSidebar';
-import {Shortcut} from '../../ui/Shortcut';
-import {ShortcutType} from '../../ui/ShortcutType';
 import {CallActions} from '../../view_model/CallingViewModel';
 import {ViewModelRepositories} from '../../view_model/MainViewModel';
 
@@ -150,8 +148,7 @@ export const TitleBar = ({
 
   const conversationSubtitle = is1to1 && firstUserEntity?.isFederated ? (firstUserEntity?.handle ?? '') : '';
 
-  const shortcut = Shortcut.getShortcutTooltip(ShortcutType.PEOPLE);
-  const peopleTooltip = t('tooltipConversationPeople', {shortcut});
+  const peopleTooltip = t('tooltipConversationPeople', {displayName});
 
   // To be changed when design chooses a breakpoint, the conditional can be integrated to the ui-kit directly
   const mdBreakpoint = useMatchMedia('max-width: 1000px');

--- a/apps/webapp/src/script/components/TitleBar/TitleBar.tsx
+++ b/apps/webapp/src/script/components/TitleBar/TitleBar.tsx
@@ -148,7 +148,7 @@ export const TitleBar = ({
 
   const conversationSubtitle = is1to1 && firstUserEntity?.isFederated ? (firstUserEntity?.handle ?? '') : '';
 
-  const peopleTooltip = t('tooltipConversationPeople', {displayName});
+  const conversationDetailsTooltip = t('tooltipConversationPeople', {displayName});
 
   // To be changed when design chooses a breakpoint, the conditional can be integrated to the ui-kit directly
   const mdBreakpoint = useMatchMedia('max-width: 1000px');
@@ -282,8 +282,8 @@ export const TitleBar = ({
         <div
           id="show-participants"
           onClick={onClickDetails}
-          title={peopleTooltip}
-          aria-label={peopleTooltip}
+          title={conversationDetailsTooltip}
+          aria-label={conversationDetailsTooltip}
           onKeyDown={event =>
             handleKeyDown({
               event,

--- a/apps/webapp/src/types/i18n.d.ts
+++ b/apps/webapp/src/types/i18n.d.ts
@@ -376,6 +376,7 @@ declare module 'I18n/en-US.json' {
     'callingRestrictedConferenceCallTeamMemberModalTitle': `Feature unavailable`;
     'cameraStatusOff': `off`;
     'cameraStatusOn': `on`;
+    'cells.breadcrumb.files': `{conversationName} files`;
     'cells.clearFilters.button': `Clear all`;
     'cells.deleteModal.description': `This will permanently delete the file {name} for all participants.`;
     'cells.deleteModal.error': `Something went wrong, please try again later and refresh the list.`;
@@ -401,8 +402,6 @@ declare module 'I18n/en-US.json' {
     'cells.filtersModal.title': `Filters`;
     'cells.folderBreadcrumbCombained': `Show more`;
     'cells.heading': `Files`;
-    'cells.sharedDrive.title': `Shared Drive`;
-    'cells.sharedDrive.description': `Find any file or folder in this conversation`;
     'cells.imageFullScreenModal.closeButton': `Close`;
     'cells.imageFullScreenModal.downloadButton': `Download`;
     'cells.modal.closeButton': `Close`;
@@ -479,7 +478,6 @@ declare module 'I18n/en-US.json' {
     'cells.search.closeButton': `Close`;
     'cells.search.failed': `Something went wrong, please try again later.`;
     'cells.search.placeholder': `Search files and folders`;
-    'cells.breadcrumb.files': `{conversationName} files`;
     'cells.selfDeletingMessage.info': `The feature is not available for conversations with a shared Drive.`;
     'cells.shareModal.changePassword': `Change Password`;
     'cells.shareModal.copyLink': `Copy Link`;
@@ -506,6 +504,8 @@ declare module 'I18n/en-US.json' {
     'cells.shareModal.password.error.required': `Enter a password`;
     'cells.shareModal.password.label': `Set password`;
     'cells.shareModal.primaryAction': `Save`;
+    'cells.sharedDrive.description': `Find any file or folder in this conversation`;
+    'cells.sharedDrive.title': `Shared Drive`;
     'cells.sidebar.heading': `Drive`;
     'cells.sidebar.title': `Files`;
     'cells.tableRow.actions': `More options`;
@@ -1019,8 +1019,8 @@ declare module 'I18n/en-US.json' {
     'federationDelete': `[bold]Your backend[/bold] stopped federating with [bold]{backendUrl}.[/bold]`;
     'fileCardDefaultCloseButtonLabel': `Close`;
     'fileFullscreenModal.editor.error': `Failed to load edit preview`;
-    'fileFullscreenModal.editor.errorTitle': `Unable to open file edit mode`;
     'fileFullscreenModal.editor.errorDescription': `There was a problem connecting to the server. Please try again.`;
+    'fileFullscreenModal.editor.errorTitle': `Unable to open file edit mode`;
     'fileFullscreenModal.editor.iframeTitle': `Document editor`;
     'fileFullscreenModal.noPreviewAvailable.callToAction': `Download File`;
     'fileFullscreenModal.noPreviewAvailable.description': `There is no preview available for this file. Download the file instead.`;
@@ -1966,7 +1966,7 @@ declare module 'I18n/en-US.json' {
     'tooltipConversationInputOneUserTyping': `{user1} is typing`;
     'tooltipConversationInputPlaceholder': `Type a message`;
     'tooltipConversationInputTwoUserTyping': `{user1} and {user2} are typing`;
-    'tooltipConversationPeople': `People ({shortcut})`;
+    'tooltipConversationPeople': `{displayName}, conversation details`;
     'tooltipConversationPicture': `Add picture`;
     'tooltipConversationPing': `Ping`;
     'tooltipConversationSearch': `Search`;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22737" title="WPB-22737" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22737</a>  [Web] Visible labeling in the conversation overview is not part of the accessible name
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Give an alt text that better describes the action of clicking on a conversation title.
Change alt-text and tooltip from "People <keyboard-shortcut>" to "<conversation-name>, conversation details"

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
