### PR TITLE
chore(types): enable strictNullChecks in base config with explicit null guards in server/config/core [WPB-23695]

### DIFF
--- a/apps/server/index.ts
+++ b/apps/server/index.ts
@@ -23,6 +23,16 @@ import {formatDate} from './util/TimeUtil';
 
 const server = new Server(serverConfig, clientConfig);
 
+function getUnhandledRejectionType(unhandledRejection: unknown): string {
+  if (unhandledRejection instanceof Error) {
+    return unhandledRejection.name;
+  }
+  if (unhandledRejection === null) {
+    return 'null';
+  }
+  return typeof unhandledRejection;
+}
+
 server
   .start()
   .then(port => {
@@ -37,5 +47,5 @@ process.on('uncaughtException', error =>
   console.error(`[${formatDate()}] Uncaught exception: ${error.message}`, error),
 );
 process.on('unhandledRejection', error =>
-  console.error(`[${formatDate()}] Uncaught rejection "${error.constructor.name}"`, error),
+  console.error(`[${formatDate()}] Uncaught rejection "${getUnhandledRejectionType(error)}"`, error),
 );

--- a/apps/server/routes/Root.ts
+++ b/apps/server/routes/Root.ts
@@ -25,11 +25,20 @@ async function addGeoIP(req: Request) {
   let countryCode = '';
 
   try {
-    const ip = req.header('X-Forwarded-For') || req.ip;
-    const lookup = await maxmind.open<CountryResponse>(geolite2.paths.country);
-    const result = lookup.get(ip);
+    const ipAddress = req.header('X-Forwarded-For') ?? req.ip ?? '';
+    if (ipAddress.length === 0) {
+      return;
+    }
+
+    const countryDatabasePath = geolite2.paths.country;
+    if (countryDatabasePath === undefined) {
+      return;
+    }
+
+    const lookup = await maxmind.open<CountryResponse>(countryDatabasePath);
+    const result = lookup.get(ipAddress);
     if (result) {
-      countryCode = result.country.iso_code;
+      countryCode = result.country?.iso_code ?? '';
     }
   } catch (error) {
     // It's okay to go without a detected country.

--- a/apps/server/routes/client-version-check/ClientBuildDate.test.ts
+++ b/apps/server/routes/client-version-check/ClientBuildDate.test.ts
@@ -1,6 +1,8 @@
 import {Maybe, Result} from 'true-myth';
 import {parseMinimumRequiredClientBuildDate, ParseMinimumRequiredClientBuildDateDependencies} from './ClientBuildDate';
 
+const validClientVersion = '2026.02.12.17.51.00';
+
 type Overrides = {
   readonly parseClientVersion?: jest.Mock;
   readonly clientVersion?: string | undefined;
@@ -16,20 +18,34 @@ function createParseMinimumRequiredClientBuildDateDependencies(
 }
 
 describe('parseMinimumRequiredClientBuildDate()', () => {
-  it('returns a Nothing when parseClientVersion() returns a Result Err', () => {
+  it('returns a Nothing when no client version is configured', () => {
+    const parseClientVersion = jest.fn();
     const dependencies = createParseMinimumRequiredClientBuildDateDependencies({
-      parseClientVersion: jest.fn().mockReturnValue(Result.err()),
+      parseClientVersion,
+      clientVersion: undefined,
     });
 
     expect(parseMinimumRequiredClientBuildDate(dependencies)).toStrictEqual(Maybe.nothing());
+    expect(parseClientVersion).not.toHaveBeenCalled();
   });
 
-  it('returns a Just when parseClientVersion() returns a Result Ok', () => {
-    const expectedDate = new Date(2026, 1, 12, 17, 51, 0);
+  it.each([
+    {
+      description: 'returns a Nothing when parseClientVersion() returns a Result Err',
+      parseResult: Result.err<Date, Error>(),
+      expectedResult: Maybe.nothing<Date>(),
+    },
+    {
+      description: 'returns a Just when parseClientVersion() returns a Result Ok',
+      parseResult: Result.ok(new Date(2026, 1, 12, 17, 51, 0)),
+      expectedResult: Maybe.just(new Date(2026, 1, 12, 17, 51, 0)),
+    },
+  ])('$description', ({parseResult, expectedResult}) => {
     const dependencies = createParseMinimumRequiredClientBuildDateDependencies({
-      parseClientVersion: jest.fn().mockReturnValue(Result.ok(expectedDate)),
+      parseClientVersion: jest.fn().mockReturnValue(parseResult),
+      clientVersion: validClientVersion,
     });
 
-    expect(parseMinimumRequiredClientBuildDate(dependencies)).toStrictEqual(Maybe.just(expectedDate));
+    expect(parseMinimumRequiredClientBuildDate(dependencies)).toStrictEqual(expectedResult);
   });
 });

--- a/apps/server/routes/client-version-check/ClientBuildDate.ts
+++ b/apps/server/routes/client-version-check/ClientBuildDate.ts
@@ -29,5 +29,9 @@ export function parseMinimumRequiredClientBuildDate(
 ): Maybe<Date> {
   const {parseClientVersion, clientVersion} = dependencies;
 
+  if (clientVersion === undefined || clientVersion.length === 0) {
+    return Maybe.nothing();
+  }
+
   return toolbelt.fromResult(parseClientVersion(clientVersion));
 }

--- a/apps/server/util/BrowserUtil.test.ts
+++ b/apps/server/util/BrowserUtil.test.ts
@@ -19,36 +19,61 @@
 
 import * as BrowserUtil from './BrowserUtil';
 
+type UserAgentExpectation = readonly [
+  description: string,
+  userAgent: string,
+  expectedIos: boolean,
+  expectedAndroid: boolean,
+  expectedMobile: boolean,
+];
+
+function parseUserAgentOrThrow(userAgent: string) {
+  const parsedUserAgent = BrowserUtil.parseUserAgent(userAgent);
+
+  if (parsedUserAgent === null) {
+    throw new Error('Expected parseUserAgent to return a parsed user agent.');
+  }
+
+  return parsedUserAgent;
+}
+
+const userAgentExpectations: UserAgentExpectation[] = [
+  [
+    'detects iPhone',
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 10_0_1 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) Version/10.0 Mobile/14A403 Safari/602.1',
+    true,
+    false,
+    true,
+  ],
+  [
+    'detects iPad',
+    'Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1',
+    true,
+    false,
+    true,
+  ],
+  [
+    'detects Android',
+    'Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36',
+    false,
+    true,
+    true,
+  ],
+  [
+    'detects Android tablet',
+    'Mozilla/5.0 (Linux; Android 7.1; vivo 1716 Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36',
+    false,
+    true,
+    true,
+  ],
+];
+
 describe('BrowserUtil', () => {
-  it('detects iPhone', () => {
-    const userAgent =
-      'Mozilla/5.0 (iPhone; CPU iPhone OS 10_0_1 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) Version/10.0 Mobile/14A403 Safari/602.1';
+  it.each(userAgentExpectations)('%s', (_description, userAgent, expectedIos, expectedAndroid, expectedMobile) => {
+    const parsedUserAgent = parseUserAgentOrThrow(userAgent);
 
-    expect(BrowserUtil.parseUserAgent(userAgent).is.ios).toBe(true);
-    expect(BrowserUtil.parseUserAgent(userAgent).is.mobile).toBe(true);
-  });
-
-  it('detects iPad', () => {
-    const userAgent =
-      'Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1';
-
-    expect(BrowserUtil.parseUserAgent(userAgent).is.ios).toBe(true);
-    expect(BrowserUtil.parseUserAgent(userAgent).is.mobile).toBe(true);
-  });
-
-  it('detects Android', () => {
-    const userAgent =
-      'Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36';
-
-    expect(BrowserUtil.parseUserAgent(userAgent).is.android).toBe(true);
-    expect(BrowserUtil.parseUserAgent(userAgent).is.mobile).toBe(true);
-  });
-
-  it('detects Android tablet', () => {
-    const userAgent =
-      'Mozilla/5.0 (Linux; Android 7.1; vivo 1716 Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36';
-
-    expect(BrowserUtil.parseUserAgent(userAgent).is.android).toBe(true);
-    expect(BrowserUtil.parseUserAgent(userAgent).is.mobile).toBe(true);
+    expect(parsedUserAgent.is.ios).toBe(expectedIos);
+    expect(parsedUserAgent.is.android).toBe(expectedAndroid);
+    expect(parsedUserAgent.is.mobile).toBe(expectedMobile);
   });
 });

--- a/apps/webapp/tsconfig.json
+++ b/apps/webapp/tsconfig.json
@@ -27,6 +27,7 @@
     "rootDirs": ["src"],
     "target": "ESNext",
     "strict": true,
+    "strictNullChecks": false,
     "strictFunctionTypes": false
   },
   "types": ["@types/wicg-file-system-access", "jest", "@testing-library/jest-dom"],

--- a/libraries/config/src/server.config.spec.ts
+++ b/libraries/config/src/server.config.spec.ts
@@ -65,12 +65,33 @@ describe('Server Config', () => {
       expect(config.ENVIRONMENT).toBe('production');
     });
 
-    it('should map URL parameters correctly', () => {
-      const config = generateConfig(mockParams, mockEnv);
+    it.each([
+      {
+        description: 'maps configured URL parameters',
+        params: mockParams,
+        expectedAppBase: 'https://app.wire.com',
+        expectedBackendRest: 'https://prod-nginz-https.wire.com',
+        expectedBackendWebSocket: 'wss://prod-nginz-ssl.wire.com',
+        expectedTlsEnabled: true,
+      },
+      {
+        description: 'defaults missing URL parameters to empty strings',
+        params: {
+          ...mockParams,
+          urls: {},
+        },
+        expectedAppBase: '',
+        expectedBackendRest: '',
+        expectedBackendWebSocket: '',
+        expectedTlsEnabled: false,
+      },
+    ])('should $description', ({params, expectedAppBase, expectedBackendRest, expectedBackendWebSocket, expectedTlsEnabled}) => {
+      const config = generateConfig(params, mockEnv);
 
-      expect(config.APP_BASE).toBe('https://app.wire.com');
-      expect(config.BACKEND_REST).toBe('https://prod-nginz-https.wire.com');
-      expect(config.BACKEND_WS).toBe('wss://prod-nginz-ssl.wire.com');
+      expect(config.APP_BASE).toBe(expectedAppBase);
+      expect(config.BACKEND_REST).toBe(expectedBackendRest);
+      expect(config.BACKEND_WS).toBe(expectedBackendWebSocket);
+      expect(config.DEVELOPMENT_ENABLE_TLS).toBe(expectedTlsEnabled);
     });
 
     it('should parse PORT correctly with default', () => {

--- a/libraries/config/src/server.config.ts
+++ b/libraries/config/src/server.config.ts
@@ -50,7 +50,7 @@ const logger = logdown('config', {
   markdown: false,
 });
 
-function readFile(filePath: string, fallback?: string): string {
+function readFile(filePath: string, fallback: string = ''): string {
   try {
     return fs.readFileSync(filePath, {encoding: 'utf8', flag: 'r'});
   } catch (error) {
@@ -59,15 +59,28 @@ function readFile(filePath: string, fallback?: string): string {
   }
 }
 
-function parseCommaSeparatedList(list: string = ''): string[] {
+function parseCommaSeparatedList(list: string | undefined = ''): string[] {
   const cleanedList = list.replace(/\s/g, '');
-  if (!cleanedList) {
+  if (cleanedList.length === 0) {
     return [];
   }
   return cleanedList.split(',');
 }
 
-function mergedCSP({urls}: ConfigGeneratorParams, env: Record<string, string>): Record<string, Iterable<string>> {
+function getNonEmptyStringValueOrDefault(value: string | undefined, fallback: string): string {
+  return value !== undefined && value.length > 0 ? value : fallback;
+}
+
+function resolveServerCertificatePath(certificateFileName: string): string {
+  const certificatePathInWorkspaceRoot = path.resolve(process.cwd(), `certificate/${certificateFileName}`);
+  if (fs.existsSync(certificatePathInWorkspaceRoot)) {
+    return certificatePathInWorkspaceRoot;
+  }
+
+  return path.resolve(process.cwd(), `apps/server/dist/certificate/${certificateFileName}`);
+}
+
+function mergedCSP({urls}: ConfigGeneratorParams, env: Env): Record<string, Iterable<string>> {
   const objectSrc = parseCommaSeparatedList(env.CSP_EXTRA_OBJECT_SRC);
   const csp = {
     connectSrc: [
@@ -96,16 +109,27 @@ function mergedCSP({urls}: ConfigGeneratorParams, env: Record<string, string>): 
 
 export function generateConfig(params: ConfigGeneratorParams, env: Env) {
   const {commit, version, urls, env: nodeEnv} = params;
+  const baseUrl = urls.base ?? '';
+  const apiUrl = urls.api ?? '';
+  const websocketUrl = urls.ws ?? '';
+  const parsedHttpPort = Number(env.PORT);
+  const isHttpPortMissingOrZero = Number.isNaN(parsedHttpPort) || parsedHttpPort === 0;
+  const httpPort = isHttpPortMissingOrZero ? 21080 : parsedHttpPort;
+  const defaultSslCertificateKeyPath = resolveServerCertificatePath('development-key.pem');
+  const defaultSslCertificatePath = resolveServerCertificatePath('development-cert.pem');
+  const sslCertificateKeyPath = getNonEmptyStringValueOrDefault(env.SSL_CERTIFICATE_KEY_PATH, defaultSslCertificateKeyPath);
+  const sslCertificatePath = getNonEmptyStringValueOrDefault(env.SSL_CERTIFICATE_PATH, defaultSslCertificatePath);
+
   return {
-    APP_BASE: urls.base,
+    APP_BASE: baseUrl,
     COMMIT: commit,
     VERSION: version,
     CACHE_DURATION_SECONDS: 300,
     CSP: mergedCSP(params, env),
-    BACKEND_REST: urls.api,
-    BACKEND_WS: urls.ws,
+    BACKEND_REST: apiUrl,
+    BACKEND_WS: websocketUrl,
     DEVELOPMENT: nodeEnv === 'development',
-    DEVELOPMENT_ENABLE_TLS: urls.base.startsWith('https://'),
+    DEVELOPMENT_ENABLE_TLS: baseUrl.startsWith('https://'),
     ENFORCE_HTTPS: env.ENFORCE_HTTPS != 'false',
     ENVIRONMENT: nodeEnv,
     GOOGLE_WEBMASTER_ID: env.GOOGLE_WEBMASTER_ID,
@@ -115,23 +139,15 @@ export function generateConfig(params: ConfigGeneratorParams, env: Env) {
       TITLE: env.OPEN_GRAPH_TITLE,
     },
     ENABLE_DYNAMIC_HOSTNAME: env.ENABLE_DYNAMIC_HOSTNAME === 'true',
-    PORT_HTTP: Number(env.PORT) || 21080,
+    PORT_HTTP: httpPort,
     MINIMUM_REQUIRED_CLIENT_BUILD_DATE: env.MINIMUM_REQUIRED_CLIENT_BUILD_DATE,
     ROBOTS: {
       ALLOW: readFile(ROBOTS_ALLOW_FILE, 'User-agent: *\r\nDisallow: /'),
       ALLOWED_HOSTS: ['app.wire.com'],
       DISALLOW: readFile(ROBOTS_DISALLOW_FILE, 'User-agent: *\r\nDisallow: /'),
     },
-    SSL_CERTIFICATE_KEY_PATH:
-      env.SSL_CERTIFICATE_KEY_PATH ||
-      (fs.existsSync(path.resolve(process.cwd(), 'certificate/development-key.pem'))
-        ? path.resolve(process.cwd(), 'certificate/development-key.pem')
-        : path.resolve(process.cwd(), 'apps/server/dist/certificate/development-key.pem')),
-    SSL_CERTIFICATE_PATH:
-      env.SSL_CERTIFICATE_PATH ||
-      (fs.existsSync(path.resolve(process.cwd(), 'certificate/development-cert.pem'))
-        ? path.resolve(process.cwd(), 'certificate/development-cert.pem')
-        : path.resolve(process.cwd(), 'apps/server/dist/certificate/development-cert.pem')),
+    SSL_CERTIFICATE_KEY_PATH: sslCertificateKeyPath,
+    SSL_CERTIFICATE_PATH: sslCertificatePath,
   } as const;
 }
 

--- a/libraries/core/src/linkPreview/LinkPreviewService.test.ts
+++ b/libraries/core/src/linkPreview/LinkPreviewService.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {QualifiedId} from '@wireapp/api-client/lib/user';
+
+import {AssetService} from '../conversation';
+import {LinkPreviewContent} from '../conversation/content';
+import {EncryptedAssetUploaded} from '../cryptography';
+
+import {LinkPreviewService} from './LinkPreviewService';
+
+const conversationIdentifier: QualifiedId = {
+  domain: 'wire.com',
+  id: 'conversation-id',
+};
+
+const linkPreviewWithMissingTitle: LinkPreviewContent = {
+  url: 'https://wire.com',
+  urlOffset: 0,
+  title: null,
+  image: {
+    data: new Uint8Array([1, 2, 3]),
+    height: 100,
+    type: 'image/png',
+    width: 100,
+  },
+};
+
+describe('LinkPreviewService', () => {
+  it('uses an empty filename for audit uploads when the link preview title is missing', async () => {
+    const uploadedAsset: EncryptedAssetUploaded = {
+      cipherText: new Uint8Array([1, 2, 3]),
+      domain: 'wire.com',
+      key: 'asset-key',
+      keyBytes: new Uint8Array([4, 5, 6]),
+      sha256: new Uint8Array([7, 8, 9]),
+      token: 'asset-token',
+    };
+
+    const uploadAsset = jest.fn().mockResolvedValue({
+      cancel: jest.fn(),
+      response: Promise.resolve(uploadedAsset),
+    });
+
+    const assetService: AssetService = {uploadAsset} as unknown as AssetService;
+    const linkPreviewService = new LinkPreviewService(assetService);
+
+    await linkPreviewService.uploadLinkPreviewImage(linkPreviewWithMissingTitle, conversationIdentifier, true);
+
+    expect(uploadAsset).toHaveBeenCalledWith(linkPreviewWithMissingTitle.image.data, {
+      domain: conversationIdentifier.domain,
+      auditData: {
+        conversationId: conversationIdentifier,
+        filename: '',
+        filetype: linkPreviewWithMissingTitle.image.type,
+      },
+    });
+  });
+});

--- a/libraries/core/src/linkPreview/LinkPreviewService.ts
+++ b/libraries/core/src/linkPreview/LinkPreviewService.ts
@@ -31,7 +31,7 @@ export class LinkPreviewService {
     isAuditLogEnabled: boolean = false,
   ): Promise<LinkPreviewUploadedContent> {
     const {image, ...preview} = linkPreview;
-    if (!image) {
+    if (image === undefined || image === null) {
       return preview;
     }
 
@@ -40,7 +40,7 @@ export class LinkPreviewService {
       await this.assetService.uploadAsset(linkPreview.image.data, {
         domain: conversationId.domain,
         ...(isAuditLogEnabled && {
-          auditData: {conversationId, filename: linkPreview.title, filetype: linkPreview.image.type},
+          auditData: {conversationId, filename: linkPreview.title ?? '', filetype: linkPreview.image.type},
         }),
       })
     ).response;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,7 +12,7 @@
     "downlevelIteration": true,
     "alwaysStrict": true,
     "strict": true,
-    "strictNullChecks": false,
+    "strictNullChecks": true,
     "useUnknownInCatchVariables": false,
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": true,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23695" title="WPB-23695" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23695</a>  [Web] Enable strict TypeScript mode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- enable strictNullChecks in base TypeScript config
- fix strict-null regressions in server, config-lib, and core-lib with explicit null/undefined checks (no implicit truthy/falsy checks in touched code)
- improve unhandled rejection type logging with explicit type narrowing
- add/update tests for new null-handling behavior:
  - client build date parsing when version is missing
  - server config defaults when URLs are missing
  - link preview audit upload with missing title
  - browser util test helper null safety
- keep webapp temporarily opted out via local strictNullChecks: false override due to existing nullability backlog and unresolved module typing in webapp:type-check

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
