### PR TITLE
chore: if build or deployment is failed then playwright tests should not run [WPB-22420]

### DIFF
--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -171,7 +171,7 @@ jobs:
 
   e2e_tests:
     name: E2E Tests Execution
-    if: ${{ !cancelled() && github.repository == 'wireapp/wire-webapp' }}
+    if: ${{ success() && github.repository == 'wireapp/wire-webapp' }}
     needs: [check_edits_to_e2e_tests, deploy_to_aws]
     uses: ./.github/workflows/e2e-tests.yml
     with:
@@ -183,7 +183,7 @@ jobs:
 
   run_e2e_tests:
     name: Playwright Critical Flow (precommit)
-    if: ${{ !cancelled() && github.repository == 'wireapp/wire-webapp' }}
+    if: ${{ success() && github.repository == 'wireapp/wire-webapp' }}
     needs: [e2e_tests]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary

- What did I change and why?
In the screenshot it seems like the build is failed but still all the tests are passed because new deployment was not done. This is misleading.
If build or deployment is failed then playwright tests should not run.
This is also optimize resource utilization.
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)
<img width="1135" height="347" alt="image" src="https://github.com/user-attachments/assets/6d668d55-e4d6-41f0-8e0c-15823eebe785" />


## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
