### PR TITLE
test: clean out utils of conversation POM [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -342,11 +342,6 @@ export class ConversationPage {
     await startCallButton.click();
   }
 
-  async isSystemMessageVisible(messageText: string) {
-    await this.systemMessages.filter({hasText: messageText}).first().waitFor({state: 'visible'});
-    return true;
-  }
-
   async isConversationReadonly() {
     await this.messageInput.waitFor({state: 'detached'});
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -330,29 +330,6 @@ export class ConversationPage {
     await audioPlayButton.click();
   }
 
-  async isAudioPlaying() {
-    const audioTimeLocator = this.page
-      .getByTestId('item-message')
-      .getByTestId('audio-asset')
-      .getByTestId('status-audio-time');
-
-    const audioTimeText = (await audioTimeLocator.textContent())?.trim();
-    if (!audioTimeText) {
-      throw new Error('Audio time text is empty or undefined');
-    }
-    const seconds = parseInt(audioTimeText.split(':')[1], 10);
-    return seconds > 0;
-  }
-
-  async isAudioMessageVisible() {
-    const audioMessageLocator = this.page.getByTestId('item-message').getByTestId('audio-asset');
-
-    // Wait for at least one matching element to appear (optional timeout can be set)
-    await audioMessageLocator.first().waitFor({state: 'visible'});
-
-    return await audioMessageLocator.isVisible();
-  }
-
   async isFileMessageVisible() {
     const fileMessageLocator = this.page.getByTestId('item-message').getByTestId('file-asset');
 

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -190,16 +190,6 @@ export class ConversationPage {
     await this.messageInput.press('Enter');
   }
 
-  async isImageFromUserVisible(user: User) {
-    // Trying multiple times for the image to appear
-    const locator = this.getImageLocator(user);
-
-    // Wait for at least one matching element to appear (optional timeout can be set)
-    await locator.first().waitFor({state: 'visible'});
-
-    return await locator.isVisible();
-  }
-
   async getImageScreenshot(user: User): Promise<Buffer> {
     const locator = this.getImageLocator(user);
 

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -342,14 +342,6 @@ export class ConversationPage {
     await startCallButton.click();
   }
 
-  async isConversationReadonly() {
-    await this.messageInput.waitFor({state: 'detached'});
-  }
-
-  async isMessageInputVisible() {
-    return await this.messageInput.isVisible();
-  }
-
   async toggleGroupInformation() {
     await this.openGroupInformationViaName.click();
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -379,10 +379,6 @@ export class ConversationPage {
     await this.addMemberButton.click();
   }
 
-  async getTitle() {
-    return await this.conversationTitle.innerText();
-  }
-
   async sendPing() {
     await this.pingButton.click();
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -346,14 +346,6 @@ export class ConversationPage {
     await this.openGroupInformationViaName.click();
   }
 
-  async isUserGroupAdmin(name: string) {
-    await this.adminsList
-      .getByTestId('item-user')
-      .and(this.page.locator(`[data-uie-value="${name}"]`))
-      .waitFor({state: 'visible'});
-    return true;
-  }
-
   async makeUserAdmin(name: string) {
     await this.membersList
       .getByTestId('item-user')

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -330,15 +330,6 @@ export class ConversationPage {
     await audioPlayButton.click();
   }
 
-  async isFileMessageVisible() {
-    const fileMessageLocator = this.page.getByTestId('item-message').getByTestId('file-asset');
-
-    // Wait for at least one matching element to appear (optional timeout can be set)
-    await fileMessageLocator.first().waitFor({state: 'visible'});
-
-    return await fileMessageLocator.isVisible();
-  }
-
   async isReplyMessageVisible(replyText: string) {
     const replyMessageLocator = this.page
       .getByTestId('item-message')

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -313,15 +313,6 @@ export class ConversationPage {
     return await plusOneReactionIcon.isVisible();
   }
 
-  async isVideoMessageVisible() {
-    const videoMessageLocator = this.page.getByTestId('item-message').getByTestId('video-asset');
-
-    // Wait for at least one matching element to appear (optional timeout can be set)
-    await videoMessageLocator.first().waitFor({state: 'visible'});
-
-    return await videoMessageLocator.isVisible();
-  }
-
   async playVideo() {
     const videoPlayButton = this.page
       .getByTestId('item-message')
@@ -329,20 +320,6 @@ export class ConversationPage {
       .getByTestId('do-play-media');
 
     await videoPlayButton.click();
-  }
-
-  async isVideoPlaying() {
-    const videoTimeLocator = this.page
-      .getByTestId('item-message')
-      .getByTestId('video-asset')
-      .getByTestId('status-video-time');
-
-    const videoTimeText = (await videoTimeLocator.textContent())?.trim();
-    if (!videoTimeText) {
-      throw new Error('Video time text is empty or undefined');
-    }
-    const seconds = parseInt(videoTimeText.split(':')[1]);
-    return seconds < 30;
   }
 
   async playAudio() {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -330,17 +330,6 @@ export class ConversationPage {
     await audioPlayButton.click();
   }
 
-  async isReplyMessageVisible(replyText: string) {
-    const replyMessageLocator = this.page
-      .getByTestId('item-message')
-      .locator('.message-body.message-quoted .text', {hasText: replyText});
-
-    // Wait for at least one matching element to appear (optional timeout can be set)
-    await replyMessageLocator.first().waitFor({state: 'visible'});
-
-    return await replyMessageLocator.isVisible();
-  }
-
   async downloadFile(outputDir: string) {
     const downloadButton = this.page.getByTestId('item-message').getByTestId('file-asset');
 

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -186,16 +186,6 @@ export class ConversationPage {
     await this.messageInput.press('Enter');
   }
 
-  async getImageScreenshot(user: User): Promise<Buffer> {
-    const locator = this.getImageLocator(user);
-
-    // Wait for the image to be visible
-    await locator.waitFor({state: 'visible'});
-
-    // Take a screenshot of the image
-    return await locator.screenshot();
-  }
-
   /**
    * Util to get a message in the conversation
    * @param options.content Only match messages containing this text

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -117,10 +117,6 @@ export class ConversationPage {
       .and(this.page.locator(`[alt^="${this.getImageAltText(user)}"]`));
   }
 
-  async isConversationOpen(conversationName: string) {
-    return (await this.page.getByTestId('status-conversation-title-bar-label').textContent()) === conversationName;
-  }
-
   async clickConversationTitle() {
     await this.conversationTitle.click();
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -300,19 +300,6 @@ export class ConversationPage {
     await locator.click();
   }
 
-  async isPlusOneReactionVisible() {
-    const plusOneReactionIcon = this.page
-      .getByTestId('item-message')
-      .getByTestId('message-reactions')
-      .getByTestId('emoji-pill')
-      .and(this.page.locator('button[aria-label="1 reaction, react with +1 emoji"]'));
-
-    // Wait for at least one matching element to appear (optional timeout can be set)
-    await plusOneReactionIcon.first().waitFor({state: 'visible'});
-
-    return await plusOneReactionIcon.isVisible();
-  }
-
   async playVideo() {
     const videoPlayButton = this.page
       .getByTestId('item-message')

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -379,10 +379,6 @@ export class ConversationPage {
     await this.addMemberButton.click();
   }
 
-  async messageCount() {
-    return await this.messages.count();
-  }
-
   async getTitle() {
     return await this.conversationTitle.innerText();
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -346,13 +346,6 @@ export class ConversationPage {
     await this.openGroupInformationViaName.click();
   }
 
-  async isUserGroupMember(name: string) {
-    return this.membersList
-      .getByTestId('item-user')
-      .and(this.page.locator(`[data-uie-value="${name}"]`))
-      .isVisible();
-  }
-
   async isUserGroupAdmin(name: string) {
     await this.adminsList
       .getByTestId('item-user')

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
@@ -183,7 +183,9 @@ test(
       await pages.conversation().removeMemberFromGroup(member2.fullName);
 
       // Verify member is no longer in the conversation by checking system message
-      expect(await pages.conversation().isSystemMessageVisible(`You removed ${member2.fullName}`)).toBeTruthy();
+      await expect(
+        pages.conversation().systemMessages.filter({hasText: `You removed ${member2.fullName}`}),
+      ).toBeVisible();
     });
 
     await test.step('Team owner removes a service from a group', async () => {
@@ -192,7 +194,7 @@ test(
       await pages.conversationDetails().removeServiceFromConversation('Poll');
 
       // Verify service was removed by checking for system message
-      expect(await pages.conversation().isSystemMessageVisible('You removed Poll Bot')).toBeTruthy();
+      await expect(pages.conversation().systemMessages.filter({hasText: 'You removed Poll Bot'})).toBeVisible();
     });
   },
 );

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsManagement-TC-8752.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsManagement-TC-8752.spec.ts
@@ -56,7 +56,7 @@ test('Channels Management', {tag: ['@TC-8752', '@crit-flow-web']}, async ({creat
 
     await memberPages.conversation().leaveConversation();
     await memberModals.leaveConversation().clickConfirm();
-    await memberPages.conversation().isConversationReadonly();
+    await expect(memberPages.conversation().messageInput).not.toBeAttached();
   });
 
   await test.step('Team owner confirm member left', async () => {
@@ -89,7 +89,7 @@ test('Channels Management', {tag: ['@TC-8752', '@crit-flow-web']}, async ({creat
 
   await test.step('Team member verifies they have been removed by the owner', async () => {
     await memberPages.conversationList().openConversation(conversation2);
-    await memberPages.conversation().isConversationReadonly();
+    await expect(memberPages.conversation().messageInput).not.toBeAttached();
   });
 
   await test.step('Team owner add member back to the same conversation', async () => {

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
@@ -101,7 +101,6 @@ test('Conversation Management', {tag: ['@TC-8636', '@crit-flow-web']}, async ({c
     await pages.conversationList().leaveConversation();
     await modals.leaveConversation().toggleCheckbox();
     await modals.leaveConversation().clickConfirm();
-    await pages.conversation().isConversationReadonly();
-    expect(await pages.conversation().isMessageInputVisible()).toBeFalsy();
+    await expect(pages.conversation().messageInput).not.toBeAttached();
   });
 });

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
@@ -66,7 +66,12 @@ test('Messages in 1:1', {tag: ['@TC-8750', '@crit-flow-web']}, async ({createTea
 
     // Verify QR Code in the image
     const localQRCodeValue = await getLocalQRCodeValue(imageFilePath);
-    const imageScreenshot = await memberBPageManager.webapp.pages.conversation().getImageScreenshot(memberA);
+    const imageScreenshot = await memberBPageManager.webapp.pages
+      .conversation()
+      .getMessage()
+      .locator(`img[alt*="Image from ${memberA.fullName}"]`)
+      .screenshot();
+
     const screenshotQRCodeValue = await getQRCodeValueFromScreenshot(imageScreenshot);
     expect(screenshotQRCodeValue).toBe(localQRCodeValue);
   });

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
@@ -108,7 +108,7 @@ test('Messages in 1:1', {tag: ['@TC-8750', '@crit-flow-web']}, async ({createTea
   await test.step('User B can play the video', async () => {
     const {pages} = memberBPageManager.webapp;
     await pages.conversation().playVideo();
-    await expect.poll(() => pages.conversation().isVideoPlaying()).toBeTruthy();
+    await expect(pages.conversation().getMessage({sender: memberA}).locator('video')).toHaveJSProperty('paused', false);
   });
 
   // Step 5: Audio Files

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
@@ -118,8 +118,10 @@ test('Messages in 1:1', {tag: ['@TC-8750', '@crit-flow-web']}, async ({createTea
   });
   await test.step('User B can play the file', async () => {
     const {pages} = memberAPageManager.webapp;
+    await expect(pages.conversation().getMessage({sender: memberA}).locator('audio')).toHaveJSProperty('paused', true);
+
     await pages.conversation().playAudio();
-    await expect.poll(() => pages.conversation().isAudioPlaying()).toBeTruthy();
+    await expect(pages.conversation().getMessage({sender: memberA}).locator('audio')).toHaveJSProperty('paused', false);
   });
 
   // Step 6: Ephemeral messages

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
@@ -121,15 +121,15 @@ test(
     await test.step('User A sends audio file', async () => {
       const {pages, components} = userAPageManager.webapp;
       await components.inputBarControls().clickShareFile(audioFilePath);
-      expect(await pages.conversation().isAudioMessageVisible()).toBeTruthy();
+      await expect(pages.conversation().getMessage({sender: userA}).locator('audio')).toBeAttached();
     });
 
     await test.step('User B can play the audio file', async () => {
       const {pages} = userBPageManager.webapp;
+      await expect(pages.conversation().getMessage({sender: userA}).locator('audio')).toHaveJSProperty('paused', true);
+
       await pages.conversation().playAudio();
-      // Wait for 5 seconds to ensure audio starts playing
-      await userBPage.waitForTimeout(3000);
-      expect(await pages.conversation().isAudioPlaying()).toBeTruthy();
+      await expect(pages.conversation().getMessage({sender: userA}).locator('audio')).toHaveJSProperty('paused', false);
     });
 
     await test.step('User A sends a quick (10 sec) self deleting message', async () => {

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
@@ -71,7 +71,12 @@ test(
       await pages.conversationList().openConversation(channelName);
       await components.inputBarControls().clickShareImage(imageFilePath);
 
-      expect(await userBPageManager.webapp.pages.conversation().isImageFromUserVisible(userA)).toBeTruthy();
+      await expect(
+        userBPageManager.webapp.pages
+          .conversation()
+          .getMessage({sender: userA})
+          .getByRole('button', {name: `Image from ${userA.fullName}`}),
+      ).toBeVisible();
     });
 
     await test.step('User B can open the image preview and see the image', async () => {

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
@@ -96,12 +96,16 @@ test(
       const {pages, modals} = userBPageManager.webapp;
       await modals.detailViewModal().givePlusOneReaction();
       await modals.detailViewModal().closeModal();
-      expect(await pages.conversation().isPlusOneReactionVisible()).toBeTruthy();
+
+      const message = pages.conversation().getMessage({sender: userA});
+      await expect(pages.conversation().getReactionOnMessage(message, 'plus-one')).toBeVisible();
     });
 
     await test.step('User A can see the reaction', async () => {
       const {pages} = userAPageManager.webapp;
-      expect(await pages.conversation().isPlusOneReactionVisible()).toBeTruthy();
+
+      const message = pages.conversation().getMessage({sender: userA});
+      await expect(pages.conversation().getReactionOnMessage(message, 'plus-one')).toBeVisible();
     });
 
     await test.step('User A sends video message', async () => {

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
@@ -163,7 +163,7 @@ test(
     await test.step('User A sends asset', async () => {
       const {pages, components} = userAPageManager.webapp;
       await components.inputBarControls().clickShareFile(textFilePath);
-      expect(await pages.conversation().isFileMessageVisible()).toBeTruthy();
+      await expect(pages.conversation().getMessage({sender: userA}).getByTestId('file-asset')).toBeVisible();
     });
 
     await test.step('User B can download the file', async () => {

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
@@ -36,14 +36,9 @@ const textFilePath = getTextFilePath();
 test(
   'Messages in Channels',
   {tag: ['@TC-8753', '@crit-flow-web']},
-  async ({createUser, createTeam, createPage, api}, testInfo) => {
+  async ({createUser, createTeam, createPage}, testInfo) => {
     const userB = await createUser();
-    const {owner: userA} = await createTeam('Critical Team', {users: [userB]});
-
-    // TODO: Remove below line when we have a SQS workaround
-    await api.brig.enableMLSFeature(userA.teamId);
-    await api.brig.unlockChannelFeature(userA.teamId);
-    await api.brig.enableChannelsFeature(userA.teamId);
+    const {owner: userA} = await createTeam('Critical Team', {users: [userB], features: {channels: true}});
 
     const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
     const [userAPageManager, userBPageManager] = [PageManager.from(userAPage), PageManager.from(userBPage)];
@@ -84,9 +79,8 @@ test(
       // Click on the image to open it in a preview
       await pages.conversation().clickImage(userA);
       // Verify that the detail view modal is visible
-      await modals.detailViewModal().waitForVisibility();
-      expect(await modals.detailViewModal().isVisible()).toBeTruthy();
-      expect(await modals.detailViewModal().isImageVisible()).toBeTruthy();
+      await expect(modals.detailViewModal().mainWindow).toBeVisible();
+      await expect(modals.detailViewModal().image).toBeVisible();
     });
 
     await test.step('User B can download the image', async () => {
@@ -113,15 +107,15 @@ test(
     await test.step('User A sends video message', async () => {
       const {pages, components} = userAPageManager.webapp;
       await components.inputBarControls().clickShareFile(videoFilePath);
-      expect(await pages.conversation().isVideoMessageVisible()).toBeTruthy();
+      await expect(pages.conversation().getMessage({sender: userA}).locator('video')).toBeAttached();
     });
 
     await test.step('User B can play the received video', async () => {
       const {pages} = userBPageManager.webapp;
+      await expect(pages.conversation().getMessage({sender: userA}).locator('video')).toHaveJSProperty('paused', true);
+
       await pages.conversation().playVideo();
-      // Wait for 5 seconds to ensure video starts playing
-      await userBPage.waitForTimeout(5000);
-      // ToDO: Bug -> Video is not loaded from the server, so we cannot check if it is playing
+      await expect(pages.conversation().getMessage({sender: userA}).locator('video')).toHaveJSProperty('paused', false);
     });
 
     await test.step('User A sends audio file', async () => {

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
@@ -158,7 +158,7 @@ test('Messages in Groups', {tag: ['@TC-8751', '@crit-flow-web']}, async ({create
   await test.step('User A sends asset', async () => {
     const {pages, components} = userAPageManager.webapp;
     await components.inputBarControls().clickShareFile(textFilePath);
-    expect(await pages.conversation().isFileMessageVisible()).toBeTruthy();
+    await expect(pages.conversation().getMessage({sender: userA}).getByTestId('file-asset')).toBeVisible();
   });
 
   await test.step('User B can download the file', async () => {

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
@@ -66,7 +66,12 @@ test('Messages in Groups', {tag: ['@TC-8751', '@crit-flow-web']}, async ({create
     await pages.conversationList().openConversation(conversationName);
     await components.inputBarControls().clickShareImage(imageFilePath);
 
-    expect(await userBPageManager.webapp.pages.conversation().isImageFromUserVisible(userA)).toBeTruthy();
+    await expect(
+        userBPageManager.webapp.pages
+          .conversation()
+          .getMessage({sender: userA})
+          .getByRole('button', {name: `Image from ${userA.fullName}`}),
+      ).toBeVisible();
   });
 
   await test.step('User B can open the image preview and see the image', async () => {

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
@@ -117,15 +117,15 @@ test('Messages in Groups', {tag: ['@TC-8751', '@crit-flow-web']}, async ({create
   await test.step('User A sends audio file', async () => {
     const {pages, components} = userAPageManager.webapp;
     await components.inputBarControls().clickShareFile(audioFilePath);
-    expect(await pages.conversation().isAudioMessageVisible()).toBeTruthy();
+    await expect(pages.conversation().getMessage({sender: userA}).locator("audio")).toBeAttached()
   });
 
   await test.step('User B can play the audio file', async () => {
     const {pages} = userBPageManager.webapp;
+    await expect(pages.conversation().getMessage({sender: userA}).locator('audio')).toHaveJSProperty('paused', true);
+
     await pages.conversation().playAudio();
-    // Wait for 3 seconds to ensure audio starts playing
-    await userBPage.waitForTimeout(3000);
-    expect(await pages.conversation().isAudioPlaying()).toBeTruthy();
+    await expect(pages.conversation().getMessage({sender: userA}).locator('audio')).toHaveJSProperty('paused', false);
   });
   await test.step('User A sends a quick (10 sec) self deleting message', async () => {
     const {pages} = userAPageManager.webapp;

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
@@ -92,12 +92,15 @@ test('Messages in Groups', {tag: ['@TC-8751', '@crit-flow-web']}, async ({create
     const {pages, modals} = userBPageManager.webapp;
     await modals.detailViewModal().givePlusOneReaction();
     await modals.detailViewModal().closeModal();
-    expect(await pages.conversation().isPlusOneReactionVisible()).toBeTruthy();
+
+    const message = pages.conversation().getMessage({sender: userA});
+      await expect(pages.conversation().getReactionOnMessage(message, 'plus-one')).toBeVisible();
   });
 
   await test.step('User A can see the reaction', async () => {
     const {pages} = userAPageManager.webapp;
-    expect(await pages.conversation().isPlusOneReactionVisible()).toBeTruthy();
+    const message = pages.conversation().getMessage({sender: userA});
+      await expect(pages.conversation().getReactionOnMessage(message, 'plus-one')).toBeVisible();
   });
 
   await test.step('User A sends video message', async () => {

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
@@ -103,15 +103,15 @@ test('Messages in Groups', {tag: ['@TC-8751', '@crit-flow-web']}, async ({create
   await test.step('User A sends video message', async () => {
     const {pages, components} = userAPageManager.webapp;
     await components.inputBarControls().clickShareFile(videoFilePath);
-    expect(await pages.conversation().isVideoMessageVisible()).toBeTruthy();
+    await expect(pages.conversation().getMessage({sender: userA}).locator('video')).toBeAttached();
   });
 
   await test.step('User B can play the received video', async () => {
     const {pages} = userBPageManager.webapp;
+    await expect(pages.conversation().getMessage({sender: userA}).locator('video')).toHaveJSProperty('paused', true);
+
     await pages.conversation().playVideo();
-    // Wait for 5 seconds to ensure video starts playing
-    await userBPage.waitForTimeout(5000);
-    // ToDO: Bug -> Video is not loaded from the server, so we cannot check if it is playing
+    await expect(pages.conversation().getMessage({sender: userA}).locator('video')).toHaveJSProperty('paused', false);
   });
 
   await test.step('User A sends audio file', async () => {

--- a/apps/webapp/test/e2e_tests/specs/Drive/replyingToMultipartMessage-TC-8787.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Drive/replyingToMultipartMessage-TC-8787.spec.ts
@@ -110,7 +110,8 @@ test(
       await userBComponents.inputBarControls().setMessageInput(replyMessageText);
       await userBComponents.inputBarControls().clickSendMessage();
 
-      expect(await userAPages.cellsConversation().isReplyMessageVisible(replyMessageText)).toBeTruthy();
+      const reply = userAPages.conversation().getMessage({content: replyMessageText});
+      await expect(reply).toBeVisible();
     });
   },
 );


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

This PR removes utils from the conversations POM. Some of them were unused, specific to one use case / test or following bad practices.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Notes for reviewers

- This PR uses atomic commits, feel free to step through them individually during review to reduce cognitive load