### PR TITLE
chore: enable unknown-typed catch bindings across TypeScript code [WPB-22420]

### DIFF
--- a/apps/server/routes/Root.ts
+++ b/apps/server/routes/Root.ts
@@ -40,7 +40,7 @@ async function addGeoIP(req: Request) {
     if (result) {
       countryCode = result.country?.iso_code ?? '';
     }
-  } catch (error) {
+  } catch (error: unknown) {
     // It's okay to go without a detected country.
   }
 

--- a/apps/webapp/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/apps/webapp/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -265,7 +265,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
       const oidcService = this.createOIDCService();
       try {
         return await oidcService.authenticate(keyAuth, challenge.url, silent);
-      } catch (error) {
+      } catch (error: unknown) {
         if (silent) {
           // if we attempted a silent login and it failed, we need to try again with a redirect
           return oidcService.authenticate(keyAuth, challenge.url, false);
@@ -335,7 +335,7 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
       }
 
       await this.showSuccessMessage(isCertificateRenewal);
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error('E2EI enrollment failed', error);
 
       setTimeout(removeCurrentModal, 0);

--- a/apps/webapp/src/script/E2EIdentity/OIDCService/OauthEncryptedStore.ts
+++ b/apps/webapp/src/script/E2EIdentity/OIDCService/OauthEncryptedStore.ts
@@ -42,7 +42,7 @@ export class EncryptedStorage {
       );
       const base64Value = Encoder.toBase64(encryptedValue).asString;
       window.localStorage.setItem(key, JSON.stringify({value: base64Value, iv: Array.from(iv)}));
-    } catch (error) {
+    } catch (error: unknown) {
       console.error(error);
       throw error;
     }

