### PR TITLE
refactor: Rename version check route parameters [WPB-23299]

### DIFF
--- a/apps/server/Server.ts
+++ b/apps/server/Server.ts
@@ -23,6 +23,7 @@ import hbs from 'hbs';
 import helmet from 'helmet';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import nocache from 'nocache';
+import {Maybe} from 'true-myth';
 
 import fs from 'fs';
 import http from 'http';
@@ -30,7 +31,6 @@ import https from 'https';
 import path from 'path';
 
 import type {ClientConfig, ServerConfig} from '@wireapp/config';
-import {Maybe} from 'true-myth';
 
 import {HealthCheckRoute} from './routes/_health/HealthRoute';
 import {AppleAssociationRoute} from './routes/appleassociation/AppleAssociationRoute';
@@ -82,7 +82,7 @@ class Server {
       createClientVersionCheckRoute({
         router: Router(),
         parseClientVersion,
-        disallowedClientVersion: Maybe.nothing<Date>(),
+        minimumRequiredClientBuildDate: Maybe.nothing(),
       }),
     );
     this.app.use(NotFoundRoute());

--- a/apps/server/routes/client-version-check/ClientVersionCheckRoute.test.ts
+++ b/apps/server/routes/client-version-check/ClientVersionCheckRoute.test.ts
@@ -5,16 +5,16 @@ import {createClientVersionCheckRoute} from './ClientVersionCheckRoute';
 type ClientVersionCheckRouteDependencyFunctionOverrides = {
   readonly get?: jest.Mock;
   readonly parseClientVersion?: jest.Mock;
-  readonly disallowedClientVersion?: Maybe<Date>;
+  readonly minimumRequiredClientBuildDate?: Maybe<Date>;
 };
 
 function createClientVersionCheckRouteDependencies(overrides: ClientVersionCheckRouteDependencyFunctionOverrides = {}) {
   const get = overrides.get ?? jest.fn();
   const parseClientVersion = overrides.parseClientVersion ?? jest.fn().mockReturnValue(Result.ok(new Date()));
-  const disallowedClientVersion = overrides.disallowedClientVersion ?? Maybe.nothing<Date>();
+  const minimumRequiredClientBuildDate = overrides.minimumRequiredClientBuildDate ?? Maybe.nothing<Date>();
   const router = {get} as unknown as Router;
 
-  return {router, parseClientVersion, disallowedClientVersion, get};
+  return {router, parseClientVersion, minimumRequiredClientBuildDate, get};
 }
 
 describe('/client-version-check', () => {
@@ -92,7 +92,7 @@ describe('/client-version-check', () => {
     const fakeResponse = {sendStatus, status} as unknown as Response;
     const dependencies = createClientVersionCheckRouteDependencies({
       parseClientVersion: jest.fn().mockReturnValue(Result.ok(blockedVersionDate)),
-      disallowedClientVersion: Maybe.just(blockedVersionDate),
+      minimumRequiredClientBuildDate: Maybe.just(blockedVersionDate),
       get: jest.fn((_routePath, routeHandler) => {
         routeHandler(fakeRequest, fakeResponse);
       }),
@@ -115,7 +115,7 @@ describe('/client-version-check', () => {
     const fakeResponse = {sendStatus, status} as unknown as Response;
     const dependencies = createClientVersionCheckRouteDependencies({
       parseClientVersion: jest.fn().mockReturnValue(Result.ok(clientVersionDate)),
-      disallowedClientVersion: Maybe.just(blockedVersionDate),
+      minimumRequiredClientBuildDate: Maybe.just(blockedVersionDate),
       get: jest.fn((_routePath, routeHandler) => {
         routeHandler(fakeRequest, fakeResponse);
       }),
@@ -136,7 +136,7 @@ describe('/client-version-check', () => {
     const fakeResponse = {sendStatus} as unknown as Response;
     const dependencies = createClientVersionCheckRouteDependencies({
       parseClientVersion: jest.fn().mockReturnValue(Result.ok(clientVersionDate)),
-      disallowedClientVersion: Maybe.just(blockedVersionDate),
+      minimumRequiredClientBuildDate: Maybe.just(blockedVersionDate),
       get: jest.fn((_routePath, routeHandler) => {
         routeHandler(fakeRequest, fakeResponse);
       }),

--- a/apps/server/routes/client-version-check/ClientVersionCheckRoute.ts
+++ b/apps/server/routes/client-version-check/ClientVersionCheckRoute.ts
@@ -25,11 +25,11 @@ import {Maybe, result, type Result} from 'true-myth';
 type ClientVersionCheckRouteDependencies = {
   readonly router: ReturnType<typeof Router>;
   readonly parseClientVersion: (clientVersionHeaderValue: string) => Result<Date, Error>;
-  readonly disallowedClientVersion: Maybe<Date>;
+  readonly minimumRequiredClientBuildDate: Maybe<Date>;
 };
 
 export function createClientVersionCheckRoute(dependencies: ClientVersionCheckRouteDependencies) {
-  const {router, parseClientVersion, disallowedClientVersion} = dependencies;
+  const {router, parseClientVersion, minimumRequiredClientBuildDate} = dependencies;
 
   return router.get('/client-version-check', (request, response) => {
     const clientVersionHeaderValue = request.header('Wire-Client-Version');
@@ -44,15 +44,16 @@ export function createClientVersionCheckRoute(dependencies: ClientVersionCheckRo
       return response.sendStatus(HTTP_STATUS.BAD_REQUEST);
     }
 
-    return disallowedClientVersion.match({
-      Just: blockedClientVersionDate => {
-        const isClientVersionBlocked = parsedClientVersion.value.getTime() <= blockedClientVersionDate.getTime();
+    return minimumRequiredClientBuildDate.match({
+      Just: minimumRequiredClientBuildDateValue => {
+        const isClientVersionAllowed =
+          parsedClientVersion.value.getTime() > minimumRequiredClientBuildDateValue.getTime();
 
-        if (isClientVersionBlocked) {
-          return response.status(HTTP_STATUS.UPGRADE_REQUIRED).json({action: 'reload'});
+        if (isClientVersionAllowed) {
+          return response.sendStatus(HTTP_STATUS.OK);
         }
 
-        return response.sendStatus(HTTP_STATUS.OK);
+        return response.status(HTTP_STATUS.UPGRADE_REQUIRED).json({action: 'reload'});
       },
 
       Nothing: () => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23299" title="WPB-23299" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23299</a>  [Web] Add support for remote force reload 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- What did I change and why?
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
