### PR TITLE
fix(api-client): Add http-status-codes back as dependency of api client [WPB-22420]

### DIFF
--- a/libraries/api-client/package.json
+++ b/libraries/api-client/package.json
@@ -24,6 +24,7 @@
     "@wireapp/protocol-messaging": "1.56.0",
     "axios-retry": "4.5.0",
     "cells-sdk-ts": "0.1.1-alpha18",
+    "http-status-codes": "2.3.0",
     "pako": "2.1.0",
     "reconnecting-websocket": "4.4.0",
     "spark-md5": "3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10873,6 +10873,7 @@ __metadata:
     browser-sync: "npm:3.0.4"
     cells-sdk-ts: "npm:0.1.1-alpha18"
     concurrently: "npm:9.2.1"
+    http-status-codes: "npm:2.3.0"
     jest: "npm:^29.7.0"
     pako: "npm:2.1.0"
     react: "npm:18.3.1"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- Fixed api client by adding http-status-codes back as dependency of api-client

---

## Security Checklist (required)

- [ X ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ X ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ X ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ X ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ X ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ X ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):


[WPB-22420]: https://wearezeta.atlassian.net/browse/WPB-22420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