### PR TITLE
feat: Consume environment variable for client version check route [WPB-23299]

### DIFF
--- a/apps/server/Server.ts
+++ b/apps/server/Server.ts
@@ -23,7 +23,7 @@ import hbs from 'hbs';
 import helmet from 'helmet';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import nocache from 'nocache';
-import {Maybe} from 'true-myth';
+import {toolbelt} from 'true-myth';
 
 import fs from 'fs';
 import http from 'http';
@@ -82,7 +82,9 @@ class Server {
       createClientVersionCheckRoute({
         router: Router(),
         parseClientVersion,
-        minimumRequiredClientBuildDate: Maybe.nothing(),
+        minimumRequiredClientBuildDate: toolbelt.fromResult(
+          parseClientVersion(this.config.MINIMUM_REQUIRED_CLIENT_BUILD_DATE),
+        ),
       }),
     );
     this.app.use(NotFoundRoute());

--- a/libraries/config/src/env.ts
+++ b/libraries/config/src/env.ts
@@ -228,6 +228,9 @@ export type Env = {
   /** Limits the number of participants in a legacy video call */
   MAX_VIDEO_PARTICIPANTS: string;
 
+  /** Minimum required client build date */
+  MINIMUM_REQUIRED_CLIENT_BUILD_DATE: string | undefined;
+
   /** Minimum number of characters when setting a password */
   NEW_PASSWORD_MINIMUM_LENGTH: string;
 

--- a/libraries/config/src/server.config.ts
+++ b/libraries/config/src/server.config.ts
@@ -116,6 +116,7 @@ export function generateConfig(params: ConfigGeneratorParams, env: Env) {
     },
     ENABLE_DYNAMIC_HOSTNAME: env.ENABLE_DYNAMIC_HOSTNAME === 'true',
     PORT_HTTP: Number(env.PORT) || 21080,
+    MINIMUM_REQUIRED_CLIENT_BUILD_DATE: env.MINIMUM_REQUIRED_CLIENT_BUILD_DATE,
     ROBOTS: {
       ALLOW: readFile(ROBOTS_ALLOW_FILE, 'User-agent: *\r\nDisallow: /'),
       ALLOWED_HOSTS: ['app.wire.com'],


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23299" title="WPB-23299" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23299</a>  [Web] Add support for remote force reload 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- What did I change and why?
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
