### PR TITLE
fix: handle semicolon on links [WPB-22693]

### DIFF
--- a/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/url.test.tsx
+++ b/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/url.test.tsx
@@ -64,6 +64,8 @@ describe('validateUrl', () => {
     expect(URL_REGEX.test('http://valid.com')).toBe(true);
     expect(URL_REGEX.test('https://sub.domain/path?query=1')).toBe(true);
     expect(URL_REGEX.test('https://example.com,')).toBe(true);
+    expect(URL_REGEX.test('https://example.com/path;param=value')).toBe(true);
+    expect(URL_REGEX.test('https://example.com/app;jsessionid=abc123?foo=bar')).toBe(true);
   });
 
   test('should reject invalid URLs with URL_REGEX', () => {

--- a/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/url.ts
+++ b/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/url.ts
@@ -20,7 +20,7 @@
 const SUPPORTED_URL_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'sms:', 'tel:']);
 
 export const URL_REGEX =
-  /https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z]{2,6}(?:[-a-zA-Z0-9()@:%_+.~#?&//=,]*)/;
+  /https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z]{2,6}(?:[-a-zA-Z0-9()@:%_+.~#?&//=,;]*)/;
 
 export const sanitizeUrl = (url: string): string => {
   try {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22693" title="WPB-22693" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22693</a>  [Web] Link with semicolon breaks if you paste it into the text input
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Handle semicolon on links while sending messages.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
