### PR TITLE
refactor: use unique outputDir for file downloads [WPB-19969]

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/cells/cellsFileDetailView.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/cells/cellsFileDetailView.modal.ts
@@ -42,8 +42,8 @@ export class CellsFileDetailViewModal {
     await this.closeButton.click();
   }
 
-  async downloadAsset() {
+  async downloadAsset(outputDir: string) {
     await this.downloadButton.waitFor({state: 'visible'});
-    return await downloadAssetAndGetFilePath(this.page, this.downloadButton);
+    return await downloadAssetAndGetFilePath(this.page, this.downloadButton, outputDir);
   }
 }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/detailView.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/detailView.modal.ts
@@ -63,7 +63,7 @@ export class DetailViewModal {
     await this.closeButton.click();
   }
 
-  async downloadAsset() {
-    return await downloadAssetAndGetFilePath(this.page, this.downloadButton);
+  async downloadAsset(outputDir: string) {
+    return await downloadAssetAndGetFilePath(this.page, this.downloadButton, outputDir);
   }
 }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -390,10 +390,10 @@ export class ConversationPage {
     return await replyMessageLocator.isVisible();
   }
 
-  async downloadFile() {
+  async downloadFile(outputDir: string) {
     const downloadButton = this.page.getByTestId('item-message').getByTestId('file-asset');
 
-    const filePath = await downloadAssetAndGetFilePath(this.page, downloadButton);
+    const filePath = await downloadAssetAndGetFilePath(this.page, downloadButton, outputDir);
     return filePath;
   }
 

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/historyExport.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/historyExport.page.ts
@@ -47,7 +47,7 @@ export class HistoryExportPage {
     await this.cancelButton.click();
   }
 
-  async downloadFile() {
-    return await downloadAssetAndGetFilePath(this.page, this.saveFileButton);
+  async downloadFile(outputDir: string) {
+    return await downloadAssetAndGetFilePath(this.page, this.saveFileButton, outputDir);
   }
 }

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
@@ -30,7 +30,7 @@ const textFilePath = getTextFilePath();
 
 const selfDestructMessageText = 'This message will self-destruct in 10 seconds.';
 
-test('Messages in 1:1', {tag: ['@TC-8750', '@crit-flow-web']}, async ({createTeam, createPage}) => {
+test('Messages in 1:1', {tag: ['@TC-8750', '@crit-flow-web']}, async ({createTeam, createPage}, testInfo) => {
   // Precondition: Users A and B exist in two separate teams
   const [{owner: memberA}, {owner: memberB}] = await Promise.all([createTeam('Critical A'), createTeam('Critical B')]);
 
@@ -80,7 +80,7 @@ test('Messages in 1:1', {tag: ['@TC-8750', '@crit-flow-web']}, async ({createTea
   });
   await test.step('User B can download the image', async () => {
     // Click on the download button to download the image
-    const filePath = await memberBPageManager.webapp.modals.detailViewModal().downloadAsset();
+    const filePath = await memberBPageManager.webapp.modals.detailViewModal().downloadAsset(testInfo.outputDir);
     const downloadQRCodeValue = await getLocalQRCodeValue(filePath);
     const localQRCodeValue = await getLocalQRCodeValue(imageFilePath);
     expect(downloadQRCodeValue).toBe(localQRCodeValue);
@@ -158,7 +158,7 @@ test('Messages in 1:1', {tag: ['@TC-8750', '@crit-flow-web']}, async ({createTea
   });
   await test.step('User B can download the file', async () => {
     await expect(async () => {
-      const filePath = await memberBPageManager.webapp.pages.conversation().downloadFile();
+      const filePath = await memberBPageManager.webapp.pages.conversation().downloadFile(testInfo.outputDir);
       expect(await isAssetDownloaded(filePath)).toBeTruthy();
     }).toPass();
   });

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
@@ -36,7 +36,7 @@ const textFilePath = getTextFilePath();
 test(
   'Messages in Channels',
   {tag: ['@TC-8753', '@crit-flow-web']},
-  async ({createUser, createTeam, createPage, api}) => {
+  async ({createUser, createTeam, createPage, api}, testInfo) => {
     const userB = await createUser();
     const {owner: userA} = await createTeam('Critical Team', {users: [userB]});
 
@@ -92,7 +92,7 @@ test(
     await test.step('User B can download the image', async () => {
       const {modals} = userBPageManager.webapp;
       // Click on the download button to download the image
-      const filePath = await modals.detailViewModal().downloadAsset();
+      const filePath = await modals.detailViewModal().downloadAsset(testInfo.outputDir);
       const downloadQRCodeValue = await getLocalQRCodeValue(filePath);
       const localQRCodeValue = await getLocalQRCodeValue(imageFilePath);
       expect(downloadQRCodeValue).toBe(localQRCodeValue);
@@ -174,7 +174,7 @@ test(
 
     await test.step('User B can download the file', async () => {
       const {pages} = userBPageManager.webapp;
-      const filePath = await pages.conversation().downloadFile();
+      const filePath = await pages.conversation().downloadFile(testInfo.outputDir);
       expect(await isAssetDownloaded(filePath)).toBeTruthy();
     });
   },

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
@@ -35,7 +35,7 @@ const videoFilePath = getVideoFilePath();
 const audioFilePath = getAudioFilePath();
 const textFilePath = getTextFilePath();
 
-test('Messages in Groups', {tag: ['@TC-8751', '@crit-flow-web']}, async ({createUser, createTeam, createPage}) => {
+test('Messages in Groups', {tag: ['@TC-8751', '@crit-flow-web']}, async ({createUser, createTeam, createPage}, testInfo) => {
   const userB = await createUser();
   const {owner: userA} = await createTeam('Critical Team', {users: [userB]});
 
@@ -82,7 +82,7 @@ test('Messages in Groups', {tag: ['@TC-8751', '@crit-flow-web']}, async ({create
   await test.step('User B can download the image', async () => {
     const {modals} = userBPageManager.webapp;
     // Click on the download button to download the image
-    const filePath = await modals.detailViewModal().downloadAsset();
+    const filePath = await modals.detailViewModal().downloadAsset(testInfo.outputDir);
     const downloadQRCodeValue = await getLocalQRCodeValue(filePath);
     const localQRCodeValue = await getLocalQRCodeValue(imageFilePath);
     expect(downloadQRCodeValue).toBe(localQRCodeValue);
@@ -163,7 +163,7 @@ test('Messages in Groups', {tag: ['@TC-8751', '@crit-flow-web']}, async ({create
 
   await test.step('User B can download the file', async () => {
     const {pages} = userBPageManager.webapp;
-    const filePath = await pages.conversation().downloadFile();
+    const filePath = await pages.conversation().downloadFile(testInfo.outputDir);
     expect(await isAssetDownloaded(filePath)).toBeTruthy();
   });
 });

--- a/apps/webapp/test/e2e_tests/specs/Drive/uploadingFileInGroupConversation-TC-8785.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Drive/uploadingFileInGroupConversation-TC-8785.spec.ts
@@ -41,7 +41,7 @@ const imageFilePath = getImageFilePath();
 test(
   'Uploading an file in a group conversation',
   {tag: ['@crit-flow-cells', '@regression', '@TC-8785']},
-  async ({pageManager: userAPageManager, browser, api}) => {
+  async ({pageManager: userAPageManager, browser, api}, testInfo) => {
     const {pages: userAPages, modals: userAModals, components: userAComponents} = userAPageManager.webapp;
 
     const userBContext = await browser.newContext();
@@ -108,7 +108,7 @@ test(
     });
 
     await test.step('User B downloads the image in the conversation', async () => {
-      const filePath = await userBModals.cellsFileDetailView().downloadAsset();
+      const filePath = await userBModals.cellsFileDetailView().downloadAsset(testInfo.outputDir);
       const downloadQRCodeValue = await getLocalQRCodeValue(filePath);
       const localQRCodeValue = await getLocalQRCodeValue(imageFilePath);
       expect(downloadQRCodeValue).toBe(localQRCodeValue);

--- a/apps/webapp/test/e2e_tests/utils/asset.util.ts
+++ b/apps/webapp/test/e2e_tests/utils/asset.util.ts
@@ -22,8 +22,6 @@ import {Locator, Page} from '@playwright/test';
 import {readFile} from 'fs';
 import path from 'path';
 
-export const DownloadFilePath = './test-results/downloads/';
-
 const e2eRootDir = path.join(__dirname, '../');
 const fileTransferAssetsDir = path.join(e2eRootDir, 'assets/filetransfer');
 export const VideoFileName = 'example.mp4';
@@ -54,11 +52,15 @@ export const getTextFilePath = () => {
   return path.join(fileTransferAssetsDir, TextFileName);
 };
 
-export const downloadAssetAndGetFilePath = async (page: Page, downloadButtonLocator: Locator): Promise<string> => {
+export const downloadAssetAndGetFilePath = async (
+  page: Page,
+  downloadButtonLocator: Locator,
+  outputDir: string,
+): Promise<string> => {
   const downloadPromise = page.waitForEvent('download');
   await downloadButtonLocator.click();
   const download = await downloadPromise;
-  const filePath = `${DownloadFilePath}${download.suggestedFilename()}`;
+  const filePath = path.join(outputDir, download.suggestedFilename());
   await download.saveAs(filePath);
   return filePath;
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19969" title="WPB-19969" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19969</a>  [Web/QA] Write the Sending Assets regression tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Replaced the hardcoded global download path with Playwright's unique testInfo.outputDir to ensure each test runs in its own isolated folder. 
This prevents race conditions and file conflicts when running tests in parallel, making the suite more stable.

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
