### PR TITLE
test: remove util "doesConversationHasMentionIndicator" [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -72,12 +72,6 @@ export class ConversationListPage {
     return await this.getConversationLocator(conversationName).getByTestId('status-blocked').isVisible();
   }
 
-  async doesConversationHasMentionIndicator(conversationName: string) {
-    const mentionIndicator = this.getConversationLocator(conversationName).getByTestId('status-mention');
-    await mentionIndicator.waitFor({state: 'visible'});
-    return await mentionIndicator.isVisible();
-  }
-
   async openConversation(conversationName: string, options?: Parameters<typeof this.getConversationLocator>[1]) {
     await this.getConversationLocator(conversationName, options).click();
   }

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
@@ -65,7 +65,7 @@ test(
 
     await test.step('User B should receive mention', async () => {
       const {pages} = userBPageManager.webapp;
-      expect(await pages.conversationList().doesConversationHasMentionIndicator(channelName)).toBeTruthy();
+      await expect(pages.conversationList().getConversationLocator(channelName).mentionIndicator).toBeVisible();
 
       await pages.conversationList().openConversation(channelName);
       await expect(pages.conversation().getMessage({content: `@${userB.fullName} ${messageText}`})).toBeVisible();

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
@@ -55,7 +55,7 @@ test('Messages in Groups', {tag: ['@TC-8751', '@crit-flow-web']}, async ({create
 
   await test.step('User B should receive mention', async () => {
     const {pages} = userBPageManager.webapp;
-    expect(await pages.conversationList().doesConversationHasMentionIndicator(conversationName)).toBeTruthy();
+    await expect(pages.conversationList().getConversationLocator(conversationName).mentionIndicator).toBeVisible();
 
     await pages.conversationList().openConversation(conversationName);
     await expect(pages.conversation().getMessage({content: `@${userB.fullName} ${messageText}`})).toBeVisible();


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

The util follows bad practices and we already have a better replacement for it.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
