### PR TITLE
fix(ci): use otto-the-bot token for library release PRs to trigger CI [WPB-23275]

### DIFF
--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -9,10 +9,10 @@ permissions:
 jobs:
   activate-auto-merge:
     runs-on: ubuntu-latest
-    if: ${{github.actor == 'github-actions' || github.actor == 'dependabot[bot]' || github.actor == 'otto-the-bot'}}
+    if: ${{github.actor == 'dependabot[bot]' || github.actor == 'otto-the-bot'}}
     steps:
       - name: Approve PR
-        if: ${{ github.actor == 'github-actions' || github.actor == 'otto-the-bot' || (github.actor == 'dependabot[bot]' && (steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major')) }}
+        if: ${{ github.actor == 'otto-the-bot' || (github.actor == 'dependabot[bot]' && (steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major')) }}
         run: gh pr review --approve "$PR_URL"
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -11,19 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{github.actor == 'dependabot[bot]' || github.actor == 'otto-the-bot'}}
     steps:
-      - name: Approve PR
-        if: ${{ github.actor == 'otto-the-bot' || (github.actor == 'dependabot[bot]' && (steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major')) }}
-        run: gh pr review --approve "$PR_URL"
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          PR_URL: ${{github.event.pull_request.html_url}}
-
       - name: Fetch Dependabot metadata
         if: ${{github.actor == 'dependabot[bot]'}}
         id: dependabot-metadata
         uses: dependabot/fetch-metadata@v2.5.0
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Approve PR
+        if: ${{ github.actor == 'otto-the-bot' || (github.actor == 'dependabot[bot]' && (steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major')) }}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR_URL: ${{github.event.pull_request.html_url}}
 
       - name: Enable auto-merge
         if: ${{github.actor == 'otto-the-bot' || (github.actor == 'dependabot[bot]' && steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major') || (github.event.pull_request.labels && contains(github.event.pull_request.labels.*.name, 'publish-to-npm')) }}

--- a/.github/workflows/publish-libraries-on-merge.yml
+++ b/.github/workflows/publish-libraries-on-merge.yml
@@ -38,8 +38,8 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "otto-the-bot"
+          git config user.email "8736538+otto-the-bot@users.noreply.github.com"
 
       - name: Install dependencies
         run: yarn --immutable

--- a/.github/workflows/publish-libraries.yml
+++ b/.github/workflows/publish-libraries.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: dev
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.OTTO_THE_BOT_GH_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -32,8 +32,8 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "otto-the-bot"
+          git config user.email "8736538+otto-the-bot@users.noreply.github.com"
 
       - name: Create release branch
         run: |
@@ -79,4 +79,4 @@ jobs:
             --label "publish-to-npm" \
             --body "Automated release PR created by nx release. ⚠️ **Important:** Do NOT squash merge this PR. Use 'Merge commit' to preserve git tags."
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OTTO_THE_BOT_GH_TOKEN }}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23275" title="WPB-23275" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23275</a>  [Web] Fix publish workflow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

## What did I change and why?

Library release PRs created by `publish-libraries.yml` were stuck with CI checks showing "Waiting for status to be reported". This happened because GitHub does not trigger workflows from events created with `GITHUB_TOKEN` (to prevent recursive loops).

## Changes

- Use `OTTO_THE_BOT_GH_TOKEN` instead of `GITHUB_TOKEN` in `publish-libraries.yml` for checkout, push, and PR creation
- Update git author to `otto-the-bot` in both publish workflows
- Remove unused `github-actions` actor checks from `pr-auto-merge.yml`

## Why this works

PRs created with a PAT (like `OTTO_THE_BOT_GH_TOKEN`) are treated as real user events, so they trigger CI and auto-merge workflows normally. The existing `pr-auto-merge.yml` already handles `otto-the-bot` — it approves and enables auto-merge automatically.

## References

- [GitHub docs: GITHUB_TOKEN does not trigger workflows](https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs)

- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
