### PR TITLE
fix(webapp): bump lexical and fix preview-off serialization [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/parseMentions.test.ts
+++ b/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/parseMentions.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {$createParagraphNode, $createTextNode, $getRoot, createEditor} from 'lexical';
+
+import {User} from 'Repositories/entity/User';
+
+import {$createMentionNode, MentionNode} from '../nodes/MentionNode';
+
+import {parseMentions} from './parseMentions';
+import {serializeMessage} from './serializeMessage';
+
+describe('parseMentions', () => {
+  it('keeps multiline mention offsets aligned with preview-off serialization', () => {
+    const editor = createEditor({nodes: [MentionNode]});
+
+    editor.update(
+      () => {
+        const root = $getRoot();
+
+        const firstParagraph = $createParagraphNode();
+        firstParagraph.append($createTextNode('hello '), $createMentionNode('@', 'Alice'));
+
+        const secondParagraph = $createParagraphNode();
+        secondParagraph.append($createTextNode('https://wire.com/'));
+
+        root.append(firstParagraph, secondParagraph);
+      },
+      {discrete: true},
+    );
+
+    const user = new User('11111111-1111-4111-8111-111111111111', 'wire.test');
+    user.name('Alice');
+
+    const serializedMessage = editor.getEditorState().read(() => serializeMessage(false));
+    const mentions = parseMentions(editor, serializedMessage, [user]);
+
+    expect(serializedMessage).toBe('hello @Alice\nhttps://wire.com/');
+    expect(mentions).toHaveLength(1);
+    expect(mentions[0].startIndex).toBe(6);
+    expect(mentions[0].length).toBe(6);
+    expect(mentions[0].userId).toBe('11111111-1111-4111-8111-111111111111');
+    expect(mentions[0].domain).toBe('wire.test');
+  });
+
+  it('keeps mention offsets aligned after an intentional empty line', () => {
+    const editor = createEditor({nodes: [MentionNode]});
+
+    editor.update(
+      () => {
+        const root = $getRoot();
+
+        const firstParagraph = $createParagraphNode();
+        firstParagraph.append($createTextNode('first line'));
+
+        const emptyParagraph = $createParagraphNode();
+
+        const thirdParagraph = $createParagraphNode();
+        thirdParagraph.append($createMentionNode('@', 'Alice'));
+
+        root.append(firstParagraph, emptyParagraph, thirdParagraph);
+      },
+      {discrete: true},
+    );
+
+    const user = new User('11111111-1111-4111-8111-111111111111', 'wire.test');
+    user.name('Alice');
+
+    const serializedMessage = editor.getEditorState().read(() => serializeMessage(false));
+    const mentions = parseMentions(editor, serializedMessage, [user]);
+
+    expect(serializedMessage).toBe('first line\n\n@Alice');
+    expect(mentions).toHaveLength(1);
+    expect(mentions[0].startIndex).toBe(12);
+  });
+});

--- a/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/serializeMessage.test.ts
+++ b/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/serializeMessage.test.ts
@@ -22,16 +22,19 @@ import {$createParagraphNode, $createTextNode, $getRoot, createEditor} from 'lex
 import {serializeMessage} from './serializeMessage';
 
 describe('serializeMessage', () => {
-  const createEditorWithText = (text: string) => {
+  const createEditorWithParagraphs = (paragraphs: string[]) => {
     const editor = createEditor();
 
     editor.update(
       () => {
         const root = $getRoot();
-        const paragraph = $createParagraphNode();
 
-        paragraph.append($createTextNode(text));
-        root.append(paragraph);
+        paragraphs.forEach(text => {
+          const paragraph = $createParagraphNode();
+
+          paragraph.append($createTextNode(text));
+          root.append(paragraph);
+        });
       },
       {discrete: true},
     );
@@ -40,15 +43,31 @@ describe('serializeMessage', () => {
   };
 
   it('preserves raw markdown markers when preview is disabled', () => {
-    const editor = createEditorWithText('**bold** _italic_');
+    const editor = createEditorWithParagraphs(['**bold** _italic_']);
 
     const message = editor.getEditorState().read(() => serializeMessage(false));
 
     expect(message).toBe('**bold** _italic_');
   });
 
+  it('preserves a single line break between paragraphs when preview is disabled', () => {
+    const editor = createEditorWithParagraphs(['check this out', 'https://wire.com/']);
+
+    const message = editor.getEditorState().read(() => serializeMessage(false));
+
+    expect(message).toBe('check this out\nhttps://wire.com/');
+  });
+
+  it('preserves intentional empty lines when preview is disabled', () => {
+    const editor = createEditorWithParagraphs(['first line', '', 'third line']);
+
+    const message = editor.getEditorState().read(() => serializeMessage(false));
+
+    expect(message).toBe('first line\n\nthird line');
+  });
+
   it('uses Lexical markdown serialization when preview is enabled', () => {
-    const editor = createEditorWithText('**bold** _italic_');
+    const editor = createEditorWithParagraphs(['**bold** _italic_']);
 
     const message = editor.getEditorState().read(() => serializeMessage(true));
 

--- a/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/serializeMessage.ts
+++ b/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/serializeMessage.ts
@@ -24,7 +24,10 @@ import {markdownTransformers} from './markdownTransformers';
 
 export const serializeMessage = (showMarkdownPreview: boolean): string => {
   if (!showMarkdownPreview) {
-    return $getRoot().getTextContent();
+    return $getRoot()
+      .getChildren()
+      .map(node => node.getTextContent())
+      .join('\n');
   }
 
   return $convertToMarkdownString(markdownTransformers, undefined, true);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Upgrade Lexical to 0.41.0 and stop using Lexical markdown export when markdown preview is disabled.

This restores correct sending of raw markdown input, fixes extra blank lines in multiline messages, and keeps mention offsets aligned in preview-off mode.

Adds regression tests for serializer and multiline mention edge cases.

