### PR TITLE
test: write the second part of Guestroom regression tests [WPB-19953]

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -61,6 +61,7 @@ export class ConversationPage {
   readonly cancelRequest: Locator;
   readonly mentionSuggestions: Locator;
   readonly invitePeopleButton: Locator;
+  readonly guestsIndicator: Locator;
 
   readonly getImageAltText = (user: User) => `Image from ${user.fullName}`;
 
@@ -108,6 +109,7 @@ export class ConversationPage {
     this.cancelRequest = page.getByRole('button', {name: 'Cancel connection request'});
     this.mentionSuggestions = page.getByRole('listbox').getByTestId('item-mention-suggestion');
     this.invitePeopleButton = page.getByRole('button', {name: 'Invite people'});
+    this.guestsIndicator = page.getByTestId('status-indication-badge');
   }
 
   getImageLocator(user: User): Locator {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -60,6 +60,7 @@ export class ConversationPage {
   readonly ignoreButton: Locator;
   readonly cancelRequest: Locator;
   readonly mentionSuggestions: Locator;
+  readonly invitePeopleButton: Locator;
 
   readonly getImageAltText = (user: User) => `Image from ${user.fullName}`;
 
@@ -106,6 +107,7 @@ export class ConversationPage {
     this.ignoreButton = page.getByRole('button', {name: 'Ignore'});
     this.cancelRequest = page.getByRole('button', {name: 'Cancel connection request'});
     this.mentionSuggestions = page.getByRole('listbox').getByTestId('item-mention-suggestion');
+    this.invitePeopleButton = page.getByRole('button', {name: 'Invite people'});
   }
 
   getImageLocator(user: User): Locator {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationJoin.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationJoin.page.ts
@@ -6,6 +6,7 @@ export const ConversationJoinPage = (page: Page) => {
   const nameInput = page.getByRole('textbox', {name: 'Your name'});
   const acceptTermsCheckBox = page.getByText(/I accept .* terms of use/i);
   const joinAsGuestButton = page.getByRole('button', {name: 'Join as Temporary Guest'});
+  const joinAsMemberButton = page.getByRole('button', {name: 'Join', exact: true});
 
   const joinAsGuest = async (name: string) => {
     await nameInput.fill(name);
@@ -18,5 +19,6 @@ export const ConversationJoinPage = (page: Page) => {
     joinAsGuest,
     joinBrowserButton,
     joinAsGuestButton,
+    joinAsMemberButton,
   };
 };

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationJoin.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationJoin.page.ts
@@ -7,6 +7,7 @@ export const ConversationJoinPage = (page: Page) => {
   const acceptTermsCheckBox = page.getByText(/I accept .* terms of use/i);
   const joinAsGuestButton = page.getByRole('button', {name: 'Join as Temporary Guest'});
   const joinAsMemberButton = page.getByRole('button', {name: 'Join', exact: true});
+  const enterpriseLoginButton = page.getByRole('button', {name: 'Enterprise Login'});
 
   const joinAsGuest = async (name: string) => {
     await nameInput.fill(name);
@@ -20,5 +21,6 @@ export const ConversationJoinPage = (page: Page) => {
     joinBrowserButton,
     joinAsGuestButton,
     joinAsMemberButton,
+    enterpriseLoginButton,
   };
 };

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -416,6 +416,40 @@ test.describe('Guestroom', () => {
   );
 
   test(
+    'I want to see the "Open in Wire" button if I was logged in permanently before',
+    {tag: ['@TC-3351', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, guestPage] = await Promise.all([
+        createPage(withLogin(userA)),
+        createPage(withLogin(guestUser)),
+      ]);
+
+      const guestPageManager = PageManager.from(guestPage);
+      const guestPages = guestPageManager.webapp.pages;
+      const pages = PageManager.from(userAPage).webapp.pages;
+
+      // UserA creates a guest link for a conversation
+      await createGroup(pages, groupName, []);
+      createdLink = await generateGroupGuestsLink(pages, groupName);
+
+      // Quest confirms that he was logged in before and can join the conversation directly
+      await guestPage.goto(createdLink.toString());
+      await guestPages.conversationJoin().joinBrowserButton.click();
+      await expect(guestPages.conversationJoin().joinAsGuestButton).toBeVisible();
+
+      // Sync domain with WEBAPP_URL using in test to ensure login cookies are sent.
+      const envUrl = new URL(process.env.WEBAPP_URL);
+      const invitationLink = new URL(guestPage.url());
+
+      invitationLink.hostname = envUrl.hostname;
+      await guestPage.goto(invitationLink.toString());
+
+      await expect(guestPages.conversationJoin().joinAsMemberButton).toBeVisible();
+      await expect(guestPage.getByText(`You are logged in as ${guestUser.fullName}`)).toBeVisible();
+    },
+  );
+
+  test(
     'I want to get logged out with a reason when my account expires',
     {tag: ['@TC-3365', '@regression']},
     async ({createPage}) => {

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -1,5 +1,5 @@
 import {Page} from 'playwright/test';
-import {User} from 'test/e2e_tests/data/user';
+import {getUser, User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {
   test,
@@ -294,12 +294,12 @@ test.describe('Guestroom', () => {
     {tag: ['@TC-3334', '@regression']},
     async ({createPage}) => {
       const [userAPage, guestPage] = await Promise.all([createPage(withLogin(userA)), createPage()]);
-
+     
       const ownerPages = PageManager.from(userAPage).webapp.pages;
       const {pages: guestPages, modals: guestModals} = PageManager.from(guestPage).webapp;
 
       await createGroup(ownerPages, groupName, []);
-      createdLink = await generateGroupGuestsLink(ownerPages, groupName);
+      const createdLink = await generateGroupGuestsLink(ownerPages, groupName);
 
       await guestPage.goto(createdLink.toString());
       await guestPages.conversationJoin().joinBrowserButton.click();
@@ -361,6 +361,7 @@ test.describe('Guestroom', () => {
     {tag: ['@TC-3337', '@regression']},
     async ({createPage}) => {
       test.setTimeout(150_000);
+      let createdLink: string;
       const [userAPage, guestPage] = await Promise.all([createPage(withLogin(userA)), createPage()]);
 
       const pages = PageManager.from(userAPage).webapp.pages;
@@ -409,7 +410,7 @@ test.describe('Guestroom', () => {
       const {pages} = PageManager.from(await createPage(withLogin(userA))).webapp;
 
       await createGroup(pages, groupName, []);
-      createdLink = await generateGroupGuestsLink(pages, groupName);
+      const createdLink = await generateGroupGuestsLink(pages, groupName);
 
       await createPage(withGuestUser(createdLink, guestUser.firstName));
       await expect(pages.conversation().guestsIndicator).toBeVisible({timeout: LOGIN_TIMEOUT});
@@ -446,7 +447,7 @@ test.describe('Guestroom', () => {
 
       // UserA creates a guest link for a conversation
       await createGroup(pages, groupName, []);
-      createdLink = await generateGroupGuestsLink(pages, groupName);
+      const createdLink = await generateGroupGuestsLink(pages, groupName);
 
       // Quest confirms that he was logged in before and can join the conversation directly
       await guestPage.goto(createdLink.toString());
@@ -471,7 +472,7 @@ test.describe('Guestroom', () => {
       const {pages} = PageManager.from(await createPage(withLogin(userA))).webapp;
 
       await createGroup(pages, groupName, []);
-      createdLink = await generateGroupGuestsLink(pages, groupName);
+      const createdLink = await generateGroupGuestsLink(pages, groupName);
 
       const guestPage = await createPage(withGuestUser(createdLink, guestUser.firstName));
       const {pages: guestPages, modals: guestModals} = PageManager.from(guestPage).webapp;
@@ -504,7 +505,7 @@ test.describe('Guestroom', () => {
 
       // UserA creates a guest link for a conversation
       await createGroup(pages, groupName, []);
-      createdLink = await generateGroupGuestsLink(pages, groupName);
+      const createdLink = await generateGroupGuestsLink(pages, groupName);
 
       // Quest confirms that he was logged in before and can join the conversation directly
       await guestPage.goto(createdLink.toString());
@@ -573,6 +574,55 @@ test.describe('Guestroom', () => {
           'You were signed out because your account was deleted.',
         );
       });
+    },
+  );
+
+  const ssoUser = getUser({
+    email: process.env.SCIM_USER_SSO_CODE,
+    username: process.env.SCIM_USER_EMAIL,
+    password: process.env.SCIM_USER_PASSWORD,
+  });
+
+  test(
+    'I want to join guestroom invite with enterprise login',
+    {tag: ['@TC-3477', '@regression']},
+    async ({context, createPage, api}) => {
+      const [userAPage, guestPage] = await Promise.all([createPage(withLogin(userA)), createPage(context)]);
+
+      const userAPageManager = PageManager.from(userAPage).webapp;
+      const guestPageManager = PageManager.from(guestPage);
+      const {pages: guestPages, components: guestComponents} = guestPageManager.webapp;
+      const {pages} = userAPageManager;
+
+      await createGroup(pages, groupName, []);
+      const createdLink = await generateGroupGuestsLink(pages, groupName);
+
+      await guestPage.goto(createdLink.toString());
+      await guestPages.conversationJoin().joinBrowserButton.click();
+      await expect(guestPages.conversationJoin().enterpriseLoginButton).toBeVisible();
+
+      await guestPages.conversationJoin().enterpriseLoginButton.click();
+
+      const [idpPage] = await Promise.all([
+        context.waitForEvent('page'),
+        guestPages.singleSignOn().enterEmailOnSSOPage(ssoUser.email),
+      ]);
+
+      await idpPage.getByRole('textbox', {name: 'Username'}).fill(ssoUser.username, {timeout: 20_000});
+      await idpPage.getByRole('textbox', {name: 'Password'}).fill(ssoUser.password);
+      await idpPage.getByRole('button', {name: 'Sign In'}).click();
+
+      await guestPage.getByRole('button', {name: 'Remove device'}).first().click({timeout: LOGIN_TIMEOUT});
+      // // We will also always be prompted to confirm the new history on this device
+      await guestPages.historyInfo().clickConfirmButton();
+
+      await expect(guestComponents.conversationSidebar().sidebar, `Login took more than ${LOGIN_TIMEOUT}s`).toBeVisible(
+        {
+          timeout: LOGIN_TIMEOUT,
+        },
+      );
+
+      await expect(guestPages.conversationList().list.filter({hasText: groupName})).toBeVisible();
     },
   );
 });

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -465,6 +465,41 @@ test.describe('Guestroom', () => {
   });
 
   test(
+    'I want to see the conversation added to the conversation list',
+    {tag: ['@TC-3354', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, guestPage] = await Promise.all([
+        createPage(withLogin(userA)),
+        createPage(withLogin(guestUser)),
+      ]);
+
+      const guestPageManager = PageManager.from(guestPage);
+      const guestPages = guestPageManager.webapp.pages;
+      const pages = PageManager.from(userAPage).webapp.pages;
+
+      // UserA creates a guest link for a conversation
+      await createGroup(pages, groupName, []);
+      createdLink = await generateGroupGuestsLink(pages, groupName);
+
+      // Quest confirms that he was logged in before and can join the conversation directly
+      await guestPage.goto(createdLink.toString());
+      await guestPages.conversationJoin().joinBrowserButton.click();
+      await expect(guestPages.conversationJoin().joinAsGuestButton).toBeVisible();
+
+      // Sync domain with WEBAPP_URL using in test to ensure login cookies are sent.
+      const envUrl = new URL(process.env.WEBAPP_URL);
+      const invitationLink = new URL(guestPage.url());
+
+      invitationLink.hostname = envUrl.hostname;
+      await guestPage.goto(invitationLink.toString());
+
+      await guestPages.conversationJoin().joinAsMemberButton.click();
+      await guestPages.conversation().conversationTitle.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
+      await expect(guestPages.conversationList().list.filter({hasText: groupName})).toBeVisible();
+    },
+  );
+
+  test(
     'I want to get logged out with a reason when my account expires',
     {tag: ['@TC-3365', '@regression']},
     async ({createPage}) => {

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -322,6 +322,30 @@ test.describe('Guestroom', () => {
   );
 
   test(
+    'I want to see Invite People button when Allow Guests is on',
+    {tag: ['@TC-3335', '@regression']},
+    async ({createPage}) => {
+      const ownerPage = await createPage(withLogin(userA));
+      const ownerPages = PageManager.from(ownerPage).webapp.pages;
+
+      await createGroup(ownerPages, groupName, []);
+      await ownerPages.conversationList().openConversation(groupName);
+
+      await expect(
+        ownerPages
+          .conversation()
+          .systemMessages.filter({hasText: `People outside your team can join this conversation.`}),
+      ).toBeVisible();
+      await expect(ownerPages.conversation().invitePeopleButton).toBeVisible();
+
+      await ownerPages.conversation().invitePeopleButton.click();
+      
+      await expect(ownerPages.guestOptions().guestsToggle).toHaveAttribute('data-uie-value', 'checked');
+      await expect(ownerPages.guestOptions().createLinkButton).toBeVisible();
+    },
+  );
+
+  test(
     'I want to get logged out with a reason when my account expires',
     {tag: ['@TC-3365', '@regression']},
     async ({createPage}) => {

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -59,10 +59,12 @@ test.describe('Guestroom', () => {
 
       await test.step('User B sees error when entering incorrect password', async () => {
         await guestPage.goto(createdLink.toString());
+        await expect(guestPages.conversationJoin().joinBrowserButton).toBeVisible();
         await guestPages.conversationJoin().joinBrowserButton.click();
         await expect(guestPages.conversationJoin().joinAsGuestButton).toBeVisible();
 
         await guestPages.login().login(guestUser);
+        await expect(guestBModals.joinGuestLinkPassword().joinForm).toBeVisible();
         await guestBModals.joinGuestLinkPassword().joinConversation('WrongPassword');
         await expect(guestBModals.joinGuestLinkPassword().joinForm).toContainText(
           'Password is incorrect, please try again.',
@@ -215,11 +217,12 @@ test.describe('Guestroom', () => {
     'I want to see Wire and Wireless guest(s) are removed when I change the Allow guests from on to off',
     {tag: ['@TC-3322', '@regression']},
     async ({createPage}) => {
-      const {pages: ownerPages} = PageManager.from(await createPage(withLogin(userA))).webapp;
+      const ownerPages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
 
       await createGroup(ownerPages, groupName, []);
       await ownerPages.conversationList().openConversation(groupName);
 
+      // Owner creates a guest link
       await ownerPages.conversation().toggleGroupInformation();
       const link = await ownerPages.conversationDetails().createGuestLink();
       await createPage(withGuestUser(link, guestUser.firstName));
@@ -228,6 +231,7 @@ test.describe('Guestroom', () => {
         ownerPages.conversation().systemMessages.filter({hasText: `${guestUser.firstName} joined`}),
       ).toBeVisible();
 
+      // Owner turns off Allow guests toggle
       await ownerPages.conversationDetails().openGuestOptions();
       await ownerPages.guestOptions().toggleGuests();
 
@@ -249,6 +253,7 @@ test.describe('Guestroom', () => {
       await ownerPages.conversation().toggleGroupInformation();
 
       await ownerPages.conversationDetails().openGuestOptions();
+      // Turn off Guest options as it is on by default
       await ownerPages.guestOptions().guestsToggle.click();
 
       await expect(ownerPage.getByTestId('status-guest-options-info')).toContainText(
@@ -268,8 +273,7 @@ test.describe('Guestroom', () => {
     },
   ].forEach(({description, tag}) => {
     test(description, {tag: [tag, '@regression']}, async ({createPage}) => {
-      const ownerPage = await createPage(withLogin(userA));
-      const ownerPages = PageManager.from(ownerPage).webapp.pages;
+      const ownerPages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
 
       // UserA sees allow guests toggle is ON on group creation page
       await ownerPages.conversationList().clickCreateGroup();
@@ -294,13 +298,13 @@ test.describe('Guestroom', () => {
     {tag: ['@TC-3334', '@regression']},
     async ({createPage}) => {
       const [userAPage, guestPage] = await Promise.all([createPage(withLogin(userA)), createPage()]);
-     
       const ownerPages = PageManager.from(userAPage).webapp.pages;
       const {pages: guestPages, modals: guestModals} = PageManager.from(guestPage).webapp;
 
       await createGroup(ownerPages, groupName, []);
       const createdLink = await generateGroupGuestsLink(ownerPages, groupName);
 
+      // Guest joins the conversation using the invitation link
       await guestPage.goto(createdLink.toString());
       await guestPages.conversationJoin().joinBrowserButton.click();
       await expect(guestPages.conversationJoin().joinAsGuestButton).toBeVisible();
@@ -312,6 +316,7 @@ test.describe('Guestroom', () => {
         ownerPages.conversation().systemMessages.filter({hasText: `${guestUser.fullName} joined`}),
       ).toBeVisible();
 
+      // Guest leaves the conversation
       await guestPages.conversation().toggleGroupInformation();
       await guestPages.conversation().leaveConversation();
       await guestModals.leaveConversation().clickConfirm();
@@ -342,8 +347,7 @@ test.describe('Guestroom', () => {
     },
   ].forEach(({description, tag, verify}) => {
     test(description, {tag: [tag, '@regression']}, async ({createPage}) => {
-      const ownerPage = await createPage(withLogin(userA));
-      const ownerPages = PageManager.from(ownerPage).webapp.pages;
+      const ownerPages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
 
       await createGroup(ownerPages, groupName, []);
       await ownerPages.conversationList().openConversation(groupName);
@@ -407,13 +411,13 @@ test.describe('Guestroom', () => {
     'I want to see Guests are present indicator if there are guests in the conversation',
     {tag: ['@TC-3338', '@regression']},
     async ({createPage}) => {
-      const {pages} = PageManager.from(await createPage(withLogin(userA))).webapp;
+      const pages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
 
       await createGroup(pages, groupName, []);
       const createdLink = await generateGroupGuestsLink(pages, groupName);
 
       await createPage(withGuestUser(createdLink, guestUser.firstName));
-      await expect(pages.conversation().guestsIndicator).toBeVisible({timeout: LOGIN_TIMEOUT});
+      await expect(pages.conversation().guestsIndicator).toBeVisible();
     },
   );
 
@@ -441,8 +445,7 @@ test.describe('Guestroom', () => {
         createPage(withLogin(guestUser)),
       ]);
 
-      const guestPageManager = PageManager.from(guestPage);
-      const guestPages = guestPageManager.webapp.pages;
+      const guestPages = PageManager.from(guestPage).webapp.pages;
       const pages = PageManager.from(userAPage).webapp.pages;
 
       // UserA creates a guest link for a conversation
@@ -469,7 +472,7 @@ test.describe('Guestroom', () => {
     'I want to see my time left in left column list, participant details and account settings',
     {tag: ['@TC-3363', '@regression']},
     async ({createPage}) => {
-      const {pages} = PageManager.from(await createPage(withLogin(userA))).webapp;
+      const pages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
 
       await createGroup(pages, groupName, []);
       const createdLink = await generateGroupGuestsLink(pages, groupName);
@@ -477,9 +480,7 @@ test.describe('Guestroom', () => {
       const guestPage = await createPage(withGuestUser(createdLink, guestUser.firstName));
       const {pages: guestPages, modals: guestModals} = PageManager.from(guestPage).webapp;
 
-      await guestPages.conversation().conversationTitle.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
       await guestModals.confirm().actionButton.click();
-
       await expect(guestPage.locator('#temporary-guest')).toContainText('24h left in this guest room');
 
       await guestPages.conversation().sendMessage('Message from Guest');
@@ -499,8 +500,7 @@ test.describe('Guestroom', () => {
         createPage(withLogin(guestUser)),
       ]);
 
-      const guestPageManager = PageManager.from(guestPage);
-      const guestPages = guestPageManager.webapp.pages;
+      const guestPages = PageManager.from(guestPage).webapp.pages;
       const pages = PageManager.from(userAPage).webapp.pages;
 
       // UserA creates a guest link for a conversation
@@ -586,7 +586,7 @@ test.describe('Guestroom', () => {
   test(
     'I want to join guestroom invite with enterprise login',
     {tag: ['@TC-3477', '@regression']},
-    async ({context, createPage, api}) => {
+    async ({context, createPage}) => {
       const [userAPage, guestPage] = await Promise.all([createPage(withLogin(userA)), createPage(context)]);
 
       const userAPageManager = PageManager.from(userAPage).webapp;
@@ -602,6 +602,7 @@ test.describe('Guestroom', () => {
       await expect(guestPages.conversationJoin().enterpriseLoginButton).toBeVisible();
 
       await guestPages.conversationJoin().enterpriseLoginButton.click();
+      await expect(guestPages.singleSignOn().header).toBeVisible();
 
       const [idpPage] = await Promise.all([
         context.waitForEvent('page'),

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -392,6 +392,20 @@ test.describe('Guestroom', () => {
   );
 
   test(
+    'I want to see Guests are present indicator if there are guests in the conversation',
+    {tag: ['@TC-3338', '@regression']},
+    async ({createPage}) => {
+      const {pages} = PageManager.from(await createPage(withLogin(userA))).webapp;
+
+      await createGroup(pages, groupName, []);
+      createdLink = await generateGroupGuestsLink(pages, groupName);
+
+      await createPage(withGuestUser(createdLink, guestUser.firstName));
+      await expect(pages.conversation().guestsIndicator).toBeVisible({timeout: LOGIN_TIMEOUT});
+    },
+  );
+
+  test(
     'I want to get logged out with a reason when my account expires',
     {tag: ['@TC-3365', '@regression']},
     async ({createPage}) => {

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -289,6 +289,39 @@ test.describe('Guestroom', () => {
   });
 
   test(
+    'I want to see a system message when wireless guest has joined or left',
+    {tag: ['@TC-3334', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, guestPage] = await Promise.all([createPage(withLogin(userA)), createPage()]);
+
+      const ownerPages = PageManager.from(userAPage).webapp.pages;
+      const {pages: guestPages, modals: guestModals} = PageManager.from(guestPage).webapp;
+
+      await createGroup(ownerPages, groupName, []);
+      createdLink = await generateGroupGuestsLink(ownerPages, groupName);
+
+      await guestPage.goto(createdLink.toString());
+      await guestPages.conversationJoin().joinBrowserButton.click();
+      await expect(guestPages.conversationJoin().joinAsGuestButton).toBeVisible();
+
+      await guestPages.login().login(guestUser);
+      await guestPages.conversation().conversationTitle.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
+
+      await expect(
+        ownerPages.conversation().systemMessages.filter({hasText: `${guestUser.fullName} joined`}),
+      ).toBeVisible();
+
+      await guestPages.conversation().toggleGroupInformation();
+      await guestPages.conversation().leaveConversation();
+      await guestModals.leaveConversation().clickConfirm();
+
+      await expect(
+        ownerPages.conversation().systemMessages.filter({hasText: `${guestUser.fullName} left`}),
+      ).toBeVisible();
+    },
+  );
+
+  test(
     'I want to get logged out with a reason when my account expires',
     {tag: ['@TC-3365', '@regression']},
     async ({createPage}) => {

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -465,6 +465,31 @@ test.describe('Guestroom', () => {
   });
 
   test(
+    'I want to see my time left in left column list, participant details and account settings',
+    {tag: ['@TC-3363', '@regression']},
+    async ({createPage}) => {
+      const {pages} = PageManager.from(await createPage(withLogin(userA))).webapp;
+
+      await createGroup(pages, groupName, []);
+      createdLink = await generateGroupGuestsLink(pages, groupName);
+
+      const guestPage = await createPage(withGuestUser(createdLink, guestUser.firstName));
+      const {pages: guestPages, modals: guestModals} = PageManager.from(guestPage).webapp;
+
+      await guestPages.conversation().conversationTitle.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
+      await guestModals.confirm().actionButton.click();
+
+      await expect(guestPage.locator('#temporary-guest')).toContainText('24h left in this guest room');
+
+      await guestPages.conversation().sendMessage('Message from Guest');
+      const message = guestPages.conversation().getMessage({content: 'Message from Guest'});
+      await message.getByTestId('element-avatar-temporary-guest').click();
+
+      await expect(guestPage.getByTestId('status-expiration-text')).toContainText('24h left');
+    },
+  );
+
+  test(
     'I want to see the conversation added to the conversation list',
     {tag: ['@TC-3354', '@regression']},
     async ({createPage}) => {

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -452,12 +452,14 @@ test.describe('Guestroom', () => {
       await createGroup(pages, groupName, []);
       const createdLink = await generateGroupGuestsLink(pages, groupName);
 
-      // Quest confirms that he was logged in before and can join the conversation directly
+      // Guest confirms that he was logged in before and can join the conversation directly
       await guestPage.goto(createdLink.toString());
       await guestPages.conversationJoin().joinBrowserButton.click();
       await expect(guestPages.conversationJoin().joinAsGuestButton).toBeVisible();
 
-      // Sync domain with WEBAPP_URL using in test to ensure login cookies are sent.
+      // WORKAROUND: The 'Join in Browser' button currently redirects to Production.
+      // To maintain the existing logged-in session, we must force the invitation
+      // URL to use the same environment as our current test session.
       const envUrl = new URL(process.env.WEBAPP_URL);
       const invitationLink = new URL(guestPage.url());
 
@@ -481,7 +483,7 @@ test.describe('Guestroom', () => {
       const {pages: guestPages, modals: guestModals} = PageManager.from(guestPage).webapp;
 
       await guestModals.confirm().actionButton.click();
-      await expect(guestPage.locator('#temporary-guest')).toContainText('24h left in this guest room');
+      await expect(guestPage.getByRole('complementary')).toContainText('24h left in this guest room');
 
       await guestPages.conversation().sendMessage('Message from Guest');
       const message = guestPages.conversation().getMessage({content: 'Message from Guest'});
@@ -507,12 +509,14 @@ test.describe('Guestroom', () => {
       await createGroup(pages, groupName, []);
       const createdLink = await generateGroupGuestsLink(pages, groupName);
 
-      // Quest confirms that he was logged in before and can join the conversation directly
+      // Guest confirms that he was logged in before and can join the conversation directly
       await guestPage.goto(createdLink.toString());
       await guestPages.conversationJoin().joinBrowserButton.click();
       await expect(guestPages.conversationJoin().joinAsGuestButton).toBeVisible();
 
-      // Sync domain with WEBAPP_URL using in test to ensure login cookies are sent.
+      // WORKAROUND: The 'Join in Browser' button currently redirects to Production.
+      // To maintain the existing logged-in session, we must force the invitation
+      // URL to use the same environment as our current test session.
       const envUrl = new URL(process.env.WEBAPP_URL);
       const invitationLink = new URL(guestPage.url());
 

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -339,9 +339,55 @@ test.describe('Guestroom', () => {
       await expect(ownerPages.conversation().invitePeopleButton).toBeVisible();
 
       await ownerPages.conversation().invitePeopleButton.click();
-      
+
       await expect(ownerPages.guestOptions().guestsToggle).toHaveAttribute('data-uie-value', 'checked');
       await expect(ownerPages.guestOptions().createLinkButton).toBeVisible();
+    },
+  );
+
+  test(
+    'I want to see a system message when wireless guest has expired',
+    {tag: ['@TC-3337', '@regression']},
+    async ({createPage}) => {
+      test.setTimeout(150_000);
+      const [userAPage, guestPage] = await Promise.all([createPage(withLogin(userA)), createPage()]);
+
+      const pages = PageManager.from(userAPage).webapp.pages;
+      const guestPages = PageManager.from(guestPage).webapp.pages;
+
+      await test.step('User A creates invite link', async () => {
+        await createGroup(pages, groupName, []);
+        createdLink = await generateGroupGuestsLink(pages, groupName);
+      });
+
+      await test.step('User B joins the group using the invitation link', async () => {
+        await guestPage.goto(createdLink.toString());
+        await guestPages.conversationJoin().joinBrowserButton.click();
+        await expect(guestPages.conversationJoin().joinAsGuestButton).toBeVisible();
+
+        // Add expires_in query parameter to simulate account expiration
+        const joinLink = new URL(guestPage.url());
+        joinLink.searchParams.set('expires_in', '60');
+
+        await guestPage.goto(joinLink.toString());
+        await guestPages.conversationJoin().joinAsGuest(guestUser.firstName);
+      });
+
+      await test.step('User A sees guest details (to trigger access validation) after 1 minute', async () => {
+        await pages.conversation().toggleGroupInformation();
+        const guestMember = pages.conversationDetails().groupMembers.filter({hasText: guestUser.firstName});
+        await expect(guestMember).toBeVisible({timeout: LOGIN_TIMEOUT});
+
+        await userAPage.waitForTimeout(60_000);
+        await pages.conversationDetails().openParticipantDetails(guestUser.firstName);
+        await expect(pages.participantDetails().userStatus).toBeVisible();
+      });
+
+      await test.step('User A sees a system message when wireless guest has expired', async () => {
+        await expect(
+          pages.conversation().systemMessages.filter({hasText: `${guestUser.firstName} left`}),
+        ).toBeVisible();
+      });
     },
   );
 

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -1,3 +1,4 @@
+import {Page} from 'playwright/test';
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {
@@ -415,10 +416,25 @@ test.describe('Guestroom', () => {
     },
   );
 
-  test(
-    'I want to see the "Open in Wire" button if I was logged in permanently before',
-    {tag: ['@TC-3351', '@regression']},
-    async ({createPage}) => {
+  [
+    {
+      description: 'I want to see the "Open in Wire" button if I was logged in permanently before',
+      tag: '@TC-3351',
+      verify: async (guestPages: PageManager['webapp']['pages'], guestPage: Page) => {
+        await expect(guestPages.conversationJoin().joinAsMemberButton).toBeVisible();
+        await expect(guestPage.getByText(`You are logged in as ${guestUser.fullName}`)).toBeVisible();
+      },
+    },
+    {
+      description: 'I want to see a link to join anonymously when I was logged in before',
+      tag: '@TC-3352',
+      verify: async (guestPages: PageManager['webapp']['pages'], guestPage: Page) => {
+        await expect(guestPages.conversationJoin().joinAsGuestButton).toBeVisible();
+        await expect(guestPage.getByRole('heading', {name: "Don't have an account?"})).toBeVisible();
+      },
+    },
+  ].forEach(({description, tag, verify}) => {
+    test(description, {tag: [tag, '@regression']}, async ({createPage}) => {
       const [userAPage, guestPage] = await Promise.all([
         createPage(withLogin(userA)),
         createPage(withLogin(guestUser)),
@@ -444,10 +460,9 @@ test.describe('Guestroom', () => {
       invitationLink.hostname = envUrl.hostname;
       await guestPage.goto(invitationLink.toString());
 
-      await expect(guestPages.conversationJoin().joinAsMemberButton).toBeVisible();
-      await expect(guestPage.getByText(`You are logged in as ${guestUser.fullName}`)).toBeVisible();
-    },
-  );
+      await verify(guestPages, guestPage);
+    });
+  });
 
   test(
     'I want to get logged out with a reason when my account expires',

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -321,29 +321,39 @@ test.describe('Guestroom', () => {
     },
   );
 
-  test(
-    'I want to see Invite People button when Allow Guests is on',
-    {tag: ['@TC-3335', '@regression']},
-    async ({createPage}) => {
+  [
+    {
+      description: 'I want to see Invite People button when Allow Guests is on',
+      tag: '@TC-3335',
+      verify: async (pages: PageManager['webapp']['pages']) => {
+        await expect(pages.conversation().invitePeopleButton).toBeVisible();
+      },
+    },
+    {
+      description:
+        'I want to see a hint text that people from outside can join if the conversation is opened for guests',
+      tag: '@TC-3340',
+      verify: async (pages: PageManager['webapp']['pages']) => {
+        await expect(
+          pages.conversation().systemMessages.filter({hasText: `People outside your team can join this conversation.`}),
+        ).toBeVisible();
+      },
+    },
+  ].forEach(({description, tag, verify}) => {
+    test(description, {tag: [tag, '@regression']}, async ({createPage}) => {
       const ownerPage = await createPage(withLogin(userA));
       const ownerPages = PageManager.from(ownerPage).webapp.pages;
 
       await createGroup(ownerPages, groupName, []);
       await ownerPages.conversationList().openConversation(groupName);
 
-      await expect(
-        ownerPages
-          .conversation()
-          .systemMessages.filter({hasText: `People outside your team can join this conversation.`}),
-      ).toBeVisible();
-      await expect(ownerPages.conversation().invitePeopleButton).toBeVisible();
-
+      await verify(ownerPages);
       await ownerPages.conversation().invitePeopleButton.click();
 
       await expect(ownerPages.guestOptions().guestsToggle).toHaveAttribute('data-uie-value', 'checked');
       await expect(ownerPages.guestOptions().createLinkButton).toBeVisible();
-    },
-  );
+    });
+  });
 
   test(
     'I want to see a system message when wireless guest has expired',


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19953" title="WPB-19953" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19953</a>  [Web/QA] Write the Guestroom regression tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

This PR introduces the second phase of the Guestroom regression E2E test suite. To ensure a manageable review process, the full suite has been split into two logical parts.

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
