### PR TITLE
chore: bump core-crypto to 9.3.3 [WPB-23860]

### DIFF
--- a/libraries/core/package.json
+++ b/libraries/core/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@wireapp/api-client": "workspace:^",
-    "@wireapp/core-crypto": "9.3.2",
+    "@wireapp/core-crypto": "9.3.3",
     "@wireapp/cryptobox": "12.8.0",
     "@wireapp/priority-queue": "2.1.17",
     "@wireapp/promise-queue": "2.4.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10621,10 +10621,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/core-crypto@npm:9.3.2":
-  version: 9.3.2
-  resolution: "@wireapp/core-crypto@npm:9.3.2"
-  checksum: 10/608470af7c114b48bb25ce5bb4699378474866b845461da067985ad027000d6895c6291f9e67c7b3e577c5714fd033f1921a9cd076dd9eb09bfb95519872883c
+"@wireapp/core-crypto@npm:9.3.3":
+  version: 9.3.3
+  resolution: "@wireapp/core-crypto@npm:9.3.3"
+  checksum: 10/d6ea75da2f04514a3390139640bfa1a7363de5be19bcb8b68a7ffc45a93f36718c80f3c5cc75b89b4e1de245e072b166360e11aa49857f6b170171138ad48a53
   languageName: node
   linkType: hard
 
@@ -10637,7 +10637,7 @@ __metadata:
     "@types/lodash": "npm:4.17.23"
     "@types/long": "npm:5.0.0"
     "@wireapp/api-client": "workspace:^"
-    "@wireapp/core-crypto": "npm:9.3.2"
+    "@wireapp/core-crypto": "npm:9.3.3"
     "@wireapp/cryptobox": "npm:12.8.0"
     "@wireapp/priority-queue": "npm:2.1.17"
     "@wireapp/promise-queue": "npm:2.4.11"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23860" title="WPB-23860" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23860</a>  [Web] Prep Bund release based on Web Production release 2026-01-28-production.0
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Bumped core-crypto to [9.3.3](https://wireapp.github.io/core-crypto/CHANGELOG.html#v933---2026-03-31)

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
