### PR TITLE
feat(api-client): Update WebSocket connection logic to fallback from /websocket to /await on 404 [WPB-23436]

### DIFF
--- a/jest.preset.js
+++ b/jest.preset.js
@@ -12,6 +12,6 @@ module.exports = {
     '^.+\\.(ts|tsx)$': '@swc/jest',
     '^.+\\.(js|jsx)$': 'babel-jest',
   },
-  transformIgnorePatterns: ['/node_modules/(?!(true-myth)/)'],
+  transformIgnorePatterns: ['/node_modules/(?!(true-myth|p-timeout|p-cancelable)/)'],
   moduleFileExtensions: ['js', 'json', 'ts', 'tsx'],
 };

--- a/libraries/api-client/jest.config.js
+++ b/libraries/api-client/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     '^.+\\.(ts|tsx)$': '@swc/jest',
     '^.+\\.(js|jsx)$': '@swc/jest',
   },
-  transformIgnorePatterns: ['node_modules/'],
+  transformIgnorePatterns: ['/node_modules/(?!(true-myth|p-timeout|p-cancelable)/)'],
   coverageDirectory: '../../coverage/libraries/api-client',
   testMatch: ['<rootDir>/src/**/__tests__/**/*.[jt]s?(x)', '<rootDir>/src/**/?(*.)+(spec|test).[jt]s?(x)'],
   moduleFileExtensions: ['js', 'json', 'ts', 'tsx'],

--- a/libraries/api-client/package.json
+++ b/libraries/api-client/package.json
@@ -25,6 +25,7 @@
     "axios-retry": "4.5.0",
     "cells-sdk-ts": "0.1.1-alpha18",
     "http-status-codes": "2.3.0",
+    "p-cancelable": "4.0.1",
     "p-timeout": "7.0.1",
     "pako": "2.1.0",
     "reconnecting-websocket": "4.4.0",

--- a/libraries/api-client/package.json
+++ b/libraries/api-client/package.json
@@ -25,10 +25,12 @@
     "axios-retry": "4.5.0",
     "cells-sdk-ts": "0.1.1-alpha18",
     "http-status-codes": "2.3.0",
+    "p-timeout": "7.0.1",
     "pako": "2.1.0",
     "reconnecting-websocket": "4.4.0",
     "spark-md5": "3.0.2",
     "tough-cookie": "4.1.4",
+    "true-myth": "9.3.1",
     "ws": "8.19.0",
     "zod": "3.25.76"
   },

