### PR TITLE
ci: enforce WPB Jira key pattern in PR linking workflow [WPB-22420]

### DIFF
--- a/.github/workflows/jira-lint-and-link.yml
+++ b/.github/workflows/jira-lint-and-link.yml
@@ -21,5 +21,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           jira-token: ${{ secrets.JIRA_TOKEN }}
           jira-base-url: https://wearezeta.atlassian.net
+          custom-issue-number-regexp: '(WPB-\d+)'
           skip-branches: '^(dev|master|release\/*)$'
           fail-when-jira-issue-not-found: true


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Add custom-issue-number-regexp to the Jira description action so it only matches ticket numbers in the WPB-NUMBER format.

Example:
- WPB-23145

This prevents other Jira-style keys from being picked up accidentally.
