### PR TITLE
feat: add managed WebSocket connection wrapper [WPB-23826]

### DIFF
--- a/apps/webapp/src/script/webSocketConnection/createManagedWebSocketConnection.ts
+++ b/apps/webapp/src/script/webSocketConnection/createManagedWebSocketConnection.ts
@@ -1,0 +1,181 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {createActor} from 'xstate';
+
+import {
+  createWebSocketConnectionStateMachine,
+  webSocketConnectionStateMachineEventType,
+  WebSocketConnectionStateMachineState,
+} from './webSocketConnectionStateMachine';
+
+import {createCleanupStack} from '../cleanupStack/cleanupStack';
+
+export type WebSocketConnectionEventType = 'open' | 'close' | 'error';
+
+export type WebSocketConnectionStateListener = (state: WebSocketConnectionStateMachineState) => void;
+
+export type WebSocketConnectionTransport = {
+  readonly readyState: number;
+  readonly send: (message: string) => void;
+  readonly close: () => void;
+  readonly addEventListener: (type: WebSocketConnectionEventType, listener: (event: Event) => void) => void;
+  readonly removeEventListener: (type: WebSocketConnectionEventType, listener: (event: Event) => void) => void;
+};
+
+export type CreateWebSocketConnection = (connectionUrl: string) => WebSocketConnectionTransport;
+
+export type ManagedWebSocketConnection = {
+  readonly currentConnectionState: WebSocketConnectionStateMachineState;
+  readonly subscribeToConnectionState: (listener: WebSocketConnectionStateListener) => () => void;
+  readonly connect: (connectionUrl: string) => void;
+  readonly disconnect: () => void;
+  readonly sendMessage: (message: string) => boolean;
+  readonly dispose: () => void;
+};
+
+type CreateManagedWebSocketConnectionDependencies = {
+  readonly createWebSocketConnection: CreateWebSocketConnection;
+};
+
+type ActiveManagedWebSocketConnection = {
+  readonly webSocketConnection: WebSocketConnectionTransport;
+  readonly runCleanup: () => void;
+};
+
+const webSocketConnectionOpenReadyState = 1;
+
+export function createBrowserWebSocketConnection(connectionUrl: string): WebSocketConnectionTransport {
+  return new WebSocket(connectionUrl);
+}
+
+export function createManagedWebSocketConnection(
+  dependencies: CreateManagedWebSocketConnectionDependencies,
+): ManagedWebSocketConnection {
+  const {createWebSocketConnection} = dependencies;
+  const webSocketConnectionStateMachineActor = createActor(createWebSocketConnectionStateMachine());
+  const connectionStateListenerSet = new Set<WebSocketConnectionStateListener>();
+  const managedWebSocketConnectionCleanupStack = createCleanupStack();
+  let activeManagedWebSocketConnection: ActiveManagedWebSocketConnection | undefined;
+
+  webSocketConnectionStateMachineActor.start();
+
+  const actorSubscription = webSocketConnectionStateMachineActor.subscribe(snapshot => {
+    const currentConnectionState = snapshot.value as WebSocketConnectionStateMachineState;
+
+    connectionStateListenerSet.forEach(connectionStateListener => {
+      return connectionStateListener(currentConnectionState);
+    });
+  });
+
+  managedWebSocketConnectionCleanupStack.addCleanup(() => {
+    actorSubscription.unsubscribe();
+    connectionStateListenerSet.clear();
+    webSocketConnectionStateMachineActor.stop();
+  });
+
+  function disconnectActiveManagedWebSocketConnection(): void {
+    activeManagedWebSocketConnection?.runCleanup();
+    activeManagedWebSocketConnection = undefined;
+  }
+
+  return {
+    get currentConnectionState() {
+      return webSocketConnectionStateMachineActor.getSnapshot().value as WebSocketConnectionStateMachineState;
+    },
+
+    subscribeToConnectionState(listener) {
+      connectionStateListenerSet.add(listener);
+      listener(webSocketConnectionStateMachineActor.getSnapshot().value as WebSocketConnectionStateMachineState);
+
+      return function unsubscribeFromConnectionState(): void {
+        connectionStateListenerSet.delete(listener);
+      };
+    },
+
+    connect(connectionUrl) {
+      disconnectActiveManagedWebSocketConnection();
+
+      const webSocketConnection = createWebSocketConnection(connectionUrl);
+      const activeManagedWebSocketConnectionCleanupStack = createCleanupStack();
+
+      function onOpen(): void {
+        return webSocketConnectionStateMachineActor.send({
+          type: webSocketConnectionStateMachineEventType.connectionBecameOnline,
+        });
+      }
+
+      function onClose(): void {
+        return webSocketConnectionStateMachineActor.send({
+          type: webSocketConnectionStateMachineEventType.connectionBecameOffline,
+        });
+      }
+
+      function onError(): void {
+        return webSocketConnectionStateMachineActor.send({
+          type: webSocketConnectionStateMachineEventType.connectionBecameOffline,
+        });
+      }
+
+      webSocketConnection.addEventListener('open', onOpen);
+      webSocketConnection.addEventListener('close', onClose);
+      webSocketConnection.addEventListener('error', onError);
+
+      activeManagedWebSocketConnectionCleanupStack.addCleanup(() => {
+        webSocketConnection.removeEventListener('open', onOpen);
+        webSocketConnection.removeEventListener('close', onClose);
+        webSocketConnection.removeEventListener('error', onError);
+        webSocketConnection.close();
+      });
+
+      activeManagedWebSocketConnection = {
+        webSocketConnection,
+        runCleanup: activeManagedWebSocketConnectionCleanupStack.runAllCleanups,
+      };
+    },
+
+    disconnect() {
+      disconnectActiveManagedWebSocketConnection();
+      webSocketConnectionStateMachineActor.send({
+        type: webSocketConnectionStateMachineEventType.connectionBecameOffline,
+      });
+    },
+
+    sendMessage(message) {
+      if (activeManagedWebSocketConnection === undefined) {
+        return false;
+      }
+
+      const {webSocketConnection} = activeManagedWebSocketConnection;
+
+      if (webSocketConnection.readyState !== webSocketConnectionOpenReadyState) {
+        return false;
+      }
+
+      webSocketConnection.send(message);
+
+      return true;
+    },
+
+    dispose() {
+      disconnectActiveManagedWebSocketConnection();
+      managedWebSocketConnectionCleanupStack.runAllCleanups();
+    },
+  };
+}

