### PR TITLE
chore: add server lint target and fix existing server lint violations [WPB-22420]

### DIFF
--- a/apps/server/Server.ts
+++ b/apps/server/Server.ts
@@ -188,7 +188,7 @@ class Server {
   }
 
   private initStaticRoutes() {
-    this.app.use(RedirectRoutes(this.config, this.clientConfig));
+    this.app.use(RedirectRoutes(this.config));
 
     const staticRoutes = ['audio', 'ext', 'font', 'image', 'min', 'proto', 'style', 'worker', 'assets'];
 

--- a/apps/server/config.ts
+++ b/apps/server/config.ts
@@ -19,13 +19,14 @@
 
 import dotenv from 'dotenv-extended';
 
-import {readFileSync} from 'fs';
+import {existsSync, readFileSync} from 'fs';
 import path from 'path';
 
 import {generateClientConfig, generateServerConfig, Env} from '@wireapp/config';
 
 const versionData = readFileSync(path.resolve(__dirname, './version.json'), 'utf8');
 const version = versionData ? JSON.parse(versionData) : {version: 'unknown', commit: 'unknown'};
+const dotenvConfigurationIndentationSpaces = 2;
 
 // Determine the correct root path based on the directory structure
 // In monorepo (dev/CI): __dirname is apps/server/dist, so go up to workspace root (3 levels)
@@ -34,13 +35,13 @@ const version = versionData ? JSON.parse(versionData) : {version: 'unknown', com
 const deploymentRootPath = __dirname;
 const monorepoRootPath = path.resolve(__dirname, '../../..');
 const isMonorepo =
-  require('fs').existsSync(path.join(monorepoRootPath, '.env.defaults')) &&
-  !require('fs').existsSync(path.join(deploymentRootPath, '.env.defaults'));
+  existsSync(path.join(monorepoRootPath, '.env.defaults')) &&
+  !existsSync(path.join(deploymentRootPath, '.env.defaults'));
 const rootPath = isMonorepo ? monorepoRootPath : deploymentRootPath;
 
-console.log('[Config] Loading environment from:', rootPath);
-console.log('[Config] __dirname:', __dirname);
-console.log('[Config] Is monorepo:', isMonorepo);
+console.info('[Config] Loading environment from:', rootPath);
+console.info('[Config] __dirname:', __dirname);
+console.info('[Config] Is monorepo:', isMonorepo);
 
 const dotenvConfig = {
   path: path.join(rootPath, '.env'),
@@ -49,11 +50,11 @@ const dotenvConfig = {
   silent: false, // Don't fail silently
 };
 
-console.log('[Config] dotenv config:', JSON.stringify(dotenvConfig, null, 2));
+console.info('[Config] dotenv config:', JSON.stringify(dotenvConfig, null, dotenvConfigurationIndentationSpaces));
 
 const env = dotenv.load(dotenvConfig) as Env;
 
-console.log('[Config] Environment loaded. APP_BASE:', env.APP_BASE ? 'SET' : 'NOT SET');
+console.info('[Config] Environment loaded. APP_BASE:', env.APP_BASE ? 'SET' : 'NOT SET');
 
 function generateUrls() {
   const federation = env.FEDERATION;
@@ -65,7 +66,7 @@ function generateUrls() {
       console.error('[Config] BACKEND_REST:', env.BACKEND_REST);
       console.error('[Config] BACKEND_WS:', env.BACKEND_WS);
       console.error('[Config] Root path used:', rootPath);
-      console.error('[Config] .env.defaults exists:', require('fs').existsSync(path.join(rootPath, '.env.defaults')));
+      console.error('[Config] .env.defaults exists:', existsSync(path.join(rootPath, '.env.defaults')));
       throw new Error('missing environment variables');
     }
     return {

--- a/apps/server/index.ts
+++ b/apps/server/index.ts
@@ -18,8 +18,8 @@
  */
 
 import {clientConfig, serverConfig} from './config';
-import {logServerStartup} from './serverStartupLog';
 import {Server} from './Server';
+import {logServerStartup} from './serverStartupLog';
 import {formatDate} from './util/TimeUtil';
 
 const server = new Server(serverConfig, clientConfig);

--- a/apps/server/project.json
+++ b/apps/server/project.json
@@ -53,6 +53,12 @@
         }
       }
     },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "eslint --config eslint.config.ts --quiet --ext .js,.ts {projectRoot}"
+      }
+    },
     "type-check": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/server/routes/RedirectRoutes.ts
