### PR TITLE
feat(server): implement logic that disallowes some client version [WPB-23299]

### DIFF
--- a/apps/server/Server.ts
+++ b/apps/server/Server.ts
@@ -30,6 +30,7 @@ import https from 'https';
 import path from 'path';
 
 import type {ClientConfig, ServerConfig} from '@wireapp/config';
+import {Maybe} from 'true-myth';
 
 import {HealthCheckRoute} from './routes/_health/HealthRoute';
 import {AppleAssociationRoute} from './routes/appleassociation/AppleAssociationRoute';
@@ -77,7 +78,13 @@ class Server {
     this.app.use(ConfigRoute(this.config, this.clientConfig));
     this.app.use(GoogleWebmasterRoute(this.config));
     this.app.use(AppleAssociationRoute());
-    this.app.use(createClientVersionCheckRoute({router: Router(), parseClientVersion}));
+    this.app.use(
+      createClientVersionCheckRoute({
+        router: Router(),
+        parseClientVersion,
+        disallowedClientVersion: Maybe.nothing<Date>(),
+      }),
+    );
     this.app.use(NotFoundRoute());
     this.app.use(InternalErrorRoute());
   }

--- a/apps/server/routes/client-version-check/ClientVersionCheckRoute.test.ts
+++ b/apps/server/routes/client-version-check/ClientVersionCheckRoute.test.ts
@@ -1,18 +1,20 @@
 import {Router, type Response, type Request} from 'express';
-import {Result} from 'true-myth';
+import {Maybe, Result} from 'true-myth';
 import {createClientVersionCheckRoute} from './ClientVersionCheckRoute';
 
 type ClientVersionCheckRouteDependencyFunctionOverrides = {
   readonly get?: jest.Mock;
   readonly parseClientVersion?: jest.Mock;
+  readonly disallowedClientVersion?: Maybe<Date>;
 };
 
 function createClientVersionCheckRouteDependencies(overrides: ClientVersionCheckRouteDependencyFunctionOverrides = {}) {
   const get = overrides.get ?? jest.fn();
   const parseClientVersion = overrides.parseClientVersion ?? jest.fn().mockReturnValue(Result.ok(new Date()));
+  const disallowedClientVersion = overrides.disallowedClientVersion ?? Maybe.nothing<Date>();
   const router = {get} as unknown as Router;
 
-  return {router, parseClientVersion, get};
+  return {router, parseClientVersion, disallowedClientVersion, get};
 }
 
 describe('/client-version-check', () => {
@@ -79,5 +81,69 @@ describe('/client-version-check', () => {
 
     expect(dependencies.parseClientVersion).toHaveBeenNthCalledWith(1, '1.0.0');
     expect(sendStatus).toHaveBeenNthCalledWith(1, 400);
+  });
+
+  it('returns HTTP 426 with reload action when parsed client version equals blocked version', async () => {
+    const sendStatus = jest.fn();
+    const json = jest.fn();
+    const status = jest.fn().mockReturnValue({json});
+    const blockedVersionDate = new Date(2026, 1, 12, 17, 51, 0);
+    const fakeRequest = {header: jest.fn().mockReturnValue('2026.02.12.17.51.00')} as unknown as Request;
+    const fakeResponse = {sendStatus, status} as unknown as Response;
+    const dependencies = createClientVersionCheckRouteDependencies({
+      parseClientVersion: jest.fn().mockReturnValue(Result.ok(blockedVersionDate)),
+      disallowedClientVersion: Maybe.just(blockedVersionDate),
+      get: jest.fn((_routePath, routeHandler) => {
+        routeHandler(fakeRequest, fakeResponse);
+      }),
+    });
+
+    createClientVersionCheckRoute(dependencies);
+
+    expect(status).toHaveBeenNthCalledWith(1, 426);
+    expect(json).toHaveBeenNthCalledWith(1, {action: 'reload'});
+    expect(sendStatus).not.toHaveBeenCalled();
+  });
+
+  it('returns HTTP 426 with reload action when parsed client version is below blocked version', async () => {
+    const sendStatus = jest.fn();
+    const json = jest.fn();
+    const status = jest.fn().mockReturnValue({json});
+    const blockedVersionDate = new Date(2026, 1, 12, 17, 51, 0);
+    const clientVersionDate = new Date(2026, 1, 12, 17, 50, 59);
+    const fakeRequest = {header: jest.fn().mockReturnValue('2026.02.12.17.50.59')} as unknown as Request;
+    const fakeResponse = {sendStatus, status} as unknown as Response;
+    const dependencies = createClientVersionCheckRouteDependencies({
+      parseClientVersion: jest.fn().mockReturnValue(Result.ok(clientVersionDate)),
+      disallowedClientVersion: Maybe.just(blockedVersionDate),
+      get: jest.fn((_routePath, routeHandler) => {
+        routeHandler(fakeRequest, fakeResponse);
+      }),
+    });
+
+    createClientVersionCheckRoute(dependencies);
+
+    expect(status).toHaveBeenNthCalledWith(1, 426);
+    expect(json).toHaveBeenNthCalledWith(1, {action: 'reload'});
+    expect(sendStatus).not.toHaveBeenCalled();
+  });
+
+  it('returns HTTP 200 when parsed client version is above blocked version', async () => {
+    const sendStatus = jest.fn();
+    const blockedVersionDate = new Date(2026, 1, 12, 17, 51, 0);
+    const clientVersionDate = new Date(2026, 1, 12, 17, 51, 1);
+    const fakeRequest = {header: jest.fn().mockReturnValue('2026.02.12.17.51.01')} as unknown as Request;
+    const fakeResponse = {sendStatus} as unknown as Response;
+    const dependencies = createClientVersionCheckRouteDependencies({
+      parseClientVersion: jest.fn().mockReturnValue(Result.ok(clientVersionDate)),
+      disallowedClientVersion: Maybe.just(blockedVersionDate),
+      get: jest.fn((_routePath, routeHandler) => {
+        routeHandler(fakeRequest, fakeResponse);
+      }),
+    });
+
+    createClientVersionCheckRoute(dependencies);
+
+    expect(sendStatus).toHaveBeenNthCalledWith(1, 200);
   });
 });

