### PR TITLE
chore: cherry-pick accessibility improvements to the release branch [WPB-23860]

### DIFF
--- a/apps/webapp/src/i18n/ar-SA.json
+++ b/apps/webapp/src/i18n/ar-SA.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "اكتب الرسالة",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "الأشخاص ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "إضافة صورة",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "ابحث",

--- a/apps/webapp/src/i18n/bg-BG.json
+++ b/apps/webapp/src/i18n/bg-BG.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/bn-BD.json
+++ b/apps/webapp/src/i18n/bn-BD.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/bs-BA.json
+++ b/apps/webapp/src/i18n/bs-BA.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/ca-ES.json
+++ b/apps/webapp/src/i18n/ca-ES.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/cs-CZ.json
+++ b/apps/webapp/src/i18n/cs-CZ.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Napsat zprávu",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "Kontakty ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Přidat obrázek",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Hledat",

--- a/apps/webapp/src/i18n/da-DK.json
+++ b/apps/webapp/src/i18n/da-DK.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Skriv en besked",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "Personer ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Tilføj billede",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Søg",

--- a/apps/webapp/src/i18n/de-DE.json
+++ b/apps/webapp/src/i18n/de-DE.json
@@ -1957,7 +1957,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} schreibt",
   "tooltipConversationInputPlaceholder": "Eine Nachricht schreiben",
   "tooltipConversationInputTwoUserTyping": "{user1} und {user2} schreiben",
-  "tooltipConversationPeople": "Unterhaltungsübersicht ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Bild senden",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Suche",

--- a/apps/webapp/src/i18n/de-DE.json
+++ b/apps/webapp/src/i18n/de-DE.json
@@ -159,6 +159,7 @@
   "accessibility.rightPanel.GoBack": "Zurück",
   "accessibility.rightPanel.close": "Info zur Unterhaltung schließen",
   "accessibility.searchInput.cancel": "Eintrag löschen",
+  "accessibility.selfDeletingMessage.timer": "Selbstlöschende Nachricht, Timer läuft ab.",
   "accessibility.userProfileDeleteEntry": "Eintrag löschen",
   "accountAlreadyExistsModal.changeEmailLink": "E-Mail-Adresse ändern",
   "accountAlreadyExistsModal.content": "Die Domäne dieser E-Mail gehört zu einem lokalen Backend. Bitte ändern Sie Ihre E-Mail-Adresse in den Einstellungen oder löschen Sie Ihr Benutzerkonto. Wenn Sie Teil eines Teams sind, wenden Sie sich bitte an Ihren Team-Admin.",

--- a/apps/webapp/src/i18n/de-DE.json
+++ b/apps/webapp/src/i18n/de-DE.json
@@ -1957,7 +1957,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} schreibt",
   "tooltipConversationInputPlaceholder": "Eine Nachricht schreiben",
   "tooltipConversationInputTwoUserTyping": "{user1} und {user2} schreiben",
-  "tooltipConversationPeople": "{displayName}, conversation details",
+  "tooltipConversationPeople": "{displayName}, Unterhaltungsdetails",
   "tooltipConversationPicture": "Bild senden",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Suche",

--- a/apps/webapp/src/i18n/el-CY.json
+++ b/apps/webapp/src/i18n/el-CY.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/el-GR.json
+++ b/apps/webapp/src/i18n/el-GR.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Πληκτρολογηση μηνυματος",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "Άτομα ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Προσθήκη εικόνας",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Αναζήτηση",

--- a/apps/webapp/src/i18n/en-US.json
+++ b/apps/webapp/src/i18n/en-US.json
@@ -159,6 +159,7 @@
   "accessibility.rightPanel.GoBack": "Go back",
   "accessibility.rightPanel.close": "Close conversation info",
   "accessibility.searchInput.cancel": "Delete entry",
+  "accessibility.selfDeletingMessage.timer": "Self-deleting message, timer is counting down.",
   "accessibility.userProfileDeleteEntry": "Delete entry",
   "accountAlreadyExistsModal.changeEmailLink": "Change your email address",
   "accountAlreadyExistsModal.content": "This email's domain belongs to an on-premises backend. Please change your email in the account settings or delete your account. If you are part of a team please contact your team admin.",

