### PR TITLE
test: fix and re-enable Channels Call [WPB-23750]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsCall-TC-8755.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsCall-TC-8755.spec.ts
@@ -17,59 +17,46 @@
  *
  */
 
-import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-
 import {test, expect, withLogin} from '../../test.fixtures';
-import {createGroup} from 'test/e2e_tests/utils/userActions';
 
-const channelName = 'Test Channel';
-
-// ToDo(WPB-22442): Backoffice does not unlock calling feature for teams created during tests
-test.fixme(
+test(
   'Calls in channels with device switch and screenshare',
   {tag: ['@TC-8755', '@crit-flow-web']},
   async ({createUser, createTeam, createPage, api}) => {
     test.setTimeout(150_000);
 
-    let owner: User;
-    let member: User;
-    let ownerPageManager: PageManager;
     let callingServiceInstanceId: string;
+    const channelName = 'Test Channel';
 
-    await test.step('Preconditions: Team owner creates a channels enabled team', async () => {
-      member = await createUser();
-      const team = await createTeam('Channels Call', {users: [member]});
-      owner = team.owner;
-
-      await api.brig.enableMLSFeature(owner.teamId);
-      await api.brig.unlockChannelFeature(owner.teamId);
-      await api.brig.enableChannelsFeature(owner.teamId);
-      await api.enableConferenceCallingFeature(owner.teamId);
-
-      // Create page managers for both owner and member
-      // Member page manager is needed for the channel/calling service to work properly
-      [ownerPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(owner))),
-        // Member logs in but calling service handles call participation
-        createPage(withLogin(member)),
-      ]);
+    const member = await createUser();
+    const team = await createTeam('Channels Call', {
+      users: [member],
+      features: {channels: true, mls: true, conferenceCalling: true},
     });
+    const owner = team.owner;
+
+    // Member page manager is needed for the channel/calling service to work properly
+    const [ownerPageManager] = await Promise.all([
+      PageManager.from(createPage(withLogin(owner))),
+      // Member logs in but calling service handles call participation
+      createPage(withLogin(member)),
+    ]);
+
+    const {pages, components, modals} = ownerPageManager.webapp;
 
     await test.step('Team owner creates a channel with available member', async () => {
-      const {pages} = ownerPageManager.webapp;
-      await createGroup(pages, channelName, [member]);
+      await pages.conversationList().clickCreateGroup();
+      await modals.createConversation().createChannel(channelName, {members: [member]});
       await expect(pages.conversationList().getConversationLocator(channelName)).toBeVisible();
     });
 
     await test.step('Owner starts a call in channel', async () => {
-      const {pages} = ownerPageManager.webapp;
       try {
         const response = await api.callingService.createInstance(member.password, member.email);
         callingServiceInstanceId = response.id;
         await api.callingService.setAcceptNextCall(callingServiceInstanceId);
         await pages.conversationList().openConversation(channelName);
-        await pages.conversation().clickConversationInfoButton();
         await pages.conversation().clickCallButton();
       } catch (error: unknown) {
         console.error('Error during call initiation:', error);
@@ -78,10 +65,7 @@ test.fixme(
     });
 
     await test.step('Member answers call from calling notification', async () => {
-      const {pages} = ownerPageManager.webapp;
-      // answering happens automatically calling service
-      await pages.calling().waitForCell();
-      expect(await pages.calling().isCellVisible()).toBeTruthy();
+      await expect(pages.calling().callCell).toBeVisible();
     });
 
     await test.step('Owner switches audio on and sends audio', async () => {
@@ -93,7 +77,6 @@ test.fixme(
     });
 
     await test.step('Owner turns on camera', async () => {
-      const {pages} = ownerPageManager.webapp;
       await pages.calling().clickToggleVideoButton();
     });
 
@@ -102,7 +85,6 @@ test.fixme(
     });
 
     await test.step('Owner swaps audio and video devices', async () => {
-      const {pages, components} = ownerPageManager.webapp;
       await components.conversationSidebar().clickPreferencesButton();
       await pages.settings().clickAudioVideoSettingsButton();
       await pages.audioVideoSettings().selectMicrophone('Fake Audio Input 2');
@@ -116,7 +98,6 @@ test.fixme(
     });
 
     await test.step('Owner turns on screenshare', async () => {
-      const {pages} = ownerPageManager.webapp;
       await pages.calling().clickToggleScreenShareButton();
     });
 
@@ -125,7 +106,6 @@ test.fixme(
     });
 
     await test.step('Owner ends call', async () => {
-      const {pages} = ownerPageManager.webapp;
       await pages.calling().clickLeaveCallButton();
     });
   },


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23750" title="WPB-23750" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23750</a>  [Web/QA] Fix and re-enable TC-8755 Channels Call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Fix and re-enable previous skipped critical flow test - Channels call TC-8755

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
