### PR TITLE
feat: create reset wiring for incremental HTTP retry backoff [WPB-23381]

### DIFF
--- a/apps/webapp/jest.config.ts
+++ b/apps/webapp/jest.config.ts
@@ -50,6 +50,7 @@ const config: Config = {
   },
   testPathIgnorePatterns: ['<rootDir>/server', '<rootDir>/.yalc', '<rootDir>/test/e2e_tests'],
   testRunner: 'jest-jasmine2',
+  transformIgnorePatterns: ['/node_modules/(?!(true-myth|p-timeout|p-cancelable|noop-esm)/)'],
   // Override transform to use babel-jest for webapp (uses React automatic runtime with Emotion)
   transform: {
     '^.+\\.[tj]sx?$': 'babel-jest',

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -67,6 +67,7 @@
     "linkify-it": "5.0.0",
     "markdown-it": "14.1.1",
     "murmurhash": "2.0.1",
+    "noop-esm": "1.1.0",
     "oidc-client-ts": "3.4.1",
     "p-wait-for": "6.0.0",
     "path-to-regexp": "8.3.0",

--- a/apps/webapp/src/script/lifecycle/createIncrementalHttpRetryBackoffReset.test.ts
+++ b/apps/webapp/src/script/lifecycle/createIncrementalHttpRetryBackoffReset.test.ts
@@ -1,0 +1,166 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import assert from 'assert';
+
+import {APIClient} from '../service/APIClientSingleton';
+import {incrementalHttpRetryBackoffFeatureToggleName} from '../featureToggles/startupFeatureToggleNames';
+import {StartupFeatureToggleName} from '../featureToggles/startupFeatureToggles';
+import {createIncrementalHttpRetryBackoffReset} from './createIncrementalHttpRetryBackoffReset';
+
+type ListenerMap = Map<string, () => void>;
+
+type ConfigureIncrementalHttpRetryBackoffResetDependenciesForTest = {
+  readonly applicationSignalListeners: ListenerMap;
+  readonly apiClient: APIClient;
+  readonly resetIncrementalRetryBackoff: jest.Mock<void, []>;
+  readonly runtimeSignalListeners: ListenerMap;
+  readonly subscribeToApplicationSignal: jest.Mock<void, ['visibilitychange', () => void]>;
+  readonly subscribeToRuntimeSignal: jest.Mock<void, ['focus' | 'online' | 'unload', () => void]>;
+  readonly unsubscribeFromApplicationSignal: jest.Mock<void, ['visibilitychange', () => void]>;
+  readonly unsubscribeFromRuntimeSignal: jest.Mock<void, ['focus' | 'online', () => void]>;
+};
+
+function createConfigureIncrementalHttpRetryBackoffResetDependenciesForTest(): ConfigureIncrementalHttpRetryBackoffResetDependenciesForTest {
+  const applicationSignalListeners: ListenerMap = new Map();
+  const runtimeSignalListeners: ListenerMap = new Map();
+  const resetIncrementalRetryBackoff = jest.fn();
+  const apiClient = {
+    resetIncrementalRetryBackoff,
+  } as APIClient;
+  const subscribeToApplicationSignal = jest.fn((signalName: 'visibilitychange', listener: () => void) => {
+    applicationSignalListeners.set(signalName, listener);
+  });
+  const unsubscribeFromApplicationSignal = jest.fn((signalName: 'visibilitychange', _listener: () => void) => {
+    applicationSignalListeners.delete(signalName);
+  });
+  const subscribeToRuntimeSignal = jest.fn((signalName: 'focus' | 'online' | 'unload', listener: () => void) => {
+    runtimeSignalListeners.set(signalName, listener);
+  });
+  const unsubscribeFromRuntimeSignal = jest.fn((signalName: 'focus' | 'online', _listener: () => void) => {
+    runtimeSignalListeners.delete(signalName);
+  });
+
+  return {
+    applicationSignalListeners,
+    apiClient,
+    resetIncrementalRetryBackoff,
+    runtimeSignalListeners,
+    subscribeToApplicationSignal,
+    subscribeToRuntimeSignal,
+    unsubscribeFromApplicationSignal,
+    unsubscribeFromRuntimeSignal,
+  };
+}
+
+describe('createIncrementalHttpRetryBackoffReset', () => {
+  it('does not register listeners when the startup feature toggle is disabled', () => {
+    const dependenciesForTest = createConfigureIncrementalHttpRetryBackoffResetDependenciesForTest();
+
+    createIncrementalHttpRetryBackoffReset({
+      ...dependenciesForTest,
+      visibilityState: () => {
+        return 'visible';
+      },
+      isElectron: () => {
+        return false;
+      },
+      isFeatureToggleEnabled: (_featureToggleName: StartupFeatureToggleName) => {
+        return false;
+      },
+    });
+
+    expect(dependenciesForTest.subscribeToApplicationSignal).not.toHaveBeenCalled();
+    expect(dependenciesForTest.subscribeToRuntimeSignal).not.toHaveBeenCalled();
+  });
+
+  it('resets retry backoff when the browser tab becomes visible and when the app goes online', () => {
+    const dependenciesForTest = createConfigureIncrementalHttpRetryBackoffResetDependenciesForTest();
+    let currentDocumentVisibilityState: DocumentVisibilityState = 'hidden';
+
+    const cleanup = createIncrementalHttpRetryBackoffReset({
+      ...dependenciesForTest,
+      visibilityState: () => {
+        return currentDocumentVisibilityState;
+      },
+      isElectron: () => {
+        return false;
+      },
+      isFeatureToggleEnabled: (featureToggleName: StartupFeatureToggleName) => {
+        return featureToggleName === incrementalHttpRetryBackoffFeatureToggleName;
+      },
+    });
+
+    expect(dependenciesForTest.subscribeToApplicationSignal).toHaveBeenCalledWith(
+      'visibilitychange',
+      expect.any(Function),
+    );
+    expect(dependenciesForTest.subscribeToRuntimeSignal).toHaveBeenCalledWith('online', expect.any(Function));
+
+    const visibilityChangeListener = dependenciesForTest.applicationSignalListeners.get('visibilitychange');
+    const onlineListener = dependenciesForTest.runtimeSignalListeners.get('online');
+
+    assert(visibilityChangeListener !== undefined);
+    assert(onlineListener !== undefined);
+
+    visibilityChangeListener();
+    expect(dependenciesForTest.resetIncrementalRetryBackoff).not.toHaveBeenCalled();
+
+    currentDocumentVisibilityState = 'visible';
+    visibilityChangeListener();
+    onlineListener();
+
+    expect(dependenciesForTest.resetIncrementalRetryBackoff).toHaveBeenCalledTimes(2);
+
+    cleanup();
+
+    expect(dependenciesForTest.unsubscribeFromApplicationSignal).toHaveBeenCalledWith(
+      'visibilitychange',
+      expect.any(Function),
+    );
+    expect(dependenciesForTest.unsubscribeFromRuntimeSignal).toHaveBeenCalledWith('online', expect.any(Function));
+  });
+
+  it('resets retry backoff on window focus in electron', () => {
+    const dependenciesForTest = createConfigureIncrementalHttpRetryBackoffResetDependenciesForTest();
+
+    createIncrementalHttpRetryBackoffReset({
+      ...dependenciesForTest,
+      visibilityState: () => {
+        return 'hidden';
+      },
+      isElectron: () => {
+        return true;
+      },
+      isFeatureToggleEnabled: (featureToggleName: StartupFeatureToggleName) => {
+        return featureToggleName === incrementalHttpRetryBackoffFeatureToggleName;
+      },
+    });
+
+    expect(dependenciesForTest.subscribeToRuntimeSignal).toHaveBeenCalledWith('focus', expect.any(Function));
+
+    const focusListener = dependenciesForTest.runtimeSignalListeners.get('focus');
+
+    assert(focusListener !== undefined);
+
+    focusListener();
+
+    expect(dependenciesForTest.resetIncrementalRetryBackoff).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/webapp/src/script/lifecycle/createIncrementalHttpRetryBackoffReset.ts
+++ b/apps/webapp/src/script/lifecycle/createIncrementalHttpRetryBackoffReset.ts
@@ -1,0 +1,102 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {noop} from 'noop-esm';
+
+import {incrementalHttpRetryBackoffFeatureToggleName} from '../featureToggles/startupFeatureToggleNames';
+import {StartupFeatureToggleName} from '../featureToggles/startupFeatureToggles';
+import {APIClient} from '../service/APIClientSingleton';
+
+type ConfigureIncrementalHttpRetryBackoffResetDependencies = {
+  readonly isElectron: () => boolean;
+  readonly isFeatureToggleEnabled: (featureToggleName: StartupFeatureToggleName) => boolean;
+  readonly subscribeToApplicationSignal: (signalName: 'visibilitychange', listener: () => void) => void;
+  readonly apiClient: APIClient;
+  readonly subscribeToRuntimeSignal: (signalName: 'focus' | 'online' | 'unload', listener: () => void) => void;
+  readonly unsubscribeFromApplicationSignal: (signalName: 'visibilitychange', listener: () => void) => void;
+  readonly unsubscribeFromRuntimeSignal: (signalName: 'focus' | 'online', listener: () => void) => void;
+  readonly visibilityState: () => DocumentVisibilityState;
+};
+
+type VisibilityChangeHandlerDependencies = {
+  readonly resetRetryBackoff: () => void;
+  readonly visibilityState: () => DocumentVisibilityState;
+};
+
+function handleVisibilityChange(dependencies: VisibilityChangeHandlerDependencies): void {
+  const {resetRetryBackoff, visibilityState} = dependencies;
+
+  if (visibilityState() !== 'visible') {
+    return;
+  }
+
+  resetRetryBackoff();
+}
+
+export function createIncrementalHttpRetryBackoffReset(
+  dependencies: ConfigureIncrementalHttpRetryBackoffResetDependencies,
+): () => void {
+  const {
+    apiClient,
+    isElectron,
+    isFeatureToggleEnabled,
+    subscribeToApplicationSignal,
+    subscribeToRuntimeSignal,
+    unsubscribeFromApplicationSignal,
+    unsubscribeFromRuntimeSignal,
+    visibilityState,
+  } = dependencies;
+
+  if (!isFeatureToggleEnabled(incrementalHttpRetryBackoffFeatureToggleName)) {
+    return noop;
+  }
+
+  function resetRetryBackoff(): void {
+    apiClient.resetIncrementalRetryBackoff();
+  }
+
+  const cleanupCallbacks: (() => void)[] = [];
+
+  if (isElectron()) {
+    subscribeToRuntimeSignal('focus', resetRetryBackoff);
+    cleanupCallbacks.push(() => {
+      unsubscribeFromRuntimeSignal('focus', resetRetryBackoff);
+    });
+  } else {
+    function handleApplicationVisibilityChange(): void {
+      handleVisibilityChange({resetRetryBackoff, visibilityState});
+    }
+
+    subscribeToApplicationSignal('visibilitychange', handleApplicationVisibilityChange);
+    cleanupCallbacks.push(() => {
+      unsubscribeFromApplicationSignal('visibilitychange', handleApplicationVisibilityChange);
+    });
+  }
+
+  subscribeToRuntimeSignal('online', resetRetryBackoff);
+  cleanupCallbacks.push(() => {
+    unsubscribeFromRuntimeSignal('online', resetRetryBackoff);
+  });
+
+  return () => {
+    cleanupCallbacks.forEach(cleanupCallback => {
+      cleanupCallback();
+    });
+  };
+}

--- a/apps/webapp/src/script/main/index.tsx
+++ b/apps/webapp/src/script/main/index.tsx
@@ -41,6 +41,7 @@ import {SIGN_OUT_REASON} from '../auth/SignOutReason';
 import {createWallClock} from '../clock/wallClock';
 import {Config} from '../Config';
 import {createStartupFeatureTogglesFromLocationSearch} from '../featureToggles/startupFeatureToggles';
+import {createIncrementalHttpRetryBackoffReset} from '../lifecycle/createIncrementalHttpRetryBackoffReset';
 import {APIClient} from '../service/APIClientSingleton';
 import {Core} from '../service/CoreSingleton';
 
@@ -78,9 +79,32 @@ document.addEventListener('DOMContentLoaded', async () => {
   const {wallClock} = applicationServices;
   const apiClient = new APIClient({isFeatureToggleEnabled});
   const core = new Core(apiClient);
+  const cleanupIncrementalHttpRetryBackoffReset = createIncrementalHttpRetryBackoffReset({
+    apiClient,
+    visibilityState: () => {
+      return document.visibilityState;
+    },
+    isElectron: () => {
+      return Runtime.isElectron();
+    },
+    isFeatureToggleEnabled,
+    subscribeToApplicationSignal: (signalName, listener) => {
+      document.addEventListener(signalName, listener);
+    },
+    subscribeToRuntimeSignal: (signalName, listener) => {
+      globalThis.addEventListener(signalName, listener);
+    },
+    unsubscribeFromApplicationSignal: (signalName, listener) => {
+      document.removeEventListener(signalName, listener);
+    },
+    unsubscribeFromRuntimeSignal: (signalName, listener) => {
+      globalThis.removeEventListener(signalName, listener);
+    },
+  });
 
   container.registerInstance(APIClient, apiClient);
   container.registerInstance(Core, core);
+  globalThis.addEventListener('unload', cleanupIncrementalHttpRetryBackoffReset);
 
   createRoot(appContainer).render(
     <AppContainer

--- a/apps/webapp/src/script/service/APIClientSingleton.ts
+++ b/apps/webapp/src/script/service/APIClientSingleton.ts
@@ -33,6 +33,10 @@ type APIClientSingletonConfiguration = {
   readonly isFeatureToggleEnabled?: (featureToggleName: StartupFeatureToggleName) => boolean;
 };
 
+type RetryBackoffResettableHttpClient = {
+  readonly resetRetryBackoff: () => void;
+};
+
 @singleton()
 export class APIClient extends APIClientUnconfigured {
   constructor(apiClientSingletonConfiguration: APIClientSingletonConfiguration = {}) {
@@ -53,5 +57,11 @@ export class APIClient extends APIClientUnconfigured {
     };
 
     super(unconfiguredApiClientConfiguration);
+  }
+
+  public resetIncrementalRetryBackoff(): void {
+    const retryBackoffResettableHttpClient = this.transport.http as unknown as RetryBackoffResettableHttpClient;
+
+    retryBackoffResettableHttpClient.resetRetryBackoff();
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11217,6 +11217,7 @@ __metadata:
     linkify-it: "npm:5.0.0"
     markdown-it: "npm:14.1.1"
     murmurhash: "npm:2.0.1"
+    noop-esm: "npm:1.1.0"
     oidc-client-ts: "npm:3.4.1"
     os-browserify: "npm:0.3.0"
     p-wait-for: "npm:6.0.0"
@@ -21578,6 +21579,13 @@ __metadata:
   version: 2.0.27
   resolution: "node-releases@npm:2.0.27"
   checksum: 10/f6c78ddb392ae500719644afcbe68a9ea533242c02312eb6a34e8478506eb7482a3fb709c70235b01c32fe65625b68dfa9665113f816d87f163bc3819b62b106
+  languageName: node
+  linkType: hard
+
+"noop-esm@npm:1.1.0":
+  version: 1.1.0
+  resolution: "noop-esm@npm:1.1.0"
+  checksum: 10/592c401aa7ba19f872e4c26773715e94725d4ae286132115ba80ef906c27c24df3f77107c4296a2b30bd0c9d048d3ee4458eafd4948d8b40c4aadcc5df485520
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23381" title="WPB-23381" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23381</a>  [Web] Make sure that the web app applies incremental backoff on 420/429
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Create the webapp lifecycle wiring that resets incremental HTTP retry backoff when recovery signals indicate conditions may have improved, while keeping the behavior gated by incremental-http-retry-backoff. This keeps browser and runtime signal handling at the application edge, scopes noop-esm to the webapp workspace for the disabled cleanup path, and preserves the transport retry policy itself unchanged.

As a follow-up, these raw lifecycle and connectivity states should be modeled through a proper state machine so backoff recovery can react to semantic application state transitions instead of direct event wiring.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
