### PR TITLE
feat: reduce lifecycle update polling interval to 15 minutes [WPB-24306]

### DIFF
--- a/apps/webapp/src/script/lifecycle/newVersionHandler.ts
+++ b/apps/webapp/src/script/lifecycle/newVersionHandler.ts
@@ -29,7 +29,7 @@ interface VersionListener {
 
 const logger = getLogger('newVersionHandler');
 const VERSION_URL = '/version/';
-const CHECK_INTERVAL = TIME_IN_MILLIS.HOUR * 3;
+const CHECK_INTERVAL = TIME_IN_MILLIS.MINUTE * 15;
 
 let newVersionListeners: VersionListener[] = [];
 let pollInterval: number;

--- a/apps/webapp/test/unit_tests/lifecycle/newVersionHandlerSpec.js
+++ b/apps/webapp/test/unit_tests/lifecycle/newVersionHandlerSpec.js
@@ -32,13 +32,13 @@ describe('newVersionHandler', () => {
       expect(window.setInterval).toHaveBeenCalled();
     });
 
-    it('polls the server every 3 hours', () => {
+    it('polls the server every 15 minutes', () => {
       jest.useFakeTimers();
       spyOn(window, 'fetch').and.returnValue(Promise.resolve(new Response()));
 
       startNewVersionPolling('', () => {});
 
-      jest.advanceTimersByTime(6 * 60 * 60 * 1000);
+      jest.advanceTimersByTime(30 * 60 * 1000);
 
       expect(window.fetch).toHaveBeenCalledTimes(2);
       jest.useRealTimers();
@@ -57,7 +57,7 @@ describe('newVersionHandler', () => {
 
       startNewVersionPolling(testData.currentVersion, testData.callback);
 
-      jest.advanceTimersByTime(4 * 60 * 60 * 1000);
+      jest.advanceTimersByTime(16 * 60 * 1000);
       jest.useRealTimers();
 
       setTimeout(() => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24306" title="WPB-24306" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24306</a>  [Web] Reduce lifecycle update polling interval to 15 minutes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Right now the application is checking every 3 hours for a new version. This should be reduced to 15 minutes.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
