### PR TITLE
test: implement regression tests for in conversation search [WPB-19955]

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/collection.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/collection.page.ts
@@ -23,10 +23,12 @@ import {Locator, Page} from '@playwright/test';
 export class CollectionPage {
   readonly page: Page;
   readonly component: Locator;
+  readonly searchResults: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.component = page.locator('#collection');
+    this.searchResults = this.component.getByTestId('full-search-item');
   }
 
   get searchInput() {
@@ -41,27 +43,14 @@ export class CollectionPage {
     await this.searchInput.fill(search);
   }
 
-  get imagesSection() {
-    return this.component.locator('section').filter({has: this.page.locator('header', {hasText: 'Images'})});
+  getSection(type: 'Images' | 'Audio' | 'Files') {
+    const section = this.component.locator('section').filter({has: this.page.locator('header', {hasText: type})});
+    return Object.assign(section, {
+      showAllButton: section.getByRole('button', {name: 'Show all'}),
+    });
   }
 
-  get audioSection() {
-    return this.component.locator('section').filter({has: this.page.locator('header', {hasText: 'Audio'})});
-  }
-
-  get filesSection() {
-    return this.component.locator('section').filter({has: this.page.locator('header', {hasText: 'Files'})});
-  }
-
-  get overviewImagesButton() {
-    return this.imagesSection.getByRole('button', {name: /Show all/i});
-  }
-
-  get overviewFilesButton() {
-    return this.filesSection.getByRole('button', {name: /Show all/i});
-  }
-
-  get fullSearchBar() {
+  get searchBar() {
     return this.component.getByRole('textbox', {name: 'Search text messages'});
   }
 
@@ -69,21 +58,4 @@ export class CollectionPage {
     return this.component.getByText('No results.', {exact: true});
   }
 
-  /**
-   * Returns a locator for the highlighted (marked) text within the search results.
-   * @param searchTerm The text you expect to be highlighted.
-   */
-  getMarkedSearchResult(searchTerm: string): Locator {
-    return this.component.locator('mark').filter({hasText: searchTerm});
-  }
-
-  /** Locates the text content of every search result item */
-  get resultTexts() {
-    return this.component.locator('[data-uie-name="full-search-item-text"]');
-  }
-
-  /** Gets all result texts as an array of strings */
-  async getAllResultTexts(): Promise<string[]> {
-    return await this.resultTexts.allInnerTexts();
-  }
 }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/collection.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/collection.page.ts
@@ -21,21 +21,69 @@ import {Locator, Page} from '@playwright/test';
 
 /** POM for the "collection". This page is accessible by searching for a message within a conversation. */
 export class CollectionPage {
-  readonly page: Locator;
+  readonly page: Page;
+  readonly component: Locator;
 
   constructor(page: Page) {
-    this.page = page.locator('#collection');
+    this.page = page;
+    this.component = page.locator('#collection');
   }
 
   get searchInput() {
-    return this.page.getByRole('textbox', {name: 'Search text messages'});
+    return this.component.getByRole('textbox', {name: 'Search text messages'});
   }
 
   get searchItems() {
-    return this.page.getByTestId('full-search-item');
+    return this.component.getByTestId('full-search-item');
   }
 
   async searchForMessages(search: string) {
     await this.searchInput.fill(search);
+  }
+
+  get imagesSection() {
+    return this.component.locator('section').filter({has: this.page.locator('header', {hasText: 'Images'})});
+  }
+
+  get audioSection() {
+    return this.component.locator('section').filter({has: this.page.locator('header', {hasText: 'Audio'})});
+  }
+
+  get filesSection() {
+    return this.component.locator('section').filter({has: this.page.locator('header', {hasText: 'Files'})});
+  }
+
+  get overviewImagesButton() {
+    return this.imagesSection.getByRole('button', {name: /Show all/i});
+  }
+
+  get overviewFilesButton() {
+    return this.filesSection.getByRole('button', {name: /Show all/i});
+  }
+
+  get fullSearchBar() {
+    return this.component.getByRole('textbox', {name: 'Search text messages'});
+  }
+
+  get noResultsMessage() {
+    return this.component.getByText('No results.', {exact: true});
+  }
+
+  /**
+   * Returns a locator for the highlighted (marked) text within the search results.
+   * @param searchTerm The text you expect to be highlighted.
+   */
+  getMarkedSearchResult(searchTerm: string): Locator {
+    return this.component.locator('mark').filter({hasText: searchTerm});
+  }
+
+  /** Locates the text content of every search result item */
+  get resultTexts() {
+    return this.component.locator('[data-uie-name="full-search-item-text"]');
+  }
+
+  /** Gets all result texts as an array of strings */
+  async getAllResultTexts(): Promise<string[]> {
+    return await this.resultTexts.allInnerTexts();
   }
 }

--- a/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
@@ -183,7 +183,8 @@ test.describe('In Conversation Search', () => {
     },
   );
 
-  test('Verify I can search my own message', {tag: ['@TC-385', '@regression']}, async ({createPage}) => {
+  // TODO: [WPB-23814] - search behavior is broken
+  test.skip('Verify I can search my own message', {tag: ['@TC-385', '@regression']}, async ({createPage}) => {
     const [userAPages, userBPages] = await Promise.all([
       PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
@@ -199,11 +200,11 @@ test.describe('In Conversation Search', () => {
     const collection = userAPages.collection();
     await collection.searchBar.fill('User A');
 
-    // TODO: uncomment the next two lines when search behavior is fixed
+    // TODO: uncomment the next two lines when bug [WPB-23814] is fixed
     // await expect(collection.searchResults).toHaveCount(1);
     // await expect(collection.searchResults).toContainText('User A Message');
 
-    // TODO: remove this line when search behavior is fixed
+    // TODO: remove this line when bug [WPB-23814] is fixed
     await expect(collection.searchResults.last()).toContainText('User A Message');
   });
 
@@ -252,7 +253,6 @@ test.describe('In Conversation Search', () => {
 
     await expect(collection.searchResults).toHaveCount(1);
     await expect(collection.searchResults).toContainText('https://www.kaufland.de');
-
   });
 
   test('Verify I can not search for a deleted message', {tag: ['@TC-392', '@regression']}, async ({createPage}) => {
@@ -355,8 +355,7 @@ test.describe('In Conversation Search', () => {
       await userBPages.conversation().sendMessage('Papaya');
 
       await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await expect(userAPages.conversation().getMessage({content: 'Papaya'})).toBeVisible()
-      ;
+      await expect(userAPages.conversation().getMessage({content: 'Papaya'})).toBeVisible();
       await userAPages.conversation().sendMessage(`Message from User A: 1`);
       await userAPages.conversation().sendMessage('Empty\n'.repeat(50));
       await userAPages.conversation().sendMessage(`Message from User A: 2`);
@@ -372,10 +371,9 @@ test.describe('In Conversation Search', () => {
       await expect(collection.searchResults).toHaveCount(1);
       await expect(collection.searchResults).toContainText('Papaya');
 
-      const markedSearchResult = userAPages.collection().component.locator('mark').filter({hasText: 'Papaya'});
-      await markedSearchResult.click();
+      await userAPages.collection().searchResults.click();
       const messageFromUserB = userAPages.conversation().getMessage({sender: userB});
-      await expect(messageFromUserB).toBeVisible();
+      await expect(messageFromUserB).toBeInViewport();
     },
   );
 });

--- a/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
@@ -24,7 +24,7 @@ import {getAudioFilePath, getTextFilePath, shareAssetHelper} from 'test/e2e_test
 import {getImageFilePath} from 'test/e2e_tests/utils/sendImage.util';
 import {createGroup} from '../../utils/userActions';
 
-test.describe('Reactions', () => {
+test.describe('In Conversation Search', () => {
   let userA: User;
   let userB: User;
 

--- a/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
@@ -29,9 +29,8 @@ test.describe('In Conversation Search', () => {
   let userB: User;
 
   test.beforeEach(async ({createTeam}) => {
-    const team = await createTeam('Test Team', {withMembers: 1});
+    const team = await createTeam('Test Team', {users: [userB]});
     userA = team.owner;
-    userB = team.members[0];
   });
 
   // TODO: links are not shown to the collection - this part of the test is blocked by [WPB-22484]
@@ -41,11 +40,11 @@ test.describe('In Conversation Search', () => {
     async ({createPage}) => {
       const [userAPages, userBPages] = await Promise.all([
         PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
       // Preconditions: User B sends media from all categories (images, links, audio and files)
-      await userBPages.conversationList().openConversation(userA.fullName);
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
       const {page} = userBPages.conversation();
       // Image
       await shareAssetHelper(getImageFilePath(), page, page.getByRole('button', {name: 'Add picture'}));
@@ -54,12 +53,12 @@ test.describe('In Conversation Search', () => {
       // File
       await shareAssetHelper(getTextFilePath(), page, page.getByRole('button', {name: 'Add file'}));
 
-      await userAPages.conversationList().openConversation(userB.fullName);
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
       await userAPages.conversation().searchButton.click();
       const collection = userAPages.collection();
-      await expect(collection.imagesSection).toBeVisible();
-      await expect(collection.audioSection).toBeVisible();
-      await expect(collection.filesSection).toBeVisible();
+      await expect(collection.getSection('Images')).toBeVisible();
+      await expect(collection.getSection('Audio')).toBeVisible();
+      await expect(collection.getSection('Files')).toBeVisible();
     },
   );
 
@@ -69,27 +68,27 @@ test.describe('In Conversation Search', () => {
     async ({createPage}) => {
       const [userAPages, userBPages] = await Promise.all([
         PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
       const conversationName = 'Test Group';
       await createGroup(userAPages, conversationName, [userB]);
 
       await userBPages.conversationList().openConversation(conversationName);
-      let {page} = userBPages.conversation();
+      const {page: pageB} = userBPages.conversation();
 
-      for (let i = 0; i < 10; i++) {
-        await shareAssetHelper(getImageFilePath(), page, page.getByRole('button', {name: 'Add picture'}));
+      for (let imageCount = 0; imageCount < 10; imageCount++) {
+        await shareAssetHelper(getImageFilePath(), pageB, pageB.getByRole('button', {name: 'Add picture'}));
       }
 
       await userAPages.conversationList().openConversation(conversationName);
-      ({page} = userAPages.conversation());
-      for (let i = 0; i < 10; i++) {
-        await shareAssetHelper(getImageFilePath(), page, page.getByRole('button', {name: 'Add picture'}));
+      const {page: pageA} = userAPages.conversation();
+      for (let imageCount = 0; imageCount < 10; imageCount++) {
+        await shareAssetHelper(getImageFilePath(), pageA, pageA.getByRole('button', {name: 'Add picture'}));
       }
 
       await userAPages.conversation().searchButton.click();
-      await expect(userAPages.collection().overviewImagesButton).toBeVisible();
+      await expect(userAPages.collection().getSection('Images').showAllButton).toBeVisible();
     },
   );
 
@@ -97,22 +96,24 @@ test.describe('In Conversation Search', () => {
     'Verify opening single picture from all shared media overview',
     {tag: ['@TC-357', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      const [userAPageManager, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
+      const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
+
       await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-      let {page} = userBPages.conversation();
-      await shareAssetHelper(getImageFilePath(), page, page.getByRole('button', {name: 'Add picture'}));
+      const {page: pageB} = userBPages.conversation();
+      await shareAssetHelper(getImageFilePath(), pageB, pageB.getByRole('button', {name: 'Add picture'}));
 
       await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      ({page} = userAPages.conversation());
-      await shareAssetHelper(getImageFilePath(), page, page.getByRole('button', {name: 'Add picture'}));
+      const {page: pageA} = userAPages.conversation();
+      await shareAssetHelper(getImageFilePath(), pageA, pageA.getByRole('button', {name: 'Add picture'}));
 
       await userAPages.conversation().searchButton.click();
-      await userAPages.collection().page.getByRole('presentation').click();
-      await expect(userAPages.collection().page.getByRole('presentation')).toBeVisible();
+      await userAPages.collection().getSection('Images').getByRole('presentation').first().click();
+      await expect(userAModals.detailViewModal().image).toBeVisible();
     },
   );
 
@@ -120,7 +121,7 @@ test.describe('In Conversation Search', () => {
   test.skip('Verify opening overview of all links', {tag: ['@TC-358', '@regression']}, async ({createPage}) => {
     const [userAPages, userBPages] = await Promise.all([
       PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
     await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
@@ -136,24 +137,24 @@ test.describe('In Conversation Search', () => {
   test('Verify opening overview of all files', {tag: ['@TC-359', '@regression']}, async ({createPage}) => {
     const [userAPages, userBPages] = await Promise.all([
       PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
     await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-    let {page} = userBPages.conversation();
+    const {page: pageB} = userBPages.conversation();
 
-    for (let i = 0; i < 10; i++) {
-      await shareAssetHelper(getTextFilePath(), page, page.getByRole('button', {name: 'Add file'}));
+    for (let fileCount = 0; fileCount < 10; fileCount++) {
+      await shareAssetHelper(getTextFilePath(), pageB, pageB.getByRole('button', {name: 'Add file'}));
     }
 
     await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-    ({page} = userAPages.conversation());
-    for (let i = 0; i < 10; i++) {
-      await shareAssetHelper(getTextFilePath(), page, page.getByRole('button', {name: 'Add file'}));
+    const {page: pageA} = userAPages.conversation();
+    for (let fileCount = 0; fileCount < 10; fileCount++) {
+      await shareAssetHelper(getTextFilePath(), pageA, pageA.getByRole('button', {name: 'Add file'}));
     }
 
     await userAPages.conversation().searchButton.click();
-    await expect(userAPages.collection().overviewFilesButton).toBeVisible();
+    await expect(userAPages.collection().getSection('Files').showAllButton).toBeVisible();
   });
 
   test(
@@ -162,13 +163,14 @@ test.describe('In Conversation Search', () => {
     async ({createPage}) => {
       const [userAPages, userBPages] = await Promise.all([
         PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
       await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-      let {page} = userBPages.conversation();
-      await shareAssetHelper(getImageFilePath(), page, page.getByRole('button', {name: 'Add picture'}));
+      const {page: pageB} = userBPages.conversation();
+      await shareAssetHelper(getImageFilePath(), pageB, pageB.getByRole('button', {name: 'Add picture'}));
 
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
       const messageWithImage = userAPages.conversation().getMessage({sender: userB});
       await expect(messageWithImage).toBeVisible();
 
@@ -176,14 +178,14 @@ test.describe('In Conversation Search', () => {
       await userBPages.conversation().deleteMessage(messageB, 'Everyone');
 
       await userAPages.conversation().searchButton.click();
-      await expect(userAPages.collection().overviewImagesButton).not.toBeVisible();
+      await expect(userAPages.collection().getSection('Images').showAllButton).not.toBeVisible();
     },
   );
 
   test('Verify I can search my own message', {tag: ['@TC-385', '@regression']}, async ({createPage}) => {
     const [userAPages, userBPages] = await Promise.all([
       PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
     await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
@@ -193,8 +195,15 @@ test.describe('In Conversation Search', () => {
     await userAPages.conversation().sendMessage('User A Message');
 
     await userAPages.conversation().searchButton.click();
-    await userAPages.collection().fullSearchBar.fill('User A');
-    await expect(userAPages.collection().getMarkedSearchResult('User A')).toBeVisible();
+    const collection = userAPages.collection();
+    await collection.searchBar.fill('User A');
+
+    // TODO: uncomment the next two lines when search behavior is fixed
+    // await expect(collection.searchResults).toHaveCount(1);
+    // await expect(collection.searchResults).toContainText('User A Message');
+
+    // TODO: remove this line when search behavior is fixed
+    await expect(collection.searchResults.last()).toContainText('User A Message');
   });
 
   // TODO: links are not shown to the collection - this part of the test is blocked by [WPB-22484]
@@ -204,7 +213,7 @@ test.describe('In Conversation Search', () => {
     async ({createPage}) => {
       const [userAPages, userBPages] = await Promise.all([
         PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
       await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
@@ -214,15 +223,18 @@ test.describe('In Conversation Search', () => {
       await userAPages.conversation().sendMessage('Here is a link: [LinkPreview]https://www.kaufland.de');
 
       await userAPages.conversation().searchButton.click();
-      await userAPages.collection().fullSearchBar.fill('link: LinkPreview');
-      await expect(userAPages.collection().getMarkedSearchResult('link: linkPreview')).toBeVisible();
+
+      const collection = userAPages.collection();
+      await collection.searchBar.fill('link: LinkPreview');
+      await expect(collection.searchResults).toHaveCount(1);
+      await expect(collection.searchResults).toContainText('Here is a link: [LinkPreview]https://www.kaufland.de');
     },
   );
 
   test('Verify I can search for links without preview', {tag: ['@TC-391', '@regression']}, async ({createPage}) => {
     const [userAPages, userBPages] = await Promise.all([
       PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
     await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
@@ -231,15 +243,21 @@ test.describe('In Conversation Search', () => {
     await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
     await userAPages.conversation().sendMessage('https://www.kaufland.de');
 
+    await expect(userBPages.conversation().getMessage({content: 'https://www.kaufland.de'})).toBeVisible();
     await userAPages.conversation().searchButton.click();
-    await userAPages.collection().fullSearchBar.fill('kaufland');
-    await expect(userAPages.collection().getMarkedSearchResult('kaufland').first()).toBeVisible();
+
+    const collection = userAPages.collection();
+    await collection.searchBar.fill('kaufland');
+
+    await expect(collection.searchResults).toHaveCount(1);
+    await expect(collection.searchResults).toContainText('https://www.kaufland.de');
+
   });
 
   test('Verify I can not search for a deleted message', {tag: ['@TC-392', '@regression']}, async ({createPage}) => {
     const [userAPages, userBPages] = await Promise.all([
       PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
     await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
@@ -252,7 +270,7 @@ test.describe('In Conversation Search', () => {
     await userBPages.conversation().deleteMessage(messageUserB, 'Everyone');
 
     await userAPages.conversation().searchButton.click();
-    await userAPages.collection().fullSearchBar.fill('Papaya');
+    await userAPages.collection().searchBar.fill('Papaya');
     await expect(userAPages.collection().noResultsMessage).toBeVisible();
   });
 
@@ -262,12 +280,14 @@ test.describe('In Conversation Search', () => {
     async ({createPage}) => {
       const [userAPages, userBPages] = await Promise.all([
         PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
       // User B sends the first (older) message
       await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
       await userBPages.conversation().sendMessage('Older Message from User B');
+
+      await expect(userAPages.conversation().getMessage({sender: userB})).toBeVisible();
 
       //  User A sends the second (newer) message
       await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
@@ -275,20 +295,18 @@ test.describe('In Conversation Search', () => {
 
       await userAPages.conversation().searchButton.click();
       const collection = userAPages.collection();
-      await collection.fullSearchBar.fill('Message');
+      await collection.searchBar.fill('Message');
 
-      await expect(collection.resultTexts).toHaveCount(2);
-
-      const results = await collection.getAllResultTexts();
-      expect(results[0]).toContain('Newer Message from User A');
-      expect(results[1]).toContain('Older Message from User B');
+      await expect(collection.searchResults).toHaveCount(2);
+      await expect(collection.searchResults.first()).toContainText('Newer Message from User A');
+      await expect(collection.searchResults.last()).toContainText('Older Message from User B');
     },
   );
 
   test('Verify I can find a message with special letters', {tag: ['@TC-403', '@regression']}, async ({createPage}) => {
     const [userAPages, userBPages] = await Promise.all([
       PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
     const specialWord = 'Crème brûlée';
@@ -299,26 +317,28 @@ test.describe('In Conversation Search', () => {
     await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
     await userAPages.conversation().searchButton.click();
 
-    await userAPages.collection().fullSearchBar.fill(specialWord);
-
-    await expect(userAPages.collection().getMarkedSearchResult(specialWord)).toBeVisible();
+    const collection = userAPages.collection();
+    await collection.searchBar.fill(specialWord);
+    await expect(collection.searchResults).toHaveCount(1);
+    await expect(collection.searchResults).toContainText(`Message with diacritical letter: ${specialWord}`);
   });
 
   test('Verify invisible characters in search are trimmed', {tag: ['@TC-405', '@regression']}, async ({createPage}) => {
     const [userAPages, userBPages] = await Promise.all([
       PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
     await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-    await userBPages.conversation().sendMessage(`User B message`);
+    await userBPages.conversation().sendMessage('User B message');
 
     await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
     await userAPages.conversation().searchButton.click();
 
-    await userAPages.collection().fullSearchBar.fill('  message');
-
-    await expect(userAPages.collection().getMarkedSearchResult('message')).toBeVisible();
+    const collection = userAPages.collection();
+    await collection.searchBar.fill('  message');
+    await expect(collection.searchResults).toHaveCount(1);
+    await expect(collection.searchResults).toContainText('User B message');
   });
 
   test(
@@ -327,22 +347,32 @@ test.describe('In Conversation Search', () => {
     async ({createPage}) => {
       const [userAPages, userBPages] = await Promise.all([
         PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
       await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
       await userBPages.conversation().sendMessage('Papaya');
 
       await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      for (let i = 0; i < 20; i++) {
-        await userAPages.conversation().sendMessage(`Message from User A: ${i}`);
-      }
+      await expect(userAPages.conversation().getMessage({content: 'Papaya'})).toBeVisible()
+      ;
+      await userAPages.conversation().sendMessage(`Message from User A: 1`);
+      await userAPages.conversation().sendMessage('Empty\n'.repeat(50));
+      await userAPages.conversation().sendMessage(`Message from User A: 2`);
 
-      await expect(userAPages.conversation().getMessage({content: 'Message from User A: 19'})).toBeVisible();
+      await expect(userAPages.conversation().getMessage({content: 'Message from User A: 2'})).toBeInViewport();
+      await expect(userAPages.conversation().getMessage({content: 'Message from User A: 1'})).not.toBeInViewport();
 
       await userAPages.conversation().searchButton.click();
-      await userAPages.collection().fullSearchBar.fill('Papaya');
-      await userAPages.collection().getMarkedSearchResult('Papaya').click();
+      await userAPages.collection().searchBar.fill('Papaya');
+
+      const collection = userAPages.collection();
+      await collection.searchBar.fill('Papaya');
+      await expect(collection.searchResults).toHaveCount(1);
+      await expect(collection.searchResults).toContainText('Papaya');
+
+      const markedSearchResult = userAPages.collection().component.locator('mark').filter({hasText: 'Papaya'});
+      await markedSearchResult.click();
       const messageFromUserB = userAPages.conversation().getMessage({sender: userB});
       await expect(messageFromUserB).toBeVisible();
     },

--- a/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
@@ -201,7 +201,22 @@ test.describe('Reactions', () => {
   test.skip(
     'Verify I can search for text mixed with a link preview',
     {tag: ['@TC-388', '@regression']},
-    async () => {},
+    async ({createPage}) => {
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      ]);
+
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversation().sendMessage('User B message');
+
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversation().sendMessage('Here is a link: [LinkPreview]https://www.kaufland.de');
+
+      await userAPages.conversation().searchButton.click();
+      await userAPages.collection().fullSearchBar.fill('link: LinkPreview');
+      await expect(userAPages.collection().getMarkedSearchResult('link: linkPreview')).toBeVisible();
+    },
   );
 
   test('Verify I can search for links without preview', {tag: ['@TC-391', '@regression']}, async ({createPage}) => {

--- a/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
@@ -28,7 +28,8 @@ test.describe('In Conversation Search', () => {
   let userA: User;
   let userB: User;
 
-  test.beforeEach(async ({createTeam}) => {
+  test.beforeEach(async ({createUser, createTeam}) => {
+    userB = await createUser();
     const team = await createTeam('Test Team', {users: [userB]});
     userA = team.owner;
   });

--- a/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
@@ -1,0 +1,335 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {User} from 'test/e2e_tests/data/user';
+import {PageManager} from 'test/e2e_tests/pageManager';
+import {test, expect, withLogin, withConnectedUser} from 'test/e2e_tests/test.fixtures';
+import {getAudioFilePath, getTextFilePath, shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
+import {getImageFilePath} from 'test/e2e_tests/utils/sendImage.util';
+import {createGroup} from '../../utils/userActions';
+
+test.describe('Reactions', () => {
+  let userA: User;
+  let userB: User;
+
+  test.beforeEach(async ({createTeam}) => {
+    const team = await createTeam('Test Team', {withMembers: 1});
+    userA = team.owner;
+    userB = team.members[0];
+  });
+
+  // TODO: links are not shown to the collection - this part of the test is blocked by [WPB-22484]
+  test(
+    'Verify main overview shows media from all categories',
+    {tag: ['@TC-352', '@regression']},
+    async ({createPage}) => {
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      ]);
+
+      // Preconditions: User B sends media from all categories (images, links, audio and files)
+      await userBPages.conversationList().openConversation(userA.fullName);
+      const {page} = userBPages.conversation();
+      // Image
+      await shareAssetHelper(getImageFilePath(), page, page.getByRole('button', {name: 'Add picture'}));
+      // Audio
+      await shareAssetHelper(getAudioFilePath(), page, page.getByRole('button', {name: 'Add file'}));
+      // File
+      await shareAssetHelper(getTextFilePath(), page, page.getByRole('button', {name: 'Add file'}));
+
+      await userAPages.conversationList().openConversation(userB.fullName);
+      await userAPages.conversation().searchButton.click();
+      const collection = userAPages.collection();
+      await expect(collection.imagesSection).toBeVisible();
+      await expect(collection.audioSection).toBeVisible();
+      await expect(collection.filesSection).toBeVisible();
+    },
+  );
+
+  test(
+    'Verify opening overview of all pictures from sender and receiver in group',
+    {tag: ['@TC-356', '@regression']},
+    async ({createPage}) => {
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      ]);
+
+      const conversationName = 'Test Group';
+      await createGroup(userAPages, conversationName, [userB]);
+
+      await userBPages.conversationList().openConversation(conversationName);
+      let {page} = userBPages.conversation();
+
+      for (let i = 0; i < 10; i++) {
+        await shareAssetHelper(getImageFilePath(), page, page.getByRole('button', {name: 'Add picture'}));
+      }
+
+      await userAPages.conversationList().openConversation(conversationName);
+      ({page} = userAPages.conversation());
+      for (let i = 0; i < 10; i++) {
+        await shareAssetHelper(getImageFilePath(), page, page.getByRole('button', {name: 'Add picture'}));
+      }
+
+      await userAPages.conversation().searchButton.click();
+      await expect(userAPages.collection().overviewImagesButton).toBeVisible();
+    },
+  );
+
+  test(
+    'Verify opening single picture from all shared media overview',
+    {tag: ['@TC-357', '@regression']},
+    async ({createPage}) => {
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      ]);
+
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      let {page} = userBPages.conversation();
+      await shareAssetHelper(getImageFilePath(), page, page.getByRole('button', {name: 'Add picture'}));
+
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      ({page} = userAPages.conversation());
+      await shareAssetHelper(getImageFilePath(), page, page.getByRole('button', {name: 'Add picture'}));
+
+      await userAPages.conversation().searchButton.click();
+      await userAPages.collection().page.getByRole('presentation').click();
+      await expect(userAPages.collection().page.getByRole('presentation')).toBeVisible();
+    },
+  );
+
+  // TODO: links are not shown to the collection - this part of the test is blocked by [WPB-22484]
+  test.skip('Verify opening overview of all links', {tag: ['@TC-358', '@regression']}, async ({createPage}) => {
+    const [userAPages, userBPages] = await Promise.all([
+      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+    ]);
+
+    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    // Step: User B sends several links
+
+    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+    // Step: User B sends several links
+
+    await userAPages.conversation().searchButton.click();
+    // Step: Verify links overview button is visible
+  });
+
+  test('Verify opening overview of all files', {tag: ['@TC-359', '@regression']}, async ({createPage}) => {
+    const [userAPages, userBPages] = await Promise.all([
+      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+    ]);
+
+    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    let {page} = userBPages.conversation();
+
+    for (let i = 0; i < 10; i++) {
+      await shareAssetHelper(getTextFilePath(), page, page.getByRole('button', {name: 'Add file'}));
+    }
+
+    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+    ({page} = userAPages.conversation());
+    for (let i = 0; i < 10; i++) {
+      await shareAssetHelper(getTextFilePath(), page, page.getByRole('button', {name: 'Add file'}));
+    }
+
+    await userAPages.conversation().searchButton.click();
+    await expect(userAPages.collection().overviewFilesButton).toBeVisible();
+  });
+
+  test(
+    "Verify deleted media isn't in collection on other side",
+    {tag: ['@TC-360', '@regression']},
+    async ({createPage}) => {
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      ]);
+
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      let {page} = userBPages.conversation();
+      await shareAssetHelper(getImageFilePath(), page, page.getByRole('button', {name: 'Add picture'}));
+
+      const messageWithImage = userAPages.conversation().getMessage({sender: userB});
+      await expect(messageWithImage).toBeVisible();
+
+      const messageB = userBPages.conversation().getMessage({sender: userB});
+      await userBPages.conversation().deleteMessage(messageB, 'Everyone');
+
+      await userAPages.conversation().searchButton.click();
+      await expect(userAPages.collection().overviewImagesButton).not.toBeVisible();
+    },
+  );
+
+  test('Verify I can search my own message', {tag: ['@TC-385', '@regression']}, async ({createPage}) => {
+    const [userAPages, userBPages] = await Promise.all([
+      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+    ]);
+
+    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    await userBPages.conversation().sendMessage('User B message');
+
+    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+    await userAPages.conversation().sendMessage('User A Message');
+
+    await userAPages.conversation().searchButton.click();
+    await userAPages.collection().fullSearchBar.fill('User A');
+    await expect(userAPages.collection().getMarkedSearchResult('User A')).toBeVisible();
+  });
+
+  // TODO: links are not shown to the collection - this part of the test is blocked by [WPB-22484]
+  test.skip(
+    'Verify I can search for text mixed with a link preview',
+    {tag: ['@TC-388', '@regression']},
+    async () => {},
+  );
+
+  test('Verify I can search for links without preview', {tag: ['@TC-391', '@regression']}, async ({createPage}) => {
+    const [userAPages, userBPages] = await Promise.all([
+      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+    ]);
+
+    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    await userBPages.conversation().sendMessage('User B message');
+
+    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+    await userAPages.conversation().sendMessage('https://www.kaufland.de');
+
+    await userAPages.conversation().searchButton.click();
+    await userAPages.collection().fullSearchBar.fill('kaufland');
+    await expect(userAPages.collection().getMarkedSearchResult('kaufland').first()).toBeVisible();
+  });
+
+  test('Verify I can not search for a deleted message', {tag: ['@TC-392', '@regression']}, async ({createPage}) => {
+    const [userAPages, userBPages] = await Promise.all([
+      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+    ]);
+
+    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    await userBPages.conversation().sendMessage('User B message: Papaya');
+
+    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+    await userAPages.conversation().sendMessage('User A message: Guava');
+
+    const messageUserB = userBPages.conversation().getMessage({sender: userB});
+    await userBPages.conversation().deleteMessage(messageUserB, 'Everyone');
+
+    await userAPages.conversation().searchButton.click();
+    await userAPages.collection().fullSearchBar.fill('Papaya');
+    await expect(userAPages.collection().noResultsMessage).toBeVisible();
+  });
+
+  test(
+    'Verify results are sorted - latest message on top of list',
+    {tag: ['@TC-398', '@regression']},
+    async ({createPage}) => {
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      ]);
+
+      // User B sends the first (older) message
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversation().sendMessage('Older Message from User B');
+
+      //  User A sends the second (newer) message
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversation().sendMessage('Newer Message from User A');
+
+      await userAPages.conversation().searchButton.click();
+      const collection = userAPages.collection();
+      await collection.fullSearchBar.fill('Message');
+
+      await expect(collection.resultTexts).toHaveCount(2);
+
+      const results = await collection.getAllResultTexts();
+      expect(results[0]).toContain('Newer Message from User A');
+      expect(results[1]).toContain('Older Message from User B');
+    },
+  );
+
+  test('Verify I can find a message with special letters', {tag: ['@TC-403', '@regression']}, async ({createPage}) => {
+    const [userAPages, userBPages] = await Promise.all([
+      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+    ]);
+
+    const specialWord = 'Crème brûlée';
+
+    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    await userBPages.conversation().sendMessage(`Message with diacritical letter: ${specialWord}`);
+
+    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+    await userAPages.conversation().searchButton.click();
+
+    await userAPages.collection().fullSearchBar.fill(specialWord);
+
+    await expect(userAPages.collection().getMarkedSearchResult(specialWord)).toBeVisible();
+  });
+
+  test('Verify invisible characters in search are trimmed', {tag: ['@TC-405', '@regression']}, async ({createPage}) => {
+    const [userAPages, userBPages] = await Promise.all([
+      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+    ]);
+
+    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    await userBPages.conversation().sendMessage(`User B message`);
+
+    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+    await userAPages.conversation().searchButton.click();
+
+    await userAPages.collection().fullSearchBar.fill('  message');
+
+    await expect(userAPages.collection().getMarkedSearchResult('message')).toBeVisible();
+  });
+
+  test(
+    'I want to see message is scrolled into view when tapping on search result',
+    {tag: ['@TC-408', '@regression']},
+    async ({createPage}) => {
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      ]);
+
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversation().sendMessage('Papaya');
+
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      for (let i = 0; i < 20; i++) {
+        await userAPages.conversation().sendMessage(`Message from User A: ${i}`);
+      }
+
+      await expect(userAPages.conversation().getMessage({content: 'Message from User A: 19'})).toBeVisible();
+
+      await userAPages.conversation().searchButton.click();
+      await userAPages.collection().fullSearchBar.fill('Papaya');
+      await userAPages.collection().getMarkedSearchResult('Papaya').click();
+      const messageFromUserB = userAPages.conversation().getMessage({sender: userB});
+      await expect(messageFromUserB).toBeVisible();
+    },
+  );
+});


### PR DESCRIPTION


<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19955" title="WPB-19955" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19955</a>  [Web/QA] Write the In Conversation Search regression tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


# Pull Request

## Summary

- add regression tests for in conversation search

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers
Code duplication cannot be reduced any further since it's log in of the users.
