### PR TITLE
chore(E2E): Fixing tests race condition [WPB-24429]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
@@ -106,8 +106,8 @@ test.describe('Clear Conversation Content', () => {
       `I want to ${type} content of 1:1 conversation via conversation list`,
       {tag: [tag, '@regression']},
       async ({createPage}) => {
-        const userBPageManager = await PageManager.from(createPage(withLogin(userB)));
-        const userAPageManager = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)));
+        const userBPageManager = PageManager.from(await createPage(withLogin(userB)));
+        const userAPageManager = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB)));
 
         const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
         const userBPages = userBPageManager.webapp.pages;
@@ -257,8 +257,8 @@ test.describe('Clear Conversation Content', () => {
       `I want to clear the ${conversationType} conversation content from conversation details options`,
       {tag: [tag, '@regression']},
       async ({createPage}) => {
-        const userBPageManager = await PageManager.from(createPage(withLogin(userB)));
-        const userAPageManager = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)));
+        const userBPageManager = PageManager.from(await createPage(withLogin(userB)));
+        const userAPageManager = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB)));
 
         const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
         const userBPages = userBPageManager.webapp.pages;

--- a/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
@@ -106,10 +106,8 @@ test.describe('Clear Conversation Content', () => {
       `I want to ${type} content of 1:1 conversation via conversation list`,
       {tag: [tag, '@regression']},
       async ({createPage}) => {
-        const [userAPageManager, userBPageManager] = await Promise.all([
-          PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
-          PageManager.from(createPage(withLogin(userB))),
-        ]);
+        const userBPageManager = await PageManager.from(createPage(withLogin(userB)));
+        const userAPageManager = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)));
 
         const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
         const userBPages = userBPageManager.webapp.pages;
@@ -155,11 +153,12 @@ test.describe('Clear Conversation Content', () => {
       `I want to see incoming picture, ping and call after I clear content of a ${conversationType} conversation via conversation list`,
       {tag: [tag, '@regression']},
       async ({createPage}) => {
-        const [userAPage, userBPage, userCPage] = await Promise.all([
-          createPage(withLogin(userA), withConnectedUser(userB), withConnectedUser(userC)),
+        const [userBPage, userCPage] = await Promise.all([
           createPage(withLogin(userB)),
           createPage(withLogin(userC)),
         ]);
+
+        const userAPage = await createPage(withLogin(userA), withConnectedUser(userB), withConnectedUser(userC));
 
         const userAPageManager = PageManager.from(userAPage);
         const userBPageManager = PageManager.from(userBPage);
@@ -258,10 +257,8 @@ test.describe('Clear Conversation Content', () => {
       `I want to clear the ${conversationType} conversation content from conversation details options`,
       {tag: [tag, '@regression']},
       async ({createPage}) => {
-        const [userAPageManager, userBPageManager] = await Promise.all([
-          PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
-          PageManager.from(createPage(withLogin(userB))),
-        ]);
+        const userBPageManager = await PageManager.from(createPage(withLogin(userB)));
+        const userAPageManager = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)));
 
         const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
         const userBPages = userBPageManager.webapp.pages;

--- a/apps/webapp/test/e2e_tests/specs/Conversations/conversations.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Conversations/conversations.spec.ts
@@ -44,7 +44,7 @@ test.describe('Conversations', () => {
       const userAPages = await PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages);
 
       await createGroup(userAPages, groupName, [userB, userC]);
-      userAPages.conversationList().openConversation(groupName);
+      await userAPages.conversationList().openConversation(groupName);
 
       const firstMessage = userAPages.conversation().systemMessages.first();
       await expect(firstMessage).toContainText(new RegExp(`You started the conversation\\s*${groupName}\\s*with`, 'i'));

--- a/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
@@ -321,10 +321,8 @@ test.describe('Delete', () => {
 
   testCases.forEach(({name, tc, sendAction}) => {
     test(`Delete "For Everyone" works for ${name}`, {tag: [tc, '@regression']}, async ({createPage, api}) => {
-      const [pageA, pageB] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const pageB = await createPage(withLogin(userB));
+      const pageA = await  createPage(withLogin(userA), withConnectedUser(userB));
 
       const userAPages = PageManager.from(pageA).webapp.pages;
       const userBPages = PageManager.from(pageB).webapp.pages;

--- a/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
@@ -39,10 +39,8 @@ test.describe('In Conversation Search', () => {
     'Verify main overview shows media from all categories',
     {tag: ['@TC-352', '@regression']},
     async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const userBPage = await createPage(withLogin(userB));
+      const userAPage = await createPage(withLogin(userA), withConnectedUser(userB));
 
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;

--- a/apps/webapp/test/e2e_tests/specs/Mention/mention.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Mention/mention.spec.ts
@@ -290,10 +290,8 @@ test.describe('Mention', () => {
   );
 
   test('I want to receive a message containing a mention', {tag: ['@TC-3521', '@regression']}, async ({createPage}) => {
-    const [userAPages, userBPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-    ]);
+    const userBPages = await PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages);
+    const userAPages = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages);
 
     await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
     await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
@@ -516,16 +514,16 @@ test.describe('Mention', () => {
     {tag: ['@TC-3545', '@regression']},
     async ({createUser, createPage}) => {
       const otherUser = await createUser();
-      const [userAPages, userBPages, otherUserPages] = await Promise.all([
+      const otherUserPages = await PageManager.from(createPage(withLogin(otherUser))).then(pm => pm.webapp.pages);
+
+      const [userAPages, userBPages] = await Promise.all([
         PageManager.from(createPage(withLogin(userA), withConnectionRequest(otherUser))).then(pm => pm.webapp.pages),
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(otherUser))).then(async pm => {
-          await pm.webapp.pages.conversationList().pendingConnectionRequest.click();
-          await pm.webapp.pages.connectRequest().connectButton.click();
-          return pm.webapp.pages;
-        }),
       ]);
 
+      await otherUserPages.conversationList().pendingConnectionRequest.click();
+      await otherUserPages.connectRequest().connectButton.click();
+      
       await test.step('UserA creates a group including userB and otherUser', async () => {
         await createGroup(userAPages, 'Test Group', [userB, otherUser]);
       });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24429" title="WPB-24429" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24429</a>  [Web][QA] Investigate E2E tests that are flaky because of possible race condition.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

https://wearezeta.atlassian.net/browse/WPB-24429

- What did I change and why?

In some tests we used Promise.all() to create multiple users in parallel. The problem is some of these users depend on each other and have connection requests sent to each other. That created a rest condition. I changed such cases to create users sequentially.

- Risks and how to roll out / roll back (e.g. feature flags):

No risk, fixing tests.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
