### PR TITLE
chore(E2E): Change calling service BE to increase stability [WPB-24216]

### DIFF
--- a/apps/webapp/test/e2e_tests/backend/callingServiceClient.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/callingServiceClient.e2e.ts
@@ -38,7 +38,7 @@ export class CallingServiceClientE2E {
       email,
       password,
       verificationCode: '',
-      backend: 'DEV',
+      backend: 'MASTER',
       instanceType: {
         name: 'chrome',
         version: '103.0.5060.53',


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24216" title="WPB-24216" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24216</a>  [Web][QA] Change calling service BE to master to increase stability of calling e2e tests 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

https://wearezeta.atlassian.net/browse/WPB-24216

Changed calling service BE to Master on calling service API client used in e2e tests. Should increase stability of calling tests as Master BE is more stable than Dev BE.

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
