### PR TITLE
feat(webapp): implement automatic force-reload timeout [WPB-23299]

### DIFF
--- a/apps/webapp/src/script/page/components/ForceReloadModal/ForceReloadModal.test.tsx
+++ b/apps/webapp/src/script/page/components/ForceReloadModal/ForceReloadModal.test.tsx
@@ -17,14 +17,16 @@
  *
  */
 
+import assert from 'node:assert';
 import {ReactElement} from 'react';
 
 import {render} from '@testing-library/react';
 
 import {usePrimaryModalState} from 'Components/Modals/PrimaryModal';
-import {createDeterministicWallClock} from 'src/script/clock/deterministicWallClock';
+import {createDeterministicWallClock, DeterministicWallClock} from 'src/script/clock/deterministicWallClock';
 import {MainViewModel} from 'src/script/view_model/MainViewModel';
 import {t} from 'Util/LocalizerUtil';
+import {TIME_IN_MILLIS} from 'Util/TimeUtil';
 
 import {RootProvider} from '../../RootProvider';
 import {ForceReloadModal} from './ForceReloadModal';
@@ -32,6 +34,7 @@ import {ForceReloadModal} from './ForceReloadModal';
 interface ForceReloadModalTestContextValue {
   readonly doesApplicationNeedForceReload: boolean;
   readonly reloadApplication: () => void;
+  readonly wallClock?: DeterministicWallClock;
 }
 
 function isFeatureFlagDisabledForTest(): boolean {
@@ -65,7 +68,11 @@ function resetPrimaryModalState(): void {
 function createForceReloadModalTestElement(
   contextValue: ForceReloadModalTestContextValue,
 ): ReactElement {
-  const {doesApplicationNeedForceReload, reloadApplication} = contextValue;
+  const {
+    doesApplicationNeedForceReload,
+    reloadApplication,
+    wallClock = createDeterministicWallClock({initialCurrentTimestampInMilliseconds: 1_111}),
+  } = contextValue;
 
   return (
     <RootProvider
@@ -73,13 +80,15 @@ function createForceReloadModalTestElement(
         doesApplicationNeedForceReload,
         isFeatureFlagEnabled: isFeatureFlagDisabledForTest,
         mainViewModel: createMainViewModelForTest(),
-        wallClock: createDeterministicWallClock({initialCurrentTimestampInMilliseconds: 1_111}),
+        wallClock,
       }}
     >
       <ForceReloadModal reloadApplication={reloadApplication} />
     </RootProvider>
   );
 }
+
+const forceReloadDelayInMilliseconds = TIME_IN_MILLIS.SECOND * 60;
 
 describe('ForceReloadModal', () => {
   beforeEach(() => {
@@ -94,32 +103,89 @@ describe('ForceReloadModal', () => {
   });
 
   it('opens the modal when force reload becomes required', () => {
+    const deterministicWallClock = createDeterministicWallClock({initialCurrentTimestampInMilliseconds: 0});
     const reloadApplication = jest.fn();
-    const {rerender} = render(createForceReloadModalTestElement({doesApplicationNeedForceReload: false, reloadApplication}));
+    const {rerender} = render(
+      createForceReloadModalTestElement({
+        doesApplicationNeedForceReload: false,
+        reloadApplication,
+        wallClock: deterministicWallClock,
+      }),
+    );
 
-    rerender(createForceReloadModalTestElement({doesApplicationNeedForceReload: true, reloadApplication}));
+    rerender(
+      createForceReloadModalTestElement({
+        doesApplicationNeedForceReload: true,
+        reloadApplication,
+        wallClock: deterministicWallClock,
+      }),
+    );
 
     expect(usePrimaryModalState.getState().currentModalId).not.toBeNull();
     expect(usePrimaryModalState.getState().queue).toHaveLength(0);
   });
 
   it('does not open the modal repeatedly while force reload remains required', () => {
+    const deterministicWallClock = createDeterministicWallClock({initialCurrentTimestampInMilliseconds: 0});
     const reloadApplication = jest.fn();
-    const {rerender} = render(createForceReloadModalTestElement({doesApplicationNeedForceReload: true, reloadApplication}));
+    const {rerender} = render(
+      createForceReloadModalTestElement({
+        doesApplicationNeedForceReload: true,
+        reloadApplication,
+        wallClock: deterministicWallClock,
+      }),
+    );
 
-    rerender(createForceReloadModalTestElement({doesApplicationNeedForceReload: true, reloadApplication}));
-    rerender(createForceReloadModalTestElement({doesApplicationNeedForceReload: true, reloadApplication}));
+    rerender(
+      createForceReloadModalTestElement({
+        doesApplicationNeedForceReload: true,
+        reloadApplication,
+        wallClock: deterministicWallClock,
+      }),
+    );
+    rerender(
+      createForceReloadModalTestElement({
+        doesApplicationNeedForceReload: true,
+        reloadApplication,
+        wallClock: deterministicWallClock,
+      }),
+    );
 
     expect(usePrimaryModalState.getState().queue).toHaveLength(0);
   });
 
   it('opens the modal again after force reload status returns to false and then true', () => {
+    const deterministicWallClock = createDeterministicWallClock({initialCurrentTimestampInMilliseconds: 0});
     const reloadApplication = jest.fn();
-    const {rerender} = render(createForceReloadModalTestElement({doesApplicationNeedForceReload: false, reloadApplication}));
+    const {rerender} = render(
+      createForceReloadModalTestElement({
+        doesApplicationNeedForceReload: false,
+        reloadApplication,
+        wallClock: deterministicWallClock,
+      }),
+    );
 
-    rerender(createForceReloadModalTestElement({doesApplicationNeedForceReload: true, reloadApplication}));
-    rerender(createForceReloadModalTestElement({doesApplicationNeedForceReload: false, reloadApplication}));
-    rerender(createForceReloadModalTestElement({doesApplicationNeedForceReload: true, reloadApplication}));
+    rerender(
+      createForceReloadModalTestElement({
+        doesApplicationNeedForceReload: true,
+        reloadApplication,
+        wallClock: deterministicWallClock,
+      }),
+    );
+    rerender(
+      createForceReloadModalTestElement({
+        doesApplicationNeedForceReload: false,
+        reloadApplication,
+        wallClock: deterministicWallClock,
+      }),
+    );
+    rerender(
+      createForceReloadModalTestElement({
+        doesApplicationNeedForceReload: true,
+        reloadApplication,
+        wallClock: deterministicWallClock,
+      }),
+    );
 
     expect(usePrimaryModalState.getState().currentModalId).not.toBeNull();
     expect(usePrimaryModalState.getState().queue).toHaveLength(1);
@@ -141,11 +207,82 @@ describe('ForceReloadModal', () => {
     currentModalContent.onBgClick();
     expect(usePrimaryModalState.getState().currentModalId).toBe(currentModalIdentifierBeforeBackgroundClick);
 
-    if (!currentModalContent.primaryAction?.action) {
-      throw new Error('Primary reload action is missing');
-    }
-
+    assert(currentModalContent.primaryAction?.action);
     currentModalContent.primaryAction.action();
+
+    expect(reloadApplication).toHaveBeenCalledTimes(1);
+  });
+
+  it('reloads automatically after 60 seconds when no user action is performed', () => {
+    const deterministicWallClock = createDeterministicWallClock({initialCurrentTimestampInMilliseconds: 0});
+    const reloadApplication = jest.fn();
+
+    render(
+      createForceReloadModalTestElement({
+        doesApplicationNeedForceReload: true,
+        reloadApplication,
+        wallClock: deterministicWallClock,
+      }),
+    );
+
+    deterministicWallClock.advanceByMilliseconds(forceReloadDelayInMilliseconds - 1);
+    expect(reloadApplication).not.toHaveBeenCalled();
+
+    deterministicWallClock.advanceByMilliseconds(1);
+    expect(reloadApplication).toHaveBeenCalledTimes(1);
+
+    deterministicWallClock.advanceByMilliseconds(forceReloadDelayInMilliseconds);
+    expect(reloadApplication).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels automatic reload if force reload requirement is removed before timeout', () => {
+    const deterministicWallClock = createDeterministicWallClock({initialCurrentTimestampInMilliseconds: 0});
+    const reloadApplication = jest.fn();
+    const {rerender} = render(
+      createForceReloadModalTestElement({
+        doesApplicationNeedForceReload: false,
+        reloadApplication,
+        wallClock: deterministicWallClock,
+      }),
+    );
+
+    rerender(
+      createForceReloadModalTestElement({
+        doesApplicationNeedForceReload: true,
+        reloadApplication,
+        wallClock: deterministicWallClock,
+      }),
+    );
+    rerender(
+      createForceReloadModalTestElement({
+        doesApplicationNeedForceReload: false,
+        reloadApplication,
+        wallClock: deterministicWallClock,
+      }),
+    );
+
+    deterministicWallClock.advanceByMilliseconds(forceReloadDelayInMilliseconds);
+
+    expect(reloadApplication).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger reload twice if the user clicks reload before timeout', () => {
+    const deterministicWallClock = createDeterministicWallClock({initialCurrentTimestampInMilliseconds: 0});
+    const reloadApplication = jest.fn();
+
+    render(
+      createForceReloadModalTestElement({
+        doesApplicationNeedForceReload: true,
+        reloadApplication,
+        wallClock: deterministicWallClock,
+      }),
+    );
+
+    const {currentModalContent} = usePrimaryModalState.getState();
+
+    assert(currentModalContent.primaryAction?.action);
+    currentModalContent.primaryAction.action();
+    deterministicWallClock.advanceByMilliseconds(forceReloadDelayInMilliseconds);
 
     expect(reloadApplication).toHaveBeenCalledTimes(1);
   });

--- a/apps/webapp/src/script/page/components/ForceReloadModal/ForceReloadModal.tsx
+++ b/apps/webapp/src/script/page/components/ForceReloadModal/ForceReloadModal.tsx
@@ -17,10 +17,13 @@
  *
  */
 
-import {FunctionComponent, useEffect, useRef} from 'react';
+import {FunctionComponent, useEffect} from 'react';
+
+import {Maybe} from 'true-myth';
 
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
 import {t} from 'Util/LocalizerUtil';
+import {TIME_IN_MILLIS} from 'Util/TimeUtil';
 
 import {useApplicationContext} from '../../RootProvider';
 
@@ -28,29 +31,47 @@ interface ForceReloadModalProperties {
   readonly reloadApplication: () => void;
 }
 
+const forceReloadDelayInMilliseconds = TIME_IN_MILLIS.SECOND * 60;
+
 export const ForceReloadModal: FunctionComponent<ForceReloadModalProperties> = properties => {
   const {reloadApplication} = properties;
-  const hasForceReloadModalBeenShown = useRef(false);
-  const {doesApplicationNeedForceReload} = useApplicationContext();
+  const {doesApplicationNeedForceReload, wallClock} = useApplicationContext();
 
-  useEffect(() => {
+  useEffect((): void | (() => void) => {
     if (!doesApplicationNeedForceReload) {
-      hasForceReloadModalBeenShown.current = false;
-      return;
+      return undefined;
     }
 
-    if (hasForceReloadModalBeenShown.current) {
-      return;
+    let hasApplicationReloadBeenTriggered = false;
+    let forceReloadTimeoutIdentifier: Maybe<ReturnType<typeof globalThis.setTimeout>> = Maybe.nothing();
+
+    function clearScheduledForceReloadTimeout(): void {
+      const timeoutIdentifier = forceReloadTimeoutIdentifier.unwrapOr(undefined);
+
+      if (timeoutIdentifier !== undefined) {
+        wallClock.clearTimeout(timeoutIdentifier);
+      }
+
+      forceReloadTimeoutIdentifier = Maybe.nothing();
     }
 
-    hasForceReloadModalBeenShown.current = true;
+    function triggerReloadApplicationOnce(): void {
+      if (hasApplicationReloadBeenTriggered) {
+        return;
+      }
+
+      hasApplicationReloadBeenTriggered = true;
+      clearScheduledForceReloadTimeout();
+
+      reloadApplication();
+    }
 
     PrimaryModal.show(PrimaryModal.type.ACKNOWLEDGE, {
       hideCloseBtn: true,
       hideSecondary: true,
       preventClose: true,
       primaryAction: {
-        action: reloadApplication,
+        action: triggerReloadApplicationOnce,
         text: t('forceReloadModalAction'),
       },
       text: {
@@ -58,7 +79,14 @@ export const ForceReloadModal: FunctionComponent<ForceReloadModalProperties> = p
         htmlMessage: t('forceReloadModalMessage'),
       },
     });
-  }, [doesApplicationNeedForceReload, reloadApplication]);
+    forceReloadTimeoutIdentifier = Maybe.just(
+      wallClock.setTimeout(triggerReloadApplicationOnce, forceReloadDelayInMilliseconds),
+    );
+
+    return () => {
+      clearScheduledForceReloadTimeout();
+    };
+  }, [doesApplicationNeedForceReload, reloadApplication, wallClock]);
 
   return null;
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23299" title="WPB-23299" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23299</a>  [Web] Add support for remote force reload 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Makes the force-reload modal behavior match its user-facing message by automatically reloading the app after 60 seconds when no manual action is taken. See also https://github.com/wireapp/wire-webapp/pull/20570

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
