### PR TITLE
test(e2e): align markdown composer coverage with editor behavior

### DIFF
--- a/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/parseMentions.test.ts
+++ b/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/parseMentions.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {$createParagraphNode, $createTextNode, $getRoot, createEditor} from 'lexical';
+
+import {User} from 'Repositories/entity/User';
+
+import {$createMentionNode, MentionNode} from '../nodes/MentionNode';
+
+import {parseMentions} from './parseMentions';
+import {serializeMessage} from './serializeMessage';
+
+describe('parseMentions', () => {
+  it('keeps multiline mention offsets aligned with preview-off serialization', () => {
+    const editor = createEditor({nodes: [MentionNode]});
+
+    editor.update(
+      () => {
+        const root = $getRoot();
+
+        const firstParagraph = $createParagraphNode();
+        firstParagraph.append($createTextNode('hello '), $createMentionNode('@', 'Alice'));
+
+        const secondParagraph = $createParagraphNode();
+        secondParagraph.append($createTextNode('https://wire.com/'));
+
+        root.append(firstParagraph, secondParagraph);
+      },
+      {discrete: true},
+    );
+
+    const user = new User('11111111-1111-4111-8111-111111111111', 'wire.test');
+    user.name('Alice');
+
+    const serializedMessage = editor.getEditorState().read(() => serializeMessage(false));
+    const mentions = parseMentions(editor, serializedMessage, [user]);
+
+    expect(serializedMessage).toBe('hello @Alice\nhttps://wire.com/');
+    expect(mentions).toHaveLength(1);
+    expect(mentions[0].startIndex).toBe(6);
+    expect(mentions[0].length).toBe(6);
+    expect(mentions[0].userId).toBe('11111111-1111-4111-8111-111111111111');
+    expect(mentions[0].domain).toBe('wire.test');
+  });
+
+  it('keeps mention offsets aligned after an intentional empty line', () => {
+    const editor = createEditor({nodes: [MentionNode]});
+
+    editor.update(
+      () => {
+        const root = $getRoot();
+
+        const firstParagraph = $createParagraphNode();
+        firstParagraph.append($createTextNode('first line'));
+
+        const emptyParagraph = $createParagraphNode();
+
+        const thirdParagraph = $createParagraphNode();
+        thirdParagraph.append($createMentionNode('@', 'Alice'));
+
+        root.append(firstParagraph, emptyParagraph, thirdParagraph);
+      },
+      {discrete: true},
+    );
+
+    const user = new User('11111111-1111-4111-8111-111111111111', 'wire.test');
+    user.name('Alice');
+
+    const serializedMessage = editor.getEditorState().read(() => serializeMessage(false));
+    const mentions = parseMentions(editor, serializedMessage, [user]);
+
+    expect(serializedMessage).toBe('first line\n\n@Alice');
+    expect(mentions).toHaveLength(1);
+    expect(mentions[0].startIndex).toBe(12);
+  });
+});

