### PR TITLE
feat: add feature toggle for incremental HTTP retry backoff [WPB-23381]

### DIFF
--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
@@ -23,9 +23,10 @@ import {
   startupFeatureToggleQueryParameterName,
 } from './startupFeatureToggles';
 
-describe('startupFeatureToggles', function () {
-  const reliableWebsocketConnectionFeatureToggleName = 'reliable-websocket-connection';
+const reliableWebsocketConnectionFeatureToggleName = 'reliable-websocket-connection';
+const incrementalHttpRetryBackoffFeatureToggleName = 'incremental-http-retry-backoff';
 
+describe('startupFeatureToggles', function () {
   it('returns disabled toggles when the query parameter is missing', function () {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch('?foo=bar');
 
@@ -56,6 +57,14 @@ describe('startupFeatureToggles', function () {
     );
 
     expect(startupFeatureToggles.getEnabledFeatureToggleNames()).toEqual([]);
+  });
+
+  it('enables the incremental http retry backoff feature toggle when present in the query parameter', function () {
+    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
+      `?${startupFeatureToggleQueryParameterName}=${incrementalHttpRetryBackoffFeatureToggleName}`,
+    );
+
+    expect(startupFeatureToggles.isFeatureToggleEnabled(incrementalHttpRetryBackoffFeatureToggleName)).toBe(true);
   });
 
   it('keeps only whitelisted feature toggles when known and unknown values are mixed', function () {
@@ -106,7 +115,10 @@ describe('startupFeatureToggles', function () {
   });
 
   it('contains only whitelisted values in allowedStartupFeatureToggleNames', function () {
-    expect(allowedStartupFeatureToggleNames).toEqual([reliableWebsocketConnectionFeatureToggleName]);
+    expect(allowedStartupFeatureToggleNames).toEqual([
+      reliableWebsocketConnectionFeatureToggleName,
+      incrementalHttpRetryBackoffFeatureToggleName,
+    ]);
   });
 
   it('does not expose mutable enabled toggle state', function () {

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.ts
@@ -21,7 +21,10 @@ import {Maybe} from 'true-myth';
 
 export const startupFeatureToggleQueryParameterName = 'enabled-features';
 
-export const allowedStartupFeatureToggleNames = ['reliable-websocket-connection'] as const;
+export const allowedStartupFeatureToggleNames = [
+  'reliable-websocket-connection',
+  'incremental-http-retry-backoff',
+] as const;
 
 export type StartupFeatureToggleName = (typeof allowedStartupFeatureToggleNames)[number];
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23381" title="WPB-23381" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23381</a>  [Web] Make sure that the web app applies incremental backoff on 420/429
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Introduce the startup feature toggle incremental-http-retry-backoff so the new HTTP retry policy can be rolled out safely behind an explicit client-side gate. This keeps current transport behavior unchanged while preparing the app for a gradual, reversible backoff rollout.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
