### PR TITLE
test(WPB-23749): fix regression tests for AppLock 

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/account.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/account.page.ts
@@ -46,8 +46,8 @@ export class AccountPage {
     this.page = page;
 
     this.sendUsageDataCheckbox = page.locator("[data-uie-name='status-preference-telemetry']+label");
-    this.appLockCheckboxLabel = page.locator("[data-uie-name='status-preference-applock']+label");
-    this.appLockCheckbox = page.locator("[data-uie-name='status-preference-applock']");
+    this.appLockCheckboxLabel = page.getByText('Lock with passcode', {exact: true});
+    this.appLockCheckbox = page.getByRole('checkbox', {name: 'Lock with passcode'});
     this.deleteAccountButton = page.getByTestId('go-delete-account');
     this.backUpButton = page.getByTestId('do-backup-export');
     this.backupFileInput = page.getByTestId('input-import-file');

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/account.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/account.page.ts
@@ -23,6 +23,8 @@ export class AccountPage {
   private readonly page: Page;
 
   readonly sendUsageDataCheckbox: Locator;
+  readonly appLockCheckboxLabel: Locator;
+  readonly appLockCheckbox: Locator;
   readonly deleteAccountButton: Locator;
   readonly backUpButton: Locator;
   readonly backupFileInput: Locator;
@@ -44,6 +46,8 @@ export class AccountPage {
     this.page = page;
 
     this.sendUsageDataCheckbox = page.locator("[data-uie-name='status-preference-telemetry']+label");
+    this.appLockCheckboxLabel = page.locator("[data-uie-name='status-preference-applock']+label");
+    this.appLockCheckbox = page.locator("[data-uie-name='status-preference-applock']");
     this.deleteAccountButton = page.getByTestId('go-delete-account');
     this.backUpButton = page.getByTestId('do-backup-export');
     this.backupFileInput = page.getByTestId('input-import-file');

--- a/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
@@ -19,7 +19,6 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {checkAnyIndexedDBExists} from 'test/e2e_tests/utils/indexedDB.util';
 import {handleAppLockState} from 'test/e2e_tests/utils/userActions';
 
 import {test, expect, withLogin} from '../../test.fixtures';
@@ -91,40 +90,52 @@ test.describe('AppLock', () => {
       });
 
       test(
-        'Web: I want to unlock the app with passphrase after login',
-        {tag: ['@TC-2754', '@TC-2755', '@TC-2758', '@TC-2763', '@regression']},
+        'Web: I want the app to automatically lock after refreshing the page',
+        {tag: ['@TC-2754', '@regression']},
         async ({createPage}) => {
           const page = await createPage(withLogin(memberA));
           const pageManager = PageManager.from(page);
-          const {modals, pages} = pageManager.webapp;
+          const {modals} = PageManager.from(page).webapp;
 
-          await test.step('Web: I want the app to automatically lock after refreshing the page', async () => {
-            await handleAppLockState(pageManager, appLockPassCode);
-            await pageManager.refreshPage();
+          await handleAppLockState(pageManager, appLockPassCode);
 
-            await expect(modals.appLock().appLockModal).toBeVisible();
-          });
+          await page.reload();
 
-          await test.step('Web: I should not be able to unlock the app with wrong passphrase', async () => {
-            await handleAppLockState(pageManager, 'wrongCredentials');
-            await expect(modals.appLock().errorMessage).toHaveText('Wrong passcode');
-          });
+          await expect(modals.appLock().appLockModal).toBeVisible();
+        },
+      );
 
-          await test.step('Web: I should not be able to wipe database with wrong account password', async () => {
-            await modals.appLock().clickForgotPassphrase();
-            await modals.appLock().clickWipeDB();
-            await modals.appLock().clickReset();
-            await modals.appLock().inputUserPassword('wrong password');
+      test(
+        'Web: I want to unlock the app with passphrase after login',
+        {tag: ['@TC-2755', '@regression']},
+        async ({createPage}) => {
+          const page = await createPage(withLogin(memberA));
+          const pageManager = PageManager.from(page);
+          const {modals} = PageManager.from(page).webapp;
 
-            expect(await checkAnyIndexedDBExists(page)).toBeTruthy();
-          });
+          await handleAppLockState(pageManager, appLockPassCode);
 
-          await test.step('I want to wipe database when I forgot my app lock passphrase', async () => {
-            await modals.appLock().inputUserPassword(memberA.password);
+          await page.reload();
+          await modals.appLock().unlockAppWithPasscode(appLockPassCode);
 
-            await expect(pages.singleSignOn().ssoCodeEmailInput).toBeVisible();
-            expect(await checkAnyIndexedDBExists(page)).toBeFalsy();
-          });
+          await expect(modals.appLock().appLockModal).not.toBeVisible();
+        },
+      );
+
+      test(
+        'Web: I should not be able to unlock the app with wrong passphrase',
+        {tag: ['@TC-2758', '@regression']},
+        async ({createPage}) => {
+          const page = await createPage(withLogin(memberA));
+          const pageManager = PageManager.from(page);
+          const {modals} = PageManager.from(page).webapp;
+
+          await handleAppLockState(pageManager, appLockPassCode);
+
+          await page.reload();
+          await modals.appLock().unlockAppWithPasscode('wrongCredentials');
+
+          await expect(modals.appLock().errorMessage).toContainText('Wrong passcode');
         },
       );
 
@@ -146,6 +157,28 @@ test.describe('AppLock', () => {
           // After redirect to login page verify the whole indexDB was cleared
           await expect(pages.singleSignOn().ssoCodeEmailInput).toBeVisible();
           await expect.poll(() => page.evaluate(() => indexedDB.databases())).toHaveLength(0);
+        },
+      );
+
+      test(
+        'Web: I should not be able to wipe database with wrong account password',
+        {tag: ['@TC-2763', '@regression']},
+        async ({createPage}) => {
+          const page = await createPage(withLogin(memberA));
+          const pageManager = PageManager.from(page);
+          const {modals} = PageManager.from(page).webapp;
+
+          await handleAppLockState(pageManager, appLockPassCode);
+
+          await page.reload();
+          await modals.appLock().clickForgotPassphrase();
+          await modals.appLock().clickWipeDB();
+          await modals.appLock().clickReset();
+          await modals.appLock().inputUserPassword('invalid');
+
+          // The modal should show an error for the invalid password and not wipe indexDB
+          await expect(modals.appLock().errorMessage).toContainText('Wrong password');
+          await expect.poll(() => page.evaluate(() => indexedDB.databases())).not.toHaveLength(0);
         },
       );
 

--- a/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
@@ -19,210 +19,154 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, expect, withLogin, PagePlugin, Team, LOGIN_TIMEOUT} from 'test/e2e_tests/test.fixtures';
-import {AppLockModal} from 'test/e2e_tests/pageManager/webapp/modals/appLock.modal';
+import {checkAnyIndexedDBExists} from 'test/e2e_tests/utils/indexedDB.util';
+import {handleAppLockState} from 'test/e2e_tests/utils/userActions';
 
-/** Page plugin specific to this feature to set the app lock code upon the first login */
-const withAppLock =
-  (code: string): PagePlugin =>
-  async page => {
-    await new AppLockModal(page).setPasscode(code);
-  };
+import {test, expect, withLogin} from '../../test.fixtures';
 
 test.describe('AppLock', () => {
-  let user: User;
-  let team: Team;
+  let owner: User;
+  let memberA: User;
+  const teamName = 'AppLock';
   const appLockPassCode = '1a3!567N4';
 
-  test.beforeEach(async ({createTeam}) => {
-    team = await createTeam('AppLock Team');
-    user = team.owner;
-  });
+  test.beforeEach(async ({api, createTeam, createUser}) => {
+    memberA = await createUser();
+    const team = await createTeam(teamName, {users: [memberA]});
+    owner = team.owner;
 
-  test.describe('AppLock enforced for team', async () => {
-    test.beforeEach(async ({api}) => {
-      // Enforce app lock for the whole team
-      await api.brig.toggleAppLock(team.teamId, 'enabled', true);
-    });
-
-    test(
-      'Web: I should not be able to close app lock setup modal if app lock is enforced',
-      {tag: ['@TC-2740']},
-      async ({createPage}) => {
-        const page = await createPage();
-        const pageManager = PageManager.from(page);
-        const {modals} = pageManager.webapp;
-
-        await pageManager.openLoginPage();
-        await pageManager.webapp.pages.login().login(user);
-        await expect(modals.appLock().appLockModal).toBeVisible({timeout: LOGIN_TIMEOUT});
-
-        await page.mouse.click(200, 350); // click outside the modal
-        await expect(modals.appLock().appLockModal).toBeVisible();
-      },
-    );
-
-    test(
-      'I want to see app lock setup modal on login after app lock has been enforced for the team',
-      {tag: ['@TC-2744', '@regression']},
-      async ({createPage}) => {
-        const page = await createPage(withLogin(user));
-        const {modals} = PageManager.from(page).webapp;
-
-        await expect(modals.appLock().appLockModal).toBeVisible();
-      },
-    );
-
-    test.fixme(
-      'Web: App should not lock if I switch back to webapp tab in time (during inactivity timeout)',
-      {tag: ['@TC-2752', '@TC-2753', '@regression']},
-      async ({browser, createPage}) => {
-        const page = await createPage(withLogin(user), withAppLock(appLockPassCode));
-        const pageManager = PageManager.from(page);
-        const {modals} = pageManager.webapp;
-
-        const unrelatedPage = await browser.newPage();
-        await unrelatedPage.goto('about:blank');
-        await unrelatedPage.bringToFront();
-        await unrelatedPage.waitForTimeout(2_000); // open be only 2 sec in the other tab
-        await page.bringToFront();
-
-        await expect(modals.appLock().appLockModalHeader).not.toBeVisible();
-
-        await test.step('Web: I want the app to lock when I switch back to webapp tab after inactivity timeout expired', async () => {
-          await unrelatedPage.goto('about:blank');
-          await unrelatedPage.bringToFront();
-          await unrelatedPage.waitForTimeout(31_000);
-          await page.bringToFront();
-          await expect(modals.appLock().appLockModalHeader).toBeVisible();
-        });
-      },
-    );
-
-    test(
-      'Web: I want the app to automatically lock after refreshing the page',
-      {tag: ['@TC-2754', '@regression']},
-      async ({createPage}) => {
-        const page = await createPage(withLogin(user), withAppLock(appLockPassCode));
-        const {modals} = PageManager.from(page).webapp;
-
-        await page.reload();
-
-        await expect(modals.appLock().appLockModal).toBeVisible();
-      },
-    );
-
-    test(
-      'Web: I want to unlock the app with passphrase after login',
-      {tag: ['@TC-2755', '@regression']},
-      async ({createPage}) => {
-        const page = await createPage(withLogin(user), withAppLock(appLockPassCode));
-        const {modals} = PageManager.from(page).webapp;
-
-        await page.reload();
-        await modals.appLock().unlockAppWithPasscode(appLockPassCode);
-
-        await expect(modals.appLock().appLockModal).not.toBeVisible();
-      },
-    );
-
-    test(
-      'Web: I should not be able to unlock the app with wrong passphrase',
-      {tag: ['@TC-2758', '@regression']},
-      async ({createPage}) => {
-        const page = await createPage(withLogin(user), withAppLock(appLockPassCode));
-        const {modals} = PageManager.from(page).webapp;
-
-        await page.reload();
-        await modals.appLock().unlockAppWithPasscode('wrongCredentials');
-
-        await expect(modals.appLock().errorMessage).toContainText('Wrong passcode');
-      },
-    );
-
-    test(
-      'I want to wipe database when I forgot my app lock passphrase',
-      {tag: ['@TC-2761', '@regression']},
-      async ({createPage}) => {
-        const page = await createPage(withLogin(user), withAppLock(appLockPassCode));
-        const {pages, modals} = PageManager.from(page).webapp;
-
-        await page.reload();
-        await modals.appLock().clickForgotPassphrase();
-        await modals.appLock().clickWipeDB();
-        await modals.appLock().clickReset();
-        await modals.appLock().inputUserPassword(user.password);
-
-        // After redirect to login page verify the whole indexDB was cleared
-        await expect(pages.singleSignOn().ssoCodeEmailInput).toBeVisible();
-        await expect.poll(() => page.evaluate(() => indexedDB.databases())).toHaveLength(0);
-      },
-    );
-
-    test(
-      'Web: I should not be able to wipe database with wrong account password',
-      {tag: ['@TC-2763', '@regression']},
-      async ({createPage}) => {
-        const page = await createPage(withLogin(user), withAppLock(appLockPassCode));
-        const {modals} = PageManager.from(page).webapp;
-
-        await page.reload();
-        await modals.appLock().clickForgotPassphrase();
-        await modals.appLock().clickWipeDB();
-        await modals.appLock().clickReset();
-        await modals.appLock().inputUserPassword('invalid');
-
-        // The modal should show an error for the invalid password and not wipe indexDB
-        await expect(modals.appLock().errorMessage).toContainText('Wrong password');
-        await expect.poll(() => page.evaluate(() => indexedDB.databases())).not.toHaveLength(0);
-      },
-    );
-
-    [
-      {title: 'Web: Verify inactivity timeout set on a team level applies to team member accounts', tag: '@TC-2767'},
-      {title: 'I should not be able to switch off app lock if it is enforced for the team', tag: '@TC-2770'},
-    ].forEach(({title, tag}) => {
-      test(title, {tag: [tag, '@regression']}, async ({createPage}) => {
-        const page = await createPage(withLogin(user), withAppLock(appLockPassCode));
-        const {components, pages} = PageManager.from(page).webapp;
-
-        await components.conversationSidebar().clickPreferencesButton();
-        await expect(pages.account().privacySection.appLock.checkbox).toBeDisabled();
-        await expect(pages.account().privacySection).toContainText(
-          'Lock Wire after 30 seconds in the background. Unlock with Touch ID or enter your passcode',
-        );
-      });
-    });
-  });
-
-  test('I want to switch off app lock', {tag: ['@TC-2771', '@regression']}, async ({createPage}) => {
-    const {components, pages, modals} = PageManager.from(await createPage(withLogin(user))).webapp;
-
-    await test.step('Enable app lock', async () => {
-      await components.conversationSidebar().clickPreferencesButton();
-      await pages.account().privacySection.appLock.label.click();
-      await modals.appLock().setPasscode(appLockPassCode);
-    });
-
-    await test.step('Switch off app lock', async () => {
-      await pages.account().privacySection.appLock.label.click();
-      await modals.confirm().actionButton.click();
-    });
-
-    await expect(pages.account().privacySection.appLock.checkbox).not.toBeChecked();
+    await api.brig.toggleAppLock(owner.teamId, 'enabled', true);
   });
 
   test(
+    'I want to see app lock setup modal on login after app lock has been enforced for the team',
+    {tag: ['@TC-2744', '@TC-2740', '@regression']},
+    async ({createPage}) => {
+      const page = await createPage(withLogin(memberA));
+      const {modals} = PageManager.from(page).webapp;
+
+      await expect(modals.appLock().appLockModal).toBeVisible();
+
+      await test.step('Web: I should not be able to close app lock setup modal if app lock is enforced', async () => {
+        // click outside the modal
+        await page.mouse.click(200, 350);
+        // check if the modal still there
+        await expect(modals.appLock().appLockModal).toBeVisible();
+      });
+    },
+  );
+
+  (
+    [
+      {
+        title: 'Web: I want the app to lock when I switch back to webapp tab after inactivity timeout expired',
+        tag: '@TC-2752',
+      },
+      {
+        title: 'Web: App should not lock if I switch back to webapp tab in time (during inactivity timeout)',
+        tag: '@TC-2753',
+      },
+    ] as const
+  ).forEach(({title, tag}) => {
+    const shouldLock = tag === '@TC-2752';
+
+    test(title, {tag: [tag, '@regression']}, async ({createPage}) => {
+      const page = await createPage(withLogin(memberA));
+      const pageManager = PageManager.from(page);
+      await handleAppLockState(pageManager, appLockPassCode);
+
+      const {modals} = pageManager.webapp;
+      await page.dispatchEvent('body', 'blur');
+      await page.waitForTimeout(shouldLock ? 61_000 : 3_000);
+      await page.dispatchEvent('body', 'focus');
+
+      if (shouldLock) {
+        await expect(modals.appLock().appLockModalHeader).toBeVisible();
+      } else {
+        await expect(modals.appLock().appLockModalHeader).not.toBeVisible();
+      }
+    });
+  });
+
+  test(
+    'Web: I want to unlock the app with passphrase after login',
+    {tag: ['@TC-2754', '@TC-2755', '@TC-2758', '@TC-2763', '@regression']},
+    async ({createPage}) => {
+      const page = await createPage(withLogin(memberA));
+      const pageManager = PageManager.from(page);
+      const {modals, pages} = pageManager.webapp;
+
+      await test.step('Web: I want the app to automatically lock after refreshing the page', async () => {
+        await handleAppLockState(pageManager, appLockPassCode);
+        await pageManager.refreshPage();
+
+        await expect(modals.appLock().appLockModal).toBeVisible();
+      });
+
+      await test.step('Web: I should not be able to unlock the app with wrong passphrase', async () => {
+        await handleAppLockState(pageManager, 'wrongCredentials');
+        await expect(modals.appLock().errorMessage).toHaveText('Wrong passcode');
+      });
+
+      await test.step('Web: I should not be able to wipe database with wrong account password', async () => {
+        await modals.appLock().clickForgotPassphrase();
+        await modals.appLock().clickWipeDB();
+        await modals.appLock().clickReset();
+        await modals.appLock().inputUserPassword('wrong password');
+
+        expect(await checkAnyIndexedDBExists(page)).toBeTruthy();
+      });
+
+      await test.step('I want to wipe database when I forgot my app lock passphrase', async () => {
+        await modals.appLock().inputUserPassword(memberA.password);
+
+        await expect(pages.singleSignOn().ssoCodeEmailInput).toBeVisible();
+        expect(await checkAnyIndexedDBExists(page)).toBeFalsy();
+      });
+    },
+  );
+
+  test(
+    'I should not be able to switch off app lock if it is enforced for the team',
+    {tag: ['@TC-2770', '@TC-2767', '@regression']},
+    async ({createPage}) => {
+      const page = await createPage(withLogin(memberA));
+      const pageManager = PageManager.from(page);
+      const {components, pages} = pageManager.webapp;
+      await handleAppLockState(pageManager, appLockPassCode);
+      await components.conversationSidebar().clickPreferencesButton();
+
+      await expect(pages.account().appLockCheckbox).toBeDisabled();
+      // check here string
+
+      await expect(
+        page.getByText('Lock Wire after 30 seconds in the background. Unlock with Touch ID or enter your passcode.'),
+      ).toHaveCount(1);
+    },
+  );
+
+  test('I want to switch off app lock', {tag: ['@TC-2771', '@TC-2772', '@regression']}, async ({api, createPage}) => {
+    await api.brig.toggleAppLock(owner.teamId, 'enabled', false);
+
+    const page = await createPage(withLogin(memberA));
+    const pageManager = PageManager.from(page);
+    const {components, pages, modals} = pageManager.webapp;
+
+    await components.conversationSidebar().clickPreferencesButton();
+    await pages.account().toggleAppLock();
+    await handleAppLockState(pageManager, appLockPassCode);
+
+    await pages.account().toggleAppLock();
+
+    await modals.removeMember().clickConfirm();
+    await expect(pages.account().appLockCheckbox).not.toBeChecked();
+  });
+
+  test.skip(
     'Web: Verify inactivity timeout can be set if app lock is not enforced on a team level',
     {tag: ['@TC-2772', '@regression']},
-    async ({createPage}) => {
-      const {components, pages, modals} = PageManager.from(await createPage(withLogin(user))).webapp;
-
-      await components.conversationSidebar().clickPreferencesButton();
-      await pages.account().privacySection.appLock.label.click();
-      await modals.appLock().setPasscode(appLockPassCode);
-
-      await expect(pages.account().privacySection.appLock.checkbox).toBeChecked();
+    async () => {
+      // not implemented
     },
   );
 });

--- a/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
@@ -132,7 +132,7 @@ test.describe('AppLock', () => {
     async ({createPage}) => {
       const page = await createPage(withLogin(memberA));
       const pageManager = PageManager.from(page);
-      const {pages, modals} = PageManager.from(page).webapp;
+      const {pages, modals} = pageManager.webapp;
       await handleAppLockState(pageManager, appLockPassCode);
 
       await page.reload();

--- a/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
@@ -25,169 +25,193 @@ import {handleAppLockState} from 'test/e2e_tests/utils/userActions';
 import {test, expect, withLogin} from '../../test.fixtures';
 
 test.describe('AppLock', () => {
-  let owner: User;
-  let memberA: User;
-  const teamName = 'AppLock';
-  const appLockPassCode = '1a3!567N4';
 
-  test.beforeEach(async ({api, createTeam, createUser}) => {
-    memberA = await createUser();
-    const team = await createTeam(teamName, {users: [memberA]});
-    owner = team.owner;
+    let owner: User;
+    let memberA: User;
+    const teamName = 'AppLock';
+    const appLockPassCode = '1a3!567N4';
 
-    await api.brig.toggleAppLock(owner.teamId, 'enabled', true);
-  });
+    test.describe('AppLock enabled', () => {
+      test.beforeEach(async ({api, createTeam, createUser}) => {
+        memberA = await createUser();
+        const team = await createTeam(teamName, {users: [memberA]});
+        owner = team.owner;
 
-  test(
-    'I want to see app lock setup modal on login after app lock has been enforced for the team',
-    {tag: ['@TC-2744', '@TC-2740', '@regression']},
-    async ({createPage}) => {
-      const page = await createPage(withLogin(memberA));
-      const {modals} = PageManager.from(page).webapp;
-
-      await expect(modals.appLock().appLockModal).toBeVisible();
-
-      await test.step('Web: I should not be able to close app lock setup modal if app lock is enforced', async () => {
-        // click outside the modal
-        await page.mouse.click(200, 350);
-        // check if the modal still there
-        await expect(modals.appLock().appLockModal).toBeVisible();
+        await api.brig.toggleAppLock(owner.teamId, 'enabled', true);
       });
-    },
-  );
 
-  (
-    [
-      {
-        title: 'Web: I want the app to lock when I switch back to webapp tab after inactivity timeout expired',
-        tag: '@TC-2752',
-      },
-      {
-        title: 'Web: App should not lock if I switch back to webapp tab in time (during inactivity timeout)',
-        tag: '@TC-2753',
-      },
-    ] as const
-  ).forEach(({title, tag}) => {
-    const shouldLock = tag === '@TC-2752';
+      test(
+        'I want to see app lock setup modal on login after app lock has been enforced for the team',
+        {tag: ['@TC-2744', '@TC-2740', '@regression']},
+        async ({createPage}) => {
+          const page = await createPage(withLogin(memberA));
+          const {modals} = PageManager.from(page).webapp;
 
-    test(title, {tag: [tag, '@regression']}, async ({createPage}) => {
-      const page = await createPage(withLogin(memberA));
-      const pageManager = PageManager.from(page);
-      await handleAppLockState(pageManager, appLockPassCode);
+          await expect(modals.appLock().appLockModal).toBeVisible();
 
-      const {modals} = pageManager.webapp;
-      await page.dispatchEvent('body', 'blur');
-      await page.waitForTimeout(shouldLock ? 61_000 : 3_000);
-      await page.dispatchEvent('body', 'focus');
+          await test.step('Web: I should not be able to close app lock setup modal if app lock is enforced', async () => {
+            // click outside the modal
+            await page.mouse.click(200, 350);
+            // check if the modal still there
+            await expect(modals.appLock().appLockModal).toBeVisible();
+          });
+        },
+      );
 
-      if (shouldLock) {
-        await expect(modals.appLock().appLockModalHeader).toBeVisible();
-      } else {
-        await expect(modals.appLock().appLockModalHeader).not.toBeVisible();
-      }
+      (
+        [
+          {
+            title: 'Web: I want the app to lock when I switch back to webapp tab after inactivity timeout expired',
+            tag: '@TC-2752',
+          },
+          {
+            title: 'Web: App should not lock if I switch back to webapp tab in time (during inactivity timeout)',
+            tag: '@TC-2753',
+          },
+        ] as const
+      ).forEach(({title, tag}) => {
+        const shouldLock = tag === '@TC-2752';
+
+        test(title, {tag: [tag, '@regression']}, async ({createPage}) => {
+          const page = await createPage(withLogin(memberA));
+          const pageManager = PageManager.from(page);
+          await handleAppLockState(pageManager, appLockPassCode);
+
+          const {modals} = pageManager.webapp;
+          await page.dispatchEvent('body', 'blur');
+          await page.waitForTimeout(shouldLock ? 61_000 : 3_000);
+          await page.dispatchEvent('body', 'focus');
+
+          if (shouldLock) {
+            await expect(modals.appLock().appLockModalHeader).toBeVisible();
+          } else {
+            await expect(modals.appLock().appLockModalHeader).not.toBeVisible();
+          }
+        });
+      });
+
+      test(
+        'Web: I want to unlock the app with passphrase after login',
+        {tag: ['@TC-2754', '@TC-2755', '@TC-2758', '@TC-2763', '@regression']},
+        async ({createPage}) => {
+          const page = await createPage(withLogin(memberA));
+          const pageManager = PageManager.from(page);
+          const {modals, pages} = pageManager.webapp;
+
+          await test.step('Web: I want the app to automatically lock after refreshing the page', async () => {
+            await handleAppLockState(pageManager, appLockPassCode);
+            await pageManager.refreshPage();
+
+            await expect(modals.appLock().appLockModal).toBeVisible();
+          });
+
+          await test.step('Web: I should not be able to unlock the app with wrong passphrase', async () => {
+            await handleAppLockState(pageManager, 'wrongCredentials');
+            await expect(modals.appLock().errorMessage).toHaveText('Wrong passcode');
+          });
+
+          await test.step('Web: I should not be able to wipe database with wrong account password', async () => {
+            await modals.appLock().clickForgotPassphrase();
+            await modals.appLock().clickWipeDB();
+            await modals.appLock().clickReset();
+            await modals.appLock().inputUserPassword('wrong password');
+
+            expect(await checkAnyIndexedDBExists(page)).toBeTruthy();
+          });
+
+          await test.step('I want to wipe database when I forgot my app lock passphrase', async () => {
+            await modals.appLock().inputUserPassword(memberA.password);
+
+            await expect(pages.singleSignOn().ssoCodeEmailInput).toBeVisible();
+            expect(await checkAnyIndexedDBExists(page)).toBeFalsy();
+          });
+        },
+      );
+
+      test(
+        'I want to wipe database when I forgot my app lock passphrase',
+        {tag: ['@TC-2761', '@regression']},
+        async ({createPage}) => {
+          const page = await createPage(withLogin(memberA));
+          const pageManager = PageManager.from(page);
+          const {pages, modals} = pageManager.webapp;
+          await handleAppLockState(pageManager, appLockPassCode);
+
+          await page.reload();
+          await modals.appLock().clickForgotPassphrase();
+          await modals.appLock().clickWipeDB();
+          await modals.appLock().clickReset();
+          await modals.appLock().inputUserPassword(memberA.password);
+
+          // After redirect to login page verify the whole indexDB was cleared
+          await expect(pages.singleSignOn().ssoCodeEmailInput).toBeVisible();
+          await expect.poll(() => page.evaluate(() => indexedDB.databases())).toHaveLength(0);
+        },
+      );
+
+      test(
+        'I should not be able to switch off app lock if it is enforced for the team',
+        {tag: ['@TC-2770', '@TC-2767', '@regression']},
+        async ({createPage}) => {
+          const page = await createPage(withLogin(memberA));
+          const pageManager = PageManager.from(page);
+          const {components, pages} = pageManager.webapp;
+          await handleAppLockState(pageManager, appLockPassCode);
+          await components.conversationSidebar().clickPreferencesButton();
+
+          await expect(pages.account().appLockCheckbox).toBeDisabled();
+          // check here string
+
+          await expect(
+            page.getByText(
+              'Lock Wire after 30 seconds in the background. Unlock with Touch ID or enter your passcode.',
+            ),
+          ).toHaveCount(1);
+        },
+      );
+
+      test(
+        'I want to switch off app lock',
+        {tag: ['@TC-2771', '@TC-2772', '@regression']},
+        async ({api, createPage}) => {
+          await api.brig.toggleAppLock(owner.teamId, 'enabled', false);
+
+          const page = await createPage(withLogin(memberA));
+          const pageManager = PageManager.from(page);
+          const {components, pages, modals} = pageManager.webapp;
+
+          await components.conversationSidebar().clickPreferencesButton();
+          await pages.account().appLockCheckboxLabel.click();
+          await handleAppLockState(pageManager, appLockPassCode);
+
+          await pages.account().appLockCheckboxLabel.click();
+
+          await modals.confirm().actionButton.click();
+          await expect(pages.account().appLockCheckbox).not.toBeChecked();
+        },
+      );
     });
-  });
 
-  test(
-    'Web: I want to unlock the app with passphrase after login',
-    {tag: ['@TC-2754', '@TC-2755', '@TC-2758', '@TC-2763', '@regression']},
-    async ({createPage}) => {
-      const page = await createPage(withLogin(memberA));
-      const pageManager = PageManager.from(page);
-      const {modals, pages} = pageManager.webapp;
+  test.describe('AppLock disabled', () => {
 
-      await test.step('Web: I want the app to automatically lock after refreshing the page', async () => {
-        await handleAppLockState(pageManager, appLockPassCode);
-        await pageManager.refreshPage();
+    test.beforeEach(async ({createTeam, createUser}) => {
+      memberA = await createUser();
+      const team = await createTeam(teamName, {users: [memberA]});
+      owner = team.owner;
+    });
 
-        await expect(modals.appLock().appLockModal).toBeVisible();
-      });
+    test(
+      'Web: Verify inactivity timeout can be set if app lock is not enforced on a team level',
+      {tag: ['@TC-2772', '@regression']},
+      async ({createPage}) => {
+        const {components, pages, modals} = PageManager.from(await createPage(withLogin(memberA))).webapp;
 
-      await test.step('Web: I should not be able to unlock the app with wrong passphrase', async () => {
-        await handleAppLockState(pageManager, 'wrongCredentials');
-        await expect(modals.appLock().errorMessage).toHaveText('Wrong passcode');
-      });
+        await components.conversationSidebar().clickPreferencesButton();
+        await pages.account().privacySection.appLock.label.click();
+        await modals.appLock().setPasscode(appLockPassCode);
 
-      await test.step('Web: I should not be able to wipe database with wrong account password', async () => {
-        await modals.appLock().clickForgotPassphrase();
-        await modals.appLock().clickWipeDB();
-        await modals.appLock().clickReset();
-        await modals.appLock().inputUserPassword('wrong password');
-
-        expect(await checkAnyIndexedDBExists(page)).toBeTruthy();
-      });
-
-      await test.step('I want to wipe database when I forgot my app lock passphrase', async () => {
-        await modals.appLock().inputUserPassword(memberA.password);
-
-        await expect(pages.singleSignOn().ssoCodeEmailInput).toBeVisible();
-        expect(await checkAnyIndexedDBExists(page)).toBeFalsy();
-      });
-    },
-  );
-
-  test(
-    'I want to wipe database when I forgot my app lock passphrase',
-    {tag: ['@TC-2761', '@regression']},
-    async ({createPage}) => {
-      const page = await createPage(withLogin(memberA));
-      const pageManager = PageManager.from(page);
-      const {pages, modals} = pageManager.webapp;
-      await handleAppLockState(pageManager, appLockPassCode);
-
-      await page.reload();
-      await modals.appLock().clickForgotPassphrase();
-      await modals.appLock().clickWipeDB();
-      await modals.appLock().clickReset();
-      await modals.appLock().inputUserPassword(memberA.password);
-
-      // After redirect to login page verify the whole indexDB was cleared
-      await expect(pages.singleSignOn().ssoCodeEmailInput).toBeVisible();
-      await expect.poll(() => page.evaluate(() => indexedDB.databases())).toHaveLength(0);
-    },
-  );
-
-  test(
-    'I should not be able to switch off app lock if it is enforced for the team',
-    {tag: ['@TC-2770', '@TC-2767', '@regression']},
-    async ({createPage}) => {
-      const page = await createPage(withLogin(memberA));
-      const pageManager = PageManager.from(page);
-      const {components, pages} = pageManager.webapp;
-      await handleAppLockState(pageManager, appLockPassCode);
-      await components.conversationSidebar().clickPreferencesButton();
-
-      await expect(pages.account().appLockCheckbox).toBeDisabled();
-      // check here string
-
-      await expect(
-        page.getByText('Lock Wire after 30 seconds in the background. Unlock with Touch ID or enter your passcode.'),
-      ).toHaveCount(1);
-    },
-  );
-
-  test('I want to switch off app lock', {tag: ['@TC-2771', '@TC-2772', '@regression']}, async ({api, createPage}) => {
-    await api.brig.toggleAppLock(owner.teamId, 'enabled', false);
-
-    const page = await createPage(withLogin(memberA));
-    const pageManager = PageManager.from(page);
-    const {components, pages, modals} = pageManager.webapp;
-
-    await components.conversationSidebar().clickPreferencesButton();
-    await pages.account().appLockCheckboxLabel.click();
-    await handleAppLockState(pageManager, appLockPassCode);
-
-    await pages.account().appLockCheckboxLabel.click();
-
-    await modals.confirm().actionButton.click();
-    await expect(pages.account().appLockCheckbox).not.toBeChecked();
-  });
-
-  test.skip(
-    'Web: Verify inactivity timeout can be set if app lock is not enforced on a team level',
-    {tag: ['@TC-2772', '@regression']},
-    async () => {
-      // not implemented
-    },
-  );
+        await expect(pages.account().privacySection.appLock.checkbox).toBeChecked();
+      },
+    );
+  })
 });

--- a/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
@@ -153,12 +153,12 @@ test.describe('AppLock', () => {
     const {components, pages, modals} = pageManager.webapp;
 
     await components.conversationSidebar().clickPreferencesButton();
-    await pages.account().toggleAppLock();
+    await pages.account().appLockCheckboxLabel.click();
     await handleAppLockState(pageManager, appLockPassCode);
 
-    await pages.account().toggleAppLock();
+    await pages.account().appLockCheckboxLabel.click();
 
-    await modals.removeMember().clickConfirm();
+    await modals.confirm().actionButton.click();
     await expect(pages.account().appLockCheckbox).not.toBeChecked();
   });
 

--- a/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
@@ -127,6 +127,27 @@ test.describe('AppLock', () => {
   );
 
   test(
+    'I want to wipe database when I forgot my app lock passphrase',
+    {tag: ['@TC-2761', '@regression']},
+    async ({createPage}) => {
+      const page = await createPage(withLogin(memberA));
+      const pageManager = PageManager.from(page);
+      const {pages, modals} = PageManager.from(page).webapp;
+      await handleAppLockState(pageManager, appLockPassCode);
+
+      await page.reload();
+      await modals.appLock().clickForgotPassphrase();
+      await modals.appLock().clickWipeDB();
+      await modals.appLock().clickReset();
+      await modals.appLock().inputUserPassword(memberA.password);
+
+      // After redirect to login page verify the whole indexDB was cleared
+      await expect(pages.singleSignOn().ssoCodeEmailInput).toBeVisible();
+      await expect.poll(() => page.evaluate(() => indexedDB.databases())).toHaveLength(0);
+    },
+  );
+
+  test(
     'I should not be able to switch off app lock if it is enforced for the team',
     {tag: ['@TC-2770', '@TC-2767', '@regression']},
     async ({createPage}) => {

--- a/apps/webapp/test/e2e_tests/utils/indexedDB.util.ts
+++ b/apps/webapp/test/e2e_tests/utils/indexedDB.util.ts
@@ -1,0 +1,48 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Page} from '@playwright/test';
+/**
+ * Checks if ANY IndexedDB databases exist in the current browser context.
+ * This is used when database names are randomly generated (e.g., UUIDs).
+ * * @param page The Playwright Page object.
+ * @returns A Promise that resolves to true if ONE or MORE DBs exist, otherwise false.
+ */
+export const checkAnyIndexedDBExists = async (page: Page): Promise<boolean> => {
+  // The logic is executed directly inside the browser environment
+  return page.evaluate(async () => {
+    // Fallback for older browsers (though unlikely in modern Playwright tests)
+    if (!indexedDB.databases) {
+      console.error('Browser does not support indexedDB.databases(). Cannot check for existence.');
+      return false;
+    }
+
+    try {
+      // Retrieve a list of all existing databases for the current origin
+      const dbs = await indexedDB.databases();
+
+      // Return true if the list of databases is not empty
+      return dbs.length > 0;
+    } catch (error) {
+      // Handle potential errors (e.g., security restrictions)
+      console.error('Error retrieving IndexedDB list:', error);
+      return false;
+    }
+  });
+};

--- a/apps/webapp/test/e2e_tests/utils/userActions.ts
+++ b/apps/webapp/test/e2e_tests/utils/userActions.ts
@@ -98,13 +98,15 @@ export async function sendConnectionRequest(senderPageManager: PageManager, rece
 export const handleAppLockState = async (pageManager: PageManager, appLockPassCode: string) => {
   const {modals} = pageManager.webapp;
   const appLockModal = modals.appLock();
-  if (await appLockModal.isVisible()) {
-    if (await appLockModal.lockPasscodeInput.isVisible()) {
-      await appLockModal.setPasscode(appLockPassCode);
-    } else {
-      await appLockModal.unlockAppWithPasscode(appLockPassCode);
-    }
+
+  if (!(await appLockModal.isVisible())) return;
+
+  if (await appLockModal.lockPasscodeInput.isVisible()) {
+    await appLockModal.setPasscode(appLockPassCode);
+    return;
   }
+
+  await appLockModal.unlockAppWithPasscode(appLockPassCode);
 };
 
 /**

--- a/apps/webapp/test/e2e_tests/utils/userActions.ts
+++ b/apps/webapp/test/e2e_tests/utils/userActions.ts
@@ -95,6 +95,18 @@ export async function sendConnectionRequest(senderPageManager: PageManager, rece
   await modals.userProfile().clickConnectButton();
 }
 
+export const handleAppLockState = async (pageManager: PageManager, appLockPassCode: string) => {
+  const {modals} = pageManager.webapp;
+  const appLockModal = modals.appLock();
+  if (await appLockModal.isVisible()) {
+    if (await appLockModal.lockPasscodeInput.isVisible()) {
+      await appLockModal.setPasscode(appLockPassCode);
+    } else {
+      await appLockModal.unlockAppWithPasscode(appLockPassCode);
+    }
+  }
+};
+
 /**
  * @param testInfo is needed to create unique backup filename
  */


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23749" title="WPB-23749" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23749</a>  [Web/QA] Fix and re-enable TC-2752/2753 App lock
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- fix and re-enable flaky/broken test cases for AppLock
- TC-2752 & TC-2753

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---
