### PR TITLE
test: fix test ids and blocks not matching testiny [WPB-23747]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
@@ -175,7 +175,7 @@ test.describe('account settings', () => {
 
   test(
     'Verify link to manage a team is not shown when logged in as team member or normal use',
-    {tag: ['@TC-1723', '@regression']},
+    {tag: ['@TC-1724', '@regression']},
     async ({pageManager}) => {
       const {components} = pageManager.webapp;
 

--- a/apps/webapp/test/e2e_tests/specs/Archive/archive.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Archive/archive.spec.ts
@@ -25,14 +25,13 @@ import {createGroup} from 'test/e2e_tests/utils/userActions';
 
 import {test, expect} from '../../test.fixtures';
 
-test.describe('Accessibility', () => {
+test.describe('Archive', () => {
   let owner = getUser();
   const members = Array.from({length: 2}, () => getUser());
   const [memberA, memberB] = members;
-  const teamName = 'Accessibility';
 
   test.beforeAll(async ({api}) => {
-    const user = await bootstrapTeamForTesting(api, members, owner, teamName);
+    const user = await bootstrapTeamForTesting(api, members, owner, 'Test Team');
     owner = {...owner, ...user};
   });
 

--- a/apps/webapp/test/e2e_tests/specs/Authentication/authentication.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Authentication/authentication.spec.ts
@@ -62,7 +62,7 @@ test.describe('Authentication', () => {
 
   test(
     'Verify sign in error appearance in case of suspended team account',
-    {tag: ['@TC-3468', '@regression']},
+    {tag: ['@TC-3458', '@regression']},
     async ({pageManager}) => {
       const {pages} = pageManager.webapp;
       await pageManager.openLoginPage();

--- a/apps/webapp/test/e2e_tests/specs/Registration/registration.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Registration/registration.spec.ts
@@ -23,7 +23,7 @@ import {addCreatedUser, removeCreatedUser} from 'test/e2e_tests/utils/tearDown.u
 
 import {test, expect} from '../../test.fixtures';
 
-test.describe('registration personal account', () => {
+test.describe('Registration', () => {
   test.describe('email registration used', () => {
     const userA = getUser();
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23747" title="WPB-23747" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23747</a>  [Web/QA] Fix and re-enable TC-8632 Group call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Fixes some mismatches I discovered during auditing. E.g. due to a typo or copy paste mistakes

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
