### PR TITLE
chore: remove feature flag(WPB-23544)

### DIFF
--- a/apps/webapp/src/script/components/FileFullscreenModal/FileEditor/FileEditor.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileEditor/FileEditor.tsx
@@ -27,8 +27,6 @@ import {PrimaryModal} from 'Components/Modals/PrimaryModal';
 import {removeCurrentModal} from 'Components/Modals/PrimaryModal/PrimaryModalState';
 import {CellsRepository} from 'Repositories/cells/CellsRepository';
 import {Config} from 'src/script/Config';
-import {collaboraClipboardAccessFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
-import {useApplicationContext} from 'src/script/page/RootProvider';
 import {t} from 'Util/localizerUtil';
 import {TIME_IN_MILLIS} from 'Util/timeUtil';
 
@@ -45,7 +43,6 @@ interface FileEditorProps {
 
 export const FileEditor = ({id}: FileEditorProps) => {
   const cellsRepository = container.resolve(CellsRepository);
-  const {isFeatureToggleEnabled} = useApplicationContext();
   const [node, setNode] = useState<Node | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isError, setIsError] = useState(false);
@@ -141,7 +138,6 @@ export const FileEditor = ({id}: FileEditorProps) => {
     Maybe.of(node?.EditorURLs?.collabora?.Url),
     Config.getConfig().CELLS_PYDIO_URL,
   );
-  const shouldDelegateClipboardAccess = isFeatureToggleEnabled(collaboraClipboardAccessFeatureToggleName);
 
   if (result.isErr(urlValidation)) {
     return null;
@@ -149,7 +145,7 @@ export const FileEditor = ({id}: FileEditorProps) => {
 
   return (
     <iframe
-      allow={shouldDelegateClipboardAccess ? 'clipboard-read; clipboard-write' : undefined}
+      allow="clipboard-read; clipboard-write"
       css={styles.editorIframe}
       src={urlValidation.value}
       title={t('fileFullscreenModal.editor.iframeTitle')}

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
@@ -18,12 +18,10 @@
  */
 
 export const reliableWebsocketConnectionFeatureToggleName = 'reliable-websocket-connection';
-export const collaboraClipboardAccessFeatureToggleName = 'collabora-clipboard-access';
 export const countlyIncrementalBackoffRetryReportingFeatureToggleName = 'countly-incremental-backoff-retry-reporting';
 
 export const startupFeatureToggleNames = [
   reliableWebsocketConnectionFeatureToggleName,
-  collaboraClipboardAccessFeatureToggleName,
   countlyIncrementalBackoffRetryReportingFeatureToggleName,
 ] as const;
 

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
@@ -18,7 +18,6 @@
  */
 
 export const reliableWebsocketConnectionFeatureToggleName = 'reliable-websocket-connection';
-export const collaboraClipboardAccessFeatureToggleName = 'collabora-clipboard-access';
 export const collaboraNewDocumentCreationMenuFeatureToggleName = 'collabora-new-document-creation-menu';
 export const countlyIncrementalBackoffRetryReportingFeatureToggleName = 'countly-incremental-backoff-retry-reporting';
 

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
@@ -23,7 +23,6 @@ import {
   startupFeatureToggleQueryParameterName,
 } from './startupFeatureToggles';
 import {
-  collaboraClipboardAccessFeatureToggleName,
   countlyIncrementalBackoffRetryReportingFeatureToggleName,
   reliableWebsocketConnectionFeatureToggleName,
   startupFeatureToggleNames,
@@ -31,7 +30,6 @@ import {
 
 const featureToggleNamesWithDedicatedExistenceTests = [
   reliableWebsocketConnectionFeatureToggleName,
-  collaboraClipboardAccessFeatureToggleName,
   countlyIncrementalBackoffRetryReportingFeatureToggleName,
 ] as const;
 
@@ -66,14 +64,6 @@ describe('startupFeatureToggles', function () {
     );
 
     expect(startupFeatureToggles.getEnabledFeatureToggleNames()).toEqual([]);
-  });
-
-  it('enables the collabora clipboard access feature toggle when present in the query parameter', () => {
-    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
-      `?${startupFeatureToggleQueryParameterName}=${collaboraClipboardAccessFeatureToggleName}`,
-    );
-
-    expect(startupFeatureToggles.isFeatureToggleEnabled(collaboraClipboardAccessFeatureToggleName)).toBe(true);
   });
 
   it('keeps only whitelisted feature toggles when known and unknown values are mixed', () => {
@@ -136,7 +126,6 @@ describe('startupFeatureToggles', function () {
   it('contains only whitelisted values in allowedStartupFeatureToggleNames', () => {
     expect(allowedStartupFeatureToggleNames).toEqual([
       reliableWebsocketConnectionFeatureToggleName,
-      collaboraClipboardAccessFeatureToggleName,
       countlyIncrementalBackoffRetryReportingFeatureToggleName,
     ]);
   });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23544" title="WPB-23544" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23544</a>  [Web] Not possible to copy/paste in Collabora
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- collabora editing a file and copy/paste is working fine now therefore removing feature flags

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
