### PR TITLE
feat: handle update certificate button visibility [WPB-23318]

### DIFF
--- a/apps/webapp/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.test.tsx
+++ b/apps/webapp/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.test.tsx
@@ -119,38 +119,35 @@ describe('E2EICertificateDetails', () => {
   });
 
   describe('shows the update certificate button for the current device', () => {
-    it('for expired certificate', async () => {
-      const identity = generateIdentity(MLSStatuses.EXPIRED);
+    it.each([
+      ['valid', MLSStatuses.VALID],
+      ['expired', MLSStatuses.EXPIRED],
+      ['revoked', MLSStatuses.REVOKED],
+      ['expires soon', MLSStatuses.EXPIRES_SOON],
+    ])('for %s certificate', async (_label, status) => {
+      const identity = generateIdentity(status);
 
       const {getByText} = render(withTheme(<E2EICertificateDetails identity={identity} isCurrentDevice />));
 
       await waitFor(() => {
-        const E2EIdentityStatus = getByText('E2EI.updateCertificate');
-        expect(E2EIdentityStatus).toBeDefined();
+        const updateCertificateButton = getByText('E2EI.updateCertificate');
+        expect(updateCertificateButton).toBeDefined();
       });
     });
 
-    it('for certificate that expires soon', async () => {
-      const identity = generateIdentity(MLSStatuses.VALID);
+    it('does not show update certificate button when certificate is not activated', async () => {
+      const {queryByText} = render(withTheme(<E2EICertificateDetails isCurrentDevice />));
 
-      const instance = E2EIHandler.getInstance();
-      jest.spyOn(instance, 'hasGracePeriodStartedForSelfClient').mockResolvedValue(true);
-
-      const {getByText} = render(withTheme(<E2EICertificateDetails identity={identity} isCurrentDevice />));
-
-      await waitFor(() => {
-        const E2EIdentityStatus = getByText('E2EI.updateCertificate');
-        expect(E2EIdentityStatus).toBeDefined();
-      });
+      expect(queryByText('E2EI.updateCertificate')).toBeNull();
     });
 
-    it('for not downloaded certificate', async () => {
+    it('shows get certificate button when certificate is not activated', async () => {
       const identity = generateIdentity(MLSStatuses.NOT_ACTIVATED);
 
       const {getByText} = render(withTheme(<E2EICertificateDetails identity={identity} isCurrentDevice />));
 
-      const E2EIdentityStatus = getByText('E2EI.getCertificate');
-      expect(E2EIdentityStatus).toBeDefined();
+      const getCertificateButton = getByText('E2EI.getCertificate');
+      expect(getCertificateButton).toBeDefined();
     });
   });
 });

--- a/apps/webapp/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.tsx
+++ b/apps/webapp/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.tsx
@@ -40,9 +40,6 @@ export const E2EICertificateDetails = ({identity, isCurrentDevice}: E2EICertific
 
   const isActivated = status !== MLSStatuses.NOT_ACTIVATED;
 
-  const isValid = status === MLSStatuses.VALID;
-  const expiresSoon = status === MLSStatuses.EXPIRES_SOON;
-
   const showModal = useCertificateDetailsModal(certificate ?? '');
 
   const getCertificate = async () => {
@@ -93,7 +90,7 @@ export const E2EICertificateDetails = ({identity, isCurrentDevice}: E2EICertific
               </Button>
             )}
 
-            {((isActivated && !isValid) || expiresSoon) && (
+            {isActivated && (
               <Button
                 variant={ButtonVariant.TERTIARY}
                 onClick={getCertificate}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23318" title="WPB-23318" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23318</a>  [Web] Always show "Update certificate" button in devices list when E2EI is enabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary
Show update certificate button based on this table:
| Certificate Status | Show Certificate Details | Get Certificate | Update Certificate |
| ------------------ | ------------------------ | --------------- | ------------------ |
| valid              | ✅                        | ❌               | ✅                  |
| invalid            | ✅                        | ❌               | ✅                  |
| not activated      | ❌                        | ✅               | ❌                  |
| revoked            | ✅                        | ❌               | ✅                  |
| expired            | ✅                        | ❌               | ✅                  |


## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
