### PR TITLE
feat: ship incremental retry backoff by default [WPB-23381]

### DIFF
--- a/apps/webapp/src/script/auth/main.tsx
+++ b/apps/webapp/src/script/auth/main.tsx
@@ -40,7 +40,6 @@ import {actionRoot} from './module/action';
 import {Root} from './page/Root';
 
 import {Config} from '../Config';
-import {createStartupFeatureTogglesFromLocationSearch} from '../featureToggles/startupFeatureToggles';
 import {updateApiVersion} from '../lifecycle/updateRemoteConfigs';
 import {setAppLocale} from '../localization/Localizer';
 import {APIClient} from '../service/APIClientSingleton';
@@ -51,8 +50,7 @@ exposeWrapperGlobals();
 
 const mainId = 'main';
 
-const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(globalThis.location.search);
-const apiClient = createAPIClient(startupFeatureToggles.isFeatureToggleEnabled);
+const apiClient = createAPIClient();
 container.registerInstance(APIClient, apiClient);
 const core = container.resolve(Core);
 

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
@@ -18,12 +18,10 @@
  */
 
 export const reliableWebsocketConnectionFeatureToggleName = 'reliable-websocket-connection';
-export const incrementalHttpRetryBackoffFeatureToggleName = 'incremental-http-retry-backoff';
 export const collaboraClipboardAccessFeatureToggleName = 'collabora-clipboard-access';
 
 export const startupFeatureToggleNames = [
   reliableWebsocketConnectionFeatureToggleName,
-  incrementalHttpRetryBackoffFeatureToggleName,
   collaboraClipboardAccessFeatureToggleName,
 ] as const;
 

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
@@ -24,14 +24,12 @@ import {
 } from './startupFeatureToggles';
 import {
   collaboraClipboardAccessFeatureToggleName,
-  incrementalHttpRetryBackoffFeatureToggleName,
   reliableWebsocketConnectionFeatureToggleName,
   startupFeatureToggleNames,
 } from './startupFeatureToggleNames';
 
 const featureToggleNamesWithDedicatedExistenceTests = [
   reliableWebsocketConnectionFeatureToggleName,
-  incrementalHttpRetryBackoffFeatureToggleName,
   collaboraClipboardAccessFeatureToggleName,
 ] as const;
 
