### PR TITLE
fix(webapp): avoid window-dependent imports in backup zip worker [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/repositories/backup/zipWorker.ts
+++ b/apps/webapp/src/script/repositories/backup/zipWorker.ts
@@ -22,11 +22,25 @@ import sodium, {ready} from 'libsodium-wrappers-sumo';
 
 import {ImportError} from './Error';
 
-import {toError} from '../../util/TypePredicateUtil';
-
 type Payload =
   | {type: 'zip'; files: Record<string, ArrayBuffer | string>; encrytionKey?: Uint8Array}
   | {type: 'unzip'; bytes: ArrayBuffer; encrytionKey?: Uint8Array; headerLength?: number};
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (typeof error === 'object' && error !== null && 'message' in error && typeof error.message === 'string') {
+    return error.message;
+  }
+
+  return 'Unknown error';
+}
 
 export async function handleZipEvent(payload: Payload) {
   const zip = new JSZip();
@@ -57,7 +71,7 @@ export async function handleZipEvent(payload: Payload) {
           decryptedBytes = await decryptFile(payloadBytes, encrytionKey, headerLength);
         } catch (error: unknown) {
           // Handle decryption failure
-          throw new ImportError(toError(error).message);
+          throw new ImportError(getErrorMessage(error));
         }
       } else {
         decryptedBytes = payload.bytes;
@@ -127,6 +141,6 @@ self.addEventListener('message', async (event: MessageEvent<Payload>) => {
     const result = await handleZipEvent(event.data);
     self.postMessage(result);
   } catch (error: unknown) {
-    self.postMessage({error: toError(error).message});
+    self.postMessage({error: getErrorMessage(error)});
   }
 });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The backup zip worker imported `toError` from `TypePredicateUtil`, which pulled in app-level dependencies including `@wireapp/api-client`, `@wireapp/commons`, and `logdown`. That dependency chain assumes a browser `window`, causing the worker to fail at runtime with `ReferenceError: window is not defined`.

Replace the shared utility import with a small worker-local error message helper so the worker bundle stays environment-safe and isolated.