--- a/libraries/api-client/src/tcp/FindWebSocketAddressPrefix.test.ts
+++ b/libraries/api-client/src/tcp/FindWebSocketAddressPrefix.test.ts
@@ -1,0 +1,253 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import assert from 'node:assert';
+
+import {findWebSocketAddressPrefix, FindWebSocketAddressPrefixOptions} from './FindWebSocketAddressPrefix';
+
+type FakeSocket = {
+  close: jest.Mock;
+  onopen: (() => void) | null;
+  onerror: (() => void) | null;
+};
+
+type FakeWebSocketFactory = {
+  fakeWebSocket: jest.Mock;
+  closeFunction: jest.Mock;
+};
+
+type DependencyOverrides = {
+  webSocket?: jest.Mock;
+  baseUrl?: string;
+  queryString?: string;
+  connectionTimeoutInMilliseconds?: number;
+};
+
+function createFakeWebSocketThatOpens(): FakeWebSocketFactory {
+  const closeFunction = jest.fn();
+  const fakeWebSocket = jest.fn().mockImplementation(() => {
+    const socket: FakeSocket = {close: closeFunction, onopen: null, onerror: null};
+    setTimeout(() => socket.onopen?.(), 0);
+    return socket;
+  });
+  return {fakeWebSocket, closeFunction};
+}
+
+function createFakeWebSocketThatErrors(): FakeWebSocketFactory {
+  const closeFunction = jest.fn();
+  const fakeWebSocket = jest.fn().mockImplementation(() => {
+    const socket: FakeSocket = {close: closeFunction, onopen: null, onerror: null};
+    setTimeout(() => socket.onerror?.(), 0);
+    return socket;
+  });
+  return {fakeWebSocket, closeFunction};
+}
+
+function createFakeWebSocketThatNeverConnects(): FakeWebSocketFactory {
+  const closeFunction = jest.fn();
+  const fakeWebSocket = jest.fn().mockImplementation(() => {
+    const socket: FakeSocket = {close: closeFunction, onopen: null, onerror: null};
+    return socket;
+  });
+  return {fakeWebSocket, closeFunction};
+}
+
+function createFakeWebSocketThatThrows(): jest.Mock {
+  return jest.fn(() => {
+    throw new Error('WebSocket constructor failed');
+  });
+}
+
+function createDependencies(overrides: DependencyOverrides = {}): FindWebSocketAddressPrefixOptions {
+  return {
+    baseUrl: overrides.baseUrl ?? 'http://localhost:3000',
+    queryString: overrides.queryString ?? 'test=1',
+    webSocket: (overrides.webSocket ?? jest.fn()) as unknown as typeof WebSocket,
+    connectionTimeoutInMilliseconds: overrides.connectionTimeoutInMilliseconds ?? 5000,
+  };
+}
+
+describe('findWebSocketAddressPrefix', () => {
+  it("returns Ok('websocket') when the connection opens successfully", async () => {
+    const {fakeWebSocket} = createFakeWebSocketThatOpens();
+    const dependencies = createDependencies({webSocket: fakeWebSocket});
+
+    const result = await findWebSocketAddressPrefix(dependencies);
+
+    assert(result.isOk);
+    expect(result.value).toBe('websocket');
+  });
+
+  it("returns Err('await') when the websocket fires onerror", async () => {
+    const {fakeWebSocket} = createFakeWebSocketThatErrors();
+    const dependencies = createDependencies({webSocket: fakeWebSocket});
+
+    const result = await findWebSocketAddressPrefix(dependencies);
+
+    assert(result.isErr);
+    expect(result.error).toBe('await');
+  });
+
+  it('returns Err when the WebSocket constructor throws', async () => {
+    const fakeWebSocket = createFakeWebSocketThatThrows();
+    const dependencies = createDependencies({webSocket: fakeWebSocket});
+
+    const result = await findWebSocketAddressPrefix(dependencies);
+
+    assert(result.isErr);
+  });
+
+  it('returns Err when the connection times out', async () => {
+    const {fakeWebSocket} = createFakeWebSocketThatNeverConnects();
+    const dependencies = createDependencies({
+      webSocket: fakeWebSocket,
+      connectionTimeoutInMilliseconds: 50,
+    });
+
+    const result = await findWebSocketAddressPrefix(dependencies);
+
+    assert(result.isErr);
+  });
+
+  it('constructs the websocket URL from baseUrl and queryString', async () => {
+    const {fakeWebSocket} = createFakeWebSocketThatOpens();
+    const dependencies = createDependencies({
+      webSocket: fakeWebSocket,
+      baseUrl: 'https://prod.example.com',
+      queryString: 'client=abc123',
+    });
+
+    await findWebSocketAddressPrefix(dependencies);
+
+    expect(fakeWebSocket).toHaveBeenCalledWith('https://prod.example.com/websocket?client=abc123');
+  });
+
+  it('passes different query strings correctly in the URL', async () => {
+    const {fakeWebSocket} = createFakeWebSocketThatOpens();
+    const dependencies = createDependencies({
+      webSocket: fakeWebSocket,
+      baseUrl: 'http://localhost:8080',
+      queryString: 'foo=bar&baz=qux',
+    });
+
+    await findWebSocketAddressPrefix(dependencies);
+
+    expect(fakeWebSocket).toHaveBeenCalledWith('http://localhost:8080/websocket?foo=bar&baz=qux');
+  });
+
+  it('handles an empty query string', async () => {
+    const {fakeWebSocket} = createFakeWebSocketThatOpens();
+    const dependencies = createDependencies({
+      webSocket: fakeWebSocket,
+      queryString: '',
+    });
+
+    await findWebSocketAddressPrefix(dependencies);
+
+    expect(fakeWebSocket).toHaveBeenCalledWith('http://localhost:3000/websocket?');
+  });
+
+  it('closes the socket after a successful connection', async () => {
+    const {fakeWebSocket, closeFunction} = createFakeWebSocketThatOpens();
+    const dependencies = createDependencies({webSocket: fakeWebSocket});
+
+    await findWebSocketAddressPrefix(dependencies);
+
+    expect(closeFunction).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not close the socket when it errors (socket never opened)', async () => {
+    const {fakeWebSocket, closeFunction} = createFakeWebSocketThatErrors();
+    const dependencies = createDependencies({webSocket: fakeWebSocket});
+
+    await findWebSocketAddressPrefix(dependencies);
+
+    expect(closeFunction).not.toHaveBeenCalled();
+  });
+
+  it('instantiates the websocket exactly once per call', async () => {
+    const {fakeWebSocket} = createFakeWebSocketThatOpens();
+    const dependencies = createDependencies({webSocket: fakeWebSocket});
+
+    await findWebSocketAddressPrefix(dependencies);
+
+    expect(fakeWebSocket).toHaveBeenCalledTimes(1);
+  });
+
+  it("Ok result value is exactly 'websocket', not just a string", async () => {
+    const {fakeWebSocket} = createFakeWebSocketThatOpens();
+    const dependencies = createDependencies({webSocket: fakeWebSocket});
+
+    const result = await findWebSocketAddressPrefix(dependencies);
+
+    assert(result.isOk);
+    expect(result.value).toStrictEqual('websocket');
+  });
+
+  it("Err result from onerror carries 'await' as the error payload", async () => {
+    const {fakeWebSocket} = createFakeWebSocketThatErrors();
+    const dependencies = createDependencies({webSocket: fakeWebSocket});
+
+    const result = await findWebSocketAddressPrefix(dependencies);
+
+    assert(result.isErr);
+    expect(result.error).toStrictEqual('await');
+  });
+
+  it('succeeds if the connection opens before the timeout', async () => {
+    const {fakeWebSocket} = createFakeWebSocketThatOpens();
+    const dependencies = createDependencies({
+      webSocket: fakeWebSocket,
+      connectionTimeoutInMilliseconds: 5000,
+    });
+
+    const result = await findWebSocketAddressPrefix(dependencies);
+
+    assert(result.isOk);
+  });
+
+  it('returns Err with a TimeoutError when the connection is too slow', async () => {
+    const closeFunction = jest.fn();
+    const fakeWebSocket = jest.fn().mockImplementation(() => {
+      const socket: FakeSocket = {close: closeFunction, onopen: null, onerror: null};
+      setTimeout(() => socket.onopen?.(), 10_000);
+      return socket;
+    });
+    const dependencies = createDependencies({
+      webSocket: fakeWebSocket,
+      connectionTimeoutInMilliseconds: 50,
+    });
+
+    const result = await findWebSocketAddressPrefix(dependencies);
+
+    assert(result.isErr);
+    expect((result.error as Error).name).toBe('TimeoutError');
+  });
+
+  it('can be called multiple times independently', async () => {
+    const {fakeWebSocket: fakeWebSocket1} = createFakeWebSocketThatOpens();
+    const {fakeWebSocket: fakeWebSocket2} = createFakeWebSocketThatErrors();
+
+    const result1 = await findWebSocketAddressPrefix(createDependencies({webSocket: fakeWebSocket1}));
+    const result2 = await findWebSocketAddressPrefix(createDependencies({webSocket: fakeWebSocket2}));
+
+    assert(result1.isOk);
+    assert(result2.isErr);
+  });
+});

