### PR TITLE
test: re-enable channels management critical flow test [WPB-23751]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsManagement-TC-8752.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsManagement-TC-8752.spec.ts
@@ -16,141 +16,115 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  *
  */
-
-import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {createGroup, sendTextMessageToConversation} from 'test/e2e_tests/utils/userActions';
-
+import {sendTextMessageToConversation} from 'test/e2e_tests/utils/userActions';
 import {test, expect, withLogin} from '../../test.fixtures';
 
-// Generating test data
-const conversation1 = 'Test Channel 1';
-const conversation2 = 'Test Channel 2';
+test('Channels Management', {tag: ['@TC-8752', '@crit-flow-web']}, async ({createUser, createTeam, createPage}) => {
+  const conversation1 = 'Test Channel 1';
+  const conversation2 = 'Test Channel 2';
 
-// ToDo(WPB-22442): Backoffice does not unlock calling feature for teams created during tests
-test.fixme(
-  'Channels Management',
-  {tag: ['@TC-8752', '@crit-flow-web']},
-  async ({createUser, createTeam, createPage, api}) => {
-    let owner: User;
-    let member: User;
-    let ownerPageManager: PageManager;
-    let memberPageManager: PageManager;
+  const member = await createUser();
+  const team = await createTeam('Channels Management', {
+    users: [member],
+    features: {channels: true, mls: true},
+  });
+  const owner = team.owner;
 
-    await test.step('Preconditions: Team owner creates a channels enabled team', async () => {
-      member = await createUser();
-      const team = await createTeam('Channels Management', {users: [member]});
-      owner = team.owner;
+  const [ownerPageManager, memberPageManager] = await Promise.all([
+    PageManager.from(createPage(withLogin(owner))),
+    PageManager.from(createPage(withLogin(member))),
+  ]);
 
-      // TODO: Remove below line when we have a SQS workaround
-      await api.brig.enableMLSFeature(owner.teamId);
-      await api.brig.unlockChannelFeature(owner.teamId);
-      await api.brig.enableChannelsFeature(owner.teamId);
+  const {pages: ownerPages, modals: ownerModals} = ownerPageManager.webapp;
+  const {pages: memberPages, modals: memberModals} = memberPageManager.webapp;
 
-      const [pmOwner, pmMember] = await Promise.all([
-        PageManager.from(createPage(withLogin(owner))),
-        PageManager.from(createPage(withLogin(member))),
-      ]);
-      ownerPageManager = pmOwner;
-      memberPageManager = pmMember;
-    });
+  await test.step('Team owner creates a channel with available member', async () => {
+    await ownerPages.conversationList().clickCreateGroup();
+    await ownerModals.createConversation().createChannel(conversation1, {members: [member]});
+    await expect(ownerPages.conversationList().getConversationLocator(conversation1)).toBeVisible();
+  });
 
-    await test.step('Team owner creates a channel with available member', async () => {
-      const {pages} = ownerPageManager.webapp;
-      await createGroup(pages, conversation1, [member]);
-      await expect(pages.conversationList().getConversationLocator(conversation1)).toBeVisible();
-    });
+  await test.step('Team members leave the conversation', async () => {
+    await sendTextMessageToConversation(
+      memberPageManager,
+      conversation1,
+      `Hello ${conversation1}, ${member.firstName} here!`,
+    );
+    await memberPages.conversation().toggleGroupInformation();
+    await expect(memberPages.conversationDetails().groupMembers.filter({hasText: member.fullName})).toBeVisible();
 
-    await test.step('Team members leave the conversation', async () => {
-      await sendTextMessageToConversation(
-        memberPageManager,
-        conversation1,
-        `Hello ${conversation1}, ${member.firstName} here!`,
-      );
-      await memberPageManager.webapp.pages.conversation().toggleGroupInformation();
-      expect(await memberPageManager.webapp.pages.conversation().isUserGroupMember(member.fullName)).toBeTruthy();
-      await memberPageManager.webapp.pages.conversation().leaveConversation();
-      await memberPageManager.webapp.modals.leaveConversation().clickConfirm();
-      await memberPageManager.webapp.pages.conversation().isConversationReadonly();
-    });
+    await memberPages.conversation().leaveConversation();
+    await memberModals.leaveConversation().clickConfirm();
+    await memberPages.conversation().isConversationReadonly();
+  });
 
-    await test.step('Team owner confirm member left', async () => {
-      const {pages} = ownerPageManager.webapp;
-      await pages.conversationList().openConversation(conversation1);
-      expect(await pages.conversation().isSystemMessageVisible(`${member.fullName} left`)).toBeTruthy();
-    });
+  await test.step('Team owner confirm member left', async () => {
+    await ownerPages.conversationList().openConversation(conversation1);
+    await expect(ownerPages.conversation().systemMessages.filter({hasText: `${member.fullName} left`})).toBeVisible();
+  });
 
-    await test.step('Team owner creates another channel', async () => {
-      const {pages} = ownerPageManager.webapp;
-      await createGroup(pages, conversation2, [member]);
-      await expect(pages.conversationList().getConversationLocator(conversation2)).toBeVisible();
-    });
+  await test.step('Team owner creates another channel', async () => {
+    await ownerPages.conversationList().clickCreateGroup();
+    await ownerModals.createConversation().createChannel(conversation2, {members: [member]});
+    await expect(ownerPages.conversationList().getConversationLocator(conversation2)).toBeVisible();
+  });
 
-    await test.step('Team owner makes the member an admin', async () => {
-      const {pages} = ownerPageManager.webapp;
-      await pages.conversation().toggleGroupInformation();
-      await pages.conversation().makeUserAdmin(member.fullName);
-      await pages.conversation().toggleGroupInformation();
-    });
+  await test.step('Team owner makes the member an admin', async () => {
+    await ownerPages.conversation().toggleGroupInformation();
+    await ownerPages.conversation().makeUserAdmin(member.fullName);
+  });
 
-    await test.step('Team member confirms admin status', async () => {
-      await memberPageManager.webapp.pages.conversationList().openConversation(conversation2);
-      await memberPageManager.webapp.pages.conversation().toggleGroupInformation();
-      expect(await memberPageManager.webapp.pages.conversation().isUserGroupAdmin(member.fullName)).toBeTruthy();
-    });
+  await test.step('Team member confirms admin status', async () => {
+    await memberPages.conversationList().openConversation(conversation2);
+    await memberPages.conversation().toggleGroupInformation();
+    await expect(memberPages.conversation().adminsList.filter({hasText: member.fullName})).toBeVisible();
+  });
 
-    await test.step('Team admin remove member', async () => {
-      const {pages, modals} = ownerPageManager.webapp;
-      await pages.conversation().removeAdminFromGroup(member.fullName);
-      await modals.confirm().actionButton.click();
-      await pages.conversation().toggleGroupInformation();
-    });
+  await test.step('Team admin remove member', async () => {
+    await ownerPages.conversation().toggleGroupInformation();
+    await ownerPages.conversation().removeAdminFromGroup(member.fullName);
+    await ownerModals.confirm().actionButton.click();
+  });
 
-    await test.step('Team member verifies they have been removed by the owner', async () => {
-      await memberPageManager.webapp.pages.conversationList().openConversation(conversation2);
-      await memberPageManager.webapp.pages.conversation().isConversationReadonly();
-    });
+  await test.step('Team member verifies they have been removed by the owner', async () => {
+    await memberPages.conversationList().openConversation(conversation2);
+    await memberPages.conversation().isConversationReadonly();
+  });
 
-    await test.step('Team owner add member back to the same conversation', async () => {
-      const {pages} = ownerPageManager.webapp;
-      await pages.conversationList().openConversation(conversation2);
-      await pages.conversation().toggleGroupInformation();
-      await pages.conversationDetails().waitForSidebar();
-      await pages.conversationDetails().clickAddPeopleButton();
-      await pages.startUI().selectUsers(member.username);
-      await pages.groupCreation().clickAddMembers();
-    });
+  await test.step('Team owner add member back to the same conversation', async () => {
+    await ownerPages.conversationList().openConversation(conversation2);
+    await expect(
+      ownerPages.conversation().systemMessages.filter({hasText: `You removed ${member.fullName}`}),
+    ).toBeVisible();
+    await ownerPages.conversation().clickAddMemberButton();
+    await ownerPages.conversationDetails().addUsersToConversation([member.fullName]);
+  });
 
-    await test.step('Team member confirms they have been added back to the conversation', async () => {
-      await memberPageManager.webapp.pages.conversationList().openConversation(conversation2);
-      await memberPageManager.webapp.pages.conversation().toggleGroupInformation();
-      expect(
-        await memberPageManager.webapp.pages
-          .conversation()
-          .isSystemMessageVisible(`${owner.fullName} added you to the conversation`),
-      ).toBeTruthy();
-    });
+  await test.step('Team member confirms they have been added back to the conversation', async () => {
+    await memberPages.conversationList().openConversation(conversation2);
+    await memberPages.conversation().toggleGroupInformation();
+    await expect(
+      memberPages.conversation().systemMessages.filter({hasText: `${owner.fullName} added you to the conversation`}),
+    ).toBeVisible();
+  });
 
-    await test.step('Team owner promote member to admin', async () => {
-      const {pages} = ownerPageManager.webapp;
-      await pages.conversationList().openConversation(conversation2);
-      await pages.conversation().makeUserAdmin(member.fullName);
-    });
+  await test.step('Team owner promote member to admin', async () => {
+    await ownerPages.conversationList().openConversation(conversation2);
+    await ownerPages.conversation().makeUserAdmin(member.fullName);
+  });
 
-    await test.step('Team member confirms admin status', async () => {
-      await memberPageManager.webapp.pages.conversationList().openConversation(conversation2);
-      await memberPageManager.webapp.pages.conversation().toggleGroupInformation();
-      expect(await memberPageManager.webapp.pages.conversation().isUserGroupAdmin(member.fullName)).toBeTruthy();
-    });
+  await test.step('Team member confirms admin status', async () => {
+    await memberPages.conversationList().openConversation(conversation2);
+    await memberPages.conversation().toggleGroupInformation();
+    await expect(memberPages.conversation().adminsList.filter({hasText: member.fullName})).toBeVisible();
+  });
 
-    await test.step('Team owner send a message', async () => {
-      await sendTextMessageToConversation(ownerPageManager, conversation2, 'Hello team! Admin here.');
-    });
+  await test.step('Team owner send a message', async () => {
+    await sendTextMessageToConversation(ownerPageManager, conversation2, 'Hello team! Admin here.');
+  });
 
-    await test.step('Team member sees the message', async () => {
-      await expect(
-        memberPageManager.webapp.pages.conversation().getMessage({content: 'Hello team! Admin here.'}),
-      ).toBeVisible();
-    });
-  },
-);
+  await test.step('Team member sees the message', async () => {
+    await expect(memberPages.conversation().getMessage({content: 'Hello team! Admin here.'})).toBeVisible();
+  });
+});


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23751" title="WPB-23751" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23751</a>  [Web/QA] Fix and re-enable TC-8752 Channels Management
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

1. Re-enabled the channels-management critical flow test suite (previously skipped).
2. Utilize updated createTeam setup to ensure the Channels and MLS flags are correctly configured during test initialization

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
