### PR TITLE
fix: use normalised QualifiedId for conversation retry fetch(WPB-24660)

### DIFF
--- a/apps/webapp/src/script/view_model/ContentViewModel.ts
+++ b/apps/webapp/src/script/view_model/ContentViewModel.ts
@@ -293,10 +293,12 @@ export class ContentViewModel {
       this.showAndNavigate(conversationEntity, openNotificationSettings, filePath);
     } catch (error: unknown) {
       if (this.isConversationNotFoundError(error)) {
+        const qualifiedId = isConversationEntity(conversation) ? conversation.qualifiedId : conversation;
+
         // Retry fetching the conversation to handle race conditions
         const fetchSucceeded = await this.retryFetchConversationWithBackoff({
-          id: conversation.domain,
-          domain: conversation.domain,
+          id: qualifiedId.id,
+          domain: qualifiedId.domain,
         });
 
         if (fetchSucceeded) {


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24660" title="WPB-24660" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24660</a>  [Desktop] When hit Update banner there's an issue with conversation that can't be opened
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary

Fixes flaky conversation not found modal behavior by correcting retry fetch parameters in ContentViewModel.ts.

**Root cause**
In the retry path, the request used a wrong ID-domain pair, so backoff retries often failed even when the conversation could be fetched. [Retry attempts PR ](https://github.com/wireapp/wire-webapp/pull/19768)

**Impact**

Reduces false positive “Wire can’t open this conversation” modal.
Keeps expected modal behavior for genuine not-found/no-permission cases.

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
