### PR TITLE
chore(ci): enable GitHub merge queues [WPB-23415]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     # we want to run the CI on every PR targetting those branches
     branches: [master, dev, release/*]
 
+  merge_group:
+    branches: [master, dev, release/*]
+
   push:
     # We also run CI on dev in order to update the coverage monitoring
     branches: [dev]

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -5,7 +5,9 @@
 # Source repository: https://github.com/actions/dependency-review-action
 # Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
 name: 'Dependency Review'
-on: [pull_request]
+on:
+  pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/jira-lint-and-link.yml
+++ b/.github/workflows/jira-lint-and-link.yml
@@ -2,13 +2,20 @@ name: Link and Lint PR with Jira Ticket Number
 on:
   pull_request:
     types: [opened, edited, synchronize]
+  merge_group:
+    branches: [dev]
 jobs:
   add-jira-description:
-    # avoid triggering this action on dependabot PRs
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'otto-the-bot' }}
+    # On merge_group there is no pull request payload; keep the required check green there.
+    if: ${{ github.event_name == 'merge_group' || (github.actor != 'dependabot[bot]' && github.actor != 'otto-the-bot') }}
     runs-on: ubuntu-latest
     steps:
+      - name: Skip on merge queue
+        if: ${{ github.event_name == 'merge_group' }}
+        run: echo "Skipping Jira pull request description validation on merge queue."
+
       - uses: cakeinpanic/jira-description-action@master
+        if: ${{ github.event_name == 'pull_request' }}
         name: jira-description-action
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic-commit-lint.yml
+++ b/.github/workflows/semantic-commit-lint.yml
@@ -3,6 +3,8 @@ name: 'Semantic Commit Linting of PR titles'
 on:
   pull_request_target:
     types: [opened, edited, synchronize]
+  merge_group:
+    branches: [master, dev, release/*]
 
 permissions:
   statuses: write
@@ -11,9 +13,14 @@ jobs:
   semantic-commit-pr-title-lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Skip on merge queue
+        if: ${{ github.event_name == 'merge_group' }}
+        run: echo "Skipping semantic PR title lint on merge queue."
+
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
       - name: Run Semantic Commint Linter
+        if: ${{ github.event_name == 'pull_request_target' }}
         uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23415" title="WPB-23415" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23415</a>  [Web] Enable GitHub merge queues
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

# Pull Request

## Summary

Previously all pull requests needed to be rebased manually or through the GitHub user interface. Introducing [GitHub merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue), also sometimes called [merge trains](https://docs.gitlab.com/ci/pipelines/merge_trains/) 🚂 , helps here with increasing development velocity.

When this pull request is merged we will have a new button that will look like this one which will take care about rebasing and merging everything.

<img width="924" height="193" alt="image" src="https://github.com/user-attachments/assets/4a2bd59d-79a1-453d-ba9e-594cb5714679" />


---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).
