### PR TITLE
test: add participant profile regression tests [WPB-19962]

### DIFF
--- a/apps/webapp/test/e2e_tests/backend/teamRepository.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/teamRepository.e2e.ts
@@ -21,14 +21,15 @@ import {BackendClientE2E} from './backendClient.e2e';
 
 import {Service} from '../data/serviceInfo';
 import {User} from '../data/user';
+import {Role} from '@wireapp/api-client/lib/team';
 
 export class TeamRepositoryE2E extends BackendClientE2E {
-  async inviteUserToTeam(emailOfInvitee: string, teamOwner: User): Promise<string> {
+  async inviteUserToTeam(emailOfInvitee: string, teamOwner: User, role: Role): Promise<string> {
     const response = this.axiosInstance.post(
       `teams/${teamOwner.teamId}/invitations`,
       {
         inviterName: `${teamOwner.firstName} ${teamOwner.lastName}`,
-        role: 'member',
+        role,
         email: emailOfInvitee,
       },
       {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationDetails.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationDetails.page.ts
@@ -114,7 +114,7 @@ export class ConversationDetailsPage {
   async getLocatorByUser(fullName: string) {
     const userLocator = this.page
       .locator('#conversation-details')
-      .getByTestId('list-members')
+      .getByTestId('list-users')
       .getByTestId('item-user')
       .and(this.page.locator(`[data-uie-value="${fullName}"]`));
     await userLocator.waitFor({state: 'visible'});

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/participantDetails.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/participantDetails.page.ts
@@ -23,9 +23,8 @@ export class ParticipantDetails {
   readonly page: Page;
 
   readonly userPicture: Locator;
-  readonly adminStatus: Locator;
-  readonly guestStatus: Locator;
-  readonly externalStatus: Locator;
+  readonly userName: Locator;
+  readonly userStatus: Locator;
   readonly createGroup: Locator;
   readonly block: Locator;
   readonly closeButton: Locator;
@@ -36,12 +35,11 @@ export class ParticipantDetails {
   constructor(page: Page) {
     this.page = page;
     this.userPicture = this.page.getByTestId('status-profile-picture');
-    this.adminStatus = this.page
+    this.userName = this.page.locator('.panel-participant').getByTestId('status-name');
+    this.userStatus = this.page
       .locator('#group-participant-user')
-      .getByTestId('status-admin')
-      .filter({hasText: 'Group Admin'});
-    this.guestStatus = this.page.locator('#group-participant-user').getByTestId('status-guest');
-    this.externalStatus = this.page.locator('#group-participant-user').getByTestId('status-external');
+      .getByTestId(/^status-(external|guest|admin)$/)
+      .and(this.page.locator('.panel-participant__label'));
     this.createGroup = this.page.locator('#conversation-details').getByRole('button', {name: 'Create group'});
     this.block = this.page.getByRole('button', {name: 'Block'});
     this.closeButton = this.page.getByRole('button', {name: 'Close conversation info'});
@@ -56,10 +54,6 @@ export class ParticipantDetails {
 
   getUserEmailLocator(email: string) {
     return this.page.getByTestId('item-enriched-value').and(this.page.locator(`[data-uie-value="${email}"]`));
-  }
-
-  getUserNameLocator(userName: string) {
-    return this.page.getByTitle(userName).and(this.page.getByTestId('status-username'));
   }
 
   async closeParticipantDetails() {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/participantDetails.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/participantDetails.page.ts
@@ -25,6 +25,7 @@ export class ParticipantDetails {
   readonly userPicture: Locator;
   readonly adminStatus: Locator;
   readonly guestStatus: Locator;
+  readonly externalStatus: Locator;
   readonly createGroup: Locator;
   readonly block: Locator;
   readonly closeButton: Locator;
@@ -34,39 +35,38 @@ export class ParticipantDetails {
 
   constructor(page: Page) {
     this.page = page;
-
     this.userPicture = this.page.getByTestId('status-profile-picture');
-    this.adminStatus = this.page.locator('.panel-participant').getByTestId('status-admin');
+    this.adminStatus = this.page
+      .locator('#group-participant-user')
+      .getByTestId('status-admin')
+      .filter({hasText: 'Group Admin'});
     this.guestStatus = this.page.locator('#group-participant-user').getByTestId('status-guest');
+    this.externalStatus = this.page.locator('#group-participant-user').getByTestId('status-external');
     this.createGroup = this.page.locator('#conversation-details').getByRole('button', {name: 'Create group'});
     this.block = this.page.getByRole('button', {name: 'Block'});
     this.closeButton = this.page.getByRole('button', {name: 'Close conversation info'});
     this.cancelRequest = this.page.getByRole('button', {name: 'Cancel request'});
-    this.unblockButton = this.page.getByRole('button', {name: 'Unblock…'});
-    this.removeFromGroup = this.page.getByRole('button', {name: 'Remove from group…'});
+    this.unblockButton = this.page.getByRole('button', {name: 'Unblock'});
+    this.removeFromGroup = this.page.getByRole('button', {name: 'Remove from group'});
   }
 
   async blockUser() {
-    this.block.click();
+    await this.block.click();
   }
 
-  async getUserEmailLocator(email: string) {
+  getUserEmailLocator(email: string) {
     return this.page.getByTestId('item-enriched-value').and(this.page.locator(`[data-uie-value="${email}"]`));
   }
 
-  async getUserNameLocator(userName: string) {
-    return this.page.getByTitle(userName);
-  }
-
-  async getUserPictureLocator(userName: string) {
-    return this.page.getByRole('button', {name: userName});
+  getUserNameLocator(userName: string) {
+    return this.page.getByTitle(userName).and(this.page.getByTestId('status-username'));
   }
 
   async closeParticipantDetails() {
-    this.closeButton.click();
+    await this.closeButton.click();
   }
 
   async sendConnectRequest() {
-    this.page.getByRole('button', {name: 'Connect'}).click();
+    await this.page.getByRole('button', {name: 'Connect'}).click();
   }
 }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/participantDetails.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/participantDetails.page.ts
@@ -22,15 +22,51 @@ import {Locator, Page} from '@playwright/test';
 export class ParticipantDetails {
   readonly page: Page;
 
+  readonly userPicture: Locator;
+  readonly adminStatus: Locator;
+  readonly guestStatus: Locator;
+  readonly createGroup: Locator;
   readonly block: Locator;
+  readonly closeButton: Locator;
+  readonly cancelRequest: Locator;
+  readonly unblockButton: Locator;
+  readonly removeFromGroup: Locator;
 
   constructor(page: Page) {
     this.page = page;
 
-    this.block = this.page.getByTestId('do-block-item-text');
+    this.userPicture = this.page.getByTestId('status-profile-picture');
+    this.adminStatus = this.page.locator('.panel-participant').getByTestId('status-admin');
+    this.guestStatus = this.page.locator('#group-participant-user').getByTestId('status-guest');
+    this.createGroup = this.page.locator('#conversation-details').getByRole('button', {name: 'Create group'});
+    this.block = this.page.getByRole('button', {name: 'Block'});
+    this.closeButton = this.page.getByRole('button', {name: 'Close conversation info'});
+    this.cancelRequest = this.page.getByRole('button', {name: 'Cancel request'});
+    this.unblockButton = this.page.getByRole('button', {name: 'Unblock…'});
+    this.removeFromGroup = this.page.getByRole('button', {name: 'Remove from group…'});
   }
 
   async blockUser() {
     this.block.click();
+  }
+
+  async getUserEmailLocator(email: string) {
+    return this.page.getByTestId('item-enriched-value').and(this.page.locator(`[data-uie-value="${email}"]`));
+  }
+
+  async getUserNameLocator(userName: string) {
+    return this.page.getByTitle(userName);
+  }
+
+  async getUserPictureLocator(userName: string) {
+    return this.page.getByRole('button', {name: userName});
+  }
+
+  async closeParticipantDetails() {
+    this.closeButton.click();
+  }
+
+  async sendConnectRequest() {
+    this.page.getByRole('button', {name: 'Connect'}).click();
   }
 }

--- a/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
@@ -1,0 +1,301 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {User} from 'test/e2e_tests/data/user';
+import {PageManager} from 'test/e2e_tests/pageManager';
+import {createGroup} from 'test/e2e_tests/utils/userActions';
+
+import {test, expect, withConnectedUser, withLogin, withConnectionRequest, Team} from 'test/e2e_tests/test.fixtures';
+
+test.describe('Participant Profile', () => {
+  let team: Team;
+  let userA: User;
+  let userB: User;
+
+  test.beforeEach(async ({createTeam}) => {
+    team = await createTeam('Test Team', {withMembers: 1});
+    userA = team.owner;
+    userB = team.members[0];
+  });
+
+  test(
+    'Verify you can access profile information for the other participant in a 1to1 conversation',
+    {tag: ['@TC-1474', '@regression']},
+    async ({createPage, createUser}) => {
+      const userC = await createUser();
+      const [userAPages, userCPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectionRequest(userC))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
+      ]);
+
+      await userCPages.conversationList().openPendingConnectionRequest();
+      await userCPages.connectRequest().clickConnectButton();
+
+      await test.step('Go to any 1:1 conversation', async () => {
+        await userAPages.conversationList().openConversation(userC.fullName, {protocol: 'mls'});
+      });
+
+      await test.step('Open People popover', async () => {
+        await userAPages.conversation().clickConversationTitle();
+
+        await expect(await userAPages.participantDetails().getUserNameLocator(userC.username)).toBeVisible();
+        await expect(await userAPages.participantDetails().getUserNameLocator(userC.username)).toContainText(
+          userC.username,
+        );
+
+        await expect(userAPages.participantDetails().userPicture).toBeVisible();
+        await expect(userAPages.participantDetails().createGroup).toBeVisible();
+        await expect(userAPages.participantDetails().block).toBeVisible();
+      });
+
+      await test.step('Click on the X button to close the popover', async () => {
+        await userAPages.participantDetails().closeParticipantDetails();
+        await expect(await userAPages.participantDetails().getUserNameLocator(userB.username)).not.toBeVisible();
+        await expect(userAPages.participantDetails().userPicture).not.toBeVisible();
+      });
+    },
+  );
+
+  test(
+    'See participant profile of the user that you requested to connect with in a group conversation',
+    {tag: ['@TC-1477', '@regression']},
+    async ({createPage, createUser}) => {
+      const userC = await createUser();
+      const [userAPage, userBPages, userCPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectionRequest(userC))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
+      ]);
+
+      await userCPages.conversationList().openPendingConnectionRequest();
+      await userCPages.connectRequest().clickConnectButton();
+
+      const groupName = 'Test Group';
+      await test.step('User C is in group with User A and B. User C is not connected to user B', async () => {
+        await createGroup(userAPage, groupName, [userB, userC]);
+      });
+
+      await test.step('User B asks to connect with user C', async () => {
+        await userBPages.conversationList().openConversation(groupName);
+        await userBPages.conversation().clickConversationTitle();
+
+        await userBPages.conversationDetails().openParticipantDetails(userC.fullName);
+        await userBPages.participantDetails().sendConnectRequest();
+      });
+
+      await test.step('User B opens people popover', async () => {});
+
+      await test.step('User B opens individual people profile of user C', async () => {
+        await expect(userBPages.participantDetails().userPicture).toBeVisible();
+        await expect(userBPages.participantDetails().userPicture).toHaveAttribute('data-uie-status', 'pending');
+
+        await expect(await userBPages.participantDetails().getUserNameLocator(userC.username)).toBeVisible();
+        await expect(await userBPages.participantDetails().getUserNameLocator(userC.username)).toContainText(
+          userC.username,
+        );
+
+        await expect(await userBPages.participantDetails().getUserEmailLocator(userC.email)).not.toBeVisible();
+        await expect(userBPages.participantDetails().cancelRequest).toBeVisible();
+        await expect(userBPages.participantDetails().block).toBeVisible();
+      });
+    },
+  );
+
+  test(
+    'Verify I can see participant profile of user I blocked in a group conversation',
+    {tag: ['@TC-1479', '@regression']},
+    async ({createPage, createUser}) => {
+      const userC = await createUser();
+      const [userAPageManager, userCPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectionRequest(userC))),
+        PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
+      ]);
+
+      const {pages, modals} = userAPageManager.webapp;
+      await userCPages.conversationList().openPendingConnectionRequest();
+      await userCPages.connectRequest().clickConnectButton();
+
+      const groupName = 'Test Group';
+      await createGroup(pages, groupName, [userB, userC]);
+
+      await test.step('User A blocks User C', async () => {
+        await pages.conversationList().openConversation(groupName);
+        await pages.conversation().clickConversationTitle();
+
+        await pages.conversationDetails().openParticipantDetails(userC.fullName);
+        await pages.participantDetails().blockUser();
+        await modals.blockWarning().clickBlock();
+      });
+
+      await test.step('User C opens people popover', async () => {
+        await pages.conversationList().openConversation(groupName);
+        await pages.conversation().clickConversationTitle();
+      });
+
+      await test.step('User C opens individual people profile of User A', async () => {
+        await pages.conversationDetails().openParticipantDetails(userC.fullName);
+
+        await expect(pages.participantDetails().userPicture).toBeVisible();
+        await expect(pages.participantDetails().userPicture).toHaveAttribute('data-uie-status', 'blocked');
+
+        await expect(await pages.participantDetails().getUserNameLocator(userC.username)).toBeVisible();
+        await expect(await pages.participantDetails().getUserNameLocator(userC.username)).toContainText(userC.username);
+
+        await expect(await pages.participantDetails().getUserEmailLocator(userC.email)).not.toBeVisible();
+        await expect(pages.participantDetails().unblockButton).toBeVisible();
+        await expect(pages.participantDetails().removeFromGroup).toBeVisible();
+      });
+    },
+  );
+
+  test(
+    'Verify big profile picture ans username are shown on participant popover',
+    {tag: ['@TC-1480', '@regression']},
+    async ({createPage}) => {
+      const [adminPage, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      ]);
+
+      const groupName = 'Test Group';
+      await createGroup(adminPage, groupName, [userB]);
+
+      await userBPages.conversationList().openConversation(groupName);
+      await userBPages.conversation().clickConversationInfoButton();
+      await userBPages.conversationDetails().openParticipantDetails(userA.fullName);
+
+      await expect(await userBPages.participantDetails().getUserNameLocator(userA.username)).toBeVisible();
+      await expect(await userBPages.participantDetails().getUserNameLocator(userA.username)).toContainText(
+        userA.username,
+      );
+      await expect(userBPages.participantDetails().userPicture).toBeVisible;
+    },
+  );
+
+  test(
+    'I want to see the external icon on the profile of an external participant',
+    {tag: ['@TC-1484', '@regression']},
+    async ({createPage, createUser}) => {
+      const externalUser = await createUser();
+      const [adminPage, userBPages, userExternalPage] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectionRequest(externalUser))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(externalUser))).then(pm => pm.webapp.pages),
+      ]);
+
+      await userExternalPage.conversationList().openPendingConnectionRequest();
+      await userExternalPage.connectRequest().clickConnectButton();
+
+      const groupName = 'Test Group';
+      await createGroup(adminPage, groupName, [userB, externalUser]);
+
+      await userBPages.conversationList().openConversation(groupName);
+      await userBPages.conversation().clickConversationInfoButton();
+      await userBPages.conversationDetails().openParticipantDetails(externalUser.fullName);
+
+      await expect(userBPages.participantDetails().guestStatus).toBeVisible();
+      await expect(userBPages.participantDetails().guestStatus).toContainText('Guest');
+    },
+  );
+
+  test(
+    'I want to see the group admin icon as a member seeing the group admin profile',
+    {tag: ['@TC-1485', '@regression']},
+    async ({createPage}) => {
+      const [adminPage, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      ]);
+
+      const groupName = 'Test Group';
+      await createGroup(adminPage, groupName, [userB]);
+
+      await userBPages.conversationList().openConversation(groupName);
+      await userBPages.conversation().clickConversationInfoButton();
+      await userBPages.conversationDetails().openParticipantDetails(userA.fullName);
+
+      await expect(userBPages.participantDetails().adminStatus).toBeVisible();
+      await expect(userBPages.participantDetails().adminStatus).toContainText('Group Admin');
+    },
+  );
+
+  test(
+    'I want to see the group admin icon as an admin seeing the group admin profile',
+    {tag: ['@TC-1486', '@regression']},
+    async ({createPage}) => {
+      const adminPage = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(
+        pm => pm.webapp.pages,
+      );
+
+      const groupName = 'Test Group';
+      await createGroup(adminPage, groupName, [userB]);
+
+      await adminPage.conversationList().openConversation(groupName);
+      await adminPage.conversation().clickConversationInfoButton();
+
+      await adminPage.conversation().makeUserAdmin(userB.fullName);
+
+      await expect(adminPage.participantDetails().adminStatus).toBeVisible();
+      await expect(adminPage.participantDetails().adminStatus).toContainText('Group Admin');
+    },
+  );
+
+  test(
+    'I want to see Remove from group as an admin seeing a participants profile',
+    {tag: ['@TC-1487', '@regression']},
+    async ({createPage}) => {
+      const adminPage = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(
+        pm => pm.webapp.pages,
+      );
+
+      await createGroup(adminPage, 'Test Group', [userB]);
+      await adminPage.conversationList().openConversation('Test Group');
+
+      await adminPage.conversation().clickConversationInfoButton();
+      await adminPage.conversationDetails().openParticipantDetails(userB.fullName);
+
+      const removeFromGroup = adminPage.conversation().removeUserButton;
+      await expect(removeFromGroup).toBeVisible();
+      await expect(removeFromGroup).toContainText('Remove from group…');
+    },
+  );
+
+  test(
+    'I should not to see Remove from group as a member on participants profile',
+    {tag: ['@TC-1488', '@regression']},
+    async ({createPage, createUser}) => {
+      const userC = await createUser();
+      await team.addMember(userC);
+      const [adminPage, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      ]);
+
+      const groupName = 'Test Group';
+      await createGroup(adminPage, groupName, [userB, userC]);
+
+      await userBPages.conversationList().openConversation(groupName);
+      await userBPages.conversation().clickConversationInfoButton();
+      await userBPages.conversationDetails().openParticipantDetails(userC.fullName);
+
+      const removeFromGroup = userBPages.conversation().removeUserButton;
+      await expect(removeFromGroup).not.toBeVisible();
+    },
+  );
+});

