### PR TITLE
test: implement e2e tests for notifications [WPB-19961]

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/account.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/account.page.ts
@@ -112,6 +112,14 @@ export class AccountPage {
     await this.resetPasswordButton.click();
   }
 
+  async uploadProfilePicture(imagePath: string) {
+    const [filePicker] = await Promise.all([
+      this.page.waitForEvent('filechooser'),
+      this.page.getByLabel('Change your picture').click(),
+    ]);
+    await filePicker.setFiles(imagePath);
+  }
+
   async changeEmailAddress(newEmail: string) {
     await this.editEmailButton.click();
     await this.emailInput.fill(newEmail);

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -437,7 +437,8 @@ export class ConversationPage {
       .getByTestId('item-user')
       .and(this.page.locator(`[data-uie-value="${name}"]`))
       .click();
-    return this.removeUserButton.click();
+    await this.removeUserButton.click();
+    await new ConfirmModal(this.page).clickAction();
   }
 
   async removeAdminFromGroup(name: string) {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationDetails.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationDetails.page.ts
@@ -190,10 +190,12 @@ export class ConversationDetailsPage {
     await this.clearConversationContentButton.click();
   }
 
-  async setNotificationsForConversation(value: 'Everything' | 'Mentions and replies' | 'Nothing') {
+  async setNotifications(value: 'Everything' | 'Mentions and replies' | 'Nothing') {
     await this.notificationsButton.click();
-    const notificationsPanel = this.page.locator('aside#right-column');
-    await notificationsPanel.getByRole('radiogroup').getByText(value).click();
+    await this.page.getByRole('radiogroup').locator('label', {hasText: value}).click();
+
+    // Close the settings by clicking "Go back" button.
+    await this.page.getByRole('button', {name: 'Go back'}).click();
   }
 
   async changeConversationName(newConversationName: string) {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationDetails.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationDetails.page.ts
@@ -192,7 +192,7 @@ export class ConversationDetailsPage {
 
   async setNotifications(value: 'Everything' | 'Mentions and replies' | 'Nothing') {
     await this.notificationsButton.click();
-    await this.page.getByRole('radiogroup').locator('label', {hasText: value}).click();
+    await this.page.getByRole('radiogroup').getByText(value).click();
 
     // Close the settings by clicking "Go back" button.
     await this.page.getByRole('button', {name: 'Go back'}).click();

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -98,6 +98,11 @@ export class ConversationListPage {
     await this.archiveConversationMenuButton.click();
   }
 
+  async setNotifications(level: 'Everything' | 'Mentions and replies' | 'Nothing') {
+    await this.page.getByRole('menuitem', {name: 'Notifications'}).click(); // Click the "Notifications" menu item
+    await this.page.getByRole('radiogroup').locator('label', {hasText: level}).click(); // Click the specified radio button
+  }
+
   async unarchiveConversation() {
     await this.unarchiveConversationMenuButton.click();
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/options.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/options.page.ts
@@ -20,23 +20,17 @@
 import {Page, Locator} from '@playwright/test';
 
 export class OptionsPage {
-  readonly checkboxSoundAlertsAll: Locator;
-  readonly checkboxSoundAlertsSome: Locator;
-  readonly checkboxSoundAlertsNone: Locator;
+  readonly page: Page;
+
+  readonly soundAlertsRadioGroup: Locator;
 
   constructor(page: Page) {
-    this.checkboxSoundAlertsAll = page.getByTestId('preferences-options-audio-all');
-    this.checkboxSoundAlertsSome = page.getByTestId('preferences-options-audio-some');
-    this.checkboxSoundAlertsNone = page.getByTestId('preferences-options-audio-none');
+    this.page = page;
+
+    this.soundAlertsRadioGroup = page.getByRole('group', {name: 'Sound alerts'}).getByRole('radiogroup');
   }
 
-  async checkSoundAll() {
-    await this.checkboxSoundAlertsAll.check();
-  }
-  async checkSoundSome() {
-    await this.checkboxSoundAlertsSome.check();
-  }
-  async checkSoundNone() {
-    await this.checkboxSoundAlertsNone.check();
+  async setSoundAlerts(option: 'All' | 'Some' | 'None') {
+    await this.soundAlertsRadioGroup.locator('label', {hasText: option}).click();
   }
 }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/options.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/options.page.ts
@@ -23,14 +23,21 @@ export class OptionsPage {
   readonly page: Page;
 
   readonly soundAlertsRadioGroup: Locator;
+  readonly notificationsRadioGroup: Locator;
 
   constructor(page: Page) {
     this.page = page;
 
     this.soundAlertsRadioGroup = page.getByRole('group', {name: 'Sound alerts'}).getByRole('radiogroup');
+    this.notificationsRadioGroup = page.getByRole('group', {name: 'Notifications'}).getByRole('radiogroup');
   }
 
   async setSoundAlerts(option: 'All' | 'Some' | 'None') {
     await this.soundAlertsRadioGroup.locator('label', {hasText: option}).click();
+  }
+
+  async setNotifications(option: 'Show sender and message' | 'Show sender' | 'Hide details' | 'Off') {
+    // Radio groups in Wire are not a11y compliant so we need to click them since checking doesn't work
+    await this.notificationsRadioGroup.locator('label', {hasText: new RegExp(`^${option}$`)}).click();
   }
 }

--- a/apps/webapp/test/e2e_tests/specs/AccountSettingsSpecs/accountSettings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AccountSettingsSpecs/accountSettings.spec.ts
@@ -21,9 +21,9 @@ import {getUser} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {bootstrapTeamForTesting, completeLogin} from 'test/e2e_tests/utils/setup.util';
 import {tearDownAll} from 'test/e2e_tests/utils/tearDown.util';
-import {createChannel, createGroup, loginUser} from 'test/e2e_tests/utils/userActions';
+import {createChannel, createGroup, loginUser, logOutUser} from 'test/e2e_tests/utils/userActions';
 
-import {test, expect, LOGIN_TIMEOUT} from '../../test.fixtures';
+import {test, expect, LOGIN_TIMEOUT, withLogin} from '../../test.fixtures';
 
 test.describe('account settings', () => {
   let owner = getUser();
@@ -126,38 +126,35 @@ test.describe('account settings', () => {
     },
   );
 
-  // see https://wearezeta.atlassian.net/browse/WPB-20548
-  test.skip(
+  test(
     'Verify sound settings are saved after re-login',
     {tag: ['@TC-1718', '@TC-1720', '@regression']},
-    async ({pageManager}) => {
-      const {components, modals, pages} = pageManager.webapp;
+    async ({createUser, createPage}) => {
+      const user = await createUser();
+      const pageManager = PageManager.from(await createPage(withLogin(user)));
+      const {pages, components} = pageManager.webapp;
 
-      await completeLogin(pageManager, memberA);
       await components.conversationSidebar().clickPreferencesButton();
-
       await pages.settings().clickOptionsButton();
 
-      await pages.options().checkSoundNone(); // cannot reach the input element its behind the label element
-      await pages.settings().clickAccountButton();
-      await pages.account().clickLogoutButton();
-      await modals.confirmLogout().clickConfirm();
+      await pages.options().setSoundAlerts('None');
+      await logOutUser(pageManager);
 
-      await loginUser(memberA, pageManager);
+      await loginUser(user, pageManager);
       await components.conversationSidebar().isPageLoaded();
+      await components.conversationSidebar().clickPreferencesButton();
       await pages.settings().clickOptionsButton();
 
-      await expect(pages.options().checkboxSoundAlertsNone).toBeChecked();
+      await expect(pages.options().soundAlertsRadioGroup.getByRole('radio', {name: 'None'})).toBeChecked();
 
-      await pages.options().checkSoundAll(); // cannot reach the input element its behind the label element
-      await pages.account().clickLogoutButton();
-      await modals.confirmLogout().clickConfirm();
-      await loginUser(memberA, pageManager);
-
+      await pages.options().setSoundAlerts('All');
+      await logOutUser(pageManager);
+      await loginUser(user, pageManager);
       await components.conversationSidebar().isPageLoaded();
-      await pages.settings().clickOptionsButton();
 
-      await expect(pages.options().checkboxSoundAlertsAll).toBeChecked();
+      await components.conversationSidebar().clickPreferencesButton();
+      await pages.settings().clickOptionsButton();
+      await expect(pages.options().soundAlertsRadioGroup.getByRole('radio', {name: 'All'})).toBeChecked();
     },
   );
 

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
@@ -178,10 +178,9 @@ test(
     });
 
     await test.step('Team owner removes one group member from a group', async () => {
-      const {pages, modals} = ownerPageManager.webapp;
+      const {pages} = ownerPageManager.webapp;
       // Get the member from the members list and remove them
       await pages.conversation().removeMemberFromGroup(member2.fullName);
-      await modals.removeMember().clickConfirm();
 
       // Verify member is no longer in the conversation by checking system message
       expect(await pages.conversation().isSystemMessageVisible(`You removed ${member2.fullName}`)).toBeTruthy();

--- a/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
@@ -242,7 +242,7 @@ test.describe('History Backup', () => {
 
       await test.step('User A mutes group conversation with User B', async () => {
         await userAPages.conversation().conversationInfoButton.click();
-        await userAPages.conversationDetails().setNotificationsForConversation('Nothing');
+        await userAPages.conversationDetails().setNotifications('Nothing');
       });
 
       await test.step('User A archives 1:1 conversation with User B', async () => {

--- a/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
@@ -433,9 +433,8 @@ test.describe('Notifications', () => {
     },
   );
 
-  // ToDo: Wait for confirmation if this test is implemented correctly (title might change)
   test(
-    'Verify clicking a notification of a team opens team conversation',
+    'Verify clicking a notification of a group conversation opens this conversation',
     {tag: ['@TC-1458', '@regression']},
     async ({createPage}) => {
       const [userAPage, userBPage] = await Promise.all([
@@ -445,20 +444,20 @@ test.describe('Notifications', () => {
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
-      await createGroup(userBPages, 'Test Group', [userA]);
-      await userBPages.conversationList().openConversation('Test Group');
+      await createGroup(userAPages, 'Test Group', [userB]);
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
 
       // Start intercepting notifications
       const {clickNotification} = await interceptNotifications(userBPage);
 
-      // User A pings User B
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      // User A sends message in group
+      await userAPages.conversationList().openConversation('Test Group');
       await userAPages.conversation().sendMessage('Test Message');
 
-      await clickNotification({title: userA.fullName, body: 'Test Message'});
+      await clickNotification({title: `${userA.fullName} in Test Group`, body: 'Test Message'});
 
       // After clicking the notification B should show the 1on1 conversation instead of the group
-      await expect(userBPages.conversation().conversationTitle).toContainText(userA.fullName);
+      await expect(userBPages.conversation().conversationTitle).toContainText('Test Group');
     },
   );
 

--- a/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
@@ -135,8 +135,10 @@ test.describe('Notifications', () => {
 
         await pages.conversationList().openConversation(conversationName);
         await pages.conversation().clickConversationInfoButton();
+        await expect(pages.conversationDetails().notificationsButton).toContainText('Everything');
+
         await pages.conversationDetails().setNotifications('Nothing');
-        // ToDo: Ensure change is reflected in conversation details
+        await expect(pages.conversationDetails().notificationsButton).toContainText('Nothing');
 
         const conversation = pages.conversationList().getConversationLocator(conversationName);
         await expect(conversation.getByTitle('Muted conversation')).toBeVisible();

--- a/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
@@ -554,42 +554,6 @@ test.describe('Notifications', () => {
     },
   );
 
-  // ToDo: Check if a notification should be received when removed from group
-  test.fixme(
-    'Verify I see notification when I am removed from group conversation',
-    {tag: ['@TC-1463', '@regression']},
-    async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
-      const userAPages = PageManager.from(userAPage).webapp.pages;
-      const userBPages = PageManager.from(userBPage).webapp.pages;
-
-      await createGroup(userAPages, 'Test Group', [userB]);
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-
-      const {getNotifications} = await interceptNotifications(userBPage);
-
-      // User A removes User B from the group
-      await userAPages.conversationList().openConversation('Test Group');
-      await userAPages.conversation().toggleGroupInformation(); // Open conversation details
-      await userAPages.conversation().removeMemberFromGroup(userB.fullName);
-
-      // Verify User B receives a notification about being removed from the group
-      await expect
-        .poll(() => getNotifications())
-        .toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              title: 'Test Group',
-              body: 'You were removed',
-            }),
-          ]),
-        );
-    },
-  );
-
   test(
     'Verify I see notification when image is sent to group conversation',
     {tag: ['@TC-1464', '@regression']},

--- a/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
@@ -2,7 +2,9 @@ import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {interceptNotifications} from 'test/e2e_tests/utils/mockNotifications.util';
 import {test, withLogin, withConnectedUser, expect} from 'test/e2e_tests/test.fixtures';
-import {createGroup} from 'test/e2e_tests/utils/userActions';
+import {createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
+import {shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
+import {getImageFilePath} from 'test/e2e_tests/utils/sendImage.util';
 
 test.describe('Notifications', () => {
   let userA: User;
@@ -46,8 +48,8 @@ test.describe('Notifications', () => {
       );
   });
 
-  // TODO: This test is currently failing if it's a bug disable it and link bug ticket
-  test(
+  // WPB-21966 - This test is currently broken as the user receives notifications even for archived conversations
+  test.fixme(
     'I should not receive notifications for archived conversations',
     {tag: ['@TC-8760', '@regression']},
     async ({createPage}) => {
@@ -77,6 +79,584 @@ test.describe('Notifications', () => {
 
       // Check that B did not receive any more notifications
       await expect.poll(() => getUserBNotifications()).toHaveLength(0);
+    },
+  );
+
+  test(
+    'I want to mute 1on1 conversations via recent view',
+    {tag: ['@TC-1437', '@regression']},
+    async ({createPage}) => {
+      const pages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp.pages;
+
+      await pages.conversationList().clickConversationOptions(userB.fullName);
+      await pages.conversationList().setNotifications('Nothing');
+
+      const conversation = pages.conversationList().getConversationLocator(userB.fullName);
+      await expect(conversation.getByTitle('Muted conversation')).toBeVisible();
+    },
+  );
+
+  test(
+    'I want to unmute 1on1 conversations via recent view',
+    {tag: ['@TC-1438', '@regression']},
+    async ({createPage}) => {
+      const pages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp.pages;
+
+      await pages.conversationList().clickConversationOptions(userB.fullName);
+      await pages.conversationList().setNotifications('Nothing');
+
+      const conversation = pages.conversationList().getConversationLocator(userB.fullName);
+      await expect(conversation.getByTitle('Muted conversation')).toBeVisible();
+
+      await pages.conversationList().clickConversationOptions(userB.fullName);
+      await pages.conversationList().setNotifications('Everything');
+
+      await expect(conversation.getByTitle('Muted conversation')).not.toBeVisible();
+    },
+  );
+
+  [
+    {testId: '@TC-1439', conversationType: 'group'} as const,
+    {testId: '@TC-1440', conversationType: '1on1'} as const,
+  ].forEach(({testId, conversationType}) => {
+    test(
+      `I want to mute the ${conversationType} conversation via conversation details`,
+      {tag: [testId, '@regression']},
+      async ({createPage}) => {
+        const pages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp.pages;
+
+        let conversationName: string;
+        if (conversationType === 'group') {
+          await createGroup(pages, 'Test Group', [userB]);
+          conversationName = 'Test Group';
+        } else {
+          conversationName = userB.fullName;
+        }
+
+        await pages.conversationList().openConversation(conversationName);
+        await pages.conversation().clickConversationInfoButton();
+        await pages.conversationDetails().setNotifications('Nothing');
+        // ToDo: Ensure change is reflected in conversation details
+
+        const conversation = pages.conversationList().getConversationLocator(conversationName);
+        await expect(conversation.getByTitle('Muted conversation')).toBeVisible();
+
+        // ToDo: Ensure you don't receive notifications
+      },
+    );
+  });
+
+  test(
+    'I want to see join button on muted conversation when someone is trying to call me',
+    {tag: ['@TC-1443', '@regression']},
+    async ({createPage}) => {
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+      ]);
+
+      // User B mutes the conversation with User A
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().clickConversationOptions(userA.fullName);
+      await userBPages.conversationList().setNotifications('Nothing');
+
+      // User A initiates a call to User B
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversation().clickCallButton();
+
+      // Verify that User B sees a "Join" button on the muted conversation
+      await expect(userBPages.conversationList().joinCallButton).toBeVisible();
+    },
+  );
+
+  test(
+    'I should not receive notifications for muted 1:1 conversations',
+    {tag: ['@TC-1444', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
+      ]);
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
+
+      // Open 1on1 conversation between users
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+
+      // User B mutes the conversation with User A via recent view
+      await userBPages.conversationList().clickConversationOptions(userA.fullName);
+      await userBPages.conversationList().setNotifications('Nothing');
+
+      // Create group and open it for user B so the message won't be read immediately
+      await createGroup(userAPages, 'Test Group', [userB]);
+      await userBPages.conversationList().openConversation('Test Group');
+
+      // Start intercepting notifications for User B
+      const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
+
+      // User A sends message to User B and B received it
+      await userAPages.conversationList().openConversation(userB.fullName);
+      await userAPages.conversation().sendMessage('Test Message');
+      await expect(userBPages.conversationList().getConversationLocator(userA.fullName)).toContainText('1 message');
+
+      // Verify User B did not receive any notifications for the second message
+      await expect.poll(() => getUserBNotifications()).toHaveLength(0);
+    },
+  );
+
+  test(
+    "Verify notification for ephemeral messages does not contain the message, sender's name or image",
+    {tag: ['@TC-1448', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
+      ]);
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
+
+      // Create group and open it for user B so the message won't be read immediately
+      await createGroup(userBPages, 'Test Group', [userA]);
+      await userBPages.conversationList().openConversation('Test Group');
+
+      // Start intercepting notifications for User B
+      const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
+
+      // User A sends an ephemeral message
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversation().enableSelfDeletingMessages();
+      await userAPages.conversation().sendMessage('Ephemeral Message');
+
+      // Verify User B receives a notification, but it does not contain the message or sender's name
+      await expect
+        .poll(() => getUserBNotifications())
+        .toEqual([expect.objectContaining({title: 'Someone', body: 'Sent a message'})]);
+    },
+  );
+
+  // ToDo: Create parameterized test out of the following 4
+  test(
+    "Sender name and a message are shown in notification when 'Show sender and message' item is selected in preferences",
+    {tag: ['@TC-1450', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
+      ]);
+      const {pages: userAPages} = PageManager.from(userAPage).webapp;
+      const {pages: userBPages, components: userBComponents} = PageManager.from(userBPage).webapp;
+
+      // User B navigates to preferences and sets "Show sender and message"
+      await userBComponents.conversationSidebar().clickPreferencesButton();
+      await userBPages.settings().optionsButton.click();
+      await userBPages.options().setNotifications('Show sender and message');
+
+      // Start intercepting notifications for User B
+      const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
+
+      // ToDo: Also send types ping, link, audio, video and file transfer to 1on1 and group -> Same for 3 following tests
+      // User A sends a message to User B
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversation().sendMessage('Test Message');
+
+      // Verify User B receives a notification containing sender's name and message content
+      await expect
+        .poll(() => getUserBNotifications())
+        .toEqual([expect.objectContaining({title: userA.fullName, body: 'Test Message'})]);
+    },
+  );
+
+  test(
+    "No message content is written on notification when 'Show sender' item is selected in preferences",
+    {tag: ['@TC-1451', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
+      ]);
+      const {pages: userAPages} = PageManager.from(userAPage).webapp;
+      const {pages: userBPages, components: userBComponents} = PageManager.from(userBPage).webapp;
+
+      // User B navigates to preferences and sets "Show sender"
+      await userBComponents.conversationSidebar().clickPreferencesButton();
+      await userBPages.settings().optionsButton.click();
+      await userBPages.options().setNotifications('Show sender');
+
+      // Start intercepting notifications for User B
+      const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
+
+      // User A sends a message to User B
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversation().sendMessage('Test Message');
+
+      // Verify User B receives a notification containing sender's name and message content
+      await expect
+        .poll(() => getUserBNotifications())
+        .toEqual([expect.objectContaining({title: userA.fullName, body: 'Sent a message'})]);
+    },
+  );
+
+  test(
+    "No sender name, profile image or message content is written on notification when choose 'Hide details' in preferences",
+    {tag: ['@TC-1452', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
+      ]);
+      const {pages: userAPages} = PageManager.from(userAPage).webapp;
+      const {pages: userBPages, components: userBComponents} = PageManager.from(userBPage).webapp;
+
+      // User B navigates to preferences and sets "Show sender"
+      await userBComponents.conversationSidebar().clickPreferencesButton();
+      await userBPages.settings().optionsButton.click();
+      await userBPages.options().setNotifications('Hide details');
+
+      // Start intercepting notifications for User B
+      const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
+
+      // User A sends a message to User B
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversation().sendMessage('Test Message');
+
+      // Verify User B receives a notification containing sender's name and message content
+      await expect
+        .poll(() => getUserBNotifications())
+        .toEqual([
+          expect.objectContaining({
+            title: 'Someone',
+            body: 'Sent a message',
+            // ToDo: Give user A a profile picture to ensure this test could fail
+            icon: expect.stringMatching(/notification\.png$/),
+          }),
+        ]);
+    },
+  );
+
+  test(
+    "No notification shown when selecting 'Off' in preferences",
+    {tag: ['@TC-1453', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
+      ]);
+      const {pages: userAPages} = PageManager.from(userAPage).webapp;
+      const {pages: userBPages, components: userBComponents} = PageManager.from(userBPage).webapp;
+
+      // User B navigates to preferences and sets "Off"
+      await userBComponents.conversationSidebar().clickPreferencesButton();
+      await userBPages.settings().optionsButton.click();
+      await userBPages.options().setNotifications('Off');
+
+      // Start intercepting notifications for User B
+      const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
+
+      // User A sends a message to User B
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversation().sendMessage('Test Message');
+
+      await userBComponents.conversationSidebar().allConverationsButton.click();
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await expect(userBPages.conversation().getMessage({sender: userA})).toBeVisible();
+
+      // Verify User B receives a notification containing sender's name and message content
+      await expect.poll(() => getUserBNotifications()).toHaveLength(0);
+    },
+  );
+
+  test(
+    'Verify I can click ping notification while other conversation is opened',
+    {tag: ['@TC-1455', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
+      ]);
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
+
+      await createGroup(userBPages, 'Test Group', [userA]);
+      await userBPages.conversationList().openConversation('Test Group');
+
+      // Start intercepting notifications
+      const {clickNotification} = await interceptNotifications(userBPage);
+
+      // User A pings User B
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversation().sendPing();
+
+      await clickNotification({title: userA.fullName, body: 'Pinged'});
+
+      // After clicking the notification B should show the 1on1 conversation instead of the group
+      await expect(userBPages.conversation().conversationTitle).toContainText(userA.fullName);
+    },
+  );
+
+  test(
+    'Verify I can click calling notification while other conversation is opened',
+    {tag: ['@TC-1456', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
+      ]);
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
+
+      await createGroup(userBPages, 'Test Group', [userA]);
+      await userBPages.conversationList().openConversation('Test Group');
+
+      const {clickNotification} = await interceptNotifications(userBPage);
+
+      // User A initiates a call to User B
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversation().clickCallButton();
+
+      // Verify user B receives the call
+      await expect(userBPages.calling().acceptCallButton).toBeVisible();
+
+      // User B clicks the calling notification
+      await clickNotification({title: userA.fullName, body: 'Calling'});
+
+      // Verify clicking the notification opens the calls conversation
+      await expect(userBPages.conversation().conversationTitle).toContainText(userA.fullName);
+    },
+  );
+
+  // ToDo: Wait for confirmation if this test is implemented correctly (title might change)
+  test(
+    'Verify clicking a notification of a team opens team conversation',
+    {tag: ['@TC-1458', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
+      ]);
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
+
+      await createGroup(userBPages, 'Test Group', [userA]);
+      await userBPages.conversationList().openConversation('Test Group');
+
+      // Start intercepting notifications
+      const {clickNotification} = await interceptNotifications(userBPage);
+
+      // User A pings User B
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversation().sendMessage('Test Message');
+
+      await clickNotification({title: userA.fullName, body: 'Test Message'});
+
+      // After clicking the notification B should show the 1on1 conversation instead of the group
+      await expect(userBPages.conversation().conversationTitle).toContainText(userA.fullName);
+    },
+  );
+
+  test(
+    'Verify I see notification when someone creates a group',
+    {tag: ['@TC-1459', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
+      ]);
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+
+      const {getNotifications} = await interceptNotifications(userBPage);
+
+      const groupName = 'Test Group';
+      await createGroup(userAPages, groupName, [userB]);
+
+      // Verify User B receives a notification about the new group
+      await expect
+        .poll(() => getNotifications())
+        .toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              title: `${userA.fullName} in ${groupName}`,
+              body: expect.stringContaining(`${userA.fullName} started a conversation`),
+            }),
+          ]),
+        );
+    },
+  );
+
+  test(
+    'Verify I see notification when group name is changed',
+    {tag: ['@TC-1461', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
+      ]);
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+
+      // User A creates a group with User B
+      const originalGroupName = 'Original Group Name';
+      const newGroupName = 'New Group Name';
+      await createGroup(userAPages, originalGroupName, [userB]);
+
+      // Start intercepting notifications for User B
+      const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
+
+      // User A opens ConversationDetailsPage and changes the group name
+      await userAPages.conversationList().openConversation(originalGroupName);
+      await userAPages.conversation().clickConversationInfoButton();
+      await userAPages.conversationDetails().changeConversationName(newGroupName);
+
+      // Verify User B receives a notification about the group name change
+      await expect
+        .poll(() => getUserBNotifications())
+        .toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              title: `${userA.fullName} in ${newGroupName}`, // Assuming the new group name is in the title
+              body: `${userA.fullName} renamed the conversation to ${newGroupName}`,
+            }),
+          ]),
+        );
+    },
+  );
+
+  test(
+    'Verify I see notification when I receive a connection request',
+    {tag: ['@TC-1462', '@regression']},
+    async ({createPage, createUser}) => {
+      // Create User C as member outside the team
+      const userC = await createUser();
+
+      // Users A and B are created, but not connected for this test
+      const [userAPage, userCPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userC))]);
+
+      // Start intercepting notifications for User B
+      const {getNotifications} = await interceptNotifications(userCPage);
+
+      // User A sends a connection request to User B
+      await sendConnectionRequest(PageManager.from(userAPage), userC);
+
+      // Verify User B receives a notification about the connection request
+      await expect
+        .poll(() => getNotifications())
+        .toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              title: userA.fullName,
+              body: 'Wants to connect',
+            }),
+          ]),
+        );
+    },
+  );
+
+  // ToDo: Check if a notification should be received when removed from group
+  test.fixme(
+    'Verify I see notification when I am removed from group conversation',
+    {tag: ['@TC-1463', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
+      ]);
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
+
+      await createGroup(userAPages, 'Test Group', [userB]);
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+
+      const {getNotifications} = await interceptNotifications(userBPage);
+
+      // User A removes User B from the group
+      await userAPages.conversationList().openConversation('Test Group');
+      await userAPages.conversation().toggleGroupInformation(); // Open conversation details
+      await userAPages.conversation().removeMemberFromGroup(userB.fullName);
+
+      // Verify User B receives a notification about being removed from the group
+      await expect
+        .poll(() => getNotifications())
+        .toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              title: 'Test Group',
+              body: 'You were removed',
+            }),
+          ]),
+        );
+    },
+  );
+
+  test(
+    'Verify I see notification when image is sent to group conversation',
+    {tag: ['@TC-1464', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
+      ]);
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
+
+      const groupName = 'Image Group';
+      await createGroup(userAPages, groupName, [userB]);
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+
+      // Start intercepting notifications for User B
+      const {getNotifications} = await interceptNotifications(userBPage);
+
+      // User A sends an image to the group conversation
+      await userAPages.conversationList().openConversation(groupName);
+      await shareAssetHelper(getImageFilePath(), userAPage, userAPage.getByRole('button', {name: 'Add picture'}));
+
+      await expect
+        .poll(() => getNotifications())
+        .toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              title: `${userA.fullName} in ${groupName}`,
+              body: 'Shared a picture',
+            }),
+          ]),
+        );
+    },
+  );
+
+  test(
+    'Verify I see notification when someone changes the timer',
+    {tag: ['@TC-1466', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
+      ]);
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
+
+      await createGroup(userAPages, 'Test Group', [userB]);
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+
+      const {getNotifications} = await interceptNotifications(userBPage);
+
+      // User A changes the conversation timer to 10 seconds
+      await userAPages.conversationList().openConversation('Test Group');
+      await userAPages.conversation().toggleGroupInformation();
+      await userAPages.conversationDetails().setSelfDeletingMessages('10 seconds');
+
+      // Verify User B receives a notification about the timer change
+      await expect
+        .poll(() => getNotifications())
+        .toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              title: `${userA.fullName} in Test Group`,
+              body: `${userA.fullName} set the message timer to 10 seconds`,
+            }),
+          ]),
+        );
     },
   );
 });

