### PR TITLE
fix: keep Collabora error modal open on failed retry and close on success(WPB-22818)

### DIFF
--- a/apps/webapp/src/script/components/FileFullscreenModal/FileEditor/FileEditor.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileEditor/FileEditor.tsx
@@ -24,6 +24,7 @@ import {Maybe, result} from 'true-myth';
 import {container} from 'tsyringe';
 
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
+import {removeCurrentModal} from 'Components/Modals/PrimaryModal/PrimaryModalState';
 import {CellsRepository} from 'Repositories/cells/CellsRepository';
 import {Config} from 'src/script/Config';
 import {t} from 'Util/LocalizerUtil';
@@ -35,6 +36,7 @@ import {validateCollaboraUrl} from './validateCollaboraUrl';
 import {FileLoader} from '../FileLoader/FileLoader';
 
 const REFRESH_BUFFER_SECONDS = 10; // Refresh 10 seconds before expiry for safety
+const QA_FORCE_FILE_EDITOR_ERROR_KEY = 'qa-force-file-editor-error';
 
 interface FileEditorProps {
   id: string;
@@ -47,14 +49,16 @@ export const FileEditor = ({id}: FileEditorProps) => {
   const [isError, setIsError] = useState(false);
   const hasShownErrorModal = useRef(false);
 
-  const fetchNode = useCallback(async () => {
+  const fetchNode = useCallback(async (): Promise<boolean> => {
     try {
       setIsLoading(true);
       setIsError(false);
       const fetchedNode = await cellsRepository.getNode({uuid: id, flags: ['WithEditorURLs']});
       setNode(fetchedNode);
+      return true;
     } catch (err) {
       setIsError(true);
+      return false;
     } finally {
       setIsLoading(false);
     }
@@ -62,7 +66,12 @@ export const FileEditor = ({id}: FileEditorProps) => {
 
   const handleRetry = useCallback(() => {
     hasShownErrorModal.current = false;
-    void fetchNode();
+    void (async () => {
+      const isSuccessful = await fetchNode();
+      if (isSuccessful) {
+        removeCurrentModal();
+      }
+    })();
   }, [fetchNode]);
 
   // Initial fetch
@@ -101,6 +110,7 @@ export const FileEditor = ({id}: FileEditorProps) => {
     hasShownErrorModal.current = true;
 
     PrimaryModal.show(PrimaryModal.type.CONFIRM, {
+      closeOnConfirm: false,
       secondaryAction: {
         text: t('modalConfirmSecondary'),
       },

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileEditor/FileEditor.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileEditor/FileEditor.tsx
@@ -36,7 +36,6 @@ import {validateCollaboraUrl} from './validateCollaboraUrl';
 import {FileLoader} from '../FileLoader/FileLoader';
 
 const REFRESH_BUFFER_SECONDS = 10; // Refresh 10 seconds before expiry for safety
-const QA_FORCE_FILE_EDITOR_ERROR_KEY = 'qa-force-file-editor-error';
 
 interface FileEditorProps {
   id: string;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22818" title="WPB-22818" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22818</a>  [Web] Update error screen copy when Collabora cannot be opened
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- Updates the Collabora File Editor error handling in fullscreen mode to improve retry behavior.
- `Try again` now:
  - triggers a fresh fetch request
  - keeps the modal open if the request still fails
  - closes the modal only when retry succeeds
- `Cancel` continues to close the modal.
---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
