### PR TITLE
feat(server): parse client version [WPB-23299]

### DIFF
--- a/apps/server/jest.config.js
+++ b/apps/server/jest.config.js
@@ -23,6 +23,7 @@ module.exports = {
   moduleDirectories: ['node_modules', __dirname],
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/dist'],
+  transformIgnorePatterns: ['/node_modules/(?!(true-myth)/)'],
   transform: {
     '^.+\\.(ts|tsx)$': 'babel-jest',
     '^.+\\.(js|jsx)$': 'babel-jest',

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@wireapp/config": "workspace:^",
+    "date-fns": "4.1.0",
     "dotenv-extended": "2.9.0",
     "express": "4.22.1",
     "express-sitemap-xml": "3.1.0",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -28,7 +28,8 @@
     "maxmind": "4.3.29",
     "nocache": "4.0.0",
     "opn": "6.0.0",
-    "pm2": "6.0.14"
+    "pm2": "6.0.14",
+    "true-myth": "9.3.1"
   },
   "devDependencies": {
     "@types/express": "4.17.25",

--- a/apps/server/routes/client-version-check/ClientVersion.test.ts
+++ b/apps/server/routes/client-version-check/ClientVersion.test.ts
@@ -1,13 +1,42 @@
+import assert from 'node:assert';
 import {parseClientVersion} from './ClientVersion';
 
 describe('client version', () => {
-  it('returns an Result Err when parsing the client fails', () => {
-    const actual = parseClientVersion('2026.02.11.15.37.44');
+  it('returns an Result Err when the version number is not a date', () => {
+    const actual = parseClientVersion('not-a-date');
 
     expect(actual.isErr).toBe(true);
   });
 
-  // it('parses the client to a corresponding Date', () => {
-  //   parseClientVersion('foo');
-  // });
+  it('returns an Result Err when the version number is missing the time', () => {
+    const actual = parseClientVersion('2026.02.11');
+
+    expect(actual.isErr).toBe(true);
+  });
+
+  it('returns an Result Err when the version number is an empty string', () => {
+    const actual = parseClientVersion('');
+
+    expect(actual.isErr).toBe(true);
+  });
+
+  it('returns an Result Err when the version number is a regular ISO date', () => {
+    const actual = parseClientVersion('2026-02-12T17:51:00+01:00');
+
+    expect(actual.isErr).toBe(true);
+  });
+
+  it('returns an Result Err when the version number is valid but includes a timezone', () => {
+    const actual = parseClientVersion('2026.02.12.17.51.00+01:00');
+
+    expect(actual.isErr).toBe(true);
+  });
+
+  it('returns an Result Ok when the version number is valid', () => {
+    const actual = parseClientVersion('2026.02.12.17.51.00');
+
+    assert(actual.isOk === true);
+
+    expect(actual.value).toStrictEqual(new Date('2026-02-12T17:51:00'));
+  });
 });

--- a/apps/server/routes/client-version-check/ClientVersion.test.ts
+++ b/apps/server/routes/client-version-check/ClientVersion.test.ts
@@ -38,11 +38,14 @@ describe('client version', () => {
     '2026.02.12.24.00.00',
     '2026.02.12.17.60.00',
     '2026.02.12.17.51.60',
-  ])('returns an Result Err when the version number has out-of-range date or time values (%s)', invalidClientVersion => {
-    const actual = parseClientVersion(invalidClientVersion);
+  ])(
+    'returns an Result Err when the version number has out-of-range date or time values (%s)',
+    invalidClientVersion => {
+      const actual = parseClientVersion(invalidClientVersion);
 
-    expect(actual.isErr).toBe(true);
-  });
+      expect(actual.isErr).toBe(true);
+    },
+  );
 
   it('returns an Error with zod validation cause when parsing fails', () => {
     const actual = parseClientVersion('not-a-date');
@@ -50,6 +53,9 @@ describe('client version', () => {
     assert(actual.isErr === true);
 
     expect(actual.error).toBeInstanceOf(Error);
+    expect(actual.error.message).toBe(
+      'Invalid client version format: "not-a-date". Expected format: yyyy.MM.dd.HH.mm.ss',
+    );
     expect(actual.error.cause).toBeDefined();
   });
 

--- a/apps/server/routes/client-version-check/ClientVersion.test.ts
+++ b/apps/server/routes/client-version-check/ClientVersion.test.ts
@@ -32,11 +32,32 @@ describe('client version', () => {
     expect(actual.isErr).toBe(true);
   });
 
+  it.each([
+    '2026.13.12.17.51.00',
+    '2026.02.30.17.51.00',
+    '2026.02.12.24.00.00',
+    '2026.02.12.17.60.00',
+    '2026.02.12.17.51.60',
+  ])('returns an Result Err when the version number has out-of-range date or time values (%s)', invalidClientVersion => {
+    const actual = parseClientVersion(invalidClientVersion);
+
+    expect(actual.isErr).toBe(true);
+  });
+
+  it('returns an Error with zod validation cause when parsing fails', () => {
+    const actual = parseClientVersion('not-a-date');
+
+    assert(actual.isErr === true);
+
+    expect(actual.error).toBeInstanceOf(Error);
+    expect(actual.error.cause).toBeDefined();
+  });
+
   it('returns an Result Ok when the version number is valid', () => {
     const actual = parseClientVersion('2026.02.12.17.51.00');
 
     assert(actual.isOk === true);
 
-    expect(actual.value).toStrictEqual(new Date('2026-02-12T17:51:00'));
+    expect(actual.value).toStrictEqual(new Date(2026, 1, 12, 17, 51, 0));
   });
 });

--- a/apps/server/routes/client-version-check/ClientVersion.test.ts
+++ b/apps/server/routes/client-version-check/ClientVersion.test.ts
@@ -1,0 +1,13 @@
+import {parseClientVersion} from './ClientVersion';
+
+describe('client version', () => {
+  it('returns an Result Err when parsing the client fails', () => {
+    const actual = parseClientVersion('2026.02.11.15.37.44');
+
+    expect(actual.isErr).toBe(true);
+  });
+
+  // it('parses the client to a corresponding Date', () => {
+  //   parseClientVersion('foo');
+  // });
+});

--- a/apps/server/routes/client-version-check/ClientVersion.ts
+++ b/apps/server/routes/client-version-check/ClientVersion.ts
@@ -17,29 +17,23 @@
  *
  */
 
-import {parse, isValid} from 'date-fns';
+import {parse} from 'date-fns';
 import {Result} from 'true-myth';
 import {z} from 'zod';
 
 const clientVersionSchema = z
   .string()
-  .refine(clientVersionString => {
-    const parseResult = parse(clientVersionString, 'yyyy.MM.dd.HH.mm.ss', new Date());
-
-    return isValid(parseResult);
-  })
   .transform(clientVersionString => {
-    const parseResult = parse(clientVersionString, 'yyyy.MM.dd.HH.mm.ss', new Date());
+    return parse(clientVersionString, 'yyyy.MM.dd.HH.mm.ss', new Date());
+  })
+  .pipe(z.date());
 
-    return parseResult;
-  });
-
-export function parseClientVersion(clientVersionDate: string): Result<Error, Date> {
+export function parseClientVersion(clientVersionDate: string): Result<Date, Error> {
   const parseResult = clientVersionSchema.safeParse(clientVersionDate);
 
   if (parseResult.success) {
-    return Result.ok<Error, Date>(parseResult.data);
+    return Result.ok(parseResult.data);
   }
 
-  return Result.err<Error, Date>(new Error('foobar', {cause: parseResult.error}));
+  return Result.err(new Error('foobar', {cause: parseResult.error}));
 }

--- a/apps/server/routes/client-version-check/ClientVersion.ts
+++ b/apps/server/routes/client-version-check/ClientVersion.ts
@@ -35,5 +35,9 @@ export function parseClientVersion(clientVersionHeaderValue: string): Result<Dat
     return Result.ok(parseResult.data);
   }
 
