### PR TITLE
fix: Replace username with profile name in the version history modal(WPB-24286)

### DIFF
--- a/apps/webapp/src/script/components/Modals/FileHistoryModal/hooks/useFileVersions.ts
+++ b/apps/webapp/src/script/components/Modals/FileHistoryModal/hooks/useFileVersions.ts
@@ -27,10 +27,13 @@ import {container} from 'tsyringe';
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
 import {UserState} from 'Repositories/user/UserState';
 import {t} from 'Util/localizerUtil';
+import {getLogger} from 'Util/logger';
 import {forcedDownloadFile, getFileExtension, getName} from 'Util/util';
 
 import {FileInfo, FileVersion} from '../types';
 import {groupVersionsByDate} from '../utils/fileVersionUtils';
+
+const logger = getLogger('FileVersionHistoryModal');
 
 /**
  * Hook to fetch and manage file versions for a given node UUID.
@@ -74,14 +77,14 @@ export const useFileVersions = (nodeUuid?: string, onClose?: () => void, onResto
 
         setFileInfo(info);
 
-        const ownerNameByUserId = getOwnerNameByUserId(versions || []);
+        const ownerNamesByUserIdMap = getOwnerNamesByUserIdMap(versions || []);
         const groupedVersions = groupVersionsByDate(versions || [], version => {
           const ownerQualifiedId = parseOwnerQualifiedId(version.OwnerUuid);
           if (!ownerQualifiedId) {
             return undefined;
           }
 
-          return ownerNameByUserId.get(ownerQualifiedId.id);
+          return ownerNamesByUserIdMap.get(ownerQualifiedId.id);
         });
         setFileVersions(groupedVersions);
       } catch (err: unknown) {
@@ -159,12 +162,13 @@ const parseOwnerQualifiedId = (ownerUuid?: string): QualifiedId | undefined => {
 
   try {
     return parseQualifiedId(ownerUuid.trim());
-  } catch {
+  } catch (error) {
+    logger.warn('Failed to parse qualifiedId', ownerUuid, error);
     return undefined;
   }
 };
 
-const getOwnerNameByUserId = (versions: Partial<RestVersion>[]): Map<string, string> => {
+const getOwnerNamesByUserIdMap = (versions: Partial<RestVersion>[]): Map<string, string> => {
   const ownerIds = new Set(
     versions.flatMap(version => {
       const qualifiedId = parseOwnerQualifiedId(version.OwnerUuid);
@@ -181,7 +185,8 @@ const getOwnerNameByUserId = (versions: Partial<RestVersion>[]): Map<string, str
     const matchingUsers = users.filter(user => ownerIds.has(user.id) && user.name());
 
     return new Map<string, string>(matchingUsers.map(user => [user.id, user.name()]));
-  } catch {
+  } catch (error) {
+    logger.warn('Failed to resolve owner names from UserState', {ownerIdsCount: ownerIds.size, error});
     return new Map();
   }
 };

--- a/apps/webapp/src/script/components/Modals/FileHistoryModal/hooks/useFileVersions.ts
+++ b/apps/webapp/src/script/components/Modals/FileHistoryModal/hooks/useFileVersions.ts
@@ -19,9 +19,13 @@
 
 import {useCallback, useEffect, useState} from 'react';
 
+import {QualifiedId} from '@wireapp/api-client/lib/user';
+import {parseQualifiedId} from '@wireapp/core/lib/util/qualifiedIdUtil';
+import {RestVersion} from 'cells-sdk-ts';
 import {container} from 'tsyringe';
 
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
+import {UserState} from 'Repositories/user/UserState';
 import {t} from 'Util/localizerUtil';
 import {forcedDownloadFile, getFileExtension, getName} from 'Util/util';
 
@@ -70,7 +74,15 @@ export const useFileVersions = (nodeUuid?: string, onClose?: () => void, onResto
 
         setFileInfo(info);
 
-        const groupedVersions = groupVersionsByDate(versions || []);
+        const ownerNameByUserId = getOwnerNameByUserId(versions || []);
+        const groupedVersions = groupVersionsByDate(versions || [], version => {
+          const ownerQualifiedId = parseOwnerQualifiedId(version.OwnerUuid);
+          if (!ownerQualifiedId) {
+            return undefined;
+          }
+
+          return ownerNameByUserId.get(ownerQualifiedId.id);
+        });
         setFileVersions(groupedVersions);
       } catch (err: unknown) {
         const errorMessage = err instanceof Error ? err.message : t('fileHistoryModal.failedToLoadVersions');
@@ -138,4 +150,38 @@ export const useFileVersions = (nodeUuid?: string, onClose?: () => void, onResto
     setToBeRestoredVersionId,
     toBeRestoredVersionId,
   };
+};
+
+const parseOwnerQualifiedId = (ownerUuid?: string): QualifiedId | undefined => {
+  if (!ownerUuid) {
+    return undefined;
+  }
+
+  try {
+    return parseQualifiedId(ownerUuid.trim());
+  } catch {
+    return undefined;
+  }
+};
+
+const getOwnerNameByUserId = (versions: Partial<RestVersion>[]): Map<string, string> => {
+  const ownerIds = new Set(
+    versions.flatMap(version => {
+      const qualifiedId = parseOwnerQualifiedId(version.OwnerUuid);
+      return qualifiedId ? [qualifiedId.id] : [];
+    }),
+  );
+
+  if (!ownerIds.size) {
+    return new Map();
+  }
+
+  try {
+    const users = container.resolve(UserState).users();
+    const matchingUsers = users.filter(user => ownerIds.has(user.id) && user.name());
+
+    return new Map<string, string>(matchingUsers.map(user => [user.id, user.name()]));
+  } catch {
+    return new Map();
+  }
 };

--- a/apps/webapp/src/script/components/Modals/FileHistoryModal/utils/fileVersionUtils.ts
+++ b/apps/webapp/src/script/components/Modals/FileHistoryModal/utils/fileVersionUtils.ts
@@ -38,7 +38,7 @@ export const transformRestVersionToFileVersion = (
   return {
     versionId: version.VersionId || '',
     time: formatTime(timestamp),
-    ownerName: resolveOwnerName?.(version) || version.OwnerName || '',
+    ownerName: resolveOwnerName?.(version) ?? version.OwnerName ?? '',
     size: formatBytes(Number(version.Size) || 0),
     downloadUrl: version.PreSignedGET?.Url || '',
   };

--- a/apps/webapp/src/script/components/Modals/FileHistoryModal/utils/fileVersionUtils.ts
+++ b/apps/webapp/src/script/components/Modals/FileHistoryModal/utils/fileVersionUtils.ts
@@ -25,6 +25,7 @@ import {formatBytes} from 'Util/util';
 import {FileVersion} from '../types';
 
 type RestVersionWithOptionalFields = Partial<RestVersion>;
+type ResolveOwnerName = (version: RestVersionWithOptionalFields) => string | undefined;
 
 /**
  * Transform a RestVersion to FileVersion
@@ -32,11 +33,12 @@ type RestVersionWithOptionalFields = Partial<RestVersion>;
 export const transformRestVersionToFileVersion = (
   version: RestVersionWithOptionalFields,
   timestamp: number,
+  resolveOwnerName?: ResolveOwnerName,
 ): FileVersion => {
   return {
     versionId: version.VersionId || '',
     time: formatTime(timestamp),
-    ownerName: version.OwnerName || '',
+    ownerName: resolveOwnerName?.(version) || version.OwnerName || '',
     size: formatBytes(Number(version.Size) || 0),
     downloadUrl: version.PreSignedGET?.Url || '',
   };
@@ -45,7 +47,10 @@ export const transformRestVersionToFileVersion = (
 /**
  * Group file versions by date
  */
-export const groupVersionsByDate = (versions: RestVersionWithOptionalFields[]): Record<string, FileVersion[]> => {
+export const groupVersionsByDate = (
+  versions: RestVersionWithOptionalFields[],
+  resolveOwnerName?: ResolveOwnerName,
+): Record<string, FileVersion[]> => {
   const now = new Date();
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 
@@ -67,7 +72,7 @@ export const groupVersionsByDate = (versions: RestVersionWithOptionalFields[]): 
         acc[dateKey] = [];
       }
 
-      acc[dateKey].push(transformRestVersionToFileVersion(version, timestamp));
+      acc[dateKey].push(transformRestVersionToFileVersion(version, timestamp, resolveOwnerName));
       return acc;
     },
     {} as Record<string, FileVersion[]>,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24286" title="WPB-24286" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24286</a>  [Web][versions] Replace username with profile name in the version history modal
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

**Current state**
Username is displayed alongside the size of version. 

**Expected**
We should display full profile name instead. 

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
