### PR TITLE
test: refactor createTeam fixture to allow composition with different user roles [WPB-19946]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Accessibility/Accessibility.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Accessibility/Accessibility.spec.ts
@@ -27,10 +27,11 @@ test.describe('Accessibility', () => {
   let userA: User;
   let userB: User;
 
-  test.beforeEach(async ({createTeam}) => {
-    const team = await createTeam('Accessible Team', {withMembers: 1});
+  test.beforeEach(async ({createUser, createTeam}) => {
+    userB = await createUser();
+
+    const team = await createTeam('Accessible Team', {users: [userB]});
     userA = team.owner;
-    userB = team.members[0];
   });
 
   test(

--- a/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
@@ -30,10 +30,10 @@ test.describe('AppLock', () => {
   const teamName = 'AppLock';
   const appLockPassCode = '1a3!567N4';
 
-  test.beforeEach(async ({api, createTeam}) => {
-    const team = await createTeam(teamName, {withMembers: 1});
+  test.beforeEach(async ({api, createTeam, createUser}) => {
+    memberA = await createUser();
+    const team = await createTeam(teamName, {users: [memberA]});
     owner = team.owner;
-    memberA = team.members[0];
 
     await api.brig.toggleAppLock(owner.teamId, 'enabled', true);
   });

--- a/apps/webapp/test/e2e_tests/specs/Authentication/authentication.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Authentication/authentication.spec.ts
@@ -139,11 +139,11 @@ test.describe('Authentication', () => {
     test(
       `I want to keep my history after refreshing the page on ${deviceType} device`,
       {tag: [tag, '@regression']},
-      async ({page, pageManager, createTeam}) => {
+      async ({page, pageManager, createTeam, createUser}) => {
         const {pages} = pageManager.webapp;
-        const team = await createTeam('Test Team', {withMembers: 1});
+        const userB = await createUser();
+        const team = await createTeam('Test Team', {users: [userB]});
         const userA = team.owner;
-        const userB = team.members[0];
 
         await test.step('Log in and connect with user B', async () => {
           await pageManager.openLoginPage();
@@ -196,11 +196,11 @@ test.describe('Authentication', () => {
   test(
     'Make sure user does not see data of user of previous sessions on same browser',
     {tag: ['@TC-1311', '@regression']},
-    async ({page, pageManager, createTeam}) => {
+    async ({page, pageManager, createTeam, createUser}) => {
       const {pages, components} = pageManager.webapp;
-      const team = await createTeam('Test Team', {withMembers: 1});
+      const userB = await createUser();
+      const team = await createTeam('Test Team', {users: [userB]});
       const userA = team.owner;
-      const userB = team.members[0];
 
       await test.step('Log in with public computer checked', async () => {
         await pageManager.openLoginPage();

--- a/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
@@ -72,11 +72,11 @@ test.describe('User Blocking', () => {
     let userB: User;
     let userC: User;
 
-    test.beforeEach(async ({createTeam}) => {
-      const [teamA, teamB] = await Promise.all([createTeam('Team A', {withMembers: 1}), createTeam('Team B')]);
+    test.beforeEach(async ({createTeam, createUser}) => {
+      userC = await createUser();
+      const [teamA, teamB] = await Promise.all([createTeam('Team A', {users: [userC]}), createTeam('Team B')]);
       userA = teamA.owner;
       userB = teamB.owner;
-      userC = teamA.members[0];
     });
 
     test(
@@ -329,10 +329,10 @@ test.describe('User Blocking', () => {
     let userA: User;
     let userB: User;
 
-    test.beforeEach(async ({createTeam}) => {
-      const team = await createTeam('Test Team', {withMembers: 1});
+    test.beforeEach(async ({createTeam, createUser}) => {
+      userB = await createUser();
+      const team = await createTeam('Test Team', {users: [userB]});
       userA = team.owner;
-      userB = team.members[0];
     });
 
     test('Verify you can not block a user from your team', {tag: ['@TC-8778', '@regression']}, async ({createPage}) => {

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -28,11 +28,11 @@ test.describe('Calling', () => {
   let userB: User;
   let userC: User;
 
-  test.beforeEach(async ({createTeam}) => {
-    const team = await createTeam('Team Call Team', {withMembers: 2});
+  test.beforeEach(async ({createTeam, createUser}) => {
+    userB = await createUser();
+    userC = await createUser();
+    const team = await createTeam('Team Call Team', {users: [userB, userC]});
     userA = team.owner;
-    userB = team.members[0];
-    userC = team.members[1];
   });
 
   test(

--- a/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
@@ -30,11 +30,11 @@ test.describe('Clear Conversation Content', () => {
   let userB: User;
   let userC: User;
 
-  test.beforeEach(async ({createTeam}) => {
-    const team = await createTeam('Test Team', {withMembers: 2});
+  test.beforeEach(async ({createTeam, createUser}) => {
+    userB = await createUser();
+    userC = await createUser();
+    const team = await createTeam('Test Team', {users: [userB, userC]});
     userA = team.owner;
-    userB = team.members[0];
-    userC = team.members[1];
   });
 
   [

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
@@ -30,7 +30,7 @@ const conversationName = 'Crits';
 test(
   'Team owner adds whole team to an all team chat',
   {tag: ['@TC-8631', '@crit-flow-web']},
-  async ({createTeam, createPage, api}) => {
+  async ({createUser, createTeam, createPage, api}) => {
     let owner: User;
     let member1: User;
     let member2: User;
@@ -39,10 +39,10 @@ test(
     let member2PageManager: PageManager;
 
     await test.step('Preconditions: Creating preconditions for the test via API', async () => {
-      const team = await createTeam('Critical', {withMembers: 2});
+      member1 = await createUser();
+      member2 = await createUser();
+      const team = await createTeam('Critical', {users: [member1, member2]});
       owner = team.owner;
-      member1 = team.members[0];
-      member2 = team.members[1];
 
       const [pmOwner, pm1, pm2] = await Promise.all([
         PageManager.from(createPage(withLogin(owner))),

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/backupRestoration-TC-8634.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/backupRestoration-TC-8634.spec.ts
@@ -31,10 +31,10 @@ let passwordProtectedBackupName: string;
 
 let userA: User;
 let userB: User;
-test.beforeEach(async ({createTeam}) => {
-  const team = await createTeam('Test Team', {withMembers: 1});
+test.beforeEach(async ({createTeam, createUser}) => {
+  userB = await createUser();
+  const team = await createTeam('Test Team', {users: [userB]});
   userA = team.owner;
-  userB = team.members[0];
 });
 
 test('Setting up new device with a backup', {tag: ['@TC-8634', '@crit-flow-web']}, async ({createPage}, testInfo) => {

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsCall-TC-8755.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsCall-TC-8755.spec.ts
@@ -29,7 +29,7 @@ const channelName = 'Test Channel';
 test.fixme(
   'Calls in channels with device switch and screenshare',
   {tag: ['@TC-8755', '@crit-flow-web']},
-  async ({createTeam, createPage, api}) => {
+  async ({createUser, createTeam, createPage, api}) => {
     test.setTimeout(150_000);
 
     let owner: User;
@@ -38,9 +38,9 @@ test.fixme(
     let callingServiceInstanceId: string;
 
     await test.step('Preconditions: Team owner creates a channels enabled team', async () => {
-      const team = await createTeam('Channels Call', {withMembers: 1});
+      member = await createUser();
+      const team = await createTeam('Channels Call', {users: [member]});
       owner = team.owner;
-      member = team.members[0];
 
       await api.brig.enableMLSFeature(owner.teamId);
       await api.brig.unlockChannelFeature(owner.teamId);

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsManagement-TC-8752.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsManagement-TC-8752.spec.ts
@@ -28,125 +28,129 @@ const conversation1 = 'Test Channel 1';
 const conversation2 = 'Test Channel 2';
 
 // ToDo(WPB-22442): Backoffice does not unlock calling feature for teams created during tests
-test.fixme('Channels Management', {tag: ['@TC-8752', '@crit-flow-web']}, async ({createTeam, createPage, api}) => {
-  let owner: User;
-  let member: User;
-  let ownerPageManager: PageManager;
-  let memberPageManager: PageManager;
+test.fixme(
+  'Channels Management',
+  {tag: ['@TC-8752', '@crit-flow-web']},
+  async ({createUser, createTeam, createPage, api}) => {
+    let owner: User;
+    let member: User;
+    let ownerPageManager: PageManager;
+    let memberPageManager: PageManager;
 
-  await test.step('Preconditions: Team owner creates a channels enabled team', async () => {
-    const team = await createTeam('Channels Management', {withMembers: 1});
-    owner = team.owner;
-    member = team.members[0];
+    await test.step('Preconditions: Team owner creates a channels enabled team', async () => {
+      member = await createUser();
+      const team = await createTeam('Channels Management', {users: [member]});
+      owner = team.owner;
 
-    // TODO: Remove below line when we have a SQS workaround
-    await api.brig.enableMLSFeature(owner.teamId);
-    await api.brig.unlockChannelFeature(owner.teamId);
-    await api.brig.enableChannelsFeature(owner.teamId);
+      // TODO: Remove below line when we have a SQS workaround
+      await api.brig.enableMLSFeature(owner.teamId);
+      await api.brig.unlockChannelFeature(owner.teamId);
+      await api.brig.enableChannelsFeature(owner.teamId);
 
-    const [pmOwner, pmMember] = await Promise.all([
-      PageManager.from(createPage(withLogin(owner))),
-      PageManager.from(createPage(withLogin(member))),
-    ]);
-    ownerPageManager = pmOwner;
-    memberPageManager = pmMember;
-  });
+      const [pmOwner, pmMember] = await Promise.all([
+        PageManager.from(createPage(withLogin(owner))),
+        PageManager.from(createPage(withLogin(member))),
+      ]);
+      ownerPageManager = pmOwner;
+      memberPageManager = pmMember;
+    });
 
-  await test.step('Team owner creates a channel with available member', async () => {
-    const {pages} = ownerPageManager.webapp;
-    await createGroup(pages, conversation1, [member]);
-    await expect(pages.conversationList().getConversationLocator(conversation1)).toBeVisible();
-  });
+    await test.step('Team owner creates a channel with available member', async () => {
+      const {pages} = ownerPageManager.webapp;
+      await createGroup(pages, conversation1, [member]);
+      await expect(pages.conversationList().getConversationLocator(conversation1)).toBeVisible();
+    });
 
-  await test.step('Team members leave the conversation', async () => {
-    await sendTextMessageToConversation(
-      memberPageManager,
-      conversation1,
-      `Hello ${conversation1}, ${member.firstName} here!`,
-    );
-    await memberPageManager.webapp.pages.conversation().toggleGroupInformation();
-    expect(await memberPageManager.webapp.pages.conversation().isUserGroupMember(member.fullName)).toBeTruthy();
-    await memberPageManager.webapp.pages.conversation().leaveConversation();
-    await memberPageManager.webapp.modals.leaveConversation().clickConfirm();
-    await memberPageManager.webapp.pages.conversation().isConversationReadonly();
-  });
+    await test.step('Team members leave the conversation', async () => {
+      await sendTextMessageToConversation(
+        memberPageManager,
+        conversation1,
+        `Hello ${conversation1}, ${member.firstName} here!`,
+      );
+      await memberPageManager.webapp.pages.conversation().toggleGroupInformation();
+      expect(await memberPageManager.webapp.pages.conversation().isUserGroupMember(member.fullName)).toBeTruthy();
+      await memberPageManager.webapp.pages.conversation().leaveConversation();
+      await memberPageManager.webapp.modals.leaveConversation().clickConfirm();
+      await memberPageManager.webapp.pages.conversation().isConversationReadonly();
+    });
 
-  await test.step('Team owner confirm member left', async () => {
-    const {pages} = ownerPageManager.webapp;
-    await pages.conversationList().openConversation(conversation1);
-    expect(await pages.conversation().isSystemMessageVisible(`${member.fullName} left`)).toBeTruthy();
-  });
+    await test.step('Team owner confirm member left', async () => {
+      const {pages} = ownerPageManager.webapp;
+      await pages.conversationList().openConversation(conversation1);
+      expect(await pages.conversation().isSystemMessageVisible(`${member.fullName} left`)).toBeTruthy();
+    });
 
-  await test.step('Team owner creates another channel', async () => {
-    const {pages} = ownerPageManager.webapp;
-    await createGroup(pages, conversation2, [member]);
-    await expect(pages.conversationList().getConversationLocator(conversation2)).toBeVisible();
-  });
+    await test.step('Team owner creates another channel', async () => {
+      const {pages} = ownerPageManager.webapp;
+      await createGroup(pages, conversation2, [member]);
+      await expect(pages.conversationList().getConversationLocator(conversation2)).toBeVisible();
+    });
 
-  await test.step('Team owner makes the member an admin', async () => {
-    const {pages} = ownerPageManager.webapp;
-    await pages.conversation().toggleGroupInformation();
-    await pages.conversation().makeUserAdmin(member.fullName);
-    await pages.conversation().toggleGroupInformation();
-  });
+    await test.step('Team owner makes the member an admin', async () => {
+      const {pages} = ownerPageManager.webapp;
+      await pages.conversation().toggleGroupInformation();
+      await pages.conversation().makeUserAdmin(member.fullName);
+      await pages.conversation().toggleGroupInformation();
+    });
 
-  await test.step('Team member confirms admin status', async () => {
-    await memberPageManager.webapp.pages.conversationList().openConversation(conversation2);
-    await memberPageManager.webapp.pages.conversation().toggleGroupInformation();
-    expect(await memberPageManager.webapp.pages.conversation().isUserGroupAdmin(member.fullName)).toBeTruthy();
-  });
+    await test.step('Team member confirms admin status', async () => {
+      await memberPageManager.webapp.pages.conversationList().openConversation(conversation2);
+      await memberPageManager.webapp.pages.conversation().toggleGroupInformation();
+      expect(await memberPageManager.webapp.pages.conversation().isUserGroupAdmin(member.fullName)).toBeTruthy();
+    });
 
-  await test.step('Team admin remove member', async () => {
-    const {pages, modals} = ownerPageManager.webapp;
-    await pages.conversation().removeAdminFromGroup(member.fullName);
-    await modals.removeMember().clickConfirm();
-    await pages.conversation().toggleGroupInformation();
-  });
+    await test.step('Team admin remove member', async () => {
+      const {pages, modals} = ownerPageManager.webapp;
+      await pages.conversation().removeAdminFromGroup(member.fullName);
+      await modals.removeMember().clickConfirm();
+      await pages.conversation().toggleGroupInformation();
+    });
 
-  await test.step('Team member verifies they have been removed by the owner', async () => {
-    await memberPageManager.webapp.pages.conversationList().openConversation(conversation2);
-    await memberPageManager.webapp.pages.conversation().isConversationReadonly();
-  });
+    await test.step('Team member verifies they have been removed by the owner', async () => {
+      await memberPageManager.webapp.pages.conversationList().openConversation(conversation2);
+      await memberPageManager.webapp.pages.conversation().isConversationReadonly();
+    });
 
-  await test.step('Team owner add member back to the same conversation', async () => {
-    const {pages} = ownerPageManager.webapp;
-    await pages.conversationList().openConversation(conversation2);
-    await pages.conversation().toggleGroupInformation();
-    await pages.conversationDetails().waitForSidebar();
-    await pages.conversationDetails().clickAddPeopleButton();
-    await pages.startUI().selectUsers(member.username);
-    await pages.groupCreation().clickAddMembers();
-  });
+    await test.step('Team owner add member back to the same conversation', async () => {
+      const {pages} = ownerPageManager.webapp;
+      await pages.conversationList().openConversation(conversation2);
+      await pages.conversation().toggleGroupInformation();
+      await pages.conversationDetails().waitForSidebar();
+      await pages.conversationDetails().clickAddPeopleButton();
+      await pages.startUI().selectUsers(member.username);
+      await pages.groupCreation().clickAddMembers();
+    });
 
-  await test.step('Team member confirms they have been added back to the conversation', async () => {
-    await memberPageManager.webapp.pages.conversationList().openConversation(conversation2);
-    await memberPageManager.webapp.pages.conversation().toggleGroupInformation();
-    expect(
-      await memberPageManager.webapp.pages
-        .conversation()
-        .isSystemMessageVisible(`${owner.fullName} added you to the conversation`),
-    ).toBeTruthy();
-  });
+    await test.step('Team member confirms they have been added back to the conversation', async () => {
+      await memberPageManager.webapp.pages.conversationList().openConversation(conversation2);
+      await memberPageManager.webapp.pages.conversation().toggleGroupInformation();
+      expect(
+        await memberPageManager.webapp.pages
+          .conversation()
+          .isSystemMessageVisible(`${owner.fullName} added you to the conversation`),
+      ).toBeTruthy();
+    });
 
-  await test.step('Team owner promote member to admin', async () => {
-    const {pages} = ownerPageManager.webapp;
-    await pages.conversationList().openConversation(conversation2);
-    await pages.conversation().makeUserAdmin(member.fullName);
-  });
+    await test.step('Team owner promote member to admin', async () => {
+      const {pages} = ownerPageManager.webapp;
+      await pages.conversationList().openConversation(conversation2);
+      await pages.conversation().makeUserAdmin(member.fullName);
+    });
 
-  await test.step('Team member confirms admin status', async () => {
-    await memberPageManager.webapp.pages.conversationList().openConversation(conversation2);
-    await memberPageManager.webapp.pages.conversation().toggleGroupInformation();
-    expect(await memberPageManager.webapp.pages.conversation().isUserGroupAdmin(member.fullName)).toBeTruthy();
-  });
+    await test.step('Team member confirms admin status', async () => {
+      await memberPageManager.webapp.pages.conversationList().openConversation(conversation2);
+      await memberPageManager.webapp.pages.conversation().toggleGroupInformation();
+      expect(await memberPageManager.webapp.pages.conversation().isUserGroupAdmin(member.fullName)).toBeTruthy();
+    });
 
-  await test.step('Team owner send a message', async () => {
-    await sendTextMessageToConversation(ownerPageManager, conversation2, 'Hello team! Admin here.');
-  });
+    await test.step('Team owner send a message', async () => {
+      await sendTextMessageToConversation(ownerPageManager, conversation2, 'Hello team! Admin here.');
+    });
 
-  await test.step('Team member sees the message', async () => {
-    await expect(
-      memberPageManager.webapp.pages.conversation().getMessage({content: 'Hello team! Admin here.'}),
-    ).toBeVisible();
-  });
-});
+    await test.step('Team member sees the message', async () => {
+      await expect(
+        memberPageManager.webapp.pages.conversation().getMessage({content: 'Hello team! Admin here.'}),
+      ).toBeVisible();
+    });
+  },
+);

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
@@ -26,7 +26,7 @@ import {test, expect, withLogin} from '../../test.fixtures';
 // Generating test data
 const conversationName = 'Test Conversation';
 
-test('Conversation Management', {tag: ['@TC-8636', '@crit-flow-web']}, async ({createTeam, createPage}) => {
+test('Conversation Management', {tag: ['@TC-8636', '@crit-flow-web']}, async ({createUser, createTeam, createPage}) => {
   test.setTimeout(150_000);
 
   let owner: User;
@@ -35,9 +35,9 @@ test('Conversation Management', {tag: ['@TC-8636', '@crit-flow-web']}, async ({c
   let memberPageManagers: PageManager[];
 
   await test.step('Preconditions: Team owner created a team with 5 members', async () => {
-    const team = await createTeam('Conversation Management', {withMembers: 5});
+    members = await Promise.all(Array.from({length: 5}, createUser));
+    const team = await createTeam('Conversation Management', {users: members});
     owner = team.owner;
-    members = team.members;
 
     const [pmOwner, ...pmMembers] = await Promise.all([
       PageManager.from(createPage(withLogin(owner))),

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupCalls-TC-8632.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupCalls-TC-8632.spec.ts
@@ -29,7 +29,7 @@ import {createGroup} from 'test/e2e_tests/utils/userActions';
 test.fixme(
   'Planning group call with sending various messages during call',
   {tag: ['@TC-8632', '@crit-flow-web']},
-  async ({createTeam, createPage, api}) => {
+  async ({createUser, createTeam, createPage, api}) => {
     test.setTimeout(150_000);
 
     let owner: User;
@@ -40,9 +40,9 @@ test.fixme(
     const conversationName = 'Calling';
 
     await test.step('Preconditions: Creating preconditions for the test via API', async () => {
-      const team = await createTeam('Calling', {withMembers: 1});
+      member = await createUser();
+      const team = await createTeam('Calling', {users: [member]});
       owner = team.owner;
-      member = team.members[0];
 
       await api.enableConferenceCallingFeature(owner.teamId!);
       await api.waitForFeatureToBeEnabled(FEATURE_KEY.CONFERENCE_CALLING, owner.teamId!, owner.token);

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupVideoCall-TC-8637.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupVideoCall-TC-8637.spec.ts
@@ -40,9 +40,9 @@ test.fixme(
     let callingServiceInstanceId: string;
 
     await test.step('Preconditions: Creating preconditions for the test via API', async () => {
-      const team = await createTeam('Critical', {withMembers: 1});
+      teamMember = await createUser();
+      const team = await createTeam('Critical', {users: [teamMember]});
       teamOwner = team.owner;
-      teamMember = team.members[0];
 
       await api.enableConferenceCallingFeature(teamOwner.teamId!);
 

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/joinTeam-TC-8635.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/joinTeam-TC-8635.spec.ts
@@ -26,9 +26,9 @@ test(
   'New person joins team and sets up device',
   {tag: ['@TC-8635', '@crit-flow-web']},
   async ({createTeam, createPage, createUser}) => {
-    const team = await createTeam('Test Team', {withMembers: 1});
+    const existingMember = await createUser();
+    const team = await createTeam('Test Team', {users: [existingMember]});
     const owner = team.owner;
-    const existingMember = team.members[0];
 
     const ownerPages = PageManager.from(await createPage(withLogin(owner))).webapp.pages;
 
@@ -38,7 +38,7 @@ test(
 
     const userA = await createUser();
     await test.step('Owner adds user A to team', async () => {
-      await team.addMember(userA);
+      await team.addTeamMember(userA);
     });
 
     const userAPages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(owner))).webapp.pages;

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
@@ -40,11 +40,11 @@ test('Messages in 1:1', {tag: ['@TC-8750', '@crit-flow-web']}, async ({createTea
   // Step 1: Preconditions
   await test.step('Preconditions: Creating preconditions for the test via API', async () => {
     // Precondition: Users A and B exist in two separate teams
-    const teamA = await createTeam('Critical A', {withMembers: 1});
-    memberA = teamA.members[0];
+    const teamA = await createTeam('Critical A');
+    memberA = teamA.owner;
 
-    const teamB = await createTeam('Critical B', {withMembers: 1});
-    memberB = teamB.members[0];
+    const teamB = await createTeam('Critical B');
+    memberB = teamB.owner;
 
     // Create page managers - User A sends connection request to User B
     const [pmA, pmB] = await Promise.all([

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
@@ -34,157 +34,161 @@ const videoFilePath = getVideoFilePath();
 const audioFilePath = getAudioFilePath();
 const textFilePath = getTextFilePath();
 
-test('Messages in Channels', {tag: ['@TC-8753', '@crit-flow-web']}, async ({createTeam, createPage, api}) => {
-  let userA: User;
-  let userB: User;
-  let userAPageManager: PageManager;
-  let userBPageManager: PageManager;
+test(
+  'Messages in Channels',
+  {tag: ['@TC-8753', '@crit-flow-web']},
+  async ({createUser, createTeam, createPage, api}) => {
+    let userA: User;
+    let userB: User;
+    let userAPageManager: PageManager;
+    let userBPageManager: PageManager;
 
-  await test.step('Preconditions: Creating preconditions for the test via API', async () => {
-    const team = await createTeam('Critical Team', {withMembers: 1});
-    userA = team.owner;
-    userB = team.members[0];
+    await test.step('Preconditions: Creating preconditions for the test via API', async () => {
+      userB = await createUser();
+      const team = await createTeam('Critical Team', {users: [userB]});
+      userA = team.owner;
 
-    // TODO: Remove below line when we have a SQS workaround
-    await api.brig.enableMLSFeature(userA.teamId);
-    await api.brig.unlockChannelFeature(userA.teamId);
-    await api.brig.enableChannelsFeature(userA.teamId);
+      // TODO: Remove below line when we have a SQS workaround
+      await api.brig.enableMLSFeature(userA.teamId);
+      await api.brig.unlockChannelFeature(userA.teamId);
+      await api.brig.enableChannelsFeature(userA.teamId);
 
-    const [pmA, pmB] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA))),
-      PageManager.from(createPage(withLogin(userB))),
-    ]);
-    userAPageManager = pmA;
-    userBPageManager = pmB;
-  });
+      const [pmA, pmB] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA))),
+        PageManager.from(createPage(withLogin(userB))),
+      ]);
+      userAPageManager = pmA;
+      userBPageManager = pmB;
+    });
 
-  await test.step('User A creates a channel with User B', async () => {
-    const {pages} = userAPageManager.webapp;
-    await pages.conversationList().clickCreateGroup();
-    await pages.groupCreation().setGroupName(channelName);
-    await pages.groupCreation().clickNextButton();
-    await pages.groupCreation().selectGroupMembers(userB.username);
-    await pages.groupCreation().clickCreateGroupButton();
-  });
+    await test.step('User A creates a channel with User B', async () => {
+      const {pages} = userAPageManager.webapp;
+      await pages.conversationList().clickCreateGroup();
+      await pages.groupCreation().setGroupName(channelName);
+      await pages.groupCreation().clickNextButton();
+      await pages.groupCreation().selectGroupMembers(userB.username);
+      await pages.groupCreation().clickCreateGroupButton();
+    });
 
-  await test.step('User A mentions User B in the channel', async () => {
-    const {pages} = userAPageManager.webapp;
-    await pages.conversationList().openConversation(channelName);
-    await pages.conversation().sendMessageWithUserMention(userB.fullName, messageText);
-  });
+    await test.step('User A mentions User B in the channel', async () => {
+      const {pages} = userAPageManager.webapp;
+      await pages.conversationList().openConversation(channelName);
+      await pages.conversation().sendMessageWithUserMention(userB.fullName, messageText);
+    });
 
-  await test.step('User B should receive mention', async () => {
-    const {pages} = userBPageManager.webapp;
-    expect(await pages.conversationList().doesConversationHasMentionIndicator(channelName)).toBeTruthy();
+    await test.step('User B should receive mention', async () => {
+      const {pages} = userBPageManager.webapp;
+      expect(await pages.conversationList().doesConversationHasMentionIndicator(channelName)).toBeTruthy();
 
-    await pages.conversationList().openConversation(channelName);
-    await expect(pages.conversation().getMessage({content: `@${userB.fullName} ${messageText}`})).toBeVisible();
-  });
+      await pages.conversationList().openConversation(channelName);
+      await expect(pages.conversation().getMessage({content: `@${userB.fullName} ${messageText}`})).toBeVisible();
+    });
 
-  await test.step('User A sends image', async () => {
-    const {pages, components} = userAPageManager.webapp;
-    await pages.conversationList().openConversation(channelName);
-    await components.inputBarControls().clickShareImage(imageFilePath);
+    await test.step('User A sends image', async () => {
+      const {pages, components} = userAPageManager.webapp;
+      await pages.conversationList().openConversation(channelName);
+      await components.inputBarControls().clickShareImage(imageFilePath);
 
-    expect(await userBPageManager.webapp.pages.conversation().isImageFromUserVisible(userA)).toBeTruthy();
-  });
+      expect(await userBPageManager.webapp.pages.conversation().isImageFromUserVisible(userA)).toBeTruthy();
+    });
 
-  await test.step('User B can open the image preview and see the image', async () => {
-    const {pages, modals} = userBPageManager.webapp;
-    // Click on the image to open it in a preview
-    await pages.conversation().clickImage(userA);
-    // Verify that the detail view modal is visible
-    await modals.detailViewModal().waitForVisibility();
-    expect(await modals.detailViewModal().isVisible()).toBeTruthy();
-    expect(await modals.detailViewModal().isImageVisible()).toBeTruthy();
-  });
+    await test.step('User B can open the image preview and see the image', async () => {
+      const {pages, modals} = userBPageManager.webapp;
+      // Click on the image to open it in a preview
+      await pages.conversation().clickImage(userA);
+      // Verify that the detail view modal is visible
+      await modals.detailViewModal().waitForVisibility();
+      expect(await modals.detailViewModal().isVisible()).toBeTruthy();
+      expect(await modals.detailViewModal().isImageVisible()).toBeTruthy();
+    });
 
-  await test.step('User B can download the image', async () => {
-    const {modals} = userBPageManager.webapp;
-    // Click on the download button to download the image
-    const filePath = await modals.detailViewModal().downloadAsset();
-    const downloadQRCodeValue = await getLocalQRCodeValue(filePath);
-    const localQRCodeValue = await getLocalQRCodeValue(imageFilePath);
-    expect(downloadQRCodeValue).toBe(localQRCodeValue);
-  });
+    await test.step('User B can download the image', async () => {
+      const {modals} = userBPageManager.webapp;
+      // Click on the download button to download the image
+      const filePath = await modals.detailViewModal().downloadAsset();
+      const downloadQRCodeValue = await getLocalQRCodeValue(filePath);
+      const localQRCodeValue = await getLocalQRCodeValue(imageFilePath);
+      expect(downloadQRCodeValue).toBe(localQRCodeValue);
+    });
 
-  await test.step(`User B reacts to A's image`, async () => {
-    const {pages, modals} = userBPageManager.webapp;
-    await modals.detailViewModal().givePlusOneReaction();
-    await modals.detailViewModal().closeModal();
-    expect(await pages.conversation().isPlusOneReactionVisible()).toBeTruthy();
-  });
+    await test.step(`User B reacts to A's image`, async () => {
+      const {pages, modals} = userBPageManager.webapp;
+      await modals.detailViewModal().givePlusOneReaction();
+      await modals.detailViewModal().closeModal();
+      expect(await pages.conversation().isPlusOneReactionVisible()).toBeTruthy();
+    });
 
-  await test.step('User A can see the reaction', async () => {
-    const {pages} = userAPageManager.webapp;
-    expect(await pages.conversation().isPlusOneReactionVisible()).toBeTruthy();
-  });
+    await test.step('User A can see the reaction', async () => {
+      const {pages} = userAPageManager.webapp;
+      expect(await pages.conversation().isPlusOneReactionVisible()).toBeTruthy();
+    });
 
-  await test.step('User A sends video message', async () => {
-    const {pages, components} = userAPageManager.webapp;
-    await components.inputBarControls().clickShareFile(videoFilePath);
-    expect(await pages.conversation().isVideoMessageVisible()).toBeTruthy();
-  });
+    await test.step('User A sends video message', async () => {
+      const {pages, components} = userAPageManager.webapp;
+      await components.inputBarControls().clickShareFile(videoFilePath);
+      expect(await pages.conversation().isVideoMessageVisible()).toBeTruthy();
+    });
 
-  await test.step('User B can play the received video', async () => {
-    const {pages} = userBPageManager.webapp;
-    await pages.conversation().playVideo();
-    // Wait for 5 seconds to ensure video starts playing
-    await pages.conversation().page.waitForTimeout(5000);
-    // ToDO: Bug -> Video is not loaded from the server, so we cannot check if it is playing
-  });
+    await test.step('User B can play the received video', async () => {
+      const {pages} = userBPageManager.webapp;
+      await pages.conversation().playVideo();
+      // Wait for 5 seconds to ensure video starts playing
+      await pages.conversation().page.waitForTimeout(5000);
+      // ToDO: Bug -> Video is not loaded from the server, so we cannot check if it is playing
+    });
 
-  await test.step('User A sends audio file', async () => {
-    const {pages, components} = userAPageManager.webapp;
-    await components.inputBarControls().clickShareFile(audioFilePath);
-    expect(await pages.conversation().isAudioMessageVisible()).toBeTruthy();
-  });
+    await test.step('User A sends audio file', async () => {
+      const {pages, components} = userAPageManager.webapp;
+      await components.inputBarControls().clickShareFile(audioFilePath);
+      expect(await pages.conversation().isAudioMessageVisible()).toBeTruthy();
+    });
 
-  await test.step('User B can play the audio file', async () => {
-    const {pages} = userBPageManager.webapp;
-    await pages.conversation().playAudio();
-    // Wait for 5 seconds to ensure audio starts playing
-    await pages.conversation().page.waitForTimeout(3000);
-    expect(await pages.conversation().isAudioPlaying()).toBeTruthy();
-  });
+    await test.step('User B can play the audio file', async () => {
+      const {pages} = userBPageManager.webapp;
+      await pages.conversation().playAudio();
+      // Wait for 5 seconds to ensure audio starts playing
+      await pages.conversation().page.waitForTimeout(3000);
+      expect(await pages.conversation().isAudioPlaying()).toBeTruthy();
+    });
 
-  await test.step('User A sends a quick (10 sec) self deleting message', async () => {
-    const {pages, components} = userAPageManager.webapp;
-    await components.inputBarControls().setEphemeralTimerTo('10 seconds');
-    await pages.conversation().sendMessage(selfDestructMessageText);
-    await expect(pages.conversation().getMessage({content: selfDestructMessageText})).toBeVisible();
-  });
+    await test.step('User A sends a quick (10 sec) self deleting message', async () => {
+      const {pages, components} = userAPageManager.webapp;
+      await components.inputBarControls().setEphemeralTimerTo('10 seconds');
+      await pages.conversation().sendMessage(selfDestructMessageText);
+      await expect(pages.conversation().getMessage({content: selfDestructMessageText})).toBeVisible();
+    });
 
-  await test.step('User B sees the message', async () => {
-    const {pages} = userBPageManager.webapp;
-    await expect(pages.conversation().getMessage({content: selfDestructMessageText})).toBeVisible();
-  });
+    await test.step('User B sees the message', async () => {
+      const {pages} = userBPageManager.webapp;
+      await expect(pages.conversation().getMessage({content: selfDestructMessageText})).toBeVisible();
+    });
 
-  await test.step('User B waits 10 seconds', async () => {
-    await userBPageManager.webapp.pages.conversation().page.waitForTimeout(11_000);
-  });
+    await test.step('User B waits 10 seconds', async () => {
+      await userBPageManager.webapp.pages.conversation().page.waitForTimeout(11_000);
+    });
 
-  await test.step('Both users see the message as removed', async () => {
-    await expect(
-      userBPageManager.webapp.pages.conversation().getMessage({content: selfDestructMessageText}),
-    ).not.toBeVisible();
-    await expect(
-      userAPageManager.webapp.pages.conversation().getMessage({content: selfDestructMessageText}),
-    ).not.toBeVisible();
+    await test.step('Both users see the message as removed', async () => {
+      await expect(
+        userBPageManager.webapp.pages.conversation().getMessage({content: selfDestructMessageText}),
+      ).not.toBeVisible();
+      await expect(
+        userAPageManager.webapp.pages.conversation().getMessage({content: selfDestructMessageText}),
+      ).not.toBeVisible();
 
-    // Reset ephemeral timer to 'Off'
-    await userAPageManager.webapp.components.inputBarControls().setEphemeralTimerTo('Off');
-  });
+      // Reset ephemeral timer to 'Off'
+      await userAPageManager.webapp.components.inputBarControls().setEphemeralTimerTo('Off');
+    });
 
-  await test.step('User A sends asset', async () => {
-    const {pages, components} = userAPageManager.webapp;
-    await components.inputBarControls().clickShareFile(textFilePath);
-    expect(await pages.conversation().isFileMessageVisible()).toBeTruthy();
-  });
+    await test.step('User A sends asset', async () => {
+      const {pages, components} = userAPageManager.webapp;
+      await components.inputBarControls().clickShareFile(textFilePath);
+      expect(await pages.conversation().isFileMessageVisible()).toBeTruthy();
+    });
 
-  await test.step('User B can download the file', async () => {
-    const {pages} = userBPageManager.webapp;
-    const filePath = await pages.conversation().downloadFile();
-    expect(await isAssetDownloaded(filePath)).toBeTruthy();
-  });
-});
+    await test.step('User B can download the file', async () => {
+      const {pages} = userBPageManager.webapp;
+      const filePath = await pages.conversation().downloadFile();
+      expect(await isAssetDownloaded(filePath)).toBeTruthy();
+    });
+  },
+);

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
@@ -36,16 +36,16 @@ const videoFilePath = getVideoFilePath();
 const audioFilePath = getAudioFilePath();
 const textFilePath = getTextFilePath();
 
-test('Messages in Groups', {tag: ['@TC-8751', '@crit-flow-web']}, async ({createTeam, createPage}) => {
+test('Messages in Groups', {tag: ['@TC-8751', '@crit-flow-web']}, async ({createUser, createTeam, createPage}) => {
   let userA: User;
   let userB: User;
   let userAPageManager: PageManager;
   let userBPageManager: PageManager;
 
   await test.step('Preconditions: Creating preconditions for the test via API', async () => {
-    const team = await createTeam('Critical Team', {withMembers: 1});
+    userB = await createUser();
+    const team = await createTeam('Critical Team', {users: [userB]});
     userA = team.owner;
-    userB = team.members[0];
 
     const [pmA, pmB] = await Promise.all([
       PageManager.from(createPage(withLogin(userA))),

--- a/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
@@ -30,10 +30,10 @@ test.describe('Delete', () => {
   let userA: User;
   let userB: User;
 
-  test.beforeEach(async ({createTeam}) => {
-    const team = await createTeam('Test Team', {withMembers: 1});
+  test.beforeEach(async ({createTeam, createUser}) => {
+    userB = await createUser();
+    const team = await createTeam('Test Team', {users: [userB]});
     userA = team.owner;
-    userB = team.members[0];
   });
 
   test(

--- a/apps/webapp/test/e2e_tests/specs/Drive/searchFilesInGroupConversation-TC-8788.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Drive/searchFilesInGroupConversation-TC-8788.spec.ts
@@ -34,10 +34,10 @@ const conversationName = 'Cells Critical Conversation';
 const imageFilePath = getImageFilePath();
 const videoFilePath = getVideoFilePath();
 
-test.beforeEach(async ({createTeam}) => {
-  const team = await createTeam(teamName, {withMembers: 1});
+test.beforeEach(async ({createTeam, createUser}) => {
+  userB = await createUser();
+  const team = await createTeam(teamName, {users: [userB]});
   userA = team.owner;
-  userB = team.members[0];
 });
 
 test(

--- a/apps/webapp/test/e2e_tests/specs/Edit/edit.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Edit/edit.spec.ts
@@ -26,10 +26,10 @@ test.describe('Edit', () => {
   let userA: User;
   let userB: User;
 
-  test.beforeEach(async ({createTeam}) => {
-    const team = await createTeam('Test Team', {withMembers: 1});
+  test.beforeEach(async ({createTeam, createUser}) => {
+    userB = await createUser();
+    const team = await createTeam('Test Team', {users: [userB]});
     userA = team.owner;
-    userB = team.members[0];
   });
 
   test('I can edit my message in 1:1', {tag: ['@TC-679', '@regression']}, async ({createPage}) => {

--- a/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
@@ -60,10 +60,10 @@ test.describe('Folders', () => {
   let userB: User;
   let userAPageManager: PageManager;
 
-  test.beforeEach(async ({createTeam, createPage}) => {
-    const team = await createTeam('Team', {withMembers: 1});
+  test.beforeEach(async ({createTeam, createPage, createUser}) => {
+    userB = await createUser();
+    const team = await createTeam('Team', {users: [userB]});
     userA = team.owner;
-    userB = team.members[0];
     userAPageManager = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)));
   });
 

--- a/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
@@ -27,11 +27,10 @@ import {RequestResetPasswordPage} from '../../pageManager/webapp/pages/requestRe
 test.describe('History Backup', () => {
   let userA: User;
   let userB: User;
-
-  test.beforeEach(async ({createTeam}) => {
-    const team = await createTeam('Test Team', {withMembers: 1});
+  test.beforeEach(async ({createTeam, createUser}) => {
+    userB = await createUser();
+    const team = await createTeam('Test Team', {users: [userB]});
     userA = team.owner;
-    userB = team.members[0];
   });
 
   test(

--- a/apps/webapp/test/e2e_tests/specs/Logs/logs.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Logs/logs.spec.ts
@@ -6,10 +6,10 @@ test.describe('Logs', () => {
   let userA: User;
   let userB: User;
 
-  test.beforeEach(async ({createTeam}) => {
-    const team = await createTeam('Test Team', {withMembers: 1});
+  test.beforeEach(async ({createTeam, createUser}) => {
+    userB = await createUser();
+    const team = await createTeam('Test Team', {users: [userB]});
     userA = team.owner;
-    userB = team.members[0];
   });
 
   test(

--- a/apps/webapp/test/e2e_tests/specs/Markdown/markdown.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Markdown/markdown.spec.ts
@@ -25,10 +25,10 @@ test.describe('Markdown', () => {
   let userA: User;
   let userB: User;
 
-  test.beforeEach(async ({createTeam}) => {
-    const team = await createTeam('Test Team', {withMembers: 1});
+  test.beforeEach(async ({createTeam, createUser}) => {
+    userB = await createUser();
+    const team = await createTeam('Test Team', {users: [userB]});
     userA = team.owner;
-    userB = team.members[0];
   });
 
   test('I want to write a bold message', {tag: ['@TC-1313', '@regression']}, async ({createPage}) => {

--- a/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
@@ -10,10 +10,10 @@ test.describe('Notifications', () => {
   let userA: User;
   let userB: User;
 
-  test.beforeEach(async ({createTeam}) => {
-    const team = await createTeam('Test Team', {withMembers: 1});
+  test.beforeEach(async ({createTeam, createUser}) => {
+    userB = await createUser();
+    const team = await createTeam('Test Team', {users: [userB]});
     userA = team.owner;
-    userB = team.members[0];
   });
 
   test('I want to receive notifications for mentions', {tag: ['@TC-3499', '@regression']}, async ({createPage}) => {

--- a/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
@@ -22,7 +22,6 @@ import {PageManager} from 'test/e2e_tests/pageManager';
 import {createGroup} from 'test/e2e_tests/utils/userActions';
 
 import {test, expect, withConnectedUser, withLogin, withConnectionRequest, Team} from 'test/e2e_tests/test.fixtures';
-import {Role} from '@wireapp/api-client/lib/team';
 
 async function openParticipantDetailsFromGroup(
   pages: PageManager['webapp']['pages'],
@@ -45,10 +44,10 @@ test.describe('Participant Profile', () => {
   let userB: User;
   let groupName: string;
 
-  test.beforeEach(async ({createTeam}) => {
-    team = await createTeam('Test Team', {withMembers: 1});
+  test.beforeEach(async ({createTeam, createUser}) => {
+    userB = await createUser();
+    team = await createTeam('Test Team', {users: [userB]});
     userA = team.owner;
-    userB = team.members[0];
     groupName = 'Test Group';
   });
 
@@ -183,7 +182,7 @@ test.describe('Participant Profile', () => {
       await openParticipantDetailsFromGroup(userBPages, groupName, userA.fullName);
 
       await expect(userBPages.participantDetails().userPicture).toBeVisible();
-      await expect(userBPages.participantDetails().userName).toBeVisible;
+      await expect(userBPages.participantDetails().userName).toBeVisible();
       await expect(userBPages.participantDetails().userName).toContainText(userA.fullName);
     },
   );
@@ -193,7 +192,7 @@ test.describe('Participant Profile', () => {
     {tag: ['@TC-1484', '@regression']},
     async ({createPage, createUser}) => {
       const externalUser = await createUser();
-      await team.addMember(externalUser, {role: Role.EXTERNAL});
+      await team.addTeamMember(externalUser, {role: 'EXTERNAL'});
 
       const [adminPage, userBPages] = await Promise.all([
         PageManager.from(createPage(withLogin(userA), withConnectedUser(externalUser))).then(pm => pm.webapp.pages),
@@ -263,7 +262,7 @@ test.describe('Participant Profile', () => {
     {tag: ['@TC-1488', '@regression']},
     async ({createPage, createUser}) => {
       const userC = await createUser();
-      await team.addMember(userC);
+      await team.addTeamMember(userC);
       const [adminPage, userBPages] = await Promise.all([
         PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
         PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),

--- a/apps/webapp/test/e2e_tests/specs/Ping/ping.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Ping/ping.spec.ts
@@ -27,10 +27,10 @@ test.describe('Ping', () => {
   let userA: User;
   let userB: User;
 
-  test.beforeEach(async ({createTeam}) => {
-    team = await createTeam('Test Team', {withMembers: 1});
+  test.beforeEach(async ({createTeam, createUser}) => {
+    userB = await createUser();
+    team = await createTeam('Test Team', {users: [userB]});
     userA = team.owner;
-    userB = team.members[0];
   });
 
   const pingScenarios = [
@@ -88,7 +88,7 @@ test.describe('Ping', () => {
       const usersForBigGroup: User[] = [];
       for (let i = 0; i < 4; i++) {
         const newMember = await createUser();
-        await team.addMember(newMember);
+        await team.addTeamMember(newMember);
         usersForBigGroup.push(newMember);
       }
 

--- a/apps/webapp/test/e2e_tests/specs/Reactions/reactions.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reactions/reactions.spec.ts
@@ -29,10 +29,10 @@ test.describe('Reactions', () => {
   let userA: User;
   let userB: User;
 
-  test.beforeEach(async ({createTeam}) => {
-    const team = await createTeam('Test Team', {withMembers: 1});
+  test.beforeEach(async ({createTeam, createUser}) => {
+    userB = await createUser();
+    const team = await createTeam('Test Team', {users: [userB]});
     userA = team.owner;
-    userB = team.members[0];
   });
 
   const likeCases = [

--- a/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
@@ -28,10 +28,10 @@ test.describe('Reply', () => {
   let userA: User;
   let userB: User;
 
-  test.beforeEach(async ({createTeam}) => {
-    const team = await createTeam('Test Team', {withMembers: 1});
+  test.beforeEach(async ({createTeam, createUser}) => {
+    userB = await createUser();
+    const team = await createTeam('Test Team', {users: [userB]});
     userA = team.owner;
-    userB = team.members[0];
   });
 
   test('I should not be able to reply to a ping', {tag: ['@TC-8038', '@regression']}, async ({createPage}) => {

--- a/apps/webapp/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
@@ -27,10 +27,10 @@ test.describe('Self Deleting Messages', () => {
   let userA: User;
   let userB: User;
 
-  test.beforeEach(async ({createTeam}) => {
-    const team = await createTeam('Test Team', {withMembers: 1});
+  test.beforeEach(async ({createTeam, createUser}) => {
+    userB = await createUser();
+    const team = await createTeam('Test Team', {users: [userB]});
     userA = team.owner;
-    userB = team.members[0];
   });
 
   test('Verify sending ephemeral text message in 1:1', {tag: ['@TC-657', '@regression']}, async ({createPage}) => {

--- a/apps/webapp/test/e2e_tests/test.fixtures.ts
+++ b/apps/webapp/test/e2e_tests/test.fixtures.ts
@@ -51,17 +51,13 @@ type Fixtures = {
    * @param options.withMembers Can either be the number of team members to create or an array of existing members to add to the team
    * @returns an object containing the teams owner and an array of members. The size of the members array matches the number or array length passed to `withMembers`
    */
-  createTeam: (
-    teamName: string,
-    options?: Parameters<typeof createUser>[1] & {withMembers?: number | User[]},
-  ) => Promise<Team>;
+  createTeam: (teamName: string, options?: {users: (User | {user: User; role?: keyof typeof Role})[]}) => Promise<Team>;
 };
 
 export type Team = {
   owner: User;
-  members: User[];
   /** Add a new member to the team after its initial creation */
-  addMember: (member: User, options?: {role?: Role}) => Promise<void>;
+  addTeamMember: (member: User, options?: {role?: keyof typeof Role}) => Promise<void>;
 };
 
 export {expect} from '@playwright/test';
@@ -137,32 +133,33 @@ export const test = baseTest.extend<Fixtures>({
   createTeam: async ({api}, use) => {
     const teamOwners: User[] = [];
 
-    await use(async (teamName, {withMembers, ...options} = {}) => {
-      const owner = await createUser(api, options);
+    await use(async (teamName, options) => {
+      const owner = await createUser(api);
 
       const {teamId} = await api.auth.upgradeUserToTeamOwner(owner, teamName);
       owner.teamId = teamId;
 
       teamOwners.push(owner);
 
-      const addMember = async (member: User, {role = Role.MEMBER}: {role?: Role} = {}) => {
-        const invitationId = await api.team.inviteUserToTeam(member.email, owner, role);
+      const addTeamMember: Team['addTeamMember'] = async (member, options) => {
+        const invitationId = await api.team.inviteUserToTeam(member.email, owner, Role[options?.role ?? 'MEMBER']);
         const invitationCode = await api.brig.getTeamInvitationCodeForEmail(owner.teamId, invitationId);
         await api.team.acceptTeamInvitation(invitationCode, member);
       };
 
-      let members: User[] = [];
-      if (withMembers !== undefined) {
-        // Depending on the type of withMembers, either create the number of users or use the given array of users
-        members =
-          typeof withMembers === 'number'
-            ? await Promise.all(Array.from({length: withMembers}, () => createUser(api, options)))
-            : withMembers;
-
-        await Promise.all(members.map(member => addMember(member)));
+      if (options?.users) {
+        await Promise.all(
+          options.users.map(user => {
+            if ('user' in user) {
+              return addTeamMember(user.user, {role: user.role});
+            } else {
+              return addTeamMember(user);
+            }
+          }),
+        );
       }
 
-      return {owner, members, addMember};
+      return {owner, addTeamMember};
     });
 
     // Deletes each created team and the owner / members associated with it


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19946" title="WPB-19946" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19946</a>  [Web/QA] Write the Conversations regression tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

This allows us to add users with a given role other than member to a team (e.g. External). It also refactors the fixture to depend on more composition instead of hardcoding user creation into it.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs: If a test requires multiple members as part of the team it needs to be parallelized manually, however this is a rather rare case and also more explicit like this.
