### PR TITLE
feat: create collabora file integration(WPB-22465)

### DIFF
--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsNewMenu/CellsNewFileModal/CellsNewFileModal.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsNewMenu/CellsNewFileModal/CellsNewFileModal.tsx
@@ -22,6 +22,7 @@ import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {CellsNewNodeForm} from 'Components/Conversation/ConversationCells/common/CellsNewNodeForm/CellsNewNodeForm';
 import {
   CellsFileType,
+  getFileExtensionByType,
   useCellsNewFileForm,
 } from 'Components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm';
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
@@ -57,10 +58,12 @@ export const CellsNewFileModal = ({
     onSuccess,
     currentPath,
   });
+  const fileExtension = getFileExtensionByType(fileType);
+  const headline = `${t('cells.newItemMenuModal.headlineFile', {fileType})} (.${fileExtension})`;
 
   return (
     <CellsModal isOpen={isOpen} onClose={onClose} size="large">
-      <CellsModal.Header>{t('cells.newItemMenuModal.headlineFile', {fileType})}</CellsModal.Header>
+      <CellsModal.Header>{headline}</CellsModal.Header>
       <p css={descriptionStyles}>{t('cells.newItemMenuModal.descriptionFile')}</p>
       <CellsNewNodeForm
         label={t('cells.newItemMenuModal.labelFile')}

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsNewMenu/CellsNewFileModal/CellsNewFileModal.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsNewMenu/CellsNewFileModal/CellsNewFileModal.tsx
@@ -51,12 +51,13 @@ export const CellsNewFileModal = ({
   onSuccess,
   currentPath,
 }: CellsNewFileModalProps) => {
-  const {name, error, isSubmitting, handleSubmit, handleChange} = useCellsNewFileForm({
+  const {name, error, isSubmitting, handleSubmit, handleChange, handleClear} = useCellsNewFileForm({
     fileType,
     cellsRepository,
     conversationQualifiedId,
     onSuccess,
     currentPath,
+    isOpen,
   });
   const fileExtension = getFileExtensionByType(fileType);
   const headline = `${t('cells.newItemMenuModal.headlineFile', {fileType})} (.${fileExtension})`;
@@ -71,6 +72,7 @@ export const CellsNewFileModal = ({
         onSubmit={handleSubmit}
         inputValue={name}
         onChange={handleChange}
+        onClear={handleClear}
         error={error}
         isOpen={isOpen}
       />

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsNewMenu/CellsNewFolderModal/CellsNewFolderModal.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsNewMenu/CellsNewFolderModal/CellsNewFolderModal.tsx
@@ -45,11 +45,12 @@ export const CellsNewFolderModal = ({
   onSuccess,
   currentPath,
 }: CellsNewFolderModalProps) => {
-  const {name, error, isSubmitting, handleSubmit, handleChange} = useCellsNewFolderForm({
+  const {name, error, isSubmitting, handleSubmit, handleChange, handleClear} = useCellsNewFolderForm({
     cellsRepository,
     conversationQualifiedId,
     onSuccess,
     currentPath,
+    isOpen,
   });
 
   return (
@@ -62,6 +63,7 @@ export const CellsNewFolderModal = ({
         onSubmit={handleSubmit}
         inputValue={name}
         onChange={handleChange}
+        onClear={handleClear}
         error={error}
         isOpen={isOpen}
       />

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableRowOptions/CellsMoveNodeModal/CellsMoveNodeModal.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableRowOptions/CellsMoveNodeModal/CellsMoveNodeModal.tsx
@@ -79,6 +79,7 @@ export const CellsMoveNodeModal = ({
     isSubmitting,
     handleSubmit: handleCreateNewFolder,
     handleChange,
+    handleClear,
   } = useCellsNewFolderForm({
     cellsRepository,
     conversationQualifiedId,
@@ -87,6 +88,7 @@ export const CellsMoveNodeModal = ({
       setActiveModalContent('move');
     },
     currentPath,
+    isOpen,
   });
 
   useEffect(() => {
@@ -134,6 +136,7 @@ export const CellsMoveNodeModal = ({
             onSubmit={handleCreateNewFolder}
             inputValue={name}
             onChange={handleChange}
+            onClear={handleClear}
             error={error}
             isOpen={isOpen}
           />

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsNewNodeForm/CellsNewNodeForm.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsNewNodeForm/CellsNewNodeForm.tsx
@@ -19,7 +19,7 @@
 
 import {ChangeEvent, FormEvent} from 'react';
 
-import {ErrorMessage, Input, Label} from '@wireapp/react-ui-kit';
+import {TextInput} from 'Components/TextInput';
 
 import {inputWrapperStyles} from './CellsNewNodeForm.styles';
 
@@ -31,6 +31,7 @@ interface CellsNewNodeFormProps {
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   inputValue: string;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onClear: () => void;
   error: string | null;
   isOpen: boolean;
 }
@@ -41,6 +42,7 @@ export const CellsNewNodeForm = ({
   onSubmit,
   inputValue,
   onChange,
+  onClear,
   error,
   isOpen,
 }: CellsNewNodeFormProps) => {
@@ -49,14 +51,18 @@ export const CellsNewNodeForm = ({
   return (
     <form onSubmit={onSubmit}>
       <div css={inputWrapperStyles}>
-        <Label htmlFor="cells-new-item-name">{label}</Label>
-        <Input
-          id="cells-new-item-name"
+        <TextInput
+          label={label}
+          name="cells-new-item-name"
           value={inputValue}
           ref={inputRef}
           placeholder={placeholder}
           onChange={onChange}
-          error={error ? <ErrorMessage>{error}</ErrorMessage> : undefined}
+          onCancel={onClear}
+          isError={Boolean(error)}
+          errorMessage={error ?? undefined}
+          uieName="cells-new-item-name"
+          errorUieName="cells-new-item-name-error"
         />
       </div>
     </form>

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/cellsNodeFormUtils.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/cellsNodeFormUtils.test.ts
@@ -17,40 +17,38 @@
  *
  */
 
-import {getClientSideNodeNameError, getErrorStatus, isClientSideNodeNameError, NODE_NAME_MAX_LENGTH} from './cellsNodeFormUtils';
+import {t} from 'Util/localizerUtil';
 
-jest.mock('Util/localizerUtil', () => ({
-  t: (key: string) => key,
-}));
+import {getClientSideNodeNameError, getErrorStatus, isClientSideNodeNameError, NODE_NAME_MAX_LENGTH} from './cellsNodeFormUtils';
 
 describe('cellsNodeFormUtils', () => {
   describe('getClientSideNodeNameError', () => {
     it('returns required error for empty name', () => {
-      expect(getClientSideNodeNameError('').unwrapOr(null)).toBe('cells.newItemMenuModalForm.nameRequired');
+      expect(getClientSideNodeNameError('').unwrapOr(null)).toBe(t('cells.newItemMenuModalForm.nameRequired'));
     });
 
     it('returns max length error for names longer than the maximum', () => {
       expect(getClientSideNodeNameError('a'.repeat(NODE_NAME_MAX_LENGTH + 1)).unwrapOr(null)).toBe(
-        'cells.newItemMenuModalForm.maxLengthError',
+        t('cells.newItemMenuModalForm.maxLengthError'),
       );
     });
 
     it('returns max length error before invalid character error', () => {
       const tooLongNameWithInvalidCharacter = `${'a'.repeat(NODE_NAME_MAX_LENGTH)}/`;
       expect(getClientSideNodeNameError(tooLongNameWithInvalidCharacter).unwrapOr(null)).toBe(
-        'cells.newItemMenuModalForm.maxLengthError',
+        t('cells.newItemMenuModalForm.maxLengthError'),
       );
     });
 
     it('returns invalid character error for names starting with "."', () => {
-      expect(getClientSideNodeNameError('.hidden').unwrapOr(null)).toBe('cells.newItemMenuModalForm.invalidCharactersError');
-      expect(getClientSideNodeNameError('.').unwrapOr(null)).toBe('cells.newItemMenuModalForm.invalidCharactersError');
+      expect(getClientSideNodeNameError('.hidden').unwrapOr(null)).toBe(t('cells.newItemMenuModalForm.invalidCharactersError'));
+      expect(getClientSideNodeNameError('.').unwrapOr(null)).toBe(t('cells.newItemMenuModalForm.invalidCharactersError'));
     });
 
     it('returns invalid character error for forbidden characters', () => {
-      expect(getClientSideNodeNameError('report/name').unwrapOr(null)).toBe('cells.newItemMenuModalForm.invalidCharactersError');
-      expect(getClientSideNodeNameError('report\\name').unwrapOr(null)).toBe('cells.newItemMenuModalForm.invalidCharactersError');
-      expect(getClientSideNodeNameError('report"name').unwrapOr(null)).toBe('cells.newItemMenuModalForm.invalidCharactersError');
+      expect(getClientSideNodeNameError('report/name').unwrapOr(null)).toBe(t('cells.newItemMenuModalForm.invalidCharactersError'));
+      expect(getClientSideNodeNameError('report\\name').unwrapOr(null)).toBe(t('cells.newItemMenuModalForm.invalidCharactersError'));
+      expect(getClientSideNodeNameError('report"name').unwrapOr(null)).toBe(t('cells.newItemMenuModalForm.invalidCharactersError'));
     });
 
     it('accepts names containing dots when dot is not at the beginning', () => {
@@ -62,14 +60,14 @@ describe('cellsNodeFormUtils', () => {
 
   describe('isClientSideNodeNameError', () => {
     it('returns true for node name validation errors', () => {
-      expect(isClientSideNodeNameError('cells.newItemMenuModalForm.nameRequired').unwrapOr(false)).toBe(true);
-      expect(isClientSideNodeNameError('cells.newItemMenuModalForm.maxLengthError').unwrapOr(false)).toBe(true);
-      expect(isClientSideNodeNameError('cells.newItemMenuModalForm.invalidCharactersError').unwrapOr(false)).toBe(true);
+      expect(isClientSideNodeNameError(t('cells.newItemMenuModalForm.nameRequired')).unwrapOr(false)).toBe(true);
+      expect(isClientSideNodeNameError(t('cells.newItemMenuModalForm.maxLengthError')).unwrapOr(false)).toBe(true);
+      expect(isClientSideNodeNameError(t('cells.newItemMenuModalForm.invalidCharactersError')).unwrapOr(false)).toBe(true);
     });
 
     it('returns false for non-validation errors', () => {
       expect(isClientSideNodeNameError(null).isNothing).toBe(true);
-      expect(isClientSideNodeNameError('cells.newItemMenuModalForm.genericError').unwrapOr(false)).toBe(false);
+      expect(isClientSideNodeNameError(t('cells.newItemMenuModalForm.genericError')).unwrapOr(false)).toBe(false);
     });
   });
 

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/cellsNodeFormUtils.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/cellsNodeFormUtils.ts
@@ -26,6 +26,7 @@ export const ITEM_ALREADY_EXISTS_ERROR = 409;
 export const NODE_NAME_MAX_LENGTH = 64;
 
 const INVALID_NODE_NAME_PATTERN = /[\\/"]/u;
+const LEADING_DOT_PATTERN = /^\./u;
 
 export const getNameValidationError = (name: string): Maybe<string> => {
   if (!name) {
@@ -45,7 +46,7 @@ export const getClientSideNodeNameError = (name: string): Maybe<string> => {
     return Maybe.just(t('cells.newItemMenuModalForm.maxLengthError'));
   }
 
-  if (name.startsWith('.') || INVALID_NODE_NAME_PATTERN.test(name)) {
+  if (LEADING_DOT_PATTERN.test(name) || INVALID_NODE_NAME_PATTERN.test(name)) {
     return Maybe.just(t('cells.newItemMenuModalForm.invalidCharactersError'));
   }
 

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/cellsNodeFormUtils.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/cellsNodeFormUtils.ts
@@ -26,7 +26,6 @@ export const ITEM_ALREADY_EXISTS_ERROR = 409;
 export const NODE_NAME_MAX_LENGTH = 64;
 
 const INVALID_NODE_NAME_PATTERN = /[\\/"]/u;
-const LEADING_DOT_PATTERN = /^\./u;
 
 export const getNameValidationError = (name: string): Maybe<string> => {
   if (!name) {
@@ -46,7 +45,7 @@ export const getClientSideNodeNameError = (name: string): Maybe<string> => {
     return Maybe.just(t('cells.newItemMenuModalForm.maxLengthError'));
   }
 
-  if (LEADING_DOT_PATTERN.test(name) || INVALID_NODE_NAME_PATTERN.test(name)) {
+  if (name.startsWith('.') || INVALID_NODE_NAME_PATTERN.test(name)) {
     return Maybe.just(t('cells.newItemMenuModalForm.invalidCharactersError'));
   }
 

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm.test.ts
@@ -32,6 +32,8 @@ describe('useCellsNewFileForm', () => {
   let mockCellsRepository: jest.Mocked<CellsRepository>;
   let onSuccess: jest.Mock;
 
+  const createEvent = () => ({preventDefault: jest.fn()}) as unknown as FormEvent<HTMLFormElement>;
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockCellsRepository = {
@@ -40,8 +42,8 @@ describe('useCellsNewFileForm', () => {
     onSuccess = jest.fn();
   });
 
-  const setup = () => {
-    const {result} = renderHook(() =>
+  const renderUseCellsNewFileForm = () =>
+    renderHook(() =>
       useCellsNewFileForm({
         fileType: 'document',
         cellsRepository: mockCellsRepository,
@@ -51,16 +53,89 @@ describe('useCellsNewFileForm', () => {
       }),
     );
 
-    return {
-      result,
-      createNodeMock: mockCellsRepository.createFile,
-      onSuccess,
-    };
-  };
+  it('shows an error when name is empty', async () => {
+    const {result} = renderUseCellsNewFileForm();
+
+    await act(async () => {
+      await result.current.handleSubmit(createEvent());
+    });
+
+    expect(result.current.error).toBe('cells.newItemMenuModalForm.nameRequired');
+    expect(mockCellsRepository.createFile).not.toHaveBeenCalled();
+  });
+
+  it('does not submit when name validation fails', async () => {
+    const {result} = renderUseCellsNewFileForm();
+
+    act(() => {
+      result.current.handleChange({currentTarget: {value: 'file/name'}} as ChangeEvent<HTMLInputElement>);
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit(createEvent());
+    });
+
+    expect(result.current.error).toBe('cells.newItemMenuModalForm.invalidCharactersError');
+    expect(mockCellsRepository.createFile).not.toHaveBeenCalled();
+  });
+
+  it('maps 409 responses to already-exists error', async () => {
+    mockCellsRepository.createFile.mockRejectedValueOnce({
+      response: {status: 409},
+    });
+
+    const {result} = renderUseCellsNewFileForm();
+
+    act(() => {
+      result.current.handleChange({currentTarget: {value: 'New file'}} as ChangeEvent<HTMLInputElement>);
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit(createEvent());
+    });
+
+    expect(result.current.error).toBe('cells.newItemMenuModalForm.alreadyExistsError');
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('maps non-409 failures to generic error', async () => {
+    mockCellsRepository.createFile.mockRejectedValueOnce(new Error('network error'));
+
+    const {result} = renderUseCellsNewFileForm();
+
+    act(() => {
+      result.current.handleChange({currentTarget: {value: 'New file'}} as ChangeEvent<HTMLInputElement>);
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit(createEvent());
+    });
+
+    expect(result.current.error).toBe('cells.newItemMenuModalForm.genericError');
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('trims the name and appends extension before create call', async () => {
+    const {result} = renderUseCellsNewFileForm();
+
+    act(() => {
+      result.current.handleChange({currentTarget: {value: ' New file '}} as ChangeEvent<HTMLInputElement>);
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit(createEvent());
+    });
+
+    expect(mockCellsRepository.createFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'New file.docx',
+      }),
+    );
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
 
   it('appends selected file type extension when a mismatched extension is provided', async () => {
-    const {result} = setup();
-    const createEvent = () => ({preventDefault: jest.fn()}) as unknown as FormEvent<HTMLFormElement>;
+    const {result} = renderUseCellsNewFileForm();
 
     act(() => {
       result.current.handleChange({currentTarget: {value: 'doc124.ppt'}} as ChangeEvent<HTMLInputElement>);
@@ -70,8 +145,11 @@ describe('useCellsNewFileForm', () => {
       await result.current.handleSubmit(createEvent());
     });
 
-    expect(mockCellsRepository.createFile).toHaveBeenCalledWith(expect.objectContaining({name: 'doc124.ppt.docx'}));
+    expect(mockCellsRepository.createFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'doc124.ppt.docx',
+      }),
+    );
     expect(onSuccess).toHaveBeenCalledTimes(1);
   });
-
 });

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm.test.ts
@@ -38,6 +38,7 @@ describe('useCellsNewFileForm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockCellsRepository = {
+      checkFileAlreadyExists: jest.fn().mockResolvedValue(false),
       createFile: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<CellsRepository>;
     onSuccess = jest.fn();
@@ -96,6 +97,24 @@ describe('useCellsNewFileForm', () => {
     });
 
     expect(result.current.error).toBe('cells.newItemMenuModalForm.alreadyExistsError');
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('shows already-exists error when precheck reports a duplicate', async () => {
+    mockCellsRepository.checkFileAlreadyExists.mockResolvedValueOnce(true);
+
+    const {result} = renderUseCellsNewFileForm();
+
+    act(() => {
+      result.current.handleChange({currentTarget: {value: 'New file'}} as ChangeEvent<HTMLInputElement>);
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit(createEvent());
+    });
+
+    expect(result.current.error).toBe('cells.newItemMenuModalForm.alreadyExistsError');
+    expect(mockCellsRepository.createFile).not.toHaveBeenCalled();
     expect(onSuccess).not.toHaveBeenCalled();
   });
 

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm.test.ts
@@ -44,15 +44,18 @@ describe('useCellsNewFileForm', () => {
     onSuccess = jest.fn();
   });
 
-  const renderUseCellsNewFileForm = (fileType: CellsFileType = 'document') =>
-    renderHook(() =>
-      useCellsNewFileForm({
-        fileType,
-        cellsRepository: mockCellsRepository,
-        conversationQualifiedId: {id: 'conversation-id', domain: 'wire.com'},
-        onSuccess,
-        currentPath: '/wire-cells-web/path',
-      }),
+  const renderUseCellsNewFileForm = (fileType: CellsFileType = 'document', isOpen = true) =>
+    renderHook(
+      ({isOpen: isModalOpen}) =>
+        useCellsNewFileForm({
+          fileType,
+          cellsRepository: mockCellsRepository,
+          conversationQualifiedId: {id: 'conversation-id', domain: 'wire.com'},
+          onSuccess,
+          currentPath: '/wire-cells-web/path',
+          isOpen: isModalOpen,
+        }),
+      {initialProps: {isOpen}},
     );
 
   it('shows an error when name is empty', async () => {
@@ -193,5 +196,30 @@ describe('useCellsNewFileForm', () => {
       }),
     );
     expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+  it('resets name and error when modal is reopened', async () => {
+    const {result, rerender} = renderUseCellsNewFileForm('document', true);
+
+    act(() => {
+      result.current.handleChange({currentTarget: {value: 'invalid/name'}} as ChangeEvent<HTMLInputElement>);
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit(createEvent());
+    });
+
+    expect(result.current.name).toBe('invalid/name');
+    expect(result.current.error).toBe('cells.newItemMenuModalForm.invalidCharactersError');
+
+    act(() => {
+      rerender({isOpen: false});
+    });
+
+    act(() => {
+      rerender({isOpen: true});
+    });
+
+    expect(result.current.name).toBe('');
+    expect(result.current.error).toBeNull();
   });
 });

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm.test.ts
@@ -21,13 +21,10 @@ import {ChangeEvent, FormEvent} from 'react';
 import {act, renderHook} from '@testing-library/react';
 
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
+import {t} from 'Util/localizerUtil';
 
 import {useCellsNewFileForm} from './useCellsNewFileForm';
 import type {CellsFileType} from './useCellsNewFileForm';
-
-jest.mock('Util/localizerUtil', () => ({
-  t: (key: string) => key,
-}));
 
 describe('useCellsNewFileForm', () => {
   let mockCellsRepository: jest.Mocked<CellsRepository>;
@@ -44,51 +41,19 @@ describe('useCellsNewFileForm', () => {
     onSuccess = jest.fn();
   });
 
-  const renderUseCellsNewFileForm = (fileType: CellsFileType = 'document', isOpen = true) =>
-    renderHook(
-      ({isOpen: isModalOpen}) =>
-        useCellsNewFileForm({
-          fileType,
-          cellsRepository: mockCellsRepository,
-          conversationQualifiedId: {id: 'conversation-id', domain: 'wire.com'},
-          onSuccess,
-          currentPath: '/wire-cells-web/path',
-          isOpen: isModalOpen,
-        }),
-      {initialProps: {isOpen}},
+  const renderUseCellsNewFileForm = (fileType: CellsFileType = 'document') =>
+    renderHook(() =>
+      useCellsNewFileForm({
+        fileType,
+        cellsRepository: mockCellsRepository,
+        conversationQualifiedId: {id: 'conversation-id', domain: 'wire.com'},
+        onSuccess,
+        currentPath: '/wire-cells-web/path',
+        isOpen: true,
+      }),
     );
 
-  it('shows an error when name is empty', async () => {
-    const {result} = renderUseCellsNewFileForm();
-
-    await act(async () => {
-      await result.current.handleSubmit(createEvent());
-    });
-
-    expect(result.current.error).toBe('cells.newItemMenuModalForm.nameRequired');
-    expect(mockCellsRepository.createFile).not.toHaveBeenCalled();
-  });
-
-  it('does not submit when name validation fails', async () => {
-    const {result} = renderUseCellsNewFileForm();
-
-    act(() => {
-      result.current.handleChange({currentTarget: {value: 'file/name'}} as ChangeEvent<HTMLInputElement>);
-    });
-
-    await act(async () => {
-      await result.current.handleSubmit(createEvent());
-    });
-
-    expect(result.current.error).toBe('cells.newItemMenuModalForm.invalidCharactersError');
-    expect(mockCellsRepository.createFile).not.toHaveBeenCalled();
-  });
-
-  it('maps 409 responses to already-exists error', async () => {
-    mockCellsRepository.createFile.mockRejectedValueOnce({
-      response: {status: 409},
-    });
-
+  it('adds extension and template UUID for document files', async () => {
     const {result} = renderUseCellsNewFileForm();
 
     act(() => {
@@ -99,56 +64,11 @@ describe('useCellsNewFileForm', () => {
       await result.current.handleSubmit(createEvent());
     });
 
-    expect(result.current.error).toBe('cells.newItemMenuModalForm.alreadyExistsError');
-    expect(onSuccess).not.toHaveBeenCalled();
-  });
-
-  it('shows already-exists error when precheck reports a duplicate', async () => {
-    mockCellsRepository.checkFileAlreadyExists.mockResolvedValueOnce(true);
-
-    const {result} = renderUseCellsNewFileForm();
-
-    act(() => {
-      result.current.handleChange({currentTarget: {value: 'New file'}} as ChangeEvent<HTMLInputElement>);
-    });
-
-    await act(async () => {
-      await result.current.handleSubmit(createEvent());
-    });
-
-    expect(result.current.error).toBe('cells.newItemMenuModalForm.alreadyExistsError');
-    expect(mockCellsRepository.createFile).not.toHaveBeenCalled();
-    expect(onSuccess).not.toHaveBeenCalled();
-  });
-
-  it('maps non-409 failures to generic error', async () => {
-    mockCellsRepository.createFile.mockRejectedValueOnce(new Error('network error'));
-
-    const {result} = renderUseCellsNewFileForm();
-
-    act(() => {
-      result.current.handleChange({currentTarget: {value: 'New file'}} as ChangeEvent<HTMLInputElement>);
-    });
-
-    await act(async () => {
-      await result.current.handleSubmit(createEvent());
-    });
-
-    expect(result.current.error).toBe('cells.newItemMenuModalForm.genericError');
-    expect(onSuccess).not.toHaveBeenCalled();
-  });
-
-  it('trims the name and appends extension before create call', async () => {
-    const {result} = renderUseCellsNewFileForm();
-
-    act(() => {
-      result.current.handleChange({currentTarget: {value: ' New file '}} as ChangeEvent<HTMLInputElement>);
-    });
-
-    await act(async () => {
-      await result.current.handleSubmit(createEvent());
-    });
-
+    expect(mockCellsRepository.checkFileAlreadyExists).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'New file.docx',
+      }),
+    );
     expect(mockCellsRepository.createFile).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'New file.docx',
@@ -158,27 +78,7 @@ describe('useCellsNewFileForm', () => {
     expect(onSuccess).toHaveBeenCalledTimes(1);
   });
 
-  it('appends selected file type extension when a mismatched extension is provided', async () => {
-    const {result} = renderUseCellsNewFileForm();
-
-    act(() => {
-      result.current.handleChange({currentTarget: {value: 'doc124.ppt'}} as ChangeEvent<HTMLInputElement>);
-    });
-
-    await act(async () => {
-      await result.current.handleSubmit(createEvent());
-    });
-
-    expect(mockCellsRepository.createFile).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'doc124.ppt.docx',
-        templateUuid: '01-Microsoft Word.docx',
-      }),
-    );
-    expect(onSuccess).toHaveBeenCalledTimes(1);
-  });
-
-  it('uses matching template UUID for spreadsheet files', async () => {
+  it('uses matching extension and template UUID for spreadsheet files', async () => {
     const {result} = renderUseCellsNewFileForm('spreadsheet');
 
     act(() => {
@@ -197,29 +97,21 @@ describe('useCellsNewFileForm', () => {
     );
     expect(onSuccess).toHaveBeenCalledTimes(1);
   });
-  it('resets name and error when modal is reopened', async () => {
-    const {result, rerender} = renderUseCellsNewFileForm('document', true);
+
+  it('shows already-exists error when precheck reports a duplicate', async () => {
+    mockCellsRepository.checkFileAlreadyExists.mockResolvedValueOnce(true);
+    const {result} = renderUseCellsNewFileForm();
 
     act(() => {
-      result.current.handleChange({currentTarget: {value: 'invalid/name'}} as ChangeEvent<HTMLInputElement>);
+      result.current.handleChange({currentTarget: {value: 'New file'}} as ChangeEvent<HTMLInputElement>);
     });
 
     await act(async () => {
       await result.current.handleSubmit(createEvent());
     });
 
-    expect(result.current.name).toBe('invalid/name');
-    expect(result.current.error).toBe('cells.newItemMenuModalForm.invalidCharactersError');
-
-    act(() => {
-      rerender({isOpen: false});
-    });
-
-    act(() => {
-      rerender({isOpen: true});
-    });
-
-    expect(result.current.name).toBe('');
-    expect(result.current.error).toBeNull();
+    expect(result.current.error).toBe(t('cells.newItemMenuModalForm.alreadyExistsError'));
+    expect(mockCellsRepository.createFile).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
   });
 });

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm.test.ts
@@ -23,6 +23,7 @@ import {act, renderHook} from '@testing-library/react';
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
 
 import {useCellsNewFileForm} from './useCellsNewFileForm';
+import type {CellsFileType} from './useCellsNewFileForm';
 
 jest.mock('Util/localizerUtil', () => ({
   t: (key: string) => key,
@@ -42,10 +43,10 @@ describe('useCellsNewFileForm', () => {
     onSuccess = jest.fn();
   });
 
-  const renderUseCellsNewFileForm = () =>
+  const renderUseCellsNewFileForm = (fileType: CellsFileType = 'document') =>
     renderHook(() =>
       useCellsNewFileForm({
-        fileType: 'document',
+        fileType,
         cellsRepository: mockCellsRepository,
         conversationQualifiedId: {id: 'conversation-id', domain: 'wire.com'},
         onSuccess,
@@ -129,6 +130,7 @@ describe('useCellsNewFileForm', () => {
     expect(mockCellsRepository.createFile).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'New file.docx',
+        templateUuid: '01-Microsoft Word.docx',
       }),
     );
     expect(onSuccess).toHaveBeenCalledTimes(1);
@@ -148,6 +150,27 @@ describe('useCellsNewFileForm', () => {
     expect(mockCellsRepository.createFile).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'doc124.ppt.docx',
+        templateUuid: '01-Microsoft Word.docx',
+      }),
+    );
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses matching template UUID for spreadsheet files', async () => {
+    const {result} = renderUseCellsNewFileForm('spreadsheet');
+
+    act(() => {
+      result.current.handleChange({currentTarget: {value: 'Budget'}} as ChangeEvent<HTMLInputElement>);
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit(createEvent());
+    });
+
+    expect(mockCellsRepository.createFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Budget.xlsx',
+        templateUuid: '02-Microsoft Excel.xlsx',
       }),
     );
     expect(onSuccess).toHaveBeenCalledTimes(1);

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm.ts
@@ -51,6 +51,10 @@ const createAlreadyExistsError = () => {
   return error;
 };
 
+export const getFileExtensionByType = (fileType: CellsFileType): string => {
+  return FILE_EXTENSION_BY_TYPE[fileType];
+};
+
 interface UseCellsNewFileFormProps {
   fileType: CellsFileType;
   cellsRepository: CellsRepository;
@@ -67,7 +71,7 @@ export const useCellsNewFileForm = ({
   currentPath,
 }: UseCellsNewFileFormProps) => {
   const normalizeNameForCreation = (rawName: string): string => {
-    const extension = FILE_EXTENSION_BY_TYPE[fileType];
+    const extension = getFileExtensionByType(fileType);
     return `${rawName}.${extension}`;
   };
 

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm.ts
@@ -21,6 +21,7 @@ import {QualifiedId} from '@wireapp/api-client/lib/user';
 
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
 
+import {ITEM_ALREADY_EXISTS_ERROR} from './cellsNodeFormUtils';
 import {useCellsNewNodeFormBase} from './useCellsNewNodeFormBase';
 
 import {getCellsApiPath} from '../getCellsApiPath/getCellsApiPath';
@@ -42,6 +43,12 @@ const FILE_TEMPLATE_ID_BY_TYPE: Record<CellsFileType, string> = {
 // TO-DO Replace hard coded values with server values when GET /templates endpoint ready
 const getTemplateUuidByType = (fileType: CellsFileType): string => {
   return FILE_TEMPLATE_ID_BY_TYPE[fileType];
+};
+
+const createAlreadyExistsError = () => {
+  const error = new Error('File already exists') as Error & {response: {status: number}};
+  error.response = {status: ITEM_ALREADY_EXISTS_ERROR};
+  return error;
 };
 
 interface UseCellsNewFileFormProps {
@@ -67,6 +74,11 @@ export const useCellsNewFileForm = ({
   const createFile = async (name: string) => {
     const path = getCellsApiPath({conversationQualifiedId, currentPath});
     const templateUuid = getTemplateUuidByType(fileType);
+    const fileAlreadyExists = await cellsRepository.checkFileAlreadyExists({path, name});
+    if (fileAlreadyExists) {
+      throw createAlreadyExistsError();
+    }
+
     await cellsRepository.createFile({path, name, templateUuid});
     onSuccess();
   };

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm.ts
@@ -33,6 +33,17 @@ const FILE_EXTENSION_BY_TYPE: Record<CellsFileType, string> = {
   presentation: 'pptx',
 };
 
+const FILE_TEMPLATE_ID_BY_TYPE: Record<CellsFileType, string> = {
+  document: '01-Microsoft Word.docx',
+  spreadsheet: '02-Microsoft Excel.xlsx',
+  presentation: '03-Microsoft PowerPoint.pptx',
+};
+
+// TO-DO Replace hard coded values with server values when GET /templates endpoint ready
+const getTemplateUuidByType = (fileType: CellsFileType): string => {
+  return FILE_TEMPLATE_ID_BY_TYPE[fileType];
+};
+
 interface UseCellsNewFileFormProps {
   fileType: CellsFileType;
   cellsRepository: CellsRepository;
@@ -55,7 +66,8 @@ export const useCellsNewFileForm = ({
 
   const createFile = async (name: string) => {
     const path = getCellsApiPath({conversationQualifiedId, currentPath});
-    await cellsRepository.createFile({path, name});
+    const templateUuid = getTemplateUuidByType(fileType);
+    await cellsRepository.createFile({path, name, templateUuid});
     onSuccess();
   };
 

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm.ts
@@ -61,6 +61,7 @@ interface UseCellsNewFileFormProps {
   conversationQualifiedId: QualifiedId;
   onSuccess: () => void;
   currentPath: string;
+  isOpen: boolean;
 }
 
 export const useCellsNewFileForm = ({
@@ -69,6 +70,7 @@ export const useCellsNewFileForm = ({
   conversationQualifiedId,
   onSuccess,
   currentPath,
+  isOpen,
 }: UseCellsNewFileFormProps) => {
   const normalizeNameForCreation = (rawName: string): string => {
     const extension = getFileExtensionByType(fileType);
@@ -87,5 +89,5 @@ export const useCellsNewFileForm = ({
     onSuccess();
   };
 
-  return useCellsNewNodeFormBase({createNode: createFile, normalizeNameForCreation});
+  return useCellsNewNodeFormBase({createNode: createFile, normalizeNameForCreation, isOpen});
 };

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFolderForm.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFolderForm.test.ts
@@ -43,18 +43,21 @@ describe('useCellsNewFolderForm', () => {
     onSuccess = jest.fn();
   });
 
-  const setup = () =>
-    renderHook(() =>
-      useCellsNewFolderForm({
-        cellsRepository: mockCellsRepository,
-        conversationQualifiedId: {id: 'conversation-id', domain: 'wire.com'},
-        onSuccess,
-        currentPath: '/wire-cells-web/path',
-      }),
+  const renderUseCellsNewFolderForm = (isOpen = true) =>
+    renderHook(
+      ({isOpen: isModalOpen}) =>
+        useCellsNewFolderForm({
+          cellsRepository: mockCellsRepository,
+          conversationQualifiedId: {id: 'conversation-id', domain: 'wire.com'},
+          onSuccess,
+          currentPath: '/wire-cells-web/path',
+          isOpen: isModalOpen,
+        }),
+      {initialProps: {isOpen}},
     );
 
   it('does not append file extension or template data when creating folder names', async () => {
-    const {result} = setup();
+    const {result} = renderUseCellsNewFolderForm();
 
     act(() => {
       result.current.handleChange({currentTarget: {value: 'Project.docx'}} as ChangeEvent<HTMLInputElement>);
@@ -73,7 +76,7 @@ describe('useCellsNewFolderForm', () => {
   });
 
   it('uses createFolder repository method and never calls createFile', async () => {
-    const {result} = setup();
+    const {result} = renderUseCellsNewFolderForm();
 
     act(() => {
       result.current.handleChange({currentTarget: {value: 'New folder'}} as ChangeEvent<HTMLInputElement>);
@@ -86,5 +89,31 @@ describe('useCellsNewFolderForm', () => {
     expect(mockCellsRepository.createFolder).toHaveBeenCalledTimes(1);
     expect(mockCellsRepository.createFile).not.toHaveBeenCalled();
     expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets name and error when modal is reopened', async () => {
+    const {result, rerender} = renderUseCellsNewFolderForm(true);
+
+    act(() => {
+      result.current.handleChange({currentTarget: {value: 'invalid/name'}} as ChangeEvent<HTMLInputElement>);
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit(createEvent());
+    });
+
+    expect(result.current.name).toBe('invalid/name');
+    expect(result.current.error).toBe('cells.newItemMenuModalForm.invalidCharactersError');
+
+    act(() => {
+      rerender({isOpen: false});
+    });
+
+    act(() => {
+      rerender({isOpen: true});
+    });
+
+    expect(result.current.name).toBe('');
+    expect(result.current.error).toBeNull();
   });
 });

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFolderForm.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFolderForm.test.ts
@@ -24,10 +24,6 @@ import {CellsRepository} from 'Repositories/cells/cellsRepository';
 
 import {useCellsNewFolderForm} from './useCellsNewFolderForm';
 
-jest.mock('Util/localizerUtil', () => ({
-  t: (key: string) => key,
-}));
-
 describe('useCellsNewFolderForm', () => {
   let mockCellsRepository: jest.Mocked<CellsRepository>;
   let onSuccess: jest.Mock;
@@ -43,37 +39,16 @@ describe('useCellsNewFolderForm', () => {
     onSuccess = jest.fn();
   });
 
-  const renderUseCellsNewFolderForm = (isOpen = true) =>
-    renderHook(
-      ({isOpen: isModalOpen}) =>
-        useCellsNewFolderForm({
-          cellsRepository: mockCellsRepository,
-          conversationQualifiedId: {id: 'conversation-id', domain: 'wire.com'},
-          onSuccess,
-          currentPath: '/wire-cells-web/path',
-          isOpen: isModalOpen,
-        }),
-      {initialProps: {isOpen}},
-    );
-
-  it('does not append file extension or template data when creating folder names', async () => {
-    const {result} = renderUseCellsNewFolderForm();
-
-    act(() => {
-      result.current.handleChange({currentTarget: {value: 'Project.docx'}} as ChangeEvent<HTMLInputElement>);
-    });
-
-    await act(async () => {
-      await result.current.handleSubmit(createEvent());
-    });
-
-    expect(mockCellsRepository.createFolder).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'Project.docx',
+  const renderUseCellsNewFolderForm = () =>
+    renderHook(() =>
+      useCellsNewFolderForm({
+        cellsRepository: mockCellsRepository,
+        conversationQualifiedId: {id: 'conversation-id', domain: 'wire.com'},
+        onSuccess,
+        currentPath: '/wire-cells-web/path',
+        isOpen: true,
       }),
     );
-    expect(mockCellsRepository.createFolder).toHaveBeenCalledTimes(1);
-  });
 
   it('uses createFolder repository method and never calls createFile', async () => {
     const {result} = renderUseCellsNewFolderForm();
@@ -91,29 +66,21 @@ describe('useCellsNewFolderForm', () => {
     expect(onSuccess).toHaveBeenCalledTimes(1);
   });
 
-  it('resets name and error when modal is reopened', async () => {
-    const {result, rerender} = renderUseCellsNewFolderForm(true);
+  it('preserves provided folder name and does not append file metadata', async () => {
+    const {result} = renderUseCellsNewFolderForm();
 
     act(() => {
-      result.current.handleChange({currentTarget: {value: 'invalid/name'}} as ChangeEvent<HTMLInputElement>);
+      result.current.handleChange({currentTarget: {value: 'Project.docx'}} as ChangeEvent<HTMLInputElement>);
     });
 
     await act(async () => {
       await result.current.handleSubmit(createEvent());
     });
 
-    expect(result.current.name).toBe('invalid/name');
-    expect(result.current.error).toBe('cells.newItemMenuModalForm.invalidCharactersError');
-
-    act(() => {
-      rerender({isOpen: false});
-    });
-
-    act(() => {
-      rerender({isOpen: true});
-    });
-
-    expect(result.current.name).toBe('');
-    expect(result.current.error).toBeNull();
+    expect(mockCellsRepository.createFolder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Project.docx',
+      }),
+    );
   });
 });

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFolderForm.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFolderForm.ts
@@ -30,6 +30,7 @@ interface UseCellsNewFolderFormProps {
   conversationQualifiedId: QualifiedId;
   onSuccess: () => void;
   currentPath: string;
+  isOpen: boolean;
 }
 
 export const useCellsNewFolderForm = ({
@@ -37,6 +38,7 @@ export const useCellsNewFolderForm = ({
   conversationQualifiedId,
   onSuccess,
   currentPath,
+  isOpen,
 }: UseCellsNewFolderFormProps) => {
   const createFolder = async (name: string) => {
     const path = getCellsApiPath({conversationQualifiedId, currentPath});
@@ -44,5 +46,5 @@ export const useCellsNewFolderForm = ({
     onSuccess();
   };
 
-  return useCellsNewNodeFormBase({createNode: createFolder});
+  return useCellsNewNodeFormBase({createNode: createFolder, isOpen});
 };

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewNodeFormBase.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewNodeFormBase.test.ts
@@ -19,24 +19,37 @@
 
 import {ChangeEvent, FormEvent} from 'react';
 import {act, renderHook} from '@testing-library/react';
+import {t} from 'Util/localizerUtil';
 
 import {useCellsNewNodeFormBase} from './useCellsNewNodeFormBase';
 
-jest.mock('Util/localizerUtil', () => ({
-  t: (key: string) => key,
-}));
+type CreateNodeMock = jest.MockedFunction<(name: string) => Promise<void>>;
+
+interface SetupOptions {
+  createNode?: CreateNodeMock;
+  normalizeNameForCreation?: (rawName: string) => string;
+  isOpen?: boolean;
+}
 
 describe('useCellsNewNodeFormBase', () => {
   const createEvent = () => ({preventDefault: jest.fn()}) as unknown as FormEvent<HTMLFormElement>;
+  const createNodeMock = () => jest.fn().mockResolvedValue(undefined) as CreateNodeMock;
 
-  const setup = (
-    createNode: jest.Mock<Promise<void>, [string]> = jest.fn().mockResolvedValue(undefined),
-    normalizeNameForCreation?: (rawName: string) => string,
-  ) => {
-    const {result} = renderHook(() => useCellsNewNodeFormBase({createNode, normalizeNameForCreation}));
+  const setup = ({createNode = createNodeMock(), normalizeNameForCreation, isOpen = true}: SetupOptions = {}) => {
+
+    const {result, rerender} = renderHook(
+      ({modalIsOpen}: {modalIsOpen: boolean}) =>
+        useCellsNewNodeFormBase({
+          createNode,
+          normalizeNameForCreation,
+          isOpen: modalIsOpen,
+        }),
+      {initialProps: {modalIsOpen: isOpen}},
+    );
 
     return {
       result,
+      rerender,
       createNode,
     };
   };
@@ -48,7 +61,7 @@ describe('useCellsNewNodeFormBase', () => {
       await result.current.handleSubmit(createEvent());
     });
 
-    expect(result.current.error).toBe('cells.newItemMenuModalForm.nameRequired');
+    expect(result.current.error).toBe(t('cells.newItemMenuModalForm.nameRequired'));
     expect(createNode).not.toHaveBeenCalled();
   });
 
@@ -63,13 +76,13 @@ describe('useCellsNewNodeFormBase', () => {
       await result.current.handleSubmit(createEvent());
     });
 
-    expect(result.current.error).toBe('cells.newItemMenuModalForm.invalidCharactersError');
+    expect(result.current.error).toBe(t('cells.newItemMenuModalForm.invalidCharactersError'));
     expect(createNode).not.toHaveBeenCalled();
   });
 
   it('trims input and applies normalizeNameForCreation before calling createNode', async () => {
     const normalizeNameForCreation = jest.fn((rawName: string) => `${rawName}.normalized`);
-    const {result, createNode} = setup(jest.fn().mockResolvedValue(undefined), normalizeNameForCreation);
+    const {result, createNode} = setup({normalizeNameForCreation});
 
     act(() => {
       result.current.handleChange({currentTarget: {value: ' New item '}} as ChangeEvent<HTMLInputElement>);
@@ -84,7 +97,7 @@ describe('useCellsNewNodeFormBase', () => {
   });
 
   it('maps 409 failures to already-exists error', async () => {
-    const {result} = setup(jest.fn().mockRejectedValueOnce({response: {status: 409}}));
+    const {result} = setup({createNode: jest.fn().mockRejectedValueOnce({response: {status: 409}})});
 
     act(() => {
       result.current.handleChange({currentTarget: {value: 'New item'}} as ChangeEvent<HTMLInputElement>);
@@ -94,11 +107,11 @@ describe('useCellsNewNodeFormBase', () => {
       await result.current.handleSubmit(createEvent());
     });
 
-    expect(result.current.error).toBe('cells.newItemMenuModalForm.alreadyExistsError');
+    expect(result.current.error).toBe(t('cells.newItemMenuModalForm.alreadyExistsError'));
   });
 
   it('maps non-409 failures to generic error', async () => {
-    const {result} = setup(jest.fn().mockRejectedValueOnce(new Error('network error')));
+    const {result} = setup({createNode: jest.fn().mockRejectedValueOnce(new Error('network error'))});
 
     act(() => {
       result.current.handleChange({currentTarget: {value: 'New item'}} as ChangeEvent<HTMLInputElement>);
@@ -108,6 +121,54 @@ describe('useCellsNewNodeFormBase', () => {
       await result.current.handleSubmit(createEvent());
     });
 
-    expect(result.current.error).toBe('cells.newItemMenuModalForm.genericError');
+    expect(result.current.error).toBe(t('cells.newItemMenuModalForm.genericError'));
+  });
+
+  it('clears name and error when handleClear is called', async () => {
+    const {result} = setup();
+
+    act(() => {
+      result.current.handleChange({currentTarget: {value: 'invalid/name'}} as ChangeEvent<HTMLInputElement>);
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit(createEvent());
+    });
+
+    expect(result.current.name).toBe('invalid/name');
+    expect(result.current.error).toBe(t('cells.newItemMenuModalForm.invalidCharactersError'));
+
+    act(() => {
+      result.current.handleClear();
+    });
+
+    expect(result.current.name).toBe('');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('resets state when modal is reopened', async () => {
+    const {result, rerender} = setup({isOpen: true});
+
+    act(() => {
+      result.current.handleChange({currentTarget: {value: 'invalid/name'}} as ChangeEvent<HTMLInputElement>);
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit(createEvent());
+    });
+
+    expect(result.current.name).toBe('invalid/name');
+    expect(result.current.error).toBe(t('cells.newItemMenuModalForm.invalidCharactersError'));
+
+    act(() => {
+      rerender({modalIsOpen: false});
+    });
+
+    act(() => {
+      rerender({modalIsOpen: true});
+    });
+
+    expect(result.current.name).toBe('');
+    expect(result.current.error).toBeNull();
   });
 });

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewNodeFormBase.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewNodeFormBase.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {ChangeEvent, FormEvent, MouseEvent, useState} from 'react';
+import {ChangeEvent, FormEvent, MouseEvent, useEffect, useState} from 'react';
 
 import {t} from 'Util/localizerUtil';
 
@@ -31,6 +31,7 @@ import {
 interface UseCellsNewNodeFormBaseProps {
   createNode: (name: string) => Promise<void>;
   normalizeNameForCreation?: (rawName: string) => string;
+  isOpen?: boolean;
 }
 
 const defaultNameNormalizer = (value: string) => value;
@@ -38,10 +39,21 @@ const defaultNameNormalizer = (value: string) => value;
 export const useCellsNewNodeFormBase = ({
   createNode,
   normalizeNameForCreation = defaultNameNormalizer,
+  isOpen = true,
 }: UseCellsNewNodeFormBaseProps) => {
   const [name, setName] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    setName('');
+    setError(null);
+    setIsSubmitting(false);
+  }, [isOpen]);
 
   const handleSubmit = async (formEvent: FormEvent<HTMLFormElement> | MouseEvent<HTMLButtonElement>) => {
     formEvent.preventDefault();
@@ -84,11 +96,17 @@ export const useCellsNewNodeFormBase = ({
     }
   };
 
+  const handleClear = () => {
+    setName('');
+    setError(null);
+  };
+
   return {
     name,
     error,
     isSubmitting,
     handleSubmit,
     handleChange,
+    handleClear,
   };
 };

--- a/apps/webapp/src/script/repositories/cells/cellsRepository.ts
+++ b/apps/webapp/src/script/repositories/cells/cellsRepository.ts
@@ -179,6 +179,15 @@ export class CellsRepository {
     return this.apiClient.api.cells.createFile({path: filePath, uuid, versionId, templateUuid});
   }
 
+  async checkFileAlreadyExists({path, name}: {path: string; name: string}): Promise<boolean> {
+    const filePath = `${path || this.basePath}/${name}`;
+    const uuid = createUuid();
+    const versionId = createUuid();
+    const result = await this.apiClient.api.cells.checkNodeCreation({path: filePath, uuid, versionId, type: 'LEAF'});
+
+    return result.Results?.some(checkResult => checkResult.Exists) ?? false;
+  }
+
   async createPublicLink({
     uuid,
     link,

--- a/apps/webapp/src/script/repositories/cells/cellsRepository.ts
+++ b/apps/webapp/src/script/repositories/cells/cellsRepository.ts
@@ -171,12 +171,12 @@ export class CellsRepository {
     return this.apiClient.api.cells.createFolder({path: filePath, uuid});
   }
 
-  async createFile({path, name}: {path: string; name: string}) {
+  async createFile({path, name, templateUuid}: {path: string; name: string; templateUuid?: string}) {
     const filePath = `${path || this.basePath}/${name}`;
     const uuid = createUuid();
     const versionId = createUuid();
 
-    return this.apiClient.api.cells.createFile({path: filePath, uuid, versionId});
+    return this.apiClient.api.cells.createFile({path: filePath, uuid, versionId, templateUuid});
   }
 
   async createPublicLink({

--- a/libraries/api-client/src/cells/cellsApi.ts
+++ b/libraries/api-client/src/cells/cellsApi.ts
@@ -443,11 +443,13 @@ export class CellsAPI {
     uuid,
     type,
     versionId = '',
+    templateUuid,
   }: {
     path: NonNullable<RestNodeLocator['Path']>;
     uuid: NonNullable<RestIncomingNode['ResourceUuid']>;
     type: RestIncomingNode['Type'];
     versionId?: RestIncomingNode['VersionId'];
+    templateUuid?: NonNullable<RestIncomingNode['TemplateUuid']>;
   }): Promise<RestNodeCollection> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);
@@ -460,6 +462,7 @@ export class CellsAPI {
           Locator: {Path: path.normalize('NFC')},
           ResourceUuid: uuid,
           VersionId: versionId,
+          ...(templateUuid ? {TemplateUuid: templateUuid} : {}),
         },
       ],
     });
@@ -471,16 +474,19 @@ export class CellsAPI {
     path,
     uuid,
     versionId,
+    templateUuid,
   }: {
     path: NonNullable<RestNodeLocator['Path']>;
     uuid: NonNullable<RestIncomingNode['ResourceUuid']>;
     versionId: NonNullable<RestIncomingNode['VersionId']>;
+    templateUuid?: NonNullable<RestIncomingNode['TemplateUuid']>;
   }): Promise<RestNodeCollection> {
     return this.createNode({
       path,
       uuid,
       type: 'LEAF',
       versionId,
+      templateUuid,
     });
   }
 

--- a/libraries/api-client/src/cells/cellsApi.ts
+++ b/libraries/api-client/src/cells/cellsApi.ts
@@ -192,6 +192,29 @@ export class CellsAPI {
     return result.data;
   }
 
+  async checkNodeCreation({
+    path,
+    uuid,
+    versionId,
+    type,
+  }: {
+    path: NonNullable<RestNodeLocator['Path']>;
+    uuid: string;
+    versionId: string;
+    type: RestIncomingNode['Type'];
+  }): Promise<RestCreateCheckResponse> {
+    if (!this.client || !this.storageService) {
+      throw new Error(CONFIGURATION_ERROR);
+    }
+
+    const result = await this.client.createCheck({
+      Inputs: [{Type: type, Locator: {Path: path.normalize('NFC'), Uuid: uuid}, VersionId: versionId}],
+      FindAvailablePath: false,
+    });
+
+    return result.data;
+  }
+
   async promoteNodeDraft({uuid, versionId}: {uuid: string; versionId: string}): Promise<RestPromoteVersionResponse> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22465" title="WPB-22465" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22465</a>  [Web] Add the option to create a new Collabora document from files tab
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- Pre-checks to detect file/folder name exists
- Improved test coverage, removed jest mock
- setup template uuids - file type mapping
- added modal headline with file type
- use TextInput with clear button
- fix on modal close and reopen state not getting flushed 

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