--- a/apps/webapp/src/script/auth/component/AccountForm.tsx
+++ b/apps/webapp/src/script/auth/component/AccountForm.tsx
@@ -146,7 +146,7 @@ const AccountFormComponent = ({
       }
 
       return onSubmit();
-    } catch (error) {
+    } catch (error: unknown) {
       const label = (error as BackendError)?.label;
       if (label) {
         switch (label) {

--- a/apps/webapp/src/script/auth/component/ClientItem.tsx
+++ b/apps/webapp/src/script/auth/component/ClientItem.tsx
@@ -39,6 +39,7 @@ import {
 import {isEnterKey} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
 import {splitFingerprint} from 'Util/StringUtil';
+import {isBackendError} from 'Util/TypePredicateUtil';
 
 import {ValidationError} from '../module/action/ValidationError';
 import {parseError, parseValidationErrors} from '../util/errorUtil';
@@ -153,8 +154,8 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
 
     return Promise.resolve()
       .then(() => onClientRemoval())
-      .catch(error => {
-        if (!error.label) {
+      .catch((error: unknown) => {
+        if (!isBackendError(error)) {
           throw error;
         }
       });
@@ -182,8 +183,8 @@ const ClientItem = ({selected, onClientRemoval, onClick, client, clientError, re
         }
       })
       .then(() => onClientRemoval(password))
-      .catch(error => {
-        if (error.label) {
+      .catch((error: unknown) => {
+        if (isBackendError(error)) {
           switch (error.label) {
             default: {
               const isValidationError = Object.values(ValidationError.ERROR).some(errorType =>

--- a/apps/webapp/src/script/auth/component/ClientList.tsx
+++ b/apps/webapp/src/script/auth/component/ClientList.tsx
@@ -92,7 +92,7 @@ const ClientListComponent = ({
       }
 
       return navigate(ROUTE.HISTORY_INFO);
-    } catch (error) {
+    } catch (error: unknown) {
       logger.error(error);
     } finally {
       setShowLoading(false);

--- a/apps/webapp/src/script/auth/module/action/AuthAction.ts
+++ b/apps/webapp/src/script/auth/module/action/AuthAction.ts
@@ -28,7 +28,7 @@ import type {TeamData} from '@wireapp/api-client/lib/team/';
 import {LowDiskSpaceError} from '@wireapp/store-engine/lib/engine/error';
 import {StatusCodes as HTTP_STATUS, StatusCodes} from 'http-status-codes';
 
-import {isBackendError} from 'Util/TypePredicateUtil';
+import {isAxiosError, isBackendError, toError} from 'Util/TypePredicateUtil';
 
 import {AuthActionCreator} from './creator/';
 import {LabeledError} from './LabeledError';
@@ -40,8 +40,8 @@ import type {LoginDataState, RegistrationDataState} from '../reducer/authReducer
 
 type LoginLifecycleFunction = (dispatch: ThunkDispatch, getState: () => RootState, global: Api) => Promise<void>;
 
-const isSystemKeychainAccessError = (error: any): error is Error => {
-  return error instanceof Error && error.message.includes('cryption is not available');
+const isSystemKeychainAccessError = (errorCandidate: unknown): errorCandidate is Error => {
+  return errorCandidate instanceof Error && errorCandidate.message.includes('cryption is not available');
 };
 
 export class AuthAction {
@@ -114,8 +114,8 @@ export class AuthAction {
           ),
         );
         dispatch(AuthActionCreator.successfulLogin());
-      } catch (error) {
-        if (error.label === BackendErrorLabel.TOO_MANY_CLIENTS) {
+      } catch (error: unknown) {
+        if (isBackendError(error) && error.label === BackendErrorLabel.TOO_MANY_CLIENTS) {
           dispatch(AuthActionCreator.successfulLogin());
         } else {
           if (error instanceof LowDiskSpaceError) {
@@ -124,7 +124,7 @@ export class AuthAction {
           if (isSystemKeychainAccessError(error)) {
             error = new LabeledError(LabeledError.GENERAL_ERRORS.SYSTEM_KEYCHAIN_ACCESS, error);
           }
-          dispatch(AuthActionCreator.failedLogin(error));
+          dispatch(AuthActionCreator.failedLogin(toError(error)));
         }
         throw error;
       }
@@ -138,8 +138,8 @@ export class AuthAction {
         const url = await apiClient.api.oauth.postOAuthCode(oauthBody);
         dispatch(AuthActionCreator.successfulSendOAuthCode());
         return url;
-      } catch (error) {
-        dispatch(AuthActionCreator.failedSendOAuthCode(error));
+      } catch (error: unknown) {
+        dispatch(AuthActionCreator.failedSendOAuthCode(toError(error)));
         throw error;
       }
     };
@@ -151,7 +151,7 @@ export class AuthAction {
       try {
         await apiClient.api.user.postVerificationCode(email, VerificationActionType.LOGIN);
         dispatch(AuthActionCreator.successfulSendTwoFactorCode());
-      } catch (error) {
+      } catch (error: unknown) {
         /**  The BE can respond quite restrictively to the send code request.
          * We don't want to block the user from logging in if they have already received a code in the last few minutes.
          * Any other error should still be thrown.
@@ -166,7 +166,7 @@ export class AuthAction {
         if (isBackendError(error) && error.label === BackendErrorLabel.BAD_REQUEST) {
           error = new BackendError(error.message, SyntheticErrorLabel.EMAIL_REQUIRED, StatusCodes.BAD_REQUEST);
         }
-        dispatch(AuthActionCreator.failedSendTwoFactorCode(error));
+        dispatch(AuthActionCreator.failedSendTwoFactorCode(toError(error)));
         throw error;
       }
     };
@@ -181,11 +181,11 @@ export class AuthAction {
         await dispatch(selfAction.fetchSelf());
         await dispatch(clientAction.doInitializeClient(clientType));
         dispatch(AuthActionCreator.successfulLogin());
-      } catch (error) {
+      } catch (error: unknown) {
         if (isBackendError(error) && error.label === BackendErrorLabel.TOO_MANY_CLIENTS) {
           dispatch(AuthActionCreator.successfulLogin());
         } else {
-          dispatch(AuthActionCreator.failedLogin(error));
+          dispatch(AuthActionCreator.failedLogin(toError(error)));
         }
         throw error;
       }
@@ -199,8 +199,8 @@ export class AuthAction {
         const teamData = await apiClient.api.teams.team.getTeam(teamId);
         dispatch(AuthActionCreator.successfulFetchTeam(teamData));
         return teamData;
-      } catch (error) {
-        dispatch(AuthActionCreator.failedFetchTeam(error));
+      } catch (error: unknown) {
+        dispatch(AuthActionCreator.failedFetchTeam(toError(error)));
         throw error;
       }
     };
@@ -213,8 +213,8 @@ export class AuthAction {
         const application = await apiClient.api.oauth.getClient(applicationId);
         dispatch(AuthActionCreator.successfulFetchOAuth(application));
         return application;
-      } catch (error) {
-        dispatch(AuthActionCreator.failedFetchOAuth(error));
+      } catch (error: unknown) {
+        dispatch(AuthActionCreator.failedFetchOAuth(toError(error)));
         throw error;
       }
     };
@@ -222,8 +222,8 @@ export class AuthAction {
 
   validateSSOCode = (code: string): ThunkAction => {
     return async (dispatch, getState, {apiClient}) => {
-      const mapError = (error: any) => {
-        const statusCode = error?.response?.status;
+      const mapError = (errorCandidate: unknown) => {
+        const statusCode = isAxiosError(errorCandidate) ? errorCandidate.response?.status : undefined;
         if (statusCode === HTTP_STATUS.NOT_FOUND) {
           return new BackendError('', BackendErrorLabel.NOT_FOUND, HTTP_STATUS.NOT_FOUND);
         }
@@ -235,7 +235,7 @@ export class AuthAction {
 
       try {
         return await apiClient.api.auth.headInitiateLogin(code);
-      } catch (error) {
+      } catch (error: unknown) {
         const mappedError = mapError(error);
         dispatch(AuthActionCreator.failedLogin(mappedError));
         throw mappedError;
@@ -292,8 +292,8 @@ export class AuthAction {
         await dispatch(selfAction.fetchSelf());
         await dispatch(clientAction.doInitializeClient(clientType, undefined, undefined, entropyData));
         dispatch(AuthActionCreator.successfulRegisterPersonal(registration));
-      } catch (error) {
-        dispatch(AuthActionCreator.failedRegisterPersonal(error));
+      } catch (error: unknown) {
+        dispatch(AuthActionCreator.failedRegisterPersonal(toError(error)));
         throw error;
       }
     };
@@ -322,8 +322,8 @@ export class AuthAction {
         await (clientType !== ClientType.NONE &&
           dispatch(clientAction.doInitializeClient(clientType, undefined, undefined, entropyData)));
         dispatch(AuthActionCreator.successfulRegisterWireless(registrationData));
-      } catch (error) {
-        dispatch(AuthActionCreator.failedRegisterWireless(error));
+      } catch (error: unknown) {
+        dispatch(AuthActionCreator.failedRegisterWireless(toError(error)));
         throw error;
       }
     };
@@ -348,13 +348,13 @@ export class AuthAction {
 
         await dispatch(selfAction.fetchSelf());
         dispatch(AuthActionCreator.successfulRefresh());
-      } catch (error) {
+      } catch (error: unknown) {
         const doLogout = options.shouldValidateLocalClient ? dispatch(authAction.doLogout()) : Promise.resolve();
         const deleteClientType = options.isImmediateLogin
           ? dispatch(localStorageAction.deleteLocalStorage(LocalStorageKey.AUTH.PERSIST))
           : Promise.resolve();
         await Promise.all([doLogout, deleteClientType]);
-        dispatch(AuthActionCreator.failedRefresh(error));
+        dispatch(AuthActionCreator.failedRefresh(toError(error)));
       }
     };
   };
@@ -371,8 +371,8 @@ export class AuthAction {
       try {
         const ssoSettings = await apiClient.api.account.getSSOSettings();
         dispatch(AuthActionCreator.successfulGetSSOSettings(ssoSettings));
-      } catch (error) {
-        dispatch(AuthActionCreator.failedGetSSOSettings(error));
+      } catch (error: unknown) {
+        dispatch(AuthActionCreator.failedGetSSOSettings(toError(error)));
       }
     };
   };
@@ -382,8 +382,8 @@ export class AuthAction {
       try {
         await core.logout();
         dispatch(AuthActionCreator.successfulLogout());
-      } catch (error) {
-        dispatch(AuthActionCreator.failedLogout(error));
+      } catch (error: unknown) {
+        dispatch(AuthActionCreator.failedLogout(toError(error)));
       }
     };
   };
@@ -393,8 +393,8 @@ export class AuthAction {
       try {
         await core.logout();
         dispatch(AuthActionCreator.successfulSilentLogout());
-      } catch (error) {
-        dispatch(AuthActionCreator.failedLogout(error));
+      } catch (error: unknown) {
+        dispatch(AuthActionCreator.failedSilentLogout(toError(error)));
       }
     };
   };

--- a/apps/webapp/src/script/auth/module/action/ClientAction.ts
+++ b/apps/webapp/src/script/auth/module/action/ClientAction.ts
@@ -24,6 +24,7 @@ import {ClientInfo} from '@wireapp/core/lib/client/';
 import {Runtime} from '@wireapp/commons';
 
 import {getClientMLSConfig} from 'Repositories/client/clientMLSConfig';
+import {toError} from 'Util/TypePredicateUtil';
 
 import {ClientActionCreator} from './creator/';
 
@@ -38,8 +39,8 @@ export class ClientAction {
         const clients = await apiClient.api.client.getClients();
         dispatch(ClientActionCreator.successfulGetAllClients(clients));
         return clients;
-      } catch (error) {
-        dispatch(ClientActionCreator.failedGetAllClients(error));
+      } catch (error: unknown) {
+        dispatch(ClientActionCreator.failedGetAllClients(toError(error)));
         throw error;
       }
     };
@@ -51,8 +52,8 @@ export class ClientAction {
       try {
         await apiClient.api.client.deleteClient(clientId, password);
         dispatch(ClientActionCreator.successfulRemoveClient(clientId));
-      } catch (error) {
-        dispatch(ClientActionCreator.failedRemoveClient(error));
+      } catch (error: unknown) {
+        dispatch(ClientActionCreator.failedRemoveClient(toError(error)));
         throw error;
       }
     };

--- a/apps/webapp/src/script/auth/module/action/ConversationAction.ts
+++ b/apps/webapp/src/script/auth/module/action/ConversationAction.ts
@@ -20,9 +20,8 @@
 import type {ConversationJoinData} from '@wireapp/api-client/lib/conversation/data/ConversationJoinData';
 import type {ConversationEvent} from '@wireapp/api-client/lib/event/';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
-import {isError} from 'underscore';
 
-import {isBackendError} from 'Util/TypePredicateUtil';
+import {isBackendError, toError} from 'Util/TypePredicateUtil';
 
 import {ConversationActionCreator} from './creator/';
 
@@ -35,10 +34,8 @@ export class ConversationAction {
       try {
         await apiClient.api.conversation.postConversationCodeCheck({code, key, uri});
         dispatch(ConversationActionCreator.successfulConversationCodeCheck());
-      } catch (error) {
-        if (isError(error)) {
-          dispatch(ConversationActionCreator.failedConversationCodeCheck(error));
-        }
+      } catch (error: unknown) {
+        dispatch(ConversationActionCreator.failedConversationCodeCheck(toError(error)));
         throw error;
       }
     };
@@ -56,7 +53,7 @@ export class ConversationAction {
         const conversationEvent = await apiClient.api.conversation.postJoinByCode({code, key, uri, password});
         dispatch(ConversationActionCreator.successfulJoinConversationByCode(conversationEvent));
         return conversationEvent;
-      } catch (error) {
+      } catch (error: unknown) {
         /*
           Backend does return a password-invalid error even though we have not submitted any password
           expected: passsword-required.
@@ -71,7 +68,7 @@ export class ConversationAction {
           );
           throw error;
         }
-        dispatch(ConversationActionCreator.failedJoinConversationByCode(error));
+        dispatch(ConversationActionCreator.failedJoinConversationByCode(toError(error)));
         throw error;
       }
     };
@@ -84,7 +81,7 @@ export class ConversationAction {
         const conversationInfo = await apiClient.api.conversation.getJoinByCode({code, key});
         dispatch(ConversationActionCreator.successfulConversationCodeGetInfo(conversationInfo));
         return conversationInfo;
-      } catch (error) {
+      } catch (error: unknown) {
         if (isBackendError(error)) {
           dispatch(ConversationActionCreator.failedConversationCodeGetInfo(error));
           return undefined;

--- a/apps/webapp/src/script/auth/module/action/InvitationAction.ts
+++ b/apps/webapp/src/script/auth/module/action/InvitationAction.ts
@@ -22,6 +22,8 @@ import type {NewTeamInvitation} from '@wireapp/api-client/lib/team/';
 import {Role} from '@wireapp/api-client/lib/team/member/';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 
+import {toError} from 'Util/TypePredicateUtil';
+
 import {InvitationActionCreator} from './creator/';
 
 import type {ThunkAction} from '../reducer';
@@ -59,8 +61,8 @@ export class InvitationAction {
       try {
         const createdInvite = await apiClient.api.teams.invitation.postInvitation(teamId, newInvite);
         dispatch(InvitationActionCreator.successfulAddInvite(createdInvite));
-      } catch (error) {
-        dispatch(InvitationActionCreator.failedAddInvite(error));
+      } catch (error: unknown) {
+        dispatch(InvitationActionCreator.failedAddInvite(toError(error)));
         throw error;
       }
     };

--- a/apps/webapp/src/script/auth/module/action/LocalStorageAction.ts
+++ b/apps/webapp/src/script/auth/module/action/LocalStorageAction.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import {toError} from 'Util/TypePredicateUtil';
+
 import {LocalStorageActionCreator} from './creator/';
 
 import type {ThunkAction} from '../reducer';
@@ -36,8 +38,8 @@ export class LocalStorageAction {
       try {
         localStorage.setItem(key, JSON.stringify({data: value}));
         dispatch(LocalStorageActionCreator.successfulLocalStorageSet(key, value));
-      } catch (error) {
-        dispatch(LocalStorageActionCreator.failedLocalStorageSet(error));
+      } catch (error: unknown) {
+        dispatch(LocalStorageActionCreator.failedLocalStorageSet(toError(error)));
         throw error;
       }
     };
@@ -51,8 +53,8 @@ export class LocalStorageAction {
         data = JSON.parse(localStorage.getItem(key) ?? '{}').data;
         dispatch(LocalStorageActionCreator.successfulLocalStorageGet(key, data));
         return data;
-      } catch (error) {
-        dispatch(LocalStorageActionCreator.failedLocalStorageGet(error));
+      } catch (error: unknown) {
+        dispatch(LocalStorageActionCreator.failedLocalStorageGet(toError(error)));
         throw error;
       }
     };
@@ -64,8 +66,8 @@ export class LocalStorageAction {
       try {
         localStorage.removeItem(key);
         dispatch(LocalStorageActionCreator.successfulLocalStorageDelete(key));
-      } catch (error) {
-        dispatch(LocalStorageActionCreator.failedLocalStorageDelete(error));
+      } catch (error: unknown) {
+        dispatch(LocalStorageActionCreator.failedLocalStorageDelete(toError(error)));
         throw error;
       }
     };

--- a/apps/webapp/src/script/auth/module/action/SelfAction.test.ts
+++ b/apps/webapp/src/script/auth/module/action/SelfAction.test.ts
@@ -136,7 +136,7 @@ describe('SelfAction', () => {
     try {
       await store.dispatch(actionRoot.selfAction.doCheckPasswordState());
       fail();
-    } catch (backendError) {
+    } catch (backendError: unknown) {
       // TODO: Check for thrown error with jest error helpers (`await expect(Promise).rejects.toThrow()`)
       // eslint-disable-next-line jest/no-conditional-expect
       expect(store.getActions()).toEqual([

--- a/apps/webapp/src/script/auth/module/action/SelfAction.ts
+++ b/apps/webapp/src/script/auth/module/action/SelfAction.ts
@@ -22,6 +22,7 @@ import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 
 import {Environment} from 'Util/Environment';
 import {getLogger} from 'Util/Logger';
+import {isAxiosError, toError} from 'Util/TypePredicateUtil';
 
 import {SelfActionCreator} from './creator/';
 
@@ -38,8 +39,8 @@ export class SelfAction {
         await dispatch(selfAction.doCheckPasswordState());
         dispatch(SelfActionCreator.successfulFetchSelf(selfUser));
         return selfUser;
-      } catch (error) {
-        dispatch(SelfActionCreator.failedFetchSelf(error));
+      } catch (error: unknown) {
+        dispatch(SelfActionCreator.failedFetchSelf(toError(error)));
         throw error;
       }
     };
@@ -52,8 +53,8 @@ export class SelfAction {
         await apiClient.api.self.putHandle({handle: handle.trim().toLowerCase()});
         const selfUser = await dispatch(selfAction.fetchSelf());
         dispatch(SelfActionCreator.successfulSetHandle(selfUser));
-      } catch (error) {
-        dispatch(SelfActionCreator.failedSetHandle(error));
+      } catch (error: unknown) {
+        dispatch(SelfActionCreator.failedSetHandle(toError(error)));
         throw error;
       }
     };
@@ -69,8 +70,8 @@ export class SelfAction {
       try {
         const {results} = await apiClient.api.self.getConsents();
         dispatch(SelfActionCreator.successfulGetConsents(results));
-      } catch (error) {
-        dispatch(SelfActionCreator.failedGetConsents(error));
+      } catch (error: unknown) {
+        dispatch(SelfActionCreator.failedGetConsents(toError(error)));
         throw error;
       }
     };
@@ -91,8 +92,8 @@ export class SelfAction {
       try {
         await apiClient.api.self.putConsent(consent);
         dispatch(SelfActionCreator.successfulSetConsent(consent));
-      } catch (error) {
-        dispatch(SelfActionCreator.failedSetConsent(error));
+      } catch (error: unknown) {
+        dispatch(SelfActionCreator.failedSetConsent(toError(error)));
         throw error;
       }
     };
@@ -104,8 +105,8 @@ export class SelfAction {
       try {
         await apiClient.api.self.putPassword(changePassword);
         dispatch(SelfActionCreator.successfulSetSelfPassword());
-      } catch (error) {
-        dispatch(SelfActionCreator.failedSetSelfPassword(error));
+      } catch (error: unknown) {
+        dispatch(SelfActionCreator.failedSetSelfPassword(toError(error)));
         throw error;
       }
     };
@@ -117,8 +118,8 @@ export class SelfAction {
       try {
         await apiClient.api.auth.putEmail({email});
         dispatch(SelfActionCreator.successfulSetSelfEmail(email));
-      } catch (error) {
-        dispatch(SelfActionCreator.failedSetSelfEmail(error));
+      } catch (error: unknown) {
+        dispatch(SelfActionCreator.failedSetSelfEmail(toError(error)));
         throw error;
       }
     };
@@ -131,12 +132,12 @@ export class SelfAction {
         await apiClient.api.self.headPassword();
         dispatch(SelfActionCreator.successfulSetPasswordState({hasPassword: true}));
         return true;
-      } catch (error) {
-        if (error.response?.status === HTTP_STATUS.NOT_FOUND) {
+      } catch (error: unknown) {
+        if (isAxiosError(error) && error.response?.status === HTTP_STATUS.NOT_FOUND) {
           dispatch(SelfActionCreator.successfulSetPasswordState({hasPassword: false}));
           return false;
         }
-        dispatch(SelfActionCreator.failedSetPasswordState(error));
+        dispatch(SelfActionCreator.failedSetPasswordState(toError(error)));
         throw error;
       }
     };

--- a/apps/webapp/src/script/auth/module/action/UserAction.ts
+++ b/apps/webapp/src/script/auth/module/action/UserAction.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import {toError} from 'Util/TypePredicateUtil';
+
 import {UserActionCreator} from './creator/';
 
 import {currentLanguage} from '../../localeConfig';
@@ -36,8 +38,8 @@ export class UserAction {
       try {
         await apiClient.api.user.postActivationCode({email, locale: currentLanguage()});
         dispatch(UserActionCreator.successfulSendActivationCode());
-      } catch (error) {
-        dispatch(UserActionCreator.failedSendActivationCode(error));
+      } catch (error: unknown) {
+        dispatch(UserActionCreator.failedSendActivationCode(toError(error)));
         throw error;
       }
     };

--- a/apps/webapp/src/script/auth/page/ClientManager.tsx
+++ b/apps/webapp/src/script/auth/page/ClientManager.tsx
@@ -68,7 +68,7 @@ const ClientManagerComponent = ({doGetAllClients, doLogout}: Props & ConnectedPr
   const logout = async () => {
     try {
       await doLogout();
-    } catch (error) {
+    } catch (error: unknown) {
       // ignore errors on logout
     }
   };

--- a/apps/webapp/src/script/auth/page/ConversationJoin.tsx
+++ b/apps/webapp/src/script/auth/page/ConversationJoin.tsx
@@ -28,6 +28,7 @@ import {UrlUtil} from '@wireapp/commons';
 import {Column, Columns, H1, Muted} from '@wireapp/react-ui-kit';
 
 import {t} from 'Util/LocalizerUtil';
+import {isBackendError} from 'Util/TypePredicateUtil';
 import {noop} from 'Util/util';
 
 import {GuestLoginColumn, IsLoggedInColumn, Separator} from './ConversationJoinComponents';
@@ -112,7 +113,7 @@ const ConversationJoinComponent = ({
         await doGetAllClients();
       })
       .catch(error => {
-        if (error.label === BackendErrorLabel.INVALID_CREDENTIALS) {
+        if (isBackendError(error) && error.label === BackendErrorLabel.INVALID_CREDENTIALS) {
           return;
         }
         setIsValidLink(false);
@@ -143,9 +144,9 @@ const ConversationJoinComponent = ({
       await setLastEventDate(conversationEvent?.time ? new Date(conversationEvent.time) : new Date());
 
       routeToApp(conversationEvent?.conversation, conversationEvent?.qualified_conversation?.domain ?? '');
-    } catch (error) {
+    } catch (error: unknown) {
       setIsSubmitingName(false);
-      if (error.label === BackendErrorLabel.INVALID_CONVERSATION_PASSWORD) {
+      if (isBackendError(error) && error.label === BackendErrorLabel.INVALID_CONVERSATION_PASSWORD) {
         setIsJoinGuestLinkPasswordModalOpen(true);
         return;
       }
@@ -178,9 +179,9 @@ const ConversationJoinComponent = ({
         entropyData,
       );
       await getConversationInfoAndJoin(password);
-    } catch (error) {
+    } catch (error: unknown) {
       setIsSubmitingName(false);
-      if (error.label) {
+      if (isBackendError(error)) {
         switch (error.label) {
           default: {
             const isValidationError = Object.values(ValidationError.ERROR).some(errorType =>

--- a/apps/webapp/src/script/auth/page/Login.tsx
+++ b/apps/webapp/src/script/auth/page/Login.tsx
@@ -219,7 +219,7 @@ const LoginComponent = ({
         return navigate(`${ROUTE.AUTHORIZE}/${queryString}`);
       }
       return navigate(ROUTE.HISTORY_INFO);
-    } catch (error) {
+    } catch (error: unknown) {
       logger.error('Unable to login immediately', error);
       setShowEntropyForm(false);
     }
@@ -252,7 +252,7 @@ const LoginComponent = ({
       if (hasKeyAndCode) {
         try {
           await doLoginAndJoin(login, conversationKey, conversationCode, undefined, getEntropy, conversationPassword);
-        } catch (error) {
+        } catch (error: unknown) {
           if (isBackendError(error) && error.label === BackendErrorLabel.INVALID_CONVERSATION_PASSWORD) {
             await resetAuthError();
             setConversationSubmitData(formLoginData);
@@ -277,7 +277,7 @@ const LoginComponent = ({
       }
 
       return navigate(ROUTE.HISTORY_INFO);
-    } catch (error) {
+    } catch (error: unknown) {
       if (isBackendError(error)) {
         switch (error.label) {
           case BackendErrorLabel.INVALID_CONVERSATION_PASSWORD: {
@@ -342,7 +342,7 @@ const LoginComponent = ({
       if (email) {
         await doSendTwoFactorCode(email);
       }
-    } catch (error) {
+    } catch (error: unknown) {
       setTwoFactorSubmitError(
         new BackendError('', SyntheticErrorLabel.TOO_MANY_REQUESTS, StatusCodes.TOO_MANY_REQUESTS),
       );

--- a/apps/webapp/src/script/auth/page/OAuthPermissions.tsx
+++ b/apps/webapp/src/script/auth/page/OAuthPermissions.tsx
@@ -44,6 +44,7 @@ import {AssetRemoteData} from 'Repositories/assets/AssetRemoteData';
 import {AssetRepository} from 'Repositories/assets/AssetRepository';
 import {handleEscDown, handleKeyDown, KEY} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
+import {toError} from 'Util/TypePredicateUtil';
 import {loadDataUrl} from 'Util/util';
 
 import {
@@ -107,7 +108,7 @@ const OAuthPermissionsComponent = ({
     try {
       const url = await postOauthCode({...oauthParams, scope: cleanedScopes});
       window.location.replace(url);
-    } catch (error) {
+    } catch (error: unknown) {
       console.error(error);
     }
   };
@@ -135,12 +136,12 @@ const OAuthPermissionsComponent = ({
         throw Error('OAuth client not found');
       }
     };
-    getUserData().catch(error => {
+    getUserData().catch((error: unknown) => {
       console.error(error);
-      if (error.message === 'OAuth client not found') {
+      if (toError(error).message === 'OAuth client not found') {
         window.location.replace('/');
       } else {
-        doLogout().catch(error => {
+        doLogout().catch((error: unknown) => {
           console.error(error);
         });
       }

--- a/apps/webapp/src/script/auth/page/SetEmail.tsx
+++ b/apps/webapp/src/script/auth/page/SetEmail.tsx
@@ -26,6 +26,7 @@ import {AnyAction, Dispatch} from 'redux';
 import {Button, ContainerXS, Form, H1, Input} from '@wireapp/react-ui-kit';
 
 import {t} from 'Util/LocalizerUtil';
+import {toError} from 'Util/TypePredicateUtil';
 
 import {Page} from './Page';
 
@@ -45,7 +46,7 @@ const SetEmailComponent = ({
   isFetching,
 }: Props & ConnectedProps & DispatchProps) => {
   const emailInput = useRef<HTMLInputElement>();
-  const [error, setError] = useState();
+  const [error, setError] = useState<Error>();
   const [isValidEmail, setIsValidEmail] = useState(true);
   const [email, setEmail] = useState('');
   const navigate = useNavigate();
@@ -67,8 +68,8 @@ const SetEmailComponent = ({
       }
       await doSetEmail(currentInputNode.value);
       navigate(ROUTE.VERIFY_EMAIL_LINK);
-    } catch (error) {
-      setError(error);
+    } catch (error: unknown) {
+      setError(toError(error));
     }
   };
 

--- a/apps/webapp/src/script/auth/page/SetEntropyPage.tsx
+++ b/apps/webapp/src/script/auth/page/SetEntropyPage.tsx
@@ -40,7 +40,7 @@ const SetEntropyPageComponent = ({pushEntropyData}: Props & ConnectedProps & Dis
     try {
       await pushEntropyData(entropyData);
       navigate(ROUTE.VERIFY_EMAIL_CODE);
-    } catch (error) {
+    } catch (error: unknown) {
       console.warn(error);
     }
   };

--- a/apps/webapp/src/script/auth/page/SetHandle.tsx
+++ b/apps/webapp/src/script/auth/page/SetHandle.tsx
@@ -81,7 +81,7 @@ const SetHandleComponent = ({
         const suggestions = createSuggestions(name);
         const handle = await checkHandles(suggestions);
         setHandle(handle);
-      } catch (error) {
+      } catch (error: unknown) {
         setError(error);
       }
     })();
@@ -101,7 +101,7 @@ const SetHandleComponent = ({
       } else {
         navigate(ROUTE.SUCCESS);
       }
-    } catch (error) {
+    } catch (error: unknown) {
       if (isBackendError(error) && error.label === BackendErrorLabel.INVALID_HANDLE && handle.trim().length < 2) {
         error.label = SyntheticErrorLabel.HANDLE_TOO_SHORT;
       }

--- a/apps/webapp/src/script/auth/page/SetPassword.tsx
+++ b/apps/webapp/src/script/auth/page/SetPassword.tsx
@@ -27,6 +27,7 @@ import {ValidationUtil} from '@wireapp/commons';
 import {Button, ContainerXS, Form, H1, Input, Small} from '@wireapp/react-ui-kit';
 
 import {t} from 'Util/LocalizerUtil';
+import {toError} from 'Util/TypePredicateUtil';
 
 import {Page} from './Page';
 
@@ -47,7 +48,7 @@ const SetPasswordComponent = ({
   isFetching,
 }: Props & ConnectedProps & DispatchProps) => {
   const passwordInput = useRef<HTMLInputElement>();
-  const [error, setError] = useState();
+  const [error, setError] = useState<Error>();
   const [isValidPassword, setIsValidPassword] = useState(true);
   const [password, setPassword] = useState('');
   const navigate = useNavigate();
@@ -68,8 +69,8 @@ const SetPasswordComponent = ({
       }
       await doSetPassword({new_password: password});
       navigate(ROUTE.SET_HANDLE);
-    } catch (error) {
-      setError(error);
+    } catch (error: unknown) {
+      setError(toError(error));
     }
   };
 

--- a/apps/webapp/src/script/auth/page/SingleSignOnForm.tsx
+++ b/apps/webapp/src/script/auth/page/SingleSignOnForm.tsx
@@ -248,7 +248,7 @@ const SingleSignOnFormComponent = ({
       } else {
         await loginWithSSO(codeOrMail, password);
       }
-    } catch (error) {
+    } catch (error: unknown) {
       setIsLoading(false);
       if (isBackendError(error)) {
         switch (error.label) {

--- a/apps/webapp/src/script/auth/page/VerifyEmailCode.tsx
+++ b/apps/webapp/src/script/auth/page/VerifyEmailCode.tsx
@@ -62,7 +62,7 @@ const VerifyEmailCodeComponent = ({
       };
       await doRegisterPersonal(validAccount, entropyData);
       navigate(ROUTE.SET_HANDLE, {state: {isNewAccount: true}});
-    } catch (error) {
+    } catch (error: unknown) {
       trackTelemetryPageView(PageView.ACCOUNT_VERIFICATION_FAILED_SCREEN_2_5);
       logger.error('Failed to create personal account', error);
     }
@@ -76,7 +76,7 @@ const VerifyEmailCodeComponent = ({
 
     try {
       await doSendActivationCode(account.email);
-    } catch (error) {
+    } catch (error: unknown) {
       logger.error('Failed to send email code', error);
     }
   };

--- a/apps/webapp/src/script/browser/CheckBrowser.ts
+++ b/apps/webapp/src/script/browser/CheckBrowser.ts
@@ -85,7 +85,7 @@ const supportsIndexDB = (): Promise<boolean> =>
 
     try {
       dbOpenRequest = window.indexedDB.open('test');
-    } catch (error) {
+    } catch (error: unknown) {
       return resolve(false);
     }
 

--- a/apps/webapp/src/script/components/Avatar/AvatarImage.tsx
+++ b/apps/webapp/src/script/components/Avatar/AvatarImage.tsx
@@ -76,7 +76,7 @@ const AvatarImage: React.FunctionComponent<AvatarImageProps> = ({
               setAvatarImage(url);
             }
             setAvatarLoadingBlocked(false);
-          } catch (error) {
+          } catch (error: unknown) {
             console.warn('Failed to load avatar picture.', error);
           }
         } else {

--- a/apps/webapp/src/script/components/Cells/common/useCellPublicLink/useCellPublicLink.ts
+++ b/apps/webapp/src/script/components/Cells/common/useCellPublicLink/useCellPublicLink.ts
@@ -74,7 +74,7 @@ export const useCellPublicLink = ({
       setPublicLink(newLink);
       setLinkData(link);
       setStatus('success');
-    } catch (err) {
+    } catch (err: unknown) {
       setStatus('error');
       setPublicLink(undefined);
       createdLinkUuid.current = null;
@@ -105,7 +105,7 @@ export const useCellPublicLink = ({
       setLinkData(link);
       fetchedLinkId.current = linkId;
       setStatus('success');
-    } catch (err) {
+    } catch (err: unknown) {
       setStatus('error');
       setPublicLink(undefined);
     }
@@ -129,7 +129,7 @@ export const useCellPublicLink = ({
       await cellsRepository.deletePublicLink({uuid: linkUuid});
       setPublicLink(undefined);
       createdLinkUuid.current = null; // Clear after successful deletion
-    } catch (err) {
+    } catch (err: unknown) {
       setStatus('error');
     }
     // cellsRepository is not a dependency because it's a singleton
@@ -201,7 +201,7 @@ export const useCellPublicLink = ({
         }
 
         setStatus('success');
-      } catch (err) {
+      } catch (err: unknown) {
         setStatus('error');
         throw err;
       }

--- a/apps/webapp/src/script/components/CellsGlobalView/CellsHeader/CellsFilters/CellsFiltersMenu/useGetAllTags/useGetAllTags.ts
+++ b/apps/webapp/src/script/components/CellsGlobalView/CellsHeader/CellsFilters/CellsFiltersMenu/useGetAllTags/useGetAllTags.ts
@@ -32,7 +32,7 @@ export const useGetAllTags = ({cellsRepository}: {cellsRepository: CellsReposito
       const tags = await cellsRepository.getAllTags();
       const filteredTags = tags.Values?.map(tag => tag).filter(Boolean) ?? [];
       setTags(filteredTags);
-    } catch (error) {
+    } catch (error: unknown) {
       setError(error instanceof Error ? error : new Error('Unknown error'));
     } finally {
       setIsLoading(false);

--- a/apps/webapp/src/script/components/CellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.ts
+++ b/apps/webapp/src/script/components/CellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.ts
@@ -104,7 +104,7 @@ export const useSearchCellsNodes = ({
         }
 
         setStatus('success');
-      } catch (error) {
+      } catch (error: unknown) {
         // If the user isn't part of any cells-enabled conversations, the user will not exist in Cells database
         // the search will return a 401 error
         const hasCellsConversations = conversationRepository.getAllCellEnabledGroupConversations().length > 0;

--- a/apps/webapp/src/script/components/ConfigToolbar/ConfigToolbar.tsx
+++ b/apps/webapp/src/script/components/ConfigToolbar/ConfigToolbar.tsx
@@ -90,7 +90,7 @@ export function ConfigToolbar() {
           quoteEntity: undefined,
         });
         messageCountRef.current++;
-      } catch (error) {
+      } catch (error: unknown) {
         console.error('Error sending message:', error);
       }
 
@@ -278,7 +278,7 @@ export function ConfigToolbar() {
     setIsResettingMLSConversation(true);
     try {
       await window.wire?.app?.debug?.resetMLSConversation();
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('Error resetting MLS conversation:', error);
     } finally {
       setIsResettingMLSConversation(false);

--- a/apps/webapp/src/script/components/Conversation/Conversation.tsx
+++ b/apps/webapp/src/script/components/Conversation/Conversation.tsx
@@ -321,7 +321,7 @@ export const Conversation = ({
         try {
           const userEntity = await repositories.user.getUserById({domain: domain || '', id: userId});
           showUserDetails(userEntity);
-        } catch (error) {
+        } catch (error: unknown) {
           if (error instanceof UserError && error.type !== UserError.TYPE.USER_NOT_FOUND) {
             throw error;
           }
@@ -390,7 +390,7 @@ export const Conversation = ({
         );
         resetProgress();
       }
-    } catch (error) {
+    } catch (error: unknown) {
       messageListLogger.warn('Error while trying to reset session', error);
       resetProgress();
     }

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableRowOptions/CellsMoveNodeModal/useGetCellsFolders/useGetCellsFolders.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableRowOptions/CellsMoveNodeModal/useGetCellsFolders/useGetCellsFolders.ts
@@ -80,7 +80,7 @@ export const useGetCellsFolders = ({
 
       setFolders(filteredFolders);
       setStatus('success');
-    } catch (error) {
+    } catch (error: unknown) {
       setFolders([]);
       setStatus('error');
       throw error;

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableRowOptions/CellsMoveNodeModal/useMoveCellNode/useMoveCellsNode.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableRowOptions/CellsMoveNodeModal/useMoveCellNode/useMoveCellsNode.ts
@@ -51,7 +51,7 @@ export const useMoveCellsNode = ({
         targetPath,
       });
       setStatus('success');
-    } catch (error) {
+    } catch (error: unknown) {
       setStatus('error');
     }
   };

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableRowOptions/CellsRenameNodeModal/useCellsRenameNodeForm/useCellsRenameNodeForm.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableRowOptions/CellsRenameNodeModal/useCellsRenameNodeForm/useCellsRenameNodeForm.ts
@@ -51,7 +51,7 @@ export const useCellsRenameForm = ({node, cellsRepository, onSuccess}: UseCellsR
     try {
       await cellsRepository.renameNode({currentPath: node.path, newName: buildNewName(name)});
       onSuccess();
-    } catch (error) {
+    } catch (error: unknown) {
       setError(t('cells.renameNodeModal.error'));
     }
   };

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableRowOptions/CellsTagsModal/useTagsManagement/useGetAllTags/useGetAllTags.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableRowOptions/CellsTagsModal/useTagsManagement/useGetAllTags/useGetAllTags.ts
@@ -41,7 +41,7 @@ export const useGetAllTags = ({
       const filteredTags = tags.Values?.map(tag => tag).filter(Boolean) ?? [];
       setTags(filteredTags);
       onSuccess(filteredTags);
-    } catch (error) {
+    } catch (error: unknown) {
       setError(error instanceof Error ? error : new Error('Unknown error'));
     } finally {
       setIsLoading(false);

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableRowOptions/useDeleteNode/useDeleteNode.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableRowOptions/useDeleteNode/useDeleteNode.ts
@@ -41,7 +41,7 @@ export const useDeleteNode = ({conversationQualifiedId, cellsRepository}: UseDel
       try {
         removeNode({conversationId: conversationQualifiedId.id, nodeId: uuid});
         await cellsRepository.deleteNode({uuid, permanently});
-      } catch (error) {
+      } catch (error: unknown) {
         deleteFileFailedNotification.show();
         console.error(error);
       }

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableRowOptions/useRestoreNestedNode/useRestoreNestedNode.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableRowOptions/useRestoreNestedNode/useRestoreNestedNode.ts
@@ -43,7 +43,7 @@ export const useRestoreNestedNode = ({
       try {
         removeNode({conversationId: conversationQualifiedId.id, nodeId: node.id});
         await cellsRepository.restoreNode({uuid: node.id});
-      } catch (error) {
+      } catch (error: unknown) {
         console.error(error);
         onError();
       }

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableRowOptions/useRestoreParentNode/useRestoreParentNode.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableRowOptions/useRestoreParentNode/useRestoreParentNode.ts
@@ -68,7 +68,7 @@ export const useRestoreParentNode = ({
             path: RECYCLE_BIN_PATH,
           });
         });
-      } catch (error) {
+      } catch (error: unknown) {
         console.error(error);
         onError();
       }

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewNodeForm.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewNodeForm.ts
@@ -59,7 +59,7 @@ export const useCellsNewItemForm = ({
         await cellsRepository.createFile({path, name});
       }
       onSuccess();
-    } catch (error) {
+    } catch (error: unknown) {
       if (isAxiosError(error) && error.response?.status === ITEM_ALREADY_EXISTS_ERROR) {
         setError(t('cells.newItemMenuModalForm.alreadyExistsError'));
       } else {

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.ts
@@ -100,7 +100,7 @@ export const useConversationSearchFiles = ({
         }
 
         setStatus('success');
-      } catch (error) {
+      } catch (error: unknown) {
         setStatus('error');
         setNodes({conversationId: id, nodes: []});
         setPagination({conversationId: id, pagination: null});

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/useGetAllCellsNodes.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/useGetAllCellsNodes.ts
@@ -79,7 +79,7 @@ export const useGetAllCellsNodes = ({
       setPagination({conversationId: id, pagination});
 
       setStatus('success');
-    } catch (error) {
+    } catch (error: unknown) {
       setError(error instanceof Error ? error : new Error('Failed to fetch files', {cause: error}));
       setPagination({conversationId: id, pagination: null});
       setStatus('error');

--- a/apps/webapp/src/script/components/Conversation/useFilesUploadDropzone/useFilesUploadDropzone.ts
+++ b/apps/webapp/src/script/components/Conversation/useFilesUploadDropzone/useFilesUploadDropzone.ts
@@ -128,7 +128,7 @@ export const useFilesUploadDropzone = ({
 
     try {
       await attatchMetadataToFiles(transformedAcceptedFiles);
-    } catch (error) {
+    } catch (error: unknown) {
       logger.warn('Attaching file metadata failed', error);
     }
 
@@ -168,7 +168,7 @@ export const useFilesUploadDropzone = ({
         fileId: file.id,
         data: {remoteUuid: uuid, remoteVersionId: versionId, uploadStatus: 'success'},
       });
-    } catch (error) {
+    } catch (error: unknown) {
       if (error instanceof Error && error.name === 'AbortError') {
         return;
       }
@@ -202,7 +202,7 @@ export const useFilesUploadDropzone = ({
             fileId: file.id,
             data: {...metadata},
           });
-        } catch (error) {
+        } catch (error: unknown) {
           logger.warn('Building file metadata failed', error);
         }
       }),

--- a/apps/webapp/src/script/components/ConversationListCell/ConversationListCell.tsx
+++ b/apps/webapp/src/script/components/ConversationListCell/ConversationListCell.tsx
@@ -133,7 +133,7 @@ export const ConversationListCell = ({
         await onJoinCall(conversation, MediaType.AUDIO);
         isJoiningCallRef.current = false;
       });
-    } catch (error) {
+    } catch (error: unknown) {
       // Re-enable on error
       isJoiningCallRef.current = false;
     }

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileEditor/FileEditor.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileEditor/FileEditor.tsx
@@ -58,7 +58,7 @@ export const FileEditor = ({id}: FileEditorProps) => {
       const fetchedNode = await cellsRepository.getNode({uuid: id, flags: ['WithEditorURLs']});
       setNode(fetchedNode);
       return true;
-    } catch (err) {
+    } catch (err: unknown) {
       setIsError(true);
       return false;
     } finally {

--- a/apps/webapp/src/script/components/Giphy/Giphy.tsx
+++ b/apps/webapp/src/script/components/Giphy/Giphy.tsx
@@ -100,7 +100,7 @@ const Giphy: FC<GiphyProps> = ({giphyRepository, defaultGiphyState = GiphyState.
         setGifs(fetchedGifs);
         setGiphyState(GiphyState.RESULTS);
       }
-    } catch (error) {
+    } catch (error: unknown) {
       console.warn(error);
       setGiphyState(GiphyState.ERROR);
     }
@@ -143,7 +143,7 @@ const Giphy: FC<GiphyProps> = ({giphyRepository, defaultGiphyState = GiphyState.
       setGifs([gif]);
       setSelectedGif(gif);
       setGiphyState(GiphyState.RESULT);
-    } catch (error) {
+    } catch (error: unknown) {
       setGiphyState(GiphyState.ERROR);
     }
   };

--- a/apps/webapp/src/script/components/HistoryExport/HistoryExport.tsx
+++ b/apps/webapp/src/script/components/HistoryExport/HistoryExport.tsx
@@ -220,7 +220,7 @@ const HistoryExport = ({switchContent, user, clientState = container.resolve(Cli
       } else {
         throw new Error('No local client found');
       }
-    } catch (error) {
+    } catch (error: unknown) {
       onError(error as Error);
     }
   };

--- a/apps/webapp/src/script/components/HistoryImport/HistoryImport.tsx
+++ b/apps/webapp/src/script/components/HistoryImport/HistoryImport.tsx
@@ -192,7 +192,7 @@ const HistoryImport = ({user, backupRepository, file, switchContent}: HistoryImp
     try {
       await backupRepository.importHistory(user, data, onInit, onProgress, password);
       onSuccess();
-    } catch (error) {
+    } catch (error: unknown) {
       onError(error as Error);
     }
   };

--- a/apps/webapp/src/script/components/Image/Image.tsx
+++ b/apps/webapp/src/script/components/Image/Image.tsx
@@ -94,7 +94,7 @@ export const Image = ({
             return;
           }
           setImageUrl(url);
-        } catch (error) {
+        } catch (error: unknown) {
           console.error(error);
         }
       })();

--- a/apps/webapp/src/script/components/InputBar/FilePreviews/useFilePreview/useFilePreview.ts
+++ b/apps/webapp/src/script/components/InputBar/FilePreviews/useFilePreview/useFilePreview.ts
@@ -81,7 +81,7 @@ export const useFilePreview = ({file, cellsRepository, conversationQualifiedId}:
         fileId: file.id,
         data: {remoteUuid: uuid, remoteVersionId: versionId, uploadStatus: 'success'},
       });
-    } catch (error) {
+    } catch (error: unknown) {
       updateFile({conversationId: conversationQualifiedId.id, fileId: file.id, data: {uploadStatus: 'error'}});
     }
   };

--- a/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/plugins/PastePlugin/PastePlugin.tsx
+++ b/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/plugins/PastePlugin/PastePlugin.tsx
@@ -276,7 +276,7 @@ export const PastePlugin = ({getMentionCandidates, isPreviewMode}: PastePluginPr
           processMentions(selection, mentions, availableUsers);
 
           return true;
-        } catch (error) {
+        } catch (error: unknown) {
           console.error('Error handling paste:', error);
           $getSelection()?.insertText(plainText);
           return false;

--- a/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/plugins/TypeaheadMenuPlugin/TypeaheadMenuPlugin.tsx
+++ b/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/plugins/TypeaheadMenuPlugin/TypeaheadMenuPlugin.tsx
@@ -127,7 +127,7 @@ function tryToPositionRange(leadOffset: number, range: Range): boolean {
   try {
     range.setStart(anchorNode, startOffset);
     range.setEnd(anchorNode, endOffset);
-  } catch (error) {
+  } catch (error: unknown) {
     return false;
   }
 

--- a/apps/webapp/src/script/components/InputBar/useMessageHandling/useMessageSend/useMessageSend.ts
+++ b/apps/webapp/src/script/components/InputBar/useMessageHandling/useMessageSend/useMessageSend.ts
@@ -39,6 +39,7 @@ import {ConversationError} from 'src/script/error/ConversationError';
 import {MentionEntity} from 'src/script/message/MentionEntity';
 import {MessageHasher} from 'src/script/message/MessageHasher';
 import {QuoteEntity} from 'src/script/message/QuoteEntity';
+import {isErrorWithType} from 'src/script/util/TypePredicateUtil';
 import {t} from 'Util/LocalizerUtil';
 
 import {useSendFiles} from './useSendFiles/useSendFiles';
@@ -119,11 +120,13 @@ export const useMessageSend = ({
       }
 
       if (editedMessage) {
-        messageRepository.sendMessageEdit(conversation, messageText, editedMessage, mentionEntities).catch(error => {
-          if (error.type !== ConversationError.TYPE.NO_MESSAGE_CHANGES) {
-            throw error;
-          }
-        });
+        messageRepository
+          .sendMessageEdit(conversation, messageText, editedMessage, mentionEntities)
+          .catch((error: unknown) => {
+            if (!isErrorWithType(error) || error.type !== ConversationError.TYPE.NO_MESSAGE_CHANGES) {
+              throw error;
+            }
+          });
 
         cancelMessageReply();
       }

--- a/apps/webapp/src/script/components/InputBar/useMessageHandling/useMessageSend/useSendFiles/useSendFiles.ts
+++ b/apps/webapp/src/script/components/InputBar/useMessageHandling/useMessageSend/useSendFiles/useSendFiles.ts
@@ -52,7 +52,7 @@ export const useSendFiles = ({files, clearAllFiles, cellsRepository, conversatio
       await Promise.all(files.map(sendFile));
       files.map(file => file.preview && URL.revokeObjectURL(file.preview));
       setStatus('success');
-    } catch (error) {
+    } catch (error: unknown) {
       errorNotification.show();
       setStatus('error');
       throw error;

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageQuote.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageQuote.tsx
@@ -36,6 +36,7 @@ import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {includesOnlyEmojis} from 'Util/EmojiUtil';
 import {t} from 'Util/LocalizerUtil';
 import {formatDateNumeral, formatTimeShort, isBeforeToday} from 'Util/TimeUtil';
+import {isErrorWithType} from 'Util/TypePredicateUtil';
 
 import {AudioAsset} from './asset/AudioAsset/AudioAsset';
 import {FileAsset} from './asset/FileAsset/FileAsset';
@@ -114,8 +115,8 @@ export const Quote: FC<QuoteProps> = ({
         .then(message => {
           setQuotedMessage(message as ContentMessage);
         })
-        .catch(error => {
-          if (error.type === ConversationError.TYPE.MESSAGE_NOT_FOUND) {
+        .catch((error: unknown) => {
+          if (isErrorWithType(error) && error.type === ConversationError.TYPE.MESSAGE_NOT_FOUND) {
             return setError(QuoteEntity.ERROR.MESSAGE_NOT_FOUND);
           }
           throw error;

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/AudioAsset/AudioAsset.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/AudioAsset/AudioAsset.tsx
@@ -77,7 +77,7 @@ export const AudioAsset = ({
       try {
         const url = await getAssetUrl(asset.original_resource());
         setAudioSrc(url);
-      } catch (error) {
+      } catch (error: unknown) {
         logger.error('Failed to load audio asset ', error);
       }
       asset.status(AssetTransferState.UPLOADED);

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/useGetMultipartAsset/useGetMultipartAsset.ts
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/useGetMultipartAsset/useGetMultipartAsset.ts
@@ -118,7 +118,7 @@ export const useGetMultipartAsset = ({
         setPath(asset.Path);
         setIsRecycled(asset.IsRecycled);
         setStatus('success');
-      } catch (err) {
+      } catch (err: unknown) {
         if (!isMounted.current) {
           return;
         }

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAsset.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/VideoAsset/VideoAsset.tsx
@@ -145,7 +145,7 @@ const VideoAsset = ({
           setIsVideoLoaded(true);
           // ToDo: This needs to be revisited
           //amplify.publish(WebAppEvents.ANALYTICS.EVENT, EventName.MESSAGES.VIDEO.PLAY_SUCCESS);
-        } catch (error) {
+        } catch (error: unknown) {
           if (error instanceof Error) {
             if (error.name !== AssetError.CANCEL_ERROR) {
               setVideoPlaybackError(true);

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/common/useGetAssetUrl/useGetAssetUrl.ts
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/common/useGetAssetUrl/useGetAssetUrl.ts
@@ -54,7 +54,7 @@ export const useGetAssetUrl = ({asset, isEnabled, getAssetUrl, onError, onSucces
       const assetUrl = await getAssetUrl(asset.original_resource());
       setUrl(assetUrl.url);
       onSuccess?.(assetUrl.url);
-    } catch (error) {
+    } catch (error: unknown) {
       if (error instanceof Error && error.name !== AssetError.CANCEL_ERROR) {
         setIsError(true);
         onError?.(error);

--- a/apps/webapp/src/script/components/MessagesList/Message/E2EIVerificationMessage/E2EIVerificationMessage.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/E2EIVerificationMessage/E2EIVerificationMessage.tsx
@@ -87,7 +87,7 @@ export const E2EIVerificationMessage = ({message, conversation}: E2EIVerificatio
   const getCertificate = async () => {
     try {
       await E2EIHandler.getInstance().enroll({resetTimers: true});
-    } catch (error) {
+    } catch (error: unknown) {
       logger.error('Failed to enroll user certificate: ', error);
     }
   };

--- a/apps/webapp/src/script/components/Modals/CreateConversation/hooks/useCreateConversation.ts
+++ b/apps/webapp/src/script/components/Modals/CreateConversation/hooks/useCreateConversation.ts
@@ -172,7 +172,7 @@ export const useCreateConversation = () => {
       } else {
         createNavigate(generateConversationUrl(conversation.qualifiedId))(event);
       }
-    } catch (error) {
+    } catch (error: unknown) {
       handleException(error as Error, conversationName);
       amplify.publish(WebAppEvents.CONVERSATION.SHOW, undefined, {});
       setIsLoading(false);

--- a/apps/webapp/src/script/components/Modals/FileHistoryModal/hooks/useFileVersions.ts
+++ b/apps/webapp/src/script/components/Modals/FileHistoryModal/hooks/useFileVersions.ts
@@ -72,7 +72,7 @@ export const useFileVersions = (nodeUuid?: string, onClose?: () => void, onResto
 
         const groupedVersions = groupVersionsByDate(versions || []);
         setFileVersions(groupedVersions);
-      } catch (err) {
+      } catch (err: unknown) {
         const errorMessage = err instanceof Error ? err.message : t('fileHistoryModal.failedToLoadVersions');
         setError(errorMessage);
       } finally {
@@ -120,7 +120,7 @@ export const useFileVersions = (nodeUuid?: string, onClose?: () => void, onResto
         uuid: nodeUuid,
         versionId: toBeRestoredVersionId,
       });
-    } catch (err) {
+    } catch (err: unknown) {
       const errorMessage = err instanceof Error ? err.message : t('fileHistoryModal.failedToRestore');
       setError(errorMessage);
     } finally {

--- a/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -245,7 +245,7 @@ const GroupCreationModal = ({
         } else {
           createNavigate(generateConversationUrl(conversation.qualifiedId))(event);
         }
-      } catch (error) {
+      } catch (error: unknown) {
         if (isNonFederatingBackendsError(error)) {
           const tempName = groupName;
           setIsShown(false);

--- a/apps/webapp/src/script/components/Modals/LegalHoldModal/LegalHoldModal.tsx
+++ b/apps/webapp/src/script/components/Modals/LegalHoldModal/LegalHoldModal.tsx
@@ -38,6 +38,7 @@ import {SearchRepository} from 'Repositories/search/SearchRepository';
 import {TeamRepository} from 'Repositories/team/TeamRepository';
 import {handleEnterDown} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
+import {isErrorWithCode, toError} from 'Util/TypePredicateUtil';
 
 import {useLegalHoldModalState} from './LegalHoldModal.state';
 
@@ -156,8 +157,8 @@ const LegalHoldModal: FC<LegalHoldModalProps> = ({
       setUserDevices(undefined);
       setPasswordValue('');
       setRequestError('');
-    } catch ({code, message}) {
-      switch (code) {
+    } catch (error: unknown) {
+      switch (isErrorWithCode(error) ? error.code : undefined) {
         case HTTP_STATUS.BAD_REQUEST: {
           setRequestError(t('BackendError.LABEL.BAD_REQUEST'));
           break;
@@ -167,7 +168,7 @@ const LegalHoldModal: FC<LegalHoldModalProps> = ({
           break;
         }
         default: {
-          setRequestError(message as string);
+          setRequestError(toError(error).message);
         }
       }
 

--- a/apps/webapp/src/script/components/Modals/QualityFeedbackModal/QualityFeedbackModal.tsx
+++ b/apps/webapp/src/script/components/Modals/QualityFeedbackModal/QualityFeedbackModal.tsx
@@ -93,7 +93,7 @@ export const QualityFeedbackModal = ({callingRepository}: Props) => {
       if (!skipNotification) {
         submittedNotification.show();
       }
-    } catch (error) {
+    } catch (error: unknown) {
       logger.warn(`Can't send feedback: ${(error as Error).message}`);
     } finally {
       setQualityFeedbackModalShown(false);

--- a/apps/webapp/src/script/components/TitleBar/TitleBar.tsx
+++ b/apps/webapp/src/script/components/TitleBar/TitleBar.tsx
@@ -221,7 +221,7 @@ export const TitleBar = ({
         await callActions.startAudio(conversation);
         isStartingCallRef.current = false;
         showStartedCallAlert(isGroupOrChannel);
-      } catch (error) {
+      } catch (error: unknown) {
         // Re-enable on error
         isStartingCallRef.current = false;
       }

--- a/apps/webapp/src/script/components/UserDevices/UserDevices.tsx
+++ b/apps/webapp/src/script/components/UserDevices/UserDevices.tsx
@@ -89,7 +89,7 @@ export const UserDevices = ({
             setDeviceMode(deviceMode);
           }
         }
-      } catch (error) {
+      } catch (error: unknown) {
         logger.error(`Unable to retrieve clients for user '${user.id}': ${(error as Error).message || error}`);
       }
     })();

--- a/apps/webapp/src/script/components/calling/CallingCell/CallingCell.tsx
+++ b/apps/webapp/src/script/components/calling/CallingCell/CallingCell.tsx
@@ -250,7 +250,7 @@ export const CallingCell = ({
         await callActions.answer(call);
         isAnsweringRef.current = false;
         setCurrentView(ViewType.MOBILE_LEFT_SIDEBAR);
-      } catch (error) {
+      } catch (error: unknown) {
         // Re-enable on error
         isAnsweringRef.current = false;
       }

--- a/apps/webapp/src/script/components/components/Modals/FileHistoryModal/hooks/useFileVersions.ts
+++ b/apps/webapp/src/script/components/components/Modals/FileHistoryModal/hooks/useFileVersions.ts
@@ -72,7 +72,7 @@ export const useFileVersions = (nodeUuid?: string, onClose?: () => void, onResto
 
         const groupedVersions = groupVersionsByDate(versions || []);
         setFileVersions(groupedVersions);
-      } catch (err) {
+      } catch (err: unknown) {
         const errorMessage = err instanceof Error ? err.message : t('fileHistoryModal.failedToLoadVersions');
         setError(errorMessage);
       } finally {
@@ -120,7 +120,7 @@ export const useFileVersions = (nodeUuid?: string, onClose?: () => void, onResto
         uuid: nodeUuid,
         versionId: toBeRestoredVersionId,
       });
-    } catch (err) {
+    } catch (err: unknown) {
       const errorMessage = err instanceof Error ? err.message : t('fileHistoryModal.failedToRestore');
       setError(errorMessage);
     } finally {

--- a/apps/webapp/src/script/components/panel/UserActions.tsx
+++ b/apps/webapp/src/script/components/panel/UserActions.tsx
@@ -204,7 +204,7 @@ const UserActions = ({
             try {
               await create1to1Conversation(user, true);
               onAction(Actions.START_CONVERSATION);
-            } catch (error) {
+            } catch (error: unknown) {
               if (error instanceof ClientMLSError && error.label === ClientMLSErrorLabel.NO_KEY_PACKAGES_AVAILABLE) {
                 return PrimaryModal.show(PrimaryModal.type.ACKNOWLEDGE, {
                   text: {

--- a/apps/webapp/src/script/hooks/useInitializeMediaDevices.ts
+++ b/apps/webapp/src/script/hooks/useInitializeMediaDevices.ts
@@ -37,7 +37,7 @@ export const useInitializeMediaDevices = (devicesHandler: MediaDevicesHandler, s
       }
       await devicesHandler?.initializeMediaDevices();
       setAreMediaDevicesInitialized(true);
-    } catch (error) {
+    } catch (error: unknown) {
       logger.warn(`Initialization of media devices failed:`, error);
       setAreMediaDevicesInitialized(false);
     }

--- a/apps/webapp/src/script/main/app.ts
+++ b/apps/webapp/src/script/main/app.ts
@@ -424,7 +424,7 @@ export class App {
 
       try {
         selfUser = await this.repository.user.getSelf([{position: 'App.initiateSelfUser', vendor: 'webapp'}]);
-      } catch (error) {
+      } catch (error: unknown) {
         this.logger.error('Could not get self user', error);
         await this.repository.lifeCycle.logout(SIGN_OUT_REASON.SESSION_EXPIRED, false);
         return undefined;
@@ -440,7 +440,7 @@ export class App {
 
       try {
         await this.core.init(clientType);
-      } catch (error) {
+      } catch (error: unknown) {
         const errorMessage = error instanceof Error ? error.message : error;
         this.logger.error(`Error when initializing core: "${errorMessage}"`, error);
         throw new AccessTokenError(AccessTokenError.TYPE.REQUEST_FORBIDDEN, 'Session has expired');
@@ -476,7 +476,7 @@ export class App {
 
       try {
         await this.core.initClient(localClient, getClientMLSConfig(teamFeatures));
-      } catch (error) {
+      } catch (error: unknown) {
         console.warn('Failed to initialize client', {error});
         this.showForceLogoutModal(SIGN_OUT_REASON.CLIENT_REMOVED);
       }
@@ -644,7 +644,7 @@ export class App {
       // Load conversation labels with proper error handling
       try {
         await conversationRepository.conversationLabelRepository.loadLabels();
-      } catch (error) {
+      } catch (error: unknown) {
         this.logger.error('Failed to load conversation labels', error);
         // Continue with empty labels rather than breaking the app
       }
@@ -672,7 +672,7 @@ export class App {
       this.core.resumeNotificationQueue();
 
       return selfUser;
-    } catch (error) {
+    } catch (error: unknown) {
       if (error instanceof BaseError) {
         await this._appInitFailure(error);
         return undefined;

--- a/apps/webapp/src/script/message/MessageCategorization.ts
+++ b/apps/webapp/src/script/message/MessageCategorization.ts
@@ -101,7 +101,7 @@ export const categoryFromEvent = (event: Partial<EventRecord>): MessageCategory 
     }
 
     return category;
-  } catch (error) {
+  } catch (error: unknown) {
     return MessageCategory.UNDEFINED;
   }
 };

--- a/apps/webapp/src/script/mls/MLSConversations.ts
+++ b/apps/webapp/src/script/mls/MLSConversations.ts
@@ -117,7 +117,7 @@ export async function initMLSGroupConversation(
     });
 
     onSuccessfulJoin?.(mlsConversation);
-  } catch (error) {
+  } catch (error: unknown) {
     onError?.(mlsConversation, error);
   }
 }

--- a/apps/webapp/src/script/mls/MLSMigration/migrationFinaliser/migrationFinaliser.ts
+++ b/apps/webapp/src/script/mls/MLSMigration/migrationFinaliser/migrationFinaliser.ts
@@ -84,7 +84,7 @@ const finaliseMigrationOfMixedConversation = async (
     if (!isMLSConversation(updatedMLSConversation)) {
       throw new Error(`Conversation ${updatedMLSConversation.qualifiedId.id} has not updated its protocol to MLS.`);
     }
-  } catch (error) {
+  } catch (error: unknown) {
     mlsMigrationLogger.error(`Failed to finalise migration of mixed conversation ${mixedConversation.id}.`, error);
   }
 };

--- a/apps/webapp/src/script/mls/MLSMigration/migrationInitialiser/joinUnestablishedMixedConversations/joinUnestablishedMixedConversations.ts
+++ b/apps/webapp/src/script/mls/MLSMigration/migrationInitialiser/joinUnestablishedMixedConversations/joinUnestablishedMixedConversations.ts
@@ -76,7 +76,7 @@ export const joinUnestablishedMixedConversation = async (
       qualifiedUsers: otherUsersToAdd,
       selfUserId: selfUserId,
     });
-  } catch (error) {
+  } catch (error: unknown) {
     mlsMigrationLogger.error(
       `Failed to establish MLS group for mixed conversation with id ${mixedConversation.id}, error: `,
       error,

--- a/apps/webapp/src/script/mls/MLSMigration/migrationInitialiser/migrationInitialiser.ts
+++ b/apps/webapp/src/script/mls/MLSMigration/migrationInitialiser/migrationInitialiser.ts
@@ -99,7 +99,7 @@ const initialiseMigrationOfProteusConversation = async (
       qualifiedUsers: otherUsersToAdd,
       selfUserId: selfUserId,
     });
-  } catch (error) {
+  } catch (error: unknown) {
     mlsMigrationLogger.error(
       `Error while initialising MLS migration for "proteus" conversation: ${proteusConversation.qualifiedId.id}`,
       error,

--- a/apps/webapp/src/script/page/AppLock/AppLock.tsx
+++ b/apps/webapp/src/script/page/AppLock/AppLock.tsx
@@ -37,6 +37,7 @@ import {SIGN_OUT_REASON} from 'src/script/auth/SignOutReason';
 import {Config} from 'src/script/Config';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
+import {isErrorWithCode, toError} from 'Util/TypePredicateUtil';
 
 export enum APPLOCK_STATE {
   FORGOT = 'applock.forgot',
@@ -215,12 +216,15 @@ const AppLock = ({
       await clientRepository.clientService.deleteClient(currentClientId, target.password.value);
       appLockRepository.removeCode();
       amplify.publish(WebAppEvents.LIFECYCLE.SIGN_OUT, SIGN_OUT_REASON.USER_REQUESTED, true);
-    } catch ({code, message}) {
+    } catch (error: unknown) {
       setIsLoading(false);
-      if ([HTTP_STATUS.BAD_REQUEST, HTTP_STATUS.UNAUTHORIZED, HTTP_STATUS.FORBIDDEN].includes(code)) {
+      if (
+        isErrorWithCode(error) &&
+        [HTTP_STATUS.BAD_REQUEST, HTTP_STATUS.UNAUTHORIZED, HTTP_STATUS.FORBIDDEN].includes(error.code)
+      ) {
         return setWipeError(t('modalAppLockWipePasswordError'));
       }
-      setWipeError(message);
+      setWipeError(toError(error).message);
     }
   };
 

--- a/apps/webapp/src/script/page/LeftSidebar/panels/Conversations/utils/draftUtils.ts
+++ b/apps/webapp/src/script/page/LeftSidebar/panels/Conversations/utils/draftUtils.ts
@@ -53,7 +53,7 @@ export const conversationHasDraft = (conversation: Conversation): boolean => {
     const draft = (amplifyData as AmplifyWrapper).data || (amplifyData as DraftData);
     // Check if draft has content (editorState or plainMessage)
     return Boolean(draft && (draft.editorState || draft.plainMessage));
-  } catch (error) {
+  } catch (error: unknown) {
     // Only log error type, not the actual error to avoid exposing draft content
     logger.warn(
       `Failed to parse draft data for conversation ${conversation.id}: ${

--- a/apps/webapp/src/script/page/LeftSidebar/panels/StartUI/PeopleTab.tsx
+++ b/apps/webapp/src/script/page/LeftSidebar/panels/StartUI/PeopleTab.tsx
@@ -194,7 +194,7 @@ export const PeopleTab = ({
           onSearchResults(results);
           setResults(results);
         }
-      } catch (error) {
+      } catch (error: unknown) {
         if (isBackendError(error)) {
           if (error.code === HTTP_STATUS.UNPROCESSABLE_ENTITY) {
             return setHasFederationError(true);

--- a/apps/webapp/src/script/page/MainContent/panels/preferences/AccountPreferences.tsx
+++ b/apps/webapp/src/script/page/MainContent/panels/preferences/AccountPreferences.tsx
@@ -120,7 +120,7 @@ export const AccountPreferences = ({
             try {
               await conversationRepository.leaveGuestRoom();
               void clientRepository.logoutClient();
-            } catch (error) {
+            } catch (error: unknown) {
               logger.warn('Error while leaving room', error);
             }
           },

--- a/apps/webapp/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.tsx
+++ b/apps/webapp/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/E2EICertificateDetails.tsx
@@ -45,7 +45,7 @@ export const E2EICertificateDetails = ({identity, isCurrentDevice}: E2EICertific
   const getCertificate = async () => {
     try {
       await E2EIHandler.getInstance().enroll({resetTimers: true});
-    } catch (error) {
+    } catch (error: unknown) {
       logger.error('Cannot get E2EI instance: ', error);
     }
   };

--- a/apps/webapp/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/useCertificateDetailsModal.tsx
+++ b/apps/webapp/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/E2EICertificateDetails/useCertificateDetailsModal.tsx
@@ -80,7 +80,7 @@ export const useCertificateDetailsModal = (certificate: string) => {
           setIsTextCopied(false);
         }, COPY_MESSAGE_TIMEOUT);
       });
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('Failed to copy: ', err);
     }
   };

--- a/apps/webapp/src/script/page/MainContent/panels/preferences/accountPreferences/AvatarInput.tsx
+++ b/apps/webapp/src/script/page/MainContent/panels/preferences/accountPreferences/AvatarInput.tsx
@@ -30,6 +30,7 @@ import {UserRepository} from 'Repositories/user/UserRepository';
 import {handleKeyDown, KEY} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
 import {getLogger} from 'Util/Logger';
+import {isErrorWithType} from 'Util/TypePredicateUtil';
 import {validateProfileImageResolution} from 'Util/util';
 
 import {FileInput} from './FileInput';
@@ -98,7 +99,7 @@ export const AvatarInput = ({
       const messageString = t('modalPictureTooSmallMessage');
       const titleString = t('modalPictureTooSmallHeadline');
       return await showUploadWarning(titleString, messageString);
-    } catch (error) {
+    } catch (error: unknown) {
       logger.error('Failed to validate profile image', error);
       return false;
     } finally {
@@ -116,8 +117,8 @@ export const AvatarInput = ({
     }
     const newUserPicture = files.item(0);
     if (newUserPicture) {
-      setPicture(newUserPicture).catch(error => {
-        const isInvalidUpdate = error.type === UserError.TYPE.INVALID_UPDATE;
+      setPicture(newUserPicture).catch((error: unknown) => {
+        const isInvalidUpdate = isErrorWithType(error) && error.type === UserError.TYPE.INVALID_UPDATE;
         if (!isInvalidUpdate) {
           throw error;
         }

--- a/apps/webapp/src/script/page/MainContent/panels/preferences/accountPreferences/EmailInput.tsx
+++ b/apps/webapp/src/script/page/MainContent/panels/preferences/accountPreferences/EmailInput.tsx
@@ -23,6 +23,7 @@ import {PrimaryModal} from 'Components/Modals/PrimaryModal';
 import {UserRepository} from 'Repositories/user/UserRepository';
 import {t} from 'Util/LocalizerUtil';
 import {getLogger} from 'Util/Logger';
+import {isErrorWithCode} from 'Util/TypePredicateUtil';
 
 import {AccountInput, useInputDone} from './AccountInput';
 
@@ -50,12 +51,12 @@ const EmailInput = ({email, canEditProfile, userRepository}: EmailInputProps) =>
       await userRepository.changeEmail(enteredEmail);
       emailInputDone.done();
       showWarning(t('modalPreferencesAccountEmailHeadline'), t('authPostedResendDetail'));
-    } catch (error) {
+    } catch (error: unknown) {
       logger.warn('Failed to send reset email request', error);
-      if (error.code === HTTP_STATUS.BAD_REQUEST) {
+      if (isErrorWithCode(error) && error.code === HTTP_STATUS.BAD_REQUEST) {
         showWarning(t('modalPreferencesAccountEmailErrorHeadline'), t('modalPreferencesAccountEmailInvalidMessage'));
       }
-      if (error.code === HTTP_STATUS.CONFLICT) {
+      if (isErrorWithCode(error) && error.code === HTTP_STATUS.CONFLICT) {
         showWarning(t('modalPreferencesAccountEmailErrorHeadline'), t('modalPreferencesAccountEmailTakenMessage'));
       }
     }

--- a/apps/webapp/src/script/page/MainContent/panels/preferences/accountPreferences/NameInput.tsx
+++ b/apps/webapp/src/script/page/MainContent/panels/preferences/accountPreferences/NameInput.tsx
@@ -43,7 +43,7 @@ const NameInput = ({name, userRepository, canEditProfile}: NameInputProps) => {
       try {
         await userRepository.changeName(newName);
         nameInputDone.done();
-      } catch (error) {
+      } catch (error: unknown) {
         logger.warn('Failed to update name', error);
       }
     }

--- a/apps/webapp/src/script/page/MainContent/panels/preferences/accountPreferences/UsernameInput.tsx
+++ b/apps/webapp/src/script/page/MainContent/panels/preferences/accountPreferences/UsernameInput.tsx
@@ -24,6 +24,7 @@ import cx from 'classnames';
 import {validateHandle} from 'Repositories/user/UserHandleGenerator';
 import {UserRepository} from 'Repositories/user/UserRepository';
 import {t} from 'Util/LocalizerUtil';
+import {isErrorWithType} from 'Util/TypePredicateUtil';
 
 import {AccountInput, useInputDone} from './AccountInput';
 
@@ -65,8 +66,8 @@ const UsernameInput = ({username, domain, userRepository, canEditProfile}: Usern
             setErrorState(UserNameState.AVAILABLE);
           }
         })
-        .catch(error => {
-          const isUsernameTaken = error.type === UserError.TYPE.USERNAME_TAKEN;
+        .catch((error: unknown) => {
+          const isUsernameTaken = isErrorWithType(error) && error.type === UserError.TYPE.USERNAME_TAKEN;
           const isCurrentRequest = requestedName === enteredUsername;
           if (isUsernameTaken && isCurrentRequest) {
             setErrorState(UserNameState.TAKEN);
@@ -100,7 +101,7 @@ const UsernameInput = ({username, domain, userRepository, canEditProfile}: Usern
         setErrorState(null);
         usernameInputDone.done();
       }
-    } catch (error) {
+    } catch (error: unknown) {
       if (error instanceof UserError) {
         const isUsernameTaken = error.type === UserError.TYPE.USERNAME_TAKEN;
         const isCurrentRequest = requestedName === submittedName;

--- a/apps/webapp/src/script/page/MainContent/panels/preferences/avPreferences/CameraPreferences.tsx
+++ b/apps/webapp/src/script/page/MainContent/panels/preferences/avPreferences/CameraPreferences.tsx
@@ -73,7 +73,7 @@ const CameraPreferencesComponent = ({streamHandler, refreshStream, hasActiveCame
         }
         setStream(stream);
       }
-    } catch (error) {
+    } catch (error: unknown) {
       if (error instanceof Error) {
         logger.warn(`Requesting MediaStream for type "${MediaType.VIDEO}" failed: ${error.message}`, error);
       }

--- a/apps/webapp/src/script/page/MainContent/panels/preferences/avPreferences/MicrophonePreferences.tsx
+++ b/apps/webapp/src/script/page/MainContent/panels/preferences/avPreferences/MicrophonePreferences.tsx
@@ -62,7 +62,7 @@ const MicrophonePreferences = ({streamHandler, refreshStream, hasActiveCall}: Mi
     setIsRequesting(true);
     try {
       setStream(await refreshStream());
-    } catch (error) {
+    } catch (error: unknown) {
       if (error instanceof Error) {
         logger.warn(`Requesting MediaStream for type "${MediaType.AUDIO}" failed: ${error.message}`, error);
       }

--- a/apps/webapp/src/script/repositories/LifeCycleRepository/LifeCycleRepository.ts
+++ b/apps/webapp/src/script/repositories/LifeCycleRepository/LifeCycleRepository.ts
@@ -159,7 +159,7 @@ export class LifeCycleRepository {
       this.logger.info(`Logout triggered by '${signOutReason}': Disconnecting user from the backend.`);
       try {
         await performLogout();
-      } catch (error) {
+      } catch (error: unknown) {
         this.logger.error(
           `Logout triggered by '${signOutReason}' and errored: ${error instanceof Error ? error.message : error}.`,
         );
@@ -174,7 +174,7 @@ export class LifeCycleRepository {
     if (requiresImmediateLogout) {
       try {
         return await performLogout();
-      } catch (error) {
+      } catch (error: unknown) {
         if (error instanceof BaseError) {
           this.logger.error(`Logout triggered by '${signOutReason}' and errored: ${error.message}.`);
         }
@@ -206,7 +206,7 @@ export class LifeCycleRepository {
       try {
         await this.dependencies.conversationRepository.sendTypingStop(activeConversation);
         this.logger.debug('Sent typing stop notification for active conversation during logout.');
-      } catch (error) {
+      } catch (error: unknown) {
         this.logger.warn('Failed to send typing stop before logout.', error);
       }
     }
@@ -271,7 +271,7 @@ export class LifeCycleRepository {
 
     try {
       return this.dependencies.clientRepository.isCurrentClientPermanent();
-    } catch (error) {
+    } catch (error: unknown) {
       // Handle case where client is not set
       const isClientNotSetError = error instanceof ClientError && error.type === ClientError.TYPE.CLIENT_NOT_SET;
       if (isClientNotSetError) {
@@ -355,7 +355,7 @@ export class LifeCycleRepository {
     try {
       await this.dependencies.storageRepository.deleteDatabase();
       this.logger.info('Database deleted successfully as part of persistent storage cleanup.');
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error('Failed to delete database before logout', error);
     }
   };

--- a/apps/webapp/src/script/repositories/assets/AssetRepository.ts
+++ b/apps/webapp/src/script/repositories/assets/AssetRepository.ts
@@ -108,7 +108,7 @@ export class AssetRepository {
       const {buffer, mimeType} = await response;
 
       return new Blob([new Uint8Array(buffer)], {type: mimeType});
-    } catch (error) {
+    } catch (error: unknown) {
       if (error instanceof Error) {
         const isAssetNotFound = error.message.endsWith(HTTP_STATUS.NOT_FOUND.toString());
         const isServerError = error.message.endsWith(HTTP_STATUS.INTERNAL_SERVER_ERROR.toString());
@@ -144,7 +144,7 @@ export class AssetRepository {
         throw new Error('No blob received.');
       }
       return downloadBlob(blob, fileName);
-    } catch (error) {
+    } catch (error: unknown) {
       return this.logger.error('Failed to download blob', error);
     }
   }
@@ -158,7 +158,7 @@ export class AssetRepository {
       }
       asset.status(AssetTransferState.UPLOADED);
       return downloadBlob(blob, asset.file_name ?? 'file');
-    } catch (error) {
+    } catch (error: unknown) {
       if (error instanceof Error) {
         if (error.name === AssetError.CANCEL_ERROR) {
           asset.status(AssetTransferState.CANCELED);

--- a/apps/webapp/src/script/repositories/audio/AudioRepository.ts
+++ b/apps/webapp/src/script/repositories/audio/AudioRepository.ts
@@ -152,7 +152,7 @@ export class AudioRepository {
         try {
           await this.playAudio(audioElement, playInLoop);
           this.logger.log(`Playing sound '${audioId}' (loop: '${playInLoop}')`);
-        } catch (error) {
+        } catch (error: unknown) {
           if (error instanceof Error) {
             this.logger.error(`Failed to play sound '${audioId}': ${error.message}`);
           }

--- a/apps/webapp/src/script/repositories/backup/BackupRepository.ts
+++ b/apps/webapp/src/script/repositories/backup/BackupRepository.ts
@@ -116,7 +116,7 @@ export class BackupRepository {
       }
 
       return await this.compressHistoryFiles(user, clientId, exportedData, password);
-    } catch (error) {
+    } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : error;
       this.logger.error(`Could not export history: ${errorMessage}`, error);
       const isCancelError = isErrorOfType(error, ErrorType.CancelError);

--- a/apps/webapp/src/script/repositories/backup/BackupService.ts
+++ b/apps/webapp/src/script/repositories/backup/BackupService.ts
@@ -149,7 +149,7 @@ export class BackupService {
     try {
       await table.bulkAdd(entities, primaryKeys);
       return entities.length;
-    } catch (error) {
+    } catch (error: unknown) {
       if (error instanceof Dexie.BulkError) {
         const {failures} = error;
         const successCount = entities.length - failures.length;

--- a/apps/webapp/src/script/repositories/backup/zipWorker.ts
+++ b/apps/webapp/src/script/repositories/backup/zipWorker.ts
@@ -22,6 +22,8 @@ import sodium, {ready} from 'libsodium-wrappers-sumo';
 
 import {ImportError} from './Error';
 
+import {toError} from '../../util/TypePredicateUtil';
+
 type Payload =
   | {type: 'zip'; files: Record<string, ArrayBuffer | string>; encrytionKey?: Uint8Array}
   | {type: 'unzip'; bytes: ArrayBuffer; encrytionKey?: Uint8Array; headerLength?: number};
@@ -53,9 +55,9 @@ export async function handleZipEvent(payload: Payload) {
         const headerLength = payload.headerLength ? payload.headerLength : 0;
         try {
           decryptedBytes = await decryptFile(payloadBytes, encrytionKey, headerLength);
-        } catch (error) {
+        } catch (error: unknown) {
           // Handle decryption failure
-          throw new ImportError(error.message);
+          throw new ImportError(toError(error).message);
         }
       } else {
         decryptedBytes = payload.bytes;
@@ -124,7 +126,7 @@ self.addEventListener('message', async (event: MessageEvent<Payload>) => {
   try {
     const result = await handleZipEvent(event.data);
     self.postMessage(result);
-  } catch (error) {
-    self.postMessage({error: error.message});
+  } catch (error: unknown) {
+    self.postMessage({error: toError(error).message});
   }
 });

--- a/apps/webapp/src/script/repositories/calling/Call.ts
+++ b/apps/webapp/src/script/repositories/calling/Call.ts
@@ -164,7 +164,7 @@ export class Call {
 
       try {
         audio.audioElement = AudioSpeakerFactory.createNewCallingAudioSpeaker(audio.stream);
-      } catch (e) {
+      } catch (e: unknown) {
         this.logger.warn('Fail to playAudioStreams:', e);
       }
     });

--- a/apps/webapp/src/script/repositories/calling/CallingRepository.ts
+++ b/apps/webapp/src/script/repositories/calling/CallingRepository.ts
@@ -89,6 +89,7 @@ import {roundLogarithmic} from 'Util/NumberUtil';
 import {matchQualifiedIds} from 'Util/QualifiedId';
 import {copyStyles} from 'Util/renderElement';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
+import {toError} from 'Util/TypePredicateUtil';
 import {createUuid} from 'Util/uuid';
 
 import {Call, SerializedConversationId} from './Call';
@@ -400,7 +401,7 @@ export class CallingRepository {
         if (userId) {
           try {
             wCall.setBackground(this.wUser, 0);
-          } catch (e) {
+          } catch (e: unknown) {
             this.logger.warn(`Informed AVS about background mode failed. ${e}`);
           }
         } else {
@@ -627,7 +628,7 @@ export class CallingRepository {
         mediaStream.getTracks().forEach(track => track.stop());
       }
       return true;
-    } catch (_error) {
+    } catch (_error: unknown) {
       return false;
     }
   }
@@ -1061,7 +1062,7 @@ export class CallingRepository {
       });
 
       return call;
-    } catch (error) {
+    } catch (error: unknown) {
       if (error) {
         this.logger.error('Failed starting call', error);
       }
@@ -1183,7 +1184,7 @@ export class CallingRepository {
         VIDEO_STATE.SCREENSHARE,
       );
       selfParticipant.startedScreenSharingAt(Date.now());
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.info('Failed to get screen sharing stream', error);
     }
   };
@@ -1256,7 +1257,7 @@ export class CallingRepository {
       };
 
       call.analyticsScreenSharing = true;
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error('Error in toggleScreenShareWithVideo:', error);
       if (screenStream) {
         screenStream.getTracks().forEach(track => track.stop());
@@ -1455,7 +1456,7 @@ export class CallingRepository {
       this.sendCallingEvent(EventName.CALLING.JOINED_CALL, call, {
         [Segmentation.CALL.DIRECTION]: this.getCallDirection(call),
       });
-    } catch (error) {
+    } catch (error: unknown) {
       if (error) {
         this.logger.error('Failed answering call', error);
       }
@@ -1718,7 +1719,7 @@ export class CallingRepository {
         setConversationId(conversationId);
         setQualityFeedbackModalShown(true);
       }
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.warn(`Storage data can't found: ${(error as Error).message}`);
       setConversationId(conversationId);
       setQualityFeedbackModalShown(true);
@@ -2092,8 +2093,8 @@ export class CallingRepository {
       this.wCall?.sftResp(this.wUser!, status, jsonData, jsonData.length, context);
     };
     const avsSftResponseFailedCode = 1000;
-    _sendSFTRequest().catch(error => {
-      this.avsLogHandler(LOG_LEVEL.WARN, `Request to sft server failed with error: ${error?.message}`, error);
+    _sendSFTRequest().catch((error: unknown) => {
+      this.avsLogHandler(LOG_LEVEL.WARN, `Request to sft server failed with error: ${toError(error).message}`, error);
       avsLogger.warn(`Request to sft server failed with error`, error);
       this.wCall?.sftResp(this.wUser!, avsSftResponseFailedCode, '', 0, context);
     });
@@ -2539,7 +2540,7 @@ export class CallingRepository {
         selfParticipant.updateMediaStream(mediaStream, true);
         await selfParticipant.setBlurredBackground(this.enableBackgroundBlur);
         return selfParticipant.getMediaStream();
-      } catch (error) {
+      } catch (error: unknown) {
         this.mediaStreamQuery = undefined;
         this.logger.warn('Could not get mediaStream for call', error);
         this.handleMediaStreamError(call, missingStreams, error);

--- a/apps/webapp/src/script/repositories/client/ClientRepository.ts
+++ b/apps/webapp/src/script/repositories/client/ClientRepository.ts
@@ -38,6 +38,7 @@ import {t} from 'Util/LocalizerUtil';
 import {getLogger, Logger} from 'Util/Logger';
 import {matchQualifiedIds} from 'Util/QualifiedId';
 import {loadValue} from 'Util/StorageUtil';
+import {isAxiosError, isErrorWithCode, isErrorWithType, toError} from 'Util/TypePredicateUtil';
 
 import {ClientEntity} from './ClientEntity';
 import {constructClientId, parseClientId} from './ClientIdUtil';
@@ -129,7 +130,7 @@ export class ClientRepository {
    */
   private getClientByIdFromBackend(clientId: string): Promise<RegisteredClient> {
     return this.clientService.getClientById(clientId).catch(error => {
-      const status = error.response?.status;
+      const status = isAxiosError(error) ? error.response?.status : undefined;
       const clientNotFoundBackend = status === HTTP_STATUS.NOT_FOUND;
       if (clientNotFoundBackend) {
         this.logger.warn(`Local client no longer exists on the backend`, error);
@@ -254,10 +255,11 @@ export class ClientRepository {
       }
 
       return currentClient;
-    } catch (error) {
-      const clientNotValidated = error.type === ClientError.TYPE.NO_VALID_CLIENT;
+    } catch (error: unknown) {
+      const clientNotValidated = isErrorWithType(error) && error.type === ClientError.TYPE.NO_VALID_CLIENT;
       if (!clientNotValidated) {
-        this.logger.error(`Getting valid local client failed: ${error.code || error.message}`, error);
+        const errorMessage = isErrorWithCode(error) ? String(error.code) : toError(error).message;
+        this.logger.error(`Getting valid local client failed: ${errorMessage}`, error);
       }
 
       throw error;
@@ -496,8 +498,8 @@ export class ClientRepository {
         }
         return clientEntities;
       })
-      .catch(error => {
-        this.logger.error(`Unable to retrieve clients for user '${userId}': ${error.message}`, error);
+      .catch((error: unknown) => {
+        this.logger.error(`Unable to retrieve clients for user '${userId}': ${toError(error).message}`, error);
         throw error;
       });
   }

--- a/apps/webapp/src/script/repositories/connection/ConnectionRepository.ts
+++ b/apps/webapp/src/script/repositories/connection/ConnectionRepository.ts
@@ -40,7 +40,7 @@ import {UserState} from 'Repositories/user/UserState';
 import {replaceLink, t} from 'Util/LocalizerUtil';
 import {getLogger, Logger} from 'Util/Logger';
 import {matchQualifiedIds} from 'Util/QualifiedId';
-import {isBackendError} from 'Util/TypePredicateUtil';
+import {isBackendError, toError} from 'Util/TypePredicateUtil';
 
 import type {ConnectionEntity} from './ConnectionEntity';
 import {ConnectionMapper} from './ConnectionMapper';
@@ -204,7 +204,7 @@ export class ConnectionRepository {
         connectionStatus: response.status,
         conversationId: response.qualified_conversation || {id: response.conversation, domain: ''},
       };
-    } catch (error) {
+    } catch (error: unknown) {
       if (isBackendError(error)) {
         switch (error.label) {
           case BackendErrorLabel.LEGAL_HOLD_MISSING_CONSENT: {
@@ -351,9 +351,9 @@ export class ConnectionRepository {
       const response = await this.connectionService.putConnections(userEntity.qualifiedId, newStatus);
       const connectionEvent = {connection: response, user: {name: userEntity.name()}};
       await this.onUserConnection(connectionEvent, EventRepository.SOURCE.INJECTED);
-    } catch (error) {
+    } catch (error: unknown) {
       const logMessage = `Connection change from '${currentStatus}' to '${newStatus}' failed`;
-      this.logger.error(`${logMessage} for '${userEntity.id}' failed: ${error.message}`, error);
+      this.logger.error(`${logMessage} for '${userEntity.id}' failed: ${toError(error).message}`, error);
       switch (newStatus) {
         case ConnectionStatus.ACCEPTED: {
           PrimaryModal.show(PrimaryModal.type.ACKNOWLEDGE, {

--- a/apps/webapp/src/script/repositories/conversation/ConversationLabelRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationLabelRepository.ts
@@ -137,7 +137,7 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
     if (storedData) {
       try {
         parsedStoredData = JSON.parse(storedData);
-      } catch (error) {
+      } catch (error: unknown) {
         this.logger.warn(`Failed to parse stored labels: ${error instanceof Error ? error.message : String(error)}`);
         // Clear corrupted data
         localStorage.removeItem(ConversationLabelRepository.LocalStorageKey);
@@ -164,7 +164,7 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
       if (conversationLabelJson) {
         try {
           localData = JSON.parse(conversationLabelJson);
-        } catch (error) {
+        } catch (error: unknown) {
           this.logger.warn(
             `Failed to parse stored labels, clearing corrupted data: ${error instanceof Error ? error.message : String(error)}`,
           );
@@ -216,7 +216,7 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
         this.persistValues(updatedData);
       }
       // If both are null, labels remain empty (default state)
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.warn(`No labels were loaded: ${error instanceof Error ? error.message : String(error)}`);
       // Don't save empty state on error
     }

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -106,7 +106,7 @@ import {
   startsWith,
 } from 'Util/StringUtil';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
-import {isBackendError} from 'Util/TypePredicateUtil';
+import {isBackendError, isErrorWithType, toError} from 'Util/TypePredicateUtil';
 import {createUuid} from 'Util/uuid';
 
 import {ACCESS_STATE} from './AccessState';
@@ -533,7 +533,7 @@ export class ConversationRepository {
       }
 
       return conversationEntity;
-    } catch (error) {
+    } catch (error: unknown) {
       if (isBackendError(error)) {
         switch (error.label) {
           case BackendErrorLabel.CLIENT_ERROR:
@@ -581,7 +581,7 @@ export class ConversationRepository {
       try {
         await this.loadMissingConversations();
         await this.refreshAllConversationsUnavailableParticipants();
-      } catch (error) {
+      } catch (error: unknown) {
         this.logger.warn(`failed to refresh missing users & conversations metat data`, error);
       }
     }, TIME_IN_MILLIS.HOUR * 3);
@@ -651,10 +651,13 @@ export class ConversationRepository {
    * @returns the fetched backend conversation entity
    */
   public fetchBackendConversationEntityById = async (qualifiedId: QualifiedId): Promise<BackendConversation> => {
-    const backendConversationEntity = await this.conversationService.getConversationById(qualifiedId).catch(error => {
-      this.logger.error(`Failed to get conversation from backend: ${error.message}`);
-      throw error;
-    });
+    const backendConversationEntity = await this.conversationService
+      .getConversationById(qualifiedId)
+      .catch((error: unknown) => {
+        this.logger.error(`Failed to get conversation from backend: ${toError(error).message}`);
+        throw error;
+      });
+
     return backendConversationEntity;
   };
 
@@ -666,8 +669,8 @@ export class ConversationRepository {
     connections: ConnectionEntity[],
     deadConnections: ConnectionEntity[],
   ): Promise<Conversation[]> {
-    const remoteConversations = await this.conversationService.getAllConversations().catch(error => {
-      this.logger.error(`Failed to get all conversations from backend: ${error.message}`);
+    const remoteConversations = await this.conversationService.getAllConversations().catch((error: unknown) => {
+      this.logger.error(`Failed to get all conversations from backend: ${toError(error).message}`);
       return {found: []} as RemoteConversations;
     });
     return this.loadRemoteConversations(remoteConversations, connections, deadConnections);
@@ -684,8 +687,8 @@ export class ConversationRepository {
     }
     const remoteConversations = await this.conversationService
       .getConversationByIds(missingConversations)
-      .catch(error => {
-        this.logger.error(`Failed to get all conversations from backend: ${error.message}`);
+      .catch((error: unknown) => {
+        this.logger.error(`Failed to get all conversations from backend: ${toError(error).message}`);
         return {found: [], failed: missingConversations} as RemoteConversations;
       });
 
@@ -1114,7 +1117,7 @@ export class ConversationRepository {
           // In case a user is missing in the local state, then they will be considered an `unavailable` user
           await this.addEventsToConversation(events, conversationEntity, {offline: true});
         }
-      } catch (error) {
+      } catch (error: unknown) {
         this.logger.warn(`Could not load unread events for conversation: ${conversationEntity.id}`, error);
       }
       conversationEntity.isLoadingMessages(false);
@@ -1193,7 +1196,7 @@ export class ConversationRepository {
     try {
       await this.conversationService.deleteConversation(teamId, conversationEntity.id);
       return this.deleteConversationLocally(conversationEntity, true);
-    } catch (error) {
+    } catch (error: unknown) {
       const isAlreadyDeletedOnBackend = isBackendError(error) && error.label === BackendErrorLabel.NO_CONVERSATION;
       if (isAlreadyDeletedOnBackend) {
         return this.deleteConversationLocally(conversationEntity, true);
@@ -1268,10 +1271,11 @@ export class ConversationRepository {
 
     try {
       return await this.fetchConversationById(conversation_id);
-    } catch (error) {
-      const isConversationNotFound = error.type === ConversationError.TYPE.CONVERSATION_NOT_FOUND;
+    } catch (error: unknown) {
+      const isConversationNotFound =
+        isErrorWithType(error) && error.type === ConversationError.TYPE.CONVERSATION_NOT_FOUND;
       if (isConversationNotFound) {
-        this.logger.warn(`Failed to get conversation '${conversation_id.id}': ${error.message}`, error);
+        this.logger.warn(`Failed to get conversation '${conversation_id.id}': ${toError(error).message}`, error);
       }
 
       throw error;
@@ -1516,8 +1520,8 @@ export class ConversationRepository {
       const conversationEntity = await this.getConversationById(conversation_id);
       const messageEntity = await this.messageRepository.getMessageInConversationById(conversationEntity, message_id);
       return conversationEntity.last_read_timestamp() >= messageEntity.timestamp();
-    } catch (error) {
-      const messageNotFound = error.type === ConversationError.TYPE.MESSAGE_NOT_FOUND;
+    } catch (error: unknown) {
+      const messageNotFound = isErrorWithType(error) && error.type === ConversationError.TYPE.MESSAGE_NOT_FOUND;
       if (messageNotFound) {
         return true;
       }
@@ -1578,7 +1582,11 @@ export class ConversationRepository {
                 await this.onMemberJoin(conversationEntity, response);
               }
               amplify.publish(WebAppEvents.CONVERSATION.SHOW, conversationEntity, {});
-            } catch (error) {
+            } catch (error: unknown) {
+              if (!isBackendError(error)) {
+                throw error;
+              }
+
               switch (error.label) {
                 case BackendErrorLabel.ACCESS_DENIED:
                 case BackendErrorLabel.NO_CONVERSATION:
@@ -1608,7 +1616,11 @@ export class ConversationRepository {
             : t('modalConversationJoinHeadline'),
         },
       });
-    } catch (error) {
+    } catch (error: unknown) {
+      if (!isBackendError(error)) {
+        throw error;
+      }
+
       switch (error.label) {
         case BackendErrorLabel.NO_CONVERSATION:
         case BackendErrorLabel.NO_CONVERSATION_CODE: {
@@ -1749,7 +1761,7 @@ export class ConversationRepository {
       mlsConversation.mutedTimestamp(proteusConversationToBeKept.mutedTimestamp());
       mlsConversation.status(proteusConversationToBeKept.status());
       mlsConversation.verification_state(proteusConversationToBeKept.verification_state());
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.warn('Failed to migrate conversation properties', {
         error,
         proteusConversationToBeKept: JSON.stringify(proteusConversationToBeKept),
@@ -1937,7 +1949,7 @@ export class ConversationRepository {
     try {
       initialisedMLSConversation = await this.establishMLS1to1Conversation(mlsConversation, otherUserId);
       initialisedMLSConversation.readOnlyState(null);
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.warn(`Failed to establish MLS 1:1 conversation with user ${otherUserId.id}`, error);
       if (!allowUnestablished) {
         throw error;
@@ -2189,7 +2201,7 @@ export class ConversationRepository {
       this.conversationState.conversations.notifySubscribers();
 
       return updatedConversation;
-    } catch (error) {
+    } catch (error: unknown) {
       const isConversationNotFound =
         error instanceof ConversationError && error.type === ConversationError.TYPE.CONVERSATION_NOT_FOUND;
       if (!isConversationNotFound) {
@@ -2335,7 +2347,7 @@ export class ConversationRepository {
       }
 
       return this.ensureConversationExists({conversationId, groupId, epoch: remoteEpoch, core, retry: false});
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error('Failed to recover from local unestablished MLS conversation', {
         error,
         conversationId,
@@ -2357,7 +2369,7 @@ export class ConversationRepository {
         // a conversation marked `not_found` could be either non existing on backend or it could mean the self user is not part of it
         // We need to check if the conversation exists on backend
         await this.conversationService.getConversationById(inccessibleConversation);
-      } catch (error) {
+      } catch (error: unknown) {
         if (isBackendError(error) && error.label === BackendErrorLabel.NO_CONVERSATION) {
           // Only if the conversation triggers a not found error, we delete it locally
           await this.deleteConversationLocally(inccessibleConversation, true);
@@ -2390,7 +2402,7 @@ export class ConversationRepository {
     for (const connection of connections) {
       try {
         await this.mapConnection(connection);
-      } catch (error) {
+      } catch (error: unknown) {
         this.logger.error(
           `Failed when mapping a connection with user ${connection.userId} to a conversation, error: `,
           error,
@@ -2436,7 +2448,7 @@ export class ConversationRepository {
     for (const conversation of sortedConverstions) {
       try {
         await this.init1to1Conversation(conversation);
-      } catch (error) {
+      } catch (error: unknown) {
         this.logger.error(`Failed when initialising 1:1 conversation with id ${conversation.id}, error: `, error);
       }
     }
@@ -2673,7 +2685,7 @@ export class ConversationRepository {
           }
         }
       }
-    } catch (error) {
+    } catch (error: unknown) {
       if (isBackendError(error)) {
         this.handleAddToConversationError(error, conversation, qualifiedUsers);
       }
@@ -2710,12 +2722,12 @@ export class ConversationRepository {
       try {
         await this.addService(conversationEntity, {providerId, serviceId});
         return conversationEntity;
-      } catch (error) {
+      } catch (error: unknown) {
         // If we fail to add the service to the newly created conversation, we should delete the conversation
         await this.deleteConversation(conversationEntity);
         throw error;
       }
-    } catch (error) {
+    } catch (error: unknown) {
       PrimaryModal.show(PrimaryModal.type.ACKNOWLEDGE, {
         text: {
           message: t('modalIntegrationUnavailableMessage'),
@@ -2761,7 +2773,7 @@ export class ConversationRepository {
   ) {
     try {
       await this.addService(conversationEntity, {providerId, serviceId});
-    } catch (error) {
+    } catch (error: unknown) {
       if (isBackendError(error)) {
         return this.handleAddToConversationError(error, conversationEntity, [{domain: '', id: serviceId}]);
       }
@@ -3168,8 +3180,8 @@ export class ConversationRepository {
       const logMessage = `Changed notification state of conversation to '${mutedStatus}' on '${mutedRef}'`;
       this.logger.debug(logMessage);
       return response;
-    } catch (error) {
-      const log = `Failed to change notification state of conversation '${conversationEntity.id}': ${error.message}`;
+    } catch (error: unknown) {
+      const log = `Failed to change notification state of conversation '${conversationEntity.id}': ${toError(error).message}`;
       const rejectError = new Error(log);
       this.logger.warn(rejectError.message, error);
       throw rejectError;
@@ -3240,11 +3252,12 @@ export class ConversationRepository {
 
     const updatePromise = conversationEntity.isSelfUserRemoved()
       ? Promise.resolve()
-      : this.conversationService.updateMemberProperties(conversationId, payload).catch(error => {
-          const logMessage = `Failed to change archived state of '${conversationId}' to '${newState}': ${error.code}`;
+      : this.conversationService.updateMemberProperties(conversationId, payload).catch((error: unknown) => {
+          const errorCode = isBackendError(error) ? error.code : 'unknown';
+          const logMessage = `Failed to change archived state of '${conversationId}' to '${newState}': ${errorCode}`;
           this.logger.error(logMessage);
 
-          const isNotFound = error.code === HTTP_STATUS.NOT_FOUND;
+          const isNotFound = isBackendError(error) && error.code === HTTP_STATUS.NOT_FOUND;
           if (!isNotFound) {
             throw error;
           }
@@ -3884,8 +3897,8 @@ export class ConversationRepository {
         await this.saveConversation(conversationEntity);
       }
       return conversationEntity;
-    } catch (error) {
-      const isNoChanges = error.type === ConversationError.TYPE.NO_CHANGES;
+    } catch (error: unknown) {
+      const isNoChanges = isErrorWithType(error) && error.type === ConversationError.TYPE.NO_CHANGES;
       if (!isNoChanges) {
         throw error;
       }
@@ -4216,8 +4229,8 @@ export class ConversationRepository {
       .then(() => {
         return this.messageRepository.deleteMessageById(conversationEntity, eventData.message_id);
       })
-      .catch(error => {
-        const isNotFound = error.type === ConversationError.TYPE.MESSAGE_NOT_FOUND;
+      .catch((error: unknown) => {
+        const isNotFound = isErrorWithType(error) && error.type === ConversationError.TYPE.MESSAGE_NOT_FOUND;
         if (!isNotFound) {
           this.logger.warn(`Failed to delete message for conversation '${conversationEntity.id}'`, error);
           throw error;
@@ -4250,7 +4263,7 @@ export class ConversationRepository {
       }
       const conversationEntity = await this.getConversationById({domain: '', id: eventData.conversation_id});
       return await this.messageRepository.deleteMessageById(conversationEntity, eventData.message_id);
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.warn(
         `Failed to delete message '${eventData.message_id}' for conversation '${eventData.conversation_id}'`,
         error,
@@ -4282,8 +4295,8 @@ export class ConversationRepository {
       if (changes) {
         await this.eventService.updateEventSequentially({primary_key: messageEntity.primary_key, ...changes});
       }
-    } catch (error) {
-      const isNotFound = error.type === ConversationError.TYPE.MESSAGE_NOT_FOUND;
+    } catch (error: unknown) {
+      const isNotFound = isErrorWithType(error) && error.type === ConversationError.TYPE.MESSAGE_NOT_FOUND;
       if (!isNotFound) {
         const log = `Failed to handle reaction to message '${messageId}' in conversation '${conversationEntity.id}'`;
         this.logger.error(log, error);
@@ -4425,7 +4438,7 @@ export class ConversationRepository {
       this.logger.info(
         `Updated conversation group ID from ${oldGroupId} to ${newGroupId} for conversation ${conversationEntity.id} and set epoch to 0`,
       );
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error(`Failed to reset MLS conversation ${conversationEntity.id}`, error);
     }
   }

--- a/apps/webapp/src/script/repositories/conversation/ConversationRoleRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRoleRepository.ts
@@ -87,7 +87,7 @@ export class ConversationRoleRepository {
       try {
         const response = await this.teamRepository.getTeamConversationRoles();
         this.teamRoles = response.conversation_roles;
-      } catch (error) {
+      } catch (error: unknown) {
         this.logger.warn('Could not load team conversation roles', error);
       }
     }

--- a/apps/webapp/src/script/repositories/conversation/ConversationStateHandler.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationStateHandler.ts
@@ -25,6 +25,7 @@ import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
 import type {Conversation} from 'Repositories/entity/Conversation';
 import {t} from 'Util/LocalizerUtil';
+import {isErrorWithCode} from 'Util/TypePredicateUtil';
 
 import {AbstractConversationEventHandler, EventHandlingConfig} from './AbstractConversationEventHandler';
 import {ACCESS_STATE} from './AccessState';
@@ -73,7 +74,7 @@ export class ConversationStateHandler extends AbstractConversationEventHandler {
             await this.conversationService.putConversationAccess(conversationId, accessModes, accessRole);
 
             conversationEntity.accessState(accessState);
-          } catch (e) {
+          } catch (e: unknown) {
             let messageString: string;
             const {featureName, ...featureInfo} = featureFromStateChange(prevAccessState, accessState);
 
@@ -96,8 +97,8 @@ export class ConversationStateHandler extends AbstractConversationEventHandler {
     try {
       const response = await this.conversationService.getConversationCode(conversationEntity.id);
       return ConversationMapper.mapAccessCode(conversationEntity, response);
-    } catch (error) {
-      const isNotFound = error.code === HTTP_STATUS.NOT_FOUND;
+    } catch (error: unknown) {
+      const isNotFound = isErrorWithCode(error) && error.code === HTTP_STATUS.NOT_FOUND;
       if (!isNotFound) {
         this._showModal(t('modalConversationGuestOptionsGetCodeMessage'));
       }
@@ -111,7 +112,7 @@ export class ConversationStateHandler extends AbstractConversationEventHandler {
       if (accessCode) {
         ConversationMapper.mapAccessCode(conversationEntity, accessCode);
       }
-    } catch (e) {
+    } catch (e: unknown) {
       return this._showModal(t('modalConversationGuestOptionsRequestCodeMessage'));
     }
   }
@@ -120,7 +121,7 @@ export class ConversationStateHandler extends AbstractConversationEventHandler {
     try {
       await this.conversationService.deleteConversationCode(conversationEntity.id);
       conversationEntity.accessCode(undefined);
-    } catch (e) {
+    } catch (e: unknown) {
       return this._showModal(t('modalConversationGuestOptionsRevokeCodeMessage'));
     }
   }

--- a/apps/webapp/src/script/repositories/conversation/EventMapper.ts
+++ b/apps/webapp/src/script/repositories/conversation/EventMapper.ts
@@ -64,6 +64,7 @@ import type {EventRecord, LegacyEventRecord} from 'Repositories/storage';
 import {t} from 'Util/LocalizerUtil';
 import {getLogger, Logger} from 'Util/Logger';
 import {userReactionMapToReactionMap} from 'Util/ReactionUtil';
+import {isErrorWithType, toError} from 'Util/TypePredicateUtil';
 import {base64ToArray} from 'Util/util';
 
 import {
@@ -116,8 +117,8 @@ export class EventMapper {
     const mappedEvents = reversedEvents.map((event): Message | void => {
       try {
         return this._mapJsonEvent(event, conversationEntity);
-      } catch (error) {
-        const errorMessage = `Failure while mapping events. Affected '${event.type}' event: ${error.message}`;
+      } catch (error: unknown) {
+        const errorMessage = `Failure while mapping events. Affected '${event.type}' event: ${toError(error).message}`;
         this.logger.error(errorMessage, error);
       }
     });
@@ -134,12 +135,12 @@ export class EventMapper {
   mapJsonEvent(event: ConversationEvent | ClientConversationEvent, conversationEntity: Conversation) {
     try {
       return this._mapJsonEvent(event, conversationEntity);
-    } catch (error) {
-      const isMessageNotFound = error.type === ConversationError.TYPE.MESSAGE_NOT_FOUND;
+    } catch (error: unknown) {
+      const isMessageNotFound = isErrorWithType(error) && error.type === ConversationError.TYPE.MESSAGE_NOT_FOUND;
       if (isMessageNotFound) {
         throw error;
       }
-      const errorMessage = `Failure while mapping events. Affected '${event.type}' event: ${error.message}`;
+      const errorMessage = `Failure while mapping events. Affected '${event.type}' event: ${toError(error).message}`;
       this.logger.error(errorMessage, error);
 
       throw new ConversationError(
@@ -1093,8 +1094,8 @@ export class EventMapper {
         if (mentionEntity) {
           try {
             return mentionEntity.validate(messageText, allMentions);
-          } catch (error) {
-            this.logger.warn(`Removed invalid mention when mapping message: ${error.message}`);
+          } catch (error: unknown) {
+            this.logger.warn(`Removed invalid mention when mapping message: ${toError(error).message}`);
             return false;
           }
         }

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
@@ -93,7 +93,7 @@ import {roundLogarithmic} from 'Util/NumberUtil';
 import {matchQualifiedIds} from 'Util/QualifiedId';
 import {capitalizeFirstChar} from 'Util/StringUtil';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
-import {isBackendError} from 'Util/TypePredicateUtil';
+import {isBackendError, isErrorWithCode} from 'Util/TypePredicateUtil';
 import {loadUrlBlob, supportsMLS} from 'Util/util';
 import {createUuid} from 'Util/uuid';
 
@@ -622,7 +622,7 @@ export class MessageRepository {
 
       const uploadDuration = (Date.now() - uploadStarted) / TIME_IN_MILLIS.SECOND;
       this.logger.info(`Finished to upload asset for conversation'${conversation.id} in ${uploadDuration}`);
-    } catch (error) {
+    } catch (error: unknown) {
       if (error instanceof RequestCancellationError) {
         return;
       }
@@ -671,7 +671,7 @@ export class MessageRepository {
       return this.eventService.updateEvent(messageEntity.primary_key, {
         fileData: file,
       });
-    } catch (error) {
+    } catch (error: unknown) {
       if ((error as any).type !== ConversationError.TYPE.MESSAGE_NOT_FOUND) {
         throw error;
       }
@@ -750,7 +750,7 @@ export class MessageRepository {
       const message = MessageBuilder.buildFileMetaDataMessage({metaData: meta as FileMetaDataContent}, originalId);
       this.assetRepository.addToProcessQueue(message, conversation.id);
       return {message, metaData: meta as FileMetaDataContent};
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error('Error while building metadata for asset', JSON.stringify(error));
       const logMessage = `Couldn't render asset preview from metadata. Asset might be corrupt: ${
         (error as Error).message
@@ -1015,7 +1015,7 @@ export class MessageRepository {
         await handleSuccess(result);
       }
       return result;
-    } catch (error) {
+    } catch (error: unknown) {
       await this.updateMessageAsFailed(conversation, payload.messageId, error);
       return {id: payload.messageId, sentAt: new Date().toISOString(), state: SendAndInjectSendingState.FAILED};
     }
@@ -1066,7 +1066,7 @@ export class MessageRepository {
         amplify.publish(WebAppEvents.USER.CLIENTS_UPDATED, userId);
       }
       return await this.sendSessionReset(userId, clientId, conversation);
-    } catch (error) {
+    } catch (error: unknown) {
       const message = error instanceof Error ? error.message : error;
       const logMessage = `Failed to reset session for client '${clientId}' of user '${userId.id}': ${message}`;
       this.logger.warn(logMessage, error);
@@ -1239,8 +1239,8 @@ export class MessageRepository {
       if (!options.optimisticRemoval) {
         this.deleteMessageById(conversation, message.id);
       }
-    } catch (error) {
-      const isConversationNotFound = error.code === HTTP_STATUS.NOT_FOUND;
+    } catch (error: unknown) {
+      const isConversationNotFound = isErrorWithCode(error) && error.code === HTTP_STATUS.NOT_FOUND;
       if (isConversationNotFound) {
         this.logger.warn(`Conversation '${conversationId}' not found. Deleting message for self user only.`);
         this.deleteMessage(conversation, message);
@@ -1269,7 +1269,7 @@ export class MessageRepository {
 
       await this.sendToSelfConversations(payload);
       await this.deleteMessageById(conversation, message.id);
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.warn(
         `Failed to send delete message with id '${message.id}' for conversation '${conversation.id}'`,
         error,
@@ -1341,7 +1341,7 @@ export class MessageRepository {
       });
       const messageEntity = await this.getMessageInConversationById(conversation, message.id);
       await this.eventService.updateEventSequentially({primary_key: messageEntity.primary_key, ...changes});
-    } catch (error) {
+    } catch (error: unknown) {
       message.waitingButtonId(undefined);
       return message.setButtonError(buttonId, t('buttonActionError'));
     }
@@ -1432,7 +1432,7 @@ export class MessageRepository {
       if ((EventTypeHandling.STORE as string[]).includes(messageEntity.type) || messageEntity.hasAssetImage()) {
         return await this.eventService.updateEvent(messageEntity.primary_key, changes);
       }
-    } catch (error) {
+    } catch (error: unknown) {
       if ((error as any).type !== ConversationError.TYPE.MESSAGE_NOT_FOUND) {
         throw error;
       }
@@ -1453,7 +1453,7 @@ export class MessageRepository {
           : StatusType.FAILED;
       messageEntity.status(errorStatus);
       return this.eventService.updateEvent(messageEntity.primary_key, {status: errorStatus});
-    } catch (error) {
+    } catch (error: unknown) {
       if ((error as any).type !== ConversationError.TYPE.MESSAGE_NOT_FOUND) {
         throw error;
       }

--- a/apps/webapp/src/script/repositories/conversation/linkPreviews/index.ts
+++ b/apps/webapp/src/script/repositories/conversation/linkPreviews/index.ts
@@ -74,7 +74,7 @@ export async function getLinkPreviewFromString(string: string): Promise<LinkPrev
 
   try {
     return await getLinkPreview(linkData.url, linkData.offset);
-  } catch (error) {
+  } catch (error: unknown) {
     const isLinkPreviewError = error instanceof LinkPreviewError;
     if (!isLinkPreviewError) {
       throw error;
@@ -155,7 +155,7 @@ async function fetchOpenGraphData(link: string): Promise<OpenGraphResult | undef
       }, {} as OpenGraphResult);
     }
     return undefined;
-  } catch (error) {
+  } catch (error: unknown) {
     if (error instanceof Error) {
       logger.warn(`Error while fetching OpenGraph data: ${error.message}`);
     }

--- a/apps/webapp/src/script/repositories/cryptography/CryptographyMapper.ts
+++ b/apps/webapp/src/script/repositories/cryptography/CryptographyMapper.ts
@@ -62,6 +62,7 @@ import {MessageAddEvent} from 'Repositories/conversation/EventBuilder';
 import {ClientEvent, CONVERSATION} from 'Repositories/event/Client';
 import {getLogger, Logger} from 'Util/Logger';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
+import {toError} from 'Util/TypePredicateUtil';
 import {base64ToArray, arrayToBase64} from 'Util/util';
 
 import {PROTO_MESSAGE_TYPE} from './ProtoMessageType';
@@ -546,8 +547,8 @@ export class CryptographyMapper {
         sha256,
       });
       return GenericMessage.decode(new Uint8Array(externalMessageBuffer));
-    } catch (error) {
-      this.logger.error(`Failed to unwrap external message: ${error.message}`, error);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to unwrap external message: ${toError(error).message}`, error);
       throw new CryptographyError(CryptographyError.TYPE.BROKEN_EXTERNAL, CryptographyError.MESSAGE.BROKEN_EXTERNAL);
     }
   }

--- a/apps/webapp/src/script/repositories/event/EventRepository.ts
+++ b/apps/webapp/src/script/repositories/event/EventRepository.ts
@@ -39,6 +39,7 @@ import {EventName} from 'Repositories/tracking/EventName';
 import {UserState} from 'Repositories/user/UserState';
 import {getLogger, Logger} from 'Util/Logger';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
+import {isAxiosError, toError} from 'Util/TypePredicateUtil';
 
 import {ClientEvent} from './Client';
 import {EventMiddleware, EventProcessor, IncomingEvent} from './EventProcessor';
@@ -169,9 +170,9 @@ export class EventRepository {
     return this.eventQueue.push(async () => {
       try {
         await this.handleEvent(payload, source);
-      } catch (error) {
+      } catch (error: unknown) {
         if (source === EventSource.NOTIFICATION_STREAM) {
-          this.logger.warn(`Failed to handle event of type "${event.type}": ${error.message}`, error);
+          this.logger.warn(`Failed to handle event of type "${event.type}": ${toError(error).message}`, error);
         } else {
           throw error;
         }
@@ -323,13 +324,37 @@ export class EventRepository {
   //##############################################################################
   // Notification Stream handling
   //##############################################################################
+  private getServerTimeFromAxiosError(errorResponse: unknown): string | undefined {
+    if (!isAxiosError<{time?: string}>(errorResponse) || !errorResponse.response) {
+      return undefined;
+    }
+
+    if ('time' in errorResponse.response && typeof errorResponse.response.time === 'string') {
+      return errorResponse.response.time;
+    }
+
+    if (
+      'data' in errorResponse.response &&
+      errorResponse.response.data &&
+      typeof errorResponse.response.data === 'object' &&
+      'time' in errorResponse.response.data &&
+      typeof errorResponse.response.data.time === 'string'
+    ) {
+      return errorResponse.response.data.time;
+    }
+
+    return undefined;
+  }
+
   private async handleTimeDrift() {
     try {
       const time = await this.notificationService.getServerTime();
       this.serverTimeHandler.computeTimeOffset(time);
-    } catch (errorResponse) {
-      if (errorResponse.response?.time) {
-        this.serverTimeHandler.computeTimeOffset(errorResponse.response?.time);
+    } catch (errorResponse: unknown) {
+      const serverTime = this.getServerTimeFromAxiosError(errorResponse);
+
+      if (serverTime !== undefined) {
+        this.serverTimeHandler.computeTimeOffset(serverTime);
       }
     }
   }
@@ -529,7 +554,7 @@ export class EventRepository {
       for (const eventProcessMiddleware of this.eventProcessMiddlewares) {
         event = await eventProcessMiddleware.processEvent(event, source);
       }
-    } catch (error) {
+    } catch (error: unknown) {
       if (error instanceof EventValidationError) {
         this.logger.warn(`Event validation failed: ${error.message}`, error);
         return;

--- a/apps/webapp/src/script/repositories/event/EventService.ts
+++ b/apps/webapp/src/script/repositories/event/EventService.ts
@@ -34,6 +34,7 @@ import {
 } from 'Repositories/storage';
 import {StorageSchemata} from 'Repositories/storage/StorageSchemata';
 import {getLogger, Logger} from 'Util/Logger';
+import {toError} from 'Util/TypePredicateUtil';
 
 import {ClientEvent, CONVERSATION as CLIENT_CONVERSATION_EVENT} from './Client';
 
@@ -86,9 +87,9 @@ export class EventService {
       return records
         .filter(record => record.conversation === conversationId && eventIds.includes(record.id))
         .sort(compareEventsById);
-    } catch (error) {
+    } catch (error: unknown) {
       const logMessage = `Failed to get events '${eventIds.join(',')}' for conversation '${conversationId}': ${
-        error.message
+        toError(error).message
       }`;
       this.logger.error(logMessage, error);
       throw error;
@@ -116,8 +117,8 @@ export class EventService {
       return records
         .filter(record => record.conversation === conversationId && !!record.ephemeral_expires)
         .sort(compareEventsById);
-    } catch (error) {
-      const logMessage = `Failed to get ephemeral events for conversation '${conversationId}': ${error.message}`;
+    } catch (error: unknown) {
+      const logMessage = `Failed to get ephemeral events for conversation '${conversationId}': ${toError(error).message}`;
       this.logger.error(logMessage, error);
       throw error;
     }
@@ -156,8 +157,8 @@ export class EventService {
         .filter(record => record.id === eventId && record.conversation === conversationId)
         .sort(compareEventsById)
         .shift();
-    } catch (error) {
-      const logMessage = `Failed to get event '${eventId}' for conversation '${conversationId}': ${error.message}`;
+    } catch (error: unknown) {
+      const logMessage = `Failed to get event '${eventId}' for conversation '${conversationId}': ${toError(error).message}`;
       this.logger.error(logMessage, error);
       throw error;
     }
@@ -251,8 +252,8 @@ export class EventService {
       return this.storageService.db
         ? await (events as Dexie.Collection<any, any>).reverse().sortBy('time')
         : (events as EventRecord[]).reverse().sort(compareEventsByTime);
-    } catch (error) {
-      const message = `Failed to load events for conversation '${conversationId}' from database: '${error.message}'`;
+    } catch (error: unknown) {
+      const message = `Failed to load events for conversation '${conversationId}' from database: '${toError(error).message}'`;
       this.logger.error(message);
       throw error;
     }
@@ -524,8 +525,8 @@ export class EventService {
 
       const records = await this.storageService.getAll<EventRecord>(StorageSchemata.OBJECT_STORE.EVENTS);
       return records;
-    } catch (error) {
-      const logMessage = `Failed to get events for conversation '${conversationId}': ${error.message}`;
+    } catch (error: unknown) {
+      const logMessage = `Failed to get events for conversation '${conversationId}': ${toError(error).message}`;
       this.logger.error(logMessage, error);
       throw error;
     }

--- a/apps/webapp/src/script/repositories/event/preprocessor/QuoteDecoderMiddleware.ts
+++ b/apps/webapp/src/script/repositories/event/preprocessor/QuoteDecoderMiddleware.ts
@@ -128,7 +128,7 @@ export class QuotedMessageMiddleware implements EventMiddleware {
     try {
       const encodedQuote = base64ToArray(rawQuote);
       quote = Quote.decode(encodedQuote);
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.warn('Failed to decode quoted message.', error);
       const quoteData: ProcessedQuoteData = {
         error: {

--- a/apps/webapp/src/script/repositories/extension/GiphyRepository.ts
+++ b/apps/webapp/src/script/repositories/extension/GiphyRepository.ts
@@ -152,7 +152,7 @@ export class GiphyRepository {
       }
 
       return result;
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.warn(`Unable to fetch GIF for query: ${query}`, error);
       throw error;
     }

--- a/apps/webapp/src/script/repositories/integration/IntegrationRepository.ts
+++ b/apps/webapp/src/script/repositories/integration/IntegrationRepository.ts
@@ -30,6 +30,7 @@ import type {TeamRepository} from 'Repositories/team/TeamRepository';
 import {TeamState} from 'Repositories/team/TeamState';
 import {getLogger, Logger} from 'Util/Logger';
 import {compareTransliteration, sortByPriority} from 'Util/StringUtil';
+import {toError} from 'Util/TypePredicateUtil';
 
 import {IntegrationMapper} from './IntegrationMapper';
 import type {IntegrationService} from './IntegrationService';
@@ -215,8 +216,8 @@ export class IntegrationRepository {
         this.services(serviceEntities);
         return serviceEntities;
       }
-    } catch (error) {
-      this.logger.error(`Error searching for services: ${error.message}`, error);
+    } catch (error: unknown) {
+      this.logger.error(`Error searching for services: ${toError(error).message}`, error);
     }
     return undefined;
   }

--- a/apps/webapp/src/script/repositories/media/CanvasMediaStreamMixer.ts
+++ b/apps/webapp/src/script/repositories/media/CanvasMediaStreamMixer.ts
@@ -109,7 +109,7 @@ export class CanvasMediaStreamMixer {
       });
 
       return outputStream;
-    } catch (error) {
+    } catch (error: unknown) {
       this.releaseStreams();
       throw error;
     }
@@ -181,7 +181,7 @@ export class CanvasMediaStreamMixer {
             this.context.drawImage(this.cameraVideo, cameraOverlayX, cameraOverlayY, out_w, out_h);
             this.context.restore();
           }
-        } catch (error) {
+        } catch (error: unknown) {
           console.error('Error in mixFrames:', error);
         }
       }
@@ -211,7 +211,7 @@ export class CanvasMediaStreamMixer {
       });
 
       this.setupPipWindow(pipWindow);
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('Failed to enter Picture-in-Picture mode:', error);
       this.resetPipState();
     }

--- a/apps/webapp/src/script/repositories/media/MediaDevicesHandler.ts
+++ b/apps/webapp/src/script/repositories/media/MediaDevicesHandler.ts
@@ -266,7 +266,7 @@ export class MediaDevicesHandler {
       this.onMediaDevicesRefresh?.();
 
       return mediaDevices;
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error(`Failed to update MediaDevice list: ${error instanceof Error ? error.message : ''}`, error);
       throw error;
     }

--- a/apps/webapp/src/script/repositories/media/MediaStreamHandler.ts
+++ b/apps/webapp/src/script/repositories/media/MediaStreamHandler.ts
@@ -26,6 +26,7 @@ import {BrowserPermissionStatus} from 'Repositories/permission/BrowserPermission
 import {getPermissionStates} from 'Repositories/permission/permissionHandlers';
 import {PermissionType} from 'Repositories/permission/PermissionType';
 import {getLogger, Logger} from 'Util/Logger';
+import {isErrorWithType} from 'Util/TypePredicateUtil';
 
 import {MediaConstraintsHandler, ScreensharingMethods} from './MediaConstraintsHandler';
 import {MEDIA_STREAM_ERROR} from './MediaStreamError';
@@ -64,8 +65,8 @@ export class MediaStreamHandler {
     const hasPermission = this.hasPermissionToAccess(audio, video);
     try {
       return await this.getMediaStream(audio, video, screen, isGroup, hasPermission);
-    } catch (error) {
-      const isPermissionDenied = error.type === PermissionError.TYPE.DENIED;
+    } catch (error: unknown) {
+      const isPermissionDenied = isErrorWithType(error) && error.type === PermissionError.TYPE.DENIED;
       throw isPermissionDenied
         ? new MediaError(MediaError.TYPE.MEDIA_STREAM_PERMISSION, MediaError.MESSAGE.MEDIA_STREAM_PERMISSION)
         : error;

--- a/apps/webapp/src/script/repositories/media/VideoBackgroundBlur.ts
+++ b/apps/webapp/src/script/repositories/media/VideoBackgroundBlur.ts
@@ -63,7 +63,7 @@ function startBlurProcess(
       segmenter.segmentForVideo(videoEl, startTimeMs, result =>
         blurBackground(result, videoEl, webGlContext, videoDimensions),
       );
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('Failed to segment video', error);
     }
   }

--- a/apps/webapp/src/script/repositories/notification/NotificationRepository.ts
+++ b/apps/webapp/src/script/repositories/notification/NotificationRepository.ts
@@ -584,7 +584,7 @@ export class NotificationRepository {
     if (canShowUserImage) {
       try {
         return await this.assetRepository.getObjectUrl(userEntity.previewPictureResource());
-      } catch (error) {
+      } catch (error: unknown) {
         if (error instanceof ValidationUtilError) {
           this.logger.error(`Failed to validate an asset URL: ${error.message}`);
         }

--- a/apps/webapp/src/script/repositories/permission/permissionHandlers.ts
+++ b/apps/webapp/src/script/repositories/permission/permissionHandlers.ts
@@ -62,7 +62,7 @@ export const queryBrowserPermission = async (
     const permissionStatus = await navigator.permissions.query({name: permissionType as any});
     logger.debug(`Permission state for '${permissionType}' is '${permissionStatus.state}'`);
     return permissionStatus.state as BrowserPermissionStatus;
-  } catch (error) {
+  } catch (error: unknown) {
     logger.debug(`Failed to query permission for '${permissionType}'`, error);
     return null;
   }
@@ -89,7 +89,7 @@ export const setupPermissionListener = async (
     };
 
     return permissionStatus;
-  } catch (error) {
+  } catch (error: unknown) {
     logger.debug(`Failed to setup permission listener for '${permissionType}'`, error);
     return null;
   }
@@ -118,7 +118,7 @@ export const initializePermissions = async (
       await setupPermissionListener(permissionType, newState => {
         setPermissionState(permissionType, newState);
       });
-    } catch (error) {
+    } catch (error: unknown) {
       logger.debug(`Failed to initialize permission '${permissionType}'`, error);
     }
   });

--- a/apps/webapp/src/script/repositories/self/SelfRepository.ts
+++ b/apps/webapp/src/script/repositories/self/SelfRepository.ts
@@ -171,7 +171,7 @@ export class SelfRepository extends TypedEventEmitter<Events> {
       await this.selfService.putSupportedProtocols(supportedProtocols);
       await this.userRepository.updateUserSupportedProtocols(this.selfUser.qualifiedId, supportedProtocols);
       this.emit('selfSupportedProtocolsUpdated', supportedProtocols);
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error('Failed to update self supported protocols: ', error);
     }
   }

--- a/apps/webapp/src/script/repositories/storage/StorageService.ts
+++ b/apps/webapp/src/script/repositories/storage/StorageService.ts
@@ -25,6 +25,7 @@ import {IndexedDBEngine} from '@wireapp/store-engine-dexie';
 
 import {Logger, getLogger} from 'Util/Logger';
 import {loadValue, storeValue} from 'Util/StorageUtil';
+import {toError} from 'Util/TypePredicateUtil';
 
 import {DexieDatabase} from './DexieDatabase';
 import {StorageSchemata} from './StorageSchemata';
@@ -79,8 +80,8 @@ export class StorageService {
         this._initCrudHooks(this.db);
       }
       return this.dbName;
-    } catch (error) {
-      const logMessage = `Failed to initialize database '${this.dbName}': ${error.message || error}`;
+    } catch (error: unknown) {
+      const logMessage = `Failed to initialize database '${this.dbName}': ${toError(error).message}`;
       this.logger.error(logMessage, {error});
       throw new StorageError(StorageError.TYPE.FAILED_TO_OPEN, StorageError.MESSAGE.FAILED_TO_OPEN);
     }
@@ -171,7 +172,7 @@ export class StorageService {
       this.logger.info(`Deleting database '${this.dbName}' successful`);
       this.dbName = undefined;
       return true;
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error(`Deleting database '${this.dbName}' failed`);
       throw error;
     }
@@ -229,7 +230,7 @@ export class StorageService {
     try {
       const records = await this.engine.readAll<T>(storeName);
       return records.filter(Boolean);
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error(`Failed to load objects from store '${storeName}'`, error);
       throw error;
     }
@@ -257,7 +258,7 @@ export class StorageService {
   async load<T = Object>(storeName: string, primaryKey: string): Promise<T | undefined> {
     try {
       return await this.engine.read<T>(storeName, primaryKey);
-    } catch (error) {
+    } catch (error: unknown) {
       if (error instanceof StoreEngineError.RecordNotFoundError) {
         return undefined;
       }
@@ -290,7 +291,7 @@ export class StorageService {
     try {
       const newKey = await this.engine.updateOrCreate(storeName, primaryKey, entity);
       return newKey;
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error(`Failed to update or create '${primaryKey}' in store '${storeName}'`, error);
       throw error;
     }
@@ -345,7 +346,7 @@ export class StorageService {
       this.notifyListeners(storeName, DEXIE_CRUD_EVENT.UPDATING, oldRecord, newRecord);
 
       return 1;
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error(`Failed to update '${primaryKey}' in store '${storeName}'`, error);
       throw error;
     }

--- a/apps/webapp/src/script/repositories/team/TeamEntity.ts
+++ b/apps/webapp/src/script/repositories/team/TeamEntity.ts
@@ -44,7 +44,7 @@ export class TeamEntity {
 
     try {
       hasIcon = !!this.icon && isValidAsset(this.icon);
-    } catch (error) {
+    } catch (error: unknown) {
       // ignore error
     }
 

--- a/apps/webapp/src/script/repositories/team/TeamRepository.ts
+++ b/apps/webapp/src/script/repositories/team/TeamRepository.ts
@@ -218,7 +218,7 @@ export class TeamRepository extends TypedEventEmitter<Events> {
         updateRemoteConfigLogger.info('Updating team-settings');
         await this.getTeam();
         await this.updateFeatureConfig();
-      } catch (error) {
+      } catch (error: unknown) {
         this.logger.error(error);
       }
     };
@@ -423,7 +423,7 @@ export class TeamRepository extends TypedEventEmitter<Events> {
           if (imageBlob) {
             imageDataUrl = await loadDataUrl(imageBlob);
           }
-        } catch (error) {
+        } catch (error: unknown) {
           this.logger.warn(`Account image could not be loaded`, error);
         }
       }

--- a/apps/webapp/src/script/repositories/tracking/EventTrackingRepository.ts
+++ b/apps/webapp/src/script/repositories/tracking/EventTrackingRepository.ts
@@ -115,7 +115,7 @@ export class EventTrackingRepository {
       if (stopOnFinish) {
         this.stopProductReporting();
       }
-    } catch (error) {
+    } catch (error: unknown) {
       this.telemetryLogger.warn(`Failed to send new telemetry tracking id to other devices ${error}`);
       storeValue(EventTrackingRepository.CONFIG.USER_ANALYTICS.COUNTLY_FAILED_TO_MIGRATE_DEVICE_ID, newId);
     }
@@ -136,7 +136,7 @@ export class EventTrackingRepository {
       try {
         await this.messageRepository.sendCountlySync(this.telemetryDeviceId);
         resetStoreValue(EventTrackingRepository.CONFIG.USER_ANALYTICS.COUNTLY_UNSYNCED_DEVICE_ID_LOCAL_STORAGE_KEY);
-      } catch (error) {
+      } catch (error: unknown) {
         this.telemetryLogger.warn(`Failed to send new telemetry tracking id to other devices ${error}`);
       }
     }
@@ -158,7 +158,7 @@ export class EventTrackingRepository {
             EventTrackingRepository.CONFIG.USER_ANALYTICS.COUNTLY_SYNCED_AT_LEAST_ONCE_LOCAL_STORAGE_KEY,
             true,
           );
-        } catch (error) {
+        } catch (error: unknown) {
           storeValue(
             EventTrackingRepository.CONFIG.USER_ANALYTICS.COUNTLY_SYNCED_AT_LEAST_ONCE_LOCAL_STORAGE_KEY,
             false,
@@ -173,7 +173,7 @@ export class EventTrackingRepository {
       );
       try {
         await this.messageRepository.sendCountlySync(this.telemetryDeviceId);
-      } catch (error) {
+      } catch (error: unknown) {
         this.telemetryLogger.warn(`Failed to send new telemetry tracking id to other devices ${error}`);
         storeValue(EventTrackingRepository.CONFIG.USER_ANALYTICS.COUNTLY_UNSYNCED_DEVICE_ID_LOCAL_STORAGE_KEY, true);
       }

--- a/apps/webapp/src/script/repositories/user/UserRepository.ts
+++ b/apps/webapp/src/script/repositories/user/UserRepository.ts
@@ -66,7 +66,7 @@ import {t} from 'Util/LocalizerUtil';
 import {getLogger, Logger} from 'Util/Logger';
 import {matchQualifiedIds} from 'Util/QualifiedId';
 import {fixWebsocketString} from 'Util/StringUtil';
-import {isAxiosError, isBackendError} from 'Util/TypePredicateUtil';
+import {isAxiosError, isBackendError, isErrorWithCode, isErrorWithType, toError} from 'Util/TypePredicateUtil';
 
 import {showAvailabilityModal} from './AvailabilityModal';
 import {ConsentValue} from './ConsentValue';
@@ -548,7 +548,7 @@ export class UserRepository extends TypedEventEmitter<Events> {
     try {
       await this.selfService.deleteSelf();
       this.logger.info('Account deletion initiated');
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error(`Unable to delete self: ${error}`);
     }
   }
@@ -680,8 +680,8 @@ export class UserRepository extends TypedEventEmitter<Events> {
       this.saveUser(userEntity, true);
       await this.initMarketingConsent();
       return userEntity;
-    } catch (error) {
-      this.logger.error(`Unable to load self user: ${error.message || error}`, [error]);
+    } catch (error: unknown) {
+      this.logger.error(`Unable to load self user: ${toError(error).message}`, [error]);
       throw error;
     }
   }
@@ -707,11 +707,11 @@ export class UserRepository extends TypedEventEmitter<Events> {
     }
     try {
       return this.fetchUser(userId);
-    } catch (error) {
-      const isNotFound = error.type === UserError.TYPE.USER_NOT_FOUND;
+    } catch (error: unknown) {
+      const isNotFound = isErrorWithType(error) && error.type === UserError.TYPE.USER_NOT_FOUND;
       if (!isNotFound) {
         this.logger.warn(
-          `Failed to find user with ID '${userId.id}' and domain '${userId.domain}': ${error.message}`,
+          `Failed to find user with ID '${userId.id}' and domain '${userId.domain}': ${toError(error).message}`,
           error,
         );
       }
@@ -741,7 +741,7 @@ export class UserRepository extends TypedEventEmitter<Events> {
 
       await this.updateUserSupportedProtocols(user.qualifiedId, supportedProtocols);
       this.emit('supportedProtocolsUpdated', {user, supportedProtocols});
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.warn(`Failed to refresh supported protocols for user ${user.qualifiedId.id}`, error);
     }
   }
@@ -773,7 +773,7 @@ export class UserRepository extends TypedEventEmitter<Events> {
       //update local user entity with new supported protocols
       await this.updateUserSupportedProtocols(userId, supportedProtocols);
       return supportedProtocols;
-    } catch (error) {
+    } catch (error: unknown) {
       if (localSupportedProtocols) {
         this.logger.warn(
           `Failed when fetching supported protocols of user ${userId.id}, using local supported protocols as fallback: `,
@@ -790,7 +790,7 @@ export class UserRepository extends TypedEventEmitter<Events> {
   async getUserByHandle(fqn: QualifiedHandle): Promise<undefined | APIClientUser> {
     try {
       return await this.userService.getUserByFQN(fqn);
-    } catch (error) {
+    } catch (error: unknown) {
       // When we search for a non-existent handle, the backend will return a HTTP 404, which tells us that there is no user with that handle.
       if (
         !isBackendError(error) ||
@@ -967,8 +967,8 @@ export class UserRepository extends TypedEventEmitter<Events> {
       try {
         await this.selfService.putSelfHandle(username);
         return await this.updateUser(this.userState.self().qualifiedId, {handle: username});
-      } catch (error) {
-        if ([HTTP_STATUS.CONFLICT, HTTP_STATUS.BAD_REQUEST].includes(error.code)) {
+      } catch (error: unknown) {
+        if (isErrorWithCode(error) && [HTTP_STATUS.CONFLICT, HTTP_STATUS.BAD_REQUEST].includes(error.code)) {
           throw new UserError(UserError.TYPE.USERNAME_TAKEN, UserError.MESSAGE.USERNAME_TAKEN);
         }
         throw new UserError(UserError.TYPE.REQUEST_FAILURE, UserError.MESSAGE.REQUEST_FAILURE);
@@ -986,8 +986,8 @@ export class UserRepository extends TypedEventEmitter<Events> {
     try {
       await this.userService.checkUserHandle(handle);
       throw new UserError(UserError.TYPE.USERNAME_TAKEN, UserError.MESSAGE.USERNAME_TAKEN);
-    } catch (error) {
-      const errorCode = error.response?.status;
+    } catch (error: unknown) {
+      const errorCode = isAxiosError(error) ? error.response?.status : undefined;
 
       if (errorCode === HTTP_STATUS.NOT_FOUND) {
         return handle;
@@ -1014,8 +1014,8 @@ export class UserRepository extends TypedEventEmitter<Events> {
       ];
       await this.selfService.putSelf({assets, picture: []} as any);
       return await this.updateUser(selfUser.qualifiedId, {assets});
-    } catch (error) {
-      throw new Error(`Error during profile image upload: ${error.message || error.code || error}`);
+    } catch (error: unknown) {
+      throw new Error(`Error during profile image upload: ${toError(error).message}`);
     }
   }
 
@@ -1049,8 +1049,8 @@ export class UserRepository extends TypedEventEmitter<Events> {
           return;
         }
       }
-    } catch (error) {
-      this.logger.warn(`Failed to retrieve marketing consent: ${error.message || error.code}`, error);
+    } catch (error: unknown) {
+      this.logger.warn(`Failed to retrieve marketing consent: ${toError(error).message}`, error);
     }
   }
 }

--- a/apps/webapp/src/script/router/Router.ts
+++ b/apps/webapp/src/script/router/Router.ts
@@ -71,7 +71,7 @@ const parseRoute = () => {
 
       const paramValues = paramNames.map(name => params[name]);
       return handler(...paramValues);
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('Error matching pattern:', pattern, error);
       continue;
     }

--- a/apps/webapp/src/script/service/StoreEngineProvider.ts
+++ b/apps/webapp/src/script/service/StoreEngineProvider.ts
@@ -53,7 +53,7 @@ const providePermanentEngine = async (
 
   try {
     await engine.initWithDb(db, requestPersistentStorage);
-  } catch (error) {
+  } catch (error: unknown) {
     await engine.initWithDb(db, false);
   }
   return engine;

--- a/apps/webapp/src/script/util/ClipboardUtil.ts
+++ b/apps/webapp/src/script/util/ClipboardUtil.ts
@@ -46,7 +46,7 @@ export function copyText(text: string): Promise<void> {
     }
 
     return Promise.resolve();
-  } catch (error) {
+  } catch (error: unknown) {
     return Promise.reject(error);
   }
 }

--- a/apps/webapp/src/script/util/DebugUtil.ts
+++ b/apps/webapp/src/script/util/DebugUtil.ts
@@ -149,7 +149,7 @@ export class DebugUtil {
       this.logger.info(
         `Importing ${notificationResponse.notifications.length} event(s) took ${endTime - startTime} milliseconds`,
       );
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error(`Failed to import events: ${error}`);
     }
   }

--- a/apps/webapp/src/script/util/ImageUtil.ts
+++ b/apps/webapp/src/script/util/ImageUtil.ts
@@ -26,7 +26,7 @@ export const stripImageExifData = async (image: Blob): Promise<Blob> => {
     const canvas = drawImageOnCanvas(img);
     const strippedBlob = await canvasToBlob(canvas, image.type);
     return strippedBlob;
-  } catch (error) {
+  } catch (error: unknown) {
     if (error instanceof Error) {
       throw new Error(`Failed to strip EXIF data: ${error.message}`);
     }
@@ -91,7 +91,7 @@ export const imageHasExifData = async (image: Blob): Promise<boolean> => {
     }
 
     return containsExifData(view);
-  } catch (error) {
+  } catch (error: unknown) {
     if (error instanceof Error) {
       throw new Error(`Failed to check for EXIF data: ${error.message}`);
     }

--- a/apps/webapp/src/script/util/ModalFocusUtil.ts
+++ b/apps/webapp/src/script/util/ModalFocusUtil.ts
@@ -69,7 +69,7 @@ export function captureModalFocusContext(context: ModalFocusContext = {}): Modal
       if (additionalCallback) {
         try {
           additionalCallback();
-        } catch (error) {
+        } catch (error: unknown) {
           console.error('Error in modal close callback:', error);
         }
       }
@@ -84,7 +84,7 @@ export function captureModalFocusContext(context: ModalFocusContext = {}): Modal
           ) {
             previouslyFocusedElement.focus();
           }
-        } catch (error) {
+        } catch (error: unknown) {
           // Silently handle focus errors (e.g., element no longer in DOM)
           console.error('Failed to restore focus to element:', error);
         }

--- a/apps/webapp/src/script/util/TypePredicateUtil.test.ts
+++ b/apps/webapp/src/script/util/TypePredicateUtil.test.ts
@@ -20,7 +20,7 @@
 import {BackendError, BackendErrorLabel} from '@wireapp/api-client/lib/http/';
 import type {AxiosError} from 'axios';
 
-import {isAxiosError, isBackendError} from 'Util/TypePredicateUtil';
+import {isAxiosError, isBackendError, isErrorWithCode, isErrorWithType, toError} from 'Util/TypePredicateUtil';
 
 describe('TypePredicateUtil', () => {
   describe('isAxiosError', () => {
@@ -62,6 +62,42 @@ describe('TypePredicateUtil', () => {
     it('does not fail when an error is a string', () => {
       const actual = isBackendError('Server Error');
       expect(actual).toBeFalsy();
+    });
+  });
+
+  describe('isErrorWithCode', () => {
+    it('recognizes errors with a numeric code', () => {
+      const error = Object.assign(new Error('Server Error'), {code: 400});
+
+      const actual = isErrorWithCode(error);
+
+      expect(actual).toBeTruthy();
+    });
+  });
+
+  describe('isErrorWithType', () => {
+    it('recognizes errors with a string type', () => {
+      const error = Object.assign(new Error('Server Error'), {type: 'CLIENT_ERROR'});
+
+      const actual = isErrorWithType(error);
+
+      expect(actual).toBeTruthy();
+    });
+  });
+
+  describe('toError', () => {
+    it('returns error instances unchanged', () => {
+      const error = new Error('Server Error');
+
+      const actual = toError(error);
+
+      expect(actual).toBe(error);
+    });
+
+    it('wraps string values into errors', () => {
+      const actual = toError('Server Error');
+
+      expect(actual.message).toBe('Server Error');
     });
   });
 });

--- a/apps/webapp/src/script/util/TypePredicateUtil.ts
+++ b/apps/webapp/src/script/util/TypePredicateUtil.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import is from '@sindresorhus/is';
 import {RegisteredClient} from '@wireapp/api-client/lib/client';
 import type {BackendError} from '@wireapp/api-client/lib/http';
 import {AxiosError} from 'axios';
@@ -26,12 +27,42 @@ import {ClientRecord} from 'Repositories/storage/record/ClientRecord';
 
 import {isObject} from '../guards/common';
 
-export function isAxiosError<T>(errorCandidate: any): errorCandidate is AxiosError<T> {
-  return errorCandidate && errorCandidate.isAxiosError === true;
+type ErrorWithCode = Error & {readonly code: number};
+type ErrorWithType = Error & {readonly type: string};
+
+export function isAxiosError<T>(errorCandidate: unknown): errorCandidate is AxiosError<T> {
+  return (
+    isObject(errorCandidate) &&
+    (('isAxiosError' in errorCandidate && errorCandidate.isAxiosError === true) || 'response' in errorCandidate)
+  );
 }
 
-export function isBackendError(errorCandidate: any): errorCandidate is BackendError {
-  return errorCandidate && typeof errorCandidate.label === 'string' && typeof errorCandidate.message === 'string';
+export function isBackendError(errorCandidate: unknown): errorCandidate is BackendError {
+  return isObject(errorCandidate) && 'label' in errorCandidate && typeof errorCandidate.label === 'string';
+}
+
+export function isErrorWithCode(errorCandidate: unknown): errorCandidate is ErrorWithCode {
+  return isObject(errorCandidate) && 'code' in errorCandidate && typeof errorCandidate.code === 'number';
+}
+
+export function isErrorWithType(errorCandidate: unknown): errorCandidate is ErrorWithType {
+  return isObject(errorCandidate) && 'type' in errorCandidate && typeof errorCandidate.type === 'string';
+}
+
+export function toError(errorCandidate: unknown): Error {
+  if (is.error(errorCandidate)) {
+    return errorCandidate;
+  }
+
+  if (isObject(errorCandidate)) {
+    return errorCandidate as Error;
+  }
+
+  if (typeof errorCandidate === 'string') {
+    return new Error(errorCandidate);
+  }
+
+  return new Error('Unknown error', {cause: errorCandidate});
 }
 
 export function isConversationEntity(conversation: any): conversation is Conversation {

--- a/apps/webapp/src/script/util/UrlUtil.ts
+++ b/apps/webapp/src/script/util/UrlUtil.ts
@@ -72,7 +72,7 @@ export const cleanURL = (url: string = ''): string => {
   try {
     const {hostname, port, pathname, search, hash} = new URL(url);
     return `${hostname.replace(/^www./, '')}${port ? `:${port}` : ''}${pathname.replace(/\/$/, '')}${search}${hash}`;
-  } catch (error) {
+  } catch (error: unknown) {
     return '';
   }
 };

--- a/apps/webapp/src/script/util/localStorage.ts
+++ b/apps/webapp/src/script/util/localStorage.ts
@@ -30,7 +30,7 @@ export function getStorage(): Storage | undefined {
      * (note: Some version of Firefox do not throw an error but, instead, return a null object, we also need to account for that scenario)
      */
     return window.localStorage;
-  } catch (error) {
+  } catch (error: unknown) {
     return undefined;
   }
 }

--- a/apps/webapp/src/script/util/util.ts
+++ b/apps/webapp/src/script/util/util.ts
@@ -48,7 +48,7 @@ export const checkIndexedDb = (): Promise<void> => {
         }
         return undefined;
       };
-    } catch (error) {
+    } catch (error: unknown) {
       return Promise.reject(new AuthError(AuthError.TYPE.PRIVATE_MODE, AuthError.MESSAGE.PRIVATE_MODE));
     }
 

--- a/apps/webapp/src/script/view_model/ActionsViewModel.ts
+++ b/apps/webapp/src/script/view_model/ActionsViewModel.ts
@@ -195,7 +195,7 @@ export class ActionsViewModel {
                   await this.selfRepository.deleteSelfUserClient(clientEntity.id, password);
                   removeCurrentModal();
                   resolve();
-                } catch (error) {
+                } catch (error: unknown) {
                   if (isBackendError(error)) {
                     const {updateErrorMessage} = usePrimaryModalState.getState();
                     if (
@@ -403,7 +403,7 @@ export class ActionsViewModel {
               try {
                 await this.conversationRepository.removeMembers(conversationEntity, [userEntity.qualifiedId]);
                 resolve();
-              } catch (error) {
+              } catch (error: unknown) {
                 reject(error);
               }
             },

--- a/apps/webapp/src/script/view_model/ContentViewModel.ts
+++ b/apps/webapp/src/script/view_model/ContentViewModel.ts
@@ -233,7 +233,7 @@ export class ContentViewModel {
         await new Promise(resolve => setTimeout(resolve, initialDelayMs * (attempt + 1)));
         await this.conversationRepository.fetchBackendConversationEntityById(conversationId);
         return true;
-      } catch (error) {
+      } catch (error: unknown) {
         this.logger.warn(`Retry attempt ${attempt + 1}/${maxRetries} failed for conversation fetch`, error);
       }
     }

--- a/apps/webapp/test/e2e_tests/backend/ConversationRepository/conversationRepository.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/ConversationRepository/conversationRepository.e2e.ts
@@ -87,7 +87,7 @@ export class ConversationRepositoryE2E extends BackendClientE2E {
       const response = await this.axiosInstance.post('conversations', conversationData, this.getAuthHeaders(token));
 
       return response.data;
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('Error creating group conversation:', error);
       throw error;
     }

--- a/apps/webapp/test/e2e_tests/backend/apiManager.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/apiManager.e2e.ts
@@ -180,7 +180,7 @@ export class ApiManagerE2E {
   private extractCookieFromRegisterResponse(registerResponse: AxiosResponse): string {
     try {
       return registerResponse.headers['set-cookie']!.find((cookieStr: string) => cookieStr.startsWith('zuid='))!;
-    } catch (error) {
+    } catch (error: unknown) {
       throw new Error(
         `Error extracting zuid cookie from register response: ${error instanceof Error ? error.message : error}`,
       );

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/infoHistory.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/infoHistory.page.ts
@@ -31,7 +31,7 @@ export class HistoryInfoPage {
     try {
       await this.continueButton.waitFor({state: 'visible'});
       return true;
-    } catch (err) {
+    } catch (err: unknown) {
       return false;
     }
   }

--- a/apps/webapp/test/e2e_tests/scripts/create-playwright-report-summary.ts
+++ b/apps/webapp/test/e2e_tests/scripts/create-playwright-report-summary.ts
@@ -28,7 +28,7 @@ let report: JSONReport;
 
 try {
   report = JSON.parse(readFileSync(jsonPath, 'utf-8'));
-} catch (error) {
+} catch (error: unknown) {
   const errorMessage = `❌ Error: report.json not found at ${jsonPath} ❌`;
   writeFileSync('playwright-report-summary.txt', errorMessage);
   process.exit(1);

--- a/apps/webapp/test/e2e_tests/scripts/send-playwright-results-to-testiny.ts
+++ b/apps/webapp/test/e2e_tests/scripts/send-playwright-results-to-testiny.ts
@@ -156,7 +156,7 @@ async function appendCiDescription(runId: number): Promise<void> {
         doc.c.push(linkParagraph("Build URL:", url));
         await testinyRequest("PUT", `/testrun/${runId}?force=true`, { description: JSON.stringify(doc) });
         console.log("  ✓ Description updated");
-    } catch (err) {
+    } catch (err: unknown) {
         console.warn(`  ⚠️  Could not update description: ${err instanceof Error ? err.message : JSON.stringify(err)}`);
     }
 }
@@ -194,7 +194,7 @@ async function resolveTestCases(allTests: FlatTest[], runId: number) {
                 if (testCaseId === null) { console.log("NOT FOUND in Testiny"); skippedNotFound++; continue; }
                 pending.push({ runId, testCaseId, status });
                 console.log("queued");
-            } catch (err) {
+            } catch (err: unknown) {
                 console.log(`ERROR: ${err instanceof Error ? err.message : String(err)}`);
                 resolveErrors++;
             }
@@ -238,7 +238,7 @@ async function main(): Promise<void> {
             await bulkAddResults(dedupedResults);
             sent = dedupedResults.length;
             console.log("  ✓ Bulk upload successful");
-        } catch (err) {
+        } catch (err: unknown) {
             console.error(`  ❌ Bulk upload failed: ${err instanceof Error ? err.message : String(err)}`);
             sendError = 1;
         }

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsCall-TC-8755.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsCall-TC-8755.spec.ts
@@ -71,7 +71,7 @@ test.fixme(
         await pages.conversationList().openConversation(channelName);
         await pages.conversation().clickConversationInfoButton();
         await pages.conversation().clickCallButton();
-      } catch (error) {
+      } catch (error: unknown) {
         console.error('Error during call initiation:', error);
         throw error;
       }

--- a/apps/webapp/test/e2e_tests/specs/noInternetCallGuard.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/noInternetCallGuard.spec.ts
@@ -95,7 +95,7 @@ test.fixme('Starting call 1:1 call without internet', async ({browser, pageManag
       expect(await ownerAModals.callNotEstablished().isModalPresent());
       expect(await ownerAModals.callNotEstablished().getModalTitle()).toContain('Call not established');
       await ownerAModals.callNotEstablished().clickOk();
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('Error during call initiation:', error);
       throw error;
     }

--- a/apps/webapp/test/e2e_tests/utils/asset.util.ts
+++ b/apps/webapp/test/e2e_tests/utils/asset.util.ts
@@ -69,7 +69,7 @@ export const isAssetDownloaded = async (filePath: string): Promise<boolean> => {
   try {
     const file = await readLocalFile(filePath);
     return !!file;
-  } catch (error) {
+  } catch (error: unknown) {
     return false;
   }
 };

--- a/libraries/api-client/src/APIClient.test.ts
+++ b/libraries/api-client/src/APIClient.test.ts
@@ -117,7 +117,7 @@ describe('APIClient', () => {
       let errorMessage;
       try {
         await client.useVersion(MINIMUM_API_VERSION + 2, MINIMUM_API_VERSION + 3);
-      } catch (error) {
+      } catch (error: unknown) {
         errorMessage = error.message;
       } finally {
         expect(errorMessage).toContain('No compatible API version in range');
@@ -131,7 +131,7 @@ describe('APIClient', () => {
       let errorMessage;
       try {
         await client.useVersion(0, 3);
-      } catch (error) {
+      } catch (error: unknown) {
         errorMessage = error.message;
       } finally {
         expect(errorMessage).toContain(`Minimum supported API version is ${MINIMUM_API_VERSION}. Received: 0`);

--- a/libraries/api-client/src/APIClient.ts
+++ b/libraries/api-client/src/APIClient.ts
@@ -393,7 +393,7 @@ export class APIClient extends EventEmitter {
       if (!options.skipLogoutRequest) {
         await this.api.auth.postLogout();
       }
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.warn(error);
     }
 
@@ -411,7 +411,7 @@ export class APIClient extends EventEmitter {
     try {
       const self = await this.api.self.getSelf();
       selfDomain = self.qualified_id?.domain;
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.warn('Could not get self user', (error as BackendError).message);
     }
 

--- a/libraries/api-client/src/account/AccountAPI.ts
+++ b/libraries/api-client/src/account/AccountAPI.ts
@@ -175,7 +175,7 @@ export class AccountAPI {
     try {
       const response = await this.client.sendJSON<DomainData>(config);
       return response.data;
-    } catch (error) {
+    } catch (error: unknown) {
       const backendError = error as BackendError;
       switch (backendError.label) {
         case BackendErrorLabel.CUSTOM_BACKEND_NOT_FOUND: {
@@ -237,7 +237,7 @@ export class AccountAPI {
     try {
       const response = await this.client.sendJSON<DomainRedirectPayload>(config);
       return response.data;
-    } catch (error) {
+    } catch (error: unknown) {
       const backendError = error as BackendError;
       if (backendError.code === StatusCode.SERVICE_UNAVAILABLE) {
         return {

--- a/libraries/api-client/src/asset/AssetAPI.ts
+++ b/libraries/api-client/src/asset/AssetAPI.ts
@@ -107,7 +107,7 @@ export class AssetAPI {
           buffer: response.data,
           mimeType: response.headers['content-type'],
         };
-      } catch (error) {
+      } catch (error: unknown) {
         if ((error as BackendError).message === SyntheticErrorLabel.REQUEST_CANCELLED) {
           throw new RequestCancellationError('Asset download got cancelled.');
         }
@@ -188,7 +188,7 @@ export class AssetAPI {
         }
 
         return response.data;
-      } catch (error) {
+      } catch (error: unknown) {
         if ((error as BackendError).message === SyntheticErrorLabel.REQUEST_CANCELLED) {
           throw new RequestCancellationError('Asset upload got cancelled.');
         }

--- a/libraries/api-client/src/cells/CellsStorage/S3Service.ts
+++ b/libraries/api-client/src/cells/CellsStorage/S3Service.ts
@@ -92,7 +92,7 @@ export class S3Service implements CellsStorage {
 
     try {
       await upload.done();
-    } catch (caught) {
+    } catch (caught: unknown) {
       if (caught instanceof S3ServiceException && caught.name === 'EntityTooLarge') {
         throw new CellsStorageError(
           'The object was too large. To upload objects larger than 5GB, use the S3 console (160GB max) or the multipart upload API (5TB max).',

--- a/libraries/api-client/src/client/ClientAPI.ts
+++ b/libraries/api-client/src/client/ClientAPI.ts
@@ -88,7 +88,7 @@ export class ClientAPI {
 
     try {
       await this.client.sendJSON(config);
-    } catch (error) {
+    } catch (error: unknown) {
       switch ((error as BackendError).label) {
         case BackendErrorLabel.CLIENT_CAPABILITY_REMOVED: {
           throw new ClientCapabilityRemovedError((error as BackendError).message);

--- a/libraries/api-client/src/connection/ConnectionAPI.ts
+++ b/libraries/api-client/src/connection/ConnectionAPI.ts
@@ -124,7 +124,7 @@ export class ConnectionAPI {
     try {
       const response = await this.client.sendJSON<Connection>(config);
       return response.data;
-    } catch (error) {
+    } catch (error: unknown) {
       switch ((error as BackendError).label) {
         case BackendErrorLabel.LEGAL_HOLD_MISSING_CONSENT: {
           throw new ConnectionLegalholdMissingConsentError((error as BackendError).message);

--- a/libraries/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/libraries/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -468,7 +468,7 @@ export class ConversationAPI {
     try {
       const response = await this.client.sendJSON<ConversationEvent>(config);
       return response.data;
-    } catch (error) {
+    } catch (error: unknown) {
       const backendError = error as BackendError;
       switch (backendError.label) {
         case BackendErrorLabel.LEGAL_HOLD_MISSING_CONSENT: {
@@ -527,7 +527,7 @@ export class ConversationAPI {
     try {
       const response = await this.client.sendJSON<Conversation>(config);
       return response.data;
-    } catch (error) {
+    } catch (error: unknown) {
       const backendError = error as BackendError;
       switch (backendError.label) {
         case BackendErrorLabel.LEGAL_HOLD_MISSING_CONSENT: {
@@ -578,7 +578,7 @@ export class ConversationAPI {
 
     try {
       await this.client.sendJSON(config);
-    } catch (error) {
+    } catch (error: unknown) {
       const backendError = error as BackendError;
       switch (backendError.label) {
         case BackendErrorLabel.NO_CONVERSATION_CODE: {
@@ -604,7 +604,7 @@ export class ConversationAPI {
     try {
       const response = await this.client.sendJSON<ConversationMemberJoinEvent>(config);
       return response.data;
-    } catch (error) {
+    } catch (error: unknown) {
       const backendError = error as BackendError;
       switch (backendError.label) {
         case BackendErrorLabel.NO_CONVERSATION_CODE: {
@@ -635,7 +635,7 @@ export class ConversationAPI {
     try {
       const response = await this.client.sendJSON<ConversationJoinData>(config);
       return response.data;
-    } catch (error) {
+    } catch (error: unknown) {
       const backendError = error as BackendError;
       switch (backendError.label) {
         case BackendErrorLabel.NO_CONVERSATION_CODE: {
@@ -874,7 +874,7 @@ export class ConversationAPI {
     try {
       const response = await this.client.sendJSON<ConversationMemberJoinEvent>(config);
       return response.data;
-    } catch (error) {
+    } catch (error: unknown) {
       const backendError = error as BackendError;
       switch (backendError.label) {
         case BackendErrorLabel.LEGAL_HOLD_MISSING_CONSENT: {

--- a/libraries/api-client/src/http/HttpClient.test.ts
+++ b/libraries/api-client/src/http/HttpClient.test.ts
@@ -114,7 +114,7 @@ describe('HttpClient', () => {
       try {
         await client._sendRequest({config: {method: 'GET', baseURL: testConfig.urls.rest, url: AuthAPI.URL.ACCESS}});
         throw new Error('Should not resolve');
-      } catch (error) {
+      } catch (error: unknown) {
         backendError = error;
       } finally {
         expect((backendError as BackendError).message).toBe('Authentication failed because the token is invalid.');
@@ -138,7 +138,7 @@ describe('HttpClient', () => {
     try {
       await client._sendRequest({config: {method: 'GET', baseURL: testConfig.urls.rest, url: AuthAPI.URL.ACCESS}});
       throw new Error('Should not resolve');
-    } catch (error) {
+    } catch (error: unknown) {
       backendError = error;
     } finally {
       expect((backendError as BackendError).message).toBe('Authentication failed because the cookie is missing.');

--- a/libraries/api-client/src/http/HttpClient.ts
+++ b/libraries/api-client/src/http/HttpClient.ts
@@ -233,7 +233,7 @@ export class HttpClient extends EventEmitter {
       this.updateConnectionState(ConnectionState.CONNECTED);
 
       return response;
-    } catch (error) {
+    } catch (error: unknown) {
       const retryWithTokenRefresh = async () => {
         this.logger.warn(`Access token refresh triggered for "${config.method}" request to "${config.url}".`);
         await this.refreshAccessToken();
@@ -393,7 +393,7 @@ export class HttpClient extends EventEmitter {
 
     try {
       return await promise;
-    } catch (error) {
+    } catch (error: unknown) {
       // If the request failed due to too many requests, we want put it into the backoff queue
       // It will be retried after a (growing) delay
       const isTooManyRequestsError = axios.isAxiosError(error) && error.response?.status === 420;

--- a/libraries/api-client/src/notification/NotificationAPI/NotificationAPI.ts
+++ b/libraries/api-client/src/notification/NotificationAPI/NotificationAPI.ts
@@ -112,7 +112,7 @@ export class NotificationAPI {
           currentNotificationId,
           abortController,
         );
-      } catch (error) {
+      } catch (error: unknown) {
         const isAxiosError = axios.isAxiosError(error);
 
         //error with response body (before v3 API)

--- a/libraries/api-client/src/oauth/OAuthAPI.ts
+++ b/libraries/api-client/src/oauth/OAuthAPI.ts
@@ -61,7 +61,7 @@ export class OAuthAPI {
     };
     try {
       await this.client.sendJSON(config);
-    } catch (error) {
+    } catch (error: unknown) {
       throw error;
     }
   }
@@ -78,7 +78,7 @@ export class OAuthAPI {
     try {
       const response = await this.client.sendJSON(config);
       return response.headers.location;
-    } catch (error) {
+    } catch (error: unknown) {
       throw error;
     }
   }

--- a/libraries/api-client/src/tcp/ReconnectingWebsocket.test.ts
+++ b/libraries/api-client/src/tcp/ReconnectingWebsocket.test.ts
@@ -95,7 +95,7 @@ describe('ReconnectingWebsocket', () => {
     activeConnections.forEach(rws => {
       try {
         rws.disconnect();
-      } catch (e) {
+      } catch (e: unknown) {
         // Ignore errors during cleanup
       }
     });
@@ -542,7 +542,7 @@ describe('ReconnectingWebsocket', () => {
             sendSpy.mockRestore();
             RWS.disconnect();
             resolve();
-          } catch (error) {
+          } catch (error: unknown) {
             reject(error);
           }
         });

--- a/libraries/api-client/src/tcp/WebSocketClient.ts
+++ b/libraries/api-client/src/tcp/WebSocketClient.ts
@@ -178,7 +178,7 @@ export class WebSocketClient extends EventEmitter {
 
     try {
       await this.client.refreshAccessToken();
-    } catch (error) {
+    } catch (error: unknown) {
       if (error instanceof NetworkError) {
         this.logger.warn(error);
       } else if (

--- a/libraries/api-client/src/team/feature/FeatureAPI.ts
+++ b/libraries/api-client/src/team/feature/FeatureAPI.ts
@@ -138,7 +138,7 @@ export class FeatureAPI {
     try {
       const response = await this.client.sendJSON<FeatureConversationGuestLink>(config);
       return response.data;
-    } catch (error) {
+    } catch (error: unknown) {
       if (isBackendError(error) && error.label === BackendErrorLabel.FEATURE_LOCKED) {
         throw new FeatureLockedError(error.message);
       }
@@ -169,7 +169,7 @@ export class FeatureAPI {
     try {
       const response = await this.client.sendJSON<FeatureConferenceCalling>(config);
       return response.data;
-    } catch (error) {
+    } catch (error: unknown) {
       if (isBackendError(error) && error.label === BackendErrorLabel.FEATURE_LOCKED) {
         throw new FeatureLockedError(error.message);
       }
@@ -206,7 +206,7 @@ export class FeatureAPI {
     try {
       const response = await this.client.sendJSON<FeatureVideoCalling>(config);
       return response.data;
-    } catch (error) {
+    } catch (error: unknown) {
       if (isBackendError(error) && error.label === BackendErrorLabel.FEATURE_LOCKED) {
         throw new FeatureLockedError(error.message);
       }
@@ -237,7 +237,7 @@ export class FeatureAPI {
     try {
       const response = await this.client.sendJSON<FeatureSelfDeletingMessages>(config);
       return response.data;
-    } catch (error) {
+    } catch (error: unknown) {
       if (isBackendError(error) && error.label === BackendErrorLabel.FEATURE_LOCKED) {
         throw new FeatureLockedError(error.message);
       }
@@ -268,7 +268,7 @@ export class FeatureAPI {
     try {
       const response = await this.client.sendJSON<FeatureFileSharing>(config);
       return response.data;
-    } catch (error) {
+    } catch (error: unknown) {
       if (isBackendError(error) && error.label === BackendErrorLabel.FEATURE_LOCKED) {
         throw new FeatureLockedError(error.message);
       }
@@ -409,7 +409,7 @@ export class FeatureAPI {
     try {
       const response = await this.client.sendJSON<FeatureAppLock>(config);
       return response.data;
-    } catch (error) {
+    } catch (error: unknown) {
       switch ((error as BackendError).label) {
         case BackendErrorLabel.APP_LOCK_INVALID_TIMEOUT: {
           throw new InvalidAppLockTimeoutError((error as BackendError).message);

--- a/libraries/api-client/src/team/invitation/TeamInvitationAPI.ts
+++ b/libraries/api-client/src/team/invitation/TeamInvitationAPI.ts
@@ -108,7 +108,7 @@ export class TeamInvitationAPI {
 
     try {
       await this.client.sendJSON(config);
-    } catch (error) {
+    } catch (error: unknown) {
       if (axios.isAxiosError(error) && error.response?.status) {
         const status = error.response?.status;
         switch (status) {
@@ -134,7 +134,7 @@ export class TeamInvitationAPI {
     try {
       const response = await this.client.sendJSON<TeamInvitation>(config);
       return response.data;
-    } catch (error) {
+    } catch (error: unknown) {
       const backendError = error as BackendError;
       switch (backendError.label) {
         case BackendErrorLabel.INVITE_EMAIL_EXISTS: {

--- a/libraries/api-client/src/team/member/MemberAPI.ts
+++ b/libraries/api-client/src/team/member/MemberAPI.ts
@@ -165,7 +165,7 @@ export class MemberAPI {
           buffer: response.data,
           mimeType: response.headers['content-type'],
         };
-      } catch (error) {
+      } catch (error: unknown) {
         if ((error as BackendError).message === SyntheticErrorLabel.REQUEST_CANCELLED) {
           throw new RequestCancellationError('Member CSV download got cancelled.');
         }

--- a/libraries/api-client/src/team/search/TeamSearchAPI.ts
+++ b/libraries/api-client/src/team/search/TeamSearchAPI.ts
@@ -62,7 +62,7 @@ export class TeamSearchAPI {
       try {
         const response = await this.client.sendJSON<TeamSearchResult>(config);
         return response.data;
-      } catch (error) {
+      } catch (error: unknown) {
         if ((error as BackendError).message === SyntheticErrorLabel.REQUEST_CANCELLED) {
           throw new RequestCancellationError('Search request got cancelled');
         }

--- a/libraries/api-client/src/team/team/TeamAPI.ts
+++ b/libraries/api-client/src/team/team/TeamAPI.ts
@@ -107,7 +107,7 @@ export class TeamAPI {
       try {
         const response = await this.client.sendJSON<TeamSizeData>(config);
         return response.data;
-      } catch (error) {
+      } catch (error: unknown) {
         if ((error as BackendError).message === SyntheticErrorLabel.REQUEST_CANCELLED) {
           throw new RequestCancellationError('Team size request got cancelled');
         }

--- a/libraries/api-client/src/user/UserAPI.ts
+++ b/libraries/api-client/src/user/UserAPI.ts
@@ -300,7 +300,7 @@ export class UserAPI {
       try {
         const response = await this.client.sendJSON<SearchResult>(config);
         return response.data;
-      } catch (error) {
+      } catch (error: unknown) {
         if ((error as BackendError).message === SyntheticErrorLabel.REQUEST_CANCELLED) {
           throw new RequestCancellationError('Search request got cancelled');
         }

--- a/libraries/config/src/server.config.ts
+++ b/libraries/config/src/server.config.ts
@@ -53,7 +53,7 @@ const logger = logdown('config', {
 function readFile(filePath: string, fallback: string = ''): string {
   try {
     return fs.readFileSync(filePath, {encoding: 'utf8', flag: 'r'});
-  } catch (error) {
+  } catch (error: unknown) {
     logger.warn(`Cannot access "${filePath}": ${(error as Error).message}`);
     return fallback;
   }

--- a/libraries/core/src/Account.test.ts
+++ b/libraries/core/src/Account.test.ts
@@ -88,7 +88,7 @@ const waitFor = (assertion: () => void) => {
       try {
         assertion();
         resolve();
-      } catch (e) {
+      } catch (e: unknown) {
         if (attempts > maxAttempts) {
           throw e;
         }
@@ -275,7 +275,7 @@ describe('Account', () => {
           password: 'wrong',
         });
         throw new Error('Should not be logged in');
-      } catch (error) {
+      } catch (error: unknown) {
         backendError = error as BackendError;
       } finally {
         const {code, label} = backendError as {code: number; label: string};

--- a/libraries/core/src/Account.ts
+++ b/libraries/core/src/Account.ts
@@ -225,7 +225,7 @@ export class Account extends TypedEventEmitter<Events> {
       if (cookie && this.storeEngine) {
         try {
           await this.persistCookie(this.storeEngine, cookie);
-        } catch (error) {
+        } catch (error: unknown) {
           this.logger.error('Failed to save cookie:', error);
         }
       }
@@ -585,7 +585,7 @@ export class Account extends TypedEventEmitter<Events> {
   private readonly wipeCommonData = async (): Promise<void> => {
     try {
       await this.service?.client.deleteLocalClient();
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error('Failed to delete local client during logout cleanup:', error);
     }
 
@@ -593,14 +593,14 @@ export class Account extends TypedEventEmitter<Events> {
       if (this.storeEngine) {
         await wipeCoreCryptoDb(this.storeEngine);
       }
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error('Failed to wipe crypto database during logout cleanup:', error);
     }
 
     try {
       // needs to be wiped last
       await this.encryptedDb?.wipe();
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error('Failed to delete encrypted database during logout cleanup:', error);
     }
   };
@@ -613,7 +613,7 @@ export class Account extends TypedEventEmitter<Events> {
       if (this.storeEngine) {
         await deleteIdentity(this.storeEngine, false);
       }
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error('Failed to delete identity during logout cleanup:', error);
     }
 
@@ -621,7 +621,7 @@ export class Account extends TypedEventEmitter<Events> {
       if (this.db) {
         await deleteDB(this.db);
       }
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error('Failed to delete database during logout cleanup:', error);
     }
 
@@ -637,7 +637,7 @@ export class Account extends TypedEventEmitter<Events> {
       if (this.storeEngine) {
         await deleteIdentity(this.storeEngine, true);
       }
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error('Failed to delete identity during logout cleanup:', error);
     }
 
@@ -878,7 +878,7 @@ export class Account extends TypedEventEmitter<Events> {
             }
 
             this.logger.info(`Finished processing legacy notification "${notification.id}" in ${Date.now() - start}ms`);
-          } catch (error) {
+          } catch (error: unknown) {
             this.logger.error(
               `Failed to handle legacy notification "${notification.id}": ${(error as any).message}`,
               error,
@@ -912,7 +912,7 @@ export class Account extends TypedEventEmitter<Events> {
         this.notificationProcessingQueue
           .push(() => this.decryptAckEmitNotification(notification, handleEvent, source, onNotificationStreamProgress))
           .catch(this.handleNotificationQueueError);
-      } catch (error) {
+      } catch (error: unknown) {
         this.logger.error(`Failed to handle notification "${notification.type}": ${(error as any).message}`, error);
       }
     };
@@ -986,7 +986,7 @@ export class Account extends TypedEventEmitter<Events> {
 
       this.logger.info(`Acknowledging consumable notification on the backend "${notification.data.delivery_tag}"`);
       this.apiClient.transport.ws.acknowledgeNotification(notification);
-    } catch (err) {
+    } catch (err: unknown) {
       this.logger.error(`Failed to process notification ${notification.data.delivery_tag}`, err);
     }
   };

--- a/libraries/core/src/client/ClientService.ts
+++ b/libraries/core/src/client/ClientService.ts
@@ -92,7 +92,7 @@ export class ClientService {
     }
     try {
       await this.backend.deleteClient(localClientId, password);
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.warn('Failed to delete client on backend', error);
     }
     return this.database.deleteLocalClient();
@@ -101,7 +101,7 @@ export class ClientService {
   private async getLocalClient(): Promise<MetaClient | undefined> {
     try {
       return await this.database.getLocalClient();
-    } catch (error) {
+    } catch (error: unknown) {
       return undefined;
     }
   }
@@ -124,7 +124,7 @@ export class ClientService {
     try {
       const remoteClient = await this.apiClient.api.client.getClient(loadedClient.id);
       return this.database.updateLocalClient(remoteClient);
-    } catch (error) {
+    } catch (error: unknown) {
       const notFoundOnBackend = axios.isAxiosError(error) ? error.response?.status === StatusCodes.NOT_FOUND : false;
       if (notFoundOnBackend && this.storeEngine) {
         const shouldDeleteWholeDatabase = loadedClient.type === ClientType.TEMPORARY;

--- a/libraries/core/src/conversation/ConversationService/ConversationService.ts
+++ b/libraries/core/src/conversation/ConversationService/ConversationService.ts
@@ -623,7 +623,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
           throw error;
         },
       });
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.error('Failed to react to key material update failure', {error: e, groupId});
     }
   };
@@ -777,7 +777,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
 
       try {
         await this.subconversationService.joinConferenceSubconversation(parentConversationId, parentGroupId);
-      } catch (error) {
+      } catch (error: unknown) {
         const message = `There was an error while handling epoch mismatch in MLS subconversation (id: ${parentConversationId.id}, subconv: ${subconversationId}):`;
         this.logger.error(message, error);
       }
@@ -802,7 +802,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
       try {
         await this.joinByExternalCommit(qualifiedId);
         onSuccessfulRejoin?.();
-      } catch (error) {
+      } catch (error: unknown) {
         const message = `There was an error while handling epoch mismatch in MLS conversation (id: ${qualifiedId.id}):`;
         this.logger.error(message, error);
       }
@@ -901,7 +901,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
 
       const {conversation: updatedMLSConversation} = await this.getMLS1to1Conversation(otherUserId);
       return updatedMLSConversation;
-    } catch (error) {
+    } catch (error: unknown) {
       if (!shouldRetry) {
         this.logger.error(`Could not register MLS group with id ${groupId}: `, error);
 
@@ -964,7 +964,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
       } else {
         this.logger.debug('No other users were added to the group.');
       }
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error('Failed to establish MLS group', error);
       throw error;
     }
@@ -996,7 +996,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
           return this.mlsService.handleMLSMessageAddEvent(event, this.groupIdFromConversationId);
         },
       });
-    } catch (error) {
+    } catch (error: unknown) {
       // For unmapped or unrecoverable errors, avoid surfacing exceptions from event handling
       // and instead log and return null so the event processing queue can continue safely.
       this.logger.error('Failed to handle MLS message-add event after recovery; returning null', {error, event});

--- a/libraries/core/src/conversation/SubconversationService/SubconversationService.ts
+++ b/libraries/core/src/conversation/SubconversationService/SubconversationService.ts
@@ -113,7 +113,7 @@ export class SubconversationService extends TypedEventEmitter<Events> {
       const epoch = Number(await this.mlsService.getEpoch(subconversationGroupId));
 
       return {groupId: subconversationGroupId, epoch};
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error('Failed to join conference subconversation', {conversationId, groupId, error, shouldRetry});
       if (shouldRetry) {
         return this.joinConferenceSubconversation(conversationId, groupId, false);
@@ -149,7 +149,7 @@ export class SubconversationService extends TypedEventEmitter<Events> {
 
     try {
       await this.apiClient.api.conversation.deleteSubconversationSelf(conversationId, SUBCONVERSATION_ID.CONFERENCE);
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error('Failed to leave conference subconversation', {
         conversationId,
         subconversationId: SUBCONVERSATION_ID.CONFERENCE,
@@ -375,7 +375,7 @@ export class SubconversationService extends TypedEventEmitter<Events> {
     });
     try {
       await this.mlsService.removeClientsFromConversation(subconversationGroupId, [clientToRemoveQualifiedId]);
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error('Failed to remove client from subconversation', {
         subconversationGroupId,
         clientToRemoveQualifiedId,
@@ -390,7 +390,7 @@ export class SubconversationService extends TypedEventEmitter<Events> {
       await this.mlsService.joinByExternalCommit(() =>
         this.apiClient.api.conversation.getSubconversationGroupInfo(conversationId, subconversation),
       );
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error('Failed to join subconversation by external commit', {
         conversationId,
         subconversation,
@@ -404,7 +404,7 @@ export class SubconversationService extends TypedEventEmitter<Events> {
     this.logger.debug('Fetching conference subconversation metadata', {conversationId});
     try {
       return await this.apiClient.api.conversation.getSubconversation(conversationId, SUBCONVERSATION_ID.CONFERENCE);
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error('Failed to fetch conference subconversation metadata', {conversationId, error});
       throw error;
     }
@@ -421,7 +421,7 @@ export class SubconversationService extends TypedEventEmitter<Events> {
         SUBCONVERSATION_ID.CONFERENCE,
         data,
       );
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error('Failed to delete conference subconversation', {conversationId, data, error});
       throw error;
     }

--- a/libraries/core/src/conversation/message/MessageService.ts
+++ b/libraries/core/src/conversation/message/MessageService.ts
@@ -76,7 +76,7 @@ export class MessageService {
 
     try {
       return await send(encryptionResults);
-    } catch (error) {
+    } catch (error: unknown) {
       if (!this.isClientMismatchError(error)) {
         throw error;
       }

--- a/libraries/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/AcmeService.ts
+++ b/libraries/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/AcmeService.ts
@@ -102,7 +102,7 @@ export class AcmeService {
       const {data} = await this.axiosInstance.get(this.discoveryUrl);
       const directory = DirectoryResponseSchema.parse(data);
       return new TextEncoder().encode(JSON.stringify(directory));
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.error('Error while receiving Directory', e);
       return undefined;
     }
@@ -150,7 +150,7 @@ export class AcmeService {
       const {headers} = await this.axiosInstance.head(url);
       const nonce = this.extractNonce(headers);
       return nonce;
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.error('Error while receiving intial Nonce', e);
       return undefined;
     }

--- a/libraries/core/src/messagingProtocols/mls/E2EIdentityService/Steps/DpopChallenge/DpopChallenge.ts
+++ b/libraries/core/src/messagingProtocols/mls/E2EIdentityService/Steps/DpopChallenge/DpopChallenge.ts
@@ -28,7 +28,7 @@ const getClientNonce = async ({apiClient, clientId}: GetClientNonceParams) => {
       return nonce;
     }
     throw new Error('No client-nonce received');
-  } catch (e) {
+  } catch (e: unknown) {
     throw new Error(`Error while trying to receive a nonce with cause: ${e}`);
   }
 };

--- a/libraries/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/libraries/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -235,7 +235,7 @@ export class MLSService extends TypedEventEmitter<Events> {
           }
           break;
       }
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error(`Error while initializing client ${client.id}`, error);
       throw error;
     }
@@ -276,7 +276,7 @@ export class MLSService extends TypedEventEmitter<Events> {
       this.emit(MLSServiceEvents.MLS_EVENT_DISTRIBUTED, {events, time});
 
       return 'success';
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.warn(`Failed to upload commit bundle`, error);
 
       if (error instanceof MLSInvalidLeafNodeSignatureError || error instanceof MLSInvalidLeafNodeIndexError) {
@@ -416,7 +416,7 @@ export class MLSService extends TypedEventEmitter<Events> {
           }
 
           return keys;
-        } catch (error) {
+        } catch (error: unknown) {
           failedToFetchKeyPackages.push({id, domain});
           // Throw the error so we don't get {status: 'fulfilled', value: undefined}
           throw error;
@@ -495,7 +495,7 @@ export class MLSService extends TypedEventEmitter<Events> {
         this.emit(MLSServiceEvents.NEW_EPOCH, {groupId: groupIdStr, epoch: newEpoch});
         this.logger.info(`Joined MLS group with id ${groupIdStr} via external commit, new epoch: ${newEpoch}`);
       }
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.warn('Failed to join MLS group via external commit', error);
       throw error;
     }
@@ -534,7 +534,7 @@ export class MLSService extends TypedEventEmitter<Events> {
       this.dispatchNewCrlDistributionPoints(decryptedMessage.crlNewDistributionPoints);
       this.logger.info('Message decrypted successfully', {conversationId, duration: Date.now() - start});
       return decryptedMessage;
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.warn('Failed to decrypt MLS message', {conversationId, error});
       // According to CoreCrypto JS doc on .decryptMessage method, we should ignore some errors (corecrypto handle them internally)
       if (shouldMLSDecryptionErrorBeIgnored(error)) {
@@ -555,7 +555,7 @@ export class MLSService extends TypedEventEmitter<Events> {
     try {
       const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
       await context.updateKeyingMaterial(new ConversationId(groupIdBytes));
-    } catch (error) {
+    } catch (error: unknown) {
       if (!retry) {
         this.logger.error(`Failed to update keying material for group retrying did not fix the issue`, {
           error,
@@ -570,7 +570,7 @@ export class MLSService extends TypedEventEmitter<Events> {
       setTimeout(async () => {
         try {
           await this.updateKeyingMaterial(groupId, context, false);
-        } catch (error) {
+        } catch (error: unknown) {
           this.logger.error(`Failed to update keying material for group on retry`, {
             error,
             groupId,
@@ -727,7 +727,7 @@ export class MLSService extends TypedEventEmitter<Events> {
       await this.scheduleKeyMaterialRenewal(groupId);
 
       return [...otherUserKeysClaimingFailures, ...selfKeysClaimingFailures];
-    } catch (error) {
+    } catch (error: unknown) {
       await this.wipeConversation(groupId);
       throw error;
     }
@@ -753,7 +753,7 @@ export class MLSService extends TypedEventEmitter<Events> {
     try {
       await this.registerConversation(groupId, []);
       return true;
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.warn("Couldn't establish the MLS group", error);
       // If conversation already existed, locally, nothing more to do, we've received a welcome message.
       if (isCoreCryptoMLSConversationAlreadyExistsError(error)) {
@@ -834,7 +834,7 @@ export class MLSService extends TypedEventEmitter<Events> {
 
         await this.updateKeyingMaterial(groupId, coreCryptoContext);
       });
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error(`Error while renewing key material for groupId ${groupId}`, error);
     }
   }
@@ -881,7 +881,7 @@ export class MLSService extends TypedEventEmitter<Events> {
   public schedulePeriodicKeyMaterialRenewals(groupIds: string[]) {
     try {
       groupIds.forEach(groupId => this.scheduleKeyMaterialRenewal(groupId));
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error('Could not get last key material update dates', error);
     }
   }
@@ -959,7 +959,7 @@ export class MLSService extends TypedEventEmitter<Events> {
           [getSignatureAlgorithmForCiphersuite(this.config.defaultCiphersuite)]: clientSignature,
         },
       });
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error(`Failed to upload public keys for client ${client.id}`, error);
       throw error;
     }
@@ -1044,7 +1044,7 @@ export class MLSService extends TypedEventEmitter<Events> {
     try {
       await this.coreCryptoClient.transaction(cx => cx.commitPendingProposals(new ConversationId(groupIdBytes)));
       await this.cancelPendingProposalsTask(groupId);
-    } catch (error) {
+    } catch (error: unknown) {
       if (!shouldRetry) {
         throw error;
       }
@@ -1084,7 +1084,7 @@ export class MLSService extends TypedEventEmitter<Events> {
           }),
         );
       }
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error('Could not get pending proposals', error);
     }
   }

--- a/libraries/core/src/messagingProtocols/mls/recovery/MlsRecoveryOrchestrator.ts
+++ b/libraries/core/src/messagingProtocols/mls/recovery/MlsRecoveryOrchestrator.ts
@@ -185,7 +185,7 @@ export class MlsRecoveryOrchestratorImpl implements MlsRecoveryOrchestrator {
     try {
       this.logger.info('Executing MLS operation with recovery orchestration', {context});
       return await callBack();
-    } catch (rawError) {
+    } catch (rawError: unknown) {
       this.logger.info('Operation failed, invoking MLS recovery orchestrator', {rawError});
       const normalizedError = this.mapper.map(rawError, {
         qualifiedConversationId: context.qualifiedConversationId,
@@ -309,7 +309,7 @@ export class MlsRecoveryOrchestratorImpl implements MlsRecoveryOrchestrator {
     this.inProgressRecoveries.add(key);
     try {
       await task();
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.warn(`Recovery failed for key ${key}`, {error});
       throw error;
     } finally {

--- a/libraries/core/src/messagingProtocols/proteus/EventHandler/events/otrMessageAdd/otrMessageAdd.ts
+++ b/libraries/core/src/messagingProtocols/proteus/EventHandler/events/otrMessageAdd/otrMessageAdd.ts
@@ -63,7 +63,7 @@ export const handleOtrMessageAdd = async ({
       event,
       decryptedData: decodedData,
     };
-  } catch (error) {
+  } catch (error: unknown) {
     logger.warn('Failed to decrypt OTR message', {error});
     if (error instanceof DecryptionError) {
       return {event, decryptionError: error};

--- a/libraries/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper/CoreCryptoWrapper.ts
+++ b/libraries/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper/CoreCryptoWrapper.ts
@@ -123,7 +123,7 @@ export const wipeCoreCryptoDb = async (storeEngine: CRUDEngine): Promise<void> =
     await coreCryptoInstance?.close();
     await deleteDB(coreCryptoDbName);
     logger.log('info', 'CoreCrypto DB wiped successfully');
-  } catch (error) {
+  } catch (error: unknown) {
     logger.error('error', 'Failed to wipe CoreCrypto DB');
   }
 };
@@ -147,7 +147,7 @@ export async function buildClient(
 
         try {
           key = await migrateOnceAndGetKey(generateSecretKey, coreCryptoDbName);
-        } catch (error) {
+        } catch (error: unknown) {
           if (error instanceof CorruptedKeyError) {
             // If we are dealing with a corrupted key, we wipe the key and the coreCrypto DB to start fresh
             await wipeCoreCryptoDb(storeEngine);

--- a/libraries/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
+++ b/libraries/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
@@ -420,7 +420,7 @@ describe('ProteusService', () => {
 
         try {
           await proteusService.sendMessage(params);
-        } catch (error) {
+        } catch (error: unknown) {
           errorMessage = (error as {message: string}).message;
         } finally {
           expect(errorMessage).toContain('no userIds are given');

--- a/libraries/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/libraries/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -192,7 +192,7 @@ export class ProteusService {
   }: AddUsersToProteusConversationParams): Promise<ProteusAddUsersResponse> {
     try {
       return {event: await this.apiClient.api.conversation.postMembers(conversationId, qualifiedUsers)};
-    } catch (error) {
+    } catch (error: unknown) {
       const failureReasonsMap = {
         [FederatedBackendsErrorLabel.NON_FEDERATING_BACKENDS]: AddUsersFailureReasons.NON_FEDERATING_BACKENDS,
         [FederatedBackendsErrorLabel.UNREACHABLE_BACKENDS]: AddUsersFailureReasons.UNREACHABLE_BACKENDS,
@@ -220,7 +220,7 @@ export class ProteusService {
                     ? [{reason: failureReasonsMap[error.label], backends, users: unreachableUsers}]
                     : undefined,
               };
-            } catch (error) {
+            } catch (error: unknown) {
               if (isFederatedBackendsError(error)) {
                 return {
                   failedToAdd: [
@@ -311,7 +311,7 @@ export class ProteusService {
       }
 
       return decryptedMessage;
-    } catch (error) {
+    } catch (error: unknown) {
       throw generateDecryptionError({userId, clientId}, error);
     }
   }

--- a/libraries/core/src/notification/NotificationService.ts
+++ b/libraries/core/src/notification/NotificationService.ts
@@ -116,7 +116,7 @@ export class NotificationService extends TypedEventEmitter<Events> {
 
     try {
       databaseLastEventDate = await this.database.getLastEventDate();
-    } catch (error) {
+    } catch (error: unknown) {
       if (
         error instanceof StoreEngineError.RecordNotFoundError ||
         (error as Error).constructor.name === StoreEngineError.RecordNotFoundError.name
@@ -178,7 +178,7 @@ export class NotificationService extends TypedEventEmitter<Events> {
           total: notifications.length,
         });
         results.success++;
-      } catch (error) {
+      } catch (error: unknown) {
         const message = error instanceof Error ? error.message : error;
         this.logger.error(`Error while processing notification ${notification.id}: ${message}`, error);
         results.error++;
@@ -228,7 +228,7 @@ export class NotificationService extends TypedEventEmitter<Events> {
         if (handledEventResult.status === 'handled' && handledEventResult.payload) {
           yield handledEventResult.payload;
         }
-      } catch (error) {
+      } catch (error: unknown) {
         this.logger.error(
           `There was an error with notification ID "${notification.id}": ${(error as Error).message}`,
           error,

--- a/libraries/core/src/secretStore/secretKeyGenerator.ts
+++ b/libraries/core/src/secretStore/secretKeyGenerator.ts
@@ -47,7 +47,7 @@ export async function generateSecretKey({
     let key;
     try {
       key = await secretsDb.getSecretValue(keyId);
-    } catch (error) {
+    } catch (error: unknown) {
       await secretsDb.deleteSecretValue(keyId);
       throw new CorruptedKeyError('Could not decrypt key');
     }
@@ -70,7 +70,7 @@ export async function generateSecretKey({
       freshlyGenerated = true;
     }
     return {key, deleteKey: () => secretsDb.deleteSecretValue(keyId), freshlyGenerated};
-  } catch (error) {
+  } catch (error: unknown) {
     throw error;
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,7 +13,7 @@
     "alwaysStrict": true,
     "strict": true,
     "strictNullChecks": true,
-    "useUnknownInCatchVariables": false,
+    "useUnknownInCatchVariables": true,
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Turn on TypeScript catch-variable unknown typing in the shared base config and update existing catch sites to narrow errors explicitly. This also adds shared error guards/helpers so untyped catch bindings do not re-enter the codebase.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
