### PR TITLE
feat: leave subConversation on error during MLS conference join [WPB-23723]

### DIFF
--- a/apps/webapp/src/script/repositories/calling/CallingRepository.ts
+++ b/apps/webapp/src/script/repositories/calling/CallingRepository.ts
@@ -1556,7 +1556,7 @@ export class CallingRepository {
       if (error) {
         this.logger.error('Failed answering call', error);
       }
-      this.leaveCall(conversation.qualifiedId, LEAVE_CALL_REASON.CONVERSATION_DEGRADED);
+      this.leaveCall(conversation.qualifiedId, LEAVE_CALL_REASON.CALL_SETUP_ERROR);
       call.reason(REASON.ERROR);
       if (!!conversation && this.isMLSConference(conversation)) {
         await this.leaveMLSConferenceBecauseError(conversation);

--- a/apps/webapp/src/script/repositories/calling/CallingRepository.ts
+++ b/apps/webapp/src/script/repositories/calling/CallingRepository.ts
@@ -1535,7 +1535,13 @@ export class CallingRepository {
       if (!!conversation && this.isMLSConference(conversation)) {
         // Enable the epoch cache to save all epoch infos while init avs!
         call.epochCache.enable();
-        await this.joinMlsConferenceSubconversation(conversation);
+        try {
+          await this.joinMlsConferenceSubconversation(conversation);
+        } catch (error: unknown) {
+          this.logger.error('Failed to join MLS SubConversation', error);
+          await this.leaveMLSConferenceBecauseError(conversation);
+          return;
+        }
       }
 
       this.wCall?.answer(
@@ -1557,9 +1563,6 @@ export class CallingRepository {
         this.logger.error('Failed answering call', error);
       }
       this.rejectCall(conversation.qualifiedId);
-      if (!!conversation && this.isMLSConference(conversation)) {
-        await this.leaveMLSConferenceBecauseError(conversation);
-      }
     }
   }
 

--- a/apps/webapp/src/script/repositories/calling/CallingRepository.ts
+++ b/apps/webapp/src/script/repositories/calling/CallingRepository.ts
@@ -1535,13 +1535,7 @@ export class CallingRepository {
       if (!!conversation && this.isMLSConference(conversation)) {
         // Enable the epoch cache to save all epoch infos while init avs!
         call.epochCache.enable();
-        try {
-          await this.joinMlsConferenceSubconversation(conversation);
-        } catch (error: unknown) {
-          this.logger.error('Failed to join MLS SubConversation', error);
-          await this.leaveMLSConferenceBecauseError(conversation);
-          return;
-        }
+        await this.joinMlsConferenceSubconversation(conversation);
       }
 
       this.wCall?.answer(
@@ -1562,7 +1556,11 @@ export class CallingRepository {
       if (error) {
         this.logger.error('Failed answering call', error);
       }
-      this.rejectCall(conversation.qualifiedId);
+      this.leaveCall(conversation.qualifiedId, LEAVE_CALL_REASON.CONVERSATION_DEGRADED);
+      call.reason(REASON.ERROR);
+      if (!!conversation && this.isMLSConference(conversation)) {
+        await this.leaveMLSConferenceBecauseError(conversation);
+      }
     }
   }
 

--- a/apps/webapp/src/script/repositories/calling/enum/LeaveCallReason.ts
+++ b/apps/webapp/src/script/repositories/calling/enum/LeaveCallReason.ts
@@ -30,4 +30,5 @@ export enum LEAVE_CALL_REASON {
   ABORTED_BECAUSE_FAILED_TO_SEND_CALLING_MESSAGE = 'abort_failed_to_update_missing_clients',
   ABORTED_BECAUSE_USER_CANCELLED_MESSAGE_SENDING_BECAUSE_OF_A_DEGRADATION_WARNING = 'abort_failed_because_user_cancelled_message_sending_because_of_a_degradation_warning',
   CONVERSATION_DEGRADED = 'conversation_degraded',
+  CALL_SETUP_ERROR = 'call_setup_error',
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23723" title="WPB-23723" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23723</a>  [Web Calling] Remove automatic rejection of all incoming calls on error MLS join in Web App
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- What did I change and why?
Make independent catch block for JoinMLSConversation and answerCall.
So when there is any error on JoinMLSConversation then it will not reject the calls.
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
