### PR TITLE
test: remove duplicate test case [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/LoginSpecs/login.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/LoginSpecs/login.spec.ts
@@ -17,23 +17,7 @@
  *
  */
 
-import {generateRandomPassword} from 'Util/StringUtil';
-
 import {test, expect, LOGIN_TIMEOUT} from '../../test.fixtures';
-
-test(
-  'Verify sign in error appearance in case of wrong credentials',
-  {tag: ['@TC-3465', '@smoke']},
-  async ({pageManager}) => {
-    const {pages} = pageManager.webapp;
-
-    await pageManager.openLoginPage();
-    await pages.login().login({email: 'incorrect-email@wire.engineering', password: generateRandomPassword()});
-
-    const errorMessage = pages.login().loginErrorText;
-    await expect(errorMessage).toHaveText('Please verify your details and try again');
-  },
-);
 
 test('Verify you can sign in by email', {tag: ['@TC-3461', '@regression']}, async ({pageManager, createUser}) => {
   const {components, pages} = pageManager.webapp;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Together with @iskvortsov we discovered that this test case is a duplicate of the one also existing in the authentication tests, so I removed it

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
