### PR TITLE
test: implement remaining reaction tests [WPB-19964]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Reactions/reactions.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reactions/reactions.spec.ts
@@ -208,6 +208,61 @@ test.describe('Reactions', () => {
     },
   );
 
+  test(
+    'Verify locally deleted message can be liked by others',
+    {tag: ['@TC-1543', '@regression']},
+    async ({createPage}) => {
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+      ]);
+
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userAPages.conversation().sendMessage('Message to react to');
+
+      const userBMessage = userBPages.conversation().getMessage({sender: userA});
+      await userBPages.conversation().reactOnMessage(userBMessage, 'plus-one');
+
+      const userAMessage = userAPages.conversation().getMessage({sender: userA});
+      await userAPages.conversation().deleteMessage(userAMessage, 'Me');
+
+      const reactionPill = userBPages.conversation().getReactionOnMessage(userBMessage, 'plus-one');
+      await expect(reactionPill).toBeVisible();
+    },
+  );
+
+  test(
+    'Verify likes are reset if sender edits their message',
+    {tag: ['@TC-1544', '@regression']},
+    async ({createPage}) => {
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+      ]);
+
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userAPages.conversation().sendMessage('Message to react to');
+
+      const userBMessage = userBPages.conversation().getMessage({sender: userA});
+      await userBPages.conversation().reactOnMessage(userBMessage, 'plus-one');
+
+      const userAMessage = userAPages.conversation().getMessage({sender: userA});
+      const userAReaction = userAPages.conversation().getReactionOnMessage(userAMessage, 'plus-one');
+      const userBReaction = userBPages.conversation().getReactionOnMessage(userBMessage, 'plus-one');
+      await expect(userAReaction).toBeVisible();
+      await expect(userBReaction).toBeVisible();
+
+      await userAPages.conversation().editMessage(userAMessage);
+      await expect(userAPages.conversation().messageInput).toContainText('Message to react to');
+      await userAPages.conversation().sendMessage('Message without reaction');
+
+      await expect(userAReaction).not.toBeAttached();
+      await expect(userBReaction).not.toBeAttached();
+    },
+  );
+
   const toggleReactionCases = [
     {
       tc: '@TC-1548',


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19964" title="WPB-19964" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19964</a>  [Web/QA] Write the Reactions regression tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- Implement the two not remaining test cases for reactions TC-1543 & TC-1544

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
