### PR TITLE
chore: normalize auth nullability for strictNullChecks [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/auth/module/action/ValidationError.ts
+++ b/apps/webapp/src/script/auth/module/action/ValidationError.ts
@@ -70,14 +70,21 @@ export class ValidationError extends Error {
   };
 
   static getErrorKeyByValue = (errorValue: string): string => {
-    return Object.entries(ValidationError.ERROR).find(([key, value]) => value === errorValue)[0];
+    const matchingErrorEntry = Object.entries(ValidationError.ERROR).find(([, value]) => {
+      return value === errorValue;
+    });
+
+    if (matchingErrorEntry === undefined) {
+      throw new Error(`Unknown validation error value: ${errorValue}`);
+    }
+
+    return matchingErrorEntry[0];
   };
 
   static mapErrorsToField = (fieldName: string): ErrorTypes => {
-    return Object.entries(ValidationError.ERROR).reduce(
-      (errors, [key, value]) => ({...errors, [key]: `${fieldName}-${value}`}),
-      ValidationError.ERROR,
-    );
+    return Object.entries(ValidationError.ERROR).reduce((errors, [key, value]) => {
+      return {...errors, [key]: `${fieldName}-${value}`};
+    }, ValidationError.ERROR);
   };
 
   static FIELD = {
@@ -91,6 +98,14 @@ export class ValidationError extends Error {
   };
 
   static getFieldByName = (fieldName: string): ErrorTypes => {
-    return Object.entries(ValidationError.FIELD).find(([key, value]) => value.name === fieldName)[1];
+    const matchingFieldEntry = Object.entries(ValidationError.FIELD).find(([, value]) => {
+      return value.name === fieldName;
+    });
+
+    if (matchingFieldEntry === undefined) {
+      throw new Error(`Unknown validation field: ${fieldName}`);
+    }
+
+    return matchingFieldEntry[1];
   };
 }

--- a/apps/webapp/src/script/auth/module/reducer/inviteReducer.ts
+++ b/apps/webapp/src/script/auth/module/reducer/inviteReducer.ts
@@ -22,7 +22,7 @@ import type {TeamInvitation} from '@wireapp/api-client/lib/team/';
 import {INVITATION_ACTION, InvitationActions} from '../action/creator/';
 
 export interface InvitationState {
-  error: Error;
+  error: Error | null;
   fetching: boolean;
   invites: TeamInvitation[];
 }

--- a/apps/webapp/src/script/auth/module/reducer/selfReducer.ts
+++ b/apps/webapp/src/script/auth/module/reducer/selfReducer.ts
@@ -23,12 +23,26 @@ import {AUTH_ACTION, AppActions, SELF_ACTION} from '../action/creator/';
 
 export interface SelfState {
   consents: {[key: number]: number};
-  error: Error;
+  error: Error | null;
   fetched: boolean;
   fetching: boolean;
   hasPassword: boolean;
   self: Self;
 }
+
+const unsetSelf: Self = {
+  accent_id: undefined,
+  assets: [],
+  email: undefined,
+  expires_at: undefined,
+  handle: undefined,
+  id: '',
+  locale: '',
+  name: '',
+  qualified_id: {id: '', domain: ''},
+  sso_id: undefined,
+  team: undefined,
+};
 
 export const initialSelfState: SelfState = {
   consents: {},
@@ -36,7 +50,7 @@ export const initialSelfState: SelfState = {
   fetched: false,
   fetching: false,
   hasPassword: false,
-  self: {assets: [], id: null, qualified_id: {id: '', domain: ''}, locale: null, name: null, team: null},
+  self: unsetSelf,
 };
 
 export function selfReducer(state: SelfState = initialSelfState, action: AppActions): SelfState {

--- a/apps/webapp/src/script/auth/module/selector/SelfSelector.ts
+++ b/apps/webapp/src/script/auth/module/selector/SelfSelector.ts
@@ -27,10 +27,10 @@ const unsetSelf: Self = {
   assets: [],
   expires_at: undefined,
   handle: undefined,
-  id: undefined,
+  id: '',
   qualified_id: {id: '', domain: ''},
-  locale: undefined,
-  name: undefined,
+  locale: '',
+  name: '',
   sso_id: undefined,
   team: undefined,
 };
@@ -38,10 +38,10 @@ const unsetSelf: Self = {
 export const getConsents = (state: RootState) => state.selfState.consents || {};
 export const getSelf = (state: RootState) => state.selfState.self || unsetSelf;
 export const getSelfError = (state: RootState) => state.selfState.error;
-export const getSelfHandle = (state: RootState) => getSelf(state).handle;
-export const getSelfEmail = (state: RootState) => getSelf(state).email;
-export const getSelfName = (state: RootState) => getSelf(state).name;
-export const getSelfTeamId = (state: RootState) => getSelf(state).team;
+export const getSelfHandle = (state: RootState): string | undefined => getSelf(state).handle;
+export const getSelfEmail = (state: RootState): string | undefined => getSelf(state).email;
+export const getSelfName = (state: RootState): string | undefined => getSelf(state).name;
+export const getSelfTeamId = (state: RootState): string | undefined => getSelf(state).team;
 export const hasSelfHandle = (state: RootState) => !!getSelfHandle(state);
 export const hasSelfEmail = (state: RootState) => !!getSelfEmail(state);
 export const hasSelfPassword = (state: RootState) => !!state.selfState.hasPassword;

--- a/apps/webapp/src/script/auth/page/SetEmail.tsx
+++ b/apps/webapp/src/script/auth/page/SetEmail.tsx
@@ -45,17 +45,21 @@ const SetEmailComponent = ({
   doSetEmail,
   isFetching,
 }: Props & ConnectedProps & DispatchProps) => {
-  const emailInput = useRef<HTMLInputElement>();
-  const [error, setError] = useState<Error>();
+  const emailInput = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<Error | null>(null);
   const [isValidEmail, setIsValidEmail] = useState(true);
   const [email, setEmail] = useState('');
   const navigate = useNavigate();
 
   const onSetEmail = async (event: React.FormEvent): Promise<void> => {
     event.preventDefault();
-    let validationError: Error;
+    let validationError: ValidationError | null = null;
 
     const currentInputNode = emailInput.current;
+    if (currentInputNode === null) {
+      return;
+    }
+
     currentInputNode.value = currentInputNode.value.trim();
     currentInputNode.focus();
     if (!currentInputNode.checkValidity()) {
@@ -90,7 +94,10 @@ const SetEmailComponent = ({
             placeholder={t('setEmail.emailPlaceholder')}
             type="email"
             onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-              emailInput.current.setCustomValidity('');
+              if (emailInput.current !== null) {
+                emailInput.current.setCustomValidity('');
+              }
+
               setEmail(event.target.value);
               setError(null);
               setIsValidEmail(true);

--- a/apps/webapp/src/script/auth/page/SetPassword.tsx
+++ b/apps/webapp/src/script/auth/page/SetPassword.tsx
@@ -47,17 +47,21 @@ const SetPasswordComponent = ({
   doSetPassword,
   isFetching,
 }: Props & ConnectedProps & DispatchProps) => {
-  const passwordInput = useRef<HTMLInputElement>();
-  const [error, setError] = useState<Error>();
+  const passwordInput = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<Error | null>(null);
   const [isValidPassword, setIsValidPassword] = useState(true);
   const [password, setPassword] = useState('');
   const navigate = useNavigate();
 
   const onSetPassword = async (event: React.FormEvent): Promise<void> => {
     event.preventDefault();
-    let validationError: Error;
+    let validationError: ValidationError | null = null;
 
     const currentInputNode = passwordInput.current;
+    if (currentInputNode === null) {
+      return;
+    }
+
     currentInputNode.focus();
     if (!currentInputNode.checkValidity()) {
       validationError = ValidationError.handleValidationState(currentInputNode.name, currentInputNode.validity);
@@ -96,7 +100,10 @@ const SetPasswordComponent = ({
             hideTogglePasswordLabel={t('hideTogglePasswordLabel')}
             markInvalid={!isValidPassword}
             onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-              passwordInput.current.setCustomValidity('');
+              if (passwordInput.current !== null) {
+                passwordInput.current.setCustomValidity('');
+              }
+
               setError(null);
               setPassword(event.target.value);
               setIsValidPassword(true);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Make the auth reducers, selectors, validation helper, and setup forms explicit about absent values. This is groundwork for enabling `strictNullChecks` in `apps/webapp` in future increments by aligning the auth flow with explicit nullability, React-standard ref handling, and safer lookup guards.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
