### PR TITLE
feat(webapp): validate client version check responses with zod result schema [WPB-23299]

### DIFF
--- a/apps/webapp/src/script/application-periodic-checks/clientVersionCheckResponseSchema.test.ts
+++ b/apps/webapp/src/script/application-periodic-checks/clientVersionCheckResponseSchema.test.ts
@@ -1,0 +1,112 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import assert from 'node:assert';
+import {result} from 'true-myth';
+
+import {
+  clientVersionCheckResponseSchema,
+  invalidClientVersionCheckRequestHttpStatusCode,
+  reloadClientVersionCheckAction,
+  successfulClientVersionCheckHttpStatusCode,
+  upgradeRequiredHttpStatusCode,
+  validateClientVersionCheckResponse,
+} from './clientVersionCheckResponseSchema';
+
+describe('clientVersionCheckResponseSchema', () => {
+  const unsupportedClientVersionCheckHttpStatusCode = 500;
+
+  it.each([
+    {httpStatusCode: successfulClientVersionCheckHttpStatusCode},
+    {httpStatusCode: invalidClientVersionCheckRequestHttpStatusCode},
+    {
+      httpStatusCode: upgradeRequiredHttpStatusCode,
+      responseBody: {action: reloadClientVersionCheckAction},
+    },
+  ])('accepts valid client version check response %#', response => {
+    expect(clientVersionCheckResponseSchema.safeParse(response).success).toBe(true);
+  });
+
+  it.each([
+    {httpStatusCode: upgradeRequiredHttpStatusCode},
+    {httpStatusCode: upgradeRequiredHttpStatusCode, responseBody: {action: 'logout'}},
+    {httpStatusCode: unsupportedClientVersionCheckHttpStatusCode},
+  ])('rejects invalid client version check response %#', response => {
+    expect(clientVersionCheckResponseSchema.safeParse(response).success).toBe(false);
+  });
+});
+
+describe('validateClientVersionCheckResponse()', () => {
+  const unsupportedClientVersionCheckHttpStatusCode = 500;
+
+  it('returns Result ok for HTTP 200 response payload', () => {
+    const validationResult = validateClientVersionCheckResponse({
+      httpStatusCode: successfulClientVersionCheckHttpStatusCode,
+    });
+
+    assert(result.isOk(validationResult));
+
+    expect(validationResult.value).toEqual({
+      httpStatusCode: successfulClientVersionCheckHttpStatusCode,
+    });
+  });
+
+  it('returns Result ok for HTTP 400 response payload', () => {
+    const validationResult = validateClientVersionCheckResponse({
+      httpStatusCode: invalidClientVersionCheckRequestHttpStatusCode,
+    });
+
+    assert(result.isOk(validationResult));
+
+    expect(validationResult.value).toEqual({
+      httpStatusCode: invalidClientVersionCheckRequestHttpStatusCode,
+    });
+  });
+
+  it('returns Result ok for HTTP 426 response payload with reload action', () => {
+    const validationResult = validateClientVersionCheckResponse({
+      httpStatusCode: upgradeRequiredHttpStatusCode,
+      responseBody: {action: reloadClientVersionCheckAction},
+    });
+
+    assert(result.isOk(validationResult));
+
+    expect(validationResult.value).toEqual({
+      httpStatusCode: upgradeRequiredHttpStatusCode,
+      responseBody: {action: reloadClientVersionCheckAction},
+    });
+  });
+
+  it('returns Result err for HTTP 426 response payload with invalid body', () => {
+    const validationResult = validateClientVersionCheckResponse({
+      httpStatusCode: upgradeRequiredHttpStatusCode,
+      responseBody: {action: 'logout'},
+    });
+
+    expect(result.isErr(validationResult)).toBe(true);
+  });
+
+  it('returns Result err for unsupported status code', () => {
+    const validationResult = validateClientVersionCheckResponse({
+      httpStatusCode: unsupportedClientVersionCheckHttpStatusCode,
+    });
+
+    expect(result.isErr(validationResult)).toBe(true);
+  });
+});

