### PR TITLE
test: add missing test to AppLock tests [WPB-23754]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
@@ -212,11 +212,17 @@ test.describe('AppLock', () => {
     await expect(pages.account().privacySection.appLock.checkbox).not.toBeChecked();
   });
 
-  test.skip(
+  test(
     'Web: Verify inactivity timeout can be set if app lock is not enforced on a team level',
     {tag: ['@TC-2772', '@regression']},
-    async () => {
-      // not implemented
+    async ({createPage}) => {
+      const {components, pages, modals} = PageManager.from(await createPage(withLogin(user))).webapp;
+
+      await components.conversationSidebar().clickPreferencesButton();
+      await pages.account().privacySection.appLock.label.click();
+      await modals.appLock().setPasscode(appLockPassCode);
+
+      await expect(pages.account().privacySection.appLock.checkbox).toBeChecked();
     },
   );
 });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23754" title="WPB-23754" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23754</a>  [Web/QA] Implement TC-2772 AppLock - Verify inactivity timeout can be set if app lock is not enforced on a team level
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

The test case was for some reason not implemented previously, so we added it now.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
