### PR TITLE
feat: prevent caching of version metadata and log deployed startup version [WPB-23299]

### DIFF
--- a/apps/server/index.ts
+++ b/apps/server/index.ts
@@ -18,6 +18,7 @@
  */
 
 import {clientConfig, serverConfig} from './config';
+import {logServerStartup} from './serverStartupLog';
 import {Server} from './Server';
 import {formatDate} from './util/TimeUtil';
 
@@ -36,7 +37,18 @@ function getUnhandledRejectionType(unhandledRejection: unknown): string {
 server
   .start()
   .then(port => {
-    console.info(`[${formatDate()}] Server is running on port ${port}.`);
+    logServerStartup(
+      {
+        port,
+        serverConfiguration: serverConfig,
+      },
+      {
+        logInformation: message => {
+          console.info(`[${formatDate()}] ${message}`);
+        },
+      },
+    );
+
     if (serverConfig.DEVELOPMENT) {
       require('opn')(serverConfig.APP_BASE);
     }

--- a/apps/server/routes/RedirectRoutes.test.ts
+++ b/apps/server/routes/RedirectRoutes.test.ts
@@ -1,0 +1,41 @@
+import {type Response} from 'express';
+import {setNonCacheHeaders} from './RedirectRoutes';
+
+type HeaderValueMap = Record<string, string>;
+
+type ResponseWithHeaderCapture = {
+  readonly headerValues: HeaderValueMap;
+  readonly response: Response;
+};
+
+function createResponseWithHeaderCapture(): ResponseWithHeaderCapture {
+  const headerValues: HeaderValueMap = {};
+  const response = {
+    set(name: string, value: string) {
+      headerValues[name] = value;
+
+      return this;
+    },
+  } as unknown as Response;
+
+  return {
+    headerValues,
+    response,
+  };
+}
+
+describe('RedirectRoutes response caching', () => {
+  it('sets non-cache headers for version metadata responses', () => {
+    const {headerValues, response} = createResponseWithHeaderCapture();
+
+    const returnedResponse = setNonCacheHeaders(response);
+
+    expect(returnedResponse).toBe(response);
+    expect(headerValues).toEqual({
+      'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+      Expires: '0',
+      Pragma: 'no-cache',
+      'Surrogate-Control': 'no-store',
+    });
+  });
+});

--- a/apps/server/routes/RedirectRoutes.ts
+++ b/apps/server/routes/RedirectRoutes.ts
@@ -17,13 +17,22 @@
  *
  */
 
-import express from 'express';
+import express, {type Response} from 'express';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 
 import type {ClientConfig, ServerConfig} from '@wireapp/config';
 import * as BrowserUtil from '../util/BrowserUtil';
 
 const router = express.Router();
+
+export function setNonCacheHeaders(response: Response): Response {
+  response.set('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
+  response.set('Pragma', 'no-cache');
+  response.set('Expires', '0');
+  response.set('Surrogate-Control', 'no-store');
+
+  return response;
+}
 
 export const RedirectRoutes = (config: ServerConfig, clientConfig: ClientConfig) => [
   router.get('/robots.txt', async (req, res) => {
@@ -51,10 +60,14 @@ export const RedirectRoutes = (config: ServerConfig, clientConfig: ClientConfig)
     return res.json(parseResult);
   }),
   router.get('/commit/?', (_req, res) => {
-    return res.send(config.COMMIT);
+    const response = setNonCacheHeaders(res);
+
+    return response.send(config.COMMIT);
   }),
   router.get('/version/?', (_req, res) => {
-    return res.json({version: config.VERSION});
+    const response = setNonCacheHeaders(res);
+
+    return response.json({version: config.VERSION});
   }),
   /**
    * This route is used by the OIDC Provider to redirect the user back to the client.

--- a/apps/server/serverStartupLog.test.ts
+++ b/apps/server/serverStartupLog.test.ts
@@ -1,0 +1,64 @@
+import type {ServerConfig} from '@wireapp/config';
+import {formatServerStartupMessage, logServerStartup} from './serverStartupLog';
+
+function createServerConfiguration(): ServerConfig {
+  return {
+    APP_BASE: 'https://app.example.com',
+    BACKEND_REST: 'https://backend.example.com',
+    BACKEND_WS: 'wss://backend.example.com',
+    CACHE_DURATION_SECONDS: 300,
+    COMMIT: 'abc123',
+    CSP: {},
+    DEVELOPMENT: false,
+    DEVELOPMENT_ENABLE_TLS: false,
+    ENABLE_CLIENT_VERSION_ENFORCEMENT: false,
+    ENABLE_DYNAMIC_HOSTNAME: false,
+    ENFORCE_HTTPS: true,
+    ENVIRONMENT: 'production',
+    GOOGLE_WEBMASTER_ID: '',
+    OPEN_GRAPH: {
+      DESCRIPTION: '',
+      IMAGE_URL: '',
+      TITLE: '',
+    },
+    PORT_HTTP: 8080,
+    ROBOTS: {
+      ALLOW: 'allow',
+      ALLOWED_HOSTS: ['app.wire.com'],
+      DISALLOW: 'disallow',
+    },
+    SSL_CERTIFICATE_KEY_PATH: '/tmp/key.pem',
+    SSL_CERTIFICATE_PATH: '/tmp/cert.pem',
+    VERSION: '2026.03.16.10.30.00',
+  };
+}
+
+describe('server startup logging', () => {
+  it('formats startup message with version and commit identifiers', () => {
+    const serverConfiguration = createServerConfiguration();
+
+    const startupMessage = formatServerStartupMessage(serverConfiguration, 8080);
+
+    expect(startupMessage).toContain('Server is running on port 8080.');
+    expect(startupMessage).toContain('Deployed client version: 2026.03.16.10.30.00.');
+    expect(startupMessage).toContain('Deployed commit: abc123.');
+  });
+
+  it('logs startup message through the provided dependency', () => {
+    const serverConfiguration = createServerConfiguration();
+    const logInformation = jest.fn();
+
+    logServerStartup(
+      {
+        port: 8080,
+        serverConfiguration,
+      },
+      {logInformation},
+    );
+
+    expect(logInformation).toHaveBeenNthCalledWith(
+      1,
+      'Server is running on port 8080. Deployed client version: 2026.03.16.10.30.00. Deployed commit: abc123.',
+    );
+  });
+});

--- a/apps/server/serverStartupLog.ts
+++ b/apps/server/serverStartupLog.ts
@@ -1,0 +1,47 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {ServerConfig} from '@wireapp/config';
+
+type LogServerStartupDependencies = {
+  readonly logInformation: (message: string) => void;
+};
+
+type LogServerStartupOptions = {
+  readonly port: number;
+  readonly serverConfiguration: ServerConfig;
+};
+
+export function formatServerStartupMessage(serverConfiguration: ServerConfig, port: number): string {
+  return [
+    `Server is running on port ${port}.`,
+    `Deployed client version: ${serverConfiguration.VERSION}.`,
+    `Deployed commit: ${serverConfiguration.COMMIT}.`,
+  ].join(' ');
+}
+
+export function logServerStartup(
+  options: LogServerStartupOptions,
+  dependencies: LogServerStartupDependencies,
+): void {
+  const {port, serverConfiguration} = options;
+  const startupMessage = formatServerStartupMessage(serverConfiguration, port);
+
+  dependencies.logInformation(startupMessage);
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23299" title="WPB-23299" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23299</a>  [Web] Add support for remote force reload 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Ensure version and commit endpoints always reflect the active deployment, and make server startup logs expose the deployed client version identifiers for rollout diagnostics.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
