### PR TITLE
refactor(webapp): inject app lock crypto dependency [WPB-22420] (#20743)

### DIFF
--- a/apps/webapp/src/script/page/AppLock/AppLock.test.tsx
+++ b/apps/webapp/src/script/page/AppLock/AppLock.test.tsx
@@ -25,22 +25,23 @@ import ko from 'knockout';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import type {ClientRepository} from 'Repositories/client';
+import {User} from 'Repositories/entity/User/User';
 import {TeamState} from 'Repositories/team/TeamState';
-import {AppLockRepository} from 'Repositories/user/AppLockRepository';
+import {AppLockCrypto, AppLockRepository} from 'Repositories/user/AppLockRepository';
 import {AppLockState} from 'Repositories/user/AppLockState';
 import {UserState} from 'Repositories/user/UserState';
 import {createUuid} from 'Util/uuid';
 
 import {AppLock, APPLOCK_STATE} from './AppLock';
 
-// https://github.com/jedisct1/libsodium.js/issues/235
-jest.mock('libsodium-wrappers', () => ({
-  crypto_pwhash_str: (value: string) => value,
-  crypto_pwhash_str_verify: (value1: string, value2: string) => value1 === value2,
-  ready: Promise.resolve,
-}));
-
 const clientRepository = {} as unknown as ClientRepository;
+const appLockCrypto: AppLockCrypto = {
+  cryptoPwhashMemLimitInteractive: 1,
+  cryptoPwhashOpsLimitInteractive: 1,
+  ready: Promise.resolve(),
+  cryptoPwhashStr: (value: string) => value,
+  cryptoPwhashStrVerify: (value1: string, value2: string) => value1 === value2,
+};
 
 const createTeamState = ({
   status = 'enabled',
@@ -75,8 +76,8 @@ const createAppLockState = (teamState?: TeamState) => {
 const createAppLockRepository = (appLockState?: AppLockState) => {
   const userState = new UserState();
   appLockState = appLockState ?? createAppLockState();
-  jest.spyOn(userState, 'self').mockImplementation(ko.observable({id: createUuid()}));
-  const appLockRepository = new AppLockRepository(userState, appLockState);
+  userState.self(new User(createUuid(), ''));
+  const appLockRepository = new AppLockRepository(userState, appLockState, appLockCrypto);
   return appLockRepository;
 };
 describe('AppLock', () => {

--- a/apps/webapp/src/script/repositories/user/AppLockRepository.test.ts
+++ b/apps/webapp/src/script/repositories/user/AppLockRepository.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {User} from 'Repositories/entity/User/User';
+import {createUuid} from 'Util/uuid';
+
+import {AppLockCrypto, AppLockRepository} from './AppLockRepository';
+import {AppLockState} from './AppLockState';
+import {UserState} from './UserState';
+
+const mockCryptoPwhashStr = jest.fn();
+const mockCryptoPwhashStrVerify = jest.fn();
+
+const createAppLockRepository = (): AppLockRepository => {
+  const userState = new UserState();
+  const appLockState = new AppLockState();
+  const appLockCrypto: AppLockCrypto = {
+    cryptoPwhashMemLimitInteractive: 1,
+    cryptoPwhashOpsLimitInteractive: 1,
+    ready: Promise.resolve(),
+    cryptoPwhashStr: (code: string, opsLimit: number, memLimit: number) => mockCryptoPwhashStr(code, opsLimit, memLimit),
+    cryptoPwhashStrVerify: (hashedCode: string, code: string) => mockCryptoPwhashStrVerify(hashedCode, code),
+  };
+
+  userState.self(new User(createUuid(), ''));
+
+  return new AppLockRepository(userState, appLockState, appLockCrypto);
+};
+
+describe('AppLockRepository', () => {
+  beforeEach(() => {
+    mockCryptoPwhashStr.mockReset();
+    mockCryptoPwhashStrVerify.mockReset();
+    globalThis.localStorage.clear();
+  });
+
+  it('stores the pwhash output directly when libsodium returns a string', async () => {
+    const repository = createAppLockRepository();
+    const storedHash = '$argon2id$mocked';
+    mockCryptoPwhashStr.mockReturnValue(storedHash);
+
+    await repository.setCode('ValidPassword123!');
+
+    expect(repository.getStoredPassphrase()).toBe(storedHash);
+  });
+
+  it('throws when libsodium returns a non-string hash', async () => {
+    const repository = createAppLockRepository();
+    const hashedBytes = new Uint8Array([1, 2, 3]);
+    mockCryptoPwhashStr.mockReturnValue(hashedBytes);
+
+    await expect(repository.setCode('ValidPassword123!')).rejects.toThrow('Unexpected crypto_pwhash_str output type');
+    expect(repository.getStoredPassphrase()).toBeNull();
+  });
+});

--- a/apps/webapp/src/script/repositories/user/AppLockRepository.ts
+++ b/apps/webapp/src/script/repositories/user/AppLockRepository.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import sodium, {ready, to_string} from 'libsodium-wrappers-sumo';
+import sodium, {ready} from 'libsodium-wrappers-sumo';
 import {container, singleton} from 'tsyringe';
 
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
@@ -29,6 +29,34 @@ import {UserState} from './UserState';
 const APP_LOCK_STORAGE = 'app_lock';
 const APP_LOCK_ENABLED_STORAGE = 'app_lock_enabled';
 
+export interface AppLockCrypto {
+  readonly cryptoPwhashMemLimitInteractive: number;
+  readonly cryptoPwhashOpsLimitInteractive: number;
+  readonly ready: Promise<void>;
+  cryptoPwhashStr(code: string, opsLimit: number, memLimit: number): Uint8Array | string;
+  cryptoPwhashStrVerify(hashedCode: string, code: string): boolean;
+}
+
+const defaultAppLockCrypto: AppLockCrypto = {
+  cryptoPwhashMemLimitInteractive: sodium.crypto_pwhash_MEMLIMIT_INTERACTIVE,
+  cryptoPwhashOpsLimitInteractive: sodium.crypto_pwhash_OPSLIMIT_INTERACTIVE,
+  ready,
+  cryptoPwhashStr: (code: string, opsLimit: number, memLimit: number): Uint8Array | string =>
+    sodium.crypto_pwhash_str(code, opsLimit, memLimit),
+  cryptoPwhashStrVerify: (hashedCode: string, code: string): boolean =>
+    sodium.crypto_pwhash_str_verify(hashedCode, code),
+};
+
+// libsodium-wrappers-sumo currently returns a string here despite the published typings.
+// Upstream report: https://github.com/jedisct1/libsodium.js/issues/364
+const getStoredHash = (hashed: Uint8Array | string): string => {
+  if (typeof hashed !== 'string') {
+    throw new TypeError('Unexpected crypto_pwhash_str output type');
+  }
+
+  return hashed;
+};
+
 @singleton()
 export class AppLockRepository {
   getPassphraseStorageKey: () => string;
@@ -36,6 +64,7 @@ export class AppLockRepository {
   constructor(
     private readonly userState = container.resolve(UserState),
     private readonly appLockState = container.resolve(AppLockState),
+    private readonly appLockCrypto: AppLockCrypto = defaultAppLockCrypto,
   ) {
     this.getPassphraseStorageKey = (): string => `${APP_LOCK_STORAGE}_${this.userState.self().id}`;
     this.getEnabledStorageKey = (): string => `${APP_LOCK_ENABLED_STORAGE}_${this.userState.self().id}`;
@@ -105,13 +134,13 @@ export class AppLockRepository {
 
   setCode = async (code: string): Promise<void> => {
     this.stopPassphraseObserver();
-    await ready;
-    const hashed = sodium.crypto_pwhash_str(
+    await this.appLockCrypto.ready;
+    const hashed = this.appLockCrypto.cryptoPwhashStr(
       code,
-      sodium.crypto_pwhash_OPSLIMIT_INTERACTIVE,
-      sodium.crypto_pwhash_MEMLIMIT_INTERACTIVE,
+      this.appLockCrypto.cryptoPwhashOpsLimitInteractive,
+      this.appLockCrypto.cryptoPwhashMemLimitInteractive,
     );
-    window.localStorage.setItem(this.getPassphraseStorageKey(), to_string(hashed));
+    window.localStorage.setItem(this.getPassphraseStorageKey(), getStoredHash(hashed));
     this.startPassphraseObserver();
     this.appLockState.hasPassphrase(true);
   };
@@ -128,7 +157,7 @@ export class AppLockRepository {
       return false;
     }
 
-    await ready;
-    return sodium.crypto_pwhash_str_verify(hashedCode, code);
+    await this.appLockCrypto.ready;
+    return this.appLockCrypto.cryptoPwhashStrVerify(hashedCode, code);
   };
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
* refactor(webapp): inject app lock crypto dependency

Refactor AppLockRepository to receive its password-hashing dependency through constructor injection instead of reading libsodium directly at module scope.

This keeps production behavior unchanged through a default libsodium-backed adapter, while making tests simpler and more reliable. App-lock tests now pass plain fake crypto implementations rather than using jest.mock for libsodium.

Also preserve the runtime guard and upstream issue reference for the crypto_pwhash_str type mismatch, where the installed package returns a string despite the published TypeScript definitions declaring Uint8Array.

* fix lint issue