+++ b/apps/server/routes/RedirectRoutes.ts
@@ -20,7 +20,8 @@
 import express, {type Response} from 'express';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 
-import type {ClientConfig, ServerConfig} from '@wireapp/config';
+import type {ServerConfig} from '@wireapp/config';
+
 import * as BrowserUtil from '../util/BrowserUtil';
 
 const router = express.Router();
@@ -34,7 +35,7 @@ export function setNonCacheHeaders(response: Response): Response {
   return response;
 }
 
-export const RedirectRoutes = (config: ServerConfig, clientConfig: ClientConfig) => [
+export const RedirectRoutes = (config: ServerConfig) => [
   router.get('/robots.txt', async (req, res) => {
     const robotsContent = (config.ROBOTS.ALLOWED_HOSTS as ReadonlyArray<string>).includes(req.hostname)
       ? config.ROBOTS.ALLOW

--- a/apps/server/routes/Root.ts
+++ b/apps/server/routes/Root.ts
@@ -40,7 +40,7 @@ async function addGeoIP(req: Request) {
     if (result) {
       countryCode = result.country?.iso_code ?? '';
     }
-  } catch (error: unknown) {
+  } catch {
     // It's okay to go without a detected country.
   }
 

--- a/apps/server/routes/client-version-check/ClientVersionCheckRoute.ts
+++ b/apps/server/routes/client-version-check/ClientVersionCheckRoute.ts
@@ -21,6 +21,7 @@ import is from '@sindresorhus/is';
 import {Router} from 'express';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import {result, type Result} from 'true-myth';
+
 import {setNonCacheHeaders} from '../RedirectRoutes';
 
 type ClientVersionCheckRouteDependencies = {

--- a/apps/server/routes/config/ConfigRoute.ts
+++ b/apps/server/routes/config/ConfigRoute.ts
@@ -20,6 +20,7 @@
 import {Router} from 'express';
 
 import type {ClientConfig, ServerConfig} from '@wireapp/config';
+
 import {replaceHostname} from '../../util/hostnameReplacer';
 
 export const ConfigRoute = (serverConfig: ServerConfig, clientConfig: ClientConfig) =>

--- a/apps/server/routes/error/ErrorRoutes.ts
+++ b/apps/server/routes/error/ErrorRoutes.ts
@@ -31,6 +31,7 @@ const logger = logdown('@wireapp/wire-webapp/routes/error/errorRoutes', {
 });
 
 const InternalErrorRoute = (): express.ErrorRequestHandler => (err, req, res, next) => {
+  void next;
   logger.error(`[${formatDate()}] ${err.stack}`);
   const error = {
     code: HTTP_STATUS.INTERNAL_SERVER_ERROR,

--- a/apps/server/serverStartupLog.ts
+++ b/apps/server/serverStartupLog.ts
@@ -36,10 +36,7 @@ export function formatServerStartupMessage(serverConfiguration: ServerConfig, po
   ].join(' ');
 }
 
-export function logServerStartup(
-  options: LogServerStartupOptions,
-  dependencies: LogServerStartupDependencies,
-): void {
+export function logServerStartup(options: LogServerStartupOptions, dependencies: LogServerStartupDependencies): void {
   const {port, serverConfiguration} = options;
   const startupMessage = formatServerStartupMessage(serverConfiguration, port);
 

--- a/apps/server/util/TimeUtil.ts
+++ b/apps/server/util/TimeUtil.ts
@@ -19,12 +19,13 @@
 
 function formatDate(): string {
   const [date, time] = new Date().toISOString().split('T');
+  const formattedTimeLength = 8;
 
   if (date === undefined || time === undefined) {
     throw new Error('Expected ISO timestamp to contain date and time.');
   }
 
-  return `${date} ${time.substring(0, 8)}`;
+  return `${date} ${time.substring(0, formattedTimeLength)}`;
 }
 
 export {formatDate};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Ensure the server application is included in workspace linting so root lint runs cover browser, server, and shared packages. Clean up the current server-side ESLint violations so the new lint target passes without changing the lint ruleset.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
