### PR TITLE
fix: add a fallback if received DeviceStatus is string [WPB-23105]

### DIFF
--- a/apps/webapp/src/script/E2EIdentity/mlsStatus.ts
+++ b/apps/webapp/src/script/E2EIdentity/mlsStatus.ts
@@ -34,5 +34,7 @@ const statusMap: Record<DeviceStatus, MLSStatuses> = {
 };
 
 export const mapMLSStatus = (status?: DeviceStatus) => {
-  return !status ? MLSStatuses.NOT_ACTIVATED : statusMap[status];
+  return !status
+    ? MLSStatuses.NOT_ACTIVATED
+    : statusMap[status] || statusMap[DeviceStatus[status as unknown as keyof typeof DeviceStatus]];
 };

--- a/apps/webapp/src/script/E2EIdentity/mlsStatus.ts
+++ b/apps/webapp/src/script/E2EIdentity/mlsStatus.ts
@@ -33,10 +33,18 @@ const statusMap: Record<DeviceStatus, MLSStatuses> = {
   [DeviceStatus.Revoked]: MLSStatuses.REVOKED,
 };
 
-export const mapMLSStatus = (status?: DeviceStatus) => {
-  return !status
-    ? MLSStatuses.NOT_ACTIVATED
-    : statusMap[status] ||
-        // adding a fallback to handle potential string values coming from the API until all values are properly typed
-        statusMap[DeviceStatus[status as unknown as keyof typeof DeviceStatus]];
+/**
+ * Handles potential string values coming from the API until all values are properly typed.
+ * Maps a loosely typed status string to its corresponding DeviceStatus enum value.
+ */
+const resolveStatusFromStringValue = (status: DeviceStatus): MLSStatuses | undefined => {
+  const resolvedKey = DeviceStatus[status as unknown as keyof typeof DeviceStatus];
+  return statusMap[resolvedKey];
+};
+
+export const mapMLSStatus = (status?: DeviceStatus): MLSStatuses => {
+  if (!status) {
+    return MLSStatuses.NOT_ACTIVATED;
+  }
+  return statusMap[status] ?? resolveStatusFromStringValue(status);
 };

--- a/apps/webapp/src/script/E2EIdentity/mlsStatus.ts
+++ b/apps/webapp/src/script/E2EIdentity/mlsStatus.ts
@@ -36,5 +36,7 @@ const statusMap: Record<DeviceStatus, MLSStatuses> = {
 export const mapMLSStatus = (status?: DeviceStatus) => {
   return !status
     ? MLSStatuses.NOT_ACTIVATED
-    : statusMap[status] || statusMap[DeviceStatus[status as unknown as keyof typeof DeviceStatus]];
+    : statusMap[status] ||
+        // adding a fallback to handle potential string values coming from the API until all values are properly typed
+        statusMap[DeviceStatus[status as unknown as keyof typeof DeviceStatus]];
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23105" title="WPB-23105" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23105</a>  [Web] Certificate shown with red shield in devices page
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary


We have a mapping from [Device Status](https://wireapp.github.io/core-crypto/v9.0.0/typescript/enums/DeviceStatus.html) to localized string. The CC library is returning string instead of number.
Added a fallback to handle potential string values coming from the API until all values are properly typed.

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
