### PR TITLE
feat: add startup URL feature flag override and expose typed lookup in root context [WPB-23826]

### DIFF
--- a/apps/webapp/src/script/components/AppContainer/AppContainer.tsx
+++ b/apps/webapp/src/script/components/AppContainer/AppContainer.tsx
@@ -40,6 +40,7 @@ import {useAccentColor} from './hooks/useAccentColor';
 import {useTheme} from './hooks/useTheme';
 
 import {Config, Configuration} from '../../Config';
+import {StartupFeatureFlagMap} from '../../featureFlags/startupFeatureFlags';
 import {setAppLocale} from '../../localization/Localizer';
 import {App} from '../../main/app';
 import {AppMain} from '../../page/AppMain';
@@ -51,9 +52,10 @@ import {AppLoader} from '../AppLoader';
 interface AppProps {
   config: Configuration;
   clientType: ClientType;
+  startupFeatureFlags: StartupFeatureFlagMap;
 }
 
-export const AppContainer = ({config, clientType}: AppProps) => {
+export const AppContainer = ({config, clientType, startupFeatureFlags}: AppProps) => {
   setAppLocale();
   const app = useMemo(() => new App(container.resolve(Core), container.resolve(APIClient), config), []);
   const enableAutoLogin = Config.getConfig().FEATURE.ENABLE_AUTO_LOGIN;
@@ -110,7 +112,15 @@ export const AppContainer = ({config, clientType}: AppProps) => {
     <>
       <AppLoader init={onProgress => app.initApp(clientType, onProgress)}>
         {selfUser => {
-          return <AppMain app={app} selfUser={selfUser} mainView={mainView} locked={softLockEnabled} />;
+          return (
+            <AppMain
+              app={app}
+              selfUser={selfUser}
+              mainView={mainView}
+              locked={softLockEnabled}
+              startupFeatureFlags={startupFeatureFlags}
+            />
+          );
         }}
       </AppLoader>
 

--- a/apps/webapp/src/script/featureFlags/startupFeatureFlags.test.ts
+++ b/apps/webapp/src/script/featureFlags/startupFeatureFlags.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {
+  allowedStartupFeatureFlagNames,
+  createStartupFeatureFlagMapFromLocationSearch,
+  isStartupFeatureFlagEnabled,
+  startupFeatureFlagQueryParameterName,
+} from './startupFeatureFlags';
+
+describe('startupFeatureFlags', function () {
+  const reliableWebsocketConnectionFeatureFlagName = 'reliable-websocket-connection';
+
+  it('returns an empty feature flag map when the query parameter is missing', function () {
+    const startupFeatureFlagMap = createStartupFeatureFlagMapFromLocationSearch('?foo=bar');
+
+    expect(isStartupFeatureFlagEnabled(startupFeatureFlagMap, reliableWebsocketConnectionFeatureFlagName)).toBe(false);
+    expect(Object.keys(startupFeatureFlagMap)).toHaveLength(0);
+  });
+
+  it('enables a whitelisted feature flag when present in the query parameter', function () {
+    const startupFeatureFlagMap = createStartupFeatureFlagMapFromLocationSearch(
+      `?${startupFeatureFlagQueryParameterName}=${reliableWebsocketConnectionFeatureFlagName}`,
+    );
+
+    expect(isStartupFeatureFlagEnabled(startupFeatureFlagMap, reliableWebsocketConnectionFeatureFlagName)).toBe(true);
+  });
+
+  it('enables whitelisted flags and ignores unknown values in the same parameter', function () {
+    const startupFeatureFlagMap = createStartupFeatureFlagMapFromLocationSearch(
+      `?${startupFeatureFlagQueryParameterName}=${reliableWebsocketConnectionFeatureFlagName},unknown-feature`,
+    );
+
+    expect(isStartupFeatureFlagEnabled(startupFeatureFlagMap, reliableWebsocketConnectionFeatureFlagName)).toBe(true);
+    expect('unknown-feature' in startupFeatureFlagMap).toBe(false);
+  });
+
+  it('ignores unknown feature flags from the query parameter', function () {
+    const startupFeatureFlagMap = createStartupFeatureFlagMapFromLocationSearch(
+      `?${startupFeatureFlagQueryParameterName}=unknown-feature`,
+    );
+
+    expect(Object.keys(startupFeatureFlagMap)).toHaveLength(0);
+    expect('unknown-feature' in startupFeatureFlagMap).toBe(false);
+  });
+
+  it('keeps only whitelisted feature flags when known and unknown values are mixed', function () {
+    const startupFeatureFlagMap = createStartupFeatureFlagMapFromLocationSearch(
+      `?${startupFeatureFlagQueryParameterName}=unknown-feature,${reliableWebsocketConnectionFeatureFlagName}`,
+    );
+
+    expect(isStartupFeatureFlagEnabled(startupFeatureFlagMap, reliableWebsocketConnectionFeatureFlagName)).toBe(true);
+    expect('unknown-feature' in startupFeatureFlagMap).toBe(false);
+  });
+
+  it('trims whitespace around feature flag names', function () {
+    const startupFeatureFlagMap = createStartupFeatureFlagMapFromLocationSearch(
+      `?${startupFeatureFlagQueryParameterName}= ${reliableWebsocketConnectionFeatureFlagName} `,
+    );
+
+    expect(isStartupFeatureFlagEnabled(startupFeatureFlagMap, reliableWebsocketConnectionFeatureFlagName)).toBe(true);
+  });
+
+  it('deduplicates duplicated feature flags', function () {
+    const startupFeatureFlagMap = createStartupFeatureFlagMapFromLocationSearch(
+      `?${startupFeatureFlagQueryParameterName}=${reliableWebsocketConnectionFeatureFlagName},${reliableWebsocketConnectionFeatureFlagName}`,
+    );
+
+    expect(isStartupFeatureFlagEnabled(startupFeatureFlagMap, reliableWebsocketConnectionFeatureFlagName)).toBe(true);
+    expect(Object.keys(startupFeatureFlagMap)).toEqual([reliableWebsocketConnectionFeatureFlagName]);
+  });
+
+  it('ignores empty list entries in the feature flag query parameter', function () {
+    const startupFeatureFlagMap = createStartupFeatureFlagMapFromLocationSearch(
+      `?${startupFeatureFlagQueryParameterName}=,${reliableWebsocketConnectionFeatureFlagName},,`,
+    );
+
+    expect(isStartupFeatureFlagEnabled(startupFeatureFlagMap, reliableWebsocketConnectionFeatureFlagName)).toBe(true);
+    expect(Object.keys(startupFeatureFlagMap)).toEqual([reliableWebsocketConnectionFeatureFlagName]);
+  });
+
+  it('treats feature flag names as case-sensitive', function () {
+    const uppercaseFeatureFlagName = reliableWebsocketConnectionFeatureFlagName.toUpperCase();
+    const startupFeatureFlagMap = createStartupFeatureFlagMapFromLocationSearch(
+      `?${startupFeatureFlagQueryParameterName}=${uppercaseFeatureFlagName}`,
+    );
+
+    expect(isStartupFeatureFlagEnabled(startupFeatureFlagMap, reliableWebsocketConnectionFeatureFlagName)).toBe(
+      false,
+    );
+    expect(uppercaseFeatureFlagName in startupFeatureFlagMap).toBe(false);
+  });
+
+  it('returns a frozen feature flag map', function () {
+    const startupFeatureFlagMap = createStartupFeatureFlagMapFromLocationSearch(
+      `?${startupFeatureFlagQueryParameterName}=${reliableWebsocketConnectionFeatureFlagName}`,
+    );
+
+    expect(Object.isFrozen(startupFeatureFlagMap)).toBe(true);
+  });
+
+  it('contains only whitelisted values in allowedStartupFeatureFlagNames', function () {
+    expect(allowedStartupFeatureFlagNames).toEqual([reliableWebsocketConnectionFeatureFlagName]);
+  });
+});

--- a/apps/webapp/src/script/featureFlags/startupFeatureFlags.ts
+++ b/apps/webapp/src/script/featureFlags/startupFeatureFlags.ts
@@ -52,10 +52,8 @@ function toEnabledFeatureNameList(serializedFeatureNames: string): readonly Star
 function readEnabledFeatureNameListFromLocationSearch(locationSearch: string): readonly StartupFeatureFlagName[] {
   const queryParameters = new URLSearchParams(Maybe.of(locationSearch).unwrapOr(''));
   const enabledFeaturesParameterValue = queryParameters.get(startupFeatureFlagQueryParameterName);
-  const enabledFeatureNameListOrNull =
-    enabledFeaturesParameterValue === null ? null : toEnabledFeatureNameList(enabledFeaturesParameterValue);
 
-  return Maybe.of(enabledFeatureNameListOrNull).unwrapOr([]);
+  return Maybe.of(enabledFeaturesParameterValue).map(toEnabledFeatureNameList).unwrapOr([]);
 }
 
 export function createStartupFeatureFlagMapFromLocationSearch(locationSearch: string): StartupFeatureFlagMap {

--- a/apps/webapp/src/script/featureFlags/startupFeatureFlags.ts
+++ b/apps/webapp/src/script/featureFlags/startupFeatureFlags.ts
@@ -1,0 +1,83 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Maybe} from 'true-myth';
+
+export const startupFeatureFlagQueryParameterName = 'enabled-features';
+
+export const allowedStartupFeatureFlagNames = ['reliable-websocket-connection'] as const;
+
+export type StartupFeatureFlagName = (typeof allowedStartupFeatureFlagNames)[number];
+
+const allowedStartupFeatureFlagNameSet = new Set<StartupFeatureFlagName>(allowedStartupFeatureFlagNames);
+
+export type StartupFeatureFlagMap = Readonly<Partial<Record<StartupFeatureFlagName, true>>>;
+
+function trimFeatureFlagName(featureName: string): string {
+  return featureName.trim();
+}
+
+function isNonEmptyFeatureFlagName(featureName: string): boolean {
+  return featureName.length > 0;
+}
+
+function isAllowedStartupFeatureFlagName(featureName: string): featureName is StartupFeatureFlagName {
+  return allowedStartupFeatureFlagNameSet.has(featureName as StartupFeatureFlagName);
+}
+
+function toEnabledFeatureNameList(serializedFeatureNames: string): readonly StartupFeatureFlagName[] {
+  return serializedFeatureNames
+    .split(',')
+    .map(trimFeatureFlagName)
+    .filter(isNonEmptyFeatureFlagName)
+    .filter(isAllowedStartupFeatureFlagName);
+}
+
+function readEnabledFeatureNameListFromLocationSearch(locationSearch: string): readonly StartupFeatureFlagName[] {
+  const queryParameters = new URLSearchParams(Maybe.of(locationSearch).unwrapOr(''));
+  const enabledFeaturesParameterValue = queryParameters.get(startupFeatureFlagQueryParameterName);
+  const enabledFeatureNameListOrNull =
+    enabledFeaturesParameterValue === null ? null : toEnabledFeatureNameList(enabledFeaturesParameterValue);
+
+  return Maybe.of(enabledFeatureNameListOrNull).unwrapOr([]);
+}
+
+export function createStartupFeatureFlagMapFromLocationSearch(locationSearch: string): StartupFeatureFlagMap {
+  function addFeatureFlagToMap(
+    featureFlagMap: Partial<Record<StartupFeatureFlagName, true>>,
+    featureName: StartupFeatureFlagName,
+  ): Partial<Record<StartupFeatureFlagName, true>> {
+    featureFlagMap[featureName] = true;
+
+    return featureFlagMap;
+  }
+
+  const enabledFeatureFlagMap = readEnabledFeatureNameListFromLocationSearch(locationSearch).reduce<
+    Partial<Record<StartupFeatureFlagName, true>>
+  >(addFeatureFlagToMap, {});
+
+  return Object.freeze(enabledFeatureFlagMap);
+}
+
+export function isStartupFeatureFlagEnabled(
+  featureFlagMap: StartupFeatureFlagMap,
+  featureName: StartupFeatureFlagName,
+): boolean {
+  return Maybe.of(featureFlagMap[featureName]).isJust;
+}

--- a/apps/webapp/src/script/featureFlags/startupFeatureFlags.ts
+++ b/apps/webapp/src/script/featureFlags/startupFeatureFlags.ts
@@ -59,18 +59,13 @@ function readEnabledFeatureNameListFromLocationSearch(locationSearch: string): r
 }
 
 export function createStartupFeatureFlagMapFromLocationSearch(locationSearch: string): StartupFeatureFlagMap {
-  function addFeatureFlagToMap(
-    featureFlagMap: Partial<Record<StartupFeatureFlagName, true>>,
-    featureName: StartupFeatureFlagName,
-  ): Partial<Record<StartupFeatureFlagName, true>> {
+  const enabledFeatureFlagMap = readEnabledFeatureNameListFromLocationSearch(locationSearch).reduce<
+    Partial<Record<StartupFeatureFlagName, true>>
+  >((featureFlagMap, featureName) => {
     featureFlagMap[featureName] = true;
 
     return featureFlagMap;
-  }
-
-  const enabledFeatureFlagMap = readEnabledFeatureNameListFromLocationSearch(locationSearch).reduce<
-    Partial<Record<StartupFeatureFlagName, true>>
-  >(addFeatureFlagToMap, {});
+  }, {});
 
   return Object.freeze(enabledFeatureFlagMap);
 }

--- a/apps/webapp/src/script/main/index.tsx
+++ b/apps/webapp/src/script/main/index.tsx
@@ -36,6 +36,7 @@ import {exposeWrapperGlobals} from 'Util/wrapper';
 
 import {SIGN_OUT_REASON} from '../auth/SignOutReason';
 import {Config} from '../Config';
+import {createStartupFeatureFlagMapFromLocationSearch} from '../featureFlags/startupFeatureFlags';
 
 document.addEventListener('DOMContentLoaded', async () => {
   const config = Config.getConfig();
@@ -63,7 +64,13 @@ document.addEventListener('DOMContentLoaded', async () => {
     return doSimpleRedirect(SIGN_OUT_REASON.NOT_SIGNED_IN);
   }
 
+  const startupFeatureFlags = createStartupFeatureFlagMapFromLocationSearch(globalThis.location.search);
+
   createRoot(appContainer).render(
-    <AppContainer config={config} clientType={shouldPersist ? ClientType.PERMANENT : ClientType.TEMPORARY} />,
+    <AppContainer
+      config={config}
+      clientType={shouldPersist ? ClientType.PERMANENT : ClientType.TEMPORARY}
+      startupFeatureFlags={startupFeatureFlags}
+    />,
   );
 });

--- a/apps/webapp/src/script/page/AppMain.tsx
+++ b/apps/webapp/src/script/page/AppMain.tsx
@@ -67,6 +67,11 @@ import {ContentState, useAppState} from './useAppState';
 import {runClientVersionCheck} from '../application-periodic-checks/runClientVersionCheck';
 import {startApplicationPeriodicChecks} from '../application-periodic-checks/startApplicationPeriodicChecks';
 import {createWallClock} from '../clock/wallClock';
+import {
+  StartupFeatureFlagMap,
+  StartupFeatureFlagName,
+  isStartupFeatureFlagEnabled,
+} from '../featureFlags/startupFeatureFlags';
 import {App} from '../main/app';
 import {initialiseMLSMigrationFlow} from '../mls/MLSMigration';
 import {generateConversationUrl} from '../router/routeGenerator';
@@ -85,6 +90,7 @@ interface AppMainProps {
   app: App;
   selfUser: User;
   mainView: MainViewModel;
+  startupFeatureFlags: StartupFeatureFlagMap;
   conversationState?: ConversationState;
   callState?: CallState;
   /** will block the user from being able to interact with the application (no notifications and no messages will be shown) */
@@ -95,6 +101,7 @@ export const AppMain = ({
   app,
   mainView,
   selfUser,
+  startupFeatureFlags,
   conversationState = container.resolve(ConversationState),
   callState = container.resolve(CallState),
   locked,
@@ -299,6 +306,9 @@ export const AppMain = ({
 
   const showLeftSidebar = (isMobileView && isMobileLeftSidebarView) || (!isMobileView && !isLeftSidebarHidden);
   const showMainContent = currentTab === SidebarTabs.CELLS || !isMobileView || isMobileCentralColumnView;
+  function isFeatureFlagEnabled(featureName: StartupFeatureFlagName): boolean {
+    return isStartupFeatureFlagEnabled(startupFeatureFlags, featureName);
+  }
 
   return (
     <StyledApp
@@ -309,7 +319,7 @@ export const AppMain = ({
       data-uie-value="is-loaded"
     >
       {!locked && <WindowTitleUpdater />}
-      <RootProvider value={{mainViewModel: mainView, wallClock, doesApplicationNeedForceReload}}>
+      <RootProvider value={{mainViewModel: mainView, wallClock, doesApplicationNeedForceReload, isFeatureFlagEnabled}}>
         <ErrorBoundary FallbackComponent={ErrorFallback}>
           <ForceReloadModal reloadApplication={app.refresh} />
           {Config.getConfig().FEATURE.ENABLE_DEBUG && <ConfigToolbar />}

--- a/apps/webapp/src/script/page/MainContent/MainContent.test.tsx
+++ b/apps/webapp/src/script/page/MainContent/MainContent.test.tsx
@@ -46,6 +46,10 @@ const mockDevicesHandler = {
   currentDeviceId: () => 'mock-device-id',
 } as unknown as MediaDevicesHandler;
 
+function isFeatureFlagDisabledForTest(): boolean {
+  return false;
+}
+
 describe('Preferences', () => {
   const mainViewModel = {
     content: {
@@ -70,7 +74,14 @@ describe('Preferences', () => {
     jest.useFakeTimers();
     render(
       withTheme(
-        <RootProvider value={{mainViewModel, wallClock, doesApplicationNeedForceReload: false}}>
+        <RootProvider
+          value={{
+            mainViewModel,
+            wallClock,
+            doesApplicationNeedForceReload: false,
+            isFeatureFlagEnabled: isFeatureFlagDisabledForTest,
+          }}
+        >
           <MainContent {...defaultParams} />
         </RootProvider>,
       ),

--- a/apps/webapp/src/script/page/RootProvider.test.tsx
+++ b/apps/webapp/src/script/page/RootProvider.test.tsx
@@ -22,6 +22,7 @@ import {ReactNode, useContext} from 'react';
 import {renderHook} from '@testing-library/react';
 
 import {createFakeWallClock} from '../clock/fakeWallClock';
+import {StartupFeatureFlagName} from '../featureFlags/startupFeatureFlags';
 import {MainViewModel} from '../view_model/MainViewModel';
 import {
   RootContext,
@@ -38,6 +39,7 @@ interface WrapperProperties {
 interface RootProviderWrapper {
   wrapper: (properties: WrapperProperties) => ReactNode;
   fakeWallClock: ReturnType<typeof createFakeWallClock>;
+  isFeatureFlagEnabled: jest.Mock<boolean, [StartupFeatureFlagName]>;
 }
 
 function createRootProviderWrapper(
@@ -48,10 +50,15 @@ function createRootProviderWrapper(
   const fakeWallClock = createFakeWallClock({
     initialCurrentTimestampInMilliseconds: wallClockTimestampInMilliseconds,
   });
+  function isFeatureFlagEnabledForTest(featureName: StartupFeatureFlagName): boolean {
+    return featureName === 'reliable-websocket-connection';
+  }
+
+  const isFeatureFlagEnabled = jest.fn(isFeatureFlagEnabledForTest);
 
   function wrapper(properties: WrapperProperties): ReactNode {
     const wrappedChildren = (
-      <RootProvider value={{mainViewModel, wallClock: fakeWallClock, doesApplicationNeedForceReload}}>
+      <RootProvider value={{mainViewModel, wallClock: fakeWallClock, doesApplicationNeedForceReload, isFeatureFlagEnabled}}>
         {properties.children}
       </RootProvider>
     );
@@ -59,7 +66,7 @@ function createRootProviderWrapper(
     return wrappedChildren;
   }
 
-  return {wrapper, fakeWallClock};
+  return {wrapper, fakeWallClock, isFeatureFlagEnabled};
 }
 
 function getRootContextValue(): RootContextValue | null {
@@ -105,5 +112,14 @@ describe('RootProvider', () => {
     const {result} = renderHook(useApplicationContext, {wrapper});
 
     expect(result.current.doesApplicationNeedForceReload).toBe(true);
+  });
+
+  it('provides startup feature flag helper through useApplicationContext()', function () {
+    const {wrapper, isFeatureFlagEnabled} = createRootProviderWrapper(mainViewModel, 9_999, true);
+
+    const {result} = renderHook(useApplicationContext, {wrapper});
+
+    expect(result.current.isFeatureFlagEnabled('reliable-websocket-connection')).toBe(true);
+    expect(isFeatureFlagEnabled).toHaveBeenCalledWith('reliable-websocket-connection');
   });
 });

--- a/apps/webapp/src/script/page/RootProvider.tsx
+++ b/apps/webapp/src/script/page/RootProvider.tsx
@@ -20,12 +20,14 @@
 import {ReactNode, ReactElement, createContext, useContext, useMemo} from 'react';
 
 import {WallClock} from '../clock/wallClock';
+import {StartupFeatureFlagName} from '../featureFlags/startupFeatureFlags';
 import {MainViewModel} from '../view_model/MainViewModel';
 
 export type RootContextValue = {
   readonly mainViewModel: MainViewModel;
   readonly wallClock: WallClock;
   readonly doesApplicationNeedForceReload: boolean;
+  readonly isFeatureFlagEnabled: (featureName: StartupFeatureFlagName) => boolean;
 };
 
 export const RootContext = createContext<RootContextValue | null>(null);

--- a/apps/webapp/src/script/page/components/ForceReloadModal/ForceReloadModal.test.tsx
+++ b/apps/webapp/src/script/page/components/ForceReloadModal/ForceReloadModal.test.tsx
@@ -34,6 +34,10 @@ interface ForceReloadModalTestContextValue {
   readonly reloadApplication: () => void;
 }
 
+function isFeatureFlagDisabledForTest(): boolean {
+  return false;
+}
+
 function createMainViewModelForTest(): MainViewModel {
   return {} as MainViewModel;
 }
@@ -67,6 +71,7 @@ function createForceReloadModalTestElement(
     <RootProvider
       value={{
         doesApplicationNeedForceReload,
+        isFeatureFlagEnabled: isFeatureFlagDisabledForTest,
         mainViewModel: createMainViewModelForTest(),
         wallClock: createFakeWallClock({initialCurrentTimestampInMilliseconds: 1_111}),
       }}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23826" title="WPB-23826" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23826</a>  [Web] Optimize websocket implementation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

We need a safe way to toggle specific webapp behavior at startup via URL for controlled rollout/verification scenarios, without broadening runtime flag surface or introducing re-evaluation during app usage.

- Added a dedicated startup feature-flag slice for URL parsing.
- Added support for enabled-features query parsing at startup only.
- Limited URL-overridable flags to one explicit whitelist entry:
  - reliable-websocket-connection
- Exposed a minimal, typed feature-flag lookup via root context:
  - isFeatureFlagEnabled(...)
- Updated relevant tests to cover parsing behavior and context contract.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
