### PR TITLE
chore(ci): retarget release tags after squash-merge before npm publish [WPB-23275]

### DIFF
--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -28,11 +28,7 @@ jobs:
       - name: Enable auto-merge
         if: ${{github.actor == 'otto-the-bot' || (github.actor == 'dependabot[bot]' && steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major') || (github.event.pull_request.labels && contains(github.event.pull_request.labels.*.name, 'publish-to-npm')) }}
         run: |
-          if [[ "${{ github.event.pull_request.labels }}" == *publish-to-npm* ]]; then
-            gh pr merge --auto --merge "$PR_URL"
-          else
-            gh pr merge --auto --squash "$PR_URL"
-          fi
+          gh pr merge --auto --squash "$PR_URL"
         env:
           GITHUB_TOKEN: ${{secrets.OTTO_THE_BOT_GH_TOKEN}}
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/publish-libraries-on-merge.yml
+++ b/.github/workflows/publish-libraries-on-merge.yml
@@ -28,6 +28,54 @@ jobs:
           # if other PRs merge between trigger and job start
           ref: ${{ github.event.pull_request.merge_commit_sha }}
 
+      - name: Retarget release tags to squash merge commit
+        if: github.event_name == 'pull_request'
+        env:
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          echo "🔧 Retargeting release tags from PR head to merge commit"
+          echo "PR_HEAD_SHA=$PR_HEAD_SHA"
+          echo "MERGE_SHA=$MERGE_SHA"
+
+          git fetch --force --tags origin
+
+          # Tags are created on the PR branch commit. After squash-merge, that commit is no longer on dev,
+          # so we force-move those tags to the squash merge commit.
+          ALL_POINTS_AT="$(git tag --points-at "$PR_HEAD_SHA" || true)"
+          if [ -z "$ALL_POINTS_AT" ]; then
+            echo "❌ No git tags found pointing at PR head commit ($PR_HEAD_SHA)."
+            echo "This likely means the release workflow didn't create/push tags for this PR. Aborting publish."
+            exit 1
+          fi
+
+          # Only retarget tags matching the expected {lib}@{version} shape.
+          TAGS_TO_MOVE="$(printf '%s\n' "$ALL_POINTS_AT" | grep -E '^[A-Za-z0-9._-]+@[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$' || true)"
+          if [ -z "$TAGS_TO_MOVE" ]; then
+            echo "❌ Tags pointing at PR head exist, but none match the {lib}@{version} pattern. Aborting publish."
+            echo "Tags found:"
+            printf '%s\n' "$ALL_POINTS_AT"
+            exit 1
+          fi
+
+          echo "📌 Tags to retarget:"
+          printf '%s\n' "$TAGS_TO_MOVE"
+
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+
+            old_sha="$(git rev-parse "$tag^{commit}")"
+            git tag -f "$tag" "$MERGE_SHA"
+            new_sha="$(git rev-parse "$tag^{commit}")"
+
+            echo "🔁 $tag: $old_sha -> $new_sha"
+
+            # Force-push the updated tag ref.
+            git push origin -f "refs/tags/$tag"
+          done <<< "$TAGS_TO_MOVE"
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/publish-libraries.yml
+++ b/.github/workflows/publish-libraries.yml
@@ -77,6 +77,6 @@ jobs:
             --head "$RELEASE_BRANCH" \
             --title "chore(release): publish libraries [WPB-22420]" \
             --label "publish-to-npm" \
-            --body "Automated release PR created by nx release. ⚠️ **Important:** Do NOT squash merge this PR. Use 'Merge commit' to preserve git tags."
+            --body "Automated release PR created by nx release. ⚠️ **Important:** Squash-merge this PR (do not use 'Merge commit')."
         env:
           GITHUB_TOKEN: ${{ secrets.OTTO_THE_BOT_GH_TOKEN }}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23275" title="WPB-23275" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23275</a>  [Web] Fix publish workflow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- What did I change and why?
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
