### PR TITLE
feat: track retry count and duration in HTTP incremental backoff state [WPB-24059]

### DIFF
--- a/libraries/api-client/src/http/incrementalRetryBackoff.test.ts
+++ b/libraries/api-client/src/http/incrementalRetryBackoff.test.ts
@@ -38,6 +38,8 @@ describe('IncrementalRetryBackoff', function () {
     const incrementalRetryBackoffState = incrementalRetryBackoffPolicy.createInitialIncrementalRetryBackoffState();
 
     expect(incrementalRetryBackoffState.delayInMilliseconds).toBe(0);
+    expect(incrementalRetryBackoffState.retryCount).toBe(0);
+    expect(incrementalRetryBackoffState.totalRetryDelayInMilliseconds).toBe(0);
   });
 
   it('starts the retry progression at 100 milliseconds', () => {
@@ -48,6 +50,8 @@ describe('IncrementalRetryBackoff', function () {
       incrementalRetryBackoffPolicy.advanceState(currentIncrementalRetryBackoffState);
 
     expect(nextIncrementalRetryBackoffState.delayInMilliseconds).toBe(100);
+    expect(nextIncrementalRetryBackoffState.retryCount).toBe(1);
+    expect(nextIncrementalRetryBackoffState.totalRetryDelayInMilliseconds).toBe(100);
   });
 
   it('doubles the retry delay on each advancement', () => {
@@ -63,6 +67,12 @@ describe('IncrementalRetryBackoff', function () {
     expect(firstIncrementalRetryBackoffState.delayInMilliseconds).toBe(100);
     expect(secondIncrementalRetryBackoffState.delayInMilliseconds).toBe(200);
     expect(thirdIncrementalRetryBackoffState.delayInMilliseconds).toBe(400);
+    expect(firstIncrementalRetryBackoffState.retryCount).toBe(1);
+    expect(secondIncrementalRetryBackoffState.retryCount).toBe(2);
+    expect(thirdIncrementalRetryBackoffState.retryCount).toBe(3);
+    expect(firstIncrementalRetryBackoffState.totalRetryDelayInMilliseconds).toBe(100);
+    expect(secondIncrementalRetryBackoffState.totalRetryDelayInMilliseconds).toBe(300);
+    expect(thirdIncrementalRetryBackoffState.totalRetryDelayInMilliseconds).toBe(700);
   });
 
   it('caps the retry delay at ten minutes', () => {
@@ -84,7 +94,11 @@ describe('IncrementalRetryBackoff', function () {
     const resetBackoffState = incrementalRetryBackoffPolicy.createInitialIncrementalRetryBackoffState();
 
     expect(advancedIncrementalRetryBackoffState.delayInMilliseconds).toBe(100);
+    expect(advancedIncrementalRetryBackoffState.retryCount).toBe(1);
+    expect(advancedIncrementalRetryBackoffState.totalRetryDelayInMilliseconds).toBe(100);
     expect(resetBackoffState.delayInMilliseconds).toBe(0);
+    expect(resetBackoffState.retryCount).toBe(0);
+    expect(resetBackoffState.totalRetryDelayInMilliseconds).toBe(0);
   });
 
   it('treats 420, 429, and 5xx statuses as retryable', () => {

--- a/libraries/api-client/src/http/incrementalRetryBackoff.ts
+++ b/libraries/api-client/src/http/incrementalRetryBackoff.ts
@@ -21,6 +21,8 @@ import {Maybe} from 'true-myth';
 
 export type IncrementalRetryBackoffState = {
   readonly delayInMilliseconds: number;
+  readonly retryCount: number;
+  readonly totalRetryDelayInMilliseconds: number;
 };
 
 export type IncrementalRetryBackoffPolicy = {
@@ -42,14 +44,22 @@ export function createIncrementalRetryBackoffPolicy(): IncrementalRetryBackoffPo
       const currentDelayInMilliseconds = incrementalRetryBackoffState.delayInMilliseconds;
       const nextDelayInMilliseconds =
         currentDelayInMilliseconds === 0 ? initialRetryDelayInMilliseconds : currentDelayInMilliseconds * 2;
+      const boundedDelayInMilliseconds = Math.min(nextDelayInMilliseconds, maximumRetryDelayInMilliseconds);
 
       return {
-        delayInMilliseconds: Math.min(nextDelayInMilliseconds, maximumRetryDelayInMilliseconds),
+        delayInMilliseconds: boundedDelayInMilliseconds,
+        retryCount: incrementalRetryBackoffState.retryCount + 1,
+        totalRetryDelayInMilliseconds:
+          incrementalRetryBackoffState.totalRetryDelayInMilliseconds + boundedDelayInMilliseconds,
       };
     },
 
     createInitialIncrementalRetryBackoffState() {
-      return {delayInMilliseconds: 0};
+      return {
+        delayInMilliseconds: 0,
+        retryCount: 0,
+        totalRetryDelayInMilliseconds: 0,
+      };
     },
 
     shouldRetryWithIncrementalBackoff(statusCode) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24059" title="WPB-24059" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24059</a>  [Web] Log retried incremental backoffs to Countly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Extend the HTTP incremental retry backoff state with explicit retry count and cumulative retry duration bookkeeping.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
