### PR TITLE
feat: report API long-running retries to Countly behind feature flag [WPB-24059]

### DIFF
--- a/apps/webapp/src/script/components/AppContainer/AppContainer.tsx
+++ b/apps/webapp/src/script/components/AppContainer/AppContainer.tsx
@@ -41,6 +41,7 @@ import {useTheme} from './hooks/useTheme';
 
 import {WallClock} from '../../clock/wallClock';
 import {Config, Configuration} from '../../Config';
+import {countlyIncrementalBackoffRetryReportingFeatureToggleName} from '../../featureToggles/startupFeatureToggleNames';
 import {StartupFeatureToggleName} from '../../featureToggles/startupFeatureToggles';
 import {setAppLocale} from '../../localization/Localizer';
 import {App} from '../../main/app';
@@ -59,7 +60,19 @@ type AppProps = {
 
 export const AppContainer = ({config, clientType, isFeatureToggleEnabled, wallClock}: AppProps) => {
   setAppLocale();
-  const app = useMemo(() => new App(container.resolve(Core), container.resolve(APIClient), config), [config]);
+  const isCountlyIncrementalBackoffRetryReportingEnabled = isFeatureToggleEnabled(
+    countlyIncrementalBackoffRetryReportingFeatureToggleName,
+  );
+  const app = useMemo(
+    () =>
+      new App(
+        container.resolve(Core),
+        container.resolve(APIClient),
+        config,
+        isCountlyIncrementalBackoffRetryReportingEnabled,
+      ),
+    [config, isCountlyIncrementalBackoffRetryReportingEnabled],
+  );
   const enableAutoLogin = Config.getConfig().FEATURE.ENABLE_AUTO_LOGIN;
 
   // Publishing application on the global scope for debug and testing purposes.

--- a/apps/webapp/src/script/main/app.ts
+++ b/apps/webapp/src/script/main/app.ts
@@ -169,6 +169,7 @@ export class App {
     private readonly core: Core,
     private readonly apiClient: APIClient,
     private readonly config: Configuration,
+    private readonly isCountlyIncrementalBackoffRetryReportingEnabled: boolean = false,
   ) {
     this.config = config;
     this.apiClient.on(APIClient.TOPIC.ON_LOGOUT, () =>
@@ -290,7 +291,11 @@ export class App {
       serverTimeHandler,
     );
 
-    repositories.eventTracker = new EventTrackingRepository(repositories.message);
+    repositories.eventTracker = new EventTrackingRepository(
+      repositories.message,
+      this.apiClient,
+      this.isCountlyIncrementalBackoffRetryReportingEnabled,
+    );
 
     repositories.backup = new BackupRepository(new BackupService(), repositories.conversation);
 

--- a/apps/webapp/src/script/repositories/tracking/EventTrackingRepository.ts
+++ b/apps/webapp/src/script/repositories/tracking/EventTrackingRepository.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {HttpClient, LongRunningRetryDetails} from '@wireapp/api-client/lib/http';
 import {amplify} from 'amplify';
 import {container} from 'tsyringe';
 
@@ -45,8 +46,21 @@ import {UserData} from './UserData';
 
 import {URLParameter} from '../../auth/URLParameter';
 import {Config} from '../../Config';
+import {APIClient} from '../../service/APIClientSingleton';
 
 const TEAM_SIZE_THRESHOLD_VALUE = 6;
+
+type HttpRetryReportingClient = {
+  readonly on: (
+    event: typeof HttpClient.TOPIC.ON_LONG_RUNNING_RETRY,
+    listener: (retryDetails: LongRunningRetryDetails) => void,
+  ) => unknown;
+  readonly removeListener: (
+    event: typeof HttpClient.TOPIC.ON_LONG_RUNNING_RETRY,
+    listener: (retryDetails: LongRunningRetryDetails) => void,
+  ) => unknown;
+};
+
 export class EventTrackingRepository {
   private isProductReportingActivated: boolean = false;
   private sendAppOpenEvent: boolean = true;
@@ -72,6 +86,8 @@ export class EventTrackingRepository {
 
   constructor(
     private readonly messageRepository: MessageRepository,
+    private readonly apiClient: APIClient,
+    private readonly isCountlyIncrementalBackoffRetryReportingEnabled: boolean,
     private readonly teamState = container.resolve(TeamState),
     private readonly userState = container.resolve(UserState),
   ) {
@@ -309,8 +325,22 @@ export class EventTrackingRepository {
       },
     );
 
+    if (this.isCountlyIncrementalBackoffRetryReportingEnabled) {
+      const httpRetryReportingClient = this.apiClient.transport.http as unknown as HttpRetryReportingClient;
+
+      httpRetryReportingClient.on(HttpClient.TOPIC.ON_LONG_RUNNING_RETRY, this.onLongRunningRetry);
+    }
+
     amplify.subscribe(WebAppEvents.LIFECYCLE.SIGNED_OUT, this.stopProductReportingSession);
   }
+
+  private readonly onLongRunningRetry = (retryDetails: LongRunningRetryDetails): void => {
+    this.trackProductReportingEvent(EventName.CONNECTIVITY.RETRYING_FOR_ONE_MINUTE, {
+      [Segmentation.CONNECTIVITY.RETRY_COUNT]: retryDetails.retryCount,
+      [Segmentation.CONNECTIVITY.RETRY_DURATION_IN_MILLISECONDS]: retryDetails.retryDurationInMilliseconds,
+      [Segmentation.CONNECTIVITY.TRANSPORT]: 'api',
+    });
+  };
 
   private startProductReportingSession(): void {
     if (!telemetry.isLoaded()) {
@@ -384,6 +414,13 @@ export class EventTrackingRepository {
 
   private unsubscribeFromProductTrackingEvents(): void {
     this.logger.debug('Unsubscribing from product tracking events');
+
+    if (this.isCountlyIncrementalBackoffRetryReportingEnabled) {
+      const httpRetryReportingClient = this.apiClient.transport.http as unknown as HttpRetryReportingClient;
+
+      httpRetryReportingClient.removeListener(HttpClient.TOPIC.ON_LONG_RUNNING_RETRY, this.onLongRunningRetry);
+    }
+
     amplify.unsubscribeAll(WebAppEvents.ANALYTICS.EVENT);
   }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24059" title="WPB-24059" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24059</a>  [Web] Log retried incremental backoffs to Countly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Wire the HTTP long-running retry transport event into Countly reporting in the webapp tracking layer.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
