### PR TITLE
feat(webapp): add cleanup stack utility as explicit resource management alternative [WPB-23826]

### DIFF
--- a/apps/webapp/src/script/cleanupStack/cleanupStack.test.ts
+++ b/apps/webapp/src/script/cleanupStack/cleanupStack.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {createCleanupStack} from './cleanupStack';
+
+describe('createCleanupStack', function () {
+  it('runs cleanups in reverse registration order', function () {
+    const cleanupStack = createCleanupStack();
+    const executionOrder: string[] = [];
+
+    cleanupStack.addCleanup(() => {
+      executionOrder.push('first');
+    });
+    cleanupStack.addCleanup(() => {
+      executionOrder.push('second');
+    });
+    cleanupStack.addCleanup(() => {
+      executionOrder.push('third');
+    });
+
+    cleanupStack.runAllCleanups();
+
+    expect(executionOrder).toEqual(['third', 'second', 'first']);
+  });
+
+  it('is idempotent when run multiple times', function () {
+    const cleanupStack = createCleanupStack();
+    const cleanup = jest.fn();
+
+    cleanupStack.addCleanup(cleanup);
+    cleanupStack.runAllCleanups();
+    cleanupStack.runAllCleanups();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows cleanup errors and still runs all cleanups', function () {
+    const onCleanupError = jest.fn();
+    const cleanupStack = createCleanupStack({onCleanupError});
+    const executionOrder: string[] = [];
+
+    cleanupStack.addCleanup(function cleanupFirst(): void {
+      executionOrder.push('first');
+    });
+    cleanupStack.addCleanup(function cleanupSecond(): void {
+      executionOrder.push('second');
+      throw new Error('cleanup failed');
+    });
+    cleanupStack.addCleanup(function cleanupThird(): void {
+      executionOrder.push('third');
+    });
+
+    expect(() => {
+      cleanupStack.runAllCleanups();
+    }).not.toThrow();
+
+    expect(executionOrder).toEqual(['third', 'second', 'first']);
+    expect(onCleanupError).toHaveBeenCalledTimes(1);
+    expect(onCleanupError.mock.calls[0][0]).toBeInstanceOf(Error);
+
+    expect(() => {
+      cleanupStack.runAllCleanups();
+    }).not.toThrow();
+  });
+});

--- a/apps/webapp/src/script/cleanupStack/cleanupStack.ts
+++ b/apps/webapp/src/script/cleanupStack/cleanupStack.ts
@@ -1,0 +1,58 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Maybe} from 'true-myth';
+
+export type CleanupFunction = () => void;
+
+type CleanupStackDependencies = {
+  readonly onCleanupError?: (cleanupError: unknown) => void;
+};
+
+export type CleanupStack = {
+  readonly addCleanup: (cleanup: CleanupFunction) => void;
+  readonly runAllCleanups: () => void;
+};
+
+export function createCleanupStack(dependencies: CleanupStackDependencies = {}): CleanupStack {
+  const cleanupList: CleanupFunction[] = [];
+  const {onCleanupError} = dependencies;
+
+  return {
+    addCleanup(cleanup: CleanupFunction): void {
+      cleanupList.push(cleanup);
+    },
+
+    runAllCleanups(): void {
+      while (cleanupList.length > 0) {
+        const cleanup = Maybe.of(cleanupList.pop());
+
+        if (cleanup.isJust) {
+          const cleanupFunction = cleanup.value;
+
+          try {
+            cleanupFunction();
+          } catch (cleanupError: unknown) {
+            onCleanupError?.(cleanupError);
+          }
+        }
+      }
+    },
+  };
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23826" title="WPB-23826" target="_blank"><img alt="Epic" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10807?size=medium" />WPB-23826</a>  [Web] Optimize websocket implementation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

We need deterministic teardown that is simple, explicit, and not tied to language-level explicit resource management features. Instead of using [explicit resource management](https://github.com/tc39/proposal-explicit-resource-management), which does unfortunately [not exist in Safari](https://caniuse.com/wf-explicit-resource-management) we will have our own explicit resource management alternative.

We will use this in the upcoming WebSocket connection changes.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
