### PR TITLE
test: add test guard for URL startup feature flags [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
@@ -26,7 +26,13 @@ import {
   collaboraClipboardAccessFeatureToggleName,
   incrementalHttpRetryBackoffFeatureToggleName,
   reliableWebsocketConnectionFeatureToggleName,
+  startupFeatureToggleNames,
 } from './startupFeatureToggleNames';
+
+const featureToggleNamesWithDedicatedExistenceTests = [
+  reliableWebsocketConnectionFeatureToggleName,
+  incrementalHttpRetryBackoffFeatureToggleName,
+] as const;
 
 describe('startupFeatureToggles', function () {
   it('returns disabled toggles when the query parameter is missing', function () {
@@ -122,6 +128,10 @@ describe('startupFeatureToggles', function () {
       incrementalHttpRetryBackoffFeatureToggleName,
       collaboraClipboardAccessFeatureToggleName,
     ]);
+  });
+
+  it('requires a dedicated existence test for every startup feature toggle name', function () {
+    expect(featureToggleNamesWithDedicatedExistenceTests).toEqual(startupFeatureToggleNames);
   });
 
   it('does not expose mutable enabled toggle state', function () {

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
@@ -32,17 +32,18 @@ import {
 const featureToggleNamesWithDedicatedExistenceTests = [
   reliableWebsocketConnectionFeatureToggleName,
   incrementalHttpRetryBackoffFeatureToggleName,
+  collaboraClipboardAccessFeatureToggleName,
 ] as const;
 
 describe('startupFeatureToggles', function () {
-  it('returns disabled toggles when the query parameter is missing', function () {
+  it('returns disabled toggles when the query parameter is missing', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch('?foo=bar');
 
     expect(startupFeatureToggles.isFeatureToggleEnabled(reliableWebsocketConnectionFeatureToggleName)).toBe(false);
     expect(startupFeatureToggles.getEnabledFeatureToggleNames()).toEqual([]);
   });
 
-  it('enables a whitelisted feature toggle when present in the query parameter', function () {
+  it('enables a whitelisted feature toggle when present in the query parameter', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}=${reliableWebsocketConnectionFeatureToggleName}`,
     );
@@ -50,7 +51,7 @@ describe('startupFeatureToggles', function () {
     expect(startupFeatureToggles.isFeatureToggleEnabled(reliableWebsocketConnectionFeatureToggleName)).toBe(true);
   });
 
-  it('enables whitelisted toggles and ignores unknown values in the same parameter', function () {
+  it('enables whitelisted toggles and ignores unknown values in the same parameter', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}=${reliableWebsocketConnectionFeatureToggleName},unknown-feature`,
     );
@@ -59,7 +60,7 @@ describe('startupFeatureToggles', function () {
     expect(startupFeatureToggles.getEnabledFeatureToggleNames()).not.toContain('unknown-feature');
   });
 
-  it('ignores unknown feature toggles from the query parameter', function () {
+  it('ignores unknown feature toggles from the query parameter', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}=unknown-feature`,
     );
@@ -67,7 +68,7 @@ describe('startupFeatureToggles', function () {
     expect(startupFeatureToggles.getEnabledFeatureToggleNames()).toEqual([]);
   });
 
-  it('enables the incremental http retry backoff feature toggle when present in the query parameter', function () {
+  it('enables the incremental http retry backoff feature toggle when present in the query parameter', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}=${incrementalHttpRetryBackoffFeatureToggleName}`,
     );
@@ -75,7 +76,15 @@ describe('startupFeatureToggles', function () {
     expect(startupFeatureToggles.isFeatureToggleEnabled(incrementalHttpRetryBackoffFeatureToggleName)).toBe(true);
   });
 
-  it('keeps only whitelisted feature toggles when known and unknown values are mixed', function () {
+  it('enables the collabora clipboard access feature toggle when present in the query parameter', () => {
+    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
+      `?${startupFeatureToggleQueryParameterName}=${collaboraClipboardAccessFeatureToggleName}`,
+    );
+
+    expect(startupFeatureToggles.isFeatureToggleEnabled(collaboraClipboardAccessFeatureToggleName)).toBe(true);
+  });
+
+  it('keeps only whitelisted feature toggles when known and unknown values are mixed', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}=unknown-feature,${reliableWebsocketConnectionFeatureToggleName}`,
     );
@@ -84,7 +93,7 @@ describe('startupFeatureToggles', function () {
     expect(startupFeatureToggles.getEnabledFeatureToggleNames()).not.toContain('unknown-feature');
   });
 
-  it('trims whitespace around feature toggle names', function () {
+  it('trims whitespace around feature toggle names', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}= ${reliableWebsocketConnectionFeatureToggleName} `,
     );
@@ -92,7 +101,7 @@ describe('startupFeatureToggles', function () {
     expect(startupFeatureToggles.isFeatureToggleEnabled(reliableWebsocketConnectionFeatureToggleName)).toBe(true);
   });
 
-  it('deduplicates duplicated feature toggles', function () {
+  it('deduplicates duplicated feature toggles', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}=${reliableWebsocketConnectionFeatureToggleName},${reliableWebsocketConnectionFeatureToggleName}`,
     );
@@ -101,7 +110,7 @@ describe('startupFeatureToggles', function () {
     expect(startupFeatureToggles.getEnabledFeatureToggleNames()).toEqual([reliableWebsocketConnectionFeatureToggleName]);
   });
 
-  it('ignores empty list entries in the feature toggle query parameter', function () {
+  it('ignores empty list entries in the feature toggle query parameter', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}=,${reliableWebsocketConnectionFeatureToggleName},,`,
     );
@@ -110,7 +119,7 @@ describe('startupFeatureToggles', function () {
     expect(startupFeatureToggles.getEnabledFeatureToggleNames()).toEqual([reliableWebsocketConnectionFeatureToggleName]);
   });
 
-  it('treats feature toggle names as case-sensitive', function () {
+  it('treats feature toggle names as case-sensitive', () => {
     const uppercaseFeatureToggleName = reliableWebsocketConnectionFeatureToggleName.toUpperCase();
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}=${uppercaseFeatureToggleName}`,
@@ -122,7 +131,7 @@ describe('startupFeatureToggles', function () {
     expect(startupFeatureToggles.getEnabledFeatureToggleNames()).not.toContain(uppercaseFeatureToggleName);
   });
 
-  it('contains only whitelisted values in allowedStartupFeatureToggleNames', function () {
+  it('contains only whitelisted values in allowedStartupFeatureToggleNames', () => {
     expect(allowedStartupFeatureToggleNames).toEqual([
       reliableWebsocketConnectionFeatureToggleName,
       incrementalHttpRetryBackoffFeatureToggleName,
@@ -130,11 +139,11 @@ describe('startupFeatureToggles', function () {
     ]);
   });
 
-  it('requires a dedicated existence test for every startup feature toggle name', function () {
+  it('requires a dedicated existence test for every startup feature toggle name', () => {
     expect(featureToggleNamesWithDedicatedExistenceTests).toEqual(startupFeatureToggleNames);
   });
 
-  it('does not expose mutable enabled toggle state', function () {
+  it('does not expose mutable enabled toggle state', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}=${reliableWebsocketConnectionFeatureToggleName}`,
     );


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Keep the startup feature toggle tests in sync with the canonical URL flag list. This fails when a new URL-based startup flag is added without adding a dedicated existence test.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
