### PR TITLE
feat: move raise hand option in context menu behind feature flag [WPB-22795]

### DIFF
--- a/src/script/components/calling/VideoControls/VideoControls.tsx
+++ b/src/script/components/calling/VideoControls/VideoControls.tsx
@@ -340,15 +340,21 @@ export const VideoControls: React.FC<VideoControlsProps> = ({
         ]
       : [];
 
+    const raiseHandEntry: ContextMenuEntry[] = isInCallHandRaiseControlVisible
+      ? [
+          {
+            click: () => toggleIsHandRaised(isSelfHandRaised),
+            label: isSelfHandRaised ? t('videoCallMenuMoreLowerHand') : t('videoCallMenuMoreRaiseHand'),
+            icon: props => <RaiseHandIcon {...props} height={16} width={16} scale={1} />,
+          },
+        ]
+      : [];
+
     showContextMenu({
       event: event.nativeEvent,
       entries: [
         ...mobileEntires,
-        {
-          click: () => toggleIsHandRaised(isSelfHandRaised),
-          label: isSelfHandRaised ? t('videoCallMenuMoreLowerHand') : t('videoCallMenuMoreRaiseHand'),
-          icon: props => <RaiseHandIcon {...props} height={16} width={16} scale={1} />,
-        },
+        ...raiseHandEntry,
         {
           click: () => setIsCallViewOpen(prev => !prev),
           label: t('videoCallMenuMoreChangeView'),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22795" title="WPB-22795" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22795</a>  [Web] Hand raise UI shown despite feature flag disabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary
Move raise hand option in context menu behind feature flag

- What did I change and why?
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
