### PR TITLE
test: add markdown regression e2e tests [WPB-19959]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Markdown/markdown.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Markdown/markdown.spec.ts
@@ -31,7 +31,7 @@ test.describe('Markdown', () => {
     userB = team.members[0];
   });
 
-  test('I want to write a bold message', {tag: ['@TC-1314', '@regression']}, async ({createPage}) => {
+  test('I want to write a bold message', {tag: ['@TC-1313', '@regression']}, async ({createPage}) => {
     const [userAPages, userBPages] = await Promise.all([
       PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
       PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
@@ -42,7 +42,7 @@ test.describe('Markdown', () => {
     for (const pages of [userAPages, userBPages]) {
       const message = pages.conversation().getMessage({sender: userA});
       await expect(message).toBeVisible();
-      await expect(message.locator('strong, b')).toHaveText('Bold Message from User A');
+      await expect(message.getByRole('strong')).toHaveText('Bold Message from User A');
     }
   });
 
@@ -57,7 +57,7 @@ test.describe('Markdown', () => {
     for (const pages of [userAPages, userBPages]) {
       const message = pages.conversation().getMessage({sender: userA});
       await expect(message).toBeVisible();
-      await expect(message.locator('em, i')).toHaveText('Emphasized message from User A');
+      await expect(message.getByRole('emphasis')).toHaveText('Emphasized message from User A');
     }
   });
 
@@ -72,7 +72,7 @@ test.describe('Markdown', () => {
     for (const pages of [userAPages, userBPages]) {
       const message = pages.conversation().getMessage({sender: userA});
       await expect(message).toBeVisible();
-      await expect(message.locator('code')).toContainText('Code message from User A');
+      await expect(message.getByRole('code')).toContainText('Code message from User A');
     }
   });
 
@@ -87,8 +87,7 @@ test.describe('Markdown', () => {
     for (const pages of [userAPages, userBPages]) {
       const message = pages.conversation().getMessage({sender: userA});
       await expect(message).toBeVisible();
-      await expect(message.locator('pre')).toBeVisible();
-      await expect(message.locator('pre code')).toContainText('const a = 5; const b = 10;');
+      await expect(message.getByRole('code')).toContainText('const a = 5; const b = 10;');
     }
   });
 
@@ -103,9 +102,9 @@ test.describe('Markdown', () => {
     for (const pages of [userAPages, userBPages]) {
       const message = pages.conversation().getMessage({sender: userA});
       await expect(message).toBeVisible();
-      await expect(message.locator('strong, b')).toContainText('Bold');
-      await expect(message.locator('em, i')).toContainText('Italic');
-      await expect(message.locator('code')).toContainText('Code');
+      await expect(message.getByRole('strong')).toContainText('Bold');
+      await expect(message.getByRole('emphasis')).toContainText('Italic');
+      await expect(message.getByRole('code')).toContainText('Code');
     }
   });
 
@@ -120,8 +119,8 @@ test.describe('Markdown', () => {
     const sentMessageA = userAPages.conversation().getMessage({sender: userA});
     const sentMessageB = userBPages.conversation().getMessage({sender: userA});
 
-    await expect(sentMessageA.locator('strong, b')).toHaveText('Bold');
-    await expect(sentMessageB.locator('strong, b')).toHaveText('Bold');
+    await expect(sentMessageA.getByRole('strong')).toHaveText('Bold');
+    await expect(sentMessageB.getByRole('strong')).toHaveText('Bold');
 
     await userAPages.conversation().editMessage(sentMessageA);
     await expect(userAPages.conversation().messageInput).toContainText('Start Bold Message');
@@ -130,8 +129,8 @@ test.describe('Markdown', () => {
 
     for (const message of [sentMessageA, sentMessageB]) {
       await expect(message).toContainText('Edited to Italic Message');
-      await expect(message.locator('em, i')).toHaveText('Italic');
-      await expect(message.locator('strong, b')).not.toBeVisible();
+      await expect(message.getByRole('emphasis')).toHaveText('Italic');
+      await expect(message.getByRole('strong')).not.toBeVisible();
     }
   });
 
@@ -153,8 +152,7 @@ test.describe('Markdown', () => {
         await expect(message).toBeVisible();
         await expect(message).toContainText(`Visit ${linkText} for book a demo`);
 
-        const linkLocator = message.locator('a');
-        await expect(linkLocator).toHaveText(linkText);
+        const linkLocator = message.getByRole('link', {name: linkText});
         await expect(linkLocator).toHaveAttribute('href', url);
       }
     },

--- a/apps/webapp/test/e2e_tests/specs/Markdown/markdown.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Markdown/markdown.spec.ts
@@ -1,0 +1,162 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {User} from 'test/e2e_tests/data/user';
+import {PageManager} from 'test/e2e_tests/pageManager';
+import {test, expect, withConnectedUser, withLogin} from 'test/e2e_tests/test.fixtures';
+
+test.describe('Markdown', () => {
+  let userA: User;
+  let userB: User;
+
+  test.beforeEach(async ({createTeam}) => {
+    const team = await createTeam('Test Team', {withMembers: 1});
+    userA = team.owner;
+    userB = team.members[0];
+  });
+
+  test('I want to write a bold message', {tag: ['@TC-1314', '@regression']}, async ({createPage}) => {
+    const [userAPages, userBPages] = await Promise.all([
+      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+    ]);
+
+    await userAPages.conversation().sendMessage('**Bold Message from User A**');
+
+    for (const pages of [userAPages, userBPages]) {
+      const message = pages.conversation().getMessage({sender: userA});
+      await expect(message).toBeVisible();
+      await expect(message.locator('strong, b')).toHaveText('Bold Message from User A');
+    }
+  });
+
+  test('I want to write a emphasized message', {tag: ['@TC-1314', '@regression']}, async ({createPage}) => {
+    const [userAPages, userBPages] = await Promise.all([
+      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+    ]);
+
+    await userAPages.conversation().sendMessage('*Emphasized message from User A*');
+
+    for (const pages of [userAPages, userBPages]) {
+      const message = pages.conversation().getMessage({sender: userA});
+      await expect(message).toBeVisible();
+      await expect(message.locator('em, i')).toHaveText('Emphasized message from User A');
+    }
+  });
+
+  test('I want to write a code message', {tag: ['@TC-1315', '@regression']}, async ({createPage}) => {
+    const [userAPages, userBPages] = await Promise.all([
+      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+    ]);
+
+    await userAPages.conversation().sendMessage('`Code message from User A`');
+
+    for (const pages of [userAPages, userBPages]) {
+      const message = pages.conversation().getMessage({sender: userA});
+      await expect(message).toBeVisible();
+      await expect(message.locator('code')).toContainText('Code message from User A');
+    }
+  });
+
+  test('I want to write a long code message', {tag: ['@TC-1316', '@regression']}, async ({createPage}) => {
+    const [userAPages, userBPages] = await Promise.all([
+      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+    ]);
+    const longCodeMessage = '```\nconst a = 5;\nconst b = 10;\nconsole.log(a + b);\n```';
+    await userAPages.conversation().sendMessage(longCodeMessage);
+
+    for (const pages of [userAPages, userBPages]) {
+      const message = pages.conversation().getMessage({sender: userA});
+      await expect(message).toBeVisible();
+      await expect(message.locator('pre')).toBeVisible();
+      await expect(message.locator('pre code')).toContainText('const a = 5; const b = 10;');
+    }
+  });
+
+  test('I want to write a mixed markdown message', {tag: ['@TC-1317', '@regression']}, async ({createPage}) => {
+    const [userAPages, userBPages] = await Promise.all([
+      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+    ]);
+
+    await userAPages.conversation().sendMessage('**Bold**, *Italic* and `Code`');
+
+    for (const pages of [userAPages, userBPages]) {
+      const message = pages.conversation().getMessage({sender: userA});
+      await expect(message).toBeVisible();
+      await expect(message.locator('strong, b')).toContainText('Bold');
+      await expect(message.locator('em, i')).toContainText('Italic');
+      await expect(message.locator('code')).toContainText('Code');
+    }
+  });
+
+  test('I want to edit a markdown message', {tag: ['@TC-1319', '@regression']}, async ({createPage}) => {
+    const [userAPages, userBPages] = await Promise.all([
+      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+    ]);
+
+    await userAPages.conversation().sendMessage('Start **Bold** Message');
+
+    const sentMessageA = userAPages.conversation().getMessage({sender: userA});
+    const sentMessageB = userBPages.conversation().getMessage({sender: userA});
+
+    await expect(sentMessageA.locator('strong, b')).toHaveText('Bold');
+    await expect(sentMessageB.locator('strong, b')).toHaveText('Bold');
+
+    await userAPages.conversation().editMessage(sentMessageA);
+    await expect(userAPages.conversation().messageInput).toContainText('Start Bold Message');
+
+    await userAPages.conversation().sendMessage('Edited to *Italic* Message');
+
+    for (const message of [sentMessageA, sentMessageB]) {
+      await expect(message).toContainText('Edited to Italic Message');
+      await expect(message.locator('em, i')).toHaveText('Italic');
+      await expect(message.locator('strong, b')).not.toBeVisible();
+    }
+  });
+
+  test(
+    'I want to write a url with markdown (Mixed with text)',
+    {tag: ['@TC-1319', '@regression']},
+    async ({createPage}) => {
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      ]);
+
+      const linkText = 'Wire Website';
+      const url = 'https://wire.com';
+      await userAPages.conversation().sendMessage(`Visit [${linkText}](${url}) for book a demo`);
+
+      for (const pages of [userAPages, userBPages]) {
+        const message = pages.conversation().getMessage({sender: userA});
+        await expect(message).toBeVisible();
+        await expect(message).toContainText(`Visit ${linkText} for book a demo`);
+
+        const linkLocator = message.locator('a');
+        await expect(linkLocator).toHaveText(linkText);
+        await expect(linkLocator).toHaveAttribute('href', url);
+      }
+    },
+  );
+});


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19959" title="WPB-19959" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19959</a>  [Web/QA] Write the Markdown regression tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Added e2e regression tests to verify markdown rendering for the following elements:
Text styles: Bold, Italic
Code: Inline code and code blocks (long code)
Links: Standard markdown hyperlinks

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
