### PR TITLE
feat: add pure incremental retry backoff policy [WPB-23381]

### DIFF
--- a/libraries/api-client/src/http/IncrementalRetryBackoff.test.ts
+++ b/libraries/api-client/src/http/IncrementalRetryBackoff.test.ts
@@ -1,0 +1,118 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Maybe} from 'true-myth';
+
+import {
+  createIncrementalRetryBackoffPolicy,
+} from './IncrementalRetryBackoff';
+
+const badRequestStatusCode = 400;
+const unauthorizedStatusCode = 401;
+const notFoundStatusCode = 404;
+const tooManyRequestsStatusCode = 429;
+const internalServerErrorStatusCode = 500;
+const badGatewayStatusCode = 502;
+const serviceUnavailableStatusCode = 503;
+
+describe('IncrementalRetryBackoff', function () {
+  const incrementalRetryBackoffPolicy = createIncrementalRetryBackoffPolicy();
+
+  it('returns no delay before the first retry', () => {
+    const incrementalRetryBackoffState = incrementalRetryBackoffPolicy.createInitialIncrementalRetryBackoffState();
+
+    expect(incrementalRetryBackoffState.delayInMilliseconds).toBe(0);
+  });
+
+  it('starts the retry progression at 100 milliseconds', () => {
+    const currentIncrementalRetryBackoffState =
+      incrementalRetryBackoffPolicy.createInitialIncrementalRetryBackoffState();
+
+    const nextIncrementalRetryBackoffState =
+      incrementalRetryBackoffPolicy.advanceState(currentIncrementalRetryBackoffState);
+
+    expect(nextIncrementalRetryBackoffState.delayInMilliseconds).toBe(100);
+  });
+
+  it('doubles the retry delay on each advancement', () => {
+    const initialIncrementalRetryBackoffState =
+      incrementalRetryBackoffPolicy.createInitialIncrementalRetryBackoffState();
+    const firstIncrementalRetryBackoffState =
+      incrementalRetryBackoffPolicy.advanceState(initialIncrementalRetryBackoffState);
+    const secondIncrementalRetryBackoffState =
+      incrementalRetryBackoffPolicy.advanceState(firstIncrementalRetryBackoffState);
+    const thirdIncrementalRetryBackoffState =
+      incrementalRetryBackoffPolicy.advanceState(secondIncrementalRetryBackoffState);
+
+    expect(firstIncrementalRetryBackoffState.delayInMilliseconds).toBe(100);
+    expect(secondIncrementalRetryBackoffState.delayInMilliseconds).toBe(200);
+    expect(thirdIncrementalRetryBackoffState.delayInMilliseconds).toBe(400);
+  });
+
+  it('caps the retry delay at ten minutes', () => {
+    let incrementalRetryBackoffState = incrementalRetryBackoffPolicy.createInitialIncrementalRetryBackoffState();
+
+    for (let retryNumber = 0; retryNumber < 20; retryNumber += 1) {
+      incrementalRetryBackoffState = incrementalRetryBackoffPolicy.advanceState(incrementalRetryBackoffState);
+    }
+
+    expect(incrementalRetryBackoffState.delayInMilliseconds).toBe(10 * 60 * 1000);
+  });
+
+  it('resets back to no delay before the next retry', () => {
+    const initialIncrementalRetryBackoffState =
+      incrementalRetryBackoffPolicy.createInitialIncrementalRetryBackoffState();
+    const advancedIncrementalRetryBackoffState =
+      incrementalRetryBackoffPolicy.advanceState(initialIncrementalRetryBackoffState);
+
+    const resetBackoffState = incrementalRetryBackoffPolicy.createInitialIncrementalRetryBackoffState();
+
+    expect(advancedIncrementalRetryBackoffState.delayInMilliseconds).toBe(100);
+    expect(resetBackoffState.delayInMilliseconds).toBe(0);
+  });
+
+  it('treats 420, 429, and 5xx statuses as retryable', () => {
+    expect(incrementalRetryBackoffPolicy.shouldRetryWithIncrementalBackoff(Maybe.just(420))).toBe(true);
+    expect(incrementalRetryBackoffPolicy.shouldRetryWithIncrementalBackoff(Maybe.just(tooManyRequestsStatusCode))).toBe(
+      true,
+    );
+    expect(
+      incrementalRetryBackoffPolicy.shouldRetryWithIncrementalBackoff(Maybe.just(internalServerErrorStatusCode)),
+    ).toBe(true);
+    expect(incrementalRetryBackoffPolicy.shouldRetryWithIncrementalBackoff(Maybe.just(badGatewayStatusCode))).toBe(
+      true,
+    );
+    expect(
+      incrementalRetryBackoffPolicy.shouldRetryWithIncrementalBackoff(Maybe.just(serviceUnavailableStatusCode)),
+    ).toBe(true);
+  });
+
+  it('does not treat unrelated statuses as retryable', () => {
+    expect(incrementalRetryBackoffPolicy.shouldRetryWithIncrementalBackoff(Maybe.nothing())).toBe(false);
+    expect(incrementalRetryBackoffPolicy.shouldRetryWithIncrementalBackoff(Maybe.just(badRequestStatusCode))).toBe(
+      false,
+    );
+    expect(
+      incrementalRetryBackoffPolicy.shouldRetryWithIncrementalBackoff(Maybe.just(unauthorizedStatusCode)),
+    ).toBe(false);
+    expect(incrementalRetryBackoffPolicy.shouldRetryWithIncrementalBackoff(Maybe.just(notFoundStatusCode))).toBe(
+      false,
+    );
+  });
+});

