### PR TITLE
refactor(webapp): extract worker-safe toError utility [WPB-22420] (#20738)

### DIFF
--- a/apps/webapp/src/script/auth/module/action/AuthAction.ts
+++ b/apps/webapp/src/script/auth/module/action/AuthAction.ts
@@ -28,7 +28,8 @@ import type {TeamData} from '@wireapp/api-client/lib/team/';
 import {LowDiskSpaceError} from '@wireapp/store-engine/lib/engine/error';
 import {StatusCodes as HTTP_STATUS, StatusCodes} from 'http-status-codes';
 
-import {isAxiosError, isBackendError, toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
+import {isAxiosError, isBackendError} from 'Util/TypePredicateUtil';
 
 import {AuthActionCreator} from './creator/';
 import {LabeledError} from './LabeledError';

--- a/apps/webapp/src/script/auth/module/action/ClientAction.ts
+++ b/apps/webapp/src/script/auth/module/action/ClientAction.ts
@@ -24,7 +24,7 @@ import {ClientInfo} from '@wireapp/core/lib/client/';
 import {Runtime} from '@wireapp/commons';
 
 import {getClientMLSConfig} from 'Repositories/client/clientMLSConfig';
-import {toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
 
 import {ClientActionCreator} from './creator/';
 

--- a/apps/webapp/src/script/auth/module/action/ConversationAction.ts
+++ b/apps/webapp/src/script/auth/module/action/ConversationAction.ts
@@ -21,7 +21,8 @@ import type {ConversationJoinData} from '@wireapp/api-client/lib/conversation/da
 import type {ConversationEvent} from '@wireapp/api-client/lib/event/';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 
-import {isBackendError, toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
+import {isBackendError} from 'Util/TypePredicateUtil';
 
 import {ConversationActionCreator} from './creator/';
 

--- a/apps/webapp/src/script/auth/module/action/InvitationAction.ts
+++ b/apps/webapp/src/script/auth/module/action/InvitationAction.ts
@@ -22,7 +22,7 @@ import type {NewTeamInvitation} from '@wireapp/api-client/lib/team/';
 import {Role} from '@wireapp/api-client/lib/team/member/';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 
-import {toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
 
 import {InvitationActionCreator} from './creator/';
 

--- a/apps/webapp/src/script/auth/module/action/LocalStorageAction.ts
+++ b/apps/webapp/src/script/auth/module/action/LocalStorageAction.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
 
 import {LocalStorageActionCreator} from './creator/';
 

--- a/apps/webapp/src/script/auth/module/action/SelfAction.test.ts
+++ b/apps/webapp/src/script/auth/module/action/SelfAction.test.ts
@@ -21,6 +21,7 @@ import type {Self} from '@wireapp/api-client/lib/self/';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 
 import {SelfActionCreator} from './creator/';
+import {toError} from 'Util/toError';
 
 import {mockStoreFactory} from '../../util/test/mockStoreFactory';
 
@@ -126,6 +127,7 @@ describe('SelfAction', () => {
 
   it('handles failed password check', async () => {
     const error = {response: {status: HTTP_STATUS.BAD_REQUEST}} as unknown as Error;
+    const expectedError = toError(error);
     const mockedApiClient = {
       api: {self: {headPassword: () => Promise.reject(error)}},
     };
@@ -141,7 +143,7 @@ describe('SelfAction', () => {
       // eslint-disable-next-line jest/no-conditional-expect
       expect(store.getActions()).toEqual([
         SelfActionCreator.startSetPasswordState(),
-        SelfActionCreator.failedSetPasswordState(error),
+        SelfActionCreator.failedSetPasswordState(expectedError),
       ]);
     }
   });

--- a/apps/webapp/src/script/auth/module/action/SelfAction.ts
+++ b/apps/webapp/src/script/auth/module/action/SelfAction.ts
@@ -22,7 +22,8 @@ import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 
 import {Environment} from 'Util/Environment';
 import {getLogger} from 'Util/Logger';
-import {isAxiosError, toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
+import {isAxiosError} from 'Util/TypePredicateUtil';
 
 import {SelfActionCreator} from './creator/';
 

--- a/apps/webapp/src/script/auth/module/action/UserAction.ts
+++ b/apps/webapp/src/script/auth/module/action/UserAction.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
 
 import {UserActionCreator} from './creator/';
 

--- a/apps/webapp/src/script/auth/page/OAuthPermissions.tsx
+++ b/apps/webapp/src/script/auth/page/OAuthPermissions.tsx
@@ -44,7 +44,7 @@ import {AssetRemoteData} from 'Repositories/assets/AssetRemoteData';
 import {AssetRepository} from 'Repositories/assets/AssetRepository';
 import {handleEscDown, handleKeyDown, KEY} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
-import {toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
 import {loadDataUrl} from 'Util/util';
 
 import {

--- a/apps/webapp/src/script/auth/page/SetEmail.tsx
+++ b/apps/webapp/src/script/auth/page/SetEmail.tsx
@@ -26,7 +26,7 @@ import {AnyAction, Dispatch} from 'redux';
 import {Button, ContainerXS, Form, H1, Input} from '@wireapp/react-ui-kit';
 
 import {t} from 'Util/LocalizerUtil';
-import {toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
 
 import {Page} from './Page';
 

--- a/apps/webapp/src/script/auth/page/SetPassword.tsx
+++ b/apps/webapp/src/script/auth/page/SetPassword.tsx
@@ -27,7 +27,7 @@ import {ValidationUtil} from '@wireapp/commons';
 import {Button, ContainerXS, Form, H1, Input, Small} from '@wireapp/react-ui-kit';
 
 import {t} from 'Util/LocalizerUtil';
-import {toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
 
 import {Page} from './Page';
 

--- a/apps/webapp/src/script/components/Modals/LegalHoldModal/LegalHoldModal.tsx
+++ b/apps/webapp/src/script/components/Modals/LegalHoldModal/LegalHoldModal.tsx
@@ -38,7 +38,8 @@ import {SearchRepository} from 'Repositories/search/SearchRepository';
 import {TeamRepository} from 'Repositories/team/TeamRepository';
 import {handleEnterDown} from 'Util/KeyboardUtil';
 import {t} from 'Util/LocalizerUtil';
-import {isErrorWithCode, toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
+import {isErrorWithCode} from 'Util/TypePredicateUtil';
 
 import {useLegalHoldModalState} from './LegalHoldModal.state';
 

--- a/apps/webapp/src/script/components/UserDevices/components/DeviceDetails/DeviceDetails.tsx
+++ b/apps/webapp/src/script/components/UserDevices/components/DeviceDetails/DeviceDetails.tsx
@@ -36,7 +36,7 @@ import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
 import type {Logger} from 'Util/Logger';
 import {splitFingerprint} from 'Util/StringUtil';
-import {toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
 
 import {Config} from '../../../../Config';
 import {MotionDuration} from '../../../../motion/MotionDuration';

--- a/apps/webapp/src/script/page/AppLock/AppLock.tsx
+++ b/apps/webapp/src/script/page/AppLock/AppLock.tsx
@@ -37,7 +37,8 @@ import {SIGN_OUT_REASON} from 'src/script/auth/SignOutReason';
 import {Config} from 'src/script/Config';
 import {useKoSubscribableChildren} from 'Util/ComponentUtil';
 import {t} from 'Util/LocalizerUtil';
-import {isErrorWithCode, toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
+import {isErrorWithCode} from 'Util/TypePredicateUtil';
 
 export enum APPLOCK_STATE {
   FORGOT = 'applock.forgot',

--- a/apps/webapp/src/script/repositories/backup/zipWorker.ts
+++ b/apps/webapp/src/script/repositories/backup/zipWorker.ts
@@ -22,7 +22,7 @@ import sodium, {ready} from 'libsodium-wrappers-sumo';
 
 import {ImportError} from './Error';
 
-import {toError} from '../../util/TypePredicateUtil';
+import {toError} from '../../util/toError';
 
 type Payload =
   | {type: 'zip'; files: Record<string, ArrayBuffer | string>; encrytionKey?: Uint8Array}

--- a/apps/webapp/src/script/repositories/calling/CallingRepository.ts
+++ b/apps/webapp/src/script/repositories/calling/CallingRepository.ts
@@ -89,7 +89,7 @@ import {roundLogarithmic} from 'Util/NumberUtil';
 import {matchQualifiedIds} from 'Util/QualifiedId';
 import {copyStyles} from 'Util/renderElement';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
-import {toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
 import {createUuid} from 'Util/uuid';
 
 import {Call, SerializedConversationId} from './Call';

--- a/apps/webapp/src/script/repositories/client/ClientRepository.ts
+++ b/apps/webapp/src/script/repositories/client/ClientRepository.ts
@@ -38,7 +38,8 @@ import {t} from 'Util/LocalizerUtil';
 import {getLogger, Logger} from 'Util/Logger';
 import {matchQualifiedIds} from 'Util/QualifiedId';
 import {loadValue} from 'Util/StorageUtil';
-import {isAxiosError, isErrorWithCode, isErrorWithType, toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
+import {isAxiosError, isErrorWithCode, isErrorWithType} from 'Util/TypePredicateUtil';
 
 import {ClientEntity} from './ClientEntity';
 import {constructClientId, parseClientId} from './ClientIdUtil';

--- a/apps/webapp/src/script/repositories/connection/ConnectionRepository.ts
+++ b/apps/webapp/src/script/repositories/connection/ConnectionRepository.ts
@@ -40,7 +40,8 @@ import {UserState} from 'Repositories/user/UserState';
 import {replaceLink, t} from 'Util/LocalizerUtil';
 import {getLogger, Logger} from 'Util/Logger';
 import {matchQualifiedIds} from 'Util/QualifiedId';
-import {isBackendError, toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
+import {isBackendError} from 'Util/TypePredicateUtil';
 
 import type {ConnectionEntity} from './ConnectionEntity';
 import {ConnectionMapper} from './ConnectionMapper';

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -106,7 +106,8 @@ import {
   startsWith,
 } from 'Util/StringUtil';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
-import {isBackendError, isErrorWithType, toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
+import {isBackendError, isErrorWithType} from 'Util/TypePredicateUtil';
 import {createUuid} from 'Util/uuid';
 
 import {ACCESS_STATE} from './AccessState';

--- a/apps/webapp/src/script/repositories/conversation/EventMapper.ts
+++ b/apps/webapp/src/script/repositories/conversation/EventMapper.ts
@@ -64,7 +64,8 @@ import type {EventRecord, LegacyEventRecord} from 'Repositories/storage';
 import {t} from 'Util/LocalizerUtil';
 import {getLogger, Logger} from 'Util/Logger';
 import {userReactionMapToReactionMap} from 'Util/ReactionUtil';
-import {isErrorWithType, toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
+import {isErrorWithType} from 'Util/TypePredicateUtil';
 import {base64ToArray} from 'Util/util';
 
 import {

--- a/apps/webapp/src/script/repositories/cryptography/CryptographyMapper.ts
+++ b/apps/webapp/src/script/repositories/cryptography/CryptographyMapper.ts
@@ -62,7 +62,7 @@ import {MessageAddEvent} from 'Repositories/conversation/EventBuilder';
 import {ClientEvent, CONVERSATION} from 'Repositories/event/Client';
 import {getLogger, Logger} from 'Util/Logger';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
-import {toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
 import {base64ToArray, arrayToBase64} from 'Util/util';
 
 import {PROTO_MESSAGE_TYPE} from './ProtoMessageType';

--- a/apps/webapp/src/script/repositories/event/EventRepository.ts
+++ b/apps/webapp/src/script/repositories/event/EventRepository.ts
@@ -39,7 +39,8 @@ import {EventName} from 'Repositories/tracking/EventName';
 import {UserState} from 'Repositories/user/UserState';
 import {getLogger, Logger} from 'Util/Logger';
 import {TIME_IN_MILLIS} from 'Util/TimeUtil';
-import {isAxiosError, toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
+import {isAxiosError} from 'Util/TypePredicateUtil';
 
 import {ClientEvent} from './Client';
 import {EventMiddleware, EventProcessor, IncomingEvent} from './EventProcessor';

--- a/apps/webapp/src/script/repositories/event/EventService.ts
+++ b/apps/webapp/src/script/repositories/event/EventService.ts
@@ -34,7 +34,7 @@ import {
 } from 'Repositories/storage';
 import {StorageSchemata} from 'Repositories/storage/StorageSchemata';
 import {getLogger, Logger} from 'Util/Logger';
-import {toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
 
 import {ClientEvent, CONVERSATION as CLIENT_CONVERSATION_EVENT} from './Client';
 

--- a/apps/webapp/src/script/repositories/integration/IntegrationRepository.ts
+++ b/apps/webapp/src/script/repositories/integration/IntegrationRepository.ts
@@ -30,7 +30,7 @@ import type {TeamRepository} from 'Repositories/team/TeamRepository';
 import {TeamState} from 'Repositories/team/TeamState';
 import {getLogger, Logger} from 'Util/Logger';
 import {compareTransliteration, sortByPriority} from 'Util/StringUtil';
-import {toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
 
 import {IntegrationMapper} from './IntegrationMapper';
 import type {IntegrationService} from './IntegrationService';

--- a/apps/webapp/src/script/repositories/media/MediaStreamHandler.ts
+++ b/apps/webapp/src/script/repositories/media/MediaStreamHandler.ts
@@ -26,7 +26,8 @@ import {BrowserPermissionStatus} from 'Repositories/permission/BrowserPermission
 import {getPermissionStates} from 'Repositories/permission/permissionHandlers';
 import {PermissionType} from 'Repositories/permission/PermissionType';
 import {getLogger, Logger} from 'Util/Logger';
-import {isErrorWithType, toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
+import {isErrorWithType} from 'Util/TypePredicateUtil';
 
 import {MediaConstraintsHandler, ScreensharingMethods} from './MediaConstraintsHandler';
 import {MEDIA_STREAM_ERROR} from './MediaStreamError';

--- a/apps/webapp/src/script/repositories/storage/StorageService.ts
+++ b/apps/webapp/src/script/repositories/storage/StorageService.ts
@@ -25,7 +25,7 @@ import {IndexedDBEngine} from '@wireapp/store-engine-dexie';
 
 import {Logger, getLogger} from 'Util/Logger';
 import {loadValue, storeValue} from 'Util/StorageUtil';
-import {toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
 
 import {DexieDatabase} from './DexieDatabase';
 import {StorageSchemata} from './StorageSchemata';

--- a/apps/webapp/src/script/repositories/user/UserRepository.ts
+++ b/apps/webapp/src/script/repositories/user/UserRepository.ts
@@ -66,7 +66,8 @@ import {t} from 'Util/LocalizerUtil';
 import {getLogger, Logger} from 'Util/Logger';
 import {matchQualifiedIds} from 'Util/QualifiedId';
 import {fixWebsocketString} from 'Util/StringUtil';
-import {isAxiosError, isBackendError, isErrorWithCode, isErrorWithType, toError} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
+import {isAxiosError, isBackendError, isErrorWithCode, isErrorWithType} from 'Util/TypePredicateUtil';
 
 import {showAvailabilityModal} from './AvailabilityModal';
 import {ConsentValue} from './ConsentValue';

--- a/apps/webapp/src/script/util/TypePredicateUtil.test.ts
+++ b/apps/webapp/src/script/util/TypePredicateUtil.test.ts
@@ -20,7 +20,8 @@
 import {BackendError, BackendErrorLabel} from '@wireapp/api-client/lib/http/';
 import type {AxiosError} from 'axios';
 
-import {isAxiosError, isBackendError, isErrorWithCode, isErrorWithType, toError} from 'Util/TypePredicateUtil';
+import {isAxiosError, isBackendError, isErrorWithCode, isErrorWithType} from 'Util/TypePredicateUtil';
+import {toError} from 'Util/toError';
 
 describe('TypePredicateUtil', () => {
   describe('isAxiosError', () => {
@@ -82,22 +83,6 @@ describe('TypePredicateUtil', () => {
       const actual = isErrorWithType(error);
 
       expect(actual).toBeTruthy();
-    });
-  });
-
-  describe('toError', () => {
-    it('returns error instances unchanged', () => {
-      const error = new Error('Server Error');
-
-      const actual = toError(error);
-
-      expect(actual).toBe(error);
-    });
-
-    it('wraps string values into errors', () => {
-      const actual = toError('Server Error');
-
-      expect(actual.message).toBe('Server Error');
     });
   });
 });

--- a/apps/webapp/src/script/util/TypePredicateUtil.ts
+++ b/apps/webapp/src/script/util/TypePredicateUtil.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import is from '@sindresorhus/is';
 import {RegisteredClient} from '@wireapp/api-client/lib/client';
 import type {BackendError} from '@wireapp/api-client/lib/http';
 import {AxiosError} from 'axios';
@@ -47,22 +46,6 @@ export function isErrorWithCode(errorCandidate: unknown): errorCandidate is Erro
 
 export function isErrorWithType(errorCandidate: unknown): errorCandidate is ErrorWithType {
   return isObject(errorCandidate) && 'type' in errorCandidate && typeof errorCandidate.type === 'string';
-}
-
-export function toError(errorCandidate: unknown): Error {
-  if (is.error(errorCandidate)) {
-    return errorCandidate;
-  }
-
-  if (isObject(errorCandidate)) {
-    return errorCandidate as Error;
-  }
-
-  if (typeof errorCandidate === 'string') {
-    return new Error(errorCandidate);
-  }
-
-  return new Error('Unknown error', {cause: errorCandidate});
 }
 
 export function isConversationEntity(conversation: any): conversation is Conversation {

--- a/apps/webapp/src/script/util/toError.test.ts
+++ b/apps/webapp/src/script/util/toError.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Wire
+ * Copyright (C) 2021 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+
+import {toError} from 'Util/toError';
+
+describe('toError', () => {
+  it('returns error instances unchanged', () => {
+    const error = new Error('Server Error');
+
+    const actual = toError(error);
+
+    expect(actual).toBe(error);
+  });
+
+  it('wraps string values into errors', () => {
+    const actual = toError('Server Error');
+
+    expect(actual.message).toBe('Server Error');
+  });
+
+  it('wraps objects with a message into errors', () => {
+    const source = {message: 'Server Error'};
+
+    const actual = toError(source);
+
+    expect(actual.message).toBe('Server Error');
+    expect(actual.cause).toBe(source);
+  });
+
+  it('wraps objects without a message into unknown errors', () => {
+    const source = {code: 500};
+
+    const actual = toError(source);
+
+    expect(actual.message).toBe('Unknown error');
+    expect(actual.cause).toBe(source);
+  });
+
+  it('wraps objects with a non-string message into unknown errors', () => {
+    const source = {message: 500};
+
+    const actual = toError(source);
+
+    expect(actual.message).toBe('Unknown error');
+    expect(actual.cause).toBe(source);
+  });
+
+  it('wraps non-string primitive values into unknown errors', () => {
+    const source = 500;
+
+    const actual = toError(source);
+
+    expect(actual.message).toBe('Unknown error');
+    expect(actual.cause).toBe(source);
+  });
+});

--- a/apps/webapp/src/script/util/toError.ts
+++ b/apps/webapp/src/script/util/toError.ts
@@ -1,0 +1,40 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import is from '@sindresorhus/is';
+
+export function toError(errorCandidate: unknown): Error {
+  if (is.error(errorCandidate)) {
+    return errorCandidate;
+  }
+
+  if (is.object(errorCandidate)) {
+    if ('message' in errorCandidate && is.string(errorCandidate.message)) {
+      return new Error(errorCandidate.message, {cause: errorCandidate});
+    }
+
+    return new Error('Unknown error', {cause: errorCandidate});
+  }
+
+  if (is.string(errorCandidate)) {
+    return new Error(errorCandidate);
+  }
+
+  return new Error('Unknown error', {cause: errorCandidate});
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
* refactor(webapp): extract worker-safe toError utility

Move `toError` into a standalone utility module so it can be used from the backup zip worker without importing `TypePredicateUtil`, which pulls in app-level dependencies that are not safe in a worker context.

Update the backup worker and all `toError` consumers to import the new utility directly, while keeping `TypePredicateUtil` focused on the type-predicate helpers that depend on app/runtime types.

Also update tests to reflect the current `toError` behavior for plain object errors.

Why:
- fixes the backup worker crash caused by a `window`-dependent import chain
- keeps worker code isolated from browser app dependencies
- preserves the broader app behavior while making the dependency boundary explicit

* move tests

* refactor

* fix tests