--- a/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/serializeMessage.test.ts
+++ b/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/serializeMessage.test.ts
@@ -22,16 +22,19 @@ import {$createParagraphNode, $createTextNode, $getRoot, createEditor} from 'lex
 import {serializeMessage} from './serializeMessage';
 
 describe('serializeMessage', () => {
-  const createEditorWithText = (text: string) => {
+  const createEditorWithParagraphs = (paragraphs: string[]) => {
     const editor = createEditor();
 
     editor.update(
       () => {
         const root = $getRoot();
-        const paragraph = $createParagraphNode();
 
-        paragraph.append($createTextNode(text));
-        root.append(paragraph);
+        paragraphs.forEach(text => {
+          const paragraph = $createParagraphNode();
+
+          paragraph.append($createTextNode(text));
+          root.append(paragraph);
+        });
       },
       {discrete: true},
     );
@@ -40,15 +43,31 @@ describe('serializeMessage', () => {
   };
 
   it('preserves raw markdown markers when preview is disabled', () => {
-    const editor = createEditorWithText('**bold** _italic_');
+    const editor = createEditorWithParagraphs(['**bold** _italic_']);
 
     const message = editor.getEditorState().read(() => serializeMessage(false));
 
     expect(message).toBe('**bold** _italic_');
   });
 
+  it('preserves a single line break between paragraphs when preview is disabled', () => {
+    const editor = createEditorWithParagraphs(['check this out', 'https://wire.com/']);
+
+    const message = editor.getEditorState().read(() => serializeMessage(false));
+
+    expect(message).toBe('check this out\nhttps://wire.com/');
+  });
+
+  it('preserves intentional empty lines when preview is disabled', () => {
+    const editor = createEditorWithParagraphs(['first line', '', 'third line']);
+
+    const message = editor.getEditorState().read(() => serializeMessage(false));
+
+    expect(message).toBe('first line\n\nthird line');
+  });
+
   it('uses Lexical markdown serialization when preview is enabled', () => {
-    const editor = createEditorWithText('**bold** _italic_');
+    const editor = createEditorWithParagraphs(['**bold** _italic_']);
 
     const message = editor.getEditorState().read(() => serializeMessage(true));
 

--- a/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/serializeMessage.ts
+++ b/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/serializeMessage.ts
@@ -24,7 +24,10 @@ import {markdownTransformers} from './markdownTransformers';
 
 export const serializeMessage = (showMarkdownPreview: boolean): string => {
   if (!showMarkdownPreview) {
-    return $getRoot().getTextContent();
+    return $getRoot()
+      .getChildren()
+      .map(node => node.getTextContent())
+      .join('\n');
   }
 
   return $convertToMarkdownString(markdownTransformers, undefined, true);

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -152,6 +152,31 @@ export class ConversationPage {
     await this.messageInput.pressSequentially(message, {delay: 100});
   }
 
+  async sendTypedMessage(message: string) {
+    await this.typeMessage(message);
+    await this.sendMessageButton.click();
+  }
+
+  async sendCodeBlockMessage(code: string) {
+    await this.messageInput.click();
+    await this.messageInput.pressSequentially('```', {delay: 100});
+    await this.messageInput.press('Enter');
+
+    const lines = code.split('\n');
+
+    for (const [index, line] of lines.entries()) {
+      if (line.length > 0) {
+        await this.messageInput.pressSequentially(line, {delay: 100});
+      }
+
+      if (index < lines.length - 1) {
+        await this.messageInput.press('Shift+Enter');
+      }
+    }
+
+    await this.sendMessageButton.click();
+  }
+
   async mentionUser(userFullName: string, searchQuery?: string) {
     const textToType = searchQuery ? `@${searchQuery}` : `@${userFullName.slice(0, 3)}`;
     await this.messageInput.pressSequentially(textToType);

--- a/apps/webapp/test/e2e_tests/specs/Markdown/markdown.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Markdown/markdown.spec.ts
@@ -39,7 +39,7 @@ test.describe('Markdown', () => {
 
     await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
     await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-    await userAPages.conversation().sendMessage('**Bold Message from User A**');
+    await userAPages.conversation().sendTypedMessage('**Bold Message from User A**');
 
     for (const pages of [userAPages, userBPages]) {
       const message = pages.conversation().getMessage({sender: userA});
@@ -56,7 +56,7 @@ test.describe('Markdown', () => {
 
     await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
     await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-    await userAPages.conversation().sendMessage('*Emphasized message from User A*');
+    await userAPages.conversation().sendTypedMessage('*Emphasized message from User A*');
 
     for (const pages of [userAPages, userBPages]) {
       const message = pages.conversation().getMessage({sender: userA});
@@ -73,7 +73,7 @@ test.describe('Markdown', () => {
 
     await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
     await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-    await userAPages.conversation().sendMessage('`Code message from User A`');
+    await userAPages.conversation().sendTypedMessage('`Code message from User A`');
 
     for (const pages of [userAPages, userBPages]) {
       const message = pages.conversation().getMessage({sender: userA});
@@ -90,8 +90,8 @@ test.describe('Markdown', () => {
     await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
     await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
 
-    const longCodeMessage = '```\nconst a = 5;\nconst b = 10;\nconsole.log(a + b);\n```';
-    await userAPages.conversation().sendMessage(longCodeMessage);
+    const longCodeMessage = 'const a = 5;\nconst b = 10;\nconsole.log(a + b);';
+    await userAPages.conversation().sendCodeBlockMessage(longCodeMessage);
 
     for (const pages of [userAPages, userBPages]) {
       const message = pages.conversation().getMessage({sender: userA});
@@ -108,7 +108,7 @@ test.describe('Markdown', () => {
 
     await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
     await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-    await userAPages.conversation().sendMessage('**Bold**, *Italic* and `Code`');
+    await userAPages.conversation().sendTypedMessage('**Bold**, *Italic* and `Code`');
 
     for (const pages of [userAPages, userBPages]) {
       const message = pages.conversation().getMessage({sender: userA});
@@ -127,7 +127,7 @@ test.describe('Markdown', () => {
 
     await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
     await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-    await userAPages.conversation().sendMessage('Start **Bold** Message');
+    await userAPages.conversation().sendTypedMessage('Start **Bold** Message');
 
     const sentMessageA = userAPages.conversation().getMessage({sender: userA});
     const sentMessageB = userBPages.conversation().getMessage({sender: userA});
@@ -138,7 +138,7 @@ test.describe('Markdown', () => {
     await userAPages.conversation().editMessage(sentMessageA);
     await expect(userAPages.conversation().messageInput).toContainText('Start Bold Message');
 
-    await userAPages.conversation().sendMessage('Edited to *Italic* Message');
+    await userAPages.conversation().sendTypedMessage('Edited to *Italic* Message');
 
     for (const message of [sentMessageA, sentMessageB]) {
       await expect(message).toContainText('Edited to Italic Message');
@@ -161,7 +161,7 @@ test.describe('Markdown', () => {
 
       const linkText = 'Wire Website';
       const url = 'https://wire.com';
-      await userAPages.conversation().sendMessage(`Visit [${linkText}](${url}) for book a demo`);
+      await userAPages.conversation().sendTypedMessage(`Visit [${linkText}](${url}) for book a demo`);
 
       for (const pages of [userAPages, userBPages]) {
         const message = pages.conversation().getMessage({sender: userA});


### PR DESCRIPTION
- Align markdown e2e tests with the current composer behavior by separating plain typed markdown from multiline code block entry
- update the long code message test to use the supported code block flow instead of sending raw fenced markdown text

