### PR TITLE
chore: increase e2e test retries for CI to 3 [WPB-24216]

### DIFF
--- a/apps/webapp/playwright.config.ts
+++ b/apps/webapp/playwright.config.ts
@@ -24,7 +24,7 @@ import {resolve} from 'node:path';
 config({path: resolve(__dirname, './test/e2e_tests/.env'), quiet: true});
 
 const numberOfRetriesOnCI = 1;
-const numberOfParallelWorkersOnCI = 1;
+const numberOfParallelWorkersOnCI = 3;
 
 /**
  * See https://playwright.dev/docs/test-configuration.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24216" title="WPB-24216" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24216</a>  [Web][QA] Change calling service BE to master to increase stability of calling e2e tests 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Set max retries for CI e2e tests runner to **3**.