### PR TITLE
feat: injects wall clock into React context [WPB-23299]

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -32,6 +32,7 @@
     "@lexical/react": "0.27.2",
     "@lexical/rich-text": "0.27.2",
     "@mediapipe/tasks-vision": "0.10.32",
+    "@sindresorhus/is": "4.6.0",
     "@tanstack/react-table": "8.21.3",
     "@tanstack/react-virtual": "3.13.18",
     "@wireapp/avs": "10.2.21",

--- a/apps/webapp/src/script/components/ConnectRequests/ConnectionRequests.tsx
+++ b/apps/webapp/src/script/components/ConnectRequests/ConnectionRequests.tsx
@@ -19,6 +19,7 @@
 
 import {useContext, useEffect, useRef} from 'react';
 
+import is from '@sindresorhus/is';
 import {container} from 'tsyringe';
 
 import {Button, ButtonVariant, IconButton, IconButtonVariant, useMatchMedia} from '@wireapp/react-ui-kit';
@@ -49,7 +50,7 @@ export const ConnectRequests = ({
   const connectRequestsRefEnd = useRef<HTMLDivElement | null>(null);
   const temporaryConnectRequestsCount = useRef<number>(0);
 
-  const mainViewModel = useContext(RootContext);
+  const rootContext = useContext(RootContext);
   const {classifiedDomains} = useKoSubscribableChildren(teamState, ['classifiedDomains']);
   const {connectRequests: unsortedConnectionRequests} = useKoSubscribableChildren(userState, ['connectRequests']);
   const connectionRequests = unsortedConnectionRequests.sort((user1, user2) => {
@@ -88,11 +89,11 @@ export const ConnectRequests = ({
     scrollToBottom();
   }, []);
 
-  if (!mainViewModel) {
+  if (is.null_(rootContext)) {
     return null;
   }
 
-  const actionsViewModel = mainViewModel.actions;
+  const actionsViewModel = rootContext.mainViewModel.actions;
 
   const onIgnoreClick = (userEntity: User): void => {
     actionsViewModel.ignoreConnectionRequest(userEntity);

--- a/apps/webapp/src/script/components/HistoryExport/HistoryExport.tsx
+++ b/apps/webapp/src/script/components/HistoryExport/HistoryExport.tsx
@@ -19,6 +19,7 @@
 
 import {useContext, useEffect, useState} from 'react';
 
+import is from '@sindresorhus/is';
 import {amplify} from 'amplify';
 import {container} from 'tsyringe';
 
@@ -70,17 +71,17 @@ const HistoryExport = ({switchContent, user, clientState = container.resolve(Cli
 
   const [archiveBlob, setArchiveBlob] = useState<Blob | null>(null);
 
-  const mainViewModel = useContext(RootContext);
+  const rootContext = useContext(RootContext);
 
   useEffect(() => {
     showBackupModal();
   }, []);
 
-  if (!mainViewModel) {
+  if (is.null_(rootContext)) {
     return null;
   }
 
-  const {content: contentViewModel} = mainViewModel;
+  const contentViewModel = rootContext.mainViewModel.content;
   const backupRepository = contentViewModel.repositories.backup;
 
   const loadingProgress = Math.floor((numberOfProcessedRecords / numberOfRecords) * 100);

--- a/apps/webapp/src/script/components/Modals/CreateConversation/CreateConversationSteps/ParticipantsSelection.tsx
+++ b/apps/webapp/src/script/components/Modals/CreateConversation/CreateConversationSteps/ParticipantsSelection.tsx
@@ -37,7 +37,7 @@ import {useCreateConversation} from '../hooks/useCreateConversation';
 import {useCreateConversationModal} from '../hooks/useCreateConversationModal';
 
 export const ParticipantsSelection = () => {
-  const mainViewModel = useContext(RootContext);
+  const rootContext = useContext(RootContext);
   const userState = container.resolve(UserState);
   const teamState = container.resolve(TeamState);
   const [participantsInput, setParticipantsInput] = useState<string>('');
@@ -46,12 +46,11 @@ export const ParticipantsSelection = () => {
 
   const {isTeam} = useKoSubscribableChildren(teamState, ['isTeam', 'isMLSEnabled', 'isProtocolToggleEnabledForUser']);
 
-  const {content: contentViewModel} = mainViewModel!;
-  const {
-    conversation: conversationRepository,
-    search: searchRepository,
-    team: teamRepository,
-  } = contentViewModel.repositories;
+  const mainViewModel = rootContext!.mainViewModel;
+  const contentViewModel = mainViewModel.content;
+  const conversationRepository = contentViewModel.repositories.conversation;
+  const searchRepository = contentViewModel.repositories.search;
+  const teamRepository = contentViewModel.repositories.team;
 
   const {self: selfUser} = useKoSubscribableChildren(userState, ['self']);
 

--- a/apps/webapp/src/script/components/Modals/CreateConversation/hooks/useCreateConversation.ts
+++ b/apps/webapp/src/script/components/Modals/CreateConversation/hooks/useCreateConversation.ts
@@ -66,11 +66,13 @@ export const useCreateConversation = () => {
     access: conversationAccess,
     moderator,
   } = useCreateConversationModal();
-  const {setCurrentTab: setCurrentSidebarTab} = useSidebarStore();
+  const sidebarStore = useSidebarStore();
+  const setCurrentSidebarTab = sidebarStore.setCurrentTab;
 
-  const mainViewModel = useContext(RootContext);
-  const {content: contentViewModel} = mainViewModel!;
-  const {conversation: conversationRepository} = contentViewModel.repositories;
+  const rootContext = useContext(RootContext);
+  const mainViewModel = rootContext!.mainViewModel;
+  const contentViewModel = mainViewModel.content;
+  const conversationRepository = contentViewModel.repositories.conversation;
   const teamState = container.resolve(TeamState);
   const {isTeam, isMLSEnabled} = useKoSubscribableChildren(teamState, ['isTeam', 'isMLSEnabled']);
 

--- a/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -19,6 +19,7 @@
 
 import React, {useCallback, useContext, useEffect, useMemo, useState} from 'react';
 
+import is from '@sindresorhus/is';
 import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data/ConversationReceiptModeUpdateData';
 import {CONVERSATION_PROTOCOL, mapToConversationProtocol} from '@wireapp/api-client/lib/team';
 import {isNonFederatingBackendsError} from '@wireapp/core/lib/errors';
@@ -127,7 +128,7 @@ const GroupCreationModal = ({
     GroupCreationModalState.DEFAULT,
   );
 
-  const mainViewModel = useContext(RootContext);
+  const rootContext = useContext(RootContext);
 
   useEffect(() => {
     const showCreateGroup = (_: string, userEntity: User) => {
@@ -197,16 +198,14 @@ const GroupCreationModal = ({
     };
   }, [stateIsParticipants]);
 
-  if (!mainViewModel) {
+  if (is.null_(rootContext)) {
     return null;
   }
 
-  const {content: contentViewModel} = mainViewModel;
-  const {
-    conversation: conversationRepository,
-    search: searchRepository,
-    team: teamRepository,
-  } = contentViewModel.repositories;
+  const contentViewModel = rootContext.mainViewModel.content;
+  const conversationRepository = contentViewModel.repositories.conversation;
+  const searchRepository = contentViewModel.repositories.search;
+  const teamRepository = contentViewModel.repositories.team;
 
   const maxNameLength = ConversationRepository.CONFIG.GROUP.MAX_NAME_LENGTH;
   const maxSize = ConversationRepository.CONFIG.GROUP.MAX_SIZE;

--- a/apps/webapp/src/script/components/Modals/UserModal/UserModal.tsx
+++ b/apps/webapp/src/script/components/Modals/UserModal/UserModal.tsx
@@ -19,6 +19,7 @@
 
 import {useContext, useEffect, useState} from 'react';
 
+import is from '@sindresorhus/is';
 import cx from 'classnames';
 import {container} from 'tsyringe';
 
@@ -62,7 +63,7 @@ interface UserModalUserActionsSectionProps {
 
 const UserModalUserActionsSection = ({user, onAction, isSelfActivated, selfUser}: UserModalUserActionsSectionProps) => {
   const {isBlockedLegalHold} = useKoSubscribableChildren(user, ['isBlockedLegalHold']);
-  const mainViewModel = useContext(RootContext);
+  const rootContext = useContext(RootContext);
 
   if (isBlockedLegalHold) {
     const replaceLinkLegalHold = replaceLink(
@@ -80,14 +81,14 @@ const UserModalUserActionsSection = ({user, onAction, isSelfActivated, selfUser}
     );
   }
 
-  if (!mainViewModel) {
+  if (is.null_(rootContext)) {
     return null;
   }
 
   return (
     <UserActions
       user={user}
-      actionsViewModel={mainViewModel.actions}
+      actionsViewModel={rootContext.mainViewModel.actions}
       onAction={onAction}
       isSelfActivated={isSelfActivated}
       selfUser={selfUser}

--- a/apps/webapp/src/script/page/AppMain.tsx
+++ b/apps/webapp/src/script/page/AppMain.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {useEffect, useLayoutEffect} from 'react';
+import {useEffect, useLayoutEffect, useMemo} from 'react';
 
 import {amplify} from 'amplify';
 import cx from 'classnames';
@@ -62,6 +62,7 @@ import {RootProvider} from './RootProvider';
 import {useAppMainState, ViewType} from './state';
 import {ContentState, useAppState} from './useAppState';
 
+import {createWallClock} from '../clock/wallClock';
 import {App} from '../main/app';
 import {initialiseMLSMigrationFlow} from '../mls/MLSMigration';
 import {generateConversationUrl} from '../router/routeGenerator';
@@ -93,6 +94,9 @@ export const AppMain = ({
   callState = container.resolve(CallState),
   locked,
 }: AppMainProps) => {
+  const wallClock = useMemo(() => {
+    return createWallClock();
+  }, []);
   const apiContext = app.getAPIContext();
 
   useActiveWindow(window);
@@ -287,7 +291,7 @@ export const AppMain = ({
       data-uie-value="is-loaded"
     >
       {!locked && <WindowTitleUpdater />}
-      <RootProvider value={mainView}>
+      <RootProvider value={{mainViewModel: mainView, wallClock}}>
         <ErrorBoundary FallbackComponent={ErrorFallback}>
           {Config.getConfig().FEATURE.ENABLE_DEBUG && <ConfigToolbar />}
           {!locked && (

--- a/apps/webapp/src/script/page/MainContent/MainContent.test.tsx
+++ b/apps/webapp/src/script/page/MainContent/MainContent.test.tsx
@@ -27,6 +27,7 @@ import {MainContent} from './MainContent';
 
 import {withTheme} from '../../auth/util/test/TestUtil';
 import {MainViewModel} from '../../view_model/MainViewModel';
+import {createFakeWallClock} from '../../clock/fakeWallClock';
 import {RootProvider} from '../RootProvider';
 import {ContentState, useAppState} from '../useAppState';
 
@@ -61,6 +62,7 @@ describe('Preferences', () => {
     selfUser: new User('selfUser'),
     reloadApp: jest.fn(),
   };
+  const wallClock = createFakeWallClock();
 
   it('renders the right component according to view state', () => {
     const {setContentState} = useAppState.getState();
@@ -68,7 +70,7 @@ describe('Preferences', () => {
     jest.useFakeTimers();
     render(
       withTheme(
-        <RootProvider value={mainViewModel}>
+        <RootProvider value={{mainViewModel, wallClock}}>
           <MainContent {...defaultParams} />
         </RootProvider>,
       ),

--- a/apps/webapp/src/script/page/MainContent/MainContent.tsx
+++ b/apps/webapp/src/script/page/MainContent/MainContent.tsx
@@ -19,6 +19,7 @@
 
 import {ReactNode, useContext, useEffect, useState} from 'react';
 
+import is from '@sindresorhus/is';
 import cx from 'classnames';
 import {CSSTransition, SwitchTransition} from 'react-transition-group';
 import {container} from 'tsyringe';
@@ -77,7 +78,7 @@ const MainContent = ({
   reloadApp,
 }: MainContentProps) => {
   const [uploadedFile, setUploadedFile] = useState<File | null>(null);
-  const mainViewModel = useContext(RootContext);
+  const rootContext = useContext(RootContext);
 
   const userState = container.resolve(UserState);
   const teamState = container.resolve(TeamState);
@@ -102,10 +103,10 @@ const MainContent = ({
     }
   }, [teamState, showRequestModal]);
 
-  if (!mainViewModel) {
+  if (is.null_(rootContext)) {
     return null;
   }
-  const {content: contentViewModel} = mainViewModel;
+  const contentViewModel = rootContext.mainViewModel.content;
   const {isFederated, repositories, switchContent} = contentViewModel;
 
   /* eslint-disable react-hooks/rules-of-hooks */

--- a/apps/webapp/src/script/page/RootProvider.test.tsx
+++ b/apps/webapp/src/script/page/RootProvider.test.tsx
@@ -1,0 +1,83 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {ReactNode, useContext} from 'react';
+
+import {renderHook} from '@testing-library/react';
+
+import {createFakeWallClock} from '../clock/fakeWallClock';
+import {MainViewModel} from '../view_model/MainViewModel';
+import {RootContext, RootContextValue, RootProvider, useMainViewModel} from './RootProvider';
+
+interface WrapperProperties {
+  children: ReactNode;
+}
+
+interface RootProviderWrapper {
+  wrapper: (properties: WrapperProperties) => ReactNode;
+  fakeWallClock: ReturnType<typeof createFakeWallClock>;
+}
+
+function createRootProviderWrapper(
+  mainViewModel: MainViewModel,
+  wallClockTimestampInMilliseconds: number,
+): RootProviderWrapper {
+  const fakeWallClock = createFakeWallClock({
+    initialCurrentTimestampInMilliseconds: wallClockTimestampInMilliseconds,
+  });
+
+  function wrapper(properties: WrapperProperties): ReactNode {
+    const wrappedChildren = (
+      <RootProvider value={{mainViewModel, wallClock: fakeWallClock}}>{properties.children}</RootProvider>
+    );
+
+    return wrappedChildren;
+  }
+
+  return {wrapper, fakeWallClock};
+}
+
+function getRootContextValue(): RootContextValue | null {
+  const rootContextValue = useContext(RootContext);
+
+  return rootContextValue;
+}
+
+describe('RootProvider', () => {
+  const mainViewModel = {} as MainViewModel;
+
+  it('provides the injected wall clock through context', () => {
+    const {wrapper, fakeWallClock} = createRootProviderWrapper(mainViewModel, 1_234);
+
+    const {result} = renderHook(getRootContextValue, {wrapper});
+
+    expect(result.current?.mainViewModel).toBe(mainViewModel);
+    expect(result.current?.wallClock).toBe(fakeWallClock);
+    expect(result.current?.wallClock.currentTimestampInMilliseconds).toBe(1_234);
+  });
+
+  it('provides the main view model through useMainViewModel()', () => {
+    const {wrapper, fakeWallClock} = createRootProviderWrapper(mainViewModel, 8_765);
+
+    const {result} = renderHook(useMainViewModel, {wrapper});
+
+    expect(result.current).toBe(mainViewModel);
+    expect(fakeWallClock.currentTimestampInMilliseconds).toBe(8_765);
+  });
+});

--- a/apps/webapp/src/script/page/RootProvider.tsx
+++ b/apps/webapp/src/script/page/RootProvider.tsx
@@ -17,26 +17,38 @@
  *
  */
 
-import {FC, ReactNode, createContext, useContext} from 'react';
+import {ReactNode, ReactElement, createContext, useContext, useMemo} from 'react';
 
+import {WallClock} from '../clock/wallClock';
 import {MainViewModel} from '../view_model/MainViewModel';
 
-export const RootContext = createContext<MainViewModel | null>(null);
+export type RootContextValue = {
+  readonly mainViewModel: MainViewModel;
+  readonly wallClock: WallClock;
+};
+
+export const RootContext = createContext<RootContextValue | null>(null);
 
 interface RootProviderProps {
   children?: ReactNode;
-  value: MainViewModel;
+  value: RootContextValue;
 }
 
-export const RootProvider: FC<RootProviderProps> = ({children, value}) => {
-  return <RootContext.Provider value={value}>{children}</RootContext.Provider>;
-};
+export function RootProvider(properties: RootProviderProps): ReactElement {
+  const {value, children} = properties;
 
-export const useMainViewModel = () => {
+  const rootContextValue = useMemo(() => {
+    return value;
+  }, [value]);
+
+  return <RootContext.Provider value={rootContextValue}>{children}</RootContext.Provider>;
+}
+
+export function useMainViewModel(): MainViewModel {
   const context = useContext(RootContext);
   if (!context) {
     throw new Error('MainViewModel was not initialised');
   }
 
-  return context;
-};
+  return context.mainViewModel;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11246,6 +11246,7 @@ __metadata:
     "@nx/webpack": "npm:22.4.1"
     "@playwright/test": "npm:1.58.0"
     "@roamhq/wrtc": "npm:0.9.1"
+    "@sindresorhus/is": "npm:4.6.0"
     "@tanstack/react-table": "npm:8.21.3"
     "@tanstack/react-virtual": "npm:3.13.18"
     "@testing-library/dom": "npm:10.4.1"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23299" title="WPB-23299" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23299</a>  [Web] Add support for remote force reload 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

This will enable us to access the wall clock in all React components without any hook or something like that. This also means testability is guaranteed because for every unit test you just have to create a proper React context and inject the fake clock.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
