### PR TITLE
feat: prevent caching for client version check responses [WPB-23299]

### DIFF
--- a/apps/server/routes/client-version-check/ClientVersionCheckRoute.test.ts
+++ b/apps/server/routes/client-version-check/ClientVersionCheckRoute.test.ts
@@ -9,6 +9,18 @@ type ClientVersionCheckRouteDependencyFunctionOverrides = {
   readonly isClientVersionEnforcementEnabled?: boolean;
 };
 
+type FakeResponseOptions = {
+  readonly sendStatus?: jest.Mock;
+  readonly status?: jest.Mock;
+};
+
+type FakeResponse = {
+  readonly response: Response;
+  readonly set: jest.Mock;
+  readonly sendStatus: jest.Mock;
+  readonly status: jest.Mock;
+};
+
 function createClientVersionCheckRouteDependencies(overrides: ClientVersionCheckRouteDependencyFunctionOverrides = {}) {
   const get = overrides.get ?? jest.fn();
   const parseClientVersion = overrides.parseClientVersion ?? jest.fn().mockReturnValue(Result.ok(new Date()));
@@ -17,6 +29,23 @@ function createClientVersionCheckRouteDependencies(overrides: ClientVersionCheck
   const router = {get} as unknown as Router;
 
   return {router, parseClientVersion, deployedClientVersion, isClientVersionEnforcementEnabled, get};
+}
+
+function createFakeResponse(options: FakeResponseOptions = {}): FakeResponse {
+  const sendStatus = options.sendStatus ?? jest.fn();
+  const status = options.status ?? jest.fn();
+  const responseShape = {
+    sendStatus,
+    set: jest.fn(),
+    status,
+  };
+  responseShape.set.mockImplementation((_name: string, _value: string) => {
+    return responseShape;
+  });
+
+  const response = responseShape as unknown as Response;
+
+  return {response, set: responseShape.set, sendStatus, status};
 }
 
 describe('/client-version-check', () => {
@@ -29,14 +58,13 @@ describe('/client-version-check', () => {
   });
 
   it('returns HTTP 200 when client version enforcement is disabled and parsed client version equals deployed version', async () => {
-    const sendStatus = jest.fn();
+    const {response, set, sendStatus} = createFakeResponse();
     const fakeRequest = {header: jest.fn().mockReturnValue('2026.02.12.17.51.00')} as unknown as Request;
-    const fakeResponse = {sendStatus} as unknown as Response;
     const dependencies = createClientVersionCheckRouteDependencies({
       deployedClientVersion: '2026.02.12.17.51.00',
       isClientVersionEnforcementEnabled: false,
       get: jest.fn((_routePath, routeHandler) => {
-        routeHandler(fakeRequest, fakeResponse);
+        routeHandler(fakeRequest, response);
       }),
     });
 
@@ -44,6 +72,10 @@ describe('/client-version-check', () => {
 
     expect(dependencies.parseClientVersion).toHaveBeenNthCalledWith(1, '2026.02.12.17.51.00');
     expect(sendStatus).toHaveBeenNthCalledWith(1, 200);
+    expect(set).toHaveBeenNthCalledWith(1, 'Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
+    expect(set).toHaveBeenNthCalledWith(2, 'Pragma', 'no-cache');
+    expect(set).toHaveBeenNthCalledWith(3, 'Expires', '0');
+    expect(set).toHaveBeenNthCalledWith(4, 'Surrogate-Control', 'no-store');
   });
 
   it.each<{headerValue: string | undefined; expectedHttpStatusCode: number}>([
@@ -53,13 +85,12 @@ describe('/client-version-check', () => {
   ])(
     'returns HTTP status code $expectedHttpStatusCode if header value is "$headerValue"',
     async ({headerValue, expectedHttpStatusCode}) => {
-      const sendStatus = jest.fn();
+      const {response, sendStatus} = createFakeResponse();
       const fakeHeader = jest.fn().mockReturnValue(headerValue);
       const fakeRequest = {header: fakeHeader} as unknown as Request;
-      const fakeResponse = {sendStatus} as unknown as Response;
       const dependencies = createClientVersionCheckRouteDependencies({
         get: jest.fn((_routePath, routeHandler) => {
-          routeHandler(fakeRequest, fakeResponse);
+          routeHandler(fakeRequest, response);
         }),
       });
 
@@ -72,13 +103,12 @@ describe('/client-version-check', () => {
   );
 
   it('returns HTTP 400 if parseClientVersion() returns a Result Err', async () => {
-    const sendStatus = jest.fn();
+    const {response, sendStatus} = createFakeResponse();
     const fakeRequest = {header: jest.fn().mockReturnValue('1.0.0')} as unknown as Request;
-    const fakeResponse = {sendStatus} as unknown as Response;
     const dependencies = createClientVersionCheckRouteDependencies({
       parseClientVersion: jest.fn().mockReturnValue(Result.err(new Error('invalid version'))),
       get: jest.fn((_routePath, routeHandler) => {
-        routeHandler(fakeRequest, fakeResponse);
+        routeHandler(fakeRequest, response);
       }),
     });
 
@@ -89,16 +119,15 @@ describe('/client-version-check', () => {
   });
 
   it('returns HTTP 200 when client version enforcement is disabled and parsed client version is lower than deployed version', async () => {
-    const sendStatus = jest.fn();
+    const {response, sendStatus} = createFakeResponse();
     const clientVersionDate = new Date(2026, 1, 12, 17, 50, 59);
     const fakeRequest = {header: jest.fn().mockReturnValue('2026.02.12.17.50.59')} as unknown as Request;
-    const fakeResponse = {sendStatus} as unknown as Response;
     const dependencies = createClientVersionCheckRouteDependencies({
       parseClientVersion: jest.fn().mockReturnValue(Result.ok(clientVersionDate)),
       deployedClientVersion: '2026.02.12.17.51.00',
       isClientVersionEnforcementEnabled: false,
       get: jest.fn((_routePath, routeHandler) => {
-        routeHandler(fakeRequest, fakeResponse);
+        routeHandler(fakeRequest, response);
       }),
     });
 
@@ -108,16 +137,15 @@ describe('/client-version-check', () => {
   });
 
   it('returns HTTP 200 when client version enforcement is disabled and parsed client version is higher than deployed version', async () => {
-    const sendStatus = jest.fn();
+    const {response, sendStatus} = createFakeResponse();
     const clientVersionDate = new Date(2026, 1, 12, 17, 51, 1);
     const fakeRequest = {header: jest.fn().mockReturnValue('2026.02.12.17.51.01')} as unknown as Request;
-    const fakeResponse = {sendStatus} as unknown as Response;
     const dependencies = createClientVersionCheckRouteDependencies({
       parseClientVersion: jest.fn().mockReturnValue(Result.ok(clientVersionDate)),
       deployedClientVersion: '2026.02.12.17.51.00',
       isClientVersionEnforcementEnabled: false,
       get: jest.fn((_routePath, routeHandler) => {
-        routeHandler(fakeRequest, fakeResponse);
+        routeHandler(fakeRequest, response);
       }),
     });
 
@@ -127,16 +155,15 @@ describe('/client-version-check', () => {
   });
 
   it('returns HTTP 200 when client version enforcement is enabled and parsed client version equals deployed version', async () => {
-    const sendStatus = jest.fn();
+    const {response, sendStatus} = createFakeResponse();
     const deployedClientVersion = '2026.02.12.17.51.00';
     const fakeRequest = {header: jest.fn().mockReturnValue(deployedClientVersion)} as unknown as Request;
-    const fakeResponse = {sendStatus} as unknown as Response;
     const dependencies = createClientVersionCheckRouteDependencies({
       parseClientVersion: jest.fn().mockReturnValue(Result.ok(new Date(2026, 1, 12, 17, 51, 0))),
       deployedClientVersion,
       isClientVersionEnforcementEnabled: true,
       get: jest.fn((_routePath, routeHandler) => {
-        routeHandler(fakeRequest, fakeResponse);
+        routeHandler(fakeRequest, response);
       }),
     });
 
@@ -146,18 +173,17 @@ describe('/client-version-check', () => {
   });
 
   it('returns HTTP 426 with reload action when client version enforcement is enabled and parsed client version is below deployed version', async () => {
-    const sendStatus = jest.fn();
     const json = jest.fn();
     const status = jest.fn().mockReturnValue({json});
+    const {response, sendStatus} = createFakeResponse({status});
     const clientVersionDate = new Date(2026, 1, 12, 17, 50, 59);
     const fakeRequest = {header: jest.fn().mockReturnValue('2026.02.12.17.50.59')} as unknown as Request;
-    const fakeResponse = {sendStatus, status} as unknown as Response;
     const dependencies = createClientVersionCheckRouteDependencies({
       parseClientVersion: jest.fn().mockReturnValue(Result.ok(clientVersionDate)),
       deployedClientVersion: '2026.02.12.17.51.00',
       isClientVersionEnforcementEnabled: true,
       get: jest.fn((_routePath, routeHandler) => {
-        routeHandler(fakeRequest, fakeResponse);
+        routeHandler(fakeRequest, response);
       }),
     });
 
@@ -169,18 +195,17 @@ describe('/client-version-check', () => {
   });
 
   it('returns HTTP 426 with reload action when client version enforcement is enabled and parsed client version is above deployed version', async () => {
-    const sendStatus = jest.fn();
     const json = jest.fn();
     const status = jest.fn().mockReturnValue({json});
+    const {response, sendStatus} = createFakeResponse({status});
     const clientVersionDate = new Date(2026, 1, 12, 17, 51, 1);
     const fakeRequest = {header: jest.fn().mockReturnValue('2026.02.12.17.51.01')} as unknown as Request;
-    const fakeResponse = {sendStatus, status} as unknown as Response;
     const dependencies = createClientVersionCheckRouteDependencies({
       parseClientVersion: jest.fn().mockReturnValue(Result.ok(clientVersionDate)),
       deployedClientVersion: '2026.02.12.17.51.00',
       isClientVersionEnforcementEnabled: true,
       get: jest.fn((_routePath, routeHandler) => {
-        routeHandler(fakeRequest, fakeResponse);
+        routeHandler(fakeRequest, response);
       }),
     });
 

--- a/apps/server/routes/client-version-check/ClientVersionCheckRoute.ts
+++ b/apps/server/routes/client-version-check/ClientVersionCheckRoute.ts
@@ -21,6 +21,7 @@ import is from '@sindresorhus/is';
 import {Router} from 'express';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import {result, type Result} from 'true-myth';
+import {setNonCacheHeaders} from '../RedirectRoutes';
 
 type ClientVersionCheckRouteDependencies = {
   readonly router: ReturnType<typeof Router>;
@@ -33,6 +34,8 @@ export function createClientVersionCheckRoute(dependencies: ClientVersionCheckRo
   const {router, parseClientVersion, deployedClientVersion, isClientVersionEnforcementEnabled} = dependencies;
 
   return router.get('/client-version-check', (request, response) => {
+    setNonCacheHeaders(response);
+
     const clientVersionHeaderValue = request.header('Wire-Client-Version');
 
     if (is.undefined(clientVersionHeaderValue) || is.emptyStringOrWhitespace(clientVersionHeaderValue)) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23299" title="WPB-23299" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23299</a>  [Web] Add support for remote force reload 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

-

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
