### PR TITLE
feat(server): Check for custom header existence [WPB-23299]

### DIFF
--- a/apps/server/Server.ts
+++ b/apps/server/Server.ts
@@ -76,9 +76,9 @@ class Server {
     this.app.use(ConfigRoute(this.config, this.clientConfig));
     this.app.use(GoogleWebmasterRoute(this.config));
     this.app.use(AppleAssociationRoute());
+    this.app.use(createClientVersionCheckRoute({router: Router()}));
     this.app.use(NotFoundRoute());
     this.app.use(InternalErrorRoute());
-    this.app.use(createClientVersionCheckRoute({router: Router()}));
   }
 
   private initWebpack() {

--- a/apps/server/routes/client-version-check/ClientVersionCheckRoute.test.ts
+++ b/apps/server/routes/client-version-check/ClientVersionCheckRoute.test.ts
@@ -30,35 +30,25 @@ describe('/client-version-check', () => {
     expect(sendStatus).toHaveBeenNthCalledWith(1, 200);
   });
 
-  it("returns HTTP 400 if 'X-Webapp-Client-Version' header is missing", async () => {
-    const sendStatus = jest.fn();
-    const fakeRequest = {header: jest.fn().mockReturnValue(undefined)} as unknown as Request;
-    const fakeResponse = {sendStatus} as unknown as Response;
+  it.each<{headerValue: string | undefined; expectedHttpStatusCode: number}>([
+    {headerValue: '', expectedHttpStatusCode: 400},
+    {headerValue: undefined, expectedHttpStatusCode: 400},
+  ])(
+    'returns HTTP status code $expectedHttpStatusCode if header value is "$headerValue"',
+    async ({headerValue, expectedHttpStatusCode}) => {
+      const sendStatus = jest.fn();
+      const fakeRequest = {header: jest.fn().mockReturnValue(headerValue)} as unknown as Request;
+      const fakeResponse = {sendStatus} as unknown as Response;
 
-    const fakeRouter = {
-      get: jest.fn((_routePath, routeHandler) => {
-        routeHandler(fakeRequest, fakeResponse);
-      }),
-    } as unknown as Router;
+      const fakeRouter = {
+        get: jest.fn((_routePath, routeHandler) => {
+          routeHandler(fakeRequest, fakeResponse);
+        }),
+      } as unknown as Router;
 
-    createClientVersionCheckRoute({router: fakeRouter});
+      createClientVersionCheckRoute({router: fakeRouter});
 
-    expect(sendStatus).toHaveBeenNthCalledWith(1, 400);
-  });
-
-  it("returns HTTP 400 if 'X-Webapp-Client-Version' header is empty", async () => {
-    const sendStatus = jest.fn();
-    const fakeRequest = {header: jest.fn().mockReturnValue('')} as unknown as Request;
-    const fakeResponse = {sendStatus} as unknown as Response;
-
-    const fakeRouter = {
-      get: jest.fn((_routePath, routeHandler) => {
-        routeHandler(fakeRequest, fakeResponse);
-      }),
-    } as unknown as Router;
-
-    createClientVersionCheckRoute({router: fakeRouter});
-
-    expect(sendStatus).toHaveBeenNthCalledWith(1, 400);
-  });
+      expect(sendStatus).toHaveBeenNthCalledWith(1, expectedHttpStatusCode);
+    },
+  );
 });

--- a/apps/server/routes/client-version-check/ClientVersionCheckRoute.test.ts
+++ b/apps/server/routes/client-version-check/ClientVersionCheckRoute.test.ts
@@ -16,16 +16,49 @@ describe('/client-version-check', () => {
 
   it('returns HTTP 200', async () => {
     const sendStatus = jest.fn();
+    const fakeRequest = {header: jest.fn().mockReturnValue('1.0.0')} as unknown as Request;
     const fakeResponse = {sendStatus} as unknown as Response;
 
     const fakeRouter = {
       get: jest.fn((_routePath, routeHandler) => {
-        routeHandler(undefined, fakeResponse);
+        routeHandler(fakeRequest, fakeResponse);
       }),
     } as unknown as Router;
 
     createClientVersionCheckRoute({router: fakeRouter});
 
     expect(sendStatus).toHaveBeenNthCalledWith(1, 200);
+  });
+
+  it("returns HTTP 400 if 'X-Webapp-Client-Version' header is missing", async () => {
+    const sendStatus = jest.fn();
+    const fakeRequest = {header: jest.fn().mockReturnValue(undefined)} as unknown as Request;
+    const fakeResponse = {sendStatus} as unknown as Response;
+
+    const fakeRouter = {
+      get: jest.fn((_routePath, routeHandler) => {
+        routeHandler(fakeRequest, fakeResponse);
+      }),
+    } as unknown as Router;
+
+    createClientVersionCheckRoute({router: fakeRouter});
+
+    expect(sendStatus).toHaveBeenNthCalledWith(1, 400);
+  });
+
+  it("returns HTTP 400 if 'X-Webapp-Client-Version' header is empty", async () => {
+    const sendStatus = jest.fn();
+    const fakeRequest = {header: jest.fn().mockReturnValue('')} as unknown as Request;
+    const fakeResponse = {sendStatus} as unknown as Response;
+
+    const fakeRouter = {
+      get: jest.fn((_routePath, routeHandler) => {
+        routeHandler(fakeRequest, fakeResponse);
+      }),
+    } as unknown as Router;
+
+    createClientVersionCheckRoute({router: fakeRouter});
+
+    expect(sendStatus).toHaveBeenNthCalledWith(1, 400);
   });
 });

--- a/apps/server/routes/client-version-check/ClientVersionCheckRoute.ts
+++ b/apps/server/routes/client-version-check/ClientVersionCheckRoute.ts
@@ -28,6 +28,12 @@ export function createClientVersionCheckRoute(dependencies: ClientVersionCheckRo
   const {router} = dependencies;
 
   return router.get('/client-version-check', (request, response) => {
+    const clientVersion = request.header('X-Webapp-Client-Version');
+
+    if (clientVersion === undefined || clientVersion.trim() === '') {
+      return response.sendStatus(HTTP_STATUS.BAD_REQUEST);
+    }
+
     return response.sendStatus(HTTP_STATUS.OK);
   });
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23299" title="WPB-23299" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23299</a>  [Web] Add support for remote force reload 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- What did I change and why?
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
