### PR TITLE
feat: add startup feature flag for Countly incremental backoff retry reporting [WPB-24059]

### DIFF
--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
@@ -19,10 +19,12 @@
 
 export const reliableWebsocketConnectionFeatureToggleName = 'reliable-websocket-connection';
 export const collaboraClipboardAccessFeatureToggleName = 'collabora-clipboard-access';
+export const countlyIncrementalBackoffRetryReportingFeatureToggleName = 'countly-incremental-backoff-retry-reporting';
 
 export const startupFeatureToggleNames = [
   reliableWebsocketConnectionFeatureToggleName,
   collaboraClipboardAccessFeatureToggleName,
+  countlyIncrementalBackoffRetryReportingFeatureToggleName,
 ] as const;
 
 export type StartupFeatureToggleName = (typeof startupFeatureToggleNames)[number];

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
@@ -24,6 +24,7 @@ import {
 } from './startupFeatureToggles';
 import {
   collaboraClipboardAccessFeatureToggleName,
+  countlyIncrementalBackoffRetryReportingFeatureToggleName,
   reliableWebsocketConnectionFeatureToggleName,
   startupFeatureToggleNames,
 } from './startupFeatureToggleNames';
@@ -31,6 +32,7 @@ import {
 const featureToggleNamesWithDedicatedExistenceTests = [
   reliableWebsocketConnectionFeatureToggleName,
   collaboraClipboardAccessFeatureToggleName,
+  countlyIncrementalBackoffRetryReportingFeatureToggleName,
 ] as const;
 
 describe('startupFeatureToggles', function () {
@@ -83,6 +85,16 @@ describe('startupFeatureToggles', function () {
     expect(startupFeatureToggles.getEnabledFeatureToggleNames()).not.toContain('unknown-feature');
   });
 
+  it('enables the countly incremental backoff retry reporting feature toggle when present in the query parameter', () => {
+    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
+      `?${startupFeatureToggleQueryParameterName}=${countlyIncrementalBackoffRetryReportingFeatureToggleName}`,
+    );
+
+    expect(
+      startupFeatureToggles.isFeatureToggleEnabled(countlyIncrementalBackoffRetryReportingFeatureToggleName),
+    ).toBe(true);
+  });
+
   it('trims whitespace around feature toggle names', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}= ${reliableWebsocketConnectionFeatureToggleName} `,
@@ -125,6 +137,7 @@ describe('startupFeatureToggles', function () {
     expect(allowedStartupFeatureToggleNames).toEqual([
       reliableWebsocketConnectionFeatureToggleName,
       collaboraClipboardAccessFeatureToggleName,
+      countlyIncrementalBackoffRetryReportingFeatureToggleName,
     ]);
   });
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24059" title="WPB-24059" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24059</a>  [Web] Log retried incremental backoffs to Countly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Add the startup feature toggle `countly-incremental-backoff-retry-reporting` to the enabled-features whitelist.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
