### PR TITLE
refactor: complete private 'page' refactor in missed files [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
@@ -321,10 +321,13 @@ test.describe('Delete', () => {
 
   testCases.forEach(({name, tc, sendAction}) => {
     test(`Delete "For Everyone" works for ${name}`, {tag: [tc, '@regression']}, async ({createPage, api}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+      const [pageA, pageB] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
       ]);
+
+      const userAPages = PageManager.from(pageA).webapp.pages;
+      const userBPages = PageManager.from(pageB).webapp.pages;
 
       await test.step('Await mls conversation creation', async () => {
         await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
@@ -332,15 +335,13 @@ test.describe('Delete', () => {
       });
 
       await test.step('Execute send action', async () => {
-        const {page: pageA} = userAPages.conversation();
-        const {page: pageB} = userBPages.conversation();
         await sendAction({pageA, pageB, api});
       });
 
       let messageA: Locator;
       let messageB: Locator;
 
-      await test.step('Veryify send action', async () => {
+      await test.step('Verify send action', async () => {
         messageA = userAPages.conversation().getMessage({sender: userA});
         messageB = userBPages.conversation().getMessage({sender: userA});
         await expect(messageA).toBeAttached();

--- a/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
@@ -39,20 +39,22 @@ test.describe('In Conversation Search', () => {
     'Verify main overview shows media from all categories',
     {tag: ['@TC-352', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
       ]);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       // Preconditions: User B sends media from all categories (images, links, audio and files)
       await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-      const {page} = userBPages.conversation();
       // Image
-      await shareAssetHelper(getImageFilePath(), page, page.getByRole('button', {name: 'Add picture'}));
+      await shareAssetHelper(getImageFilePath(), userBPage, userBPage.getByRole('button', {name: 'Add picture'}));
       // Audio
-      await shareAssetHelper(getAudioFilePath(), page, page.getByRole('button', {name: 'Add file'}));
+      await shareAssetHelper(getAudioFilePath(), userBPage, userBPage.getByRole('button', {name: 'Add file'}));
       // File
-      await shareAssetHelper(getTextFilePath(), page, page.getByRole('button', {name: 'Add file'}));
+      await shareAssetHelper(getTextFilePath(), userBPage, userBPage.getByRole('button', {name: 'Add file'}));
 
       await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
       await expect(userAPages.conversation().getMessage({sender: userB})).toHaveCount(3);
@@ -69,18 +71,19 @@ test.describe('In Conversation Search', () => {
     'Verify opening overview of all pictures from sender and receiver in group',
     {tag: ['@TC-356', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+      const [pageA, pageB] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
       ]);
+
+      const userAPages = PageManager.from(pageA).webapp.pages;
+      const userBPages = PageManager.from(pageB).webapp.pages;
 
       const conversationName = 'Test Group';
       await createGroup(userAPages, conversationName, [userB]);
 
       await userBPages.conversationList().openConversation(conversationName);
       await userAPages.conversationList().openConversation(conversationName);
-      const {page: pageB} = userBPages.conversation();
-      const {page: pageA} = userAPages.conversation();
 
       for (let imageCount = 0; imageCount < 10; imageCount++) {
         await shareAssetHelper(getImageFilePath(), pageB, pageB.getByRole('button', {name: 'Add picture'}));
@@ -100,19 +103,18 @@ test.describe('In Conversation Search', () => {
     'Verify opening single picture from all shared media overview',
     {tag: ['@TC-357', '@regression']},
     async ({createPage}) => {
-      const [userAPageManager, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+      const [pageA, pageB] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
       ]);
 
-      const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
+      const {pages: userAPages, modals: userAModals} = PageManager.from(pageA).webapp;
+      const userBPages = PageManager.from(pageB).webapp.pages;
 
       await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-      const {page: pageB} = userBPages.conversation();
       await shareAssetHelper(getImageFilePath(), pageB, pageB.getByRole('button', {name: 'Add picture'}));
 
       await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      const {page: pageA} = userAPages.conversation();
       await shareAssetHelper(getImageFilePath(), pageA, pageA.getByRole('button', {name: 'Add picture'}));
 
       await userAPages.conversation().searchButton.click();
@@ -139,20 +141,21 @@ test.describe('In Conversation Search', () => {
   });
 
   test('Verify opening overview of all files', {tag: ['@TC-359', '@regression']}, async ({createPage}) => {
-    const [userAPages, userBPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+    const [pageA, pageB] = await Promise.all([
+      createPage(withLogin(userA), withConnectedUser(userB)),
+      createPage(withLogin(userB)),
     ]);
 
+    const userAPages = PageManager.from(pageA).webapp.pages;
+    const userBPages = PageManager.from(pageB).webapp.pages;
+
     await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-    const {page: pageB} = userBPages.conversation();
 
     for (let fileCount = 0; fileCount < 10; fileCount++) {
       await shareAssetHelper(getTextFilePath(), pageB, pageB.getByRole('button', {name: 'Add file'}));
     }
 
     await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-    const {page: pageA} = userAPages.conversation();
     for (let fileCount = 0; fileCount < 10; fileCount++) {
       await shareAssetHelper(getTextFilePath(), pageA, pageA.getByRole('button', {name: 'Add file'}));
     }
@@ -165,13 +168,15 @@ test.describe('In Conversation Search', () => {
     "Verify deleted media isn't in collection on other side",
     {tag: ['@TC-360', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+      const [pageA, pageB] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
       ]);
 
+      const userAPages = PageManager.from(pageA).webapp.pages;
+      const userBPages = PageManager.from(pageB).webapp.pages;
+
       await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-      const {page: pageB} = userBPages.conversation();
       await shareAssetHelper(getImageFilePath(), pageB, pageB.getByRole('button', {name: 'Add picture'}));
 
       await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});

--- a/apps/webapp/test/e2e_tests/specs/Reactions/reactions.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reactions/reactions.spec.ts
@@ -17,13 +17,12 @@
  *
  */
 
+import {Page} from 'playwright/test';
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {test, expect, withLogin, withConnectedUser} from 'test/e2e_tests/test.fixtures';
 import {getAudioFilePath, getTextFilePath, getVideoFilePath, shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
 import {getImageFilePath} from 'test/e2e_tests/utils/sendImage.util';
-
-type Pages = PageManager['webapp']['pages'];
 
 test.describe('Reactions', () => {
   let userA: User;
@@ -39,47 +38,45 @@ test.describe('Reactions', () => {
     {
       tc: '@TC-1527',
       title: 'link preview in 1:1',
-      sendFromUserB: async (userBPages: Pages) => {
+      sendFromUserB: async (page: Page) => {
         const link = 'https://www.kaufland.de/';
+        const userBPages = PageManager.from(page).webapp.pages;
         await userBPages.conversation().sendMessage(link);
       },
     },
     {
       tc: '@TC-1528',
       title: 'picture',
-      sendFromUserB: async (userBPages: Pages) => {
-        const {page} = userBPages.conversation();
+      sendFromUserB: async (page: Page) => {
         await shareAssetHelper(getImageFilePath(), page, page.getByRole('button', {name: 'Add picture'}));
       },
     },
     {
       tc: '@TC-1529',
       title: 'audio message',
-      sendFromUserB: async (userBPages: Pages) => {
-        const {page} = userBPages.conversation();
+      sendFromUserB: async (page: Page) => {
         await shareAssetHelper(getAudioFilePath(), page, page.getByRole('button', {name: 'Add file'}));
       },
     },
     {
       tc: '@TC-1530',
       title: 'video message',
-      sendFromUserB: async (userBPages: Pages) => {
-        const {page} = userBPages.conversation();
+      sendFromUserB: async (page: Page) => {
         await shareAssetHelper(getVideoFilePath(), page, page.getByRole('button', {name: 'Add file'}));
       },
     },
     {
       tc: '@TC-1532',
       title: 'shared file',
-      sendFromUserB: async (userBPages: Pages) => {
-        const {page} = userBPages.conversation();
+      sendFromUserB: async (page: Page) => {
         await shareAssetHelper(getTextFilePath(), page, page.getByRole('button', {name: 'Add file'}));
       },
     },
     {
       tc: '@TC-1536',
       title: 'message in 1:1',
-      sendFromUserB: async (userBPages: Pages) => {
+      sendFromUserB: async (page: Page) => {
+        const userBPages = PageManager.from(page).webapp.pages;
         await userBPages.conversation().sendMessage('Message from User B');
       },
     },
@@ -87,13 +84,16 @@ test.describe('Reactions', () => {
 
   for (const c of likeCases) {
     test(`Verify liking someone's ${c.title}`, {tag: [c.tc, '@regression']}, async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
       ]);
 
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
+
       await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-      await c.sendFromUserB(userBPages);
+      await c.sendFromUserB(userBPage);
 
       await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
       const messageFromUserB = userAPages.conversation().getMessage({sender: userB});
@@ -135,7 +135,7 @@ test.describe('Reactions', () => {
   });
 
   test('Verify liking an own text message', {tag: ['@TC-1534', '@regression']}, async ({createPage}) => {
-    const userAPages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
+    const userAPages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp.pages;
 
     await userAPages.conversation().sendMessage('Message from User A');
     const messageUserA = userAPages.conversation().getMessage({sender: userA});
@@ -145,7 +145,7 @@ test.describe('Reactions', () => {
   });
 
   test('Verify you cannot like a system message', {tag: ['@TC-1535', '@regression']}, async ({createPage}) => {
-    const userAPages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
+    const userAPages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp.pages;
 
     const systemMessage = userAPages.conversation().systemMessages;
     await systemMessage.hover();
@@ -182,10 +182,13 @@ test.describe('Reactions', () => {
     'Verify I can open like list by hovering the link in the tooltip of a reaction pill',
     {tag: ['@TC-1540', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
       ]);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
       await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
@@ -200,10 +203,7 @@ test.describe('Reactions', () => {
       const reaction = userAPages.conversation().getReactionOnMessage(messageUserB, 'heart');
       await reaction.hover();
 
-      const tooltip = userAPages
-        .conversation()
-        .page.getByRole('tooltip')
-        .filter({hasText: `${userA.fullName} reacted with`});
+      const tooltip = userAPage.getByRole('tooltip').filter({hasText: `${userA.fullName} reacted with`});
       await expect(tooltip).toBeVisible();
     },
   );

--- a/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
@@ -124,8 +124,8 @@ test.describe('Reply', () => {
   );
 
   test('I want to reply to a picture', {tag: ['@TC-3002', '@regression']}, async ({createPage}) => {
-    const pages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
-    const {page} = pages.conversation();
+    const page = await createPage(withLogin(userA), withConnectedUser(userB));
+    const pages = PageManager.from(page).webapp.pages;
     await shareAssetHelper(getImageFilePath(), page, page.getByRole('button', {name: 'Add picture'}));
 
     const messageWithImage = pages.conversation().getMessage({sender: userA});
@@ -137,8 +137,9 @@ test.describe('Reply', () => {
   });
 
   test('I want to reply to an audio message', {tag: ['@TC-3003', '@regression']}, async ({createPage}) => {
-    const pages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
-    const {page} = pages.conversation();
+    const page = await createPage(withLogin(userA), withConnectedUser(userB));
+    const pages = PageManager.from(page).webapp.pages;
+
     await shareAssetHelper(getAudioFilePath(), page, page.getByRole('button', {name: 'Add file'}));
 
     const messageWithAudio = pages.conversation().getMessage({sender: userA});
@@ -150,8 +151,8 @@ test.describe('Reply', () => {
   });
 
   test('I want to reply to a video message', {tag: ['@TC-3004', '@regression']}, async ({createPage}) => {
-    const pages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
-    const {page} = pages.conversation();
+    const page = await createPage(withLogin(userA), withConnectedUser(userB));
+    const pages = PageManager.from(page).webapp.pages;
     await shareAssetHelper(getVideoFilePath(), page, page.getByRole('button', {name: 'Add file'}));
 
     const messageWithVideo = pages.conversation().getMessage({sender: userA});
@@ -175,8 +176,8 @@ test.describe('Reply', () => {
   });
 
   test('I want to reply to a file', {tag: ['@TC-3006', '@regression']}, async ({createPage}) => {
-    const pages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
-    const {page} = pages.conversation();
+    const page = await createPage(withLogin(userA), withConnectedUser(userB));
+    const pages = PageManager.from(page).webapp.pages;
     await shareAssetHelper(getTextFilePath(), page, page.getByRole('button', {name: 'Add file'}));
 
     const messageWithFile = pages.conversation().getMessage({sender: userA});


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
…22420)

# Pull Request

## Summary

This PR completes the refactor started in #20641, addressing a few files where the page property was changed to private. It resolves the remaining typescript error in the missed test suites.

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
