### PR TITLE
ci: trigger precommit critical flows on ready-for-review pull requests [WPB-22420]

### DIFF
--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -3,6 +3,7 @@ name: precommit-crit-flows
 on:
   pull_request:
     branches: [master, dev, release/*]
+    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
     branches: [master, dev, release/*]
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Draft pull requests did not trigger `precommit-crit-flows` when they were converted to ready for review (see also here https://github.com/wireapp/wire-webapp/pull/20768 for example)

GitHub does not emit the default `pull_request` workflow run for the draft-to-ready transition unless `ready_for_review` is explicitly listed in the workflow trigger types. As a result, required checks such as `Playwright Critical Flow (precommit) / e2e-report` stayed in `Expected` state with "Waiting for status to be reported" and never started.

Add `ready_for_review` to the `pull_request` trigger types for `precommit-crit-flows` so the required Playwright checks start as soon as a draft PR is marked ready.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
