### PR TITLE
fix(webapp): waits until all messages are processed [WPB-22093]

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -68,6 +68,7 @@
     "markdown-it": "14.1.1",
     "murmurhash": "2.0.1",
     "oidc-client-ts": "3.4.1",
+    "p-wait-for": "6.0.0",
     "path-to-regexp": "8.3.0",
     "platform": "1.3.6",
     "prism-themes": "1.9.0",

--- a/apps/webapp/src/script/main/app.ts
+++ b/apps/webapp/src/script/main/app.ts
@@ -27,6 +27,7 @@ import {EVENTS as CoreEvents} from '@wireapp/core/lib/Account';
 import {MLSServiceEvents} from '@wireapp/core/lib/messagingProtocols/mls';
 import {amplify} from 'amplify';
 import 'core-js/full/reflect';
+import pWaitFor from 'p-wait-for';
 import platform from 'platform';
 import {pdfjs} from 'react-pdf';
 import {container} from 'tsyringe';
@@ -55,6 +56,7 @@ import {CryptographyRepository} from 'Repositories/cryptography/CryptographyRepo
 import {User} from 'Repositories/entity/User';
 import {EventRepository} from 'Repositories/event/EventRepository';
 import {EventService} from 'Repositories/event/EventService';
+import {NOTIFICATION_HANDLING_STATE} from 'Repositories/event/NotificationHandlingState';
 import {NotificationService} from 'Repositories/event/NotificationService';
 import {EventStorageMiddleware} from 'Repositories/event/preprocessor/EventStorageMiddleware';
 import {QuotedMessageMiddleware} from 'Repositories/event/preprocessor/QuoteDecoderMiddleware';
@@ -121,6 +123,20 @@ import {Warnings} from '../view_model/WarningsContainer';
 // Initialize PDF.js worker for react-pdf package
 pdfjs.GlobalWorkerOptions.workerSrc = '/min/pdf.worker.mjs';
 
+type WaitUntilAllMessagesAreProcessedDependencies = {
+  eventRepository: EventRepository;
+};
+
+export async function waitUntilAllMessagesAreProcessed(dependencies: WaitUntilAllMessagesAreProcessedDependencies) {
+  const {eventRepository} = dependencies;
+
+  await pWaitFor(
+    () => {
+      return eventRepository.notificationHandlingState() === NOTIFICATION_HANDLING_STATE.WEB_SOCKET;
+    },
+    {interval: 500},
+  );
+}
 export class App {
   static readonly LOCAL_STORAGE_LOGIN_REDIRECT_KEY = 'LOGIN_REDIRECT_KEY';
   static readonly LOCAL_STORAGE_LOGIN_CONVERSATION_KEY = 'LOGIN_CONVERSATION_KEY';
@@ -540,6 +556,7 @@ export class App {
       const useLegacyNotificationStream = !useAsyncNotificationStream;
 
       let previousMessage = '';
+
       await eventRepository.connectWebSocket(
         this.core,
         useLegacyNotificationStream,
@@ -560,6 +577,8 @@ export class App {
           }
         },
       );
+
+      await waitUntilAllMessagesAreProcessed({eventRepository});
 
       this.logger.info(`Finished loading notifications, total: ${totalNotifications}`);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11575,6 +11575,7 @@ __metadata:
     murmurhash: "npm:2.0.1"
     oidc-client-ts: "npm:3.4.1"
     os-browserify: "npm:0.3.0"
+    p-wait-for: "npm:6.0.0"
     path-browserify: "npm:1.0.1"
     path-to-regexp: "npm:8.3.0"
     platform: "npm:1.3.6"
@@ -22693,6 +22694,13 @@ __metadata:
   version: 2.2.0
   resolution: "p-try@npm:2.2.0"
   checksum: 10/f8a8e9a7693659383f06aec604ad5ead237c7a261c18048a6e1b5b85a5f8a067e469aa24f5bc009b991ea3b058a87f5065ef4176793a200d4917349881216cae
+  languageName: node
+  linkType: hard
+
+"p-wait-for@npm:6.0.0":
+  version: 6.0.0
+  resolution: "p-wait-for@npm:6.0.0"
+  checksum: 10/f7c502a9a366acba4a06aca7a07b78ae625fcf3f1bf43f13e7299de7f0edbfb36f48ba56244ec2a23231441acdc5960fe41434ff7294b533f322a9cdd5af3127
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22093" title="WPB-22093" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22093</a>  [Web] If messages received during long initial sync, these messages don't show in UI - silently syncing slowly afterwards
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

# Pull Request

## Summary

When the application is not fully done with the decryption & processing of messages that were waiting during the time app was closed we should not go to the main view processing messages (download + decrypt + push to database) is a heavy task and when in main view we already use a lot of resources hence we end up in a state where main view is visible but application has a loading indicator and is slowly processing dozens of messages, in order to avoid this scenario we need to wait for all the messages to be processed before going to main view.  

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
