### PR TITLE
feat: add incremental retry backoff runner [WPB-23381]

### DIFF
--- a/libraries/api-client/src/http/IncrementalRetryBackoffRunner.test.ts
+++ b/libraries/api-client/src/http/IncrementalRetryBackoffRunner.test.ts
@@ -1,0 +1,185 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Maybe} from 'true-myth';
+
+import {AbortableWait} from './AbortableWait';
+import {createIncrementalRetryBackoffPolicy, IncrementalRetryBackoffState} from './IncrementalRetryBackoff';
+import {createIncrementalRetryBackoffRunner} from './IncrementalRetryBackoffRunner';
+
+type RetryableError = {
+  readonly statusCode: number;
+};
+
+type IncrementalRetryBackoffRunnerDependenciesForTest = {
+  readonly abortableWait: AbortableWait;
+  readonly waitForDurationInMilliseconds: jest.Mock<Promise<void>, [number, Maybe<AbortSignal>]>;
+};
+
+function createIncrementalRetryBackoffRunnerDependenciesForTest(): IncrementalRetryBackoffRunnerDependenciesForTest {
+  const waitForDurationInMilliseconds = jest.fn<Promise<void>, [number, Maybe<AbortSignal>]>(
+    async (_durationInMilliseconds: number, _abortSignal: Maybe<AbortSignal>) => {},
+  );
+
+  return {
+    abortableWait: {
+      waitForDurationInMilliseconds,
+    },
+    waitForDurationInMilliseconds,
+  };
+}
+
+describe('IncrementalRetryBackoffRunner', () => {
+  it('returns immediately when the first request attempt succeeds', async () => {
+    const {abortableWait, waitForDurationInMilliseconds} = createIncrementalRetryBackoffRunnerDependenciesForTest();
+    const incrementalRetryBackoffPolicy = createIncrementalRetryBackoffPolicy();
+    const incrementalRetryBackoffRunner = createIncrementalRetryBackoffRunner({
+      abortableWait,
+      getStatusCode(error) {
+        return Maybe.of((error as Partial<RetryableError>).statusCode);
+      },
+      incrementalRetryBackoffPolicy,
+    });
+    let incrementalRetryBackoffState = incrementalRetryBackoffPolicy.createInitialIncrementalRetryBackoffState();
+    const runRequestAttempt = jest.fn(async () => 'response');
+
+    const response = await incrementalRetryBackoffRunner.runWithIncrementalRetryBackoff({
+      abortSignal: Maybe.nothing(),
+      getIncrementalRetryBackoffState() {
+        return incrementalRetryBackoffState;
+      },
+      runRequestAttempt,
+      setIncrementalRetryBackoffState(nextIncrementalRetryBackoffState: IncrementalRetryBackoffState) {
+        incrementalRetryBackoffState = nextIncrementalRetryBackoffState;
+
+        return incrementalRetryBackoffState;
+      },
+    });
+
+    expect(response).toBe('response');
+    expect(runRequestAttempt).toHaveBeenCalledTimes(1);
+    expect(waitForDurationInMilliseconds).not.toHaveBeenCalled();
+    expect(incrementalRetryBackoffState.delayInMilliseconds).toBe(0);
+  });
+
+  it('waits with the incremented delay before retrying a retryable failure', async () => {
+    const {abortableWait, waitForDurationInMilliseconds} = createIncrementalRetryBackoffRunnerDependenciesForTest();
+    const incrementalRetryBackoffPolicy = createIncrementalRetryBackoffPolicy();
+    const incrementalRetryBackoffRunner = createIncrementalRetryBackoffRunner({
+      abortableWait,
+      getStatusCode(error) {
+        return Maybe.of((error as Partial<RetryableError>).statusCode);
+      },
+      incrementalRetryBackoffPolicy,
+    });
+    let incrementalRetryBackoffState = incrementalRetryBackoffPolicy.createInitialIncrementalRetryBackoffState();
+    const runRequestAttempt = jest
+      .fn<Promise<string>, []>()
+      .mockRejectedValueOnce({statusCode: 503})
+      .mockResolvedValueOnce('response');
+
+    const response = await incrementalRetryBackoffRunner.runWithIncrementalRetryBackoff({
+      abortSignal: Maybe.nothing(),
+      getIncrementalRetryBackoffState() {
+        return incrementalRetryBackoffState;
+      },
+      runRequestAttempt,
+      setIncrementalRetryBackoffState(nextIncrementalRetryBackoffState: IncrementalRetryBackoffState) {
+        incrementalRetryBackoffState = nextIncrementalRetryBackoffState;
+
+        return incrementalRetryBackoffState;
+      },
+    });
+
+    expect(response).toBe('response');
+    expect(runRequestAttempt).toHaveBeenCalledTimes(2);
+    expect(waitForDurationInMilliseconds).toHaveBeenCalledWith(100, Maybe.nothing());
+    expect(incrementalRetryBackoffState.delayInMilliseconds).toBe(100);
+  });
+
+  it('continues doubling the delay across multiple retryable failures', async () => {
+    const {abortableWait, waitForDurationInMilliseconds} = createIncrementalRetryBackoffRunnerDependenciesForTest();
+    const incrementalRetryBackoffPolicy = createIncrementalRetryBackoffPolicy();
+    const incrementalRetryBackoffRunner = createIncrementalRetryBackoffRunner({
+      abortableWait,
+      getStatusCode(error) {
+        return Maybe.of((error as Partial<RetryableError>).statusCode);
+      },
+      incrementalRetryBackoffPolicy,
+    });
+    let incrementalRetryBackoffState = incrementalRetryBackoffPolicy.createInitialIncrementalRetryBackoffState();
+    const runRequestAttempt = jest
+      .fn<Promise<string>, []>()
+      .mockRejectedValueOnce({statusCode: 503})
+      .mockRejectedValueOnce({statusCode: 503})
+      .mockResolvedValueOnce('response');
+
+    const response = await incrementalRetryBackoffRunner.runWithIncrementalRetryBackoff({
+      abortSignal: Maybe.nothing(),
+      getIncrementalRetryBackoffState() {
+        return incrementalRetryBackoffState;
+      },
+      runRequestAttempt,
+      setIncrementalRetryBackoffState(nextIncrementalRetryBackoffState: IncrementalRetryBackoffState) {
+        incrementalRetryBackoffState = nextIncrementalRetryBackoffState;
+
+        return incrementalRetryBackoffState;
+      },
+    });
+
+    expect(response).toBe('response');
+    expect(runRequestAttempt).toHaveBeenCalledTimes(3);
+    expect(waitForDurationInMilliseconds).toHaveBeenNthCalledWith(1, 100, Maybe.nothing());
+    expect(waitForDurationInMilliseconds).toHaveBeenNthCalledWith(2, 200, Maybe.nothing());
+    expect(incrementalRetryBackoffState.delayInMilliseconds).toBe(200);
+  });
+
+  it('rethrows non-retryable failures without waiting', async () => {
+    const {abortableWait, waitForDurationInMilliseconds} = createIncrementalRetryBackoffRunnerDependenciesForTest();
+    const incrementalRetryBackoffPolicy = createIncrementalRetryBackoffPolicy();
+    const incrementalRetryBackoffRunner = createIncrementalRetryBackoffRunner({
+      abortableWait,
+      getStatusCode(error) {
+        return Maybe.of((error as Partial<RetryableError>).statusCode);
+      },
+      incrementalRetryBackoffPolicy,
+    });
+    let incrementalRetryBackoffState = incrementalRetryBackoffPolicy.createInitialIncrementalRetryBackoffState();
+    const nonRetryableError = {statusCode: 400};
+    const runRequestAttempt = jest.fn<Promise<string>, []>().mockRejectedValue(nonRetryableError);
+
+    await expect(
+      incrementalRetryBackoffRunner.runWithIncrementalRetryBackoff({
+        abortSignal: Maybe.nothing(),
+        getIncrementalRetryBackoffState() {
+          return incrementalRetryBackoffState;
+        },
+        runRequestAttempt,
+        setIncrementalRetryBackoffState(nextIncrementalRetryBackoffState: IncrementalRetryBackoffState) {
+          incrementalRetryBackoffState = nextIncrementalRetryBackoffState;
+
+          return incrementalRetryBackoffState;
+        },
+      }),
+    ).rejects.toBe(nonRetryableError);
+
+    expect(waitForDurationInMilliseconds).not.toHaveBeenCalled();
+    expect(incrementalRetryBackoffState.delayInMilliseconds).toBe(0);
+  });
+});

