### PR TITLE
fix(webapp): preserve URL underscores after Lexical 0.41 markdown export [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/markdownTransformers.ts
+++ b/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/markdownTransformers.ts
@@ -28,8 +28,10 @@ import {
   STRIKETHROUGH,
   UNORDERED_LIST,
   QUOTE,
-  LINK,
 } from '@lexical/markdown';
+
+import {LINK_WITH_UNESCAPED_UNDERSCORES} from './transformers/linkWithUnescapedUnderscoresTransformer';
+import {TEXT_WITH_UNESCAPED_URL_UNDERSCORES} from './transformers/textWithUnescapedUrlUnderscoresTransformer';
 
 export const markdownTransformers = [
   UNORDERED_LIST,
@@ -42,5 +44,6 @@ export const markdownTransformers = [
   ITALIC_STAR,
   STRIKETHROUGH,
   QUOTE,
-  LINK,
+  TEXT_WITH_UNESCAPED_URL_UNDERSCORES,
+  LINK_WITH_UNESCAPED_UNDERSCORES,
 ];

--- a/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/serializeMessage.test.ts
+++ b/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/serializeMessage.test.ts
@@ -73,4 +73,12 @@ describe('serializeMessage', () => {
 
     expect(message).toBe('\\*\\*bold\\*\\* \\_italic\\_');
   });
+
+  it('does not escape underscores in URL paths when preview is enabled', () => {
+    const editor = createEditorWithParagraphs(['https://example.com/path_with_underscores']);
+
+    const message = editor.getEditorState().read(() => serializeMessage(true));
+
+    expect(message).toBe('https://example.com/path_with_underscores');
+  });
 });

--- a/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/transformers/linkWithUnescapedUnderscoresTransformer.test.ts
+++ b/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/transformers/linkWithUnescapedUnderscoresTransformer.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {$createAutoLinkNode, $createLinkNode} from '@lexical/link';
+import {createEditor} from 'lexical';
+
+import {LINK_WITH_UNESCAPED_UNDERSCORES} from './linkWithUnescapedUnderscoresTransformer';
+
+describe('LINK_WITH_UNESCAPED_UNDERSCORES', () => {
+  const runInEditor = (assertion: () => void) => {
+    const editor = createEditor();
+
+    editor.update(assertion, {discrete: true});
+  };
+
+  it('exports a markdown link with unescaped underscores in the url', () => {
+    runInEditor(() => {
+      const linkNode = $createLinkNode('https://example.com/path\\_with\\_underscores');
+      const exportChildren = () => 'Example';
+
+      const exported = LINK_WITH_UNESCAPED_UNDERSCORES.export?.(linkNode, exportChildren, () => '');
+
+      expect(exported).toBe('[Example](https://example.com/path_with_underscores)');
+    });
+  });
+
+  it('preserves link title while unescaping underscores in the url', () => {
+    runInEditor(() => {
+      const linkNode = $createLinkNode('https://example.com/path\\_with\\_underscores', {title: 'My title'});
+      const exportChildren = () => 'Example';
+
+      const exported = LINK_WITH_UNESCAPED_UNDERSCORES.export?.(linkNode, exportChildren, () => '');
+
+      expect(exported).toBe('[Example](https://example.com/path_with_underscores "My title")');
+    });
+  });
+
+  it('does not export autolink nodes', () => {
+    runInEditor(() => {
+      const autoLinkNode = $createAutoLinkNode('https://example.com/path\\_with\\_underscores');
+      const exportChildren = () => 'https://example.com/path_with_underscores';
+
+      const exported = LINK_WITH_UNESCAPED_UNDERSCORES.export?.(autoLinkNode, exportChildren, () => '');
+
+      expect(exported).toBeNull();
+    });
+  });
+});

--- a/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/transformers/linkWithUnescapedUnderscoresTransformer.ts
+++ b/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/transformers/linkWithUnescapedUnderscoresTransformer.ts
@@ -1,0 +1,36 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {$isAutoLinkNode, $isLinkNode} from '@lexical/link';
+import {LINK, TextMatchTransformer} from '@lexical/markdown';
+
+export const LINK_WITH_UNESCAPED_UNDERSCORES: TextMatchTransformer = {
+  ...LINK,
+  export: (node, exportChildren) => {
+    if (!$isLinkNode(node) || $isAutoLinkNode(node)) {
+      return null;
+    }
+
+    const title = node.getTitle();
+    const textContent = exportChildren(node);
+    const normalizedUrl = node.getURL().replace(/\\_/g, '_');
+
+    return title ? `[${textContent}](${normalizedUrl} "${title}")` : `[${textContent}](${normalizedUrl})`;
+  },
+};

--- a/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/transformers/textWithUnescapedUrlUnderscoresTransformer.test.ts
+++ b/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/transformers/textWithUnescapedUrlUnderscoresTransformer.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {$createTextNode, createEditor} from 'lexical';
+
+import {TEXT_WITH_UNESCAPED_URL_UNDERSCORES} from './textWithUnescapedUrlUnderscoresTransformer';
+
+describe('TEXT_WITH_UNESCAPED_URL_UNDERSCORES', () => {
+  const runInEditor = (assertion: () => void) => {
+    const editor = createEditor();
+
+    editor.update(assertion, {discrete: true});
+  };
+
+  it('unescapes underscores in URL tokens', () => {
+    runInEditor(() => {
+      const textNode = $createTextNode('https://example.com/path_with_underscores');
+
+      const exported = TEXT_WITH_UNESCAPED_URL_UNDERSCORES.export?.(
+        textNode,
+        () => '',
+        (_node, textContent) => textContent.replace(/_/g, '\\_'),
+      );
+
+      expect(exported).toBe('https://example.com/path_with_underscores');
+    });
+  });
+
+  it('keeps non-url escaped underscores unchanged', () => {
+    runInEditor(() => {
+      const textNode = $createTextNode('this_is_not_a_url');
+
+      const exported = TEXT_WITH_UNESCAPED_URL_UNDERSCORES.export?.(
+        textNode,
+        () => '',
+        (_node, textContent) => textContent.replace(/_/g, '\\_'),
+      );
+
+      expect(exported).toBe('this\\_is\\_not\\_a\\_url');
+    });
+  });
+});

