### PR TITLE
test(e2e): Fix broken e2e tests [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/repositories/user/AppLockRepository.ts
+++ b/apps/webapp/src/script/repositories/user/AppLockRepository.ts
@@ -38,8 +38,12 @@ export interface AppLockCrypto {
 }
 
 const defaultAppLockCrypto: AppLockCrypto = {
-  cryptoPwhashMemLimitInteractive: sodium.crypto_pwhash_MEMLIMIT_INTERACTIVE,
-  cryptoPwhashOpsLimitInteractive: sodium.crypto_pwhash_OPSLIMIT_INTERACTIVE,
+  get cryptoPwhashMemLimitInteractive(): number {
+    return sodium.crypto_pwhash_MEMLIMIT_INTERACTIVE;
+  },
+  get cryptoPwhashOpsLimitInteractive(): number {
+    return sodium.crypto_pwhash_OPSLIMIT_INTERACTIVE;
+  },
   ready,
   cryptoPwhashStr: (code: string, opsLimit: number, memLimit: number): Uint8Array | string =>
     sodium.crypto_pwhash_str(code, opsLimit, memLimit),

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/appLock.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/appLock.modal.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {Locator, Page} from '@playwright/test';
+import {expect, Locator, Page} from '@playwright/test';
 
 export class AppLockModal {
   readonly lockPasscodeInput: Locator;
@@ -49,6 +49,7 @@ export class AppLockModal {
   async setPasscode(passcode: string) {
     await this.lockPasscodeInput.fill(passcode);
     await this.appLockActionButton.click();
+    await expect(this.appLockModal).toBeHidden();
   }
 
   async unlockAppWithPasscode(passcode: string) {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/infoHistory.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/infoHistory.page.ts
@@ -27,9 +27,9 @@ export class HistoryInfoPage {
     this.page = page;
     this.continueButton = this.page.getByTestId('do-history-confirm');
   }
-  async isButtonVisible() {
+  async isButtonVisible(timeout = 3_000) {
     try {
-      await this.continueButton.waitFor({state: 'visible'});
+      await this.continueButton.waitFor({state: 'visible', timeout});
       return true;
     } catch (err: unknown) {
       return false;
@@ -38,5 +38,11 @@ export class HistoryInfoPage {
 
   async clickConfirmButton() {
     await this.continueButton.click();
+  }
+
+  async clickConfirmButtonIfVisible(timeout = 3_000) {
+    if (await this.isButtonVisible(timeout)) {
+      await this.clickConfirmButton();
+    }
   }
 }

--- a/apps/webapp/test/e2e_tests/specs/Authentication/authentication.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Authentication/authentication.spec.ts
@@ -104,7 +104,7 @@ test.describe('Authentication', () => {
       await test.step('Log in again on non public computer', async () => {
         await pageManager.openLoginPage();
         await pages.login().login(user);
-        await pages.historyInfo().clickConfirmButton();
+        await pages.historyInfo().clickConfirmButtonIfVisible();
         await components.conversationSidebar().sidebar.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
       });
 
@@ -226,7 +226,7 @@ test.describe('Authentication', () => {
       await test.step('Log in again', async () => {
         await pageManager.openLoginPage();
         await pages.login().login(userA);
-        await pages.historyInfo().clickConfirmButton();
+        await pages.historyInfo().clickConfirmButtonIfVisible();
         await components.conversationSidebar().sidebar.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
       });
 

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/accountManagement-TC-8639.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/accountManagement-TC-8639.spec.ts
@@ -45,7 +45,7 @@ test('Account Management', {tag: ['@TC-8639', '@crit-flow-web']}, async ({create
   });
 
   await test.step('Member verifies if applock is working', async () => {
-    await pageManager.refreshPage();
+    await pageManager.page.reload();
     await expect(modals.appLock().appLockModalHeader).toContainText('Enter passcode to unlock', {
       timeout: LOGIN_TIMEOUT,
     });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
- fix(webapp): initialize app lock crypto limits after libsodium is ready
- test(e2e): stabilize TC-8639 app lock setup flow]
- test(e2e): handle optional history info on auth re-login