--- a/apps/webapp/src/i18n/en-US.json
+++ b/apps/webapp/src/i18n/en-US.json
@@ -1957,7 +1957,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/es-ES.json
+++ b/apps/webapp/src/i18n/es-ES.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Escriba un mensaje",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "Personas ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Añadir imagen",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Buscar",

--- a/apps/webapp/src/i18n/et-EE.json
+++ b/apps/webapp/src/i18n/et-EE.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Kirjuta sõnum",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "Inimesed ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Lisa pilt",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Otsing",

--- a/apps/webapp/src/i18n/fa-IR.json
+++ b/apps/webapp/src/i18n/fa-IR.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "پیام خود را بنویسید",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "افراد ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "اضافه کردن عکس",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "جستجو",

--- a/apps/webapp/src/i18n/fi-FI.json
+++ b/apps/webapp/src/i18n/fi-FI.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Kirjoita viesti",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "Ihmiset ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Lisää kuva",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Etsi",

--- a/apps/webapp/src/i18n/fr-FR.json
+++ b/apps/webapp/src/i18n/fr-FR.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Écrivez un message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "Contacts ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Ajouter une image",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Recherche",

--- a/apps/webapp/src/i18n/ga-IE.json
+++ b/apps/webapp/src/i18n/ga-IE.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/he-IL.json
+++ b/apps/webapp/src/i18n/he-IL.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/hi-IN.json
+++ b/apps/webapp/src/i18n/hi-IN.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "चित्र को जोड़े",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/hr-HR.json
+++ b/apps/webapp/src/i18n/hr-HR.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Upiši poruku",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "Ljudi ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Dodaj sliku",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Traži",

--- a/apps/webapp/src/i18n/hu-HU.json
+++ b/apps/webapp/src/i18n/hu-HU.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Üzenet írása",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "Partnerek ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Kép hozzáadása",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Keresés",

--- a/apps/webapp/src/i18n/id-ID.json
+++ b/apps/webapp/src/i18n/id-ID.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Mengetik pesan",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "Orang ( {shortcut} )",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Tambah gambar",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Pencarian",

--- a/apps/webapp/src/i18n/is-IS.json
+++ b/apps/webapp/src/i18n/is-IS.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/it-IT.json
+++ b/apps/webapp/src/i18n/it-IT.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Digita un messaggio",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "Persone ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Aggiungi immagine",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Cerca",

--- a/apps/webapp/src/i18n/ja-JP.json
+++ b/apps/webapp/src/i18n/ja-JP.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "メッセージを入力",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "友人 ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "写真を追加",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "検索",

--- a/apps/webapp/src/i18n/lb-LU.json
+++ b/apps/webapp/src/i18n/lb-LU.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/lt-LT.json
+++ b/apps/webapp/src/i18n/lt-LT.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Rašykite žinutę",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "Žmonės ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Pridėti paveikslą",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Ieškoti",

--- a/apps/webapp/src/i18n/lv-LV.json
+++ b/apps/webapp/src/i18n/lv-LV.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/me-ME.json
+++ b/apps/webapp/src/i18n/me-ME.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/mk-MK.json
+++ b/apps/webapp/src/i18n/mk-MK.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/ms-MY.json
+++ b/apps/webapp/src/i18n/ms-MY.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/mt-MT.json
+++ b/apps/webapp/src/i18n/mt-MT.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/nl-NL.json
+++ b/apps/webapp/src/i18n/nl-NL.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Typ een bericht",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "Mensen ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Voeg foto toe",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Zoeken",

--- a/apps/webapp/src/i18n/no-NO.json
+++ b/apps/webapp/src/i18n/no-NO.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/pl-PL.json
+++ b/apps/webapp/src/i18n/pl-PL.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Wpisz wiadomość",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "Użytkownicy ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Dodaj zdjęcie",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Wyszukaj",

--- a/apps/webapp/src/i18n/pt-BR.json
+++ b/apps/webapp/src/i18n/pt-BR.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} está digitando",
   "tooltipConversationInputPlaceholder": "Digite uma mensagem",
   "tooltipConversationInputTwoUserTyping": "{user1} e {user2} estão digitando",
