### PR TITLE
fix:  compare original name for old and new name to disable the submit button when renaming(WPB-23294)

### DIFF
--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableRowOptions/CellsRenameNodeModal/useCellsRenameNodeForm/useCellsRenameNodeForm.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableRowOptions/CellsRenameNodeModal/useCellsRenameNodeForm/useCellsRenameNodeForm.ts
@@ -37,8 +37,9 @@ export const useCellsRenameForm = ({node, cellsRepository, onSuccess}: UseCellsR
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  const originalBaseName = trimFileExtension(node.name);
   const hasInvalidCharacters = INVALID_CHARACTERS.some(char => name.includes(char));
-  const isDisabled = isSubmitting || name === node.name || !name.trim();
+  const isDisabled = isSubmitting || name === originalBaseName || !name.trim();
 
   const renameNode = async (name: string) => {
     try {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23294" title="WPB-23294" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23294</a>  [Web] When renaming a file to the same name "-1" added to the previous name
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Steps to reproduce: 
- Send a file in a Group conversation with Drive enabled
- Open Shared Drive tab
- Click rename file
- Don’t change the value and click save

Expected behavior: 
- Save button should be disabled if the name value doesn’t change

Actual behavior: 
- File is renamed to “{FILE_NAME}+1“ (e.g. original “file“, saved “file-1“)

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
