### PR TITLE
chore(dependabot): remove obsolete libsodium ignore [WPB-22420]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -75,10 +75,6 @@ updates:
       - dependency-name: '@lexical/markdown'
       - dependency-name: '@lexical/react'
       - dependency-name: '@lexical/rich-text'
-      # Wait until libsodium-wrappers:0.7.17 because: https://github.com/jedisct1/libsodium.js/issues/357
-      - dependency-name: 'libsodium-wrappers'
-        versions:
-          - '0.7.16'
 
   # Server dependencies
   - package-ecosystem: npm


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Delete the stale libsodium-wrappers 0.7.16 ignore entry from Dependabot config. The referenced upstream issue is resolved and the webapp no longer depends on libsodium-wrappers directly.
