### PR TITLE
chore: update AWS action for EB deployment [WPB-24365]

### DIFF
--- a/.github/workflows/deploy-to-test-env.yml
+++ b/.github/workflows/deploy-to-test-env.yml
@@ -48,7 +48,7 @@ jobs:
         run: yarn nx run server:package
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
         with:
           aws-access-key-id: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
@@ -56,7 +56,7 @@ jobs:
 
       - name: Deploy to Elastic Beanstalk
         id: deploy
-        uses: aws-actions/aws-elasticbeanstalk-deploy@v1.0.0
+        uses: aws-actions/aws-elasticbeanstalk-deploy@e90ca3136d2cf14ddb5c7a30538d6f214d9a3c0e
         with:
           aws-region: ${{ env.AWS_REGION }}
           application-name: ${{ env.AWS_APPLICATION_NAME }}

--- a/.github/workflows/deploy-to-test-env.yml
+++ b/.github/workflows/deploy-to-test-env.yml
@@ -23,6 +23,7 @@ jobs:
       DEPLOYMENT_RECOVERY_TIMEOUT_SECONDS: 150
       AWS_APPLICATION_NAME: Webapp
       AWS_BUILD_ZIP_PATH: apps/server/dist/s3/ebs.zip
+      AWS_REGION: eu-central-1
 
     steps:
       - name: Print environment variables
@@ -46,17 +47,23 @@ jobs:
       - name: Build and package
         run: yarn nx run server:package
 
-      - name: Deploy to Elastic Beanstalk
-        uses: einaregilsson/beanstalk-deploy@27edd8a0ebe8656ac70654372c73f06f7e9a1027
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          application_name: ${{env.AWS_APPLICATION_NAME}}
-          aws_access_key: ${{secrets.WEBTEAM_AWS_ACCESS_KEY_ID}}
-          aws_secret_key: ${{secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY}}
-          deployment_package: ${{env.AWS_BUILD_ZIP_PATH}}
-          environment_name: ${{inputs.env}}
-          region: eu-central-1
-          use_existing_version_if_available: true
-          version_description: ${{github.sha}}
-          version_label: ${{github.run_id}}
-          wait_for_deployment: false
-          wait_for_environment_recovery: ${{env.DEPLOYMENT_RECOVERY_TIMEOUT_SECONDS}}
+          aws-access-key-id: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Deploy to Elastic Beanstalk
+        id: deploy
+        uses: aws-actions/aws-elasticbeanstalk-deploy@v1.0.0
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          application-name: ${{ env.AWS_APPLICATION_NAME }}
+          environment-name: ${{ inputs.env }}
+          version-label: ${{ github.run_id }}
+          deployment-package-path: ${{ env.AWS_BUILD_ZIP_PATH }}
+          wait-for-deployment: false
+          wait-for-environment-recovery: true
+          deployment-timeout: ${{ env.DEPLOYMENT_RECOVERY_TIMEOUT_SECONDS }}
+          use-existing-application-version-if-available: true

--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -29,7 +29,6 @@ jobs:
       BUILD_ARTIFACT: ebs.zip
       CHANGELOG_FILE: ./changelog.md
       UNIT_TEST_REPORT_FILE: ./unit-tests.log
-      AWS_REGION: eu-central-1
 
     steps:
       - name: Checkout (pull_request)
@@ -86,6 +85,8 @@ jobs:
   deploy_to_aws:
     name: Deploy to precommit
     runs-on: ubuntu-latest
+    env:
+      AWS_REGION: eu-central-1
     needs: [build]
     timeout-minutes: 25
 
@@ -98,7 +99,7 @@ jobs:
           name: build-artifact
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
         with:
           aws-access-key-id: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
@@ -106,7 +107,7 @@ jobs:
 
       - name: Deploy to precommit environment
         id: deploy
-        uses: aws-actions/aws-elasticbeanstalk-deploy@v1.0.0
+        uses: aws-actions/aws-elasticbeanstalk-deploy@e90ca3136d2cf14ddb5c7a30538d6f214d9a3c0e
         with:
           aws-region: ${{ env.AWS_REGION }}
           application-name: Webapp

--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -29,6 +29,7 @@ jobs:
       BUILD_ARTIFACT: ebs.zip
       CHANGELOG_FILE: ./changelog.md
       UNIT_TEST_REPORT_FILE: ./unit-tests.log
+      AWS_REGION: eu-central-1
 
     steps:
       - name: Checkout (pull_request)
@@ -96,20 +97,25 @@ jobs:
         with:
           name: build-artifact
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
       - name: Deploy to precommit environment
         id: deploy
-        uses: einaregilsson/beanstalk-deploy@27edd8a0ebe8656ac70654372c73f06f7e9a1027 # v22
+        uses: aws-actions/aws-elasticbeanstalk-deploy@v1.0.0
         with:
