### PR TITLE
feat: toggle connect to apps flow visibility [WPB-18618]

### DIFF
--- a/apps/webapp/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
+++ b/apps/webapp/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
@@ -92,8 +92,12 @@ const StartUI = ({
   const isTeam = teamState.isTeam();
   const appsEnabled = teamState?.isAppsEnabled();
   const defaultProtocol = teamState.teamFeatures()?.mls?.config.defaultProtocol;
-  const areServicesSupportedByProtocol = defaultProtocol !== CONVERSATION_PROTOCOL.MLS;
-  const showServiceTab = isTeam && canChatWithServices() && areServicesSupportedByProtocol && appsEnabled;
+  const isProteus = defaultProtocol !== CONVERSATION_PROTOCOL.MLS;
+
+  const showServiceTab =
+    isTeam &&
+    canChatWithServices() &&
+    ((isProteus && teamState?.hasWhitelistedServices()) || (!isProteus && appsEnabled));
 
   const [searchQuery, setSearchQuery] = useState('');
   const [activeTab, setActiveTab] = useState(Tabs.PEOPLE);

--- a/apps/webapp/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
+++ b/apps/webapp/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
@@ -90,9 +90,10 @@ const StartUI = ({
 
   const actions = mainViewModel.actions;
   const isTeam = teamState.isTeam();
+  const appsEnabled = teamState?.isAppsEnabled();
   const defaultProtocol = teamState.teamFeatures()?.mls?.config.defaultProtocol;
   const areServicesSupportedByProtocol = defaultProtocol !== CONVERSATION_PROTOCOL.MLS;
-  const showServiceTab = isTeam && canChatWithServices() && areServicesSupportedByProtocol;
+  const showServiceTab = isTeam && canChatWithServices() && areServicesSupportedByProtocol && appsEnabled;
 
   const [searchQuery, setSearchQuery] = useState('');
   const [activeTab, setActiveTab] = useState(Tabs.PEOPLE);

--- a/apps/webapp/src/script/repositories/team/TeamRepository.test.ts
+++ b/apps/webapp/src/script/repositories/team/TeamRepository.test.ts
@@ -70,11 +70,13 @@ describe('TeamRepository', () => {
   };
   const team_metadata = teams_data.teams[0];
 
+  const services_data = {has_more: false, services: []};
+
   describe('getTeam()', () => {
     it('returns the team entity', async () => {
       const [teamRepo, {teamService}] = buildConnectionRepository();
       jest.spyOn(teamService, 'getTeamById').mockResolvedValue(team_metadata);
-
+      jest.spyOn(teamService, 'getWhitelistedServices').mockResolvedValue(services_data);
       jest.spyOn(teamRepo, 'getSelfMember').mockResolvedValue(new TeamMemberEntity(randomUUID()));
 
       const team_et = await teamRepo.getTeam();
@@ -89,6 +91,7 @@ describe('TeamRepository', () => {
     it('updates team feature config from backend', async () => {
       const [teamRepo, {teamService, teamState}] = buildConnectionRepository();
       jest.spyOn(teamService, 'getTeamById').mockResolvedValue(team_metadata);
+      jest.spyOn(teamService, 'getWhitelistedServices').mockResolvedValue(services_data);
       jest.spyOn(teamRepo, 'getSelfMember').mockResolvedValue(new TeamMemberEntity(randomUUID()));
 
       const localFeatures = {

--- a/apps/webapp/src/script/repositories/team/TeamRepository.ts
+++ b/apps/webapp/src/script/repositories/team/TeamRepository.ts
@@ -282,8 +282,12 @@ export class TeamRepository extends TypedEventEmitter<Events> {
 
     const teamEntity = teamData ? this.teamMapper.mapTeamFromObject(teamData, this.teamState.team()) : new TeamEntity();
     this.teamState.team(teamEntity);
+
     if (teamId) {
       await this.getSelfMember(teamId);
+      this.teamState.hasWhitelistedServices(
+        (await this.teamService.getWhitelistedServices(teamId)).services.length > 0,
+      );
     }
     // doesn't need to be awaited because it publishes the account info over amplify.
     this.sendAccountInfo();

--- a/apps/webapp/src/script/repositories/team/TeamState.ts
+++ b/apps/webapp/src/script/repositories/team/TeamState.ts
@@ -62,6 +62,7 @@ export class TeamState {
   readonly selfRole: ko.PureComputed<Role | undefined>;
   readonly isCellsEnabled: ko.PureComputed<boolean>;
   readonly isAuditLogEnabled: ko.PureComputed<boolean>;
+  readonly isAppsEnabled: ko.PureComputed<boolean>;
 
   constructor(private readonly userState = container.resolve(UserState)) {
     this.isTeam = ko.pureComputed(() => !!this.team()?.id);
@@ -141,6 +142,10 @@ export class TeamState {
 
     this.isCellsEnabled = ko.pureComputed(() => {
       return this.teamFeatures()?.cells?.status === FEATURE_STATUS.ENABLED;
+    });
+
+    this.isAppsEnabled = ko.pureComputed(() => {
+      return this.teamFeatures()?.apps?.status === FEATURE_STATUS.ENABLED;
     });
 
     this.isAuditLogEnabled = ko.pureComputed(() => {

--- a/apps/webapp/src/script/repositories/team/TeamState.ts
+++ b/apps/webapp/src/script/repositories/team/TeamState.ts
@@ -38,6 +38,7 @@ export class TeamState {
   public readonly memberInviters: ko.Observable<Record<string, string>>;
   public readonly memberRoles: ko.Observable<Record<string, ROLE>>;
   public readonly supportsLegalHold: ko.Observable<boolean>;
+  public readonly hasWhitelistedServices: ko.Observable<boolean>;
   public readonly teamName: ko.PureComputed<string>;
   public readonly teamFeatures: ko.Observable<FeatureList | undefined>;
   public readonly classifiedDomains: ko.PureComputed<string[] | undefined>;
@@ -85,6 +86,7 @@ export class TeamState {
     });
 
     this.supportsLegalHold = ko.observable(false);
+    this.hasWhitelistedServices = ko.observable(false);
 
     this.isFileSharingSendingEnabled = ko.pureComputed(() => {
       const status = this.teamFeatures()?.fileSharing?.status;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18618" title="WPB-18618" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18618</a>  [Web] [Integrations] Unhide Connect to App flow 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- Toggling the visibility of the apps tab in the connect flow based on protocols and feature flags
---

## Security Checklist (required)

- [ X ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ X ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ X ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ X ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ X ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ X ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