-  "tooltipConversationPeople": "Pessoas ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Adicionar foto",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Pesquisar",

--- a/apps/webapp/src/i18n/pt-PT.json
+++ b/apps/webapp/src/i18n/pt-PT.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Escreva uma mensagem",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "Pessoas ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Adicionar imagem",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Procurar",

--- a/apps/webapp/src/i18n/ro-RO.json
+++ b/apps/webapp/src/i18n/ro-RO.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Scrie un mesaj",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "Persoane ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Adaugă poză",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Caută",

--- a/apps/webapp/src/i18n/ru-RU.json
+++ b/apps/webapp/src/i18n/ru-RU.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} пишет",
   "tooltipConversationInputPlaceholder": "Введите сообщение",
   "tooltipConversationInputTwoUserTyping": "{user1} и {user2} пишут",
-  "tooltipConversationPeople": "Участники ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Добавить изображение",
   "tooltipConversationPing": "Пинг",
   "tooltipConversationSearch": "Поиск",

--- a/apps/webapp/src/i18n/ru-RU.json
+++ b/apps/webapp/src/i18n/ru-RU.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} пишет",
   "tooltipConversationInputPlaceholder": "Введите сообщение",
   "tooltipConversationInputTwoUserTyping": "{user1} и {user2} пишут",
-  "tooltipConversationPeople": "{displayName}, conversation details",
+  "tooltipConversationPeople": "{displayName}, детали беседы",
   "tooltipConversationPicture": "Добавить изображение",
   "tooltipConversationPing": "Пинг",
   "tooltipConversationSearch": "Поиск",

--- a/apps/webapp/src/i18n/si-LK.json
+++ b/apps/webapp/src/i18n/si-LK.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} ලියමින්",
   "tooltipConversationInputPlaceholder": "පණිවිඩයක් ලියන්න",
   "tooltipConversationInputTwoUserTyping": "{user1} හා {user2} ලියමින්",
-  "tooltipConversationPeople": "පුද්ගලයින් ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "සේයාරුවක් එකතු කරන්න",
   "tooltipConversationPing": "හඬවන්න",
   "tooltipConversationSearch": "සොයන්න",

--- a/apps/webapp/src/i18n/sk-SK.json
+++ b/apps/webapp/src/i18n/sk-SK.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Napísať správu",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "Ľudia ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Pridať obrázok",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Hladať",

--- a/apps/webapp/src/i18n/sl-SI.json
+++ b/apps/webapp/src/i18n/sl-SI.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Napiši sporočilo",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "Osebe ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Dodaj sliko",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Iščite",

--- a/apps/webapp/src/i18n/sq-AL.json
+++ b/apps/webapp/src/i18n/sq-AL.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/sr-Cyrl-ME.json
+++ b/apps/webapp/src/i18n/sr-Cyrl-ME.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/sr-SP.json
+++ b/apps/webapp/src/i18n/sr-SP.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "унесите поруку",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "Људи ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "додај слику",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Пронађи",

--- a/apps/webapp/src/i18n/sv-SE.json
+++ b/apps/webapp/src/i18n/sv-SE.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} skriver",
   "tooltipConversationInputPlaceholder": "Skriv ett meddelande",
   "tooltipConversationInputTwoUserTyping": "{user1} och {user2} skriver",
-  "tooltipConversationPeople": "Personer ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Lägg till bild",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Sök",

--- a/apps/webapp/src/i18n/th-TH.json
+++ b/apps/webapp/src/i18n/th-TH.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/tr-CY.json
+++ b/apps/webapp/src/i18n/tr-CY.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/tr-TR.json
+++ b/apps/webapp/src/i18n/tr-TR.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Bir mesaj yazın",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "İnsanlar ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Resim ekle",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Arama",

--- a/apps/webapp/src/i18n/uk-UA.json
+++ b/apps/webapp/src/i18n/uk-UA.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Напишіть повідомлення",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "Учасники ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Додати картинку",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Пошук",

