### PR TITLE
feat(webapp): include client version in periodic version checks [WPB-23299]

### DIFF
--- a/apps/webapp/src/script/application-periodic-checks/runClientVersionCheck.test.ts
+++ b/apps/webapp/src/script/application-periodic-checks/runClientVersionCheck.test.ts
@@ -23,13 +23,18 @@ import {runClientVersionCheck} from './runClientVersionCheck';
 
 describe('runClientVersionCheck', () => {
   it('requests the client version check route', () => {
+    const clientVersion = '2026.02.12.17.51.00';
     const kyInstance = {
       get: jest.fn(() => Promise.resolve()),
     } as unknown as KyInstance;
 
-    runClientVersionCheck({ky: kyInstance});
+    runClientVersionCheck({ky: kyInstance, clientVersion});
 
     expect(kyInstance.get).toHaveBeenCalledTimes(1);
-    expect(kyInstance.get).toHaveBeenCalledWith('/client-version-check');
+    expect(kyInstance.get).toHaveBeenCalledWith('/client-version-check', {
+      headers: {
+        'Wire-Client-Version': clientVersion,
+      },
+    });
   });
 });

--- a/apps/webapp/src/script/application-periodic-checks/runClientVersionCheck.ts
+++ b/apps/webapp/src/script/application-periodic-checks/runClientVersionCheck.ts
@@ -21,13 +21,18 @@ import {KyInstance} from 'ky';
 
 interface RunClientVersionCheckOptions {
   readonly ky: KyInstance;
+  readonly clientVersion: string;
 }
 
 export function runClientVersionCheck(options: RunClientVersionCheckOptions): void {
-  const {ky} = options;
+  const {ky, clientVersion} = options;
 
   const requestClientVersionCheck = async () => {
-    await ky.get('/client-version-check');
+    await ky.get('/client-version-check', {
+      headers: {
+        'Wire-Client-Version': clientVersion,
+      },
+    });
   };
 
   void requestClientVersionCheck();

--- a/apps/webapp/src/script/page/AppMain.tsx
+++ b/apps/webapp/src/script/page/AppMain.tsx
@@ -101,9 +101,10 @@ export const AppMain = ({
   const wallClock = useMemo(() => {
     return createWallClock();
   }, []);
+  const clientVersion = Config.getConfig().VERSION;
   const runApplicationPeriodicCheck: () => void = useCallback(() => {
-    runClientVersionCheck({ky});
-  }, []);
+    runClientVersionCheck({ky, clientVersion});
+  }, [clientVersion]);
   const apiContext = app.getAPIContext();
 
   useEffect(() => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23299" title="WPB-23299" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23299</a>  [Web] Add support for remote force reload 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Our own HTTP API endpoint is expecting that header.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
