### PR TITLE
ci: add temporary tag redeploy workflow for EB clone [WPB-22420]

### DIFF
--- a/.github/workflows/redeploy-temporary-from-tag.yml
+++ b/.github/workflows/redeploy-temporary-from-tag.yml
@@ -1,0 +1,131 @@
+name: Redeploy tag to temporary environment
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing production release tag to redeploy (for example 2026-03-09-production.0)'
+        required: true
+        type: string
+      confirm_temporary_redeploy:
+        description: 'Confirm that this will rebuild the selected production tag and deploy it to wire-webapp-temporary-redeploy-test'
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: redeploy-temporary-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  validate_request:
+    name: Validate redeploy request
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.validate.outputs.tag }}
+
+    steps:
+      - name: Validate input and tag
+        id: validate
+        env:
+          TAG: ${{ inputs.tag }}
+          CONFIRM_TEMPORARY_REDEPLOY: ${{ inputs.confirm_temporary_redeploy }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${CONFIRM_TEMPORARY_REDEPLOY}" != 'true' ]]; then
+            echo 'Temporary redeploy was not confirmed. Aborting.' >&2
+            exit 1
+          fi
+
+          if [[ ! "${TAG}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}-production\.[0-9]+$ ]]; then
+            echo "Tag '${TAG}' does not match the expected production release format YYYY-MM-DD-production.N." >&2
+            exit 1
+          fi
+
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+  build_artifact:
+    name: Rebuild tagged release artifact
+    runs-on: ubuntu-latest
+    needs: validate_request
+    outputs:
+      commit_sha: ${{ steps.git_metadata.outputs.commit_sha }}
+      commit_url: ${{ steps.git_metadata.outputs.commit_url }}
+      commit_subject: ${{ steps.git_metadata.outputs.commit_subject }}
+
+    steps:
+      - name: Verify remote tag exists
+        env:
+          TAG: ${{ needs.validate_request.outputs.tag }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          git ls-remote --exit-code --tags "https://github.com/${REPOSITORY}.git" "refs/tags/${TAG}"
+
+      - name: Checkout selected tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: refs/tags/${{ needs.validate_request.outputs.tag }}
+          fetch-depth: 0
+
+      - name: Collect git metadata
+        id: git_metadata
+        run: |
+          set -euo pipefail
+          commit_sha="$(git rev-parse HEAD)"
+          commit_subject="$(git show -s --format=%s HEAD)"
+          commit_url="https://github.com/${GITHUB_REPOSITORY}/commit/${commit_sha}"
+
+          {
+            echo "commit_sha=${commit_sha}"
+            echo "commit_url=${commit_url}"
+            echo "commit_subject=${commit_subject}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install JS dependencies
+        run: yarn --immutable
+
+      - name: Update configuration
+        run: yarn nx run webapp:configure
+
+      - name: Build and package
+        run: yarn nx run server:package
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: build-artifact-${{ needs.validate_request.outputs.tag }}
+          path: apps/server/dist/s3/ebs.zip
+
+  deploy_to_temporary:
+    name: Deploy to temporary environment
+    runs-on: ubuntu-latest
+    needs: [validate_request, build_artifact]
+
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: build-artifact-${{ needs.validate_request.outputs.tag }}
+
+      - name: Deploy to wire-webapp-temporary-redeploy-test
+        uses: einaregilsson/beanstalk-deploy@27edd8a0ebe8656ac70654372c73f06f7e9a1027
+        with:
+          application_name: Webapp
+          aws_access_key: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
+          aws_secret_key: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
+          deployment_package: ebs.zip
+          environment_name: wire-webapp-temporary-redeploy-test
+          region: eu-central-1
+          use_existing_version_if_available: true
+          version_description: ${{ needs.build_artifact.outputs.commit_sha }}
+          version_label: '${{ github.run_id }}-wire-webapp-temporary-redeploy-test'
+          wait_for_deployment: true
+          wait_for_environment_recovery: 150


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Add a temporary GitHub Actions workflow to redeploy an existing production tag to the cloned Elastic Beanstalk environment wire-webapp-temporary-redeploy-test. This keeps the production redeploy logic intact for end-to-end rehearsal while disabling the Wire notification side effect and waiting for deployment completion so the test verifies the full rollout.
