### PR TITLE
fix(webapp): Implement recovery mechanism for epoch number mismatch between CC and local state [WPB-23452]

### DIFF
--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -2222,13 +2222,24 @@ export class ConversationRepository {
   }): Promise<void> => {
     this.logger.info('Ensuring conversation exists', {conversationId, groupId, epoch});
     if (await this.conversationService.mlsGroupExistsLocally(groupId)) {
-      this.logger.info('Conversation already exists locally', {conversationId, groupId, epoch});
-      if (epoch === 0) {
+      const coreCryptoEpochNumber = await core.service?.mls?.getEpoch(groupId);
+      this.logger.info('Conversation already exists locally', {conversationId, groupId, epoch, coreCryptoEpochNumber});
+      if (coreCryptoEpochNumber === 0) {
         if (!retry) {
-          this.logger.error('Epoch is 0, but retry is false, not retrying again', {conversationId, groupId, epoch});
+          this.logger.error('Epoch is 0, but retry is false, not retrying again', {
+            conversationId,
+            groupId,
+            epoch,
+            coreCryptoEpochNumber,
+          });
           return;
         }
-        return this.recoverFromLocalUnestablishedMLSConversations({conversationId, groupId, epoch, core});
+        return this.recoverFromLocalUnestablishedMLSConversations({
+          conversationId,
+          groupId,
+          epoch: coreCryptoEpochNumber,
+          core,
+        });
       }
       return;
     }


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23452" title="WPB-23452" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23452</a>  [Web] Implement recovery mechanism for epoch number mismatch between CC and local web state
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary

if we read the epoch number from core crypto in case welcome is processed sooner than reset conversation will exists on core crypto but epoch number will be 0, on this scenario user will have a local unestablished MLS conversation that does exists on core crypto but with epoch number of 0. the recover for this scenario had the issue of reading the epoch number from backend (latest epoch number) hence app was trying to send MLS messages while the conversation was not established on core crypto level. 



Closing https://github.com/wireapp/wire-webapp/pull/20508 with this.