### PR TITLE
fix: collabora copy paste not working(WPB-23544)

### DIFF
--- a/apps/server/Server.ts
+++ b/apps/server/Server.ts
@@ -176,6 +176,17 @@ class Server {
       res.setHeader('X-XSS-Protection', '1; mode=block');
       next();
     });
+    // Scope clipboard delegation to self and the configured Collabora origin only.
+    // Falls back to self-only when CELLS_PYDIO_URL is not configured.
+    const collaboraOrigin = this.clientConfig.CELLS_PYDIO_URL;
+    const clipboardAllowlist = collaboraOrigin ? `(self "${collaboraOrigin}")` : '(self)';
+    this.app.use((_req, res, next) => {
+      res.setHeader(
+        'Permissions-Policy',
+        `clipboard-read=${clipboardAllowlist}, clipboard-write=${clipboardAllowlist}`,
+      );
+      next();
+    });
   }
 
   private initStaticRoutes() {

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileEditor/FileEditor.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileEditor/FileEditor.tsx
@@ -20,14 +20,17 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
 
 import {Node} from '@wireapp/api-client/lib/cells';
+import {Maybe, result} from 'true-myth';
 import {container} from 'tsyringe';
 
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
 import {CellsRepository} from 'Repositories/cells/CellsRepository';
+import {Config} from 'src/script/Config';
 import {t} from 'Util/LocalizerUtil';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
 
 import * as styles from './FileEditor.styles';
+import {validateCollaboraUrl} from './validateCollaboraUrl';
 
 import {FileLoader} from '../FileLoader/FileLoader';
 
@@ -122,10 +125,21 @@ export const FileEditor = ({id}: FileEditorProps) => {
     return <FileLoader />;
   }
 
-  const editorUrl = node?.EditorURLs?.collabora?.Url;
-  if (!editorUrl) {
+  const urlValidation = validateCollaboraUrl(
+    Maybe.of(node?.EditorURLs?.collabora?.Url),
+    Config.getConfig().CELLS_PYDIO_URL,
+  );
+
+  if (result.isErr(urlValidation)) {
     return null;
   }
 
-  return <iframe css={styles.editorIframe} src={editorUrl} title={t('fileFullscreenModal.editor.iframeTitle')} />;
+  return (
+    <iframe
+      allow="clipboard-read; clipboard-write"
+      css={styles.editorIframe}
+      src={urlValidation.value}
+      title={t('fileFullscreenModal.editor.iframeTitle')}
+    />
+  );
 };

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileEditor/validateCollaboraUrl.test.ts
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileEditor/validateCollaboraUrl.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Maybe} from 'true-myth';
+import {unwrap, unwrapErr} from 'true-myth/test-support';
+
+import {validateCollaboraUrl} from './validateCollaboraUrl';
+
+const TRUSTED_ORIGIN = 'https://cells.example.com';
+
+describe('validateCollaboraUrl', () => {
+  describe('url is empty', () => {
+    it('returns empty error when url is undefined', () => {
+      const result = validateCollaboraUrl(Maybe.of(undefined), TRUSTED_ORIGIN);
+      expect(unwrapErr(result)).toEqual({reason: 'empty'});
+    });
+
+    it('returns empty error when url is an empty string', () => {
+      const result = validateCollaboraUrl(Maybe.of(''), TRUSTED_ORIGIN);
+      expect(unwrapErr(result)).toEqual({reason: 'empty'});
+    });
+  });
+
+  describe('url is not HTTPS', () => {
+    it('returns insecure error for http url', () => {
+      const url = 'http://cells.example.com/editor';
+      const result = validateCollaboraUrl(Maybe.of(url), TRUSTED_ORIGIN);
+      expect(unwrapErr(result)).toEqual({reason: 'insecure', url});
+    });
+
+    it('returns insecure error for protocol-relative url', () => {
+      const url = '//cells.example.com/editor';
+      const result = validateCollaboraUrl(Maybe.of(url), TRUSTED_ORIGIN);
+      expect(unwrapErr(result)).toEqual({reason: 'insecure', url});
+    });
+  });
+
+  describe('url origin does not match trusted origin', () => {
+    it('returns untrusted error when origins differ', () => {
+      const url = 'https://other.example.com/editor';
+      const result = validateCollaboraUrl(Maybe.of(url), TRUSTED_ORIGIN);
+      expect(unwrapErr(result)).toEqual({reason: 'untrusted', url, trustedOrigin: TRUSTED_ORIGIN});
+    });
+
+    it('returns untrusted error when subdomain differs', () => {
+      const url = 'https://evil.cells.example.com/editor';
+      const result = validateCollaboraUrl(Maybe.of(url), TRUSTED_ORIGIN);
+      expect(unwrapErr(result)).toEqual({reason: 'untrusted', url, trustedOrigin: TRUSTED_ORIGIN});
+    });
+  });
+
+  describe('url is valid', () => {
+    it('returns ok for a matching HTTPS url', () => {
+      const url = 'https://cells.example.com/editor?token=abc';
+      const result = validateCollaboraUrl(Maybe.of(url), TRUSTED_ORIGIN);
+      expect(unwrap(result)).toBe(url);
+    });
+
+    it('skips origin check when trustedOrigin is empty (Cells not configured)', () => {
+      const url = 'https://cells.example.com/editor';
+      const result = validateCollaboraUrl(Maybe.of(url), '');
+      expect(unwrap(result)).toBe(url);
+    });
+
+    it('skips origin check when trustedOrigin is not a valid HTTPS url', () => {
+      const url = 'https://cells.example.com/editor';
+      const result = validateCollaboraUrl(Maybe.of(url), 'not-a-url');
+      expect(unwrap(result)).toBe(url);
+    });
+  });
+});

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileEditor/validateCollaboraUrl.test.ts
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileEditor/validateCollaboraUrl.test.ts
@@ -49,6 +49,12 @@ describe('validateCollaboraUrl', () => {
       const result = validateCollaboraUrl(Maybe.of(url), TRUSTED_ORIGIN);
       expect(unwrapErr(result)).toEqual({reason: 'insecure', url});
     });
