### PR TITLE
devops: bump @tony.ganchev/eslint-plugin-header to 3.2.1

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -10,8 +10,7 @@ import emotionPlugin from '@emotion/eslint-plugin';
 import importPlugin from 'eslint-plugin-import';
 import tsParser from '@typescript-eslint/parser';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
-// @ts-ignore - No types available for @tony.ganchev/eslint-plugin-header
-import headerPlugin from '@tony.ganchev/eslint-plugin-header';
+import headerPlugin, { HeaderOptions, HeaderRuleConfig } from '@tony.ganchev/eslint-plugin-header';
 import globals from 'globals';
 import type {Linter} from 'eslint';
 
@@ -117,32 +116,38 @@ const config: Linter.Config[] = [
       '@emotion/styled-import': 'error',
       'header-tony/header': [
         'error',
-        'block',
-        [
-          '',
-          ' * Wire',
-          {
-            pattern: ' \\* Copyright \\(C\\) \\d{4} Wire Swiss GmbH',
-            template: ` * Copyright (C) ${year} Wire Swiss GmbH`,
+        {
+          header: {
+            commentType: 'block',
+            lines: [
+              '',
+              ' * Wire',
+              {
+                pattern: ' \\* Copyright \\(C\\) \\d{4} Wire Swiss GmbH',
+                template: ` * Copyright (C) ${year} Wire Swiss GmbH`,
+              },
+              ' *',
+              ' * This program is free software: you can redistribute it and/or modify',
+              ' * it under the terms of the GNU General Public License as published by',
+              ' * the Free Software Foundation, either version 3 of the License, or',
+              ' * (at your option) any later version.',
+              ' *',
+              ' * This program is distributed in the hope that it will be useful,',
+              ' * but WITHOUT ANY WARRANTY; without even the implied warranty of',
+              ' * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the',
+              ' * GNU General Public License for more details.',
+              ' *',
+              ' * You should have received a copy of the GNU General Public License',
+              ' * along with this program. If not, see http://www.gnu.org/licenses/.',
+              ' *',
+              ' ',
+            ],
           },
-          ' *',
-          ' * This program is free software: you can redistribute it and/or modify',
-          ' * it under the terms of the GNU General Public License as published by',
-          ' * the Free Software Foundation, either version 3 of the License, or',
-          ' * (at your option) any later version.',
-          ' *',
-          ' * This program is distributed in the hope that it will be useful,',
-          ' * but WITHOUT ANY WARRANTY; without even the implied warranty of',
-          ' * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the',
-          ' * GNU General Public License for more details.',
-          ' *',
-          ' * You should have received a copy of the GNU General Public License',
-          ' * along with this program. If not, see http://www.gnu.org/licenses/.',
-          ' *',
-          ' ',
-        ],
-        2,
-      ],
+          trailingEmptyLines: {
+            minimum: 2,
+          },
+        } as HeaderOptions,
+      ] as HeaderRuleConfig,
       'id-length': 'warn',
       '@typescript-eslint/explicit-module-boundary-types': 'off',
       '@typescript-eslint/ban-ts-comment': 'off',

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@nx/node": "22.4.1",
     "@nx/playwright": "22.4.1",
     "@nx/workspace": "22.4.5",
-    "@tony.ganchev/eslint-plugin-header": "3.2.0",
+    "@tony.ganchev/eslint-plugin-header": "3.2.1",
     "@types/eslint": "9.6.1",
     "@types/eslint-plugin-jsx-a11y": "6.10.1",
     "@types/fs-extra": "11.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9140,12 +9140,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tony.ganchev/eslint-plugin-header@npm:3.2.0":
-  version: 3.2.0
-  resolution: "@tony.ganchev/eslint-plugin-header@npm:3.2.0"
+"@tony.ganchev/eslint-plugin-header@npm:3.2.1":
+  version: 3.2.1
+  resolution: "@tony.ganchev/eslint-plugin-header@npm:3.2.1"
   peerDependencies:
     eslint: ">=7.7.0"
-  checksum: 10/d63f6ba65b4dfda7bac4968be1b7fce6a8e012098bb2f521672fe7da175cac746d3515c41a9b32519dbd4a04f47c422a6786b30e962edbee0425c7e9213940f4
+  checksum: 10/dce363846c24bda0d90c4cc0199cad50d171b5436437416a68862a608e3012e5cf10572138e567645941bb7e70549083ff71291f2119988e13bb4762f51bbb12
   languageName: node
   linkType: hard
 
@@ -29202,7 +29202,7 @@ __metadata:
     "@nx/node": "npm:22.4.1"
     "@nx/playwright": "npm:22.4.1"
     "@nx/workspace": "npm:22.4.5"
-    "@tony.ganchev/eslint-plugin-header": "npm:3.2.0"
+    "@tony.ganchev/eslint-plugin-header": "npm:3.2.1"
     "@types/eslint": "npm:9.6.1"
     "@types/eslint-plugin-jsx-a11y": "npm:6.10.1"
     "@types/fs-extra": "npm:11.0.4"


### PR DESCRIPTION
# Pull Request

## Summary

- What did I change and why?
Updated `@tony.ganchev/eslint-plugin-header` to v3.2.1 to consume it TypeScript definitions and drop the `@ts-ignore` directives necessary before that. Additionally, migrated the ESLint configuration of the plugin to the new 3.2.x format.

- Risks and how to roll out / roll back (e.g. feature flags):
No functional change. Simply backout on CI/CD failure.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)
N/A

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