--- a/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
@@ -22,16 +22,34 @@ import {PageManager} from 'test/e2e_tests/pageManager';
 import {createGroup} from 'test/e2e_tests/utils/userActions';
 
 import {test, expect, withConnectedUser, withLogin, withConnectionRequest, Team} from 'test/e2e_tests/test.fixtures';
+import {Role} from '@wireapp/api-client/lib/team';
+
+async function openParticipantDetailsFromGroup(
+  pages: PageManager['webapp']['pages'],
+  groupName: string,
+  participantName: string,
+) {
+  await pages.conversationList().openConversation(groupName);
+  await pages.conversation().clickConversationInfoButton();
+  await pages.conversationDetails().openParticipantDetails(participantName);
+}
+
+async function acceptConnectionRequest(pages: PageManager['webapp']['pages']) {
+  await pages.conversationList().openPendingConnectionRequest();
+  await pages.connectRequest().clickConnectButton();
+}
 
 test.describe('Participant Profile', () => {
   let team: Team;
   let userA: User;
   let userB: User;
+  let groupName: string;
 
   test.beforeEach(async ({createTeam}) => {
     team = await createTeam('Test Team', {withMembers: 1});
     userA = team.owner;
     userB = team.members[0];
+    groupName = 'Test Group';
   });
 
   test(
@@ -44,8 +62,7 @@ test.describe('Participant Profile', () => {
         PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
       ]);
 
-      await userCPages.conversationList().openPendingConnectionRequest();
-      await userCPages.connectRequest().clickConnectButton();
+      await acceptConnectionRequest(userCPages);
 
       await test.step('Go to any 1:1 conversation', async () => {
         await userAPages.conversationList().openConversation(userC.fullName, {protocol: 'mls'});
@@ -54,10 +71,9 @@ test.describe('Participant Profile', () => {
       await test.step('Open People popover', async () => {
         await userAPages.conversation().clickConversationTitle();
 
-        await expect(await userAPages.participantDetails().getUserNameLocator(userC.username)).toBeVisible();
-        await expect(await userAPages.participantDetails().getUserNameLocator(userC.username)).toContainText(
-          userC.username,
-        );
+        await expect(userAPages.participantDetails().getUserNameLocator(userC.username)).toBeVisible();
+        await expect(userAPages.participantDetails().getUserNameLocator(userC.username)).toContainText(userC.username);
+        await expect(userAPages.participantDetails().getUserEmailLocator(userC.username)).not.toBeVisible();
 
         await expect(userAPages.participantDetails().userPicture).toBeVisible();
         await expect(userAPages.participantDetails().createGroup).toBeVisible();
@@ -66,7 +82,7 @@ test.describe('Participant Profile', () => {
 
       await test.step('Click on the X button to close the popover', async () => {
         await userAPages.participantDetails().closeParticipantDetails();
-        await expect(await userAPages.participantDetails().getUserNameLocator(userB.username)).not.toBeVisible();
+        await expect(userAPages.participantDetails().getUserNameLocator(userB.username)).not.toBeVisible();
         await expect(userAPages.participantDetails().userPicture).not.toBeVisible();
       });
     },
@@ -83,34 +99,25 @@ test.describe('Participant Profile', () => {
         PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
       ]);
 
-      await userCPages.conversationList().openPendingConnectionRequest();
-      await userCPages.connectRequest().clickConnectButton();
+      await acceptConnectionRequest(userCPages);
 
-      const groupName = 'Test Group';
       await test.step('User C is in group with User A and B. User C is not connected to user B', async () => {
         await createGroup(userAPage, groupName, [userB, userC]);
       });
 
       await test.step('User B asks to connect with user C', async () => {
-        await userBPages.conversationList().openConversation(groupName);
-        await userBPages.conversation().clickConversationTitle();
-
-        await userBPages.conversationDetails().openParticipantDetails(userC.fullName);
+        await openParticipantDetailsFromGroup(userBPages, groupName, userC.fullName);
         await userBPages.participantDetails().sendConnectRequest();
       });
-
-      await test.step('User B opens people popover', async () => {});
 
       await test.step('User B opens individual people profile of user C', async () => {
         await expect(userBPages.participantDetails().userPicture).toBeVisible();
         await expect(userBPages.participantDetails().userPicture).toHaveAttribute('data-uie-status', 'pending');
 
-        await expect(await userBPages.participantDetails().getUserNameLocator(userC.username)).toBeVisible();
-        await expect(await userBPages.participantDetails().getUserNameLocator(userC.username)).toContainText(
-          userC.username,
-        );
+        await expect(userBPages.participantDetails().getUserNameLocator(userC.username)).toBeVisible();
+        await expect(userBPages.participantDetails().getUserNameLocator(userC.username)).toContainText(userC.username);
 
-        await expect(await userBPages.participantDetails().getUserEmailLocator(userC.email)).not.toBeVisible();
+        await expect(userBPages.participantDetails().getUserEmailLocator(userC.email)).not.toBeVisible();
         await expect(userBPages.participantDetails().cancelRequest).toBeVisible();
         await expect(userBPages.participantDetails().block).toBeVisible();
       });
@@ -128,17 +135,12 @@ test.describe('Participant Profile', () => {
       ]);
 
       const {pages, modals} = userAPageManager.webapp;
-      await userCPages.conversationList().openPendingConnectionRequest();
-      await userCPages.connectRequest().clickConnectButton();
+      await acceptConnectionRequest(userCPages);
 
-      const groupName = 'Test Group';
       await createGroup(pages, groupName, [userB, userC]);
 
       await test.step('User A blocks User C', async () => {
-        await pages.conversationList().openConversation(groupName);
-        await pages.conversation().clickConversationTitle();
-
-        await pages.conversationDetails().openParticipantDetails(userC.fullName);
+        await openParticipantDetailsFromGroup(pages, groupName, userC.fullName);
         await pages.participantDetails().blockUser();
         await modals.blockWarning().clickBlock();
       });
@@ -154,10 +156,10 @@ test.describe('Participant Profile', () => {
         await expect(pages.participantDetails().userPicture).toBeVisible();
         await expect(pages.participantDetails().userPicture).toHaveAttribute('data-uie-status', 'blocked');
 
-        await expect(await pages.participantDetails().getUserNameLocator(userC.username)).toBeVisible();
-        await expect(await pages.participantDetails().getUserNameLocator(userC.username)).toContainText(userC.username);
+        await expect(pages.participantDetails().getUserNameLocator(userC.username)).toBeVisible();
+        await expect(pages.participantDetails().getUserNameLocator(userC.username)).toContainText(userC.username);
 
-        await expect(await pages.participantDetails().getUserEmailLocator(userC.email)).not.toBeVisible();
+        await expect(pages.participantDetails().getUserEmailLocator(userC.email)).not.toBeVisible();
         await expect(pages.participantDetails().unblockButton).toBeVisible();
         await expect(pages.participantDetails().removeFromGroup).toBeVisible();
       });
@@ -165,7 +167,7 @@ test.describe('Participant Profile', () => {
   );
 
   test(
-    'Verify big profile picture ans username are shown on participant popover',
+    'Verify big profile picture and username are shown on participant popover',
     {tag: ['@TC-1480', '@regression']},
     async ({createPage}) => {
       const [adminPage, userBPages] = await Promise.all([
@@ -173,18 +175,12 @@ test.describe('Participant Profile', () => {
         PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
       ]);
 
-      const groupName = 'Test Group';
       await createGroup(adminPage, groupName, [userB]);
+      await openParticipantDetailsFromGroup(userBPages, groupName, userA.fullName);
 
-      await userBPages.conversationList().openConversation(groupName);
-      await userBPages.conversation().clickConversationInfoButton();
-      await userBPages.conversationDetails().openParticipantDetails(userA.fullName);
-
-      await expect(await userBPages.participantDetails().getUserNameLocator(userA.username)).toBeVisible();
-      await expect(await userBPages.participantDetails().getUserNameLocator(userA.username)).toContainText(
-        userA.username,
-      );
-      await expect(userBPages.participantDetails().userPicture).toBeVisible;
+      await expect(userBPages.participantDetails().userPicture).toBeVisible();
+      await expect(userBPages.participantDetails().getUserNameLocator(userA.username)).toContainText(userA.username);
+      await expect(userBPages.participantDetails().getUserNameLocator(userA.username)).toBeVisible;
     },
   );
 
@@ -193,24 +189,18 @@ test.describe('Participant Profile', () => {
     {tag: ['@TC-1484', '@regression']},
     async ({createPage, createUser}) => {
       const externalUser = await createUser();
-      const [adminPage, userBPages, userExternalPage] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectionRequest(externalUser))).then(pm => pm.webapp.pages),
+      team.addMember(externalUser, {role: Role.EXTERNAL});
+
+      const [adminPage, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(externalUser))).then(pm => pm.webapp.pages),
         PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(externalUser))).then(pm => pm.webapp.pages),
       ]);
 
-      await userExternalPage.conversationList().openPendingConnectionRequest();
-      await userExternalPage.connectRequest().clickConnectButton();
-
-      const groupName = 'Test Group';
       await createGroup(adminPage, groupName, [userB, externalUser]);
+      await openParticipantDetailsFromGroup(userBPages, groupName, externalUser.fullName);
 
-      await userBPages.conversationList().openConversation(groupName);
-      await userBPages.conversation().clickConversationInfoButton();
-      await userBPages.conversationDetails().openParticipantDetails(externalUser.fullName);
-
-      await expect(userBPages.participantDetails().guestStatus).toBeVisible();
-      await expect(userBPages.participantDetails().guestStatus).toContainText('Guest');
+      await expect(userBPages.participantDetails().externalStatus).toBeVisible();
+      await expect(userBPages.participantDetails().externalStatus).toContainText('External');
     },
   );
 
@@ -223,12 +213,8 @@ test.describe('Participant Profile', () => {
         PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
       ]);
 
-      const groupName = 'Test Group';
       await createGroup(adminPage, groupName, [userB]);
-
-      await userBPages.conversationList().openConversation(groupName);
-      await userBPages.conversation().clickConversationInfoButton();
-      await userBPages.conversationDetails().openParticipantDetails(userA.fullName);
+      await openParticipantDetailsFromGroup(userBPages, groupName, userA.fullName);
 
       await expect(userBPages.participantDetails().adminStatus).toBeVisible();
       await expect(userBPages.participantDetails().adminStatus).toContainText('Group Admin');
@@ -243,7 +229,6 @@ test.describe('Participant Profile', () => {
         pm => pm.webapp.pages,
       );
 
-      const groupName = 'Test Group';
       await createGroup(adminPage, groupName, [userB]);
 
       await adminPage.conversationList().openConversation(groupName);
@@ -264,15 +249,12 @@ test.describe('Participant Profile', () => {
         pm => pm.webapp.pages,
       );
 
-      await createGroup(adminPage, 'Test Group', [userB]);
-      await adminPage.conversationList().openConversation('Test Group');
+      await createGroup(adminPage, groupName, [userB]);
+      await openParticipantDetailsFromGroup(adminPage, groupName, userB.fullName);
 
-      await adminPage.conversation().clickConversationInfoButton();
-      await adminPage.conversationDetails().openParticipantDetails(userB.fullName);
-
-      const removeFromGroup = adminPage.conversation().removeUserButton;
+      const removeFromGroup = adminPage.participantDetails().removeFromGroup;
       await expect(removeFromGroup).toBeVisible();
-      await expect(removeFromGroup).toContainText('Remove from group…');
+      await expect(removeFromGroup).toHaveText('Remove from group…');
     },
   );
 
@@ -287,15 +269,10 @@ test.describe('Participant Profile', () => {
         PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
       ]);
 
-      const groupName = 'Test Group';
       await createGroup(adminPage, groupName, [userB, userC]);
+      await openParticipantDetailsFromGroup(userBPages, groupName, userC.fullName);
 
-      await userBPages.conversationList().openConversation(groupName);
-      await userBPages.conversation().clickConversationInfoButton();
-      await userBPages.conversationDetails().openParticipantDetails(userC.fullName);
-
-      const removeFromGroup = userBPages.conversation().removeUserButton;
-      await expect(removeFromGroup).not.toBeVisible();
+      await expect(userBPages.participantDetails().removeFromGroup).not.toBeVisible();
     },
   );
 });

--- a/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
@@ -71,8 +71,8 @@ test.describe('Participant Profile', () => {
       await test.step('Open People popover', async () => {
         await userAPages.conversation().clickConversationTitle();
 
-        await expect(userAPages.participantDetails().getUserNameLocator(userC.username)).toBeVisible();
-        await expect(userAPages.participantDetails().getUserNameLocator(userC.username)).toContainText(userC.username);
+        await expect(userAPages.participantDetails().userName).toBeVisible();
+        await expect(userAPages.participantDetails().userName).toContainText(userC.fullName);
         await expect(userAPages.participantDetails().getUserEmailLocator(userC.username)).not.toBeVisible();
 
         await expect(userAPages.participantDetails().userPicture).toBeVisible();
@@ -82,7 +82,7 @@ test.describe('Participant Profile', () => {
 
       await test.step('Click on the X button to close the popover', async () => {
         await userAPages.participantDetails().closeParticipantDetails();
-        await expect(userAPages.participantDetails().getUserNameLocator(userB.username)).not.toBeVisible();
+        await expect(userAPages.participantDetails().userName).not.toBeVisible();
         await expect(userAPages.participantDetails().userPicture).not.toBeVisible();
       });
     },
@@ -93,7 +93,7 @@ test.describe('Participant Profile', () => {
     {tag: ['@TC-1477', '@regression']},
     async ({createPage, createUser}) => {
       const userC = await createUser();
-      const [userAPage, userBPages, userCPages] = await Promise.all([
+      const [userAPages, userBPages, userCPages] = await Promise.all([
         PageManager.from(createPage(withLogin(userA), withConnectionRequest(userC))).then(pm => pm.webapp.pages),
         PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
         PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
@@ -102,7 +102,7 @@ test.describe('Participant Profile', () => {
       await acceptConnectionRequest(userCPages);
 
       await test.step('User C is in group with User A and B. User C is not connected to user B', async () => {
-        await createGroup(userAPage, groupName, [userB, userC]);
+        await createGroup(userAPages, groupName, [userB, userC]);
       });
 
       await test.step('User B asks to connect with user C', async () => {
@@ -114,13 +114,17 @@ test.describe('Participant Profile', () => {
         await expect(userBPages.participantDetails().userPicture).toBeVisible();
         await expect(userBPages.participantDetails().userPicture).toHaveAttribute('data-uie-status', 'pending');
 
-        await expect(userBPages.participantDetails().getUserNameLocator(userC.username)).toBeVisible();
-        await expect(userBPages.participantDetails().getUserNameLocator(userC.username)).toContainText(userC.username);
+        await expect(userBPages.participantDetails().userName).toBeVisible();
+        await expect(userBPages.participantDetails().userName).toContainText(userC.fullName);
 
         await expect(userBPages.participantDetails().getUserEmailLocator(userC.email)).not.toBeVisible();
         await expect(userBPages.participantDetails().cancelRequest).toBeVisible();
         await expect(userBPages.participantDetails().block).toBeVisible();
       });
+
+      // Validate email visibility for team member in participant details
+      await openParticipantDetailsFromGroup(userAPages, groupName, userB.fullName);
+      await expect(userAPages.participantDetails().getUserEmailLocator(userB.email)).toBeVisible();
     },
   );
 
@@ -156,8 +160,8 @@ test.describe('Participant Profile', () => {
         await expect(pages.participantDetails().userPicture).toBeVisible();
         await expect(pages.participantDetails().userPicture).toHaveAttribute('data-uie-status', 'blocked');
 
-        await expect(pages.participantDetails().getUserNameLocator(userC.username)).toBeVisible();
-        await expect(pages.participantDetails().getUserNameLocator(userC.username)).toContainText(userC.username);
+        await expect(pages.participantDetails().userName).toBeVisible();
+        await expect(pages.participantDetails().userName).toContainText(userC.fullName);
 
         await expect(pages.participantDetails().getUserEmailLocator(userC.email)).not.toBeVisible();
         await expect(pages.participantDetails().unblockButton).toBeVisible();
@@ -179,8 +183,8 @@ test.describe('Participant Profile', () => {
       await openParticipantDetailsFromGroup(userBPages, groupName, userA.fullName);
 
       await expect(userBPages.participantDetails().userPicture).toBeVisible();
-      await expect(userBPages.participantDetails().getUserNameLocator(userA.username)).toContainText(userA.username);
-      await expect(userBPages.participantDetails().getUserNameLocator(userA.username)).toBeVisible;
+      await expect(userBPages.participantDetails().userName).toBeVisible;
+      await expect(userBPages.participantDetails().userName).toContainText(userA.fullName);
     },
   );
 
@@ -189,7 +193,7 @@ test.describe('Participant Profile', () => {
     {tag: ['@TC-1484', '@regression']},
     async ({createPage, createUser}) => {
       const externalUser = await createUser();
-      team.addMember(externalUser, {role: Role.EXTERNAL});
+      await team.addMember(externalUser, {role: Role.EXTERNAL});
 
       const [adminPage, userBPages] = await Promise.all([
         PageManager.from(createPage(withLogin(userA), withConnectedUser(externalUser))).then(pm => pm.webapp.pages),
@@ -199,8 +203,7 @@ test.describe('Participant Profile', () => {
       await createGroup(adminPage, groupName, [userB, externalUser]);
       await openParticipantDetailsFromGroup(userBPages, groupName, externalUser.fullName);
 
-      await expect(userBPages.participantDetails().externalStatus).toBeVisible();
-      await expect(userBPages.participantDetails().externalStatus).toContainText('External');
+      await expect(userBPages.participantDetails().userStatus).toContainText('External');
     },
   );
 
@@ -216,8 +219,7 @@ test.describe('Participant Profile', () => {
       await createGroup(adminPage, groupName, [userB]);
       await openParticipantDetailsFromGroup(userBPages, groupName, userA.fullName);
 
-      await expect(userBPages.participantDetails().adminStatus).toBeVisible();
-      await expect(userBPages.participantDetails().adminStatus).toContainText('Group Admin');
+      await expect(userBPages.participantDetails().userStatus).toContainText('Group Admin');
     },
   );
 
@@ -235,9 +237,7 @@ test.describe('Participant Profile', () => {
       await adminPage.conversation().clickConversationInfoButton();
 
       await adminPage.conversation().makeUserAdmin(userB.fullName);
-
-      await expect(adminPage.participantDetails().adminStatus).toBeVisible();
-      await expect(adminPage.participantDetails().adminStatus).toContainText('Group Admin');
+      await expect(adminPage.participantDetails().userStatus).toContainText('Group Admin');
     },
   );
 

--- a/apps/webapp/test/e2e_tests/test.fixtures.ts
+++ b/apps/webapp/test/e2e_tests/test.fixtures.ts
@@ -24,6 +24,7 @@ import {getUser, User} from './data/user';
 import {PageManager} from './pageManager';
 import {connectWithUser, sendConnectionRequest} from './utils/userActions';
 import {mockAudioAndVideoDevices} from './utils/mockVideoDevice.util';
+import {Role} from '@wireapp/api-client/lib/team';
 
 type PagePlugin = (page: Page) => void | Promise<void>;
 
@@ -60,7 +61,7 @@ export type Team = {
   owner: User;
   members: User[];
   /** Add a new member to the team after its initial creation */
-  addMember: (member: User) => Promise<void>;
+  addMember: (member: User, options?: {role?: Role}) => Promise<void>;
 };
 
 export {expect} from '@playwright/test';
@@ -144,8 +145,8 @@ export const test = baseTest.extend<Fixtures>({
 
       teamOwners.push(owner);
 
-      const addMember = async (member: User) => {
-        const invitationId = await api.team.inviteUserToTeam(member.email, owner);
+      const addMember = async (member: User, {role = Role.MEMBER}: {role?: Role} = {}) => {
+        const invitationId = await api.team.inviteUserToTeam(member.email, owner, role);
         const invitationCode = await api.brig.getTeamInvitationCodeForEmail(owner.teamId, invitationId);
         await api.team.acceptTeamInvitation(invitationCode, member);
       };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19962" title="WPB-19962" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19962</a>  [Web/QA] Write the Participant Profile regression tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

New Tests: Added E2E regression suite for Participant Profiles.
Fixture Update: Enhanced addMember in the createTeam fixture to support role specification.
Locator Logic: Refactored getLocatorByUser to select users regardless of their role (Admin vs. Member) or list placement.

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
