### PR TITLE
fix: Improve media stream error handling using async/await and unified error mapping [WPB-23385]

### DIFF
--- a/apps/webapp/src/script/repositories/media/MediaStreamHandler.ts
+++ b/apps/webapp/src/script/repositories/media/MediaStreamHandler.ts
@@ -60,10 +60,10 @@ export class MediaStreamHandler {
     }
   }
 
-  requestMediaStream(audio: boolean, video: boolean, screen: boolean, isGroup: boolean): Promise<MediaStream> {
+  async requestMediaStream(audio: boolean, video: boolean, screen: boolean, isGroup: boolean): Promise<MediaStream> {
     const hasPermission = this.hasPermissionToAccess(audio, video);
     try {
-      return this.getMediaStream(audio, video, screen, isGroup, hasPermission);
+      return await this.getMediaStream(audio, video, screen, isGroup, hasPermission);
     } catch (error) {
       const isPermissionDenied = error.type === PermissionError.TYPE.DENIED;
       throw isPermissionDenied


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23385" title="WPB-23385" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23385</a>  [Web] - Screenshare in connecting status - also the user who shared  had secondary device in call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

This PR refactors requestMediaStream to use async/await in order to properly catch and normalize permission-related errors.

- Converted requestMediaStream to async/await
- Wrapped the getMediaStream call in a try/catch
- Mapped PermissionError.TYPE.DENIED to a unified MediaError of type MEDIA_STREAM_PERMISSION
- Preserved existing error behavior for all other error types
---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
