### PR TITLE
feat: interrupt active incremental HTTP backoff waits on reset [WPB-23381]

### DIFF
--- a/libraries/api-client/src/http/HttpClient.test.ts
+++ b/libraries/api-client/src/http/HttpClient.test.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import assert from 'assert';
 import nock from 'nock';
 import {AxiosHeaders, AxiosResponse} from 'axios';
 
@@ -292,10 +293,16 @@ describe('HttpClient', () => {
     it('retries immediately when the retry backoff is reset during an active wait', async () => {
       let scheduledTimeoutHandler: (() => void) | undefined;
       const observedDelayInMilliseconds: number[] = [];
+      let resolveWaitWasScheduled: (() => void) | undefined;
+      const waitWasScheduled = new Promise<void>((resolve) => {
+        resolveWaitWasScheduled = resolve;
+      });
       const clearTimeout = jest.fn();
       const setTimeout = jest.fn((handler: () => void, delayInMilliseconds: number) => {
         scheduledTimeoutHandler = handler;
         observedDelayInMilliseconds.push(delayInMilliseconds);
+        assert(resolveWaitWasScheduled !== undefined);
+        resolveWaitWasScheduled();
 
         return 1 as ReturnType<typeof globalThis.setTimeout>;
       });
@@ -318,23 +325,63 @@ describe('HttpClient', () => {
         .mockResolvedValueOnce(response);
 
       const responsePromise = client.sendRequest({method: 'GET', url: '/conversations'});
-      for (let microtaskTurn = 0; microtaskTurn < 10; microtaskTurn += 1) {
-        if (setTimeout.mock.calls.length > 0) {
-          break;
-        }
-
-        await Promise.resolve();
-      }
+      await waitWasScheduled;
 
       expect(client._sendRequest).toHaveBeenCalledTimes(1);
       expect(setTimeout).toHaveBeenCalledTimes(1);
-      expect(scheduledTimeoutHandler).toBeDefined();
+      assert(scheduledTimeoutHandler !== undefined);
 
       client.resetRetryBackoff();
 
       await expect(responsePromise).resolves.toBe(response);
       expect(clearTimeout).toHaveBeenCalledWith(1);
       expect(client._sendRequest).toHaveBeenCalledTimes(2);
+      expect(observedDelayInMilliseconds).toEqual([100]);
+    });
+
+    it('stops retrying when the request is aborted during an active wait', async () => {
+      let scheduledTimeoutHandler: (() => void) | undefined;
+      const observedDelayInMilliseconds: number[] = [];
+      let resolveWaitWasScheduled: (() => void) | undefined;
+      const waitWasScheduled = new Promise<void>((resolve) => {
+        resolveWaitWasScheduled = resolve;
+      });
+      const abortController = new AbortController();
+      const clearTimeout = jest.fn();
+      const setTimeout = jest.fn((handler: () => void, delayInMilliseconds: number) => {
+        scheduledTimeoutHandler = handler;
+        observedDelayInMilliseconds.push(delayInMilliseconds);
+        assert(resolveWaitWasScheduled !== undefined);
+        resolveWaitWasScheduled();
+
+        return 1 as ReturnType<typeof globalThis.setTimeout>;
+      });
+      const client = new HttpClient(
+        testConfig,
+        mockedAccessTokenStore as AccessTokenStore,
+        {
+          dependencies: {
+            clearTimeout,
+            setTimeout,
+          },
+          shouldUseIncrementalRetryBackoff: true,
+        },
+      );
+
+      client._sendRequest = jest.fn().mockRejectedValueOnce(createRetryableBackendError(StatusCode.SERVICE_UNAVAILABLE));
+
+      const responsePromise = client.sendRequest({method: 'GET', url: '/conversations'}, false, abortController);
+      await waitWasScheduled;
+
+      expect(client._sendRequest).toHaveBeenCalledTimes(1);
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      assert(scheduledTimeoutHandler !== undefined);
+
+      abortController.abort();
+
+      await expect(responsePromise).rejects.toThrow('The wait was aborted.');
+      expect(clearTimeout).toHaveBeenCalledWith(1);
+      expect(client._sendRequest).toHaveBeenCalledTimes(1);
       expect(observedDelayInMilliseconds).toEqual([100]);
     });
   });

--- a/libraries/api-client/src/http/HttpClient.test.ts
+++ b/libraries/api-client/src/http/HttpClient.test.ts
@@ -239,5 +239,54 @@ describe('HttpClient', () => {
 
       expect(httpClientDependenciesForTest.observedDelayInMilliseconds).toEqual([100, 200, 100]);
     });
+
+    it('retries immediately when the retry backoff is reset during an active wait', async () => {
+      let scheduledTimeoutHandler: (() => void) | undefined;
+      const observedDelayInMilliseconds: number[] = [];
+      const clearTimeout = jest.fn();
+      const setTimeout = jest.fn((handler: () => void, delayInMilliseconds: number) => {
+        scheduledTimeoutHandler = handler;
+        observedDelayInMilliseconds.push(delayInMilliseconds);
+
+        return 1 as ReturnType<typeof globalThis.setTimeout>;
+      });
+      const client = new HttpClient(
+        testConfig,
+        mockedAccessTokenStore as AccessTokenStore,
+        {
+          dependencies: {
+            clearTimeout,
+            setTimeout,
+          },
+          shouldUseIncrementalRetryBackoff: true,
+        },
+      );
+      const response = {data: {ok: true}} as any;
+
+      client._sendRequest = jest
+        .fn()
+        .mockRejectedValueOnce(createRetryableBackendError(StatusCode.SERVICE_UNAVAILABLE))
+        .mockResolvedValueOnce(response);
+
+      const responsePromise = client.sendRequest({method: 'GET', url: '/conversations'});
+      for (let microtaskTurn = 0; microtaskTurn < 10; microtaskTurn += 1) {
+        if (setTimeout.mock.calls.length > 0) {
+          break;
+        }
+
+        await Promise.resolve();
+      }
+
+      expect(client._sendRequest).toHaveBeenCalledTimes(1);
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(scheduledTimeoutHandler).toBeDefined();
+
+      client.resetRetryBackoff();
+
+      await expect(responsePromise).resolves.toBe(response);
+      expect(clearTimeout).toHaveBeenCalledWith(1);
+      expect(client._sendRequest).toHaveBeenCalledTimes(2);
+      expect(observedDelayInMilliseconds).toEqual([100]);
+    });
   });
 });

