### PR TITLE
chore(dependabot): limit open pull requests to 5 [WPB-22420]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       timezone: 'Europe/Berlin'
     cooldown:
       default-days: 3
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 5
     labels:
       - 'type: chore 🧹'
     ignore:
@@ -29,7 +29,7 @@ updates:
       timezone: 'Europe/Berlin'
     cooldown:
       default-days: 3
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 5
     labels:
       - 'type: chore 🧹'
     ignore:
@@ -47,7 +47,7 @@ updates:
       timezone: 'Europe/Berlin'
     cooldown:
       default-days: 3
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 5
     labels:
       - 'type: chore 🧹'
     groups:
@@ -86,7 +86,7 @@ updates:
       timezone: 'Europe/Berlin'
     cooldown:
       default-days: 3
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 5
     labels:
       - 'type: chore 🧹'
     ignore:
@@ -109,7 +109,7 @@ updates:
       timezone: 'Europe/Berlin'
     cooldown:
       default-days: 3
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 5
     labels:
       - 'type: chore 🧹'
     ignore:
@@ -129,7 +129,7 @@ updates:
       timezone: 'Europe/Berlin'
     cooldown:
       default-days: 3
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 5
     labels:
       - 'type: chore 🧹'
     ignore:
@@ -142,7 +142,7 @@ updates:
   # Github actions
   - package-ecosystem: 'github-actions'
     directory: '/'
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 5
     schedule:
       interval: 'daily'
       time: '16:00'
@@ -152,6 +152,6 @@ updates:
   # Docker
   - package-ecosystem: 'docker'
     directory: '/'
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 5
     schedule:
       interval: 'daily'


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Limit Dependabot to 5 open pull requests to avoid saturating the shared precommit environment.

`precommit-crit-flows` runs through the single `precommit-deploy` concurrency lane, so pull requests are processed sequentially. Without a cap, Dependabot pull requests queue behind each other and block progress.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