-          application_name: Webapp
-          aws_access_key: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
-          aws_secret_key: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
-          deployment_package: ${{ needs.build.outputs.build_artifact }}
-          environment_name: wire-webapp-precommit
-          region: eu-central-1
-          use_existing_version_if_available: true
-          version_description: ${{ needs.build.outputs.committer }} — ${{ needs.build.outputs.commit_url }}
-          version_label: ${{ github.run_id }}
-          wait_for_deployment: true # ✅ wait until EB is green
+          aws-region: ${{ env.AWS_REGION }}
+          application-name: Webapp
+          environment-name: wire-webapp-precommit
+          version-label: ${{ github.run_id }}
+          deployment-package-path: ${{ needs.build.outputs.build_artifact }}
+          wait-for-deployment: true
+          wait-for-environment-recovery: true
+          use-existing-application-version-if-available: true
 
       - name: Fetch precommit URL
         id: fetch_url
@@ -119,10 +125,6 @@ jobs:
             --environment-names wire-webapp-precommit \
             --query "Environments[0].CNAME" --output text)
           echo "url=https://$URL" >> "$GITHUB_OUTPUT"
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: eu-central-1
 
       - name: Deployment Status
         if: ${{ always() }}

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -1,9 +1,7 @@
 name: precommit
 
-#on:
-#  pull_request:
-#    # we want to run the CI on every PR targetting those branches
-#    branches: [dev]
+on:
+  pull_request:
 
 concurrency:
   group: precommit-deploy
@@ -71,6 +69,8 @@ jobs:
   deploy_to_aws:
     name: 'Deploy to live environments'
     runs-on: ubuntu-latest
+    env:
+      AWS_REGION: eu-central-1
     needs: [build]
 
     steps:
@@ -85,23 +85,28 @@ jobs:
           if [[ ${{ needs.build.outputs.total_additions }} -le 100 || "${{ github.actor }}" == "dependabot[bot]" ]]; then
             echo "Skipping deployment"
             exit 0
-            fi
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Deploy to precommit environment
         id: deploy
-        uses: einaregilsson/beanstalk-deploy@27edd8a0ebe8656ac70654372c73f06f7e9a1027
+        uses: aws-actions/aws-elasticbeanstalk-deploy@v1.0.0
         with:
-          application_name: Webapp
-          aws_access_key: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
-          aws_secret_key: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
-          deployment_package: ${{needs.build.outputs.build_artifact}}
-          environment_name: wire-webapp-precommit
-          region: eu-central-1
-          use_existing_version_if_available: true
-          version_description: ${{ github.sha }}
-          version_label: ${{ github.run_id }}
-          wait_for_deployment: false
-          wait_for_environment_recovery: 150
+          aws-region: ${{ env.AWS_REGION }}
+          application-name: Webapp
+          environment-name: wire-webapp-precommit
+          version-label: ${{ github.run_id }}
+          deployment-package-path: ${{ needs.build.outputs.build_artifact }}
+          wait-for-deployment: false
+          wait-for-environment-recovery: true
+          deployment-timeout: 150
+          use-existing-application-version-if-available: true
 
       - name: Deployment Status
         if: ${{ always() }}

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -88,7 +88,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
         with:
           aws-access-key-id: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
@@ -96,7 +96,7 @@ jobs:
 
       - name: Deploy to precommit environment
         id: deploy
-        uses: aws-actions/aws-elasticbeanstalk-deploy@v1.0.0
+        uses: aws-actions/aws-elasticbeanstalk-deploy@e90ca3136d2cf14ddb5c7a30538d6f214d9a3c0e
         with:
           aws-region: ${{ env.AWS_REGION }}
           application-name: Webapp

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -1,7 +1,9 @@
 name: precommit
 
-on:
-  pull_request:
+#on:
+#  pull_request:
+#    # we want to run the CI on every PR targetting those branches
+#    branches: [dev]
 
 concurrency:
   group: precommit-deploy

--- a/.github/workflows/publish-and-deploy-webapp.yml
+++ b/.github/workflows/publish-and-deploy-webapp.yml
@@ -32,6 +32,7 @@ jobs:
       COMMIT_URL: ${{github.event.head_commit.url}}
       COMMITTER: ${{github.event.head_commit.committer.name}}
       CHANGELOG_FILE: './changelog.md'
+      AWS_REGION: eu-central-1
 
     steps:
       - name: Checkout
@@ -299,20 +300,26 @@ jobs:
         with:
           name: 'build-artifact'
 
