### PR TITLE
chore: downgrade AVS to latest stable v10.2.27 [WPB-22420]

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -35,7 +35,7 @@
     "@sindresorhus/is": "4.6.0",
     "@tanstack/react-table": "8.21.3",
     "@tanstack/react-virtual": "3.13.21",
-    "@wireapp/avs": "10.3.1",
+    "@wireapp/avs": "10.2.27",
     "@wireapp/avs-debugger": "0.0.7",
     "@wireapp/config": "workspace:^",
     "@wireapp/core": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12476,10 +12476,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/avs@npm:10.3.1":
-  version: 10.3.1
-  resolution: "@wireapp/avs@npm:10.3.1"
-  checksum: 10/a1d2b9b48da0eb67a7358f4106e79d8444b659d941d51e6ebfb1bf3916021fdec671b27fbcab999147c9da988ad0f36c30e5898ce13fd9d0c1c7016943458d33
+"@wireapp/avs@npm:10.2.27":
+  version: 10.2.27
+  resolution: "@wireapp/avs@npm:10.2.27"
+  checksum: 10/3beea97bc8a7f1f5bdf9aaf2cefd4f7b0dfd8820ae9ebbcb19d16b1d04b230e01f61a8b4582abfdfdf5e446f1a98ce322bc89d474cb45a072a0b76e510e531a5
   languageName: node
   linkType: hard
 
@@ -12842,7 +12842,7 @@ __metadata:
     "@types/webpack-bundle-analyzer": "npm:4.7.0"
     "@types/webpack-env": "npm:1.18.8"
     "@types/wicg-file-system-access": "npm:2023.10.7"
-    "@wireapp/avs": "npm:10.3.1"
+    "@wireapp/avs": "npm:10.2.27"
     "@wireapp/avs-debugger": "npm:0.0.7"
     "@wireapp/config": "workspace:^"
     "@wireapp/core": "workspace:^"


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary

- What did I change and why?
Downgrade AVS to latest stable v10.2.27
As of now 10.3.X are in testing phase so before upgrading to other version in future please confirm from the AVS team.
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
