### PR TITLE
chore: Publish libraries on merge workflow [WPB-23275]

### DIFF
--- a/.github/workflows/publish-libraries-on-merge.yml
+++ b/.github/workflows/publish-libraries-on-merge.yml
@@ -11,7 +11,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: publish-libraries-${{ github.event.pull_request.base.ref }}
+  group: publish-libraries
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/publish-libraries-on-merge.yml
+++ b/.github/workflows/publish-libraries-on-merge.yml
@@ -16,7 +16,6 @@ concurrency:
 
 jobs:
   publish:
-    name: Publish Libraries to NPM
     if: |
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'publish-to-npm')

--- a/.github/workflows/publish-libraries-on-merge.yml
+++ b/.github/workflows/publish-libraries-on-merge.yml
@@ -19,7 +19,7 @@ jobs:
     name: Publish Libraries to NPM
     if: |
       github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'chore/library-release-')
+      contains(github.event.pull_request.labels.*.name, 'publish-to-npm')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/publish-libraries-on-merge.yml
+++ b/.github/workflows/publish-libraries-on-merge.yml
@@ -26,7 +26,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: dev
+          # Pin to the exact merge commit to avoid publishing code from a newer dev head
+          # if other PRs merge between trigger and job start
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/publish-libraries-on-merge.yml
+++ b/.github/workflows/publish-libraries-on-merge.yml
@@ -1,0 +1,55 @@
+name: Publish Libraries on Release PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - dev
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: publish-libraries-${{ github.event.pull_request.base.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish Libraries to NPM
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'chore/library-release-')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: dev
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Install dependencies
+        run: yarn --immutable
+
+      - name: Build libraries
+        run: yarn nx run-many -t build --projects=tag:type:lib
+
+      - name: Publish to npm
+        run: |
+          echo "📦 Publishing release to npm..."
+          yarn nx release publish --verbose
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/publish-libraries-on-merge.yml
+++ b/.github/workflows/publish-libraries-on-merge.yml
@@ -1,4 +1,4 @@
-name: Publish Libraries on Release PR Merge
+name: Publish packages to npm
 
 on:
   pull_request:

--- a/.github/workflows/publish-libraries.yml
+++ b/.github/workflows/publish-libraries.yml
@@ -76,6 +76,7 @@ jobs:
             --base dev \
             --head "$RELEASE_BRANCH" \
             --title "chore(release): publish libraries" \
+            --label "publish-to-npm" \
             --body "Automated release PR created by nx release. ⚠️ **Important:** Do NOT squash merge this PR. Use 'Merge commit' to preserve git tags."
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/library-publishing.md
+++ b/docs/library-publishing.md
@@ -118,23 +118,24 @@ git commit -m "feat(api-client)!: remove deprecated auth methods"
 
 ## NPM Trusted Publishing Setup
 
-The workflow uses **npm provenance** for secure, keyless publishing:
+The workflow uses **OIDC-based trusted publishing** for secure, keyless npm authentication — no npm tokens are stored as secrets.
+
+### How It Works
+
+GitHub Actions mints a short-lived OIDC token during the workflow run. npm verifies the token against the trusted publisher configuration on the package, confirming the publish originated from the expected repository and workflow. The `NPM_CONFIG_PROVENANCE` flag attaches a cryptographic provenance attestation to the published package.
 
 ### Requirements:
-1. **GitHub Actions workflow** named `publish-libraries-on-merge.yml` (the workflow that runs `nx release publish`)
-2. **Permissions** in workflow:
+1. **GitHub Actions workflow** must have:
    ```yaml
    permissions:
-     id-token: write  # for provenance
+     id-token: write  # for OIDC token / provenance
      contents: write  # for tags/commits
    ```
-3. **NPM package settings**:
-   - Enable "Require 2FA or Automation tokens" 
-   - Configure trusted publisher:
-     - **Workflow**: `publish-libraries-on-merge.yml`
+2. **NPM package settings** (configured per-package on npmjs.com):
+   - Go to **Settings → Publishing access → Configure trusted publishers**
+   - Add a trusted publisher:
      - **Repository**: `wireapp/wire-webapp`
-
-4. **NPM_TOKEN secret** in GitHub repository settings
+     - **Workflow**: `publish-libraries-on-merge.yml`
 
 ### Environment Variable:
 ```yaml
@@ -157,7 +158,8 @@ This generates cryptographic proof that the package was built in GitHub Actions 
 
 ### Publish fails
 - Verify the merged PR has the `publish-to-npm` label
-- Verify `NPM_TOKEN` secret is set in GitHub
+- Ensure the npm package has a trusted publisher configured for `wireapp/wire-webapp` and the `publish-libraries-on-merge.yml` workflow
+- Check that the workflow has `id-token: write` permission
 - Check npm package permissions
 - Review workflow logs in GitHub Actions
 

--- a/docs/library-publishing.md
+++ b/docs/library-publishing.md
@@ -19,9 +19,10 @@ When you push changes to libraries on main/dev branches:
 
 ### Workflow Trigger
 
-The workflow (`.github/workflows/publish-libraries.yml`) runs when:
-- Changes are pushed to `libraries/**` on `main` or `dev` branches
-- Manually triggered via GitHub Actions UI
+The release process uses two workflows:
+
+1. **`.github/workflows/publish-libraries.yml`** — Creates a release PR with version bumps. Triggered manually via GitHub Actions UI.
+2. **`.github/workflows/publish-libraries-on-merge.yml`** — Publishes to npm when the release PR is merged to `dev`.
 
 ### Publishing Behavior
 
@@ -144,7 +145,7 @@ git commit -m "feat(api-client)!: remove deprecated auth methods"
 The workflow uses **npm provenance** for secure, keyless publishing:
 
 ### Requirements:
-1. **GitHub Actions workflow** named `publish-libraries.yml` 
+1. **GitHub Actions workflow** named `publish-libraries-on-merge.yml` (the workflow that runs `nx release publish`)
 2. **Permissions** in workflow:
    ```yaml
    permissions:
@@ -154,7 +155,7 @@ The workflow uses **npm provenance** for secure, keyless publishing:
 3. **NPM package settings**:
    - Enable "Require 2FA or Automation tokens" 
    - Configure trusted publisher:
-     - **Workflow**: `publish-libraries.yml`
+     - **Workflow**: `publish-libraries-on-merge.yml`
      - **Repository**: `wireapp/wire-webapp`
 
 4. **NPM_TOKEN secret** in GitHub repository settings

--- a/docs/library-publishing.md
+++ b/docs/library-publishing.md
@@ -8,34 +8,28 @@ The monorepo uses **Nx Release** to automate versioning and publishing of librar
 
 ## How It Works
 
-### Automatic Publishing
+The release process is a **two-step workflow** triggered manually and gated by a PR review:
 
-When you push changes to libraries on main/dev branches:
+1. **Create a release PR** — Run the `Create Library Release PR` workflow from the GitHub Actions UI. It lints, tests, and builds the libraries, bumps versions using conventional commits, and opens a PR to `dev` with the `publish-to-npm` label.
+2. **Publish on merge** — When the release PR is merged to `dev`, a second workflow detects the `publish-to-npm` label and publishes the built libraries to npm with provenance.
 
-- Automatically versions, creates tags, and publishes to npm (uses `beta` tag on merge to `dev`)
-- Uses conventional commits to determine version bump (major/minor/patch)
-- Creates GitHub releases
-- Publishes with npm provenance for security
+### Key Details
 
-### Workflow Trigger
+- Uses **conventional commits** to determine version bumps (major/minor/patch)
+- Creates GitHub releases and git tags
+- Publishes with **npm provenance** for supply-chain security
+- The release PR must be **merge-committed** (not squash-merged) to preserve git tags
 
-The release process uses two workflows:
+### Workflow Files
 
-1. **`.github/workflows/publish-libraries.yml`** — Creates a release PR with version bumps. Triggered manually via GitHub Actions UI.
-2. **`.github/workflows/publish-libraries-on-merge.yml`** — Publishes to npm when the release PR is merged to `dev`.
+1. **`.github/workflows/publish-libraries.yml`** — Creates the release PR. Triggered manually via `workflow_dispatch`.
+2. **`.github/workflows/publish-libraries-on-merge.yml`** — Publishes to npm when a PR with the `publish-to-npm` label is merged to `dev`.
 
-### Publishing Behavior
+### Tagged Projects
 
-**Main Branch (Stable Releases)**
-- Publishes to npm with the `latest` tag
-- Version format: `1.0.0`, `1.1.0`, `2.0.0`
-- Users install with: `npm install @wireapp/api-client`
-
-**Dev Branch (Beta Releases)**  
-- Publishes to npm with the `beta` tag
-- Version format: `1.0.0-beta.0`, `1.0.0-beta.1`, `1.1.0-beta.0`
-- Users install with: `npm install @wireapp/api-client@beta`
-- Does not affect the `latest` tag
+Only libraries with the `npm:public` tag in their `project.json` are published:
+- `libraries/core` → `@wireapp/core`
+- `libraries/api-client` → `@wireapp/api-client`
 
 ### Tagged Projects
 
@@ -71,47 +65,29 @@ Only libraries with the `npm:public` tag in their `project.json` are published:
 
 ## Publishing Workflow
 
-### Option 1: Automatic - Main Branch (Stable Release)
+### Creating a Release
 
-1. Make changes to a library (e.g., `libraries/api-client/`)
-2. Commit with conventional commit messages:
+1. Merge your library changes to `dev` using conventional commit messages:
    ```bash
    git commit -m "feat: add new API method"      # → minor bump
    git commit -m "fix: resolve auth issue"       # → patch bump
    git commit -m "feat!: breaking API change"    # → major bump
    ```
-3. Push to `main`:
-   ```bash
-   git push origin main
-   ```
-4. GitHub Actions will automatically:
-   - Build and test the library
-   - Determine version bump from commits
-   - Update `package.json` version (e.g., `1.0.0` → `1.1.0`)
-   - Create CHANGELOG
-   - Create git tag
-   - Publish to npm with `latest` tag
-   - Create GitHub release
+2. Go to **GitHub Actions → Create Library Release PR → Run workflow**.
+3. The workflow will:
+   - Lint, test, and build all libraries
+   - Run `nx release version` to bump versions based on conventional commits
+   - Push a release branch and open a PR to `dev` with the `publish-to-npm` label
+4. Review the PR — verify version bumps and changelog entries look correct.
+5. **Merge the PR using a merge commit** (do NOT squash — this preserves git tags).
+6. On merge, the publish workflow automatically:
+   - Builds the libraries
+   - Publishes to npm with provenance
+   - Creates GitHub releases
 
-### Option 2: Automatic - Dev Branch (Beta Release)
+### Local Testing (Dry Run)
 
-1. Make changes to a library and merge to `dev`
-2. Push to `dev`:
-   ```bash
-   git push origin dev
-   ```
-3. GitHub Actions will automatically:
-   - Build and test the library
-   - Determine version bump from commits
-   - Update `package.json` version with beta prerelease (e.g., `1.0.0` → `1.1.0-beta.0`)
-   - Create CHANGELOG
-   - Create git tag
-   - Publish to npm with `beta` tag
-   - Users can test with: `npm install @wireapp/api-client@beta`
-
-### Option 3: Manual Testing
-
-Test the release locally before pushing:
+Preview what a release would do without publishing:
 
 ```bash
 # Dry run to see what would happen
@@ -173,16 +149,21 @@ This generates cryptographic proof that the package was built in GitHub Actions 
 ### Version not incrementing
 - Check commit messages use conventional commit format
 - Run `yarn release:dry-run` to preview changes
-- Ensure commits are on `main` branch
+- Ensure commits are on the `dev` branch before triggering the workflow
+
+### Release PR not created
+- The workflow skips PR creation if no version changes are detected
+- Verify new conventional commits exist since the last release tag
 
 ### Publish fails
+- Verify the merged PR has the `publish-to-npm` label
 - Verify `NPM_TOKEN` secret is set in GitHub
 - Check npm package permissions
 - Review workflow logs in GitHub Actions
 
 ### Want to skip a release
-- Add `[skip ci]` to commit message
-- Or manually increment version in affected `package.json` files
+- Simply don't trigger the release workflow
+- Or close the release PR without merging
 
 ## Manual Release (Emergency)
 

--- a/libraries/api-client/src/APIClient.ts
+++ b/libraries/api-client/src/APIClient.ts
@@ -405,7 +405,7 @@ export class APIClient extends EventEmitter {
       const self = await this.api.self.getSelf();
       selfDomain = self.qualified_id?.domain;
     } catch (error) {
-      this.logger.warn('Could not get self user', (error as BackendError).message);
+      this.logger.warn('Could not get self user:', (error as BackendError).message);
     }
 
     this.context = this.context

--- a/libraries/api-client/src/APIClient.ts
+++ b/libraries/api-client/src/APIClient.ts
@@ -405,7 +405,7 @@ export class APIClient extends EventEmitter {
       const self = await this.api.self.getSelf();
       selfDomain = self.qualified_id?.domain;
     } catch (error) {
-      this.logger.warn('Could not get self user:', (error as BackendError).message);
+      this.logger.warn('Could not get self user', (error as BackendError).message);
     }
 
     this.context = this.context

--- a/nx.json
+++ b/nx.json
@@ -39,6 +39,7 @@
     "version": {
       "conventionalCommits": true,
       "fallbackCurrentVersionResolver": "disk",
+      "preserveLocalDependencyProtocols": false,
       "git": {
         "commit": true,
         "tag": true,


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23275" title="WPB-23275" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23275</a>  [Web] Fix publish workflow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

# Pull Request

## Summary

## Why `preserveLocalDependencyProtocols: false`

`@wireapp/core` depends on `@wireapp/api-client` using the `workspace:^` protocol. Since Nx v21, this protocol is preserved by default during `nx release version`. At publish time, `nx release publish` expects the package manager to dynamically replace `workspace:^` with a real semver in the published tarball — but only pnpm and bun support this. Yarn does not, causing publish to fail:

> _Cannot publish package "@wireapp/core" because it contains a local dependency protocol in its "dependencies", and your package manager is yarn._

Setting `preserveLocalDependencyProtocols: false` tells `nx release version` to resolve `workspace:^` → the actual version (e.g., `27.95.5`) in the source `package.json` during the versioning step, so by the time `nx release publish` runs, the dependency is already a valid semver. This aligns with our fixed version convention and has no impact on local development — Yarn workspaces still symlinks the local package as long as the version matches.

- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [X] **External inputs are validated & sanitized** on client and/or server where applicable.
- [X] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [X] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [X] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [X] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [X] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).