### PR TITLE
chore(refactor): pass wall clock explicitly from bootstrap [WPB-23299]

### DIFF
--- a/apps/webapp/src/script/components/AppContainer/AppContainer.tsx
+++ b/apps/webapp/src/script/components/AppContainer/AppContainer.tsx
@@ -39,6 +39,7 @@ import {isDetachedCallingFeatureEnabled} from 'Util/isDetachedCallingFeatureEnab
 import {useAccentColor} from './hooks/useAccentColor';
 import {useTheme} from './hooks/useTheme';
 
+import {WallClock} from '../../clock/wallClock';
 import {Config, Configuration} from '../../Config';
 import {StartupFeatureToggles} from '../../featureToggles/startupFeatureToggles';
 import {setAppLocale} from '../../localization/Localizer';
@@ -49,13 +50,14 @@ import {Core} from '../../service/CoreSingleton';
 import {MainViewModel} from '../../view_model/MainViewModel';
 import {AppLoader} from '../AppLoader';
 
-interface AppProps {
-  config: Configuration;
-  clientType: ClientType;
-  startupFeatureToggles: StartupFeatureToggles;
-}
+type AppProps = {
+  readonly config: Configuration;
+  readonly clientType: ClientType;
+  readonly startupFeatureToggles: StartupFeatureToggles;
+  readonly wallClock: WallClock;
+};
 
-export const AppContainer = ({config, clientType, startupFeatureToggles}: AppProps) => {
+export const AppContainer = ({config, clientType, startupFeatureToggles, wallClock}: AppProps) => {
   setAppLocale();
   const app = useMemo(() => new App(container.resolve(Core), container.resolve(APIClient), config), []);
   const enableAutoLogin = Config.getConfig().FEATURE.ENABLE_AUTO_LOGIN;
@@ -119,6 +121,7 @@ export const AppContainer = ({config, clientType, startupFeatureToggles}: AppPro
               mainView={mainView}
               locked={softLockEnabled}
               startupFeatureToggles={startupFeatureToggles}
+              wallClock={wallClock}
             />
           );
         }}

--- a/apps/webapp/src/script/main/createApplicationServices.test.ts
+++ b/apps/webapp/src/script/main/createApplicationServices.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {createDeterministicWallClock} from '../clock/deterministicWallClock';
+import {createApplicationServices} from './createApplicationServices';
+
+describe('createApplicationServices', () => {
+  it('creates wall clock through injected dependency', () => {
+    const deterministicWallClock = createDeterministicWallClock();
+    const createWallClock = jest.fn(() => {
+      return deterministicWallClock;
+    });
+
+    const applicationServices = createApplicationServices({
+      createWallClock,
+    });
+
+    expect(applicationServices.wallClock).toBe(deterministicWallClock);
+    expect(createWallClock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/webapp/src/script/main/createApplicationServices.ts
+++ b/apps/webapp/src/script/main/createApplicationServices.ts
@@ -1,0 +1,36 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {WallClock} from '../clock/wallClock';
+
+export type ApplicationServices = {
+  readonly wallClock: WallClock;
+};
+
+type CreateApplicationServicesDependencies = {
+  readonly createWallClock: () => WallClock;
+};
+
+export function createApplicationServices(dependencies: CreateApplicationServicesDependencies): ApplicationServices {
+  const {createWallClock} = dependencies;
+
+  return {
+    wallClock: createWallClock(),
+  };
+}

--- a/apps/webapp/src/script/main/index.tsx
+++ b/apps/webapp/src/script/main/index.tsx
@@ -34,7 +34,10 @@ import {enableLogging} from 'Util/LoggerUtil';
 import {loadValue} from 'Util/StorageUtil';
 import {exposeWrapperGlobals} from 'Util/wrapper';
 
+import {createApplicationServices} from './createApplicationServices';
+
 import {SIGN_OUT_REASON} from '../auth/SignOutReason';
+import {createWallClock} from '../clock/wallClock';
 import {Config} from '../Config';
 import {createStartupFeatureTogglesFromLocationSearch} from '../featureToggles/startupFeatureToggles';
 
@@ -65,12 +68,17 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(globalThis.location.search);
+  const applicationServices = createApplicationServices({
+    createWallClock,
+  });
+  const {wallClock} = applicationServices;
 
   createRoot(appContainer).render(
     <AppContainer
       config={config}
       clientType={shouldPersist ? ClientType.PERMANENT : ClientType.TEMPORARY}
       startupFeatureToggles={startupFeatureToggles}
+      wallClock={wallClock}
     />,
   );
 });

--- a/apps/webapp/src/script/page/AppMain.tsx
+++ b/apps/webapp/src/script/page/AppMain.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {useCallback, useEffect, useLayoutEffect, useMemo, useState} from 'react';
+import {useCallback, useEffect, useLayoutEffect, useState} from 'react';
 
 import {amplify} from 'amplify';
 import cx from 'classnames';
@@ -66,7 +66,7 @@ import {ContentState, useAppState} from './useAppState';
 
 import {runClientVersionCheck} from '../application-periodic-checks/runClientVersionCheck';
 import {startApplicationPeriodicChecks} from '../application-periodic-checks/startApplicationPeriodicChecks';
-import {createWallClock} from '../clock/wallClock';
+import {WallClock} from '../clock/wallClock';
 import {StartupFeatureToggles} from '../featureToggles/startupFeatureToggles';
 import {App} from '../main/app';
 import {initialiseMLSMigrationFlow} from '../mls/MLSMigration';
@@ -82,16 +82,17 @@ export type RightSidebarParams = {
   highlighted?: User[];
 };
 
-interface AppMainProps {
-  app: App;
-  selfUser: User;
-  mainView: MainViewModel;
-  startupFeatureToggles: StartupFeatureToggles;
-  conversationState?: ConversationState;
-  callState?: CallState;
+type AppMainProps = {
+  readonly app: App;
+  readonly selfUser: User;
+  readonly mainView: MainViewModel;
+  readonly startupFeatureToggles: StartupFeatureToggles;
+  readonly conversationState?: ConversationState;
+  readonly callState?: CallState;
+  readonly wallClock: WallClock;
   /** will block the user from being able to interact with the application (no notifications and no messages will be shown) */
-  locked: boolean;
-}
+  readonly locked: boolean;
+};
 
 export const AppMain = ({
   app,
@@ -100,11 +101,9 @@ export const AppMain = ({
   startupFeatureToggles,
   conversationState = container.resolve(ConversationState),
   callState = container.resolve(CallState),
+  wallClock,
   locked,
 }: AppMainProps) => {
-  const wallClock = useMemo(() => {
-    return createWallClock();
-  }, []);
   const [doesApplicationNeedForceReload, setDoesApplicationNeedForceReload] = useState(false);
   const clientVersion = Config.getConfig().VERSION;
   const runApplicationPeriodicCheck: () => void = useCallback(() => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23299" title="WPB-23299" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23299</a>  [Web] Add support for remote force reload 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Move the clock creation one level up to the application entry point

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
