### PR TITLE
feat(webapp): add timeout support to wall clock [WPB-23299]

### DIFF
--- a/apps/webapp/src/script/clock/fakeWallClock.test.ts
+++ b/apps/webapp/src/script/clock/fakeWallClock.test.ts
@@ -94,4 +94,48 @@ describe('createFakeWallClock', () => {
     expect(intervalHandler).toHaveBeenCalledTimes(1);
   });
 
+  it('executes timeout callback once when time reaches the delay', () => {
+    const fakeWallClock = createFakeWallClock({initialCurrentTimestampInMilliseconds: 0});
+    const timeoutHandler = jest.fn();
+
+    fakeWallClock.setTimeout(timeoutHandler, 100, 'timeout argument');
+    fakeWallClock.advanceByMilliseconds(100);
+    fakeWallClock.advanceByMilliseconds(500);
+
+    expect(timeoutHandler).toHaveBeenCalledTimes(1);
+    expect(timeoutHandler).toHaveBeenNthCalledWith(1, 'timeout argument');
+  });
+
+  it('does not execute timeout callback before the delay', () => {
+    const fakeWallClock = createFakeWallClock({initialCurrentTimestampInMilliseconds: 0});
+    const timeoutHandler = jest.fn();
+
+    fakeWallClock.setTimeout(timeoutHandler, 100);
+    fakeWallClock.advanceByMilliseconds(99);
+
+    expect(timeoutHandler).not.toHaveBeenCalled();
+  });
+
+  it('stops executing timeout callback after clearTimeout', () => {
+    const fakeWallClock = createFakeWallClock({initialCurrentTimestampInMilliseconds: 0});
+    const timeoutHandler = jest.fn();
+
+    const timeoutIdentifier = fakeWallClock.setTimeout(timeoutHandler, 100);
+    fakeWallClock.clearTimeout(timeoutIdentifier);
+    fakeWallClock.advanceByMilliseconds(100);
+
+    expect(timeoutHandler).not.toHaveBeenCalled();
+  });
+
+  it('executes due timeout callbacks in registration order for the same execution timestamp', () => {
+    const fakeWallClock = createFakeWallClock({initialCurrentTimestampInMilliseconds: 0});
+    const executionOrder: string[] = [];
+
+    fakeWallClock.setTimeout(() => executionOrder.push('first timeout'), 100);
+    fakeWallClock.setTimeout(() => executionOrder.push('second timeout'), 100);
+    fakeWallClock.setTimeout(() => executionOrder.push('third timeout'), 100);
+    fakeWallClock.advanceByMilliseconds(100);
+
+    expect(executionOrder).toEqual(['first timeout', 'second timeout', 'third timeout']);
+  });
 });

--- a/apps/webapp/src/script/clock/fakeWallClock.ts
+++ b/apps/webapp/src/script/clock/fakeWallClock.ts
@@ -29,6 +29,11 @@ type IntervalRegistration = {
   nextExecutionTimestampInMilliseconds: number;
 };
 
+type TimeoutRegistration = {
+  readonly execute: () => void;
+  readonly executionTimestampInMilliseconds: number;
+};
+
 export type FakeWallClock = WallClock & {
   setCurrentTimestampInMilliseconds(nextTimestampInMilliseconds: number): void;
   advanceByMilliseconds(delayInMilliseconds: number): void;
@@ -39,7 +44,9 @@ export function createFakeWallClock(options: FakeWallClockOptions = {}): FakeWal
 
   let currentTimestampInMilliseconds = initialCurrentTimestampInMilliseconds;
   let nextIntervalIdentifier = 0;
+  let nextTimeoutIdentifier = 0;
   const intervalRegistrations = new Map<number, IntervalRegistration>();
+  const timeoutRegistrations = new Map<number, TimeoutRegistration>();
 
   const runDueIntervalRegistrations = () => {
     intervalRegistrations.forEach((intervalRegistration, intervalIdentifier) => {
@@ -55,6 +62,34 @@ export function createFakeWallClock(options: FakeWallClockOptions = {}): FakeWal
         latestIntervalRegistration.nextExecutionTimestampInMilliseconds +=
           latestIntervalRegistration.delayInMilliseconds;
       }
+    });
+  };
+
+  const runDueTimeoutRegistrations = () => {
+    const dueTimeoutRegistrations = Array.from(timeoutRegistrations.entries())
+      .filter(([, timeoutRegistration]) => {
+        return timeoutRegistration.executionTimestampInMilliseconds <= currentTimestampInMilliseconds;
+      })
+      .sort((firstTimeoutEntry, secondTimeoutEntry) => {
+        const [firstTimeoutIdentifier, firstTimeoutRegistration] = firstTimeoutEntry;
+        const [secondTimeoutIdentifier, secondTimeoutRegistration] = secondTimeoutEntry;
+
+        if (
+          firstTimeoutRegistration.executionTimestampInMilliseconds !==
+          secondTimeoutRegistration.executionTimestampInMilliseconds
+        ) {
+          return (
+            firstTimeoutRegistration.executionTimestampInMilliseconds -
+            secondTimeoutRegistration.executionTimestampInMilliseconds
+          );
+        }
+
+        return firstTimeoutIdentifier - secondTimeoutIdentifier;
+      });
+
+    dueTimeoutRegistrations.forEach(([timeoutIdentifier, timeoutRegistration]) => {
+      timeoutRegistrations.delete(timeoutIdentifier);
+      timeoutRegistration.execute();
     });
   };
 
