### PR TITLE
test(WPB-24471): add missing test cases for in conversation search

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
@@ -68,6 +68,65 @@ test.describe('In Conversation Search', () => {
   );
 
   test(
+    "Verify ephemeral messages aren't shown in collection after timeout",
+    {tag: ['@TC-354', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
+      ]);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
+
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversation().enableSelfDeletingMessages();
+      await userBPages.conversation().sendMessage('Gone in 10s');
+
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await expect(userAPages.conversation().getMessage({sender: userB})).toBeVisible();
+      await userAPage.waitForTimeout(10_000);
+
+
+      await userAPages.conversation().searchButton.click();
+
+      const collection = userAPages.collection();
+      await collection.searchBar.fill('Gone in 10s');
+
+      await expect(collection.searchResults).toHaveCount(0);
+    },
+  );
+
+  test(
+    'Verify ephemeral messages show in collection before timeout',
+    {tag: ['@TC-355', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
+      ]);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
+
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversation().enableSelfDeletingMessages();
+      await userBPages.conversation().sendMessage('Gone in 10s');
+
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await expect(userAPages.conversation().getMessage({sender: userB})).toBeVisible();
+
+      await userAPages.conversation().searchButton.click();
+
+      const collection = userAPages.collection();
+      await collection.searchBar.fill('Gone in 10s');
+
+      await expect(collection.searchResults).toHaveCount(1);
+      await expect(collection.searchResults).toContainText('Gone in 10s');
+    },
+  );
+
+  test(
     'Verify opening overview of all pictures from sender and receiver in group',
     {tag: ['@TC-356', '@regression']},
     async ({createPage}) => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24471" title="WPB-24471" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24471</a>  [Web][QA] Implement missing tests for In conversation search
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary

- add two new test cases to the in conversation search test suite
- TC-354: Verify ephemeral messages aren't shown in collection after timeout
- TC-355: Verify ephemeral messages show in collection before timeout


---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

