### PR TITLE
feat: introduce a wall clock [WPB-23299]

### DIFF
--- a/apps/webapp/src/script/clock/fakeWallClock.test.ts
+++ b/apps/webapp/src/script/clock/fakeWallClock.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {createFakeWallClock} from './fakeWallClock';
+
+describe('createFakeWallClock', () => {
+  it('starts at zero by default', () => {
+    const fakeWallClock = createFakeWallClock();
+
+    expect(typeof fakeWallClock.currentTimestampInMilliseconds).toBe('number');
+    expect(fakeWallClock.currentDate).toBeInstanceOf(Date);
+    expect(fakeWallClock.currentTimestampInMilliseconds).toBe(0);
+    expect(fakeWallClock.currentDate.getTime()).toBe(0);
+  });
+
+  it('starts with the provided initial timestamp', () => {
+    const initialCurrentTimestampInMilliseconds = 1_704_067_200_000;
+    const fakeWallClock = createFakeWallClock({initialCurrentTimestampInMilliseconds});
+
+    expect(typeof fakeWallClock.currentTimestampInMilliseconds).toBe('number');
+    expect(fakeWallClock.currentDate).toBeInstanceOf(Date);
+    expect(fakeWallClock.currentTimestampInMilliseconds).toBe(initialCurrentTimestampInMilliseconds);
+    expect(fakeWallClock.currentDate.getTime()).toBe(initialCurrentTimestampInMilliseconds);
+  });
+
+  it('sets the current timestamp in milliseconds', () => {
+    const fakeWallClock = createFakeWallClock();
+    const nextTimestampInMilliseconds = 1_800_000;
+
+    fakeWallClock.setCurrentTimestampInMilliseconds(nextTimestampInMilliseconds);
+
+    expect(fakeWallClock.currentTimestampInMilliseconds).toBe(nextTimestampInMilliseconds);
+    expect(fakeWallClock.currentDate.getTime()).toBe(nextTimestampInMilliseconds);
+  });
+
+  it('advances current timestamp by the provided delay', () => {
+    const fakeWallClock = createFakeWallClock({initialCurrentTimestampInMilliseconds: 10_000});
+
+    fakeWallClock.advanceByMilliseconds(500);
+    fakeWallClock.advanceByMilliseconds(1_500);
+
+    expect(fakeWallClock.currentTimestampInMilliseconds).toBe(12_000);
+    expect(fakeWallClock.currentDate.getTime()).toBe(12_000);
+  });
+
+  it('returns a new date instance for each call', () => {
+    const fakeWallClock = createFakeWallClock({initialCurrentTimestampInMilliseconds: 100});
+
+    const firstCurrentDate = fakeWallClock.currentDate;
+    const secondCurrentDate = fakeWallClock.currentDate;
+
+    expect(firstCurrentDate).not.toBe(secondCurrentDate);
+    expect(firstCurrentDate.getTime()).toBe(100);
+    expect(secondCurrentDate.getTime()).toBe(100);
+  });
+
+});

--- a/apps/webapp/src/script/clock/fakeWallClock.ts
+++ b/apps/webapp/src/script/clock/fakeWallClock.ts
@@ -1,0 +1,53 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {WallClock} from './wallClock';
+
+type FakeWallClockOptions = {
+  readonly initialCurrentTimestampInMilliseconds?: number;
+};
+
+export type FakeWallClock = WallClock & {
+  setCurrentTimestampInMilliseconds(nextTimestampInMilliseconds: number): void;
+  advanceByMilliseconds(delayInMilliseconds: number): void;
+};
+
+export function createFakeWallClock(options: FakeWallClockOptions = {}): FakeWallClock {
+  const {initialCurrentTimestampInMilliseconds = 0} = options;
+
+  let currentTimestampInMilliseconds = initialCurrentTimestampInMilliseconds;
+
+  return {
+    get currentTimestampInMilliseconds() {
+      return currentTimestampInMilliseconds;
+    },
+
+    get currentDate() {
+      return new Date(currentTimestampInMilliseconds);
+    },
+
+    setCurrentTimestampInMilliseconds(nextTimestampInMilliseconds: number) {
+      currentTimestampInMilliseconds = nextTimestampInMilliseconds;
+    },
+
+    advanceByMilliseconds(delayInMilliseconds: number) {
+      currentTimestampInMilliseconds += delayInMilliseconds;
+    },
+  };
+}

--- a/apps/webapp/src/script/clock/wallClock.test.ts
+++ b/apps/webapp/src/script/clock/wallClock.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import timers from 'node:timers/promises';
+
+import {createWallClock} from './wallClock';
+
+describe('wall clock', () => {
+  it('returns the current timestamp in milliseconds', () => {
+    const lowerTimestampBound = Date.now();
+    const wallClock = createWallClock();
+    const currentTimestamp = wallClock.currentTimestampInMilliseconds;
+    const upperTimestampBound = Date.now();
+
+    expect(typeof currentTimestamp).toBe('number');
+    expect(currentTimestamp).toBeGreaterThanOrEqual(lowerTimestampBound);
+    expect(currentTimestamp).toBeLessThanOrEqual(upperTimestampBound);
+  });
+
+  it('returns the current date based on Date.now()', () => {
+    const lowerTimestampBound = Date.now();
+    const wallClock = createWallClock();
+    const currentDate = wallClock.currentDate;
+    const upperTimestampBound = Date.now();
+
+    expect(currentDate).toBeInstanceOf(Date);
+    expect(currentDate.getTime()).toBeGreaterThanOrEqual(lowerTimestampBound);
+    expect(currentDate.getTime()).toBeLessThanOrEqual(upperTimestampBound);
+  });
+
+  it('returns a new date instance for each call', async () => {
+    const wallClock = createWallClock();
+
+    const firstCurrentDate = wallClock.currentDate;
+    await timers.setTimeout(1);
+    const secondCurrentDate = wallClock.currentDate;
+
+    expect(firstCurrentDate).not.toBe(secondCurrentDate);
+    expect(secondCurrentDate.getTime()).toBeGreaterThanOrEqual(firstCurrentDate.getTime());
+  });
+});

--- a/apps/webapp/src/script/clock/wallClock.ts
+++ b/apps/webapp/src/script/clock/wallClock.ts
@@ -1,0 +1,35 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export type WallClock = {
+  readonly currentTimestampInMilliseconds: number;
+  readonly currentDate: Date;
+};
+
+export function createWallClock(): WallClock {
+  return {
+    get currentTimestampInMilliseconds() {
+      return Date.now();
+    },
+
+    get currentDate() {
+      return new Date(Date.now());
+    },
+  };
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23299" title="WPB-23299" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23299</a>  [Web] Add support for remote force reload 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

We will need a wall clock in the near future to implement a periodic version check. This is best done with a wall clock. For testing purposes we will also have a fake wall clock which always be frozen and static and does not tick.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
