### PR TITLE
refactor: split & clean up connections e2e tests [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -103,8 +103,8 @@ export class ConversationPage {
     this.filesTab = page.locator('#conversation-tab-files');
     this.typingIndicator = page.getByTestId('typing-indicator-title');
     this.itemPendingRequest = page.getByTestId('item-pending-requests');
-    this.ignoreButton = page.getByTestId('do-ignore');
-    this.cancelRequest = page.getByTestId('do-cancel-request');
+    this.ignoreButton = page.getByRole('button', {name: 'Ignore'});
+    this.cancelRequest = page.getByRole('button', {name: 'Cancel connection request'});
     this.mentionSuggestions = page.getByRole('listbox').getByTestId('item-mention-suggestion');
   }
 

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -121,10 +121,6 @@ export class ConversationPage {
     return (await this.page.getByTestId('status-conversation-title-bar-label').textContent()) === conversationName;
   }
 
-  async clickItemPendingRequest() {
-    await this.itemPendingRequest.click();
-  }
-
   async clickConversationTitle() {
     await this.conversationTitle.click();
   }
@@ -143,10 +139,6 @@ export class ConversationPage {
 
   async clickIgnoreButton() {
     await this.ignoreButton.click();
-  }
-
-  async clickCancelRequest() {
-    await this.cancelRequest.click();
   }
 
   async sendMessage(message: string) {

--- a/apps/webapp/test/e2e_tests/specs/Connections/Connections.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Connections/Connections.spec.ts
@@ -17,65 +17,99 @@
  *
  */
 
-import {getUser} from 'test/e2e_tests/data/user';
+import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {completeLogin} from 'test/e2e_tests/utils/setup.util';
-import {tearDownAll} from 'test/e2e_tests/utils/tearDown.util';
 
-import {test, expect} from '../../test.fixtures';
+import {test, expect, withLogin, withConnectionRequest} from '../../test.fixtures';
+import {createGroup} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Connections', () => {
-  const members = Array.from({length: 2}, () => getUser());
-  const [memberA, memberB] = members;
+  let memberA: User;
+  let memberB: User;
 
-  test.beforeAll(async ({api}) => {
-    await api.createPersonalUser(memberA);
-    await api.createPersonalUser(memberB);
+  test.beforeEach(async ({createUser}) => {
+    [memberA, memberB] = await Promise.all([createUser(), createUser()]);
   });
 
   test(
     'Verify 1on1 conversation is not created on the second end after you ignore connection request',
-    {tag: ['@TC-365', '@TC-369', '@TC-370', '@TC-371', '@regression']},
-    async ({pageManager: memberPageManagerA, browser}) => {
-      const memberContext = await browser.newContext();
-      const memberPage = await memberContext.newPage();
-      const memberPageManagerB = PageManager.from(memberPage);
+    {tag: ['@TC-365', '@regression']},
+    async ({createPage}) => {
+      const [memberBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(memberB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(memberA), withConnectionRequest(memberB))),
+      ]);
 
-      const {pages, components, modals} = memberPageManagerA.webapp;
-      const {pages: pagesB} = memberPageManagerB.webapp;
+      await memberBPages.conversationList().pendingConnectionRequest.click();
+      await memberBPages.conversation().clickIgnoreButton();
 
-      await Promise.all([completeLogin(memberPageManagerA, memberA), completeLogin(memberPageManagerB, memberB)]);
+      await expect(memberBPages.conversation().itemPendingRequest).not.toBeVisible();
+    },
+  );
 
-      await components.conversationSidebar().clickConnectButton();
-      await pages.startUI().selectUsers(memberB.username);
-      await modals.userProfile().clickConnectButton();
-      await pagesB.conversationList().openPendingConnectionRequest();
-      await pagesB.conversation().clickItemPendingRequest();
-      await pagesB.conversation().clickIgnoreButton();
+  test(
+    'Verify sending a connection request to user from conversation view',
+    {tag: ['@TC-369', '@regression']},
+    async ({createPage, createUser}) => {
+      const memberC = await createUser();
+      const [memberAPages, memberBPages, memberCPages] = await Promise.all([
+        PageManager.from(
+          createPage(withLogin(memberA), withConnectionRequest(memberB), withConnectionRequest(memberC)),
+        ).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(memberB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(memberC))).then(pm => pm.webapp.pages),
+      ]);
 
-      await expect(pagesB.conversation().itemPendingRequest).toHaveCount(0);
-
-      await test.step('I want to cancel a pending request from conversation list', async () => {
-        await pages.conversation().clickCancelRequest();
-        await modals.confirm().clickAction();
+      await test.step('B & C accept connection requests from A', async () => {
+        for (const pages of [memberBPages, memberCPages]) {
+          await pages.conversationList().pendingConnectionRequest.click();
+          await pages.connectRequest().connectButton.click();
+        }
       });
 
-      await test.step('I want to archive a pending request from conversation list', async () => {
-        await components.conversationSidebar().clickConnectButton();
-        await pages.startUI().selectUsers(memberB.username);
-        await modals.userProfile().clickConnectButton();
-        await pagesB.conversationList().openPendingConnectionRequest();
-        await pagesB.conversation().clickItemPendingRequest();
-        await pages.conversationList().clickConversationOptions(memberB.fullName);
-        await pages.conversationList().archiveConversation();
-        await components.conversationSidebar().clickArchive();
+      await test.step('A creates a group with B & C', async () => {
+        await createGroup(memberAPages, 'Group', [memberB, memberC]);
+      });
 
-        await expect(pages.conversationList().getConversationLocator(memberB.fullName)).toBeVisible();
+      await test.step('B sends a connection request to C via the group conversation', async () => {
+        await memberBPages.conversationList().openConversation('Group');
+        await memberBPages.conversation().conversationInfoButton.click();
+        await memberBPages.conversationDetails().openParticipantDetails(memberC.fullName);
+        await memberBPages.participantDetails().sendConnectRequest();
+      });
+
+      await test.step('C sees the connection request from B', async () => {
+        await expect(memberCPages.conversationList().pendingConnectionRequest).toBeVisible();
       });
     },
   );
 
-  test.afterAll(async ({api}) => {
-    await tearDownAll(api);
-  });
+  test(
+    'I want to cancel a pending request from conversation list',
+    {tag: ['@TC-370', '@regression']},
+    async ({createPage}) => {
+      const [memberBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(memberB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(memberA), withConnectionRequest(memberB))).then(pm => pm.webapp.pages),
+      ]);
+
+      await memberBPages.conversationList().pendingConnectionRequest.click();
+      await memberBPages.conversation().ignoreButton.click();
+
+      await expect(memberBPages.conversationList().getConversationLocator(memberB.fullName)).not.toBeVisible();
+    },
+  );
+
+  test(
+    'I want to archive a pending request from conversation list',
+    {tag: ['@TC-371', '@regression']},
+    async ({createPage}) => {
+      const {pages} = PageManager.from(await createPage(withLogin(memberA), withConnectionRequest(memberB))).webapp;
+
+      await pages.conversationList().clickConversationOptions(memberB.fullName);
+      await pages.conversationList().archiveConversation();
+
+      await expect(pages.conversationList().getConversationLocator(memberB.fullName)).toBeVisible();
+    },
+  );
 });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- Split test cases for connection tests so they will be reported correctly in testiny
- Refactor tests to no longer depend on outdated utils
- Refactor & remove some locators in the conversation POM

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
