### PR TITLE
chore(Playwright): Optimize the size of playwright reports [WPB-24280]

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -26,6 +26,10 @@ on:
       testinyRunName:
         type: string
         description: Define Testiny Run name to upload results to
+      keep_traces:
+        description: 'Attach traces to HTML report'
+        type: boolean
+        default: false
   # Options for calling the workflow within an other workflow
   workflow_call:
     inputs:
@@ -38,6 +42,10 @@ on:
       grep:
         type: string
         description: Define which tests to run, the given value will be passed to the `--grep` flag of playwright
+      keep_traces:
+        type: boolean
+        description: 'Keep Playwright traces'
+        default: false
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN:
         required: true
@@ -141,6 +149,17 @@ jobs:
           else
             echo "Trace data directory not found"
           fi  
+
+      - name: Delete trace artifacts
+        if: ${{ !inputs.keep_traces }}
+        working-directory: apps/webapp
+        run: |
+          if [ -d "playwright-report/html/data" ]; then
+            DELETED_COUNT=$(find playwright-report/html/data -name "*.zip" -type f -delete -print)
+            echo "Deleted $DELETED_COUNT trace archive files"
+          else
+            echo "Trace data directory not found, skipping trace cleanup"
+          fi
 
       - name: Delete blob report artifacts
         if: always()

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -136,6 +136,12 @@ jobs:
           yarn playwright merge-reports --config ./playwright.config.ts playwright-report/blob-reports
           rm -rf playwright-report/blob-reports
 
+      - name: Delete blob report artifacts
+        if: always()
+        uses: geekyeggo/delete-artifact@751caa63d0e09850ee55dcd2f0561e00476fbfa0
+        with:
+          name: blob-report-*
+
       - name: Upload test report
         id: upload_playwright_report
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -135,7 +135,12 @@ jobs:
         run: |
           yarn playwright merge-reports --config ./playwright.config.ts playwright-report/blob-reports
           rm -rf playwright-report/blob-reports
-          rm -f playwright-report/html/data/*.zip
+          if [ -d "playwright-report/html/data" ]; then
+            DELETED_COUNT=$(find playwright-report/html/data -name "*.zip" -type f -delete -print)
+            echo "Cleaned up $DELETED_COUNT trace archive files"
+          else
+            echo "Trace data directory not found"
+          fi  
 
       - name: Delete blob report artifacts
         if: always()

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -143,12 +143,6 @@ jobs:
         run: |
           yarn playwright merge-reports --config ./playwright.config.ts playwright-report/blob-reports
           rm -rf playwright-report/blob-reports
-          if [ -d "playwright-report/html/data" ]; then
-            DELETED_COUNT=$(find playwright-report/html/data -name "*.zip" -type f -delete -print)
-            echo "Cleaned up $DELETED_COUNT trace archive files"
-          else
-            echo "Trace data directory not found"
-          fi  
 
       - name: Delete trace artifacts
         if: ${{ !inputs.keep_traces }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -134,7 +134,7 @@ jobs:
         working-directory: apps/webapp
         run: |
           yarn playwright merge-reports --config ./playwright.config.ts playwright-report/blob-reports
-          rm -rf playwright-report/blob-reports/report*
+          rm -rf playwright-report/blob-reports
 
       - name: Upload test report
         id: upload_playwright_report

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -129,12 +129,13 @@ jobs:
           pattern: blob-report-*
           merge-multiple: true
 
-      # Merge reports and delete blob reports, only keep resources to include within the artifact
+      # Merge reports and delete blob reports and zip archives for traces, only keep resources to include within the artifact
       - name: Merge playwright reports
         working-directory: apps/webapp
         run: |
           yarn playwright merge-reports --config ./playwright.config.ts playwright-report/blob-reports
           rm -rf playwright-report/blob-reports
+          rm -f playwright-report/html/data/*.zip
 
       - name: Delete blob report artifacts
         if: always()

--- a/apps/webapp/playwright.config.ts
+++ b/apps/webapp/playwright.config.ts
@@ -17,11 +17,11 @@
  *
  */
 
-import {defineConfig, devices} from '@playwright/test';
-import {config} from 'dotenv';
-import {resolve} from 'node:path';
+import { defineConfig, devices } from '@playwright/test';
+import { config } from 'dotenv';
+import { resolve } from 'node:path';
 
-config({path: resolve(__dirname, './test/e2e_tests/.env'), quiet: true});
+config({ path: resolve(__dirname, './test/e2e_tests/.env'), quiet: true });
 
 const numberOfRetriesOnCI = 1;
 const numberOfParallelWorkersOnCI = 3;
@@ -43,14 +43,19 @@ module.exports = defineConfig({
   workers: process.env.CI ? numberOfParallelWorkersOnCI : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
-    ['html', {outputFolder: 'playwright-report/html', open: 'never'}],
-    ['json', {outputFile: 'playwright-report/report.json'}],
+    ['html', { outputFolder: 'playwright-report/html', open: 'never' }],
+    ['json', { outputFile: 'playwright-report/report.json' }],
     ['line'],
   ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    trace: {
+      mode: 'on-first-retry',
+      snapshots: false,
+      sources: false,
+      attachments: true,
+    },
     screenshot: 'only-on-failure',
     permissions: ['camera', 'microphone'],
     actionTimeout: 20_000, // 20 seconds

--- a/apps/webapp/playwright.config.ts
+++ b/apps/webapp/playwright.config.ts
@@ -54,7 +54,7 @@ module.exports = defineConfig({
       mode: 'on-first-retry',
       snapshots: false,
       sources: false,
-      attachments: true,
+      attachments: false,
     },
     screenshot: 'only-on-failure',
     permissions: ['camera', 'microphone'],

--- a/apps/webapp/playwright.config.ts
+++ b/apps/webapp/playwright.config.ts
@@ -17,11 +17,11 @@
  *
  */
 
-import { defineConfig, devices } from '@playwright/test';
-import { config } from 'dotenv';
-import { resolve } from 'node:path';
+import {defineConfig, devices} from '@playwright/test';
+import {config} from 'dotenv';
+import {resolve} from 'node:path';
 
-config({ path: resolve(__dirname, './test/e2e_tests/.env'), quiet: true });
+config({path: resolve(__dirname, './test/e2e_tests/.env'), quiet: true});
 
 const numberOfRetriesOnCI = 1;
 const numberOfParallelWorkersOnCI = 3;
@@ -43,8 +43,8 @@ module.exports = defineConfig({
   workers: process.env.CI ? numberOfParallelWorkersOnCI : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
-    ['html', { outputFolder: 'playwright-report/html', open: 'never' }],
-    ['json', { outputFile: 'playwright-report/report.json' }],
+    ['html', {outputFolder: 'playwright-report/html', open: 'never'}],
+    ['json', {outputFile: 'playwright-report/report.json'}],
     ['line'],
   ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION


<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24280" title="WPB-24280" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24280</a>  [Web][QA] Optimize the size of Playwright reports
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Summary

https://wearezeta.atlassian.net/browse/WPB-24280

- Added removing of blob reports after they are merged.
- Added removing trace .zip archives for every failure
- Modified trace settings to exclude snapshots from it.

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs: Removing snapshots in traces
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
