### PR TITLE
feat(server): parse client version in /client-version-check route [WPB-23299]

### DIFF
--- a/apps/server/Server.ts
+++ b/apps/server/Server.ts
@@ -33,6 +33,7 @@ import type {ClientConfig, ServerConfig} from '@wireapp/config';
 
 import {HealthCheckRoute} from './routes/_health/HealthRoute';
 import {AppleAssociationRoute} from './routes/appleassociation/AppleAssociationRoute';
+import {parseClientVersion} from './routes/client-version-check/ClientVersion';
 import {createClientVersionCheckRoute} from './routes/client-version-check/ClientVersionCheckRoute';
 import {ConfigRoute} from './routes/config/ConfigRoute';
 import {InternalErrorRoute, NotFoundRoute} from './routes/error/ErrorRoutes';
@@ -76,7 +77,7 @@ class Server {
     this.app.use(ConfigRoute(this.config, this.clientConfig));
     this.app.use(GoogleWebmasterRoute(this.config));
     this.app.use(AppleAssociationRoute());
-    this.app.use(createClientVersionCheckRoute({router: Router()}));
+    this.app.use(createClientVersionCheckRoute({router: Router(), parseClientVersion}));
     this.app.use(NotFoundRoute());
     this.app.use(InternalErrorRoute());
   }

