### PR TITLE
ci: scope precommit critical flow concurrency by branch [WPB-22420]

### DIFF
--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -8,7 +8,7 @@ on:
 
 # One at a time lane for the shared precommit environment
 concurrency:
-  group: precommit-deploy
+  group: precommit-deploy-${{ github.base_ref || github.ref_name }}
   cancel-in-progress: false # queue newer runs
 
 jobs:


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary

After enabling the workflow for `master`, `dev`, and `release/*` in https://github.com/wireapp/wire-webapp/pull/20755, all runs were sharing one global `precommit-deploy` lane. That caused unrelated branches to block each other and left the required GitHub check pending longer than needed.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
