### PR TITLE
fix: speaker output not updating during active call when changed in main settings [WPB-23766]

### DIFF
--- a/apps/webapp/src/script/page/MainContent/panels/preferences/AVPreferences.tsx
+++ b/apps/webapp/src/script/page/MainContent/panels/preferences/AVPreferences.tsx
@@ -68,7 +68,12 @@ const AVPreferencesComponent = ({propertiesRepository, callingRepository, device
           hasActiveCall={callingRepository.hasActiveCall()}
         />
       )}
-      {areMediaDevicesInitialized && deviceSupport.audiooutput && <AudioOutPreferences />}
+      {areMediaDevicesInitialized && deviceSupport.audiooutput && (
+        <AudioOutPreferences
+          refreshCallOutputSpeaker={() => callingRepository.refreshAudioOutput()}
+          hasActiveCall={callingRepository.hasActiveCall()}
+        />
+      )}
       {areMediaDevicesInitialized && deviceSupport.videoinput && (
         <CameraPreferences
           key={`camera-${shouldReloadCamera}`} // Force remount when call ends

--- a/apps/webapp/src/script/page/MainContent/panels/preferences/avPreferences/AudioOutPreferences.tsx
+++ b/apps/webapp/src/script/page/MainContent/panels/preferences/avPreferences/AudioOutPreferences.tsx
@@ -17,6 +17,8 @@
  *
  */
 
+import {FunctionComponent} from 'react';
+
 import * as Icon from 'Components/Icon';
 import {useMediaDevicesStore} from 'Repositories/media/useMediaDevicesStore';
 import {t} from 'Util/LocalizerUtil';
@@ -30,7 +32,10 @@ interface AudioOutPreferencesProps {
   hasActiveCall: boolean;
 }
 
-const AudioOutPreferences = ({refreshCallOutputSpeaker, hasActiveCall}: AudioOutPreferencesProps) => {
+const AudioOutPreferences: FunctionComponent<AudioOutPreferencesProps> = ({
+  refreshCallOutputSpeaker,
+  hasActiveCall,
+}: AudioOutPreferencesProps) => {
   const {audioOutputDeviceId, setAudioOutputDeviceId, audioOutputDevices} = useMediaDevicesStore(state => ({
     audioOutputDeviceId: state.audio.output.selectedId,
     setAudioOutputDeviceId: state.setAudioOutputDeviceId,

--- a/apps/webapp/src/script/page/MainContent/panels/preferences/avPreferences/AudioOutPreferences.tsx
+++ b/apps/webapp/src/script/page/MainContent/panels/preferences/avPreferences/AudioOutPreferences.tsx
@@ -25,18 +25,32 @@ import {DeviceSelect} from './DeviceSelect';
 
 import {PreferencesSection} from '../components/PreferencesSection';
 
-const AudioOutPreferences = () => {
+interface AudioOutPreferencesProps {
+  refreshCallOutputSpeaker: () => void;
+  hasActiveCall: boolean;
+}
+
+const AudioOutPreferences = ({refreshCallOutputSpeaker, hasActiveCall}: AudioOutPreferencesProps) => {
   const {audioOutputDeviceId, setAudioOutputDeviceId, audioOutputDevices} = useMediaDevicesStore(state => ({
     audioOutputDeviceId: state.audio.output.selectedId,
     setAudioOutputDeviceId: state.setAudioOutputDeviceId,
     audioOutputDevices: state.audio.output.devices,
   }));
 
+  const handleChange = async (deviceId: string) => {
+    if (deviceId !== audioOutputDeviceId) {
+      setAudioOutputDeviceId(deviceId);
+      if (hasActiveCall) {
+        await refreshCallOutputSpeaker();
+      }
+    }
+  };
+
   return (
     <PreferencesSection title={t('preferencesAVSpeakers')}>
       <DeviceSelect
         uieName="enter-speaker"
-        onChange={deviceId => setAudioOutputDeviceId(deviceId)}
+        onChange={handleChange}
         devices={audioOutputDevices}
         value={audioOutputDeviceId}
         icon={Icon.SpeakerIcon}

--- a/apps/webapp/src/script/page/MainContent/panels/preferences/avPreferences/AudioOutPreferences.tsx
+++ b/apps/webapp/src/script/page/MainContent/panels/preferences/avPreferences/AudioOutPreferences.tsx
@@ -37,11 +37,11 @@ const AudioOutPreferences = ({refreshCallOutputSpeaker, hasActiveCall}: AudioOut
     audioOutputDevices: state.audio.output.devices,
   }));
 
-  const handleChange = async (deviceId: string) => {
+  const handleChange = (deviceId: string): void => {
     if (deviceId !== audioOutputDeviceId) {
       setAudioOutputDeviceId(deviceId);
       if (hasActiveCall) {
-        await refreshCallOutputSpeaker();
+        refreshCallOutputSpeaker();
       }
     }
   };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23766" title="WPB-23766" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23766</a>  Audio device changed in Settings during call is not applied; call continues using previously selected device
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

This PR fixes an issue where changing the audio output device (speaker) in the main settings did not update the active call.

## Summary

When a user changed the speaker in the main settings while a call is already active, the selected output device was updated, but the ongoing call continued using the previously selected output device.

When the speaker is changed and an active call is present, the media sinkId of audio html elements is now refreshed with the selected output device.
This ensures that the new output device is applied immediately to the ongoing call.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