@@ -66,14 +64,6 @@ describe('startupFeatureToggles', function () {
     );
 
     expect(startupFeatureToggles.getEnabledFeatureToggleNames()).toEqual([]);
-  });
-
-  it('enables the incremental http retry backoff feature toggle when present in the query parameter', () => {
-    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
-      `?${startupFeatureToggleQueryParameterName}=${incrementalHttpRetryBackoffFeatureToggleName}`,
-    );
-
-    expect(startupFeatureToggles.isFeatureToggleEnabled(incrementalHttpRetryBackoffFeatureToggleName)).toBe(true);
   });
 
   it('enables the collabora clipboard access feature toggle when present in the query parameter', () => {
@@ -134,7 +124,6 @@ describe('startupFeatureToggles', function () {
   it('contains only whitelisted values in allowedStartupFeatureToggleNames', () => {
     expect(allowedStartupFeatureToggleNames).toEqual([
       reliableWebsocketConnectionFeatureToggleName,
-      incrementalHttpRetryBackoffFeatureToggleName,
       collaboraClipboardAccessFeatureToggleName,
     ]);
   });

--- a/apps/webapp/src/script/lifecycle/createIncrementalHttpRetryBackoffReset.test.ts
+++ b/apps/webapp/src/script/lifecycle/createIncrementalHttpRetryBackoffReset.test.ts
@@ -20,8 +20,6 @@
 import assert from 'assert';
 
 import {APIClient} from '../service/APIClientSingleton';
-import {incrementalHttpRetryBackoffFeatureToggleName} from '../featureToggles/startupFeatureToggleNames';
-import {StartupFeatureToggleName} from '../featureToggles/startupFeatureToggles';
 import {createIncrementalHttpRetryBackoffReset} from './createIncrementalHttpRetryBackoffReset';
 
 type ListenerMap = Map<string, () => void>;
@@ -70,26 +68,6 @@ function createConfigureIncrementalHttpRetryBackoffResetDependenciesForTest(): C
 }
 
 describe('createIncrementalHttpRetryBackoffReset', () => {
-  it('does not register listeners when the startup feature toggle is disabled', () => {
-    const dependenciesForTest = createConfigureIncrementalHttpRetryBackoffResetDependenciesForTest();
-
-    createIncrementalHttpRetryBackoffReset({
-      ...dependenciesForTest,
-      visibilityState: () => {
-        return 'visible';
-      },
-      isElectron: () => {
-        return false;
-      },
-      isFeatureToggleEnabled: (_featureToggleName: StartupFeatureToggleName) => {
-        return false;
-      },
-    });
-
-    expect(dependenciesForTest.subscribeToApplicationSignal).not.toHaveBeenCalled();
-    expect(dependenciesForTest.subscribeToRuntimeSignal).not.toHaveBeenCalled();
-  });
-
   it('resets retry backoff when the browser tab becomes visible and when the app goes online', () => {
     const dependenciesForTest = createConfigureIncrementalHttpRetryBackoffResetDependenciesForTest();
     let currentDocumentVisibilityState: DocumentVisibilityState = 'hidden';
@@ -101,9 +79,6 @@ describe('createIncrementalHttpRetryBackoffReset', () => {
       },
       isElectron: () => {
         return false;
-      },
-      isFeatureToggleEnabled: (featureToggleName: StartupFeatureToggleName) => {
-        return featureToggleName === incrementalHttpRetryBackoffFeatureToggleName;
       },
     });
 
@@ -147,9 +122,6 @@ describe('createIncrementalHttpRetryBackoffReset', () => {
       },
       isElectron: () => {
         return true;
-      },
-      isFeatureToggleEnabled: (featureToggleName: StartupFeatureToggleName) => {
-        return featureToggleName === incrementalHttpRetryBackoffFeatureToggleName;
       },
     });
 

--- a/apps/webapp/src/script/lifecycle/createIncrementalHttpRetryBackoffReset.ts
+++ b/apps/webapp/src/script/lifecycle/createIncrementalHttpRetryBackoffReset.ts
@@ -17,15 +17,10 @@
  *
  */
 
-import {noop} from 'noop-esm';
-
-import {incrementalHttpRetryBackoffFeatureToggleName} from '../featureToggles/startupFeatureToggleNames';
-import {StartupFeatureToggleName} from '../featureToggles/startupFeatureToggles';
 import {APIClient} from '../service/APIClientSingleton';
 
 type ConfigureIncrementalHttpRetryBackoffResetDependencies = {
   readonly isElectron: () => boolean;
-  readonly isFeatureToggleEnabled: (featureToggleName: StartupFeatureToggleName) => boolean;
   readonly subscribeToApplicationSignal: (signalName: 'visibilitychange', listener: () => void) => void;
   readonly apiClient: APIClient;
   readonly subscribeToRuntimeSignal: (signalName: 'focus' | 'online' | 'unload', listener: () => void) => void;
@@ -55,17 +50,12 @@ export function createIncrementalHttpRetryBackoffReset(
   const {
     apiClient,
     isElectron,
-    isFeatureToggleEnabled,
     subscribeToApplicationSignal,
     subscribeToRuntimeSignal,
     unsubscribeFromApplicationSignal,
     unsubscribeFromRuntimeSignal,
     visibilityState,
   } = dependencies;
-
-  if (!isFeatureToggleEnabled(incrementalHttpRetryBackoffFeatureToggleName)) {
-    return noop;
-  }
 
   function resetRetryBackoff(): void {
     apiClient.resetIncrementalRetryBackoff();

--- a/apps/webapp/src/script/main/index.tsx
+++ b/apps/webapp/src/script/main/index.tsx
@@ -78,7 +78,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   });
   const {isFeatureToggleEnabled} = startupFeatureToggles;
   const {wallClock} = applicationServices;
-  const apiClient = createAPIClient(isFeatureToggleEnabled);
+  const apiClient = createAPIClient();
   const core = new Core(apiClient);
   const cleanupIncrementalHttpRetryBackoffReset = createIncrementalHttpRetryBackoffReset({
     apiClient,
@@ -88,7 +88,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     isElectron: () => {
       return Runtime.isElectron();
     },
-    isFeatureToggleEnabled,
     subscribeToApplicationSignal: (signalName, listener) => {
       document.addEventListener(signalName, listener);
     },

--- a/apps/webapp/src/script/service/APIClientSingleton.test.ts
+++ b/apps/webapp/src/script/service/APIClientSingleton.test.ts
@@ -18,7 +18,6 @@
  */
 
 import {Config} from '../Config';
-import {incrementalHttpRetryBackoffFeatureToggleName} from '../featureToggles/startupFeatureToggleNames';
 import {APIClient} from './APIClientSingleton';
 
 describe('APIClientSingleton', () => {
@@ -35,27 +34,11 @@ describe('APIClientSingleton', () => {
     }
   });
 
-  it('enables incremental http retry backoff when the startup feature toggle is enabled', () => {
-    const isFeatureToggleEnabled = jest.fn((featureToggleName) => {
-      return featureToggleName === incrementalHttpRetryBackoffFeatureToggleName;
-    });
-    const apiClient = new APIClient({
-      isFeatureToggleEnabled,
-    });
-
-    try {
-      expect(isFeatureToggleEnabled).toHaveBeenCalledWith(incrementalHttpRetryBackoffFeatureToggleName);
-      expect(apiClient.transport.http['shouldUseIncrementalRetryBackoff']).toBe(true);
-    } finally {
-      apiClient.disconnect();
-    }
-  });
-
-  it('keeps incremental http retry backoff disabled when no toggle reader is injected', () => {
+  it('uses the incremental http retry backoff http client by default', () => {
     const apiClient = new APIClient();
 
     try {
-      expect(apiClient.transport.http['shouldUseIncrementalRetryBackoff']).toBe(false);
+      expect(apiClient.transport.http['incrementalRetryBackoffRunner']).toBeDefined();
     } finally {
       apiClient.disconnect();
     }

--- a/apps/webapp/src/script/service/APIClientSingleton.ts
+++ b/apps/webapp/src/script/service/APIClientSingleton.ts
@@ -22,16 +22,10 @@ import {singleton} from 'tsyringe';
 import {APIClient as APIClientUnconfigured} from '@wireapp/api-client';
 
 import {Config} from '../Config';
-import {incrementalHttpRetryBackoffFeatureToggleName} from '../featureToggles/startupFeatureToggleNames';
-import {StartupFeatureToggleName} from '../featureToggles/startupFeatureToggles';
 
 const wireClientHeaderName = 'Wire-Client';
 const wireClientVersionHeaderName = 'Wire-Client-Version';
 const wireClientIdentifier = 'Web';
-
-type APIClientSingletonConfiguration = {
-  readonly isFeatureToggleEnabled?: (featureToggleName: StartupFeatureToggleName) => boolean;
-};
 
 type RetryBackoffResettableHttpClient = {
   readonly resetRetryBackoff: () => void;
@@ -39,16 +33,14 @@ type RetryBackoffResettableHttpClient = {
 
 @singleton()
 export class APIClient extends APIClientUnconfigured {
-  constructor(apiClientSingletonConfiguration: APIClientSingletonConfiguration = {}) {
+  constructor() {
     const webAppConfiguration = Config.getConfig();
-    const {isFeatureToggleEnabled} = apiClientSingletonConfiguration;
 
     const unconfiguredApiClientConfiguration = {
       headers: {
         [wireClientHeaderName]: wireClientIdentifier,
         [wireClientVersionHeaderName]: webAppConfiguration.VERSION,
       },
-      shouldUseIncrementalRetryBackoff: isFeatureToggleEnabled?.(incrementalHttpRetryBackoffFeatureToggleName) ?? false,
       urls: {
         name: webAppConfiguration.ENVIRONMENT,
         rest: webAppConfiguration.BACKEND_REST,

--- a/apps/webapp/src/script/service/createAPIClient.test.ts
+++ b/apps/webapp/src/script/service/createAPIClient.test.ts
@@ -16,31 +16,14 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  *
  */
-
-import {incrementalHttpRetryBackoffFeatureToggleName} from '../featureToggles/startupFeatureToggleNames';
-
 import {createAPIClient} from './createAPIClient';
 
 describe('createAPIClient', () => {
-  it('enables incremental http retry backoff when the startup feature toggle reader returns true', () => {
-    const apiClient = createAPIClient(featureToggleName => {
-      return featureToggleName === incrementalHttpRetryBackoffFeatureToggleName;
-    });
+  it('creates an api client with incremental http retry backoff support', () => {
+    const apiClient = createAPIClient();
 
     try {
-      expect(apiClient.transport.http['shouldUseIncrementalRetryBackoff']).toBe(true);
-    } finally {
-      apiClient.disconnect();
-    }
-  });
-
-  it('keeps incremental http retry backoff disabled when the startup feature toggle reader returns false', () => {
-    const apiClient = createAPIClient(() => {
-      return false;
-    });
-
-    try {
-      expect(apiClient.transport.http['shouldUseIncrementalRetryBackoff']).toBe(false);
+      expect(apiClient.transport.http['incrementalRetryBackoffRunner']).toBeDefined();
     } finally {
       apiClient.disconnect();
     }

--- a/apps/webapp/src/script/service/createAPIClient.ts
+++ b/apps/webapp/src/script/service/createAPIClient.ts
@@ -19,12 +19,6 @@
 
 import {APIClient} from './APIClientSingleton';
 
-import {StartupFeatureToggleName} from '../featureToggles/startupFeatureToggles';
-
-export function createAPIClient(
-  isFeatureToggleEnabled: (featureToggleName: StartupFeatureToggleName) => boolean,
-): APIClient {
-  return new APIClient({
-    isFeatureToggleEnabled,
-  });
+export function createAPIClient(): APIClient {
+  return new APIClient();
 }

--- a/libraries/api-client/src/apiClient.test.ts
+++ b/libraries/api-client/src/apiClient.test.ts
@@ -95,15 +95,12 @@ describe('APIClient', () => {
       expect(client.transport.ws['baseUrl']).toBe(APIClient.BACKEND.PRODUCTION.ws);
     });
 
-    it('passes the incremental retry backoff constructor configuration to the http client', () => {
-      const client = new APIClient({
-        ...testConfig,
-        shouldUseIncrementalRetryBackoff: true,
-      });
+    it('constructs an http client with incremental retry backoff support', () => {
+      const client = new APIClient(testConfig);
 
       apiClients.push(client);
 
-      expect(client.transport.http['shouldUseIncrementalRetryBackoff']).toBe(true);
+      expect(client.transport.http['incrementalRetryBackoffRunner']).toBeDefined();
     });
   });
 

--- a/libraries/api-client/src/apiClient.ts
+++ b/libraries/api-client/src/apiClient.ts
@@ -94,9 +94,7 @@ export interface APIClient {
   on(event: TOPIC.ACCESS_TOKEN_REFRESH, listener: (accessToken: AccessTokenData) => void): this;
 }
 
-export type APIClientConfiguration = {
-  readonly shouldUseIncrementalRetryBackoff?: boolean;
-};
+export type APIClientConfiguration = {};
 
 export type APIClientConstructorConfiguration = Config & APIClientConfiguration;
 
@@ -182,7 +180,6 @@ export class APIClient extends EventEmitter {
 
   constructor(config?: APIClientConstructorConfiguration) {
     super();
-    const {shouldUseIncrementalRetryBackoff = false} = config ?? {};
     this.config = {...defaultConfig, ...config};
     this.accessTokenStore = new AccessTokenStore();
     this.accessTokenStore.on(AccessTokenStore.TOPIC.ACCESS_TOKEN_REFRESH, (accessToken: AccessTokenData) =>
@@ -194,7 +191,7 @@ export class APIClient extends EventEmitter {
 
     this.logger = LogFactory.getLogger('@wireapp/api-client/Client');
 
-    const httpClient = new HttpClient(this.config, this.accessTokenStore, {shouldUseIncrementalRetryBackoff});
+    const httpClient = new HttpClient(this.config, this.accessTokenStore);
     const webSocket = new WebSocketClient(this.config.urls.ws, httpClient);
 
     const onInvalidCredentials = async (error: InvalidTokenError | MissingCookieError) => {

--- a/libraries/api-client/src/http/httpClient.test.ts
+++ b/libraries/api-client/src/http/httpClient.test.ts
@@ -174,17 +174,12 @@ describe('HttpClient', () => {
         },
       ] as const,
     )(
-      'retries $expectedDescription backend errors when incremental retry backoff is enabled',
+      'retries $expectedDescription backend errors with incremental retry backoff',
       async ({retryableStatusCode}) => {
         const httpClientDependenciesForTest = createHttpClientDependenciesForTest();
-        const client = new HttpClient(
-          testConfig,
-          mockedAccessTokenStore as AccessTokenStore,
-        {
+        const client = new HttpClient(testConfig, mockedAccessTokenStore as AccessTokenStore, {
           dependencies: httpClientDependenciesForTest,
-          shouldUseIncrementalRetryBackoff: true,
-        },
-      );
+        });
         const response = createAxiosResponseForTest({ok: true});
 
         client._sendRequest = jest
@@ -200,16 +195,11 @@ describe('HttpClient', () => {
       },
     );
 
-    it('retries retryable backend errors when incremental retry backoff is enabled', async () => {
+    it('retries retryable backend errors with incremental retry backoff', async () => {
       const httpClientDependenciesForTest = createHttpClientDependenciesForTest();
-      const client = new HttpClient(
-        testConfig,
-        mockedAccessTokenStore as AccessTokenStore,
-        {
-          dependencies: httpClientDependenciesForTest,
-          shouldUseIncrementalRetryBackoff: true,
-        },
-      );
+      const client = new HttpClient(testConfig, mockedAccessTokenStore as AccessTokenStore, {
+        dependencies: httpClientDependenciesForTest,
+      });
       const response = createAxiosResponseForTest({ok: true});
 
       client._sendRequest = jest
@@ -224,16 +214,11 @@ describe('HttpClient', () => {
       expect(httpClientDependenciesForTest.observedDelayInMilliseconds).toEqual([100]);
     });
 
-    it('does not retry non-retryable backend errors when incremental retry backoff is enabled', async () => {
+    it('does not retry non-retryable backend errors with incremental retry backoff', async () => {
       const httpClientDependenciesForTest = createHttpClientDependenciesForTest();
-      const client = new HttpClient(
-        testConfig,
-        mockedAccessTokenStore as AccessTokenStore,
-        {
-          dependencies: httpClientDependenciesForTest,
-          shouldUseIncrementalRetryBackoff: true,
-        },
-      );
+      const client = new HttpClient(testConfig, mockedAccessTokenStore as AccessTokenStore, {
+        dependencies: httpClientDependenciesForTest,
+      });
       const nonRetryableBackendError = new BackendError('Bad request', undefined, StatusCode.BAD_REQUEST);
 
       client._sendRequest = jest.fn().mockRejectedValueOnce(nonRetryableBackendError);
@@ -243,32 +228,11 @@ describe('HttpClient', () => {
       expect(httpClientDependenciesForTest.observedDelayInMilliseconds).toEqual([]);
     });
 
-    it('preserves the existing behavior when incremental retry backoff is disabled', async () => {
-      const httpClientDependenciesForTest = createHttpClientDependenciesForTest();
-      const client = new HttpClient(
-        testConfig,
-        mockedAccessTokenStore as AccessTokenStore,
-        {dependencies: httpClientDependenciesForTest},
-      );
-      const tooManyRequestsBackendError = new BackendError('Too many requests', undefined, StatusCode.TOO_MANY_REQUESTS);
-
-      client._sendRequest = jest.fn().mockRejectedValueOnce(tooManyRequestsBackendError);
-
-      await expect(client.sendRequest({method: 'GET', url: '/conversations'})).rejects.toBe(tooManyRequestsBackendError);
-      expect(client._sendRequest).toHaveBeenCalledTimes(1);
-      expect(httpClientDependenciesForTest.observedDelayInMilliseconds).toEqual([]);
-    });
-
     it('restarts with the initial retry delay after the retry backoff is reset', async () => {
       const httpClientDependenciesForTest = createHttpClientDependenciesForTest();
-      const client = new HttpClient(
-        testConfig,
-        mockedAccessTokenStore as AccessTokenStore,
-        {
-          dependencies: httpClientDependenciesForTest,
-          shouldUseIncrementalRetryBackoff: true,
-        },
-      );
+      const client = new HttpClient(testConfig, mockedAccessTokenStore as AccessTokenStore, {
+        dependencies: httpClientDependenciesForTest,
+      });
       const response = createAxiosResponseForTest({ok: true});
 
       client._sendRequest = jest
@@ -306,17 +270,12 @@ describe('HttpClient', () => {
 
         return 1 as ReturnType<typeof globalThis.setTimeout>;
       });
-      const client = new HttpClient(
-        testConfig,
-        mockedAccessTokenStore as AccessTokenStore,
-        {
-          dependencies: {
-            clearTimeout,
-            setTimeout,
-          },
-          shouldUseIncrementalRetryBackoff: true,
+      const client = new HttpClient(testConfig, mockedAccessTokenStore as AccessTokenStore, {
+        dependencies: {
+          clearTimeout,
+          setTimeout,
         },
-      );
+      });
       const response = createAxiosResponseForTest({ok: true});
 
       client._sendRequest = jest
@@ -364,7 +323,6 @@ describe('HttpClient', () => {
             clearTimeout,
             setTimeout,
           },
-          shouldUseIncrementalRetryBackoff: true,
         },
       );
 

--- a/libraries/api-client/src/http/httpClient.ts
+++ b/libraries/api-client/src/http/httpClient.ts
@@ -64,7 +64,6 @@ export type HttpClientDependencies = {
 
 export type HttpClientConfiguration = {
   readonly dependencies?: HttpClientDependencies;
-  readonly shouldUseIncrementalRetryBackoff?: boolean;
 };
 
 export interface HttpClient {
@@ -80,13 +79,11 @@ export class HttpClient extends EventEmitter {
   private readonly logger: logdown.Logger;
   private connectionState: ConnectionState;
   private readonly requestQueue: PriorityQueue;
-  private readonly backOffQueue: PriorityQueue;
   private readonly incrementalRetryBackoffPolicy = createIncrementalRetryBackoffPolicy();
   private readonly incrementalRetryBackoffRunner;
   private incrementalRetryBackoffResetAbortController = new AbortController();
   private incrementalRetryBackoffResetCount = 0;
   private incrementalRetryBackoffState: IncrementalRetryBackoffState;
-  private shouldUseIncrementalRetryBackoff = false;
   public static readonly TOPIC = TOPIC;
   private versionPrefix = '';
 
@@ -98,7 +95,7 @@ export class HttpClient extends EventEmitter {
     httpClientConfiguration: HttpClientConfiguration = {},
   ) {
     super();
-    const {dependencies = {}, shouldUseIncrementalRetryBackoff = false} = httpClientConfiguration;
+    const {dependencies = {}} = httpClientConfiguration;
     const setTimeout = dependencies.setTimeout ?? globalThis.setTimeout.bind(globalThis);
     const clearTimeout = dependencies.clearTimeout ?? globalThis.clearTimeout.bind(globalThis);
 
@@ -128,7 +125,6 @@ export class HttpClient extends EventEmitter {
     });
 
     this.connectionState = ConnectionState.UNDEFINED;
-    this.shouldUseIncrementalRetryBackoff = shouldUseIncrementalRetryBackoff;
     this.incrementalRetryBackoffState = this.incrementalRetryBackoffPolicy.createInitialIncrementalRetryBackoffState();
     this.incrementalRetryBackoffRunner = createIncrementalRetryBackoffRunner({
       abortableWait: createAbortableWait({clearTimeout, setTimeout}),
@@ -151,16 +147,6 @@ export class HttpClient extends EventEmitter {
     this.requestQueue = new PriorityQueue({
       maxRetries: 0,
       retryDelay: TimeUtil.TimeInMillis.SECOND,
-    });
-
-    this.backOffQueue = new PriorityQueue({
-      maxRetries: 10,
-      retryDelay: 200,
-      maxRetryDelay: 2000,
-      shouldRetry: error => {
-        const isTooManyRequestsError = axios.isAxiosError(error) && error.response?.status === 420;
-        return isTooManyRequestsError;
-      },
     });
   }
 
@@ -368,44 +354,24 @@ export class HttpClient extends EventEmitter {
       return this._sendRequest<T>({config, abortController});
     };
 
-    if (this.shouldUseIncrementalRetryBackoff) {
-      return this.incrementalRetryBackoffRunner.runWithIncrementalRetryBackoff({
-        abortSignal: this.getIncrementalRetryBackoffAbortSignal(abortController),
-        getIncrementalRetryBackoffState: () => {
-          return this.incrementalRetryBackoffState;
-        },
-        getRetryBackoffResetCount: () => {
-          return this.incrementalRetryBackoffResetCount;
-        },
-        isRequestAborted: () => {
-          return abortController?.signal.aborted === true;
-        },
-        runRequestAttempt,
-        setIncrementalRetryBackoffState: nextIncrementalRetryBackoffState => {
-          this.incrementalRetryBackoffState = nextIncrementalRetryBackoffState;
+    return this.incrementalRetryBackoffRunner.runWithIncrementalRetryBackoff({
+      abortSignal: this.getIncrementalRetryBackoffAbortSignal(abortController),
+      getIncrementalRetryBackoffState: () => {
+        return this.incrementalRetryBackoffState;
+      },
+      getRetryBackoffResetCount: () => {
+        return this.incrementalRetryBackoffResetCount;
+      },
+      isRequestAborted: () => {
+        return abortController?.signal.aborted === true;
+      },
+      runRequestAttempt,
+      setIncrementalRetryBackoffState: nextIncrementalRetryBackoffState => {
+        this.incrementalRetryBackoffState = nextIncrementalRetryBackoffState;
 
-          return this.incrementalRetryBackoffState;
-        },
-      });
-    }
-
-    const promise = runRequestAttempt();
-
-    try {
-      return await promise;
-    } catch (error: unknown) {
-      // If the request failed due to too many requests, we want put it into the backoff queue
-      // It will be retried after a (growing) delay
-      const isTooManyRequestsError = axios.isAxiosError(error) && error.response?.status === 420;
-
-      if (isTooManyRequestsError) {
-        return await this.backOffQueue.add(() => {
-          return this._sendRequest<T>({config, abortController});
-        });
-      }
-
-      throw error;
-    }
+        return this.incrementalRetryBackoffState;
+      },
+    });
   }
 
   public sendJSON<T>(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23381" title="WPB-23381" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23381</a>  [Web] Make sure that the web app applies incremental backoff on 420/429
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Enable incremental retry backoff as the standard request retry behavior for webapp. This removes the rollout gate and makes the retry behavior consistent in production, including resetting the backoff when the app becomes active again.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