@@ -74,6 +109,25 @@ export function createFakeWallClock(options: FakeWallClockOptions = {}): FakeWal
     advanceByMilliseconds(delayInMilliseconds: number) {
       currentTimestampInMilliseconds += delayInMilliseconds;
       runDueIntervalRegistrations();
+      runDueTimeoutRegistrations();
+    },
+
+    setTimeout(handler, delayInMilliseconds, ...args) {
+      const timeoutIdentifier = nextTimeoutIdentifier;
+      nextTimeoutIdentifier += 1;
+
+      timeoutRegistrations.set(timeoutIdentifier, {
+        execute: () => {
+          handler(...args);
+        },
+        executionTimestampInMilliseconds: currentTimestampInMilliseconds + delayInMilliseconds,
+      });
+
+      return timeoutIdentifier as unknown as ReturnType<typeof globalThis.setTimeout>;
+    },
+
+    clearTimeout(timeoutIdentifier) {
+      timeoutRegistrations.delete(timeoutIdentifier as unknown as number);
     },
 
     setInterval(handler, delayInMilliseconds, ...args) {

--- a/apps/webapp/src/script/clock/wallClock.test.ts
+++ b/apps/webapp/src/script/clock/wallClock.test.ts
@@ -107,4 +107,57 @@ describe('wall clock', () => {
       globalThis.clearInterval = originalClearInterval;
     }
   });
+
+  it('binds setTimeout to globalThis', () => {
+    const originalSetTimeout = globalThis.setTimeout;
+    const timeoutIdentifier = 123 as unknown as ReturnType<typeof globalThis.setTimeout>;
+    const timeoutInvocationContexts: unknown[] = [];
+
+    function setTimeoutStub(this: unknown) {
+      timeoutInvocationContexts.push(this);
+      return timeoutIdentifier;
+    }
+
+    globalThis.setTimeout = setTimeoutStub as unknown as typeof globalThis.setTimeout;
+
+    try {
+      const wallClock = createWallClock();
+      const returnedTimeoutIdentifier = wallClock.setTimeout(() => {
+        return undefined;
+      }, 1);
+
+      expect(returnedTimeoutIdentifier).toBe(timeoutIdentifier);
+      expect(timeoutInvocationContexts[0]).toBe(globalThis);
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  });
+
+  it('binds clearTimeout to globalThis', () => {
+    const originalClearTimeout = globalThis.clearTimeout;
+    const clearTimeoutInvocationContexts: unknown[] = [];
+    const clearTimeoutArguments: ReturnType<typeof globalThis.setTimeout>[] = [];
+
+    function clearTimeoutStub(
+      this: unknown,
+      providedTimeoutIdentifier: ReturnType<typeof globalThis.setTimeout>,
+    ) {
+      clearTimeoutInvocationContexts.push(this);
+      clearTimeoutArguments.push(providedTimeoutIdentifier);
+    }
+
+    globalThis.clearTimeout = clearTimeoutStub as unknown as typeof globalThis.clearTimeout;
+
+    try {
+      const wallClock = createWallClock();
+      const timeoutIdentifier = 123 as unknown as ReturnType<typeof globalThis.setTimeout>;
+
+      wallClock.clearTimeout(timeoutIdentifier);
+
+      expect(clearTimeoutInvocationContexts[0]).toBe(globalThis);
+      expect(clearTimeoutArguments).toEqual([timeoutIdentifier]);
+    } finally {
+      globalThis.clearTimeout = originalClearTimeout;
+    }
+  });
 });

--- a/apps/webapp/src/script/clock/wallClock.ts
+++ b/apps/webapp/src/script/clock/wallClock.ts
@@ -20,6 +20,12 @@
 export type WallClock = {
   readonly currentTimestampInMilliseconds: number;
   readonly currentDate: Date;
+  readonly setTimeout: <Arguments extends readonly unknown[]>(
+    handler: (...args: Arguments) => void,
+    delayInMilliseconds: number,
+    ...args: Arguments
+  ) => ReturnType<typeof globalThis.setTimeout>;
+  readonly clearTimeout: (timeoutIdentifier: ReturnType<typeof globalThis.setTimeout>) => void;
   readonly setInterval: <Arguments extends readonly unknown[]>(
     handler: (...args: Arguments) => void,
     delayInMilliseconds: number,
@@ -37,6 +43,10 @@ export function createWallClock(): WallClock {
     get currentDate() {
       return new Date(Date.now());
     },
+
+    setTimeout: globalThis.setTimeout.bind(globalThis),
+
+    clearTimeout: globalThis.clearTimeout.bind(globalThis),
 
     setInterval: globalThis.setInterval.bind(globalThis),
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23299" title="WPB-23299" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23299</a>  [Web] Add support for remote force reload 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Expose `setTimeout`/`clearTimeout` on `WallClock` and `FakeWallClock` so timeout-based behavior can use injected time dependencies instead of global timers.

Expected outcome: timeout logic is deterministic and easy to test in unit tests, matching the existing interval-based clock pattern.

We need this to automatically reload the application after 60 seconds here https://github.com/wireapp/wire-webapp/pull/20560

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
