### PR TITLE
fix: update labels to resolve translations at render time so they pick up the active locale instead of being frozen at module load(WPB-23271)

### DIFF
--- a/apps/webapp/src/script/components/Cells/ShareModal/CellsShareModalContent.tsx
+++ b/apps/webapp/src/script/components/Cells/ShareModal/CellsShareModalContent.tsx
@@ -148,7 +148,7 @@ const DEFAULT_SWITCH_COLORS: SwitchColorProps = {
   disabledColorDark: COLOR_V2.GRAY_60,
 };
 
-const DEFAULT_LABELS: CellsShareModalContentLabels = {
+const getDefaultLabels = (): CellsShareModalContentLabels => ({
   enablePublicLink: t('cells.shareModal.enablePublicLink'),
   password: t('cells.shareModal.password'),
   passwordDescription: t('cells.shareModal.password.description'),
@@ -172,7 +172,7 @@ const DEFAULT_LABELS: CellsShareModalContentLabels = {
   passwordCopied: t('guestOptionsPasswordCopyToClipboardSuccess'),
   showTogglePasswordLabel: t('showTogglePasswordLabel'),
   hideTogglePasswordLabel: t('hideTogglePasswordLabel'),
-};
+});
 
 export const CellsShareModalContent = ({
   publicLinkDescription,
@@ -184,7 +184,7 @@ export const CellsShareModalContent = ({
   styles,
   switchColors,
 }: CellsShareModalContentProps) => {
-  const resolvedLabels = {...DEFAULT_LABELS, ...labels};
+  const resolvedLabels = {...getDefaultLabels(), ...labels};
   const shouldShowLink = publicLink.isEnabled && publicLink.status === 'success' && publicLink.link;
   const areDependentTogglesDisabled = !publicLink.isEnabled;
   const publicLinkColors = switchColors?.publicLink ?? DEFAULT_SWITCH_COLORS;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23271" title="WPB-23271" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23271</a>  Add German strings from Crowdin
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- update labels to resolve translations at render time so they pick up the active locale instead of being frozen at module load

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