--- a/libraries/api-client/src/http/IncrementalRetryBackoffRunner.ts
+++ b/libraries/api-client/src/http/IncrementalRetryBackoffRunner.ts
@@ -1,0 +1,87 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Maybe} from 'true-myth';
+
+import {AbortableWait} from './AbortableWait';
+import {IncrementalRetryBackoffPolicy, IncrementalRetryBackoffState} from './IncrementalRetryBackoff';
+
+export type IncrementalRetryBackoffRunnerDependencies = {
+  readonly abortableWait: AbortableWait;
+  readonly getStatusCode: (error: unknown) => Maybe<number>;
+  readonly incrementalRetryBackoffPolicy: IncrementalRetryBackoffPolicy;
+};
+
+export type RunWithIncrementalRetryBackoffDependencies<ResponseValue> = {
+  readonly abortSignal: Maybe<AbortSignal>;
+  readonly getIncrementalRetryBackoffState: () => IncrementalRetryBackoffState;
+  readonly runRequestAttempt: () => Promise<ResponseValue>;
+  readonly setIncrementalRetryBackoffState: (
+    incrementalRetryBackoffState: IncrementalRetryBackoffState,
+  ) => IncrementalRetryBackoffState;
+};
+
+export type IncrementalRetryBackoffRunner = {
+  readonly runWithIncrementalRetryBackoff: <ResponseValue>(
+    dependencies: RunWithIncrementalRetryBackoffDependencies<ResponseValue>,
+  ) => Promise<Awaited<ResponseValue>>;
+};
+
+export function createIncrementalRetryBackoffRunner(
+  dependencies: IncrementalRetryBackoffRunnerDependencies,
+): IncrementalRetryBackoffRunner {
+  const {abortableWait, getStatusCode, incrementalRetryBackoffPolicy} = dependencies;
+
+  return {
+    async runWithIncrementalRetryBackoff<ResponseValue>(
+      runWithIncrementalRetryBackoffDependencies: RunWithIncrementalRetryBackoffDependencies<ResponseValue>,
+    ): Promise<Awaited<ResponseValue>> {
+      const {abortSignal, getIncrementalRetryBackoffState, runRequestAttempt, setIncrementalRetryBackoffState} =
+        runWithIncrementalRetryBackoffDependencies;
+
+      async function runRequestAttemptWithRetry(): Promise<Awaited<ResponseValue>> {
+        try {
+          return await runRequestAttempt();
+        } catch (error: unknown) {
+          const statusCode = getStatusCode(error);
+          const shouldRetry = incrementalRetryBackoffPolicy.shouldRetryWithIncrementalBackoff(statusCode);
+
+          if (!shouldRetry) {
+            throw error;
+          }
+
+          const nextIncrementalRetryBackoffState = incrementalRetryBackoffPolicy.advanceState(
+            getIncrementalRetryBackoffState(),
+          );
+
+          setIncrementalRetryBackoffState(nextIncrementalRetryBackoffState);
+
+          await abortableWait.waitForDurationInMilliseconds(
+            nextIncrementalRetryBackoffState.delayInMilliseconds,
+            abortSignal,
+          );
+
+          return runRequestAttemptWithRetry();
+        }
+      }
+
+      return runRequestAttemptWithRetry();
+    },
+  };
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23381" title="WPB-23381" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23381</a>  [Web] Make sure that the web app applies incremental backoff on 420/429
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Introduce a function-based retry runner that composes the incremental backoff policy, abortable wait dependency, and status-code extraction. The runner keeps backoff state caller-owned and adds focused tests for successful requests, retryable failures, backoff progression, and non-retryable failures without changing HTTP client behavior yet.

Why Promise and throwing errors are preferred here over Task:

- HttpClient, axios, and the request pipeline communicate failure via rejected promises
- adding Task in only this local runner would introduce an extra abstraction boundary without simplifying integration
- cancellation is already modeled explicitly via AbortSignal, so Task is not needed to express cancellation here
- using Promise keeps this step atomic; switching to Task would be a larger architectural refactor across multiple layers

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
