### PR TITLE
test: verify user messages aren't logged [WPB-22526]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Logs/logs.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Logs/logs.spec.ts
@@ -1,0 +1,45 @@
+import {User} from 'test/e2e_tests/data/user';
+import {PageManager} from 'test/e2e_tests/pageManager';
+import {test, expect, withLogin, withConnectedUser} from 'test/e2e_tests/test.fixtures';
+
+test.describe('Logs', () => {
+  let userA: User;
+  let userB: User;
+
+  test.beforeEach(async ({createTeam}) => {
+    const team = await createTeam('Test Team', {withMembers: 1});
+    userA = team.owner;
+    userB = team.members[0];
+  });
+
+  test(
+    'Check that user messages are not being console logged',
+    {tag: ['@TC-8794', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB), withConnectedUser(userA)),
+      ]);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
+
+      const messageA = 'Hello from UserA! This is a secret message.';
+      const messageB = 'Hi from UserB! No logging allowed.';
+
+      await userAPages.conversation().sendMessage(messageA);
+      await userBPages.conversation().sendMessage(messageB);
+
+      // Wait for messages to appear to ensure all related console output has happened
+      await expect(userBPages.conversation().getMessage({content: messageA})).toBeVisible();
+      await expect(userAPages.conversation().getMessage({content: messageB})).toBeVisible();
+
+      // Assert that message content is not present in console logs
+      const userALogs = await userAPage.consoleMessages();
+      const hasMessageInLogs = userALogs
+        .map(log => log.text())
+        .some(log => log.includes(messageA) || log.includes(messageB));
+      expect(hasMessageInLogs).toBe(false);
+    },
+  );
+});


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22526" title="WPB-22526" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22526</a>  [Web] Create e2e test checking that user messages are not being logged
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- Implement test

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
