### PR TITLE
fix: asset cryptography browser mapping regression [WPB-22420]

### DIFF
--- a/libraries/core/package.json
+++ b/libraries/core/package.json
@@ -22,7 +22,7 @@
     }
   },
   "browser": {
-    "./lib/cryptography/AssetCryptography/crypto.node": "./lib/cryptography/AssetCryptography/crypto.browser.js"
+    "./lib/cryptography/assetCryptography/crypto.node": "./lib/cryptography/assetCryptography/crypto.browser.js"
   },
   "dependencies": {
     "@wireapp/api-client": "27.96.0",

--- a/libraries/core/src/cryptography/assetCryptography/assetCryptography.test.ts
+++ b/libraries/core/src/cryptography/assetCryptography/assetCryptography.test.ts
@@ -18,6 +18,7 @@
  */
 
 import {decryptAsset, encryptAsset} from './assetCryptography';
+import {crypto as browserCrypto} from './crypto.browser';
 
 describe('AssetCrypto', () => {
   it('should encrypt and decrypt ArrayBuffer', async () => {
@@ -46,5 +47,22 @@ describe('AssetCrypto', () => {
 
     const {cipherText, keyBytes} = await encryptAsset({plainText: bytes});
     await expect(decryptAsset({cipherText, keyBytes, sha256: new Uint8Array([])})).rejects.toThrow();
+  });
+
+  it('should expose the lower-case browser mapping for asset cryptography', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const packageJson = require('../../../package.json');
+
+    expect(packageJson.browser['./lib/cryptography/assetCryptography/crypto.node']).toBe(
+      './lib/cryptography/assetCryptography/crypto.browser.js',
+    );
+    expect(packageJson.browser['./lib/cryptography/AssetCryptography/crypto.node']).toBeUndefined();
+  });
+
+  it('should use the browser crypto implementation through globalThis', async () => {
+    const digest = await browserCrypto.digest(new Uint8Array([1, 2, 3]));
+
+    expect(digest).toBeInstanceOf(Uint8Array);
+    expect(digest.byteLength).toBe(32);
   });
 });

--- a/libraries/core/src/cryptography/assetCryptography/crypto.browser.ts
+++ b/libraries/core/src/cryptography/assetCryptography/crypto.browser.ts
@@ -21,20 +21,31 @@ import {Crypto} from './interfaces';
 
 import {toBufferSource} from '../../util/bufferUtils';
 
-const cryptoLib = window.crypto;
+function getBrowserCrypto(): globalThis.Crypto {
+  const browserCrypto = globalThis.crypto;
+
+  if (!browserCrypto?.subtle) {
+    throw new Error('Web Crypto API is unavailable');
+  }
+
+  return browserCrypto;
+}
 
 export const crypto: Crypto = {
   async digest(cipherText: Uint8Array): Promise<Uint8Array> {
-    const checksum = await cryptoLib.subtle.digest('SHA-256', toBufferSource(cipherText));
+    const browserCrypto = getBrowserCrypto();
+    const checksum = await browserCrypto.subtle.digest('SHA-256', toBufferSource(cipherText));
+
     return new Uint8Array(checksum);
   },
 
   async decrypt(cipherText: Uint8Array, keyBytes: Uint8Array): Promise<Uint8Array> {
-    const key = await cryptoLib.subtle.importKey('raw', toBufferSource(keyBytes), 'AES-CBC', false, ['decrypt']);
+    const browserCrypto = getBrowserCrypto();
+    const key = await browserCrypto.subtle.importKey('raw', toBufferSource(keyBytes), 'AES-CBC', false, ['decrypt']);
 
     const initializationVector = cipherText.slice(0, 16);
     const assetCipherText = cipherText.slice(16);
-    const decipher = await cryptoLib.subtle.decrypt(
+    const decipher = await browserCrypto.subtle.decrypt(
       {iv: toBufferSource(initializationVector), name: 'AES-CBC'},
       key,
       toBufferSource(assetCipherText),
@@ -44,7 +55,9 @@ export const crypto: Crypto = {
   },
 
   getRandomValues(size: number): Uint8Array {
-    return cryptoLib.getRandomValues(new Uint8Array(size));
+    const browserCrypto = getBrowserCrypto();
+
+    return browserCrypto.getRandomValues(new Uint8Array(size));
   },
 
   async encrypt(
@@ -52,10 +65,12 @@ export const crypto: Crypto = {
     keyBytes: Uint8Array,
     initializationVector: Uint8Array,
   ): Promise<{key: Uint8Array; cipher: Uint8Array | ArrayBuffer}> {
-    const key = await cryptoLib.subtle.importKey('raw', toBufferSource(keyBytes), 'AES-CBC', true, ['encrypt']);
+    const browserCrypto = getBrowserCrypto();
+    const key = await browserCrypto.subtle.importKey('raw', toBufferSource(keyBytes), 'AES-CBC', true, ['encrypt']);
+
     return {
-      key: new Uint8Array(await cryptoLib.subtle.exportKey('raw', key)),
-      cipher: await cryptoLib.subtle.encrypt(
+      key: new Uint8Array(await browserCrypto.subtle.exportKey('raw', key)),
+      cipher: await browserCrypto.subtle.encrypt(
         {iv: toBufferSource(initializationVector), name: 'AES-CBC'},
         key,
         toBufferSource(plainText),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Restore browser asset decryption after the filename rollout by fixing the package browser override and adding regression coverage for the browser crypto path

<img width="877" height="98" alt="Screenshot 2026-03-30 at 14 37 27" src="https://github.com/user-attachments/assets/3779c4c7-94b2-4760-be6a-3544125d3590" />

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
