### PR TITLE
refactor: create base hook wrapper for shared file/folder functionality(WPB-22465)

### DIFF
--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/cellsNodeFormUtils.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/cellsNodeFormUtils.ts
@@ -26,7 +26,6 @@ export const ITEM_ALREADY_EXISTS_ERROR = 409;
 export const NODE_NAME_MAX_LENGTH = 64;
 
 const INVALID_NODE_NAME_PATTERN = /[\\/"]/u;
-const LEADING_DOT_PATTERN = /^\./u;
 
 export const getNameValidationError = (name: string): Maybe<string> => {
   if (!name) {
@@ -46,7 +45,7 @@ export const getClientSideNodeNameError = (name: string): Maybe<string> => {
     return Maybe.just(t('cells.newItemMenuModalForm.maxLengthError'));
   }
 
-  if (LEADING_DOT_PATTERN.test(name) || INVALID_NODE_NAME_PATTERN.test(name)) {
+  if (name.startsWith('.') || INVALID_NODE_NAME_PATTERN.test(name)) {
     return Maybe.just(t('cells.newItemMenuModalForm.invalidCharactersError'));
   }
 

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm.test.ts
@@ -20,7 +20,7 @@
 import {ChangeEvent, FormEvent} from 'react';
 import {act, renderHook} from '@testing-library/react';
 
-import {CellsRepository} from 'Repositories/cells/CellsRepository';
+import {CellsRepository} from 'Repositories/cells/cellsRepository';
 
 import {useCellsNewFileForm} from './useCellsNewFileForm';
 
@@ -32,8 +32,6 @@ describe('useCellsNewFileForm', () => {
   let mockCellsRepository: jest.Mocked<CellsRepository>;
   let onSuccess: jest.Mock;
 
-  const createEvent = () => ({preventDefault: jest.fn()}) as unknown as FormEvent<HTMLFormElement>;
-
   beforeEach(() => {
     jest.clearAllMocks();
     mockCellsRepository = {
@@ -42,8 +40,8 @@ describe('useCellsNewFileForm', () => {
     onSuccess = jest.fn();
   });
 
-  const renderUseCellsNewFileForm = () =>
-    renderHook(() =>
+  const setup = () => {
+    const {result} = renderHook(() =>
       useCellsNewFileForm({
         fileType: 'document',
         cellsRepository: mockCellsRepository,
@@ -53,89 +51,16 @@ describe('useCellsNewFileForm', () => {
       }),
     );
 
-  it('shows an error when name is empty', async () => {
-    const {result} = renderUseCellsNewFileForm();
-
-    await act(async () => {
-      await result.current.handleSubmit(createEvent());
-    });
-
-    expect(result.current.error).toBe('cells.newItemMenuModalForm.nameRequired');
-    expect(mockCellsRepository.createFile).not.toHaveBeenCalled();
-  });
-
-  it('does not submit when name validation fails', async () => {
-    const {result} = renderUseCellsNewFileForm();
-
-    act(() => {
-      result.current.handleChange({currentTarget: {value: 'file/name'}} as ChangeEvent<HTMLInputElement>);
-    });
-
-    await act(async () => {
-      await result.current.handleSubmit(createEvent());
-    });
-
-    expect(result.current.error).toBe('cells.newItemMenuModalForm.invalidCharactersError');
-    expect(mockCellsRepository.createFile).not.toHaveBeenCalled();
-  });
-
-  it('maps 409 responses to already-exists error', async () => {
-    mockCellsRepository.createFile.mockRejectedValueOnce({
-      response: {status: 409},
-    });
-
-    const {result} = renderUseCellsNewFileForm();
-
-    act(() => {
-      result.current.handleChange({currentTarget: {value: 'New file'}} as ChangeEvent<HTMLInputElement>);
-    });
-
-    await act(async () => {
-      await result.current.handleSubmit(createEvent());
-    });
-
-    expect(result.current.error).toBe('cells.newItemMenuModalForm.alreadyExistsError');
-    expect(onSuccess).not.toHaveBeenCalled();
-  });
-
-  it('maps non-409 failures to generic error', async () => {
-    mockCellsRepository.createFile.mockRejectedValueOnce(new Error('network error'));
-
-    const {result} = renderUseCellsNewFileForm();
-
-    act(() => {
-      result.current.handleChange({currentTarget: {value: 'New file'}} as ChangeEvent<HTMLInputElement>);
-    });
-
-    await act(async () => {
-      await result.current.handleSubmit(createEvent());
-    });
-
-    expect(result.current.error).toBe('cells.newItemMenuModalForm.genericError');
-    expect(onSuccess).not.toHaveBeenCalled();
-  });
-
-  it('trims the name and appends extension before create call', async () => {
-    const {result} = renderUseCellsNewFileForm();
-
-    act(() => {
-      result.current.handleChange({currentTarget: {value: ' New file '}} as ChangeEvent<HTMLInputElement>);
-    });
-
-    await act(async () => {
-      await result.current.handleSubmit(createEvent());
-    });
-
-    expect(mockCellsRepository.createFile).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'New file.docx',
-      }),
-    );
-    expect(onSuccess).toHaveBeenCalledTimes(1);
-  });
+    return {
+      result,
+      createNodeMock: mockCellsRepository.createFile,
+      onSuccess,
+    };
+  };
 
   it('appends selected file type extension when a mismatched extension is provided', async () => {
-    const {result} = renderUseCellsNewFileForm();
+    const {result} = setup();
+    const createEvent = () => ({preventDefault: jest.fn()}) as unknown as FormEvent<HTMLFormElement>;
 
     act(() => {
       result.current.handleChange({currentTarget: {value: 'doc124.ppt'}} as ChangeEvent<HTMLInputElement>);
@@ -145,11 +70,7 @@ describe('useCellsNewFileForm', () => {
       await result.current.handleSubmit(createEvent());
     });
 
-    expect(mockCellsRepository.createFile).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'doc124.ppt.docx',
-      }),
-    );
+    expect(mockCellsRepository.createFile).toHaveBeenCalledWith(expect.objectContaining({name: 'doc124.ppt.docx'}));
     expect(onSuccess).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFileForm.ts
@@ -17,19 +17,11 @@
  *
  */
 
-import {ChangeEvent, FormEvent, MouseEvent, useState} from 'react';
-
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
-import {t} from 'Util/localizerUtil';
 
-import {
-  ITEM_ALREADY_EXISTS_ERROR,
-  getClientSideNodeNameError,
-  getErrorStatus,
-  isClientSideNodeNameError,
-} from './cellsNodeFormUtils';
+import {useCellsNewNodeFormBase} from './useCellsNewNodeFormBase';
 
 import {getCellsApiPath} from '../getCellsApiPath/getCellsApiPath';
 
@@ -56,69 +48,16 @@ export const useCellsNewFileForm = ({
   onSuccess,
   currentPath,
 }: UseCellsNewFileFormProps) => {
-  const [name, setName] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
   const normalizeNameForCreation = (rawName: string): string => {
     const extension = FILE_EXTENSION_BY_TYPE[fileType];
     return `${rawName}.${extension}`;
   };
 
-  const createFile = async (fileName: string) => {
+  const createFile = async (name: string) => {
     const path = getCellsApiPath({conversationQualifiedId, currentPath});
-
-    try {
-      await cellsRepository.createFile({path, name: fileName});
-      onSuccess();
-    } catch (err: unknown) {
-      const isAlreadyExistsError = getErrorStatus(err)
-        .map(status => status === ITEM_ALREADY_EXISTS_ERROR)
-        .unwrapOr(false);
-      if (isAlreadyExistsError) {
-        setError(t('cells.newItemMenuModalForm.alreadyExistsError'));
-      } else {
-        setError(t('cells.newItemMenuModalForm.genericError'));
-      }
-    }
+    await cellsRepository.createFile({path, name});
+    onSuccess();
   };
 
-  const handleSubmit = async (formEvent: FormEvent<HTMLFormElement> | MouseEvent<HTMLButtonElement>) => {
-    formEvent.preventDefault();
-
-    if (isSubmitting) {
-      return;
-    }
-
-    const trimmedName = name.trim();
-    const validationError = getClientSideNodeNameError(trimmedName).unwrapOr(null);
-    if (validationError) {
-      setError(validationError);
-      return;
-    }
-
-    setError(null);
-    setIsSubmitting(true);
-
-    try {
-      await createFile(normalizeNameForCreation(trimmedName));
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setName(event.currentTarget.value);
-    if (isClientSideNodeNameError(error).unwrapOr(false)) {
-      setError(null);
-    }
-  };
-
-  return {
-    name,
-    error,
-    isSubmitting,
-    handleSubmit,
-    handleChange,
-  };
+  return useCellsNewNodeFormBase({createNode: createFile, normalizeNameForCreation});
 };

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFolderForm.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFolderForm.test.ts
@@ -20,7 +20,7 @@
 import {ChangeEvent, FormEvent} from 'react';
 import {act, renderHook} from '@testing-library/react';
 
-import {CellsRepository} from 'Repositories/cells/CellsRepository';
+import {CellsRepository} from 'Repositories/cells/cellsRepository';
 
 import {useCellsNewFolderForm} from './useCellsNewFolderForm';
 
@@ -38,11 +38,12 @@ describe('useCellsNewFolderForm', () => {
     jest.clearAllMocks();
     mockCellsRepository = {
       createFolder: jest.fn().mockResolvedValue(undefined),
+      createFile: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<CellsRepository>;
     onSuccess = jest.fn();
   });
 
-  const renderUseCellsNewFolderForm = () =>
+  const setup = () =>
     renderHook(() =>
       useCellsNewFolderForm({
         cellsRepository: mockCellsRepository,
@@ -52,58 +53,11 @@ describe('useCellsNewFolderForm', () => {
       }),
     );
 
-  it('shows an error when name is empty', async () => {
-    const {result} = renderUseCellsNewFolderForm();
-
-    await act(async () => {
-      await result.current.handleSubmit(createEvent());
-    });
-
-    expect(result.current.error).toBe('cells.newItemMenuModalForm.nameRequired');
-    expect(mockCellsRepository.createFolder).not.toHaveBeenCalled();
-  });
-
-  it('maps 409 responses to already-exists error', async () => {
-    mockCellsRepository.createFolder.mockRejectedValueOnce({
-      response: {status: 409},
-    });
-
-    const {result} = renderUseCellsNewFolderForm();
+  it('does not append file extension or template data when creating folder names', async () => {
+    const {result} = setup();
 
     act(() => {
-      result.current.handleChange({currentTarget: {value: 'New folder'}} as ChangeEvent<HTMLInputElement>);
-    });
-
-    await act(async () => {
-      await result.current.handleSubmit(createEvent());
-    });
-
-    expect(result.current.error).toBe('cells.newItemMenuModalForm.alreadyExistsError');
-    expect(onSuccess).not.toHaveBeenCalled();
-  });
-
-  it('maps non-409 failures to generic error', async () => {
-    mockCellsRepository.createFolder.mockRejectedValueOnce(new Error('network error'));
-
-    const {result} = renderUseCellsNewFolderForm();
-
-    act(() => {
-      result.current.handleChange({currentTarget: {value: 'New folder'}} as ChangeEvent<HTMLInputElement>);
-    });
-
-    await act(async () => {
-      await result.current.handleSubmit(createEvent());
-    });
-
-    expect(result.current.error).toBe('cells.newItemMenuModalForm.genericError');
-    expect(onSuccess).not.toHaveBeenCalled();
-  });
-
-  it('trims the name before create call', async () => {
-    const {result} = renderUseCellsNewFolderForm();
-
-    act(() => {
-      result.current.handleChange({currentTarget: {value: ' New folder '}} as ChangeEvent<HTMLInputElement>);
+      result.current.handleChange({currentTarget: {value: 'Project.docx'}} as ChangeEvent<HTMLInputElement>);
     });
 
     await act(async () => {
@@ -112,10 +66,25 @@ describe('useCellsNewFolderForm', () => {
 
     expect(mockCellsRepository.createFolder).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: 'New folder',
+        name: 'Project.docx',
       }),
     );
-    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(mockCellsRepository.createFolder).toHaveBeenCalledTimes(1);
   });
 
+  it('uses createFolder repository method and never calls createFile', async () => {
+    const {result} = setup();
+
+    act(() => {
+      result.current.handleChange({currentTarget: {value: 'New folder'}} as ChangeEvent<HTMLInputElement>);
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit(createEvent());
+    });
+
+    expect(mockCellsRepository.createFolder).toHaveBeenCalledTimes(1);
+    expect(mockCellsRepository.createFile).not.toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFolderForm.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFolderForm.ts
@@ -17,14 +17,10 @@
  *
  */
 
-import {ChangeEvent, FormEvent, MouseEvent, useState} from 'react';
-
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
-import {t} from 'Util/localizerUtil';
-
-import {ITEM_ALREADY_EXISTS_ERROR, getClientSideNodeNameError, getErrorStatus} from './cellsNodeFormUtils';
+import {useCellsNewNodeFormBase} from './useCellsNewNodeFormBase';
 
 import {getCellsApiPath} from '../getCellsApiPath/getCellsApiPath';
 
@@ -41,64 +37,11 @@ export const useCellsNewFolderForm = ({
   onSuccess,
   currentPath,
 }: UseCellsNewFolderFormProps) => {
-  const [name, setName] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  const createFolder = async (folderName: string) => {
+  const createFolder = async (name: string) => {
     const path = getCellsApiPath({conversationQualifiedId, currentPath});
-
-    try {
-      await cellsRepository.createFolder({path, name: folderName});
-      onSuccess();
-    } catch (err: unknown) {
-      const isAlreadyExistsError = getErrorStatus(err)
-        .map(status => status === ITEM_ALREADY_EXISTS_ERROR)
-        .unwrapOr(false);
-      if (isAlreadyExistsError) {
-        setError(t('cells.newItemMenuModalForm.alreadyExistsError'));
-      } else {
-        setError(t('cells.newItemMenuModalForm.genericError'));
-      }
-    }
+    await cellsRepository.createFolder({path, name});
+    onSuccess();
   };
 
-  const handleSubmit = async (formEvent: FormEvent<HTMLFormElement> | MouseEvent<HTMLButtonElement>) => {
-    formEvent.preventDefault();
-
-    if (isSubmitting) {
-      return;
-    }
-
-    const trimmedName = name.trim();
-    const validationError = getClientSideNodeNameError(trimmedName).unwrapOr(null);
-    if (validationError) {
-      setError(validationError);
-      return;
-    }
-
-    setError(null);
-    setIsSubmitting(true);
-
-    try {
-      await createFolder(trimmedName);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setName(event.currentTarget.value);
-    if (error === t('cells.newItemMenuModalForm.nameRequired')) {
-      setError(null);
-    }
-  };
-
-  return {
-    name,
-    error,
-    isSubmitting,
-    handleSubmit,
-    handleChange,
-  };
+  return useCellsNewNodeFormBase({createNode: createFolder});
 };

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFolderForm.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewFolderForm.ts
@@ -20,6 +20,7 @@
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
+
 import {useCellsNewNodeFormBase} from './useCellsNewNodeFormBase';
 
 import {getCellsApiPath} from '../getCellsApiPath/getCellsApiPath';

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewNodeFormBase.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewNodeFormBase.test.ts
@@ -1,0 +1,113 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {ChangeEvent, FormEvent} from 'react';
+import {act, renderHook} from '@testing-library/react';
+
+import {useCellsNewNodeFormBase} from './useCellsNewNodeFormBase';
+
+jest.mock('Util/localizerUtil', () => ({
+  t: (key: string) => key,
+}));
+
+describe('useCellsNewNodeFormBase', () => {
+  const createEvent = () => ({preventDefault: jest.fn()}) as unknown as FormEvent<HTMLFormElement>;
+
+  const setup = (
+    createNode: jest.Mock<Promise<void>, [string]> = jest.fn().mockResolvedValue(undefined),
+    normalizeNameForCreation?: (rawName: string) => string,
+  ) => {
+    const {result} = renderHook(() => useCellsNewNodeFormBase({createNode, normalizeNameForCreation}));
+
+    return {
+      result,
+      createNode,
+    };
+  };
+
+  it('shows required-name error and blocks submit when name is empty', async () => {
+    const {result, createNode} = setup();
+
+    await act(async () => {
+      await result.current.handleSubmit(createEvent());
+    });
+
+    expect(result.current.error).toBe('cells.newItemMenuModalForm.nameRequired');
+    expect(createNode).not.toHaveBeenCalled();
+  });
+
+  it('shows invalid-characters error and blocks submit for invalid name', async () => {
+    const {result, createNode} = setup();
+
+    act(() => {
+      result.current.handleChange({currentTarget: {value: 'file/name'}} as ChangeEvent<HTMLInputElement>);
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit(createEvent());
+    });
+
+    expect(result.current.error).toBe('cells.newItemMenuModalForm.invalidCharactersError');
+    expect(createNode).not.toHaveBeenCalled();
+  });
+
+  it('trims input and applies normalizeNameForCreation before calling createNode', async () => {
+    const normalizeNameForCreation = jest.fn((rawName: string) => `${rawName}.normalized`);
+    const {result, createNode} = setup(jest.fn().mockResolvedValue(undefined), normalizeNameForCreation);
+
+    act(() => {
+      result.current.handleChange({currentTarget: {value: ' New item '}} as ChangeEvent<HTMLInputElement>);
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit(createEvent());
+    });
+
+    expect(normalizeNameForCreation).toHaveBeenCalledWith('New item');
+    expect(createNode).toHaveBeenCalledWith('New item.normalized');
+  });
+
+  it('maps 409 failures to already-exists error', async () => {
+    const {result} = setup(jest.fn().mockRejectedValueOnce({response: {status: 409}}));
+
+    act(() => {
+      result.current.handleChange({currentTarget: {value: 'New item'}} as ChangeEvent<HTMLInputElement>);
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit(createEvent());
+    });
+
+    expect(result.current.error).toBe('cells.newItemMenuModalForm.alreadyExistsError');
+  });
+
+  it('maps non-409 failures to generic error', async () => {
+    const {result} = setup(jest.fn().mockRejectedValueOnce(new Error('network error')));
+
+    act(() => {
+      result.current.handleChange({currentTarget: {value: 'New item'}} as ChangeEvent<HTMLInputElement>);
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit(createEvent());
+    });
+
+    expect(result.current.error).toBe('cells.newItemMenuModalForm.genericError');
+  });
+});

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewNodeFormBase.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsNewNodeForm/useCellsNewNodeFormBase.ts
@@ -1,0 +1,94 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {ChangeEvent, FormEvent, MouseEvent, useState} from 'react';
+
+import {t} from 'Util/localizerUtil';
+
+import {
+  ITEM_ALREADY_EXISTS_ERROR,
+  getClientSideNodeNameError,
+  getErrorStatus,
+  isClientSideNodeNameError,
+} from './cellsNodeFormUtils';
+
+interface UseCellsNewNodeFormBaseProps {
+  createNode: (name: string) => Promise<void>;
+  normalizeNameForCreation?: (rawName: string) => string;
+}
+
+const defaultNameNormalizer = (value: string) => value;
+
+export const useCellsNewNodeFormBase = ({
+  createNode,
+  normalizeNameForCreation = defaultNameNormalizer,
+}: UseCellsNewNodeFormBaseProps) => {
+  const [name, setName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (formEvent: FormEvent<HTMLFormElement> | MouseEvent<HTMLButtonElement>) => {
+    formEvent.preventDefault();
+
+    if (isSubmitting) {
+      return;
+    }
+
+    const trimmedName = name.trim();
+    const validationError = getClientSideNodeNameError(trimmedName).unwrapOr(null);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      await createNode(normalizeNameForCreation(trimmedName));
+    } catch (err: unknown) {
+      const isAlreadyExistsError = getErrorStatus(err)
+        .map(status => status === ITEM_ALREADY_EXISTS_ERROR)
+        .unwrapOr(false);
+
+      if (isAlreadyExistsError) {
+        setError(t('cells.newItemMenuModalForm.alreadyExistsError'));
+      } else {
+        setError(t('cells.newItemMenuModalForm.genericError'));
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setName(event.currentTarget.value);
+    if (isClientSideNodeNameError(error).unwrapOr(false)) {
+      setError(null);
+    }
+  };
+
+  return {
+    name,
+    error,
+    isSubmitting,
+    handleSubmit,
+    handleChange,
+  };
+};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22465" title="WPB-22465" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22465</a>  [Web] Add the option to create a new Collabora document from files tab
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- Refactored duplicated file/folder creation form logic into a shared base hook: useCellsNewNodeFormBase.
- Kept useCellsNewFileForm and useCellsNewFolderForm as lightweight wrappers with type-specific behavior.

Moved common validation/submit/error handling tests to useCellsNewNodeFormBase.test.ts.

Kept wrapper-specific tests in:
- useCellsNewFileForm.test.ts (file extension-specific behavior)
- useCellsNewFolderForm.test.ts (folder-specific behavior)

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
