### PR TITLE
test: re-enable group call test in clearing conversation tests [WPB-23752]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
@@ -30,10 +30,14 @@ test.describe('Clear Conversation Content', () => {
   let userB: User;
   let userC: User;
 
-  test.beforeEach(async ({createTeam, createUser}) => {
+  test.beforeEach(async ({createTeam, createUser}, testInfo) => {
     userB = await createUser();
     userC = await createUser();
-    const team = await createTeam('Test Team', {users: [userB, userC]});
+    const team = await createTeam('Test Team', {
+      users: [userB, userC],
+      // Only one of the test cases requires conference calling to be enabled
+      features: {conferenceCalling: testInfo.tags.includes('@TC-156')},
+    });
     userA = team.owner;
   });
 
@@ -151,8 +155,6 @@ test.describe('Clear Conversation Content', () => {
       `I want to see incoming picture, ping and call after I clear content of a ${conversationType} conversation via conversation list`,
       {tag: [tag, '@regression']},
       async ({createPage}) => {
-        test.skip(conversationType === 'group', 'Blocked [WPB-22442] - Group call feature requires Enterprise Account');
-
         // Step 1: Create a group conversation with User A, B and C
         const [userAPageManager, userBPageManager, userCPageManager] = await Promise.all([
           PageManager.from(createPage(withLogin(userA), withConnectedUser(userB), withConnectedUser(userC))),

--- a/apps/webapp/test/e2e_tests/test.fixtures.ts
+++ b/apps/webapp/test/e2e_tests/test.fixtures.ts
@@ -167,7 +167,7 @@ export const test = baseTest.extend<Fixtures>({
         );
       }
 
-      if (options?.features) {
+      if (options?.features && Object.values(options.features).every(Boolean)) {
         // The team will be reset right after initialization, so we need to wait a short time for it to finish
         // before changing feature configs since they would otherwise be overwritten (See WPB-23698)
         await new Promise(resolve => setTimeout(resolve, 5000));


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23752" title="WPB-23752" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23752</a>  [Web/QA] Fix and re-enable TC-156 Group call after clearing conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- Only wait 5s in `createTeam` fixture if one feature was actually set to true
- Re-enable previously skipped tests which depended on enterprise features

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