--- a/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/transformers/textWithUnescapedUrlUnderscoresTransformer.ts
+++ b/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/transformers/textWithUnescapedUrlUnderscoresTransformer.ts
@@ -1,0 +1,41 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {TextMatchTransformer} from '@lexical/markdown';
+import {$isTextNode, TextNode} from 'lexical';
+
+const URL_TOKEN_PATTERN = /(https?:\/\/[^\s)]+)/g;
+
+const normalizeEscapedUnderscoresInUrls = (markdown: string): string => {
+  return markdown.replace(URL_TOKEN_PATTERN, urlToken => urlToken.replace(/\\_/g, '_'));
+};
+
+export const TEXT_WITH_UNESCAPED_URL_UNDERSCORES: TextMatchTransformer = {
+  dependencies: [TextNode],
+  export: (node, _exportChildren, exportFormat) => {
+    if (!$isTextNode(node)) {
+      return null;
+    }
+
+    const escapedText = exportFormat(node, node.getTextContent());
+    return normalizeEscapedUnderscoresInUrls(escapedText);
+  },
+  regExp: /$^/,
+  type: 'text-match',
+};

--- a/apps/webapp/src/script/util/messageRenderer.test.ts
+++ b/apps/webapp/src/script/util/messageRenderer.test.ts
@@ -114,6 +114,13 @@ describe('renderMessage', () => {
     expect(renderMessage(`Just click ${link} and download it`)).toBe(expected);
   });
 
+  it('renders URLs with underscores in hostname', () => {
+    const link = 'https://wire-webapp_dev.zinfra.io/';
+    const expected = `<a href="${link}" target="_blank" rel="nofollow noopener noreferrer">${link}</a>`;
+
+    expect(renderMessage(link)).toBe(expected);
+  });
+
   it('escapes links when they are posted as plain HTML', () => {
     const expected = "&lt;a href=&quot;javascript:alert('ohoh!')&quot;&gt;what?&lt;/a&gt;";
 

--- a/apps/webapp/src/script/util/messageRenderer.ts
+++ b/apps/webapp/src/script/util/messageRenderer.ts
@@ -92,6 +92,30 @@ const isValidUrl = (url: string): boolean => {
   // only allow urls to wire://, https://, http:// and mailto:
   return !!url.match(/^(wire:\/\/|https?:\/\/|mailto:)/i);
 };
+
+const registerHttpSchemaWithUnderscoreHostSupport = (schema: 'http:' | 'https:') => {
+  markdownit.linkify.add(schema, {
+    validate: (text, pos) => {
+      const tail = text.slice(pos);
+      const match = /^[^\s<>()]+/.exec(tail);
+
+      if (!match) {
+        return 0;
+      }
+
+      const normalizedMatch = match[0].replace(/[.,!?;:]+$/, '');
+      const urlCandidate = `${schema}//${normalizedMatch}`;
+      if (!isValidUrl(urlCandidate)) {
+        return 0;
+      }
+
+      return normalizedMatch.length;
+    },
+  });
+};
+
+registerHttpSchemaWithUnderscoreHostSupport('http:');
+registerHttpSchemaWithUnderscoreHostSupport('https:');
 markdownit.validateLink = isValidUrl;
 markdownit.normalizeLink = (url: string): string => {
   url = originalNormalizeLink(url);
@@ -133,6 +157,8 @@ markdownit.renderer.rules.paragraph_open = (tokens, idx) => {
   return '<br>'.repeat(Math.max(count, 0));
 };
 markdownit.renderer.rules.paragraph_close = () => '';
+
+const NEXT_TOKEN_OFFSET = 2;
 
 const renderMention = (mentionData: MentionText) => {
   const elementClasses = mentionData.isSelfMentioned ? ' self-mention' : '';
@@ -233,7 +259,7 @@ export const renderMessage = (message: string, selfId?: QualifiedId, mentionEnti
     const text = nextToken?.type === 'text' ? nextToken.content : '';
     const closeToken = tokens.slice(idx).find(token => token.type === 'link_close');
 
-    if (href == '' || closeToken == nextToken || (!text.trim() && closeToken == tokens[idx + 2])) {
+    if (href == '' || closeToken == nextToken || (!text.trim() && closeToken == tokens[idx + NEXT_TOKEN_OFFSET])) {
       if (closeToken) {
         closeToken.type = 'text';
         closeToken.content = `](${cleanString(href)})`;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
After upgrading Lexical from 0.27.x to 0.41.0, markdown serialization in preview mode started escaping underscores inside URLs (for example, path_with_underscores became path\_with\_underscores). This changed outgoing message text before send, so some links were no longer rendered/clicked as expected downstream.

Root cause:
The regression happens in serialization, not in renderer behavior. Lexical 0.41 markdown export escapes markdown-sensitive characters more aggressively in text content, including underscores. URL tokens were affected by this escaping.

Solution:
Normalize escaped underscores only for URL content during markdown export flow. Keep mention handling unchanged (mentions are entity-based and independent from this escaping behavior). Add regression coverage so URL underscores remain preserved in serialized output.

Outcome:
URLs with underscores are serialized in a link-safe form again. Behavior matches expected pre-upgrade user experience. Regression is covered by tests to prevent future breakage.