-      - name: Deploy to ${{matrix.target}}
-        uses: einaregilsson/beanstalk-deploy@27edd8a0ebe8656ac70654372c73f06f7e9a1027
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          application_name: Webapp
-          aws_access_key: ${{secrets.WEBTEAM_AWS_ACCESS_KEY_ID}}
-          aws_secret_key: ${{secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY}}
-          deployment_package: ${{needs.build.outputs.build_artifact}}
-          environment_name: ${{matrix.target}}
-          region: eu-central-1
-          use_existing_version_if_available: true
-          version_description: ${{github.sha}}
-          version_label: '${{github.run_id}}-${{matrix.target}}'
-          wait_for_deployment: false
-          wait_for_environment_recovery: 150
+          aws-access-key-id: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Deploy to ${{matrix.target}}
+        id: deploy
+        uses: aws-actions/aws-elasticbeanstalk-deploy@v1.0.0
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          application-name: Webapp
+          environment-name: ${{ matrix.target }}
+          version-label: ${{ github.run_id }}-${{ matrix.target }}
+          deployment-package-path: ${{ needs.build.outputs.build_artifact }}
+          wait-for-deployment: false
+          wait-for-environment-recovery: true
+          deployment-timeout: 150
+          use-existing-application-version-if-available: true
 
   create_gh_release:
     name: 'Create Github release'

--- a/.github/workflows/publish-and-deploy-webapp.yml
+++ b/.github/workflows/publish-and-deploy-webapp.yml
@@ -301,7 +301,7 @@ jobs:
           name: 'build-artifact'
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
         with:
           aws-access-key-id: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
@@ -309,7 +309,7 @@ jobs:
 
       - name: Deploy to ${{matrix.target}}
         id: deploy
-        uses: aws-actions/aws-elasticbeanstalk-deploy@v1.0.0
+        uses: aws-actions/aws-elasticbeanstalk-deploy@e90ca3136d2cf14ddb5c7a30538d6f214d9a3c0e
         with:
           aws-region: ${{ env.AWS_REGION }}
           application-name: Webapp

--- a/.github/workflows/redeploy-production-from-tag.yml
+++ b/.github/workflows/redeploy-production-from-tag.yml
@@ -119,7 +119,7 @@ jobs:
           name: build-artifact-${{ needs.validate_request.outputs.tag }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
         with:
           aws-access-key-id: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
@@ -127,7 +127,7 @@ jobs:
 
       - name: Deploy to wire-webapp-prod
         id: deploy
-        uses: aws-actions/aws-elasticbeanstalk-deploy@v1.0.0
+        uses: aws-actions/aws-elasticbeanstalk-deploy@e90ca3136d2cf14ddb5c7a30538d6f214d9a3c0e
         with:
           aws-region: ${{ env.AWS_REGION }}
           application-name: Webapp

--- a/.github/workflows/redeploy-production-from-tag.yml
+++ b/.github/workflows/redeploy-production-from-tag.yml
@@ -21,6 +21,8 @@ jobs:
   validate_request:
     name: Validate redeploy request
     runs-on: ubuntu-latest
+    env:
+      AWS_REGION: eu-central-1
     outputs:
       tag: ${{ steps.validate.outputs.tag }}
 
@@ -116,20 +118,26 @@ jobs:
         with:
           name: build-artifact-${{ needs.validate_request.outputs.tag }}
 
-      - name: Deploy to wire-webapp-prod
-        uses: einaregilsson/beanstalk-deploy@27edd8a0ebe8656ac70654372c73f06f7e9a1027
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          application_name: Webapp
-          aws_access_key: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
-          aws_secret_key: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
-          deployment_package: ebs.zip
-          environment_name: wire-webapp-prod
-          region: eu-central-1
-          use_existing_version_if_available: true
-          version_description: ${{ needs.build_artifact.outputs.commit_sha }}
-          version_label: '${{ github.run_id }}-wire-webapp-prod-redeploy'
-          wait_for_deployment: false
-          wait_for_environment_recovery: 150
+          aws-access-key-id: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Deploy to wire-webapp-prod
+        id: deploy
+        uses: aws-actions/aws-elasticbeanstalk-deploy@v1.0.0
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          application-name: Webapp
+          environment-name: wire-webapp-prod
+          version-label: ${{ github.run_id }}-wire-webapp-prod-redeploy
+          deployment-package-path: ebs.zip
+          wait-for-deployment: false
+          wait-for-environment-recovery: true
+          deployment-timeout: 150
+          use-existing-application-version-if-available: true
 
   notify_redeploy:
     name: Notify redeploy


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24365" title="WPB-24365" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24365</a>  [Web] Migrate all GitHub workflows from einaregilsson/beanstalk-deploy to official AWS action
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- What did I change and why?
Replace the old action of EB Deployment with AWS maintained action.
`einaregilsson/beanstalk-deploy` only supports node v20 and soon it will be deprecated for the action worker.
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
