### PR TITLE
fix: call e2eRotate on existing conversations [WPB-24528]

### DIFF
--- a/apps/webapp/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/apps/webapp/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -314,14 +314,19 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
         },
         certificateTtl: this.certificateTtl,
         getAllConversations: async () => {
-          if (!isCertificateRenewal) {
-            return Promise.resolve([]);
+          if (is.undefined(this.core.service)) {
+            return [];
           }
           const conversations = await this.core.service.conversation.getConversations();
+
+          if (!is.array(conversations.found)) {
+            return [];
+          }
+
           return conversations.found
             .filter(conversation => is.nonEmptyString(conversation.group_id))
             .map(({group_id}) => ({
-              group_id,
+              group_id: group_id!,
             }));
         },
       });

--- a/libraries/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
+++ b/libraries/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
@@ -276,8 +276,19 @@ export class E2EIServiceInternal {
       const newCrlDistributionPoints = await cx.saveX509Credential(identity, certificate);
       for (const conversation of conversations) {
         if (Boolean(conversation.group_id?.length)) {
-          const idAsBytes = Decoder.fromBase64(conversation.group_id).asBytes;
-          await cx.e2eiRotate(new ConversationId(idAsBytes));
+          try {
+            const idAsBytes = Decoder.fromBase64(conversation.group_id).asBytes;
+            const conversationId = new ConversationId(idAsBytes);
+
+            // Check if conversation exists before rotating
+            const conversationExists = await cx.conversationExists(conversationId);
+            if (conversationExists) {
+              await cx.e2eiRotate(conversationId);
+            }
+          } catch (error) {
+            // Log error but don't fail the entire enrollment if one conversation fails
+            this.logger.warn('Failed to rotate conversation', {groupId: conversation.group_id, error});
+          }
         } else {
           this.logger.error('No group id found in conversation');
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24528" title="WPB-24528" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24528</a>  [Web] User not able to send messages after e2ei was enbaled while user is logged in
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

When we enable e2eI for existing MLS client, all the conversations must me called with `e2eiRotate`.

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
