### PR TITLE
fix:  Conversation images previews do not seem to use actual server-provided previews, but original image(WPB-22331)

### DIFF
--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssetPreview.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssetPreview.tsx
@@ -55,13 +55,11 @@ export const MultipartAssetPreview: FC<MultipartAssetPreviewProps> = ({
   const extension = firstAsset?.initialName ? getFileExtension(firstAsset.initialName) : '';
   const isImage = firstAsset?.contentType?.startsWith('image');
   const isVideo = firstAsset?.contentType?.startsWith('video');
-  const canPreviewImage = isPreviewableImage({mimeType: firstAsset?.contentType, extension});
-  const hasPreview = ((isImage && canPreviewImage) || isVideo) && !!firstAsset?.uuid;
 
   const {src, imagePreviewUrl, isLoading} = useGetMultipartAsset({
     uuid: firstAsset?.uuid || '',
     cellsRepository,
-    isEnabled: hasPreview,
+    isEnabled: !!firstAsset?.uuid,
     retryPreviewUntilSuccess: false,
   });
 
@@ -69,7 +67,9 @@ export const MultipartAssetPreview: FC<MultipartAssetPreviewProps> = ({
     return null;
   }
 
-  const previewUrl = isVideo ? imagePreviewUrl : src;
+  const canPreviewImage = isPreviewableImage({mimeType: firstAsset?.contentType, extension}) || !!imagePreviewUrl;
+  const hasPreview = ((isImage && canPreviewImage) || isVideo) && !!firstAsset?.uuid;
+  const previewUrl = isVideo ? imagePreviewUrl : imagePreviewUrl || src;
 
   // Show loading state or preview for images/videos
   const shouldDisplayImagePreview = hasPreview && (previewUrl || isLoading);
@@ -136,7 +136,7 @@ export const MultipartAssetPreview: FC<MultipartAssetPreviewProps> = ({
           id={modalId}
           isOpen={isModalOpen}
           onClose={() => setIsModalOpen(false)}
-          filePreviewUrl={isVideo ? imagePreviewUrl : src}
+          filePreviewUrl={previewUrl}
           fileExtension={fileExtension}
           fileName={fileName}
           fileUrl={src}

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetCard.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetCard.tsx
@@ -23,7 +23,8 @@ import {ImageAssetLarge} from './ImageAssetLarge/ImageAssetLarge';
 import {ImageAssetSmall} from './ImageAssetSmall/ImageAssetSmall';
 
 interface ImageAssetCardProps {
-  src?: string;
+  filePreviewUrl?: string;
+  fileUrl?: string;
   name: string;
   extension: string;
   senderName: string;
@@ -37,7 +38,8 @@ interface ImageAssetCardProps {
 
 export const ImageAssetCard = ({
   id,
-  src,
+  filePreviewUrl,
+  fileUrl,
   name,
   extension,
   senderName,
@@ -51,7 +53,8 @@ export const ImageAssetCard = ({
     return (
       <ImageAssetLarge
         id={id}
-        src={src}
+        filePreviewUrl={filePreviewUrl}
+        fileUrl={fileUrl}
         name={name}
         extension={extension}
         metadata={metadata}
@@ -65,7 +68,8 @@ export const ImageAssetCard = ({
   return (
     <ImageAssetSmall
       id={id}
-      src={src}
+      filePreviewUrl={filePreviewUrl}
+      fileUrl={fileUrl}
       name={name}
       extension={extension}
       isLoading={isLoading}

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetLarge/ImageAssetLarge.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetLarge/ImageAssetLarge.tsx
@@ -123,7 +123,7 @@ export const ImageAssetLarge = ({
         onClose={() => setIsOpen(false)}
         filePreviewUrl={filePreviewUrl}
         fileExtension={extension}
-        fileUrl={fileUrl || filePreviewUrl}
+        fileUrl={fileUrl}
         fileName={name}
         senderName={senderName}
         timestamp={timestamp}

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetLarge/ImageAssetLarge.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetLarge/ImageAssetLarge.tsx
@@ -38,7 +38,8 @@ import {
 import {FileFullscreenModal} from '../../../../../../../FileFullscreenModal/FileFullscreenModal';
 
 interface ImageAssetLargeProps {
-  src?: string;
+  filePreviewUrl?: string;
+  fileUrl?: string;
   name: string;
   extension: string;
   metadata: ICellAsset['image'];
@@ -50,7 +51,8 @@ interface ImageAssetLargeProps {
 
 export const ImageAssetLarge = ({
   id,
-  src,
+  filePreviewUrl,
+  fileUrl,
   name,
   extension,
   metadata,
@@ -98,7 +100,7 @@ export const ImageAssetLarge = ({
         </div>
         <div css={imageWrapperStyles}>
           <img
-            src={src}
+            src={filePreviewUrl}
             alt=""
             css={imageStyle}
             style={
@@ -119,9 +121,9 @@ export const ImageAssetLarge = ({
         id={id}
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
-        filePreviewUrl={src}
+        filePreviewUrl={filePreviewUrl}
         fileExtension={extension}
-        fileUrl={src}
+        fileUrl={fileUrl || filePreviewUrl}
         fileName={name}
         senderName={senderName}
         timestamp={timestamp}

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetSmall/ImageAssetSmall.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetSmall/ImageAssetSmall.tsx
@@ -27,7 +27,8 @@ import {FileFullscreenModal} from '../../../../../../../FileFullscreenModal/File
 import {MediaFilePreviewCard} from '../../common/MediaFilePreviewCard/MediaFilePreviewCard';
 
 interface ImageAssetSmallProps {
-  src?: string;
+  filePreviewUrl?: string;
+  fileUrl?: string;
   name: string;
   extension: string;
   isLoading: boolean;
@@ -39,7 +40,8 @@ interface ImageAssetSmallProps {
 
 export const ImageAssetSmall = ({
   id,
-  src,
+  filePreviewUrl,
+  fileUrl,
   name,
   extension,
   isLoading,
@@ -67,13 +69,13 @@ export const ImageAssetSmall = ({
         disabled={isUnavailable}
       >
         <MediaFilePreviewCard
-          label={src ? t('conversationFileImagePreviewLabel', {src}) : ''}
+          label={filePreviewUrl ? t('conversationFileImagePreviewLabel', {src: filePreviewUrl}) : ''}
           isLoading={!isLoaded}
           isError={isUnavailable}
         >
-          {!isLoading && !isUnavailable && src && (
+          {!isLoading && !isUnavailable && filePreviewUrl && (
             <img
-              src={src}
+              src={filePreviewUrl}
               alt=""
               css={imageStyles}
               onLoad={() => setIsLoaded(true)}
@@ -89,10 +91,10 @@ export const ImageAssetSmall = ({
         id={id}
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
-        filePreviewUrl={src}
+        filePreviewUrl={filePreviewUrl}
         fileExtension={extension}
         fileName={name}
-        fileUrl={src}
+        fileUrl={fileUrl || filePreviewUrl}
         senderName={senderName}
         timestamp={timestamp}
       />

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetSmall/ImageAssetSmall.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/ImageAssetCard/ImageAssetSmall/ImageAssetSmall.tsx
@@ -94,7 +94,7 @@ export const ImageAssetSmall = ({
         filePreviewUrl={filePreviewUrl}
         fileExtension={extension}
         fileName={name}
-        fileUrl={fileUrl || filePreviewUrl}
+        fileUrl={fileUrl}
         senderName={senderName}
         timestamp={timestamp}
       />

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.test.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.test.tsx
@@ -482,5 +482,44 @@ describe('MultipartAssets', () => {
 
       expect(screen.queryByLabelText('accessibility.conversationAssetImageAlt')).not.toBeInTheDocument();
     });
+
+    it('should render an image card when a server preview is available for HEIC', async () => {
+      const heicPreviewNode: RestNode = {
+        ...mockNode,
+        Previews: [
+          {
+            ContentType: 'image/jpeg',
+            PreSignedGET: {
+              Url: 'https://example.com/preview.jpg',
+            },
+          },
+        ],
+      } as RestNode;
+
+      mockCellsRepository.getNode.mockResolvedValue(heicPreviewNode);
+
+      const assets: ICellAsset[] = [
+        {
+          ...createMockAsset('test-uuid', 'image/heic', 'sample.heic'),
+          image: {width: 100, height: 100},
+        },
+      ];
+
+      render(
+        withTheme(
+          <MultipartAssets
+            assets={assets}
+            conversationId="conv-123"
+            cellsRepository={mockCellsRepository}
+            senderName="John Doe"
+            timestamp={Date.now()}
+          />,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('accessibility.conversationAssetImageAlt')).toBeInTheDocument();
+      });
+    });
   });
 });

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.tsx
@@ -146,7 +146,8 @@ const MultipartAsset = ({
       <li ref={elementRef} css={imageCardStyles}>
         <ImageAssetCard
           id={uuid}
-          src={imageSrc}
+          filePreviewUrl={imageSrc}
+          fileUrl={src}
           name={name}
           extension={extension}
           variant={variant}

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.tsx
@@ -101,7 +101,6 @@ const MultipartAsset = ({
 
   const isImage = contentType.startsWith('image');
   const isVideo = contentType.startsWith('video');
-  const canPreviewImage = isPreviewableImage({mimeType: contentType, extension});
 
   const isSingleAsset = assetsCount === 1;
   const variant = isSingleAsset ? 'large' : 'small';
@@ -114,6 +113,8 @@ const MultipartAsset = ({
   });
 
   const name = path ? getName(path) : getName(initialName!);
+  const canPreviewImage = isPreviewableImage({mimeType: contentType, extension}) || !!imagePreviewUrl;
+  const imageSrc = imagePreviewUrl || src;
 
   /**
    * Listen to hash changes within the current conversation (excluding the `/files` view)
@@ -145,7 +146,7 @@ const MultipartAsset = ({
       <li ref={elementRef} css={imageCardStyles}>
         <ImageAssetCard
           id={uuid}
-          src={src}
+          src={imageSrc}
           name={name}
           extension={extension}
           variant={variant}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22331" title="WPB-22331" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22331</a>  [Web] Conversation images previews do not seem to use actual server-provided previews, but original image
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- For image assets the UI tries to display the original HEIC instead of the server‑generated preview. The fix would be to prefer imagePreviewUrl for image assets (fallback to original only if preview missing).
---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