--- a/apps/webapp/src/i18n/uz-UZ.json
+++ b/apps/webapp/src/i18n/uz-UZ.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/vi-VN.json
+++ b/apps/webapp/src/i18n/vi-VN.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/zh-CN.json
+++ b/apps/webapp/src/i18n/zh-CN.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "输入一条消息",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "成员（{shortcut}）",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "添加图片",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "搜索",

--- a/apps/webapp/src/i18n/zh-HK.json
+++ b/apps/webapp/src/i18n/zh-HK.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "Type a message",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "People ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "Add picture",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "Search",

--- a/apps/webapp/src/i18n/zh-TW.json
+++ b/apps/webapp/src/i18n/zh-TW.json
@@ -1956,7 +1956,7 @@
   "tooltipConversationInputOneUserTyping": "{user1} is typing",
   "tooltipConversationInputPlaceholder": "請輸入一段訊息",
   "tooltipConversationInputTwoUserTyping": "{user1} and {user2} are typing",
-  "tooltipConversationPeople": "成員 ({shortcut})",
+  "tooltipConversationPeople": "{displayName}, conversation details",
   "tooltipConversationPicture": "新增相片",
   "tooltipConversationPing": "Ping",
   "tooltipConversationSearch": "搜索",

--- a/apps/webapp/src/script/components/MessagesList/Message/EphemeralTimer.styles.ts
+++ b/apps/webapp/src/script/components/MessagesList/Message/EphemeralTimer.styles.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2018 Wire Swiss GmbH
+ * Copyright (C) 2026 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,22 +17,21 @@
  *
  */
 
-@strokewidth: 4px;
-@strokelength: @strokewidth * pi();
+import {CSSObject} from '@emotion/react';
 
-.ephemeral-timer {
-  &__background {
-    fill: var(--foreground-fade-16);
-    stroke: var(--foreground);
-    stroke-width: 1px;
-  }
+const strokewidth = 4;
+const strokelength = strokewidth * Math.PI;
 
-  &__dial {
-    --offset: 1;
-    fill: none;
-    stroke: var(--foreground);
-    stroke-dasharray: @strokelength;
-    stroke-dashoffset: calc(@strokelength * (1 + var(--offset)));
-    stroke-width: @strokewidth;
-  }
-}
+export const ephemeralTimerBackgroundStyle: CSSObject = {
+  fill: 'var(--app-bg-secondary)',
+  stroke: 'var(--foreground)',
+  strokeWidth: '1px',
+};
+
+export const ephemeralTimerDialStyle: (offset: number) => CSSObject = (offset = 1) => ({
+  fill: 'none',
+  stroke: 'var(--foreground)',
+  strokeDasharray: strokelength,
+  strokeDashoffset: `${strokelength * (1 + offset)}`,
+  strokeWidth: strokewidth,
+});

--- a/apps/webapp/src/script/components/MessagesList/Message/EphemeralTimer.test.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/EphemeralTimer.test.tsx
@@ -36,7 +36,12 @@ describe('EphemeralTimer', () => {
 
     const circle = getByTestId('ephemeral-timer-circle');
 
-    expect(window.getComputedStyle(circle).getPropertyValue('--offset')).toBe('1');
+    const offset = 1;
+    const strokewidth = 4;
+    const strokelength = strokewidth * Math.PI;
+    const expected = strokelength * (1 + offset); // offset === 1 => (1 + offset)
+
+    expect(parseFloat(window.getComputedStyle(circle).getPropertyValue('stroke-dashoffset'))).toBeCloseTo(expected, 5);
   });
 
   it('hides the icon when no ephemeral timer was started', () => {
@@ -46,6 +51,11 @@ describe('EphemeralTimer', () => {
 
     const circle = getByTestId('ephemeral-timer-circle');
 
-    expect(window.getComputedStyle(circle).getPropertyValue('--offset')).toBe('0');
+    const offset = 0;
+    const strokewidth = 4;
+    const strokelength = strokewidth * Math.PI;
+    const expected = strokelength * (1 + offset);
+
+    expect(parseFloat(window.getComputedStyle(circle).getPropertyValue('stroke-dashoffset'))).toBeCloseTo(expected, 5);
   });
 });

