### PR TITLE
test: fix tests depending on location service [WPB-22420]

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -58,8 +58,9 @@ jobs:
 
     services:
       # Run the kalium testservice as service container of the current job
+      # (The tag specifies the commit in kalium to use for tests, see https://quay.io/repository/wire/testservice?tab=history for the latest version)
       testservice:
-        image: quay.io/wire/testservice:latest
+        image: quay.io/wire/testservice:5ec1c95b75daa7241e38c97f2916a06a2e40ce1b
         ports:
           - 8080:8080
 

--- a/apps/webapp/test/e2e_tests/backend/ConversationRepository/conversationRepository.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/ConversationRepository/conversationRepository.e2e.ts
@@ -68,7 +68,11 @@ export class ConversationRepositoryE2E extends BackendClientE2E {
     }
   }
 
-  async getConversationWithUser(token: string, conversationPartnerId: string) {
+  async getConversationWithUser(
+    token: string,
+    conversationPartnerId: string,
+    options?: {protocol?: 'proteus' | 'mls'},
+  ) {
     const listIdsResponse = await this.axiosInstance.post(
       'conversations/list-ids',
       {},
@@ -96,11 +100,26 @@ export class ConversationRepositoryE2E extends BackendClientE2E {
       },
     );
 
+    type Conversation = {
+      qualified_id: {id: string};
+      members: {
+        others: {
+          conversation_role: string;
+          id: string;
+        }[];
+      };
+      protocol: 'proteus' | 'mls';
+    };
+
     // Find a conversation with the given user
-    const conversation = response.data.found.find(
-      (conversation: {members: {others: {conversation_role: string; id: string}[]}}) =>
-        conversation.members.others.some((member: {id: string}) => member.id === conversationPartnerId),
+    const conversation = (response.data.found as Conversation[]).find(conversation =>
+      conversation.members.others.some(
+        member =>
+          member.id === conversationPartnerId &&
+          // If a specific protocol to use was provided also filter by it
+          (options?.protocol ? conversation.protocol === options.protocol : true),
+      ),
     );
-    return conversation?.qualified_id?.id;
+    return conversation?.qualified_id.id;
   }
 }

--- a/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
@@ -276,7 +276,7 @@ test.describe('Delete', () => {
     {
       name: 'location sharing',
       tc: '@TC-582',
-      sendAction: async ({pageB, api}) => {
+      sendAction: async ({api}) => {
         const {instanceId} = await api.testService.createInstance(
           userA.password,
           userA.email,
@@ -284,7 +284,10 @@ test.describe('Delete', () => {
           false,
         );
 
-        const conversationId = await api.conversation.getConversationWithUser(userA.token, userB.id!);
+        const conversationId = await api.conversation.getConversationWithUser(userA.token, userB.id!, {
+          protocol: 'mls',
+        });
+        if (conversationId === undefined) throw new Error("Couldn't find MLS conversation of userB with userA");
         await api.testService.sendLocation(instanceId, conversationId, {
           locationName: 'Test Location',
           latitude: 52.5170365,

--- a/apps/webapp/test/e2e_tests/specs/Reactions/reactions.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reactions/reactions.spec.ts
@@ -117,7 +117,8 @@ test.describe('Reactions', () => {
         'Test Service Device',
         false,
       );
-      const conversationId = await api.conversation.getConversationWithUser(userB.token, userA.id!);
+      const conversationId = await api.conversation.getConversationWithUser(userB.token, userA.id!, {protocol: 'mls'});
+      if (conversationId === undefined) throw new Error("Couldn't find MLS conversation of user B with user A");
       await api.testService.sendLocation(instanceId, conversationId, {
         locationName: 'Test Location',
         latitude: 52.5170365,

--- a/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
@@ -227,6 +227,7 @@ test.describe('Reply', () => {
         false,
       );
       const conversationId = await api.conversation.getConversationWithUser(userA.token, userB.id!);
+      if (conversationId === undefined) throw new Error("Couldn't find conversation of userA with userB");
       await api.testService.sendLocation(instanceId, conversationId, {
         locationName: 'Test Location',
         latitude: 52.5170365,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

This solves an issue where the conversation the testservice sends the message into would still be the proteus one instead of the id of the MLS conversation. (Maybe some update in the backend changed to order of conversation ids, now it's deterministic)

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Notes for reviewers

- 
