### PR TITLE
ci: stop rerunning unit tests in publish workflow [WPB-22420]

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,6 @@ jobs:
       release_name: ${{ steps.push_docker_image.outputs.release_name }}
       chart_version: ${{ steps.bump_chart_version.outputs.chart_version }}
       changelog: ${{ steps.generate_changelog.outputs.changelog }}
-      unit_tests_report: ${{ env.UNIT_TEST_REPORT_FILE }}
       build_artifact: ${{ env.BUILD_ARTIFACT }}
 
     env:
@@ -33,7 +32,6 @@ jobs:
       COMMIT_URL: ${{github.event.head_commit.url}}
       COMMITTER: ${{github.event.head_commit.committer.name}}
       CHANGELOG_FILE: './changelog.md'
-      UNIT_TEST_REPORT_FILE: './unit-tests.log'
 
     steps:
       - name: Checkout
@@ -70,27 +68,6 @@ jobs:
 
       - name: Update configuration
         run: yarn nx run webapp:configure
-
-      - name: Test
-        run: |
-          set -o pipefail
-          yarn nx run-many -t test --all -- --detectOpenHandles=false 2>&1 | tee ${{ env.UNIT_TEST_REPORT_FILE }}
-          echo -e "COMMIT SHA = ${{ github.sha }}" >> ${{env.UNIT_TEST_REPORT_FILE}}
-          echo -e "TEST RUN DATE = $(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> ${{env.UNIT_TEST_REPORT_FILE}}
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: 'unit-tests-report'
-          path: ${{env.UNIT_TEST_REPORT_FILE}}
-
-      - name: Upload unit-tests.log to S3
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: eu-west-1
-        run: |
-          TIMESTAMP=$(date -u +'%Y%m%dT%H%M%SZ')
-          aws s3 cp ${{env.UNIT_TEST_REPORT_FILE}} s3://wire-webapp/unit-tests-${TIMESTAMP}-${{ github.sha }}.log
 
       - name: Build and package
         run: yarn nx run server:package
@@ -351,10 +328,6 @@ jobs:
         with:
           name: 'changelog'
 
-      - uses: actions/download-artifact@v8
-        with:
-          name: 'unit-tests-report'
-
       - name: Create GitHub release
         id: 'release'
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
@@ -363,7 +336,6 @@ jobs:
         with:
           tag_name: ${{needs.build.outputs.release_name}}
           body_path: ${{ needs.build.outputs.changelog }}
-          files: ${{ needs.build.outputs.unit_tests_report }}
           draft: true
           prerelease: ${{contains(needs.build.outputs.release_name, 'staging')}}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Stop rerunning the full unit test suite in the publish workflow.

Pull request and merge-queue continuous integration pipelines already validate changes before they reach the published branches, so the extra test pass in publish was redundant and added avoidable latency. Keep publish-time validation focused on packaging, Docker image creation, and Helm chart publishing.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