--- a/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
@@ -45,4 +45,38 @@ test.describe('Notifications', () => {
         ]),
       );
   });
+
+  // TODO: This test is currently failing if it's a bug disable it and link bug ticket
+  test(
+    'I should not receive notifications for archived conversations',
+    {tag: ['@TC-8760', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
+      ]);
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const {pages: userBPages, components: userBComponents} = PageManager.from(userBPage).webapp;
+
+      // Start intercepting notifications
+      const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
+
+      // Archive conversation for user B
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().clickConversationOptions(userA.fullName);
+      await userBPages.conversationList().archiveConversation();
+
+      // Send message from A to B in 1on1 conversation
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversation().sendMessage('Hello');
+
+      // Open the archived conversation and ensure the message was received
+      await userBComponents.conversationSidebar().clickArchive();
+      await userBPages.conversationList().openConversation(userA.fullName);
+      await expect(userBPages.conversation().getMessage({sender: userA})).toBeVisible();
+
+      // Check that B did not receive any more notifications
+      await expect.poll(() => getUserBNotifications()).toHaveLength(0);
+    },
+  );
 });

--- a/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
@@ -123,27 +123,41 @@ test.describe('Notifications', () => {
       `I want to mute the ${conversationType} conversation via conversation details`,
       {tag: [testId, '@regression']},
       async ({createPage}) => {
-        const pages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp.pages;
+        const [userAPage, userBPage] = await Promise.all([
+          createPage(withLogin(userA), withConnectedUser(userB)),
+          createPage(withLogin(userB)),
+        ]);
+        const userAPages = PageManager.from(userAPage).webapp.pages;
+        const userBPages = PageManager.from(userBPage).webapp.pages;
+        await createGroup(userAPages, 'Test Group', [userB]);
 
-        let conversationName: string;
-        if (conversationType === 'group') {
-          await createGroup(pages, 'Test Group', [userB]);
-          conversationName = 'Test Group';
+        // Depending on the current test case mute either the group or the 1on1
+        await userBPages
+          .conversationList()
+          .openConversation(conversationType === 'group' ? 'Test Group' : userA.fullName);
+        await userBPages.conversation().clickConversationInfoButton();
+        await expect(userBPages.conversationDetails().notificationsButton).toContainText('Everything');
+
+        // Verify the changed setting is reflected
+        await userBPages.conversationDetails().setNotifications('Nothing');
+        await expect(userBPages.conversationDetails().notificationsButton).toContainText('Nothing');
+
+        // Open the not muted conversation for for userB so a notification could be received
+        if (conversationType == 'group') {
+          await userBPages.conversationList().openConversation(userA.fullName);
         } else {
-          conversationName = userB.fullName;
+          await userBPages.conversationList().openConversation('Test Group');
         }
 
-        await pages.conversationList().openConversation(conversationName);
-        await pages.conversation().clickConversationInfoButton();
-        await expect(pages.conversationDetails().notificationsButton).toContainText('Everything');
+        // Start intercepting notifications for User B
+        const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
 
-        await pages.conversationDetails().setNotifications('Nothing');
-        await expect(pages.conversationDetails().notificationsButton).toContainText('Nothing');
-
-        const conversation = pages.conversationList().getConversationLocator(conversationName);
-        await expect(conversation.getByTitle('Muted conversation')).toBeVisible();
-
-        // ToDo: Ensure you don't receive notifications
+        // User A sends a message to the muted conversation
+        await userAPages
+          .conversationList()
+          .openConversation(conversationType === 'group' ? 'Test Group' : userB.fullName);
+        await userAPages.conversation().sendMessage('Test Message');
+        await expect.poll(() => getUserBNotifications()).toHaveLength(0);
       },
     );
   });

