### PR TITLE
chore: update precommit-crit-flows to report status correctly [WPB-17563]

### DIFF
--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -166,8 +166,8 @@ jobs:
           echo "tests_to_run=@crit-flow-web" >> $GITHUB_OUTPUT
           echo "Merge queue run detected, executing critical flow tests"
 
-  run_e2e_tests:
-    name: Playwright Critical Flow (precommit)
+  e2e_tests:
+    name: E2E Tests Execution
     if: ${{ !cancelled() && github.repository == 'wireapp/wire-webapp' }}
     needs: [check_edits_to_e2e_tests, deploy_to_aws]
     uses: ./.github/workflows/e2e-tests.yml
@@ -178,9 +178,18 @@ jobs:
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
+  run_e2e_tests:
+    name: Playwright Critical Flow (precommit)
+    if: ${{ !cancelled() && github.repository == 'wireapp/wire-webapp' }}
+    needs: [e2e_tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report Status
+        run: echo "E2E tests completed with status - ${{ needs.e2e_tests.result }}"
+
   e2e-report:
     name: Generate test report
-    needs: run_e2e_tests
+    needs: e2e_tests
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
@@ -205,7 +214,7 @@ jobs:
       - name: Download report
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          artifact-ids: ${{ needs.run_e2e_tests.outputs.reportArtifactId }}
+          artifact-ids: ${{ needs.e2e_tests.outputs.reportArtifactId }}
           path: apps/webapp/playwright-report
 
       - name: Generate PR comment
@@ -238,7 +247,7 @@ jobs:
         with:
           header: playwright-summary
           message: |
-            🔗 [Download Full Report Artifact](${{ needs.run_e2e_tests.outputs.reportUrl }})
+            🔗 [Download Full Report Artifact](${{ needs.e2e_tests.outputs.reportUrl }})
 
             ${{ steps.generate_comment.outputs.comment }}
         env:


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17563" title="WPB-17563" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17563</a>  [Web] - Add critical flow tests to precommit pipeline
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary

When using reusable workflows with workflow_call, the status reporting can be tricky. It's like a black box. Other jobs couldn't reliably check "did it pass or fail?" or access its outputs.
I added additional step to check the status. 

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