--- a/libraries/api-client/src/http/IncrementalRetryBackoff.ts
+++ b/libraries/api-client/src/http/IncrementalRetryBackoff.ts
@@ -1,0 +1,67 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Maybe} from 'true-myth';
+
+export type IncrementalRetryBackoffState = {
+  readonly delayInMilliseconds: number;
+};
+
+export type IncrementalRetryBackoffPolicy = {
+  readonly advanceState: (incrementalRetryBackoffState: IncrementalRetryBackoffState) => IncrementalRetryBackoffState;
+  readonly createInitialIncrementalRetryBackoffState: () => IncrementalRetryBackoffState;
+  readonly shouldRetryWithIncrementalBackoff: (statusCode: Maybe<number>) => boolean;
+};
+
+const initialRetryDelayInMilliseconds = 100;
+const maximumRetryDelayInMilliseconds = 10 * 60 * 1000;
+const nonStandardRetryableStatusCode = 420;
+const tooManyRequestsStatusCode = 429;
+const serverErrorStatusCodeRangeStart = 500;
+const serverErrorStatusCodeRangeEnd = 599;
+
+export function createIncrementalRetryBackoffPolicy(): IncrementalRetryBackoffPolicy {
+  return {
+    advanceState(incrementalRetryBackoffState) {
+      const currentDelayInMilliseconds = incrementalRetryBackoffState.delayInMilliseconds;
+      const nextDelayInMilliseconds =
+        currentDelayInMilliseconds === 0 ? initialRetryDelayInMilliseconds : currentDelayInMilliseconds * 2;
+
+      return {
+        delayInMilliseconds: Math.min(nextDelayInMilliseconds, maximumRetryDelayInMilliseconds),
+      };
+    },
+
+    createInitialIncrementalRetryBackoffState() {
+      return {delayInMilliseconds: 0};
+    },
+
+    shouldRetryWithIncrementalBackoff(statusCode) {
+      return statusCode
+        .map((statusCodeValue): boolean => {
+          if (statusCodeValue === nonStandardRetryableStatusCode || statusCodeValue === tooManyRequestsStatusCode) {
+            return true;
+          }
+
+          return statusCodeValue >= serverErrorStatusCodeRangeStart && statusCodeValue <= serverErrorStatusCodeRangeEnd;
+        })
+        .unwrapOr(false);
+    },
+  };
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23381" title="WPB-23381" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23381</a>  [Web] Make sure that the web app applies incremental backoff on 420/429
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Define the incremental HTTP retry backoff policy as a function-based HTTP-layer module with explicit caller-owned state and focused tests. This adds the retry progression and retryable-status policy without changing request behavior yet.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
