### PR TITLE
test: disable tests known to always fail [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
@@ -56,7 +56,7 @@ test.describe('AppLock', () => {
     },
   );
 
-  test(
+  test.fixme(
     'Web: App should not lock if I switch back to webapp tab in time (during inactivity timeout)',
     {tag: ['@TC-2752', '@TC-2753', '@regression']},
     async ({browser, createPage}) => {

--- a/apps/webapp/test/e2e_tests/specs/noInternetCallGuard.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/noInternetCallGuard.spec.ts
@@ -32,7 +32,7 @@ let ownerB = getUser();
 const teamAName = 'Direct Call A';
 const teamBName = 'Direct Call B';
 
-test('Starting call 1:1 call without internet', async ({browser, pageManager: ownerAPageManager, api}) => {
+test.fixme('Starting call 1:1 call without internet', async ({browser, pageManager: ownerAPageManager, api}) => {
   test.setTimeout(150_000);
 
   const {pages: ownerAPages, modals: ownerAModals, components: ownerAComponents} = ownerAPageManager.webapp;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

We currently have two e2e tests in the repo which are known to always fail. To reduce confusion and questions about if it's ok that they fail I marked them as fixme to disable them for now.
Tests:
- AppLock -> This test needs to be refactored to work (it has always been failing and should ideally never have been merged)
- noInternetCallGuard -> @zskhan is looking into whether this test case is needed or not with QA. Once there's a decision it will either be fixed and documented in Testiny or removed entirely

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Notes for reviewers

- 