--- a/libraries/api-client/src/tcp/FindWebSocketAddressPrefix.ts
+++ b/libraries/api-client/src/tcp/FindWebSocketAddressPrefix.ts
@@ -1,0 +1,64 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import PCancelable from 'p-cancelable';
+import pTimeout from 'p-timeout';
+import {Task, task} from 'true-myth';
+
+type WebSocketAddressPrefix = 'websocket' | 'await';
+
+export type FindWebSocketAddressPrefixOptions = {
+  baseUrl: string;
+  queryString: string;
+  webSocket: typeof WebSocket;
+  connectionTimeoutInMilliseconds: number;
+};
+
+function tryToEstablishWebSocketConnection(
+  webSocket: typeof WebSocket,
+  websocketUrl: string,
+): PCancelable<WebSocketAddressPrefix> {
+  return new PCancelable<WebSocketAddressPrefix>((resolve, reject, onCancel) => {
+    const testSocket = new webSocket(websocketUrl);
+    onCancel(() => {
+      testSocket.close();
+    });
+    testSocket.onopen = () => {
+      testSocket.close();
+      resolve('websocket');
+    };
+    testSocket.onerror = () => {
+      reject('await');
+    };
+  });
+}
+
+export function findWebSocketAddressPrefix(
+  dependencies: FindWebSocketAddressPrefixOptions,
+): Task<WebSocketAddressPrefix, unknown> {
+  const {baseUrl, queryString, webSocket, connectionTimeoutInMilliseconds} = dependencies;
+
+  const websocketUrl = `${baseUrl}/websocket?${queryString}`;
+
+  const timeoutPromise = pTimeout(tryToEstablishWebSocketConnection(webSocket, websocketUrl), {
+    milliseconds: connectionTimeoutInMilliseconds,
+  });
+
+  return task.fromPromise<WebSocketAddressPrefix>(timeoutPromise);
+}

