### PR TITLE
feat: starts periodic checks when application is mounted [WPB-23299]

### DIFF
--- a/apps/webapp/src/script/page/AppMain.tsx
+++ b/apps/webapp/src/script/page/AppMain.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {useEffect, useLayoutEffect, useMemo} from 'react';
+import {useCallback, useEffect, useLayoutEffect, useMemo} from 'react';
 
 import {amplify} from 'amplify';
 import cx from 'classnames';
@@ -59,6 +59,7 @@ import {SidebarTabs, useSidebarStore} from './LeftSidebar/panels/Conversations/u
 import {MainContent} from './MainContent';
 import {PanelEntity, PanelState, RightSidebar} from './RightSidebar';
 import {RootProvider} from './RootProvider';
+import {startApplicationPeriodicChecks} from './startApplicationPeriodicChecks';
 import {useAppMainState, ViewType} from './state';
 import {ContentState, useAppState} from './useAppState';
 
@@ -67,6 +68,7 @@ import {App} from '../main/app';
 import {initialiseMLSMigrationFlow} from '../mls/MLSMigration';
 import {generateConversationUrl} from '../router/routeGenerator';
 import {configureRoutes, navigate} from '../router/Router';
+import {TIME_IN_MILLIS} from '../util/TimeUtil';
 import {MainViewModel} from '../view_model/MainViewModel';
 import {WarningsContainer} from '../view_model/WarningsContainer/WarningsContainer';
 
@@ -97,7 +99,18 @@ export const AppMain = ({
   const wallClock = useMemo(() => {
     return createWallClock();
   }, []);
+  const runApplicationPeriodicCheck: () => void = useCallback(() => {
+    return undefined;
+  }, []);
   const apiContext = app.getAPIContext();
+
+  useEffect(() => {
+    return startApplicationPeriodicChecks({
+      wallClock,
+      periodicChecksIntervalDelayInMilliseconds: TIME_IN_MILLIS.MINUTE * 5,
+      runPeriodicCheck: runApplicationPeriodicCheck,
+    });
+  }, [wallClock, runApplicationPeriodicCheck]);
 
   useActiveWindow(window);
 

--- a/apps/webapp/src/script/page/startApplicationPeriodicChecks.test.ts
+++ b/apps/webapp/src/script/page/startApplicationPeriodicChecks.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {createFakeWallClock} from '../clock/fakeWallClock';
+import {startApplicationPeriodicChecks} from './startApplicationPeriodicChecks';
+
+describe('startApplicationPeriodicChecks', () => {
+  it('executes periodic checks immediately and again after each configured delay', () => {
+    const fakeWallClock = createFakeWallClock({initialCurrentTimestampInMilliseconds: 0});
+    const periodicChecksIntervalDelayInMilliseconds = 1_234;
+    const runPeriodicCheck = jest.fn();
+
+    startApplicationPeriodicChecks({
+      wallClock: fakeWallClock,
+      periodicChecksIntervalDelayInMilliseconds,
+      runPeriodicCheck,
+    });
+
+    expect(runPeriodicCheck).toHaveBeenCalledTimes(1);
+
+    fakeWallClock.advanceByMilliseconds(periodicChecksIntervalDelayInMilliseconds - 1);
+    expect(runPeriodicCheck).toHaveBeenCalledTimes(1);
+
+    fakeWallClock.advanceByMilliseconds(periodicChecksIntervalDelayInMilliseconds);
+
+    expect(runPeriodicCheck).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops executing periodic checks after cleanup is called', () => {
+    const fakeWallClock = createFakeWallClock({initialCurrentTimestampInMilliseconds: 0});
+    const periodicChecksIntervalDelayInMilliseconds = 567;
+    const runPeriodicCheck = jest.fn();
+
+    const stopPeriodicChecks = startApplicationPeriodicChecks({
+      wallClock: fakeWallClock,
+      periodicChecksIntervalDelayInMilliseconds,
+      runPeriodicCheck,
+    });
+
+    fakeWallClock.advanceByMilliseconds(periodicChecksIntervalDelayInMilliseconds);
+    stopPeriodicChecks();
+    fakeWallClock.advanceByMilliseconds(periodicChecksIntervalDelayInMilliseconds);
+
+    expect(runPeriodicCheck).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/webapp/src/script/page/startApplicationPeriodicChecks.ts
+++ b/apps/webapp/src/script/page/startApplicationPeriodicChecks.ts
@@ -1,0 +1,38 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {WallClock} from '../clock/wallClock';
+
+interface StartApplicationPeriodicChecksOptions {
+  readonly wallClock: WallClock;
+  readonly periodicChecksIntervalDelayInMilliseconds: number;
+  readonly runPeriodicCheck: () => void;
+}
+
+export function startApplicationPeriodicChecks(options: StartApplicationPeriodicChecksOptions): () => void {
+  const {wallClock, periodicChecksIntervalDelayInMilliseconds, runPeriodicCheck} = options;
+
+  runPeriodicCheck();
+
+  const intervalIdentifier = wallClock.setInterval(runPeriodicCheck, periodicChecksIntervalDelayInMilliseconds);
+
+  return () => {
+    wallClock.clearInterval(intervalIdentifier);
+  };
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23299" title="WPB-23299" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23299</a>  [Web] Add support for remote force reload 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

This will start a periodic check with a [noop](https://en.wikipedia.org/wiki/NOP_(code)) every 5 minutes. This is needed to check for the version number every 5 minutes when the application starts.

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
