### PR TITLE
fix: input bar emoji selection during message editing [WPB-24575]

### DIFF
--- a/apps/webapp/src/script/components/EmojiPicker/EmojiPicker.test.tsx
+++ b/apps/webapp/src/script/components/EmojiPicker/EmojiPicker.test.tsx
@@ -1,0 +1,87 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import React from 'react';
+
+import {render, waitFor} from '@testing-library/react';
+
+import {withTheme} from 'src/script/auth/util/test/TestUtil';
+
+import {EmojiPicker} from './EmojiPicker';
+
+import {handleClickOutsideOfInputBar} from '../InputBar/util/clickHandlers';
+
+describe('EmojiPicker', () => {
+  it('marks the dialog as ignored for input bar outside-click handling', async () => {
+    const wrapperRef = React.createRef<HTMLDivElement>();
+    const {getByTestId} = render(
+      withTheme(
+        <div ref={wrapperRef}>
+          <EmojiPicker
+            posX={100}
+            posY={100}
+            onKeyPress={() => {
+              return undefined;
+            }}
+            resetActionMenuStates={() => {
+              return undefined;
+            }}
+            wrapperRef={wrapperRef}
+            handleReactionClick={() => {
+              return undefined;
+            }}
+          />
+        </div>,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('emoji-picker-dialog')).toBeDefined();
+    });
+
+    expect(getByTestId('emoji-picker-dialog')).toHaveAttribute('data-outside-click-ignore');
+  });
+
+  it('does not treat emoji picker clicks as outside input bar clicks', async () => {
+    const wrapperRef = React.createRef<HTMLDivElement>();
+    const handleOutsideClick = jest.fn();
+    const {getByTestId} = render(
+      withTheme(
+        <div ref={wrapperRef}>
+          <EmojiPicker
+            posX={100}
+            posY={100}
+            onKeyPress={() => undefined}
+            resetActionMenuStates={() => undefined}
+            wrapperRef={wrapperRef}
+            handleReactionClick={() => undefined}
+          />
+        </div>,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('emoji-picker-dialog')).toBeDefined();
+    });
+
+    handleClickOutsideOfInputBar({target: getByTestId('emoji-picker-dialog')} as Event, handleOutsideClick);
+
+    expect(handleOutsideClick).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/src/script/components/EmojiPicker/EmojiPicker.tsx
+++ b/apps/webapp/src/script/components/EmojiPicker/EmojiPicker.tsx
@@ -17,32 +17,30 @@
  *
  */
 
-import {useState, useEffect, useRef, RefObject} from 'react';
+import {useState, useEffect, useRef} from 'react';
+import type {FunctionComponent, RefObject} from 'react';
 
-import EmojiPickerReact, {EmojiClickData, EmojiStyle, SkinTones} from 'emoji-picker-react';
 import {createPortal} from 'react-dom';
 
+import {IgnoreOutsideClickWrapper} from 'Components/InputBar/util/clickHandlers';
 import {useClickOutside} from 'src/script/hooks/useClickOutside';
 import {isEnterKey, isEscapeKey} from 'Util/keyboardUtil';
 import {t} from 'Util/localizerUtil';
 
-interface EmojiPickerProps {
-  posX: number;
-  posY: number;
-  onKeyPress: () => void;
-  resetActionMenuStates: () => void;
-  wrapperRef: RefObject<HTMLDivElement>;
-  handleReactionClick: (emoji: string) => void;
+import {EmojiPickerAdapter, SkinTones} from './EmojiPickerAdapter';
+import type {EmojiPickerSelection} from './EmojiPickerAdapter';
+
+interface EmojiPickerProperties {
+  readonly posX: number;
+  readonly posY: number;
+  readonly onKeyPress: () => void;
+  readonly resetActionMenuStates: () => void;
+  readonly wrapperRef: RefObject<HTMLDivElement>;
+  readonly handleReactionClick: (emoji: string) => void;
 }
 
-export const EmojiPicker = ({
-  posX,
-  posY,
-  onKeyPress,
-  resetActionMenuStates,
-  wrapperRef,
-  handleReactionClick,
-}: EmojiPickerProps) => {
+export const EmojiPicker: FunctionComponent<EmojiPickerProperties> = properties => {
+  const {posX, posY, onKeyPress, resetActionMenuStates, wrapperRef, handleReactionClick} = properties;
   const emojiRef = useRef<HTMLDivElement>(null);
   useClickOutside(emojiRef, resetActionMenuStates, wrapperRef);
   const [style, setStyle] = useState<object>({
@@ -80,10 +78,10 @@ export const EmojiPicker = ({
     return () => window.removeEventListener('resize', updateSize);
   }, [posX, posY]);
 
-  function onEmojiClick(emojiData: EmojiClickData, event: MouseEvent) {
-    localStorage.setItem('activeSkinTone', emojiData.activeSkinTone);
+  function onEmojiClick(emojiPickerSelection: EmojiPickerSelection) {
+    localStorage.setItem('activeSkinTone', emojiPickerSelection.activeSkinTone);
 
-    handleReactionClick(emojiData.emoji);
+    handleReactionClick(emojiPickerSelection.emoji);
 
     if (isKeyboardEvent) {
       // keyboard event still retains emoji button focus
@@ -116,8 +114,7 @@ export const EmojiPicker = ({
             }
           }}
         >
-          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */}
-          <div
+          <IgnoreOutsideClickWrapper
             ref={emojiRef}
             style={{maxHeight: window.innerHeight, ...style}}
             role="dialog"
@@ -128,13 +125,12 @@ export const EmojiPicker = ({
               event.stopPropagation();
             }}
           >
-            <EmojiPickerReact
-              emojiStyle={EmojiStyle.NATIVE}
+            <EmojiPickerAdapter
               onEmojiClick={onEmojiClick}
-              searchPlaceHolder={t('accessibility.emojiPickerSearchPlaceholder')}
+              searchPlaceholder={t('accessibility.emojiPickerSearchPlaceholder')}
               defaultSkinTone={getSkinTone()}
             />
-          </div>
+          </IgnoreOutsideClickWrapper>
         </div>,
         document.body,
       )}

--- a/apps/webapp/src/script/components/EmojiPicker/EmojiPickerAdapter.tsx
+++ b/apps/webapp/src/script/components/EmojiPicker/EmojiPickerAdapter.tsx
@@ -1,0 +1,59 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {FunctionComponent} from 'react';
+
+import EmojiPickerReact, {EmojiClickData, EmojiStyle, SkinTones} from 'emoji-picker-react';
+
+export {SkinTones};
+
+export interface EmojiPickerSelection {
+  readonly emoji: string;
+  readonly activeSkinTone: string;
+}
+
+export interface EmojiPickerAdapterProperties {
+  readonly onEmojiClick: (emojiPickerSelection: EmojiPickerSelection) => void;
+  readonly searchPlaceholder: string;
+  readonly defaultSkinTone: SkinTones;
+}
+
+export const defaultEmojiStyle = EmojiStyle.NATIVE;
+
+export const EmojiPickerAdapter: FunctionComponent<EmojiPickerAdapterProperties> = properties => {
+  const {onEmojiClick, searchPlaceholder, defaultSkinTone} = properties;
+
+  function handleEmojiClick(emojiClickData: EmojiClickData) {
+    const emojiPickerSelection: EmojiPickerSelection = {
+      emoji: emojiClickData.emoji,
+      activeSkinTone: emojiClickData.activeSkinTone,
+    };
+
+    onEmojiClick(emojiPickerSelection);
+  }
+
+  return (
+    <EmojiPickerReact
+      emojiStyle={defaultEmojiStyle}
+      onEmojiClick={handleEmojiClick}
+      searchPlaceHolder={searchPlaceholder}
+      defaultSkinTone={defaultSkinTone}
+    />
+  );
+};

--- a/apps/webapp/src/script/components/InputBar/util/clickHandlers.tsx
+++ b/apps/webapp/src/script/components/InputBar/util/clickHandlers.tsx
@@ -17,20 +17,25 @@
  *
  */
 
-import {HTMLProps, ReactNode} from 'react';
+import {forwardRef, HTMLProps, ReactNode} from 'react';
 
 const dataAttribute = 'data-outside-click-ignore';
 
 interface IgnoreOutsideClickWrapperProps extends HTMLProps<HTMLDivElement> {
   children: ReactNode;
 }
-const IgnoreOutsideClickWrapper = ({children, ...rest}: IgnoreOutsideClickWrapperProps) => {
-  return (
-    <div {...rest} {...{[dataAttribute]: ''}}>
-      {children}
-    </div>
-  );
-};
+
+const IgnoreOutsideClickWrapper = forwardRef<HTMLDivElement, IgnoreOutsideClickWrapperProps>(
+  ({children, ...rest}, reference) => {
+    return (
+      <div ref={reference} {...rest} {...{[dataAttribute]: ''}}>
+        {children}
+      </div>
+    );
+  },
+);
+
+IgnoreOutsideClickWrapper.displayName = 'IgnoreOutsideClickWrapper';
 
 const handleClickOutsideOfInputBar = (event: Event, callback: () => void): void => {
   const ignoredParent = (event.target as HTMLElement).closest(`div[${dataAttribute}]`) !== null;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24575" title="WPB-24575" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24575</a>  [Web] Emoji picker does not work when editing a message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

This fixes a regression where editing the last message with ArrowUp was cancelled when selecting an emoji from the composer emoji picker.

The root cause was that the emoji picker is rendered in a portal, but edit mode cancels on outside clicks unless the clicked element is explicitly marked as part of the input flow. Because the picker dialog was not participating in that contract, clicking an emoji was treated as a click outside the composer and the edit draft was cleared.

![Screen Recording 2026-04-07 at 12 03 24](https://github.com/user-attachments/assets/2844d1a7-6b6e-4850-83a0-1a38839a32f6)

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
