### PR TITLE
ci: add manual production redeploy workflow [WPB-23915]

### DIFF
--- a/.github/workflows/redeploy-production-from-tag.yml
+++ b/.github/workflows/redeploy-production-from-tag.yml
@@ -55,19 +55,19 @@ jobs:
       commit_subject: ${{ steps.git_metadata.outputs.commit_subject }}
 
     steps:
+      - name: Verify remote tag exists
+        env:
+          TAG: ${{ needs.validate_request.outputs.tag }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          git ls-remote --exit-code --tags "https://github.com/${REPOSITORY}.git" "refs/tags/${TAG}"
+
       - name: Checkout selected tag
         uses: actions/checkout@v6
         with:
           ref: refs/tags/${{ needs.validate_request.outputs.tag }}
           fetch-depth: 0
-
-      - name: Verify remote tag exists
-        env:
-          TAG: ${{ needs.validate_request.outputs.tag }}
-        run: |
-          set -euo pipefail
-          git fetch --tags --force origin
-          git ls-remote --exit-code --tags origin "refs/tags/${TAG}"
 
       - name: Collect git metadata
         id: git_metadata

--- a/.github/workflows/redeploy-production-from-tag.yml
+++ b/.github/workflows/redeploy-production-from-tag.yml
@@ -1,0 +1,147 @@
+name: Redeploy production from tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing production release tag to redeploy (for example 2026-03-09-production.0)'
+        required: true
+        type: string
+      confirm_production_redeploy:
+        description: 'Confirm that this will rebuild the selected production tag and deploy it to wire-webapp-prod'
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: redeploy-production-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  validate_request:
+    name: Validate redeploy request
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.validate.outputs.tag }}
+
+    steps:
+      - name: Validate input, actor, and tag
+        id: validate
+        env:
+          TAG: ${{ inputs.tag }}
+          CONFIRM_PRODUCTION_REDEPLOY: ${{ inputs.confirm_production_redeploy }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${CONFIRM_PRODUCTION_REDEPLOY}" != 'true' ]]; then
+            echo 'Production redeploy was not confirmed. Aborting.' >&2
+            exit 1
+          fi
+
+          if [[ ! "${TAG}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}-production\.[0-9]+$ ]]; then
+            echo "Tag '${TAG}' does not match the expected production release format YYYY-MM-DD-production.N." >&2
+            exit 1
+          fi
+
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+  build_artifact:
+    name: Rebuild tagged release artifact
+    runs-on: ubuntu-latest
+    needs: validate_request
+    outputs:
+      commit_sha: ${{ steps.git_metadata.outputs.commit_sha }}
+      commit_url: ${{ steps.git_metadata.outputs.commit_url }}
+      commit_subject: ${{ steps.git_metadata.outputs.commit_subject }}
+
+    steps:
+      - name: Checkout selected tag
+        uses: actions/checkout@v6
+        with:
+          ref: refs/tags/${{ needs.validate_request.outputs.tag }}
+          fetch-depth: 0
+
+      - name: Verify remote tag exists
+        env:
+          TAG: ${{ needs.validate_request.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git fetch --tags --force origin
+          git ls-remote --exit-code --tags origin "refs/tags/${TAG}"
+
+      - name: Collect git metadata
+        id: git_metadata
+        run: |
+          set -euo pipefail
+          commit_sha="$(git rev-parse HEAD)"
+          commit_subject="$(git show -s --format=%s HEAD)"
+          commit_url="https://github.com/${GITHUB_REPOSITORY}/commit/${commit_sha}"
+
+          {
+            echo "commit_sha=${commit_sha}"
+            echo "commit_url=${commit_url}"
+            echo "commit_subject=${commit_subject}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install JS dependencies
+        run: yarn --immutable
+
+      - name: Update configuration
+        run: yarn nx run webapp:configure
+
+      - name: Build and package
+        run: yarn nx run server:package
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-artifact-${{ needs.validate_request.outputs.tag }}
+          path: apps/server/dist/s3/ebs.zip
+
+  deploy_to_production:
+    name: Deploy to production
+    runs-on: ubuntu-latest
+    needs: [validate_request, build_artifact]
+    environment: wire-webapp-prod
+
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: build-artifact-${{ needs.validate_request.outputs.tag }}
+
+      - name: Deploy to wire-webapp-prod
+        uses: einaregilsson/beanstalk-deploy@v22
+        with:
+          application_name: Webapp
+          aws_access_key: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
+          aws_secret_key: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
+          deployment_package: ebs.zip
+          environment_name: wire-webapp-prod
+          region: eu-central-1
+          use_existing_version_if_available: true
+          version_description: ${{ needs.build_artifact.outputs.commit_sha }}
+          version_label: '${{ github.run_id }}-wire-webapp-prod-redeploy'
+          wait_for_deployment: false
+          wait_for_environment_recovery: 150
+
+  notify_redeploy:
+    name: Notify redeploy
+    runs-on: ubuntu-latest
+    needs: [validate_request, build_artifact, deploy_to_production]
+    if: ${{ needs.deploy_to_production.result == 'success' }}
+
+    steps:
+      - name: Announce production redeploy
+        uses: wireapp/github-action-wire-messenger@v2.0.0
+        with:
+          email: ${{ secrets.WIRE_BOT_EMAIL }}
+          password: ${{ secrets.WIRE_BOT_PASSWORD }}
+          conversation: '697c93e8-0b13-4204-a35e-59270462366a'
+          send_text: 'Production redeploy completed for tag ${{ needs.validate_request.outputs.tag }} by ${{ github.actor }}. Commit: [${{ needs.build_artifact.outputs.commit_sha }}](${{ needs.build_artifact.outputs.commit_url }}) — ${{ needs.build_artifact.outputs.commit_subject }}'


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23915" title="WPB-23915" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23915</a>  [Web] Create workflow dispatch to production
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Add a manual workflow to rebuild an existing production tag, deploy the packaged artifact to wire-webapp-prod, and notify Wire after a successful redeploy. The workflow validates the release tag format and keeps deployment behind the production environment gate.