--- a/apps/webapp/src/script/application-periodic-checks/clientVersionCheckResponseSchema.ts
+++ b/apps/webapp/src/script/application-periodic-checks/clientVersionCheckResponseSchema.ts
@@ -1,0 +1,78 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Result} from 'true-myth';
+import {z} from 'zod';
+
+export const successfulClientVersionCheckHttpStatusCode = 200;
+export const invalidClientVersionCheckRequestHttpStatusCode = 400;
+export const upgradeRequiredHttpStatusCode = 426;
+export const reloadClientVersionCheckAction = 'reload';
+
+const successfulClientVersionCheckResponseSchema = z.object({
+  httpStatusCode: z.literal(successfulClientVersionCheckHttpStatusCode),
+});
+
+const invalidClientVersionCheckRequestResponseSchema = z.object({
+  httpStatusCode: z.literal(invalidClientVersionCheckRequestHttpStatusCode),
+});
+
+const upgradeRequiredClientVersionCheckResponseSchema = z.object({
+  httpStatusCode: z.literal(upgradeRequiredHttpStatusCode),
+  responseBody: z.object({
+    action: z.literal(reloadClientVersionCheckAction),
+  }),
+});
+
+export const clientVersionCheckResponseSchema = z.discriminatedUnion('httpStatusCode', [
+  successfulClientVersionCheckResponseSchema,
+  invalidClientVersionCheckRequestResponseSchema,
+  upgradeRequiredClientVersionCheckResponseSchema,
+]);
+
+export type ClientVersionCheckResponse = z.infer<typeof clientVersionCheckResponseSchema>;
+
+interface ClientVersionCheckValidationInput {
+  readonly httpStatusCode: number;
+  readonly responseBody?: unknown;
+}
+
+export function validateClientVersionCheckResponse(
+  clientVersionCheckValidationInput: ClientVersionCheckValidationInput,
+): Result<ClientVersionCheckResponse, Error> {
+  const {httpStatusCode, responseBody} = clientVersionCheckValidationInput;
+  let validationResult;
+
+  if (httpStatusCode === upgradeRequiredHttpStatusCode) {
+    validationResult = clientVersionCheckResponseSchema.safeParse({
+      httpStatusCode,
+      responseBody,
+    });
+  } else {
+    validationResult = clientVersionCheckResponseSchema.safeParse({
+      httpStatusCode,
+    });
+  }
+
+  if (validationResult.success) {
+    return Result.ok(validationResult.data);
+  }
+
+  return Result.err(validationResult.error);
+}

--- a/apps/webapp/src/script/application-periodic-checks/runClientVersionCheck.test.ts
+++ b/apps/webapp/src/script/application-periodic-checks/runClientVersionCheck.test.ts
@@ -19,13 +19,19 @@
 
 import {KyInstance} from 'ky';
 
+import {successfulClientVersionCheckHttpStatusCode} from './clientVersionCheckResponseSchema';
 import {runClientVersionCheck} from './runClientVersionCheck';
 
 describe('runClientVersionCheck', () => {
   it('requests the client version check route', () => {
     const clientVersion = '2026.02.12.17.51.00';
     const kyInstance = {
-      get: jest.fn(() => Promise.resolve()),
+      get: jest.fn(() => {
+        return Promise.resolve({
+          status: successfulClientVersionCheckHttpStatusCode,
+          json: jest.fn(),
+        } as unknown as Response);
+      }),
     } as unknown as KyInstance;
 
     runClientVersionCheck({ky: kyInstance, clientVersion});
@@ -35,6 +41,7 @@ describe('runClientVersionCheck', () => {
       headers: {
         'Wire-Client-Version': clientVersion,
       },
+      throwHttpErrors: false,
     });
   });
 });

--- a/apps/webapp/src/script/application-periodic-checks/runClientVersionCheck.ts
+++ b/apps/webapp/src/script/application-periodic-checks/runClientVersionCheck.ts
@@ -19,6 +19,8 @@
 
 import {KyInstance} from 'ky';
 
+import {upgradeRequiredHttpStatusCode, validateClientVersionCheckResponse} from './clientVersionCheckResponseSchema';
+
 interface RunClientVersionCheckOptions {
   readonly ky: KyInstance;
   readonly clientVersion: string;
@@ -27,13 +29,23 @@ interface RunClientVersionCheckOptions {
 export function runClientVersionCheck(options: RunClientVersionCheckOptions): void {
   const {ky, clientVersion} = options;
 
-  const requestClientVersionCheck = async () => {
-    await ky.get('/client-version-check', {
+  async function requestClientVersionCheck() {
+    const clientVersionCheckResponse = await ky.get('/client-version-check', {
       headers: {
         'Wire-Client-Version': clientVersion,
       },
+      throwHttpErrors: false,
     });
-  };
+
+    const httpStatusCode = clientVersionCheckResponse.status;
+    let responseBody: unknown = undefined;
+
+    if (httpStatusCode === upgradeRequiredHttpStatusCode) {
+      responseBody = await clientVersionCheckResponse.json();
+    }
+
+    validateClientVersionCheckResponse({httpStatusCode, responseBody});
+  }
 
   void requestClientVersionCheck();
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23299" title="WPB-23299" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23299</a>  [Web] Add support for remote force reload 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Ensure periodic client version checks only accept expected backend responses and establish a safer foundation for handling update-required cases.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
