### PR TITLE
chore(dependabot): add 3-day cooldown for npm updates [WPB-22420]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       day: sunday
       time: '16:00'
       timezone: 'Europe/Berlin'
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 99
     labels:
       - 'type: chore 🧹'
@@ -25,6 +27,8 @@ updates:
       interval: daily
       time: '16:00'
       timezone: 'Europe/Berlin'
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 99
     labels:
       - 'type: chore 🧹'
@@ -41,6 +45,8 @@ updates:
       day: sunday
       time: '16:00'
       timezone: 'Europe/Berlin'
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 99
     labels:
       - 'type: chore 🧹'
@@ -82,6 +88,8 @@ updates:
       day: sunday
       time: '16:00'
       timezone: 'Europe/Berlin'
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 99
     labels:
       - 'type: chore 🧹'
@@ -103,6 +111,8 @@ updates:
       day: sunday
       time: '16:00'
       timezone: 'Europe/Berlin'
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 99
     labels:
       - 'type: chore 🧹'
@@ -121,6 +131,8 @@ updates:
       day: sunday
       time: '16:00'
       timezone: 'Europe/Berlin'
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 99
     labels:
       - 'type: chore 🧹'


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Add a 3-day Dependabot cooldown to all npm update entries so version update PRs are delayed similarly to this repo's Yarn npmMinimalAgeGate policy.

This reduces noise from brand-new releases and gives newly published npm packages time to settle before Dependabot proposes them.

Notes:
- Applies to npm version updates only
- Does not delay Dependabot security updates
- Keeps existing schedules, labels, and ignore rules unchanged
