### PR TITLE
refactor: remove test util "isConversationItemVisible" [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -62,12 +62,6 @@ export class ConversationListPage {
     this.clearContentButton = page.getByRole('button', {name: 'Clear content'});
   }
 
-  async isConversationItemVisible(conversationName: string) {
-    const conversation = this.getConversationLocator(conversationName);
-    await conversation.waitFor({state: 'visible'});
-    return await conversation.isVisible();
-  }
-
   async isConversationBlocked(conversationName: string) {
     return await this.getConversationLocator(conversationName).getByTestId('status-blocked').isVisible();
   }

--- a/apps/webapp/test/e2e_tests/specs/AccountSettingsSpecs/accountSettings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AccountSettingsSpecs/accountSettings.spec.ts
@@ -239,7 +239,7 @@ test.describe('account settings', () => {
 
       await createGroup(pages, groupName, [memberB]);
       // check that the chat is open
-      expect(await pages.conversationList().isConversationItemVisible(groupName)).toBeTruthy();
+      await expect(pages.conversationList().getConversationLocator(groupName)).toBeVisible();
       await pages.conversation().sendMessage('test');
       const message = pages.conversation().getMessage({content: 'test', sender: memberA});
 

--- a/apps/webapp/test/e2e_tests/specs/ArchiveSpecs/archive.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ArchiveSpecs/archive.spec.ts
@@ -50,13 +50,13 @@ test.describe('Accessibility', () => {
       await pages.conversationList().archiveConversation();
       await components.conversationSidebar().clickArchive();
 
-      expect(await pages.conversationList().isConversationItemVisible(memberB.fullName)).toBeTruthy();
+      await expect(pages.conversationList().getConversationLocator(memberB.fullName)).toBeVisible();
 
       await pages.conversationList().clickConversationOptions(memberB.fullName);
       await pages.conversationList().unarchiveConversation();
       await components.conversationSidebar().clickAllConversationsButton();
 
-      expect(await pages.conversationList().isConversationItemVisible(memberB.fullName)).toBeTruthy();
+      await expect(pages.conversationList().getConversationLocator(memberB.fullName)).toBeVisible();
     },
   );
 
@@ -87,7 +87,7 @@ test.describe('Accessibility', () => {
       }
       await pages.conversationList().clickConversationOptions(memberB.fullName);
 
-      expect(await pages.conversationList().isConversationItemVisible(memberB.fullName)).toBeTruthy();
+      await expect(pages.conversationList().getConversationLocator(memberB.fullName)).toBeVisible();
 
       await componentsB.conversationSidebar().clickAllConversationsButton();
       await pagesB.conversationList().openConversation(memberA.fullName);
@@ -95,7 +95,7 @@ test.describe('Accessibility', () => {
       await pages.conversationList().archiveConversation();
       await components.conversationSidebar().clickArchive();
 
-      expect(await pages.conversationList().isConversationItemVisible(memberB.fullName)).toBeTruthy();
+      await expect(pages.conversationList().getConversationLocator(memberB.fullName)).toBeVisible();
 
       await pages.conversationList().clickConversationOptions(memberB.fullName);
       await pages.conversationList().unarchiveConversation();
@@ -116,7 +116,7 @@ test.describe('Accessibility', () => {
       await pageManager.waitForTimeout(400);
       await components.conversationSidebar().clickArchive();
 
-      expect(await pages.conversationList().isConversationItemVisible(groupName)).toBeTruthy();
+      await expect(pages.conversationList().getConversationLocator(groupName)).toBeVisible();
 
       await pages.conversationList().clickConversationOptions(groupName);
       await pages.conversationList().unarchiveConversation();
@@ -140,7 +140,7 @@ test.describe('Accessibility', () => {
       await pages.conversationDetails().clickArchiveButton();
       await components.conversationSidebar().clickArchive();
 
-      expect(await pages.conversationList().isConversationItemVisible(memberB.fullName)).toBeTruthy();
+      await expect(pages.conversationList().getConversationLocator(memberB.fullName)).toBeVisible();
 
       await pages.conversationList().clickConversationOptions(memberB.fullName);
       await pages.conversationList().unarchiveConversation();

--- a/apps/webapp/test/e2e_tests/specs/Connections/Connections.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Connections/Connections.spec.ts
@@ -70,7 +70,7 @@ test.describe('Connections', () => {
         await pages.conversationList().archiveConversation();
         await components.conversationSidebar().clickArchive();
 
-        expect(await pages.conversationList().isConversationItemVisible(memberB.fullName)).toBeTruthy();
+        await expect(pages.conversationList().getConversationLocator(memberB.fullName)).toBeVisible();
       });
     },
   );

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
@@ -57,7 +57,7 @@ test(
     await test.step('Team owner creates group conversation with team members', async () => {
       const {pages} = ownerPageManager.webapp;
       await createGroup(pages, conversationName, [member1, member2]);
-      expect(await pages.conversationList().isConversationItemVisible(conversationName)).toBeTruthy();
+      await expect(pages.conversationList().getConversationLocator(conversationName)).toBeVisible();
     });
 
     await test.step('Team owner adds a service to newly created group', async () => {

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsCall-TC-8755.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsCall-TC-8755.spec.ts
@@ -59,7 +59,7 @@ test.fixme(
     await test.step('Team owner creates a channel with available member', async () => {
       const {pages} = ownerPageManager.webapp;
       await createGroup(pages, channelName, [member]);
-      expect(await pages.conversationList().isConversationItemVisible(channelName)).toBeTruthy();
+      await expect(pages.conversationList().getConversationLocator(channelName)).toBeVisible();
     });
 
     await test.step('Owner starts a call in channel', async () => {

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsManagement-TC-8752.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsManagement-TC-8752.spec.ts
@@ -55,7 +55,7 @@ test.fixme('Channels Management', {tag: ['@TC-8752', '@crit-flow-web']}, async (
   await test.step('Team owner creates a channel with available member', async () => {
     const {pages} = ownerPageManager.webapp;
     await createGroup(pages, conversation1, [member]);
-    expect(await pages.conversationList().isConversationItemVisible(conversation1)).toBeTruthy();
+    await expect(pages.conversationList().getConversationLocator(conversation1)).toBeVisible();
   });
 
   await test.step('Team members leave the conversation', async () => {
@@ -80,7 +80,7 @@ test.fixme('Channels Management', {tag: ['@TC-8752', '@crit-flow-web']}, async (
   await test.step('Team owner creates another channel', async () => {
     const {pages} = ownerPageManager.webapp;
     await createGroup(pages, conversation2, [member]);
-    expect(await pages.conversationList().isConversationItemVisible(conversation2)).toBeTruthy();
+    await expect(pages.conversationList().getConversationLocator(conversation2)).toBeVisible();
   });
 
   await test.step('Team owner makes the member an admin', async () => {

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
@@ -50,7 +50,7 @@ test('Conversation Management', {tag: ['@TC-8636', '@crit-flow-web']}, async ({c
   await test.step('Team owner creates a group with all the five members', async () => {
     const {pages} = ownerPageManager.webapp;
     await createGroup(pages, conversationName, members);
-    expect(await pages.conversationList().isConversationItemVisible(conversationName)).toBeTruthy();
+    await expect(pages.conversationList().getConversationLocator(conversationName)).toBeVisible();
   });
 
   await test.step('Team owner sends a message in the conversation', async () => {
@@ -98,7 +98,7 @@ test('Conversation Management', {tag: ['@TC-8636', '@crit-flow-web']}, async ({c
     const {pages} = ownerPageManager.webapp;
     await pages.conversationList().searchConversation(conversationName);
     await pages.conversationList().openConversation(conversationName);
-    expect(await pages.conversationList().isConversationItemVisible(conversationName)).toBeTruthy();
+    await expect(pages.conversationList().getConversationLocator(conversationName)).toBeVisible();
     await pages.conversationList().openConversation(conversationName);
   });
 

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupCalls-TC-8632.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupCalls-TC-8632.spec.ts
@@ -58,7 +58,7 @@ test.fixme(
     await test.step('Owner creates group and adds the member', async () => {
       const {pages} = ownerPageManager.webapp;
       await createGroup(pages, conversationName, [member]);
-      expect(await pages.conversationList().isConversationItemVisible(conversationName)).toBeTruthy();
+      await expect(pages.conversationList().getConversationLocator(conversationName)).toBeVisible();
     });
 
     await test.step('Owner starts call', async () => {

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupVideoCall-TC-8637.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupVideoCall-TC-8637.spec.ts
@@ -65,7 +65,7 @@ test.fixme(
     await test.step('Owner and team member are in a group conversation together', async () => {
       const {pages} = ownerPageManager.webapp;
       await createGroup(pages, conversationName, [teamMember]);
-      expect(await pages.conversationList().isConversationItemVisible(conversationName)).toBeTruthy();
+      await expect(pages.conversationList().getConversationLocator(conversationName)).toBeVisible();
     });
 
     await test.step('Owner invites guest user to the group', async () => {
@@ -80,7 +80,7 @@ test.fixme(
 
     await test.step('Guest user joins the group', async () => {
       const {pages} = guestPageManager.webapp;
-      expect(await pages.conversationList().isConversationItemVisible(conversationName)).toBeTruthy();
+      await expect(pages.conversationList().getConversationLocator(conversationName)).toBeVisible();
     });
 
     await test.step('Owner calls the group', async () => {

--- a/apps/webapp/test/e2e_tests/specs/noInternetCallGuard.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/noInternetCallGuard.spec.ts
@@ -80,7 +80,7 @@ test.fixme('Starting call 1:1 call without internet', async ({browser, pageManag
     await ownerAPages.startUI().selectUsers(ownerB.username);
     await ownerAModals.userProfile().clickConnectButton();
 
-    expect(await ownerAPages.conversationList().isConversationItemVisible(ownerB.fullName));
+    await expect(ownerAPages.conversationList().getConversationLocator(ownerB.fullName)).toBeVisible();
     await expect(ownerBPage).toHaveTitle('(1) Wire');
 
     await ownerBPages.conversationList().openPendingConnectionRequest();


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

The removed util followed bad practices and was easy to replace with retriable assertions of playwright

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
