### PR TITLE
ci(WPB-22420): fix conditional execution of e2e tests in PR

### DIFF
--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -129,7 +129,7 @@ jobs:
     name: Check if the PR touches e2e tests
     runs-on: ubuntu-latest
     outputs:
-      edits_e2e_tests: ${{ steps.check_e2e_tests.outputs.edits_e2e_tests}}
+      tests_to_run: ${{ steps.check_e2e_tests.outputs.tests_to_run}}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -140,22 +140,24 @@ jobs:
         run: |
           git diff --exit-code origin/${{ github.base_ref }}...HEAD -- apps/webapp/test/e2e_tests/ || RESULT=$?
 
+          # If the e2e_tests folder was touched within the PR run all tests, otherwise just the critical flow ones
           if [ $RESULT -eq 1 ]; then
+            echo "tests_to_run=" >> $GITHUB_OUTPUT
             echo "E2E Tests have been modified, executing all tests"
           else
+            echo "tests_to_run=@crit-flow-web" >> $GITHUB_OUTPUT
             echo "E2E Tests have not been modified, executing critical flow tests only"
           fi
 
   run_e2e_tests:
     name: Playwright Critical Flow (precommit)
     if: ${{ !cancelled() && github.repository == 'wireapp/wire-webapp' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot' }}
-    needs: [deploy_to_aws, check_edits_to_e2e_tests]
+    needs: [check_edits_to_e2e_tests, deploy_to_aws]
     uses: ./.github/workflows/e2e-tests.yml
     with:
       webappUrl: https://wire-webapp-precommit.zinfra.io/
       backendUrl: https://staging-nginz-https.zinfra.io/
-      # If the e2e_tests folder was touched within the PR run all tests, otherwise just the critical flow ones
-      grep: ${{ needs.check_edits_to_e2e_tests.outputs.edits_e2e_tests && '' || '@crit-flow-web' }}
+      grep: ${{ needs.check_edits_to_e2e_tests.outputs.tests_to_run }}
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 

--- a/apps/webapp/test/e2e_tests/specs/Edit/edit.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Edit/edit.spec.ts
@@ -37,7 +37,7 @@ test.describe('Edit', () => {
     await pages.conversation().sendMessage('Test Message');
 
     const message = pages.conversation().getMessage({sender: userA});
-    await expect(message).toContainText('Test Message!!!');
+    await expect(message).toContainText('Test Message');
 
     await pages.conversation().editMessage(message);
     await expect(pages.conversation().messageInput).toContainText('Test Message');

--- a/apps/webapp/test/e2e_tests/specs/Edit/edit.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Edit/edit.spec.ts
@@ -37,7 +37,7 @@ test.describe('Edit', () => {
     await pages.conversation().sendMessage('Test Message');
 
     const message = pages.conversation().getMessage({sender: userA});
-    await expect(message).toContainText('Test Message');
+    await expect(message).toContainText('Test Message!!!');
 
     await pages.conversation().editMessage(message);
     await expect(pages.conversation().messageInput).toContainText('Test Message');


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->




# Pull Request

## Summary

Turns out I forgot to set the output of the actions output throughout all the testing of the Precommit Pipeline...
This will make the condition work ^^'

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Notes for reviewers

- [Test execution of pipeline with changes in the e2e_test folder](https://github.com/wireapp/wire-webapp/actions/runs/21714488931)
- [TEst execution of pipeline without changes in the e2e_test folder](https://github.com/wireapp/wire-webapp/actions/runs/21715033582?pr=20311)