-  return Result.err(new Error('foobar', {cause: parseResult.error}));
+  return Result.err(
+    new Error(`Invalid client version format: "${clientVersionHeaderValue}". Expected format: yyyy.MM.dd.HH.mm.ss`, {
+      cause: parseResult.error,
+    }),
+  );
 }

--- a/apps/server/routes/client-version-check/ClientVersion.ts
+++ b/apps/server/routes/client-version-check/ClientVersion.ts
@@ -1,0 +1,24 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Result} from 'true-myth';
+
+export function parseClientVersion(clientVersion: string): Result<Error, Date> {
+  return Result.err(new Error('foo'));
+}

--- a/apps/server/routes/client-version-check/ClientVersion.ts
+++ b/apps/server/routes/client-version-check/ClientVersion.ts
@@ -28,8 +28,8 @@ const clientVersionSchema = z
   })
   .pipe(z.date());
 
-export function parseClientVersion(clientVersionDate: string): Result<Date, Error> {
-  const parseResult = clientVersionSchema.safeParse(clientVersionDate);
+export function parseClientVersion(clientVersionHeaderValue: string): Result<Date, Error> {
+  const parseResult = clientVersionSchema.safeParse(clientVersionHeaderValue);
 
   if (parseResult.success) {
     return Result.ok(parseResult.data);

--- a/apps/server/routes/client-version-check/ClientVersion.ts
+++ b/apps/server/routes/client-version-check/ClientVersion.ts
@@ -17,8 +17,29 @@
  *
  */
 
+import {parse, isValid} from 'date-fns';
 import {Result} from 'true-myth';
+import {z} from 'zod';
 
-export function parseClientVersion(clientVersion: string): Result<Error, Date> {
-  return Result.err(new Error('foo'));
+const clientVersionSchema = z
+  .string()
+  .refine(clientVersionString => {
+    const parseResult = parse(clientVersionString, 'yyyy.MM.dd.HH.mm.ss', new Date());
+
+    return isValid(parseResult);
+  })
+  .transform(clientVersionString => {
+    const parseResult = parse(clientVersionString, 'yyyy.MM.dd.HH.mm.ss', new Date());
+
+    return parseResult;
+  });
+
+export function parseClientVersion(clientVersionDate: string): Result<Error, Date> {
+  const parseResult = clientVersionSchema.safeParse(clientVersionDate);
+
+  if (parseResult.success) {
+    return Result.ok<Error, Date>(parseResult.data);
+  }
+
+  return Result.err<Error, Date>(new Error('foobar', {cause: parseResult.error}));
 }

--- a/apps/server/routes/client-version-check/ClientVersionCheckRoute.test.ts
+++ b/apps/server/routes/client-version-check/ClientVersionCheckRoute.test.ts
@@ -37,7 +37,8 @@ describe('/client-version-check', () => {
     'returns HTTP status code $expectedHttpStatusCode if header value is "$headerValue"',
     async ({headerValue, expectedHttpStatusCode}) => {
       const sendStatus = jest.fn();
-      const fakeRequest = {header: jest.fn().mockReturnValue(headerValue)} as unknown as Request;
+      const fakeHeader = jest.fn().mockReturnValue(headerValue);
+      const fakeRequest = {header: fakeHeader} as unknown as Request;
       const fakeResponse = {sendStatus} as unknown as Response;
 
       const fakeRouter = {
@@ -48,6 +49,7 @@ describe('/client-version-check', () => {
 
       createClientVersionCheckRoute({router: fakeRouter});
 
+      expect(fakeHeader).toHaveBeenNthCalledWith(1, 'Wire-Client-Version');
       expect(sendStatus).toHaveBeenNthCalledWith(1, expectedHttpStatusCode);
     },
   );

--- a/apps/server/routes/client-version-check/ClientVersionCheckRoute.ts
+++ b/apps/server/routes/client-version-check/ClientVersionCheckRoute.ts
@@ -28,7 +28,7 @@ export function createClientVersionCheckRoute(dependencies: ClientVersionCheckRo
   const {router} = dependencies;
 
   return router.get('/client-version-check', (request, response) => {
-    const clientVersion = request.header('X-Webapp-Client-Version');
+    const clientVersion = request.header('Wire-Client-Version');
 
     if (clientVersion === undefined || clientVersion.trim() === '') {
       return response.sendStatus(HTTP_STATUS.BAD_REQUEST);

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -12,6 +12,6 @@ module.exports = {
     '^.+\\.(ts|tsx)$': '@swc/jest',
     '^.+\\.(js|jsx)$': 'babel-jest',
   },
-  transformIgnorePatterns: ['node_modules/'],
+  transformIgnorePatterns: ['node_modules/', '/node_modules/(?!(true-myth)/)'],
   moduleFileExtensions: ['js', 'json', 'ts', 'tsx'],
 };

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -12,6 +12,6 @@ module.exports = {
     '^.+\\.(ts|tsx)$': '@swc/jest',
     '^.+\\.(js|jsx)$': 'babel-jest',
   },
-  transformIgnorePatterns: ['node_modules/', '/node_modules/(?!(true-myth)/)'],
+  transformIgnorePatterns: ['/node_modules/(?!(true-myth)/)'],
   moduleFileExtensions: ['js', 'json', 'ts', 'tsx'],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -11153,6 +11153,7 @@ __metadata:
     nocache: "npm:4.0.0"
     opn: "npm:6.0.0"
     pm2: "npm:6.0.14"
+    true-myth: "npm:9.3.1"
   languageName: unknown
   linkType: soft
 
@@ -27607,6 +27608,13 @@ __metadata:
   bin:
     tree-kill: cli.js
   checksum: 10/49117f5f410d19c84b0464d29afb9642c863bc5ba40fcb9a245d474c6d5cc64d1b177a6e6713129eb346b40aebb9d4631d967517f9fbe8251c35b21b13cd96c7
+  languageName: node
+  linkType: hard
+
+"true-myth@npm:9.3.1":
+  version: 9.3.1
+  resolution: "true-myth@npm:9.3.1"
+  checksum: 10/390791d6f917dd445f82c37174317ce9dfd1e21fd0dba5ac18615aa0761c7daf87cc9e8f13cde588dc3a4a61373dc6dc5a333aa693ccae345d288fbbf97547ed
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11138,6 +11138,7 @@ __metadata:
     "@types/geolite2": "npm:2.0.2"
     "@types/hbs": "npm:4.0.5"
     "@wireapp/config": "workspace:^"
+    date-fns: "npm:4.1.0"
     dotenv-extended: "npm:2.9.0"
     express: "npm:4.22.1"
     express-sitemap-xml: "npm:3.1.0"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23299" title="WPB-23299" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23299</a>  [Web] Add support for remote force reload 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

The version number needs to be parsed first before we can evaluate if we want to allow it or not.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
