### PR TITLE
fix: umlauts in folder names [WPB-22692]

### DIFF
--- a/apps/webapp/src/script/repositories/conversation/ConversationLabelRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationLabelRepository.ts
@@ -230,12 +230,15 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
 
   readonly onUserEvent = (event: any) => {
     if (event.type === USER_EVENT.PROPERTIES_SET && event.key === propertiesKey) {
-      const value: LabelProperty = {
-        ...event.value,
-        labels: (event.value?.labels ?? []).map((label: ConversationLabelJson) => ({
+      const normalizedLabels = event.value?.labels?.map((label: ConversationLabelJson) => {
+        return {
           ...label,
           name: label.name ? fixWebsocketString(label.name) : undefined,
-        })),
+        };
+      });
+      const value: LabelProperty = {
+        ...event.value,
+        labels: normalizedLabels ?? [],
       };
       this.unmarshal(value);
     }

--- a/apps/webapp/src/script/repositories/conversation/ConversationLabelRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationLabelRepository.ts
@@ -234,7 +234,7 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
         ...event.value,
         labels: (event.value?.labels ?? []).map((label: ConversationLabelJson) => ({
           ...label,
-          name: label.name ? fixWebsocketString(label.name) : label.name,
+          name: label.name ? fixWebsocketString(label.name) : undefined,
         })),
       };
       this.unmarshal(value);

--- a/apps/webapp/src/script/repositories/conversation/ConversationLabelRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationLabelRepository.ts
@@ -29,6 +29,7 @@ import type {PropertiesService} from 'Repositories/properties/PropertiesService'
 import {SidebarTabs, useSidebarStore} from 'src/script/page/LeftSidebar/panels/Conversations/useSidebarStore';
 import {t} from 'Util/LocalizerUtil';
 import {getLogger, Logger} from 'Util/Logger';
+import {fixWebsocketString} from 'Util/StringUtil';
 import {TypedEventTarget} from 'Util/TypedEventTarget';
 import {createUuid} from 'Util/uuid';
 
@@ -229,7 +230,14 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
 
   readonly onUserEvent = (event: any) => {
     if (event.type === USER_EVENT.PROPERTIES_SET && event.key === propertiesKey) {
-      this.unmarshal(event.value);
+      const value: LabelProperty = {
+        ...event.value,
+        labels: (event.value?.labels ?? []).map((label: ConversationLabelJson) => ({
+          ...label,
+          name: label.name ? fixWebsocketString(label.name) : label.name,
+        })),
+      };
+      this.unmarshal(value);
     }
   };
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22692" title="WPB-22692" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22692</a>  [Web] Folders created on iOS with Umlaut (ü ä ö) are not correctly displayed on Web
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Handled umlauts properly in folder names 

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