+
+    it('returns insecure error for malformed https url', () => {
+      const url = 'https://[cells.example.com/editor';
+      const result = validateCollaboraUrl(Maybe.of(url), TRUSTED_ORIGIN);
+      expect(unwrapErr(result)).toEqual({reason: 'insecure', url});
+    });
   });
 
   describe('url origin does not match trusted origin', () => {

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileEditor/validateCollaboraUrl.ts
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileEditor/validateCollaboraUrl.ts
@@ -30,7 +30,7 @@ const HTTPS_URL_PATTERN = /^https:\/\/\S+$/;
  * Validates a Collabora editor URL is safe to embed with clipboard permissions.
  */
 export const validateCollaboraUrl = (url: Maybe<string>, trustedOrigin: string): Result<string, CollaboraUrlError> => {
-  if (!url.isJust) {
+  if (!url.isJust || url.value === '') {
     return Result.err({reason: 'empty'});
   }
 

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileEditor/validateCollaboraUrl.ts
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileEditor/validateCollaboraUrl.ts
@@ -1,0 +1,46 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Maybe, Result} from 'true-myth';
+
+export type CollaboraUrlError =
+  | {readonly reason: 'empty'}
+  | {readonly reason: 'insecure'; readonly url: string}
+  | {readonly reason: 'untrusted'; readonly url: string; readonly trustedOrigin: string};
+
+const HTTPS_URL_PATTERN = /^https:\/\/\S+$/;
+
+/**
+ * Validates a Collabora editor URL is safe to embed with clipboard permissions.
+ */
+export const validateCollaboraUrl = (url: Maybe<string>, trustedOrigin: string): Result<string, CollaboraUrlError> => {
+  if (!url.isJust) {
+    return Result.err({reason: 'empty'});
+  }
+
+  if (!HTTPS_URL_PATTERN.test(url.value)) {
+    return Result.err({reason: 'insecure', url: url.value});
+  }
+
+  if (HTTPS_URL_PATTERN.test(trustedOrigin) && new URL(url.value).origin !== new URL(trustedOrigin).origin) {
+    return Result.err({reason: 'untrusted', url: url.value, trustedOrigin});
+  }
+
+  return Result.ok(url.value);
+};

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileEditor/validateCollaboraUrl.ts
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileEditor/validateCollaboraUrl.ts
@@ -17,14 +17,30 @@
  *
  */
 
-import {Maybe, Result} from 'true-myth';
+import {Maybe, Result, result} from 'true-myth';
 
 export type CollaboraUrlError =
   | {readonly reason: 'empty'}
   | {readonly reason: 'insecure'; readonly url: string}
   | {readonly reason: 'untrusted'; readonly url: string; readonly trustedOrigin: string};
 
-const HTTPS_URL_PATTERN = /^https:\/\/\S+$/;
+const parseUrl = (url: string): Maybe<URL> => {
+  try {
+    return Maybe.just(new URL(url));
+  } catch {
+    return Maybe.nothing();
+  }
+};
+
+const validateSecureUrl = (url: string): Result<URL, CollaboraUrlError> => {
+  const parsedUrl = parseUrl(url);
+
+  if (!parsedUrl.isJust || parsedUrl.value.protocol !== 'https:') {
+    return Result.err({reason: 'insecure', url});
+  }
+
+  return Result.ok(parsedUrl.value);
+};
 
 /**
  * Validates a Collabora editor URL is safe to embed with clipboard permissions.
@@ -34,11 +50,17 @@ export const validateCollaboraUrl = (url: Maybe<string>, trustedOrigin: string):
     return Result.err({reason: 'empty'});
   }
 
-  if (!HTTPS_URL_PATTERN.test(url.value)) {
-    return Result.err({reason: 'insecure', url: url.value});
+  const validatedUrl = validateSecureUrl(url.value);
+  if (result.isErr(validatedUrl)) {
+    return Result.err(validatedUrl.error);
   }
 
-  if (HTTPS_URL_PATTERN.test(trustedOrigin) && new URL(url.value).origin !== new URL(trustedOrigin).origin) {
+  const trustedOriginUrl = parseUrl(trustedOrigin);
+  if (
+    trustedOriginUrl.isJust &&
+    trustedOriginUrl.value.protocol === 'https:' &&
+    validatedUrl.value.origin !== trustedOriginUrl.value.origin
+  ) {
     return Result.err({reason: 'untrusted', url: url.value, trustedOrigin});
   }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23544" title="WPB-23544" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23544</a>  [Web] Not possible to copy/paste in Collabora
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Copy and paste did not work inside the Collabora editor when opened via Wire web or desktop.

- **Copy** did not work at all
- **Paste** only worked after multiple attempts
- Collabora showed a modal indicating it had limited clipboard access

The root cause:
1. The Collabora iframe was missing the `allow="clipboard-read; clipboard-write"` attribute, so the browser never granted clipboard access to the iframe
2. Permissions-Policy was missing too

## Solution

Added `allow="clipboard-read; clipboard-write"` to the Collabora iframe in `FileEditor.tsx`, but only after the editor URL passes `validateCollaboraUrl`. The attribute is never rendered for an invalid URL.

### URL validation (`validateCollaboraUrl.ts`)

New pure function `validateCollaboraUrl(url: Maybe<string>, trustedOrigin: string)` returns `Result<string, CollaboraUrlError>` with three typed failure reasons:

 `empty` | No editor URL in the API response |
  `insecure` | URL is not HTTPS — clipboard grant would go to an insecure origin |
  `untrusted` | URL origin does not match `CELLS_PYDIO_URL` — rejects unexpected HTTPS domains

### `Permissions-Policy` header — scoped to Collabora origin (`Server.ts`)

Permissions-Policy with an explicit allowlist scoped to `CELLS_PYDIO_URL`:

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