--- a/libraries/api-client/src/tcp/WebSocketClient.ts
+++ b/libraries/api-client/src/tcp/WebSocketClient.ts
@@ -66,6 +66,7 @@ export class WebSocketClient extends EventEmitter {
   private bufferedMessages: string[];
   private abortHandler?: AbortController;
   private versionPrefix = '';
+  private cachedSocketAddress?: 'websocket' | 'await';
 
   public static readonly TOPIC = TOPIC;
 
@@ -268,7 +269,10 @@ export class WebSocketClient extends EventEmitter {
 
     const queryString = queryParams.toString();
 
-    const socketAddressToUse = await this.findSocketAddressToUse(this.baseUrl, queryString);
+    if (!this.cachedSocketAddress) {
+      this.cachedSocketAddress = await this.findSocketAddressToUse(this.baseUrl, queryString);
+    }
+    const socketAddressToUse = this.cachedSocketAddress;
 
     const websocketAddress = this.useLegacySocket
       ? `${this.baseUrl}/${socketAddressToUse}?${queryString}`
@@ -286,25 +290,27 @@ export class WebSocketClient extends EventEmitter {
     return new Promise<'websocket' | 'await'>(resolve => {
       const testSocket = new WebSocket(websocketUrl);
 
+      // In case the connection hangs, we fallback to the await endpoint after 5 seconds
+      const timeoutId = setTimeout(() => {
+        if (testSocket.readyState !== WebSocket.OPEN) {
+          handleFailure();
+        }
+      }, 5000);
+
       const handleSuccess = () => {
+        clearTimeout(timeoutId);
         testSocket.close();
         resolve('websocket');
       };
 
       const handleFailure = () => {
+        clearTimeout(timeoutId);
         testSocket.close();
         resolve('await');
       };
 
       testSocket.onopen = handleSuccess;
       testSocket.onerror = handleFailure;
-
-      // In case the connection hangs, we fallback to the await endpoint after 5 seconds
-      setTimeout(() => {
-        if (testSocket.readyState !== WebSocket.OPEN) {
-          handleFailure();
-        }
-      }, 5000);
     });
   }
 

--- a/libraries/api-client/src/tcp/WebSocketClient.ts
+++ b/libraries/api-client/src/tcp/WebSocketClient.ts
@@ -362,5 +362,3 @@ export class WebSocketClient extends EventEmitter {
     return this.socket.checkHealth();
   }
 }
-
-console.info('running new code 3');

--- a/libraries/api-client/src/tcp/WebSocketClient.ts
+++ b/libraries/api-client/src/tcp/WebSocketClient.ts
@@ -126,7 +126,7 @@ export class WebSocketClient extends EventEmitter {
       // before we try any connection, we first refresh the access token to make sure we will avoid concurrent accessToken refreshes
       await this.refreshAccessToken();
     }
-    return this.buildWebSocketUrl();
+    return await this.buildWebSocketUrl();
   };
 
   private readonly onOpen = () => {
@@ -235,22 +235,7 @@ export class WebSocketClient extends EventEmitter {
     return this.isSocketLocked;
   }
 
-  /**
-   * this is a temporary hack method to check if app is running on
-   * wire.com domain in order to use a different temporary websocket
-   * endpoint on wire production server
-   * delete this method as soon as /websocket no longer exists on prod backend
-   * (possibly with next release of web), and change line 284 to use /await only
-   * @returns true if app is connected to wire.com backend
-   */
-  private _temporaryIsProdBackend() {
-    if (typeof window === 'undefined') {
-      return false;
-    }
-    return window.location.hostname.includes('wire.com');
-  }
-
-  public buildWebSocketUrl(): string {
+  public async buildWebSocketUrl(): Promise<string> {
     const {
       accessTokenStore: {getAccessToken, getNextMarkerToken},
     } = this.client;
@@ -283,13 +268,44 @@ export class WebSocketClient extends EventEmitter {
 
     const queryString = queryParams.toString();
 
+    const socketAddressToUse = await this.findSocketAddressToUse(this.baseUrl, queryString);
+
     const websocketAddress = this.useLegacySocket
-      ? `${this.baseUrl}/${this._temporaryIsProdBackend() ? 'websocket' : 'await'}?${queryString}`
+      ? `${this.baseUrl}/${socketAddressToUse}?${queryString}`
       : `${this.baseUrl}${this.versionPrefix}/events?${queryString}`;
 
     this.logger.info(`WebSocket URL: ${websocketAddress}`);
 
     return websocketAddress;
+  }
+
+  private findSocketAddressToUse(baseUrl: string, queryString: string): Promise<'websocket' | 'await'> {
+    const websocketUrl = `${baseUrl}/websocket?${queryString}`;
+
+    // We try to connect to the websocket endpoint first, if it fails we fallback to the await endpoint
+    return new Promise<'websocket' | 'await'>(resolve => {
+      const testSocket = new WebSocket(websocketUrl);
+
+      const handleSuccess = () => {
+        testSocket.close();
+        resolve('websocket');
+      };
+
+      const handleFailure = () => {
+        testSocket.close();
+        resolve('await');
+      };
+
+      testSocket.onopen = handleSuccess;
+      testSocket.onerror = handleFailure;
+
+      // In case the connection hangs, we fallback to the await endpoint after 5 seconds
+      setTimeout(() => {
+        if (testSocket.readyState !== WebSocket.OPEN) {
+          handleFailure();
+        }
+      }, 5000);
+    });
   }
 
   public useAsyncNotificationsSocket() {
@@ -346,3 +362,5 @@ export class WebSocketClient extends EventEmitter {
     return this.socket.checkHealth();
   }
 }
+
+console.info('running new code 3');

--- a/libraries/api-client/src/tcp/WebSocketClient.ts
+++ b/libraries/api-client/src/tcp/WebSocketClient.ts
@@ -19,13 +19,14 @@
 
 import logdown from 'logdown';
 import {ErrorEvent} from 'reconnecting-websocket';
-import {Maybe} from 'true-myth';
+import {Maybe, toolbelt} from 'true-myth';
 
 import {EventEmitter} from 'events';
 
 import {LogFactory} from '@wireapp/commons';
 
 import {AcknowledgeType} from './AcknowledgeEvent.types';
+import {findWebSocketAddressPrefix} from './FindWebSocketAddressPrefix';
 import {ReconnectingWebsocket, WEBSOCKET_STATE} from './ReconnectingWebsocket';
 
 import {InvalidTokenError, MissingCookieAndTokenError, MissingCookieError} from '../auth/';
@@ -271,7 +272,14 @@ export class WebSocketClient extends EventEmitter {
     const queryString = queryParams.toString();
 
     if (this.cachedSocketAddress.isNothing) {
-      this.cachedSocketAddress = Maybe.just(await this.findSocketAddressToUse(this.baseUrl, queryString));
+      const webSocketAddressPrefix = await findWebSocketAddressPrefix({
+        baseUrl: this.baseUrl,
+        queryString,
+        webSocket: WebSocket,
+        connectionTimeoutInMilliseconds: 5000,
+      });
+
+      this.cachedSocketAddress = toolbelt.fromResult(webSocketAddressPrefix);
     }
 
     const webSocketAddress = this.cachedSocketAddress.match({
@@ -288,37 +296,6 @@ export class WebSocketClient extends EventEmitter {
     this.logger.info(`WebSocket URL: ${webSocketAddress}`);
 
     return webSocketAddress;
-  }
-
-  private findSocketAddressToUse(baseUrl: string, queryString: string): Promise<'websocket' | 'await'> {
-    const websocketUrl = `${baseUrl}/websocket?${queryString}`;
-
-    // We try to connect to the websocket endpoint first, if it fails we fallback to the await endpoint
-    return new Promise<'websocket' | 'await'>(resolve => {
-      const testSocket = new WebSocket(websocketUrl);
-
-      // In case the connection hangs, we fallback to the await endpoint after 5 seconds
-      const timeoutId = setTimeout(() => {
-        if (testSocket.readyState !== WebSocket.OPEN) {
-          handleFailure();
-        }
-      }, 5000);
-
-      const handleSuccess = () => {
-        clearTimeout(timeoutId);
-        testSocket.close();
-        resolve('websocket');
-      };
-
-      const handleFailure = () => {
-        clearTimeout(timeoutId);
-        testSocket.close();
-        resolve('await');
-      };
-
-      testSocket.onopen = handleSuccess;
-      testSocket.onerror = handleFailure;
-    });
   }
 
   public useAsyncNotificationsSocket() {

--- a/libraries/api-client/src/tcp/WebSocketClient.ts
+++ b/libraries/api-client/src/tcp/WebSocketClient.ts
@@ -19,6 +19,7 @@
 
 import logdown from 'logdown';
 import {ErrorEvent} from 'reconnecting-websocket';
+import {Maybe} from 'true-myth';
 
 import {EventEmitter} from 'events';
 
@@ -66,7 +67,7 @@ export class WebSocketClient extends EventEmitter {
   private bufferedMessages: string[];
   private abortHandler?: AbortController;
   private versionPrefix = '';
-  private cachedSocketAddress?: 'websocket' | 'await';
+  private cachedSocketAddress: Maybe<'websocket' | 'await'> = Maybe.nothing();
 
   public static readonly TOPIC = TOPIC;
 
@@ -269,18 +270,24 @@ export class WebSocketClient extends EventEmitter {
 
     const queryString = queryParams.toString();
 
-    if (!this.cachedSocketAddress) {
-      this.cachedSocketAddress = await this.findSocketAddressToUse(this.baseUrl, queryString);
+    if (this.cachedSocketAddress.isNothing) {
+      this.cachedSocketAddress = Maybe.just(await this.findSocketAddressToUse(this.baseUrl, queryString));
     }
-    const socketAddressToUse = this.cachedSocketAddress;
 
-    const websocketAddress = this.useLegacySocket
-      ? `${this.baseUrl}/${socketAddressToUse}?${queryString}`
-      : `${this.baseUrl}${this.versionPrefix}/events?${queryString}`;
+    const webSocketAddress = this.cachedSocketAddress.match({
+      Just: cachedSocketPrefixValue => {
+        return this.useLegacySocket
+          ? `${this.baseUrl}/${cachedSocketPrefixValue}?${queryString}`
+          : `${this.baseUrl}${this.versionPrefix}/events?${queryString}`;
+      },
+      Nothing: () => {
+        return `${this.baseUrl}/await?${queryString}`;
+      },
+    });
 
-    this.logger.info(`WebSocket URL: ${websocketAddress}`);
+    this.logger.info(`WebSocket URL: ${webSocketAddress}`);
 
-    return websocketAddress;
+    return webSocketAddress;
   }
 
   private findSocketAddressToUse(baseUrl: string, queryString: string): Promise<'websocket' | 'await'> {

--- a/libraries/core/jest.config.js
+++ b/libraries/core/jest.config.js
@@ -32,7 +32,7 @@ module.exports = {
     '^.+\\.(ts|tsx)$': '@swc/jest',
     '^.+\\.(js|jsx)$': '@swc/jest',
   },
-  transformIgnorePatterns: ['node_modules/'],
+  transformIgnorePatterns: ['/node_modules/(?!(true-myth|p-timeout|p-cancelable)/)'],
   coverageDirectory: '../../coverage/libraries/core',
   testMatch: ['<rootDir>/src/**/__tests__/**/*.[jt]s?(x)', '<rootDir>/src/**/?(*.)+(spec|test).[jt]s?(x)'],
   moduleFileExtensions: ['js', 'json', 'ts', 'tsx'],

--- a/libraries/core/package.json
+++ b/libraries/core/package.json
@@ -25,7 +25,7 @@
     "./lib/cryptography/AssetCryptography/crypto.node": "./lib/cryptography/AssetCryptography/crypto.browser.js"
   },
   "dependencies": {
-    "@wireapp/api-client": "27.95.5",
+    "@wireapp/api-client": "27.95.6",
     "@wireapp/core-crypto": "9.1.2",
     "@wireapp/cryptobox": "12.8.0",
     "@wireapp/priority-queue": "2.1.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10840,26 +10840,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/api-client@npm:27.95.5":
-  version: 27.95.5
-  resolution: "@wireapp/api-client@npm:27.95.5"
-  dependencies:
-    "@aws-sdk/client-s3": "npm:3.975.0"
-    "@aws-sdk/lib-storage": "npm:3.975.0"
-    "@wireapp/priority-queue": "npm:2.1.19"
-    "@wireapp/protocol-messaging": "npm:1.56.0"
-    axios-retry: "npm:4.5.0"
-    cells-sdk-ts: "npm:0.1.1-alpha18"
-    pako: "npm:2.1.0"
-    reconnecting-websocket: "npm:4.4.0"
-    spark-md5: "npm:3.0.2"
-    tough-cookie: "npm:4.1.4"
-    ws: "npm:8.19.0"
-  checksum: 10/f8f1889dcba896144274a016ce80b64562a45eac4f22374d2bab5877ad301b0288d533acc4e4ec730960dbdbf38dbcf6a6b1c067a5619f142b9e31134449be6a
-  languageName: node
-  linkType: hard
-
-"@wireapp/api-client@workspace:libraries/api-client":
+"@wireapp/api-client@npm:27.95.6, @wireapp/api-client@workspace:libraries/api-client":
   version: 0.0.0-use.local
   resolution: "@wireapp/api-client@workspace:libraries/api-client"
   dependencies:
@@ -10973,7 +10954,7 @@ __metadata:
     "@swc/jest": "npm:0.2.39"
     "@types/lodash": "npm:4.17.23"
     "@types/long": "npm:5.0.0"
-    "@wireapp/api-client": "npm:27.95.5"
+    "@wireapp/api-client": "npm:27.95.6"
     "@wireapp/core-crypto": "npm:9.1.2"
     "@wireapp/cryptobox": "npm:12.8.0"
     "@wireapp/priority-queue": "npm:2.1.19"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10863,12 +10863,14 @@ __metadata:
     concurrently: "npm:9.2.1"
     http-status-codes: "npm:2.3.0"
     jest: "npm:^29.7.0"
+    p-timeout: "npm:7.0.1"
     pako: "npm:2.1.0"
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
     reconnecting-websocket: "npm:4.4.0"
     spark-md5: "npm:3.0.2"
     tough-cookie: "npm:4.1.4"
+    true-myth: "npm:9.3.1"
     ts-node: "npm:^10.9.2"
     webpack: "npm:^5.104.1"
     ws: "npm:8.19.0"
@@ -22250,6 +22252,13 @@ __metadata:
     p-limit: "npm:^2.2.2"
     p-reflect: "npm:^2.1.0"
   checksum: 10/83b3dcffef469e572284b2f36ad78db67b271376ef755ed0f91e4ceaf7d81905fb88aeb7e0aa411c7d5cbf74bf9dec8715a241f2d058f712d0f67827140bf1c0
+  languageName: node
+  linkType: hard
+
+"p-timeout@npm:7.0.1":
+  version: 7.0.1
+  resolution: "p-timeout@npm:7.0.1"
+  checksum: 10/1d65827a07fd10eae5bc1fa493ef5c40522acda21cbbb04131cdb0f63f703c91e5fac2701431e28e308992284a86807d7138dbc2be694e2b8342bee20be652f6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10863,6 +10863,7 @@ __metadata:
     concurrently: "npm:9.2.1"
     http-status-codes: "npm:2.3.0"
     jest: "npm:^29.7.0"
+    p-cancelable: "npm:4.0.1"
     p-timeout: "npm:7.0.1"
     pako: "npm:2.1.0"
     react: "npm:18.3.1"
@@ -22143,6 +22144,13 @@ __metadata:
     object-keys: "npm:^1.1.1"
     safe-push-apply: "npm:^1.0.0"
   checksum: 10/ab4bb3b8636908554fc19bf899e225444195092864cb61503a0d048fdaf662b04be2605b636a4ffeaf6e8811f6fcfa8cbb210ec964c0eb1a41eb853e1d5d2f41
+  languageName: node
+  linkType: hard
+
+"p-cancelable@npm:4.0.1":
+  version: 4.0.1
+  resolution: "p-cancelable@npm:4.0.1"
+  checksum: 10/64de7b0be4c8bacc006488e0e90aa66fbcceb4da4f6fb84584573145f015f9650fe6ac26470897b3e82a3b528f6c60ea276b84cc315e35c45e9f12dec062a295
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23436" title="WPB-23436" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23436</a>  [Web] Update WebSocket connection logic to fallback from /websocket to /await on 404
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- What did I change and why?
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
