### PR TITLE
feat(webapp): add YouTube iframe referrerpolicy for embed rendering

### DIFF
--- a/apps/webapp/src/script/repositories/media/MediaEmbeds.test.ts
+++ b/apps/webapp/src/script/repositories/media/MediaEmbeds.test.ts
@@ -47,7 +47,7 @@ describe('MediaEmbeds', () => {
 
   const buildYoutubeIframe = (link: string) => {
     const embed_url = MediaEmbeds.generateYouTubeEmbedUrl(link);
-    return `<a href="${link}" target="_blank" rel="nofollow">${link}</a><div class="iframe-container iframe-container-video"><iframe class="youtube" width="100%" height="100%" src="${embed_url}" frameborder="0" allowfullscreen></iframe></div>`;
+    return `<a href="${link}" target="_blank" rel="nofollow">${link}</a><div class="iframe-container iframe-container-video"><iframe class="youtube" width="100%" height="100%" src="${embed_url}" frameborder="0" allowfullscreen referrerpolicy="strict-origin-when-cross-origin"></iframe></div>`;
   };
 
   const buildSoundcloudIframeForTracks = (link: string) => {
@@ -380,8 +380,10 @@ describe('MediaEmbeds', () => {
         const link = 'https://www.youtube-nocookie.com/watch?v=oHg5SJYRHA0&autoplay=1';
 
         const message = buildMessageWithAnchor(link);
-        const iframe =
-          '<a href="https://www.youtube-nocookie.com/watch?v=oHg5SJYRHA0&autoplay=1" target="_blank" rel="nofollow">https://www.youtube-nocookie.com/watch?v=oHg5SJYRHA0&autoplay=1</a><div class="iframe-container iframe-container-video"><iframe class="youtube" width="100%" height="100%" src="https://www.youtube-nocookie.com/embed/oHg5SJYRHA0?html5=1&enablejsapi=0&modestbranding=1&rel=0" frameborder="0" allowfullscreen></iframe></div>';
+        const iframe = buildYoutubeIframe(link);
+        const embedUrl = MediaEmbeds.generateYouTubeEmbedUrl(link);
+
+        expect(embedUrl).not.toContain('autoplay=');
 
         expect(new MediaParser().renderMediaEmbeds(message)).toBe(iframe);
       });
@@ -395,11 +397,14 @@ describe('MediaEmbeds', () => {
         const link = 'https://www.youtube-nocookie.com/watch?autoplay=1&v=oHg5SJYRHA0';
 
         const message = buildMessageWithAnchor(link);
-        const iframe =
-          '<a href="https://www.youtube-nocookie.com/watch?autoplay=1&v=oHg5SJYRHA0" target="_blank" rel="nofollow">https://www.youtube-nocookie.com/watch?autoplay=1&v=oHg5SJYRHA0</a><div class="iframe-container iframe-container-video"><iframe class="youtube" width="100%" height="100%" src="https://www.youtube-nocookie.com/embed/oHg5SJYRHA0?html5=1&enablejsapi=0&modestbranding=1&rel=0" frameborder="0" allowfullscreen></iframe></div>';
+        const iframe = buildYoutubeIframe(link);
+        const embedUrl = MediaEmbeds.generateYouTubeEmbedUrl(link);
+
+        expect(embedUrl).not.toContain('autoplay=');
 
         expect(new MediaParser().renderMediaEmbeds(message)).toBe(iframe);
       });
+
     });
 
     describe('SoundCloud', () => {

--- a/apps/webapp/src/script/repositories/media/MediaEmbeds.ts
+++ b/apps/webapp/src/script/repositories/media/MediaEmbeds.ts
@@ -26,6 +26,7 @@ interface IFrameOptions {
   class: string;
   frameborder: string;
   height: string;
+  referrerpolicy: string;
   src?: string;
   type: string;
   video: boolean;
@@ -43,13 +44,14 @@ const _createIFrameContainer = (options?: Partial<IFrameOptions>): string => {
     class: 'iframe-container iframe-container-video',
     frameborder: '0',
     height: '100%',
+    referrerpolicy: '',
     type: 'default',
     video: true,
     width: '100%',
   };
 
   options = {...defaults, ...options};
-  const iFrameContainer = `<div class="{0}"><iframe class="${options.type}" width="{1}" height="{2}" src="{3}" frameborder="{4}"{5}></iframe></div>`;
+  const iFrameContainer = `<div class="{0}"><iframe class="${options.type}" width="{1}" height="{2}" src="{3}" frameborder="{4}"{5}{6}></iframe></div>`;
 
   if (!options.video) {
     options.allowfullscreen = '';
@@ -68,6 +70,7 @@ const _createIFrameContainer = (options?: Partial<IFrameOptions>): string => {
     options.src,
     options.frameborder,
     options.allowfullscreen,
+    options.referrerpolicy,
   );
 };
 
@@ -285,6 +288,7 @@ export const MediaEmbeds = {
 
     if (embedUrl) {
       const iFrame = _createIFrameContainer({
+        referrerpolicy: ' referrerpolicy="strict-origin-when-cross-origin"',
         src: embedUrl,
         type: 'youtube',
       });


### PR DESCRIPTION
- Add referrerpolicy="strict-origin-when-cross-origin" to YouTube iframes created by media embed rendering.
- Keep existing embed behavior unchanged for non-YouTube providers.
- Update YouTube embed test expectations to include the new iframe attribute.
