### PR TITLE
feat: emit HTTP long-running retry transport event [WPB-24059]

### DIFF
--- a/libraries/api-client/src/http/httpClient.ts
+++ b/libraries/api-client/src/http/httpClient.ts
@@ -49,7 +49,13 @@ import {sendRequestWithCookie} from '../shims/node/cookie';
 enum TOPIC {
   ON_CONNECTION_STATE_CHANGE = 'HttpClient.TOPIC.ON_CONNECTION_STATE_CHANGE',
   ON_INVALID_TOKEN = 'HttpClient.TOPIC.ON_INVALID_TOKEN',
+  ON_LONG_RUNNING_RETRY = 'HttpClient.TOPIC.ON_LONG_RUNNING_RETRY',
 }
+
+export type LongRunningRetryDetails = {
+  readonly retryCount: number;
+  readonly retryDurationInMilliseconds: number;
+};
 
 type SendRequest = {
   config: AxiosRequestConfig;
@@ -70,9 +76,12 @@ export interface HttpClient {
   on(event: TOPIC.ON_CONNECTION_STATE_CHANGE, listener: (state: ConnectionState) => void): this;
 
   on(event: TOPIC.ON_INVALID_TOKEN, listener: (error: InvalidTokenError | MissingCookieError) => void): this;
+
+  on(event: TOPIC.ON_LONG_RUNNING_RETRY, listener: (retryDetails: LongRunningRetryDetails) => void): this;
 }
 
 const FILE_SIZE_100_MB = 104857600;
+const longRunningRetryThresholdInMilliseconds = TimeUtil.TimeInMillis.MINUTE;
 
 export class HttpClient extends EventEmitter {
   public readonly client: AxiosInstance;
@@ -84,6 +93,7 @@ export class HttpClient extends EventEmitter {
   private incrementalRetryBackoffResetAbortController = new AbortController();
   private incrementalRetryBackoffResetCount = 0;
   private incrementalRetryBackoffState: IncrementalRetryBackoffState;
+  private hasReportedLongRunningRetry = false;
   public static readonly TOPIC = TOPIC;
   private versionPrefix = '';
 
@@ -173,8 +183,25 @@ export class HttpClient extends EventEmitter {
   public resetRetryBackoff(): void {
     this.incrementalRetryBackoffResetCount += 1;
     this.incrementalRetryBackoffState = this.incrementalRetryBackoffPolicy.createInitialIncrementalRetryBackoffState();
+    this.hasReportedLongRunningRetry = false;
     this.incrementalRetryBackoffResetAbortController.abort();
     this.incrementalRetryBackoffResetAbortController = new AbortController();
+  }
+
+  private reportLongRunningRetryIfNeeded(nextIncrementalRetryBackoffState: IncrementalRetryBackoffState): void {
+    if (this.hasReportedLongRunningRetry) {
+      return;
+    }
+
+    if (nextIncrementalRetryBackoffState.totalRetryDelayInMilliseconds < longRunningRetryThresholdInMilliseconds) {
+      return;
+    }
+
+    this.hasReportedLongRunningRetry = true;
+    this.emit(HttpClient.TOPIC.ON_LONG_RUNNING_RETRY, {
+      retryCount: nextIncrementalRetryBackoffState.retryCount,
+      retryDurationInMilliseconds: nextIncrementalRetryBackoffState.totalRetryDelayInMilliseconds,
+    });
   }
 
   private getIncrementalRetryBackoffAbortSignal(abortController?: AbortController): Maybe<AbortSignal> {
@@ -364,6 +391,9 @@ export class HttpClient extends EventEmitter {
       },
       isRequestAborted: () => {
         return abortController?.signal.aborted === true;
+      },
+      onIncrementalRetryBackoffStateChanged: nextIncrementalRetryBackoffState => {
+        this.reportLongRunningRetryIfNeeded(nextIncrementalRetryBackoffState);
       },
       runRequestAttempt,
       setIncrementalRetryBackoffState: nextIncrementalRetryBackoffState => {

--- a/libraries/api-client/src/http/incrementalRetryBackoffRunner.ts
+++ b/libraries/api-client/src/http/incrementalRetryBackoffRunner.ts
@@ -33,6 +33,7 @@ export type RunWithIncrementalRetryBackoffDependencies<ResponseValue> = {
   readonly getIncrementalRetryBackoffState: () => IncrementalRetryBackoffState;
   readonly getRetryBackoffResetCount: () => number;
   readonly isRequestAborted: () => boolean;
+  readonly onIncrementalRetryBackoffStateChanged?: (incrementalRetryBackoffState: IncrementalRetryBackoffState) => void;
   readonly runRequestAttempt: () => Promise<ResponseValue>;
   readonly setIncrementalRetryBackoffState: (
     incrementalRetryBackoffState: IncrementalRetryBackoffState,
@@ -59,6 +60,7 @@ export function createIncrementalRetryBackoffRunner(
         getIncrementalRetryBackoffState,
         getRetryBackoffResetCount,
         isRequestAborted,
+        onIncrementalRetryBackoffStateChanged,
         runRequestAttempt,
         setIncrementalRetryBackoffState,
       } = runWithIncrementalRetryBackoffDependencies;
@@ -79,6 +81,7 @@ export function createIncrementalRetryBackoffRunner(
           );
 
           setIncrementalRetryBackoffState(nextIncrementalRetryBackoffState);
+          onIncrementalRetryBackoffStateChanged?.(nextIncrementalRetryBackoffState);
 
           const retryBackoffResetCount = getRetryBackoffResetCount();
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24059" title="WPB-24059" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24059</a>  [Web] Log retried incremental backoffs to Countly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

-

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
