### PR TITLE
refactor: add missing default to new role parameter to fix TS error [WPB-19962]

### DIFF
--- a/apps/webapp/test/e2e_tests/backend/teamRepository.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/teamRepository.e2e.ts
@@ -24,7 +24,7 @@ import {User} from '../data/user';
 import {Role} from '@wireapp/api-client/lib/team';
 
 export class TeamRepositoryE2E extends BackendClientE2E {
-  async inviteUserToTeam(emailOfInvitee: string, teamOwner: User, role: Role): Promise<string> {
+  async inviteUserToTeam(emailOfInvitee: string, teamOwner: User, role: Role = Role.MEMBER): Promise<string> {
     const response = this.axiosInstance.post(
       `teams/${teamOwner.teamId}/invitations`,
       {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19962" title="WPB-19962" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19962</a>  [Web/QA] Write the Participant Profile regression tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- A TS Error was accidentially introduced due to type checking being disabled in CI

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
