### PR TITLE
fix: keep the version details always in a single line and introduce a hiding behind a button behaviour in case details are very long(WPB-24288)

### DIFF
--- a/apps/webapp/src/script/components/Modals/FileHistoryModal/FileHistoryModal.styles.ts
+++ b/apps/webapp/src/script/components/Modals/FileHistoryModal/FileHistoryModal.styles.ts
@@ -123,8 +123,8 @@ export const fileVersionItemWrapperCss: CSSObject = {
   borderRadius: '8px',
   ':hover': {
     backgroundColor: 'var(--gray-20)',
-    button: {
-      visibility: 'visible',
+    '& [data-version-actions="true"]': {
+      display: 'flex',
     },
   },
 };
@@ -151,6 +151,7 @@ export const versionDotOldCss: CSSObject = {
 
 export const versionInfoContainerCss: CSSObject = {
   flex: 1,
+  minWidth: 0,
 };
 
 export const versionTimeTextCss: CSSObject = {
@@ -163,21 +164,33 @@ export const versionMetaTextCss: CSSObject = {
   color: 'var(--gray-70)',
   marginTop: '4px',
   margin: 0,
+  display: 'flex',
+  alignItems: 'center',
+  minWidth: 0,
 };
 
 export const versionOwnerSpanCss: CSSObject = {
+  flexShrink: 1,
+  minWidth: 0,
   marginRight: '8px',
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+};
+
+export const versionSizeSpanCss: CSSObject = {
+  flexShrink: 0,
 };
 
 // Action button styles
 export const versionActionsWrapperCss: CSSObject = {
-  display: 'flex',
+  display: 'none',
   gap: '8px',
   marginLeft: 'auto',
+  flexShrink: 0,
 };
 
 export const versionButtonCss: CSSObject = {
-  visibility: 'hidden',
   height: '32px',
   minHeight: 'auto',
   minWidth: 'auto',

--- a/apps/webapp/src/script/components/Modals/FileHistoryModal/FileVersionItem.tsx
+++ b/apps/webapp/src/script/components/Modals/FileHistoryModal/FileVersionItem.tsx
@@ -32,6 +32,7 @@ import {
   versionInfoContainerCss,
   versionMetaTextCss,
   versionOwnerSpanCss,
+  versionSizeSpanCss,
   versionTimeTextCss,
 } from './FileHistoryModal.styles';
 
@@ -49,6 +50,8 @@ interface FileVersionItemProps {
 }
 
 export const FileVersionItem = ({version, isCurrentVersion, onDownload, onRestore}: FileVersionItemProps) => {
+  const versionDetailsTitle = `${version.ownerName} ${version.size}`.trim();
+
   return (
     <div key={version.versionId} css={fileVersionItemWrapperCss}>
       <div css={isCurrentVersion ? versionDotCurrentCss : versionDotOldCss} aria-hidden="true" />
@@ -56,12 +59,12 @@ export const FileVersionItem = ({version, isCurrentVersion, onDownload, onRestor
         <p css={versionTimeTextCss}>
           {version.time} {isCurrentVersion && t('cells.versionHistory.current')}
         </p>
-        <p css={versionMetaTextCss}>
+        <p css={versionMetaTextCss} title={versionDetailsTitle} data-version-meta-text="true">
           <span css={versionOwnerSpanCss}>{version.ownerName}</span>
-          {version.size}
+          <span css={versionSizeSpanCss}>{version.size}</span>
         </p>
       </div>
-      <div css={versionActionsWrapperCss}>
+      <div css={versionActionsWrapperCss} data-version-actions="true">
         <Button
           variant={ButtonVariant.SECONDARY}
           css={versionButtonCss}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24288" title="WPB-24288" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24288</a>  [Web][versions] Reduce name and size to single line of text
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Summary

**Description**

Currently the version details (username and size) often appear in two lines (in order to make space for the buttons in hover state. 

**Acceptance criteria**

Instead, we want to keep the details always in a single line and introduce a hiding behind a button behavior in case details are very long. (two versions of design, depending on effort)

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)
<img width="1512" height="982" alt="Screenshot 2026-04-09 at 14 46 36" src="https://github.com/user-attachments/assets/1ea5b3eb-57f0-4c8c-bbdc-ace5abe75608" />


## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
