### PR TITLE
feat: ignore epoch advancing on enabling camera on video call [WPB-23232]

### DIFF
--- a/apps/webapp/src/script/repositories/calling/CallingRepository.ts
+++ b/apps/webapp/src/script/repositories/calling/CallingRepository.ts
@@ -1537,7 +1537,6 @@ export class CallingRepository {
     const subconversationEpochInfo = await this.subconversationService.getSubconversationEpochInfo(
       conversationId,
       conversation.groupId,
-      true,
     );
 
     if (!subconversationEpochInfo) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23232" title="WPB-23232" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-23232</a>  [Web] Generate new epoch info without advancing the epoch on wcall_set_req_new_epoch_handler
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- What did I change and why?
Remove the flag which bumps the epoch on refreshing epoch/enable camera in video call.
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
