### PR TITLE
feat: add abortable wait helper for retry timing [WPB-23381]

### DIFF
--- a/libraries/api-client/src/http/AbortableWait.test.ts
+++ b/libraries/api-client/src/http/AbortableWait.test.ts
@@ -1,0 +1,125 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Maybe} from 'true-myth';
+
+import {AbortableWaitDependencies, createAbortableWait} from './AbortableWait';
+
+type AbortableWaitDependenciesForTest = {
+  readonly abortableWaitDependencies: AbortableWaitDependencies;
+  readonly clearTimeout: jest.Mock<void, [ReturnType<typeof globalThis.setTimeout>]>;
+  readonly invokeScheduledTimeout: () => void;
+  readonly setTimeout: jest.Mock<ReturnType<typeof globalThis.setTimeout>, [() => void, number]>;
+};
+
+type AbortableWaitDependenciesOverrides = Partial<AbortableWaitDependencies>;
+
+function createAbortableWaitDependenciesForTest(
+  overrides: AbortableWaitDependenciesOverrides = {},
+): AbortableWaitDependenciesForTest {
+  let scheduledTimeoutHandler: (() => void) | undefined;
+
+  const setTimeout = jest.fn(
+    overrides.setTimeout ??
+      ((handler: () => void, _delayInMilliseconds: number) => {
+        scheduledTimeoutHandler = handler;
+
+        return 123 as ReturnType<typeof globalThis.setTimeout>;
+      }),
+  );
+  const clearTimeout = jest.fn(overrides.clearTimeout ?? (() => {}));
+
+  return {
+    abortableWaitDependencies: {
+      clearTimeout,
+      setTimeout,
+    },
+    clearTimeout,
+    invokeScheduledTimeout() {
+      if (scheduledTimeoutHandler === undefined) {
+        throw new Error('No timeout handler was scheduled.');
+      }
+
+      scheduledTimeoutHandler();
+    },
+    setTimeout,
+  };
+}
+
+describe('AbortableWait', () => {
+  it('resolves after the requested duration when no abort signal is provided', async () => {
+    const {abortableWaitDependencies, clearTimeout, invokeScheduledTimeout, setTimeout} =
+      createAbortableWaitDependenciesForTest();
+    const abortableWait = createAbortableWait(abortableWaitDependencies);
+
+    const waitPromise = abortableWait.waitForDurationInMilliseconds(100, Maybe.nothing());
+
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 100);
+
+    invokeScheduledTimeout();
+
+    await expect(waitPromise).resolves.toBeUndefined();
+    expect(clearTimeout).not.toHaveBeenCalled();
+  });
+
+  it('resolves after the requested duration when the abort signal is not aborted', async () => {
+    const {abortableWaitDependencies, clearTimeout, invokeScheduledTimeout, setTimeout} =
+      createAbortableWaitDependenciesForTest();
+    const abortableWait = createAbortableWait(abortableWaitDependencies);
+    const abortController = new AbortController();
+
+    const waitPromise = abortableWait.waitForDurationInMilliseconds(100, Maybe.just(abortController.signal));
+
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 100);
+
+    invokeScheduledTimeout();
+
+    await expect(waitPromise).resolves.toBeUndefined();
+    expect(clearTimeout).not.toHaveBeenCalled();
+  });
+
+  it('rejects when aborted before the requested duration elapses', async () => {
+    const {abortableWaitDependencies, clearTimeout, setTimeout} = createAbortableWaitDependenciesForTest();
+    const abortableWait = createAbortableWait(abortableWaitDependencies);
+    const abortController = new AbortController();
+
+    const waitPromise = abortableWait.waitForDurationInMilliseconds(100, Maybe.just(abortController.signal));
+
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 100);
+
+    abortController.abort();
+
+    await expect(waitPromise).rejects.toThrow('The wait was aborted.');
+    expect(clearTimeout).toHaveBeenCalledWith(123);
+  });
+
+  it('rejects immediately when the signal is already aborted', async () => {
+    const {abortableWaitDependencies, clearTimeout, setTimeout} = createAbortableWaitDependenciesForTest();
+    const abortableWait = createAbortableWait(abortableWaitDependencies);
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const waitPromise = abortableWait.waitForDurationInMilliseconds(100, Maybe.just(abortController.signal));
+
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 100);
+
+    await expect(waitPromise).rejects.toThrow('The wait was aborted.');
+    expect(clearTimeout).toHaveBeenCalledWith(123);
+  });
+});

--- a/libraries/api-client/src/http/AbortableWait.ts
+++ b/libraries/api-client/src/http/AbortableWait.ts
@@ -1,0 +1,63 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Maybe} from 'true-myth';
+
+export type AbortableWaitDependencies = {
+  readonly clearTimeout: (timeoutIdentifier: ReturnType<typeof globalThis.setTimeout>) => void;
+  readonly setTimeout: (handler: () => void, delayInMilliseconds: number) => ReturnType<typeof globalThis.setTimeout>;
+};
+
+export type AbortableWait = {
+  readonly waitForDurationInMilliseconds: (
+    durationInMilliseconds: number,
+    abortSignal: Maybe<AbortSignal>,
+  ) => Promise<void>;
+};
+
+export function createAbortableWait(dependencies: AbortableWaitDependencies): AbortableWait {
+  const {clearTimeout, setTimeout} = dependencies;
+
+  return {
+    waitForDurationInMilliseconds(durationInMilliseconds, abortSignal) {
+      return new Promise((resolve, reject) => {
+        const abortSignalOrUndefined = abortSignal.unwrapOr(undefined);
+
+        const handleAbort = () => {
+          clearTimeout(timeoutIdentifier);
+          abortSignalOrUndefined?.removeEventListener('abort', handleAbort);
+          reject(new Error('The wait was aborted.'));
+        };
+
+        const timeoutIdentifier = setTimeout(() => {
+          abortSignalOrUndefined?.removeEventListener('abort', handleAbort);
+          resolve();
+        }, durationInMilliseconds);
+
+        if (abortSignalOrUndefined?.aborted) {
+          handleAbort();
+
+          return;
+        }
+
+        abortSignalOrUndefined?.addEventListener('abort', handleAbort, {once: true});
+      });
+    },
+  };
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23381" title="WPB-23381" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23381</a>  [Web] Make sure that the web app applies incremental backoff on 420/429
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Introduce an HTTP-local abortable wait helper with injected timeout dependencies. This prepares the retry flow for injected clock-based timing without changing request behavior yet. The helper currently depends on an injected timeout surface instead of the full wall clock because the existing wall clock lives in the application layer and cannot be imported into the shared package without crossing package boundaries.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
