### PR TITLE
feat(webapp): expose force-reload flag via root context from version check [WPB-23299]

### DIFF
--- a/apps/webapp/src/script/application-periodic-checks/runClientVersionCheck.test.ts
+++ b/apps/webapp/src/script/application-periodic-checks/runClientVersionCheck.test.ts
@@ -19,12 +19,17 @@
 
 import {KyInstance} from 'ky';
 
-import {successfulClientVersionCheckHttpStatusCode} from './clientVersionCheckResponseSchema';
+import {
+  reloadClientVersionCheckAction,
+  successfulClientVersionCheckHttpStatusCode,
+  upgradeRequiredHttpStatusCode,
+} from './clientVersionCheckResponseSchema';
 import {runClientVersionCheck} from './runClientVersionCheck';
 
 describe('runClientVersionCheck', () => {
-  it('requests the client version check route', () => {
+  it('requests the client version check route', async () => {
     const clientVersion = '2026.02.12.17.51.00';
+    const setDoesApplicationNeedForceReload = jest.fn();
     const kyInstance = {
       get: jest.fn(() => {
         return Promise.resolve({
@@ -34,7 +39,7 @@ describe('runClientVersionCheck', () => {
       }),
     } as unknown as KyInstance;
 
-    runClientVersionCheck({ky: kyInstance, clientVersion});
+    await runClientVersionCheck({ky: kyInstance, clientVersion, setDoesApplicationNeedForceReload});
 
     expect(kyInstance.get).toHaveBeenCalledTimes(1);
     expect(kyInstance.get).toHaveBeenCalledWith('/client-version-check', {
@@ -43,5 +48,30 @@ describe('runClientVersionCheck', () => {
       },
       throwHttpErrors: false,
     });
+    expect(setDoesApplicationNeedForceReload).toHaveBeenCalledTimes(1);
+    expect(setDoesApplicationNeedForceReload).toHaveBeenNthCalledWith(1, false);
+  });
+
+  it('sets force reload status to true when backend requires upgrade', async () => {
+    const setDoesApplicationNeedForceReload = jest.fn();
+    const kyInstance = {
+      get: jest.fn(() => {
+        return Promise.resolve({
+          status: upgradeRequiredHttpStatusCode,
+          json: jest.fn(() => {
+            return Promise.resolve({action: reloadClientVersionCheckAction});
+          }),
+        } as unknown as Response);
+      }),
+    } as unknown as KyInstance;
+
+    await runClientVersionCheck({
+      ky: kyInstance,
+      clientVersion: '2026.02.12.17.51.00',
+      setDoesApplicationNeedForceReload,
+    });
+
+    expect(setDoesApplicationNeedForceReload).toHaveBeenCalledTimes(1);
+    expect(setDoesApplicationNeedForceReload).toHaveBeenCalledWith(true);
   });
 });

--- a/apps/webapp/src/script/application-periodic-checks/runClientVersionCheck.ts
+++ b/apps/webapp/src/script/application-periodic-checks/runClientVersionCheck.ts
@@ -18,34 +18,41 @@
  */
 
 import {KyInstance} from 'ky';
+import {result} from 'true-myth';
 
 import {upgradeRequiredHttpStatusCode, validateClientVersionCheckResponse} from './clientVersionCheckResponseSchema';
 
 interface RunClientVersionCheckOptions {
   readonly ky: KyInstance;
   readonly clientVersion: string;
+  readonly setDoesApplicationNeedForceReload: (doesApplicationNeedForceReload: boolean) => void;
 }
 
-export function runClientVersionCheck(options: RunClientVersionCheckOptions): void {
-  const {ky, clientVersion} = options;
+export async function runClientVersionCheck(options: RunClientVersionCheckOptions): Promise<void> {
+  const {ky, clientVersion, setDoesApplicationNeedForceReload} = options;
 
-  async function requestClientVersionCheck() {
-    const clientVersionCheckResponse = await ky.get('/client-version-check', {
-      headers: {
-        'Wire-Client-Version': clientVersion,
-      },
-      throwHttpErrors: false,
-    });
+  const clientVersionCheckResponse = await ky.get('/client-version-check', {
+    headers: {
+      'Wire-Client-Version': clientVersion,
+    },
+    throwHttpErrors: false,
+  });
 
-    const httpStatusCode = clientVersionCheckResponse.status;
-    let responseBody: unknown = undefined;
+  const httpStatusCode = clientVersionCheckResponse.status;
+  let responseBody: unknown = undefined;
 
-    if (httpStatusCode === upgradeRequiredHttpStatusCode) {
-      responseBody = await clientVersionCheckResponse.json();
-    }
-
-    validateClientVersionCheckResponse({httpStatusCode, responseBody});
+  if (httpStatusCode === upgradeRequiredHttpStatusCode) {
+    responseBody = await clientVersionCheckResponse.json();
   }
 
-  void requestClientVersionCheck();
+  const clientVersionCheckValidationResult = validateClientVersionCheckResponse({httpStatusCode, responseBody});
+
+  if (result.isErr(clientVersionCheckValidationResult)) {
+    return;
+  }
+
+  const doesApplicationNeedForceReload =
+    clientVersionCheckValidationResult.value.httpStatusCode === upgradeRequiredHttpStatusCode;
+
+  setDoesApplicationNeedForceReload(doesApplicationNeedForceReload);
 }

--- a/apps/webapp/src/script/page/AppMain.tsx
+++ b/apps/webapp/src/script/page/AppMain.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {useCallback, useEffect, useLayoutEffect, useMemo} from 'react';
+import {useCallback, useEffect, useLayoutEffect, useMemo, useState} from 'react';
 
 import {amplify} from 'amplify';
 import cx from 'classnames';
@@ -101,9 +101,10 @@ export const AppMain = ({
   const wallClock = useMemo(() => {
     return createWallClock();
   }, []);
+  const [doesApplicationNeedForceReload, setDoesApplicationNeedForceReload] = useState(false);
   const clientVersion = Config.getConfig().VERSION;
   const runApplicationPeriodicCheck: () => void = useCallback(() => {
-    runClientVersionCheck({ky, clientVersion});
+    void runClientVersionCheck({ky, clientVersion, setDoesApplicationNeedForceReload});
   }, [clientVersion]);
   const apiContext = app.getAPIContext();
 
@@ -307,7 +308,7 @@ export const AppMain = ({
       data-uie-value="is-loaded"
     >
       {!locked && <WindowTitleUpdater />}
-      <RootProvider value={{mainViewModel: mainView, wallClock}}>
+      <RootProvider value={{mainViewModel: mainView, wallClock, doesApplicationNeedForceReload}}>
         <ErrorBoundary FallbackComponent={ErrorFallback}>
           {Config.getConfig().FEATURE.ENABLE_DEBUG && <ConfigToolbar />}
           {!locked && (

--- a/apps/webapp/src/script/page/MainContent/MainContent.test.tsx
+++ b/apps/webapp/src/script/page/MainContent/MainContent.test.tsx
@@ -70,7 +70,7 @@ describe('Preferences', () => {
     jest.useFakeTimers();
     render(
       withTheme(
-        <RootProvider value={{mainViewModel, wallClock}}>
+        <RootProvider value={{mainViewModel, wallClock, doesApplicationNeedForceReload: false}}>
           <MainContent {...defaultParams} />
         </RootProvider>,
       ),

--- a/apps/webapp/src/script/page/RootProvider.test.tsx
+++ b/apps/webapp/src/script/page/RootProvider.test.tsx
@@ -23,7 +23,12 @@ import {renderHook} from '@testing-library/react';
 
 import {createFakeWallClock} from '../clock/fakeWallClock';
 import {MainViewModel} from '../view_model/MainViewModel';
-import {RootContext, RootContextValue, RootProvider, useMainViewModel} from './RootProvider';
+import {
+  RootContext,
+  RootContextValue,
+  RootProvider,
+  useMainViewModel,
+} from './RootProvider';
 
 interface WrapperProperties {
   children: ReactNode;
@@ -37,6 +42,7 @@ interface RootProviderWrapper {
 function createRootProviderWrapper(
   mainViewModel: MainViewModel,
   wallClockTimestampInMilliseconds: number,
+  doesApplicationNeedForceReload: boolean,
 ): RootProviderWrapper {
   const fakeWallClock = createFakeWallClock({
     initialCurrentTimestampInMilliseconds: wallClockTimestampInMilliseconds,
@@ -44,7 +50,9 @@ function createRootProviderWrapper(
 
   function wrapper(properties: WrapperProperties): ReactNode {
     const wrappedChildren = (
-      <RootProvider value={{mainViewModel, wallClock: fakeWallClock}}>{properties.children}</RootProvider>
+      <RootProvider value={{mainViewModel, wallClock: fakeWallClock, doesApplicationNeedForceReload}}>
+        {properties.children}
+      </RootProvider>
     );
 
     return wrappedChildren;
@@ -63,21 +71,30 @@ describe('RootProvider', () => {
   const mainViewModel = {} as MainViewModel;
 
   it('provides the injected wall clock through context', () => {
-    const {wrapper, fakeWallClock} = createRootProviderWrapper(mainViewModel, 1_234);
+    const {wrapper, fakeWallClock} = createRootProviderWrapper(mainViewModel, 1_234, false);
 
     const {result} = renderHook(getRootContextValue, {wrapper});
 
     expect(result.current?.mainViewModel).toBe(mainViewModel);
     expect(result.current?.wallClock).toBe(fakeWallClock);
     expect(result.current?.wallClock.currentTimestampInMilliseconds).toBe(1_234);
+    expect(result.current?.doesApplicationNeedForceReload).toBe(false);
   });
 
   it('provides the main view model through useMainViewModel()', () => {
-    const {wrapper, fakeWallClock} = createRootProviderWrapper(mainViewModel, 8_765);
+    const {wrapper, fakeWallClock} = createRootProviderWrapper(mainViewModel, 8_765, false);
 
     const {result} = renderHook(useMainViewModel, {wrapper});
 
     expect(result.current).toBe(mainViewModel);
     expect(fakeWallClock.currentTimestampInMilliseconds).toBe(8_765);
+  });
+
+  it('provides force reload status through RootContext', () => {
+    const {wrapper} = createRootProviderWrapper(mainViewModel, 5_555, true);
+
+    const {result} = renderHook(getRootContextValue, {wrapper});
+
+    expect(result.current?.doesApplicationNeedForceReload).toBe(true);
   });
 });

--- a/apps/webapp/src/script/page/RootProvider.tsx
+++ b/apps/webapp/src/script/page/RootProvider.tsx
@@ -25,6 +25,7 @@ import {MainViewModel} from '../view_model/MainViewModel';
 export type RootContextValue = {
   readonly mainViewModel: MainViewModel;
   readonly wallClock: WallClock;
+  readonly doesApplicationNeedForceReload: boolean;
 };
 
 export const RootContext = createContext<RootContextValue | null>(null);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23299" title="WPB-23299" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23299</a>  [Web] Add support for remote force reload 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Ensure the application has a single, always-available signal for mandatory client reloads so UI flows can react consistently to backend version enforcement.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
