### PR TITLE
fix(webapp): Implement recovery mechanism for epoch number mismatch between CC and local state [WPB-23452]

### DIFF
--- a/apps/webapp/src/script/mls/MLSConversations.test.ts
+++ b/apps/webapp/src/script/mls/MLSConversations.test.ts
@@ -63,6 +63,7 @@ describe('MLSConversations', () => {
       const conversationRepository = await testFactory.exposeConversationActors();
       const repositoryCore = (conversationRepository as any).core as Core;
       jest.spyOn(repositoryCore.service!.conversation, 'mlsGroupExistsLocally').mockResolvedValue(false);
+      jest.spyOn(repositoryCore.service!.mls!, 'getEpoch').mockResolvedValue(1);
       const joinSpy = jest.spyOn(repositoryCore.service!.conversation, 'joinByExternalCommit');
 
       await initMLSGroupConversations(mlsConversations, conversationRepository, {core: repositoryCore});
@@ -149,6 +150,8 @@ describe('MLSConversations', () => {
 
       const conversationRepository = await testFactory.exposeConversationActors();
       const repositoryCore = (conversationRepository as any).core as Core;
+      jest.spyOn(repositoryCore.service!.mls!, 'getEpoch').mockResolvedValue(1);
+
       // MLS group is not yet established locally
       jest.spyOn(repositoryCore.service!.mls!, 'isConversationEstablished').mockResolvedValue(false);
       const joinSpy = jest.spyOn(repositoryCore.service!.conversation!, 'joinByExternalCommit');

--- a/apps/webapp/src/script/mls/MLSConversations.ts
+++ b/apps/webapp/src/script/mls/MLSConversations.ts
@@ -108,7 +108,6 @@ export async function initMLSGroupConversation(
     }
 
     // otherwise we should try to ensure the conversation exists (this will establish it if epoch is 0, or join by external commit if epoch > 0)
-    console.info('Conversation does not exist, ensuring establishment');
     await conversationRepository.ensureConversationExists({
       groupId,
       conversationId: qualifiedId,

--- a/apps/webapp/src/script/mls/MLSConversations.ts
+++ b/apps/webapp/src/script/mls/MLSConversations.ts
@@ -112,7 +112,6 @@ export async function initMLSGroupConversation(
     await conversationRepository.ensureConversationExists({
       groupId,
       conversationId: qualifiedId,
-      epoch: mlsConversation.epoch,
       core,
     });
 
@@ -179,7 +178,6 @@ export async function initialiseSelfAndTeamConversations(
       await conversationRepository.ensureConversationExists({
         conversationId: conversation.qualifiedId,
         groupId: conversation.groupId,
-        epoch: conversation.epoch,
         core,
       });
     }),

--- a/apps/webapp/src/script/mls/MLSMigration/migrationFinaliser/joinConversationsAfterMigrationFinalisation/joinConversationsAfterMigrationFinalisation.test.ts
+++ b/apps/webapp/src/script/mls/MLSMigration/migrationFinaliser/joinConversationsAfterMigrationFinalisation/joinConversationsAfterMigrationFinalisation.test.ts
@@ -126,6 +126,7 @@ describe('joinConversationsAfterMigrationFinalisation', () => {
     const mockCore = container.resolve(Core);
 
     jest.spyOn(mockCore.service!.conversation, 'mlsGroupExistsLocally').mockResolvedValue(false);
+    jest.spyOn(mockCore.service!.mls!, 'getEpoch').mockResolvedValue(1);
 
     const conversationId = 'conversation1';
     const mockDomain = 'anta.wire.link';

--- a/apps/webapp/src/script/mls/MLSMigration/migrationInitialiser/joinUnestablishedMixedConversations/joinUnestablishedMixedConversations.test.ts
+++ b/apps/webapp/src/script/mls/MLSMigration/migrationInitialiser/joinUnestablishedMixedConversations/joinUnestablishedMixedConversations.test.ts
@@ -60,6 +60,8 @@ describe('joinUnestablishedMixedConversations', () => {
       return Promise.resolve(!groupId.includes('unestablished'));
     });
 
+    jest.spyOn(repositoryCore.service!.mls!, 'getEpoch').mockResolvedValue(1);
+
     // Spy on joinByExternalCommit of the repository's core instance
     const joinSpy = jest.spyOn(repositoryCore.service!.conversation!, 'joinByExternalCommit');
 
@@ -90,6 +92,7 @@ describe('joinUnestablishedMixedConversations', () => {
       return Promise.resolve(!groupId.includes('unestablished'));
     });
     jest.spyOn(mockedConversationRepository, 'tryEstablishingMLSGroup');
+    jest.spyOn(repositoryCore.service!.mls!, 'getEpoch').mockResolvedValue(0);
 
     await joinUnestablishedMixedConversations(
       [mixedConversation1, mixedConversation2, mixedConversation3, mixedConversation4],

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -2210,39 +2210,52 @@ export class ConversationRepository {
   public ensureConversationExists = async ({
     conversationId,
     groupId,
-    epoch,
     core = this.core,
     retry = true,
   }: {
     conversationId: QualifiedId;
     groupId: string;
-    epoch: number;
     core?: Account;
     retry?: boolean;
   }): Promise<void> => {
-    this.logger.info('Ensuring conversation exists', {conversationId, groupId, epoch});
+    const coreCryptoEpochNumber = await this.core.service?.mls?.getEpoch(groupId);
+
+    this.logger.info('Ensuring conversation exists', {conversationId, groupId, epoch: coreCryptoEpochNumber});
     if (await this.conversationService.mlsGroupExistsLocally(groupId)) {
-      this.logger.info('Conversation already exists locally', {conversationId, groupId, epoch});
-      if (epoch === 0) {
+      this.logger.info('Conversation already exists locally', {conversationId, groupId, epoch: coreCryptoEpochNumber});
+      if (coreCryptoEpochNumber === 0) {
         if (!retry) {
-          this.logger.error('Epoch is 0, but retry is false, not retrying again', {conversationId, groupId, epoch});
+          this.logger.error('Epoch is 0, but retry is false, not retrying again', {
+            conversationId,
+            groupId,
+            epoch: coreCryptoEpochNumber,
+          });
           return;
         }
-        return this.recoverFromLocalUnestablishedMLSConversations({conversationId, groupId, epoch, core});
+        return this.recoverFromLocalUnestablishedMLSConversations({
+          conversationId,
+          groupId,
+          epoch: coreCryptoEpochNumber,
+          core,
+        });
       }
       return;
     }
 
     // establish the conversation if epoch is 0
-    if (epoch === 0) {
-      this.logger.info('Establishing conversation as epoch is 0', {conversationId, groupId, epoch});
-      await this.establishMlsGroupConversation({conversationId, groupId, epoch, core});
+    if (coreCryptoEpochNumber === 0) {
+      this.logger.info('Establishing conversation as epoch is 0', {
+        conversationId,
+        groupId,
+        epoch: coreCryptoEpochNumber,
+      });
+      await this.establishMlsGroupConversation({conversationId, groupId, epoch: coreCryptoEpochNumber, core});
       return;
     }
 
     // join by external commit
-    this.logger.info('Joining conversation by external commit', {conversationId, epoch});
-    if (epoch && epoch > 0) {
+    this.logger.info('Joining conversation by external commit', {conversationId, epoch: coreCryptoEpochNumber});
+    if (coreCryptoEpochNumber && coreCryptoEpochNumber > 0) {
       await this.core.service?.conversation?.joinByExternalCommit(conversationId);
     }
   };

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -2255,7 +2255,7 @@ export class ConversationRepository {
 
     // join by external commit
     this.logger.info('Joining conversation by external commit', {conversationId, epoch: coreCryptoEpochNumber});
-    if (coreCryptoEpochNumber && coreCryptoEpochNumber > 0) {
+    if (coreCryptoEpochNumber !== undefined && coreCryptoEpochNumber > 0) {
       await this.core.service?.conversation?.joinByExternalCommit(conversationId);
     }
   };

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -2336,7 +2336,7 @@ export class ConversationRepository {
         throw new Error(errorMessage);
       }
 
-      return this.ensureConversationExists({conversationId, groupId, epoch: remoteEpoch, core, retry: false});
+      return this.ensureConversationExists({conversationId, groupId, core, retry: false});
     } catch (error) {
       this.logger.error('Failed to recover from local unestablished MLS conversation', {
         error,

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -2218,7 +2218,7 @@ export class ConversationRepository {
     core?: Account;
     retry?: boolean;
   }): Promise<void> => {
-    const coreCryptoEpochNumber = await this.core.service?.mls?.getEpoch(groupId);
+    const coreCryptoEpochNumber = await core.service?.mls?.getEpoch(groupId);
 
     this.logger.info('Ensuring conversation exists', {conversationId, groupId, epoch: coreCryptoEpochNumber});
     if (await this.conversationService.mlsGroupExistsLocally(groupId)) {

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
@@ -1006,7 +1006,6 @@ export class MessageRepository {
         await this.conversationRepositoryProvider().ensureConversationExists({
           conversationId: conversation.qualifiedId,
           groupId: conversation.groupId,
-          epoch: conversation.epoch,
         });
       }
       const result = await this.conversationService.send(sendOptions);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23452" title="WPB-23452" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23452</a>  [Web] Implement recovery mechanism for epoch number mismatch between CC and local web state
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Problem:

if we read the epoch number from core crypto in case welcome is processed sooner than reset conversation will exists on core crypto but epoch number will be 0, on this scenario user will have a local unestablished MLS conversation

## Solution:

In order to fix this we should not rely on the epoch number that we have on our local state and always read the epoch number from core crypto.


