### PR TITLE
refactor: make page property in POMs private [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/index.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/index.ts
@@ -80,7 +80,7 @@ export const webAppPath = process.env.WEBAPP_URL ?? '';
 export class PageManager {
   private readonly cache = new Map<string, any>();
 
-  constructor(readonly page: Page) {}
+  constructor(public readonly page: Page) {}
 
   static from(page: Page): PageManager;
   static from(page: Promise<Page>): Promise<PageManager>;

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/cells/cellsConversationFiles.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/cells/cellsConversationFiles.page.ts
@@ -20,12 +20,10 @@
 import {Locator, Page} from '@playwright/test';
 
 export class CellsConversationFilesPage {
-  readonly page: Page;
   filesList: Locator;
   readonly searchInput: Locator;
 
   constructor(page: Page) {
-    this.page = page;
     this.filesList = page.locator('table td[data-cell="Name"]');
     this.searchInput = page.getByRole('textbox', {name: 'Search files and folders'});
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/cells/cellsFileDetailView.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/cells/cellsFileDetailView.modal.ts
@@ -21,7 +21,7 @@ import {Locator, Page} from '@playwright/test';
 import {downloadAssetAndGetFilePath} from 'test/e2e_tests/utils/asset.util';
 
 export class CellsFileDetailViewModal {
-  readonly page: Page;
+  private readonly page: Page;
   readonly closeButton: Locator;
   readonly downloadButton: Locator;
   readonly image: Locator;

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/components/conversationList.component.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/components/conversationList.component.ts
@@ -20,11 +20,9 @@
 import {Page, Locator} from '@playwright/test';
 
 export class ContactList {
-  readonly page: Page;
   readonly searchList: Locator;
 
   constructor(page: Page) {
-    this.page = page;
     this.searchList = page.getByTestId('search-list');
   }
 

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/components/conversationSidebar.component.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/components/conversationSidebar.component.ts
@@ -21,7 +21,7 @@ import {Page, Locator} from '@playwright/test';
 
 export class ConversationSidebar {
   readonly pageLoadingTimeout = 60_000;
-  readonly page: Page;
+  private readonly page: Page;
   readonly navigation: Locator;
   readonly personalStatusLabel: Locator;
   readonly personalStatusIcon: Locator;

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/components/inputBarControls.component.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/components/inputBarControls.component.ts
@@ -24,7 +24,7 @@ import {shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
 export const EPHEMERAL_TIMER_CHOICES = ['10 seconds', '5 minutes', '1 hour', 'Off'] as const;
 
 export class InputBarControls {
-  readonly page: Page;
+  private readonly page: Page;
 
   readonly shareImage: Locator;
   readonly shareFile: Locator;

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/appLock.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/appLock.modal.ts
@@ -20,8 +20,6 @@
 import {Locator, Page} from '@playwright/test';
 
 export class AppLockModal {
-  readonly page: Page;
-
   readonly lockPasscodeInput: Locator;
   readonly unlockPasscodeInput: Locator;
   readonly appLockWipeInput: Locator;
@@ -35,8 +33,6 @@ export class AppLockModal {
   readonly wipeDatabaseButton: Locator;
 
   constructor(page: Page) {
-    this.page = page;
-
     this.appLockModal = page.locator("[data-uie-name='applock-modal']");
     this.lockPasscodeInput = page.locator("[data-uie-name='applock-modal'] [data-uie-name='input-applock-set-a']");
     this.unlockPasscodeInput = page.locator("[data-uie-name='applock-modal'] [data-uie-name='input-applock-unlock']");

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/base.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/base.modal.ts
@@ -20,7 +20,6 @@
 import {Locator, Page} from '@playwright/test';
 
 export abstract class BaseModal {
-  readonly page: Page;
   readonly modal: Locator;
   readonly modalTitle: Locator;
   readonly modalText: Locator;
@@ -28,7 +27,6 @@ export abstract class BaseModal {
   readonly cancelButton: Locator;
 
   constructor(page: Page, modalLocator: string) {
-    this.page = page;
     this.modal = page.getByTestId(modalLocator);
     this.modalTitle = this.modal.getByTestId('status-modal-title');
     this.modalText = this.modal.getByTestId('status-modal-text');

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/deleteAccount.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/deleteAccount.modal.ts
@@ -20,8 +20,6 @@
 import {Page, Locator} from '@playwright/test';
 
 export class DeleteAccountModal {
-  readonly page: Page;
-
   readonly modal: Locator;
   readonly modalTitle: Locator;
   readonly modalText: Locator;
@@ -29,8 +27,6 @@ export class DeleteAccountModal {
   readonly cancelButton: Locator;
 
   constructor(page: Page) {
-    this.page = page;
-
     this.modal = page.getByRole('dialog').filter({hasText: 'Delete account'});
     this.modalTitle = this.modal.locator("[data-uie-name='status-modal-title']");
     this.modalText = this.modal.locator("[data-uie-name='status-modal-text']");

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/detailView.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/detailView.modal.ts
@@ -21,7 +21,7 @@ import {Locator, Page} from '@playwright/test';
 import {downloadAssetAndGetFilePath} from 'test/e2e_tests/utils/asset.util';
 
 export class DetailViewModal {
-  readonly page: Page;
+  private readonly page: Page;
 
   readonly mainWindow: Locator;
   readonly image: Locator;

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/leaveConversation.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/leaveConversation.modal.ts
@@ -20,16 +20,12 @@
 import {Page, Locator} from '@playwright/test';
 
 export class LeaveConversationModal {
-  readonly page: Page;
-
   readonly modal: Locator;
   readonly modalCheckbox: Locator;
   readonly cancelButton: Locator;
   readonly confirmButton: Locator;
 
   constructor(page: Page) {
-    this.page = page;
-
     this.modal = page.getByTestId('modal-template-option');
     this.modalCheckbox = this.modal.getByText('clear the content');
     this.cancelButton = this.modal.getByTestId('do-secondary');

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/marketingConsent.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/marketingConsent.modal.ts
@@ -20,16 +20,12 @@
 import {Locator, Page} from '@playwright/test';
 
 export class MarketingConsentModal {
-  readonly page: Page;
-
   readonly modalTitle: Locator;
   readonly modalText: Locator;
   readonly modalLink: Locator;
   readonly actionButton: Locator;
 
   constructor(page: Page) {
-    this.page = page;
-
     this.modalTitle = page.locator(
       "[data-uie-name='modal-marketing-consent'] [data-uie-name='modal-marketing-consent-title']",
     );

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/userProfile.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/userProfile.modal.ts
@@ -20,15 +20,12 @@
 import {Page, Locator} from '@playwright/test';
 
 export class UserProfileModal {
-  readonly page: Page;
-
   readonly modal: Locator;
   readonly connectButton: Locator;
   readonly startConversationButton: Locator;
   readonly unblockButton: Locator;
 
   constructor(page: Page) {
-    this.page = page;
     this.modal = page.getByTestId('modal-user-profile');
     this.connectButton = page.getByTestId('modal-user-profile').getByTestId('do-send-request');
     this.startConversationButton = page.getByTestId('modal-user-profile').getByTestId('start-conversation');

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/account.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/account.page.ts
@@ -20,7 +20,7 @@
 import {Page, Locator} from '@playwright/test';
 
 export class AccountPage {
-  readonly page: Page;
+  private readonly page: Page;
 
   readonly sendUsageDataCheckbox: Locator;
   readonly deleteAccountButton: Locator;

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/audioVideoSettings.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/audioVideoSettings.page.ts
@@ -20,7 +20,7 @@
 import {Locator, Page} from '@playwright/test';
 
 export class AudioVideoSettingsPage {
-  readonly page: Page;
+  private readonly page: Page;
 
   readonly microphoneDropdown: Locator;
   readonly speakerDropdown: Locator;

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/calling.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/calling.page.ts
@@ -22,7 +22,7 @@ import {Page, Locator} from '@playwright/test';
 import {FullScreenCallPage} from './fullScreenCall.page';
 
 export class CallingPage {
-  readonly page: Page;
+  private readonly page: Page;
 
   // Core call UI elements
   readonly callCell: Locator;

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/collection.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/collection.page.ts
@@ -21,7 +21,7 @@ import {Locator, Page} from '@playwright/test';
 
 /** POM for the "collection". This page is accessible by searching for a message within a conversation. */
 export class CollectionPage {
-  readonly page: Page;
+  private readonly page: Page;
   readonly component: Locator;
   readonly searchResults: Locator;
 
@@ -57,5 +57,4 @@ export class CollectionPage {
   get noResultsMessage() {
     return this.component.getByText('No results.', {exact: true});
   }
-
 }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/connectRequest.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/connectRequest.page.ts
@@ -20,13 +20,9 @@
 import {Page, Locator} from '@playwright/test';
 
 export class ConnectRequestPage {
-  readonly page: Page;
-
   readonly connectButton: Locator;
 
   constructor(page: Page) {
-    this.page = page;
-
     this.connectButton = page.locator('[data-uie-name="connect-request"] [data-uie-name="do-accept"]');
   }
 

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -27,7 +27,7 @@ import {ConfirmModal} from '../modals/confirm.modal';
 type EmojiReaction = 'plus-one' | 'heart' | 'joy';
 
 export class ConversationPage {
-  readonly page: Page;
+  private readonly page: Page;
 
   /** The back button is shown on narrow screens e.g. phones to navigate back to the conversation list */
   readonly backButton: Locator;

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationDetails.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationDetails.page.ts
@@ -21,7 +21,7 @@ import {Locator, Page} from '@playwright/test';
 import {GuestOptionsPage} from './guestOptions.page';
 
 export class ConversationDetailsPage {
-  readonly page: Page;
+  private readonly page: Page;
 
   readonly groupAdmins: Locator;
   readonly groupMembers: Locator;

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -22,7 +22,7 @@ import {Locator, Page} from '@playwright/test';
 import {User} from 'test/e2e_tests/data/user';
 
 export class ConversationListPage {
-  readonly page: Page;
+  private readonly page: Page;
 
   readonly list: Locator;
   readonly blockConversationMenuButton: Locator;

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/deleteAccount.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/deleteAccount.page.ts
@@ -20,14 +20,10 @@
 import {Page, Locator} from '@playwright/test';
 
 export class DeleteAccountPage {
-  readonly page: Page;
-
   readonly deleteAccountButton: Locator;
   readonly accountDeletedHeadline: Locator;
 
   constructor(page: Page) {
-    this.page = page;
-
     this.deleteAccountButton = page.locator("[data-uie-name='do-delete-account']");
     this.accountDeletedHeadline = page.locator("[data-uie-name='successful-delete-account-headline']");
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/devices.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/devices.page.ts
@@ -20,14 +20,10 @@
 import {Locator, Page} from '@playwright/test';
 
 export class DevicesPage {
-  readonly page: Page;
-
   readonly proteusId: Locator;
   readonly activeDevices: Locator;
 
   constructor(page: Page) {
-    this.page = page;
-
     // The id is not using any label or similar but just multiple paragraphs beneath each other
     this.proteusId = page.locator("p:text('Proteus ID') + p");
     this.activeDevices = page.getByRole('group', {name: 'Active'}).getByRole('button', {name: /device details/});

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/emailVerification.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/emailVerification.page.ts
@@ -21,7 +21,7 @@ import {Locator, Page} from '@playwright/test';
 
 export class EmailVerificationPage {
   readonly codeLength = 6;
-  readonly page: Page;
+  private readonly page: Page;
 
   readonly verificationCodeInput: Locator;
   readonly verificationCodeInputLabel: Locator;

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/groupCreation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/groupCreation.page.ts
@@ -20,8 +20,6 @@
 import {Page, Locator} from '@playwright/test';
 
 export class GroupCreationPage {
-  readonly page: Page;
-
   readonly groupCreationModal: Locator;
   readonly searchPeopleList: Locator;
   readonly groupNameInput: Locator;
@@ -34,8 +32,6 @@ export class GroupCreationPage {
   readonly searchPeopleResults: Locator;
 
   constructor(page: Page) {
-    this.page = page;
-
     this.groupCreationModal = page.locator('#group-creation-modal');
     this.groupNameInput = page.locator('[data-uie-name="enter-group-name"]');
     this.nextButton = page.locator('[data-uie-name="go-next"]');

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/historyExport.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/historyExport.page.ts
@@ -21,7 +21,7 @@ import {Locator, Page} from '@playwright/test';
 import {downloadAssetAndGetFilePath} from 'test/e2e_tests/utils/asset.util';
 
 export class HistoryExportPage {
-  readonly page: Page;
+  private readonly page: Page;
 
   readonly exportSuccessHeadline: Locator;
   readonly saveFileButton: Locator;

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/infoHistory.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/infoHistory.page.ts
@@ -20,7 +20,7 @@
 import {Locator, Page} from '@playwright/test';
 
 export class HistoryInfoPage {
-  readonly page: Page;
+  private readonly page: Page;
   readonly continueButton: Locator;
 
   constructor(page: Page) {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/login.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/login.page.ts
@@ -21,8 +21,6 @@ import type {Page, Locator} from '@playwright/test';
 import type {User} from 'test/e2e_tests/data/user';
 
 export class LoginPage {
-  readonly page: Page;
-
   readonly signInButton: Locator;
   readonly emailInput: Locator;
   readonly passwordInput: Locator;
@@ -30,8 +28,6 @@ export class LoginPage {
   readonly publicComputerCheckbox: Locator;
 
   constructor(page: Page) {
-    this.page = page;
-
     this.signInButton = page.locator('[data-uie-name="do-sign-in"]');
     this.emailInput = page.locator('[data-uie-name="enter-email"]');
     this.passwordInput = page.locator('[data-uie-name="enter-password"]');

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/messageDetails.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/messageDetails.page.ts
@@ -23,13 +23,11 @@ import {Locator, Page} from '@playwright/test';
  * POM for the right sidebar shown when opening the details of a message sent in a group conversation
  */
 export class MessageDetailsPage {
-  readonly page: Page;
   readonly component: Locator;
 
   readonly timeEdited: Locator;
 
   constructor(page: Page) {
-    this.page = page;
     this.component = page.locator('#message-details');
 
     this.timeEdited = this.component.getByTestId('status-message-details-edited');

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/options.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/options.page.ts
@@ -20,14 +20,10 @@
 import {Page, Locator} from '@playwright/test';
 
 export class OptionsPage {
-  readonly page: Page;
-
   readonly soundAlertsRadioGroup: Locator;
   readonly notificationsRadioGroup: Locator;
 
   constructor(page: Page) {
-    this.page = page;
-
     this.soundAlertsRadioGroup = page.getByRole('group', {name: 'Sound alerts'}).getByRole('radiogroup');
     this.notificationsRadioGroup = page.getByRole('group', {name: 'Notifications'}).getByRole('radiogroup');
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/outgoingConnection.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/outgoingConnection.page.ts
@@ -21,7 +21,7 @@ import {Locator, Page} from '@playwright/test';
 import {escapeHtml} from 'test/e2e_tests/utils/userDataProcessor';
 
 export class OutgoingConnectionPage {
-  readonly page: Page;
+  private readonly page: Page;
 
   readonly uniqueUsernameOutgoing: Locator;
 

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/participantDetails.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/participantDetails.page.ts
@@ -21,7 +21,7 @@ import {Locator, Page} from '@playwright/test';
 import {ConfirmModal} from '../modals/confirm.modal';
 
 export class ParticipantDetails {
-  readonly page: Page;
+  private readonly page: Page;
 
   readonly userPicture: Locator;
   readonly userName: Locator;

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/registerSuccess.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/registerSuccess.page.ts
@@ -20,16 +20,12 @@
 import {Page, Locator} from '@playwright/test';
 
 export class RegisterSuccessPage {
-  readonly page: Page;
-
   readonly downloadWireButton: Locator;
   readonly openWireWebButton: Locator;
   readonly manageTeamButton: Locator;
   readonly teamSignUpSuccessMessage: Locator;
 
   constructor(page: Page) {
-    this.page = page;
-
     this.downloadWireButton = page.locator('[data-uie-name="do-download-wire"]');
     this.openWireWebButton = page.locator('[data-uie-name="do-open-wire-web"]');
     this.manageTeamButton = page.locator('[data-uie-name="do-manage-team"]');

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/registration.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/registration.page.ts
@@ -21,8 +21,6 @@ import {Locator, Page} from '@playwright/test';
 import {User} from 'test/e2e_tests/data/user';
 
 export class RegistrationPage {
-  readonly page: Page;
-
   readonly passwordPolicyInfo: Locator;
   readonly nameInput: Locator;
   readonly emailInput: Locator;
@@ -34,7 +32,6 @@ export class RegistrationPage {
   readonly passwordPolicy: Locator;
 
   constructor(page: Page) {
-    this.page = page;
     this.passwordPolicyInfo = page.locator('[data-uie-name="element-password-help"]');
     this.nameInput = page.locator('[data-uie-name="enter-name"]');
     this.emailInput = page.locator('[data-uie-name="enter-email"]');

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/requestResetPassword.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/requestResetPassword.page.ts
@@ -20,14 +20,11 @@
 import {Page, Locator} from '@playwright/test';
 
 export class RequestResetPasswordPage {
-  readonly page: Page;
-
   readonly emailInput: Locator;
   readonly resetPasswordButton: Locator;
   readonly goBackToLoginButton: Locator;
 
   constructor(page: Page) {
-    this.page = page;
     this.emailInput = page.getByTestId('enter-email');
     this.resetPasswordButton = page.getByTestId('do-send-password-reset-email');
     this.goBackToLoginButton = page.getByTestId('do-go-back-to-login');

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/resetPassword.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/resetPassword.page.ts
@@ -20,15 +20,11 @@
 import {Locator, Page} from '@playwright/test';
 
 export class ResetPasswordPage {
-  readonly page: Page;
-
   readonly newPasswordInput: Locator;
   readonly passwordChangeMessage: Locator;
   readonly setNewPasswordButton: Locator;
 
   constructor(page: Page) {
-    this.page = page;
-
     this.newPasswordInput = page.getByTestId('enter-new-password');
     this.passwordChangeMessage = page.getByText('You can now log in with your new password.');
     this.setNewPasswordButton = page.getByTestId('do-set-new-password');

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/setUsername.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/setUsername.page.ts
@@ -20,14 +20,10 @@
 import {Page, Locator} from '@playwright/test';
 
 export class SetUsernamePage {
-  readonly page: Page;
-
   readonly handleInput: Locator;
   readonly nextButton: Locator;
 
   constructor(page: Page) {
-    this.page = page;
-
     this.handleInput = page.locator('[data-uie-name="enter-handle"]');
     this.nextButton = page.locator('[data-uie-name="do-send-handle"]');
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/settings.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/settings.page.ts
@@ -20,15 +20,12 @@
 import {Page, Locator} from '@playwright/test';
 
 export class SettingsPage {
-  readonly page: Page;
-
   readonly accountButton: Locator;
   readonly devicesButton: Locator;
   readonly optionsButton: Locator;
   readonly audioVideoButton: Locator;
 
   constructor(page: Page) {
-    this.page = page;
     this.accountButton = page.getByRole('button', {name: 'Account'});
     this.devicesButton = page.getByRole('button', {name: 'Devices'});
     this.optionsButton = page.getByRole('button', {name: 'Options'});

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/singleSignOn.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/singleSignOn.page.ts
@@ -20,14 +20,10 @@
 import {Locator, Page} from '@playwright/test';
 
 export class SingleSignOnPage {
-  readonly page: Page;
-
   readonly ssoCodeEmailInput: Locator;
   readonly ssoSignInButton: Locator;
 
   constructor(page: Page) {
-    this.page = page;
-
     this.ssoCodeEmailInput = page.locator('#sso-code-email');
     this.ssoSignInButton = page.locator('[data-uie-name="do-sso-sign-in"]');
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/welcome.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/welcome.page.ts
@@ -20,8 +20,6 @@
 import {Locator, Page} from '@playwright/test';
 
 export class WelcomePage {
-  readonly page: Page;
-
   readonly loginButton: Locator;
   readonly createAccountButton: Locator;
   readonly createEnterpriseAccountButton: Locator;
@@ -30,8 +28,6 @@ export class WelcomePage {
   readonly ssoCode: Locator;
 
   constructor(page: Page) {
-    this.page = page;
-
     this.loginButton = page.locator('[data-uie-name="go-login"]');
     this.createAccountButton = page.locator('[data-uie-name="go-create-account"]');
     this.createEnterpriseAccountButton = page.locator(

--- a/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
@@ -180,10 +180,12 @@ test.describe('account settings', () => {
   );
 
   test('Verify I can retrieve calling logs', {tag: ['@TC-1725', '@regression']}, async ({createPage}) => {
-    const [memberAPages, memberBPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(memberA), withConnectedUser(memberB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(memberB))).then(pm => pm.webapp.pages),
+    const [memberAPage, memberBPage] = await Promise.all([
+      createPage(withLogin(memberA), withConnectedUser(memberB)),
+      createPage(withLogin(memberB)),
     ]);
+    const memberAPages = PageManager.from(memberAPage).webapp.pages;
+    const memberBPages = PageManager.from(memberBPage).webapp.pages;
 
     await memberAPages.conversationList().openConversation(memberB.fullName, {protocol: 'mls'});
 
@@ -192,7 +194,7 @@ test.describe('account settings', () => {
 
     const expectedLog = '@wireapp/webapp/avs'; // get one phone call
     await expect
-      .poll(async () => (await memberAPages.account().page.consoleMessages()).map(m => m.text()))
+      .poll(async () => (await memberAPage.consoleMessages()).map(m => m.text()))
       .toEqual(expect.arrayContaining([expect.stringContaining(expectedLog)]));
   });
 

--- a/apps/webapp/test/e2e_tests/specs/Authentication/authentication.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Authentication/authentication.spec.ts
@@ -242,7 +242,7 @@ test.describe('Authentication', () => {
     {tag: ['@TC-1312', '@regression']},
     async ({createPage, createUser}) => {
       const user = await createUser();
-      const device1Pages = PageManager.from(await createPage(withLogin(user))).webapp.pages;
+      const device1Page = await createPage(withLogin(user));
 
       const {
         pages: device2Pages,
@@ -257,9 +257,7 @@ test.describe('Authentication', () => {
       await device2Modals.password().passwordInput.fill(user.password);
       await device2Modals.password().clickAction();
 
-      await expect(
-        device1Pages.singleSignOn().page.getByText('You were signed out because your device was deleted'),
-      ).toBeVisible();
+      await expect(device1Page.getByText('You were signed out because your device was deleted')).toBeVisible();
     },
   );
 });

--- a/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
@@ -155,17 +155,21 @@ test.describe('Clear Conversation Content', () => {
       `I want to see incoming picture, ping and call after I clear content of a ${conversationType} conversation via conversation list`,
       {tag: [tag, '@regression']},
       async ({createPage}) => {
-        // Step 1: Create a group conversation with User A, B and C
-        const [userAPageManager, userBPageManager, userCPageManager] = await Promise.all([
-          PageManager.from(createPage(withLogin(userA), withConnectedUser(userB), withConnectedUser(userC))),
-          PageManager.from(createPage(withLogin(userB))),
-          PageManager.from(createPage(withLogin(userC))),
+        const [userAPage, userBPage, userCPage] = await Promise.all([
+          createPage(withLogin(userA), withConnectedUser(userB), withConnectedUser(userC)),
+          createPage(withLogin(userB)),
+          createPage(withLogin(userC)),
         ]);
+
+        const userAPageManager = PageManager.from(userAPage);
+        const userBPageManager = PageManager.from(userBPage);
+        const userCPageManager = PageManager.from(userCPage);
 
         const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
         const userBPages = userBPageManager.webapp.pages;
         const userCPages = userCPageManager.webapp.pages;
 
+        // Step 1: Create a group conversation with User A, B and C
         const conversationName = conversationType === 'group' ? 'Group conversation' : userB.fullName;
 
         if (conversationType === 'group') {
@@ -220,22 +224,21 @@ test.describe('Clear Conversation Content', () => {
         await expect(userAPages.conversation().getPing()).toBeVisible();
 
         // 5.3 Pictures
-        const {page} = userBPages.conversation();
-        await shareAssetHelper(getImageFilePath(), page, page.getByRole('button', {name: 'Add picture'}));
+        await shareAssetHelper(getImageFilePath(), userBPage, userBPage.getByRole('button', {name: 'Add picture'}));
 
         const messageWithImage = userAPages
           .conversation()
           .getMessage({sender: userB})
-          .filter({has: userAPages.conversation().page.getByRole('img')});
+          .filter({has: userAPage.getByRole('img')});
         await expect(messageWithImage).toBeVisible();
 
         // 5.4 Files
         await userAPages.conversationList().openConversation(conversationName);
-        await shareAssetHelper(getTextFilePath(), page, page.getByRole('button', {name: 'Add file'}));
+        await shareAssetHelper(getTextFilePath(), userBPage, userBPage.getByRole('button', {name: 'Add file'}));
         const messageWithFile = userAPages
           .conversation()
           .getMessage({sender: userB})
-          .filter({has: userAPages.conversation().page.locator('[data-uie-name="file-asset"]')});
+          .filter({has: userAPage.locator('[data-uie-name="file-asset"]')});
         await expect(messageWithFile).toBeVisible();
 
         // 5.5 Calls

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {createGroup, sendTextMessageToConversation} from 'test/e2e_tests/utils/userActions';
 
@@ -29,23 +28,17 @@ const conversationName = 'Test Conversation';
 test('Conversation Management', {tag: ['@TC-8636', '@crit-flow-web']}, async ({createUser, createTeam, createPage}) => {
   test.setTimeout(150_000);
 
-  let owner: User;
-  let members: User[];
-  let ownerPageManager: PageManager;
-  let memberPageManagers: PageManager[];
+  const members = await Promise.all(Array.from({length: 5}, createUser));
+  const {owner} = await createTeam('Conversation Management', {users: members});
 
-  await test.step('Preconditions: Team owner created a team with 5 members', async () => {
-    members = await Promise.all(Array.from({length: 5}, createUser));
-    const team = await createTeam('Conversation Management', {users: members});
-    owner = team.owner;
-
-    const [pmOwner, ...pmMembers] = await Promise.all([
-      PageManager.from(createPage(withLogin(owner))),
-      ...members.map(member => PageManager.from(createPage(withLogin(member)))),
-    ]);
-    ownerPageManager = pmOwner;
-    memberPageManagers = pmMembers;
-  });
+  const [ownerPage, ...memberPages] = await Promise.all([
+    createPage(withLogin(owner)),
+    ...members.map(member => createPage(withLogin(member))),
+  ]);
+  const [ownerPageManager, ...memberPageManagers] = [
+    PageManager.from(ownerPage),
+    ...memberPages.map(page => PageManager.from(page)),
+  ];
 
   await test.step('Team owner creates a group with all the five members', async () => {
     const {pages} = ownerPageManager.webapp;
@@ -88,7 +81,7 @@ test('Conversation Management', {tag: ['@TC-8636', '@crit-flow-web']}, async ({c
 
     await expect(pages.conversation().getMessage({content: textMessage})).toBeVisible();
     // Wait for more than 10 seconds to ensure the message is deleted
-    await pages.conversation().page.waitForTimeout(11000);
+    await ownerPage.waitForTimeout(11000);
 
     await expect(pages.conversation().getMessage({content: textMessage})).not.toBeVisible();
     await components.inputBarControls().setEphemeralTimerTo('Off');

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {getVideoFilePath, getAudioFilePath, getTextFilePath, isAssetDownloaded} from 'test/e2e_tests/utils/asset.util';
 import {getImageFilePath, getLocalQRCodeValue, getQRCodeValueFromScreenshot} from 'test/e2e_tests/utils/sendImage.util';
@@ -32,28 +31,15 @@ const textFilePath = getTextFilePath();
 const selfDestructMessageText = 'This message will self-destruct in 10 seconds.';
 
 test('Messages in 1:1', {tag: ['@TC-8750', '@crit-flow-web']}, async ({createTeam, createPage}) => {
-  let memberA: User;
-  let memberB: User;
-  let memberAPageManager: PageManager;
-  let memberBPageManager: PageManager;
+  // Precondition: Users A and B exist in two separate teams
+  const [{owner: memberA}, {owner: memberB}] = await Promise.all([createTeam('Critical A'), createTeam('Critical B')]);
 
-  // Step 1: Preconditions
-  await test.step('Preconditions: Creating preconditions for the test via API', async () => {
-    // Precondition: Users A and B exist in two separate teams
-    const teamA = await createTeam('Critical A');
-    memberA = teamA.owner;
-
-    const teamB = await createTeam('Critical B');
-    memberB = teamB.owner;
-
-    // Create page managers - User A sends connection request to User B
-    const [pmA, pmB] = await Promise.all([
-      PageManager.from(createPage(withLogin(memberA), withConnectionRequest(memberB))),
-      PageManager.from(createPage(withLogin(memberB))),
-    ]);
-    memberAPageManager = pmA;
-    memberBPageManager = pmB;
-  });
+  // Create page managers - User A sends connection request to User B
+  const [memberAPage, memberBPage] = await Promise.all([
+    createPage(withLogin(memberA), withConnectionRequest(memberB)),
+    createPage(withLogin(memberB)),
+  ]);
+  const [memberAPageManager, memberBPageManager] = [PageManager.from(memberAPage), PageManager.from(memberBPage)];
 
   // Step 1-1: Preconditions
   await test.step('User B accepts connection request from User A', async () => {
@@ -152,7 +138,7 @@ test('Messages in 1:1', {tag: ['@TC-8750', '@crit-flow-web']}, async ({createTea
 
   // Step 7: Message removal
   await test.step('Wait 11 seconds', async () => {
-    await memberBPageManager.webapp.pages.conversation().page.waitForTimeout(11_000);
+    await memberBPage.waitForTimeout(11_000);
   });
   await test.step('Both users see the message as removed', async () => {
     const {pages, components} = memberAPageManager.webapp;

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {getVideoFilePath, getAudioFilePath, getTextFilePath, isAssetDownloaded} from 'test/e2e_tests/utils/asset.util';
 import {getImageFilePath, getLocalQRCodeValue} from 'test/e2e_tests/utils/sendImage.util';
@@ -38,28 +37,16 @@ test(
   'Messages in Channels',
   {tag: ['@TC-8753', '@crit-flow-web']},
   async ({createUser, createTeam, createPage, api}) => {
-    let userA: User;
-    let userB: User;
-    let userAPageManager: PageManager;
-    let userBPageManager: PageManager;
+    const userB = await createUser();
+    const {owner: userA} = await createTeam('Critical Team', {users: [userB]});
 
-    await test.step('Preconditions: Creating preconditions for the test via API', async () => {
-      userB = await createUser();
-      const team = await createTeam('Critical Team', {users: [userB]});
-      userA = team.owner;
+    // TODO: Remove below line when we have a SQS workaround
+    await api.brig.enableMLSFeature(userA.teamId);
+    await api.brig.unlockChannelFeature(userA.teamId);
+    await api.brig.enableChannelsFeature(userA.teamId);
 
-      // TODO: Remove below line when we have a SQS workaround
-      await api.brig.enableMLSFeature(userA.teamId);
-      await api.brig.unlockChannelFeature(userA.teamId);
-      await api.brig.enableChannelsFeature(userA.teamId);
-
-      const [pmA, pmB] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA))),
-        PageManager.from(createPage(withLogin(userB))),
-      ]);
-      userAPageManager = pmA;
-      userBPageManager = pmB;
-    });
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    const [userAPageManager, userBPageManager] = [PageManager.from(userAPage), PageManager.from(userBPage)];
 
     await test.step('User A creates a channel with User B', async () => {
       const {pages} = userAPageManager.webapp;
@@ -133,7 +120,7 @@ test(
       const {pages} = userBPageManager.webapp;
       await pages.conversation().playVideo();
       // Wait for 5 seconds to ensure video starts playing
-      await pages.conversation().page.waitForTimeout(5000);
+      await userBPage.waitForTimeout(5000);
       // ToDO: Bug -> Video is not loaded from the server, so we cannot check if it is playing
     });
 
@@ -147,7 +134,7 @@ test(
       const {pages} = userBPageManager.webapp;
       await pages.conversation().playAudio();
       // Wait for 5 seconds to ensure audio starts playing
-      await pages.conversation().page.waitForTimeout(3000);
+      await userBPage.waitForTimeout(3000);
       expect(await pages.conversation().isAudioPlaying()).toBeTruthy();
     });
 
@@ -164,7 +151,7 @@ test(
     });
 
     await test.step('User B waits 10 seconds', async () => {
-      await userBPageManager.webapp.pages.conversation().page.waitForTimeout(11_000);
+      await userBPage.waitForTimeout(11_000);
     });
 
     await test.step('Both users see the message as removed', async () => {

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {getVideoFilePath, getAudioFilePath, getTextFilePath, isAssetDownloaded} from 'test/e2e_tests/utils/asset.util';
 import {getImageFilePath, getLocalQRCodeValue} from 'test/e2e_tests/utils/sendImage.util';
@@ -37,23 +36,11 @@ const audioFilePath = getAudioFilePath();
 const textFilePath = getTextFilePath();
 
 test('Messages in Groups', {tag: ['@TC-8751', '@crit-flow-web']}, async ({createUser, createTeam, createPage}) => {
-  let userA: User;
-  let userB: User;
-  let userAPageManager: PageManager;
-  let userBPageManager: PageManager;
+  const userB = await createUser();
+  const {owner: userA} = await createTeam('Critical Team', {users: [userB]});
 
-  await test.step('Preconditions: Creating preconditions for the test via API', async () => {
-    userB = await createUser();
-    const team = await createTeam('Critical Team', {users: [userB]});
-    userA = team.owner;
-
-    const [pmA, pmB] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA))),
-      PageManager.from(createPage(withLogin(userB))),
-    ]);
-    userAPageManager = pmA;
-    userBPageManager = pmB;
-  });
+  const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+  const [userAPageManager, userBPageManager] = [PageManager.from(userAPage), PageManager.from(userBPage)];
 
   await test.step('User A creates a group with User B', async () => {
     const {pages} = userAPageManager.webapp;
@@ -123,7 +110,7 @@ test('Messages in Groups', {tag: ['@TC-8751', '@crit-flow-web']}, async ({create
     const {pages} = userBPageManager.webapp;
     await pages.conversation().playVideo();
     // Wait for 5 seconds to ensure video starts playing
-    await pages.conversation().page.waitForTimeout(5000);
+    await userBPage.waitForTimeout(5000);
     // ToDO: Bug -> Video is not loaded from the server, so we cannot check if it is playing
   });
 
@@ -137,7 +124,7 @@ test('Messages in Groups', {tag: ['@TC-8751', '@crit-flow-web']}, async ({create
     const {pages} = userBPageManager.webapp;
     await pages.conversation().playAudio();
     // Wait for 3 seconds to ensure audio starts playing
-    await pages.conversation().page.waitForTimeout(3000);
+    await userBPage.waitForTimeout(3000);
     expect(await pages.conversation().isAudioPlaying()).toBeTruthy();
   });
   await test.step('User A sends a quick (10 sec) self deleting message', async () => {
@@ -153,7 +140,7 @@ test('Messages in Groups', {tag: ['@TC-8751', '@crit-flow-web']}, async ({create
   });
 
   await test.step('User B waits 10 seconds', async () => {
-    await userBPageManager.webapp.pages.conversation().page.waitForTimeout(11_000);
+    await userBPage.waitForTimeout(11_000);
   });
 
   await test.step('Both users see the message as removed', async () => {

--- a/apps/webapp/test/e2e_tests/utils/userActions.ts
+++ b/apps/webapp/test/e2e_tests/utils/userActions.ts
@@ -115,7 +115,7 @@ export async function createAndSaveBackup(
   await expect(modals.passwordAdvancedSecurity().modal).toBeHidden();
   await expect(pages.historyExport().exportSuccessHeadline).toBeVisible();
   const [download] = await Promise.all([
-    pages.historyExport().page.waitForEvent('download'),
+    pageManager.page.waitForEvent('download'),
     pages.historyExport().clickSaveFileButton(),
   ]);
   const safePrefix = filenamePrefix ?? '';


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

# Pull Request

## Summary

I had noticed many times now that people access the page through a POM they previously passed it into. To avoid complicated data flows I now made it private in all POMs and fixed all previous usages.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
