### PR TITLE
fix(api-client): add zod back as dependency of api client [WPB-22420]

### DIFF
--- a/libraries/api-client/package.json
+++ b/libraries/api-client/package.json
@@ -28,7 +28,8 @@
     "reconnecting-websocket": "4.4.0",
     "spark-md5": "3.0.2",
     "tough-cookie": "4.1.4",
-    "ws": "8.19.0"
+    "ws": "8.19.0",
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@swc/core": "^1.15.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10864,6 +10864,7 @@ __metadata:
     ts-node: "npm:^10.9.2"
     webpack: "npm:^5.104.1"
     ws: "npm:8.19.0"
+    zod: "npm:3.25.76"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- Fix api client by adding back zod as dependency

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
