### PR TITLE
test: re-enable crit flow group call [WPB-23747]

### DIFF
--- a/apps/webapp/test/e2e_tests/data/user.ts
+++ b/apps/webapp/test/e2e_tests/data/user.ts
@@ -46,10 +46,11 @@ export const getUser = (user: Partial<User> = {}): User => {
   // Ensure lastName is always defined, as it is used in email and username generation
   const lastName = user.lastName ?? generateLastName();
   const firstName = user.firstName ?? generateFirstName();
+  const email = user.email ?? generateWireEmail(firstName, lastName);
 
   return {
     ...user,
-    email: user.email ?? generateWireEmail(lastName),
+    email,
     password: user.password ?? generateSecurePassword(),
     firstName,
     lastName,

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/audioVideoSettings.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/audioVideoSettings.page.ts
@@ -41,11 +41,6 @@ export class AudioVideoSettingsPage {
     await this.page.getByRole('listbox').getByRole('option', {name: microphoneName}).click();
   }
 
-  async isMicrophoneSetTo(expectedMicrophoneName: string) {
-    const selectedMicrophone = this.microphoneDropdown.getByText(expectedMicrophoneName, {exact: true});
-    return selectedMicrophone.isVisible();
-  }
-
   async selectSpeaker(speakerName: string) {
     // The Select component doesn't implement the disabled state correctly so we need to use this workaround
     await this.speakerDropdown.getByRole('combobox', {name: 'Speakers'}).isEditable();
@@ -53,20 +48,10 @@ export class AudioVideoSettingsPage {
     await this.page.getByRole('listbox').getByRole('option', {name: speakerName}).click();
   }
 
-  async isSpeakerSetTo(expectedSpeakerName: string) {
-    const selectedSpeaker = this.speakerDropdown.getByText(expectedSpeakerName, {exact: true});
-    return selectedSpeaker.isVisible();
-  }
-
   async selectCamera(cameraName: string) {
     // The Select component doesn't implement the disabled state correctly so we need to use this workaround
     await this.cameraDropdown.getByRole('combobox', {name: 'Camera'}).isEditable();
     await this.cameraDropdown.click();
     await this.page.getByRole('listbox').getByRole('option', {name: cameraName}).click();
-  }
-
-  async isCameraSetTo(expectedCameraName: string) {
-    const selectedCamera = this.cameraDropdown.getByText(expectedCameraName, {exact: true});
-    return selectedCamera.isVisible();
   }
 }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/calling.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/calling.page.ts
@@ -115,11 +115,6 @@ export class CallingPage {
 
   // ─── Mute Controls ──────────────────────────────────────────────────────
 
-  async isSelfUserMutedInFullScreen(): Promise<boolean> {
-    const state = await this.fullScreenMuteButton.getAttribute('data-uie-value');
-    return state === 'active';
-  }
-
   async muteSelfInFullScreen() {
     return await this.fullScreenMuteButton.click();
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/calling.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/calling.page.ts
@@ -36,6 +36,7 @@ export class CallingPage {
   readonly leaveCallButton: Locator;
 
   // Participant and self state
+  readonly gridTiles: Locator;
   readonly fullScreenMuteButton: Locator;
   readonly fullScreenGridTileMuteIcon: Locator;
   readonly selfVideoThumbnail: Locator;
@@ -50,6 +51,8 @@ export class CallingPage {
     this.goFullScreen = page.locator('[data-uie-name="do-maximize-call"]');
     this.acceptCallButton = this.callCell.getByRole('button', {name: 'Accept'});
     this.leaveCallButton = this.callCell.getByRole('button', {name: 'Hang Up'});
+
+    this.gridTiles = this.page.getByTestId('item-grid');
 
     // Mute / Unmute control
     this.fullScreenMuteButton = page.locator('[data-uie-name="do-call-controls-video-call-mute"]');
@@ -127,32 +130,12 @@ export class CallingPage {
     return this.fullScreenMuteButton.isVisible();
   }
 
-  // ─── Participant Verification ───────────────────────────────────────────
+  getGridTile(name: string) {
+    const tile = this.gridTiles.filter({hasText: name});
 
-  async waitForParticipantNameToBeVisible(userId?: string): Promise<void> {
-    if (!userId) {
-      throw new Error('User ID is required to verify participant visibility.');
-    }
-
-    await this.page
-      .getByTestId('call-participant-name')
-      .and(this.page.locator(`[data-uie-value="${userId}"]`))
-      .waitFor({state: 'visible', timeout: 20_000});
-  }
-
-  // ─── Mute State for Other Users ─────────────────────────────────────────
-
-  waitForGridTileMuteIconToBeVisibleForUser(userId: string): Promise<void> {
-    return this.page
-      .getByTestId('mic-icon-off')
-      .and(this.page.locator(`[data-uie-value="${userId}"]`))
-      .waitFor({state: 'visible'});
-  }
-
-  isGridTileMuteIconVisibleForUser(userId: string): Promise<boolean> {
-    return this.page
-      .getByTestId('mic-icon-off')
-      .and(this.page.locator(`[data-uie-value="${userId}"]`))
-      .isVisible();
+    return Object.assign(tile, {
+      /** Icon indicating that the given user is muted */
+      muteIcon: tile.getByTestId('mic-icon-off'),
+    });
   }
 }

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/accountManagement-TC-8639.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/accountManagement-TC-8639.spec.ts
@@ -19,7 +19,7 @@
 
 import {PageManager} from 'test/e2e_tests/pageManager';
 
-import {expect, test, withLogin} from '../../test.fixtures';
+import {expect, LOGIN_TIMEOUT, test, withLogin} from '../../test.fixtures';
 import {generateSecurePassword, generateWireEmail} from '../../utils/userDataGenerator';
 import {loginUser} from 'test/e2e_tests/utils/userActions';
 
@@ -46,7 +46,9 @@ test('Account Management', {tag: ['@TC-8639', '@crit-flow-web']}, async ({create
 
   await test.step('Member verifies if applock is working', async () => {
     await pageManager.refreshPage();
-    await expect(modals.appLock().appLockModalHeader).toContainText('Enter passcode to unlock');
+    await expect(modals.appLock().appLockModalHeader).toContainText('Enter passcode to unlock', {
+      timeout: LOGIN_TIMEOUT,
+    });
     await expect(modals.appLock().appLockModalText).toContainText('Passcode');
 
     await modals.appLock().unlockAppWithPasscode(appLockPassphrase);
@@ -74,9 +76,9 @@ test('Account Management', {tag: ['@TC-8639', '@crit-flow-web']}, async ({create
     await pages.audioVideoSettings().selectMicrophone(fakeAudioInput);
     await pages.audioVideoSettings().selectSpeaker(fakeAudioOutput);
     await pages.audioVideoSettings().selectCamera(fakeCamera);
-    expect(await pages.audioVideoSettings().isMicrophoneSetTo(fakeAudioInput));
-    expect(await pages.audioVideoSettings().isSpeakerSetTo(fakeAudioOutput));
-    expect(await pages.audioVideoSettings().isCameraSetTo(fakeCamera));
+    await expect(pages.audioVideoSettings().microphoneDropdown).toContainText(fakeAudioInput);
+    await expect(pages.audioVideoSettings().speakerDropdown).toContainText(fakeAudioOutput);
+    await expect(pages.audioVideoSettings().cameraDropdown).toContainText(fakeCamera);
   });
 
   await test.step('Member turns off data consent', async () => {

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/accountManagement-TC-8639.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/accountManagement-TC-8639.spec.ts
@@ -55,7 +55,7 @@ test('Account Management', {tag: ['@TC-8639', '@crit-flow-web']}, async ({create
   await components.conversationSidebar().clickPreferencesButton();
 
   await test.step('Member changes their email address to a new email address', async () => {
-    const newEmail = generateWireEmail(user.lastName);
+    const newEmail = generateWireEmail(user.firstName, user.lastName);
     await pages.account().changeEmailAddress(newEmail);
     await modals.acknowledge().clickAction(); // Acknowledge verify email address modal
 

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupCalls-TC-8632.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupCalls-TC-8632.spec.ts
@@ -25,88 +25,73 @@ import {PageManager} from 'test/e2e_tests/pageManager';
 import {test, expect, withLogin} from '../../test.fixtures';
 import {createGroup} from 'test/e2e_tests/utils/userActions';
 
+let owner: User;
+let member: User;
+const conversationName = 'Calling';
+
+test.beforeEach(async ({api, createUser, createTeam}) => {
+  member = await createUser();
+  const team = await createTeam('Calling', {users: [member]});
+  owner = team.owner;
+
+  // The team will be reset right after initialization, so we need to wait a short time for it to finish before changing feature configs since they would otherwise be overwritten
+  await new Promise(resolve => setTimeout(resolve, 5000));
+  await api.enableConferenceCallingFeature(owner.teamId!);
+  await api.waitForFeatureToBeEnabled(FEATURE_KEY.CONFERENCE_CALLING, owner.teamId!, owner.token);
+});
+
 test(
   'Planning group call with sending various messages during call',
   {tag: ['@TC-8632', '@crit-flow-web']},
-  async ({createUser, createTeam, createPage, api}) => {
-    test.setTimeout(150_000);
-
-    let owner: User;
-    let member: User;
-    let ownerPageManager: PageManager;
-    let memberPageManager: PageManager;
-
-    const conversationName = 'Calling';
-
-    await test.step('Preconditions: Creating preconditions for the test via API', async () => {
-      member = await createUser();
-      const team = await createTeam('Calling', {users: [member]});
-      owner = team.owner;
-
-      // The team will be reset right after initialization, so we need to wait a short time for it to finish before changing feature configs since they would otherwise be overwritten
-      await new Promise(resolve => setTimeout(resolve, 5000));
-      await api.enableConferenceCallingFeature(owner.teamId!);
-      await api.waitForFeatureToBeEnabled(FEATURE_KEY.CONFERENCE_CALLING, owner.teamId!, owner.token);
-
-      const [pmOwner, pmMember] = await Promise.all([
-        PageManager.from(createPage(withLogin(owner))),
-        PageManager.from(createPage(withLogin(member))),
-      ]);
-
-      ownerPageManager = pmOwner;
-      memberPageManager = pmMember;
-    });
+  async ({createPage}) => {
+    const [ownerPageManager, memberPageManager] = await Promise.all([
+      PageManager.from(createPage(withLogin(owner))),
+      PageManager.from(createPage(withLogin(member))),
+    ]);
 
     await test.step('Owner creates group and adds the member', async () => {
       const {pages} = ownerPageManager.webapp;
       await createGroup(pages, conversationName, [member]);
-      await expect(pages.conversationList().getConversationLocator(conversationName)).toBeVisible();
     });
 
     await test.step('Owner starts call', async () => {
       const {pages, components} = ownerPageManager.webapp;
-      const ownerCalling = components.calling();
       await pages.conversationList().openConversation(conversationName);
       await pages.conversation().startCall();
 
-      await expect(ownerCalling.callCell).toBeVisible();
+      await expect(components.calling().callCell).toBeVisible();
     });
 
     await test.step('Member joins call and goes full screen', async () => {
       const {pages, components} = memberPageManager.webapp;
-      const memberCalling = components.calling();
       await pages.conversationList().openConversation(conversationName);
-      await memberCalling.waitForCell();
-      expect(await memberCalling.isCellVisible()).toBeTruthy();
+      const memberCalling = components.calling();
+      await expect(memberCalling.callCell).toBeVisible();
 
       await memberCalling.clickAcceptCallButton();
-      expect(await memberCalling.isCellVisible()).toBeTruthy();
-
-      expect(await memberCalling.isFullScreenVisible()).toBeFalsy();
+      await expect(memberCalling.fullScreen).not.toBeVisible();
 
       await memberCalling.maximizeCell();
-      await memberCalling.waitForGoFullScreen();
-      expect(await memberCalling.isFullScreenVisible()).toBeTruthy();
+      await expect(memberCalling.fullScreen).toBeVisible();
     });
 
     await test.step('Owner goes full screen', async () => {
       const {components} = ownerPageManager.webapp;
-      const ownerCalling = components.calling();
-      await ownerCalling.maximizeCell();
-      await ownerCalling.waitForGoFullScreen();
-      expect(await ownerCalling.isFullScreenVisible()).toBeTruthy();
+      await components.calling().maximizeCell();
+      await expect(components.calling().fullScreen).toBeVisible();
     });
 
     await test.step('Validation: Participants see each other', async () => {
       const ownerCalling = ownerPageManager.webapp.components.calling();
       const memberCalling = memberPageManager.webapp.components.calling();
-      await ownerCalling.waitForParticipantNameToBeVisible(member.qualifiedId?.id);
-      await memberCalling.waitForParticipantNameToBeVisible(owner.qualifiedId?.id);
+
+      await expect(ownerCalling.getGridTile(member.fullName)).toBeVisible();
+      await expect(memberCalling.getGridTile(owner.fullName)).toBeVisible();
     });
 
     await test.step('Validation: Owner sees member is muted', async () => {
       const ownerCalling = ownerPageManager.webapp.components.calling();
-      expect(await ownerCalling.isGridTileMuteIconVisibleForUser(member.username)).toBeFalsy();
+      await expect(ownerCalling.getGridTile(member.fullName).muteIcon).toBeVisible();
     });
 
     await test.step('Member unmutes themselves', async () => {
@@ -117,7 +102,7 @@ test(
 
     await test.step('Validation: Owner sees member is unmuted', async () => {
       const ownerCalling = ownerPageManager.webapp.components.calling();
-      expect(await ownerCalling.isGridTileMuteIconVisibleForUser(member.username)).toBeFalsy();
+      await expect(ownerCalling.getGridTile(member.fullName).muteIcon).not.toBeVisible();
     });
   },
 );

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupCalls-TC-8632.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupCalls-TC-8632.spec.ts
@@ -17,8 +17,6 @@
  *
  */
 
-import {FEATURE_KEY} from '@wireapp/api-client/lib/team/feature';
-
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 
@@ -29,16 +27,10 @@ let owner: User;
 let member: User;
 const conversationName = 'Calling';
 
-test.beforeEach(async ({api, createUser, createTeam}) => {
+test.beforeEach(async ({createUser, createTeam}) => {
   member = await createUser();
-  const team = await createTeam('Calling', {users: [member]});
+  const team = await createTeam('Calling', {users: [member], features: {conferenceCalling: true}});
   owner = team.owner;
-
-  // The team will be reset right after initialization, so we need to wait a short time for it to finish
-  // before changing feature configs since they would otherwise be overwritten (See WPB-23698)
-  await new Promise(resolve => setTimeout(resolve, 5000));
-  await api.enableConferenceCallingFeature(owner.teamId!);
-  await api.waitForFeatureToBeEnabled(FEATURE_KEY.CONFERENCE_CALLING, owner.teamId!, owner.token);
 });
 
 test(

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupCalls-TC-8632.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupCalls-TC-8632.spec.ts
@@ -34,7 +34,8 @@ test.beforeEach(async ({api, createUser, createTeam}) => {
   const team = await createTeam('Calling', {users: [member]});
   owner = team.owner;
 
-  // The team will be reset right after initialization, so we need to wait a short time for it to finish before changing feature configs since they would otherwise be overwritten
+  // The team will be reset right after initialization, so we need to wait a short time for it to finish
+  // before changing feature configs since they would otherwise be overwritten (See WPB-23698)
   await new Promise(resolve => setTimeout(resolve, 5000));
   await api.enableConferenceCallingFeature(owner.teamId!);
   await api.waitForFeatureToBeEnabled(FEATURE_KEY.CONFERENCE_CALLING, owner.teamId!, owner.token);

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupCalls-TC-8632.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupCalls-TC-8632.spec.ts
@@ -25,8 +25,7 @@ import {PageManager} from 'test/e2e_tests/pageManager';
 import {test, expect, withLogin} from '../../test.fixtures';
 import {createGroup} from 'test/e2e_tests/utils/userActions';
 
-// ToDo(WPB-22442): Backoffice does not unlock calling feature for teams created during tests
-test.fixme(
+test(
   'Planning group call with sending various messages during call',
   {tag: ['@TC-8632', '@crit-flow-web']},
   async ({createUser, createTeam, createPage, api}) => {
@@ -44,6 +43,8 @@ test.fixme(
       const team = await createTeam('Calling', {users: [member]});
       owner = team.owner;
 
+      // The team will be reset right after initialization, so we need to wait a short time for it to finish before changing feature configs since they would otherwise be overwritten
+      await new Promise(resolve => setTimeout(resolve, 5000));
       await api.enableConferenceCallingFeature(owner.teamId!);
       await api.waitForFeatureToBeEnabled(FEATURE_KEY.CONFERENCE_CALLING, owner.teamId!, owner.token);
 
@@ -51,6 +52,7 @@ test.fixme(
         PageManager.from(createPage(withLogin(owner))),
         PageManager.from(createPage(withLogin(member))),
       ]);
+
       ownerPageManager = pmOwner;
       memberPageManager = pmMember;
     });
@@ -66,9 +68,8 @@ test.fixme(
       const ownerCalling = components.calling();
       await pages.conversationList().openConversation(conversationName);
       await pages.conversation().startCall();
-      await ownerCalling.waitForCell();
 
-      expect(await ownerCalling.isCellVisible()).toBeTruthy();
+      await expect(ownerCalling.callCell).toBeVisible();
     });
 
     await test.step('Member joins call and goes full screen', async () => {
@@ -111,8 +112,7 @@ test.fixme(
     await test.step('Member unmutes themselves', async () => {
       const memberCalling = memberPageManager.webapp.components.calling();
       await memberCalling.unmuteSelfInFullScreen();
-      await memberPageManager.waitForTimeout(250);
-      expect(await memberCalling.isSelfUserMutedInFullScreen()).toBeFalsy();
+      await expect(memberCalling.fullScreenMuteButton).toHaveAttribute('data-uie-value', 'active');
     });
 
     await test.step('Validation: Owner sees member is unmuted', async () => {

--- a/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
@@ -212,7 +212,7 @@ test.describe('History Backup', () => {
         const renamedSystemMessage = userAPages
           .conversation()
           .systemMessages.filter({hasText: `${userB.fullName} renamed the conversation`});
-        await expect(renamedSystemMessage).toContainText(`${userB.fullName} renamed the conversation`);
+        await expect(renamedSystemMessage).toBeVisible();
       });
     },
   );

--- a/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
@@ -63,7 +63,7 @@ test.describe('History Backup', () => {
       const backupName = await createAndSaveBackup(testInfo, userAPageManager);
 
       await test.step('User A changes their Email address', async () => {
-        const newEmail = generateWireEmail(userA.lastName);
+        const newEmail = generateWireEmail(userA.firstName, userA.lastName);
         await userAPages.account().changeEmailAddress(newEmail);
         await userAModals.acknowledge().clickAction(); // Acknowledge verify email address modal
 
@@ -139,7 +139,7 @@ test.describe('History Backup', () => {
         backupName = await createAndSaveBackup(testInfo, userAPageManager);
       });
 
-      await test.step('User B tries to restore User A\'s backup', async () => {
+      await test.step("User B tries to restore User A's backup", async () => {
         await logOutUser(userBPageManager, true);
         await loginUser(userB, userBPageManager);
         await userBPages.historyInfo().clickConfirmButton();
@@ -189,7 +189,7 @@ test.describe('History Backup', () => {
         await userAComponents.conversationSidebar().clickPreferencesButton();
         backupName = await createAndSaveBackup(testInfo, userAPageManager);
         await userAComponents.conversationSidebar().allConverationsButton.click();
-        await userAPages.conversationList().openConversation(userB.fullName, { protocol: 'mls' });
+        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
       });
 
       await test.step('User B renames group conversation', async () => {
@@ -209,7 +209,9 @@ test.describe('History Backup', () => {
 
         // User A sees system message that User B had renamed the conversation
         await userAPages.conversationList().openConversation(renamedConversationName);
-        const renamedSystemMessage = userAPages.conversation().systemMessages.filter({hasText: `${userB.fullName} renamed the conversation`});
+        const renamedSystemMessage = userAPages
+          .conversation()
+          .systemMessages.filter({hasText: `${userB.fullName} renamed the conversation`});
         await expect(renamedSystemMessage).toContainText(`${userB.fullName} renamed the conversation`);
       });
     },

--- a/apps/webapp/test/e2e_tests/test.fixtures.ts
+++ b/apps/webapp/test/e2e_tests/test.fixtures.ts
@@ -51,7 +51,10 @@ type Fixtures = {
    * @param options.withMembers Can either be the number of team members to create or an array of existing members to add to the team
    * @returns an object containing the teams owner and an array of members. The size of the members array matches the number or array length passed to `withMembers`
    */
-  createTeam: (teamName: string, options?: {users: (User | {user: User; role?: keyof typeof Role})[]}) => Promise<Team>;
+  createTeam: (
+    teamName: string,
+    options?: {users: (User | {user: User; role?: keyof typeof Role})[]; features?: {conferenceCalling?: boolean}},
+  ) => Promise<Team>;
 };
 
 export type Team = {
@@ -159,7 +162,17 @@ export const test = baseTest.extend<Fixtures>({
         );
       }
 
-      return {owner, addTeamMember};
+      if (options?.features) {
+        // The team will be reset right after initialization, so we need to wait a short time for it to finish
+        // before changing feature configs since they would otherwise be overwritten (See WPB-23698)
+        await new Promise(resolve => setTimeout(resolve, 5000));
+
+        if (options.features.conferenceCalling) {
+          await api.enableConferenceCallingFeature(teamId);
+        }
+      }
+
+      return {teamId, owner, addTeamMember};
     });
 
     // Deletes each created team and the owner / members associated with it

--- a/apps/webapp/test/e2e_tests/utils/userDataGenerator.ts
+++ b/apps/webapp/test/e2e_tests/utils/userDataGenerator.ts
@@ -49,8 +49,10 @@ export const generateFirstName = (): string => {
   return faker.person.firstName().replace(/[^a-zA-Z]+/g, '');
 };
 
-export const generateWireEmail = (lastName: string): string => {
-  return faker.internet.email({lastName: sanitizeName(lastName), provider: 'wire.engineering'}).toLowerCase();
+export const generateWireEmail = (firstName: string, lastName: string): string => {
+  return faker.internet
+    .email({firstName: sanitizeName(firstName), lastName: sanitizeName(lastName), provider: 'wire.engineering'})
+    .toLowerCase();
 };
 
 export const generateUsername = (firstName: string, lastName: string): string => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23747" title="WPB-23747" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23747</a>  [Web/QA] Fix and re-enable TC-8632 Group call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

This PR re-enables the previously skipped critical flow test for group calling. It was skipped due to a limitation with enterprise features not being unlockable which was resolved. The PR also:
- Makes the emails of generated users follow their first and last name instead of just last name (for easier debugging)
- Refactors the critical flow test to follow best practices
- Removes a lot of no longer needed utils

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).