--- a/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
@@ -3,7 +3,7 @@ import {PageManager} from 'test/e2e_tests/pageManager';
 import {interceptNotifications} from 'test/e2e_tests/utils/mockNotifications.util';
 import {test, withLogin, withConnectedUser, expect} from 'test/e2e_tests/test.fixtures';
 import {createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
-import {shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
+import {getAudioFilePath, getTextFilePath, getVideoFilePath, shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
 import {getImageFilePath} from 'test/e2e_tests/utils/sendImage.util';
 
 test.describe('Notifications', () => {
@@ -254,15 +254,43 @@ test.describe('Notifications', () => {
       // Start intercepting notifications for User B
       const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
 
-      // ToDo: Also send types ping, link, audio, video and file transfer to 1on1 and group -> Same for 3 following tests
-      // User A sends a message to User B
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userAPages.conversation().sendMessage('Test Message');
+      for (const conversation of ['1on1', 'group'] as const) {
+        await test.step(`User A opens the ${conversation} conversation`, async () => {
+          if (conversation === '1on1') {
+            await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+          } else {
+            await createGroup(userAPages, 'Test Group', [userB]);
+            await userAPages.conversationList().openConversation('Test Group');
+          }
+        });
 
-      // Verify User B receives a notification containing sender's name and message content
-      await expect
-        .poll(() => getUserBNotifications())
-        .toEqual([expect.objectContaining({title: userA.fullName, body: 'Test Message'})]);
+        await test.step('User A sends a text message, ping, link, picture, audio, video and file to User B', async () => {
+          await userAPages.conversation().sendMessage('Test Message');
+          await userAPages.conversation().sendPing();
+          await userAPages.conversation().sendMessage('https://lidl.de');
+          await shareAssetHelper(getImageFilePath(), userAPage, userAPage.getByRole('button', {name: 'Add picture'}));
+          await shareAssetHelper(getAudioFilePath(), userAPage, userAPage.getByRole('button', {name: 'Add file'}));
+          await shareAssetHelper(getVideoFilePath(), userAPage, userAPage.getByRole('button', {name: 'Add file'}));
+          await shareAssetHelper(getTextFilePath(), userAPage, userAPage.getByRole('button', {name: 'Add file'}));
+        });
+
+        await test.step('UserB should have received a notification for each message', async () => {
+          const expectedTitle = conversation === '1on1' ? userA.fullName : `${userA.fullName} in Test Group`;
+          await expect
+            .poll(() => getUserBNotifications())
+            .toEqual(
+              expect.arrayContaining([
+                expect.objectContaining({title: expectedTitle, body: 'Test Message'}),
+                expect.objectContaining({title: expectedTitle, body: 'Pinged'}),
+                expect.objectContaining({title: expectedTitle, body: 'https://lidl.de'}),
+                expect.objectContaining({title: expectedTitle, body: 'Shared a picture'}),
+                expect.objectContaining({title: expectedTitle, body: 'Shared an audio message'}),
+                expect.objectContaining({title: expectedTitle, body: 'Shared a video'}),
+                expect.objectContaining({title: expectedTitle, body: 'Shared a file'}),
+              ]),
+            );
+        });
+      }
     },
   );
 

--- a/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
@@ -234,22 +234,87 @@ test.describe('Notifications', () => {
     },
   );
 
-  // ToDo: Create parameterized test out of the following 4
-  test(
-    "Sender name and a message are shown in notification when 'Show sender and message' item is selected in preferences",
-    {tag: ['@TC-1450', '@regression']},
-    async ({createPage}) => {
+  (
+    [
+      {
+        testId: '@TC-1450',
+        title:
+          "Sender name and a message are shown in notification when 'Show sender and message' item is selected in preferences",
+        notificationPreference: 'Show sender and message',
+        getExpectedNotifications: (conversationType: '1on1' | 'group') => {
+          const expectedTitle = conversationType === '1on1' ? userA.fullName : `${userA.fullName} in Test Group`;
+          return [
+            {title: expectedTitle, body: 'Test Message'},
+            {title: expectedTitle, body: 'Pinged'},
+            {title: expectedTitle, body: 'https://lidl.de'},
+            {title: expectedTitle, body: 'Shared a picture'},
+            {title: expectedTitle, body: 'Shared an audio message'},
+            {title: expectedTitle, body: 'Shared a video'},
+            {title: expectedTitle, body: 'Shared a file'},
+          ];
+        },
+      },
+      {
+        testId: '@TC-1451',
+        title: "No message content is written on notification when 'Show sender' item is selected in preferences",
+        notificationPreference: 'Show sender',
+        getExpectedNotifications: (conversationType: '1on1' | 'group') => {
+          const expectedTitle = conversationType === '1on1' ? userA.fullName : `${userA.fullName} in Test Group`;
+          return [
+            {title: expectedTitle, body: 'Sent a message'},
+            {title: expectedTitle, body: 'Sent a message'},
+            {title: expectedTitle, body: 'Sent a message'},
+            {title: expectedTitle, body: 'Sent a message'},
+            {title: expectedTitle, body: 'Sent a message'},
+            {title: expectedTitle, body: 'Sent a message'},
+            {title: expectedTitle, body: 'Sent a message'},
+          ];
+        },
+      },
+      {
+        testId: '@TC-1452',
+        title:
+          "No sender name, profile image or message content is written on notification when choose 'Hide details' in preferences",
+        notificationPreference: 'Hide details',
+        getExpectedNotifications: () => [
+          // The default wire icon is called "notification.png", if it is set the users profile picture isn't shown
+          {title: 'Someone', body: 'Sent a message', icon: expect.stringMatching(/notification\.png$/)},
+          {title: 'Someone', body: 'Sent a message', icon: expect.stringMatching(/notification\.png$/)},
+          {title: 'Someone', body: 'Sent a message', icon: expect.stringMatching(/notification\.png$/)},
+          {title: 'Someone', body: 'Sent a message', icon: expect.stringMatching(/notification\.png$/)},
+          {title: 'Someone', body: 'Sent a message', icon: expect.stringMatching(/notification\.png$/)},
+          {title: 'Someone', body: 'Sent a message', icon: expect.stringMatching(/notification\.png$/)},
+          {title: 'Someone', body: 'Sent a message', icon: expect.stringMatching(/notification\.png$/)},
+        ],
+      },
+      {
+        testId: '@TC-1453',
+        title: "No notification shown when selecting 'Off' in preferences",
+        notificationPreference: 'Off',
+        getExpectedNotifications: () => [],
+      },
+    ] as const
+  ).forEach(({testId, title, notificationPreference, getExpectedNotifications}) => {
+    test(title, {tag: [testId, '@regression']}, async ({createPage}) => {
       const [userAPage, userBPage] = await Promise.all([
         createPage(withLogin(userA), withConnectedUser(userB)),
         createPage(withLogin(userB)),
       ]);
-      const {pages: userAPages} = PageManager.from(userAPage).webapp;
+      const {pages: userAPages, components: userAComponents} = PageManager.from(userAPage).webapp;
       const {pages: userBPages, components: userBComponents} = PageManager.from(userBPage).webapp;
 
-      // User B navigates to preferences and sets "Show sender and message"
-      await userBComponents.conversationSidebar().clickPreferencesButton();
-      await userBPages.settings().optionsButton.click();
-      await userBPages.options().setNotifications('Show sender and message');
+      await test.step('User A uploads a profile picture which should not be shown in the notification', async () => {
+        await userAComponents.conversationSidebar().preferencesButton.click();
+        await userAPages.settings().accountButton.click();
+        await userAPages.account().uploadProfilePicture(getImageFilePath());
+        await userAComponents.conversationSidebar().allConverationsButton.click();
+      });
+
+      await test.step(`User B navigates to preferences and sets "${notificationPreference}"`, async () => {
+        await userBComponents.conversationSidebar().clickPreferencesButton();
+        await userBPages.settings().optionsButton.click();
+        await userBPages.options().setNotifications(notificationPreference);
+      });
 
       // Start intercepting notifications for User B
       const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
@@ -275,129 +340,16 @@ test.describe('Notifications', () => {
         });
 
         await test.step('UserB should have received a notification for each message', async () => {
-          const expectedTitle = conversation === '1on1' ? userA.fullName : `${userA.fullName} in Test Group`;
+          const expectedNotifications = getExpectedNotifications(conversation).map(notification =>
+            expect.objectContaining(notification),
+          );
           await expect
             .poll(() => getUserBNotifications())
-            .toEqual(
-              expect.arrayContaining([
-                expect.objectContaining({title: expectedTitle, body: 'Test Message'}),
-                expect.objectContaining({title: expectedTitle, body: 'Pinged'}),
-                expect.objectContaining({title: expectedTitle, body: 'https://lidl.de'}),
-                expect.objectContaining({title: expectedTitle, body: 'Shared a picture'}),
-                expect.objectContaining({title: expectedTitle, body: 'Shared an audio message'}),
-                expect.objectContaining({title: expectedTitle, body: 'Shared a video'}),
-                expect.objectContaining({title: expectedTitle, body: 'Shared a file'}),
-              ]),
-            );
+            .toEqual(expectedNotifications.length ? expect.arrayContaining(expectedNotifications) : []);
         });
       }
-    },
-  );
-
-  test(
-    "No message content is written on notification when 'Show sender' item is selected in preferences",
-    {tag: ['@TC-1451', '@regression']},
-    async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
-      const {pages: userAPages} = PageManager.from(userAPage).webapp;
-      const {pages: userBPages, components: userBComponents} = PageManager.from(userBPage).webapp;
-
-      // User B navigates to preferences and sets "Show sender"
-      await userBComponents.conversationSidebar().clickPreferencesButton();
-      await userBPages.settings().optionsButton.click();
-      await userBPages.options().setNotifications('Show sender');
-
-      // Start intercepting notifications for User B
-      const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
-
-      // User A sends a message to User B
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userAPages.conversation().sendMessage('Test Message');
-
-      // Verify User B receives a notification containing sender's name and message content
-      await expect
-        .poll(() => getUserBNotifications())
-        .toEqual([expect.objectContaining({title: userA.fullName, body: 'Sent a message'})]);
-    },
-  );
-
-  test(
-    "No sender name, profile image or message content is written on notification when choose 'Hide details' in preferences",
-    {tag: ['@TC-1452', '@regression']},
-    async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
-      const {pages: userAPages, components: userAComponents} = PageManager.from(userAPage).webapp;
-      const {pages: userBPages, components: userBComponents} = PageManager.from(userBPage).webapp;
-
-      // User A uploads a profile picture which should not be shown in the notification
-      await userAComponents.conversationSidebar().preferencesButton.click();
-      await userAPages.settings().accountButton.click();
-      await userAPages.account().uploadProfilePicture(getImageFilePath());
-      await userAComponents.conversationSidebar().allConverationsButton.click();
-
-      // User B navigates to preferences and sets "Show sender"
-      await userBComponents.conversationSidebar().preferencesButton.click();
-      await userBPages.settings().optionsButton.click();
-      await userBPages.options().setNotifications('Hide details');
-
-      // Start intercepting notifications for User B
-      const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
-
-      // User A sends a message to User B
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userAPages.conversation().sendMessage('Test Message');
-
-      // Verify User B receives a notification containing sender's name and message content
-      await expect
-        .poll(() => getUserBNotifications())
-        .toEqual([
-          expect.objectContaining({
-            title: 'Someone',
-            body: 'Sent a message',
-            // Verify the icon of the notification is the default one and not the users profile picture
-            icon: expect.stringMatching(/notification\.png$/),
-          }),
-        ]);
-    },
-  );
-
-  test(
-    "No notification shown when selecting 'Off' in preferences",
-    {tag: ['@TC-1453', '@regression']},
-    async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
-      const {pages: userAPages} = PageManager.from(userAPage).webapp;
-      const {pages: userBPages, components: userBComponents} = PageManager.from(userBPage).webapp;
-
-      // User B navigates to preferences and sets "Off"
-      await userBComponents.conversationSidebar().clickPreferencesButton();
-      await userBPages.settings().optionsButton.click();
-      await userBPages.options().setNotifications('Off');
-
-      // Start intercepting notifications for User B
-      const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
-
-      // User A sends a message to User B
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userAPages.conversation().sendMessage('Test Message');
-
-      await userBComponents.conversationSidebar().allConverationsButton.click();
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-      await expect(userBPages.conversation().getMessage({sender: userA})).toBeVisible();
-
-      // Verify User B receives a notification containing sender's name and message content
-      await expect.poll(() => getUserBNotifications()).toHaveLength(0);
-    },
-  );
+    });
+  });
 
   test(
     'Verify I can click ping notification while other conversation is opened',

--- a/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
@@ -305,11 +305,17 @@ test.describe('Notifications', () => {
         createPage(withLogin(userA), withConnectedUser(userB)),
         createPage(withLogin(userB)),
       ]);
-      const {pages: userAPages} = PageManager.from(userAPage).webapp;
+      const {pages: userAPages, components: userAComponents} = PageManager.from(userAPage).webapp;
       const {pages: userBPages, components: userBComponents} = PageManager.from(userBPage).webapp;
 
+      // User A uploads a profile picture which should not be shown in the notification
+      await userAComponents.conversationSidebar().preferencesButton.click();
+      await userAPages.settings().accountButton.click();
+      await userAPages.account().uploadProfilePicture(getImageFilePath());
+      await userAComponents.conversationSidebar().allConverationsButton.click();
+
       // User B navigates to preferences and sets "Show sender"
-      await userBComponents.conversationSidebar().clickPreferencesButton();
+      await userBComponents.conversationSidebar().preferencesButton.click();
       await userBPages.settings().optionsButton.click();
       await userBPages.options().setNotifications('Hide details');
 
@@ -327,7 +333,7 @@ test.describe('Notifications', () => {
           expect.objectContaining({
             title: 'Someone',
             body: 'Sent a message',
-            // ToDo: Give user A a profile picture to ensure this test could fail
+            // Verify the icon of the notification is the default one and not the users profile picture
             icon: expect.stringMatching(/notification\.png$/),
           }),
         ]);

--- a/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
@@ -515,17 +515,17 @@ test.describe('Notifications', () => {
       // Create User C as member outside the team
       const userC = await createUser();
 
-      // Users A and B are created, but not connected for this test
+      // Users A and C are created, but not connected for this test
       const [userAPage, userCPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userC))]);
       const userAPageManager = PageManager.from(userAPage);
 
-      // Start intercepting notifications for User B
+      // Start intercepting notifications for User C
       const {getNotifications} = await interceptNotifications(userCPage);
 
-      // User A sends a connection request to User B
+      // User A sends a connection request to User C
       await sendConnectionRequest(userAPageManager, userC);
 
-      // Verify User B receives a notification about the connection request
+      // Verify User C receives a notification about the connection request
       await expect
         .poll(() => getNotifications())
         .toEqual(

--- a/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
@@ -22,11 +22,6 @@ test.describe('Notifications', () => {
       createPage(withLogin(userB)),
     ]);
     const userAPages = PageManager.from(userAPage).webapp.pages;
-    const userBPages = PageManager.from(userBPage).webapp.pages;
-
-    // Create group so B can open it while A sends the message so a notification will be sent for it
-    await createGroup(userAPages, 'Test Group', [userB]);
-    await userBPages.conversationList().openConversation('Test Group');
 
     // Start intercepting notifications
     const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
@@ -142,13 +137,6 @@ test.describe('Notifications', () => {
         await userBPages.conversationDetails().setNotifications('Nothing');
         await expect(userBPages.conversationDetails().notificationsButton).toContainText('Nothing');
 
-        // Open the not muted conversation for for userB so a notification could be received
-        if (conversationType == 'group') {
-          await userBPages.conversationList().openConversation(userA.fullName);
-        } else {
-          await userBPages.conversationList().openConversation('Test Group');
-        }
-
         // Start intercepting notifications for User B
         const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
 
@@ -230,11 +218,6 @@ test.describe('Notifications', () => {
         createPage(withLogin(userB)),
       ]);
       const userAPages = PageManager.from(userAPage).webapp.pages;
-      const userBPages = PageManager.from(userBPage).webapp.pages;
-
-      // Create group and open it for user B so the message won't be read immediately
-      await createGroup(userBPages, 'Test Group', [userA]);
-      await userBPages.conversationList().openConversation('Test Group');
 
       // Start intercepting notifications for User B
       const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
@@ -554,12 +537,13 @@ test.describe('Notifications', () => {
 
       // Users A and B are created, but not connected for this test
       const [userAPage, userCPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userC))]);
+      const userAPageManager = PageManager.from(userAPage);
 
       // Start intercepting notifications for User B
       const {getNotifications} = await interceptNotifications(userCPage);
 
       // User A sends a connection request to User B
-      await sendConnectionRequest(PageManager.from(userAPage), userC);
+      await sendConnectionRequest(userAPageManager, userC);
 
       // Verify User B receives a notification about the connection request
       await expect

--- a/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
@@ -19,7 +19,6 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {ConfirmModal} from 'test/e2e_tests/pageManager/webapp/modals/confirm.modal';
 import {test, expect, withLogin, withConnectedUser} from 'test/e2e_tests/test.fixtures';
 import {getAudioFilePath, getTextFilePath, getVideoFilePath, shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
 import {getImageFilePath} from 'test/e2e_tests/utils/sendImage.util';
@@ -306,7 +305,6 @@ test.describe('Reply', () => {
 
       await userAPages.conversation().clickConversationInfoButton();
       await userAPages.conversation().removeMemberFromGroup(userB.fullName);
-      await new ConfirmModal(userAPages.conversation().page).clickAction();
       await expect(
         userBPages.conversation().systemMessages.filter({hasText: `${userA.fullName} removed you`}),
       ).toBeVisible();

--- a/apps/webapp/test/e2e_tests/utils/mockNotifications.util.ts
+++ b/apps/webapp/test/e2e_tests/utils/mockNotifications.util.ts
@@ -1,4 +1,4 @@
-import {type Page} from 'playwright/test';
+import {test, expect, type Page} from 'playwright/test';
 
 declare global {
   interface Window {
@@ -42,7 +42,43 @@ const getNotifications = async (page: Page) => {
       title: notification.title,
       body: notification.body,
       data: notification.data,
+      icon: notification.icon,
     })),
+  );
+};
+
+/** Search for a notification matching the given parameters and click it */
+const clickNotification = async (
+  page: Page,
+  notification: {title?: string; body?: string},
+  options?: {timeout?: number},
+) => {
+  // Create a boxed test step so this action shows up like a normal one in the trace viewer
+  await test.step(
+    `Click notification ${JSON.stringify(notification)}`,
+    async () => {
+      // Wrap action with expect to have it retry automatically using global default timeouts
+      await expect(async () => {
+        const notifications = await getNotifications(page);
+
+        // Find a notification matching the given properties
+        const index = notifications.findIndex(
+          n =>
+            // Ignore the property if it's undefined
+            (notification.title !== undefined ? n.title === notification.title : true) &&
+            (notification.body !== undefined ? n.body === notification.body : true),
+        );
+
+        if (index < 0)
+          throw new Error(
+            `Can't click notification ${JSON.stringify(notification)} as it doesn't exist in:\n\n${JSON.stringify(notifications, undefined, 2)}`,
+          );
+
+        // If found trigger its "onclick" callback
+        await page.evaluate(index => window.__wireNotifications.at(index)?.onclick?.(new Event('click')), index);
+      }).toPass({timeout: options?.timeout, intervals: [1_000]});
+    },
+    {box: true},
   );
 };
 
@@ -65,6 +101,12 @@ export const interceptNotifications = async (page: Page) => {
      * Async function to get the notifications the intercepted page received so far.
      * Pass this to `expect.poll()` to avoid flake due to timing issues.
      */
-    getNotifications: () => getNotifications(page),
+    getNotifications: getNotifications.bind(undefined, page),
+    /**
+     * Search for a notification matching the given parameters and click it
+     *
+     * Note: This function won't retry automatically, ensure the notification exists before calling it
+     */
+    clickNotification: clickNotification.bind(undefined, page),
   };
 };


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19961" title="WPB-19961" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19961</a>  [Web/QA] Write the Notification regression tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

# Pull Request

## Summary

- Implement all notification regression tests
- Extend util for intercepting notifications to allow clicking them
- Add util to upload a profile picture for a user within settings
- Fix account settings test
- refactor some utils within POMs along the way

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Notes for reviewers

- 
