### PR TITLE
feat: report WebSocket long-running retries to Countly [WPB-24059]

### DIFF
--- a/apps/webapp/src/script/repositories/tracking/EventTrackingRepository.ts
+++ b/apps/webapp/src/script/repositories/tracking/EventTrackingRepository.ts
@@ -18,6 +18,7 @@
  */
 
 import {HttpClient, LongRunningRetryDetails} from '@wireapp/api-client/lib/http';
+import {WebSocketClient} from '@wireapp/api-client/lib/tcp';
 import {amplify} from 'amplify';
 import {container} from 'tsyringe';
 
@@ -57,6 +58,17 @@ type HttpRetryReportingClient = {
   ) => unknown;
   readonly removeListener: (
     event: typeof HttpClient.TOPIC.ON_LONG_RUNNING_RETRY,
+    listener: (retryDetails: LongRunningRetryDetails) => void,
+  ) => unknown;
+};
+
+type WebSocketRetryReportingClient = {
+  readonly on: (
+    event: typeof WebSocketClient.TOPIC.ON_LONG_RUNNING_RETRY,
+    listener: (retryDetails: LongRunningRetryDetails) => void,
+  ) => unknown;
+  readonly removeListener: (
+    event: typeof WebSocketClient.TOPIC.ON_LONG_RUNNING_RETRY,
     listener: (retryDetails: LongRunningRetryDetails) => void,
   ) => unknown;
 };
@@ -327,20 +339,30 @@ export class EventTrackingRepository {
 
     if (this.isCountlyIncrementalBackoffRetryReportingEnabled) {
       const httpRetryReportingClient = this.apiClient.transport.http as unknown as HttpRetryReportingClient;
+      const webSocketRetryReportingClient = this.apiClient.transport.ws as unknown as WebSocketRetryReportingClient;
 
       httpRetryReportingClient.on(HttpClient.TOPIC.ON_LONG_RUNNING_RETRY, this.onLongRunningRetry);
+      webSocketRetryReportingClient.on(WebSocketClient.TOPIC.ON_LONG_RUNNING_RETRY, this.onLongRunningWebSocketRetry);
     }
 
     amplify.subscribe(WebAppEvents.LIFECYCLE.SIGNED_OUT, this.stopProductReportingSession);
   }
 
   private readonly onLongRunningRetry = (retryDetails: LongRunningRetryDetails): void => {
+    this.trackLongRunningRetry('api', retryDetails);
+  };
+
+  private readonly onLongRunningWebSocketRetry = (retryDetails: LongRunningRetryDetails): void => {
+    this.trackLongRunningRetry('websocket', retryDetails);
+  };
+
+  private trackLongRunningRetry(transport: 'api' | 'websocket', retryDetails: LongRunningRetryDetails): void {
     this.trackProductReportingEvent(EventName.CONNECTIVITY.RETRYING_FOR_ONE_MINUTE, {
       [Segmentation.CONNECTIVITY.RETRY_COUNT]: retryDetails.retryCount,
       [Segmentation.CONNECTIVITY.RETRY_DURATION_IN_MILLISECONDS]: retryDetails.retryDurationInMilliseconds,
-      [Segmentation.CONNECTIVITY.TRANSPORT]: 'api',
+      [Segmentation.CONNECTIVITY.TRANSPORT]: transport,
     });
-  };
+  }
 
   private startProductReportingSession(): void {
     if (!telemetry.isLoaded()) {
@@ -417,8 +439,13 @@ export class EventTrackingRepository {
 
     if (this.isCountlyIncrementalBackoffRetryReportingEnabled) {
       const httpRetryReportingClient = this.apiClient.transport.http as unknown as HttpRetryReportingClient;
+      const webSocketRetryReportingClient = this.apiClient.transport.ws as unknown as WebSocketRetryReportingClient;
 
       httpRetryReportingClient.removeListener(HttpClient.TOPIC.ON_LONG_RUNNING_RETRY, this.onLongRunningRetry);
+      webSocketRetryReportingClient.removeListener(
+        WebSocketClient.TOPIC.ON_LONG_RUNNING_RETRY,
+        this.onLongRunningWebSocketRetry,
+      );
     }
 
     amplify.unsubscribeAll(WebAppEvents.ANALYTICS.EVENT);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24059" title="WPB-24059" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24059</a>  [Web] Log retried incremental backoffs to Countly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Subscribe to the WebSocket long-running retry transport event in the tracking layer and report it to Countly.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