--- a/apps/server/routes/client-version-check/ClientVersionCheckRoute.ts
+++ b/apps/server/routes/client-version-check/ClientVersionCheckRoute.ts
@@ -20,15 +20,16 @@
 import is from '@sindresorhus/is';
 import {Router} from 'express';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
-import type {Result} from 'true-myth';
+import {Maybe, result, type Result} from 'true-myth';
 
 type ClientVersionCheckRouteDependencies = {
   readonly router: ReturnType<typeof Router>;
   readonly parseClientVersion: (clientVersionHeaderValue: string) => Result<Date, Error>;
+  readonly disallowedClientVersion: Maybe<Date>;
 };
 
 export function createClientVersionCheckRoute(dependencies: ClientVersionCheckRouteDependencies) {
-  const {router, parseClientVersion} = dependencies;
+  const {router, parseClientVersion, disallowedClientVersion} = dependencies;
 
   return router.get('/client-version-check', (request, response) => {
     const clientVersionHeaderValue = request.header('Wire-Client-Version');
@@ -39,10 +40,24 @@ export function createClientVersionCheckRoute(dependencies: ClientVersionCheckRo
 
     const parsedClientVersion = parseClientVersion(clientVersionHeaderValue);
 
-    if (parsedClientVersion.isErr) {
+    if (result.isErr(parsedClientVersion)) {
       return response.sendStatus(HTTP_STATUS.BAD_REQUEST);
     }
 
-    return response.sendStatus(HTTP_STATUS.OK);
+    return disallowedClientVersion.match({
+      Just: blockedClientVersionDate => {
+        const isClientVersionBlocked = parsedClientVersion.value.getTime() <= blockedClientVersionDate.getTime();
+
+        if (isClientVersionBlocked) {
+          return response.status(HTTP_STATUS.UPGRADE_REQUIRED).json({action: 'reload'});
+        }
+
+        return response.sendStatus(HTTP_STATUS.OK);
+      },
+
+      Nothing: () => {
+        return response.sendStatus(HTTP_STATUS.OK);
+      },
+    });
   });
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23299" title="WPB-23299" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23299</a>  [Web] Add support for remote force reload 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

In order to trigger a Browser force reload we need to compare the given versions with the client version.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