--- a/apps/server/jest.config.js
+++ b/apps/server/jest.config.js
@@ -23,7 +23,7 @@ module.exports = {
   moduleDirectories: ['node_modules', __dirname],
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/dist'],
-  transformIgnorePatterns: ['/node_modules/(?!(true-myth)/)'],
+  transformIgnorePatterns: ['/node_modules/(?!(true-myth|@sindresorhus/is)/)'],
   transform: {
     '^.+\\.(ts|tsx)$': 'babel-jest',
     '^.+\\.(js|jsx)$': 'babel-jest',

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -13,6 +13,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@sindresorhus/is": "^7.2.0",
     "@wireapp/config": "workspace:^",
     "date-fns": "4.1.0",
     "dotenv-extended": "2.9.0",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -13,7 +13,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@sindresorhus/is": "^7.2.0",
+    "@sindresorhus/is": "4.6.0",
     "@wireapp/config": "workspace:^",
     "date-fns": "4.1.0",
     "dotenv-extended": "2.9.0",

--- a/apps/server/routes/client-version-check/ClientVersionCheckRoute.test.ts
+++ b/apps/server/routes/client-version-check/ClientVersionCheckRoute.test.ts
@@ -1,4 +1,4 @@
-import {Router, type Response} from 'express';
+import {Router, type Response, type Request} from 'express';
 import {Result} from 'true-myth';
 import {createClientVersionCheckRoute} from './ClientVersionCheckRoute';
 

--- a/apps/server/routes/client-version-check/ClientVersionCheckRoute.test.ts
+++ b/apps/server/routes/client-version-check/ClientVersionCheckRoute.test.ts
@@ -7,9 +7,7 @@ type ClientVersionCheckRouteDependencyFunctionOverrides = {
   readonly parseClientVersion?: jest.Mock;
 };
 
-function createClientVersionCheckRouteDependencies(
-  overrides: ClientVersionCheckRouteDependencyFunctionOverrides = {},
-) {
+function createClientVersionCheckRouteDependencies(overrides: ClientVersionCheckRouteDependencyFunctionOverrides = {}) {
   const get = overrides.get ?? jest.fn();
   const parseClientVersion = overrides.parseClientVersion ?? jest.fn().mockReturnValue(Result.ok(new Date()));
   const router = {get} as unknown as Router;
@@ -66,7 +64,7 @@ describe('/client-version-check', () => {
     },
   );
 
-  it('returns HTTP 400 if parseClientVersion() returns an Result Err', async () => {
+  it('returns HTTP 400 if parseClientVersion() returns a Result Err', async () => {
     const sendStatus = jest.fn();
     const fakeRequest = {header: jest.fn().mockReturnValue('1.0.0')} as unknown as Request;
     const fakeResponse = {sendStatus} as unknown as Response;

--- a/apps/server/routes/client-version-check/ClientVersionCheckRoute.test.ts
+++ b/apps/server/routes/client-version-check/ClientVersionCheckRoute.test.ts
@@ -1,32 +1,44 @@
 import {Router, type Response} from 'express';
+import {Result} from 'true-myth';
 import {createClientVersionCheckRoute} from './ClientVersionCheckRoute';
+
+type ClientVersionCheckRouteDependencyFunctionOverrides = {
+  readonly get?: jest.Mock;
+  readonly parseClientVersion?: jest.Mock;
+};
+
+function createClientVersionCheckRouteDependencies(
+  overrides: ClientVersionCheckRouteDependencyFunctionOverrides = {},
+) {
+  const get = overrides.get ?? jest.fn();
+  const parseClientVersion = overrides.parseClientVersion ?? jest.fn().mockReturnValue(Result.ok(new Date()));
+  const router = {get} as unknown as Router;
+
+  return {router, parseClientVersion, get};
+}
 
 describe('/client-version-check', () => {
   it('listens on /client-version-check path', async () => {
-    const fakeGet = jest.fn();
+    const dependencies = createClientVersionCheckRouteDependencies();
 
-    const fakeRouter = {
-      get: fakeGet,
-    } as unknown as Router;
+    createClientVersionCheckRoute(dependencies);
 
-    createClientVersionCheckRoute({router: fakeRouter});
-
-    expect(fakeGet).toHaveBeenNthCalledWith(1, '/client-version-check', expect.any(Function));
+    expect(dependencies.get).toHaveBeenNthCalledWith(1, '/client-version-check', expect.any(Function));
   });
 
   it('returns HTTP 200', async () => {
     const sendStatus = jest.fn();
-    const fakeRequest = {header: jest.fn().mockReturnValue('1.0.0')} as unknown as Request;
+    const fakeRequest = {header: jest.fn().mockReturnValue('2026.02.12.17.51.00')} as unknown as Request;
     const fakeResponse = {sendStatus} as unknown as Response;
-
-    const fakeRouter = {
+    const dependencies = createClientVersionCheckRouteDependencies({
       get: jest.fn((_routePath, routeHandler) => {
         routeHandler(fakeRequest, fakeResponse);
       }),
-    } as unknown as Router;
+    });
 
-    createClientVersionCheckRoute({router: fakeRouter});
+    createClientVersionCheckRoute(dependencies);
 
+    expect(dependencies.parseClientVersion).toHaveBeenNthCalledWith(1, '2026.02.12.17.51.00');
     expect(sendStatus).toHaveBeenNthCalledWith(1, 200);
   });
 
@@ -40,17 +52,34 @@ describe('/client-version-check', () => {
       const fakeHeader = jest.fn().mockReturnValue(headerValue);
       const fakeRequest = {header: fakeHeader} as unknown as Request;
       const fakeResponse = {sendStatus} as unknown as Response;
-
-      const fakeRouter = {
+      const dependencies = createClientVersionCheckRouteDependencies({
         get: jest.fn((_routePath, routeHandler) => {
           routeHandler(fakeRequest, fakeResponse);
         }),
-      } as unknown as Router;
+      });
 
-      createClientVersionCheckRoute({router: fakeRouter});
+      createClientVersionCheckRoute(dependencies);
 
       expect(fakeHeader).toHaveBeenNthCalledWith(1, 'Wire-Client-Version');
+      expect(dependencies.parseClientVersion).not.toHaveBeenCalled();
       expect(sendStatus).toHaveBeenNthCalledWith(1, expectedHttpStatusCode);
     },
   );
+
+  it('returns HTTP 400 if parseClientVersion() returns an Result Err', async () => {
+    const sendStatus = jest.fn();
+    const fakeRequest = {header: jest.fn().mockReturnValue('1.0.0')} as unknown as Request;
+    const fakeResponse = {sendStatus} as unknown as Response;
+    const dependencies = createClientVersionCheckRouteDependencies({
+      parseClientVersion: jest.fn().mockReturnValue(Result.err(new Error('invalid version'))),
+      get: jest.fn((_routePath, routeHandler) => {
+        routeHandler(fakeRequest, fakeResponse);
+      }),
+    });
+
+    createClientVersionCheckRoute(dependencies);
+
+    expect(dependencies.parseClientVersion).toHaveBeenNthCalledWith(1, '1.0.0');
+    expect(sendStatus).toHaveBeenNthCalledWith(1, 400);
+  });
 });

--- a/apps/server/routes/client-version-check/ClientVersionCheckRoute.ts
+++ b/apps/server/routes/client-version-check/ClientVersionCheckRoute.ts
@@ -17,20 +17,29 @@
  *
  */
 
+import {isEmptyStringOrWhitespace, isUndefined} from '@sindresorhus/is';
 import {Router} from 'express';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
+import type {Result} from 'true-myth';
 
 type ClientVersionCheckRouteDependencies = {
   readonly router: ReturnType<typeof Router>;
+  readonly parseClientVersion: (clientVersionHeaderValue: string) => Result<Date, Error>;
 };
 
 export function createClientVersionCheckRoute(dependencies: ClientVersionCheckRouteDependencies) {
-  const {router} = dependencies;
+  const {router, parseClientVersion} = dependencies;
 
   return router.get('/client-version-check', (request, response) => {
-    const clientVersion = request.header('Wire-Client-Version');
+    const clientVersionHeaderValue = request.header('Wire-Client-Version');
 
-    if (clientVersion === undefined || clientVersion.trim() === '') {
+    if (isUndefined(clientVersionHeaderValue) || isEmptyStringOrWhitespace(clientVersionHeaderValue)) {
+      return response.sendStatus(HTTP_STATUS.BAD_REQUEST);
+    }
+
+    const parsedClientVersion = parseClientVersion(clientVersionHeaderValue);
+
+    if (parsedClientVersion.isErr) {
       return response.sendStatus(HTTP_STATUS.BAD_REQUEST);
     }
 

--- a/apps/server/routes/client-version-check/ClientVersionCheckRoute.ts
+++ b/apps/server/routes/client-version-check/ClientVersionCheckRoute.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {isEmptyStringOrWhitespace, isUndefined} from '@sindresorhus/is';
+import is from '@sindresorhus/is';
 import {Router} from 'express';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import type {Result} from 'true-myth';
@@ -33,7 +33,7 @@ export function createClientVersionCheckRoute(dependencies: ClientVersionCheckRo
   return router.get('/client-version-check', (request, response) => {
     const clientVersionHeaderValue = request.header('Wire-Client-Version');
 
-    if (isUndefined(clientVersionHeaderValue) || isEmptyStringOrWhitespace(clientVersionHeaderValue)) {
+    if (is.undefined(clientVersionHeaderValue) || is.emptyStringOrWhitespace(clientVersionHeaderValue)) {
       return response.sendStatus(HTTP_STATUS.BAD_REQUEST);
     }
 

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -12,6 +12,6 @@ module.exports = {
     '^.+\\.(ts|tsx)$': '@swc/jest',
     '^.+\\.(js|jsx)$': 'babel-jest',
   },
-  transformIgnorePatterns: ['/node_modules/(?!(true-myth)/)'],
+  transformIgnorePatterns: ['/node_modules/(?!(true-myth|@sindresorhus/is)/)'],
   moduleFileExtensions: ['js', 'json', 'ts', 'tsx'],
 };

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -12,6 +12,6 @@ module.exports = {
     '^.+\\.(ts|tsx)$': '@swc/jest',
     '^.+\\.(js|jsx)$': 'babel-jest',
   },
-  transformIgnorePatterns: ['/node_modules/(?!(true-myth|@sindresorhus/is)/)'],
+  transformIgnorePatterns: ['/node_modules/(?!(true-myth)/)'],
   moduleFileExtensions: ['js', 'json', 'ts', 'tsx'],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8136,10 +8136,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sindresorhus/is@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "@sindresorhus/is@npm:7.2.0"
-  checksum: 10/d4f93d0fae3a799e1cb1cf31cdcc77f087f4203e2659e25afd7296493d9b4d430f37c4193404f56658d220a7467928fd2b29946dc141218bf42a2d2ebf8597fb
+"@sindresorhus/is@npm:4.6.0":
+  version: 4.6.0
+  resolution: "@sindresorhus/is@npm:4.6.0"
+  checksum: 10/e7f36ed72abfcd5e0355f7423a72918b9748bb1ef370a59f3e5ad8d40b728b85d63b272f65f63eec1faf417cda89dcb0aeebe94015647b6054659c1442fe5ce0
   languageName: node
   linkType: hard
 
@@ -11139,7 +11139,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@wireapp/server@workspace:apps/server"
   dependencies:
-    "@sindresorhus/is": "npm:^7.2.0"
+    "@sindresorhus/is": "npm:4.6.0"
     "@types/express": "npm:4.17.25"
     "@types/express-sitemap-xml": "npm:3.0.4"
     "@types/express-useragent": "npm:1.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8136,6 +8136,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sindresorhus/is@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "@sindresorhus/is@npm:7.2.0"
+  checksum: 10/d4f93d0fae3a799e1cb1cf31cdcc77f087f4203e2659e25afd7296493d9b4d430f37c4193404f56658d220a7467928fd2b29946dc141218bf42a2d2ebf8597fb
+  languageName: node
+  linkType: hard
+
 "@sinonjs/commons@npm:^2.0.0":
   version: 2.0.0
   resolution: "@sinonjs/commons@npm:2.0.0"
@@ -11132,6 +11139,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@wireapp/server@workspace:apps/server"
   dependencies:
+    "@sindresorhus/is": "npm:^7.2.0"
     "@types/express": "npm:4.17.25"
     "@types/express-sitemap-xml": "npm:3.0.4"
     "@types/express-useragent": "npm:1.0.5"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23299" title="WPB-23299" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23299</a>  [Web] Add support for remote force reload 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

The client version needs to be parsed in our `/client-version-check` route to be able to introduce a "not allowed list" later on.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
