### PR TITLE
ci(github-actions): run precommit critical flow for all pull requests [WPB-22420]

### DIFF
--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -14,8 +14,6 @@ concurrency:
 
 jobs:
   build:
-    # Skip entire job for Dependabot PRs
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'dependabot' }}
     runs-on: buildjet-8vcpu-ubuntu-2204
     timeout-minutes: 20
 
@@ -86,7 +84,6 @@ jobs:
 
   deploy_to_aws:
     name: Deploy to precommit
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'dependabot' }}
     runs-on: ubuntu-latest
     needs: [build]
     timeout-minutes: 25
@@ -171,7 +168,7 @@ jobs:
 
   run_e2e_tests:
     name: Playwright Critical Flow (precommit)
-    if: ${{ !cancelled() && github.repository == 'wireapp/wire-webapp' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot' }}
+    if: ${{ !cancelled() && github.repository == 'wireapp/wire-webapp' }}
     needs: [check_edits_to_e2e_tests, deploy_to_aws]
     uses: ./.github/workflows/e2e-tests.yml
     with:
@@ -212,7 +209,7 @@ jobs:
           path: apps/webapp/playwright-report
 
       - name: Generate PR comment
-        if: ${{ always() && github.event_name == 'pull_request' }}
+        if: ${{ always() && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot' }}
         id: generate_comment
         run: |
           echo "Checking for Playwright report..."
@@ -236,7 +233,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Comment on PR
-        if: ${{ always() && github.event_name == 'pull_request' }}
+        if: ${{ always() && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot' }}
         uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987
         with:
           header: playwright-summary


### PR DESCRIPTION


<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Summary

Make the precommit critical-flow pipeline run for every pull request, regardless of who created it.

The current workflow skips the build, deploy, and Playwright critical-flow jobs for Dependabot pull requests. That means branch protection cannot rely on the same end-to-end gate for all pull requests, and Dependabot updates are merged without exercising the full precommit path.

We want one consistent merge gate for every pull request. The critical-flow check should represent the same pipeline outcome for human-created pull requests and Dependabot-created pull requests.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
