### PR TITLE
test: un-skip & fix TC-3460 & TC-1311 [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Authentication/authentication.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Authentication/authentication.spec.ts
@@ -72,7 +72,7 @@ test.describe('Authentication', () => {
     },
   );
 
-  test.skip(
+  test(
     'Verify current browser is set as temporary device',
     {tag: ['@TC-3460', '@regression']},
     async ({createUser, createPage}) => {
@@ -99,7 +99,7 @@ test.describe('Authentication', () => {
       await test.step('Log out of public computer', async () => {
         await pages.settings().accountButton.click();
         await pages.account().clickLogoutButton();
-        await expect(pages.login().signInButton).toBeVisible({timeout: LOGIN_TIMEOUT});
+        await expect(pages.singleSignOn().ssoSignInButton).toBeVisible();
       });
 
       await test.step('Log in again on non public computer', async () => {
@@ -194,7 +194,7 @@ test.describe('Authentication', () => {
     },
   );
 
-  test.skip(
+  test(
     'Make sure user does not see data of user of previous sessions on same browser',
     {tag: ['@TC-1311', '@regression']},
     async ({createUser, createTeam, createPage}) => {
@@ -222,7 +222,7 @@ test.describe('Authentication', () => {
         await components.conversationSidebar().clickPreferencesButton();
         await pages.settings().accountButton.click();
         await pages.account().clickLogoutButton();
-        await expect(pages.login().signInButton).toBeVisible({timeout: LOGIN_TIMEOUT});
+        await expect(pages.singleSignOn().ssoSignInButton).toBeVisible();
       });
 
       await test.step('Log in again', async () => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

These tests were previously skipped as part of #20812 most likely due to a change in behavior. Now the user is redirected to the SSO page instead of the login page upon logout. This PR fixes the assertions and un-skips the tests.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
