### PR TITLE
fix: Use small file cards when no preview is available(WPB-23340)

### DIFF
--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.test.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.test.tsx
@@ -113,6 +113,30 @@ describe('MultipartAssets', () => {
       expect(screen.queryByText('cells.unavailableFile')).not.toBeInTheDocument();
     });
 
+    it('should render a small file card when no preview is available', async () => {
+      mockCellsRepository.getNode.mockResolvedValue(mockNode);
+
+      const assets: ICellAsset[] = [createMockAsset('test-uuid', 'application/zip', 'archive.zip')];
+
+      render(
+        withTheme(
+          <MultipartAssets
+            assets={assets}
+            conversationId="conv-123"
+            cellsRepository={mockCellsRepository}
+            senderName="John Doe"
+            timestamp={Date.now()}
+          />,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(mockCellsRepository.getNode).toHaveBeenCalledWith({uuid: 'test-uuid'});
+      });
+
+      expect(screen.queryByText('cells.unavailableFilePreview')).not.toBeInTheDocument();
+    });
+
     it('should render multiple assets with mixed recycled state', async () => {
       mockCellsRepository.getNode
         .mockResolvedValueOnce(mockNode)

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/MultipartAssets.tsx
@@ -105,16 +105,19 @@ const MultipartAsset = ({
   const isSingleAsset = assetsCount === 1;
   const variant = isSingleAsset ? 'large' : 'small';
 
-  const {src, isLoading, isError, imagePreviewUrl, pdfPreviewUrl, path, isRecycled, fetchData} = useGetMultipartAsset({
-    uuid,
-    cellsRepository,
-    isEnabled: hasBeenInView,
-    retryPreviewUntilSuccess: isSingleAsset && !isImage && !isVideo,
-  });
+  const {src, isLoading, isError, imagePreviewUrl, pdfPreviewUrl, hasPreview, path, isRecycled, fetchData} =
+    useGetMultipartAsset({
+      uuid,
+      cellsRepository,
+      isEnabled: hasBeenInView,
+      retryPreviewUntilSuccess: isSingleAsset && !isImage && !isVideo,
+    });
 
   const name = path ? getName(path) : getName(initialName!);
   const canPreviewImage = isPreviewableImage({mimeType: contentType, extension}) || !!imagePreviewUrl;
   const imageSrc = imagePreviewUrl || src;
+  const hasFilePreview = hasPreview ?? false;
+  const fileVariant = isSingleAsset && hasFilePreview ? 'large' : 'small';
 
   /**
    * Listen to hash changes within the current conversation (excluding the `/files` view)
@@ -185,7 +188,7 @@ const MultipartAsset = ({
       <FileAssetCard
         id={uuid}
         src={src}
-        variant={variant}
+        variant={fileVariant}
         extension={extension}
         name={name}
         size={size}

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/useGetMultipartAsset/useGetMultipartAsset.test.ts
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/useGetMultipartAsset/useGetMultipartAsset.test.ts
@@ -310,6 +310,49 @@ describe('useGetMultipartAsset', () => {
   });
 
   describe('preview retry logic', () => {
+    it('should set hasPreview to true when previews are available', async () => {
+      mockCellsRepository.getNode.mockResolvedValue(mockNode);
+
+      const {result} = renderHook(() =>
+        useGetMultipartAsset({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+          isEnabled: true,
+          retryPreviewUntilSuccess: false,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.hasPreview).toBe(true);
+    });
+
+    it('should set hasPreview to false when no previews are available', async () => {
+      const noPreviewNode: RestNode = {
+        ...mockNode,
+        Previews: [],
+      };
+
+      mockCellsRepository.getNode.mockResolvedValue(noPreviewNode);
+
+      const {result} = renderHook(() =>
+        useGetMultipartAsset({
+          uuid: 'test-uuid',
+          cellsRepository: mockCellsRepository,
+          isEnabled: true,
+          retryPreviewUntilSuccess: false,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.hasPreview).toBe(false);
+    });
+
     it('should return immediately when retryPreviewUntilSuccess is false', async () => {
       const processingNode: RestNode = {
         ...mockNode,

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/useGetMultipartAsset/useGetMultipartAsset.ts
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/useGetMultipartAsset/useGetMultipartAsset.ts
@@ -60,6 +60,7 @@ export const useGetMultipartAsset = ({
   const [src, setSrc] = useState<string | undefined>(undefined);
   const [imagePreviewUrl, setImagePreviewUrl] = useState<string | undefined>(undefined);
   const [pdfPreviewUrl, setPdfPreviewUrl] = useState<string | undefined>(undefined);
+  const [hasPreview, setHasPreview] = useState<boolean | undefined>(undefined);
   const [status, setStatus] = useState<Status>('idle');
   const [isRecycled, setIsRecycled] = useState<boolean | undefined>(undefined);
 
@@ -87,6 +88,7 @@ export const useGetMultipartAsset = ({
 
         const imagePreview = asset.Previews?.find(preview => preview?.ContentType?.startsWith('image/'));
         const pdfPreview = asset.Previews?.find(preview => preview?.ContentType?.startsWith('application/pdf'));
+        setHasPreview(!!imagePreview || !!pdfPreview);
 
         const shouldReturnImmediately =
           !retryPreviewUntilSuccess || (!imagePreview && !pdfPreview) || (imagePreview?.Error && pdfPreview?.Error);
@@ -170,6 +172,7 @@ export const useGetMultipartAsset = ({
     src,
     imagePreviewUrl,
     pdfPreviewUrl,
+    hasPreview,
     isLoading: ['loading', 'retrying', 'idle'].includes(status),
     isError: status === 'error',
     path,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23340" title="WPB-23340" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23340</a>  [Web] Non-preview Enabled files are displaying as big card with an error
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- Whenever we upload one “lambda” file type that does not support previews (e.g. Zip archive, binary, etc..), it appears with a large card w. preview and an error in preview generation.

Expected:
- any file type that doesn’t have a preview should default to a small card

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

### BEFORE:
<img width="631" height="353" alt="Capture d’écran 2026-02-06 à 10 43 11" src="https://github.com/user-attachments/assets/7d31e9e5-c4be-4302-aad4-12696ac88082" />

### AFTER:
<img width="477" height="95" alt="Screenshot 2026-02-09 at 06 40 09" src="https://github.com/user-attachments/assets/7a1560d4-6caf-448a-bfda-93c52e2d3600" />

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