--- a/apps/webapp/src/script/components/MessagesList/Message/EphemeralTimer.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/EphemeralTimer.tsx
@@ -17,10 +17,13 @@
  *
  */
 
-import {CSSProperties} from 'react';
+import {TabIndex} from '@wireapp/react-ui-kit';
 
 import type {Message} from 'Repositories/entity/message/Message';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
+import {t} from 'Util/LocalizerUtil';
+
+import {ephemeralTimerBackgroundStyle, ephemeralTimerDialStyle} from './EphemeralTimer.styles';
 
 interface EphemeralTimerProps {
   message: Message;
@@ -36,15 +39,21 @@ const EphemeralTimer = ({message}: EphemeralTimerProps) => {
   const duration = Number(expires) - started;
 
   return (
-    <svg aria-hidden="true" className="ephemeral-timer" viewBox="0 0 8 8" width={8} height={8}>
-      <circle className="ephemeral-timer__background" cx={4} cy={4} r={3.5} />
+    <svg
+      aria-label={t('accessibility.selfDeletingMessage.timer')}
+      className="ephemeral-timer"
+      tabIndex={TabIndex.FOCUSABLE}
+      viewBox="0 0 8 8"
+      width={8}
+      height={8}
+    >
+      <circle css={ephemeralTimerBackgroundStyle} cx={4} cy={4} r={3.5} />
       <circle
+        css={ephemeralTimerDialStyle(remaining / duration || 0)}
         data-uie-name="ephemeral-timer-circle"
-        className="ephemeral-timer__dial"
         cx={4}
         cy={4}
         r={2}
-        style={{'--offset': remaining / duration || 0} as CSSProperties}
         transform="rotate(-90 4 4)"
       />
     </svg>

--- a/apps/webapp/src/script/components/TitleBar/TitleBar.tsx
+++ b/apps/webapp/src/script/components/TitleBar/TitleBar.tsx
@@ -47,8 +47,6 @@ import {TIME_IN_MILLIS} from 'Util/TimeUtil';
 
 import {RightSidebarParams} from '../../page/AppMain';
 import {PanelState} from '../../page/RightSidebar';
-import {Shortcut} from '../../ui/Shortcut';
-import {ShortcutType} from '../../ui/ShortcutType';
 import {CallActions} from '../../view_model/CallingViewModel';
 import {ViewModelRepositories} from '../../view_model/MainViewModel';
 
@@ -150,8 +148,7 @@ export const TitleBar = ({
 
   const conversationSubtitle = is1to1 && firstUserEntity?.isFederated ? (firstUserEntity?.handle ?? '') : '';
 
-  const shortcut = Shortcut.getShortcutTooltip(ShortcutType.PEOPLE);
-  const peopleTooltip = t('tooltipConversationPeople', {shortcut});
+  const conversationDetailsTooltip = t('tooltipConversationPeople', {displayName});
 
   // To be changed when design chooses a breakpoint, the conditional can be integrated to the ui-kit directly
   const mdBreakpoint = useMatchMedia('max-width: 1000px');
@@ -285,8 +282,8 @@ export const TitleBar = ({
         <div
           id="show-participants"
           onClick={onClickDetails}
-          title={peopleTooltip}
-          aria-label={peopleTooltip}
+          title={conversationDetailsTooltip}
+          aria-label={conversationDetailsTooltip}
           onKeyDown={event =>
             handleKeyDown({
               event,

--- a/apps/webapp/src/style/foundation/main.less
+++ b/apps/webapp/src/style/foundation/main.less
@@ -62,7 +62,6 @@
 @import '../components/image';
 @import '../components/classified-bar';
 @import '../components/device-card';
-@import '../components/ephemeral-timer';
 @import '../components/message-timer-button';
 @import '../components/full-search';
 @import '../components/input-level';

--- a/apps/webapp/src/types/i18n.d.ts
+++ b/apps/webapp/src/types/i18n.d.ts
@@ -163,6 +163,7 @@ declare module 'I18n/en-US.json' {
     'accessibility.rightPanel.GoBack': `Go back`;
     'accessibility.rightPanel.close': `Close conversation info`;
     'accessibility.searchInput.cancel': `Delete entry`;
+    'accessibility.selfDeletingMessage.timer': `Self-deleting message, timer is counting down.`;
     'accessibility.userProfileDeleteEntry': `Delete entry`;
     'accountAlreadyExistsModal.changeEmailLink': `Change your email address`;
     'accountAlreadyExistsModal.content': `This email\'s domain belongs to an on-premises backend. Please change your email in the account settings or delete your account. If you are part of a team please contact your team admin.`;

--- a/apps/webapp/src/types/i18n.d.ts
+++ b/apps/webapp/src/types/i18n.d.ts
@@ -376,6 +376,7 @@ declare module 'I18n/en-US.json' {
     'callingRestrictedConferenceCallTeamMemberModalTitle': `Feature unavailable`;
     'cameraStatusOff': `off`;
     'cameraStatusOn': `on`;
+    'cells.breadcrumb.files': `{conversationName} files`;
     'cells.clearFilters.button': `Clear all`;
     'cells.deleteModal.description': `This will permanently delete the file {name} for all participants.`;
     'cells.deleteModal.error': `Something went wrong, please try again later and refresh the list.`;
@@ -400,7 +401,7 @@ declare module 'I18n/en-US.json' {
     'cells.filtersModal.tags.placeholder': `Select a tag`;
     'cells.filtersModal.title': `Filters`;
     'cells.folderBreadcrumbCombained': `Show more`;
-    'cells.heading': `All files`;
+    'cells.heading': `Files`;
     'cells.imageFullScreenModal.closeButton': `Close`;
     'cells.imageFullScreenModal.downloadButton': `Download`;
     'cells.modal.closeButton': `Close`;
@@ -503,6 +504,8 @@ declare module 'I18n/en-US.json' {
     'cells.shareModal.password.error.required': `Enter a password`;
     'cells.shareModal.password.label': `Set password`;
     'cells.shareModal.primaryAction': `Save`;
+    'cells.sharedDrive.description': `Find any file or folder in this conversation`;
+    'cells.sharedDrive.title': `Shared Drive`;
     'cells.sidebar.heading': `Drive`;
     'cells.sidebar.title': `Files`;
     'cells.tableRow.actions': `More options`;
@@ -1016,6 +1019,8 @@ declare module 'I18n/en-US.json' {
     'federationDelete': `[bold]Your backend[/bold] stopped federating with [bold]{backendUrl}.[/bold]`;
     'fileCardDefaultCloseButtonLabel': `Close`;
     'fileFullscreenModal.editor.error': `Failed to load edit preview`;
+    'fileFullscreenModal.editor.errorDescription': `There was a problem connecting to the server. Please try again.`;
+    'fileFullscreenModal.editor.errorTitle': `Unable to open file edit mode`;
     'fileFullscreenModal.editor.iframeTitle': `Document editor`;
     'fileFullscreenModal.noPreviewAvailable.callToAction': `Download File`;
     'fileFullscreenModal.noPreviewAvailable.description': `There is no preview available for this file. Download the file instead.`;
@@ -1961,7 +1966,7 @@ declare module 'I18n/en-US.json' {
     'tooltipConversationInputOneUserTyping': `{user1} is typing`;
     'tooltipConversationInputPlaceholder': `Type a message`;
     'tooltipConversationInputTwoUserTyping': `{user1} and {user2} are typing`;
-    'tooltipConversationPeople': `People ({shortcut})`;
+    'tooltipConversationPeople': `{displayName}, conversation details`;
     'tooltipConversationPicture': `Add picture`;
     'tooltipConversationPing': `Ping`;
     'tooltipConversationSearch': `Search`;


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23860" title="WPB-23860" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23860</a>  [Web] Prep Bund release based on Web Production release 2026-01-28-production.0
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

# Pull Request

## Summary

Cherry pick required accessibility changes to the LTS release branch
https://github.com/wireapp/wire-webapp/pull/20296 and translations
https://github.com/wireapp/wire-webapp/pull/20251 and translations

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
