### PR TITLE
test(WPB-22420): fix tests using calling service by targeting dev over staging

### DIFF
--- a/apps/webapp/test/e2e_tests/backend/callingServiceClient.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/callingServiceClient.e2e.ts
@@ -38,13 +38,7 @@ export class CallingServiceClientE2E {
       email,
       password,
       verificationCode: '',
-      backend: 'MASTER',
-      customBackend: {
-        name: 'staging',
-        webappUrl: 'https://wire-webapp-dev.zinfra.io/',
-        backendUrl: 'https://staging-nginz-https.zinfra.io/',
-        websocketUrl: 'wss://staging-nginz-ssl.zinfra.io',
-      },
+      backend: 'DEV',
       instanceType: {
         name: 'chrome',
         version: '103.0.5060.53',

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/oneOnOneCall-TC-8754.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/oneOnOneCall-TC-8754.spec.ts
@@ -28,11 +28,11 @@ test(
     test.setTimeout(150_000);
 
     const [{owner: userA}, {owner: userB}] = await Promise.all([createTeam('User A Team'), createTeam('User B Team')]);
+    const {id: callingServiceInstanceId} = await api.callingService.createInstance(userB.password, userB.email);
     const [userAPageManager, userBPageManager] = await Promise.all([
       PageManager.from(createPage(withLogin(userA), withConnectionRequest(userB))),
-      PageManager.from(createPage(withLogin(userB))),
+      PageManager.from(createPage(withLogin(userB, {confirmNewHistory: true}))),
     ]);
-    const {id: callingServiceInstanceId} = await api.callingService.createInstance(userB.password, userB.email);
 
     await test.step('User B accepts connection request from User A', async () => {
       const {pages} = userBPageManager.webapp;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Staging is currently broken, that's why we need to target dev with the calling service in order for it to continue to work.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