--- a/libraries/api-client/src/http/HttpClient.test.ts
+++ b/libraries/api-client/src/http/HttpClient.test.ts
@@ -18,6 +18,7 @@
  */
 
 import nock from 'nock';
+import {AxiosHeaders, AxiosResponse} from 'axios';
 
 import {BackendErrorLabel} from './BackendErrorLabel';
 import {HttpClient} from './HttpClient';
@@ -51,6 +52,16 @@ function createHttpClientDependenciesForTest(): HttpClientDependenciesForTest {
 
 function createRetryableBackendError(statusCode: number): BackendError {
   return new BackendError('Retryable backend error', undefined, statusCode);
+}
+
+function createAxiosResponseForTest<ResponseValue>(data: ResponseValue): AxiosResponse<ResponseValue> {
+  return {
+    config: {headers: new AxiosHeaders()},
+    data,
+    headers: {},
+    status: StatusCode.OK,
+    statusText: 'OK',
+  };
 }
 
 describe('HttpClient', () => {
@@ -150,6 +161,44 @@ describe('HttpClient', () => {
   });
 
   describe('sendRequest with incremental retry backoff', () => {
+    it.each(
+      [
+        {
+          expectedDescription: '420',
+          retryableStatusCode: 420,
+        },
+        {
+          expectedDescription: '429',
+          retryableStatusCode: StatusCode.TOO_MANY_REQUESTS,
+        },
+      ] as const,
+    )(
+      'retries $expectedDescription backend errors when incremental retry backoff is enabled',
+      async ({retryableStatusCode}) => {
+        const httpClientDependenciesForTest = createHttpClientDependenciesForTest();
+        const client = new HttpClient(
+          testConfig,
+          mockedAccessTokenStore as AccessTokenStore,
+        {
+          dependencies: httpClientDependenciesForTest,
+          shouldUseIncrementalRetryBackoff: true,
+        },
+      );
+        const response = createAxiosResponseForTest({ok: true});
+
+        client._sendRequest = jest
+          .fn()
+          .mockRejectedValueOnce(createRetryableBackendError(retryableStatusCode))
+          .mockResolvedValueOnce(response);
+
+        const result = await client.sendRequest({method: 'GET', url: '/conversations'});
+
+        expect(result).toBe(response);
+        expect(client._sendRequest).toHaveBeenCalledTimes(2);
+        expect(httpClientDependenciesForTest.observedDelayInMilliseconds).toEqual([100]);
+      },
+    );
+
     it('retries retryable backend errors when incremental retry backoff is enabled', async () => {
       const httpClientDependenciesForTest = createHttpClientDependenciesForTest();
       const client = new HttpClient(
@@ -160,7 +209,7 @@ describe('HttpClient', () => {
           shouldUseIncrementalRetryBackoff: true,
         },
       );
-      const response = {data: {ok: true}} as any;
+      const response = createAxiosResponseForTest({ok: true});
 
       client._sendRequest = jest
         .fn()
@@ -219,7 +268,7 @@ describe('HttpClient', () => {
           shouldUseIncrementalRetryBackoff: true,
         },
       );
-      const response = {data: {ok: true}} as any;
+      const response = createAxiosResponseForTest({ok: true});
 
       client._sendRequest = jest
         .fn()
@@ -261,7 +310,7 @@ describe('HttpClient', () => {
           shouldUseIncrementalRetryBackoff: true,
         },
       );
-      const response = {data: {ok: true}} as any;
+      const response = createAxiosResponseForTest({ok: true});
 
       client._sendRequest = jest
         .fn()

--- a/libraries/api-client/src/http/HttpClient.ts
+++ b/libraries/api-client/src/http/HttpClient.ts
@@ -83,6 +83,8 @@ export class HttpClient extends EventEmitter {
   private readonly backOffQueue: PriorityQueue;
   private readonly incrementalRetryBackoffPolicy = createIncrementalRetryBackoffPolicy();
   private readonly incrementalRetryBackoffRunner;
+  private incrementalRetryBackoffResetAbortController = new AbortController();
+  private incrementalRetryBackoffResetCount = 0;
   private incrementalRetryBackoffState: IncrementalRetryBackoffState;
   private shouldUseIncrementalRetryBackoff = false;
   public static readonly TOPIC = TOPIC;
@@ -183,7 +185,20 @@ export class HttpClient extends EventEmitter {
   }
 
   public resetRetryBackoff(): void {
+    this.incrementalRetryBackoffResetCount += 1;
     this.incrementalRetryBackoffState = this.incrementalRetryBackoffPolicy.createInitialIncrementalRetryBackoffState();
+    this.incrementalRetryBackoffResetAbortController.abort();
+    this.incrementalRetryBackoffResetAbortController = new AbortController();
+  }
+
+  private getIncrementalRetryBackoffAbortSignal(abortController?: AbortController): Maybe<AbortSignal> {
+    if (abortController !== undefined) {
+      return Maybe.just(
+        AbortSignal.any([abortController.signal, this.incrementalRetryBackoffResetAbortController.signal]),
+      );
+    }
+
+    return Maybe.just(this.incrementalRetryBackoffResetAbortController.signal);
   }
 
   private updateConnectionState(state: ConnectionState): void {
@@ -355,9 +370,15 @@ export class HttpClient extends EventEmitter {
 
     if (this.shouldUseIncrementalRetryBackoff) {
       return this.incrementalRetryBackoffRunner.runWithIncrementalRetryBackoff({
-        abortSignal: Maybe.of(abortController?.signal),
+        abortSignal: this.getIncrementalRetryBackoffAbortSignal(abortController),
         getIncrementalRetryBackoffState: () => {
           return this.incrementalRetryBackoffState;
+        },
+        getRetryBackoffResetCount: () => {
+          return this.incrementalRetryBackoffResetCount;
+        },
+        isRequestAborted: () => {
+          return abortController?.signal.aborted === true;
         },
         runRequestAttempt,
         setIncrementalRetryBackoffState: nextIncrementalRetryBackoffState => {

--- a/libraries/api-client/src/http/IncrementalRetryBackoffRunner.test.ts
+++ b/libraries/api-client/src/http/IncrementalRetryBackoffRunner.test.ts
@@ -64,6 +64,12 @@ describe('IncrementalRetryBackoffRunner', () => {
       getIncrementalRetryBackoffState() {
         return incrementalRetryBackoffState;
       },
+      getRetryBackoffResetCount() {
+        return 0;
+      },
+      isRequestAborted() {
+        return false;
+      },
       runRequestAttempt,
       setIncrementalRetryBackoffState(nextIncrementalRetryBackoffState: IncrementalRetryBackoffState) {
         incrementalRetryBackoffState = nextIncrementalRetryBackoffState;
@@ -98,6 +104,12 @@ describe('IncrementalRetryBackoffRunner', () => {
       abortSignal: Maybe.nothing(),
       getIncrementalRetryBackoffState() {
         return incrementalRetryBackoffState;
+      },
+      getRetryBackoffResetCount() {
+        return 0;
+      },
+      isRequestAborted() {
+        return false;
       },
       runRequestAttempt,
       setIncrementalRetryBackoffState(nextIncrementalRetryBackoffState: IncrementalRetryBackoffState) {
@@ -135,6 +147,12 @@ describe('IncrementalRetryBackoffRunner', () => {
       getIncrementalRetryBackoffState() {
         return incrementalRetryBackoffState;
       },
+      getRetryBackoffResetCount() {
+        return 0;
+      },
+      isRequestAborted() {
+        return false;
+      },
       runRequestAttempt,
       setIncrementalRetryBackoffState(nextIncrementalRetryBackoffState: IncrementalRetryBackoffState) {
         incrementalRetryBackoffState = nextIncrementalRetryBackoffState;
@@ -170,6 +188,12 @@ describe('IncrementalRetryBackoffRunner', () => {
         getIncrementalRetryBackoffState() {
           return incrementalRetryBackoffState;
         },
+        getRetryBackoffResetCount() {
+          return 0;
+        },
+        isRequestAborted() {
+          return false;
+        },
         runRequestAttempt,
         setIncrementalRetryBackoffState(nextIncrementalRetryBackoffState: IncrementalRetryBackoffState) {
           incrementalRetryBackoffState = nextIncrementalRetryBackoffState;
@@ -181,5 +205,56 @@ describe('IncrementalRetryBackoffRunner', () => {
 
     expect(waitForDurationInMilliseconds).not.toHaveBeenCalled();
     expect(incrementalRetryBackoffState.delayInMilliseconds).toBe(0);
+  });
+
+  it('retries immediately when the retry backoff is reset while waiting', async () => {
+    const waitForDurationInMilliseconds = jest.fn<Promise<void>, [number, Maybe<AbortSignal>]>();
+    const incrementalRetryBackoffPolicy = createIncrementalRetryBackoffPolicy();
+    const incrementalRetryBackoffRunner = createIncrementalRetryBackoffRunner({
+      abortableWait: {
+        waitForDurationInMilliseconds,
+      },
+      getStatusCode(error) {
+        return Maybe.of((error as Partial<RetryableError>).statusCode);
+      },
+      incrementalRetryBackoffPolicy,
+    });
+    let incrementalRetryBackoffState = incrementalRetryBackoffPolicy.createInitialIncrementalRetryBackoffState();
+    let retryBackoffResetCount = 0;
+    const resetAbortController = new AbortController();
+    const runRequestAttempt = jest
+      .fn<Promise<string>, []>()
+      .mockRejectedValueOnce({statusCode: 503})
+      .mockResolvedValueOnce('response');
+
+    waitForDurationInMilliseconds.mockImplementationOnce(async (_durationInMilliseconds, abortSignal) => {
+      retryBackoffResetCount = 1;
+      resetAbortController.abort();
+
+      await abortSignal.unwrapOr(undefined)?.throwIfAborted();
+    });
+
+    const response = await incrementalRetryBackoffRunner.runWithIncrementalRetryBackoff({
+      abortSignal: Maybe.just(resetAbortController.signal),
+      getIncrementalRetryBackoffState() {
+        return incrementalRetryBackoffState;
+      },
+      getRetryBackoffResetCount() {
+        return retryBackoffResetCount;
+      },
+      isRequestAborted() {
+        return false;
+      },
+      runRequestAttempt,
+      setIncrementalRetryBackoffState(nextIncrementalRetryBackoffState: IncrementalRetryBackoffState) {
+        incrementalRetryBackoffState = nextIncrementalRetryBackoffState;
+
+        return incrementalRetryBackoffState;
+      },
+    });
+
+    expect(response).toBe('response');
+    expect(runRequestAttempt).toHaveBeenCalledTimes(2);
+    expect(waitForDurationInMilliseconds).toHaveBeenCalledTimes(1);
   });
 });

--- a/libraries/api-client/src/http/IncrementalRetryBackoffRunner.test.ts
+++ b/libraries/api-client/src/http/IncrementalRetryBackoffRunner.test.ts
@@ -257,4 +257,53 @@ describe('IncrementalRetryBackoffRunner', () => {
     expect(runRequestAttempt).toHaveBeenCalledTimes(2);
     expect(waitForDurationInMilliseconds).toHaveBeenCalledTimes(1);
   });
+
+  it('rethrows the wait error when the request is aborted while waiting', async () => {
+    const waitForDurationInMilliseconds = jest.fn<Promise<void>, [number, Maybe<AbortSignal>]>();
+    const incrementalRetryBackoffPolicy = createIncrementalRetryBackoffPolicy();
+    const incrementalRetryBackoffRunner = createIncrementalRetryBackoffRunner({
+      abortableWait: {
+        waitForDurationInMilliseconds,
+      },
+      getStatusCode(error) {
+        return Maybe.of((error as Partial<RetryableError>).statusCode);
+      },
+      incrementalRetryBackoffPolicy,
+    });
+    let incrementalRetryBackoffState = incrementalRetryBackoffPolicy.createInitialIncrementalRetryBackoffState();
+    const requestAbortController = new AbortController();
+    const runRequestAttempt = jest.fn<Promise<string>, []>().mockRejectedValueOnce({statusCode: 503});
+
+    waitForDurationInMilliseconds.mockImplementationOnce(async (_durationInMilliseconds, abortSignal) => {
+      requestAbortController.abort();
+
+      await abortSignal.unwrapOr(undefined)?.throwIfAborted();
+    });
+
+    const runWithIncrementalRetryBackoffPromise = incrementalRetryBackoffRunner.runWithIncrementalRetryBackoff({
+      abortSignal: Maybe.just(requestAbortController.signal),
+      getIncrementalRetryBackoffState() {
+        return incrementalRetryBackoffState;
+      },
+      getRetryBackoffResetCount() {
+        return 0;
+      },
+      isRequestAborted() {
+        return true;
+      },
+      runRequestAttempt,
+      setIncrementalRetryBackoffState(nextIncrementalRetryBackoffState: IncrementalRetryBackoffState) {
+        incrementalRetryBackoffState = nextIncrementalRetryBackoffState;
+
+        return incrementalRetryBackoffState;
+      },
+    });
+
+    await expect(runWithIncrementalRetryBackoffPromise).rejects.toMatchObject({
+      name: 'AbortError',
+    });
+
+    expect(runRequestAttempt).toHaveBeenCalledTimes(1);
+    expect(waitForDurationInMilliseconds).toHaveBeenCalledTimes(1);
+  });
 });

--- a/libraries/api-client/src/http/IncrementalRetryBackoffRunner.ts
+++ b/libraries/api-client/src/http/IncrementalRetryBackoffRunner.ts
@@ -31,6 +31,8 @@ export type IncrementalRetryBackoffRunnerDependencies = {
 export type RunWithIncrementalRetryBackoffDependencies<ResponseValue> = {
   readonly abortSignal: Maybe<AbortSignal>;
   readonly getIncrementalRetryBackoffState: () => IncrementalRetryBackoffState;
+  readonly getRetryBackoffResetCount: () => number;
+  readonly isRequestAborted: () => boolean;
   readonly runRequestAttempt: () => Promise<ResponseValue>;
   readonly setIncrementalRetryBackoffState: (
     incrementalRetryBackoffState: IncrementalRetryBackoffState,
@@ -52,8 +54,14 @@ export function createIncrementalRetryBackoffRunner(
     async runWithIncrementalRetryBackoff<ResponseValue>(
       runWithIncrementalRetryBackoffDependencies: RunWithIncrementalRetryBackoffDependencies<ResponseValue>,
     ): Promise<Awaited<ResponseValue>> {
-      const {abortSignal, getIncrementalRetryBackoffState, runRequestAttempt, setIncrementalRetryBackoffState} =
-        runWithIncrementalRetryBackoffDependencies;
+      const {
+        abortSignal,
+        getIncrementalRetryBackoffState,
+        getRetryBackoffResetCount,
+        isRequestAborted,
+        runRequestAttempt,
+        setIncrementalRetryBackoffState,
+      } = runWithIncrementalRetryBackoffDependencies;
 
       async function runRequestAttemptWithRetry(): Promise<Awaited<ResponseValue>> {
         try {
@@ -72,10 +80,23 @@ export function createIncrementalRetryBackoffRunner(
 
           setIncrementalRetryBackoffState(nextIncrementalRetryBackoffState);
 
-          await abortableWait.waitForDurationInMilliseconds(
-            nextIncrementalRetryBackoffState.delayInMilliseconds,
-            abortSignal,
-          );
+          const retryBackoffResetCount = getRetryBackoffResetCount();
+
+          try {
+            await abortableWait.waitForDurationInMilliseconds(
+              nextIncrementalRetryBackoffState.delayInMilliseconds,
+              abortSignal,
+            );
+          } catch (error: unknown) {
+            const hasRetryBackoffBeenReset = retryBackoffResetCount !== getRetryBackoffResetCount();
+            const wasRequestAborted = isRequestAborted();
+
+            if (hasRetryBackoffBeenReset && !wasRequestAborted) {
+              return runRequestAttemptWithRetry();
+            }
+
+            throw error;
+          }
 
           return runRequestAttemptWithRetry();
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23381" title="WPB-23381" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23381</a>  [Web] Make sure that the web app applies incremental backoff on 420/429
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Make incremental HTTP backoff resets wake requests that are already waiting so recovery signals such as foreground and connectivity improvements trigger an immediate retry instead of only affecting future delay state. This tightens the transport behavior to match the intended recovery semantics while preserving explicit request-abort handling and the existing flagged rollout boundary.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
