### PR TITLE
feat: emit WebSocket long-running retry transport event [WPB-24059]

### DIFF
--- a/libraries/api-client/src/tcp/reconnectingWebsocket.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.ts
@@ -17,8 +17,10 @@
  *
  */
 
+import is from '@sindresorhus/is';
 import logdown from 'logdown';
 import RWS, {CloseEvent, ErrorEvent, Event, Options} from 'reconnecting-websocket';
+import {Maybe} from 'true-myth';
 
 import {LogFactory, TimeUtil} from '@wireapp/commons';
 
@@ -45,6 +47,13 @@ export enum PingMessage {
   PONG = 'pong',
 }
 
+export type LongRunningRetryDetails = {
+  readonly retryCount: number;
+  readonly retryDurationInMilliseconds: number;
+};
+
+const longRunningRetryThresholdInMilliseconds = TimeUtil.TimeInMillis.MINUTE;
+
 export class ReconnectingWebsocket {
   private static readonly RECONNECTING_OPTIONS: Options = {
     WebSocket: WebSocketNode,
@@ -65,6 +74,7 @@ export class ReconnectingWebsocket {
   private onMessage?: (data: string) => void;
   private onError?: (error: ErrorEvent) => void;
   private onClose?: (event: CloseEvent) => void;
+  private onLongRunningRetry?: (retryDetails: LongRunningRetryDetails) => void;
   /**
    * Cleanup function returned by onBackFromSleep to stop the sleep detection interval.
    * This prevents memory leaks by ensuring the interval is cleared when the WebSocket is disconnected.
@@ -74,6 +84,10 @@ export class ReconnectingWebsocket {
   private isPingingEnabled = true;
   private readonly pendingHealthChecks = new Set<(isHealthy: boolean) => void>();
   private lastMessageTimestamp = 0;
+  private reconnectAttemptCount = 0;
+  private reconnectSequenceRetryCount = 0;
+  private reconnectSequenceStartTimestamp: Maybe<number> = Maybe.nothing<number>();
+  private hasReportedLongRunningRetry = false;
 
   constructor(
     private readonly onReconnect: () => Promise<string>,
@@ -136,6 +150,7 @@ export class ReconnectingWebsocket {
 
   private readonly internalOnOpen = (event: Event) => {
     this.logger.debug('WebSocket opened');
+    this.resetLongRunningRetrySequence();
     if (this.socket) {
       this.socket.binaryType = 'arraybuffer';
     }
@@ -146,6 +161,7 @@ export class ReconnectingWebsocket {
 
   private readonly internalOnReconnect = async (): Promise<string> => {
     this.logger.debug('Connecting to WebSocket');
+    this.recordReconnectAttempt(Date.now());
     // The ping is needed to keep the connection alive as long as possible.
     // Otherwise the connection would be closed after 1 min of inactivity and re-established.
     if (this.isPingingEnabled) {
@@ -194,6 +210,7 @@ export class ReconnectingWebsocket {
   };
 
   public connect(): void {
+    this.resetLongRunningRetrySequence();
     this.socket = this.getReconnectingWebsocket();
     this.socket.onmessage = this.internalOnMessage;
     this.socket.onerror = this.internalOnError;
@@ -258,6 +275,7 @@ export class ReconnectingWebsocket {
   }
 
   public disconnect(reason = 'Closed by client'): void {
+    this.resetLongRunningRetrySequence();
     if (this.socket) {
       this.logger.info(`Disconnecting from WebSocket (reason: "${reason}")`);
       this.socket.close(CloseEventCode.NORMAL_CLOSURE, reason);
@@ -305,8 +323,58 @@ export class ReconnectingWebsocket {
     this.onClose = onClose;
   }
 
+  public setOnLongRunningRetry(onLongRunningRetry: (retryDetails: LongRunningRetryDetails) => void): void {
+    this.onLongRunningRetry = onLongRunningRetry;
+  }
+
   public disablePinging(): void {
     this.isPingingEnabled = false;
     this.stopPinging();
+  }
+
+  private recordReconnectAttempt(nowInMilliseconds: number): void {
+    this.reconnectAttemptCount += 1;
+
+    if (this.reconnectAttemptCount === 1) {
+      return;
+    }
+
+    if (this.reconnectSequenceStartTimestamp.isNothing) {
+      this.reconnectSequenceStartTimestamp = Maybe.just(nowInMilliseconds);
+    }
+
+    this.reconnectSequenceRetryCount += 1;
+    this.reportLongRunningRetryIfNeeded(nowInMilliseconds);
+  }
+
+  private reportLongRunningRetryIfNeeded(nowInMilliseconds: number): void {
+    if (this.hasReportedLongRunningRetry) {
+      return;
+    }
+
+    const reconnectSequenceStartTimestamp = this.reconnectSequenceStartTimestamp.unwrapOr(undefined);
+
+    if (!is.number(reconnectSequenceStartTimestamp)) {
+      return;
+    }
+
+    const retryDurationInMilliseconds = nowInMilliseconds - reconnectSequenceStartTimestamp;
+
+    if (retryDurationInMilliseconds < longRunningRetryThresholdInMilliseconds) {
+      return;
+    }
+
+    this.hasReportedLongRunningRetry = true;
+    this.onLongRunningRetry?.({
+      retryCount: this.reconnectSequenceRetryCount,
+      retryDurationInMilliseconds,
+    });
+  }
+
+  private resetLongRunningRetrySequence(): void {
+    this.hasReportedLongRunningRetry = false;
+    this.reconnectAttemptCount = 0;
+    this.reconnectSequenceRetryCount = 0;
+    this.reconnectSequenceStartTimestamp = Maybe.nothing<number>();
   }
 }

--- a/libraries/api-client/src/tcp/webSocketClient.test.ts
+++ b/libraries/api-client/src/tcp/webSocketClient.test.ts
@@ -223,5 +223,47 @@ describe('WebSocketClient', () => {
         websocketClient.unlock();
       });
     });
+
+    it('emits a long-running retry event once reconnect retries reach one minute', async () => {
+      const websocketClient = new WebSocketClient('ws://url', fakeHttpClient);
+      webSocketClients.push(websocketClient);
+      const retryDetailsListener = jest.fn();
+      const socket = websocketClient['socket'];
+
+      websocketClient.useVersion(MINIMUM_API_VERSION);
+      websocketClient.on(WebSocketClient.TOPIC.ON_LONG_RUNNING_RETRY, retryDetailsListener);
+      jest.spyOn(socket as any, 'getReconnectingWebsocket').mockReturnValue(fakeSocket);
+      jest.spyOn(Date, 'now').mockReturnValueOnce(0).mockReturnValueOnce(1000).mockReturnValueOnce(61000);
+
+      websocketClient.connect();
+      await socket['internalOnReconnect']();
+      await socket['internalOnReconnect']();
+      await socket['internalOnReconnect']();
+
+      expect(retryDetailsListener).toHaveBeenCalledTimes(1);
+      expect(retryDetailsListener).toHaveBeenCalledWith({
+        retryCount: 2,
+        retryDurationInMilliseconds: 60000,
+      });
+    });
+
+    it('does not emit a long-running retry event before reconnect retries reach one minute', async () => {
+      const websocketClient = new WebSocketClient('ws://url', fakeHttpClient);
+      webSocketClients.push(websocketClient);
+      const retryDetailsListener = jest.fn();
+      const socket = websocketClient['socket'];
+
+      websocketClient.useVersion(MINIMUM_API_VERSION);
+      websocketClient.on(WebSocketClient.TOPIC.ON_LONG_RUNNING_RETRY, retryDetailsListener);
+      jest.spyOn(socket as any, 'getReconnectingWebsocket').mockReturnValue(fakeSocket);
+      jest.spyOn(Date, 'now').mockReturnValueOnce(0).mockReturnValueOnce(1000).mockReturnValueOnce(60000);
+
+      websocketClient.connect();
+      await socket['internalOnReconnect']();
+      await socket['internalOnReconnect']();
+      await socket['internalOnReconnect']();
+
+      expect(retryDetailsListener).not.toHaveBeenCalled();
+    });
   });
 });

--- a/libraries/api-client/src/tcp/webSocketClient.ts
+++ b/libraries/api-client/src/tcp/webSocketClient.ts
@@ -25,7 +25,7 @@ import {EventEmitter} from 'events';
 import {LogFactory} from '@wireapp/commons';
 
 import {AcknowledgeType} from './acknowledgeEvent.types';
-import {ReconnectingWebsocket, WEBSOCKET_STATE} from './reconnectingWebsocket';
+import {LongRunningRetryDetails, ReconnectingWebsocket, WEBSOCKET_STATE} from './reconnectingWebsocket';
 
 import {InvalidTokenError, MissingCookieAndTokenError, MissingCookieError} from '../auth/';
 import {MINIMUM_API_VERSION} from '../config';
@@ -41,6 +41,7 @@ import {
 enum TOPIC {
   ON_ERROR = 'WebSocketClient.TOPIC.ON_ERROR',
   ON_INVALID_TOKEN = 'WebSocketClient.TOPIC.ON_INVALID_TOKEN',
+  ON_LONG_RUNNING_RETRY = 'WebSocketClient.TOPIC.ON_LONG_RUNNING_RETRY',
   ON_MESSAGE = 'WebSocketClient.TOPIC.ON_MESSAGE',
   ON_STATE_CHANGE = 'WebSocketClient.TOPIC.ON_STATE_CHANGE',
 }
@@ -48,6 +49,7 @@ enum TOPIC {
 export interface WebSocketClient {
   on(event: TOPIC.ON_ERROR, listener: (error: Error | ErrorEvent) => void): this;
   on(event: TOPIC.ON_INVALID_TOKEN, listener: (error: InvalidTokenError | MissingCookieError) => void): this;
+  on(event: TOPIC.ON_LONG_RUNNING_RETRY, listener: (retryDetails: LongRunningRetryDetails) => void): this;
   on(event: TOPIC.ON_MESSAGE, listener: (notification: Notification | ConsumableNotification) => void): this;
   on(event: TOPIC.ON_STATE_CHANGE, listener: (state: WEBSOCKET_STATE) => void): this;
 }
@@ -139,6 +141,10 @@ export class WebSocketClient extends EventEmitter {
     this.onStateChange(this.socket.getState());
   };
 
+  private readonly onLongRunningRetry = (retryDetails: LongRunningRetryDetails) => {
+    this.emit(WebSocketClient.TOPIC.ON_LONG_RUNNING_RETRY, retryDetails);
+  };
+
   /**
    * Attaches all listeners to the websocket and establishes the connection.
    *
@@ -157,6 +163,7 @@ export class WebSocketClient extends EventEmitter {
     this.onStateChange(WEBSOCKET_STATE.CONNECTING);
     this.socket.setOnMessage(this.onMessage);
     this.socket.setOnError(this.onError);
+    this.socket.setOnLongRunningRetry(this.onLongRunningRetry);
     this.socket.setOnOpen(() => {
       this.onOpen();
       if (onConnect) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24059" title="WPB-24059" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24059</a>  [Web] Log retried incremental backoffs to Countly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

-

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
