### PR TITLE
ci(WPB-22420): conditionally run all e2e tests within the PR

### DIFF
--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -124,15 +124,38 @@ jobs:
             echo "❌ Deployment failed"; exit 1
           fi
 
+  # An extra step is needed to see if the e2e_tests folder was touched as part of the PR
+  check_edits_to_e2e_tests:
+    name: Check if the PR touches e2e tests
+    runs-on: ubuntu-latest
+    outputs:
+      edits_e2e_tests: ${{ steps.check_e2e_tests.outputs.edits_e2e_tests}}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for e2e tests changes
+        id: check_e2e_tests
+        run: |
+          git diff --exit-code origin/${{ github.base_ref }}...HEAD -- apps/webapp/test/e2e_tests/ || RESULT=$?
+
+          if [ $RESULT -eq 1 ]; then
+            echo "E2E Tests have been modified, executing all tests"
+          else
+            echo "E2E Tests have not been modified, executing critical flow tests only"
+          fi
+
   run_e2e_tests:
     name: Playwright Critical Flow (precommit)
     if: ${{ !cancelled() && github.repository == 'wireapp/wire-webapp' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot' }}
-    needs: deploy_to_aws
+    needs: [deploy_to_aws, check_edits_to_e2e_tests]
     uses: ./.github/workflows/e2e-tests.yml
     with:
       webappUrl: https://wire-webapp-precommit.zinfra.io/
       backendUrl: https://staging-nginz-https.zinfra.io/
-      grep: '@crit-flow-web|@regression'
+      # If the e2e_tests folder was touched within the PR run all tests, otherwise just the critical flow ones
+      grep: ${{ needs.check_edits_to_e2e_tests.outputs.edits_e2e_tests && '' || '@crit-flow-web' }}
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

If the PR touches the e2e_tests folder we want to execute all tests since they might have changed, otherwise only run the critical flow ones to save on time and resources.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
