### PR TITLE
feat: inject startup feature toggles into API client creation [WPB-23381]

### DIFF
--- a/apps/webapp/src/script/auth/main.tsx
+++ b/apps/webapp/src/script/auth/main.tsx
@@ -40,16 +40,20 @@ import {actionRoot} from './module/action';
 import {Root} from './page/Root';
 
 import {Config} from '../Config';
+import {createStartupFeatureTogglesFromLocationSearch} from '../featureToggles/startupFeatureToggles';
 import {updateApiVersion} from '../lifecycle/updateRemoteConfigs';
 import {setAppLocale} from '../localization/Localizer';
 import {APIClient} from '../service/APIClientSingleton';
 import {Core} from '../service/CoreSingleton';
+import {createAPIClient} from '../service/createAPIClient';
 
 exposeWrapperGlobals();
 
 const mainId = 'main';
 
-const apiClient = container.resolve(APIClient);
+const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(globalThis.location.search);
+const apiClient = createAPIClient(startupFeatureToggles.isFeatureToggleEnabled);
+container.registerInstance(APIClient, apiClient);
 const core = container.resolve(Core);
 
 let localStorage;

--- a/apps/webapp/src/script/main/index.tsx
+++ b/apps/webapp/src/script/main/index.tsx
@@ -44,6 +44,7 @@ import {createStartupFeatureTogglesFromLocationSearch} from '../featureToggles/s
 import {createIncrementalHttpRetryBackoffReset} from '../lifecycle/createIncrementalHttpRetryBackoffReset';
 import {APIClient} from '../service/APIClientSingleton';
 import {Core} from '../service/CoreSingleton';
+import {createAPIClient} from '../service/createAPIClient';
 
 document.addEventListener('DOMContentLoaded', async () => {
   const config = Config.getConfig();
@@ -77,7 +78,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   });
   const {isFeatureToggleEnabled} = startupFeatureToggles;
   const {wallClock} = applicationServices;
-  const apiClient = new APIClient({isFeatureToggleEnabled});
+  const apiClient = createAPIClient(isFeatureToggleEnabled);
   const core = new Core(apiClient);
   const cleanupIncrementalHttpRetryBackoffReset = createIncrementalHttpRetryBackoffReset({
     apiClient,

--- a/apps/webapp/src/script/service/createAPIClient.test.ts
+++ b/apps/webapp/src/script/service/createAPIClient.test.ts
@@ -17,42 +17,27 @@
  *
  */
 
-import {Config} from '../Config';
 import {incrementalHttpRetryBackoffFeatureToggleName} from '../featureToggles/startupFeatureToggleNames';
-import {APIClient} from './APIClientSingleton';
 
-describe('APIClientSingleton', () => {
-  it('configures wire client metadata headers for backend requests', () => {
-    const apiClient = new APIClient();
+import {createAPIClient} from './createAPIClient';
 
-    try {
-      expect(apiClient.config.headers).toEqual({
-        'Wire-Client': 'Web',
-        'Wire-Client-Version': Config.getConfig().VERSION,
-      });
-    } finally {
-      apiClient.disconnect();
-    }
-  });
-
-  it('enables incremental http retry backoff when the startup feature toggle is enabled', () => {
-    const isFeatureToggleEnabled = jest.fn((featureToggleName) => {
+describe('createAPIClient', () => {
+  it('enables incremental http retry backoff when the startup feature toggle reader returns true', () => {
+    const apiClient = createAPIClient(featureToggleName => {
       return featureToggleName === incrementalHttpRetryBackoffFeatureToggleName;
     });
-    const apiClient = new APIClient({
-      isFeatureToggleEnabled,
-    });
 
     try {
-      expect(isFeatureToggleEnabled).toHaveBeenCalledWith(incrementalHttpRetryBackoffFeatureToggleName);
       expect(apiClient.transport.http['shouldUseIncrementalRetryBackoff']).toBe(true);
     } finally {
       apiClient.disconnect();
     }
   });
 
-  it('keeps incremental http retry backoff disabled when no toggle reader is injected', () => {
-    const apiClient = new APIClient();
+  it('keeps incremental http retry backoff disabled when the startup feature toggle reader returns false', () => {
+    const apiClient = createAPIClient(() => {
+      return false;
+    });
 
     try {
       expect(apiClient.transport.http['shouldUseIncrementalRetryBackoff']).toBe(false);

--- a/apps/webapp/src/script/service/createAPIClient.ts
+++ b/apps/webapp/src/script/service/createAPIClient.ts
@@ -1,0 +1,30 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {APIClient} from './APIClientSingleton';
+
+import {StartupFeatureToggleName} from '../featureToggles/startupFeatureToggles';
+
+export function createAPIClient(
+  isFeatureToggleEnabled: (featureToggleName: StartupFeatureToggleName) => boolean,
+): APIClient {
+  return new APIClient({
+    isFeatureToggleEnabled,
+  });
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23381" title="WPB-23381" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23381</a>  [Web] Make sure that the web app applies incremental backoff on 420/429
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

This fixes the incremental retry backoff flag being skipped in entry points that resolved APIClient through dependency injection without passing startup feature toggles.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