--- a/apps/webapp/src/script/webSocketConnection/managedWebSocketConnection.test.ts
+++ b/apps/webapp/src/script/webSocketConnection/managedWebSocketConnection.test.ts
@@ -1,0 +1,204 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {
+  createManagedWebSocketConnection,
+  WebSocketConnectionEventType,
+  WebSocketConnectionTransport,
+} from './createManagedWebSocketConnection';
+import {webSocketConnectionStateMachineState} from './webSocketConnectionStateMachine';
+
+type FakeWebSocketConnectionContext = {
+  readonly fakeWebSocketConnection: WebSocketConnectionTransport;
+  readonly getCloseCallCount: () => number;
+  readonly sentMessageList: readonly string[];
+  readonly setReadyState: (readyState: number) => void;
+  readonly triggerEvent: (eventType: WebSocketConnectionEventType) => void;
+};
+
+function createFakeWebSocketConnectionContext(): FakeWebSocketConnectionContext {
+  const listenerSetByEventType = new Map<WebSocketConnectionEventType, Set<(event: Event) => void>>();
+  const sentMessageList: string[] = [];
+  let closeCallCount = 0;
+  let readyState = 0;
+
+  function addEventListener(type: WebSocketConnectionEventType, listener: (event: Event) => void): void {
+    const listenerSet = listenerSetByEventType.get(type) ?? new Set<(event: Event) => void>();
+
+    listenerSet.add(listener);
+    listenerSetByEventType.set(type, listenerSet);
+  }
+
+  function removeEventListener(type: WebSocketConnectionEventType, listener: (event: Event) => void): void {
+    return listenerSetByEventType.get(type)?.delete(listener);
+  }
+
+  function send(message: string): void {
+    return sentMessageList.push(message);
+  }
+
+  function close(): void {
+    closeCallCount += 1;
+    readyState = 3;
+  }
+
+  function setReadyState(updatedReadyState: number): void {
+    readyState = updatedReadyState;
+  }
+
+  function triggerEvent(eventType: WebSocketConnectionEventType): void {
+    const listenerSet = listenerSetByEventType.get(eventType);
+
+    listenerSet?.forEach((listener) => {
+      return listener(new Event(eventType));
+    });
+  }
+
+  return {
+    fakeWebSocketConnection: {
+      get readyState() {
+        return readyState;
+      },
+
+      send(message: string): void {
+        return send(message);
+      },
+
+      close(): void {
+        return close();
+      },
+
+      addEventListener(type: WebSocketConnectionEventType, listener: (event: Event) => void): void {
+        return addEventListener(type, listener);
+      },
+
+      removeEventListener(type: WebSocketConnectionEventType, listener: (event: Event) => void): void {
+        return removeEventListener(type, listener);
+      },
+    },
+    getCloseCallCount(): number {
+      return closeCallCount;
+    },
+    sentMessageList,
+    setReadyState(updatedReadyState: number): void {
+      return setReadyState(updatedReadyState);
+    },
+    triggerEvent(eventType: WebSocketConnectionEventType): void {
+      return triggerEvent(eventType);
+    },
+  };
+}
+
+describe('createManagedWebSocketConnection', () => {
+  it('starts in offline state', () => {
+    const fakeWebSocketConnectionContext = createFakeWebSocketConnectionContext();
+    const managedWebSocketConnection = createManagedWebSocketConnection({
+      createWebSocketConnection() {
+        return fakeWebSocketConnectionContext.fakeWebSocketConnection;
+      },
+    });
+
+    expect(managedWebSocketConnection.currentConnectionState).toBe(webSocketConnectionStateMachineState.offline);
+
+    managedWebSocketConnection.dispose();
+  });
+
+  it('updates to online state when the connection emits open', () => {
+    const fakeWebSocketConnectionContext = createFakeWebSocketConnectionContext();
+    const managedWebSocketConnection = createManagedWebSocketConnection({
+      createWebSocketConnection() {
+        return fakeWebSocketConnectionContext.fakeWebSocketConnection;
+      },
+    });
+
+    managedWebSocketConnection.connect('wss://example.test/socket');
+    fakeWebSocketConnectionContext.triggerEvent('open');
+
+    expect(managedWebSocketConnection.currentConnectionState).toBe(webSocketConnectionStateMachineState.online);
+
+    managedWebSocketConnection.dispose();
+  });
+
+  it('returns to offline state and closes the active connection on disconnect', () => {
+    const fakeWebSocketConnectionContext = createFakeWebSocketConnectionContext();
+    const managedWebSocketConnection = createManagedWebSocketConnection({
+      createWebSocketConnection() {
+        return fakeWebSocketConnectionContext.fakeWebSocketConnection;
+      },
+    });
+
+    managedWebSocketConnection.connect('wss://example.test/socket');
+    fakeWebSocketConnectionContext.triggerEvent('open');
+    managedWebSocketConnection.disconnect();
+
+    expect(managedWebSocketConnection.currentConnectionState).toBe(webSocketConnectionStateMachineState.offline);
+    expect(fakeWebSocketConnectionContext.getCloseCallCount()).toBe(1);
+
+    managedWebSocketConnection.dispose();
+  });
+
+  it('sends a message only when the connection is open', () => {
+    const fakeWebSocketConnectionContext = createFakeWebSocketConnectionContext();
+    const managedWebSocketConnection = createManagedWebSocketConnection({
+      createWebSocketConnection() {
+        return fakeWebSocketConnectionContext.fakeWebSocketConnection;
+      },
+    });
+
+    managedWebSocketConnection.connect('wss://example.test/socket');
+
+    expect(managedWebSocketConnection.sendMessage('before-open')).toBe(false);
+
+    fakeWebSocketConnectionContext.setReadyState(1);
+    fakeWebSocketConnectionContext.triggerEvent('open');
+
+    expect(managedWebSocketConnection.sendMessage('after-open')).toBe(true);
+    expect(fakeWebSocketConnectionContext.sentMessageList).toEqual(['after-open']);
+
+    managedWebSocketConnection.dispose();
+  });
+
+  it('notifies subscribed listeners when the connection state changes', () => {
+    const fakeWebSocketConnectionContext = createFakeWebSocketConnectionContext();
+    const managedWebSocketConnection = createManagedWebSocketConnection({
+      createWebSocketConnection() {
+        return fakeWebSocketConnectionContext.fakeWebSocketConnection;
+      },
+    });
+    const observedConnectionStateList: string[] = [];
+
+    const unsubscribeFromConnectionState = managedWebSocketConnection.subscribeToConnectionState((connectionState) => {
+      return observedConnectionStateList.push(connectionState);
+    });
+
+    managedWebSocketConnection.connect('wss://example.test/socket');
+    fakeWebSocketConnectionContext.triggerEvent('open');
+    fakeWebSocketConnectionContext.triggerEvent('close');
+    unsubscribeFromConnectionState();
+    fakeWebSocketConnectionContext.triggerEvent('open');
+
+    expect(observedConnectionStateList).toEqual([
+      webSocketConnectionStateMachineState.offline,
+      webSocketConnectionStateMachineState.online,
+      webSocketConnectionStateMachineState.offline,
+    ]);
+
+    managedWebSocketConnection.dispose();
+  });
+});


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23826" title="WPB-23826" target="_blank"><img alt="Epic" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10807?size=medium" />WPB-23826</a>  [Web] Optimize websocket implementation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

# Pull Request

## Summary

Introduce an effectful wrapper around the existing WebSocket connection state machine. This adds a concrete boundary for connection lifecycle, state observation, message sending, and cleanup without yet wiring it into bootstrap or React.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
