### PR TITLE
test: wait for message to arrive before searching for it [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
@@ -55,6 +55,8 @@ test.describe('In Conversation Search', () => {
       await shareAssetHelper(getTextFilePath(), page, page.getByRole('button', {name: 'Add file'}));
 
       await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await expect(userAPages.conversation().getMessage({sender: userB})).toHaveCount(3);
+
       await userAPages.conversation().searchButton.click();
       const collection = userAPages.collection();
       await expect(collection.getSection('Images')).toBeVisible();
@@ -76,14 +78,15 @@ test.describe('In Conversation Search', () => {
       await createGroup(userAPages, conversationName, [userB]);
 
       await userBPages.conversationList().openConversation(conversationName);
+      await userAPages.conversationList().openConversation(conversationName);
       const {page: pageB} = userBPages.conversation();
+      const {page: pageA} = userAPages.conversation();
 
       for (let imageCount = 0; imageCount < 10; imageCount++) {
         await shareAssetHelper(getImageFilePath(), pageB, pageB.getByRole('button', {name: 'Add picture'}));
       }
+      await expect(userAPages.conversation().getMessage({sender: userB})).toHaveCount(10);
 
-      await userAPages.conversationList().openConversation(conversationName);
-      const {page: pageA} = userAPages.conversation();
       for (let imageCount = 0; imageCount < 10; imageCount++) {
         await shareAssetHelper(getImageFilePath(), pageA, pageA.getByRole('button', {name: 'Add picture'}));
       }
@@ -177,6 +180,7 @@ test.describe('In Conversation Search', () => {
 
       const messageB = userBPages.conversation().getMessage({sender: userB});
       await userBPages.conversation().deleteMessage(messageB, 'Everyone');
+      await expect(messageWithImage).not.toBeVisible();
 
       await userAPages.conversation().searchButton.click();
       await expect(userAPages.collection().getSection('Images').showAllButton).not.toBeVisible();
@@ -314,11 +318,12 @@ test.describe('In Conversation Search', () => {
     const specialWord = 'Crème brûlée';
 
     await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-    await userBPages.conversation().sendMessage(`Message with diacritical letter: ${specialWord}`);
-
     await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-    await userAPages.conversation().searchButton.click();
 
+    await userBPages.conversation().sendMessage(`Message with diacritical letter: ${specialWord}`);
+    await expect(userAPages.conversation().getMessage({content: specialWord})).toBeAttached();
+
+    await userAPages.conversation().searchButton.click();
     const collection = userAPages.collection();
     await collection.searchBar.fill(specialWord);
     await expect(collection.searchResults).toHaveCount(1);
@@ -332,11 +337,12 @@ test.describe('In Conversation Search', () => {
     ]);
 
     await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-    await userBPages.conversation().sendMessage('User B message');
-
     await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-    await userAPages.conversation().searchButton.click();
 
+    await userBPages.conversation().sendMessage('User B message');
+    await expect(userAPages.conversation().getMessage({sender: userB})).toBeVisible();
+
+    await userAPages.conversation().searchButton.click();
     const collection = userAPages.collection();
     await collection.searchBar.fill('  message');
     await expect(collection.searchResults).toHaveCount(1);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

This should reduce some flake we're currently experiencing in some of the in conversation search tests

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
