### PR TITLE
chore: restore legacy test report output and run reports from the latest branch head [WPB-24626]

### DIFF
--- a/.github/workflows/generate_test_report.yml
+++ b/.github/workflows/generate_test_report.yml
@@ -3,8 +3,8 @@ name: Generate test reports
 on:
   workflow_dispatch:
     inputs:
-      commit:
-        description: 'Commit SHA'
+      branch:
+        description: 'Git branch to generate the test report for'
         required: true
         type: string
 
@@ -19,7 +19,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          ref: ${{ inputs.commit }}
+          ref: refs/heads/${{ inputs.branch }}
+
+      - name: Capture checked out commit SHA
+        run: echo "TESTED_COMMIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
       - name: Set TITLE
         env:
@@ -47,9 +50,18 @@ jobs:
 
       - name: Test
         run: |
-          set -o pipefail
-          yarn nx run-many -t test --all -- --coverage --coverage_reporters=lcov --verbose 2>&1 | tee ${{ env.UNIT_TEST_REPORT_FILE }}
-          echo -e "COMMIT SHA = ${{ inputs.commit }}" >> ${{ env.UNIT_TEST_REPORT_FILE }}
+          set -euo pipefail
+          : > ${{ env.UNIT_TEST_REPORT_FILE }}
+          (
+            cd ./apps/server
+            node ../../node_modules/jest/bin/jest.js --config jest.config.js --coverage --coverageReporters=lcov
+          ) 2>&1 | tee -a ${{ env.UNIT_TEST_REPORT_FILE }}
+          (
+            cd ./apps/webapp
+            node ../../node_modules/jest/bin/jest.js --config jest.report.config.cjs --coverage --coverageReporters=lcov --verbose
+          ) 2>&1 | tee -a ${{ env.UNIT_TEST_REPORT_FILE }}
+          echo -e "BRANCH = ${{ inputs.branch }}" >> ${{ env.UNIT_TEST_REPORT_FILE }}
+          echo -e "COMMIT SHA = ${TESTED_COMMIT_SHA}" >> ${{ env.UNIT_TEST_REPORT_FILE }}
           echo -e "TEST RUN DATE = $(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> ${{ env.UNIT_TEST_REPORT_FILE }}
 
       - name: Upload unit-tests.log to S3
@@ -59,4 +71,4 @@ jobs:
           AWS_DEFAULT_REGION: eu-west-1
         run: |
           TIMESTAMP=$(date -u +'%Y%m%dT%H%M%SZ')
-          aws s3 cp ${{ env.UNIT_TEST_REPORT_FILE }} s3://wire-webapp/unit-tests-${TIMESTAMP}-${{ inputs.commit }}.log
+          aws s3 cp ${{ env.UNIT_TEST_REPORT_FILE }} s3://wire-webapp/unit-tests-${TIMESTAMP}-${TESTED_COMMIT_SHA}.log

--- a/apps/webapp/jest.report.config.cjs
+++ b/apps/webapp/jest.report.config.cjs
@@ -1,0 +1,48 @@
+/*
+ * Wire
+ * Copyright (C) 2020 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+process.env.TZ = 'UTC';
+
+module.exports = {
+  preset: '../../jest.preset.js',
+  collectCoverageFrom: ['src/script/**/*.{ts,tsx}', '!src/script/util/test/**/*.*'],
+  moduleDirectories: ['node_modules', __dirname],
+  moduleNameMapper: {
+    'Components/(.*)': '<rootDir>/src/script/components/$1',
+    'Hooks/(.*)': '<rootDir>/src/script/hooks/$1',
+    'I18n/(.*)': '<rootDir>/src/i18n/$1',
+    'Repositories/(.*)': '<rootDir>/src/script/repositories/$1',
+    'Resource/(.*)': '<rootDir>/resource/$1',
+    'Util/(.*)': '<rootDir>/src/script/util/$1',
+    '^react(.*)$': '<rootDir>/../../node_modules/react$1',
+    '.*\\.glsl': 'jest-transform-stub',
+  },
+  reporters: ['default'],
+  setupFilesAfterEnv: ['<rootDir>/setupTests.js'],
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    customExportConditions: ['node', 'node-addons'],
+  },
+  testPathIgnorePatterns: ['<rootDir>/server', '<rootDir>/.yalc', '<rootDir>/test/e2e_tests'],
+  testRunner: 'jest-jasmine2',
+  transformIgnorePatterns: ['/node_modules/(?!(true-myth|p-timeout|p-cancelable|noop-esm)/)'],
+  transform: {
+    '^.+\\.[tj]sx?$': 'babel-jest',
+  },
+};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24626" title="WPB-24626" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24626</a>  [Web] Unit test report for Bund is not correctly generated
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
